### PR TITLE
Generate valid file Pod Names and test for them

### DIFF
--- a/pkg/kubelet/config/etcd.go
+++ b/pkg/kubelet/config/etcd.go
@@ -118,7 +118,7 @@ func responseToPods(response *etcd.Response) ([]kubelet.Pod, error) {
 	for i, manifest := range manifests.Items {
 		name := manifest.ID
 		if name == "" {
-			name = fmt.Sprintf("_%d", i+1)
+			name = fmt.Sprintf("%d", i+1)
 		}
 		pods = append(pods, kubelet.Pod{Name: name, Manifest: manifest})
 	}

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -77,8 +77,8 @@ func TestExtractFromHttpSingle(t *testing.T) {
 
 func TestExtractFromHttpMultiple(t *testing.T) {
 	manifests := []api.ContainerManifest{
-		{Version: "v1beta1", ID: ""},
-		{Version: "v1beta1", ID: "bar"},
+		{Version: "v1beta1", ID: "", Containers: []api.Container{{Name: "1", Image: "foo"}}},
+		{Version: "v1beta1", ID: "bar", Containers: []api.Container{{Name: "1", Image: "foo"}}},
 	}
 	data, err := json.Marshal(manifests)
 	if err != nil {
@@ -102,6 +102,11 @@ func TestExtractFromHttpMultiple(t *testing.T) {
 	expected := CreatePodUpdate(kubelet.SET, kubelet.Pod{Name: "1", Manifest: manifests[0]}, kubelet.Pod{Name: "bar", Manifest: manifests[1]})
 	if !reflect.DeepEqual(expected, update) {
 		t.Errorf("Expected: %#v, Got: %#v", expected, update)
+	}
+	for i := range update.Pods {
+		if errs := kubelet.ValidatePod(&update.Pods[i]); len(errs) != 0 {
+			t.Errorf("Expected no validation errors on %#v, Got %#v", update.Pods[i], errs)
+		}
 	}
 }
 


### PR DESCRIPTION
Ensure that pods coming from the unit test configuration validate,
and that proper names are generated.

Closes #744
