### PR TITLE
Watch and Get on the same Etcd key.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -539,7 +540,7 @@ func (kl *Kubelet) ResponseToManifests(response *etcd.Response) ([]api.Container
 }
 
 func (kl *Kubelet) getKubeletStateFromEtcd(key string, updateChannel chan<- manifestUpdate) error {
-	response, err := kl.EtcdClient.Get(key+"/kubelet", true, false)
+	response, err := kl.EtcdClient.Get(key, true, false)
 	if err != nil {
 		if util.IsEtcdNotFound(err) {
 			return nil
@@ -561,7 +562,8 @@ func (kl *Kubelet) getKubeletStateFromEtcd(key string, updateChannel chan<- mani
 // The channel to send new configurations across
 // This function loops forever and is intended to be run in a go routine.
 func (kl *Kubelet) SyncAndSetupEtcdWatch(updateChannel chan<- manifestUpdate) {
-	key := "/registry/hosts/" + strings.TrimSpace(kl.Hostname)
+	key := path.Join("registry", "hosts", strings.TrimSpace(kl.Hostname), "kubelet")
+
 	// First fetch the initial configuration (watch only gives changes...)
 	for {
 		err := kl.getKubeletStateFromEtcd(key, updateChannel)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -378,7 +378,7 @@ func TestGetKubeletStateFromEtcdNoData(t *testing.T) {
 		R: &etcd.Response{},
 		E: nil,
 	}
-	err := kubelet.getKubeletStateFromEtcd("/registry/hosts/machine", channel)
+	err := kubelet.getKubeletStateFromEtcd("/registry/hosts/machine/kubelet", channel)
 	if err == nil {
 		t.Error("Unexpected no err.")
 	}
@@ -404,7 +404,7 @@ func TestGetKubeletStateFromEtcd(t *testing.T) {
 		},
 		E: nil,
 	}
-	err := kubelet.getKubeletStateFromEtcd("/registry/hosts/machine", channel)
+	err := kubelet.getKubeletStateFromEtcd("/registry/hosts/machine/kubelet", channel)
 	expectNoError(t, err)
 	close(channel)
 	list := reader.GetList()
@@ -426,7 +426,7 @@ func TestGetKubeletStateFromEtcdNotFound(t *testing.T) {
 			ErrorCode: 100,
 		},
 	}
-	err := kubelet.getKubeletStateFromEtcd("/registry/hosts/machine", channel)
+	err := kubelet.getKubeletStateFromEtcd("/registry/hosts/machine/kubelet", channel)
 	expectNoError(t, err)
 	close(channel)
 	list := reader.GetList()
@@ -448,7 +448,7 @@ func TestGetKubeletStateFromEtcdError(t *testing.T) {
 			ErrorCode: 200, // non not found error
 		},
 	}
-	err := kubelet.getKubeletStateFromEtcd("/registry/hosts/machine", channel)
+	err := kubelet.getKubeletStateFromEtcd("/registry/hosts/machine/kubelet", channel)
 	if err == nil {
 		t.Error("Unexpected non-error")
 	}


### PR DESCRIPTION
Kubelet was killing existing pods when creating a new one because new
files were being set as /registry/hosts/<machine>/pods/<id> and
/registry/hosts/<machine>/kubelet.

I'm not entirely sure why we're setting in both places. It seems like /pods/ is for master only use whereas /kubelet is the 'outbound' config for the kubelet to read.
