### PR TITLE
Avoid data race in Proxier.OnUpdate

### DIFF
--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -193,7 +193,7 @@ func (proxier *Proxier) addServiceCommon(service string, l net.Listener) {
 // OnUpdate manages the active set of service proxies.
 // Active service proxies are reinitialized if found in the update set or
 // shutdown if missing from the update set.
-func (proxier Proxier) OnUpdate(services []api.Service) {
+func (proxier *Proxier) OnUpdate(services []api.Service) {
 	glog.Infof("Received update notice: %+v", services)
 	activeServices := util.StringSet{}
 	for _, service := range services {


### PR DESCRIPTION
Should close #795.

The bug was that the proxier is passed as value on method decleration.
This caused a copy of Proxier to be created when the method was invoked.
The copy being a shallow copy turned out to have them both reference
a same map instance, but their mutexes were different instances.
This turned out to use different mutexes before operating on a same map
instance, which didn't make sense.
