### PR TITLE
Proposal for scheduler API

### DIFF
--- a/pkg/api/helper.go
+++ b/pkg/api/helper.go
@@ -64,6 +64,7 @@ func init() {
 		ServerOp{},
 		ContainerManifestList{},
 		Endpoints{},
+		Binding{},
 	)
 	AddKnownTypes("v1beta1",
 		v1beta1.PodList{},
@@ -79,6 +80,7 @@ func init() {
 		v1beta1.ServerOp{},
 		v1beta1.ContainerManifestList{},
 		v1beta1.Endpoints{},
+		v1beta1.Binding{},
 	)
 
 	// TODO: when we get more of this stuff, move to its own file. This is not a

--- a/pkg/api/helper_test.go
+++ b/pkg/api/helper_test.go
@@ -152,6 +152,7 @@ func TestTypes(t *testing.T) {
 		&ServerOp{},
 		&ContainerManifestList{},
 		&Endpoints{},
+		&Binding{},
 	}
 	for _, item := range table {
 		// Try a few times, since runTest uses random values.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -335,6 +335,13 @@ type MinionList struct {
 	Items    []Minion `json:"minions,omitempty" yaml:"minions,omitempty"`
 }
 
+// Binding is written by a scheduler to cause a pod to be bound to a host.
+type Binding struct {
+	JSONBase `json:",inline" yaml:",inline"`
+	PodID    string `json:"podID" yaml:"podID"`
+	Host     string `json:"host" yaml:"host"`
+}
+
 // Status is a return value for calls that don't return other objects.
 // TODO: this could go in apiserver, but I'm including it here so clients needn't
 // import both.

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -338,6 +338,13 @@ type MinionList struct {
 	Items    []Minion `json:"minions,omitempty" yaml:"minions,omitempty"`
 }
 
+// Binding is written by a scheduler to cause a pod to be bound to a host.
+type Binding struct {
+	JSONBase `json:",inline" yaml:",inline"`
+	PodID    string `json:"podID" yaml:"podID"`
+	Host     string `json:"host" yaml:"host"`
+}
+
 // Status is a return value for calls that don't return other objects.
 // TODO: this could go in apiserver, but I'm including it here so clients needn't
 // import both.

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -122,6 +122,7 @@ func (m *Master) init(cloud cloudprovider.Interface, podInfoGetter client.PodInf
 		"replicationControllers": registry.NewControllerRegistryStorage(m.controllerRegistry, m.podRegistry),
 		"services":               registry.MakeServiceRegistryStorage(m.serviceRegistry, cloud, m.minionRegistry),
 		"minions":                registry.MakeMinionRegistryStorage(m.minionRegistry),
+		"bindings":               registry.MakeBindingStorage(m.podRegistry),
 	}
 }
 

--- a/pkg/registry/bindingstorage.go
+++ b/pkg/registry/bindingstorage.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+)
+
+// BindingStorage implements the RESTStorage interface. When bindings are written, it
+// changes the location of the affected pods. This information is eventually reflected
+// in the pod's CurrentState.Host field.
+type BindingStorage struct {
+	podRegistry PodRegistry
+}
+
+// MakeBindingStorage makes a new BindingStorage backed by the given PodRegistry.
+func MakeBindingStorage(podRegistry PodRegistry) *BindingStorage {
+	return &BindingStorage{
+		podRegistry: podRegistry,
+	}
+}
+
+// List returns an error because bindings are write-only objects.
+func (*BindingStorage) List(selector labels.Selector) (interface{}, error) {
+	return nil, apiserver.NewNotFoundErr("binding", "list")
+}
+
+// Get returns an error because bindings are write-only objects.
+func (*BindingStorage) Get(id string) (interface{}, error) {
+	return nil, apiserver.NewNotFoundErr("binding", id)
+}
+
+// Delete returns an error because bindings are write-only objects.
+func (*BindingStorage) Delete(id string) (<-chan interface{}, error) {
+	return nil, apiserver.NewNotFoundErr("binding", id)
+}
+
+// New returns a new binding object fit for having data unmarshalled into it.
+func (*BindingStorage) New() interface{} {
+	return &api.Binding{}
+}
+
+// Create attempts to make the assignment indicated by the binding it recieves.
+func (b *BindingStorage) Create(obj interface{}) (<-chan interface{}, error) {
+	binding, ok := obj.(*api.Binding)
+	if !ok {
+		return nil, fmt.Errorf("incorrect type: %#v", obj)
+	}
+	_ = binding
+	return nil, fmt.Errorf("Implementation coming in the future. Storage layer can't easily support this yet.")
+}
+
+// Update returns an error-- this object may not be updated.
+func (b *BindingStorage) Update(obj interface{}) (<-chan interface{}, error) {
+	return nil, fmt.Errorf("Bindings may not be changed.")
+}

--- a/pkg/registry/bindingstorage_test.go
+++ b/pkg/registry/bindingstorage_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+func TestBindingStorage_Extract(t *testing.T) {
+	b := &BindingStorage{}
+
+	binding := &api.Binding{
+		PodID: "foo",
+		Host:  "bar",
+	}
+	body, err := api.Encode(binding)
+	if err != nil {
+		t.Fatalf("Unexpected encode error %v", err)
+	}
+	obj := b.New()
+	err = api.DecodeInto(body, obj)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	if e, a := binding, obj; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, but got %#v", e, a)
+	}
+}


### PR DESCRIPTION
This commit adds a Binding object. The idea is that schedulers can write
these to cause pods to be asssigned to hosts. No implementation is
provided; if this is accepted, I'll write that once we get pods moved to
a different etcd key.

This continues k8s' tradition of phrasing all APIs as RESTful handlers.
