### PR TITLE
structured message for selector; matching functionality

### DIFF
--- a/pkg/labels/selector_test.go
+++ b/pkg/labels/selector_test.go
@@ -18,6 +18,8 @@ package labels
 
 import (
 	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 func TestSelectorParse(t *testing.T) {
@@ -178,10 +180,10 @@ func expectNoMatchRequirement(t *testing.T, req Requirement, ls Set) {
 
 func TestRequirementMatches(t *testing.T) {
 	s := Set{"x": "foo", "y": "baz"}
-	a := Requirement{key: "x", comparator: IN, strValues: []string{"foo"}}
-	b := Requirement{key: "x", comparator: NOT_IN, strValues: []string{"beta"}}
-	c := Requirement{key: "y", comparator: IN, strValues: nil}
-	d := Requirement{key: "y", strValues: []string{"foo"}}
+	a := Requirement{key: "x", operator: IN, strValues: util.NewStringSet("foo")}
+	b := Requirement{key: "x", operator: NOT_IN, strValues: util.NewStringSet("beta")}
+	c := Requirement{key: "y", operator: IN, strValues: nil}
+	d := Requirement{key: "y", strValues: util.NewStringSet("foo")}
 	expectMatchRequirement(t, a, s)
 	expectMatchRequirement(t, b, s)
 	expectNoMatchRequirement(t, c, s)
@@ -204,14 +206,14 @@ func TestLabelSelectorMatches(t *testing.T) {
 	s := Set{"x": "foo", "y": "baz"}
 	allMatch := LabelSelector{
 		Requirements: []Requirement{
-			{key: "x", comparator: IN, strValues: []string{"foo"}},
-			{key: "y", comparator: NOT_IN, strValues: []string{"alpha"}},
+			{key: "x", operator: IN, strValues: util.NewStringSet("foo")},
+			{key: "y", operator: NOT_IN, strValues: util.NewStringSet("alpha")},
 		},
 	}
 	singleNonMatch := LabelSelector{
 		Requirements: []Requirement{
-			{key: "x", comparator: IN, strValues: []string{"foo"}},
-			{key: "y", comparator: IN, strValues: []string{"alpha"}},
+			{key: "x", operator: IN, strValues: util.NewStringSet("foo")},
+			{key: "y", operator: IN, strValues: util.NewStringSet("alpha")},
 		},
 	}
 	expectMatchLabSelector(t, allMatch, s)

--- a/pkg/labels/selector_test.go
+++ b/pkg/labels/selector_test.go
@@ -163,3 +163,57 @@ func TestSetIsEmpty(t *testing.T) {
 		t.Errorf("Nested andTerm should not be empty")
 	}
 }
+
+func expectMatchRequirement(t *testing.T, req Requirement, ls Set) {
+	if !req.Matches(ls) {
+		t.Errorf("Wanted '%+v' to match '%s', but it did not.\n", req, ls)
+	}
+}
+
+func expectNoMatchRequirement(t *testing.T, req Requirement, ls Set) {
+	if req.Matches(ls) {
+		t.Errorf("Wanted '%+v' to not match '%s', but it did.", req, ls)
+	}
+}
+
+func TestRequirementMatches(t *testing.T) {
+	s := Set{"x": "foo", "y": "baz"}
+	a := Requirement{key: "x", comparator: IN, strValues: []string{"foo"}}
+	b := Requirement{key: "x", comparator: NOT_IN, strValues: []string{"beta"}}
+	c := Requirement{key: "y", comparator: IN, strValues: nil}
+	d := Requirement{key: "y", strValues: []string{"foo"}}
+	expectMatchRequirement(t, a, s)
+	expectMatchRequirement(t, b, s)
+	expectNoMatchRequirement(t, c, s)
+	expectNoMatchRequirement(t, d, s)
+}
+
+func expectMatchLabSelector(t *testing.T, lsel LabelSelector, s Set) {
+	if !lsel.Matches(s) {
+		t.Errorf("Wanted '%+v' to match '%s', but it did not.\n", lsel, s)
+	}
+}
+
+func expectNoMatchLabSelector(t *testing.T, lsel LabelSelector, s Set) {
+	if lsel.Matches(s) {
+		t.Errorf("Wanted '%+v' to not match '%s', but it did.\n", lsel, s)
+	}
+}
+
+func TestLabelSelectorMatches(t *testing.T) {
+	s := Set{"x": "foo", "y": "baz"}
+	allMatch := LabelSelector{
+		Requirements: []Requirement{
+			{key: "x", comparator: IN, strValues: []string{"foo"}},
+			{key: "y", comparator: NOT_IN, strValues: []string{"alpha"}},
+		},
+	}
+	singleNonMatch := LabelSelector{
+		Requirements: []Requirement{
+			{key: "x", comparator: IN, strValues: []string{"foo"}},
+			{key: "y", comparator: IN, strValues: []string{"alpha"}},
+		},
+	}
+	expectMatchLabSelector(t, allMatch, s)
+	expectNoMatchLabSelector(t, singleNonMatch, s)
+}


### PR DESCRIPTION
In response to https://github.com/GoogleCloudPlatform/kubernetes/pull/360. This is an incremental change. To more fully realize the goals outlined therein, a string form would need to be added, deprecated selector code in this commit's files would need to be removed and the structured message would need to be expanded.
