### PR TITLE
When the apiserver panics, log a stacktrace.

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"runtime/debug"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
@@ -77,7 +78,7 @@ func (server *ApiServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		if x := recover(); x != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprint(w, "apiserver panic. Look in log for details.")
-			log.Printf("ApiServer panic'd: %#v\n", x)
+			log.Printf("ApiServer panic'd: %#v\n%s\n", x, debug.Stack())
 		}
 	}()
 	log.Printf("%s %s", req.Method, req.RequestURI)


### PR DESCRIPTION
I was running into a problem where apiserver was panicking...but found it hard to debug without a backtrace. This logs the backtrack on panics.
