### PR TITLE
e2e-test: expose minion 8080 port

### DIFF
--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -33,9 +33,20 @@ $(dirname $0)/../cluster/kube-up.sh
 # Auto shutdown cluster when we exit
 function shutdown-test-cluster () {
   echo "Shutting down test cluster in background."
+  gcloud compute firewalls delete --quiet ${MINION_TAG}-http-alt \
+    --project ${PROJECT} &
   $(dirname $0)/../cluster/kube-down.sh > /dev/null &
 }
 trap shutdown-test-cluster EXIT
+
+# Detect the project into $PROJECT if it isn't set
+detect-project
+
+# Open up port 8080 so nginx containers on minions can be reached
+gcloud compute firewalls create --quiet ${MINION_TAG}-http-alt \
+  --project ${PROJECT} \
+  --target-tags ${MINION_TAG} \
+  --allow tcp:8080 &
 
 # Launch a container
 $(dirname $0)/../cluster/cloudcfg.sh -p 8080:80 run dockerfile/nginx 2 myNginx


### PR DESCRIPTION
Otherwise the e2e-test fails when trying to reach the nginx containers.
