### PR TITLE
The quotes around the coverfile are unnecessary

### DIFF
--- a/build/build-image/run-tests.sh
+++ b/build/build-image/run-tests.sh
@@ -36,10 +36,10 @@ cd "${KUBE_TARGET}"
 echo "+++ Running unit tests"
 
 if [[ -n "$1" ]]; then
-  go test -cover -coverprofile="tmp.out" "$KUBE_GO_PACKAGE/$1"
+  go test -cover -coverprofile=tmp.out "$KUBE_GO_PACKAGE/$1"
   exit 0
 fi
 
 for package in $(find_test_dirs); do
-  go test -cover -coverprofile="tmp.out" "${KUBE_GO_PACKAGE}/${package}"
+  go test -cover -coverprofile=tmp.out "${KUBE_GO_PACKAGE}/${package}"
 done

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -36,7 +36,7 @@ find_test_dirs() {
 }
 
 # -covermode=atomic becomes default with -race in Go >=1.3
-KUBE_COVER="-cover -covermode=atomic -coverprofile=\"tmp.out\""
+KUBE_COVER="-cover -covermode=atomic -coverprofile=tmp.out"
 
 cd "${KUBE_TARGET}"
 


### PR DESCRIPTION
In Go 1.2 on the Mac they result in a file created with actual
quotes.
