### PR TITLE
Use latest cAdvisor image.

### DIFF
--- a/cluster/saltbase/salt/cadvisor/cadvisor.manifest
+++ b/cluster/saltbase/salt/cadvisor/cadvisor.manifest
@@ -2,7 +2,7 @@ version: v1beta2
 id: cadvisor-agent
 containers:
   - name: cadvisor
-    image: google/cadvisor
+    image: google/cadvisor:latest
     ports:
       - name: http
         containerPort: 8080


### PR DESCRIPTION
This keeps us from downloading all cAdvisor images just to use "latest".
