### PR TITLE
Add a pause image for the net container.

### DIFF
--- a/build/pause/Dockerfile
+++ b/build/pause/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+ADD pause /
+ENTRYPOINT ["/pause"]

--- a/build/pause/pause.go
+++ b/build/pause/pause.go
@@ -1,0 +1,8 @@
+package main
+
+import "syscall"
+
+func main() {
+	// Halts execution, waiting on signal.
+	syscall.Pause()
+}

--- a/build/pause/prepare.sh
+++ b/build/pause/prepare.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+set -x
+
+go build --ldflags '-extldflags "-static" -s' pause.go

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -541,7 +541,10 @@ func (kl *Kubelet) WatchEtcd(watchChannel <-chan *etcd.Response, updateChannel c
 	}
 }
 
-const networkContainerName = "net"
+const (
+	networkContainerName  = "net"
+	networkContainerImage = "kubernetes/pause:latest"
+)
 
 // Create a network container for a manifest. Returns the docker container ID of the newly created container.
 func (kl *Kubelet) createNetworkContainer(manifest *api.ContainerManifest) (DockerID, error) {
@@ -552,12 +555,11 @@ func (kl *Kubelet) createNetworkContainer(manifest *api.ContainerManifest) (Dock
 		ports = append(ports, container.Ports...)
 	}
 	container := &api.Container{
-		Name:    networkContainerName,
-		Image:   "busybox",
-		Command: []string{"sh", "-c", "rm -f nap && mkfifo nap && exec cat nap"},
-		Ports:   ports,
+		Name:  networkContainerName,
+		Image: networkContainerImage,
+		Ports: ports,
 	}
-	kl.DockerPuller.Pull("busybox")
+	kl.DockerPuller.Pull(networkContainerImage)
 	return kl.runContainer(manifest, container, nil, "")
 }
 

--- a/third_party/pause/LICENSE
+++ b/third_party/pause/LICENSE
@@ -1,0 +1,19 @@
+The Expat/MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the 
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in 
+all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL 
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+DEALINGS IN THE SOFTWARE.

--- a/third_party/pause/Makefile
+++ b/third_party/pause/Makefile
@@ -1,0 +1,13 @@
+pause: pause.asm
+ifneq ($(shell uname), Linux)
+	echo "Must build on Linux"
+	exit 1
+else
+	nasm -o $@ $<
+	chmod +x pause
+endif
+
+all: pause
+
+clean:
+	rm -f pause

--- a/third_party/pause/pause.asm
+++ b/third_party/pause/pause.asm
@@ -1,0 +1,57 @@
+; This is heavily based on https://github.com/tianon/dockerfiles/tree/master/true
+; which is in turn especially thanks to:
+; http://blog.markloiseau.com/2012/05/tiny-64-bit-elf-executables/
+
+BITS 64
+	org	0x00400000	; Program load offset
+
+; 64-bit ELF header
+ehdr:
+	;  1), 0 (ABI ver.)
+	db 0x7F, "ELF", 2, 1, 1, 0       ; e_ident
+	times 8 db 0                     ; reserved (zeroes)
+
+	dw 2              ; e_type:	Executable file
+	dw 0x3e           ; e_machine:	AMD64
+	dd 1              ; e_version:	current version
+	dq _start         ; e_entry:	program entry address (0x78)
+	dq phdr - $$      ; e_phoff	program header offset (0x40)
+	dq 0              ; e_shoff	no section headers
+	dd 0              ; e_flags	no flags
+	dw ehdrsize       ; e_ehsize:	ELF header size (0x40)
+	dw phdrsize       ; e_phentsize:	program header size (0x38)
+	dw 1              ; e_phnum:	one program header
+	dw 0              ; e_shentsize
+	dw 0              ; e_shnum
+	dw 0              ; e_shstrndx
+
+ehdrsize equ $ - ehdr
+
+; 64-bit ELF program header
+phdr:
+	dd 1              ; p_type:	loadable segment
+	dd 5              ; p_flags	read and execute
+	dq 0              ; p_offset
+	dq $$             ; p_vaddr:	start of the current section
+	dq $$             ; p_paddr:	"		"
+	dq filesize       ; p_filesz
+	dq filesize       ; p_memsz
+	dq 0x200000       ; p_align:	2^11=200000 = section alignment
+
+; program header size
+phdrsize equ $ - phdr
+
+_start:
+	; pause()
+
+	mov	al, 34	; pause syscall number
+	syscall
+
+	; sys_exit(return_code)
+
+	mov	al, 60	; sys_exit syscall number
+	cdq		; Sign-extend eax into edi to return 0 (success)
+	syscall
+
+; File size calculation
+filesize equ $ - $$


### PR DESCRIPTION
The pause image is a 240KB image that simply pauses waiting on a signal.
Use this for the net container which only needs to act as a placeholder.
Current net image is ~2.5MB. From my tests, this reduces startup time
for the net container from ~14s to ~6s.
