### PR TITLE
Fix guestbook example json syntax error

### DIFF
--- a/examples/guestbook/redis-slave-service.json
+++ b/examples/guestbook/redis-slave-service.json
@@ -3,7 +3,7 @@
   "port": 10001,
   "labels": {
     "name": "redisslave"
-  }
+  },
   "selector": {
     "name": "redisslave"
   }


### PR DESCRIPTION
Headline says it all.

Tiny JSON syntax error in redis-slave-service.json
