### PR TITLE
Minor: log cleanups

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -523,7 +523,7 @@ func (kl *Kubelet) getKubeletStateFromEtcd(key string, updateChannel chan<- mani
 		log.Printf("Error parsing response (%#v): %s", response, err)
 		return err
 	}
-	log.Printf("Got initial state from etcd: %+v", manifests)
+	log.Printf("Got state from etcd: %+v", manifests)
 	updateChannel <- manifestUpdate{etcdSource, manifests}
 	return nil
 }
@@ -592,11 +592,11 @@ func (kl *Kubelet) WatchEtcd(watchChannel <-chan *etcd.Response, updateChannel c
 	defer util.HandleCrash()
 	for {
 		watchResponse := <-watchChannel
-		log.Printf("Got change: %#v", watchResponse)
 		// This means the channel has been closed.
 		if watchResponse == nil {
 			return
 		}
+		log.Printf("Got etcd change: %#v", watchResponse)
 		manifests, err := kl.extractFromEtcd(watchResponse)
 		if err != nil {
 			log.Printf("Error handling response from etcd: %#v", err)
@@ -643,7 +643,7 @@ func (kl *Kubelet) createNetworkContainer(manifest *api.ContainerManifest) (stri
 
 // Sync the configured list of containers (desired state) with the host current state
 func (kl *Kubelet) SyncManifests(config []api.ContainerManifest) error {
-	log.Printf("Desired:%#v", config)
+	log.Printf("Desired: %#v", config)
 	var err error
 	desired := map[string]bool{}
 	for _, manifest := range config {
@@ -653,7 +653,7 @@ func (kl *Kubelet) SyncManifests(config []api.ContainerManifest) error {
 			continue
 		}
 		if !exists {
-			log.Printf("Network container doesn't exit, creating")
+			log.Printf("Network container doesn't exist, creating")
 			netName, err = kl.createNetworkContainer(&manifest)
 			if err != nil {
 				log.Printf("Failed to create network container: %#v", err)
@@ -695,7 +695,7 @@ func (kl *Kubelet) SyncManifests(config []api.ContainerManifest) error {
 		}
 	}
 	existingContainers, _ := kl.ListContainers()
-	log.Printf("Existing:\n%#v Desired: %#v", existingContainers, desired)
+	log.Printf("Existing: %#v Desired: %#v", existingContainers, desired)
 	for _, container := range existingContainers {
 		// Skip containers that we didn't create to allow users to manually
 		// spin up their own containers if they want.


### PR DESCRIPTION
Clean up log messages to be more obvious.  Fix a typo (exit -> exist).
