### PR TITLE
Pull golang from golang to fix error where hash does not match in salt state

### DIFF
--- a/cluster/saltbase/salt/golang.sls
+++ b/cluster/saltbase/salt/golang.sls
@@ -1,9 +1,8 @@
-{% set go_version = '1.2' %}
+{% set go_version = '1.2.2' %}
 {% set go_arch = 'linux-amd64' %}
 {% set go_archive = 'go%s.%s.tar.gz' | format(go_version, go_arch) %}
-{% set go_url = 'https://go.googlecode.com/files/' + go_archive %}
-{% set go_hash = 'md5=68901bbf8a04e71e0b30aa19c3946b21' %}
-
+{% set go_url = 'http://golang.org/dl/' + go_archive %}
+{% set go_hash = 'sha1=6bd151ca49c435462c8bf019477a6244b958ebb5' %}
 
 get-golang:
   file.managed:


### PR DESCRIPTION
I attempted to bring up a new cluster and received following error:

==> master: ----------
==> master:           ID: get-golang
==> master:     Function: file.managed
==> master:         Name: /var/cache/go1.2.linux-amd64.tar.gz
==> master:       Result: False
==> master:      Comment: File sum set for file /var/cache/go1.2.linux-amd64.tar.gz of 68901bbf8a04e71e0b30aa19c3946b21 does not match real sum of 17c156b6f4019e9fd21fe1388a8b0014
==> master:      Changes:  
==> master:               ----------
==> master:               diff:
==> master:                   New file

It looks like the hash changed for the file from googlecode, and this stopped golang install.

I moved to pull from the official golang site (which the old site was redirecting to) and updated the hash.  Salt no longer errors.
