### PR TITLE
pkg/proxy: filtering before comparing

### DIFF
--- a/pkg/proxy/roundrobbin.go
+++ b/pkg/proxy/roundrobbin.go
@@ -85,9 +85,10 @@ func (impl LoadBalancerRR) OnUpdate(endpoints []api.Endpoints) {
 	// First update / add all new endpoints for services.
 	for _, value := range endpoints {
 		existingEndpoints, exists := impl.endpointsMap[value.Name]
-		if !exists || !reflect.DeepEqual(value.Endpoints, existingEndpoints) {
+		validEndpoints := impl.FilterValidEndpoints(value.Endpoints)
+		if !exists || !reflect.DeepEqual(existingEndpoints, validEndpoints) {
 			glog.Infof("LoadBalancerRR: Setting endpoints for %s to %+v", value.Name, value.Endpoints)
-			impl.endpointsMap[value.Name] = impl.FilterValidEndpoints(value.Endpoints)
+			impl.endpointsMap[value.Name] = validEndpoints
 			// Start RR from the beginning if added or updated.
 			impl.rrIndex[value.Name] = 0
 		}


### PR DESCRIPTION
Proxy should not be updated if the only difference is an invalid endpoint. 
