### PR TITLE
Extract proxy/config common functions for reuse

### DIFF
--- a/pkg/proxy/config/config_test.go
+++ b/pkg/proxy/config/config_test.go
@@ -14,13 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package config
+package config_test
 
 import (
 	"reflect"
+	"sort"
+	"sync"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	. "github.com/GoogleCloudPlatform/kubernetes/pkg/proxy/config"
 )
 
 const TomcatPort int = 8080
@@ -33,40 +36,80 @@ const MysqlName = "mysql"
 
 var MysqlEndpoints = map[string]string{"c0": "1.1.1.1:13306", "c3": "2.2.2.2:13306"}
 
+type sortedServices []api.Service
+
+func (s sortedServices) Len() int {
+	return len(s)
+}
+func (s sortedServices) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s sortedServices) Less(i, j int) bool {
+	return s[i].JSONBase.ID < s[j].JSONBase.ID
+}
+
 type ServiceHandlerMock struct {
 	services []api.Service
+	updated  sync.WaitGroup
 }
 
-func NewServiceHandlerMock() ServiceHandlerMock {
-	return ServiceHandlerMock{services: make([]api.Service, 0)}
+func NewServiceHandlerMock() *ServiceHandlerMock {
+	return &ServiceHandlerMock{services: make([]api.Service, 0)}
 }
 
-func (impl ServiceHandlerMock) OnUpdate(services []api.Service) {
-	impl.services = services
+func (h *ServiceHandlerMock) OnUpdate(services []api.Service) {
+	sort.Sort(sortedServices(services))
+	h.services = services
+	h.updated.Done()
 }
 
-func (impl ServiceHandlerMock) ValidateServices(t *testing.T, expectedServices []api.Service) {
-	if reflect.DeepEqual(impl.services, expectedServices) {
-		t.Errorf("Services don't match %+v expected: %+v", impl.services, expectedServices)
+func (h *ServiceHandlerMock) ValidateServices(t *testing.T, expectedServices []api.Service) {
+	h.updated.Wait()
+	if !reflect.DeepEqual(h.services, expectedServices) {
+		t.Errorf("Expected %#v, Got %#v", expectedServices, h.services)
 	}
+}
+
+func (h *ServiceHandlerMock) Wait(waits int) {
+	h.updated.Add(waits)
+}
+
+type sortedEndpoints []api.Endpoints
+
+func (s sortedEndpoints) Len() int {
+	return len(s)
+}
+func (s sortedEndpoints) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s sortedEndpoints) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
 }
 
 type EndpointsHandlerMock struct {
 	endpoints []api.Endpoints
+	updated   sync.WaitGroup
 }
 
-func NewEndpointsHandlerMock() EndpointsHandlerMock {
-	return EndpointsHandlerMock{endpoints: make([]api.Endpoints, 0)}
+func NewEndpointsHandlerMock() *EndpointsHandlerMock {
+	return &EndpointsHandlerMock{endpoints: make([]api.Endpoints, 0)}
 }
 
-func (impl EndpointsHandlerMock) OnUpdate(endpoints []api.Endpoints) {
-	impl.endpoints = endpoints
+func (h *EndpointsHandlerMock) OnUpdate(endpoints []api.Endpoints) {
+	sort.Sort(sortedEndpoints(endpoints))
+	h.endpoints = endpoints
+	h.updated.Done()
 }
 
-func (impl EndpointsHandlerMock) ValidateEndpoints(t *testing.T, expectedEndpoints []api.Endpoints) {
-	if reflect.DeepEqual(impl.endpoints, expectedEndpoints) {
-		t.Errorf("Endpoints don't match %+v", impl.endpoints, expectedEndpoints)
+func (h *EndpointsHandlerMock) ValidateEndpoints(t *testing.T, expectedEndpoints []api.Endpoints) {
+	h.updated.Wait()
+	if !reflect.DeepEqual(h.endpoints, expectedEndpoints) {
+		t.Errorf("Expected %#v, Got %#v", expectedEndpoints, h.endpoints)
 	}
+}
+
+func (h *EndpointsHandlerMock) Wait(waits int) {
+	h.updated.Add(waits)
 }
 
 func CreateServiceUpdate(op Operation, services ...api.Service) ServiceUpdate {
@@ -87,35 +130,12 @@ func CreateEndpointsUpdate(op Operation, endpoints ...api.Endpoints) EndpointsUp
 	return ret
 }
 
-func TestServiceConfigurationChannels(t *testing.T) {
-	config := NewServiceConfig()
-	channelOne := config.GetServiceConfigurationChannel("one")
-	if channelOne != config.GetServiceConfigurationChannel("one") {
-		t.Error("Didn't get the same service configuration channel back with the same name")
-	}
-	channelTwo := config.GetServiceConfigurationChannel("two")
-	if channelOne == channelTwo {
-		t.Error("Got back the same service configuration channel for different names")
-	}
-}
-
-func TestEndpointConfigurationChannels(t *testing.T) {
-	config := NewServiceConfig()
-	channelOne := config.GetEndpointsConfigurationChannel("one")
-	if channelOne != config.GetEndpointsConfigurationChannel("one") {
-		t.Error("Didn't get the same endpoint configuration channel back with the same name")
-	}
-	channelTwo := config.GetEndpointsConfigurationChannel("two")
-	if channelOne == channelTwo {
-		t.Error("Got back the same endpoint configuration channel for different names")
-	}
-}
-
 func TestNewServiceAddedAndNotified(t *testing.T) {
 	config := NewServiceConfig()
-	channel := config.GetServiceConfigurationChannel("one")
+	channel := config.Channel("one")
 	handler := NewServiceHandlerMock()
-	config.RegisterServiceHandler(&handler)
+	handler.Wait(1)
+	config.RegisterHandler(handler)
 	serviceUpdate := CreateServiceUpdate(ADD, api.Service{JSONBase: api.JSONBase{ID: "foo"}, Port: 10})
 	channel <- serviceUpdate
 	handler.ValidateServices(t, serviceUpdate.Services)
@@ -124,24 +144,28 @@ func TestNewServiceAddedAndNotified(t *testing.T) {
 
 func TestServiceAddedRemovedSetAndNotified(t *testing.T) {
 	config := NewServiceConfig()
-	channel := config.GetServiceConfigurationChannel("one")
+	channel := config.Channel("one")
 	handler := NewServiceHandlerMock()
-	config.RegisterServiceHandler(&handler)
+	config.RegisterHandler(handler)
 	serviceUpdate := CreateServiceUpdate(ADD, api.Service{JSONBase: api.JSONBase{ID: "foo"}, Port: 10})
+	handler.Wait(1)
 	channel <- serviceUpdate
 	handler.ValidateServices(t, serviceUpdate.Services)
 
 	serviceUpdate2 := CreateServiceUpdate(ADD, api.Service{JSONBase: api.JSONBase{ID: "bar"}, Port: 20})
+	handler.Wait(1)
 	channel <- serviceUpdate2
-	services := []api.Service{serviceUpdate.Services[0], serviceUpdate2.Services[0]}
+	services := []api.Service{serviceUpdate2.Services[0], serviceUpdate.Services[0]}
 	handler.ValidateServices(t, services)
 
 	serviceUpdate3 := CreateServiceUpdate(REMOVE, api.Service{JSONBase: api.JSONBase{ID: "foo"}})
+	handler.Wait(1)
 	channel <- serviceUpdate3
 	services = []api.Service{serviceUpdate2.Services[0]}
 	handler.ValidateServices(t, services)
 
 	serviceUpdate4 := CreateServiceUpdate(SET, api.Service{JSONBase: api.JSONBase{ID: "foobar"}, Port: 99})
+	handler.Wait(1)
 	channel <- serviceUpdate4
 	services = []api.Service{serviceUpdate4.Services[0]}
 	handler.ValidateServices(t, services)
@@ -149,89 +173,102 @@ func TestServiceAddedRemovedSetAndNotified(t *testing.T) {
 
 func TestNewMultipleSourcesServicesAddedAndNotified(t *testing.T) {
 	config := NewServiceConfig()
-	channelOne := config.GetServiceConfigurationChannel("one")
-	channelTwo := config.GetServiceConfigurationChannel("two")
+	channelOne := config.Channel("one")
+	channelTwo := config.Channel("two")
 	if channelOne == channelTwo {
 		t.Error("Same channel handed back for one and two")
 	}
 	handler := NewServiceHandlerMock()
-	config.RegisterServiceHandler(handler)
+	config.RegisterHandler(handler)
 	serviceUpdate1 := CreateServiceUpdate(ADD, api.Service{JSONBase: api.JSONBase{ID: "foo"}, Port: 10})
 	serviceUpdate2 := CreateServiceUpdate(ADD, api.Service{JSONBase: api.JSONBase{ID: "bar"}, Port: 20})
+	handler.Wait(2)
 	channelOne <- serviceUpdate1
 	channelTwo <- serviceUpdate2
-	services := []api.Service{serviceUpdate1.Services[0], serviceUpdate2.Services[0]}
+	services := []api.Service{serviceUpdate2.Services[0], serviceUpdate1.Services[0]}
 	handler.ValidateServices(t, services)
 }
 
 func TestNewMultipleSourcesServicesMultipleHandlersAddedAndNotified(t *testing.T) {
 	config := NewServiceConfig()
-	channelOne := config.GetServiceConfigurationChannel("one")
-	channelTwo := config.GetServiceConfigurationChannel("two")
+	channelOne := config.Channel("one")
+	channelTwo := config.Channel("two")
 	handler := NewServiceHandlerMock()
 	handler2 := NewServiceHandlerMock()
-	config.RegisterServiceHandler(handler)
-	config.RegisterServiceHandler(handler2)
+	config.RegisterHandler(handler)
+	config.RegisterHandler(handler2)
 	serviceUpdate1 := CreateServiceUpdate(ADD, api.Service{JSONBase: api.JSONBase{ID: "foo"}, Port: 10})
 	serviceUpdate2 := CreateServiceUpdate(ADD, api.Service{JSONBase: api.JSONBase{ID: "bar"}, Port: 20})
+	handler.Wait(2)
+	handler2.Wait(2)
 	channelOne <- serviceUpdate1
 	channelTwo <- serviceUpdate2
-	services := []api.Service{serviceUpdate1.Services[0], serviceUpdate2.Services[0]}
+	services := []api.Service{serviceUpdate2.Services[0], serviceUpdate1.Services[0]}
 	handler.ValidateServices(t, services)
 	handler2.ValidateServices(t, services)
 }
 
 func TestNewMultipleSourcesEndpointsMultipleHandlersAddedAndNotified(t *testing.T) {
-	config := NewServiceConfig()
-	channelOne := config.GetEndpointsConfigurationChannel("one")
-	channelTwo := config.GetEndpointsConfigurationChannel("two")
+	config := NewEndpointsConfig()
+	channelOne := config.Channel("one")
+	channelTwo := config.Channel("two")
 	handler := NewEndpointsHandlerMock()
 	handler2 := NewEndpointsHandlerMock()
-	config.RegisterEndpointsHandler(handler)
-	config.RegisterEndpointsHandler(handler2)
+	config.RegisterHandler(handler)
+	config.RegisterHandler(handler2)
 	endpointsUpdate1 := CreateEndpointsUpdate(ADD, api.Endpoints{Name: "foo", Endpoints: []string{"endpoint1", "endpoint2"}})
 	endpointsUpdate2 := CreateEndpointsUpdate(ADD, api.Endpoints{Name: "bar", Endpoints: []string{"endpoint3", "endpoint4"}})
+	handler.Wait(2)
+	handler2.Wait(2)
 	channelOne <- endpointsUpdate1
 	channelTwo <- endpointsUpdate2
 
-	endpoints := []api.Endpoints{endpointsUpdate1.Endpoints[0], endpointsUpdate2.Endpoints[0]}
+	endpoints := []api.Endpoints{endpointsUpdate2.Endpoints[0], endpointsUpdate1.Endpoints[0]}
 	handler.ValidateEndpoints(t, endpoints)
 	handler2.ValidateEndpoints(t, endpoints)
 }
 
 func TestNewMultipleSourcesEndpointsMultipleHandlersAddRemoveSetAndNotified(t *testing.T) {
-	config := NewServiceConfig()
-	channelOne := config.GetEndpointsConfigurationChannel("one")
-	channelTwo := config.GetEndpointsConfigurationChannel("two")
+	config := NewEndpointsConfig()
+	channelOne := config.Channel("one")
+	channelTwo := config.Channel("two")
 	handler := NewEndpointsHandlerMock()
 	handler2 := NewEndpointsHandlerMock()
-	config.RegisterEndpointsHandler(handler)
-	config.RegisterEndpointsHandler(handler2)
+	config.RegisterHandler(handler)
+	config.RegisterHandler(handler2)
 	endpointsUpdate1 := CreateEndpointsUpdate(ADD, api.Endpoints{Name: "foo", Endpoints: []string{"endpoint1", "endpoint2"}})
 	endpointsUpdate2 := CreateEndpointsUpdate(ADD, api.Endpoints{Name: "bar", Endpoints: []string{"endpoint3", "endpoint4"}})
+	handler.Wait(2)
+	handler2.Wait(2)
 	channelOne <- endpointsUpdate1
 	channelTwo <- endpointsUpdate2
 
-	endpoints := []api.Endpoints{endpointsUpdate1.Endpoints[0], endpointsUpdate2.Endpoints[0]}
+	endpoints := []api.Endpoints{endpointsUpdate2.Endpoints[0], endpointsUpdate1.Endpoints[0]}
 	handler.ValidateEndpoints(t, endpoints)
 	handler2.ValidateEndpoints(t, endpoints)
 
 	// Add one more
 	endpointsUpdate3 := CreateEndpointsUpdate(ADD, api.Endpoints{Name: "foobar", Endpoints: []string{"endpoint5", "endpoint6"}})
+	handler.Wait(1)
+	handler2.Wait(1)
 	channelTwo <- endpointsUpdate3
-	endpoints = []api.Endpoints{endpointsUpdate1.Endpoints[0], endpointsUpdate2.Endpoints[0], endpointsUpdate3.Endpoints[0]}
+	endpoints = []api.Endpoints{endpointsUpdate2.Endpoints[0], endpointsUpdate1.Endpoints[0], endpointsUpdate3.Endpoints[0]}
 	handler.ValidateEndpoints(t, endpoints)
 	handler2.ValidateEndpoints(t, endpoints)
 
 	// Update the "foo" service with new endpoints
 	endpointsUpdate1 = CreateEndpointsUpdate(ADD, api.Endpoints{Name: "foo", Endpoints: []string{"endpoint77"}})
+	handler.Wait(1)
+	handler2.Wait(1)
 	channelOne <- endpointsUpdate1
-	endpoints = []api.Endpoints{endpointsUpdate1.Endpoints[0], endpointsUpdate2.Endpoints[0], endpointsUpdate3.Endpoints[0]}
+	endpoints = []api.Endpoints{endpointsUpdate2.Endpoints[0], endpointsUpdate1.Endpoints[0], endpointsUpdate3.Endpoints[0]}
 	handler.ValidateEndpoints(t, endpoints)
 	handler2.ValidateEndpoints(t, endpoints)
 
 	// Remove "bar" service
 	endpointsUpdate2 = CreateEndpointsUpdate(REMOVE, api.Endpoints{Name: "bar"})
+	handler.Wait(1)
+	handler2.Wait(1)
 	channelTwo <- endpointsUpdate2
 
 	endpoints = []api.Endpoints{endpointsUpdate1.Endpoints[0], endpointsUpdate3.Endpoints[0]}

--- a/pkg/proxy/config/file.go
+++ b/pkg/proxy/config/file.go
@@ -70,16 +70,16 @@ func NewConfigSourceFile(filename string, serviceChannel chan ServiceUpdate, end
 }
 
 // Run begins watching the config file.
-func (impl ConfigSourceFile) Run() {
-	glog.Infof("Watching file %s", impl.filename)
+func (s ConfigSourceFile) Run() {
+	glog.Infof("Watching file %s", s.filename)
 	var lastData []byte
 	var lastServices []api.Service
 	var lastEndpoints []api.Endpoints
 
 	for {
-		data, err := ioutil.ReadFile(impl.filename)
+		data, err := ioutil.ReadFile(s.filename)
 		if err != nil {
-			glog.Errorf("Couldn't read file: %s : %v", impl.filename, err)
+			glog.Errorf("Couldn't read file: %s : %v", s.filename, err)
 			continue
 		}
 
@@ -103,12 +103,12 @@ func (impl ConfigSourceFile) Run() {
 		}
 		if !reflect.DeepEqual(lastServices, newServices) {
 			serviceUpdate := ServiceUpdate{Op: SET, Services: newServices}
-			impl.serviceChannel <- serviceUpdate
+			s.serviceChannel <- serviceUpdate
 			lastServices = newServices
 		}
 		if !reflect.DeepEqual(lastEndpoints, newEndpoints) {
 			endpointsUpdate := EndpointsUpdate{Op: SET, Endpoints: newEndpoints}
-			impl.endpointsChannel <- endpointsUpdate
+			s.endpointsChannel <- endpointsUpdate
 			lastEndpoints = newEndpoints
 		}
 

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or cied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"sync"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+type Merger interface {
+	// Invoked when a change from a source is received.  May also function as an incremental
+	// merger if you wish to consume changes incrementally.  Must be reentrant when more than
+	// one source is defined.
+	Merge(source string, update interface{}) error
+}
+
+// MergeFunc implements the Merger interface
+type MergeFunc func(source string, update interface{}) error
+
+func (f MergeFunc) Merge(source string, update interface{}) error {
+	return f(source, update)
+}
+
+// Mux is a class for merging configuration from multiple sources.  Changes are
+// pushed via channels and sent to the merge function.
+type Mux struct {
+	// Invoked when an update is sent to a source.
+	merger Merger
+
+	// Sources and their lock.
+	sourceLock sync.RWMutex
+	// Maps source names to channels
+	sources map[string]chan interface{}
+}
+
+// NewMux creates a new mux that can merge changes from multiple sources.
+func NewMux(merger Merger) *Mux {
+	mux := &Mux{
+		sources: make(map[string]chan interface{}),
+		merger:  merger,
+	}
+	return mux
+}
+
+// Channel returns a channel where a configuration source
+// can send updates of new configurations. Multiple calls with the same
+// source will return the same channel. This allows change and state based sources
+// to use the same channel. Different source names however will be treated as a
+// union.
+func (m *Mux) Channel(source string) chan interface{} {
+	if len(source) == 0 {
+		panic("Channel given an empty name")
+	}
+	m.sourceLock.Lock()
+	defer m.sourceLock.Unlock()
+	channel, exists := m.sources[source]
+	if exists {
+		return channel
+	}
+	newChannel := make(chan interface{})
+	m.sources[source] = newChannel
+	go util.Forever(func() { m.listen(source, newChannel) }, 0)
+	return newChannel
+}
+
+func (m *Mux) listen(source string, listenChannel <-chan interface{}) {
+	for update := range listenChannel {
+		m.merger.Merge(source, update)
+	}
+}
+
+// Accessor is an interface for retrieving the current merge state.
+type Accessor interface {
+	// MergedState returns a representation of the current merge state.
+	// Must be reentrant when more than one source is defined.
+	MergedState() interface{}
+}
+
+// AccessorFunc implements the Accessor interface
+type AccessorFunc func() interface{}
+
+func (f AccessorFunc) MergedState() interface{} {
+	return f()
+}
+
+type Listener interface {
+	// OnUpdate is invoked when a change is made to an object.
+	OnUpdate(instance interface{})
+}
+
+// ListenerFunc receives a representation of the change or object.
+type ListenerFunc func(instance interface{})
+
+func (f ListenerFunc) OnUpdate(instance interface{}) {
+	f(instance)
+}
+
+type Watcher struct {
+	// Listeners for changes and their lock.
+	listenerLock sync.RWMutex
+	listeners    []Listener
+}
+
+// Register a set of listeners that support the Listener interface and
+// notify them on changes.
+func NewWatcher() *Watcher {
+	return &Watcher{}
+}
+
+// Register Listener to receive updates of changes.
+func (m *Watcher) Add(listener Listener) {
+	m.listenerLock.Lock()
+	defer m.listenerLock.Unlock()
+	m.listeners = append(m.listeners, listener)
+}
+
+// Notify all listeners
+func (m *Watcher) Notify(instance interface{}) {
+	m.listenerLock.RLock()
+	listeners := m.listeners
+	m.listenerLock.RUnlock()
+	for _, listener := range listeners {
+		listener.OnUpdate(instance)
+	}
+}

--- a/pkg/util/config/config_test.go
+++ b/pkg/util/config/config_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConfigurationChannels(t *testing.T) {
+	mux := NewMux(nil)
+	channelOne := mux.Channel("one")
+	if channelOne != mux.Channel("one") {
+		t.Error("Didn't get the same muxuration channel back with the same name")
+	}
+	channelTwo := mux.Channel("two")
+	if channelOne == channelTwo {
+		t.Error("Got back the same muxuration channel for different names")
+	}
+}
+
+type MergeMock struct {
+	source string
+	update interface{}
+	t      *testing.T
+}
+
+func (m MergeMock) Merge(source string, update interface{}) error {
+	if m.source != source {
+		m.t.Errorf("Expected %s, Got %s", m.source, source)
+	}
+	if !reflect.DeepEqual(m.update, update) {
+		m.t.Errorf("Expected %s, Got %s", m.update, update)
+	}
+	return nil
+}
+
+func TestMergeInvoked(t *testing.T) {
+	merger := MergeMock{"one", "test", t}
+	mux := NewMux(&merger)
+	mux.Channel("one") <- "test"
+}
+
+func TestMergeFuncInvoked(t *testing.T) {
+	ch := make(chan bool)
+	mux := NewMux(MergeFunc(func(source string, update interface{}) error {
+		if source != "one" {
+			t.Errorf("Expected %s, Got %s", "one", source)
+		}
+		if update.(string) != "test" {
+			t.Errorf("Expected %s, Got %s", "test", update)
+		}
+		ch <- true
+		return nil
+	}))
+	mux.Channel("one") <- "test"
+	<-ch
+}
+
+func TestSimultaneousMerge(t *testing.T) {
+	ch := make(chan bool, 2)
+	mux := NewMux(MergeFunc(func(source string, update interface{}) error {
+		switch source {
+		case "one":
+			if update.(string) != "test" {
+				t.Errorf("Expected %s, Got %s", "test", update)
+			}
+		case "two":
+			if update.(string) != "test2" {
+				t.Errorf("Expected %s, Got %s", "test2", update)
+			}
+		default:
+			t.Errorf("Unexpected source, Got %s", update)
+		}
+		ch <- true
+		return nil
+	}))
+	source := mux.Channel("one")
+	source2 := mux.Channel("two")
+	source <- "test"
+	source2 <- "test2"
+	<-ch
+	<-ch
+}
+
+func TestWatcher(t *testing.T) {
+	watch := NewWatcher()
+	watch.Notify(struct{}{})
+
+	ch := make(chan bool, 2)
+	watch.Add(ListenerFunc(func(object interface{}) {
+		if object != "test" {
+			t.Errorf("Expected %s, Got %s", "test", object)
+		}
+		ch <- true
+	}))
+	watch.Add(ListenerFunc(func(object interface{}) {
+		if object != "test" {
+			t.Errorf("Expected %s, Got %s", "test", object)
+		}
+		ch <- true
+	}))
+	watch.Notify("test")
+	<-ch
+	<-ch
+}

--- a/pkg/util/config/doc.go
+++ b/pkg/util/config/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config provides utility objects for decoupling sources of configuration and the
+// actual configuration state. Consumers must implement the Merger interface to unify
+// the sources of change into an object.
+package config


### PR DESCRIPTION
Refactor proxy to use the common config.  This is a prereq for #356 and the commits 
have had feedback from @thockin only.
Also fix tests.
