### PR TITLE
named container ports should have sane env var names

### DIFF
--- a/pkg/registry/service_registry.go
+++ b/pkg/registry/service_registry.go
@@ -50,7 +50,7 @@ func makeLinkVariables(service api.Service, machine string) []api.EnvVar {
 	} else {
 		port = strconv.Itoa(service.ContainerPort.IntVal)
 	}
-	portPrefix := prefix + "_PORT_" + port + "_TCP"
+	portPrefix := prefix + "_PORT_" + strings.ToUpper(strings.Replace(port,"-","_",-1)) + "_TCP"
 	return []api.EnvVar{
 		{
 			Name:  prefix + "_PORT",

--- a/pkg/registry/service_registry_test.go
+++ b/pkg/registry/service_registry_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 func TestServiceRegistry(t *testing.T) {
@@ -159,6 +160,20 @@ func TestServiceRegistryDeleteExternal(t *testing.T) {
 			t.Errorf("memory.GetService(%q) failed with %v; expected failure with not found error", svc.ID, err)
 		} else {
 			t.Errorf("memory.GetService(%q) = %v; expected failure with not found error", svc.ID, srv)
+		}
+	}
+}
+
+func TestServiceRegistryMakeLinkVariables(t *testing.T) {
+	service := api.Service {
+		JSONBase:	api.JSONBase{ID: "foo"},
+		Selector:	map[string]string{"bar": "baz"},
+		ContainerPort:	util.IntOrString { Kind: util.IntstrString, StrVal: "a-b-c" },
+	}
+	vars := makeLinkVariables(service, "mars")
+	for _, v := range vars {
+		if !util.IsCIdentifier(v.Name) {
+			t.Errorf("Environment variable name is not valid: %v", v.Name)
 		}
 	}
 }


### PR DESCRIPTION
Resolves problems like this:

```
EnvVar.Name: invalid value 'RM_PORT_abc-def_TCP' 
EnvVar.Name: invalid value 'RM_PORT_abc-def_TCP_PROTO' 
EnvVar.Name: invalid value 'RM_PORT_abc-def_TCP_PORT' 
EnvVar.Name: invalid value 'RM_PORT_abc-def_TCP_ADDR' 
```
