### PR TITLE
normalize -etcd_servers flag across all commands

### DIFF
--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -42,7 +42,7 @@ var (
 )
 
 func init() {
-	flag.Var(&etcdServerList, "etcd_servers", "Servers for the etcd (http://ip:port), comma separated")
+	flag.Var(&etcdServerList, "etcd_servers", "List of etcd servers to watch (http://ip:port), comma separated")
 	flag.Var(&machineList, "machines", "List of machines to schedule onto, comma separated.")
 }
 

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -106,7 +106,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 		SyncFrequency:      5 * time.Second,
 		HTTPCheckFrequency: 5 * time.Second,
 	}
-	go myKubelet.RunKubelet("", "", manifestURL, servers[0], "localhost", 10250)
+	go myKubelet.RunKubelet("", "", manifestURL, servers, "localhost", 10250)
 
 	// Create a second kubelet so that the guestbook example's two redis slaves both
 	// have a place they can schedule.
@@ -118,7 +118,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 		SyncFrequency:      5 * time.Second,
 		HTTPCheckFrequency: 5 * time.Second,
 	}
-	go otherKubelet.RunKubelet("", "", "", servers[0], "localhost", 10251)
+	go otherKubelet.RunKubelet("", "", "", servers, "localhost", 10251)
 
 	return apiserver.URL
 }

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -37,7 +37,6 @@ import (
 
 var (
 	config             = flag.String("config", "", "Path to the config file or directory of files")
-	etcdServers        = flag.String("etcd_servers", "", "Url of etcd servers in the cluster")
 	syncFrequency      = flag.Duration("sync_frequency", 10*time.Second, "Max period between synchronizing running containers and config")
 	fileCheckFrequency = flag.Duration("file_check_frequency", 20*time.Second, "Duration between checking config files for new data")
 	httpCheckFrequency = flag.Duration("http_check_frequency", 20*time.Second, "Duration between checking http for new data")
@@ -46,7 +45,12 @@ var (
 	port               = flag.Uint("port", 10250, "The port for the info server to serve on")
 	hostnameOverride   = flag.String("hostname_override", "", "If non-empty, will use this string as identification instead of the actual hostname.")
 	dockerEndpoint     = flag.String("docker_endpoint", "", "If non-empty, use this for the docker endpoint to communicate with")
+	etcdServerList     util.StringList
 )
+
+func init() {
+	flag.Var(&etcdServerList, "etcd_servers", "List of etcd servers to watch (http://ip:port), comma separated")
+}
 
 func getDockerEndpoint() string {
 	var endpoint string
@@ -96,5 +100,5 @@ func main() {
 		SyncFrequency:      *syncFrequency,
 		HTTPCheckFrequency: *httpCheckFrequency,
 	}
-	k.RunKubelet(*dockerEndpoint, *config, *manifestURL, *etcdServers, *address, *port)
+	k.RunKubelet(*dockerEndpoint, *config, *manifestURL, etcdServerList, *address, *port)
 }

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -27,9 +27,13 @@ import (
 )
 
 var (
-	configFile  = flag.String("configfile", "/tmp/proxy_config", "Configuration file for the proxy")
-	etcdServers = flag.String("etcd_servers", "http://10.240.10.57:4001", "Servers for the etcd cluster (http://ip:port).")
+	configFile     = flag.String("configfile", "/tmp/proxy_config", "Configuration file for the proxy")
+	etcdServerList util.StringList
 )
+
+func init() {
+	flag.Var(&etcdServerList, "etcd_servers", "List of etcd servers to watch (http://ip:port), comma separated")
+}
 
 func main() {
 	flag.Parse()
@@ -39,13 +43,13 @@ func main() {
 	// Set up logger for etcd client
 	etcd.SetLogger(util.NewLogger("etcd "))
 
-	glog.Infof("Using configuration file %s and etcd_servers %s", *configFile, *etcdServers)
+	glog.Infof("Using configuration file %s and etcd_servers %v", *configFile, etcdServerList)
 
 	serviceConfig := config.NewServiceConfig()
 	endpointsConfig := config.NewEndpointsConfig()
 
 	// Create a configuration source that handles configuration from etcd.
-	etcdClient := etcd.NewClient([]string{*etcdServers})
+	etcdClient := etcd.NewClient(etcdServerList)
 	config.NewConfigSourceEtcd(etcdClient,
 		serviceConfig.Channel("etcd"),
 		endpointsConfig.Channel("etcd"))

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -93,7 +93,7 @@ const (
 
 // RunKubelet starts background goroutines. If config_path, manifest_url, or address are empty,
 // they are not watched. Never returns.
-func (kl *Kubelet) RunKubelet(dockerEndpoint, configPath, manifestURL, etcdServers, address string, port uint) {
+func (kl *Kubelet) RunKubelet(dockerEndpoint, configPath, manifestURL string, etcdServers []string, address string, port uint) {
 	if kl.CadvisorClient == nil {
 		var err error
 		kl.CadvisorClient, err = cadvisor.NewClient("http://127.0.0.1:5000")
@@ -119,10 +119,9 @@ func (kl *Kubelet) RunKubelet(dockerEndpoint, configPath, manifestURL, etcdServe
 			}
 		}, kl.HTTPCheckFrequency)
 	}
-	if etcdServers != "" {
-		servers := []string{etcdServers}
-		glog.Infof("Watching for etcd configs at %v", servers)
-		kl.EtcdClient = etcd.NewClient(servers)
+	if len(etcdServers) > 0 {
+		glog.Infof("Watching for etcd configs at %v", etcdServers)
+		kl.EtcdClient = etcd.NewClient(etcdServers)
 		go util.Forever(func() { kl.SyncAndSetupEtcdWatch(updateChannel) }, 20*time.Second)
 	}
 	if address != "" {


### PR DESCRIPTION
The -etcd_servers flag is used inconsistently by the Kubernetes commands,
both externally and internally.

This patch fixes the issue by using the same type to represent a list of
etcd servers internally, and declares the -etcd_servers flag consistently
across all commands.

This patch should be 100% backwards compatible with no changes in behavior.
