### PR TITLE
Improve test coverage for the health package and remove mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,4 +204,3 @@ sudo docker build -t kubernetes/raml2html .
 sudo docker run --name="docgen" kubernetes/raml2html
 sudo docker cp docgen:/data/kubernetes.html .
 ```
-

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -42,12 +42,10 @@ type HTTPGetInterface interface {
 // It returns Unknown and err if the HTTP communication itself fails.
 func Check(url string, client HTTPGetInterface) (Status, error) {
 	res, err := client.Get(url)
-	if res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return Unknown, err
 	}
+	defer res.Body.Close()
 	if res.StatusCode >= http.StatusOK && res.StatusCode < http.StatusBadRequest {
 		return Healthy, nil
 	}

--- a/pkg/registry/healthy_minion_registry_test.go
+++ b/pkg/registry/healthy_minion_registry_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package registry
 
 import (
+	"bytes"
+	"io/ioutil"
 	"net/http"
 	"reflect"
 	"testing"
@@ -24,10 +26,15 @@ import (
 
 type alwaysYes struct{}
 
-func (alwaysYes) Get(url string) (*http.Response, error) {
+func fakeHTTPResponse(status int) *http.Response {
 	return &http.Response{
-		StatusCode: http.StatusOK,
-	}, nil
+		StatusCode: status,
+		Body:       ioutil.NopCloser(&bytes.Buffer{}),
+	}
+}
+
+func (alwaysYes) Get(url string) (*http.Response, error) {
+	return fakeHTTPResponse(http.StatusOK), nil
 }
 
 func TestBasicDelegation(t *testing.T) {
@@ -66,9 +73,9 @@ type notMinion struct {
 
 func (n *notMinion) Get(url string) (*http.Response, error) {
 	if url != "http://"+n.minion+":10250/healthz" {
-		return &http.Response{StatusCode: http.StatusOK}, nil
+		return fakeHTTPResponse(http.StatusOK), nil
 	} else {
-		return &http.Response{StatusCode: http.StatusInternalServerError}, nil
+		return fakeHTTPResponse(http.StatusInternalServerError), nil
 	}
 }
 


### PR DESCRIPTION
The current tests for the health package utilize a fake HTTP client
for testing health checks and only cover a limited set of test cases.

This patch removes the need for mocks by using the httptest package
from the standard library. After removing the fake HTTP client a bug
was found in the health.Check function; it incorrectly assumes that
a http.Response is always non-nil. Fix the issue by moving the defer
that closes the http.Response.Body after error handling.

Related tests in the registry package have be refactored to work with
the changes made to the health.Check function. All methods that implement
the health.HTTPGetInterface interface now return a http.Response with
with a noop http.Response.Body.

This patch does not introduce any changes in behavior.
