### PR TITLE
Removes the htpasswd prerequisite from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,6 @@ However, initial development was done on GCE and so our instructions and scripts
 
         git clone https://github.com/GoogleCloudPlatform/kubernetes.git
 
-6. Setting up a cluster requires the `htpasswd` tool in order to hash a randomly generated password for accessing the API server.  This is already installed on recent version of Mac OS X but on Linux you need to install it yourself.  On Debian/Ubuntu you can do this with:
-
-        sudo apt-get update
-        sudo apt-get install apache2-utils
-
 ### Setup
 
 The setup script builds Kubernetes, then creates Google Compute Engine instances, firewall rules, and routes:


### PR DESCRIPTION
Looks like htpasswd dependency was removed in this commit.
4eccd64e0ff5dd77e24f01a720a576fe24a953a3
