### PR TITLE
Fix hack/build-go.sh to work on all platforms

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -31,4 +31,7 @@ if [ $# -gt 0 ]; then
   BINARIES="$@"
 fi
 
-go build $(for b in $BINARIES; do echo "${KUBE_GO_PACKAGE}"/${b}; done)
+for b in ${BINARIES}; do
+  echo "+++ Building ${b}"
+  go build "${KUBE_GO_PACKAGE}/${b}"
+done


### PR DESCRIPTION
Currently the hack/build-go.sh build script does not work
on OS X 10.9.x systems. This changes reverts back to building
one binary via a for loop.
