### PR TITLE
rename client.ClientInterface to client.Interface

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -29,8 +29,9 @@ import (
 	"github.com/golang/glog"
 )
 
-// ClientInterface holds the methods for clients of Kubenetes, an interface to allow mock testing
-type ClientInterface interface {
+// Interface holds the methods for clients of Kubenetes,
+// an interface to allow mock testing.
+type Interface interface {
 	ListPods(selector labels.Selector) (api.PodList, error)
 	GetPod(name string) (api.Pod, error)
 	DeletePod(name string) error

--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -36,7 +36,7 @@ import (
 // TODO: Remove the etcd dependency and re-factor in terms of a generic watch interface
 type ReplicationManager struct {
 	etcdClient tools.EtcdClient
-	kubeClient client.ClientInterface
+	kubeClient client.Interface
 	podControl PodControlInterface
 	syncTime   <-chan time.Time
 
@@ -55,7 +55,7 @@ type PodControlInterface interface {
 
 // RealPodControl is the default implementation of PodControllerInterface.
 type RealPodControl struct {
-	kubeClient client.ClientInterface
+	kubeClient client.Interface
 }
 
 func (r RealPodControl) createReplica(controllerSpec api.ReplicationController) {
@@ -81,7 +81,7 @@ func (r RealPodControl) deletePod(podID string) error {
 }
 
 // MakeReplicationManager craetes a new ReplicationManager.
-func MakeReplicationManager(etcdClient tools.EtcdClient, kubeClient client.ClientInterface) *ReplicationManager {
+func MakeReplicationManager(etcdClient tools.EtcdClient, kubeClient client.Interface) *ReplicationManager {
 	rm := &ReplicationManager{
 		kubeClient: kubeClient,
 		etcdClient: etcdClient,

--- a/pkg/kubecfg/kubecfg.go
+++ b/pkg/kubecfg/kubecfg.go
@@ -67,7 +67,7 @@ func LoadAuthInfo(path string) (*client.AuthInfo, error) {
 // 'name' points to a replication controller.
 // 'client' is used for updating pods.
 // 'updatePeriod' is the time between pod updates.
-func Update(name string, client client.ClientInterface, updatePeriod time.Duration) error {
+func Update(name string, client client.Interface, updatePeriod time.Duration) error {
 	controller, err := client.GetReplicationController(name)
 	if err != nil {
 		return err
@@ -91,7 +91,7 @@ func Update(name string, client client.ClientInterface, updatePeriod time.Durati
 }
 
 // StopController stops a controller named 'name' by setting replicas to zero
-func StopController(name string, client client.ClientInterface) error {
+func StopController(name string, client client.Interface) error {
 	controller, err := client.GetReplicationController(name)
 	if err != nil {
 		return err
@@ -110,7 +110,7 @@ func StopController(name string, client client.ClientInterface) error {
 }
 
 // ResizeController resizes a controller named 'name' by setting replicas to 'replicas'
-func ResizeController(name string, replicas int, client client.ClientInterface) error {
+func ResizeController(name string, replicas int, client client.Interface) error {
 	controller, err := client.GetReplicationController(name)
 	if err != nil {
 		return err
@@ -153,7 +153,7 @@ func makePorts(spec string) []api.Port {
 }
 
 // RunController creates a new replication controller named 'name' which creates 'replicas' pods running 'image'
-func RunController(image, name string, replicas int, client client.ClientInterface, portSpec string, servicePort int) error {
+func RunController(image, name string, replicas int, client client.Interface, portSpec string, servicePort int) error {
 	controller := api.ReplicationController{
 		JSONBase: api.JSONBase{
 			ID: name,
@@ -208,7 +208,7 @@ func RunController(image, name string, replicas int, client client.ClientInterfa
 	return nil
 }
 
-func createService(name string, port int, client client.ClientInterface) (api.Service, error) {
+func createService(name string, port int, client client.Interface) (api.Service, error) {
 	svc := api.Service{
 		JSONBase: api.JSONBase{ID: name},
 		Port:     port,
@@ -225,7 +225,7 @@ func createService(name string, port int, client client.ClientInterface) (api.Se
 
 // DeleteController deletes a replication controller named 'name', requires that the controller
 // already be stopped
-func DeleteController(name string, client client.ClientInterface) error {
+func DeleteController(name string, client client.Interface) error {
 	controller, err := client.GetReplicationController(name)
 	if err != nil {
 		return err


### PR DESCRIPTION
This is the first of a series of cleanup changes I would like to make. My goal is to gradually do small refactorings to make this an idiomatic Go project.
