### PR TITLE
Don't double-close the channel when etcd returns an error.

### DIFF
--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -105,11 +105,10 @@ func (rm *ReplicationManager) watchControllers() {
 	}()
 	go func() {
 		defer util.HandleCrash()
-		defer func() {
-			close(watchChannel)
-		}()
 		_, err := rm.etcdClient.Watch("/registry/controllers", 0, true, watchChannel, stop)
-		if err != etcd.ErrWatchStoppedByUser {
+		if err == etcd.ErrWatchStoppedByUser {
+			close(watchChannel)
+		} else {
 			glog.Errorf("etcd.Watch stopped unexpectedly: %v (%#v)", err, err)
 		}
 	}()

--- a/pkg/util/fake_etcd_client.go
+++ b/pkg/util/fake_etcd_client.go
@@ -135,6 +135,8 @@ func (f *FakeEtcdClient) Watch(prefix string, waitIndex uint64, recursive bool, 
 	case <-stop:
 		return nil, etcd.ErrWatchStoppedByUser
 	case err := <-injectedError:
+		// Emulate etcd's behavior.
+		close(receiver)
 		return nil, err
 	}
 	// Never get here.


### PR DESCRIPTION
Fail more nicely when etcd flakes in integration tests.
