### PR TITLE
use correct syntax for alternative value of KUBE_MINIONS

### DIFF
--- a/build/run-images/apiserver/run.sh
+++ b/build/run-images/apiserver/run.sh
@@ -16,6 +16,6 @@
 
 # If the user doesn't specify a minion, assume we are running in a single node
 # configuration and that we have a local minion.
-KUBE_MINIONS=${KUBE_MINIONS:$(hostname -f)}
+KUBE_MINIONS="${KUBE_MINIONS:-$(hostname -f)}"
 
 ./apiserver -address=0.0.0.0 -etcd_servers="${ETCD_SERVERS}" --machines="${KUBE_MINIONS}"


### PR DESCRIPTION
Fixes errors starting up apiserver container
`/kubernetes/run.sh: line 19: KUBE_MINIONS: 5a09d105bfbb: value too great for base (error token is "5a09d105bfbb")`
