### PR TITLE
Fix proxy error condition and simplify method

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -75,7 +75,7 @@ func New(storage map[string]RESTStorage, prefix string) *APIServer {
 	s.mux.HandleFunc(s.operationPrefix()+"/", s.handleOperation)
 
 	// Proxy minion requests
-	s.mux.HandleFunc("/proxy/minion/", s.handleProxyMinion)
+	s.mux.Handle("/proxy/minion/", http.StripPrefix("/proxy/minion", http.HandlerFunc(handleProxyMinion)))
 
 	return s
 }

--- a/pkg/apiserver/errors.go
+++ b/pkg/apiserver/errors.go
@@ -70,3 +70,9 @@ func notFound(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusNotFound)
 	fmt.Fprintf(w, "Not Found: %#v", req.RequestURI)
 }
+
+// badGatewayError renders a simple bad gateway error
+func badGatewayError(w http.ResponseWriter, req *http.Request) {
+	w.WriteHeader(http.StatusBadGateway)
+	fmt.Fprintf(w, "Bad Gateway: %#v", req.RequestURI)
+}


### PR DESCRIPTION
Proxy was not properly handling incorrect backends (for
no such host proxy errors).  Add new minion proxy test case,
and remove path transformations inside the handler.
