### PR TITLE
Fix #663

### DIFF
--- a/pkg/registry/healthy_minion_registry.go
+++ b/pkg/registry/healthy_minion_registry.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/health"
+	"github.com/golang/glog"
 )
 
 type HealthyMinionRegistry struct {
@@ -50,7 +51,8 @@ func (h *HealthyMinionRegistry) List() (currentMinions []string, err error) {
 	for _, minion := range list {
 		status, err := health.Check(h.makeMinionURL(minion), h.client)
 		if err != nil {
-			return result, err
+			glog.Errorf("%s failed health check with error: %s", minion, err)
+			continue
 		}
 		if status == health.Healthy {
 			result = append(result, minion)


### PR DESCRIPTION
Return all healthy minions instead of only returning the first several
healthy minions. Without the PR, if the first minion failed with health
check, the machine list is empty, thus GET /api/v1beta1/pods failed
with code 500
