### PR TITLE
Set kubelet user home directory to /var/lib/kubelet

### DIFF
--- a/cluster/saltbase/salt/kubelet/init.sls
+++ b/cluster/saltbase/salt/kubelet/init.sls
@@ -93,7 +93,7 @@ kubelet:
     - system: True
     - gid_from_name: True
     - shell: /sbin/nologin
-    - home: /var/kubelet
+    - home: /var/lib/kubelet
     - groups:
       - docker
     - require:


### PR DESCRIPTION
The kubelet user does not have permissions to create directories in
/var/lib. This sets the home directory to /var/lib/kubelet so that the
directory is made prior to running the kubelet. This matches the
default root directory path (/var/lib/kubelet) and allows kubelet to
use that directory.
