### PR TITLE
Retry failed release downloads

### DIFF
--- a/cluster/templates/download-release.sh
+++ b/cluster/templates/download-release.sh
@@ -21,7 +21,7 @@
 # master and run.
 
 echo "Downloading release ($MASTER_RELEASE_TAR)"
-gsutil cp $MASTER_RELEASE_TAR master-release.tgz
+until gsutil cp $MASTER_RELEASE_TAR master-release.tgz; do sleep 1 ; echo "Retrying master download" ; done
 
 
 echo "Unpacking release"


### PR DESCRIPTION
gsutil cp is prone to failure during initial creation of a Kubernetes
cluster. This 'until' loop will keep trying as suggested in the 'gsutil
cp' documentation.
