### PR TITLE
pkg/proxy: remove unnecessary go routine

### DIFF
--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -83,7 +83,7 @@ func (proxier Proxier) AcceptHandler(service string, listener net.Listener) {
 			inConn.Close()
 			continue
 		}
-		go ProxyConnection(inConn.(*net.TCPConn), outConn.(*net.TCPConn))
+		ProxyConnection(inConn.(*net.TCPConn), outConn.(*net.TCPConn))
 	}
 }
 


### PR DESCRIPTION
ProxyConnection is non-blocking. It does not need to create a go routine to serve the connection.
