### PR TITLE
Slightly friendlier pre-commit errors.

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [[ "$(grep -c "# then delete this line" $1)" == "1" ]]; then
-  echo "Unresolved gofmt errors. Aborting commit."
+if [[ "$(grep -c "COMMIT_BLOCKED" $1)" -gt 0 ]]; then
+  echo "FAILED: Unresolved errors - aborting the commit."
   echo "The message of your attempted commit was:"
   cat $1
   exit 1

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -2,23 +2,46 @@
 
 KUBE_HOOKS_DIR="$(dirname "$(test -L "$0" && echo "$(dirname $0)/$(readlink "$0")" || echo "$0")")"
 
-errors=0
+files_need_gofmt=""
+files_need_boilerplate=""
 for file in $(git diff --cached --name-only --diff-filter ACM | grep "\.go" | grep -v "third_party"); do
+  # Check for files that fail gofmt.
   diff="$(git show ":${file}" | gofmt -s -d)"
   if [[ -n "$diff" ]]; then
-    echo "# *** ERROR: *** File ${file} has not been gofmt'd." >> $1
-    errors=1
+    files_need_gofmt="${files_need_gofmt} ${file}"
   fi
+
+  # Check for files without the required boilerplate.
   boilerplate="$(${KUBE_HOOKS_DIR}/boilerplate.sh ${file})"
   if [[ "$boilerplate" -eq "0" ]]; then
-    echo "# *** ERROR: *** File ${file} needs the boilerplate header in hooks/boilerplate.txt." >> $1
-    errors=1
+    files_need_boilerplate="${files_need_boilerplate} ${file}"
   fi
 done
 
-if [[ $errors == "1" ]]; then
-  echo "# To fix these errors, run gofmt -s -w <file>." >> $1
-  echo "# If you want to commit in spite of these format errors," >> $1
-  echo "# then delete this line. Otherwise, your commit will be" >> $1
-  echo "# aborted." >> $1
+if [[ -n "${files_need_gofmt}" ]]; then
+  (
+    echo
+    echo "# *** ERROR: *** Some files have not been gofmt'd.  To fix these"
+    echo "# errors, run gofmt -s -w <file>, or cut and paste the following:"
+    echo "#   gofmt -s -w ${files_need_gofmt}"
+    echo "#"
+    echo "# Your commit will be aborted unless you override this warning. To"
+    echo "# commit in spite of these format errors, delete the following line:"
+    echo "#   COMMIT_BLOCKED_ON_GOFMT"
+  ) >> $1
+fi
+
+if [[ -n "${files_need_boilerplate}" ]]; then
+  (
+    echo
+    echo "# *** ERROR: *** Some files are missing the required boilerplate"
+    echo "# header from hooks/boilerplate.txt:"
+    for file in ${files_need_boilerplate}; do
+      echo "#   ${file}"
+    done
+    echo "#"
+    echo "# Your commit will be aborted unless you fix these."
+    echo "#   COMMIT_BLOCKED_ON_BOILERPLATE"
+    echo
+  ) >> $1
 fi


### PR DESCRIPTION
Make the pre-commit check spit out cut-and-paste commands and be more
obvious about errors.  Tested by making an invalid change and observing the
message generated.
