### PR TITLE
Revert build to previous commit.

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -31,4 +31,7 @@ if [ $# -gt 0 ]; then
   BINARIES="$@"
 fi
 
-go build $(for b in $BINARIES; do echo "${KUBE_GO_PACKAGE}"/${b}; done)
+for b in $BINARIES; do
+  echo "+++ Building ${b}"
+  go build "${KUBE_GO_PACKAGE}"/${b}
+done


### PR DESCRIPTION
- Not sure if this is a bug, but on my computer if I don't do it this
  way, when I check the output/release/go there is no:
  - apiserver
  - controller-manager
    ...
