### PR TITLE
More reliable vagrant handling

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -53,7 +53,10 @@ EOF
   # install.  See https://github.com/saltstack/salt-bootstrap/issues/270
   #
   # -M installs the master
-  curl -L http://bootstrap.saltstack.com | sh -s -- -M
+  #curl -L http://bootstrap.saltstack.com | sh -s -- -M
+  yum -y install salt-master
+  systemctl enable salt-master.service
+  systemctl restart salt-master
 
   mkdir -p /srv/salt/nginx
   echo $MASTER_HTPASSWD > /srv/salt/nginx/htpasswd

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -54,9 +54,11 @@ EOF
   #
   # -M installs the master
   #curl -L http://bootstrap.saltstack.com | sh -s -- -M
-  yum -y install salt-master
+  yum -y install salt-master salt-minion
   systemctl enable salt-master.service
+  systemctl enable salt-minion.service
   systemctl restart salt-master
+  systemctl restart salt-minion
 
   mkdir -p /srv/salt/nginx
   echo $MASTER_HTPASSWD > /srv/salt/nginx/htpasswd

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -40,7 +40,7 @@ function verify-prereqs {
 
 # Instantiate a kubernetes cluster
 function kube-up {
-	vagrant up
+	vagrant up --provider virtualbox
 }
 
 # Delete a kubernetes cluster


### PR DESCRIPTION
This addresses some issues when running a local Vagrant cluster.
- Ensure the virtualbox provider is used (in util.sh), as the fedora box is virtualbox based.
- Use YUM install instead of salt bootstrap. Salt is in EPEL (http://docs.saltstack.com/en/latest/topics/installation/fedora.html), bootstrap does not support Fedora 20 and fails handling systemctl/systemd units (see supported operating systems https://github.com/saltstack/salt-bootstrap)
