### PR TITLE
httptest.NewTLSServer is ~0.2s of setup per test

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -320,7 +320,7 @@ func (c *testClient) Setup() *testClient {
 	if responseBody := body(c.Response.Body, c.Response.RawBody); responseBody != nil {
 		c.handler.ResponseBody = *responseBody
 	}
-	c.server = httptest.NewTLSServer(c.handler)
+	c.server = httptest.NewServer(c.handler)
 	if c.Client == nil {
 		c.Client = New("", nil)
 	}
@@ -430,7 +430,7 @@ func TestDoRequestAccepted(t *testing.T) {
 		ResponseBody: string(expectedBody),
 		T:            t,
 	}
-	testServer := httptest.NewTLSServer(&fakeHandler)
+	testServer := httptest.NewServer(&fakeHandler)
 	request, _ := http.NewRequest("GET", testServer.URL+"/foo/bar", nil)
 	auth := AuthInfo{User: "user", Password: "pass"}
 	c := New(testServer.URL, &auth)
@@ -464,7 +464,7 @@ func TestDoRequestAcceptedSuccess(t *testing.T) {
 		ResponseBody: string(expectedBody),
 		T:            t,
 	}
-	testServer := httptest.NewTLSServer(&fakeHandler)
+	testServer := httptest.NewServer(&fakeHandler)
 	request, _ := http.NewRequest("GET", testServer.URL+"/foo/bar", nil)
 	auth := AuthInfo{User: "user", Password: "pass"}
 	c := New(testServer.URL, &auth)

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -43,7 +43,7 @@ func TestDoRequestNewWay(t *testing.T) {
 		ResponseBody: string(expectedBody),
 		T:            t,
 	}
-	testServer := httptest.NewTLSServer(&fakeHandler)
+	testServer := httptest.NewServer(&fakeHandler)
 	auth := AuthInfo{User: "user", Password: "pass"}
 	s := New(testServer.URL, &auth)
 	obj, err := s.Verb("POST").
@@ -81,7 +81,7 @@ func TestDoRequestNewWayReader(t *testing.T) {
 		ResponseBody: string(expectedBody),
 		T:            t,
 	}
-	testServer := httptest.NewTLSServer(&fakeHandler)
+	testServer := httptest.NewServer(&fakeHandler)
 	auth := AuthInfo{User: "user", Password: "pass"}
 	s := New(testServer.URL, &auth)
 	obj, err := s.Verb("POST").
@@ -121,7 +121,7 @@ func TestDoRequestNewWayObj(t *testing.T) {
 		ResponseBody: string(expectedBody),
 		T:            t,
 	}
-	testServer := httptest.NewTLSServer(&fakeHandler)
+	testServer := httptest.NewServer(&fakeHandler)
 	auth := AuthInfo{User: "user", Password: "pass"}
 	s := New(testServer.URL, &auth)
 	obj, err := s.Verb("POST").
@@ -174,7 +174,7 @@ func TestDoRequestNewWayFile(t *testing.T) {
 		ResponseBody: string(expectedBody),
 		T:            t,
 	}
-	testServer := httptest.NewTLSServer(&fakeHandler)
+	testServer := httptest.NewServer(&fakeHandler)
 	auth := AuthInfo{User: "user", Password: "pass"}
 	s := New(testServer.URL, &auth)
 	obj, err := s.Verb("POST").
@@ -266,7 +266,7 @@ func TestPolling(t *testing.T) {
 	}
 
 	callNumber := 0
-	testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		data, err := api.Encode(objects[callNumber])
 		if err != nil {
 			t.Errorf("Unexpected encode error")
@@ -360,7 +360,7 @@ func TestWatch(t *testing.T) {
 	}
 
 	auth := AuthInfo{User: "user", Password: "pass"}
-	testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		checkAuth(t, auth, r)
 		flusher, ok := w.(http.Flusher)
 		if !ok {


### PR DESCRIPTION
We're not exercising anything TLS related in client and request,
set these back to NewServer.  Should add a new TLS end-to-end
test for hack/test-cmd.sh with real (test) certs.
