### PR TITLE
Localkube wasn't seeding it's random number generator

### DIFF
--- a/cmd/localkube/localkube.go
+++ b/cmd/localkube/localkube.go
@@ -23,6 +23,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math/rand"
 	"net"
 	"os"
 	"strconv"
@@ -96,6 +97,7 @@ func controller_manager() {
 
 func main() {
 	flag.Parse()
+	rand.Seed(time.Now().UTC().UnixNano())
 
 	// Set up logger for etcd client
 	etcd.SetLogger(log.New(os.Stderr, "etcd ", log.LstdFlags))


### PR DESCRIPTION
This leads to conflicting docker container names.
