### PR TITLE
integration: Fix multiple response.WriteHeader calls

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -74,6 +74,7 @@ type delegateHandler struct {
 func (h *delegateHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if h.delegate != nil {
 		h.delegate.ServeHTTP(w, req)
+		return
 	}
 	w.WriteHeader(http.StatusNotFound)
 }


### PR DESCRIPTION
The current integration tests do not return after delegating
HTTP requests, as a result an extra call to response.WriteHeader
is made for every request.

Fix the issue by returning after delegating HTTP requests.
