### PR TITLE
Give api server operation tracking ability

### DIFF
--- a/pkg/api/helper.go
+++ b/pkg/api/helper.go
@@ -37,6 +37,8 @@ func init() {
 		MinionList{},
 		Minion{},
 		Status{},
+		ServerOpList{},
+		ServerOp{},
 	)
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -207,3 +207,14 @@ const (
 	StatusFailure = "failure"
 	StatusWorking = "working"
 )
+
+// Operation information, as delivered to API clients.
+type ServerOp struct {
+	JSONBase `yaml:",inline" json:",inline"`
+}
+
+// Operation list, as delivered to API clients.
+type ServerOpList struct {
+	JSONBase `yaml:",inline" json:",inline"`
+	Items    []ServerOp `yaml:"items,omitempty" json:"items,omitempty"`
+}

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -41,11 +41,25 @@ type RESTStorage interface {
 	Update(interface{}) (<-chan interface{}, error)
 }
 
-func MakeAsync(fn func() interface{}) <-chan interface{} {
-	channel := make(chan interface{}, 1)
+// MakeAsync takes a function and executes it, delivering the result in the way required
+// by RESTStorage's Update, Delete, and Create methods.
+func MakeAsync(fn func() (interface{}, error)) <-chan interface{} {
+	channel := make(chan interface{})
 	go func() {
 		defer util.HandleCrash()
-		channel <- fn()
+		obj, err := fn()
+		if err != nil {
+			channel <- &api.Status{
+				Status:  api.StatusFailure,
+				Details: err.Error(),
+			}
+		} else {
+			channel <- obj
+		}
+		// 'close' is used to signal that no further values will
+		// be written to the channel. Not strictly necessary, but
+		// also won't hurt.
+		close(channel)
 	}()
 	return channel
 }
@@ -59,6 +73,7 @@ func MakeAsync(fn func() interface{}) <-chan interface{} {
 type ApiServer struct {
 	prefix  string
 	storage map[string]RESTStorage
+	ops     *Operations
 }
 
 // New creates a new ApiServer object.
@@ -68,6 +83,7 @@ func New(storage map[string]RESTStorage, prefix string) *ApiServer {
 	return &ApiServer{
 		storage: storage,
 		prefix:  prefix,
+		ops:     NewOperations(),
 	}
 }
 
@@ -108,6 +124,10 @@ func (server *ApiServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		server.notFound(req, w)
 		return
 	}
+	if requestParts[0] == "operations" {
+		server.handleOperationRequest(requestParts[1:], w, req)
+		return
+	}
 	storage := server.storage[requestParts[0]]
 	if storage == nil {
 		logger.Addf("'%v' has no storage object", requestParts[0])
@@ -144,15 +164,30 @@ func (server *ApiServer) readBody(req *http.Request) ([]byte, error) {
 	return body, err
 }
 
-func (server *ApiServer) waitForObject(out <-chan interface{}, timeout time.Duration) (interface{}, error) {
-	tick := time.After(timeout)
-	var obj interface{}
-	select {
-	case obj = <-out:
-		return obj, nil
-	case <-tick:
-		return nil, fmt.Errorf("Timed out waiting for synchronization.")
+// finishReq finishes up a request, waiting until the operation finishes or, after a timeout, creating an
+// Operation to recieve the result and returning its ID down the writer.
+func (server *ApiServer) finishReq(out <-chan interface{}, sync bool, timeout time.Duration, w http.ResponseWriter) {
+	op := server.ops.NewOperation(out)
+	if sync {
+		op.WaitFor(timeout)
 	}
+	obj, complete := op.Describe()
+	if complete {
+		server.write(http.StatusOK, obj, w)
+	} else {
+		server.write(http.StatusAccepted, obj, w)
+	}
+}
+
+func parseTimeout(str string) time.Duration {
+	if str != "" {
+		timeout, err := time.ParseDuration(str)
+		if err == nil {
+			return timeout
+		}
+		glog.Errorf("Failed to parse: %#v '%s'", err, str)
+	}
+	return 30 * time.Second
 }
 
 // handleREST is the main dispatcher for the server.  It switches on the HTTP method, and then
@@ -170,11 +205,7 @@ func (server *ApiServer) waitForObject(out <-chan interface{}, timeout time.Dura
 //    labels=<label-selector> Used for filtering list operations
 func (server *ApiServer) handleREST(parts []string, requestUrl *url.URL, req *http.Request, w http.ResponseWriter, storage RESTStorage) {
 	sync := requestUrl.Query().Get("sync") == "true"
-	timeout, err := time.ParseDuration(requestUrl.Query().Get("timeout"))
-	if err != nil && len(requestUrl.Query().Get("timeout")) > 0 {
-		glog.Errorf("Failed to parse: %#v '%s'", err, requestUrl.Query().Get("timeout"))
-		timeout = time.Second * 30
-	}
+	timeout := parseTimeout(requestUrl.Query().Get("timeout"))
 	switch req.Method {
 	case "GET":
 		switch len(parts) {
@@ -184,12 +215,12 @@ func (server *ApiServer) handleREST(parts []string, requestUrl *url.URL, req *ht
 				server.error(err, w)
 				return
 			}
-			controllers, err := storage.List(selector)
+			list, err := storage.List(selector)
 			if err != nil {
 				server.error(err, w)
 				return
 			}
-			server.write(http.StatusOK, controllers, w)
+			server.write(http.StatusOK, list, w)
 		case 2:
 			item, err := storage.Get(parts[1])
 			if err != nil {
@@ -204,7 +235,6 @@ func (server *ApiServer) handleREST(parts []string, requestUrl *url.URL, req *ht
 		default:
 			server.notFound(req, w)
 		}
-		return
 	case "POST":
 		if len(parts) != 1 {
 			server.notFound(req, w)
@@ -221,44 +251,22 @@ func (server *ApiServer) handleREST(parts []string, requestUrl *url.URL, req *ht
 			return
 		}
 		out, err := storage.Create(obj)
-		if err == nil && sync {
-			obj, err = server.waitForObject(out, timeout)
-		}
 		if err != nil {
 			server.error(err, w)
 			return
 		}
-		var statusCode int
-		if sync {
-			statusCode = http.StatusOK
-		} else {
-			statusCode = http.StatusAccepted
-		}
-		server.write(statusCode, obj, w)
-		return
+		server.finishReq(out, sync, timeout, w)
 	case "DELETE":
 		if len(parts) != 2 {
 			server.notFound(req, w)
 			return
 		}
 		out, err := storage.Delete(parts[1])
-		var obj interface{}
-		obj = api.Status{Status: api.StatusSuccess}
-		if err == nil && sync {
-			obj, err = server.waitForObject(out, timeout)
-		}
 		if err != nil {
 			server.error(err, w)
 			return
 		}
-		var statusCode int
-		if sync {
-			statusCode = http.StatusOK
-		} else {
-			statusCode = http.StatusAccepted
-		}
-		server.write(statusCode, obj, w)
-		return
+		server.finishReq(out, sync, timeout, w)
 	case "PUT":
 		if len(parts) != 2 {
 			server.notFound(req, w)
@@ -274,22 +282,36 @@ func (server *ApiServer) handleREST(parts []string, requestUrl *url.URL, req *ht
 			return
 		}
 		out, err := storage.Update(obj)
-		if err == nil && sync {
-			obj, err = server.waitForObject(out, timeout)
-		}
 		if err != nil {
 			server.error(err, w)
 			return
 		}
-		var statusCode int
-		if sync {
-			statusCode = http.StatusOK
-		} else {
-			statusCode = http.StatusAccepted
-		}
-		server.write(statusCode, obj, w)
-		return
+		server.finishReq(out, sync, timeout, w)
 	default:
 		server.notFound(req, w)
+	}
+}
+
+func (server *ApiServer) handleOperationRequest(parts []string, w http.ResponseWriter, req *http.Request) {
+	if req.Method != "GET" {
+		server.notFound(req, w)
+	}
+	if len(parts) == 0 {
+		// List outstanding operations.
+		list := server.ops.List()
+		server.write(http.StatusOK, list, w)
+		return
+	}
+
+	op := server.ops.Get(parts[0])
+	if op == nil {
+		server.notFound(req, w)
+	}
+
+	obj, complete := op.Describe()
+	if complete {
+		server.write(http.StatusOK, obj, w)
+	} else {
+		server.write(http.StatusAccepted, obj, w)
 	}
 }

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -338,7 +338,7 @@ func TestParseTimeout(t *testing.T) {
 func TestSyncCreate(t *testing.T) {
 	storage := SimpleRESTStorage{
 		injectedFunction: func(obj interface{}) (interface{}, error) {
-			time.Sleep(2 * time.Second)
+			time.Sleep(200 * time.Millisecond)
 			return obj, nil
 		},
 	}
@@ -375,7 +375,7 @@ func TestSyncCreate(t *testing.T) {
 func TestSyncCreateTimeout(t *testing.T) {
 	storage := SimpleRESTStorage{
 		injectedFunction: func(obj interface{}) (interface{}, error) {
-			time.Sleep(10 * time.Second)
+			time.Sleep(400 * time.Millisecond)
 			return obj, nil
 		},
 	}
@@ -387,7 +387,7 @@ func TestSyncCreateTimeout(t *testing.T) {
 
 	simple := Simple{Name: "foo"}
 	data, _ := api.Encode(simple)
-	request, err := http.NewRequest("POST", server.URL+"/prefix/version/foo?sync=true&timeout=2s", bytes.NewBuffer(data))
+	request, err := http.NewRequest("POST", server.URL+"/prefix/version/foo?sync=true&timeout=200ms", bytes.NewBuffer(data))
 	expectNoError(t, err)
 	wg := sync.WaitGroup{}
 	wg.Add(1)

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -60,7 +60,8 @@ type SimpleRESTStorage struct {
 	updated Simple
 	created Simple
 
-	// called when answering update, delete, create
+	// If non-nil, called inside the WorkFunc when answering update, delete, create.
+	// obj recieves the original input to the update, delete, or create call.
 	injectedFunction func(obj interface{}) (returnObj interface{}, err error)
 }
 

--- a/pkg/apiserver/operation.go
+++ b/pkg/apiserver/operation.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+func init() {
+	api.AddKnownTypes(ServerOp{}, ServerOpList{})
+}
+
+// Operation information, as delivered to API clients.
+type ServerOp struct {
+	api.JSONBase `yaml:",inline" json:",inline"`
+}
+
+// Operation list, as delivered to API clients.
+type ServerOpList struct {
+	api.JSONBase `yaml:",inline" json:",inline"`
+	Items        []ServerOp `yaml:"items,omitempty" json:"items,omitempty"`
+}
+
+// Operation represents an ongoing action which the server is performing.
+type Operation struct {
+	ID       string
+	result   interface{}
+	awaiting <-chan interface{}
+	finished *time.Time
+	lock     sync.Mutex
+	notify   chan bool
+}
+
+// Operations tracks all the ongoing operations.
+type Operations struct {
+	lock   sync.Mutex
+	ops    map[string]*Operation
+	nextID int
+}
+
+// Returns a new Operations repository.
+func NewOperations() *Operations {
+	ops := &Operations{
+		ops: map[string]*Operation{},
+	}
+	go util.Forever(func() { ops.expire(10 * time.Minute) }, 5*time.Minute)
+	return ops
+}
+
+// Add a new operation.
+func (ops *Operations) NewOperation(from <-chan interface{}) *Operation {
+	ops.lock.Lock()
+	defer ops.lock.Unlock()
+	id := fmt.Sprintf("%v", ops.nextID)
+	ops.nextID++
+
+	op := &Operation{
+		ID:       id,
+		awaiting: from,
+		notify:   make(chan bool, 1),
+	}
+	go op.wait()
+	ops.ops[id] = op
+	return op
+}
+
+// List operations for an API client.
+func (ops *Operations) List() ServerOpList {
+	ops.lock.Lock()
+	defer ops.lock.Unlock()
+
+	ids := []string{}
+	for id := range ops.ops {
+		ids = append(ids, id)
+	}
+	sort.StringSlice(ids).Sort()
+	ol := ServerOpList{}
+	for _, id := range ids {
+		ol.Items = append(ol.Items, ServerOp{JSONBase: api.JSONBase{ID: id}})
+	}
+	return ol
+}
+
+// Returns the operation with the given ID, or nil
+func (ops *Operations) Get(id string) *Operation {
+	ops.lock.Lock()
+	defer ops.lock.Unlock()
+	return ops.ops[id]
+}
+
+// Garbage collect operations that have finished longer than maxAge ago.
+func (ops *Operations) expire(maxAge time.Duration) {
+	ops.lock.Lock()
+	defer ops.lock.Unlock()
+	keep := map[string]*Operation{}
+	limitTime := time.Now().Add(-maxAge)
+	for id, op := range ops.ops {
+		if !op.expired(limitTime) {
+			keep[id] = op
+		}
+	}
+	ops.ops = keep
+}
+
+// Waits forever for the operation to complete; call via go when
+// the operation is created. Sets op.finished when the operation
+// does complete. Does not keep op locked while waiting.
+func (op *Operation) wait() {
+	defer util.HandleCrash()
+	result := <-op.awaiting
+
+	op.lock.Lock()
+	defer op.lock.Unlock()
+	op.result = result
+	finished := time.Now()
+	op.finished = &finished
+	op.notify <- true
+}
+
+// Wait for the specified duration, or until the operation finishes,
+// whichever happens first.
+func (op *Operation) WaitFor(timeout time.Duration) {
+	select {
+	case <-time.After(timeout):
+	case <-op.notify:
+		// Re-send on this channel in case there are others
+		// waiting for notification.
+		op.notify <- true
+	}
+}
+
+// Returns true if this operation finished before limitTime.
+func (op *Operation) expired(limitTime time.Time) bool {
+	op.lock.Lock()
+	defer op.lock.Unlock()
+	if op.finished == nil {
+		return false
+	}
+	return op.finished.Before(limitTime)
+}
+
+// Return status information or the result of the operation if it is complete,
+// with a bool indicating true in the latter case.
+func (op *Operation) Describe() (description interface{}, finished bool) {
+	op.lock.Lock()
+	defer op.lock.Unlock()
+
+	if op.finished == nil {
+		return api.Status{
+			Status:  api.StatusWorking,
+			Details: op.ID,
+		}, false
+	}
+	return op.result, true
+}

--- a/pkg/apiserver/operation_test.go
+++ b/pkg/apiserver/operation_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"testing"
+	"time"
+)
+
+func TestOperation(t *testing.T) {
+	ops := NewOperations()
+
+	c := make(chan interface{})
+	op := ops.NewOperation(c)
+	go func() {
+		time.Sleep(5 * time.Second)
+		c <- "All done"
+	}()
+
+	if op.expired(time.Now().Add(-time.Minute)) {
+		t.Errorf("Expired before finished: %#v", op)
+	}
+	ops.expire(time.Minute)
+	if tmp := ops.Get(op.ID); tmp == nil {
+		t.Errorf("expire incorrectly removed the operation %#v", ops)
+	}
+
+	op.WaitFor(time.Second)
+	if _, completed := op.Describe(); completed {
+		t.Errorf("Unexpectedly fast completion")
+	}
+
+	op.WaitFor(5 * time.Second)
+	if _, completed := op.Describe(); !completed {
+		t.Errorf("Unexpectedly slow completion")
+	}
+
+	time.Sleep(900 * time.Millisecond)
+
+	if op.expired(time.Now().Add(-time.Second)) {
+		t.Errorf("Should not be expired: %#v", op)
+	}
+	if !op.expired(time.Now().Add(-800 * time.Millisecond)) {
+		t.Errorf("Should be expired: %#v", op)
+	}
+
+	ops.expire(800 * time.Millisecond)
+	if tmp := ops.Get(op.ID); tmp != nil {
+		t.Errorf("expire failed to remove the operation %#v", ops)
+	}
+
+	if op.result.(string) != "All done" {
+		t.Errorf("Got unexpected result: %#v", op.result)
+	}
+}

--- a/pkg/apiserver/operation_test.go
+++ b/pkg/apiserver/operation_test.go
@@ -27,7 +27,7 @@ func TestOperation(t *testing.T) {
 	c := make(chan interface{})
 	op := ops.NewOperation(c)
 	go func() {
-		time.Sleep(5 * time.Second)
+		time.Sleep(500 * time.Millisecond)
 		c <- "All done"
 	}()
 
@@ -39,26 +39,26 @@ func TestOperation(t *testing.T) {
 		t.Errorf("expire incorrectly removed the operation %#v", ops)
 	}
 
-	op.WaitFor(time.Second)
+	op.WaitFor(10 * time.Millisecond)
 	if _, completed := op.Describe(); completed {
 		t.Errorf("Unexpectedly fast completion")
 	}
 
-	op.WaitFor(5 * time.Second)
+	op.WaitFor(time.Second)
 	if _, completed := op.Describe(); !completed {
 		t.Errorf("Unexpectedly slow completion")
 	}
 
-	time.Sleep(900 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	if op.expired(time.Now().Add(-time.Second)) {
 		t.Errorf("Should not be expired: %#v", op)
 	}
-	if !op.expired(time.Now().Add(-800 * time.Millisecond)) {
+	if !op.expired(time.Now().Add(-80 * time.Millisecond)) {
 		t.Errorf("Should be expired: %#v", op)
 	}
 
-	ops.expire(800 * time.Millisecond)
+	ops.expire(80 * time.Millisecond)
 	if tmp := ops.Get(op.ID); tmp != nil {
 		t.Errorf("expire failed to remove the operation %#v", ops)
 	}

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -58,7 +58,7 @@ func TestDoRequestNewWay(t *testing.T) {
 		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
 	}
 	fakeHandler.ValidateRequest(t, "/api/v1beta1/foo/bar/baz", "POST", &reqBody)
-	if fakeHandler.RequestReceived.URL.RawQuery != "labels=name%3Dfoo&timeout=1s" {
+	if fakeHandler.RequestReceived.URL.RawQuery != "labels=name%3Dfoo&sync=true&timeout=1s" {
 		t.Errorf("Unexpected query: %v", fakeHandler.RequestReceived.URL.RawQuery)
 	}
 	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
@@ -83,6 +83,7 @@ func TestDoRequestNewWayReader(t *testing.T) {
 		Path("foo/bar").
 		Path("baz").
 		Selector(labels.Set{"name": "foo"}.AsSelector()).
+		Sync(false).
 		Timeout(time.Second).
 		Body(bytes.NewBuffer(reqBodyExpected)).
 		Do().Get()
@@ -97,7 +98,7 @@ func TestDoRequestNewWayReader(t *testing.T) {
 	}
 	tmpStr := string(reqBodyExpected)
 	fakeHandler.ValidateRequest(t, "/api/v1beta1/foo/bar/baz", "POST", &tmpStr)
-	if fakeHandler.RequestReceived.URL.RawQuery != "labels=name%3Dfoo&timeout=1s" {
+	if fakeHandler.RequestReceived.URL.RawQuery != "labels=name%3Dfoo" {
 		t.Errorf("Unexpected query: %v", fakeHandler.RequestReceived.URL.RawQuery)
 	}
 	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
@@ -136,7 +137,7 @@ func TestDoRequestNewWayObj(t *testing.T) {
 	}
 	tmpStr := string(reqBodyExpected)
 	fakeHandler.ValidateRequest(t, "/api/v1beta1/foo/bar/baz", "POST", &tmpStr)
-	if fakeHandler.RequestReceived.URL.RawQuery != "labels=name%3Dfoo&timeout=1s" {
+	if fakeHandler.RequestReceived.URL.RawQuery != "labels=name%3Dfoo&sync=true&timeout=1s" {
 		t.Errorf("Unexpected query: %v", fakeHandler.RequestReceived.URL.RawQuery)
 	}
 	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
@@ -181,7 +182,7 @@ func TestDoRequestNewWayFile(t *testing.T) {
 	}
 	tmpStr := string(reqBodyExpected)
 	fakeHandler.ValidateRequest(t, "/api/v1beta1/foo/bar/baz", "POST", &tmpStr)
-	if fakeHandler.RequestReceived.URL.RawQuery != "labels=name%3Dfoo&timeout=1s" {
+	if fakeHandler.RequestReceived.URL.RawQuery != "labels=name%3Dfoo&sync=true&timeout=1s" {
 		t.Errorf("Unexpected query: %v", fakeHandler.RequestReceived.URL.RawQuery)
 	}
 	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
@@ -211,5 +212,21 @@ func TestAbsPath(t *testing.T) {
 	r := c.Post().Path("/foo").AbsPath(expectedPath)
 	if r.path != expectedPath {
 		t.Errorf("unexpected path: %s, expected %s", r.path, expectedPath)
+	}
+}
+
+func TestSync(t *testing.T) {
+	c := New("", nil)
+	r := c.Get()
+	if !r.sync {
+		t.Errorf("sync has wrong default")
+	}
+	r.Sync(false)
+	if r.sync {
+		t.Errorf("'Sync' doesn't work")
+	}
+	r.Sync(true)
+	if !r.sync {
+		t.Errorf("'Sync' doesn't work")
 	}
 }

--- a/pkg/registry/minion_registry_test.go
+++ b/pkg/registry/minion_registry_test.go
@@ -73,20 +73,32 @@ func TestMinionRegistryStorage(t *testing.T) {
 		t.Errorf("has unexpected object")
 	}
 
-	if _, err := ms.Create(api.Minion{JSONBase: api.JSONBase{ID: "baz"}}); err != nil {
+	c, err := ms.Create(api.Minion{JSONBase: api.JSONBase{ID: "baz"}})
+	if err != nil {
 		t.Errorf("insert failed")
+	}
+	obj := <-c
+	if m, ok := obj.(api.Minion); !ok || m.ID != "baz" {
+		t.Errorf("insert return value was weird: %#v", obj)
 	}
 	if obj, err := ms.Get("baz"); err != nil || obj.(api.Minion).ID != "baz" {
 		t.Errorf("insert didn't actually insert")
 	}
 
-	if _, err := ms.Delete("bar"); err != nil {
+	c, err = ms.Delete("bar")
+	if err != nil {
 		t.Errorf("delete failed")
+	}
+	obj = <-c
+	if s, ok := obj.(api.Status); !ok || s.Status != api.StatusSuccess {
+		t.Errorf("delete return value was weird: %#v", obj)
 	}
 	if _, err := ms.Get("bar"); err != ErrDoesNotExist {
 		t.Errorf("delete didn't actually delete")
 	}
-	if _, err := ms.Delete("bar"); err != ErrDoesNotExist {
+
+	_, err = ms.Delete("bar")
+	if err != ErrDoesNotExist {
 		t.Errorf("delete returned wrong error")
 	}
 

--- a/pkg/registry/service_registry_test.go
+++ b/pkg/registry/service_registry_test.go
@@ -34,7 +34,8 @@ func TestServiceRegistry(t *testing.T) {
 	svc := api.Service{
 		JSONBase: api.JSONBase{ID: "foo"},
 	}
-	storage.Create(svc)
+	c, _ := storage.Create(svc)
+	<-c
 
 	if len(fakeCloud.Calls) != 0 {
 		t.Errorf("Unexpected call(s): %#v", fakeCloud.Calls)
@@ -57,7 +58,8 @@ func TestServiceRegistryExternalService(t *testing.T) {
 		JSONBase:                   api.JSONBase{ID: "foo"},
 		CreateExternalLoadBalancer: true,
 	}
-	storage.Create(svc)
+	c, _ := storage.Create(svc)
+	<-c
 
 	if len(fakeCloud.Calls) != 1 || fakeCloud.Calls[0] != "create" {
 		t.Errorf("Unexpected call(s): %#v", fakeCloud.Calls)
@@ -82,7 +84,8 @@ func TestServiceRegistryExternalServiceError(t *testing.T) {
 		JSONBase:                   api.JSONBase{ID: "foo"},
 		CreateExternalLoadBalancer: true,
 	}
-	storage.Create(svc)
+	c, _ := storage.Create(svc)
+	<-c
 
 	if len(fakeCloud.Calls) != 1 || fakeCloud.Calls[0] != "create" {
 		t.Errorf("Unexpected call(s): %#v", fakeCloud.Calls)
@@ -106,7 +109,8 @@ func TestServiceRegistryDelete(t *testing.T) {
 	}
 	memory.CreateService(svc)
 
-	storage.Delete(svc.ID)
+	c, _ := storage.Delete(svc.ID)
+	<-c
 
 	if len(fakeCloud.Calls) != 0 {
 		t.Errorf("Unexpected call(s): %#v", fakeCloud.Calls)
@@ -131,7 +135,8 @@ func TestServiceRegistryDeleteExternal(t *testing.T) {
 	}
 	memory.CreateService(svc)
 
-	storage.Delete(svc.ID)
+	c, _ := storage.Delete(svc.ID)
+	<-c
 
 	if len(fakeCloud.Calls) != 1 || fakeCloud.Calls[0] != "delete" {
 		t.Errorf("Unexpected call(s): %#v", fakeCloud.Calls)


### PR DESCRIPTION
Pending and recently completed operations now served at: /api/v1beta1/operations/id#

Handling of async operations is now consistent and sensible (ish). We check for admissibility before starting a long wait. I added some ID != "" checks here, but probably more things should be checked.
