### PR TITLE
Slow down proxy config file errors

### DIFF
--- a/pkg/proxy/config/file.go
+++ b/pkg/proxy/config/file.go
@@ -76,7 +76,7 @@ func (s ConfigSourceFile) Run() {
 	var lastServices []api.Service
 	var lastEndpoints []api.Endpoints
 
-	for {
+	for ; ; time.Sleep(5 * time.Second) {
 		data, err := ioutil.ReadFile(s.filename)
 		if err != nil {
 			glog.Errorf("Couldn't read file: %s : %v", s.filename, err)
@@ -112,6 +112,5 @@ func (s ConfigSourceFile) Run() {
 			lastEndpoints = newEndpoints
 		}
 
-		time.Sleep(5 * time.Second)
 	}
 }


### PR DESCRIPTION
If /tmp/proxy_config doesn't exist, kube-proxy was burning cpu cycles
like it's going out of style.
