### PR TITLE
Make RESTful operations return 404 Not Found when the target resource does not exist.

### DIFF
--- a/pkg/registry/memory_registry.go
+++ b/pkg/registry/memory_registry.go
@@ -18,6 +18,7 @@ package registry
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 )
 
@@ -52,7 +53,7 @@ func (registry *MemoryRegistry) GetPod(podID string) (*api.Pod, error) {
 	if found {
 		return &pod, nil
 	} else {
-		return nil, nil
+		return nil, apiserver.NewNotFoundErr("pod", podID)
 	}
 }
 
@@ -62,11 +63,17 @@ func (registry *MemoryRegistry) CreatePod(machine string, pod api.Pod) error {
 }
 
 func (registry *MemoryRegistry) DeletePod(podID string) error {
+	if _, ok := registry.podData[podID]; !ok {
+		return apiserver.NewNotFoundErr("pod", podID)
+	}
 	delete(registry.podData, podID)
 	return nil
 }
 
 func (registry *MemoryRegistry) UpdatePod(pod api.Pod) error {
+	if _, ok := registry.podData[pod.ID]; !ok {
+		return apiserver.NewNotFoundErr("pod", pod.ID)
+	}
 	registry.podData[pod.ID] = pod
 	return nil
 }
@@ -84,7 +91,7 @@ func (registry *MemoryRegistry) GetController(controllerID string) (*api.Replica
 	if found {
 		return &controller, nil
 	} else {
-		return nil, nil
+		return nil, apiserver.NewNotFoundErr("replicationController", controllerID)
 	}
 }
 
@@ -94,11 +101,17 @@ func (registry *MemoryRegistry) CreateController(controller api.ReplicationContr
 }
 
 func (registry *MemoryRegistry) DeleteController(controllerID string) error {
+	if _, ok := registry.controllerData[controllerID]; !ok {
+		return apiserver.NewNotFoundErr("replicationController", controllerID)
+	}
 	delete(registry.controllerData, controllerID)
 	return nil
 }
 
 func (registry *MemoryRegistry) UpdateController(controller api.ReplicationController) error {
+	if _, ok := registry.controllerData[controller.ID]; !ok {
+		return apiserver.NewNotFoundErr("replicationController", controller.ID)
+	}
 	registry.controllerData[controller.ID] = controller
 	return nil
 }
@@ -121,16 +134,22 @@ func (registry *MemoryRegistry) GetService(name string) (*api.Service, error) {
 	if found {
 		return &svc, nil
 	} else {
-		return nil, nil
+		return nil, apiserver.NewNotFoundErr("service", name)
 	}
 }
 
 func (registry *MemoryRegistry) DeleteService(name string) error {
+	if _, ok := registry.serviceData[name]; !ok {
+		return apiserver.NewNotFoundErr("service", name)
+	}
 	delete(registry.serviceData, name)
 	return nil
 }
 
 func (registry *MemoryRegistry) UpdateService(svc api.Service) error {
+	if _, ok := registry.serviceData[svc.ID]; !ok {
+		return apiserver.NewNotFoundErr("service", svc.ID)
+	}
 	return registry.CreateService(svc)
 }
 

--- a/pkg/registry/service_registry_test.go
+++ b/pkg/registry/service_registry_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
 )
 
@@ -94,9 +95,12 @@ func TestServiceRegistryExternalServiceError(t *testing.T) {
 		t.Errorf("Unexpected call(s): %#v", fakeCloud.Calls)
 	}
 	srv, err := memory.GetService("foo")
-	expectNoError(t, err)
-	if srv != nil {
-		t.Errorf("Unexpected service: %#v", *srv)
+	if !apiserver.IsNotFound(err) {
+		if err != nil {
+			t.Errorf("memory.GetService(%q) failed with %v; expected failure with not found error", svc.ID, err)
+		} else {
+			t.Errorf("memory.GetService(%q) = %v; expected failure with not found error", svc.ID, srv)
+		}
 	}
 }
 
@@ -120,9 +124,12 @@ func TestServiceRegistryDelete(t *testing.T) {
 		t.Errorf("Unexpected call(s): %#v", fakeCloud.Calls)
 	}
 	srv, err := memory.GetService(svc.ID)
-	expectNoError(t, err)
-	if srv != nil {
-		t.Errorf("Unexpected service: %#v", *srv)
+	if !apiserver.IsNotFound(err) {
+		if err != nil {
+			t.Errorf("memory.GetService(%q) failed with %v; expected failure with not found error", svc.ID, err)
+		} else {
+			t.Errorf("memory.GetService(%q) = %v; expected failure with not found error", svc.ID, srv)
+		}
 	}
 }
 
@@ -147,8 +154,11 @@ func TestServiceRegistryDeleteExternal(t *testing.T) {
 		t.Errorf("Unexpected call(s): %#v", fakeCloud.Calls)
 	}
 	srv, err := memory.GetService(svc.ID)
-	expectNoError(t, err)
-	if srv != nil {
-		t.Errorf("Unexpected service: %#v", *srv)
+	if !apiserver.IsNotFound(err) {
+		if err != nil {
+			t.Errorf("memory.GetService(%q) failed with %v; expected failure with not found error", svc.ID, err)
+		} else {
+			t.Errorf("memory.GetService(%q) = %v; expected failure with not found error", svc.ID, srv)
+		}
 	}
 }

--- a/pkg/tools/etcd_tools.go
+++ b/pkg/tools/etcd_tools.go
@@ -72,20 +72,8 @@ func IsEtcdConflict(err error) bool {
 
 // Returns true iff err is an etcd error, whose errorCode matches errorCode
 func isEtcdErrorNum(err error, errorCode int) bool {
-	if err == nil {
-		return false
-	}
-	switch err.(type) {
-	case *etcd.EtcdError:
-		etcdError := err.(*etcd.EtcdError)
-		if etcdError == nil {
-			return false
-		}
-		if etcdError.ErrorCode == errorCode {
-			return true
-		}
-	}
-	return false
+	etcdError, ok := err.(*etcd.EtcdError)
+	return ok && etcdError != nil && etcdError.ErrorCode == errorCode
 }
 
 func (h *EtcdHelper) listEtcdNode(key string) ([]*etcd.Node, error) {


### PR DESCRIPTION
In the original implementation, GET, DELETE and PUT operations on
non-existent resources used to return 500 but not 404.
