### PR TITLE
Allow the use of a network other than default

### DIFF
--- a/cluster/config-default.sh
+++ b/cluster/config-default.sh
@@ -19,6 +19,7 @@ MINION_SIZE=g1-small
 NUM_MINIONS=4
 # gcloud will expand this to the latest supported image.
 IMAGE=debian-7-backports
+NETWORK=default
 INSTANCE_PREFIX=kubernetes
 MASTER_NAME="${INSTANCE_PREFIX}-master"
 MASTER_TAG="${INSTANCE_PREFIX}-master"

--- a/cluster/config-test.sh
+++ b/cluster/config-test.sh
@@ -19,6 +19,7 @@ MINION_SIZE=g1-small
 NUM_MINIONS=2
 # gcloud will expand this to the latest supported image.
 IMAGE=debian-7-backports
+NETWORK=default
 INSTANCE_PREFIX="e2e-test-${USER}"
 MASTER_NAME="${INSTANCE_PREFIX}-master"
 MASTER_TAG="${INSTANCE_PREFIX}-master"


### PR DESCRIPTION
Disclaimer:  I have not tested this, I'll get around to that this evening, but from what I've seen this should work just fine.

It would be nice to be able to specify the network that firewalls/routes/instances are created in.
