### PR TITLE
Allow hack/test-go.sh to support flags

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -39,10 +39,10 @@ find_test_dirs() {
 cd "${KUBE_TARGET}"
 
 if [ "$1" != "" ]; then
-  go test -race -cover -coverprofile="tmp.out" "$KUBE_GO_PACKAGE/$1"
+  go test -race -cover -coverprofile="tmp.out" "$KUBE_GO_PACKAGE/$1" "${@:2}"
   exit 0
 fi
 
 for package in $(find_test_dirs); do
-  go test -race -cover -coverprofile="tmp.out" "${KUBE_GO_PACKAGE}/${package}"
+  go test -race -cover -coverprofile="tmp.out" "${KUBE_GO_PACKAGE}/${package}" "${@:2}"
 done


### PR DESCRIPTION
Pass arguments after the package directly to go test

```
hack/test-go.sh pkg/util -v -test.run=TestNewStringSet
```

And also allow global flags

```
hack/test-go.sh "" -v
```
