### PR TITLE
Escape manifest IDs when hunting the network container.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -620,7 +620,7 @@ func (kl *Kubelet) networkContainerExists(manifest *api.ContainerManifest) (stri
 		return "", false, err
 	}
 	for _, name := range pods {
-		if strings.Contains(name, containerNamePrefix+"--"+networkContainerName+"--"+manifest.Id+"--") {
+		if strings.Contains(name, containerNamePrefix+"--"+networkContainerName+"--"+escapeDash(manifest.Id)+"--") {
 			return name, true, nil
 		}
 	}


### PR DESCRIPTION
This makes it possible to have manifests with _ in the ID.  I'm not sure we
want to allow this, but we do for now.  I hope to follow this up with a deeper
change to make this a bit more robust.
