### PR TITLE
Add a New() for Kubelet.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -74,6 +74,10 @@ type CadvisorInterface interface {
 	MachineInfo() (*info.MachineInfo, error)
 }
 
+func New() *Kubelet {
+	return &Kubelet{}
+}
+
 // The main kubelet implementation
 type Kubelet struct {
 	Hostname           string


### PR DESCRIPTION
This will make it easier to add new fields that need to be initialized. Also refactors tests to ease making fake Kubelets. This is a prefactoring for an upcoming addition to the Kubelet struct.
