### PR TITLE
Remove extra test flags from all commands

### DIFF
--- a/pkg/kubelet/config/config_test.go
+++ b/pkg/kubelet/config/config_test.go
@@ -24,20 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
 )
 
-// TODO: remove this
-func expectError(t *testing.T, err error) {
-	if err == nil {
-		t.Errorf("Expected error, Got %v", err)
-	}
-}
-
-// TODO: remove this
-func expectNoError(t *testing.T, err error) {
-	if err != nil {
-		t.Errorf("Expected no error, Got %v", err)
-	}
-}
-
 func expectEmptyChannel(t *testing.T, ch <-chan interface{}) {
 	select {
 	case update := <-ch:

--- a/pkg/kubelet/config/etcd_test.go
+++ b/pkg/kubelet/config/etcd_test.go
@@ -64,7 +64,9 @@ func TestGetEtcdNoData(t *testing.T) {
 	}
 	c := SourceEtcd{"/registry/hosts/machine/kubelet", fakeClient, ch, time.Millisecond}
 	_, err := c.fetchNextState(0)
-	expectError(t, err)
+	if err == nil {
+		t.Errorf("Expected error")
+	}
 	expectEmptyChannel(t, ch)
 }
 
@@ -82,7 +84,9 @@ func TestGetEtcd(t *testing.T) {
 	}
 	c := SourceEtcd{"/registry/hosts/machine/kubelet", fakeClient, ch, time.Millisecond}
 	lastIndex, err := c.fetchNextState(0)
-	expectNoError(t, err)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
 	if lastIndex != 2 {
 		t.Errorf("Expected %#v, Got %#v", 2, lastIndex)
 	}
@@ -107,7 +111,9 @@ func TestWatchEtcd(t *testing.T) {
 	}
 	c := SourceEtcd{"/registry/hosts/machine/kubelet", fakeClient, ch, time.Millisecond}
 	lastIndex, err := c.fetchNextState(1)
-	expectNoError(t, err)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
 	if lastIndex != 3 {
 		t.Errorf("Expected %d, Got %d", 3, lastIndex)
 	}
@@ -127,7 +133,9 @@ func TestGetEtcdNotFound(t *testing.T) {
 	}
 	c := SourceEtcd{"/registry/hosts/machine/kubelet", fakeClient, ch, time.Millisecond}
 	_, err := c.fetchNextState(0)
-	expectError(t, err)
+	if err == nil {
+		t.Errorf("Expected error")
+	}
 	expectEmptyChannel(t, ch)
 }
 
@@ -142,6 +150,8 @@ func TestGetEtcdError(t *testing.T) {
 	}
 	c := SourceEtcd{"/registry/hosts/machine/kubelet", fakeClient, ch, time.Millisecond}
 	_, err := c.fetchNextState(0)
-	expectError(t, err)
+	if err == nil {
+		t.Errorf("Expected error")
+	}
 	expectEmptyChannel(t, ch)
 }

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -42,7 +42,9 @@ func TestExtractFromHttpBadness(t *testing.T) {
 	ch := make(chan interface{}, 1)
 	c := SourceURL{"http://localhost:49575/_not_found_", ch}
 	err := c.extractFromURL()
-	expectError(t, err)
+	if err == nil {
+		t.Errorf("Expected error")
+	}
 	expectEmptyChannel(t, ch)
 }
 
@@ -63,7 +65,9 @@ func TestExtractFromHttpSingle(t *testing.T) {
 	c := SourceURL{testServer.URL, ch}
 
 	err = c.extractFromURL()
-	expectNoError(t, err)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
 	update := (<-ch).(kubelet.PodUpdate)
 	expected := CreatePodUpdate(kubelet.SET, kubelet.Pod{Name: "foo", Manifest: manifests[0]})
 	if !reflect.DeepEqual(expected, update) {
@@ -90,7 +94,9 @@ func TestExtractFromHttpMultiple(t *testing.T) {
 	c := SourceURL{testServer.URL, ch}
 
 	err = c.extractFromURL()
-	expectNoError(t, err)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
 
 	update := (<-ch).(kubelet.PodUpdate)
 	expected := CreatePodUpdate(kubelet.SET, kubelet.Pod{Name: "1", Manifest: manifests[0]}, kubelet.Pod{Name: "bar", Manifest: manifests[1]})
@@ -115,7 +121,9 @@ func TestExtractFromHttpEmptyArray(t *testing.T) {
 	c := SourceURL{testServer.URL, ch}
 
 	err = c.extractFromURL()
-	expectNoError(t, err)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
 	update := (<-ch).(kubelet.PodUpdate)
 	expected := CreatePodUpdate(kubelet.SET)
 	if !reflect.DeepEqual(expected, update) {

--- a/pkg/tools/fake_etcd_client.go
+++ b/pkg/tools/fake_etcd_client.go
@@ -18,7 +18,6 @@ package tools
 
 import (
 	"fmt"
-	"testing"
 
 	"github.com/coreos/go-etcd/etcd"
 )
@@ -28,13 +27,19 @@ type EtcdResponseWithError struct {
 	E error
 }
 
+// TestLogger is a type passed to Test functions to support formatted test logs.
+type TestLogger interface {
+	Errorf(format string, args ...interface{})
+	Logf(format string, args ...interface{})
+}
+
 type FakeEtcdClient struct {
 	watchCompletedChan chan bool
 
 	Data        map[string]EtcdResponseWithError
 	DeletedKeys []string
 	Err         error
-	t           *testing.T
+	t           TestLogger
 	Ix          int
 
 	// Will become valid after Watch is called; tester may write to it. Tester may
@@ -45,7 +50,7 @@ type FakeEtcdClient struct {
 	WatchStop        chan<- bool
 }
 
-func MakeFakeEtcdClient(t *testing.T) *FakeEtcdClient {
+func MakeFakeEtcdClient(t TestLogger) *FakeEtcdClient {
 	ret := &FakeEtcdClient{
 		t:    t,
 		Data: map[string]EtcdResponseWithError{},


### PR DESCRIPTION
Currently all commands are being build with extra flags.
The extra flags appear because of a direct import of the
testing package from the fake_etcd_client.go source file.

Remove the direct import of the testing package and refactor
related tests not to rely on its use. Also clean up two TODO
items by remove using of the expectError and expectNoError
functions.

Fixes #579
