### PR TITLE
make build script works on os x if the current dir is not the kubernetes root

### DIFF
--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -38,7 +38,7 @@ if [ "${TRAVIS}" != "true" ]; then
 fi
 
 if [[ "$OSTYPE" == *darwin* ]]; then
-  KUBE_REPO_ROOT="${PWD}"
+  KUBE_REPO_ROOT="${PWD}/$(dirname ${BASH_SOURCE:-$0})/.."
 else
   KUBE_REPO_REL_ROOT="$(dirname ${BASH_SOURCE:-$0})/.."
   KUBE_REPO_ROOT="$(readlink -f ${KUBE_REPO_REL_ROOT})"


### PR DESCRIPTION
makes build-go.sh workable if the current dir is hack/ or any other directories
