### PR TITLE
Update guestbook.md

### DIFF
--- a/examples/guestbook/guestbook.md
+++ b/examples/guestbook/guestbook.md
@@ -94,7 +94,7 @@ Using master: kubernetes-master (external IP: 1.2.3.4)
 If you ssh to that machine, you can run `docker ps` to see the actual pod:
 
 ```shell
-$ gcutil ssh kubernetes-minion-3 --zone us-central1-b
+$ gcutil ssh --zone us-central1-b kubernetes-minion-3
 $ sudo docker ps
 
 me@kubernetes-minion-3:~$ sudo docker ps


### PR DESCRIPTION
The previous gcutil command fails to connect:

lynchb-macbookpro2:kubernetes lynchb$ gcutil ssh kubernetes-minion-3 --zone us-central1-b
INFO: Zone for kubernetes-minion-3 detected as us-central1-b.
INFO: Running command line: ssh -o UserKnownHostsFile=/dev/null -o CheckHostIP=no -o StrictHostKeyChecking=no -i /Users/lynchb/.ssh/google_compute_engine -A -p 22 lynchb@23.236.61.38 -- --zone us-central1-b
Warning: Permanently added '23.236.61.38' (RSA) to the list of known hosts.
bash: --: invalid option
Usage:  bash [GNU long option] [option] ...
    bash [GNU long option] [option] script-file ...
GNU long options:
    --debug
    --debugger
    --dump-po-strings
    --dump-strings
    --help
    --init-file
    --login
    --noediting
    --noprofile
    --norc
    --posix
    --protected
    --rcfile
    --restricted
    --verbose
    --version
Shell options:
    -irsD or -c command or -O shopt_option      (invocation only)
    -abefhkmnptuvxBCHP or -o option
