### PR TITLE
Container manifests can define docker registry

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -131,6 +131,21 @@ type EnvVar struct {
 	Value string `yaml:"value,omitempty" json:"value,omitempty"`
 }
 
+// DockerRegistry contains details about the registry to pull the Image
+type DockerRegistry struct {
+	// Optional: the docker registry to connect to. Defaults to "" to
+	// use Docker's default
+	Host string             `yaml:"host,omitempty" json:"host,omitempty"`
+	Auth DockerRegistryAuth `yaml:"auth,omitempty" json:"auth,omitempty"`
+}
+
+// DockerRegistryAuth represents docker registry authentication details
+type DockerRegistryAuth struct {
+	Username string `yaml:"username" json:"username"`
+	Password string `yaml:"password" json:"password"`
+	Email    string `yaml:"email" json:"email"`
+}
+
 // HTTPGetProbe describes a liveness probe based on HTTP Get requests.
 type HTTPGetProbe struct {
 	// Path to access on the http server
@@ -161,9 +176,10 @@ type Container struct {
 	// Optional: Defaults to whatever is defined in the image.
 	Command []string `yaml:"command,omitempty" json:"command,omitempty"`
 	// Optional: Defaults to Docker's default.
-	WorkingDir string   `yaml:"workingDir,omitempty" json:"workingDir,omitempty"`
-	Ports      []Port   `yaml:"ports,omitempty" json:"ports,omitempty"`
-	Env        []EnvVar `yaml:"env,omitempty" json:"env,omitempty"`
+	WorkingDir string         `yaml:"workingDir,omitempty" json:"workingDir,omitempty"`
+	Ports      []Port         `yaml:"ports,omitempty" json:"ports,omitempty"`
+	Env        []EnvVar       `yaml:"env,omitempty" json:"env,omitempty"`
+	Registry   DockerRegistry `yaml:"registry,omitempty" json:"registry,omitempty"`
 	// Optional: Defaults to unlimited.
 	Memory int `yaml:"memory,omitempty" json:"memory,omitempty"`
 	// Optional: Defaults to unlimited.

--- a/pkg/kubelet/docker.go
+++ b/pkg/kubelet/docker.go
@@ -48,7 +48,7 @@ type DockerID string
 
 // DockerPuller is an abstract interface for testability.  It abstracts image pull operations.
 type DockerPuller interface {
-	Pull(image string) error
+	Pull(image string, registry api.DockerRegistry) error
 }
 
 // dockerPuller is the default implementation of DockerPuller.
@@ -63,7 +63,7 @@ func NewDockerPuller(client DockerInterface) DockerPuller {
 	}
 }
 
-func (p dockerPuller) Pull(image string) error {
+func (p dockerPuller) Pull(image string, registry api.DockerRegistry) error {
 	image, tag := parseImageName(image)
 
 	// If no tag was specified, use the default "latest".
@@ -74,8 +74,13 @@ func (p dockerPuller) Pull(image string) error {
 	opts := docker.PullImageOptions{
 		Repository: image,
 		Tag:        tag,
+		Registry:   registry.Host,
 	}
-	return p.client.PullImage(opts, docker.AuthConfiguration{})
+	return p.client.PullImage(opts, docker.AuthConfiguration{
+		Username: registry.Auth.Username,
+		Password: registry.Auth.Password,
+		Email:    registry.Auth.Email,
+	})
 }
 
 // DockerContainers is a map of containers

--- a/pkg/kubelet/fake_docker_client.go
+++ b/pkg/kubelet/fake_docker_client.go
@@ -19,6 +19,7 @@ package kubelet
 import (
 	"fmt"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/fsouza/go-dockerclient"
 )
 
@@ -107,7 +108,7 @@ type FakeDockerPuller struct {
 }
 
 // Pull records the image pull attempt, and optionally injects an error.
-func (f *FakeDockerPuller) Pull(image string) error {
+func (f *FakeDockerPuller) Pull(image string, registry api.DockerRegistry) error {
 	f.ImagesPulled = append(f.ImagesPulled, image)
 
 	if n := len(f.ErrorsToInject); n > 0 {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -565,7 +565,7 @@ func (kl *Kubelet) createNetworkContainer(manifest *api.ContainerManifest) (Dock
 		Image: networkContainerImage,
 		Ports: ports,
 	}
-	kl.DockerPuller.Pull(networkContainerImage)
+	kl.DockerPuller.Pull(networkContainerImage, api.DockerRegistry{})
 	return kl.runContainer(manifest, container, nil, "")
 }
 
@@ -612,7 +612,8 @@ func (kl *Kubelet) syncManifest(manifest *api.ContainerManifest, dockerContainer
 		}
 
 		glog.Infof("%+v doesn't exist, creating", container)
-		if err := kl.DockerPuller.Pull(container.Image); err != nil {
+		// use custom Docker registry and authentication from ContainerManifest
+		if err := kl.DockerPuller.Pull(container.Image, container.Registry); err != nil {
 			glog.Errorf("Failed to create container: %v skipping manifest %s container %s.", err, manifest.ID, container.Name)
 			continue
 		}


### PR DESCRIPTION
- Allows for each image to be pulled from a custom docker registry
- ContainerManifest can specify authentication for a private registry
- No breaking changes
