### PR TITLE
refactor 

### DIFF
--- a/pkg/apiserver/operation.go
+++ b/pkg/apiserver/operation.go
@@ -34,7 +34,7 @@ type Operation struct {
 	awaiting <-chan interface{}
 	finished *time.Time
 	lock     sync.Mutex
-	notify   chan bool
+	notify   chan struct{}
 }
 
 // Operations tracks all the ongoing operations.
@@ -62,7 +62,7 @@ func (ops *Operations) NewOperation(from <-chan interface{}) *Operation {
 	op := &Operation{
 		ID:       strconv.FormatInt(id, 10),
 		awaiting: from,
-		notify:   make(chan bool, 1),
+		notify:   make(chan struct{}),
 	}
 	go op.wait()
 	go ops.insert(op)
@@ -128,7 +128,7 @@ func (op *Operation) wait() {
 	op.result = result
 	finished := time.Now()
 	op.finished = &finished
-	op.notify <- true
+	close(op.notify)
 }
 
 // WaitFor waits for the specified duration, or until the operation finishes,
@@ -137,9 +137,6 @@ func (op *Operation) WaitFor(timeout time.Duration) {
 	select {
 	case <-time.After(timeout):
 	case <-op.notify:
-		// Re-send on this channel in case there are others
-		// waiting for notification.
-		op.notify <- true
 	}
 }
 


### PR DESCRIPTION
Fixed the window time issue by watch on a given index.
Eliminate unnecessary timeout ticker.
Changed kubelet.getKubeletStateFromEtcd() to return an error
if the etcd is not found.
Replaced with close(channel) to signal notification in some places.
