### PR TITLE
Some examples don't pass Manifest validation

### DIFF
--- a/examples/guestbook/frontend-controller.json
+++ b/examples/guestbook/frontend-controller.json
@@ -9,6 +9,7 @@
              "version": "v1beta1",
              "id": "frontendController",
              "containers": [{
+               "name": "php-redis",
                "image": "brendanburns/php-redis",
                "ports": [{"containerPort": 80, "hostPort": 8000}]
              }]

--- a/examples/guestbook/frontend-service.json
+++ b/examples/guestbook/frontend-service.json
@@ -1,0 +1,7 @@
+{
+  "id": "frontend",
+  "port": 9998,
+  "selector": {
+    "name": "frontend"
+  }
+}

--- a/examples/guestbook/redis-slave-controller.json
+++ b/examples/guestbook/redis-slave-controller.json
@@ -9,6 +9,7 @@
              "version": "v1beta1",
              "id": "redisSlaveController",
              "containers": [{
+               "name": "slave"
                "image": "brendanburns/redis-slave",
                "ports": [{"containerPort": 6379, "hostPort": 6380}]
              }]


### PR DESCRIPTION
A few of the examples don't have a "Name" in their manifest which fails
the new validation logic.  Also, add a frontend-service.json example
which can do simple load balancing to the frontends.
