### PR TITLE
Make api able to marshal its types correctly

### DIFF
--- a/cmd/cloudcfg/cloudcfg.go
+++ b/cmd/cloudcfg/cloudcfg.go
@@ -168,7 +168,7 @@ func executeAPIRequest(method string, auth *kube_client.AuthInfo) bool {
 		printer = &cloudcfg.HumanReadablePrinter{}
 	}
 
-	var body string
+	var body []byte
 	if body, err = cloudcfg.DoRequest(request, auth); err == nil {
 		if err = printer.Print(body, os.Stdout); err != nil {
 			log.Fatalf("Failed to print: %#v\nRaw received text:\n%v\n", err, string(body))

--- a/pkg/api/helper.go
+++ b/pkg/api/helper.go
@@ -65,7 +65,7 @@ func Encode(obj interface{}) (data []byte, err error) {
 	if _, contains := knownTypes[name]; !contains {
 		return nil, fmt.Errorf("struct %v can't be unmarshalled because it's not in knownTypes", name)
 	}
-	jsonBase.FieldByName("Kind").Set(reflect.ValueOf(name))
+	jsonBase.FieldByName("Kind").SetString(name)
 	return json.Marshal(obj)
 }
 
@@ -104,7 +104,9 @@ func DecodeInto(data []byte, obj interface{}) error {
 		return err
 	}
 	foundName := jsonBase.FieldByName("Kind").Interface().(string)
-	if foundName != "" && foundName != name {
+	if foundName == "" {
+		jsonBase.FieldByName("Kind").SetString(name)
+	} else if foundName != name {
 		return fmt.Errorf("data had kind %v, but passed object was of type %v", foundName, name)
 	}
 	return nil

--- a/pkg/api/helper.go
+++ b/pkg/api/helper.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+var knownTypes = map[string]reflect.Type{}
+
+func init() {
+	types := []interface{}{
+		PodList{}, Pod{}, ReplicationControllerList{},
+		ReplicationController{}, ServiceList{}, Service{},
+	}
+	for _, obj := range types {
+		t := reflect.TypeOf(obj)
+		knownTypes[t.Name()] = t
+	}
+}
+
+// Returns the name of the type (sans pointer), and its kind field. Takes pointer-to-struct..
+func nameAndJSONBase(obj interface{}) (string, reflect.Value, error) {
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr {
+		return "", reflect.Value{}, fmt.Errorf("expected pointer, but got %v", v.Type().Name())
+	}
+	v = v.Elem()
+	name := v.Type().Name()
+	if v.Kind() != reflect.Struct {
+		return "", reflect.Value{}, fmt.Errorf("expected struct, but got %v", name)
+	}
+	jsonBase := v.FieldByName("JSONBase")
+	if !jsonBase.IsValid() {
+		return "", reflect.Value{}, fmt.Errorf("struct %v lacks embedded JSON type", name)
+	}
+	return name, jsonBase, nil
+}
+
+// Encode turns the given api object into an appropriate JSON string.
+// Will return an error if the object doesn't have an embedded JSONBase.
+// Obj must be a pointer to a struct. Note, this sets the object's Kind
+// field.
+func Encode(obj interface{}) (data []byte, err error) {
+	name, jsonBase, err := nameAndJSONBase(obj)
+	if err != nil {
+		return nil, err
+	}
+	if _, contains := knownTypes[name]; !contains {
+		return nil, fmt.Errorf("struct %v can't be unmarshalled because it's not in knownTypes", name)
+	}
+	jsonBase.FieldByName("Kind").Set(reflect.ValueOf(name))
+	return json.Marshal(obj)
+}
+
+// Decode converts a JSON string back into a pointer to an api object. Deduces the type
+// based upon the Kind field (set by encode).
+func Decode(data []byte) (interface{}, error) {
+	findKind := struct {
+		Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+	}{}
+	err := json.Unmarshal(data, &findKind)
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't get kind: %#v", err)
+	}
+	objType, found := knownTypes[findKind.Kind]
+	if !found {
+		return nil, fmt.Errorf("%v is not a known type", findKind.Kind)
+	}
+	obj := reflect.New(objType).Interface()
+	err = json.Unmarshal(data, obj)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+// DecodeInto parses a JSON string and stores it in obj. Returns an error
+// if data.Kind is set and doesn't match the type of obj. Obj should be a
+// pointer to an api type.
+func DecodeInto(data []byte, obj interface{}) error {
+	err := json.Unmarshal(data, obj)
+	if err != nil {
+		return err
+	}
+	name, jsonBase, err := nameAndJSONBase(obj)
+	if err != nil {
+		return err
+	}
+	foundName := jsonBase.FieldByName("Kind").Interface().(string)
+	if foundName != "" && foundName != name {
+		return fmt.Errorf("data had kind %v, but passed object was of type %v", foundName, name)
+	}
+	return nil
+}

--- a/pkg/api/helper.go
+++ b/pkg/api/helper.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+
+	"gopkg.in/v1/yaml"
 )
 
 var knownTypes = map[string]reflect.Type{}
@@ -29,6 +31,7 @@ func init() {
 		PodList{}, Pod{},
 		ReplicationControllerList{}, ReplicationController{},
 		ServiceList{}, Service{},
+		Status{},
 	)
 }
 
@@ -117,7 +120,8 @@ func Decode(data []byte) (interface{}, error) {
 	findKind := struct {
 		Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
 	}{}
-	err := json.Unmarshal(data, &findKind)
+	// yaml is a superset of json, so we use it to decode here. That way, we understand both.
+	err := yaml.Unmarshal(data, &findKind)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't get kind: %#v", err)
 	}
@@ -126,7 +130,7 @@ func Decode(data []byte) (interface{}, error) {
 		return nil, fmt.Errorf("%v is not a known type", findKind.Kind)
 	}
 	obj := reflect.New(objType).Interface()
-	err = json.Unmarshal(data, obj)
+	err = yaml.Unmarshal(data, obj)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +147,7 @@ func Decode(data []byte) (interface{}, error) {
 // if data.Kind is set and doesn't match the type of obj. Obj should be a
 // pointer to an api type.
 func DecodeInto(data []byte, obj interface{}) error {
-	err := json.Unmarshal(data, obj)
+	err := yaml.Unmarshal(data, obj)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/helper_test.go
+++ b/pkg/api/helper_test.go
@@ -61,7 +61,19 @@ func TestTypes(t *testing.T) {
 			},
 		},
 		&Service{},
-		&ServiceList{},
+		&ServiceList{
+			Items: []Service{
+				{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				}, {
+					Labels: map[string]string{
+						"foo": "baz",
+					},
+				},
+			},
+		},
 		&ReplicationControllerList{},
 		&ReplicationController{},
 		&PodList{},

--- a/pkg/api/helper_test.go
+++ b/pkg/api/helper_test.go
@@ -71,4 +71,34 @@ func TestTypes(t *testing.T) {
 	}
 }
 
+func TestNonPtr(t *testing.T) {
+	obj := interface{}(Pod{Labels: map[string]string{"name": "foo"}})
+	data, err := Encode(obj)
+	obj2, err2 := Decode(data)
+	if err != nil || err2 != nil {
+		t.Errorf("Failure: %v %v", err2, err2)
+	}
+	if _, ok := obj2.(*Pod); !ok {
+		t.Errorf("Got wrong type")
+	}
+	if !reflect.DeepEqual(obj2, &Pod{Labels: map[string]string{"name": "foo"}}) {
+		t.Errorf("Something changed: %#v", obj2)
+	}
+}
+
+func TestPtr(t *testing.T) {
+	obj := interface{}(&Pod{Labels: map[string]string{"name": "foo"}})
+	data, err := Encode(obj)
+	obj2, err2 := Decode(data)
+	if err != nil || err2 != nil {
+		t.Errorf("Failure: %v %v", err2, err2)
+	}
+	if _, ok := obj2.(*Pod); !ok {
+		t.Errorf("Got wrong type")
+	}
+	if !reflect.DeepEqual(obj2, &Pod{Labels: map[string]string{"name": "foo"}}) {
+		t.Errorf("Something changed: %#v", obj2)
+	}
+}
+
 // TODO: test rejection of bad JSON.

--- a/pkg/api/helper_test.go
+++ b/pkg/api/helper_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"reflect"
+	"testing"
+)
+
+func runTest(t *testing.T, source interface{}) {
+	name := reflect.TypeOf(source).Name()
+	data, err := Encode(source)
+	if err != nil {
+		t.Errorf("%v: %v", name, err)
+		return
+	}
+	obj2, err := Decode(data)
+	if err != nil {
+		t.Errorf("%v: %v", name, err)
+		return
+	}
+	if !reflect.DeepEqual(source, obj2) {
+		t.Errorf("%v: wanted %#v, got %#v", name, source, obj2)
+		return
+	}
+	obj3 := reflect.New(reflect.TypeOf(source).Elem()).Interface()
+	err = DecodeInto(data, obj3)
+	if err != nil {
+		t.Errorf("%v: %v", name, err)
+		return
+	}
+	if !reflect.DeepEqual(source, obj3) {
+		t.Errorf("%v: wanted %#v, got %#v", name, source, obj3)
+		return
+	}
+}
+
+func TestTypes(t *testing.T) {
+	// TODO: auto-fill all fields.
+	table := []interface{}{
+		&Pod{
+			JSONBase: JSONBase{
+				ID: "mylittlepod",
+			},
+			Labels: map[string]string{
+				"name": "pinky",
+			},
+		},
+		&Service{},
+		&ServiceList{},
+		&ReplicationControllerList{},
+		&ReplicationController{},
+		&PodList{},
+	}
+	for _, item := range table {
+		runTest(t, item)
+	}
+}
+
+// TODO: test rejection of bad JSON.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -174,3 +174,21 @@ type Endpoints struct {
 	Name      string
 	Endpoints []string
 }
