### PR TITLE
Ignore files that start with '.' when processing a config dir.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -407,7 +407,7 @@ func (kl *Kubelet) extractFromFile(name string) (api.ContainerManifest, error) {
 func (kl *Kubelet) extractFromDir(name string) ([]api.ContainerManifest, error) {
 	var manifests []api.ContainerManifest
 
-	files, err := filepath.Glob(filepath.Join(name, "*"))
+	files, err := filepath.Glob(filepath.Join(name, "[^.]*"))
 	if err != nil {
 		return manifests, err
 	}


### PR DESCRIPTION
Super minor, but I was getting annoyed when editing the files w/ vim:) This also seems to align with other configdir practices.
