### PR TITLE
cloudcfg: resize <name> <replicas> command

### DIFF
--- a/cmd/cloudcfg/cloudcfg.go
+++ b/cmd/cloudcfg/cloudcfg.go
@@ -131,6 +131,21 @@ func main() {
 			log.Fatalf("Error: %#v", err)
 		}
 		return
+	case "resize":
+		args := flag.Args()
+		if len(args) < 3 {
+			log.Fatal("usage: cloudcfg resize <name> <replicas>")
+		}
+		name := args[1]
+		replicas, err := strconv.Atoi(args[2])
+		if err != nil {
+			log.Fatalf("Error parsing replicas: %#v", err)
+		}
+		err = cloudcfg.ResizeController(name, replicas, kube_client.Client{Host: *httpServer, Auth: auth})
+		if err != nil {
+			log.Fatalf("Error: %#v", err)
+		}
+		return
 	case "rm":
 		err = cloudcfg.DeleteController(flag.Arg(1), kube_client.Client{Host: *httpServer, Auth: auth})
 		if err != nil {

--- a/pkg/cloudcfg/cloudcfg.go
+++ b/pkg/cloudcfg/cloudcfg.go
@@ -150,6 +150,25 @@ func StopController(name string, client client.ClientInterface) error {
 	return nil
 }
 
+// ResizeController resizes a controller named 'name' by setting replicas to 'replicas'
+func ResizeController(name string, replicas int, client client.ClientInterface) error {
+	controller, err := client.GetReplicationController(name)
+	if err != nil {
+		return err
+	}
+	controller.DesiredState.Replicas = replicas
+	controllerOut, err := client.UpdateReplicationController(controller)
+	if err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(controllerOut)
+	if err != nil {
+		return err
+	}
+	fmt.Print(string(data))
+	return nil
+}
+
 func makePorts(spec string) []api.Port {
 	parts := strings.Split(spec, ",")
 	var result []api.Port

--- a/pkg/cloudcfg/cloudcfg_test.go
+++ b/pkg/cloudcfg/cloudcfg_test.go
@@ -221,6 +221,25 @@ func TestStopController(t *testing.T) {
 	}
 }
 
+func TestResizeController(t *testing.T) {
+	fakeClient := FakeKubeClient{}
+	name := "name"
+	replicas := 17
+	ResizeController(name, replicas, &fakeClient)
+	if len(fakeClient.actions) != 2 {
+		t.Errorf("Unexpected actions: %#v", fakeClient.actions)
+	}
+	if fakeClient.actions[0].action != "get-controller" ||
+		fakeClient.actions[0].value.(string) != name {
+		t.Errorf("Unexpected action: %#v", fakeClient.actions[0])
+	}
+	controller := fakeClient.actions[1].value.(ReplicationController)
+	if fakeClient.actions[1].action != "update-controller" ||
+		controller.DesiredState.Replicas != 17 {
+		t.Errorf("Unexpected action: %#v", fakeClient.actions[1])
+	}
+}
+
 func TestCloudCfgDeleteController(t *testing.T) {
 	fakeClient := FakeKubeClient{}
 	name := "name"


### PR DESCRIPTION
Add a command to cloudcfg to allow setting the number of replicas without having to issue a run command and re-specify all of the original configuration,
