### PR TITLE
Normalize apiserver error handling of standard errors

### DIFF
--- a/pkg/apiserver/async.go
+++ b/pkg/apiserver/async.go
@@ -17,10 +17,6 @@ limitations under the License.
 package apiserver
 
 import (
-	"net/http"
-
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
@@ -37,16 +33,7 @@ func MakeAsync(fn WorkFunc) <-chan interface{} {
 		defer util.HandleCrash()
 		obj, err := fn()
 		if err != nil {
-			status := http.StatusInternalServerError
-			switch {
-			case tools.IsEtcdTestFailed(err):
-				status = http.StatusConflict
-			}
-			channel <- &api.Status{
-				Status:  api.StatusFailure,
-				Message: err.Error(),
-				Code:    status,
-			}
+			channel <- errToAPIStatus(err)
 		} else {
 			channel <- obj
 		}

--- a/pkg/apiserver/errors_test.go
+++ b/pkg/apiserver/errors_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestErrorNew(t *testing.T) {
+	err := NewAlreadyExistsErr("test", "1")
+	if !IsAlreadyExists(err) {
+		t.Errorf("expected to be already_exists")
+	}
+	if IsConflict(err) {
+		t.Errorf("expected to not be confict")
+	}
+	if IsNotFound(err) {
+		t.Errorf("expected to not be not_found")
+	}
+
+	if !IsConflict(NewConflictErr("test", "2", errors.New("message"))) {
+		t.Errorf("expected to be confict")
+	}
+	if !IsNotFound(NewNotFoundErr("test", "3")) {
+		t.Errorf("expected to be not found")
+	}
+}

--- a/pkg/apiserver/watch.go
+++ b/pkg/apiserver/watch.go
@@ -31,6 +31,7 @@ import (
 
 type WatchHandler struct {
 	storage map[string]RESTStorage
+	codec   Codec
 }
 
 func getWatchParams(query url.Values) (label, field labels.Selector, resourceVersion uint64) {
@@ -64,7 +65,7 @@ func (h *WatchHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		label, field, resourceVersion := getWatchParams(req.URL.Query())
 		watching, err := watcher.Watch(label, field, resourceVersion)
 		if err != nil {
-			internalError(err, w)
+			errorJSON(err, h.codec, w)
 			return
 		}
 


### PR DESCRIPTION
Now rebased on top of master, adds a few simple standard errors that can be used by etcd to warn of duplicate creation, update conflict, and not found.
