### PR TITLE
add tests for the healthz package

### DIFF
--- a/pkg/healthz/healthz_test.go
+++ b/pkg/healthz/healthz_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthz
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestInstallHandler(t *testing.T) {
+	mux := http.NewServeMux()
+	InstallHandler(mux)
+	req, err := http.NewRequest("GET", "http://example.com/healthz", nil)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected %v, got %v", http.StatusOK, w.Code)
+	}
+	if w.Body.String() != "ok" {
+		t.Errorf("Expected %v, got %v", "ok", w.Body.String())
+	}
+}


### PR DESCRIPTION
Currently there are no tests for the healthz package. This patch adds
an initial set of tests and improves test coverage.
