### PR TITLE
Extract "pkg/version".PrintAndExitIfRequested() to its own package

### DIFF
--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
+	verflag "github.com/GoogleCloudPlatform/kubernetes/pkg/version/flag"
 	"github.com/golang/glog"
 )
 
@@ -67,7 +67,7 @@ func main() {
 	util.InitLogs()
 	defer util.FlushLogs()
 
-	version.PrintAndExitIfRequested()
+	verflag.PrintAndExitIfRequested()
 	verifyMinionFlags()
 
 	var cloud cloudprovider.Interface

--- a/cmd/controller-manager/controller-manager.go
+++ b/cmd/controller-manager/controller-manager.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/controller"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
+	verflag "github.com/GoogleCloudPlatform/kubernetes/pkg/version/flag"
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/golang/glog"
 )
@@ -47,7 +47,7 @@ func main() {
 	util.InitLogs()
 	defer util.FlushLogs()
 
-	version.PrintAndExitIfRequested()
+	verflag.PrintAndExitIfRequested()
 
 	if len(etcdServerList) == 0 || len(*master) == 0 {
 		glog.Fatal("usage: controller-manager -etcd_servers <servers> -master <master>")

--- a/cmd/kubecfg/kubecfg.go
+++ b/cmd/kubecfg/kubecfg.go
@@ -33,6 +33,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubecfg"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
+	verflag "github.com/GoogleCloudPlatform/kubernetes/pkg/version/flag"
 	"github.com/golang/glog"
 )
 
@@ -106,7 +107,7 @@ func main() {
 	util.InitLogs()
 	defer util.FlushLogs()
 
-	version.PrintAndExitIfRequested()
+	verflag.PrintAndExitIfRequested()
 
 	secure := true
 	var masterServer string

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -35,7 +35,7 @@ import (
 	kconfig "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/config"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
+	verflag "github.com/GoogleCloudPlatform/kubernetes/pkg/version/flag"
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
@@ -96,7 +96,7 @@ func main() {
 	defer util.FlushLogs()
 	rand.Seed(time.Now().UTC().UnixNano())
 
-	version.PrintAndExitIfRequested()
+	verflag.PrintAndExitIfRequested()
 
 	etcd.SetLogger(util.NewLogger("etcd "))
 

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -22,7 +22,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/proxy"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/proxy/config"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
+	verflag "github.com/GoogleCloudPlatform/kubernetes/pkg/version/flag"
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/golang/glog"
 )
@@ -41,7 +41,7 @@ func main() {
 	util.InitLogs()
 	defer util.FlushLogs()
 
-	version.PrintAndExitIfRequested()
+	verflag.PrintAndExitIfRequested()
 
 	// Set up logger for etcd client
 	etcd.SetLogger(util.NewLogger("etcd "))

--- a/pkg/version/flag/flag.go
+++ b/pkg/version/flag/flag.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package flag defines utility functions to handle command line flags related to version of Kubernetes.
+package flag
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
+)
+
+var (
+	versionFlag = flag.Bool("version", false, "Print version information and quit")
+)
+
+// PrintAndExitIfRequested will check if the -version flag was passed
+// and, if so, print the version and exit.
+func PrintAndExitIfRequested() {
+	if *versionFlag {
+		fmt.Printf("Kubernetes %s\n", version.Get())
+		os.Exit(0)
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,13 +17,7 @@ limitations under the License.
 package version
 
 import (
-	"flag"
 	"fmt"
-	"os"
-)
-
-var (
-	versionFlag = flag.Bool("version", false, "Print version information and quit")
 )
 
 // Info contains versioning information.
@@ -48,13 +42,4 @@ func Get() Info {
 // String returns info as a human-friendly version string.
 func (info Info) String() string {
 	return fmt.Sprintf("version %s.%s, build %s", info.Major, info.Minor, info.GitCommit)
-}
-
-// PrintAndExitIfRequested will check if the -version flag was passed
-// and, if so, print the version and exit.
-func PrintAndExitIfRequested() {
-	if *versionFlag {
-		fmt.Printf("Kubernetes %s\n", Get())
-		os.Exit(0)
-	}
 }


### PR DESCRIPTION
because it causes a runtime panic if a binary which has its own implementation
of "-version" flag tries to reuse a package library which indirectly depend on
"pkg/version".

e.g. If such an user-defined binary tires to link "pkg/api" or "pkg/client",
the binary fails with a runtime panic "flag redefined: version".
