### PR TITLE
Call build-go.sh before bundling a release

### DIFF
--- a/hack/dev-build-and-push.sh
+++ b/hack/dev-build-and-push.sh
@@ -16,11 +16,17 @@
 
 # This script will build a dev release and push it to an existing cluster.
 
-# First build a release
+# First build the binaries
+$(dirname $0)/build-go.sh
+if [ "$?" != "0" ]; then
+        exit 1
+fi
+
+# Then build a release
 $(dirname $0)/../release/release.sh
 if [ "$?" != "0" ]; then
-       echo "Building a release failed!"
-       exit 1
+        echo "Building a release failed!"
+        exit 1
 fi
 
 # Now push this out to the cluster

--- a/hack/dev-build-and-up.sh
+++ b/hack/dev-build-and-up.sh
@@ -17,11 +17,17 @@
 # This script will build a dev release and bring up a new cluster with that
 # release.
 
-# First build a release
+# First build the binaries
+$(dirname $0)/build-go.sh
+if [ "$?" != "0" ]; then
+        exit 1
+fi
+
+# Then build a release
 $(dirname $0)/../release/release.sh
 if [ "$?" != "0" ]; then
-      echo "Building the release failed!"
-      exit 1
+        echo "Building the release failed!"
+        exit 1
 fi
 
 # Now bring a new cluster up with that release.


### PR DESCRIPTION
Now the dev-build-and-\* scripts actually work.
