### PR TITLE
Cleanup handling of config channels in RunSyncLoop

### DIFF
--- a/pkg/kubelet/kubelet_server.go
+++ b/pkg/kubelet/kubelet_server.go
@@ -29,7 +29,7 @@ import (
 
 type KubeletServer struct {
 	Kubelet       kubeletInterface
-	UpdateChannel chan []api.ContainerManifest
+	UpdateChannel chan manifestUpdate
 }
 
 // kubeletInterface contains all the kubelet methods required by the server.
@@ -67,7 +67,7 @@ func (s *KubeletServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				s.error(w, err)
 				return
 			}
-			s.UpdateChannel <- []api.ContainerManifest{manifest}
+			s.UpdateChannel <- manifestUpdate{httpServerSource, []api.ContainerManifest{manifest}}
 		} else if u.Path == "/containers" {
 			var manifests []api.ContainerManifest
 			err = yaml.Unmarshal(data, &manifests)
@@ -75,7 +75,7 @@ func (s *KubeletServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				s.error(w, err)
 				return
 			}
-			s.UpdateChannel <- manifests
+			s.UpdateChannel <- manifestUpdate{httpServerSource, manifests}
 		}
 	case u.Path == "/containerStats":
 		container := u.Query().Get("container")

--- a/pkg/kubelet/kubelet_server_test.go
+++ b/pkg/kubelet/kubelet_server_test.go
@@ -33,7 +33,7 @@ func (fk *fakeKubelet) GetContainerStats(name string) (*api.ContainerStats, erro
 }
 
 type serverTestFramework struct {
-	updateChan      chan []api.ContainerManifest
+	updateChan      chan manifestUpdate
 	updateReader    *channelReader
 	serverUnderTest *KubeletServer
 	fakeKubelet     *fakeKubelet
@@ -42,7 +42,7 @@ type serverTestFramework struct {
 
 func makeServerTest() *serverTestFramework {
 	fw := &serverTestFramework{
-		updateChan: make(chan []api.ContainerManifest),
+		updateChan: make(chan manifestUpdate),
 	}
 	fw.updateReader = startReading(fw.updateChan)
 	fw.fakeKubelet = &fakeKubelet{}


### PR DESCRIPTION
Pass a map of channels instead of a bunch of vars.

My go concurrency-foo is currently weak, so please take a close look:)
