### PR TITLE
Issue 341: generalize label selectors

### DIFF
--- a/pkg/labels/selector.go
+++ b/pkg/labels/selector.go
@@ -22,6 +22,17 @@ import (
 	"strings"
 )
 
+const (
+	SelectorSep = ","
+	NotEq       = "!="
+	SingleEq    = "="
+	DoubleEq    = "=="
+	WildCard    = "*"
+	SetPref     = "<<"
+	SetSuff     = ">>"
+	SetSep      = "$"
+)
+
 // Represents a selector.
 type Selector interface {
 	// Returns true if this selector matches the given set of labels.
@@ -45,7 +56,7 @@ func (t *hasTerm) Matches(ls Labels) bool {
 }
 
 func (t *hasTerm) String() string {
-	return fmt.Sprintf("%v=%v", t.label, t.value)
+	return t.label + SingleEq + t.value
 }
 
 type notHasTerm struct {
@@ -57,7 +68,64 @@ func (t *notHasTerm) Matches(ls Labels) bool {
 }
 
 func (t *notHasTerm) String() string {
-	return fmt.Sprintf("%v!=%v", t.label, t.value)
+	return t.label + NotEq + t.value
+}
+
+type labelExists struct {
+	label string
+}
+
+// There is an ambiguity here. It is possible
+// to have an empty string as a label's value.
+// Label's Get method only returns a single string
+// value and no boolean. Therefore, the case of
+// a key not existing is generalized to it having
+// an empty string value in addition to it not
+// being present at all.
+func (t *labelExists) Matches(ls Labels) bool {
+	return ls.Get(t.label) != ""
+}
+
+func (t *labelExists) String() string {
+	return t.label + SingleEq + WildCard
+}
+
+type labelIsIn struct {
+	label  string
+	values map[string]bool
+}
+
+func (t *labelIsIn) Matches(ls Labels) bool {
+	return t.values[ls.Get(t.label)]
+}
+
+func (t *labelIsIn) String() string {
+	v := make([]string, 0, len(t.values))
+	for val := range t.values {
+		v = append(v, val)
+	}
+	// Sort for determinism.
+	sort.Strings(v)
+	return t.label + SingleEq + SetPref + strings.Join(v, SetSep) + SetSuff
+}
+
+type labelIsNotIn struct {
+	label  string
+	values map[string]bool
+}
+
+func (t *labelIsNotIn) Matches(ls Labels) bool {
+	return !t.values[ls.Get(t.label)]
+}
+
+func (t *labelIsNotIn) String() string {
+	v := make([]string, 0, len(t.values))
+	for val := range t.values {
+		v = append(v, val)
+	}
+	// Sort for determinism.
+	sort.Strings(v)
+	return t.label + NotEq + SetPref + strings.Join(v, SetSep) + SetSuff
 }
 
 type andTerm []Selector
@@ -76,7 +144,7 @@ func (t andTerm) String() string {
 	for _, q := range t {
 		terms = append(terms, q.String())
 	}
-	return strings.Join(terms, ",")
+	return strings.Join(terms, SelectorSep)
 }
 
 func try(selectorPiece, op string) (lhs, rhs string, ok bool) {
@@ -85,6 +153,47 @@ func try(selectorPiece, op string) (lhs, rhs string, ok bool) {
 		return pieces[0], pieces[1], true
 	}
 	return "", "", false
+}
+
+// Parses string of values into set
+func parseValueSet(valuesSetEncoded, op string) map[string]bool {
+	valueSet := make(map[string]bool)
+	values := strings.Split(valuesSetEncoded, op)
+	for _, value := range values {
+		valueSet[value] = true
+	}
+	return valueSet
+}
+
+// Determines if string of values has
+// empty string as one of its values
+func hasSetEncodedEmptyValues(setEncoded string) bool {
+	return setEncoded == SetPref+SetSuff ||
+		strings.Contains(setEncoded, SetSep+SetSep) ||
+		strings.HasPrefix(setEncoded, SetPref+SetSep) ||
+		strings.HasSuffix(setEncoded, SetSep+SetSuff)
+}
+
+func parseLabelValue(lhs, rhs string, isEqual bool) (Selector, error) {
+	if rhs == WildCard {
+		return &labelExists{label: lhs}, nil
+	} else if strings.HasPrefix(rhs, SetPref) && strings.HasSuffix(rhs, SetSuff) {
+		if hasSetEncodedEmptyValues(rhs) {
+			return nil, fmt.Errorf("invalid value set: '%s'; can't have empty string as value", rhs)
+		}
+		valueSet := parseValueSet(rhs[len(SetPref):len(rhs)-len(SetSuff)], SetSep)
+		if isEqual {
+			return &labelIsIn{label: lhs, values: valueSet}, nil
+		} else {
+			return &labelIsNotIn{label: lhs, values: valueSet}, nil
+		}
+	} else {
+		if isEqual {
+			return &hasTerm{label: lhs, value: rhs}, nil
+		} else {
+			return &notHasTerm{label: lhs, value: rhs}, nil
+		}
+	}
 }
 
 // Given a Set, return a Selector which will match exactly that Set.
@@ -100,20 +209,40 @@ func SelectorFromSet(ls Set) Selector {
 }
 
 // Takes a string repsenting a selector and returns an object suitable for matching, or an error.
+// Allowed formats: (1) x!=foo
+//                  (2) x=foo
+//                  (3) x=*
+//                  (4) x=<<foo>> or x!=<<foo>>
+//                  (5) x=<<foo$bar>> or x!=<<foo$bar>> or any number of '$' separated values
 func ParseSelector(selector string) (Selector, error) {
-	parts := strings.Split(selector, ",")
+	parts := strings.Split(selector, SelectorSep)
 	sort.StringSlice(parts).Sort()
 	var items []Selector
 	for _, part := range parts {
 		if part == "" {
 			continue
 		}
-		if lhs, rhs, ok := try(part, "!="); ok {
-			items = append(items, &notHasTerm{label: lhs, value: rhs})
-		} else if lhs, rhs, ok := try(part, "=="); ok {
-			items = append(items, &hasTerm{label: lhs, value: rhs})
-		} else if lhs, rhs, ok := try(part, "="); ok {
-			items = append(items, &hasTerm{label: lhs, value: rhs})
+		if lhs, rhs, ok := try(part, NotEq); ok {
+			if rhs == WildCard {
+				return nil, fmt.Errorf("invalid selector: '%s'; can't check non-existence", selector)
+			}
+			sel, err := parseLabelValue(lhs, rhs, false)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, sel)
+		} else if lhs, rhs, ok := try(part, DoubleEq); ok {
+			sel, err := parseLabelValue(lhs, rhs, true)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, sel)
+		} else if lhs, rhs, ok := try(part, SingleEq); ok {
+			sel, err := parseLabelValue(lhs, rhs, true)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, sel)
 		} else {
 			return nil, fmt.Errorf("invalid selector: '%s'; can't understand '%s'", selector, part)
 		}


### PR DESCRIPTION
As discussed in issue https://github.com/GoogleCloudPlatform/kubernetes/issues/341, current allowable selectors (in string format) include:
(1) `"x=foo"` or `"x!=foo"` meaning label x equals/does not equal foo

This change adds:
(2) `"x=*"` meaning label x equals any value
(3a) `"x=<<foo>>"` or `"x!=<<foo>>"` meaning label x equals/does not equal foo
(3b) `"x=<<foo$bar>>"` or `"x!=<<foo$bar>>"` or any number of '$' separated values meaning label x is in/not in the set {foo, bar}
(Absent from this is "x!=*" since the case of a label not existing was not requested in the issue.)

The downside of this implementation is that there are now more special characters that users should avoid. The way the code is written however can limit this downside. Namely, string constants for these special characters are written in one place and can be easily changed. Intuitively, the more non-traditional the string constants are, the less likely it will be that a user will have difficulty including certain label values.

This fix requires the following additional rules:
1. If a user does not wish to indicate a set, the label's value should not start with `SetPref` and end in `SetSuff`
2. If a user does wish to indicate a set, the set's values should not include `SetSep`
