### PR TITLE
Decouple apiserver from codec implementation

### DIFF
--- a/pkg/apiserver/interfaces.go
+++ b/pkg/apiserver/interfaces.go
@@ -24,6 +24,10 @@ import (
 // RESTStorage is a generic interface for RESTful storage services
 // Resources which are exported to the RESTful API of apiserver need to implement this interface.
 type RESTStorage interface {
+	// New returns an empty object that can be used with Create and Update after request data has been put into it.
+	// This object must be a pointer type for use with Codec.DecodeInto([]byte, interface{})
+	New() interface{}
+
 	// List selects resources in the storage which match to the selector.
 	List(labels.Selector) (interface{}, error)
 
@@ -35,7 +39,6 @@ type RESTStorage interface {
 	// Although it can return an arbitrary error value, IsNotFound(err) is true for the returned error value err when the specified resource is not found.
 	Delete(id string) (<-chan interface{}, error)
 
-	Extract(body []byte) (interface{}, error)
 	Create(interface{}) (<-chan interface{}, error)
 	Update(interface{}) (<-chan interface{}, error)
 }

--- a/pkg/apiserver/minionproxy_test.go
+++ b/pkg/apiserver/minionproxy_test.go
@@ -127,7 +127,7 @@ func TestApiServerMinionProxy(t *testing.T) {
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte(req.URL.Path))
 	}))
