### PR TITLE
Reduce logging noise

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -61,7 +61,7 @@ func main() {
 
 	controllerManager.Run(1 * time.Second)
 
-	// Kublet
+	// Kubelet
 	fakeDocker1 := &kubelet.FakeDockerClient{}
 	myKubelet := kubelet.Kubelet{
 		Hostname:           machineList[0],
@@ -73,7 +73,7 @@ func main() {
 	}
 	go myKubelet.RunKubelet("", manifestUrl, servers[0], "localhost", "", 0)
 
-	// Create a second kublet so that the guestbook example's two redis slaves both
+	// Create a second kubelet so that the guestbook example's two redis slaves both
 	// have a place they can schedule.
 	fakeDocker2 := &kubelet.FakeDockerClient{}
 	otherKubelet := kubelet.Kubelet{

--- a/pkg/kubelet/doc.go
+++ b/pkg/kubelet/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package kubelet is the package that contains the libraries that drive the Kublet binary.
-// The kublet is responsible for node level pod management.  It runs on each worker in the cluster.
+// Package kubelet is the package that contains the libraries that drive the Kubelet binary.
+// The kubelet is responsible for node level pod management.  It runs on each worker in the cluster.
 package kubelet

--- a/pkg/kubelet/fake_docker_client.go
+++ b/pkg/kubelet/fake_docker_client.go
@@ -20,7 +20,7 @@ import (
 	"github.com/fsouza/go-dockerclient"
 )
 
-// A simple fake docker client, so that kublet can be run for testing without requiring a real docker setup.
+// A simple fake docker client, so that kubelet can be run for testing without requiring a real docker setup.
 type FakeDockerClient struct {
 	containerList []docker.APIContainers
 	container     *docker.Container

--- a/pkg/kubelet/kubelet_server.go
+++ b/pkg/kubelet/kubelet_server.go
@@ -41,7 +41,7 @@ type kubeletInterface interface {
 
 func (s *KubeletServer) error(w http.ResponseWriter, err error) {
 	w.WriteHeader(http.StatusInternalServerError)
-	fmt.Fprintf(w, "Internal Error: %#v", err)
+	fmt.Fprintf(w, "Internal Error: %v", err)
 }
 
 func (s *KubeletServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -87,7 +87,7 @@ func (s *KubeletServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		stats, err := s.Kubelet.GetContainerStats(container)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, "Internal Error: %#v", err)
+			fmt.Fprintf(w, "Internal Error: %v", err)
 			return
 		}
 		if stats == nil {
@@ -98,7 +98,7 @@ func (s *KubeletServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		data, err := json.Marshal(stats)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, "Internal Error: %#v", err)
+			fmt.Fprintf(w, "Internal Error: %v", err)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
@@ -116,7 +116,7 @@ func (s *KubeletServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		data, err := s.Kubelet.GetContainerInfo(container)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, "Internal Error: %#v", err)
+			fmt.Fprintf(w, "Internal Error: %v", err)
 			return
 		}
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Don't use %#v for errors.
Do use %+v when more detail than %v is needed.
Fix typos Kublet -> Kubelet.
