### PR TITLE
[WIP] - Do a backoff of waits for operations

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -91,7 +91,6 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	etcdClient := etcd.NewClient(servers)
 
 	cl := client.New(apiserver.URL, nil)
-	cl.PollPeriod = time.Second * 1
 	cl.Sync = true
 
 	// Master

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -65,6 +65,22 @@ type AuthInfo struct {
 	Password string
 }
 
+type FuncPollFactory func() FuncPollPeriod
+type FuncPollPeriod func() time.Duration
+
+func gracefulPollBackoff(start, max time.Duration) FuncPollFactory {
+	return func() FuncPollPeriod {
+		current := start
+		return func() time.Duration {
+			next := current * 2
+			if next > max {
+				next = max
+			}
+			return next
+		}
+	}
+}
+
 // Client is the actual implementation of a Kubernetes client.
 // Host is the http://... base for the URL
 type Client struct {
@@ -72,7 +88,7 @@ type Client struct {
 	auth       *AuthInfo
 	httpClient *http.Client
 	Sync       bool
-	PollPeriod time.Duration
+	PollFunc   FuncPollFactory
 	Timeout    time.Duration
 }
 
@@ -88,9 +104,9 @@ func New(host string, auth *AuthInfo) *Client {
 				},
 			},
 		},
-		Sync:       false,
-		PollPeriod: time.Second * 20,
-		Timeout:    time.Second * 20,
+		Sync:     false,
+		PollFunc: gracefulPollBackoff(time.Second/10, time.Second*20),
+		Timeout:  time.Second * 20,
 	}
 }
 


### PR DESCRIPTION
Want feedback on approach - was thinking 0.1s, 0.3s, 1s, 3s, 9s
or similar

In practice create operations will probably settle into a distribution 
between 10ms and a few hundred ms, and when #353 is altered the longest
ops will get much shorter.  So in practice we'd want to catch 50% of the
op completions in 1 cycle, 75% in the next, etc.
