### PR TITLE
Better fix of #212

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -49,25 +49,25 @@ func main() {
 
 	// Kublet
 	fakeDocker := &kubelet.FakeDockerClient{}
-	my_kubelet := kubelet.Kubelet{
+	myKubelet := kubelet.Kubelet{
 		Hostname:           machineList[0],
 		DockerClient:       fakeDocker,
 		FileCheckFrequency: 5 * time.Second,
 		SyncFrequency:      5 * time.Second,
 		HTTPCheckFrequency: 5 * time.Second,
 	}
-	go my_kubelet.RunKubelet("", "https://raw.githubusercontent.com/GoogleCloudPlatform/container-vm-guestbook-redis-python/master/manifest.yaml", servers[0], "localhost", 0)
+	go myKubelet.RunKubelet("", "https://raw.githubusercontent.com/GoogleCloudPlatform/container-vm-guestbook-redis-python/master/manifest.yaml", servers[0], "localhost", 0)
 
 	// Create a second kublet so that the guestbook example's two redis slaves both
 	// have a place they can schedule.
-	other_kubelet := kubelet.Kubelet{
+	otherKubelet := kubelet.Kubelet{
 		Hostname:           machineList[1],
 		DockerClient:       &kubelet.FakeDockerClient{},
 		FileCheckFrequency: 5 * time.Second,
 		SyncFrequency:      5 * time.Second,
 		HTTPCheckFrequency: 5 * time.Second,
 	}
-	go other_kubelet.RunKubelet("", "", servers[0], "localhost", 0)
+	go otherKubelet.RunKubelet("", "", servers[0], "localhost", 0)
 
 	// Ok. we're good to go.
 	log.Printf("API Server started on %s", apiserver.URL)
@@ -102,8 +102,7 @@ func main() {
 	createdPods := map[string]struct{}{}
 	for _, p := range fakeDocker.Created {
 		// The last 8 characters are random, so slice them off.
-		n := len(p)
-		if n > 8 {
+		if n := len(p); n > 8 {
 			createdPods[p[:n-8]] = struct{}{}
 		}
 	}

--- a/cmd/localkube/localkube.go
+++ b/cmd/localkube/localkube.go
@@ -43,52 +43,52 @@ var (
 	syncFrequency      = flag.Duration("sync_frequency", 10*time.Second, "Max period between synchronizing running containers and config")
 	fileCheckFrequency = flag.Duration("file_check_frequency", 20*time.Second, "Duration between checking file for new data")
 	httpCheckFrequency = flag.Duration("http_check_frequency", 20*time.Second, "Duration between checking http for new data")
-	manifest_url       = flag.String("manifest_url", "", "URL for accessing the container manifest")
-	kubelet_address    = flag.String("kubelet_address", "127.0.0.1", "The address for the kubelet info server to serve on")
-	kubelet_port       = flag.Uint("kubelet_port", 10250, "The port for the kubelete info server to serve on")
+	manifestUrl        = flag.String("manifest_url", "", "URL for accessing the container manifest")
+	kubeletAddress     = flag.String("kubelet_address", "127.0.0.1", "The address for the kubelet info server to serve on")
+	kubeletPort        = flag.Uint("kubelet_port", 10250, "The port for the kubelete info server to serve on")
 )
 
 // master flags
 var (
-	master_port    = flag.Uint("master_port", 8080, "The port for the master to listen on.  Default 8080.")
-	master_address = flag.String("master_address", "127.0.0.1", "The address for the master to listen to. Default 127.0.0.1")
-	apiPrefix      = flag.String("api_prefix", "/api/v1beta1", "The prefix for API requests on the server. Default '/api/v1beta1'")
+	masterPort    = flag.Uint("master_port", 8080, "The port for the master to listen on.  Default 8080.")
+	masterAddress = flag.String("master_address", "127.0.0.1", "The address for the master to listen to. Default 127.0.0.1")
+	apiPrefix     = flag.String("api_prefix", "/api/v1beta1", "The prefix for API requests on the server. Default '/api/v1beta1'")
 )
 
 // flags that affect both
 var (
-	etcd_server = flag.String("etcd_server", "http://localhost:4001", "Url of local etcd server")
+	etcdServer = flag.String("etcd_server", "http://localhost:4001", "Url of local etcd server")
 )
 
 // Starts kubelet services. Never returns.
-func fake_kubelet() {
+func fakeKubelet() {
 	endpoint := "unix:///var/run/docker.sock"
 	dockerClient, err := docker.NewClient(endpoint)
 	if err != nil {
 		log.Fatal("Couldn't connnect to docker.")
 	}
 
-	my_kubelet := kubelet.Kubelet{
-		Hostname:           *kubelet_address,
+	myKubelet := kubelet.Kubelet{
+		Hostname:           *kubeletAddress,
 		DockerClient:       dockerClient,
 		FileCheckFrequency: *fileCheckFrequency,
 		SyncFrequency:      *syncFrequency,
 		HTTPCheckFrequency: *httpCheckFrequency,
 	}
-	my_kubelet.RunKubelet(*file, *manifest_url, *etcd_server, *kubelet_address, *kubelet_port)
+	myKubelet.RunKubelet(*file, *manifestUrl, *etcdServer, *kubeletAddress, *kubeletPort)
 }
 
 // Starts api services (the master). Never returns.
-func api_server() {
-	m := master.New([]string{*etcd_server}, []string{*kubelet_address}, nil)
-	log.Fatal(m.Run(net.JoinHostPort(*master_address, strconv.Itoa(int(*master_port))), *apiPrefix))
+func apiServer() {
+	m := master.New([]string{*etcdServer}, []string{*kubeletAddress}, nil)
+	log.Fatal(m.Run(net.JoinHostPort(*masterAddress, strconv.Itoa(int(*masterPort))), *apiPrefix))
 }
 
 // Starts up a controller manager. Never returns.
-func controller_manager() {
+func controllerManager() {
 	controllerManager := controller.MakeReplicationManager(
-		etcd.NewClient([]string{*etcd_server}),
-		client.New(fmt.Sprintf("http://%s:%d", *master_address, *master_port), nil))
+		etcd.NewClient([]string{*etcdServer}),
+		client.New(fmt.Sprintf("http://%s:%d", *masterAddress, *masterPort), nil))
 
 	controllerManager.Run(20 * time.Second)
 	select {}
@@ -101,12 +101,12 @@ func main() {
 	// Set up logger for etcd client
 	etcd.SetLogger(log.New(os.Stderr, "etcd ", log.LstdFlags))
 
-	go api_server()
-	go fake_kubelet()
-	go controller_manager()
+	go apiServer()
+	go fakeKubelet()
+	go controllerManager()
 
 	log.Printf("All components started.\nMaster running at: http://%s:%d\nKubelet running at: http://%s:%d\n",
-		*master_address, *master_port,
-		*kubelet_address, *kubelet_port)
+		*masterAddress, *masterPort,
+		*kubeletAddress, *kubeletPort)
 	select {}
 }

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -22,7 +22,7 @@ fi
 # Stop right away if the build fails
 set -e
 
-$(dirname $0)/build-go.sh
+$(dirname $0)/build-go.sh integration
 
 ETCD_DIR=$(mktemp -d -t kube-integration.XXXXXX)
 trap "rm -rf ${ETCD_DIR}" EXIT

--- a/pkg/kubelet/fake_docker_client.go
+++ b/pkg/kubelet/fake_docker_client.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"github.com/fsouza/go-dockerclient"
+)
+
+// A simple fake docker client, so that kublet can be run for testing without requiring a real docker setup.
+type FakeDockerClient struct {
+	containerList []docker.APIContainers
+	container     *docker.Container
+	err           error
+	called        []string
+	stopped       []string
+	Created       []string
+}
+
+func (f *FakeDockerClient) clearCalls() {
+	f.called = []string{}
+}
+
+func (f *FakeDockerClient) appendCall(call string) {
+	f.called = append(f.called, call)
+}
+
+func (f *FakeDockerClient) ListContainers(options docker.ListContainersOptions) ([]docker.APIContainers, error) {
+	f.appendCall("list")
+	return f.containerList, f.err
+}
+
+func (f *FakeDockerClient) InspectContainer(id string) (*docker.Container, error) {
+	f.appendCall("inspect")
+	return f.container, f.err
+}
+
+func (f *FakeDockerClient) CreateContainer(c docker.CreateContainerOptions) (*docker.Container, error) {
+	f.appendCall("create")
+	f.Created = append(f.Created, c.Name)
+	// This is not a very good fake. We'll just add this container's name to the list.
+	// Docker likes to add a '/', so copy that behavior.
+	f.containerList = append(f.containerList, docker.APIContainers{ID: c.Name, Names: []string{"/" + c.Name}})
+	return &docker.Container{ID: "/" + c.Name}, nil
+}
+
+func (f *FakeDockerClient) StartContainer(id string, hostConfig *docker.HostConfig) error {
+	f.appendCall("start")
+	return nil
+}
+
+func (f *FakeDockerClient) StopContainer(id string, timeout uint) error {
+	f.appendCall("stop")
+	f.stopped = append(f.stopped, id)
+	return nil
+}

--- a/pkg/kubelet/fake_docker_client.go
+++ b/pkg/kubelet/fake_docker_client.go
@@ -67,3 +67,23 @@ func (f *FakeDockerClient) StopContainer(id string, timeout uint) error {
 	f.stopped = append(f.stopped, id)
 	return nil
 }
+
+type FakeDockerPuller struct {
+	ImagesPulled []string
+
+	// Every pull will return the first error here, and then reslice
+	// to remove it. Will give nil errors if this slice is empty.
+	ErrorsToInject []error
+}
+
+// Records the image pull attempt, and optionally injects an error.
+func (f *FakeDockerPuller) Pull(image string) error {
+	f.ImagesPulled = append(f.ImagesPulled, image)
+
+	if n := len(f.ErrorsToInject); n > 0 {
+		err := f.ErrorsToInject[0]
+		f.ErrorsToInject = f.ErrorsToInject[:n-1]
+		return err
+	}
+	return nil
+}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -75,9 +75,15 @@ func verifyError(t *testing.T, e error) {
 	}
 }
 
+func makeTestKubelet() *Kubelet {
+	return &Kubelet{
+		DockerPuller: &FakeDockerPuller{},
+	}
+}
+
 func TestExtractJSON(t *testing.T) {
 	obj := TestObject{}
-	kubelet := Kubelet{}
+	kubelet := makeTestKubelet()
 	data := `{ "name": "foo", "data": { "value": "bar", "number": 10 } }`
 	kubelet.ExtractYAMLData([]byte(data), &obj)
 
@@ -133,6 +139,7 @@ func TestContainerExists(t *testing.T) {
 	}
 	kubelet := Kubelet{
 		DockerClient: &fakeDocker,
+		DockerPuller: &FakeDockerPuller{},
 	}
 	manifest := api.ContainerManifest{
 		Id: "qux",
@@ -176,6 +183,7 @@ func TestGetContainerID(t *testing.T) {
 	}
 	kubelet := Kubelet{
 		DockerClient: &fakeDocker,
+		DockerPuller: &FakeDockerPuller{},
 	}
 	fakeDocker.containerList = []docker.APIContainers{
 		{
@@ -214,6 +222,7 @@ func TestGetContainerByName(t *testing.T) {
 	}
 	kubelet := Kubelet{
 		DockerClient: &fakeDocker,
+		DockerPuller: &FakeDockerPuller{},
 	}
 	fakeDocker.containerList = []docker.APIContainers{
 		{
@@ -242,6 +251,7 @@ func TestListContainers(t *testing.T) {
 	}
 	kubelet := Kubelet{
 		DockerClient: &fakeDocker,
+		DockerPuller: &FakeDockerPuller{},
 	}
 	fakeDocker.containerList = []docker.APIContainers{
 		{
@@ -272,6 +282,7 @@ func TestKillContainerWithError(t *testing.T) {
 	}
 	kubelet := Kubelet{
 		DockerClient: &fakeDocker,
+		DockerPuller: &FakeDockerPuller{},
 	}
 	err := kubelet.KillContainer("foo")
 	verifyError(t, err)
@@ -284,6 +295,7 @@ func TestKillContainer(t *testing.T) {
 	}
 	kubelet := Kubelet{
 		DockerClient: &fakeDocker,
+		DockerPuller: &FakeDockerPuller{},
 	}
 	fakeDocker.containerList = []docker.APIContainers{
 		{
@@ -303,7 +315,7 @@ func TestKillContainer(t *testing.T) {
 }
 
 func TestResponseToContainersNil(t *testing.T) {
-	kubelet := Kubelet{}
+	kubelet := makeTestKubelet()
 	list, err := kubelet.ResponseToManifests(&etcd.Response{Node: nil})
 	if len(list) != 0 {
 		t.Errorf("Unexpected non-zero list: %#v", list)
@@ -314,7 +326,7 @@ func TestResponseToContainersNil(t *testing.T) {
 }
 
 func TestResponseToManifests(t *testing.T) {
-	kubelet := Kubelet{}
+	kubelet := makeTestKubelet()
 	list, err := kubelet.ResponseToManifests(&etcd.Response{
 		Node: &etcd.Node{
 			Value: util.MakeJSONString([]api.ContainerManifest{
@@ -468,6 +480,7 @@ func TestSyncManifestsDoesNothing(t *testing.T) {
 	}
 	kubelet := Kubelet{
 		DockerClient: &fakeDocker,
+		DockerPuller: &FakeDockerPuller{},
 	}
 	err := kubelet.SyncManifests([]api.ContainerManifest{
 		{
@@ -510,6 +523,7 @@ func TestSyncManifestsDeletes(t *testing.T) {
 	}
 	kubelet := Kubelet{
 		DockerClient: &fakeDocker,
+		DockerPuller: &FakeDockerPuller{},
 	}
 	err := kubelet.SyncManifests([]api.ContainerManifest{})
 	expectNoError(t, err)
@@ -962,6 +976,7 @@ func TestGetContainerStats(t *testing.T) {
 
 	kubelet := Kubelet{
 		DockerClient:   &fakeDocker,
+		DockerPuller:   &FakeDockerPuller{},
 		CadvisorClient: mockCadvisor,
 	}
 	fakeDocker.containerList = []docker.APIContainers{
@@ -990,6 +1005,7 @@ func TestGetContainerStatsWithoutCadvisor(t *testing.T) {
 
 	kubelet := Kubelet{
 		DockerClient: &fakeDocker,
+		DockerPuller: &FakeDockerPuller{},
 	}
 	fakeDocker.containerList = []docker.APIContainers{
 		{
@@ -1027,6 +1043,7 @@ func TestGetContainerStatsWhenCadvisorFailed(t *testing.T) {
 
 	kubelet := Kubelet{
 		DockerClient:   &fakeDocker,
+		DockerPuller:   &FakeDockerPuller{},
 		CadvisorClient: mockCadvisor,
 	}
 	fakeDocker.containerList = []docker.APIContainers{
@@ -1059,6 +1076,7 @@ func TestGetContainerStatsOnNonExistContainer(t *testing.T) {
 
 	kubelet := Kubelet{
 		DockerClient:   &fakeDocker,
+		DockerPuller:   &FakeDockerPuller{},
 		CadvisorClient: mockCadvisor,
 	}
 	fakeDocker.containerList = []docker.APIContainers{}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -86,48 +86,6 @@ func TestExtractJSON(t *testing.T) {
 	verifyIntEquals(t, obj.Data.Number, 10)
 }
 
-type FakeDockerClient struct {
-	containerList []docker.APIContainers
-	container     *docker.Container
-	err           error
-	called        []string
-	stopped       []string
-}
-
-func (f *FakeDockerClient) clearCalls() {
-	f.called = []string{}
-}
-
-func (f *FakeDockerClient) appendCall(call string) {
-	f.called = append(f.called, call)
-}
-
-func (f *FakeDockerClient) ListContainers(options docker.ListContainersOptions) ([]docker.APIContainers, error) {
-	f.appendCall("list")
-	return f.containerList, f.err
-}
-
-func (f *FakeDockerClient) InspectContainer(id string) (*docker.Container, error) {
-	f.appendCall("inspect")
-	return f.container, f.err
-}
-
-func (f *FakeDockerClient) CreateContainer(docker.CreateContainerOptions) (*docker.Container, error) {
-	f.appendCall("create")
-	return nil, nil
-}
-
-func (f *FakeDockerClient) StartContainer(id string, hostConfig *docker.HostConfig) error {
-	f.appendCall("start")
-	return nil
-}
-
-func (f *FakeDockerClient) StopContainer(id string, timeout uint) error {
-	f.appendCall("stop")
-	f.stopped = append(f.stopped, id)
-	return nil
-}
-
 func verifyCalls(t *testing.T, fakeDocker FakeDockerClient, calls []string) {
 	verifyStringArrayEquals(t, fakeDocker.called, calls)
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -98,3 +98,12 @@ func (m *Master) Run(myAddress, apiPrefix string) error {
 	}
 	return s.ListenAndServe()
 }
+
+// Instead of calling Run, call ConstructHandler to get a handler for your own
+// server. Intended for testing. Only call once.
+func (m *Master) ConstructHandler(apiPrefix string) http.Handler {
+	endpoints := registry.MakeEndpointController(m.serviceRegistry, m.podRegistry)
+	go util.Forever(func() { endpoints.SyncServiceEndpoints() }, time.Second*10)
+
+	return apiserver.New(m.storage, apiPrefix)
+}


### PR DESCRIPTION
The manifest-from-url feature of kubelet will now accept either single or arrays of manifests.

I'm adding a bit to integration test that makes sure our container vm guestbook example causes a container to be created. I had to start caching it to make travis work.
