### PR TITLE
Test rejection of bad JSON.

### DIFF
--- a/pkg/api/helper_test.go
+++ b/pkg/api/helper_test.go
@@ -113,4 +113,17 @@ func TestPtr(t *testing.T) {
 	}
 }
 
-// TODO: test rejection of bad JSON.
+func TestBadJSONRejection(t *testing.T) {
+	badJSONMissingKind := []byte(`{ }`)
+	if _, err := Decode(badJSONMissingKind); err == nil {
+		t.Errorf("Did not reject despite lack of kind field: %s", badJSONMissingKind)
+	}
+	badJSONUnknownType := []byte(`{"kind": "bar"}`)
+	if _, err1 := Decode(badJSONUnknownType); err1 == nil {
+		t.Errorf("Did not reject despite use of unknown type: %s", badJSONUnknownType)
+	}
+	badJSONKindMismatch := []byte(`{"kind": "Pod"}`)
+	if err2 := DecodeInto(badJSONKindMismatch, &Minion{}); err2 == nil {
+		t.Errorf("Kind is set but doesn't match the object type: %s", badJSONKindMismatch)
+	}
+}


### PR DESCRIPTION
(1) Added a few test cases to see if checks in [`Decode()` and `DecodeInto()`](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/api/helper.go) were working as indicated.

(2) Did not include the case of invalid JSON syntax, such as the use of a number as a key. I was not sure if such a case is outside the scope of these tests.

(3) I kept with the terminology of "known type" in reference to the terminology used for the `map` in `helper.go`.
