### PR TITLE
Solve issue with realpath on Mac OS X.

### DIFF
--- a/release/release.sh
+++ b/release/release.sh
@@ -26,8 +26,7 @@ set -e
 SCRIPT_DIR=$(CDPATH="" cd $(dirname $0); pwd)
 
 source $SCRIPT_DIR/config.sh
-
-KUBE_REPO_ROOT="$(realpath "$(dirname $0)/..")"
+KUBE_REPO_ROOT="$(cd "$(dirname "$0")/../" && pwd -P)"
 
 source "${KUBE_REPO_ROOT}/cluster/kube-env.sh"
 source $(dirname ${BASH_SOURCE})/../cluster/${KUBERNETES_PROVIDER}/${KUBE_CONFIG_FILE-"config-default.sh"}


### PR DESCRIPTION
- realpath doesn't work on Mac OS systems. I found the following workaround that should work in any distro. More info [here](http://serverfault.com/questions/40144/how-can-i-retrieve-the-absolute-filename-in-a-shell-script-on-mac-os-x)
