### PR TITLE
Allow to set global KUBERNETES_PROVIDER env var

### DIFF
--- a/cluster/kube-env.sh
+++ b/cluster/kube-env.sh
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Set provider independent environment variables
+# Set the default provider of Kubernetes cluster to know where to load provider-specific scripts
+# You can override the default provider by exporting the KUBERNETES_PROVIDER
+# variable in your bashrc
+#
+# The valid values: 'gce', 'azure' and 'vagrant'
 
-# Set provider of Kubernetes cluster to know where to load provider-specific scripts, values: gce, vagrant, etc.
-KUBERNETES_PROVIDER="gce"
-#KUBERNETES_PROVIDER="vagrant"
+KUBERNETES_PROVIDER=${KUBERNETES_PROVIDER:-gce}


### PR DESCRIPTION
If you change this file to use 'vagrant' then you have to put this file into the `gitignore`. I would prefer to have global environment variable set in my bashrc, rather than modifying the `kube-env.sh` file.
