### PR TITLE
ServiceRegistryStorage.Delete should respect zone.

### DIFF
--- a/pkg/registry/servicestorage_test.go
+++ b/pkg/registry/servicestorage_test.go
@@ -211,7 +211,7 @@ func TestServiceRegistryDeleteExternal(t *testing.T) {
 	c, _ := storage.Delete(svc.ID)
 	<-c
 
-	if len(fakeCloud.Calls) != 1 || fakeCloud.Calls[0] != "delete" {
+	if len(fakeCloud.Calls) != 2 || fakeCloud.Calls[0] != "get-zone" || fakeCloud.Calls[1] != "delete" {
 		t.Errorf("Unexpected call(s): %#v", fakeCloud.Calls)
 	}
 	srv, err := memory.GetService(svc.ID)


### PR DESCRIPTION
Before this CL, the "us-central1" zone was hard coded. This CL fixes the issue by querying zone on delete.
