### PR TITLE
Remove unnecessary expectNoError helper function

### DIFF
--- a/pkg/kubecfg/kubecfg_test.go
+++ b/pkg/kubecfg/kubecfg_test.go
@@ -27,13 +27,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 )
 
-// TODO: This doesn't reduce typing enough to make it worth the less readable errors. Remove.
-func expectNoError(t *testing.T, err error) {
-	if err != nil {
-		t.Errorf("Unexpected error: %#v", err)
-	}
-}
-
 type Action struct {
 	action string
 	value  interface{}
@@ -223,7 +216,9 @@ func TestCloudCfgDeleteController(t *testing.T) {
 	fakeClient := FakeKubeClient{}
 	name := "name"
 	err := DeleteController(name, &fakeClient)
-	expectNoError(t, err)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
 	if len(fakeClient.actions) != 2 {
 		t.Errorf("Unexpected actions: %#v", fakeClient.actions)
 	}

--- a/pkg/kubecfg/proxy_server_test.go
+++ b/pkg/kubecfg/proxy_server_test.go
@@ -26,20 +26,30 @@ import (
 func TestFileServing(t *testing.T) {
 	data := "This is test data"
 	dir, err := ioutil.TempDir("", "data")
-	expectNoError(t, err)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
 	err = ioutil.WriteFile(dir+"/test.txt", []byte(data), 0755)
-	expectNoError(t, err)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
 	prefix := "/foo/"
 	handler := makeFileHandler(prefix, dir)
 	server := httptest.NewServer(handler)
 	client := http.Client{}
 	req, err := http.NewRequest("GET", server.URL+prefix+"test.txt", nil)
-	expectNoError(t, err)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
 	res, err := client.Do(req)
-	expectNoError(t, err)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
 	defer res.Body.Close()
 	b, err := ioutil.ReadAll(res.Body)
-	expectNoError(t, err)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
 	if res.StatusCode != http.StatusOK {
 		t.Errorf("Unexpected status: %d", res.StatusCode)
 	}


### PR DESCRIPTION
This patch completes a TODO item for the kubecfg package test suite by
removing the expectNoError helper function, which does not reduce enough
typing to justify its usage.
