### PR TITLE
Disable curl progress bar when running vagrant up

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -59,7 +59,7 @@ EOF
   # Merge is here: https://github.com/saltstack/salt/pull/13554
   # Fedora git repository is here: http://pkgs.fedoraproject.org/cgit/salt.git/
   # (a new service file needs to be added for salt-api)
-  curl -L https://raw.githubusercontent.com/saltstack/salt-bootstrap/v2014.06.30/bootstrap-salt.sh | sh -s -- -M
+  curl -sS -L https://raw.githubusercontent.com/saltstack/salt-bootstrap/v2014.06.30/bootstrap-salt.sh | sh -s -- -M
 
   mkdir -p /srv/salt/nginx
   echo $MASTER_HTPASSWD > /srv/salt/nginx/htpasswd

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -45,7 +45,7 @@ EOF
   #
   # We specify -X to avoid a race condition that can cause minion failure to
   # install.  See https://github.com/saltstack/salt-bootstrap/issues/270
-  curl -L http://bootstrap.saltstack.com | sh -s -- -X
+  curl -sS -L http://bootstrap.saltstack.com | sh -s -- -X
 
   ## TODO this only works on systemd distros, need to find a work-around as removing -X above fails to start the services installed
   systemctl enable salt-minion


### PR DESCRIPTION
Removes this ugly output, but preserves the error messages.

```
    master: Running: inline script
==> master:  
==> master:  
==> master: %
==> master:  
==> master: R
==> master: e
==> master: c
==> master: e
==> master: i
==> master: v
==> master: e
==> master: d
==> master:  
==> master: %
==> master:  
==> master: X
==> master: f
==> master: erd  Average Speed   Time    Time     Time  Current
==> master:                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

```
