### PR TITLE
remove unnecessary expectNoError helper function

### DIFF
--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -228,7 +228,7 @@ func TestHandleWatchResponseNotSet(t *testing.T) {
 		Action: "update",
 	})
 	if err != nil {
-		t.Errorf("Unexpected error: %#v", err)
+		t.Errorf("Unexpected error: %v", err)
 	}
 }
 
@@ -295,7 +295,7 @@ func TestHandleWatchResponse(t *testing.T) {
 
 	data, err := json.Marshal(controller)
 	if err != nil {
-		t.Errorf("Unexpected error: %#v", err)
+		t.Errorf("Unexpected error: %v", err)
 	}
 	controllerOut, err := manager.handleWatchResponse(&etcd.Response{
 		Action: "set",
@@ -329,7 +329,7 @@ func TestHandleWatchResponseDelete(t *testing.T) {
 
 	data, err := json.Marshal(controller)
 	if err != nil {
-		t.Errorf("Unexpected error: %#v", err)
+		t.Errorf("Unexpected error: %v", err)
 	}
 	controllerOut, err := manager.handleWatchResponse(&etcd.Response{
 		Action: "delete",

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -34,13 +34,6 @@ import (
 // TODO: Move this to a common place, it's needed in multiple tests.
 var apiPath = "/api/v1beta1"
 
-// TODO: This doesn't reduce typing enough to make it worth the less readable errors. Remove.
-func expectNoError(t *testing.T, err error) {
-	if err != nil {
-		t.Errorf("Unexpected error: %#v", err)
-	}
-}
-
 func makeURL(suffix string) string {
 	return apiPath + suffix
 }
@@ -234,7 +227,9 @@ func TestHandleWatchResponseNotSet(t *testing.T) {
 	_, err := manager.handleWatchResponse(&etcd.Response{
 		Action: "update",
 	})
-	expectNoError(t, err)
+	if err != nil {
+		t.Errorf("Unexpected error: %#v", err)
+	}
 }
 
 func TestHandleWatchResponseNoNode(t *testing.T) {
@@ -299,7 +294,9 @@ func TestHandleWatchResponse(t *testing.T) {
 	controller := makeReplicationController(2)
 
 	data, err := json.Marshal(controller)
-	expectNoError(t, err)
+	if err != nil {
+		t.Errorf("Unexpected error: %#v", err)
+	}
 	controllerOut, err := manager.handleWatchResponse(&etcd.Response{
 		Action: "set",
 		Node: &etcd.Node{
@@ -331,7 +328,9 @@ func TestHandleWatchResponseDelete(t *testing.T) {
 	controller := makeReplicationController(2)
 
 	data, err := json.Marshal(controller)
-	expectNoError(t, err)
+	if err != nil {
+		t.Errorf("Unexpected error: %#v", err)
+	}
 	controllerOut, err := manager.handleWatchResponse(&etcd.Response{
 		Action: "delete",
 		PrevNode: &etcd.Node{


### PR DESCRIPTION
This patch completes a TODO item for the replication_controller test
suite by removing the expectNoError helper function, which does not
reduce enough typing to justify its usage.
