### PR TITLE
api/doc: add manifest schema

### DIFF
--- a/api/doc/manifest-schema.json
+++ b/api/doc/manifest-schema.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "type": "object",
+  "description": "Manifest describing group of [Docker containers](http://docker.io); also used by [Google Cloud Platform's container-vm images](https://developers.google.com/compute/docs/containers).",
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "The version of the manifest.",
+      "enum": [
+        "v1beta1"
+      ]
+    },
+    "containers": {
+      "type": "array",
+      "description": "The list of containers to launch.",
+      "items": {
+        "type": "object",
+        "required": [
+          "image"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description" : "A symbolic name used to create and track the container. Must be an RFC1035 compatible value (a single segment of a DNS name). All containers must have unique names."
+          }, 
+          "image": {
+            "type": "string",
+            "description" : "The container image to run."
+          }, 
+          "command": {
+            "type": "array",
+            "description" : "The command line to run. If this is omitted, the container is assumed to have a command embedded in it.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "workingDir": {
+            "type": "string",
+            "description" : "The initial working directory for the command. Default is the container’s embedded working directory or else the Docker default."
+          }, 
+          "volumeMounts": {
+            "type": "array",
+            "description" : "Data volumes to expose into the container.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description" : "The name of the volume to mount. This must match the name of a volume defined in volumes[]."
+                }, 
+                "mountPath": {
+                  "type": "string",
+                  "description" : "The path at which to mount the volume inside the container. This must be an absolute path and no longer than 512 characters."
+                }, 
+                "readOnly": {
+                  "type": "boolean",
+                  "description" : "Whether this volume should be read-only. Default is false (read-write)."
+                }
+              }
+            }
+          },
+          "ports": {
+            "type": "array",
+            "description" : "Ports to expose from the container. All of these are exposed out through the public interface of the VM.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description" : "A symbolic name used to create and track the port. Must be an RFC1035 compatible value (a single segment of a DNS name)."
+                },
+                "containerPort": {
+                  "type": "integer",
+                  "description" : "The port on which the container is listening."
+                }, 
+                "hostPort": {
+                  "type": "integer",
+                  "description" : "The port on the host which maps to the containerPort. Default is auto-allocated."
+                }, 
+                "protocol": {
+                  "type": "string",
+                  "description" : "The protocol for this port. Valid options are TCP and UDP. Default is TCP."
+                }
+              }
+            }
+          },
+          "env": {
+            "type": "array",
+            "description" : "Environment variables to set before the container runs.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description" : "The name of the environment variable."
+                }, 
+                "value": {
+                  "type": "string",
+                  "description" : "The value of the environment variable."
+                }
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "volumes": {
+      "type": "array", 
+      "description" : "A list of volumes to share between containers.",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description" : "The name of the volume. Must be an RFC1035 compatible value (a single segment of a DNS name). All volumes must have unique names. These are referenced by `containers[].volumeMounts[].name`.",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])*"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    }
+  }
+}

--- a/api/doc/manifest-schema.json
+++ b/api/doc/manifest-schema.json
@@ -110,16 +110,16 @@
       "uniqueItems": true,
       "items": {
         "type": "object",
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "type": "string",
             "description" : "The name of the volume. Must be an RFC1035 compatible value (a single segment of a DNS name). All volumes must have unique names. These are referenced by `containers[].volumeMounts[].name`.",
             "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])*"
           }
-        },
-        "required": [
-          "name"
-        ]
+        }
       }
     }
   }


### PR DESCRIPTION
ported the manifest from https://github.com/GoogleCloudPlatform/container-agent

a few notes:
- it's using draft v4
- I reused the description from https://developers.google.com/compute/docs/containers/container_vms#container_manifest
- I tested it against the simple `pod.json` example

```
>>> import json
>>> pod = json.loads(open('pod.json').read())
>>> manifest = pod['desiredState']['manifest']
>>> import jsonschema
>>> schema = json.loads(open('../doc/manifest-schema.json').read())
>>> jsonschema.validate(manifest, schema)
>>> 
```
- I didn't link it yet in the documentation (I have yet to figure out how to reference a subresource schema from an external file)

/cc @bgrant0607 
