### PR TITLE
Add Dockerfiles, plain Docker deployment instructions and minor fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu
+MAINTAINER https://github.com/GoogleCloudPlatform/kubernetes
+
+RUN  apt-get update && apt-get install -yq curl git mercurial
+
+ENV  GO_VERSION 1.2
+RUN  curl -s https://go.googlecode.com/files/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+ENV  GOPATH  /go
+ENV  PATH    $GOPATH/bin:/usr/local/go/bin:$PATH
+
+ADD     . $GOPATH/src/github.com/GoogleCloudPlatform/kubernetes
+WORKDIR /go/src/github.com/GoogleCloudPlatform/kubernetes/cmd
+
+RUN set -e; for c in *; do ( cd $c && go get -d && go build -o /usr/bin/$c ); done

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ hack/local-up.sh
 
 This will build and start a lightweight local cluster, consisting of a master and a single minion. Type Control-C to shut it down. While it's running, you can use `hack/localcfg.sh` in place of `cluster/cloudcfg.sh` to talk to it.
 
+## Running kubernetes in Docker containers
+There are two Docker images to get you started. First you need to deploy [google/kubernetes-node](kubernetes-node/) to all Docker nodes in your cluster, then you can deploy [google/kubernetes-server](kubernetes-server/) and use `cmd/cloudcfg/cloudcfg` to schedule your containers.
+
 ## Where to go next?
 [Detailed example application](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/examples/guestbook/guestbook.md)
 

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -45,8 +45,6 @@ var (
 	hostnameOverride   = flag.String("hostname_override", "", "If non-empty, will use this string as identification instead of the actual hostname.")
 )
 
