### PR TITLE
Slightly pause on requests to allow most to finish

### DIFF
--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -400,6 +400,7 @@ func TestCreate(t *testing.T) {
 	handler := New(map[string]RESTStorage{
 		"foo": simpleStorage,
 	}, "/prefix/version")
+	handler.asyncOpWait = 0
 	server := httptest.NewServer(handler)
 	client := http.Client{}
 

--- a/pkg/apiserver/operation_test.go
+++ b/pkg/apiserver/operation_test.go
@@ -95,6 +95,7 @@ func TestOpGet(t *testing.T) {
 	handler := New(map[string]RESTStorage{
 		"foo": simpleStorage,
 	}, "/prefix/version")
+	handler.asyncOpWait = 0
 	server := httptest.NewServer(handler)
 	client := http.Client{}
 


### PR DESCRIPTION
Currently, every write will result in a 202 (etcd adding a few
ms of latency to each request).  This forces clients to go into
a poll loop and pick a reasonable server poll frequency, which
results in 1 + N queries to the server for the single operation
and adds unavoidable latency to each request which affects their
perception of the service.

Add a very slight (25ms by default) delay to wait for requests
to finish.  For clients doing normal writes this reduces the
requests made against the server to 1.  For clients on long requests
this has no effect.  The downside is that http connections are held
on to for a longer period in high write loads.  The decrease in
perceived latency from the kubecfg is significant.
