### PR TITLE
Fix up version string for gcloud compute version.

### DIFF
--- a/cluster/kube-up.sh
+++ b/cluster/kube-up.sh
@@ -96,9 +96,9 @@ for (( i=0; i<${#MINION_NAMES[@]}; i++)); do
     --can-ip-forward \
     --metadata-from-file startup-script=${KUBE_TEMP}/minion-start-${i}.sh &
 
-  # 'gcloud compute' past 2014.06.08 breaks the way we are specifying
+  # 'gcloud compute' past 2014.06.11 breaks the way we are specifying
   # --next-hop-instance and there is no way to be compatible with both versions.
-  if [[ $GCLOUD_VERSION < "2014.06.08" ]]; then
+  if [[ $GCLOUD_VERSION < "2014.06.11" ]]; then
     gcloud compute routes create ${MINION_NAMES[$i]} \
       --project ${PROJECT} \
       --destination-range ${MINION_IP_RANGES[$i]} \


### PR DESCRIPTION
This might break again as the version that this change will land isn't stable.  I'm going to switch back to gcutil until we know we won't break again.  That will come in a future PR.
