### PR TITLE
Add config dir support to kubelet

### DIFF
--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -33,7 +33,7 @@ import (
 )
 
 var (
-	file               = flag.String("config", "", "Path to the config file")
+	file               = flag.String("config", "", "Path to the config file/dir")
 	etcdServers        = flag.String("etcd_servers", "", "Url of etcd servers in the cluster")
 	syncFrequency      = flag.Duration("sync_frequency", 10*time.Second, "Max period between synchronizing running containers and config")
 	fileCheckFrequency = flag.Duration("file_check_frequency", 20*time.Second, "Duration between checking file for new data")

--- a/cmd/localkube/localkube.go
+++ b/cmd/localkube/localkube.go
@@ -38,7 +38,7 @@ import (
 
 // kubelet flags
 var (
-	file               = flag.String("config", "", "Path to the config file")
+	file               = flag.String("config", "", "Path to the config file/dir")
 	syncFrequency      = flag.Duration("sync_frequency", 10*time.Second, "Max period between synchronizing running containers and config")
 	fileCheckFrequency = flag.Duration("file_check_frequency", 20*time.Second, "Duration between checking file for new data")
 	httpCheckFrequency = flag.Duration("http_check_frequency", 20*time.Second, "Duration between checking http for new data")

--- a/hack/local-up.sh
+++ b/hack/local-up.sh
@@ -46,6 +46,6 @@ ETCD_PID=$!
 sleep 5
 
 echo "Running localkube as root (so it can talk to docker's unix socket)"
-sudo $(dirname $0)/../output/go/localkube
+sudo $(dirname $0)/../output/go/localkube $*
 
 kill $ETCD_PID

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -393,6 +394,8 @@ func (kl *Kubelet) extractFromDir(name string) ([]api.ContainerManifest, error) 
 	if err != nil {
 		return manifests, err
 	}
+
+	sort.Strings(files)
 
 	for _, file := range files {
 		manifest, err := kl.extractFromFile(file)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubelet
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -79,12 +78,14 @@ type Kubelet struct {
 // Starts background goroutines. If file, manifest_url, or address are empty,
 // they are not watched. Never returns.
 func (kl *Kubelet) RunKubelet(file, manifest_url, etcd_servers, address string, port uint) {
-	fileChannel := make(chan api.ContainerManifest)
+	fileChannel := make(chan []api.ContainerManifest)
 	etcdChannel := make(chan []api.ContainerManifest)
-	httpChannel := make(chan api.ContainerManifest)
-	serverChannel := make(chan api.ContainerManifest)
+	httpChannel := make(chan []api.ContainerManifest)
+	serverChannel := make(chan []api.ContainerManifest)
 
-	go util.Forever(func() { kl.WatchFile(file, fileChannel) }, 20*time.Second)
+	if file != "" {
+		go util.Forever(func() { kl.WatchFile(file, fileChannel) }, 20*time.Second)
+	}
 	if manifest_url != "" {
 		go util.Forever(func() { kl.WatchHTTP(manifest_url, httpChannel) }, 20*time.Second)
 	}
@@ -363,72 +364,78 @@ func (kl *Kubelet) KillContainer(name string) error {
 	return err
 }
 
-func (kl *Kubelet) extractFromFile(lastData []byte, name string, changeChannel chan<- api.ContainerManifest) ([]byte, error) {
+func (kl *Kubelet) extractFromFile(name string, changeChannel chan<- []api.ContainerManifest) error {
 	var file *os.File
 	var err error
 	if file, err = os.Open(name); err != nil {
-		return lastData, err
+		return err
 	}
 
-	return kl.extractFromReader(lastData, file, changeChannel)
+	return kl.extractFromReader(file, changeChannel)
 }
 
-func (kl *Kubelet) extractFromReader(lastData []byte, reader io.Reader, changeChannel chan<- api.ContainerManifest) ([]byte, error) {
+func (kl *Kubelet) extractFromReader(reader io.Reader, changeChannel chan<- []api.ContainerManifest) error {
 	var manifest api.ContainerManifest
 	data, err := ioutil.ReadAll(reader)
 	if err != nil {
-		log.Printf("Couldn't read file: %v", err)
-		return lastData, err
+		log.Printf("Couldn't read from reader: %v", err)
+		return err
 	}
 	if err = kl.ExtractYAMLData(data, &manifest); err != nil {
-		return lastData, err
+		return err
 	}
-	if !bytes.Equal(lastData, data) {
-		lastData = data
-		// Ok, we have a valid configuration, send to channel for
-		// rejiggering.
-		changeChannel <- manifest
-		return data, nil
+	changeChannel <- []api.ContainerManifest{manifest}
+	return nil
+}
+
+func (kl *Kubelet) extractMultipleFromReader(reader io.Reader, changeChannel chan<- []api.ContainerManifest) error {
+	var manifests []api.ContainerManifest
+	data, err := ioutil.ReadAll(reader)
+	if err != nil {
+		log.Printf("Couldn't read from reader: %v", err)
+		return err
 	}
-	return lastData, nil
+	if err = kl.ExtractYAMLData(data, &manifests); err != nil {
+		return err
+	}
+	changeChannel <- manifests
+	return nil
 }
 
 // Watch a file for changes to the set of pods that should run on this Kubelet
 // This function loops forever and is intended to be run as a goroutine
-func (kl *Kubelet) WatchFile(file string, changeChannel chan<- api.ContainerManifest) {
-	var lastData []byte
+func (kl *Kubelet) WatchFile(file string, changeChannel chan<- []api.ContainerManifest) {
 	for {
 		var err error
 		time.Sleep(kl.FileCheckFrequency)
-		lastData, err = kl.extractFromFile(lastData, file, changeChannel)
+		err = kl.extractFromFile(file, changeChannel)
 		if err != nil {
 			log.Printf("Error polling file: %#v", err)
 		}
 	}
 }
 
-func (kl *Kubelet) extractFromHTTP(lastData []byte, url string, changeChannel chan<- api.ContainerManifest) ([]byte, error) {
+func (kl *Kubelet) extractFromHTTP(url string, changeChannel chan<- []api.ContainerManifest) error {
 	client := &http.Client{}
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return lastData, err
+		return err
 	}
 	response, err := client.Do(request)
 	if err != nil {
-		return lastData, err
+		return err
 	}
 	defer response.Body.Close()
-	return kl.extractFromReader(lastData, response.Body, changeChannel)
+	return kl.extractMultipleFromReader(response.Body, changeChannel)
 }
 
 // Watch an HTTP endpoint for changes to the set of pods that should run on this Kubelet
 // This function runs forever and is intended to be run as a goroutine
-func (kl *Kubelet) WatchHTTP(url string, changeChannel chan<- api.ContainerManifest) {
-	var lastData []byte
+func (kl *Kubelet) WatchHTTP(url string, changeChannel chan<- []api.ContainerManifest) {
 	for {
 		var err error
 		time.Sleep(kl.HTTPCheckFrequency)
-		lastData, err = kl.extractFromHTTP(lastData, url, changeChannel)
+		err = kl.extractFromHTTP(url, changeChannel)
 		if err != nil {
 			log.Printf("Error syncing http: %#v", err)
 		}
@@ -655,27 +662,27 @@ func (kl *Kubelet) SyncManifests(config []api.ContainerManifest) error {
 }
 
 // runSyncLoop is the main loop for processing changes. It watches for changes from
-// four channels (file, etcd, server, and http) and creates a union of the two. For
+// four channels (file, etcd, server, and http) and creates a union of them. For
 // any new change seen, will run a sync against desired state and running state. If
 // no changes are seen to the configuration, will synchronize the last known desired
 // state every sync_frequency seconds.
 // Never returns.
-func (kl *Kubelet) RunSyncLoop(etcdChannel <-chan []api.ContainerManifest, fileChannel, serverChannel, httpChannel <-chan api.ContainerManifest, handler SyncHandler) {
+func (kl *Kubelet) RunSyncLoop(etcdChannel, fileChannel, serverChannel, httpChannel <-chan []api.ContainerManifest, handler SyncHandler) {
 	var lastFile, lastEtcd, lastHttp, lastServer []api.ContainerManifest
 	for {
 		select {
-		case manifest := <-fileChannel:
-			log.Printf("Got new manifest from file... %v", manifest)
-			lastFile = []api.ContainerManifest{manifest}
+		case manifests := <-fileChannel:
+			log.Printf("Got new configuration from file... %v", manifests)
+			lastFile = manifests
 		case manifests := <-etcdChannel:
 			log.Printf("Got new configuration from etcd... %v", manifests)
 			lastEtcd = manifests
-		case manifest := <-httpChannel:
-			log.Printf("Got new manifest from external http... %v", manifest)
-			lastHttp = []api.ContainerManifest{manifest}
-		case manifest := <-serverChannel:
-			log.Printf("Got new manifest from our server... %v", manifest)
-			lastServer = []api.ContainerManifest{manifest}
+		case manifests := <-httpChannel:
+			log.Printf("Got new configuration from external http... %v", manifests)
+			lastHttp = manifests
+		case manifests := <-serverChannel:
+			log.Printf("Got new configuration from our server... %v", manifests)
+			lastServer = manifests
 		case <-time.After(kl.SyncFrequency):
 		}
 
@@ -683,6 +690,7 @@ func (kl *Kubelet) RunSyncLoop(etcdChannel <-chan []api.ContainerManifest, fileC
 		manifests = append(manifests, lastEtcd...)
 		manifests = append(manifests, lastHttp...)
 		manifests = append(manifests, lastServer...)
+
 		err := handler.SyncManifests(manifests)
 		if err != nil {
 			log.Printf("Couldn't sync containers : %#v", err)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -373,6 +373,7 @@ func (kl *Kubelet) extractFromFile(name string) (api.ContainerManifest, error) {
 	if file, err = os.Open(name); err != nil {
 		return manifest, err
 	}
+	defer file.Close()
 
 	data, err := ioutil.ReadAll(file)
 	if err != nil {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package kubelet
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -730,164 +729,120 @@ func TestMakePortsAndBindings(t *testing.T) {
 
 func TestExtractFromNonExistentFile(t *testing.T) {
 	kubelet := Kubelet{}
-	changeChannel := make(chan api.ContainerManifest)
-	lastData := []byte{1, 2, 3}
-	data, err := kubelet.extractFromFile(lastData, "/some/fake/file", changeChannel)
+	changeChannel := make(chan []api.ContainerManifest)
+	reader := startReading(changeChannel)
+
+	err := kubelet.extractFromFile("/some/fake/file", changeChannel)
+	close(changeChannel)
+
 	if err == nil {
 		t.Error("Unexpected non-error.")
 	}
-	if !bytes.Equal(data, lastData) {
-		t.Errorf("Unexpected data response.  Expected %#v, found %#v", lastData, data)
+
+	list := reader.GetList()
+	if len(list) != 0 {
+		t.Errorf("Unexpected list: %#v", list)
 	}
 }
 
 func TestExtractFromBadDataFile(t *testing.T) {
 	kubelet := Kubelet{}
-	changeChannel := make(chan api.ContainerManifest)
-	lastData := []byte{1, 2, 3}
+	changeChannel := make(chan []api.ContainerManifest)
+	reader := startReading(changeChannel)
+
+	badData := []byte{1, 2, 3}
 	file, err := ioutil.TempFile("", "foo")
 	expectNoError(t, err)
 	name := file.Name()
 	file.Close()
-	ioutil.WriteFile(name, lastData, 0755)
-	data, err := kubelet.extractFromFile(lastData, name, changeChannel)
+	ioutil.WriteFile(name, badData, 0755)
+	err = kubelet.extractFromFile(name, changeChannel)
+	close(changeChannel)
 
 	if err == nil {
 		t.Error("Unexpected non-error.")
 	}
-	if !bytes.Equal(data, lastData) {
-		t.Errorf("Unexpected data response.  Expected %#v, found %#v", lastData, data)
+
+	list := reader.GetList()
+	if len(list) != 0 {
+		t.Errorf("Unexpected list: %#v", list)
 	}
 }
 
-func TestExtractFromSameDataFile(t *testing.T) {
+func TestExtractFromValidDataFile(t *testing.T) {
 	kubelet := Kubelet{}
-	changeChannel := make(chan api.ContainerManifest)
-	manifest := api.ContainerManifest{
-		Id: "foo",
+	changeChannel := make(chan []api.ContainerManifest)
+	reader := startReading(changeChannel)
+
+	manifests := []api.ContainerManifest{
+		{Id: "bar"},
 	}
-	lastData, err := json.Marshal(manifest)
+	data, err := json.Marshal(manifests[0]) // Right now, files only support a single manifest
 	expectNoError(t, err)
 	file, err := ioutil.TempFile("", "foo")
 	expectNoError(t, err)
 	name := file.Name()
 	expectNoError(t, file.Close())
-	ioutil.WriteFile(name, lastData, 0755)
-	data, err := kubelet.extractFromFile(lastData, name, changeChannel)
-
-	expectNoError(t, err)
-	if !bytes.Equal(data, lastData) {
-		t.Errorf("Unexpected data response.  Expected %#v, found %#v", lastData, data)
-	}
-}
-
-func TestExtractFromChangedDataFile(t *testing.T) {
-	kubelet := Kubelet{}
-	changeChannel := make(chan api.ContainerManifest)
-	reader := startReadingSingle(changeChannel)
-	oldManifest := api.ContainerManifest{
-		Id: "foo",
-	}
-	newManifest := api.ContainerManifest{
-		Id: "bar",
-	}
-	lastData, err := json.Marshal(oldManifest)
-	expectNoError(t, err)
-	newData, err := json.Marshal(newManifest)
-	expectNoError(t, err)
-	file, err := ioutil.TempFile("", "foo")
-	expectNoError(t, err)
-	name := file.Name()
-	expectNoError(t, file.Close())
-	ioutil.WriteFile(name, newData, 0755)
-	data, err := kubelet.extractFromFile(lastData, name, changeChannel)
+	ioutil.WriteFile(name, data, 0755)
+	err = kubelet.extractFromFile(name, changeChannel)
 	close(changeChannel)
 
 	expectNoError(t, err)
-	if !bytes.Equal(data, newData) {
-		t.Errorf("Unexpected data response.  Expected %#v, found %#v", lastData, data)
-	}
 	read := reader.GetList()
 	if len(read) != 1 {
 		t.Errorf("Unexpected channel traffic: %#v", read)
 	}
-	if !reflect.DeepEqual(read[0], newManifest) {
-		t.Errorf("Unexpected difference.  Expected %#v, got %#v", newManifest, read[0])
+	if !reflect.DeepEqual(read[0], manifests) {
+		t.Errorf("Unexpected difference.  Expected %#v, got %#v", manifests, read[0])
 	}
 }
 
 func TestExtractFromHttpBadness(t *testing.T) {
 	kubelet := Kubelet{}
-	lastData := []byte{1, 2, 3}
-	changeChannel := make(chan api.ContainerManifest)
-	data, err := kubelet.extractFromHTTP(lastData, "http://localhost:12345", changeChannel)
+	changeChannel := make(chan []api.ContainerManifest)
+	reader := startReading(changeChannel)
+
+	err := kubelet.extractFromHTTP("http://localhost:12345", changeChannel)
 	if err == nil {
 		t.Error("Unexpected non-error.")
 	}
-	if !bytes.Equal(lastData, data) {
-		t.Errorf("Unexpected difference.  Expected: %#v, Saw: %#v", lastData, data)
+	close(changeChannel)
+	list := reader.GetList()
+
+	if len(list) != 0 {
+		t.Errorf("Unexpected list: %#v", list)
 	}
 }
 
-func TestExtractFromHttpNoChange(t *testing.T) {
+func TestExtractFromHttp(t *testing.T) {
 	kubelet := Kubelet{}
-	changeChannel := make(chan api.ContainerManifest)
+	changeChannel := make(chan []api.ContainerManifest)
+	reader := startReading(changeChannel)
 
-	manifest := api.ContainerManifest{
-		Id: "foo",
+	manifests := []api.ContainerManifest{
+		{Id: "foo"},
 	}
-	lastData, err := json.Marshal(manifest)
+	data, err := json.Marshal(manifests)
 
 	fakeHandler := util.FakeHandler{
 		StatusCode:   200,
-		ResponseBody: string(lastData),
+		ResponseBody: string(data),
 	}
 	testServer := httptest.NewServer(&fakeHandler)
 
-	data, err := kubelet.extractFromHTTP(lastData, testServer.URL, changeChannel)
+	err = kubelet.extractFromHTTP(testServer.URL, changeChannel)
 	if err != nil {
 		t.Errorf("Unexpected error: %#v", err)
 	}
-	if !bytes.Equal(lastData, data) {
-		t.Errorf("Unexpected difference.  Expected: %#v, Saw: %#v", lastData, data)
-	}
-}
-
-func TestExtractFromHttpChanges(t *testing.T) {
-	kubelet := Kubelet{}
-	changeChannel := make(chan api.ContainerManifest)
-	reader := startReadingSingle(changeChannel)
-
-	manifest := api.ContainerManifest{
-		Id: "foo",
-	}
-	newManifest := api.ContainerManifest{
-		Id: "bar",
-	}
-	lastData, _ := json.Marshal(manifest)
-	newData, _ := json.Marshal(newManifest)
-	fakeHandler := util.FakeHandler{
-		StatusCode:   200,
-		ResponseBody: string(newData),
-	}
-	testServer := httptest.NewServer(&fakeHandler)
-
-	data, err := kubelet.extractFromHTTP(lastData, testServer.URL, changeChannel)
 	close(changeChannel)
 
 	read := reader.GetList()
 
-	if err != nil {
-		t.Errorf("Unexpected error: %#v", err)
-	}
 	if len(read) != 1 {
 		t.Errorf("Unexpected list: %#v", read)
 	}
-	if !bytes.Equal(newData, data) {
-		t.Errorf("Unexpected difference.  Expected: %#v, Saw: %#v", lastData, data)
-	}
-	if !reflect.DeepEqual(newManifest, read[0]) {
-		t.Errorf("Unexpected difference.  Expected: %#v, Saw: %#v", newManifest, read[0])
+	if !reflect.DeepEqual(manifests, read[0]) {
+		t.Errorf("Unexpected difference.  Expected: %#v, Saw: %#v", manifests, read[0])
 	}
 }
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -785,8 +785,8 @@ func TestExtractFromDir(t *testing.T) {
 	kubelet := Kubelet{}
 
 	manifests := []api.ContainerManifest{
-		{Id: "foo"},
-		{Id: "bar"},
+		{Id: "aaaa"},
+		{Id: "bbbb"},
 	}
 
 	dirName, err := ioutil.TempDir("", "foo")
@@ -795,7 +795,7 @@ func TestExtractFromDir(t *testing.T) {
 	for _, manifest := range manifests {
 		data, err := json.Marshal(manifest)
 		expectNoError(t, err)
-		file, err := ioutil.TempFile(dirName, "kub")
+		file, err := ioutil.TempFile(dirName, manifest.Id)
 		expectNoError(t, err)
 		name := file.Name()
 		expectNoError(t, file.Close())


### PR DESCRIPTION
See #134.

This maintains compatibility with existing single-manifests for config files and the existing HTTP push endpoint (/container). I added an additional endpoint (/containers) that supports receiving a list. Single-container support isn't likely to be useful, so I'd be in favor of removing it entirely.
