### PR TITLE
Kubelet should have a max think time before auto resync

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -115,7 +115,6 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	config.NewSourceURL(manifestURL, 5*time.Second, cfg1.Channel("url"))
 	myKubelet := kubelet.NewIntegrationTestKubelet(machineList[0], &fakeDocker1)
 	go util.Forever(func() { myKubelet.Run(cfg1.Updates()) }, 0)
-	go util.Forever(cfg1.Sync, 3*time.Second)
 	go util.Forever(func() {
 		kubelet.ListenAndServeKubeletServer(myKubelet, cfg1.Channel("http"), http.DefaultServeMux, "localhost", 10250)
 	}, 0)
@@ -127,7 +126,6 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	config.NewSourceEtcd(config.EtcdKeyForHost(machineList[1]), etcdClient, 30*time.Second, cfg2.Channel("etcd"))
 	otherKubelet := kubelet.NewIntegrationTestKubelet(machineList[1], &fakeDocker2)
 	go util.Forever(func() { otherKubelet.Run(cfg2.Updates()) }, 0)
-	go util.Forever(cfg2.Sync, 3*time.Second)
 	go util.Forever(func() {
 		kubelet.ListenAndServeKubeletServer(otherKubelet, cfg2.Channel("http"), http.DefaultServeMux, "localhost", 10251)
 	}, 0)

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -148,15 +148,11 @@ func main() {
 		dockerClient,
 		cadvisorClient,
 		etcdClient,
-		*rootDirectory)
+		*rootDirectory,
+		*syncFrequency)
 
 	// start the kubelet
 	go util.Forever(func() { k.Run(cfg.Updates()) }, 0)
-
-	// resynchronize periodically
-	// TODO: make this part of PodConfig so that it is only delivered after syncFrequency has elapsed without
-	// an update
-	go util.Forever(cfg.Sync, *syncFrequency)
 
 	// start the kubelet server
 	if *enableServer {


### PR DESCRIPTION
The sync frequency should be part of the syncLoop and resync no less often than every X seconds (and no more often than the time between updates or X, whichever is lower).  The current implementation runs
even if a config update was delivered less than X seconds ago.
