### PR TITLE
PodInfo should indicate when a pod is not found

### DIFF
--- a/pkg/client/podinfo.go
+++ b/pkg/client/podinfo.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -26,6 +27,9 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 )
+
+// ErrPodInfoNotAvailable may be returned when the requested pod info is not available
+var ErrPodInfoNotAvailable = errors.New("no pod info available")
 
 // PodInfoGetter is an interface for things that can get information about a pod's containers.
 // Injectable for easy testing.
@@ -58,6 +62,9 @@ func (c *HTTPPodInfoGetter) GetPodInfo(host, podID string) (api.PodInfo, error) 
 		return nil, err
 	}
 	defer response.Body.Close()
+	if response.StatusCode == http.StatusNotFound {
+		return nil, ErrPodInfoNotAvailable
+	}
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return nil, err

--- a/pkg/kubelet/docker.go
+++ b/pkg/kubelet/docker.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubelet
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -115,6 +116,9 @@ func getKubeletDockerContainers(client DockerInterface) (DockerContainers, error
 	return result, nil
 }
 
+// ErrNoContainersInPod is returned when there are no running containers for a given pod
+var ErrNoContainersInPod = errors.New("no containers exist for this pod")
+
 // GetDockerPodInfo returns docker info for all containers in the pod/manifest.
 func getDockerPodInfo(client DockerInterface, manifestID string) (api.PodInfo, error) {
 	info := api.PodInfo{}
@@ -140,6 +144,10 @@ func getDockerPodInfo(client DockerInterface, manifestID string) (api.PodInfo, e
 			info[dockerContainerName] = *inspectResult
 		}
 	}
+	if len(info) == 0 {
+		return nil, ErrNoContainersInPod
+	}
+
 	return info, nil
 }
 

--- a/pkg/master/pod_cache.go
+++ b/pkg/master/pod_cache.go
@@ -17,7 +17,6 @@ limitations under the License.
 package master
 
 import (
-	"errors"
 	"sync"
 	"time"
 
@@ -57,7 +56,7 @@ func (p *PodCache) GetPodInfo(host, podID string) (api.PodInfo, error) {
 	defer p.podLock.Unlock()
 	value, ok := p.podInfo[podID]
 	if !ok {
-		return nil, errors.New("no cached pod info")
+		return nil, client.ErrPodInfoNotAvailable
 	}
 	return value, nil
 }
@@ -82,7 +81,7 @@ func (p *PodCache) UpdateAllContainers() {
 	}
 	for _, pod := range pods {
 		err := p.updatePodInfo(pod.CurrentState.Host, pod.ID)
-		if err != nil {
+		if err != nil && err != client.ErrPodInfoNotAvailable {
 			glog.Errorf("Error synchronizing container: %#v", err)
 		}
 	}

--- a/pkg/registry/pod_registry.go
+++ b/pkg/registry/pod_registry.go
@@ -86,12 +86,16 @@ func (storage *PodRegistryStorage) fillPodInfo(pod *api.Pod) {
 	if storage.podCache != nil {
 		info, err := storage.podCache.GetPodInfo(pod.CurrentState.Host, pod.ID)
 		if err != nil {
-			glog.Errorf("Error getting container info from cache: %#v", err)
+			if err != client.ErrPodInfoNotAvailable {
+				glog.Errorf("Error getting container info from cache: %#v", err)
+			}
 			if storage.podInfoGetter != nil {
 				info, err = storage.podInfoGetter.GetPodInfo(pod.CurrentState.Host, pod.ID)
 			}
 			if err != nil {
-				glog.Errorf("Error getting fresh container info: %#v", err)
+				if err != client.ErrPodInfoNotAvailable {
+					glog.Errorf("Error getting fresh container info: %#v", err)
+				}
 				return
 			}
 		}
@@ -104,7 +108,7 @@ func (storage *PodRegistryStorage) fillPodInfo(pod *api.Pod) {
 				glog.Warningf("No network settings: %#v", netContainerInfo)
 			}
 		} else {
-			glog.Warningf("Couldn't find network container in %v", info)
+			glog.Warningf("Couldn't find network container for %s in %v", pod.ID, info)
 		}
 	}
 }


### PR DESCRIPTION
Client should react.  Also, dial down the chattiness of errors for
pods which do not exist and stop processing NotFound earlier in
the podinfo chain

This makes kubelet integration test output a lot cleaner.
