### PR TITLE
Make RESTful operations return 404 Not Found when the target resource does not exist

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -32,11 +32,39 @@ import (
 	"github.com/golang/glog"
 )
 
+// errNotFound is an error which indicates that a specified resource is not found.
+type errNotFound string
+
+// Error returns a string representation of the err.
+func (err errNotFound) Error() string {
+	return string(err)
+}
+
+// IsNotFound determines if the err is an error which indicates that a specified resource was not found.
+func IsNotFound(err error) bool {
+	_, ok := err.(errNotFound)
+	return ok
+}
+
+// NewNotFoundErr returns a new error which indicates that the resource of the kind and the name was not found.
+func NewNotFoundErr(kind, name string) error {
+	return errNotFound(fmt.Sprintf("%s %q not found", kind, name))
+}
+
 // RESTStorage is a generic interface for RESTful storage services
+// Storages whicih are exported to the RESTful API of apiserver need to implement this interface.
 type RESTStorage interface {
+	// List selects resources in the storage which match to the selector.
 	List(labels.Selector) (interface{}, error)
+
+	// Get finds a resource in the storage by id and returns it.
+	// Although it can return an arbitrary error value, IsNotFound(err) is true for the returned error value err when the specified resource is not found.
 	Get(id string) (interface{}, error)
+
+	// Delete finds a resource in the storage and deletes it.
+	// Although it can return an arbitrary error value, IsNotFound(err) is true for the returned error value err when the specified resource is not found.
 	Delete(id string) (<-chan interface{}, error)
+
 	Extract(body []byte) (interface{}, error)
 	Create(interface{}) (<-chan interface{}, error)
 	Update(interface{}) (<-chan interface{}, error)
@@ -256,12 +284,12 @@ func (server *APIServer) handleREST(parts []string, requestURL *url.URL, req *ht
 			server.write(http.StatusOK, list, w)
 		case 2:
 			item, err := storage.Get(parts[1])
-			if err != nil {
-				server.error(err, w)
+			if IsNotFound(err) {
+				server.notFound(req, w)
 				return
 			}
-			if item == nil {
-				server.notFound(req, w)
+			if err != nil {
+				server.error(err, w)
 				return
 			}
 			server.write(http.StatusOK, item, w)
@@ -295,6 +323,10 @@ func (server *APIServer) handleREST(parts []string, requestURL *url.URL, req *ht
 			return
 		}
 		out, err := storage.Delete(parts[1])
+		if IsNotFound(err) {
+			server.notFound(req, w)
+			return
+		}
 		if err != nil {
 			server.error(err, w)
 			return
@@ -310,6 +342,10 @@ func (server *APIServer) handleREST(parts []string, requestURL *url.URL, req *ht
 			server.error(err, w)
 		}
 		obj, err := storage.Extract(body)
+		if IsNotFound(err) {
+			server.notFound(req, w)
+			return
+		}
 		if err != nil {
 			server.error(err, w)
 			return

--- a/pkg/registry/memory_registry.go
+++ b/pkg/registry/memory_registry.go
@@ -18,6 +18,7 @@ package registry
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 )
 
@@ -52,7 +53,7 @@ func (registry *MemoryRegistry) GetPod(podID string) (*api.Pod, error) {
 	if found {
 		return &pod, nil
 	} else {
-		return nil, nil
+		return nil, apiserver.NewNotFoundErr("pod", podID)
 	}
 }
 
@@ -62,11 +63,17 @@ func (registry *MemoryRegistry) CreatePod(machine string, pod api.Pod) error {
 }
 
 func (registry *MemoryRegistry) DeletePod(podID string) error {
+	if _, ok := registry.podData[podID]; !ok {
+		return apiserver.NewNotFoundErr("pod", podID)
+	}
 	delete(registry.podData, podID)
 	return nil
 }
 
 func (registry *MemoryRegistry) UpdatePod(pod api.Pod) error {
+	if _, ok := registry.podData[pod.ID]; !ok {
+		return apiserver.NewNotFoundErr("pod", pod.ID)
+	}
 	registry.podData[pod.ID] = pod
 	return nil
 }
@@ -84,7 +91,7 @@ func (registry *MemoryRegistry) GetController(controllerID string) (*api.Replica
 	if found {
 		return &controller, nil
 	} else {
-		return nil, nil
+		return nil, apiserver.NewNotFoundErr("replicationController", controllerID)
 	}
 }
 
@@ -94,11 +101,17 @@ func (registry *MemoryRegistry) CreateController(controller api.ReplicationContr
 }
 
 func (registry *MemoryRegistry) DeleteController(controllerID string) error {
+	if _, ok := registry.controllerData[controllerID]; !ok {
+		return apiserver.NewNotFoundErr("replicationController", controllerID)
+	}
 	delete(registry.controllerData, controllerID)
 	return nil
 }
 
 func (registry *MemoryRegistry) UpdateController(controller api.ReplicationController) error {
+	if _, ok := registry.controllerData[controller.ID]; !ok {
+		return apiserver.NewNotFoundErr("replicationController", controller.ID)
+	}
 	registry.controllerData[controller.ID] = controller
 	return nil
 }
@@ -121,16 +134,22 @@ func (registry *MemoryRegistry) GetService(name string) (*api.Service, error) {
 	if found {
 		return &svc, nil
 	} else {
-		return nil, nil
+		return nil, apiserver.NewNotFoundErr("service", name)
 	}
 }
 
 func (registry *MemoryRegistry) DeleteService(name string) error {
+	if _, ok := registry.serviceData[name]; !ok {
+		return apiserver.NewNotFoundErr("service", name)
+	}
 	delete(registry.serviceData, name)
 	return nil
 }
 
 func (registry *MemoryRegistry) UpdateService(svc api.Service) error {
+	if _, ok := registry.serviceData[svc.ID]; !ok {
+		return apiserver.NewNotFoundErr("service", svc.ID)
+	}
 	return registry.CreateService(svc)
 }
 

--- a/pkg/registry/service_registry_test.go
+++ b/pkg/registry/service_registry_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
 )
 
@@ -94,9 +95,12 @@ func TestServiceRegistryExternalServiceError(t *testing.T) {
 		t.Errorf("Unexpected call(s): %#v", fakeCloud.Calls)
 	}
 	srv, err := memory.GetService("foo")
-	expectNoError(t, err)
-	if srv != nil {
-		t.Errorf("Unexpected service: %#v", *srv)
+	if !apiserver.IsNotFound(err) {
+		if err != nil {
+			t.Errorf("memory.GetService(%q) failed with %v; expected failure with not found error", svc.ID, err)
+		} else {
+			t.Errorf("memory.GetService(%q) = %v; expected failure with not found error", svc.ID, srv)
+		}
 	}
 }
 
@@ -120,9 +124,12 @@ func TestServiceRegistryDelete(t *testing.T) {
 		t.Errorf("Unexpected call(s): %#v", fakeCloud.Calls)
 	}
 	srv, err := memory.GetService(svc.ID)
-	expectNoError(t, err)
-	if srv != nil {
-		t.Errorf("Unexpected service: %#v", *srv)
+	if !apiserver.IsNotFound(err) {
+		if err != nil {
+			t.Errorf("memory.GetService(%q) failed with %v; expected failure with not found error", svc.ID, err)
+		} else {
+			t.Errorf("memory.GetService(%q) = %v; expected failure with not found error", svc.ID, srv)
+		}
 	}
 }
 
@@ -147,8 +154,11 @@ func TestServiceRegistryDeleteExternal(t *testing.T) {
 		t.Errorf("Unexpected call(s): %#v", fakeCloud.Calls)
 	}
 	srv, err := memory.GetService(svc.ID)
-	expectNoError(t, err)
-	if srv != nil {
-		t.Errorf("Unexpected service: %#v", *srv)
+	if !apiserver.IsNotFound(err) {
+		if err != nil {
+			t.Errorf("memory.GetService(%q) failed with %v; expected failure with not found error", svc.ID, err)
+		} else {
+			t.Errorf("memory.GetService(%q) = %v; expected failure with not found error", svc.ID, srv)
+		}
 	}
 }


### PR DESCRIPTION
In the original implementation, GET, DELETE and PUT operations on
non-existent resources used to return 500 instead of 404.
