### PR TITLE
Kubelet etcd watch skipping indices

### DIFF
--- a/pkg/kubelet/config/etcd_test.go
+++ b/pkg/kubelet/config/etcd_test.go
@@ -83,8 +83,8 @@ func TestGetEtcd(t *testing.T) {
 	c := SourceEtcd{"/registry/hosts/machine/kubelet", fakeClient, ch, time.Millisecond}
 	lastIndex, err := c.fetchNextState(0)
 	expectNoError(t, err)
-	if lastIndex != 1 {
-		t.Errorf("Expected %#v, Got %#v", 1, lastIndex)
+	if lastIndex != 2 {
+		t.Errorf("Expected %#v, Got %#v", 2, lastIndex)
 	}
 	update := (<-ch).(kubelet.PodUpdate)
 	expected := CreatePodUpdate(kubelet.SET, kubelet.Pod{Name: "foo", Manifest: api.ContainerManifest{ID: "foo"}})
@@ -108,8 +108,8 @@ func TestWatchEtcd(t *testing.T) {
 	c := SourceEtcd{"/registry/hosts/machine/kubelet", fakeClient, ch, time.Millisecond}
 	lastIndex, err := c.fetchNextState(1)
 	expectNoError(t, err)
-	if lastIndex != 2 {
-		t.Errorf("Expected %d, Got %d", 1, lastIndex)
+	if lastIndex != 3 {
+		t.Errorf("Expected %d, Got %d", 3, lastIndex)
 	}
 	update := (<-ch).(kubelet.PodUpdate)
 	expected := CreatePodUpdate(kubelet.SET)


### PR DESCRIPTION
The next index to watch should always be current+1 if we got a
response from etcd, but otherwise it should always be current.
Moved the increment into fetchNextState which returns the next
index to watch for (or the same if an error occurs)

The kubelet will miss config changes in some cases without this
fix.
