### PR TITLE
/api/v1beta1/operations was returning Not Found

### DIFF
--- a/pkg/apiserver/operation.go
+++ b/pkg/apiserver/operation.go
@@ -42,6 +42,9 @@ func (s *APIServer) handleOperation(w http.ResponseWriter, req *http.Request) {
 	}
 	trimmed := strings.TrimLeft(req.URL.Path[len(opPrefix):], "/")
 	parts := strings.Split(trimmed, "/")
+	if trimmed == "" {
+		parts = []string{}
+	}
 	if len(parts) > 1 {
 		notFound(w, req)
 		return


### PR DESCRIPTION
Splitting an empty string returns []string{""}, not []string{}
