### PR TITLE
Renames HasAll to IsSuperset; HasAll uses slice.

### DIFF
--- a/pkg/api/validation_test.go
+++ b/pkg/api/validation_test.go
@@ -34,8 +34,7 @@ func TestValidateVolumes(t *testing.T) {
 	if len(errs) != 0 {
 		t.Errorf("expected success: %v", errs)
 	}
-	expectedSet := util.NewStringSet("abc", "123", "abc-123", "empty")
-	if len(names) != 4 || !names.HasAll(expectedSet) {
+	if len(names) != 4 || !names.HasAll("abc", "123", "abc-123", "empty") {
 		t.Errorf("wrong names result: %v", names)
 	}
 

--- a/pkg/util/set.go
+++ b/pkg/util/set.go
@@ -51,7 +51,17 @@ func (s StringSet) Has(item string) bool {
 }
 
 // HasAll returns true iff all items are contained in the set.
-func (s1 StringSet) HasAll(s2 StringSet) bool {
+func (s StringSet) HasAll(items ...string) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// IsSuperset returns true iff s1 is a superset of s2.
+func (s1 StringSet) IsSuperset(s2 StringSet) bool {
 	for item, _ := range s2 {
 		if !s1.Has(item) {
 			return false

--- a/pkg/util/set_test.go
+++ b/pkg/util/set_test.go
@@ -43,12 +43,18 @@ func TestStringSet(t *testing.T) {
 		t.Errorf("Unexpected contents: %#v", s)
 	}
 	s.Insert("a")
+	if s.HasAll("a","b","d") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.HasAll("a","b",) {
+		t.Errorf("Missing contents: %#v", s)
+	}
 	s2.Insert("a","b","d")
-	if s.HasAll(s2) {
+	if s.IsSuperset(s2) {
 		t.Errorf("Unexpected contents: %#v", s)
 	}
 	s2.Delete("d")
-	if !s.HasAll(s2) {
+	if !s.IsSuperset(s2) {
 		t.Errorf("Missing contents: %#v", s)
 	}
 }


### PR DESCRIPTION
For the pedants: HasAll is now called IsSuperset and
the new HasAll method takes a slice instead of a set.
