### PR TITLE
Expose an Encoding/Versioning interface for use with etcd

### DIFF
--- a/pkg/api/helper.go
+++ b/pkg/api/helper.go
@@ -25,6 +25,20 @@ import (
 	"gopkg.in/v1/yaml"
 )
 
+type EncodingInterface interface {
+	Encode(obj interface{}) (data []byte, err error)
+	Decode(data []byte) (interface{}, error)
+	DecodeInto(data []byte, obj interface{}) error
+}
+
+type VersioningInterface interface {
+	SetResourceVersion(obj interface{}, version uint64) error
+	ResourceVersion(obj interface{}) (uint64, error)
+}
+
+var Encoding EncodingInterface
+var Versioning VersioningInterface
+
 var conversionScheme *conversion.Scheme
 
 func init() {
@@ -86,6 +100,9 @@ func init() {
 			return nil
 		},
 	)
+
+	Encoding = conversionScheme
+	Versioning = JSONBaseVersioning{}
 }
 
 // AddKnownTypes registers the types of the arguments to the marshaller of the package api.

--- a/pkg/api/jsonbase.go
+++ b/pkg/api/jsonbase.go
@@ -21,6 +21,26 @@ import (
 	"reflect"
 )
 
+// versionedJSONBase allows access to the version state of a JSONBase object
+type JSONBaseVersioning struct{}
+
+func (v JSONBaseVersioning) ResourceVersion(obj interface{}) (uint64, error) {
+	json, err := FindJSONBaseRO(obj)
+	if err != nil {
+		return 0, err
+	}
+	return json.ResourceVersion, nil
+}
+
+func (v JSONBaseVersioning) SetResourceVersion(obj interface{}, version uint64) error {
+	json, err := FindJSONBase(obj)
+	if err != nil {
+		return err
+	}
+	json.SetResourceVersion(version)
+	return nil
+}
+
 // JSONBase lets you work with a JSONBase from any of the versioned or
 // internal APIObjects.
 type JSONBaseInterface interface {

--- a/pkg/api/jsonbase_test.go
+++ b/pkg/api/jsonbase_test.go
@@ -57,3 +57,35 @@ func TestGenericJSONBase(t *testing.T) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 }
+
+func TestVersioningOfAPI(t *testing.T) {
+	type T struct {
+		Object   interface{}
+		Expected uint64
+	}
+	testCases := map[string]T{
+		"empty api object":                   {Service{}, 0},
+		"api object with version":            {Service{JSONBase: JSONBase{ResourceVersion: 1}}, 1},
+		"pointer to api object with version": {&Service{JSONBase: JSONBase{ResourceVersion: 1}}, 1},
+	}
+	versioning := JSONBaseVersioning{}
+	for key, testCase := range testCases {
+		actual, err := versioning.ResourceVersion(testCase.Object)
+		if err != nil {
+			t.Errorf("%s: unexpected error %#v", key, err)
+		}
+		if actual != testCase.Expected {
+			t.Errorf("%s: expected %d, got %d", key, testCase.Expected, actual)
+		}
+	}
+
+	failingCases := map[string]T{
+		"not a valid object to try": {JSONBase{ResourceVersion: 1}, 1},
+	}
+	for key, testCase := range failingCases {
+		_, err := versioning.ResourceVersion(testCase.Object)
+		if err == nil {
+			t.Errorf("%s: expected error, got nil", key)
+		}
+	}
+}


### PR DESCRIPTION
etcd_tools.go is not dependent on the specific implementation
(which is provided by pkg/api).  All EtcdHelpers are created
with an encoding object which handles Encode/Decode/DecodeInto.
Additional tests added to verify simple atomic flows.

Begins to break up api singleton pattern.