+
+// Status is a return value for calls that don't return other objects.
+// Arguably, this could go in apiserver, but I'm including it here so clients needn't
+// import both.
+type Status struct {
+	JSONBase `json:",inline" yaml:",inline"`
+	// One of: "success", "failure", "working" (for operations not yet completed)
+	// TODO: if "working", include an operation identifier so final status can be
+	// checked.
+	Status string `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+// Values of Status.Status
+const (
+	StatusSuccess = "success"
+	StatusFailure = "failure"
+	StatusWorking = "working"
+)

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -36,7 +36,7 @@ type RESTStorage interface {
 	List(labels.Selector) (interface{}, error)
 	Get(id string) (interface{}, error)
 	Delete(id string) (<-chan interface{}, error)
-	Extract(body string) (interface{}, error)
+	Extract(body []byte) (interface{}, error)
 	Create(interface{}) (<-chan interface{}, error)
 	Update(interface{}) (<-chan interface{}, error)
 }
@@ -143,10 +143,10 @@ func (server *ApiServer) error(err error, w http.ResponseWriter) {
 	fmt.Fprintf(w, "Internal Error: %#v", err)
 }
 
-func (server *ApiServer) readBody(req *http.Request) (string, error) {
+func (server *ApiServer) readBody(req *http.Request) ([]byte, error) {
 	defer req.Body.Close()
 	body, err := ioutil.ReadAll(req.Body)
-	return string(body), err
+	return body, err
 }
 
 func (server *ApiServer) waitForObject(out <-chan interface{}, timeout time.Duration) (interface{}, error) {

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -125,7 +125,7 @@ func (server *ApiServer) notFound(req *http.Request, w http.ResponseWriter) {
 
 func (server *ApiServer) write(statusCode int, object interface{}, w http.ResponseWriter) {
 	w.WriteHeader(statusCode)
-	output, err := api.EncodeIndent(object)
+	output, err := api.Encode(object)
 	if err != nil {
 		server.error(err, w)
 		return

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -50,11 +50,6 @@ func MakeAsync(fn func() interface{}) <-chan interface{} {
 	return channel
 }
 
-// Status is a return value for calls that don't return other objects
-type Status struct {
-	Success bool
-}
-
 // ApiServer is an HTTPHandler that delegates to RESTStorage objects.
 // It handles URLs of the form:
 // ${prefix}/${storage_key}[/${object_name}]
@@ -248,7 +243,7 @@ func (server *ApiServer) handleREST(parts []string, requestUrl *url.URL, req *ht
 		}
 		out, err := storage.Delete(parts[1])
 		var obj interface{}
-		obj = Status{Success: true}
+		obj = api.Status{Status: api.StatusSuccess}
 		if err == nil && sync {
 			obj, err = server.waitForObject(out, timeout)
 		}

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apiserver
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -27,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
@@ -130,7 +130,7 @@ func (server *ApiServer) notFound(req *http.Request, w http.ResponseWriter) {
 
 func (server *ApiServer) write(statusCode int, object interface{}, w http.ResponseWriter) {
 	w.WriteHeader(statusCode)
-	output, err := json.MarshalIndent(object, "", "    ")
+	output, err := api.EncodeIndent(object)
 	if err != nil {
 		server.error(err, w)
 		return

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -26,8 +26,13 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 )
+
+func init() {
+	api.AddKnownTypes(Simple{}, SimpleList{})
+}
 
 // TODO: This doesn't reduce typing enough to make it worth the less readable errors. Remove.
 func expectNoError(t *testing.T, err error) {
@@ -37,11 +42,13 @@ func expectNoError(t *testing.T, err error) {
 }
 
 type Simple struct {
-	Name string
+	JSONBase api.JSONBase `json:",inline"`
+	Name     string
 }
 
 type SimpleList struct {
-	Items []Simple
+	JSONBase api.JSONBase `json:",inline"`
+	Items    []Simple
 }
 
 type SimpleRESTStorage struct {
@@ -54,7 +61,7 @@ type SimpleRESTStorage struct {
 }
 
 func (storage *SimpleRESTStorage) List(labels.Selector) (interface{}, error) {
-	result := SimpleList{
+	result := &SimpleList{
 		Items: storage.list,
 	}
 	return result, storage.err
@@ -71,7 +78,7 @@ func (storage *SimpleRESTStorage) Delete(id string) (<-chan interface{}, error) 
 
 func (storage *SimpleRESTStorage) Extract(body []byte) (interface{}, error) {
 	var item Simple
-	json.Unmarshal(body, &item)
+	api.DecodeInto(body, &item)
 	return item, storage.err
 }
 
@@ -90,7 +97,7 @@ func extractBody(response *http.Response, object interface{}) (string, error) {
 	if err != nil {
 		return string(body), err
 	}
-	err = json.Unmarshal(body, object)
+	err = api.DecodeInto(body, object)
 	return string(body), err
 }
 
@@ -150,6 +157,7 @@ func TestNonEmptyList(t *testing.T) {
 	body, err := extractBody(resp, &listOut)
 	if len(listOut.Items) != 1 {
 		t.Errorf("Unexpected response: %#v", listOut)
+		return
 	}
 	if listOut.Items[0].Name != simpleStorage.list[0].Name {
 		t.Errorf("Unexpected data: %#v, %s", listOut.Items[0], string(body))

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -69,9 +69,9 @@ func (storage *SimpleRESTStorage) Delete(id string) (<-chan interface{}, error) 
 	return storage.channel, storage.err
 }
 
-func (storage *SimpleRESTStorage) Extract(body string) (interface{}, error) {
+func (storage *SimpleRESTStorage) Extract(body []byte) (interface{}, error) {
 	var item Simple
-	json.Unmarshal([]byte(body), &item)
+	json.Unmarshal(body, &item)
 	return item, storage.err
 }
 

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -42,13 +42,13 @@ func expectNoError(t *testing.T, err error) {
 }
 
 type Simple struct {
-	JSONBase api.JSONBase `json:",inline"`
-	Name     string
+	api.JSONBase `yaml:",inline" json:",inline"`
+	Name         string `yaml:"name,omitempty" json:"name,omitempty"`
 }
 
 type SimpleList struct {
-	JSONBase api.JSONBase `json:",inline"`
-	Items    []Simple
+	api.JSONBase `yaml:",inline" json:",inline"`
+	Items        []Simple `yaml:"items,omitempty" json:"items,omitempty"`
 }
 
 type SimpleRESTStorage struct {
@@ -155,6 +155,7 @@ func TestNonEmptyList(t *testing.T) {
 
 	var listOut SimpleList
 	body, err := extractBody(resp, &listOut)
+	expectNoError(t, err)
 	if len(listOut.Items) != 1 {
 		t.Errorf("Unexpected response: %#v", listOut)
 		return

--- a/pkg/cloudcfg/cloudcfg.go
+++ b/pkg/cloudcfg/cloudcfg.go
@@ -113,7 +113,7 @@ func RequestWithBodyData(data []byte, url, method string) (*http.Request, error)
 }
 
 // Execute a request, adds authentication (if auth != nil), and HTTPS cert ignoring.
-func DoRequest(request *http.Request, auth *client.AuthInfo) (string, error) {
+func DoRequest(request *http.Request, auth *client.AuthInfo) ([]byte, error) {
 	if auth != nil {
 		request.SetBasicAuth(auth.User, auth.Password)
 	}
@@ -123,11 +123,11 @@ func DoRequest(request *http.Request, auth *client.AuthInfo) (string, error) {
 	client := &http.Client{Transport: tr}
 	response, err := client.Do(request)
 	if err != nil {
-		return "", err
+		return []byte{}, err
 	}
 	defer response.Body.Close()
 	body, err := ioutil.ReadAll(response.Body)
-	return string(body), err
+	return body, err
 }
 
 // StopController stops a controller named 'name' by setting replicas to zero

--- a/pkg/cloudcfg/cloudcfg_test.go
+++ b/pkg/cloudcfg/cloudcfg_test.go
@@ -164,7 +164,7 @@ func TestDoRequest(t *testing.T) {
 	if err != nil {
 		t.Error("Unexpected error")
 	}
-	if body != expectedBody {
+	if string(body) != expectedBody {
 		t.Errorf("Expected body: '%s', saw: '%s'", expectedBody, body)
 	}
 	fakeHandler.ValidateRequest(t, "/foo/bar", "GET", nil)

--- a/pkg/cloudcfg/parse.go
+++ b/pkg/cloudcfg/parse.go
@@ -1,12 +1,10 @@
 package cloudcfg
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"gopkg.in/v1/yaml"
 )
 
 var storageToType = map[string]reflect.Type{
@@ -25,9 +23,9 @@ func ToWireFormat(data []byte, storage string) ([]byte, error) {
 	}
 
 	obj := reflect.New(prototypeType).Interface()
-	err := yaml.Unmarshal(data, obj)
+	err := api.DecodeInto(data, obj)
 	if err != nil {
 		return nil, err
 	}
-	return json.Marshal(obj)
+	return api.Encode(obj)
 }

--- a/pkg/cloudcfg/parse_test.go
+++ b/pkg/cloudcfg/parse_test.go
@@ -1,7 +1,6 @@
 package cloudcfg
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -16,7 +15,7 @@ func TestParseBadStorage(t *testing.T) {
 }
 
 func DoParseTest(t *testing.T, storage string, obj interface{}) {
-	json_data, _ := json.Marshal(obj)
+	json_data, _ := api.Encode(obj)
 	yaml_data, _ := yaml.Marshal(obj)
 	t.Logf("Intermediate yaml:\n%v\n", string(yaml_data))
 

--- a/pkg/registry/controller_registry.go
+++ b/pkg/registry/controller_registry.go
@@ -34,7 +34,7 @@ func MakeControllerRegistryStorage(registry ControllerRegistry) apiserver.RESTSt
 }
 
 func (storage *ControllerRegistryStorage) List(selector labels.Selector) (interface{}, error) {
-	result := api.ReplicationControllerList{JSONBase: api.JSONBase{Kind: "cluster#replicationControllerList"}}
+	result := api.ReplicationControllerList{}
 	controllers, err := storage.registry.ListControllers()
 	if err == nil {
 		for _, controller := range controllers {
@@ -55,7 +55,7 @@ func (storage *ControllerRegistryStorage) Get(id string) (interface{}, error) {
 }
 
 func (storage *ControllerRegistryStorage) Delete(id string) (<-chan interface{}, error) {
-	return apiserver.MakeAsync(func() interface{} { return apiserver.Status{Success: true} }), storage.registry.DeleteController(id)
+	return apiserver.MakeAsync(func() interface{} { return api.Status{Status: api.StatusSuccess} }), storage.registry.DeleteController(id)
 }
 
 func (storage *ControllerRegistryStorage) Extract(body []byte) (interface{}, error) {

--- a/pkg/registry/controller_registry.go
+++ b/pkg/registry/controller_registry.go
@@ -17,8 +17,6 @@ limitations under the License.
 package registry
 
 import (
-	"encoding/json"
-
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
@@ -53,7 +51,6 @@ func (storage *ControllerRegistryStorage) Get(id string) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	controller.Kind = "cluster#replicationController"
 	return controller, err
 }
 
@@ -63,8 +60,7 @@ func (storage *ControllerRegistryStorage) Delete(id string) (<-chan interface{},
 
 func (storage *ControllerRegistryStorage) Extract(body []byte) (interface{}, error) {
 	result := api.ReplicationController{}
-	err := json.Unmarshal(body, &result)
-	result.Kind = "cluster#replicationController"
+	err := api.DecodeInto(body, &result)
 	return result, err
 }
 

--- a/pkg/registry/controller_registry.go
+++ b/pkg/registry/controller_registry.go
@@ -61,9 +61,9 @@ func (storage *ControllerRegistryStorage) Delete(id string) (<-chan interface{},
 	return apiserver.MakeAsync(func() interface{} { return apiserver.Status{Success: true} }), storage.registry.DeleteController(id)
 }
 
-func (storage *ControllerRegistryStorage) Extract(body string) (interface{}, error) {
+func (storage *ControllerRegistryStorage) Extract(body []byte) (interface{}, error) {
 	result := api.ReplicationController{}
-	err := json.Unmarshal([]byte(body), &result)
+	err := json.Unmarshal(body, &result)
 	result.Kind = "cluster#replicationController"
 	return result, err
 }

--- a/pkg/registry/controller_registry_test.go
+++ b/pkg/registry/controller_registry_test.go
@@ -123,7 +123,7 @@ func TestExtractControllerJson(t *testing.T) {
 	}
 	body, err := json.Marshal(controller)
 	expectNoError(t, err)
-	controllerOut, err := storage.Extract(string(body))
+	controllerOut, err := storage.Extract(body)
 	expectNoError(t, err)
 	// Extract adds a Kind
 	controller.Kind = "cluster#replicationController"

--- a/pkg/registry/controller_registry_test.go
+++ b/pkg/registry/controller_registry_test.go
@@ -121,12 +121,10 @@ func TestExtractControllerJson(t *testing.T) {
 			ID: "foo",
 		},
 	}
-	body, err := json.Marshal(controller)
+	body, err := api.Encode(&controller)
 	expectNoError(t, err)
 	controllerOut, err := storage.Extract(body)
 	expectNoError(t, err)
-	// Extract adds a Kind
-	controller.Kind = "cluster#replicationController"
 	if !reflect.DeepEqual(controller, controllerOut) {
 		t.Errorf("Expected %#v, found %#v", controller, controllerOut)
 	}

--- a/pkg/registry/pod_registry.go
+++ b/pkg/registry/pod_registry.go
@@ -130,7 +130,7 @@ func (storage *PodRegistryStorage) Get(id string) (interface{}, error) {
 }
 
 func (storage *PodRegistryStorage) Delete(id string) (<-chan interface{}, error) {
-	return apiserver.MakeAsync(func() interface{} { return apiserver.Status{Success: true} }), storage.registry.DeletePod(id)
+	return apiserver.MakeAsync(func() interface{} { return api.Status{Status: api.StatusSuccess} }), storage.registry.DeletePod(id)
 }
 
 func (storage *PodRegistryStorage) Extract(body []byte) (interface{}, error) {

--- a/pkg/registry/pod_registry.go
+++ b/pkg/registry/pod_registry.go
@@ -136,9 +136,9 @@ func (storage *PodRegistryStorage) Delete(id string) (<-chan interface{}, error)
 	return apiserver.MakeAsync(func() interface{} { return apiserver.Status{Success: true} }), storage.registry.DeletePod(id)
 }
 
-func (storage *PodRegistryStorage) Extract(body string) (interface{}, error) {
+func (storage *PodRegistryStorage) Extract(body []byte) (interface{}, error) {
 	pod := api.Pod{}
-	err := json.Unmarshal([]byte(body), &pod)
+	err := json.Unmarshal(body, &pod)
 	pod.Kind = "cluster#pod"
 	return pod, err
 }

--- a/pkg/registry/pod_registry.go
+++ b/pkg/registry/pod_registry.go
@@ -16,7 +16,6 @@ limitations under the License.
 package registry
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
@@ -73,7 +72,6 @@ func (storage *PodRegistryStorage) List(selector labels.Selector) (interface{}, 
 		}
 	}
 
-	result.Kind = "cluster#podList"
 	return result, err
 }
 
@@ -128,7 +126,6 @@ func (storage *PodRegistryStorage) Get(id string) (interface{}, error) {
 	}
 	pod.CurrentState.HostIP = getInstanceIP(storage.cloud, pod.CurrentState.Host)
 
-	pod.Kind = "cluster#pod"
 	return pod, err
 }
 
@@ -138,8 +135,7 @@ func (storage *PodRegistryStorage) Delete(id string) (<-chan interface{}, error)
 
 func (storage *PodRegistryStorage) Extract(body []byte) (interface{}, error) {
 	pod := api.Pod{}
-	err := json.Unmarshal(body, &pod)
-	pod.Kind = "cluster#pod"
+	err := api.DecodeInto(body, &pod)
 	return pod, err
 }
 

--- a/pkg/registry/pod_registry_test.go
+++ b/pkg/registry/pod_registry_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package registry
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
@@ -102,12 +101,10 @@ func TestExtractJson(t *testing.T) {
 			ID: "foo",
 		},
 	}
-	body, err := json.Marshal(pod)
+	body, err := api.Encode(&pod)
 	expectNoError(t, err)
 	podOut, err := storage.Extract(body)
 	expectNoError(t, err)
-	// Extract adds in a kind
-	pod.Kind = "cluster#pod"
 	if !reflect.DeepEqual(pod, podOut) {
 		t.Errorf("Expected %#v, found %#v", pod, podOut)
 	}

--- a/pkg/registry/pod_registry_test.go
+++ b/pkg/registry/pod_registry_test.go
@@ -104,7 +104,7 @@ func TestExtractJson(t *testing.T) {
 	}
 	body, err := json.Marshal(pod)
 	expectNoError(t, err)
-	podOut, err := storage.Extract(string(body))
+	podOut, err := storage.Extract(body)
 	expectNoError(t, err)
 	// Extract adds in a kind
 	pod.Kind = "cluster#pod"

--- a/pkg/registry/service_registry.go
+++ b/pkg/registry/service_registry.go
@@ -17,7 +17,6 @@ limitations under the License.
 package registry
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -64,7 +63,6 @@ func (sr *ServiceRegistryStorage) List(selector labels.Selector) (interface{}, e
 	if err != nil {
 		return nil, err
 	}
-	list.Kind = "cluster#serviceList"
 	var filtered []api.Service
 	for _, service := range list.Items {
 		if selector.Matches(labels.Set(service.Labels)) {
@@ -80,7 +78,6 @@ func (sr *ServiceRegistryStorage) Get(id string) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	service.Kind = "cluster#service"
 	return service, err
 }
 
@@ -107,8 +104,7 @@ func (sr *ServiceRegistryStorage) Delete(id string) (<-chan interface{}, error) 
 
 func (sr *ServiceRegistryStorage) Extract(body []byte) (interface{}, error) {
 	var svc api.Service
-	err := json.Unmarshal([]byte(body), &svc)
-	svc.Kind = "cluster#service"
+	err := api.DecodeInto(body, &svc)
 	return svc, err
 }
 

--- a/pkg/registry/service_registry.go
+++ b/pkg/registry/service_registry.go
@@ -99,7 +99,7 @@ func (sr *ServiceRegistryStorage) Delete(id string) (<-chan interface{}, error) 
 			}
 		}
 	}
-	return apiserver.MakeAsync(func() interface{} { return apiserver.Status{Success: true} }), sr.registry.DeleteService(id)
+	return apiserver.MakeAsync(func() interface{} { return api.Status{Status: api.StatusSuccess} }), sr.registry.DeleteService(id)
 }
 
 func (sr *ServiceRegistryStorage) Extract(body []byte) (interface{}, error) {

--- a/pkg/registry/service_registry.go
+++ b/pkg/registry/service_registry.go
@@ -105,7 +105,7 @@ func (sr *ServiceRegistryStorage) Delete(id string) (<-chan interface{}, error) 
 	return apiserver.MakeAsync(func() interface{} { return apiserver.Status{Success: true} }), sr.registry.DeleteService(id)
 }
 
-func (sr *ServiceRegistryStorage) Extract(body string) (interface{}, error) {
+func (sr *ServiceRegistryStorage) Extract(body []byte) (interface{}, error) {
 	var svc api.Service
 	err := json.Unmarshal([]byte(body), &svc)
 	svc.Kind = "cluster#service"


### PR DESCRIPTION
This frees everyone from having to think about the "Kind" field: use api.Encode and api.Decode[Into] instead of json|yaml.Marshal/Unmarshal.

To make it easy on tests, I'm also making the rule that the Kind field is _not_ set in go objects. Since we already know what type they are, it's not needed.

I also switched some types that we were passing as string but converting to []byte everywhere. More efficient to pass as []byte, anyway.
