### PR TITLE
Build binaries using Go 1.3

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -26,8 +26,11 @@ RUN apt-get update -y && apt-get install --no-install-recommends -y -q \
   rsync
 
 # Install Go
-# TODO(jbeda) -- we need to verify this against the hash
-RUN curl -s https://storage.googleapis.com/golang/go1.2.2.src.tar.gz | tar -C /usr/local -xz
+# Save the SHA1 checksum from http://golang.org/dl
+RUN echo '9f9dfcbcb4fa126b2b66c0830dc733215f2f056e  go1.3.src.tar.gz' > go1.3.src.tar.gz.sha1
+RUN curl -O -s https://storage.googleapis.com/golang/go1.3.src.tar.gz
+RUN sha1sum --check go1.3.src.tar.gz.sha1
+RUN tar -xzf go1.3.src.tar.gz -C /usr/local
 ENV PATH  /usr/local/go/bin:$PATH
 RUN cd /usr/local/go/src && ./make.bash --no-clean 2>&1
 


### PR DESCRIPTION
Currently binaries are built using Go 1.2.2, which results
in larger binaries than those produced by newer versions of
Go. The Go source archive used for the build process is not
verified against its SHA1 hash.

Update the build-image Dockerfile to use Go 1.3 to build all
binaries, as a result binaries are now 20% - 30% smaller. The
Go source archive used for building binaries is now verified
against its SHA1 hash.
