### PR TITLE
Build all commands at the same time

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -31,7 +31,4 @@ if [ $# -gt 0 ]; then
   BINARIES="$@"
 fi
 
-for b in $BINARIES; do
-  echo "+++ Building ${b}"
-  go build "${KUBE_GO_PACKAGE}"/cmd/${b}
-done
+go build $(for b in $BINARIES; do echo "${KUBE_GO_PACKAGE}"/cmd/${b}; done)

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -25,10 +25,10 @@ source $(dirname $0)/config-go.sh
 
 cd "${KUBE_TARGET}"
 
-BINARIES="proxy integration apiserver controller-manager kubelet kubecfg"
+BINARIES="cmd/proxy cmd/integration cmd/apiserver cmd/controller-manager cmd/kubelet cmd/kubecfg"
 
 if [ $# -gt 0 ]; then
   BINARIES="$@"
 fi
 
-go build $(for b in $BINARIES; do echo "${KUBE_GO_PACKAGE}"/cmd/${b}; done)
+go build $(for b in $BINARIES; do echo "${KUBE_GO_PACKAGE}"/${b}; done)

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -22,7 +22,7 @@ fi
 # Stop right away if the build fails
 set -e
 
-$(dirname $0)/build-go.sh integration
+$(dirname $0)/build-go.sh cmd/integration
 
 ETCD_DIR=$(mktemp -d -t kube-integration.XXXXXX)
 trap "rm -rf ${ETCD_DIR}" EXIT


### PR DESCRIPTION
In Go it's much more efficient to build several commands in the same
`go build` because the build has to load most of the dependency tree
each time.  Roughly 50% on my machine:

Together (go1.2 on OS X):

```
real  0m4.049s
user  0m8.387s
sys   0m2.766s
```

Separate:

```
real  0m13.392s
user  0m12.420s
sys   0m6.882s
```