-const dockerBinary = "/usr/bin/docker"
-
 func main() {
 	flag.Parse()
 	rand.Seed(time.Now().UTC().UnixNano())

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -43,6 +43,7 @@ var (
 	address            = flag.String("address", "127.0.0.1", "The address for the info server to serve on")
 	port               = flag.Uint("port", 10250, "The port for the info server to serve on")
 	hostnameOverride   = flag.String("hostname_override", "", "If non-empty, will use this string as identification instead of the actual hostname.")
+	dockerAddr         = flag.String("docker", "unix:///var/run/docker.sock", "Address of docker daemon")
 )
 
 func main() {
@@ -52,8 +53,7 @@ func main() {
 	// Set up logger for etcd client
 	etcd.SetLogger(log.New(os.Stderr, "etcd ", log.LstdFlags))
 
-	endpoint := "unix:///var/run/docker.sock"
-	dockerClient, err := docker.NewClient(endpoint)
+	dockerClient, err := docker.NewClient(*dockerAddr)
 	if err != nil {
 		log.Fatal("Couldn't connnect to docker.")
 	}

--- a/kubernetes-node/Dockerfile
+++ b/kubernetes-node/Dockerfile
@@ -1,0 +1,12 @@
+FROM       google/kubernetes
+MAINTAINER https://github.com/GoogleCloudPlatform/kubernetes
+
+ENV  ETCD_VERSION 0.4.3
+RUN  mkdir /etcd && touch /etc/kubelet.conf
+RUN  curl -Ls https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz | tar -C /etcd --strip-components=1 -xvzf -
+
+ADD  run.sh    /
+RUN  chmod a+x /run.sh
+
+EXPOSE 10250 4001 7001
+ENTRYPOINT [ "/run.sh" ]

--- a/kubernetes-node/README.md
+++ b/kubernetes-node/README.md
@@ -1,0 +1,13 @@
+# Kubernetes-Node
+
+This image consists of etcd to persist the scheduler state and kubelet to talk
+to Docker. This should be deployed to all your Docker nodes. You need to
+provide the node's external IP and a cluster discovery endpoint. Get a new
+cluster discovery endpoint [here](https://discovery.etcd.io/new).
+Since kubelet needs to talk to Docker, you need to also bind-mount
+`/var/run/docker.sock` to your container:
+
+
+```
+docker run -v /var/run/docker.sock:/docker.sock -d -P kubernetes-node external-ip:7001 external-ip:4001 etcd-cluster-discovery-endpoint
+```

--- a/kubernetes-node/run.sh
+++ b/kubernetes-node/run.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+if [ -z "$3" ]
+then
+  echo "$0 peer-addr addr discovery-url"
+  exit 1
+fi
+
+ID="ip_`echo $1 | cut -d: -f1|tr '.' '_'`"
+echo "ID=$ID"
+kubelet -config /etc/kubelet.conf -docker unix:///docker.sock \
+        -address="0.0.0.0" -hostname_override=$ID -etcd_servers="http://localhost:4001" &
+
+/etcd/etcd -peer-addr $1 -addr $2 -discovery $3

--- a/kubernetes-server/Dockerfile
+++ b/kubernetes-server/Dockerfile
@@ -1,0 +1,6 @@
+FROM       google/kubernetes
+MAINTAINER https://github.com/GoogleCloudPlatform/kubernetes
+
+EXPOSE 8080
+ADD run.sh /
+ENTRYPOINT [ "/run.sh" ]

--- a/kubernetes-server/README.md
+++ b/kubernetes-server/README.md
@@ -1,0 +1,9 @@
+# Kubernetes-Server
+
+This image consists of the apiserver and controller-manager.
+
+You need to point it to all your Docker daemons and etcd nodes:
+
+```
+docker run kubernetes-server http://etcd1:4001 http://etcd2:4001 [http://...] hostname1 hostname2 [hostname...]
+```

--- a/kubernetes-server/run.sh
+++ b/kubernetes-server/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+ETCD_SERVERS=$1
+MACHINES=$2
+
+if [ -z "$MACHINES " ]
+then
+  echo "$0 etcd-servers-http-urls machines-hostnames (both comma separated)"
+  exit 1
+fi
+
+apiserver -address 0.0.0.0 -etcd_servers=$ETCD_SERVERS -machines=$MACHINES &
+controller-manager -master localhost:8080 -etcd_servers=$ETCD_SERVERS

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -148,7 +148,7 @@ func (kl *Kubelet) LogEvent(event *api.Event) error {
 	response, err = kl.Client.AddChild(fmt.Sprintf("/events/%s", event.Container.Name), string(data), 60*60*48 /* 2 days */)
 	// TODO(bburns) : examine response here.
 	if err != nil {
-		log.Printf("Error writing event: %s\n", err)
+		log.Printf("Error writing event: %v\n", err)
 		if response != nil {
 			log.Printf("Response was: %#v\n", *response)
 		}
@@ -473,7 +473,7 @@ func (kl *Kubelet) WatchFiles(config_path string, updateChannel chan<- manifestU
 	} else if statInfo.Mode().IsRegular() {
 		manifest, err := kl.extractFromFile(config_path)
 		if err != nil {
-			log.Printf("Error polling file: %#v", err)
+			log.Printf("Error polling file: %v", err)
 			return
 		}
 		updateChannel <- manifestUpdate{fileSource, []api.ContainerManifest{manifest}}
@@ -523,7 +523,7 @@ func (kl *Kubelet) getKubeletStateFromEtcd(key string, updateChannel chan<- mani
 	}
 	manifests, err := kl.ResponseToManifests(response)
 	if err != nil {
-		log.Printf("Error parsing response (%#v): %s", response, err)
+		log.Printf("Error parsing response (%#v): %v", response, err)
 		return err
 	}
 	log.Printf("Got state from etcd: %+v", manifests)
@@ -602,7 +602,7 @@ func (kl *Kubelet) WatchEtcd(watchChannel <-chan *etcd.Response, updateChannel c
 		log.Printf("Got etcd change: %#v", watchResponse)
 		manifests, err := kl.extractFromEtcd(watchResponse)
 		if err != nil {
-			log.Printf("Error handling response from etcd: %#v", err)
+			log.Printf("Error handling response from etcd: %v", err)
 			continue
 		}
 		log.Printf("manifests: %#v", manifests)
@@ -669,14 +669,14 @@ func (kl *Kubelet) SyncManifests(config []api.ContainerManifest) error {
 			var exists bool
 			exists, actualName, err := kl.ContainerExists(&manifest, &element)
 			if err != nil {
-				log.Printf("Error detecting container: %#v skipping.", err)
+				log.Printf("Error detecting container: %v skipping.", err)
 				continue
 			}
 			if !exists {
 				log.Printf("%#v doesn't exist, creating", element)
 				err = kl.pullImage(element.Image)
 				if err != nil {
-					log.Printf("Error pulling container: %#v", err)
+					log.Printf("Error pulling container: %v", err)
 					continue
 				}
 				// netName has the '/' prefix, so slice it off
@@ -687,7 +687,7 @@ func (kl *Kubelet) SyncManifests(config []api.ContainerManifest) error {
 
 				if err != nil {
 					// TODO(bburns) : Perhaps blacklist a container after N failures?
-					log.Printf("Error creating container: %#v", err)
+					log.Printf("Error creating container: %v", err)
 					desired[actualName] = true
 					continue
 				}
@@ -709,7 +709,7 @@ func (kl *Kubelet) SyncManifests(config []api.ContainerManifest) error {
 			log.Printf("Killing: %s", container)
 			err = kl.KillContainer(container)
 			if err != nil {
-				log.Printf("Error killing container: %#v", err)
+				log.Printf("Error killing container: %v", err)
 			}
 		}
 	}
@@ -739,7 +739,7 @@ func (kl *Kubelet) RunSyncLoop(updateChannel <-chan manifestUpdate, handler Sync
 
 		err := handler.SyncManifests(manifests)
 		if err != nil {
-			log.Printf("Couldn't sync containers : %#v", err)
+			log.Printf("Couldn't sync containers : %v", err)
 		}
 	}
 }


### PR DESCRIPTION
Hi,

I've put all this in one PR, hope that's okay. It's basically what I had to change to get it working in my everything-is-dockerized environment.
I've tried to come up with "good commits". Let me know if you prefer single PRs for each of them.

So the idea here is to run kubernetes itself in Docker containers, therefor I created three Dockerfiles. The documentation assumes that this will be added as automated builds in the Google account. Guess that's up for discussion so let me know if I should change that.
The Dockerfile in / will create a kubernetes 'base image' which just includes the code/binaries and is used by kubernetes-node and kubernetes-server. This might not fit all all deployments but it's a good start and easy to understand.
To make this possible I added a `-docker` flag to point to the docker address (since with the bind-mount we can't use /var/run/docker.sock in the container). Beside that I made kubelet use the client lib for pulling the image instead of the binary (which isn't installed in the container).
