### PR TITLE
Adds a flag to specify root working directory.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -62,12 +62,14 @@ func NewMainKubelet(
 	hn string,
 	dc DockerInterface,
 	cc CadvisorInterface,
-	ec tools.EtcdClient) *Kubelet {
+	ec tools.EtcdClient,
+	rd string) *Kubelet {
 	return &Kubelet{
 		hostname:       hn,
 		dockerClient:   dc,
 		cadvisorClient: cc,
 		etcdClient:     ec,
+		rootDirectory:  rd,
 	}
 }
 
@@ -83,8 +85,9 @@ func NewIntegrationTestKubelet(hn string, dc DockerInterface) *Kubelet {
 
 // Kubelet is the main kubelet implementation.
 type Kubelet struct {
-	hostname     string
-	dockerClient DockerInterface
+	hostname      string
+	dockerClient  DockerInterface
+	rootDirectory string
 
 	// Optional, no events will be sent without it
 	etcdClient tools.EtcdClient
@@ -210,7 +213,7 @@ func milliCPUToShares(milliCPU int) int {
 func (kl *Kubelet) mountExternalVolumes(manifest *api.ContainerManifest) (volumeMap, error) {
 	podVolumes := make(volumeMap)
 	for _, vol := range manifest.Volumes {
-		extVolume, err := volume.CreateVolume(&vol, manifest.ID)
+		extVolume, err := volume.CreateVolume(&vol, manifest.ID, kl.rootDirectory)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/volume/volume_test.go
+++ b/pkg/volume/volume_test.go
@@ -38,9 +38,10 @@ func TestCreateVolumes(t *testing.T) {
 		},
 	}
 	fakePodID := "my-id"
-	expectedPaths := []string{"/dir/path", "/exports/my-id/empty-dir"}
+	rootDir := "/var/lib/kubelet"
+	expectedPaths := []string{"/dir/path", "/var/lib/kubelet/my-id/volumes/empty/empty-dir"}
 	for i, volume := range volumes {
-		extVolume, _ := CreateVolume(&volume, fakePodID)
+		extVolume, _ := CreateVolume(&volume, fakePodID, rootDir)
 		expectedPath := expectedPaths[i]
 		path := extVolume.GetPath()
 		if expectedPath != path {


### PR DESCRIPTION
--root_dir specifies the directory kubelet will use for it's
procedures. Currently used for volume mounts.
