### PR TITLE
Build runtime Docker images.

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -4,13 +4,48 @@ To build Kubernetes you need to have access to a Docker installation through eit
 
 ## Requirements
 
-1. Run on Mac OS X.  The best way to go is to use `boot2docker`.  See instructions [here](https://docs.docker.com/installation/mac/).
-2. Run on Linux against a local Docker.  Install Docker according to the [instructions](https://docs.docker.com/installation/#installation) for your OS.  The scripts here assume that they are using a local Docker server and that they can "reach around" docker and grab results directly from the file system.
+1. Be running Docker.  2 options supported/tested:
+  1. **Mac OS X** The best way to go is to use `boot2docker`.  See instructions [here](https://docs.docker.com/installation/mac/).
+  1. **Linux with local Docker**  Install Docker according to the [instructions](https://docs.docker.com/installation/#installation) for your OS.  The scripts here assume that they are using a local Docker server and that they can "reach around" docker and grab results directly from the file system.
+1. Have python installed.  Pretty much it is installed everywhere at this point so you can probably ignore this.
+1. For releasing, have the [Google Cloud SDK](https://developers.google.com/cloud/sdk/) installed and configured.  The default release mechanism will upload Docker images to a private registry backed by Google Cloud Storage.  Non-image release artifacts will be uploaded to Google Cloud Storage also.
+
+## Key scripts
+
+* `make-binaries.sh`: This will compile all of the Kubernetes binaries in a Docker container
+* `run-tests.sh`: This will run the Kubernetes unit tests in a Docker container
+* `run-integration.sh`: This will build and run the integration test in a Docker container
+* `make-cross.sh`: This will make all cross-compiled binaries (currently just cloudcfg).
+* `copy-output.sh`: This will copy the contents of `output/build` from any remote Docker container to the local `output/build`.  Right now this is only necessary on Mac OS X with `boot2docker`.
+* `make-clean.sh`: Clean out the contents of `output/build`.
+* `shell.sh`: Drop into a `bash` shell in a build container with a snapshot of the current repo code.
+* `release.sh`: Build everything, test it, upload the results to a GCS bucket.  Docker images are also sent to the same bucket using the [`google/docker-registry`](https://registry.hub.docker.com/u/google/docker-registry/) Docker image.
+
+## Releasing
+
+The `release.sh` script will build a release.  It will build binaries, run tests, build runtime Docker images and then upload all build artifacts to a GCS bucket.
+
+The GCS bucket that is used is named `kubernetes-releases-NNNNN`.  The `NNNNN` is a random string derived from an md5 hash of the project name.
+
+The release process can be customized with environment variables:
+* `KUBE_RELEASE_BUCKET`: Override the bucket to be used for uploading releases.
+* `KUBE_RELEASE_PREFIX`: The prefix for all non-docker image build artifacts.  This defaults to `devel/`
+* `KUBE_DOCKER_REG_PREFIX`: The prefix for storage of the docker registry.  This defaults to `docker-reg/`
+
+The release Docker images (all defined in `build/run-images/*/Dockerfile`):
+* `kubernetes-apiserver`: Runs the main API server. It is parameterized with environment variables for `ETCD_SERVERS` and `KUBE_MINIONS` with defaults for localhost.
+* `kubernetes-controller-manager`: Runs a set external controllers (see `DESIGN.md` for details).  It is parameterized with environment variables for `ETCD_SERVERS` and `API_SERVER`.
+* `kubernetes-proxy`: Runs the proxy server on each individual node.  This is parameterized for `ETCD_SERVERS` and is required to be launched with `--net=host` Docker option to function correctly.
+
+Other build artifacts:
+* **TODO:** package up client utilties and cluster bring up scripts.
 
 ## Basic Flow
 
 The scripts directly under `build/` are used to build and test.  They will ensure that the `kube-build` Docker image is built (based on `build/build-image/Dockerfile`) and then execute the appropriate command in that container.  If necessary (for Mac OS X), the scripts will also copy results out.
 
-The `kube-build` container image is built by first creating a "context" directory in `output/build-image`.  It is done there instead of at the root of the Kubernetes repo to minimize the amount of data we need to package up when building the image.
+The `kube-build` container image is built by first creating a "context" directory in `output/images/build-image`.  It is done there instead of at the root of the Kubernetes repo to minimize the amount of data we need to package up when building the image.
 
 Everything in `build/build-image/` is meant to be run inside of the container.  If it doesn't think it is running in the container it'll throw a warning.  While you can run some of that stuff outside of the container, it wasn't built to do so.
+
+The files necessarily for the release Docker images are in `build/run-images/*`.  All of this is staged into `output/images` similar to build-image.  The `base` image is used as a base for each of the specialized containers and is generally never pushed to a shared repository.

--- a/build/README.md
+++ b/build/README.md
@@ -49,3 +49,16 @@ The `kube-build` container image is built by first creating a "context" director
 Everything in `build/build-image/` is meant to be run inside of the container.  If it doesn't think it is running in the container it'll throw a warning.  While you can run some of that stuff outside of the container, it wasn't built to do so.
 
 The files necessarily for the release Docker images are in `build/run-images/*`.  All of this is staged into `output/images` similar to build-image.  The `base` image is used as a base for each of the specialized containers and is generally never pushed to a shared repository.
+
+## TODOs
+
+@jbeda is going on vacation and can't complete this work for a while.  Here are the logical next steps:
+
+* [ ] Get a cluster up and running with the Docker images.  Perhaps start with a local cluster and move up to a GCE cluster.
+* [ ] Implement #186 and #187.  This will make it easier to develop Kubernetes.
+* [ ] Deprecate/replace most of the stuff in the hack/
+* [ ] Put together a true client distribution.  You should be able to download the tarball for your platform and get a Kube cluster running in <5 minutes.  Not `git clone`.
+* [ ] Plumb in a version so we can do proper versioned releases.  Probably create a `./VERSION` and dope it with the git hash or something?
+* [ ] Create an install script that'll let us do a `curl https://[URL] | bash` to get that tarball down and ensure that other dependencies (cloud SDK?) are installed and configured correctly.
+* [ ] Support Windows as a client.
+* [ ] Support uploading to the Docker index instead of the GCS bucket.  This'll allow easier installs for those not running on GCE

--- a/build/build-image/make-binaries.sh
+++ b/build/build-image/make-binaries.sh
@@ -20,4 +20,4 @@ set -e
 
 source $(dirname $0)/common.sh
 
-make-binaries
+make-binaries "$@"

--- a/build/build-image/run-integration.sh
+++ b/build/build-image/run-integration.sh
@@ -21,11 +21,13 @@ source $(dirname $0)/common.sh
 ETCD_DIR="${KUBE_REPO_ROOT}/output/etcd"
 mkdir -p "${ETCD_DIR}"
 
+echo "+++ Running integration test"
+
 etcd -name test -data-dir ${ETCD_DIR} > "${KUBE_REPO_ROOT}/output/etcd.log" &
 ETCD_PID=$!
 
 sleep 5
 
-${KUBE_TARGET}/integration
+${KUBE_TARGET}/linux/amd64/integration
 
 kill $ETCD_PID

--- a/build/build-image/run-tests.sh
+++ b/build/build-image/run-tests.sh
@@ -33,6 +33,8 @@ find_test_dirs() {
 
 cd "${KUBE_TARGET}"
 
+echo "+++ Running unit tests"
+
 if [[ -n "$1" ]]; then
   go test -cover -coverprofile="tmp.out" "$KUBE_GO_PACKAGE/$1"
   exit 0

--- a/build/common.sh
+++ b/build/common.sh
@@ -115,7 +115,7 @@ function ensure-gcs-release-bucket() {
   HASH=${HASH:0:5}
   KUBE_RELEASE_BUCKET=${KUBE_RELEASE_BUCKET-kubernetes-releases-$HASH}
   KUBE_RELEASE_PREFIX=${KUBE_RELEASE_PREFIX-devel/}
-  DOCKER_REG_PREFIX=${DOCKER_REG_PREFIX-docker-reg/}
+  KUBE_DOCKER_REG_PREFIX=${KUBE_DOCKER_REG_PREFIX-docker-reg/}
 
   if ! gsutil ls gs://${KUBE_RELEASE_BUCKET} >/dev/null 2>&1 ; then
     echo "Creating Google Cloud Storage bucket: $RELEASE_BUCKET"
@@ -211,7 +211,7 @@ function ensure-gcs-docker-registry() {
   echo "+++ Starting GCS backed Docker registry"
   local DOCKER="docker run -d --name=${REG_CONTAINER_NAME} "
   DOCKER+="-e GCS_BUCKET=${KUBE_RELEASE_BUCKET} "
-  DOCKER+="-e STORAGE_PATH=${DOCKER_REG_PREFIX} "
+  DOCKER+="-e STORAGE_PATH=${KUBE_DOCKER_REG_PREFIX} "
   DOCKER+="-e GCP_OAUTH2_REFRESH_TOKEN=${REFRESH_TOKEN} "
   DOCKER+="-p 127.0.0.1:5000:5000 "
   DOCKER+="jbeda/docker-registry"
@@ -227,7 +227,7 @@ function push-images-to-gcs() {
 
   # Tag each of our run binaries with the right registry and push
   for b in ${KUBE_RUN_BINARIES} ; do
-    echo "+++ Tagging and pushing ${KUBE_RUN_IMAGE_BASE}-$b"
+    echo "+++ Tagging and pushing ${KUBE_RUN_IMAGE_BASE}-$b to GCS bucket ${KUBE_RELEASE_BUCKET}"
     docker tag "${KUBE_RUN_IMAGE_BASE}-$b" "localhost:5000/${KUBE_RUN_IMAGE_BASE}-$b"
     docker push "localhost:5000/${KUBE_RUN_IMAGE_BASE}-$b"
     docker rmi "localhost:5000/${KUBE_RUN_IMAGE_BASE}-$b"

--- a/build/common.sh
+++ b/build/common.sh
@@ -269,7 +269,7 @@ function ensure-gcs-docker-registry() {
   DOCKER+="-e STORAGE_PATH=${KUBE_DOCKER_REG_PREFIX} "
   DOCKER+="-e GCP_OAUTH2_REFRESH_TOKEN=${REFRESH_TOKEN} "
   DOCKER+="-p 127.0.0.1:5000:5000 "
-  DOCKER+="jbeda/docker-registry"
+  DOCKER+="google/docker-registry"
 
   ${DOCKER}
 

--- a/build/common.sh
+++ b/build/common.sh
@@ -37,39 +37,95 @@ readonly REMOTE_OUTPUT_DIR="/go/src/${KUBE_GO_PACKAGE}/output/build"
 readonly DOCKER_CONTAINER_NAME=kube-build
 readonly DOCKER_MOUNT="-v ${LOCAL_OUTPUT_DIR}:${REMOTE_OUTPUT_DIR}"
 
-# Verify that the right utilitites and such are installed.
-if [[ -z "$(which docker)" ]]; then
-  echo "Can't find 'docker' in PATH, please fix and retry." >&2
-  echo "See https://docs.docker.com/installation/#installation for installation instructions." >&2
-  exit 1
-fi
+readonly KUBE_RUN_IMAGE_BASE="kubernetes"
+readonly KUBE_RUN_BINARIES="
+    apiserver
+    controller-manager
+    proxy
+  "
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  if [[ -z "$(which boot2docker)" ]]; then
-    echo "It looks like you are running on Mac OS X and boot2docker can't be found." >&2
-    echo "See: https://docs.docker.com/installation/mac/" >&2
-    exit 1
+# Verify that the right utilities and such are installed for building Kube.
+function verify-prereqs() {
+  if [[ -z "$(which docker)" ]]; then
+    echo "Can't find 'docker' in PATH, please fix and retry." >&2
+    echo "See https://docs.docker.com/installation/#installation for installation instructions." >&2
+    return 1
   fi
-  if [[ $(boot2docker status) != "running" ]]; then
-    echo "boot2docker VM isn't started.  Please run 'boot2docker start'" >&2
-    exit 1
-  fi
-fi
 
-if ! docker info > /dev/null 2>&1 ; then
-  echo "Can't connect to 'docker' daemon.  please fix and retry." >&2
-  echo >&2
-  echo "Possible causes:" >&2
-  echo "  - On Mac OS X, boot2docker VM isn't started" >&2
-  echo "  - On Mac OS X, DOCKER_HOST env variable isn't set approriately" >&2
-  echo "  - On Linux, user isn't in 'docker' group.  Add and relogin." >&2
-  echo "  - On Linux, Docker daemon hasn't been started or has crashed" >&2
-  exit 1
-fi
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    if [[ -z "$(which boot2docker)" ]]; then
+      echo "It looks like you are running on Mac OS X and boot2docker can't be found." >&2
+      echo "See: https://docs.docker.com/installation/mac/" >&2
+      return 1
+    fi
+    if [[ $(boot2docker status) != "running" ]]; then
+      echo "boot2docker VM isn't started.  Please run 'boot2docker start'" >&2
+      return 1
+    fi
+  fi
+
+  if ! docker info > /dev/null 2>&1 ; then
+    echo "Can't connect to 'docker' daemon.  please fix and retry." >&2
+    echo >&2
+    echo "Possible causes:" >&2
+    echo "  - On Mac OS X, boot2docker VM isn't started" >&2
+    echo "  - On Mac OS X, DOCKER_HOST env variable isn't set approriately" >&2
+    echo "  - On Linux, user isn't in 'docker' group.  Add and relogin." >&2
+    echo "  - On Linux, Docker daemon hasn't been started or has crashed" >&2
+    return 1
+  fi
+}
+
+# Verify things are set up for uploading to GCS
+function verify-gcs-prereqs() {
+  if [[ -z "$(which gsutil)" || -z "$(which gcloud)" ]]; then
+    echo "Releasing Kubernetes requires gsutil and gcloud.  Please download,"
+    echo "install and authorize through the Google Cloud SDK: "
+    echo
+    echo "  https://developers.google.com/cloud/sdk/"
+    return 1
+  fi
+
+  FIND_ACCOUNT="gcloud auth list 2>/dev/null | grep '(active)' | awk '{ print \$2 }'"
+  GCLOUD_ACCOUNT=${GCLOUD_ACCOUNT-$(eval ${FIND_ACCOUNT})}
+  if [[ -z "${GCLOUD_ACCOUNT}" ]]; then
+    echo "No account authorized through gcloud.  Please fix with:"
+    echo
+    echo "  gcloud auth login"
+    return 1
+  fi
+
+  FIND_PROJECT="gcloud config list project | tail -n 1 | awk '{ print \$3 }'"
+  GCLOUD_PROJECT=${GCLOUD_PROJECT-$(eval ${FIND_PROJECT})}
+  if [[ -z "${GCLOUD_PROJECT}" ]]; then
+    echo "No account authorized through gcloud.  Please fix with:"
+    echo
+    echo "  gcloud config set project <project id>"
+    return 1
+  fi
+}
+
+# Create a unique bucket name for releasing Kube and make sure it exists.
+function ensure-gcs-release-bucket() {
+  if which md5 > /dev/null; then
+    HASH=$(md5 -q -s "$GCLOUD_PROJECT")
+  else
+    HASH=$(echo -n "$GCLOUD_PROJECT" | md5sum)
+  fi
+  HASH=${HASH:0:5}
+  KUBE_RELEASE_BUCKET=${KUBE_RELEASE_BUCKET-kubernetes-releases-$HASH}
+  KUBE_RELEASE_PREFIX=${KUBE_RELEASE_PREFIX-devel/}
+  DOCKER_REG_PREFIX=${DOCKER_REG_PREFIX-docker-reg/}
+
+  if ! gsutil ls gs://${KUBE_RELEASE_BUCKET} >/dev/null 2>&1 ; then
+    echo "Creating Google Cloud Storage bucket: $RELEASE_BUCKET"
+    gsutil mb gs://${KUBE_RELEASE_BUCKET}
+  fi
+}
 
 # Set up the context directory for the kube-build image and build it.
 function build-image() {
-  local -r BUILD_CONTEXT_DIR=${KUBE_REPO_ROOT}/output/build-image
+  local -r BUILD_CONTEXT_DIR="${KUBE_REPO_ROOT}/output/images/${KUBE_BUILD_IMAGE}"
   local -r SOURCE="
     api
     build
@@ -79,19 +135,47 @@ function build-image() {
     third_party
     LICENSE
   "
-  local -r DOCKER_BUILD_CMD="docker build -t ${KUBE_BUILD_IMAGE} ${BUILD_CONTEXT_DIR}"
-
-  echo "+++ Building Docker image ${KUBE_BUILD_IMAGE}.  First run can take minutes."
-
   mkdir -p ${BUILD_CONTEXT_DIR}
   tar czf ${BUILD_CONTEXT_DIR}/kube-source.tar.gz ${SOURCE}
   cp build/build-image/Dockerfile ${BUILD_CONTEXT_DIR}/Dockerfile
+  docker-build "${KUBE_BUILD_IMAGE}" "${BUILD_CONTEXT_DIR}"
+}
 
+# Builds the runtime image.  Assumes that the appropriate binaries are already
+# built and in output/build/.
+function run-image() {
+  local -r BUILD_CONTEXT_BASE="${KUBE_REPO_ROOT}/output/images/${KUBE_RUN_IMAGE_BASE}"
+
+  # First build the base image.  This one brings in all of the binaries.
+  mkdir -p "${BUILD_CONTEXT_BASE}"
+  tar czf ${BUILD_CONTEXT_BASE}/kube-bins.tar.gz \
+    -C "output/build/linux/amd64" \
+    ${KUBE_RUN_BINARIES}
+  cp -R build/run-images/base/* "${BUILD_CONTEXT_BASE}/"
+  docker-build "${KUBE_RUN_IMAGE_BASE}" "${BUILD_CONTEXT_BASE}"
+
+  for b in $KUBE_RUN_BINARIES ; do
+    local SUB_CONTEXT_DIR="${BUILD_CONTEXT_BASE}-$b"
+    mkdir -p "${SUB_CONTEXT_DIR}"
+    cp -R build/run-images/$b/* "${SUB_CONTEXT_DIR}/"
+    docker-build "${KUBE_RUN_IMAGE_BASE}-$b" "${SUB_CONTEXT_DIR}"
+  done
+}
+
+# Build a docker image from a Dockerfile.
+# $1 is the name of the image to build
+# $2 is the location of the "context" directory, with the Dockerfile at the root.
+function docker-build() {
+  local -r IMAGE=$1
+  local -r CONTEXT_DIR=$2
+  local -r BUILD_CMD="docker build -t ${IMAGE} ${CONTEXT_DIR}"
+
+  echo "+++ Building Docker image ${IMAGE}. This can take a while."
   set +e # We are handling the error here manually
-  local -r DOCKER_OUTPUT="$(${DOCKER_BUILD_CMD} 2>&1)"
+  local -r DOCKER_OUTPUT="$(${BUILD_CMD} 2>&1)"
   if [ $? -ne 0 ]; then
     set -e
-    echo "+++ Docker build command failed." >&2
+    echo "+++ Docker build command failed for ${IMAGE}" >&2
     echo >&2
     echo "${DOCKER_OUTPUT}" >&2
     echo >&2
@@ -102,7 +186,52 @@ function build-image() {
     return 1
   fi
   set -e
+}
 
+function ensure-gcs-docker-registry() {
+  local -r REG_CONTAINER_NAME="gcs-registry"
+
+  local -r RUNNING=$(docker inspect ${REG_CONTAINER_NAME} 2>/dev/null \
+    | build/json-extractor.py 0.State.Running 2>/dev/null)
+
+  [[ "$RUNNING" != "true" ]] || return 0
+
+  # Grovel around and find the OAuth token in the gcloud config
+  local -r BOTO=~/.config/gcloud/legacy_credentials/${GCLOUD_ACCOUNT}/.boto
+  local -r REFRESH_TOKEN=$(grep 'gs_oauth2_refresh_token =' $BOTO | awk '{ print $3 }')
+
+  if [[ -z $REFRESH_TOKEN ]]; then
+    echo "Couldn't find OAuth 2 refresh token in ${BOTO}" >&2
+    return 1
+  fi
+
+  # If we have an old one sitting around, remove it
+  docker rm ${REG_CONTAINER_NAME} >/dev/null 2>&1 || true
+
+  echo "+++ Starting GCS backed Docker registry"
+  local DOCKER="docker run -d --name=${REG_CONTAINER_NAME} "
+  DOCKER+="-e GCS_BUCKET=${KUBE_RELEASE_BUCKET} "
+  DOCKER+="-e STORAGE_PATH=${DOCKER_REG_PREFIX} "
+  DOCKER+="-e GCP_OAUTH2_REFRESH_TOKEN=${REFRESH_TOKEN} "
+  DOCKER+="-p 127.0.0.1:5000:5000 "
+  DOCKER+="jbeda/docker-registry"
+
+  ${DOCKER}
+
+  # Give it time to spin up before we start throwing stuff at it
+  sleep 5
+}
+
+function push-images-to-gcs() {
+  ensure-gcs-docker-registry
+
+  # Tag each of our run binaries with the right registry and push
+  for b in ${KUBE_RUN_BINARIES} ; do
+    echo "+++ Tagging and pushing ${KUBE_RUN_IMAGE_BASE}-$b"
+    docker tag "${KUBE_RUN_IMAGE_BASE}-$b" "localhost:5000/${KUBE_RUN_IMAGE_BASE}-$b"
+    docker push "localhost:5000/${KUBE_RUN_IMAGE_BASE}-$b"
+    docker rmi "localhost:5000/${KUBE_RUN_IMAGE_BASE}-$b"
+  done
 }
 
 # Run a command in the kube-build image.  This assumes that the image has

--- a/build/copy-output.sh
+++ b/build/copy-output.sh
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make all of the Kubernetes binaries.
+# Copies any built binaries off the Docker machine.
 #
-# This makes the docker build image, builds the binaries and copies them out
-# of the docker container.
+# This is a no-op on Linux when the Docker daemon is local.  This is only
+# necessary on Mac OS X with boot2docker.
 
 set -e
 
 source $(dirname $0)/common.sh
 
+verify-prereqs
 copy-output

--- a/build/json-extractor.py
+++ b/build/json-extractor.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a very simple utility that reads a JSON document from stdin, parses it
+# and returns the specified value.  The value is described using a simple dot
+# notation.  If any errors are encountered along the way, an error is output and
+# a failure value is returned.
+
+from __future__ import print_function
+
+import json
+import sys
+
+def PrintError(*err):
+  print(*err, file=sys.stderr)
+
+def main():
+  try:
+    obj = json.load(sys.stdin)
+  except Exception, e:
+    PrintError("Error loading JSON: {0}".format(str(e)))
+
+  if len(sys.argv) == 1:
+    # if we don't have a query string, return success
+    return 0
+  elif len(sys.argv) > 2:
+    PrintError("Usage: {0} <json query>".format(sys.args[0]))
+    return 1
+
+  query_list = sys.argv[1].split('.')
+  for q in query_list:
+    if isinstance(obj, dict):
+      if q not in obj:
+        PrintError("Couldn't find '{0}' in dict".format(q))
+        return 1
+      obj = obj[q]
+    elif isinstance(obj, list):
+      try:
+        index = int(q)
+      except:
+        PrintError("Can't use '{0}' to index into array".format(q))
+        return 1
+      if index >= len(obj):
+        PrintError("Index ({0}) is greater than length of list ({1})".format(q, len(obj)))
+        return 1
+      obj = obj[index]
+    else:
+      PrintError("Trying to query non-queryable object: {0}".format(q))
+      return 1
+
+  if isinstance(obj, str):
+    print(obj)
+  else:
+    print(json.dumps(obj, indent=2))
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/build/make-build-image.sh
+++ b/build/make-build-image.sh
@@ -25,4 +25,5 @@ set -e
 
 source $(dirname $0)/common.sh
 
+verify-prereqs
 build-image

--- a/build/make-clean.sh
+++ b/build/make-clean.sh
@@ -14,14 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make all of the Kubernetes binaries.
-#
-# This makes the docker build image, builds the binaries and copies them out
-# of the docker container.
+# Clean out the output directory on the docker host.
 
 set -e
 
 source $(dirname $0)/common.sh
 
+verify-prereqs
 build-image
 run-build-command rm -rf output/build/*

--- a/build/make-cross.sh
+++ b/build/make-cross.sh
@@ -14,14 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make all of the Kubernetes binaries.
+# Make all of the Kubernetes binaries for cross compile targets
 #
-# This makes the docker build image, builds the binaries and copies them out
-# of the docker container.
+# This makes the docker build image, builds the cross binaries and copies them
+# out of the docker container.
 
 set -e
 
 source $(dirname $0)/common.sh
 
+verify-prereqs
 build-image
 run-build-command build/build-image/make-cross.sh

--- a/build/make-run-image.sh
+++ b/build/make-run-image.sh
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make all of the Kubernetes binaries.
+# Build the docker image necessary for running Kubernetes
 #
-# This makes the docker build image, builds the binaries and copies them out
-# of the docker container.
+# This script will make the 'run image' after building all of the necessary
+# binaries.
 
 set -e
 
@@ -26,3 +26,5 @@ source $(dirname $0)/common.sh
 verify-prereqs
 build-image
 run-build-command build/build-image/make-binaries.sh "$@"
+copy-output
+run-image

--- a/build/release.sh
+++ b/build/release.sh
@@ -32,4 +32,6 @@ run-build-command build/build-image/run-tests.sh
 run-build-command build/build-image/run-integration.sh
 copy-output
 run-image
+package-tarballs
 push-images-to-gcs
+copy-release-to-gcs

--- a/build/release.sh
+++ b/build/release.sh
@@ -14,15 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make all of the Kubernetes binaries.
-#
-# This makes the docker build image, builds the binaries and copies them out
-# of the docker container.
+# Build a Kubernetes release.  This will build the binaries, create the Docker
+# images and other build artifacts.  All intermediate artifacts will be hosted
+# publicly on Google Cloud Storage currently.
 
 set -e
 
 source $(dirname $0)/common.sh
 
 verify-prereqs
+verify-gcs-prereqs
+ensure-gcs-release-bucket
 build-image
-run-build-command build/build-image/make-binaries.sh "$@"
+run-build-command build/build-image/make-binaries.sh
+run-build-command build/build-image/make-cross.sh
+run-build-command build/build-image/run-tests.sh
+run-build-command build/build-image/run-integration.sh
+copy-output
+run-image
+push-images-to-gcs

--- a/build/run-images/apiserver/Dockerfile
+++ b/build/run-images/apiserver/Dockerfile
@@ -1,5 +1,3 @@
-#! /bin/bash
-
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make all of the Kubernetes binaries.
-#
-# This makes the docker build image, builds the binaries and copies them out
-# of the docker container.
+# This file creates a minimal container for running Kubernetes binaries
 
-set -e
+FROM  kubernetes
+MAINTAINER  Joe Beda <jbeda@google.com>
 
-source $(dirname $0)/common.sh
+ENV ETCD_SERVERS http://127.0.0.1:4001
+ENV KUBE_MINIONS ""
 
-verify-prereqs
-build-image
-run-build-command build/build-image/make-binaries.sh "$@"
+ADD . /kubernetes
+
+CMD ['./run.sh']

--- a/build/run-images/apiserver/run.sh
+++ b/build/run-images/apiserver/run.sh
@@ -14,15 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make all of the Kubernetes binaries.
-#
-# This makes the docker build image, builds the binaries and copies them out
-# of the docker container.
+# If the user doesn't specify a minion, assume we are running in a single node
+# configuration and that we have a local minion.
+KUBE_MINIONS=${KUBE_MINIONS:$(hostname -f)}
 
-set -e
-
-source $(dirname $0)/common.sh
-
-verify-prereqs
-build-image
-run-build-command build/build-image/make-binaries.sh "$@"
+./apiserver -master=127.0.0.1:8080 -etcd_servers="${ETCD_SERVERS}" --machines="${KUBE_MINIONS}"

--- a/build/run-images/base/Dockerfile
+++ b/build/run-images/base/Dockerfile
@@ -1,5 +1,3 @@
-#! /bin/bash
-
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make all of the Kubernetes binaries.
-#
-# This makes the docker build image, builds the binaries and copies them out
-# of the docker container.
+# This file creates a minimal container for running Kubernetes binaries
 
-set -e
+FROM  busybox
+MAINTAINER  Joe Beda <jbeda@google.com>
 
-source $(dirname $0)/common.sh
+WORKDIR /kubernetes
 
-verify-prereqs
-build-image
-run-build-command build/build-image/make-binaries.sh "$@"
+# Upload Kubernetes
+ADD kube-bins.tar.gz /kubernetes

--- a/build/run-images/controller-manager/Dockerfile
+++ b/build/run-images/controller-manager/Dockerfile
@@ -1,5 +1,3 @@
-#! /bin/bash
-
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make all of the Kubernetes binaries.
-#
-# This makes the docker build image, builds the binaries and copies them out
-# of the docker container.
+# This file creates a minimal container for running Kubernetes binaries
 
-set -e
+FROM  kubernetes
+MAINTAINER  Joe Beda <jbeda@google.com>
 
-source $(dirname $0)/common.sh
+ENV ETCD_SERVERS http://127.0.0.1:4001
+ENV API_SERVER   127.0.0.1:8080
 
-verify-prereqs
-build-image
-run-build-command build/build-image/make-binaries.sh "$@"
+ADD . /kubernetes
+
+CMD ['./run.sh']

--- a/build/run-images/controller-manager/run.sh
+++ b/build/run-images/controller-manager/run.sh
@@ -14,15 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make all of the Kubernetes binaries.
-#
-# This makes the docker build image, builds the binaries and copies them out
-# of the docker container.
-
-set -e
-
-source $(dirname $0)/common.sh
-
-verify-prereqs
-build-image
-run-build-command build/build-image/make-binaries.sh "$@"
+./controller-manager -etcd_servers="${ETCD_SERVERS}" -master="${API_SERVER}"

--- a/build/run-images/proxy/Dockerfile
+++ b/build/run-images/proxy/Dockerfile
@@ -1,5 +1,3 @@
-#! /bin/bash
-
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,15 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make all of the Kubernetes binaries.
-#
-# This makes the docker build image, builds the binaries and copies them out
-# of the docker container.
+# This file creates a minimal container for running Kubernetes binaries
 
-set -e
+FROM  kubernetes
+MAINTAINER  Joe Beda <jbeda@google.com>
 
-source $(dirname $0)/common.sh
+ENV ETCD_SERVERS http://127.0.0.1:4001
 
-verify-prereqs
-build-image
-run-build-command build/build-image/make-binaries.sh "$@"
+ADD . /kubernetes
+
+CMD ['./run.sh']

--- a/build/run-images/proxy/run.sh
+++ b/build/run-images/proxy/run.sh
@@ -14,15 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make all of the Kubernetes binaries.
-#
-# This makes the docker build image, builds the binaries and copies them out
-# of the docker container.
-
-set -e
-
-source $(dirname $0)/common.sh
-
-verify-prereqs
-build-image
-run-build-command build/build-image/make-binaries.sh "$@"
+./proxy --etcd_servers="${ETCD_SERVERS}"

--- a/build/run-integration.sh
+++ b/build/run-integration.sh
@@ -14,15 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make all of the Kubernetes binaries.
-#
-# This makes the docker build image, builds the binaries and copies them out
-# of the docker container.
+# Run the integration test.
 
 set -e
 
 source $(dirname $0)/common.sh
 
+verify-prereqs
 build-image
 run-build-command build/build-image/make-binaries.sh "integration"
 run-build-command build/build-image/run-integration.sh

--- a/build/run-tests.sh
+++ b/build/run-tests.sh
@@ -14,14 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make all of the Kubernetes binaries.
-#
-# This makes the docker build image, builds the binaries and copies them out
-# of the docker container.
+# Run all of the golang unit tests.
 
 set -e
 
 source $(dirname $0)/common.sh
 
+verify-prereqs
 build-image
 run-build-command build/build-image/run-tests.sh "$@"

--- a/build/shell.sh
+++ b/build/shell.sh
@@ -14,16 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Build the docker image necessary for building Kubernetes
+# Run a bash script in the Docker build image.
 #
-# This script will package the parts of the repo that we need to build
-# Kubernetes into a tar file and put it in the right place in the output
-# directory.  It will then copy over the Dockerfile and build the kube-build
-# image.
+# This container will have a snapshot of the current sources.
 
 set -e
 
 source $(dirname $0)/common.sh
 
+verify-prereqs
 build-image
 run-build-command bash


### PR DESCRIPTION
Also added release process to push these images to GCS.

Notes:
- Currently this uses jbeda/docker-registry instead of google/docker-registry.  I can change it over when https://github.com/GoogleCloudPlatform/docker-registry/pull/9 is in.
- Currently we only upload docker images to GCS.  This is to enable fast testing on GCE.  There should be a mode/option to upload to the docker index instead.
