### PR TITLE
Stopy proxying etcd (localhost:4001) on https:/$MASTER_IP/etcd.

### DIFF
--- a/cluster/saltbase/salt/nginx/kubernetes-site
+++ b/cluster/saltbase/salt/nginx/kubernetes-site
@@ -58,18 +58,4 @@ server {
           # Disable retry
           proxy_next_upstream off;
         }
-        location /etcd/ {
-          auth_basic            "Restricted";
-          auth_basic_user_file  /usr/share/nginx/htpasswd;
-
-          # Proxy settings
-          proxy_pass http://localhost:4001/;
-          proxy_connect_timeout 159s;
-          proxy_send_timeout   600s;
-          proxy_read_timeout   600s;
-          proxy_buffer_size    64k;
-          proxy_buffers     16 32k;
-          proxy_busy_buffers_size 64k;
-          proxy_temp_file_write_size 64k;
-        }
 }


### PR DESCRIPTION
This is a small first step towards implementing the changes discussed in #443.
It removes the proxying of /etcd by the nginx proxy.  This is necessary in order to cleanly remove Basic Auth from the system entirely, in order to replace it with token-based auth.

I ran e2e locally, and basic.sh failed while guestbook.sh passed.
The fact that the more complex test passed makes me think the failure was due to flakiness.  So, I'm making the PR so travis can run e2e again.
