### PR TITLE
Run go-build on each kubepush and vagrant log only states that change or error to improve readability

### DIFF
--- a/cluster/saltbase/salt/apiserver/init.sls
+++ b/cluster/saltbase/salt/apiserver/init.sls
@@ -51,14 +51,14 @@ apiserver-third-party-go:
     - mode: 644
 
 apiserver-build:
-  cmd.wait:
+  cmd.run:
     - cwd: {{ root }}
     - names:
       - go build {{ package }}/cmd/apiserver
     - env:
       - PATH: {{ grains['path'] }}:/usr/local/bin
       - GOPATH: {{ root }}
-    - watch:
+    - require:
       - file: {{ package_dir }}
 
 /usr/local/bin/apiserver:

--- a/cluster/saltbase/salt/controller-manager/init.sls
+++ b/cluster/saltbase/salt/controller-manager/init.sls
@@ -51,14 +51,14 @@ controller-manager-third-party-go:
     - mode: 644
 
 controller-manager-build:
-  cmd.wait:
+  cmd.run:
     - cwd: {{ root }}
     - names:
       - go build {{ package }}/cmd/controller-manager
     - env:
       - PATH: {{ grains['path'] }}:/usr/local/bin
       - GOPATH: {{ root }}
-    - watch:
+    - require:
       - file: {{ package_dir }}
 
 /usr/local/bin/controller-manager:

--- a/cluster/saltbase/salt/kube-proxy/init.sls
+++ b/cluster/saltbase/salt/kube-proxy/init.sls
@@ -43,14 +43,14 @@ third-party-go:
       - mode
 
 kube-proxy-build:
-  cmd.wait:
+  cmd.run:
     - cwd: {{ root }}
     - names:
       - go build {{ package }}/cmd/proxy
     - env:
       - PATH: {{ grains['path'] }}:/usr/local/bin
       - GOPATH: {{ root }}
-    - watch:
+    - require:
       - file: {{ package_dir }}
 
 /usr/local/bin/kube-proxy:

--- a/cluster/saltbase/salt/kubelet/init.sls
+++ b/cluster/saltbase/salt/kubelet/init.sls
@@ -51,14 +51,14 @@ kubelet-third-party-go:
     - mode: 644
 
 kubelet-build:
-  cmd.wait:
+  cmd.run:
     - cwd: {{ root }}
     - names:
       - go build {{ package }}/cmd/kubelet
     - env:
       - PATH: {{ grains['path'] }}:/usr/local/bin
       - GOPATH: {{ root }}
-    - watch:
+    - require:
       - file: {{ package_dir }}
 
 /usr/local/bin/kubelet:

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -47,6 +47,12 @@ reactor:
     - /srv/reactor/start.sls
 EOF
 
+  cat <<EOF >/etc/salt/master.d/salt-output.conf
+# Minimize the amount of output to terminal
+state_verbose: False
+state_output: mixed  
+EOF
+
   # Install Salt
   #
   # We specify -X to avoid a race condition that can cause minion failure to


### PR DESCRIPTION
There are two problems addressed by this PR:
1. The current vagrant provision output that shows the salt results is too verbose and hard to parse.
2. The Salt SLS for go-build operations was only occuring if the source on disk actually changed.  This had the negative impact of a user doing a cluster/kube-push.sh and getting a compile error, then making a call again to cluster/kube-push.sh and because they made no source edit, salt did not report a job failure because the go-build only ran if the contents on disk changed.  As a result, user thinks they are running latest code, but only running the code that had previously compiled (which is now old).

This PR does the following:
1. minimizes logging to only show errors or state changes.
2. modifies the go-builds driven by our Salt files to always run on each invocation even when source on disk has not changed from previous execution.

Therefore, no more false positives reported by Salt.
