### PR TITLE
Fixed SCRIPT_DIR computation when CDPATH is set.

### DIFF
--- a/release/build-release.sh
+++ b/release/build-release.sh
@@ -21,7 +21,7 @@ set -eu
 set -o pipefail
 IFS=$'\n\t'
 
-SCRIPT_DIR=$(cd $(dirname $0); pwd)
+SCRIPT_DIR=$(CDPATH="" cd $(dirname $0); pwd)
 
 INSTANCE_PREFIX=$1
 

--- a/release/release.sh
+++ b/release/release.sh
@@ -23,7 +23,7 @@
 # exit on any error
 set -e
 
-SCRIPT_DIR=$(cd $(dirname $0); pwd)
+SCRIPT_DIR=$(CDPATH="" cd $(dirname $0); pwd)
 
 source $SCRIPT_DIR/config.sh
 


### PR DESCRIPTION
When `CDPATH` is set, the `cd` command echoes the directory where it actually went. In this case, the `SCRIPT_DIR` variable will contain the path twice: `/path/to/release/dir /path/to/release/dir` instead of `/path/to/release/dir`.

This fix unset `CDPATH` when computing `SCRIPT_DIR`.
