### PR TITLE
Update salt config for apiserver to support Azure.

### DIFF
--- a/cluster/azure/templates/salt-master.sh
+++ b/cluster/azure/templates/salt-master.sh
@@ -22,6 +22,7 @@ cat <<EOF >/etc/salt/minion.d/grains.conf
 grains:
   roles:
     - kubernetes-master
+  cloud: azure
 EOF
 
 # Auto accept all keys from minions that try to join

--- a/cluster/azure/templates/salt-minion.sh
+++ b/cluster/azure/templates/salt-minion.sh
@@ -21,12 +21,16 @@ echo "master: $MASTER_NAME" > /etc/salt/minion.d/master.conf
 # Turn on debugging for salt-minion
 # echo "DAEMON_ARGS=\"\$DAEMON_ARGS --log-file-level=debug\"" > /etc/default/salt-minion
 
+hostnamef=$(hostname -f)
+
 # Our minions will have a pool role to distinguish them from the master.
 cat <<EOF >/etc/salt/minion.d/grains.conf
 grains:
   roles:
     - kubernetes-pool
   cbr-cidr: $MINION_IP_RANGE
+  cloud: azure
+  hostnamef: $hostnamef
 EOF
 
 # Install Salt

--- a/cluster/saltbase/salt/apiserver/default
+++ b/cluster/saltbase/salt/apiserver/default
@@ -1,5 +1,11 @@
 {%- set ips = salt['mine.get']('roles:kubernetes-master', 'network.ip_addrs', 'grain').values() %}
-DAEMON_ARGS="$DAEMON_ARGS -etcd_servers=http://{{ ips[0][0] }}:4001 -minion_regexp '{{ pillar['instance_prefix'] }}.*'"
+DAEMON_ARGS="$DAEMON_ARGS -etcd_servers=http://{{ ips[0][0] }}:4001"
 
+{% if grains['cloud'] is not defined or grains['cloud'] != 'azure' %}
+DAEMON_ARGS="$DAEMON_ARGS -minion_regexp='{{ pillar['instance_prefix'] }}.*'"
 MACHINES="{{ ','.join(salt['mine.get']('roles:kubernetes-pool', 'network.ip_addrs', expr_form='grain').keys()) }}"
-DAEMON_ARGS="$DAEMON_ARGS --machines $MACHINES"
+{% else %}
+MACHINES="{{ salt['mine.get']('roles:kubernetes-pool', 'grains.items', expr_form='grain').values()|join(',', attribute='hostnamef') }}"
+{% endif %}
+
+DAEMON_ARGS="$DAEMON_ARGS -machines=$MACHINES"

--- a/cluster/saltbase/salt/apiserver/default
+++ b/cluster/saltbase/salt/apiserver/default
@@ -1,10 +1,10 @@
 {%- set ips = salt['mine.get']('roles:kubernetes-master', 'network.ip_addrs', 'grain').values() %}
 DAEMON_ARGS="$DAEMON_ARGS -etcd_servers=http://{{ ips[0][0] }}:4001"
 
-{% if grains['cloud'] is not defined or grains['cloud'] != 'azure' %}
-DAEMON_ARGS="$DAEMON_ARGS -minion_regexp='{{ pillar['instance_prefix'] }}.*'"
+{% if grains['cloud'] is defined and grains['cloud'] == 'gce' %}
+DAEMON_ARGS="$DAEMON_ARGS -cloud_provider=gce -minion_regexp='{{ pillar['instance_prefix'] }}.*'"
 MACHINES="{{ ','.join(salt['mine.get']('roles:kubernetes-pool', 'network.ip_addrs', expr_form='grain').keys()) }}"
-{% else %}
+{% elif grains['cloud'] is defined and grains['cloud'] == 'azure' %}
 MACHINES="{{ salt['mine.get']('roles:kubernetes-pool', 'grains.items', expr_form='grain').values()|join(',', attribute='hostnamef') }}"
 {% endif %}
 

--- a/cluster/saltbase/salt/apiserver/init.sls
+++ b/cluster/saltbase/salt/apiserver/init.sls
@@ -57,6 +57,7 @@ apiserver-build:
 /etc/init.d/apiserver:
   file.managed:
     - source: salt://apiserver/initd
+    - template: jinja
     - user: root
     - group: root
     - mode: 755

--- a/cluster/saltbase/salt/apiserver/init.sls
+++ b/cluster/saltbase/salt/apiserver/init.sls
@@ -57,7 +57,6 @@ apiserver-build:
 /etc/init.d/apiserver:
   file.managed:
     - source: salt://apiserver/initd
-    - template: jinja
     - user: root
     - group: root
     - mode: 755
@@ -79,4 +78,3 @@ apiserver:
       - file: /etc/default/apiserver
       - file: /usr/local/bin/apiserver
       - file: /etc/init.d/apiserver
-

--- a/cluster/saltbase/salt/apiserver/initd
+++ b/cluster/saltbase/salt/apiserver/initd
@@ -17,9 +17,6 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="The Kubernetes API server"
 NAME=apiserver
 DAEMON=/usr/local/bin/apiserver
-{% if grains['cloud'] is not defined or grains['cloud'] != 'azure' %}
-DAEMON_ARGS="-cloud_provider gce"
-{% endif %}
 DAEMON_LOG_FILE=/var/log/$NAME.log
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME

--- a/cluster/saltbase/salt/apiserver/initd
+++ b/cluster/saltbase/salt/apiserver/initd
@@ -17,7 +17,9 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="The Kubernetes API server"
 NAME=apiserver
 DAEMON=/usr/local/bin/apiserver
-DAEMON_ARGS="-cloud_provider gce" 
+{% if grains['cloud'] is not defined or grains['cloud'] != 'azure' %}
+DAEMON_ARGS="-cloud_provider gce"
+{% endif %}
 DAEMON_LOG_FILE=/var/log/$NAME.log
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME

--- a/cluster/templates/salt-master.sh
+++ b/cluster/templates/salt-master.sh
@@ -25,6 +25,7 @@ cat <<EOF >/etc/salt/minion.d/grains.conf
 grains:
   roles:
     - kubernetes-master
+  cloud: gce
 EOF
 
 # Auto accept all keys from minions that try to join

--- a/cluster/templates/salt-minion.sh
+++ b/cluster/templates/salt-minion.sh
@@ -31,6 +31,7 @@ grains:
   roles:
     - kubernetes-pool
   cbr-cidr: $MINION_IP_RANGE
+  cloud: gce
 EOF
 
 # Install Salt


### PR DESCRIPTION
Shall I add the grain `cloud: gce` to the default salt scripts, and change around the `if grains['cloud'] != 'azure'` to `if grains['cloud'] == 'gce'`? Or leave as is?
