### PR TITLE
Improve watch

### DIFF
--- a/cmd/kubecfg/kubecfg.go
+++ b/cmd/kubecfg/kubecfg.go
@@ -247,7 +247,7 @@ func executeAPIRequest(method string, s *kube_client.Client) bool {
 
 	r := s.Verb(verb).
 		Path(path).
-		ParseSelector(*selector)
+		ParseSelectorParam("labels", *selector)
 	if setBody {
 		if version != 0 {
 			data := readConfig(storage)

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -64,13 +64,8 @@ type SimpleRESTStorage struct {
 	updated *Simple
 	created *Simple
 
-	// Valid if WatchAll or WatchSingle is called
-	fakeWatch *watch.FakeWatcher
-
-	// Set if WatchSingle is called
-	requestedID string
-
-	// Set if WatchAll is called
+	// These are set when Watch is called
+	fakeWatch                *watch.FakeWatcher
 	requestedLabelSelector   labels.Selector
 	requestedFieldSelector   labels.Selector
 	requestedResourceVersion uint64
@@ -135,22 +130,11 @@ func (storage *SimpleRESTStorage) Update(obj interface{}) (<-chan interface{}, e
 }
 
 // Implement ResourceWatcher.
-func (storage *SimpleRESTStorage) WatchAll(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+func (storage *SimpleRESTStorage) Watch(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
 	storage.requestedLabelSelector = label
 	storage.requestedFieldSelector = field
 	storage.requestedResourceVersion = resourceVersion
-	if err := storage.errors["watchAll"]; err != nil {
-		return nil, err
-	}
-	storage.fakeWatch = watch.NewFake()
-	return storage.fakeWatch, nil
-}
-
-// Implement ResourceWatcher.
-func (storage *SimpleRESTStorage) WatchSingle(id string, resourceVersion uint64) (watch.Interface, error) {
-	storage.requestedID = id
-	storage.requestedResourceVersion = resourceVersion
-	if err := storage.errors["watchSingle"]; err != nil {
+	if err := storage.errors["watch"]; err != nil {
 		return nil, err
 	}
 	storage.fakeWatch = watch.NewFake()

--- a/pkg/apiserver/interfaces.go
+++ b/pkg/apiserver/interfaces.go
@@ -29,6 +29,7 @@ type RESTStorage interface {
 	New() interface{}
 
 	// List selects resources in the storage which match to the selector.
+	// TODO: add field selector in addition to label selector.
 	List(labels.Selector) (interface{}, error)
 
 	// Get finds a resource in the storage by id and returns it.
@@ -46,7 +47,10 @@ type RESTStorage interface {
 // ResourceWatcher should be implemented by all RESTStorage objects that
 // want to offer the ability to watch for changes through the watch api.
 type ResourceWatcher interface {
-	// TODO: take a query, like List, to filter out unwanted events.
-	WatchAll() (watch.Interface, error)
-	WatchSingle(id string) (watch.Interface, error)
+	// label selects on labels; field selects on the objects fields. Not all fields
+	// are supported; an error will be returned if you try to select for a field that
+	// isn't supported.
+	WatchAll(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error)
+	// TODO: Decide if we need to keep WatchSingle?
+	WatchSingle(id string, resourceVersion uint64) (watch.Interface, error)
 }

--- a/pkg/apiserver/interfaces.go
+++ b/pkg/apiserver/interfaces.go
@@ -33,11 +33,13 @@ type RESTStorage interface {
 	List(labels.Selector) (interface{}, error)
 
 	// Get finds a resource in the storage by id and returns it.
-	// Although it can return an arbitrary error value, IsNotFound(err) is true for the returned error value err when the specified resource is not found.
+	// Although it can return an arbitrary error value, IsNotFound(err) is true for the
+	// returned error value err when the specified resource is not found.
 	Get(id string) (interface{}, error)
 
 	// Delete finds a resource in the storage and deletes it.
-	// Although it can return an arbitrary error value, IsNotFound(err) is true for the returned error value err when the specified resource is not found.
+	// Although it can return an arbitrary error value, IsNotFound(err) is true for the
+	// returned error value err when the specified resource is not found.
 	Delete(id string) (<-chan interface{}, error)
 
 	Create(interface{}) (<-chan interface{}, error)
@@ -47,10 +49,9 @@ type RESTStorage interface {
 // ResourceWatcher should be implemented by all RESTStorage objects that
 // want to offer the ability to watch for changes through the watch api.
 type ResourceWatcher interface {
-	// label selects on labels; field selects on the objects fields. Not all fields
-	// are supported; an error will be returned if you try to select for a field that
-	// isn't supported.
-	WatchAll(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error)
-	// TODO: Decide if we need to keep WatchSingle?
-	WatchSingle(id string, resourceVersion uint64) (watch.Interface, error)
+	// 'label' selects on labels; 'field' selects on the object's fields. Not all fields
+	// are supported; an error should be returned if 'field' tries to select on a field that
+	// isn't supported. 'resourceVersion' allows for continuing/starting a watch at a
+	// particular version.
+	Watch(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error)
 }

--- a/pkg/apiserver/watch.go
+++ b/pkg/apiserver/watch.go
@@ -19,15 +19,36 @@ package apiserver
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
+	"strconv"
 
 	"code.google.com/p/go.net/websocket"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
 type WatchHandler struct {
 	storage map[string]RESTStorage
+}
+
+func (s *APIServer) getWatchParams(query url.Values) (id string, label, field labels.Selector, resourceVersion uint64) {
+	id = query.Get("id")
+	if s, err := labels.ParseSelector(query.Get("labels")); err != nil {
+		label = labels.Everything()
+	} else {
+		label = s
+	}
+	if s, err := labels.ParseSelector(query.Get("fields")); err != nil {
+		field = labels.Everything()
+	} else {
+		field = s
+	}
+	if rv, err := strconv.ParseUint(query.Get("resourceVersion"), 10, 64); err == nil {
+		resourceVersion = rv
+	}
+	return id, label, field, resourceVersion
 }
 
 // handleWatch processes a watch request
@@ -43,10 +64,11 @@ func (h *WatchHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if watcher, ok := storage.(ResourceWatcher); ok {
 		var watching watch.Interface
 		var err error
-		if id := req.URL.Query().Get("id"); id != "" {
-			watching, err = watcher.WatchSingle(id)
+		id, label, field, resourceVersion := s.getWatchParams(req.URL.Query())
+		if id != "" {
+			watching, err = watcher.WatchSingle(id, resourceVersion)
 		} else {
-			watching, err = watcher.WatchAll()
+			watching, err = watcher.WatchAll(label, field, resourceVersion)
 		}
 		if err != nil {
 			internalError(err, w)

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -146,7 +146,7 @@ func TestWatchParamParsing(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
 	handler := New(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, "/prefix/version")
+	}, codec, "/prefix/version")
 	server := httptest.NewServer(handler)
 
 	dest, _ := url.Parse(server.URL)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -169,7 +169,7 @@ func (c *Client) makeURL(path string) string {
 
 // ListPods takes a selector, and returns the list of pods that match that selector
 func (c *Client) ListPods(selector labels.Selector) (result api.PodList, err error) {
-	err = c.Get().Path("pods").Selector(selector).Do().Into(&result)
+	err = c.Get().Path("pods").SelectorParam("labels", selector).Do().Into(&result)
 	return
 }
 
@@ -202,7 +202,7 @@ func (c *Client) UpdatePod(pod api.Pod) (result api.Pod, err error) {
 
 // ListReplicationControllers takes a selector, and returns the list of replication controllers that match that selector
 func (c *Client) ListReplicationControllers(selector labels.Selector) (result api.ReplicationControllerList, err error) {
-	err = c.Get().Path("replicationControllers").Selector(selector).Do().Into(&result)
+	err = c.Get().Path("replicationControllers").SelectorParam("labels", selector).Do().Into(&result)
 	return
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -28,11 +28,14 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/golang/glog"
 )
 
 // Interface holds the methods for clients of Kubenetes,
 // an interface to allow mock testing.
+// TODO: split this up by resource?
+// TODO: these should return/take pointers.
 type Interface interface {
 	ListPods(selector labels.Selector) (api.PodList, error)
 	GetPod(name string) (api.Pod, error)
@@ -45,6 +48,7 @@ type Interface interface {
 	CreateReplicationController(api.ReplicationController) (api.ReplicationController, error)
 	UpdateReplicationController(api.ReplicationController) (api.ReplicationController, error)
 	DeleteReplicationController(string) error
+	WatchReplicationControllers(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error)
 
 	GetService(name string) (api.Service, error)
 	CreateService(api.Service) (api.Service, error)
@@ -231,6 +235,17 @@ func (c *Client) UpdateReplicationController(controller api.ReplicationControlle
 // DeleteReplicationController deletes an existing replication controller.
 func (c *Client) DeleteReplicationController(name string) error {
 	return c.Delete().Path("replicationControllers").Path(name).Do().Error()
+}
+
+// WatchReplicationControllers returns a watch.Interface that watches the requested controllers.
+func (c *Client) WatchReplicationControllers(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+	return c.Get().
+		Path("watch").
+		Path("replicationControllers").
+		UintParam("resourceVersion", resourceVersion).
+		SelectorParam("labels", label).
+		SelectorParam("fields", field).
+		Watch()
 }
 
 // GetService returns information about a particular service.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -42,7 +42,7 @@ func TestListEmptyPods(t *testing.T) {
 		Request:  testRequest{Method: "GET", Path: "/pods"},
 		Response: Response{StatusCode: 200, Body: api.PodList{}},
 	}
-	podList, err := c.Setup().ListPods(nil)
+	podList, err := c.Setup().ListPods(labels.Everything())
 	c.Validate(t, podList, err)
 }
 
@@ -65,7 +65,7 @@ func TestListPods(t *testing.T) {
 			},
 		},
 	}
-	receivedPodList, err := c.Setup().ListPods(nil)
+	receivedPodList, err := c.Setup().ListPods(labels.Everything())
 	c.Validate(t, receivedPodList, err)
 }
 
@@ -191,7 +191,7 @@ func TestListControllers(t *testing.T) {
 			},
 		},
 	}
-	receivedControllerList, err := c.Setup().ListReplicationControllers(nil)
+	receivedControllerList, err := c.Setup().ListReplicationControllers(labels.Everything())
 	c.Validate(t, receivedControllerList, err)
 
 }

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// FakeClient implements Interface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeClient struct {
+	// FakeClient by default keeps a simple list of the methods that have been called.
+	Actions []string
+}
+
+func (client *FakeClient) ListPods(selector labels.Selector) (api.PodList, error) {
+	client.Actions = append(client.Actions, "list-pods")
+	return api.PodList{}, nil
+}
+
+func (client *FakeClient) GetPod(name string) (api.Pod, error) {
+	client.Actions = append(client.Actions, "get-pod")
+	return api.Pod{}, nil
+}
+
+func (client *FakeClient) DeletePod(name string) error {
+	client.Actions = append(client.Actions, "delete-pod")
+	return nil
+}
+
+func (client *FakeClient) CreatePod(pod api.Pod) (api.Pod, error) {
+	client.Actions = append(client.Actions, "create-pod")
+	return api.Pod{}, nil
+}
+
+func (client *FakeClient) UpdatePod(pod api.Pod) (api.Pod, error) {
+	client.Actions = append(client.Actions, "update-pod")
+	return api.Pod{}, nil
+}
+
+func (client *FakeClient) ListReplicationControllers(selector labels.Selector) (api.ReplicationControllerList, error) {
+	client.Actions = append(client.Actions, "list-controllers")
+	return api.ReplicationControllerList{}, nil
+}
+
+func (client *FakeClient) GetReplicationController(name string) (api.ReplicationController, error) {
+	client.Actions = append(client.Actions, "get-controller")
+	return api.ReplicationController{}, nil
+}
+
+func (client *FakeClient) CreateReplicationController(controller api.ReplicationController) (api.ReplicationController, error) {
+	client.Actions = append(client.Actions, "create-controller")
+	return api.ReplicationController{}, nil
+}
+
+func (client *FakeClient) UpdateReplicationController(controller api.ReplicationController) (api.ReplicationController, error) {
+	client.Actions = append(client.Actions, "update-controller")
+	return api.ReplicationController{}, nil
+}
+
+func (client *FakeClient) DeleteReplicationController(controller string) error {
+	client.Actions = append(client.Actions, "delete-controller")
+	return nil
+}
+
+func (client *FakeClient) WatchReplicationControllers(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+	client.Actions = append(client.Actions, "watch-controllers")
+	return watch.NewFake(), nil
+}
+
+func (client *FakeClient) GetService(name string) (api.Service, error) {
+	client.Actions = append(client.Actions, "get-controller")
+	return api.Service{}, nil
+}
+
+func (client *FakeClient) CreateService(controller api.Service) (api.Service, error) {
+	client.Actions = append(client.Actions, "create-service")
+	return api.Service{}, nil
+}
+
+func (client *FakeClient) UpdateService(controller api.Service) (api.Service, error) {
+	client.Actions = append(client.Actions, "update-service")
+	return api.Service{}, nil
+}
+
+func (client *FakeClient) DeleteService(controller string) error {
+	client.Actions = append(client.Actions, "delete-service")
+	return nil
+}

--- a/pkg/client/fake_test.go
+++ b/pkg/client/fake_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+)
+
+// This test file just ensures that FakeClient and structs it is embedded in
+// implement Interface.
+
+func TestFakeImplementsInterface(t *testing.T) {
+	_ = Interface(&FakeClient{})
+}
+
+type MyFake struct {
+	*FakeClient
+}
+
+func TestEmbeddedFakeImplementsInterface(t *testing.T) {
+	_ = Interface(MyFake{&FakeClient{}})
+	_ = Interface(&MyFake{&FakeClient{}})
+}

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -49,7 +49,7 @@ func TestDoRequestNewWay(t *testing.T) {
 	obj, err := s.Verb("POST").
 		Path("foo/bar").
 		Path("baz").
-		ParseSelector("name=foo").
+		ParseSelectorParam("labels", "name=foo").
 		Timeout(time.Second).
 		Body([]byte(reqBody)).
 		Do().Get()
@@ -87,7 +87,7 @@ func TestDoRequestNewWayReader(t *testing.T) {
 	obj, err := s.Verb("POST").
 		Path("foo/bar").
 		Path("baz").
-		Selector(labels.Set{"name": "foo"}.AsSelector()).
+		SelectorParam("labels", labels.Set{"name": "foo"}.AsSelector()).
 		Sync(false).
 		Timeout(time.Second).
 		Body(bytes.NewBuffer(reqBodyExpected)).
@@ -127,7 +127,7 @@ func TestDoRequestNewWayObj(t *testing.T) {
 	obj, err := s.Verb("POST").
 		Path("foo/bar").
 		Path("baz").
-		Selector(labels.Set{"name": "foo"}.AsSelector()).
+		SelectorParam("labels", labels.Set{"name": "foo"}.AsSelector()).
 		Timeout(time.Second).
 		Body(reqObj).
 		Do().Get()
@@ -180,7 +180,7 @@ func TestDoRequestNewWayFile(t *testing.T) {
 	obj, err := s.Verb("POST").
 		Path("foo/bar").
 		Path("baz").
-		ParseSelector("name=foo").
+		ParseSelectorParam("labels", "name=foo").
 		Timeout(time.Second).
 		Body(file.Name()).
 		Do().Get()
@@ -241,6 +241,26 @@ func TestSync(t *testing.T) {
 	r.Sync(true)
 	if !r.sync {
 		t.Errorf("'Sync' doesn't work")
+	}
+}
+
+func TestUintParam(t *testing.T) {
+	table := []struct {
+		name      string
+		testVal   uint64
+		expectStr string
+	}{
+		{"foo", 31415, "?foo=31415"},
+		{"bar", 42, "?bar=42"},
+		{"baz", 0, "?baz=0"},
+	}
+
+	for _, item := range table {
+		c := New("", nil)
+		r := c.Get().AbsPath("").UintParam(item.name, item.testVal)
+		if e, a := item.expectStr, r.finalURL(); e != a {
+			t.Errorf("expected %v, got %v", e, a)
+		}
 	}
 }
 

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -264,6 +264,25 @@ func TestUintParam(t *testing.T) {
 	}
 }
 
+func TestUnacceptableParamNames(t *testing.T) {
+	table := []struct {
+		name          string
+		testVal       string
+		expectSuccess bool
+	}{
+		{"sync", "foo", false},
+		{"timeout", "42", false},
+	}
+
+	for _, item := range table {
+		c := New("", nil)
+		r := c.Get().setParam(item.name, item.testVal)
+		if e, a := item.expectSuccess, r.err == nil; e != a {
+			t.Errorf("expected %v, got %v (%v)", e, a, r.err)
+		}
+	}
+}
+
 func TestSetPollPeriod(t *testing.T) {
 	c := New("", nil)
 	r := c.Get()

--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -24,7 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/golang/glog"
 )
 
@@ -37,9 +36,6 @@ type ReplicationManager struct {
 
 	// To allow injection of syncReplicationController for testing.
 	syncHandler func(controllerSpec api.ReplicationController) error
-
-	// To allow injection of watch creation.
-	watchMaker func() (watch.Interface, error)
 }
 
 // PodControlInterface is an interface that knows how to add or delete pods

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -339,8 +339,8 @@ func TestWatchControllers(t *testing.T) {
 		return nil
 	}
 
-	index := uint64(0)
-	go manager.watchControllers(&index)
+	resourceVersion := uint64(0)
+	go manager.watchControllers(&resourceVersion)
 
 	// Test normal case
 	testControllerSpec.ID = "foo"

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -305,7 +306,7 @@ func TestSyncronize(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 		t.Errorf("Unexpected request for %v", req.RequestURI)
 	})
-	testServer := httptest.NewTLSServer(mux)
+	testServer := httptest.NewServer(mux)
 	client := client.New(testServer.URL, nil)
 	manager := MakeReplicationManager(client)
 	fakePodControl := FakePodControl{}
@@ -316,13 +317,18 @@ func TestSyncronize(t *testing.T) {
 	validateSyncReplication(t, &fakePodControl, 7, 0)
 }
 
-func TestWatchControllers(t *testing.T) {
-	fakeWatcher := watch.NewFake()
-	manager := MakeReplicationManager(nil)
-	manager.watchMaker = func() (watch.Interface, error) {
-		return fakeWatcher, nil
-	}
+type FakeWatcher struct {
+	w *watch.FakeWatcher
+	*client.FakeClient
+}
 
+func (fw FakeWatcher) WatchReplicationControllers(l, f labels.Selector, rv uint64) (watch.Interface, error) {
+	return fw.w, nil
+}
+
+func TestWatchControllers(t *testing.T) {
+	client := FakeWatcher{watch.NewFake(), &client.FakeClient{}}
+	manager := MakeReplicationManager(client)
 	var testControllerSpec api.ReplicationController
 	received := make(chan struct{})
 	manager.syncHandler = func(controllerSpec api.ReplicationController) error {
@@ -333,11 +339,12 @@ func TestWatchControllers(t *testing.T) {
 		return nil
 	}
 
-	go manager.watchControllers()
+	index := uint64(0)
+	go manager.watchControllers(&index)
 
 	// Test normal case
 	testControllerSpec.ID = "foo"
-	fakeWatcher.Add(&testControllerSpec)
+	client.w.Add(&testControllerSpec)
 
 	select {
 	case <-received:

--- a/pkg/kubecfg/kubecfg_test.go
+++ b/pkg/kubecfg/kubecfg_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
 type Action struct {
@@ -88,6 +89,11 @@ func (client *FakeKubeClient) UpdateReplicationController(controller api.Replica
 func (client *FakeKubeClient) DeleteReplicationController(controller string) error {
 	client.actions = append(client.actions, Action{action: "delete-controller", value: controller})
 	return nil
+}
+
+func (client *FakeKubeClient) WatchReplicationControllers(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+	client.actions = append(client.actions, Action{action: "watch-controllers"})
+	return watch.NewFake(), nil
 }
 
 func (client *FakeKubeClient) GetService(name string) (api.Service, error) {

--- a/pkg/registry/controllerstorage.go
+++ b/pkg/registry/controllerstorage.go
@@ -17,7 +17,6 @@ limitations under the License.
 package registry
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -138,12 +137,6 @@ func (storage *ControllerRegistryStorage) waitForController(ctrl api.Replication
 
 // WatchAll returns ReplicationController events via a watch.Interface, implementing
 // apiserver.ResourceWatcher.
-func (storage *ControllerRegistryStorage) WatchAll(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+func (storage *ControllerRegistryStorage) Watch(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
 	return storage.registry.WatchControllers(label, field, resourceVersion)
-}
-
-// WatchSingle returns events for a single ReplicationController via a watch.Interface,
-// implementing apiserver.ResourceWatcher.
-func (storage *ControllerRegistryStorage) WatchSingle(id string, resourceVersion uint64) (watch.Interface, error) {
-	return nil, errors.New("unimplemented")
 }

--- a/pkg/registry/controllerstorage.go
+++ b/pkg/registry/controllerstorage.go
@@ -138,12 +138,12 @@ func (storage *ControllerRegistryStorage) waitForController(ctrl api.Replication
 
 // WatchAll returns ReplicationController events via a watch.Interface, implementing
 // apiserver.ResourceWatcher.
-func (storage *ControllerRegistryStorage) WatchAll() (watch.Interface, error) {
-	return storage.registry.WatchControllers()
+func (storage *ControllerRegistryStorage) WatchAll(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+	return storage.registry.WatchControllers(label, field, resourceVersion)
 }
 
 // WatchSingle returns events for a single ReplicationController via a watch.Interface,
 // implementing apiserver.ResourceWatcher.
-func (storage *ControllerRegistryStorage) WatchSingle(id string) (watch.Interface, error) {
+func (storage *ControllerRegistryStorage) WatchSingle(id string, resourceVersion uint64) (watch.Interface, error) {
 	return nil, errors.New("unimplemented")
 }

--- a/pkg/registry/controllerstorage_test.go
+++ b/pkg/registry/controllerstorage_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
+// TODO: Why do we have this AND MemoryRegistry?
 type MockControllerRegistry struct {
 	err         error
 	controllers []api.ReplicationController
@@ -49,10 +50,12 @@ func (registry *MockControllerRegistry) CreateController(controller api.Replicat
 func (registry *MockControllerRegistry) UpdateController(controller api.ReplicationController) error {
 	return registry.err
 }
+
 func (registry *MockControllerRegistry) DeleteController(ID string) error {
 	return registry.err
 }
-func (registry *MockControllerRegistry) WatchControllers() (watch.Interface, error) {
+
+func (registry *MockControllerRegistry) WatchControllers(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
 	return nil, registry.err
 }
 

--- a/pkg/registry/etcdregistry.go
+++ b/pkg/registry/etcdregistry.go
@@ -205,9 +205,13 @@ func (registry *EtcdRegistry) ListControllers() ([]api.ReplicationController, er
 }
 
 // WatchControllers begins watching for new, changed, or deleted controllers.
-// TODO: Add id/selector parameters?
-func (registry *EtcdRegistry) WatchControllers() (watch.Interface, error) {
-	return registry.helper.WatchList("/registry/controllers", tools.Everything)
+func (registry *EtcdRegistry) WatchControllers(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+	if field.String() != "" {
+		return nil, fmt.Errorf("no field selector implemented for controllers")
+	}
+	return registry.helper.WatchList("/registry/controllers", resourceVersion, func(obj interface{}) bool {
+		return label.Matches(labels.Set(obj.(*api.ReplicationController).Labels))
+	})
 }
 
 func makeControllerKey(id string) string {

--- a/pkg/registry/etcdregistry.go
+++ b/pkg/registry/etcdregistry.go
@@ -206,7 +206,7 @@ func (registry *EtcdRegistry) ListControllers() ([]api.ReplicationController, er
 
 // WatchControllers begins watching for new, changed, or deleted controllers.
 func (registry *EtcdRegistry) WatchControllers(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
-	if field.String() != "" {
+	if !field.Empty() {
 		return nil, fmt.Errorf("no field selector implemented for controllers")
 	}
 	return registry.helper.WatchList("/registry/controllers", resourceVersion, func(obj interface{}) bool {

--- a/pkg/registry/interfaces.go
+++ b/pkg/registry/interfaces.go
@@ -39,7 +39,7 @@ type PodRegistry interface {
 // ControllerRegistry is an interface for things that know how to store ReplicationControllers.
 type ControllerRegistry interface {
 	ListControllers() ([]api.ReplicationController, error)
-	WatchControllers() (watch.Interface, error)
+	WatchControllers(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error)
 	GetController(controllerID string) (*api.ReplicationController, error)
 	CreateController(controller api.ReplicationController) error
 	UpdateController(controller api.ReplicationController) error

--- a/pkg/registry/memory_registry.go
+++ b/pkg/registry/memory_registry.go
@@ -89,7 +89,7 @@ func (registry *MemoryRegistry) ListControllers() ([]api.ReplicationController, 
 	return result, nil
 }
 
-func (registry *MemoryRegistry) WatchControllers() (watch.Interface, error) {
+func (registry *MemoryRegistry) WatchControllers(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
 	return nil, errors.New("unimplemented")
 }
 

--- a/pkg/tools/etcd_tools_test.go
+++ b/pkg/tools/etcd_tools_test.go
@@ -325,6 +325,30 @@ func TestAtomicUpdate_CreateCollision(t *testing.T) {
 	}
 }
 
+func TestWatchInterpretation_ListCreate(t *testing.T) {
+	w := newEtcdWatcher(true, func(interface{}) bool {
+		t.Errorf("unexpected filter call")
+		return true
+	}, encoding)
+	pod := &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}
+	podBytes, _ := encoding.Encode(pod)
+
+	go w.sendResult(&etcd.Response{
+		Action: "create",
+		Node: &etcd.Node{
+			Value: string(podBytes),
+		},
+	})
+
+	got := <-w.outgoing
+	if e, a := watch.Added, got.Type; e != a {
+		t.Errorf("Expected %v, got %v", e, a)
+	}
+	if e, a := pod, got.Object; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %v, got %v", e, a)
+	}
+}
+
 func TestWatchInterpretation_ListAdd(t *testing.T) {
 	w := newEtcdWatcher(true, func(interface{}) bool {
 		t.Errorf("unexpected filter call")
@@ -341,7 +365,7 @@ func TestWatchInterpretation_ListAdd(t *testing.T) {
 	})
 
 	got := <-w.outgoing
-	if e, a := watch.Added, got.Type; e != a {
+	if e, a := watch.Modified, got.Type; e != a {
 		t.Errorf("Expected %v, got %v", e, a)
 	}
 	if e, a := pod, got.Object; !reflect.DeepEqual(e, a) {
@@ -420,7 +444,7 @@ func TestWatch(t *testing.T) {
 	fakeClient := MakeFakeEtcdClient(t)
 	h := EtcdHelper{fakeClient, codec, versioner}
 
-	watching, err := h.Watch("/some/key")
+	watching, err := h.Watch("/some/key", 0)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -438,7 +462,7 @@ func TestWatch(t *testing.T) {
 	}
 
 	event := <-watching.ResultChan()
-	if e, a := watch.Added, event.Type; e != a {
+	if e, a := watch.Modified, event.Type; e != a {
 		t.Errorf("Expected %v, got %v", e, a)
 	}
 	if e, a := pod, event.Object; !reflect.DeepEqual(e, a) {
@@ -462,7 +486,7 @@ func TestWatchPurposefulShutdown(t *testing.T) {
 	h := EtcdHelper{fakeClient, codec, versioner}
 
 	// Test purposeful shutdown
-	watching, err := h.Watch("/some/key")
+	watching, err := h.Watch("/some/key", 0)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/tools/etcd_tools_test.go
+++ b/pkg/tools/etcd_tools_test.go
@@ -329,9 +329,9 @@ func TestWatchInterpretation_ListCreate(t *testing.T) {
 	w := newEtcdWatcher(true, func(interface{}) bool {
 		t.Errorf("unexpected filter call")
 		return true
-	}, encoding)
+	}, codec)
 	pod := &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}
-	podBytes, _ := encoding.Encode(pod)
+	podBytes, _ := codec.Encode(pod)
 
 	go w.sendResult(&etcd.Response{
 		Action: "create",


### PR DESCRIPTION
The idea here is to let watch:
- take a resource version so you can pick up where you left off if you get disconnected
- take a label selector so you can watch things with specific labels
- take a field selector so you can watch things with specific fields (so if a scheduler wants to watch for unassigned pods, it can watch for pods with Host="".)
  - The idea is that, for the moment, you'd only be able to watch for specific fields if the server supports watching on those fields, otherwise you'll get an error. I'm not writing a fully general struct field watcher just yet.
- I had to make client a bit more testable & flexible for this.

I'll squash some of these commits down once it's confirmed that this is a good direction.
