### PR TITLE
Fix: cluster/kube-up.sh curl timeout a little bit short.

### DIFF
--- a/cluster/kube-up.sh
+++ b/cluster/kube-up.sh
@@ -127,7 +127,7 @@ echo "  This might loop forever if there was some uncaught error during start"
 echo "  up."
 echo
 
-until $(curl --insecure --user ${user}:${passwd} --max-time 1 \
+until $(curl --insecure --user ${user}:${passwd} --max-time 5 \
         --fail --output /dev/null --silent https://${KUBE_MASTER_IP}/api/v1beta1/pods); do
     printf "."
     sleep 2


### PR DESCRIPTION
In my environment, curl timeout a little bit short.
And kube-up.sh loop eternity because of curl timeout.

testing only curl is as follows.

```
$ curl --insecure --user user:password --max-time 1 https://xxx.xxx.xxx.xxx/api/v1beta1/pods
curl: (28) Operation timed out after 1292 milliseconds with 0 out of -1 bytes received
$  curl --insecure --user user:password --max-time 1 https://xxx.xxx.xxx.xxx/api/v1beta1/pods
curl: (28) Connection timed out after 1000 milliseconds
$  curl --insecure --user user:password --max-time 1 https://xxx.xxx.xxx.xxx/api/v1beta1/pods
curl: (28) Operation timed out after 1341 milliseconds with 0 out of -1 bytes received
```

Same settings and environments, the difference is timeout value is as follows.

```
$ curl --insecure --user user:password --max-time 5 https://xxx.xxx.xxx.xxx/api/v1beta1/pods
{
    "kind": "PodList",
    "items": []
}
$ curl --insecure --user user:password --max-time 5 https://xxx.xxx.xxx.xxx/api/v1beta1/pods
{
    "kind": "PodList",
    "items": []
}
$ curl --insecure --user user:password --max-time 5 https://xxx.xxx.xxx.xxx/api/v1beta1/pods
{
    "kind": "PodList",
    "items": []
}
```
