### PR TITLE
Solved data races in pkg/registry

### DIFF
--- a/pkg/registry/controller_registry_test.go
+++ b/pkg/registry/controller_registry_test.go
@@ -217,6 +217,7 @@ func TestCreateController(t *testing.T) {
 		t.Error("Unexpected read from async channel")
 	}
 
+	mockPodRegistry.Lock()
 	mockPodRegistry.pods = []api.Pod{
 		{
 			JSONBase: api.JSONBase{ID: "foo"},
@@ -225,8 +226,7 @@ func TestCreateController(t *testing.T) {
 			JSONBase: api.JSONBase{ID: "bar"},
 		},
 	}
-
-	time.Sleep(time.Millisecond * 30)
+	mockPodRegistry.Unlock()
 
 	select {
 	case <-time.After(time.Second * 1):

--- a/pkg/registry/mock_registry.go
+++ b/pkg/registry/mock_registry.go
@@ -17,6 +17,8 @@ limitations under the License.
 package registry
 
 import (
+	"sync"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 )
@@ -25,6 +27,7 @@ type MockPodRegistry struct {
 	err  error
 	pod  *api.Pod
 	pods []api.Pod
+	sync.RWMutex
 }
 
 func MakeMockPodRegistry(pods []api.Pod) *MockPodRegistry {
@@ -34,6 +37,8 @@ func MakeMockPodRegistry(pods []api.Pod) *MockPodRegistry {
 }
 
 func (registry *MockPodRegistry) ListPods(selector labels.Selector) ([]api.Pod, error) {
+	registry.RLock()
+	defer registry.RUnlock()
 	if registry.err != nil {
 		return registry.pods, registry.err
 	}
@@ -47,16 +52,24 @@ func (registry *MockPodRegistry) ListPods(selector labels.Selector) ([]api.Pod, 
 }
 
 func (registry *MockPodRegistry) GetPod(podId string) (*api.Pod, error) {
+	registry.RLock()
+	defer registry.RUnlock()
 	return registry.pod, registry.err
 }
 
 func (registry *MockPodRegistry) CreatePod(machine string, pod api.Pod) error {
+	registry.RLock()
+	defer registry.RUnlock()
 	return registry.err
 }
 
 func (registry *MockPodRegistry) UpdatePod(pod api.Pod) error {
+	registry.RLock()
+	defer registry.RUnlock()
 	return registry.err
 }
 func (registry *MockPodRegistry) DeletePod(podId string) error {
+	registry.RLock()
+	defer registry.RUnlock()
 	return registry.err
 }

--- a/pkg/registry/mock_registry.go
+++ b/pkg/registry/mock_registry.go
@@ -27,7 +27,7 @@ type MockPodRegistry struct {
 	err  error
 	pod  *api.Pod
 	pods []api.Pod
-	sync.RWMutex
+	sync.Mutex
 }
 
 func MakeMockPodRegistry(pods []api.Pod) *MockPodRegistry {
@@ -37,8 +37,8 @@ func MakeMockPodRegistry(pods []api.Pod) *MockPodRegistry {
 }
 
 func (registry *MockPodRegistry) ListPods(selector labels.Selector) ([]api.Pod, error) {
-	registry.RLock()
-	defer registry.RUnlock()
+	registry.Lock()
+	defer registry.Unlock()
 	if registry.err != nil {
 		return registry.pods, registry.err
 	}
@@ -52,24 +52,24 @@ func (registry *MockPodRegistry) ListPods(selector labels.Selector) ([]api.Pod, 
 }
 
 func (registry *MockPodRegistry) GetPod(podId string) (*api.Pod, error) {
-	registry.RLock()
-	defer registry.RUnlock()
+	registry.Lock()
+	defer registry.Unlock()
 	return registry.pod, registry.err
 }
 
 func (registry *MockPodRegistry) CreatePod(machine string, pod api.Pod) error {
-	registry.RLock()
-	defer registry.RUnlock()
+	registry.Lock()
+	defer registry.Unlock()
 	return registry.err
 }
 
 func (registry *MockPodRegistry) UpdatePod(pod api.Pod) error {
-	registry.RLock()
-	defer registry.RUnlock()
+	registry.Lock()
+	defer registry.Unlock()
 	return registry.err
 }
 func (registry *MockPodRegistry) DeletePod(podId string) error {
-	registry.RLock()
-	defer registry.RUnlock()
+	registry.Lock()
+	defer registry.Unlock()
 	return registry.err
 }


### PR DESCRIPTION
The old version has a data race detected by `go test -race`.
