### PR TITLE
fix broken replication controller command handling

### DIFF
--- a/cmd/kubecfg/kubecfg.go
+++ b/cmd/kubecfg/kubecfg.go
@@ -157,10 +157,6 @@ func main() {
 }
 
 func executeAPIRequest(method string, s *kube_client.Client) bool {
-	if len(flag.Args()) < 2 {
-		glog.Fatalf("usage: kubecfg [OPTIONS] get|list|create|update|delete <%s>[/<id>]", prettyWireStorage())
-	}
-
 	verb := ""
 	segments := strings.SplitN(flag.Arg(1), "/", 2)
 	storage := segments[0]
@@ -188,6 +184,10 @@ func executeAPIRequest(method string, s *kube_client.Client) bool {
 		}
 	default:
 		return false
+	}
+
+	if len(flag.Args()) < 2 {
+		glog.Fatalf("usage: kubecfg [OPTIONS] get|list|create|update|delete <%s>[/<id>]", prettyWireStorage())
 	}
 
 	r := s.Verb(verb).


### PR DESCRIPTION
fbd7bc375fd6616bfb76759f78f8e70c100f0497 broke this, the condition at this line
prohibits to ever check for controller commands and you always get a fatal error,
eg trying to resize
