### PR TITLE
-cover causes races in tests in Go 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
   - 1.3
+  - 1.2
   - tip
 
 install: 
@@ -9,6 +10,7 @@ install:
   - go get github.com/coreos/etcd
   - ./hack/verify-gofmt.sh
   - ./hack/verify-boilerplate.sh
+  - ./hack/install-std-race.sh
   - ./hack/build-go.sh
 
 script:

--- a/hack/install-std-race.sh
+++ b/hack/install-std-race.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script installs std -race on Travis (see https://code.google.com/p/go/issues/detail?id=6479)
+
+set -e
+
+if [ "${TRAVIS}" == "true" ]; then
+  GO_VERSION=($(go version))
+
+  if [ ${GO_VERSION[2]} \< "go1.3" ]; then
+    echo "Installing the -race compatible version of the std go library"
+    go install -a -race std
+  fi
+fi

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -35,14 +35,16 @@ find_test_dirs() {
   )
 }
 
+# -covermode=atomic becomes default with -race in Go >=1.3
+KUBE_COVER="-cover -covermode=atomic -coverprofile=\"tmp.out\""
 
 cd "${KUBE_TARGET}"
 
 if [ "$1" != "" ]; then
-  go test -race -cover -coverprofile="tmp.out" "$KUBE_GO_PACKAGE/$1" "${@:2}"
+  go test -race $KUBE_COVER "$KUBE_GO_PACKAGE/$1" "${@:2}"
   exit 0
 fi
 
 for package in $(find_test_dirs); do
-  go test -race -cover -coverprofile="tmp.out" "${KUBE_GO_PACKAGE}/${package}" "${@:2}"
+  go test -race $KUBE_COVER "${KUBE_GO_PACKAGE}/${package}" "${@:2}"
 done


### PR DESCRIPTION
Make -covermode=atomic the default until we drop 1.2 support
