### PR TITLE
Clean up pkg/apiserver

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -115,8 +115,8 @@ func New(storage map[string]RESTStorage, prefix string) *APIServer {
 	s.mux.HandleFunc(s.prefix+"/", s.ServeREST)
 	healthz.InstallHandler(s.mux)
 
-	s.mux.HandleFunc("/", s.handleIndex)
 	s.mux.HandleFunc("/version", s.handleVersionReq)
+	s.mux.HandleFunc("/", handleIndex)
 
 	// Handle both operations and operations/* with the same handler
 	s.mux.HandleFunc(s.operationPrefix(), s.handleOperationRequest)
@@ -137,17 +137,6 @@ func (server *APIServer) watchPrefix() string {
 	return path.Join(server.prefix, "watch")
 }
 
-func (server *APIServer) handleIndex(w http.ResponseWriter, req *http.Request) {
-	if req.URL.Path != "/" && req.URL.Path != "/index.html" {
-		server.notFound(w, req)
-		return
-	}
-	w.WriteHeader(http.StatusOK)
-	// TODO: serve this out of a file?
-	data := "<html><body>Welcome to Kubernetes</body></html>"
-	fmt.Fprint(w, data)
-}
-
 // handleVersionReq writes the server's version information.
 func (server *APIServer) handleVersionReq(w http.ResponseWriter, req *http.Request) {
 	server.writeRawJSON(http.StatusOK, version.Get(), w)
@@ -156,7 +145,7 @@ func (server *APIServer) handleVersionReq(w http.ResponseWriter, req *http.Reque
 func (server *APIServer) handleMinionReq(w http.ResponseWriter, req *http.Request) {
 	minionPrefix := "/proxy/minion/"
 	if !strings.HasPrefix(req.URL.Path, minionPrefix) {
-		server.notFound(w, req)
+		notFound(w, req)
 		return
 	}
 
@@ -301,27 +290,22 @@ func (server *APIServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // ServeREST handles requests to all our RESTStorage objects.
 func (server *APIServer) ServeREST(w http.ResponseWriter, req *http.Request) {
 	if !strings.HasPrefix(req.URL.Path, server.prefix) {
-		server.notFound(w, req)
+		notFound(w, req)
 		return
 	}
 	requestParts := strings.Split(req.URL.Path[len(server.prefix):], "/")[1:]
 	if len(requestParts) < 1 {
-		server.notFound(w, req)
+		notFound(w, req)
 		return
 	}
 	storage := server.storage[requestParts[0]]
 	if storage == nil {
 		httplog.LogOf(w).Addf("'%v' has no storage object", requestParts[0])
-		server.notFound(w, req)
+		notFound(w, req)
 		return
 	}
 
 	server.handleREST(requestParts, req, w, storage)
-}
-
-func (server *APIServer) notFound(w http.ResponseWriter, req *http.Request) {
-	w.WriteHeader(http.StatusNotFound)
-	fmt.Fprintf(w, "Not Found: %#v", req)
 }
 
 // write writes an API object in wire format.
@@ -430,7 +414,7 @@ func (server *APIServer) handleREST(parts []string, req *http.Request, w http.Re
 		case 2:
 			item, err := storage.Get(parts[1])
 			if IsNotFound(err) {
-				server.notFound(w, req)
+				notFound(w, req)
 				return
 			}
 			if err != nil {
@@ -439,11 +423,11 @@ func (server *APIServer) handleREST(parts []string, req *http.Request, w http.Re
 			}
 			server.write(http.StatusOK, item, w)
 		default:
-			server.notFound(w, req)
+			notFound(w, req)
 		}
 	case "POST":
 		if len(parts) != 1 {
-			server.notFound(w, req)
+			notFound(w, req)
 			return
 		}
 		body, err := server.readBody(req)
@@ -453,7 +437,7 @@ func (server *APIServer) handleREST(parts []string, req *http.Request, w http.Re
 		}
 		obj, err := storage.Extract(body)
 		if IsNotFound(err) {
-			server.notFound(w, req)
+			notFound(w, req)
 			return
 		}
 		if err != nil {
@@ -462,7 +446,7 @@ func (server *APIServer) handleREST(parts []string, req *http.Request, w http.Re
 		}
 		out, err := storage.Create(obj)
 		if IsNotFound(err) {
-			server.notFound(w, req)
+			notFound(w, req)
 			return
 		}
 		if err != nil {
@@ -472,12 +456,12 @@ func (server *APIServer) handleREST(parts []string, req *http.Request, w http.Re
 		server.finishReq(out, sync, timeout, w)
 	case "DELETE":
 		if len(parts) != 2 {
-			server.notFound(w, req)
+			notFound(w, req)
 			return
 		}
 		out, err := storage.Delete(parts[1])
 		if IsNotFound(err) {
-			server.notFound(w, req)
+			notFound(w, req)
 			return
 		}
 		if err != nil {
@@ -487,7 +471,7 @@ func (server *APIServer) handleREST(parts []string, req *http.Request, w http.Re
 		server.finishReq(out, sync, timeout, w)
 	case "PUT":
 		if len(parts) != 2 {
-			server.notFound(w, req)
+			notFound(w, req)
 			return
 		}
 		body, err := server.readBody(req)
@@ -497,7 +481,7 @@ func (server *APIServer) handleREST(parts []string, req *http.Request, w http.Re
 		}
 		obj, err := storage.Extract(body)
 		if IsNotFound(err) {
-			server.notFound(w, req)
+			notFound(w, req)
 			return
 		}
 		if err != nil {
@@ -506,7 +490,7 @@ func (server *APIServer) handleREST(parts []string, req *http.Request, w http.Re
 		}
 		out, err := storage.Update(obj)
 		if IsNotFound(err) {
-			server.notFound(w, req)
+			notFound(w, req)
 			return
 		}
 		if err != nil {
@@ -515,24 +499,24 @@ func (server *APIServer) handleREST(parts []string, req *http.Request, w http.Re
 		}
 		server.finishReq(out, sync, timeout, w)
 	default:
-		server.notFound(w, req)
+		notFound(w, req)
 	}
 }
 
 func (server *APIServer) handleOperationRequest(w http.ResponseWriter, req *http.Request) {
 	opPrefix := server.operationPrefix()
 	if !strings.HasPrefix(req.URL.Path, opPrefix) {
-		server.notFound(w, req)
+		notFound(w, req)
 		return
 	}
 	trimmed := strings.TrimLeft(req.URL.Path[len(opPrefix):], "/")
 	parts := strings.Split(trimmed, "/")
 	if len(parts) > 1 {
-		server.notFound(w, req)
+		notFound(w, req)
 		return
 	}
 	if req.Method != "GET" {
-		server.notFound(w, req)
+		notFound(w, req)
 		return
 	}
 	if len(parts) == 0 {
@@ -544,7 +528,7 @@ func (server *APIServer) handleOperationRequest(w http.ResponseWriter, req *http
 
 	op := server.ops.Get(parts[0])
 	if op == nil {
-		server.notFound(w, req)
+		notFound(w, req)
 		return
 	}
 
@@ -559,16 +543,16 @@ func (server *APIServer) handleOperationRequest(w http.ResponseWriter, req *http
 func (server *APIServer) handleWatch(w http.ResponseWriter, req *http.Request) {
 	prefix := server.watchPrefix()
 	if !strings.HasPrefix(req.URL.Path, prefix) {
-		server.notFound(w, req)
+		notFound(w, req)
 		return
 	}
 	parts := strings.Split(req.URL.Path[len(prefix):], "/")[1:]
 	if req.Method != "GET" || len(parts) < 1 {
-		server.notFound(w, req)
+		notFound(w, req)
 	}
 	storage := server.storage[parts[0]]
 	if storage == nil {
-		server.notFound(w, req)
+		notFound(w, req)
 	}
 	if watcher, ok := storage.(ResourceWatcher); ok {
 		var watching watch.Interface
@@ -594,5 +578,5 @@ func (server *APIServer) handleWatch(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	server.notFound(w, req)
+	notFound(w, req)
 }

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -79,35 +79,32 @@ func New(storage map[string]RESTStorage, prefix string) *APIServer {
 		mux:     http.NewServeMux(),
 	}
 
-	s.mux.Handle("/logs/", http.StripPrefix("/logs/", http.FileServer(http.Dir("/var/log/"))))
+	// Primary API methods
 	s.mux.HandleFunc(s.prefix+"/", s.handleREST)
-	healthz.InstallHandler(s.mux)
+	s.mux.HandleFunc(s.watchPrefix()+"/", s.handleWatch)
 
-	s.mux.HandleFunc("/version", s.handleVersionReq)
+	// Support services for the apiserver
+	s.mux.Handle("/logs/", http.StripPrefix("/logs/", http.FileServer(http.Dir("/var/log/"))))
+	healthz.InstallHandler(s.mux)
+	s.mux.HandleFunc("/version", handleVersion)
 	s.mux.HandleFunc("/", handleIndex)
 
 	// Handle both operations and operations/* with the same handler
 	s.mux.HandleFunc(s.operationPrefix(), s.handleOperationRequest)
 	s.mux.HandleFunc(s.operationPrefix()+"/", s.handleOperationRequest)
 
-	s.mux.HandleFunc(s.watchPrefix()+"/", s.handleWatch)
-
+	// Proxy minion requests
 	s.mux.HandleFunc("/proxy/minion/", s.handleProxyMinion)
 
 	return s
 }
 
-// handleVersionReq writes the server's version information.
-func (s *APIServer) handleVersionReq(w http.ResponseWriter, req *http.Request) {
-	writeRawJSON(http.StatusOK, version.Get(), w)
-}
-
-// HTTP Handler interface
+// ServeHTTP implements the standard net/http interface.
 func (s *APIServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	defer func() {
 		if x := recover(); x != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprint(w, "apiserver panic. Look in log for details.")
+			fmt.Fprint(w, "apis panic. Look in log for details.")
 			glog.Infof("APIServer panic'd on %v %v: %#v\n%s\n", req.Method, req.RequestURI, x, debug.Stack())
 		}
 	}()
@@ -143,33 +140,6 @@ func (s *APIServer) handleREST(w http.ResponseWriter, req *http.Request) {
 	}
 
 	s.handleRESTStorage(requestParts, req, w, storage)
-}
-
-// finishReq finishes up a request, waiting until the operation finishes or, after a timeout, creating an
-// Operation to receive the result and returning its ID down the writer.
-func (s *APIServer) finishReq(out <-chan interface{}, sync bool, timeout time.Duration, w http.ResponseWriter) {
-	op := s.ops.NewOperation(out)
-	if sync {
-		op.WaitFor(timeout)
-	}
-	obj, complete := op.StatusOrResult()
-	if complete {
-		status := http.StatusOK
-		switch stat := obj.(type) {
-		case api.Status:
-			httplog.LogOf(w).Addf("programmer error: use *api.Status as a result, not api.Status.")
-			if stat.Code != 0 {
-				status = stat.Code
-			}
-		case *api.Status:
-			if stat.Code != 0 {
-				status = stat.Code
-			}
-		}
-		writeJSON(status, obj, w)
-	} else {
-		writeJSON(http.StatusAccepted, obj, w)
-	}
 }
 
 // handleRESTStorage is the main dispatcher for a storage object.  It switches on the HTTP method, and then
@@ -217,6 +187,7 @@ func (s *APIServer) handleRESTStorage(parts []string, req *http.Request, w http.
 		default:
 			notFound(w, req)
 		}
+
 	case "POST":
 		if len(parts) != 1 {
 			notFound(w, req)
@@ -245,7 +216,9 @@ func (s *APIServer) handleRESTStorage(parts []string, req *http.Request, w http.
 			internalError(err, w)
 			return
 		}
-		s.finishReq(out, sync, timeout, w)
+		op := s.createOperation(out, sync, timeout)
+		s.finishReq(op, w)
+
 	case "DELETE":
 		if len(parts) != 2 {
 			notFound(w, req)
@@ -260,7 +233,9 @@ func (s *APIServer) handleRESTStorage(parts []string, req *http.Request, w http.
 			internalError(err, w)
 			return
 		}
-		s.finishReq(out, sync, timeout, w)
+		op := s.createOperation(out, sync, timeout)
+		s.finishReq(op, w)
+
 	case "PUT":
 		if len(parts) != 2 {
 			notFound(w, req)
@@ -289,9 +264,48 @@ func (s *APIServer) handleRESTStorage(parts []string, req *http.Request, w http.
 			internalError(err, w)
 			return
 		}
-		s.finishReq(out, sync, timeout, w)
+		op := s.createOperation(out, sync, timeout)
+		s.finishReq(op, w)
+
 	default:
 		notFound(w, req)
+	}
+}
+
+// handleVersionReq writes the server's version information.
+func handleVersion(w http.ResponseWriter, req *http.Request) {
+	writeRawJSON(http.StatusOK, version.Get(), w)
+}
+
+// createOperation creates an operation to process a channel response
+func (s *APIServer) createOperation(out <-chan interface{}, sync bool, timeout time.Duration) *Operation {
+	op := s.ops.NewOperation(out)
+	if sync {
+		op.WaitFor(timeout)
+	}
+	return op
+}
+
+// finishReq finishes up a request, waiting until the operation finishes or, after a timeout, creating an
+// Operation to receive the result and returning its ID down the writer.
+func (s *APIServer) finishReq(op *Operation, w http.ResponseWriter) {
+	obj, complete := op.StatusOrResult()
+	if complete {
+		status := http.StatusOK
+		switch stat := obj.(type) {
+		case api.Status:
+			httplog.LogOf(w).Addf("programmer error: use *api.Status as a result, not api.Status.")
+			if stat.Code != 0 {
+				status = stat.Code
+			}
+		case *api.Status:
+			if stat.Code != 0 {
+				status = stat.Code
+			}
+		}
+		writeJSON(status, obj, w)
+	} else {
+		writeJSON(http.StatusAccepted, obj, w)
 	}
 }
 
@@ -340,6 +354,7 @@ func (s *APIServer) watchPrefix() string {
 	return path.Join(s.prefix, "watch")
 }
 
+// handleWatch processes a watch request
 func (s *APIServer) handleWatch(w http.ResponseWriter, req *http.Request) {
 	prefix := s.watchPrefix()
 	if !strings.HasPrefix(req.URL.Path, prefix) {
@@ -381,6 +396,7 @@ func (s *APIServer) handleWatch(w http.ResponseWriter, req *http.Request) {
 	notFound(w, req)
 }
 
+// writeJSON renders an object as JSON to the response
 func writeJSON(statusCode int, object interface{}, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -97,14 +97,6 @@ func New(storage map[string]RESTStorage, prefix string) *APIServer {
 	return s
 }
 
-func (server *APIServer) operationPrefix() string {
-	return path.Join(server.prefix, "operations")
-}
-
-func (server *APIServer) watchPrefix() string {
-	return path.Join(server.prefix, "watch")
-}
-
 // handleVersionReq writes the server's version information.
 func (server *APIServer) handleVersionReq(w http.ResponseWriter, req *http.Request) {
 	server.writeRawJSON(http.StatusOK, version.Get(), w)
@@ -157,7 +149,7 @@ func (s *APIServer) ServeREST(w http.ResponseWriter, req *http.Request) {
 func (s *APIServer) write(statusCode int, object interface{}, w http.ResponseWriter) {
 	output, err := api.Encode(object)
 	if err != nil {
-		s.error(err, w)
+		internalError(err, w)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -338,6 +330,10 @@ func (s *APIServer) handleREST(parts []string, req *http.Request, w http.Respons
 	}
 }
 
+func (s *APIServer) operationPrefix() string {
+	return path.Join(s.prefix, "operations")
+}
+
 func (s *APIServer) handleOperationRequest(w http.ResponseWriter, req *http.Request) {
 	opPrefix := s.operationPrefix()
 	if !strings.HasPrefix(req.URL.Path, opPrefix) {
@@ -373,6 +369,10 @@ func (s *APIServer) handleOperationRequest(w http.ResponseWriter, req *http.Requ
 	} else {
 		s.write(http.StatusAccepted, obj, w)
 	}
+}
+
+func (s *APIServer) watchPrefix() string {
+	return path.Join(s.prefix, "watch")
 }
 
 func (s *APIServer) handleWatch(w http.ResponseWriter, req *http.Request) {

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -17,21 +17,15 @@ limitations under the License.
 package apiserver
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
-	"net/http/httputil"
-	"net/url"
 	"path"
 	"runtime/debug"
 	"strings"
 	"time"
 
-	"code.google.com/p/go.net/html"
-	"code.google.com/p/go.net/html/atom"
 	"code.google.com/p/go.net/websocket"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
@@ -98,7 +92,7 @@ func New(storage map[string]RESTStorage, prefix string) *APIServer {
 
 	s.mux.HandleFunc(s.watchPrefix()+"/", s.handleWatch)
 
-	s.mux.HandleFunc("/proxy/minion/", s.handleMinionReq)
+	s.mux.HandleFunc("/proxy/minion/", s.handleProxyMinion)
 
 	return s
 }
@@ -114,129 +108,6 @@ func (server *APIServer) watchPrefix() string {
 // handleVersionReq writes the server's version information.
 func (server *APIServer) handleVersionReq(w http.ResponseWriter, req *http.Request) {
 	server.writeRawJSON(http.StatusOK, version.Get(), w)
-}
-
-func (server *APIServer) handleMinionReq(w http.ResponseWriter, req *http.Request) {
-	minionPrefix := "/proxy/minion/"
-	if !strings.HasPrefix(req.URL.Path, minionPrefix) {
-		notFound(w, req)
-		return
-	}
-
-	path := req.URL.Path[len(minionPrefix):]
-	rawQuery := req.URL.RawQuery
-
-	// Expect path as: ${minion}/${query_to_minion}
-	// and query_to_minion can be any query that kubelet will accept.
-	//
-	// For example:
-	// To query stats of a minion or a pod or a container,
-	// path string can be ${minion}/stats/<podid>/<containerName> or
-	// ${minion}/podInfo?podID=<podid>
-	//
-	// To query logs on a minion, path string can be:
-	// ${minion}/logs/
-	idx := strings.Index(path, "/")
-	minionHost := path[:idx]
-	_, port, _ := net.SplitHostPort(minionHost)
-	if port == "" {
-		// Couldn't retrieve port information
-		// TODO: Retrieve port info from a common object
-		minionHost += ":10250"
-	}
-	minionPath := path[idx:]
-
-	minionURL := &url.URL{
-		Scheme: "http",
-		Host:   minionHost,
-	}
-	newReq, err := http.NewRequest("GET", minionPath+"?"+rawQuery, nil)
-	if err != nil {
-		glog.Errorf("Failed to create request: %s", err)
-	}
-
-	proxy := httputil.NewSingleHostReverseProxy(minionURL)
-	proxy.Transport = &minionTransport{}
-	proxy.ServeHTTP(w, newReq)
-}
-
-type minionTransport struct{}
-
-func (t *minionTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	resp, err := http.DefaultTransport.RoundTrip(req)
-
-	if err != nil && strings.Contains(err.Error(), "connection refused") {
-		message := fmt.Sprintf("Failed to connect to minion:%s", req.URL.Host)
-		resp = &http.Response{
-			StatusCode: http.StatusServiceUnavailable,
-			Body:       ioutil.NopCloser(strings.NewReader(message)),
-		}
-		return resp, nil
-	}
-
-	if strings.Contains(resp.Header.Get("Content-Type"), "text/plain") {
-		// Do nothing, simply pass through
-		return resp, err
-	}
-
-	resp, err = t.ProcessResponse(req, resp)
-	return resp, err
-}
-
-func (t *minionTransport) ProcessResponse(req *http.Request, resp *http.Response) (*http.Response, error) {
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		// copying the response body did not work
-		return nil, err
-	}
-
-	bodyNode := &html.Node{
-		Type:     html.ElementNode,
-		Data:     "body",
-		DataAtom: atom.Body,
-	}
-	nodes, err := html.ParseFragment(bytes.NewBuffer(body), bodyNode)
-	if err != nil {
-		glog.Errorf("Failed to found <body> node: %v", err)
-		return resp, err
-	}
-
-	// Define the method to traverse the doc tree and update href node to
-	// point to correct minion
-	var updateHRef func(*html.Node)
-	updateHRef = func(n *html.Node) {
-		if n.Type == html.ElementNode && n.Data == "a" {
-			for i, attr := range n.Attr {
-				if attr.Key == "href" {
-					Url := &url.URL{
-						Path: "/proxy/minion/" + req.URL.Host + req.URL.Path + attr.Val,
-					}
-					n.Attr[i].Val = Url.String()
-					break
-				}
-			}
-		}
-		for c := n.FirstChild; c != nil; c = c.NextSibling {
-			updateHRef(c)
-		}
-	}
-
-	newContent := &bytes.Buffer{}
-	for _, n := range nodes {
-		updateHRef(n)
-		err = html.Render(newContent, n)
-		if err != nil {
-			glog.Errorf("Failed to render: %v", err)
-		}
-	}
-
-	resp.Body = ioutil.NopCloser(newContent)
-	// Update header node with new content-length
-	// TODO: Remove any hash/signature headers here?
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = int64(newContent.Len())
-
-	return resp, err
 }
 
 // HTTP Handler interface

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -61,32 +61,6 @@ func NewNotFoundErr(kind, name string) error {
 	return errNotFound(fmt.Sprintf("%s %q not found", kind, name))
 }
 
-// RESTStorage is a generic interface for RESTful storage services
-// Resources which are exported to the RESTful API of apiserver need to implement this interface.
-type RESTStorage interface {
-	// List selects resources in the storage which match to the selector.
-	List(labels.Selector) (interface{}, error)
-
-	// Get finds a resource in the storage by id and returns it.
-	// Although it can return an arbitrary error value, IsNotFound(err) is true for the returned error value err when the specified resource is not found.
-	Get(id string) (interface{}, error)
-
-	// Delete finds a resource in the storage and deletes it.
-	// Although it can return an arbitrary error value, IsNotFound(err) is true for the returned error value err when the specified resource is not found.
-	Delete(id string) (<-chan interface{}, error)
-
-	Extract(body []byte) (interface{}, error)
-	Create(interface{}) (<-chan interface{}, error)
-	Update(interface{}) (<-chan interface{}, error)
-}
-
-// ResourceWatcher should be implemented by all RESTStorage objects that
-// want to offer the ability to watch for changes through the watch api.
-type ResourceWatcher interface {
-	WatchAll() (watch.Interface, error)
-	WatchSingle(id string) (watch.Interface, error)
-}
-
 // APIServer is an HTTPHandler that delegates to RESTStorage objects.
 // It handles URLs of the form:
 // ${prefix}/${storage_key}[/${object_name}]

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -536,43 +536,6 @@ func TestSyncCreateTimeout(t *testing.T) {
 	}
 }
 
-func TestOpGet(t *testing.T) {
-	simpleStorage := &SimpleRESTStorage{}
-	handler := New(map[string]RESTStorage{
-		"foo": simpleStorage,
-	}, "/prefix/version")
-	server := httptest.NewServer(handler)
-	client := http.Client{}
-
-	simple := Simple{
-		Name: "foo",
-	}
-	data, err := api.Encode(simple)
-	t.Log(string(data))
-	expectNoError(t, err)
-	request, err := http.NewRequest("POST", server.URL+"/prefix/version/foo", bytes.NewBuffer(data))
-	expectNoError(t, err)
-	response, err := client.Do(request)
-	expectNoError(t, err)
-	if response.StatusCode != http.StatusAccepted {
-		t.Errorf("Unexpected response %#v", response)
-	}
-
-	var itemOut api.Status
-	body, err := extractBody(response, &itemOut)
-	expectNoError(t, err)
-	if itemOut.Status != api.StatusWorking || itemOut.Details == "" {
-		t.Errorf("Unexpected status: %#v (%s)", itemOut, string(body))
-	}
-
-	req2, err := http.NewRequest("GET", server.URL+"/prefix/version/operations/"+itemOut.Details, nil)
-	expectNoError(t, err)
-	_, err = client.Do(req2)
-	expectNoError(t, err)
-	if response.StatusCode != http.StatusAccepted {
-		t.Errorf("Unexpected response %#v", response)
-	}
-}
 func TestMinionTransport(t *testing.T) {
 	content := string(`<pre><a href="kubelet.log">kubelet.log</a><a href="google.log">google.log</a></pre>`)
 	transport := &minionTransport{}

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -18,7 +18,6 @@ package apiserver
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -31,7 +30,6 @@ import (
 	"testing"
 	"time"
 
-	"code.google.com/p/go.net/websocket"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -575,119 +573,6 @@ func TestOpGet(t *testing.T) {
 		t.Errorf("Unexpected response %#v", response)
 	}
 }
-
-var watchTestTable = []struct {
-	t   watch.EventType
-	obj interface{}
-}{
-	{watch.Added, &Simple{Name: "A Name"}},
-	{watch.Modified, &Simple{Name: "Another Name"}},
-	{watch.Deleted, &Simple{Name: "Another Name"}},
-}
-
-func TestWatchWebsocket(t *testing.T) {
-	simpleStorage := &SimpleRESTStorage{}
-	handler := New(map[string]RESTStorage{
-		"foo": simpleStorage,
-	}, "/prefix/version")
-	server := httptest.NewServer(handler)
-
-	dest, _ := url.Parse(server.URL)
-	dest.Scheme = "ws" // Required by websocket, though the server never sees it.
-	dest.Path = "/prefix/version/watch/foo"
-	dest.RawQuery = "id=myID"
-
-	ws, err := websocket.Dial(dest.String(), "", "http://localhost")
-	expectNoError(t, err)
-
-	if a, e := simpleStorage.requestedID, "myID"; a != e {
-		t.Fatalf("Expected %v, got %v", e, a)
-	}
-
-	try := func(action watch.EventType, object interface{}) {
-		// Send
-		simpleStorage.fakeWatch.Action(action, object)
-		// Test receive
-		var got api.WatchEvent
-		err := websocket.JSON.Receive(ws, &got)
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-		if got.Type != action {
-			t.Errorf("Unexpected type: %v", got.Type)
-		}
-		if e, a := object, got.Object.Object; !reflect.DeepEqual(e, a) {
-			t.Errorf("Expected %v, got %v", e, a)
-		}
-	}
-
-	for _, item := range watchTestTable {
-		try(item.t, item.obj)
-	}
-	simpleStorage.fakeWatch.Stop()
-
-	var got api.WatchEvent
-	err = websocket.JSON.Receive(ws, &got)
-	if err == nil {
-		t.Errorf("Unexpected non-error")
-	}
-}
-
-func TestWatchHTTP(t *testing.T) {
-	simpleStorage := &SimpleRESTStorage{}
-	handler := New(map[string]RESTStorage{
-		"foo": simpleStorage,
-	}, "/prefix/version")
-	server := httptest.NewServer(handler)
-	client := http.Client{}
-
-	dest, _ := url.Parse(server.URL)
-	dest.Path = "/prefix/version/watch/foo"
-	dest.RawQuery = "id=myID"
-
-	request, err := http.NewRequest("GET", dest.String(), nil)
-	expectNoError(t, err)
-	response, err := client.Do(request)
-	expectNoError(t, err)
-	if response.StatusCode != http.StatusOK {
-		t.Errorf("Unexpected response %#v", response)
-	}
-
-	if a, e := simpleStorage.requestedID, "myID"; a != e {
-		t.Fatalf("Expected %v, got %v", e, a)
-	}
-
-	decoder := json.NewDecoder(response.Body)
-
-	try := func(action watch.EventType, object interface{}) {
-		// Send
-		simpleStorage.fakeWatch.Action(action, object)
-		// Test receive
-		var got api.WatchEvent
-		err := decoder.Decode(&got)
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-		if got.Type != action {
-			t.Errorf("Unexpected type: %v", got.Type)
-		}
-		if e, a := object, got.Object.Object; !reflect.DeepEqual(e, a) {
-			t.Errorf("Expected %v, got %v", e, a)
-		}
-	}
-
-	for _, item := range watchTestTable {
-		try(item.t, item.obj)
-	}
-	simpleStorage.fakeWatch.Stop()
-
-	var got api.WatchEvent
-	err = decoder.Decode(&got)
-	if err == nil {
-		t.Errorf("Unexpected non-error")
-	}
-}
-
 func TestMinionTransport(t *testing.T) {
 	content := string(`<pre><a href="kubelet.log">kubelet.log</a><a href="google.log">google.log</a></pre>`)
 	transport := &minionTransport{}

--- a/pkg/apiserver/async.go
+++ b/pkg/apiserver/async.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+// WorkFunc is used to perform any time consuming work for an api call, after
+// the input has been validated. Pass one of these to MakeAsync to create an
+// appropriate return value for the Update, Delete, and Create methods.
+type WorkFunc func() (result interface{}, err error)
+
+// MakeAsync takes a function and executes it, delivering the result in the way required
+// by RESTStorage's Update, Delete, and Create methods.
+func MakeAsync(fn WorkFunc) <-chan interface{} {
+	channel := make(chan interface{})
+	go func() {
+		defer util.HandleCrash()
+		obj, err := fn()
+		if err != nil {
+			status := http.StatusInternalServerError
+			switch {
+			case tools.IsEtcdConflict(err):
+				status = http.StatusConflict
+			}
+			channel <- &api.Status{
+				Status:  api.StatusFailure,
+				Details: err.Error(),
+				Code:    status,
+			}
+		} else {
+			channel <- obj
+		}
+		// 'close' is used to signal that no further values will
+		// be written to the channel. Not strictly necessary, but
+		// also won't hurt.
+		close(channel)
+	}()
+	return channel
+}

--- a/pkg/apiserver/errors.go
+++ b/pkg/apiserver/errors.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// notFound renders a simple not found error
+func notFound(w http.ResponseWriter, req *http.Request) {
+	w.WriteHeader(http.StatusNotFound)
+	fmt.Fprintf(w, "Not Found: %#v", req.RequestURI)
+}

--- a/pkg/apiserver/errors.go
+++ b/pkg/apiserver/errors.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 )
 
+// internalError renders a generic error to the response
 func internalError(err error, w http.ResponseWriter) {
 	w.WriteHeader(http.StatusInternalServerError)
 	fmt.Fprintf(w, "Internal Error: %#v", err)

--- a/pkg/apiserver/errors.go
+++ b/pkg/apiserver/errors.go
@@ -21,6 +21,11 @@ import (
 	"net/http"
 )
 
+func internalError(err error, w http.ResponseWriter) {
+	w.WriteHeader(http.StatusInternalServerError)
+	fmt.Fprintf(w, "Internal Error: %#v", err)
+}
+
 // notFound renders a simple not found error
 func notFound(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusNotFound)

--- a/pkg/apiserver/index.go
+++ b/pkg/apiserver/index.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// handleIndex is the root index page for Kubernetes
+func handleIndex(w http.ResponseWriter, req *http.Request) {
+	if req.URL.Path != "/" && req.URL.Path != "/index.html" {
+		notFound(w, req)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	// TODO: serve this out of a file?
+	data := "<html><body>Welcome to Kubernetes</body></html>"
+	fmt.Fprint(w, data)
+}

--- a/pkg/apiserver/interfaces.go
+++ b/pkg/apiserver/interfaces.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// RESTStorage is a generic interface for RESTful storage services
+// Resources which are exported to the RESTful API of apiserver need to implement this interface.
+type RESTStorage interface {
+	// List selects resources in the storage which match to the selector.
+	List(labels.Selector) (interface{}, error)
+
+	// Get finds a resource in the storage by id and returns it.
+	// Although it can return an arbitrary error value, IsNotFound(err) is true for the returned error value err when the specified resource is not found.
+	Get(id string) (interface{}, error)
+
+	// Delete finds a resource in the storage and deletes it.
+	// Although it can return an arbitrary error value, IsNotFound(err) is true for the returned error value err when the specified resource is not found.
+	Delete(id string) (<-chan interface{}, error)
+
+	Extract(body []byte) (interface{}, error)
+	Create(interface{}) (<-chan interface{}, error)
+	Update(interface{}) (<-chan interface{}, error)
+}
+
+// ResourceWatcher should be implemented by all RESTStorage objects that
+// want to offer the ability to watch for changes through the watch api.
+type ResourceWatcher interface {
+	WatchAll() (watch.Interface, error)
+	WatchSingle(id string) (watch.Interface, error)
+}

--- a/pkg/apiserver/minionproxy.go
+++ b/pkg/apiserver/minionproxy.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"code.google.com/p/go.net/html"
+	"code.google.com/p/go.net/html/atom"
+	"github.com/golang/glog"
+)
+
+func (server *APIServer) handleProxyMinion(w http.ResponseWriter, req *http.Request) {
+	minionPrefix := "/proxy/minion/"
+	if !strings.HasPrefix(req.URL.Path, minionPrefix) {
+		notFound(w, req)
+		return
+	}
+
+	path := req.URL.Path[len(minionPrefix):]
+	rawQuery := req.URL.RawQuery
+
+	// Expect path as: ${minion}/${query_to_minion}
+	// and query_to_minion can be any query that kubelet will accept.
+	//
+	// For example:
+	// To query stats of a minion or a pod or a container,
+	// path string can be ${minion}/stats/<podid>/<containerName> or
+	// ${minion}/podInfo?podID=<podid>
+	//
+	// To query logs on a minion, path string can be:
+	// ${minion}/logs/
+	idx := strings.Index(path, "/")
+	minionHost := path[:idx]
+	_, port, _ := net.SplitHostPort(minionHost)
+	if port == "" {
+		// Couldn't retrieve port information
+		// TODO: Retrieve port info from a common object
+		minionHost += ":10250"
+	}
+	minionPath := path[idx:]
+
+	minionURL := &url.URL{
+		Scheme: "http",
+		Host:   minionHost,
+	}
+	newReq, err := http.NewRequest("GET", minionPath+"?"+rawQuery, nil)
+	if err != nil {
+		glog.Errorf("Failed to create request: %s", err)
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(minionURL)
+	proxy.Transport = &minionTransport{}
+	proxy.ServeHTTP(w, newReq)
+}
+
+type minionTransport struct{}
+
+func (t *minionTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := http.DefaultTransport.RoundTrip(req)
+
+	if err != nil && strings.Contains(err.Error(), "connection refused") {
+		message := fmt.Sprintf("Failed to connect to minion:%s", req.URL.Host)
+		resp = &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Body:       ioutil.NopCloser(strings.NewReader(message)),
+		}
+		return resp, nil
+	}
+
+	if strings.Contains(resp.Header.Get("Content-Type"), "text/plain") {
+		// Do nothing, simply pass through
+		return resp, err
+	}
+
+	resp, err = t.ProcessResponse(req, resp)
+	return resp, err
+}
+
+func (t *minionTransport) ProcessResponse(req *http.Request, resp *http.Response) (*http.Response, error) {
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		// copying the response body did not work
+		return nil, err
+	}
+
+	bodyNode := &html.Node{
+		Type:     html.ElementNode,
+		Data:     "body",
+		DataAtom: atom.Body,
+	}
+	nodes, err := html.ParseFragment(bytes.NewBuffer(body), bodyNode)
+	if err != nil {
+		glog.Errorf("Failed to found <body> node: %v", err)
+		return resp, err
+	}
+
+	// Define the method to traverse the doc tree and update href node to
+	// point to correct minion
+	var updateHRef func(*html.Node)
+	updateHRef = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			for i, attr := range n.Attr {
+				if attr.Key == "href" {
+					Url := &url.URL{
+						Path: "/proxy/minion/" + req.URL.Host + req.URL.Path + attr.Val,
+					}
+					n.Attr[i].Val = Url.String()
+					break
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			updateHRef(c)
+		}
+	}
+
+	newContent := &bytes.Buffer{}
+	for _, n := range nodes {
+		updateHRef(n)
+		err = html.Render(newContent, n)
+		if err != nil {
+			glog.Errorf("Failed to render: %v", err)
+		}
+	}
+
+	resp.Body = ioutil.NopCloser(newContent)
+	// Update header node with new content-length
+	// TODO: Remove any hash/signature headers here?
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = int64(newContent.Len())
+
+	return resp, err
+}

--- a/pkg/apiserver/minionproxy_test.go
+++ b/pkg/apiserver/minionproxy_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestMinionTransport(t *testing.T) {
+	content := string(`<pre><a href="kubelet.log">kubelet.log</a><a href="google.log">google.log</a></pre>`)
+	transport := &minionTransport{}
+
+	// Test /logs/
+	request := &http.Request{
+		Method: "GET",
+		URL: &url.URL{
+			Scheme: "http",
+			Host:   "minion1:10250",
+			Path:   "/logs/",
+		},
+	}
+	response := &http.Response{
+		Status:     "200 OK",
+		StatusCode: http.StatusOK,
+		Body:       ioutil.NopCloser(strings.NewReader(content)),
+		Close:      true,
+	}
+	updated_resp, _ := transport.ProcessResponse(request, response)
+	body, _ := ioutil.ReadAll(updated_resp.Body)
+	expected := string(`<pre><a href="/proxy/minion/minion1:10250/logs/kubelet.log">kubelet.log</a><a href="/proxy/minion/minion1:10250/logs/google.log">google.log</a></pre>`)
+	if !strings.Contains(string(body), expected) {
+		t.Errorf("Received wrong content: %s", string(body))
+	}
+
+	// Test subdir under /logs/
+	request = &http.Request{
+		Method: "GET",
+		URL: &url.URL{
+			Scheme: "http",
+			Host:   "minion1:8080",
+			Path:   "/whatever/apt/",
+		},
+	}
+	response = &http.Response{
+		Status:     "200 OK",
+		StatusCode: http.StatusOK,
+		Body:       ioutil.NopCloser(strings.NewReader(content)),
+		Close:      true,
+	}
+	updated_resp, _ = transport.ProcessResponse(request, response)
+	body, _ = ioutil.ReadAll(updated_resp.Body)
+	expected = string(`<pre><a href="/proxy/minion/minion1:8080/whatever/apt/kubelet.log">kubelet.log</a><a href="/proxy/minion/minion1:8080/whatever/apt/google.log">google.log</a></pre>`)
+	if !strings.Contains(string(body), expected) {
+		t.Errorf("Received wrong content: %s", string(body))
+	}
+}

--- a/pkg/apiserver/operation_test.go
+++ b/pkg/apiserver/operation_test.go
@@ -17,9 +17,14 @@ limitations under the License.
 package apiserver
 
 import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 )
 
 func TestOperation(t *testing.T) {
@@ -82,5 +87,43 @@ func TestOperation(t *testing.T) {
 
 	if op.result.(string) != "All done" {
 		t.Errorf("Got unexpected result: %#v", op.result)
+	}
+}
+
+func TestOpGet(t *testing.T) {
+	simpleStorage := &SimpleRESTStorage{}
+	handler := New(map[string]RESTStorage{
+		"foo": simpleStorage,
+	}, "/prefix/version")
+	server := httptest.NewServer(handler)
+	client := http.Client{}
+
+	simple := Simple{
+		Name: "foo",
+	}
+	data, err := api.Encode(simple)
+	t.Log(string(data))
+	expectNoError(t, err)
+	request, err := http.NewRequest("POST", server.URL+"/prefix/version/foo", bytes.NewBuffer(data))
+	expectNoError(t, err)
+	response, err := client.Do(request)
+	expectNoError(t, err)
+	if response.StatusCode != http.StatusAccepted {
+		t.Errorf("Unexpected response %#v", response)
+	}
+
+	var itemOut api.Status
+	body, err := extractBody(response, &itemOut)
+	expectNoError(t, err)
+	if itemOut.Status != api.StatusWorking || itemOut.Details == "" {
+		t.Errorf("Unexpected status: %#v (%s)", itemOut, string(body))
+	}
+
+	req2, err := http.NewRequest("GET", server.URL+"/prefix/version/operations/"+itemOut.Details, nil)
+	expectNoError(t, err)
+	_, err = client.Do(req2)
+	expectNoError(t, err)
+	if response.StatusCode != http.StatusAccepted {
+		t.Errorf("Unexpected response %#v", response)
 	}
 }

--- a/pkg/apiserver/watch.go
+++ b/pkg/apiserver/watch.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"code.google.com/p/go.net/websocket"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// WatchServer serves a watch.Interface over a websocket or vanilla HTTP.
+type WatchServer struct {
+	watching watch.Interface
+}
+
+// HandleWS implements a websocket handler.
+func (w *WatchServer) HandleWS(ws *websocket.Conn) {
+	done := make(chan struct{})
+	go func() {
+		var unused interface{}
+		// Expect this to block until the connection is closed. Client should not
+		// send anything.
+		websocket.JSON.Receive(ws, &unused)
+		close(done)
+	}()
+	for {
+		select {
+		case <-done:
+			w.watching.Stop()
+			return
+		case event, ok := <-w.watching.ResultChan():
+			if !ok {
+				// End of results.
+				return
+			}
+			err := websocket.JSON.Send(ws, &api.WatchEvent{
+				Type:   event.Type,
+				Object: api.APIObject{event.Object},
+			})
+			if err != nil {
+				// Client disconnect.
+				w.watching.Stop()
+				return
+			}
+		}
+	}
+}
+
+// ServeHTTP serves a series of JSON encoded events via straight HTTP with
+// Transfer-Encoding: chunked.
+func (self *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	loggedW := httplog.LogOf(w)
+	w = httplog.Unlogged(w)
+
+	cn, ok := w.(http.CloseNotifier)
+	if !ok {
+		loggedW.Addf("unable to get CloseNotifier")
+		http.NotFound(loggedW, req)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		loggedW.Addf("unable to get Flusher")
+		http.NotFound(loggedW, req)
+		return
+	}
+
+	loggedW.Header().Set("Transfer-Encoding", "chunked")
+	loggedW.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	encoder := json.NewEncoder(w)
+	for {
+		select {
+		case <-cn.CloseNotify():
+			self.watching.Stop()
+			return
+		case event, ok := <-self.watching.ResultChan():
+			if !ok {
+				// End of results.
+				return
+			}
+			err := encoder.Encode(&api.WatchEvent{
+				Type:   event.Type,
+				Object: api.APIObject{event.Object},
+			})
+			if err != nil {
+				// Client disconnect.
+				self.watching.Stop()
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"code.google.com/p/go.net/websocket"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+var watchTestTable = []struct {
+	t   watch.EventType
+	obj interface{}
+}{
+	{watch.Added, &Simple{Name: "A Name"}},
+	{watch.Modified, &Simple{Name: "Another Name"}},
+	{watch.Deleted, &Simple{Name: "Another Name"}},
+}
+
+func TestWatchWebsocket(t *testing.T) {
+	simpleStorage := &SimpleRESTStorage{}
+	handler := New(map[string]RESTStorage{
+		"foo": simpleStorage,
+	}, "/prefix/version")
+	server := httptest.NewServer(handler)
+
+	dest, _ := url.Parse(server.URL)
+	dest.Scheme = "ws" // Required by websocket, though the server never sees it.
+	dest.Path = "/prefix/version/watch/foo"
+	dest.RawQuery = "id=myID"
+
+	ws, err := websocket.Dial(dest.String(), "", "http://localhost")
+	expectNoError(t, err)
+
+	if a, e := simpleStorage.requestedID, "myID"; a != e {
+		t.Fatalf("Expected %v, got %v", e, a)
+	}
+
+	try := func(action watch.EventType, object interface{}) {
+		// Send
+		simpleStorage.fakeWatch.Action(action, object)
+		// Test receive
+		var got api.WatchEvent
+		err := websocket.JSON.Receive(ws, &got)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if got.Type != action {
+			t.Errorf("Unexpected type: %v", got.Type)
+		}
+		if e, a := object, got.Object.Object; !reflect.DeepEqual(e, a) {
+			t.Errorf("Expected %v, got %v", e, a)
+		}
+	}
+
+	for _, item := range watchTestTable {
+		try(item.t, item.obj)
+	}
+	simpleStorage.fakeWatch.Stop()
+
+	var got api.WatchEvent
+	err = websocket.JSON.Receive(ws, &got)
+	if err == nil {
+		t.Errorf("Unexpected non-error")
+	}
+}
+
+func TestWatchHTTP(t *testing.T) {
+	simpleStorage := &SimpleRESTStorage{}
+	handler := New(map[string]RESTStorage{
+		"foo": simpleStorage,
+	}, "/prefix/version")
+	server := httptest.NewServer(handler)
+	client := http.Client{}
+
+	dest, _ := url.Parse(server.URL)
+	dest.Path = "/prefix/version/watch/foo"
+	dest.RawQuery = "id=myID"
+
+	request, err := http.NewRequest("GET", dest.String(), nil)
+	expectNoError(t, err)
+	response, err := client.Do(request)
+	expectNoError(t, err)
+	if response.StatusCode != http.StatusOK {
+		t.Errorf("Unexpected response %#v", response)
+	}
+
+	if a, e := simpleStorage.requestedID, "myID"; a != e {
+		t.Fatalf("Expected %v, got %v", e, a)
+	}
+
+	decoder := json.NewDecoder(response.Body)
+
+	try := func(action watch.EventType, object interface{}) {
+		// Send
+		simpleStorage.fakeWatch.Action(action, object)
+		// Test receive
+		var got api.WatchEvent
+		err := decoder.Decode(&got)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if got.Type != action {
+			t.Errorf("Unexpected type: %v", got.Type)
+		}
+		if e, a := object, got.Object.Object; !reflect.DeepEqual(e, a) {
+			t.Errorf("Expected %v, got %v", e, a)
+		}
+	}
+
+	for _, item := range watchTestTable {
+		try(item.t, item.obj)
+	}
+	simpleStorage.fakeWatch.Stop()
+
+	var got api.WatchEvent
+	err = decoder.Decode(&got)
+	if err == nil {
+		t.Errorf("Unexpected non-error")
+	}
+}


### PR DESCRIPTION
In order to make changes in #656 easier, I did a refactor
for style and clarity in apiserver.  Methods were moved
into various files, some methods were removed from APIServer,
and tests were split out as well.  No functional changes
intended here except notFound() only printing the requested
URI, not the entire request.