-	server := httptest.NewServer(New(nil, "/prefix"))
+	server := httptest.NewServer(New(nil, nil, "/prefix"))
 	proxy, _ := url.Parse(proxyServer.URL)
 	resp, err := http.Get(fmt.Sprintf("%s/proxy/minion/%s%s", server.URL, proxy.Host, "/test"))
 	if err != nil {

--- a/pkg/apiserver/operation.go
+++ b/pkg/apiserver/operation.go
@@ -56,7 +56,7 @@ func (s *APIServer) handleOperation(w http.ResponseWriter, req *http.Request) {
 	if len(parts) == 0 {
 		// List outstanding operations.
 		list := s.ops.List()
-		writeJSON(http.StatusOK, list, w)
+		writeJSON(http.StatusOK, s.codec, list, w)
 		return
 	}
 
@@ -68,9 +68,9 @@ func (s *APIServer) handleOperation(w http.ResponseWriter, req *http.Request) {
 
 	obj, complete := op.StatusOrResult()
 	if complete {
-		writeJSON(http.StatusOK, obj, w)
+		writeJSON(http.StatusOK, s.codec, obj, w)
 	} else {
-		writeJSON(http.StatusAccepted, obj, w)
+		writeJSON(http.StatusAccepted, s.codec, obj, w)
 	}
 }
 

--- a/pkg/apiserver/operation_test.go
+++ b/pkg/apiserver/operation_test.go
@@ -95,7 +95,7 @@ func TestOperationsList(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
 	handler := New(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, "/prefix/version")
+	}, codec, "/prefix/version")
 	handler.asyncOpWait = 0
 	server := httptest.NewServer(handler)
 	client := http.Client{}
@@ -103,7 +103,7 @@ func TestOperationsList(t *testing.T) {
 	simple := Simple{
 		Name: "foo",
 	}
-	data, err := api.Encode(simple)
+	data, err := codec.Encode(simple)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestOperationsList(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	obj, err := api.Decode(body)
+	obj, err := codec.Decode(body)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestOpGet(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
 	handler := New(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, "/prefix/version")
+	}, codec, "/prefix/version")
 	handler.asyncOpWait = 0
 	server := httptest.NewServer(handler)
 	client := http.Client{}
@@ -151,7 +151,7 @@ func TestOpGet(t *testing.T) {
 	simple := Simple{
 		Name: "foo",
 	}
-	data, err := api.Encode(simple)
+	data, err := codec.Encode(simple)
 	t.Log(string(data))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -42,7 +42,7 @@ func TestWatchWebsocket(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
 	handler := New(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, "/prefix/version")
+	}, codec, "/prefix/version")
 	server := httptest.NewServer(handler)
 
 	dest, _ := url.Parse(server.URL)
@@ -92,7 +92,7 @@ func TestWatchHTTP(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
 	handler := New(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, "/prefix/version")
+	}, codec, "/prefix/version")
 	server := httptest.NewServer(handler)
 	client := http.Client{}
 

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
@@ -140,5 +141,5 @@ func (m *Master) Run(myAddress, apiPrefix string) error {
 // Instead of calling Run, you can call this function to get a handler for your own server.
 // It is intended for testing. Only call once.
 func (m *Master) ConstructHandler(apiPrefix string) http.Handler {
-	return apiserver.New(m.storage, apiPrefix)
+	return apiserver.New(m.storage, api.Codec, apiPrefix)
 }

--- a/pkg/registry/controllerstorage_test.go
+++ b/pkg/registry/controllerstorage_test.go
@@ -123,23 +123,23 @@ func TestListControllerList(t *testing.T) {
 	}
 }
 
-func TestExtractControllerJson(t *testing.T) {
+func TestControllerDecode(t *testing.T) {
 	mockRegistry := MockControllerRegistry{}
 	storage := ControllerRegistryStorage{
 		registry: &mockRegistry,
 	}
-	controller := api.ReplicationController{
+	controller := &api.ReplicationController{
 		JSONBase: api.JSONBase{
 			ID: "foo",
 		},
 	}
-	body, err := api.Encode(&controller)
+	body, err := api.Encode(controller)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	controllerOut, err := storage.Extract(body)
-	if err != nil {
+	controllerOut := storage.New()
+	if err := api.DecodeInto(body, controllerOut); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
@@ -249,7 +249,7 @@ func TestCreateController(t *testing.T) {
 		podRegistry: &mockPodRegistry,
 		pollPeriod:  time.Millisecond * 1,
 	}
-	controller := api.ReplicationController{
+	controller := &api.ReplicationController{
 		JSONBase: api.JSONBase{ID: "test"},
 		DesiredState: api.ReplicationControllerState{
 			Replicas:        2,
@@ -314,7 +314,7 @@ func TestControllerStorageValidatesCreate(t *testing.T) {
 		},
 	}
 	for _, failureCase := range failureCases {
-		c, err := storage.Create(failureCase)
+		c, err := storage.Create(&failureCase)
 		if c != nil {
 			t.Errorf("Expected nil channel")
 		}
@@ -345,7 +345,7 @@ func TestControllerStorageValidatesUpdate(t *testing.T) {
 		},
 	}
 	for _, failureCase := range failureCases {
-		c, err := storage.Update(failureCase)
+		c, err := storage.Update(&failureCase)
 		if c != nil {
 			t.Errorf("Expected nil channel")
 		}

--- a/pkg/registry/minionstorage.go
+++ b/pkg/registry/minionstorage.go
@@ -59,14 +59,12 @@ func (storage *MinionRegistryStorage) Get(id string) (interface{}, error) {
 	return storage.toApiMinion(id), err
 }
 
-func (storage *MinionRegistryStorage) Extract(body []byte) (interface{}, error) {
-	var minion api.Minion
-	err := api.DecodeInto(body, &minion)
-	return minion, err
+func (storage *MinionRegistryStorage) New() interface{} {
+	return &api.Minion{}
 }
 
 func (storage *MinionRegistryStorage) Create(obj interface{}) (<-chan interface{}, error) {
-	minion, ok := obj.(api.Minion)
+	minion, ok := obj.(*api.Minion)
 	if !ok {
 		return nil, fmt.Errorf("not a minion: %#v", obj)
 	}

--- a/pkg/registry/minionstorage_test.go
+++ b/pkg/registry/minionstorage_test.go
@@ -38,7 +38,7 @@ func TestMinionRegistryStorage(t *testing.T) {
 		t.Errorf("has unexpected object")
 	}
 
-	c, err := ms.Create(api.Minion{JSONBase: api.JSONBase{ID: "baz"}})
+	c, err := ms.Create(&api.Minion{JSONBase: api.JSONBase{ID: "baz"}})
 	if err != nil {
 		t.Errorf("insert failed")
 	}

--- a/pkg/registry/podstorage_test.go
+++ b/pkg/registry/podstorage_test.go
@@ -64,7 +64,7 @@ func TestCreatePodRegistryError(t *testing.T) {
 			Version: "v1beta1",
 		},
 	}
-	pod := api.Pod{DesiredState: desiredState}
+	pod := &api.Pod{DesiredState: desiredState}
 	ch, err := storage.Create(pod)
 	if err != nil {
 		t.Errorf("Expected %#v, Got %#v", nil, err)
@@ -95,7 +95,7 @@ func TestCreatePodSchedulerError(t *testing.T) {
 			Version: "v1beta1",
 		},
 	}
-	pod := api.Pod{DesiredState: desiredState}
+	pod := &api.Pod{DesiredState: desiredState}
 	ch, err := storage.Create(pod)
 	if err != nil {
 		t.Errorf("Expected %#v, Got %#v", nil, err)
@@ -127,7 +127,7 @@ func TestCreatePodSetsIds(t *testing.T) {
 			Version: "v1beta1",
 		},
 	}
-	pod := api.Pod{DesiredState: desiredState}
+	pod := &api.Pod{DesiredState: desiredState}
 	ch, err := storage.Create(pod)
 	if err != nil {
 		t.Errorf("Expected %#v, Got %#v", nil, err)
@@ -208,28 +208,28 @@ func TestListPodList(t *testing.T) {
 	}
 }
 
-func TestExtractJson(t *testing.T) {
+func TestPodDecode(t *testing.T) {
 	mockRegistry := MockPodRegistry{}
 	storage := PodRegistryStorage{
 		registry: &mockRegistry,
 	}
-	pod := api.Pod{
+	expected := &api.Pod{
 		JSONBase: api.JSONBase{
 			ID: "foo",
 		},
 	}
-	body, err := api.Encode(&pod)
+	body, err := api.Encode(expected)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	podOut, err := storage.Extract(body)
-	if err != nil {
+	actual := storage.New()
+	if err := api.DecodeInto(body, actual); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if !reflect.DeepEqual(pod, podOut) {
-		t.Errorf("Expected %#v, found %#v", pod, podOut)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %#v, Got %#v", expected, actual)
 	}
 }
 
@@ -373,7 +373,7 @@ func TestPodStorageValidatesCreate(t *testing.T) {
 		scheduler: &MockScheduler{machine: "test"},
 		registry:  mockRegistry,
 	}
-	pod := api.Pod{}
+	pod := &api.Pod{}
 	c, err := storage.Create(pod)
 	if c != nil {
 		t.Errorf("Expected nil channel")
@@ -391,7 +391,7 @@ func TestPodStorageValidatesUpdate(t *testing.T) {
 		scheduler: &MockScheduler{machine: "test"},
 		registry:  mockRegistry,
 	}
-	pod := api.Pod{}
+	pod := &api.Pod{}
 	c, err := storage.Update(pod)
 	if c != nil {
 		t.Errorf("Expected nil channel")
@@ -421,7 +421,7 @@ func TestCreatePod(t *testing.T) {
 			Version: "v1beta1",
 		},
 	}
-	pod := api.Pod{
+	pod := &api.Pod{
 		JSONBase:     api.JSONBase{ID: "foo"},
 		DesiredState: desiredState,
 	}

--- a/pkg/registry/servicestorage_test.go
+++ b/pkg/registry/servicestorage_test.go
@@ -33,7 +33,7 @@ func TestServiceRegistry(t *testing.T) {
 
 	storage := MakeServiceRegistryStorage(memory, fakeCloud, MakeMinionRegistry(machines))
 
-	svc := api.Service{
+	svc := &api.Service{
 		JSONBase: api.JSONBase{ID: "foo"},
 		Selector: map[string]string{"bar": "baz"},
 	}
@@ -68,7 +68,7 @@ func TestServiceStorageValidatesCreate(t *testing.T) {
 		},
 	}
 	for _, failureCase := range failureCases {
-		c, err := storage.Create(failureCase)
+		c, err := storage.Create(&failureCase)
 		if c != nil {
 			t.Errorf("Expected nil channel")
 		}
@@ -97,7 +97,7 @@ func TestServiceStorageValidatesUpdate(t *testing.T) {
 		},
 	}
 	for _, failureCase := range failureCases {
-		c, err := storage.Update(failureCase)
+		c, err := storage.Update(&failureCase)
 		if c != nil {
 			t.Errorf("Expected nil channel")
 		}
@@ -114,7 +114,7 @@ func TestServiceRegistryExternalService(t *testing.T) {
 
 	storage := MakeServiceRegistryStorage(memory, fakeCloud, MakeMinionRegistry(machines))
 
-	svc := api.Service{
+	svc := &api.Service{
 		JSONBase:                   api.JSONBase{ID: "foo"},
 		Selector:                   map[string]string{"bar": "baz"},
 		CreateExternalLoadBalancer: true,
@@ -144,7 +144,7 @@ func TestServiceRegistryExternalServiceError(t *testing.T) {
 
 	storage := MakeServiceRegistryStorage(memory, fakeCloud, MakeMinionRegistry(machines))
 
-	svc := api.Service{
+	svc := &api.Service{
 		JSONBase:                   api.JSONBase{ID: "foo"},
 		Selector:                   map[string]string{"bar": "baz"},
 		CreateExternalLoadBalancer: true,


### PR DESCRIPTION
The apiserver on initialization must be provided with a codec for encoding
and decoding all handled objects including api.Status and api.ServerOp.  In
addition, RESTStorage objects may now optionally implement Extract() or
instead rely on the codec to decode for them.

NOTE: Only the last commit is new, the other commit is in #806
