### PR TITLE
list replicationControllers appears broken

### DIFF
--- a/pkg/api/helper.go
+++ b/pkg/api/helper.go
@@ -460,7 +460,7 @@ func internalize(obj interface{}) (interface{}, error) {
 	case *v1beta1.ReplicationControllerList:
 		var items []ReplicationController
 		if cObj.Items != nil {
-			items := make([]ReplicationController, len(cObj.Items))
+			items = make([]ReplicationController, len(cObj.Items))
 			for ix := range cObj.Items {
 				rc, err := internalize(cObj.Items[ix])
 				if err != nil {


### PR DESCRIPTION
Working through the guestbook example, my replicationControllers get created and can be get-ed, but 'list replicationControllers' returns nothing:

jcarriere@docker:~/kubernetes$ cluster/kubecfg.sh list replicationControllers
Name                Image(s)            Selector            Replicas

---

jcarriere@docker:~/kubernetes$ cluster/kubecfg.sh get replicationControllers/redisSlaveController
Name                   Image(s)                   Selector            Replicas

---

redisSlaveController   brendanburns/redis-slave   name=redisslave     2
