### PR TITLE
Temporarily point to older bootstrap script

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -53,7 +53,13 @@ EOF
   # install.  See https://github.com/saltstack/salt-bootstrap/issues/270
   #
   # -M installs the master
-  curl -L http://bootstrap.saltstack.com | sh -s -- -M
+  # FIXME: The following line should be replaced with:
+  # curl -L http://bootstrap.saltstack.com | sh -s -- -M
+  # when the merged salt-api service is included in the fedora salt-master rpm
+  # Merge is here: https://github.com/saltstack/salt/pull/13554
+  # Fedora git repository is here: http://pkgs.fedoraproject.org/cgit/salt.git/
+  # (a new service file needs to be added for salt-api)
+  curl -L https://raw.githubusercontent.com/saltstack/salt-bootstrap/v2014.06.30/bootstrap-salt.sh | sh -s -- -M
 
   mkdir -p /srv/salt/nginx
   echo $MASTER_HTPASSWD > /srv/salt/nginx/htpasswd


### PR DESCRIPTION
The most recent saltstack bootstrap file expects a salt-api service to
exist. The most recent Fedora salt-master rpm doesn't include this
service yet. Pointing to the previous version of the bootstrap script.
