### PR TITLE
Make replication controllers use new watch interface

### DIFF
--- a/pkg/apiserver/interfaces.go
+++ b/pkg/apiserver/interfaces.go
@@ -43,6 +43,7 @@ type RESTStorage interface {
 // ResourceWatcher should be implemented by all RESTStorage objects that
 // want to offer the ability to watch for changes through the watch api.
 type ResourceWatcher interface {
+	// TODO: take a query, like List, to filter out unwanted events.
 	WatchAll() (watch.Interface, error)
 	WatchSingle(id string) (watch.Interface, error)
 }

--- a/pkg/registry/controller_registry.go
+++ b/pkg/registry/controller_registry.go
@@ -17,6 +17,7 @@ limitations under the License.
 package registry
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
 // ControllerRegistryStorage is an implementation of RESTStorage for the api server.
@@ -134,4 +136,16 @@ func (storage *ControllerRegistryStorage) waitForController(ctrl api.Replication
 		time.Sleep(storage.pollPeriod)
 	}
 	return ctrl, nil
+}
+
+// WatchAll returns ReplicationController events via a watch.Interface, implementing
+// apiserver.ResourceWatcher.
+func (storage *ControllerRegistryStorage) WatchAll() (watch.Interface, error) {
+	return storage.registry.WatchControllers()
+}
+
+// WatchSingle returns events for a single ReplicationController via a watch.Interface,
+// implementing apiserver.ResourceWatcher.
+func (storage *ControllerRegistryStorage) WatchSingle(id string) (watch.Interface, error) {
+	return nil, errors.New("unimplemented")
 }

--- a/pkg/registry/controller_registry_test.go
+++ b/pkg/registry/controller_registry_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
 type MockControllerRegistry struct {
@@ -50,6 +51,9 @@ func (registry *MockControllerRegistry) UpdateController(controller api.Replicat
 }
 func (registry *MockControllerRegistry) DeleteController(ID string) error {
 	return registry.err
+}
+func (registry *MockControllerRegistry) WatchControllers() (watch.Interface, error) {
+	return nil, registry.err
 }
 
 func TestListControllersError(t *testing.T) {
@@ -267,13 +271,13 @@ func TestControllerStorageValidatesCreate(t *testing.T) {
 	}
 
 	failureCases := map[string]api.ReplicationController{
-		"empty ID": api.ReplicationController{
+		"empty ID": {
 			JSONBase: api.JSONBase{ID: ""},
 			DesiredState: api.ReplicationControllerState{
 				ReplicaSelector: map[string]string{"bar": "baz"},
 			},
 		},
-		"empty selector": api.ReplicationController{
+		"empty selector": {
 			JSONBase:     api.JSONBase{ID: "abc"},
 			DesiredState: api.ReplicationControllerState{},
 		},
@@ -298,13 +302,13 @@ func TestControllerStorageValidatesUpdate(t *testing.T) {
 	}
 
 	failureCases := map[string]api.ReplicationController{
-		"empty ID": api.ReplicationController{
+		"empty ID": {
 			JSONBase: api.JSONBase{ID: ""},
 			DesiredState: api.ReplicationControllerState{
 				ReplicaSelector: map[string]string{"bar": "baz"},
 			},
 		},
-		"empty selector": api.ReplicationController{
+		"empty selector": {
 			JSONBase:     api.JSONBase{ID: "abc"},
 			DesiredState: api.ReplicationControllerState{},
 		},

--- a/pkg/registry/etcd_registry.go
+++ b/pkg/registry/etcd_registry.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/golang/glog"
 )
 
@@ -205,6 +206,12 @@ func (registry *EtcdRegistry) ListControllers() ([]api.ReplicationController, er
 	var controllers []api.ReplicationController
 	err := registry.helper().ExtractList("/registry/controllers", &controllers)
 	return controllers, err
+}
+
+// WatchControllers begins watching for new, changed, or deleted controllers.
+// TODO: Add id/selector parameters?
+func (registry *EtcdRegistry) WatchControllers() (watch.Interface, error) {
+	return registry.helper().WatchList("/registry/controllers", tools.Everything)
 }
 
 func makeControllerKey(id string) string {

--- a/pkg/registry/interfaces.go
+++ b/pkg/registry/interfaces.go
@@ -19,6 +19,7 @@ package registry
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
 // PodRegistry is an interface implemented by things that know how to store Pod objects.
@@ -38,6 +39,7 @@ type PodRegistry interface {
 // ControllerRegistry is an interface for things that know how to store ReplicationControllers.
 type ControllerRegistry interface {
 	ListControllers() ([]api.ReplicationController, error)
+	WatchControllers() (watch.Interface, error)
 	GetController(controllerID string) (*api.ReplicationController, error)
 	CreateController(controller api.ReplicationController) error
 	UpdateController(controller api.ReplicationController) error

--- a/pkg/registry/memory_registry.go
+++ b/pkg/registry/memory_registry.go
@@ -17,9 +17,12 @@ limitations under the License.
 package registry
 
 import (
+	"errors"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
 // An implementation of PodRegistry and ControllerRegistry that is backed by memory
@@ -84,6 +87,10 @@ func (registry *MemoryRegistry) ListControllers() ([]api.ReplicationController, 
 		result = append(result, value)
 	}
 	return result, nil
+}
+
+func (registry *MemoryRegistry) WatchControllers() (watch.Interface, error) {
+	return nil, errors.New("unimplemented")
 }
 
 func (registry *MemoryRegistry) GetController(controllerID string) (*api.ReplicationController, error) {

--- a/pkg/tools/decoder.go
+++ b/pkg/tools/decoder.go
@@ -18,6 +18,7 @@ package tools
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -44,7 +45,14 @@ func NewAPIEventDecoder(stream io.ReadCloser) *APIEventDecoder {
 func (d *APIEventDecoder) Decode() (action watch.EventType, object interface{}, err error) {
 	var got api.WatchEvent
 	err = d.decoder.Decode(&got)
-	return got.Type, got.Object.Object, err
+	if err != nil {
+		return action, nil, err
+	}
+	switch got.Type {
+	case watch.Added, watch.Modified, watch.Deleted:
+		return got.Type, got.Object.Object, err
+	}
+	return action, nil, fmt.Errorf("got invalid watch event type: %v", got.Type)
 }
 
 // Close closes the underlying stream.

--- a/pkg/tools/fake_etcd_client.go
+++ b/pkg/tools/fake_etcd_client.go
@@ -215,6 +215,9 @@ func (f *FakeEtcdClient) Watch(prefix string, waitIndex uint64, recursive bool, 
 
 	if receiver == nil {
 		return f.Get(prefix, false, recursive)
+	} else {
+		// Emulate etcd's behavior. (I think.)
+		defer close(receiver)
 	}
 
 	f.watchCompletedChan <- true
@@ -222,8 +225,6 @@ func (f *FakeEtcdClient) Watch(prefix string, waitIndex uint64, recursive bool, 
 	case <-stop:
 		return nil, etcd.ErrWatchStoppedByUser
 	case err := <-injectedError:
-		// Emulate etcd's behavior.
-		close(receiver)
 		return nil, err
 	}
 	// Never get here.


### PR DESCRIPTION
Only the last commit is intended to be part of this PR, the others are already pending in other PRs.

> To make sure the etcd watcher works, I changed the replication controller to use watch.Interface. I made apiserver support watches on controllers, so replicationController can be run only off of the apiserver. I made sure all the etcd watch testing that used to be in replicationController is now tested on the new etcd watcher in pkg/tools/.
