### PR TITLE
Validate on replicas being non-negative

### DIFF
--- a/pkg/api/validation.go
+++ b/pkg/api/validation.go
@@ -318,6 +318,9 @@ func ValidateReplicationController(controller *ReplicationController) []error {
 	if labels.Set(controller.DesiredState.ReplicaSelector).AsSelector().Empty() {
 		errors = append(errors, makeInvalidError("ReplicationController.ReplicaSelector", controller.DesiredState.ReplicaSelector))
 	}
+	if controller.DesiredState.Replicas < 0 {
+		errors = append(errors, makeInvalidError("ReplicationController.Replicas", controller.DesiredState.Replicas ))
+	}
 	errors = append(errors, ValidateManifest(&controller.DesiredState.PodTemplate.DesiredState.Manifest)...)
 	return errors
 }

--- a/pkg/api/validation_test.go
+++ b/pkg/api/validation_test.go
@@ -417,6 +417,13 @@ func TestValidateReplicationController(t *testing.T) {
 				ReplicaSelector: validSelector,
 			},
 		},
+		"negative_replicas": {
+			JSONBase: JSONBase{ID: "abc"},
+			DesiredState: ReplicationControllerState{
+				Replicas: -1,
+				ReplicaSelector: validSelector,
+			},
+		},
 	}
 	for k, v := range errorCases {
 		if errs := ValidateReplicationController(&v); len(errs) == 0 {


### PR DESCRIPTION
Fix validation logic error on replicas being allowed to persist a negative value.

Previously, this caused operations like following to wait forever:

cluster/kubcfg.sh resize myNginx -1 
