### PR TITLE
pkg/proxy: remove unnecessary io.EOF checking

### DIFF
--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -41,7 +41,7 @@ func CopyBytes(in, out *net.TCPConn) {
 	glog.Infof("Copying from %v <-> %v <-> %v <-> %v",
 		in.RemoteAddr(), in.LocalAddr(), out.LocalAddr(), out.RemoteAddr())
 	_, err := io.Copy(in, out)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		glog.Errorf("I/O error: %v", err)
 	}
 


### PR DESCRIPTION
reference: http://golang.org/pkg/io/#Copy
