### PR TITLE
Cleanly delete service without endpoints key

### DIFF
--- a/pkg/registry/etcd_registry.go
+++ b/pkg/registry/etcd_registry.go
@@ -274,6 +274,10 @@ func (registry *EtcdRegistry) GetService(name string) (*api.Service, error) {
 	return &svc, nil
 }
 
+func makeServiceEndpointsKey(name string) string {
+	return "/registry/services/endpoints/" + name
+}
+
 // DeleteService deletes a Service specified by its name.
 func (registry *EtcdRegistry) DeleteService(name string) error {
 	key := makeServiceKey(name)
@@ -284,9 +288,12 @@ func (registry *EtcdRegistry) DeleteService(name string) error {
 	if err != nil {
 		return err
 	}
-	key = "/registry/services/endpoints/" + name
+	key = makeServiceEndpointsKey(name)
 	_, err = registry.etcdClient.Delete(key, true)
-	return err
+	if !tools.IsEtcdNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 // UpdateService replaces an existing Service.


### PR DESCRIPTION
If a service is deleted before the etcd corresponding to its
endpoints has been created, a 500 error is returned (etcd key
not found).  Instead, key not found should be ignored silently.

There is a potential race condition with the controller creating
endpoints after the service has been deleted which a cleanup task
should handle in the future.

Closes #684
