### PR TITLE
Rename IsEtcdConflict to IsEtcdTestFailed

### DIFF
--- a/pkg/apiserver/async.go
+++ b/pkg/apiserver/async.go
@@ -39,7 +39,7 @@ func MakeAsync(fn WorkFunc) <-chan interface{} {
 		if err != nil {
 			status := http.StatusInternalServerError
 			switch {
-			case tools.IsEtcdConflict(err):
+			case tools.IsEtcdTestFailed(err):
 				status = http.StatusConflict
 			}
 			channel <- &api.Status{

--- a/pkg/tools/etcd_tools.go
+++ b/pkg/tools/etcd_tools.go
@@ -82,14 +82,14 @@ type EtcdHelper struct {
 	Versioning Versioning
 }
 
-// Returns true iff err is an etcd not found error.
+// IsEtcdNotFound returns true iff err is an etcd not found error.
 func IsEtcdNotFound(err error) bool {
-	return isEtcdErrorNum(err, 100)
+	return isEtcdErrorNum(err, EtcdErrorCodeNotFound)
 }
 
-// Returns true iff err is an etcd write conflict.
-func IsEtcdConflict(err error) bool {
-	return isEtcdErrorNum(err, 101)
+// IsEtcdTestFailed returns true iff err is an etcd write conflict.
+func IsEtcdTestFailed(err error) bool {
+	return isEtcdErrorNum(err, EtcdErrorCodeTestFailed)
 }
 
 // IsEtcdWatchStoppedByUser returns true iff err is a client triggered stop.
@@ -242,7 +242,7 @@ func (h *EtcdHelper) AtomicUpdate(key string, ptrToType interface{}, tryUpdate E
 			return err
 		}
 		_, err = h.Client.CompareAndSwap(key, string(data), 0, origBody, index)
-		if IsEtcdConflict(err) {
+		if IsEtcdTestFailed(err) {
 			continue
 		}
 		return err

--- a/pkg/tools/etcd_tools_test.go
+++ b/pkg/tools/etcd_tools_test.go
@@ -50,7 +50,7 @@ func init() {
 	scheme.AddKnownTypes("v1beta1", TestResource{})
 }
 
-func TestIsNotFoundErr(t *testing.T) {
+func TestIsEtcdNotFound(t *testing.T) {
 	try := func(err error, isNotFound bool) {
 		if IsEtcdNotFound(err) != isNotFound {
 			t.Errorf("Expected %#v to return %v, but it did not", err, isNotFound)


### PR DESCRIPTION
IsEtcdConflict checks for the etcd errror "TestFailed" for the conflict error name.
https://github.com/coreos/etcd/blob/a563d82f95d60c6f3ddf3619ed150e09856daf2f/Documentation/errorcode.md

Bonus:
- Replaces magic numbers with const.
- Rename test function to have format: Test[TargetFuncName]
- Method name should come first in its doc comment.
