### PR TITLE
Define EtcdErrorCode as constant and reuse EtcdError instances

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -324,9 +324,7 @@ func TestGetKubeletStateFromEtcdNotFound(t *testing.T) {
 	reader := startReading(channel)
 	fakeClient.Data["/registry/hosts/machine/kubelet"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
-		E: &etcd.EtcdError{
-			ErrorCode: 100,
-		},
+		E: tools.EtcdErrorNotFound,
 	}
 	err := kubelet.getKubeletStateFromEtcd("/registry/hosts/machine/kubelet", channel)
 	expectNoError(t, err)

--- a/pkg/registry/etcd_registry_test.go
+++ b/pkg/registry/etcd_registry_test.go
@@ -53,9 +53,7 @@ func TestEtcdGetPodNotFound(t *testing.T) {
 		R: &etcd.Response{
 			Node: nil,
 		},
-		E: &etcd.EtcdError{
-			ErrorCode: 100,
-		},
+		E: tools.EtcdErrorNotFound,
 	}
 	registry := MakeTestEtcdRegistry(fakeClient, []string{"machine"})
 	_, err := registry.GetPod("foo")
@@ -70,7 +68,7 @@ func TestEtcdCreatePod(t *testing.T) {
 		R: &etcd.Response{
 			Node: nil,
 		},
-		E: &etcd.EtcdError{ErrorCode: 100},
+		E: tools.EtcdErrorNotFound,
 	}
 	fakeClient.Set("/registry/hosts/machine/kubelet", util.MakeJSONString([]api.ContainerManifest{}), 0)
 	registry := MakeTestEtcdRegistry(fakeClient, []string{"machine"})
@@ -133,13 +131,13 @@ func TestEtcdCreatePodWithContainersError(t *testing.T) {
 		R: &etcd.Response{
 			Node: nil,
 		},
-		E: &etcd.EtcdError{ErrorCode: 100},
+		E: tools.EtcdErrorNotFound,
 	}
 	fakeClient.Data["/registry/hosts/machine/kubelet"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
 		},
-		E: &etcd.EtcdError{ErrorCode: 200},
+		E: tools.EtcdErrorValueRequired,
 	}
 	registry := MakeTestEtcdRegistry(fakeClient, []string{"machine"})
 	err := registry.CreatePod("machine", api.Pod{
@@ -154,7 +152,7 @@ func TestEtcdCreatePodWithContainersError(t *testing.T) {
 	if err == nil {
 		t.Error("Unexpected non-error")
 	}
-	if err != nil && err.(*etcd.EtcdError).ErrorCode != 100 {
+	if !tools.IsEtcdNotFound(err) {
 		t.Errorf("Unexpected error: %#v", err)
 	}
 }
@@ -165,13 +163,13 @@ func TestEtcdCreatePodWithContainersNotFound(t *testing.T) {
 		R: &etcd.Response{
 			Node: nil,
 		},
-		E: &etcd.EtcdError{ErrorCode: 100},
+		E: tools.EtcdErrorNotFound,
 	}
 	fakeClient.Data["/registry/hosts/machine/kubelet"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
 		},
-		E: &etcd.EtcdError{ErrorCode: 100},
+		E: tools.EtcdErrorNotFound,
 	}
 	registry := MakeTestEtcdRegistry(fakeClient, []string{"machine"})
 	err := registry.CreatePod("machine", api.Pod{
@@ -213,7 +211,7 @@ func TestEtcdCreatePodWithExistingContainers(t *testing.T) {
 		R: &etcd.Response{
 			Node: nil,
 		},
-		E: &etcd.EtcdError{ErrorCode: 100},
+		E: tools.EtcdErrorNotFound,
 	}
 	fakeClient.Set("/registry/hosts/machine/kubelet", util.MakeJSONString([]api.ContainerManifest{
 		{
@@ -329,7 +327,7 @@ func TestEtcdListPodsNotFound(t *testing.T) {
 	key := "/registry/hosts/machine/pods"
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
-		E: &etcd.EtcdError{ErrorCode: 100},
+		E: tools.EtcdErrorNotFound,
 	}
 	registry := MakeTestEtcdRegistry(fakeClient, []string{"machine"})
 	pods, err := registry.ListPods(labels.Everything())
@@ -374,7 +372,7 @@ func TestEtcdListControllersNotFound(t *testing.T) {
 	key := "/registry/controllers"
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
-		E: &etcd.EtcdError{ErrorCode: 100},
+		E: tools.EtcdErrorNotFound,
 	}
 	registry := MakeTestEtcdRegistry(fakeClient, []string{"machine"})
 	controllers, err := registry.ListControllers()
@@ -389,7 +387,7 @@ func TestEtcdListServicesNotFound(t *testing.T) {
 	key := "/registry/services/specs"
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
-		E: &etcd.EtcdError{ErrorCode: 100},
+		E: tools.EtcdErrorNotFound,
 	}
 	registry := MakeTestEtcdRegistry(fakeClient, []string{"machine"})
 	services, err := registry.ListServices()
@@ -442,9 +440,7 @@ func TestEtcdGetControllerNotFound(t *testing.T) {
 		R: &etcd.Response{
 			Node: nil,
 		},
-		E: &etcd.EtcdError{
-			ErrorCode: 100,
-		},
+		E: tools.EtcdErrorNotFound,
 	}
 	registry := MakeTestEtcdRegistry(fakeClient, []string{"machine"})
 	ctrl, err := registry.GetController("foo")
@@ -538,7 +534,7 @@ func TestEtcdCreateService(t *testing.T) {
 		R: &etcd.Response{
 			Node: nil,
 		},
-		E: &etcd.EtcdError{ErrorCode: 100},
+		E: tools.EtcdErrorNotFound,
 	}
 	registry := MakeTestEtcdRegistry(fakeClient, []string{"machine"})
 	err := registry.CreateService(api.Service{
@@ -572,9 +568,7 @@ func TestEtcdGetServiceNotFound(t *testing.T) {
 		R: &etcd.Response{
 			Node: nil,
 		},
-		E: &etcd.EtcdError{
-			ErrorCode: 100,
-		},
+		E: tools.EtcdErrorNotFound,
 	}
 	registry := MakeTestEtcdRegistry(fakeClient, []string{"machine"})
 	_, err := registry.GetService("foo")

--- a/pkg/tools/etcd_tools.go
+++ b/pkg/tools/etcd_tools.go
@@ -25,6 +25,16 @@ import (
 	"github.com/coreos/go-etcd/etcd"
 )
 
+const (
+	EtcdErrorCodeNotFound      = 100
+	EtcdErrorCodeValueRequired = 200
+)
+
+var (
+	EtcdErrorNotFound      = &etcd.EtcdError{ErrorCode: EtcdErrorCodeNotFound}
+	EtcdErrorValueRequired = &etcd.EtcdError{ErrorCode: EtcdErrorCodeValueRequired}
+)
+
 // EtcdClient is an injectable interface for testing.
 type EtcdClient interface {
 	AddChild(key, data string, ttl uint64) (*etcd.Response, error)

--- a/pkg/tools/etcd_tools_test.go
+++ b/pkg/tools/etcd_tools_test.go
@@ -36,7 +36,7 @@ func TestIsNotFoundErr(t *testing.T) {
 			t.Errorf("Expected %#v to return %v, but it did not", err, isNotFound)
 		}
 	}
-	try(&etcd.EtcdError{ErrorCode: 100}, true)
+	try(EtcdErrorNotFound, true)
 	try(&etcd.EtcdError{ErrorCode: 101}, false)
 	try(nil, false)
 	try(fmt.Errorf("some other kind of error"), false)

--- a/pkg/tools/fake_etcd_client.go
+++ b/pkg/tools/fake_etcd_client.go
@@ -74,7 +74,7 @@ func (f *FakeEtcdClient) Get(key string, sort, recursive bool) (*etcd.Response, 
 	result := f.Data[key]
 	if result.R == nil {
 		f.t.Errorf("Unexpected get for %s", key)
-		return &etcd.Response{}, &etcd.EtcdError{ErrorCode: 100} // Key not found
+		return &etcd.Response{}, EtcdErrorNotFound
 	}
 	f.t.Logf("returning %v: %v %#v", key, result.R, result.E)
 	return result.R, result.E
@@ -105,7 +105,7 @@ func (f *FakeEtcdClient) Delete(key string, recursive bool) (*etcd.Response, err
 		R: &etcd.Response{
 			Node: nil,
 		},
-		E: &etcd.EtcdError{ErrorCode: 100},
+		E: EtcdErrorNotFound,
 	}
 
 	f.DeletedKeys = append(f.DeletedKeys, key)


### PR DESCRIPTION
I was puzzled by what 100 and 200 meant. This PR attempts to remove those magic numbers from code.
