### PR TITLE
Switch from the deprecated bootstrap.saltstack.org to the .com redirect

### DIFF
--- a/cluster/templates/salt-master.sh
+++ b/cluster/templates/salt-master.sh
@@ -47,6 +47,6 @@ echo $MASTER_HTPASSWD > /srv/salt/nginx/htpasswd
 # install.  See https://github.com/saltstack/salt-bootstrap/issues/270
 #
 # -M installs the master
-curl -L http://bootstrap.saltstack.org | sh -s -- -M -X
+curl -L http://bootstrap.saltstack.com | sh -s -- -M -X
 
 echo $MASTER_HTPASSWD > /srv/salt/nginx/htpasswd

--- a/cluster/templates/salt-minion.sh
+++ b/cluster/templates/salt-minion.sh
@@ -35,4 +35,4 @@ EOF
 #
 # We specify -X to avoid a race condition that can cause minion failure to
 # install.  See https://github.com/saltstack/salt-bootstrap/issues/270
-curl -L http://bootstrap.saltstack.org | sh -s -- -X
+curl -L http://bootstrap.saltstack.com | sh -s -- -X


### PR DESCRIPTION
As per saltstack/salt#12105
