### PR TITLE
[WIP] Image integration with Kubernetes

### DIFF
--- a/pkg/apiserver/errors.go
+++ b/pkg/apiserver/errors.go
@@ -21,6 +21,21 @@ import (
 	"net/http"
 )
 
+type errAlreadyExists string
+
+func (err errAlreadyExists) Error() string {
+	return string(err)
+}
+
+func IsAlreadyExists(err error) bool {
+	_, ok := err.(errAlreadyExists)
+	return ok
+}
+
+func NewAlreadyExistsErr(kind, name string) error {
+	return errAlreadyExists(fmt.Sprintf("%s %q already exists", kind, name))
+}
+
 // internalError renders a generic error to the response
 func internalError(err error, w http.ResponseWriter) {
 	w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/apiserver/operation.go
+++ b/pkg/apiserver/operation.go
@@ -36,11 +36,11 @@ func (s *APIServer) operationPrefix() string {
 
 func (s *APIServer) handleOperation(w http.ResponseWriter, req *http.Request) {
 	opPrefix := s.operationPrefix()
-	if !strings.HasPrefix(req.URL.Path, opPrefix) {
+	if !strings.HasPrefix(req.RequestURI, opPrefix) {
 		notFound(w, req)
 		return
 	}
-	trimmed := strings.TrimLeft(req.URL.Path[len(opPrefix):], "/")
+	trimmed := strings.TrimLeft(getRawPath(req)[len(opPrefix):], "/")
 	parts := strings.Split(trimmed, "/")
 	if len(parts) > 1 {
 		notFound(w, req)
@@ -57,7 +57,7 @@ func (s *APIServer) handleOperation(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	op := s.ops.Get(parts[0])
+	op := s.ops.Get(decodeRawPathSegment(parts[0]))
 	if op == nil {
 		notFound(w, req)
 		return

--- a/pkg/apiserver/watch.go
+++ b/pkg/apiserver/watch.go
@@ -35,15 +35,15 @@ func (s *APIServer) watchPrefix() string {
 // handleWatch processes a watch request
 func (s *APIServer) handleWatch(w http.ResponseWriter, req *http.Request) {
 	prefix := s.watchPrefix()
-	if !strings.HasPrefix(req.URL.Path, prefix) {
+	if !strings.HasPrefix(req.RequestURI, prefix) {
 		notFound(w, req)
 		return
 	}
-	parts := strings.Split(req.URL.Path[len(prefix):], "/")[1:]
+	parts := strings.Split(getRawPath(req)[len(prefix):], "/")[1:]
 	if req.Method != "GET" || len(parts) < 1 {
 		notFound(w, req)
 	}
-	storage := s.storage[parts[0]]
+	storage := s.storage[decodeRawPathSegment(parts[0])]
 	if storage == nil {
 		notFound(w, req)
 	}

--- a/pkg/image/image_repository_storage.go
+++ b/pkg/image/image_repository_storage.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/image/imageapi"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+)
+
+// ImageRepositoryRegistryStorage is an implementation of RESTStorage for the api server.
+type ImageRepositoryRegistryStorage struct {
+	registry      ImageRepositoryRegistry
+	imageRegistry ImageRegistry
+}
+
+func NewImageRepositoryRegistryStorage(registry ImageRepositoryRegistry, imageRegistry ImageRegistry) apiserver.RESTStorage {
+	return &ImageRepositoryRegistryStorage{
+		registry:      registry,
+		imageRegistry: imageRegistry,
+	}
+}
+
+// List obtains a list of ImageRepositorys that match selector.
+func (s *ImageRepositoryRegistryStorage) List(selector labels.Selector) (interface{}, error) {
+	result := imageapi.ImageRepositoryList{}
+	images, err := s.registry.ListImageRepositories(selector)
+	if err == nil {
+		result.Items = images
+	}
+	return result, err
+}
+
+// Get obtains the ImageRepository specified by its id.
+func (s *ImageRepositoryRegistryStorage) Get(id string) (interface{}, error) {
+	image, err := s.registry.GetImageRepository(id)
+	if err != nil {
+		return nil, err
+	}
+	return image, err
+}
+
+// Delete asynchronously deletes the ImageRepository specified by its id.
+func (s *ImageRepositoryRegistryStorage) Delete(id string) (<-chan interface{}, error) {
+	return apiserver.MakeAsync(func() (interface{}, error) {
+		return api.Status{Status: api.StatusSuccess}, s.registry.DeleteImageRepository(id)
+	}), nil
+}
+
+// Extract deserializes user provided data into an imageapi.ImageRepository.
+func (s *ImageRepositoryRegistryStorage) Extract(body []byte) (interface{}, error) {
+	result := imageapi.ImageRepository{}
+	err := api.DecodeInto(body, &result)
+	return result, err
+}
+
+// Create registers a given new ImageRepository instance to the registry.
+func (s *ImageRepositoryRegistryStorage) Create(obj interface{}) (<-chan interface{}, error) {
+	repository, ok := obj.(imageapi.ImageRepository)
+	if !ok {
+		return nil, fmt.Errorf("not an image repository: %#v", obj)
+	}
+	repository.ID = repository.Name
+	if repository.ID == "" {
+		return nil, fmt.Errorf("image repository must have a name: %#v", obj)
+	}
+	for tag, imageID := range repository.Tags {
+		if _, err := s.imageRegistry.GetImage(imageID); err != nil {
+			return nil, fmt.Errorf("unable to set tag '%s' to image '%s': %v", tag, imageID, err)
+		}
+	}
+
+	return apiserver.MakeAsync(func() (interface{}, error) {
+		if err := s.registry.CreateImageRepository(repository); err != nil {
+			return nil, err
+		}
+		if err := s.associateTags(repository); err != nil {
+			return nil, err
+		}
+		return s.registry.GetImageRepository(repository.ID)
+	}), nil
+}
+
+// Update replaces a given ImageRepository instance with an existing instance in the registry.
+func (s *ImageRepositoryRegistryStorage) Update(obj interface{}) (<-chan interface{}, error) {
+	repository, ok := obj.(imageapi.ImageRepository)
+	if !ok {
+		return nil, fmt.Errorf("not an image repository: %#v", obj)
+	}
+	if len(repository.ID) == 0 {
+		return nil, fmt.Errorf("ID should not be empty: %#v", repository)
+	}
+	for tag, imageID := range repository.Tags {
+		if _, err := s.imageRegistry.GetImage(imageID); err != nil {
+			return nil, fmt.Errorf("unable to set tag '%s' to image '%s': %v", tag, imageID, err)
+		}
+	}
+
+	return apiserver.MakeAsync(func() (interface{}, error) {
+		if err := s.registry.UpdateImageRepository(repository); err != nil {
+			return nil, err
+		}
+		if err := s.associateTags(repository); err != nil {
+			return nil, err
+		}
+		return s.registry.GetImageRepository(repository.ID)
+	}), nil
+}
+
+// associateTags adds each of the tagged images to the registry.
+func (s *ImageRepositoryRegistryStorage) associateTags(repository imageapi.ImageRepository) error {
+	errors := []error{}
+	for tag, imageID := range repository.Tags {
+		if err := s.registry.AddImageToRepository(repository.ID, imageID); err != nil {
+			errors = append(errors, fmt.Errorf("unable to set tag '%s' to image '%s': %v", tag, imageID, err))
+		}
+	}
+	if len(errors) > 0 {
+		return fmt.Errorf("tags not applied: %v", errors)
+	}
+	return nil
+}

--- a/pkg/image/image_storage.go
+++ b/pkg/image/image_storage.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import (
+	"fmt"
+
+	"code.google.com/p/go-uuid/uuid"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/image/imageapi"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+)
+
+// ImageRegistryStorage is an implementation of RESTStorage for the api server.
+type ImageRegistryStorage struct {
+	registry ImageRegistry
+}
+
+func NewImageRegistryStorage(registry ImageRegistry) apiserver.RESTStorage {
+	return &ImageRegistryStorage{
+		registry: registry,
+	}
+}
+
+// List obtains a list of Images that match selector.
+func (s *ImageRegistryStorage) List(selector labels.Selector) (interface{}, error) {
+	result := imageapi.ImageList{}
+	images, err := s.registry.ListImages(selector)
+	if err == nil {
+		result.Items = images
+	}
+	return result, err
+}
+
+// Get obtains the Image specified by its id.
+func (s *ImageRegistryStorage) Get(id string) (interface{}, error) {
+	image, err := s.registry.GetImage(id)
+	if err != nil {
+		return nil, err
+	}
+	return image, err
+}
+
+// Delete asynchronously deletes the Image specified by its id.
+func (s *ImageRegistryStorage) Delete(id string) (<-chan interface{}, error) {
+	return apiserver.MakeAsync(func() (interface{}, error) {
+		return api.Status{Status: api.StatusSuccess}, s.registry.DeleteImage(id)
+	}), nil
+}
+
+// Extract deserializes user provided data into an imageapi.Image.
+func (s *ImageRegistryStorage) Extract(body []byte) (interface{}, error) {
+	result := imageapi.Image{}
+	err := api.DecodeInto(body, &result)
+	return result, err
+}
+
+// Create registers a given new Image instance to s.registry.
+func (s *ImageRegistryStorage) Create(obj interface{}) (<-chan interface{}, error) {
+	image, ok := obj.(imageapi.Image)
+	if !ok {
+		return nil, fmt.Errorf("not an image: %#v", obj)
+	}
+	if len(image.ID) == 0 {
+		image.ID = uuid.NewUUID().String()
+	}
+
+	return apiserver.MakeAsync(func() (interface{}, error) {
+		err := s.registry.CreateImage(image)
+		if err != nil {
+			return nil, err
+		}
+		return s.registry.GetImage(image.ID)
+	}), nil
+}
+
+// Update replaces a given Image instance with an existing instance in s.registry.
+func (s *ImageRegistryStorage) Update(obj interface{}) (<-chan interface{}, error) {
+	return s.Create(obj)
+}

--- a/pkg/image/imageapi/types.go
+++ b/pkg/image/imageapi/types.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imageapi
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/fsouza/go-dockerclient"
+)
+
+type Image struct {
+	api.JSONBase `json:",inline" yaml:",inline"`
+	Labels       map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Metadata     docker.Image      `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Reference    string            `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+type ImageList struct {
+	api.JSONBase `json:",inline" yaml:",inline"`
+	Items        []Image `json:"items,omitempty" yaml:"items,omitempty"`
+}
+
+type ImageRepository struct {
+	api.JSONBase     `json:",inline" yaml:",inline"`
+	Name             string            `json:"name,omitempty" yaml:"name,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	OverrideMetadata *docker.Image     `json:"overrideMetadata,omitempty" yaml:"overrideMetadata,omitempty"`
+	Tags             map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+}
+
+type ImageRepositoryList struct {
+	api.JSONBase `json:",inline" yaml:",inline"`
+	Items        []ImageRepository `json:"items,omitempty" yaml:"items,omitempty"`
+}
+
+type ImageRepositoryMapping struct {
+	api.JSONBase   `json:",inline" yaml:",inline"`
+	Image          Image  `json:"image,omitempty" yaml:"image,omitempty"`
+	RepositoryName string `json:"repositoryName,omitempty" yaml:"repositoryName,omitempty"`
+}
+
+func init() {
+	api.AddKnownTypes("",
+		Image{},
+		ImageList{},
+		ImageRepository{},
+		ImageRepositoryList{},
+		ImageRepositoryMapping{},
+	)
+	api.AddKnownTypes("v1beta1",
+		Image{},
+		ImageList{},
+		ImageRepository{},
+		ImageRepositoryList{},
+		ImageRepositoryMapping{},
+	)
+}

--- a/pkg/image/images_by_repository_storage.go
+++ b/pkg/image/images_by_repository_storage.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/image/imageapi"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+)
+
+// ImagesByRepositoryRegistryStorage is an implementation of RESTStorage for the api server.
+type ImagesByRepositoryRegistryStorage struct {
+	registry      ImageRepositoryRegistry
+	imageRegistry ImageRegistry
+}
+
+func NewImagesByRepositoryRegistryStorage(registry ImageRepositoryRegistry, imageRegistry ImageRegistry) apiserver.RESTStorage {
+	return &ImagesByRepositoryRegistryStorage{
+		registry:      registry,
+		imageRegistry: imageRegistry,
+	}
+}
+
+func mappingFromID(id string) (*imageapi.ImageRepositoryMapping, error) {
+	segments := strings.SplitN(id, "!", 2)
+	if len(segments) < 2 || segments[0] == "" || segments[1] == "" {
+		return nil, errors.New("mapping ID is invalid")
+	}
+	return &imageapi.ImageRepositoryMapping{
+		JSONBase:       api.JSONBase{ID: id},
+		RepositoryName: segments[0],
+		Image:          imageapi.Image{JSONBase: api.JSONBase{ID: segments[1]}},
+	}, nil
+}
+
+func mappingToID(mapping *imageapi.ImageRepositoryMapping) string {
+	if mapping.RepositoryName != "" && mapping.Image.ID != "" {
+		return ""
+	}
+	return fmt.Sprintf("%s!%s", mapping.RepositoryName, mapping.Image.ID)
+}
+
+// List obtains a list of ImageRepositorys that match selector.
+func (s *ImagesByRepositoryRegistryStorage) List(selector labels.Selector) (interface{}, error) {
+	return nil, errors.New("not supported")
+}
+
+// Get returns the Images in the ImageRepository specified by its id.
+func (s *ImagesByRepositoryRegistryStorage) Get(id string) (interface{}, error) {
+	result := imageapi.ImageList{}
+	imageIDs, err := s.registry.ListImagesFromRepository(id, labels.Everything())
+	if err != nil {
+		return result, err
+	}
+	for _, imageID := range imageIDs {
+		if image, err := s.imageRegistry.GetImage(imageID); err == nil {
+			result.Items = append(result.Items, *image)
+		}
+	}
+	return result, nil
+}
+
+// Delete asynchronously deletes the ImageRepository specified by its id.
+func (s *ImagesByRepositoryRegistryStorage) Delete(id string) (<-chan interface{}, error) {
+	mapping, err := mappingFromID(id)
+	if err != nil {
+		return nil, err
+	}
+	return apiserver.MakeAsync(func() (interface{}, error) {
+		return &api.Status{Status: api.StatusSuccess}, s.registry.RemoveImageFromRepository(mapping.RepositoryName, mapping.Image.ID)
+	}), nil
+}
+
+// Extract deserializes user provided data into an imageapi.ImageRepository.
+func (s *ImagesByRepositoryRegistryStorage) Extract(body []byte) (interface{}, error) {
+	result := imageapi.ImageRepositoryMapping{}
+	err := api.DecodeInto(body, &result)
+	return result, err
+}
+
+// Create binds a new or existing image to an image repository
+func (s *ImagesByRepositoryRegistryStorage) Create(obj interface{}) (<-chan interface{}, error) {
+	mapping, ok := obj.(imageapi.ImageRepositoryMapping)
+	if !ok {
+		return nil, fmt.Errorf("not an image repository mapping: %#v", obj)
+	}
+
+	if mapping.Image.ID == "" {
+		return nil, fmt.Errorf("no image ID defined: %#v", mapping)
+	}
+
+	return apiserver.MakeAsync(func() (interface{}, error) {
+		_, err := s.registry.GetImageRepository(mapping.RepositoryName)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := s.imageRegistry.CreateImage(mapping.Image); err != nil && !apiserver.IsAlreadyExists(err) {
+			return nil, err
+		}
+
+		if err := s.registry.AddImageToRepository(mapping.RepositoryName, mapping.Image.ID); err != nil {
+			return nil, err
+		}
+		return mapping, nil
+	}), nil
+}
+
+// Update replaces a given ImageRepository instance with an existing instance in the registry.
+func (s *ImagesByRepositoryRegistryStorage) Update(obj interface{}) (<-chan interface{}, error) {
+	return s.Create(obj)
+}

--- a/pkg/image/interfaces.go
+++ b/pkg/image/interfaces.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/image/imageapi"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+)
+
+// ImageRegistry is an interface implemented by things that know how to store Image objects.
+type ImageRegistry interface {
+	ListImages(selector labels.Selector) ([]imageapi.Image, error)
+	GetImage(imageID string) (*imageapi.Image, error)
+	CreateImage(image imageapi.Image) error
+	DeleteImage(imageID string) error
+}
+
+// ImageRepositoryRegistry is an interface for things that know how to store ImageRepository objects.
+type ImageRepositoryRegistry interface {
+	ListImageRepositories(selector labels.Selector) ([]imageapi.ImageRepository, error)
+	ListImagesFromRepository(repositoryID string, selector labels.Selector) ([]string, error)
+	GetImageRepository(repositoryID string) (*imageapi.ImageRepository, error)
+	CreateImageRepository(repository imageapi.ImageRepository) error
+	UpdateImageRepository(repository imageapi.ImageRepository) error
+	DeleteImageRepository(repositoryID string) error
+	AddImageToRepository(repositoryID string, imageID string) error
+	RemoveImageFromRepository(repositoryID string, imageID string) error
+}

--- a/pkg/image/memory_registry.go
+++ b/pkg/image/memory_registry.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/image/imageapi"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/golang/glog"
+)
+
+// An implementation of ImageRegistry and ImageRepositoryRegistry that is backed by memory
+// Mainly used for testing.
+type MemoryRegistry struct {
+	imageData           map[string]imageapi.Image
+	imageRepositoryData map[string]imageapi.ImageRepository
+	repositoryImages    map[string][]string
+}
+
+func MakeMemoryRegistry() *MemoryRegistry {
+	return &MemoryRegistry{
+		imageData:           map[string]imageapi.Image{},
+		imageRepositoryData: map[string]imageapi.ImageRepository{},
+		repositoryImages:    map[string][]string{},
+	}
+}
+
+func (r *MemoryRegistry) ListImages(selector labels.Selector) ([]imageapi.Image, error) {
+	result := []imageapi.Image{}
+	for _, value := range r.imageData {
+		if selector.Matches(labels.Set(value.Labels)) {
+			result = append(result, value)
+		}
+	}
+	return result, nil
+}
+
+func (r *MemoryRegistry) GetImage(imageID string) (*imageapi.Image, error) {
+	image, found := r.imageData[imageID]
+	if found {
+		return &image, nil
+	} else {
+		return nil, apiserver.NewNotFoundErr("image", imageID)
+	}
+}
+
+func (r *MemoryRegistry) CreateImage(image imageapi.Image) error {
+	if _, found := r.imageData[image.ID]; found {
+		return apiserver.NewAlreadyExistsErr("image", image.ID)
+	}
+	r.imageData[image.ID] = image
+	return nil
+}
+
+func (r *MemoryRegistry) DeleteImage(imageID string) error {
+	if _, ok := r.imageData[imageID]; !ok {
+		return apiserver.NewNotFoundErr("image", imageID)
+	}
+	delete(r.imageData, imageID)
+	return nil
+}
+
+func (r *MemoryRegistry) ListImageRepositories(selector labels.Selector) ([]imageapi.ImageRepository, error) {
+	result := []imageapi.ImageRepository{}
+	for _, value := range r.imageRepositoryData {
+		if selector.Matches(labels.Set(value.Labels)) {
+			result = append(result, value)
+		}
+	}
+	return result, nil
+}
+
+func (r *MemoryRegistry) ListImagesFromRepository(repositoryID string, selector labels.Selector) ([]string, error) {
+	_, err := r.GetImageRepository(repositoryID)
+	if err != nil {
+		return []string{}, err
+	}
+	imageIDs, found := r.repositoryImages[repositoryID]
+	if !found {
+		return []string{}, err
+	}
+	return imageIDs, nil
+}
+
+func (r *MemoryRegistry) GetImageRepository(repositoryID string) (*imageapi.ImageRepository, error) {
+	repository, found := r.imageRepositoryData[repositoryID]
+	if !found {
+		return nil, apiserver.NewNotFoundErr("imageRepository", repositoryID)
+	}
+	return &repository, nil
+}
+
+func (r *MemoryRegistry) CreateImageRepository(repository imageapi.ImageRepository) error {
+	if _, found := r.imageRepositoryData[repository.ID]; found {
+		return apiserver.NewAlreadyExistsErr("imageRepository", repository.ID)
+	}
+	delete(r.repositoryImages, repository.ID)
+	r.imageRepositoryData[repository.ID] = repository
+	return nil
+}
+
+func (r *MemoryRegistry) UpdateImageRepository(repository imageapi.ImageRepository) error {
+	if _, ok := r.imageRepositoryData[repository.ID]; !ok {
+		return apiserver.NewNotFoundErr("imageRepository", repository.ID)
+	}
+	r.imageRepositoryData[repository.ID] = repository
+	return nil
+}
+
+func (r *MemoryRegistry) DeleteImageRepository(repositoryID string) error {
+	if _, ok := r.imageRepositoryData[repositoryID]; !ok {
+		return apiserver.NewNotFoundErr("imageRepository", repositoryID)
+	}
+	delete(r.repositoryImages, repositoryID)
+	delete(r.imageRepositoryData, repositoryID)
+	return nil
+}
+
+func (r *MemoryRegistry) AddImageToRepository(repositoryID string, imageID string) error {
+	glog.Infof("adding %s/%s to %#v", repositoryID, imageID, r.repositoryImages)
+	list, found := r.repositoryImages[repositoryID]
+	if !found {
+		list = []string{}
+	}
+	list = append(list, imageID)
+	r.repositoryImages[repositoryID] = list
+	return nil
+}
+
+func (r *MemoryRegistry) RemoveImageFromRepository(repositoryID string, imageID string) error {
+	list, found := r.repositoryImages[repositoryID]
+	if !found {
+		list = []string{}
+	}
+	filtered := []string{}
+	for _, id := range list {
+		if id != imageID {
+			filtered = append(filtered, id)
+		}
+	}
+	r.repositoryImages[repositoryID] = list
+	return nil
+}


### PR DESCRIPTION
This is modelled as a simple plugin - adding the ability to record image metadata for use by other components within Kubernetes (pod generators, etc).  A repository object can keep tags, references to images, and a default set of override metadata for new images.

The demonstrated integration is with a Docker registry that has been configured to a) tag images with their IDs on push and b) notify Kubernetes via API that a new image has been tagged.  This allows clients to `docker push <registry>/foo/bar` and have `foo/bar` be updated in Kubernetes transparently.  See https://github.com/smarterclayton/docker-registry/compare/kubernetes_integration

The key use case is providing image metadata for use with other, higher level components, and ensuring that immutable references are available for historical image data.  The docker client cannot pull anything other than tags today (see Docker issue 7262 for a discussion), therefore any image that a client wants to repeatably deploy must be uniquely tagged.  In this case, the registry is ensuring that pushed images are tagged with their ID although clients could coordinate that on their own.

This does not yet, but will, support a pass through / cache mode for a real Docker registry allowing consumers to map multiple real registries into a single namespace and to lazily instantiate data.
