### PR TITLE
kubecfg: improve tests around authentication

### DIFF
--- a/cmd/kubecfg/kubecfg.go
+++ b/cmd/kubecfg/kubecfg.go
@@ -130,7 +130,7 @@ func main() {
 
 	var auth *kube_client.AuthInfo
 	if secure {
-		auth, err = kubecfg.LoadAuthInfo(*authConfig)
+		auth, err = kubecfg.LoadAuthInfo(*authConfig, os.Stdin)
 		if err != nil {
 			glog.Fatalf("Error loading auth: %v", err)
 		}

--- a/pkg/kubecfg/kubecfg.go
+++ b/pkg/kubecfg/kubecfg.go
@@ -19,6 +19,7 @@ package kubecfg
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -32,19 +33,19 @@ import (
 	"gopkg.in/v1/yaml"
 )
 
-func promptForString(field string) string {
+func promptForString(field string, r io.Reader) string {
 	fmt.Printf("Please enter %s: ", field)
 	var result string
-	fmt.Scan(&result)
+	fmt.Fscan(r, &result)
 	return result
 }
 
 // LoadAuthInfo parses an AuthInfo object from a file path. It prompts user and creates file if it doesn't exist.
-func LoadAuthInfo(path string) (*client.AuthInfo, error) {
+func LoadAuthInfo(path string, r io.Reader) (*client.AuthInfo, error) {
 	var auth client.AuthInfo
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		auth.User = promptForString("Username")
-		auth.Password = promptForString("Password")
+		auth.User = promptForString("Username", r)
+		auth.Password = promptForString("Password", r)
 		data, err := json.Marshal(auth)
 		if err != nil {
 			return &auth, err


### PR DESCRIPTION
This change adds additional test coverage for the kubecfg
command. There is now a test for the case when the auth info
file does not exist. LoadAuthInfo tests have been refactored
to use table testing.
