### PR TITLE
Allow the apiserver to support raw URLs

### DIFF
--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -410,6 +410,34 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+func TestUpdateWithEncodedPath(t *testing.T) {
+	storage := map[string]RESTStorage{}
+	simpleStorage := SimpleRESTStorage{}
+	storage["simple"] = &simpleStorage
+	handler := New(storage, "/prefix/version")
+	server := httptest.NewServer(handler)
+
+	item := Simple{
+		Name: "bar",
+	}
+	body, err := api.Encode(item)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	client := http.Client{}
+	request, err := http.NewRequest("PUT", server.URL, bytes.NewReader(body))
+	request.URL.Path = "/prefix/version/simple/" + "id%2Fsegment"
+	_, err = client.Do(request)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if simpleStorage.updated.Name != item.Name {
+		t.Errorf("Unexpected update value %#v, expected %#v.", simpleStorage.updated, item)
+	}
+}
+
 func TestUpdateMissing(t *testing.T) {
 	storage := map[string]RESTStorage{}
 	ID := "id"

--- a/pkg/apiserver/operation.go
+++ b/pkg/apiserver/operation.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -34,16 +33,8 @@ type OperationHandler struct {
 }
 
 func (h *OperationHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	trimmed := strings.TrimLeft(req.URL.Path, "/")
-	parts := strings.Split(trimmed, "/")
-	if trimmed == "" {
-		parts = []string{}
-	}
-	if len(parts) > 1 {
-		notFound(w, req)
-		return
-	}
-	if req.Method != "GET" {
+	parts, err := util.SplitRawPath(req.URL.Path)
+	if err != nil || req.Method != "GET" || len(parts) > 1 {
 		notFound(w, req)
 		return
 	}

--- a/pkg/apiserver/watch.go
+++ b/pkg/apiserver/watch.go
@@ -19,7 +19,6 @@ package apiserver
 import (
 	"encoding/json"
 	"net/http"
-	"path"
 	"strings"
 
 	"code.google.com/p/go.net/websocket"
@@ -28,22 +27,17 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
-func (s *APIServer) watchPrefix() string {
-	return path.Join(s.prefix, "watch")
+type WatchHandler struct {
+	storage map[string]RESTStorage
 }
 
 // handleWatch processes a watch request
-func (s *APIServer) handleWatch(w http.ResponseWriter, req *http.Request) {
-	prefix := s.watchPrefix()
-	if !strings.HasPrefix(req.URL.Path, prefix) {
-		notFound(w, req)
-		return
-	}
-	parts := strings.Split(req.URL.Path[len(prefix):], "/")[1:]
+func (h *WatchHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	parts := strings.Split(req.URL.Path, "/")
 	if req.Method != "GET" || len(parts) < 1 {
 		notFound(w, req)
 	}
-	storage := s.storage[parts[0]]
+	storage := h.storage[parts[0]]
 	if storage == nil {
 		notFound(w, req)
 	}

--- a/pkg/apiserver/watch.go
+++ b/pkg/apiserver/watch.go
@@ -19,11 +19,11 @@ package apiserver
 import (
 	"encoding/json"
 	"net/http"
-	"strings"
 
 	"code.google.com/p/go.net/websocket"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
@@ -33,12 +33,12 @@ type WatchHandler struct {
 
 // handleWatch processes a watch request
 func (h *WatchHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	parts := strings.Split(req.URL.Path, "/")
-	if req.Method != "GET" || len(parts) < 1 {
+	parts, err := util.SplitRawPath(req.URL.Path)
+	if err != nil || req.Method != "GET" || len(parts) < 1 {
 		notFound(w, req)
 	}
-	storage := h.storage[parts[0]]
-	if storage == nil {
+	storage, ok := h.storage[parts[0]]
+	if !ok {
 		notFound(w, req)
 	}
 	if watcher, ok := storage.(ResourceWatcher); ok {

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -1,0 +1,156 @@
+package util
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// RawURL is a wrapper http.Handler for setting URL.Path to the unescaped
+// version of the URI to allow clients to handle encoded slashes.
+func RawURL(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s := r.RequestURI
+		u, _ := split(s, "#", true)
+		rest, _ := split(u, "?", true)
+		r.URL.Path = rest
+		h.ServeHTTP(w, r)
+	})
+}
+
+// SplitRawPath is a helper method for breaking an escaped URL path into
+// segments according to RFC3986, which Go 1.X does not correctly handle
+// (see https://code.google.com/p/go/issues/detail?id=3659).  This allows
+// URL handlers to properly handle encoded path segments which might be
+// part of an escaped URL path like:
+//
+//    /api/resource/encoded%2Fpath%2Fsegment
+//
+// This method will return "api", "resource", and "encoded/path/segment".
+func SplitRawPath(path string) ([]string, error) {
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return []string{}, nil
+	}
+	parts := strings.Split(path, "/")
+	for i := range parts {
+		part, err := unescape(parts[i], encodePath)
+		if err != nil {
+			return nil, err
+		}
+		parts[i] = part
+	}
+	return parts, nil
+}
+
+// The following code is copied from Go 1.2.2 directly - no modifications have been made.
+// These methods are private in net/url and allow Go compatible splitting and unescaping
+// of urls.
+
+// Maybe s is of the form t c u.
+// If so, return t, c u (or t, u if cutc == true).
+// If not, return s, "".
+// copied from net/url/url.go#split
+func split(s string, c string, cutc bool) (string, string) {
+	i := strings.Index(s, c)
+	if i < 0 {
+		return s, ""
+	}
+	if cutc {
+		return s[0:i], s[i+len(c):]
+	}
+	return s[0:i], s[i:]
+}
+
+// copied from net/url/url.go
+type encoding int
+
+// copied from net/url/url.go
+const (
+	encodePath encoding = 1 + iota
+	encodeUserPassword
+	encodeQueryComponent
+	encodeFragment
+)
+
+// copied from net/url/url.go#unhex
+func ishex(c byte) bool {
+	switch {
+	case '0' <= c && c <= '9':
+		return true
+	case 'a' <= c && c <= 'f':
+		return true
+	case 'A' <= c && c <= 'F':
+		return true
+	}
+	return false
+}
+
+// copied from net/url/url.go#unhex
+func unhex(c byte) byte {
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0'
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10
+	case 'A' <= c && c <= 'F':
+		return c - 'A' + 10
+	}
+	return 0
+}
+
+// unescape unescapes a string; the mode specifies
+// which section of the URL string is being unescaped.
+// copied from net/url/url.go#unescape
+func unescape(s string, mode encoding) (string, error) {
+	// Count %, check that they're well-formed.
+	n := 0
+	hasPlus := false
+	for i := 0; i < len(s); {
+		switch s[i] {
+		case '%':
+			n++
+			if i+2 >= len(s) || !ishex(s[i+1]) || !ishex(s[i+2]) {
+				s = s[i:]
+				if len(s) > 3 {
+					s = s[0:3]
+				}
+				return "", url.EscapeError(s)
+			}
+			i += 3
+		case '+':
+			hasPlus = mode == encodeQueryComponent
+			i++
+		default:
+			i++
+		}
+	}
+
+	if n == 0 && !hasPlus {
+		return s, nil
+	}
+
+	t := make([]byte, len(s)-2*n)
+	j := 0
+	for i := 0; i < len(s); {
+		switch s[i] {
+		case '%':
+			t[j] = unhex(s[i+1])<<4 | unhex(s[i+2])
+			j++
+			i += 3
+		case '+':
+			if mode == encodeQueryComponent {
+				t[j] = ' '
+			} else {
+				t[j] = '+'
+			}
+			j++
+			i++
+		default:
+			t[j] = s[i]
+			j++
+			i++
+		}
+	}
+	return string(t), nil
+}

--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -1,0 +1,79 @@
+package util
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestRawURL(t *testing.T) {
+	testCases := map[string]string{
+		"":      "/",
+		"/":     "/",
+		"/bar":  "/bar",
+		"/bar/": "/bar/",
+
+		"/bar?test=1":          "/bar",
+		"/bar%3Ftest=1":        "/bar%3Ftest=1",
+		"/bar?test=1#fragment": "/bar",
+		"/bar#fragment":        "/bar",
+
+		"/%2F":      "/%2F",
+		"/%2F/a%2F": "/%2F/a%2F",
+	}
+	ch := make(chan string, 1)
+	server := httptest.NewServer(RawURL(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ch <- req.URL.Path
+	})))
+	for source, expected := range testCases {
+		target, _ := url.Parse(server.URL)
+		target.Opaque = source
+		req := &http.Request{Method: "GET", URL: target}
+		client := http.Client{}
+		_, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+		actual := <-ch
+		if expected != actual {
+			t.Errorf("expected %s to become %s, got %s", source, expected, actual)
+		}
+	}
+	close(ch)
+	server.Close()
+}
+
+func TestSplitRawPath(t *testing.T) {
+	testCases := map[string][]string{
+		"":           []string{},
+		"/":          []string{},
+		"//":         []string{},
+		"/bar":       []string{"bar"},
+		"/%2F":       []string{"/"},
+		"/%2F/a%2F":  []string{"/", "a/"},
+		"/%2F/a%2F/": []string{"/", "a/"},
+	}
+	for source, expected := range testCases {
+		actual, err := SplitRawPath(source)
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+			continue
+		}
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("expected %s to become %v, got %v", source, expected, actual)
+		}
+	}
+
+	failureCases := []string{
+		"/%2", // single escape char
+		"/%Z", // out of range
+	}
+	for _, source := range failureCases {
+		_, err := SplitRawPath(source)
+		if err == nil {
+			t.Errorf("unexpected non-error for %s", source)
+		}
+	}
+}


### PR DESCRIPTION
Supports handling paths like "/foo/bar%2Fbaz", which Go 1.X does not correctly handle according to RFC
(https://code.google.com/p/go/issues/detail?id=3659). A concrete case for this is REST resources whose ID contains slashes which could include Docker repository/registry names, URLs, and path segments.

Broken into three pieces for easier review.
