### PR TITLE
Kubelet

### DIFF
--- a/pkg/kubelet/health_check.go
+++ b/pkg/kubelet/health_check.go
@@ -28,9 +28,9 @@ import (
 type HealthCheckStatus int
 
 const (
-	CheckHealthy   HealthCheckStatus = 0
-	CheckUnhealthy HealthCheckStatus = 1
-	CheckUnknown   HealthCheckStatus = 2
+	CheckHealthy HealthCheckStatus = iota
+	CheckUnhealthy
+	CheckUnknown
 )
 
 type HealthChecker interface {

--- a/pkg/kubelet/health_check.go
+++ b/pkg/kubelet/health_check.go
@@ -102,13 +102,11 @@ func (h *HTTPHealthChecker) HealthCheck(container api.Container) (HealthCheckSta
 	}
 	url := fmt.Sprintf("http://%s:%d%s", host, port, params.Path)
 	res, err := h.client.Get(url)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		// At this point, if it fails, its either a policy (unlikely) or HTTP protocol (likely) error.
 		return CheckUnhealthy, nil
 	}
+	defer res.Body.Close()
 	if res.StatusCode == http.StatusOK {
 		return CheckHealthy, nil
 	}

--- a/pkg/kubelet/health_check_test.go
+++ b/pkg/kubelet/health_check_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package kubelet
 
 import (
+	"bytes"
+	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -38,6 +40,7 @@ func TestHttpHealth(t *testing.T) {
 	fakeClient := fakeHTTPClient{
 		res: http.Response{
 			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewReader(make([]byte, 0))),
 		},
 	}
 


### PR DESCRIPTION
If http client return a nil err, resp always contains a non-nil resp.Body. 
reference: http://golang.org/pkg/net/http/#Client.Get

This pull request removes the unnecessary the checking and fixes the fakeHTTPClient. 

Do you think it is a better to just use the httpTest server?
http://golang.org/pkg/net/http/httptest/
