### PR TITLE
Add master.Config type and cleanup master configuration

### DIFF
--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -83,9 +83,23 @@ func main() {
 
 	var m *master.Master
 	if len(etcdServerList) > 0 {
-		m = master.New(etcdServerList, machineList, podInfoGetter, cloud, *minionRegexp, client, *healthCheckMinions, *minionCacheTTL)
+		m = master.New(&master.Config{
+			Client:             client,
+			Cloud:              cloud,
+			EtcdServers:        etcdServerList,
+			HealthCheckMinions: *healthCheckMinions,
+			Minions:            machineList,
+			MinionCacheTTL:     *minionCacheTTL,
+			MinionRegexp:       *minionRegexp,
+			PodInfoGetter:      podInfoGetter,
+		})
 	} else {
-		m = master.NewMemoryServer(machineList, podInfoGetter, cloud, client)
+		m = master.NewMemoryServer(&master.Config{
+			Client:        client,
+			Cloud:         cloud,
+			Minions:       machineList,
+			PodInfoGetter: podInfoGetter,
+		})
 	}
 
 	glog.Fatal(m.Run(net.JoinHostPort(*address, strconv.Itoa(int(*port))), *apiPrefix))

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -95,7 +95,12 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	cl.Sync = true
 
 	// Master
-	m := master.New(servers, machineList, fakePodInfoGetter{}, nil, "", cl, false, 0)
+	m := master.New(&master.Config{
+		Client:        cl,
+		EtcdServers:   servers,
+		Minions:       machineList,
+		PodInfoGetter: fakePodInfoGetter{},
+	})
 	handler.delegate = m.ConstructHandler("/api/v1beta1")
 
 	controllerManager := controller.MakeReplicationManager(etcdClient, cl)


### PR DESCRIPTION
Setting up a new master.Master instance requires passing
around too many arguments.

Add a master.Config type and group related master configs.
Refactor all commands to instantiate new masters using a
master.Config struct.
