### PR TITLE
kubecfg doesn't allow updates because of path checks

### DIFF
--- a/pkg/kubecfg/parse.go
+++ b/pkg/kubecfg/parse.go
@@ -44,3 +44,11 @@ func ToWireFormat(data []byte, storage string) ([]byte, error) {
 	}
 	return api.Encode(obj)
 }
+
+func SupportedWireStorage() []string {
+	types := []string{}
+	for k, _ := range storageToType {
+		types = append(types, k)
+	}
+	return types
+}


### PR DESCRIPTION
Currently, `kubecfg -c <json> update services/<id>` fails because `services/<id>` is checked by ToWireFormat instead of just `services`.  Updates should allow two path segments and check storage on the first.

Check for 1 path segment on create/list, 2 on update/delete, and allow any number of path segments on get (for now).

Also pretty prints the list of actual types that are supported for create/update, which today corresponds to the list of types that are supported period.
