### PR TITLE
Clean up the -address flag in kubelet

### DIFF
--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -1,6 +1,6 @@
 {% set daemon_args = "$DAEMON_ARGS" %}
 {% if grains['os_family'] == 'RedHat' %}
-	{% set daemon_args = "" %}
+  {% set daemon_args = "" %}
 {% endif %}
 {% if grains.etcd_servers is defined %}
   {% set etcd_servers = "-etcd_servers=http://" + grains.etcd_servers + ":4001" %}
@@ -9,10 +9,9 @@
   {% set etcd_servers = "-etcd_servers=http://" + ips[0][0] + ":4001" %}
 {% endif %}
 
+{% set hostname_override = "" %}
 {% if grains.minion_ip is defined %}
-  {% set address = "-address=" + grains.minion_ip + " -hostname_override=" + grains.minion_ip %}
-{% else %}
-  {% set address = "-address=$HOSTNAME" %}
+  {% set hostname_override = " -hostname_override=" + grains.minion_ip %}
 {% endif %}
 
-DAEMON_ARGS="{{daemon_args}} {{etcd_servers}} {{address}} -config=/etc/kubernetes/manifests"
+DAEMON_ARGS="{{daemon_args}} {{etcd_servers}} {{hostname_override}} -config=/etc/kubernetes/manifests"

--- a/cluster/saltbase/salt/kubelet/initd
+++ b/cluster/saltbase/salt/kubelet/initd
@@ -17,7 +17,7 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="The Kubernetes container manager"
 NAME=kubelet
 DAEMON=/usr/local/bin/kubelet
-DAEMON_ARGS=" -config /etc/kubelet/data/`hostname`"
+DAEMON_ARGS=" -config /etc/kubelet/data/`hostname` -address=0.0.0.0"
 DAEMON_LOG_FILE=/var/log/$NAME.log
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -50,7 +50,8 @@ var (
 	fileCheckFrequency = flag.Duration("file_check_frequency", 20*time.Second, "Duration between checking config files for new data")
 	httpCheckFrequency = flag.Duration("http_check_frequency", 20*time.Second, "Duration between checking http for new data")
 	manifestURL        = flag.String("manifest_url", "", "URL for accessing the container manifest")
-	address            = flag.String("address", "127.0.0.1", "The address for the info server to serve on")
+	enableServer       = flag.Bool("enable_server", true, "Enable the info server")
+	address            = flag.String("address", "127.0.0.1", "The address for the info server to serve on (set to 0.0.0.0 or \"\" for all interfaces)")
 	port               = flag.Uint("port", 10250, "The port for the info server to serve on")
 	hostnameOverride   = flag.String("hostname_override", "", "If non-empty, will use this string as identification instead of the actual hostname.")
 	dockerEndpoint     = flag.String("docker_endpoint", "", "If non-empty, use this for the docker endpoint to communicate with")
@@ -158,7 +159,7 @@ func main() {
 	go util.Forever(cfg.Sync, *syncFrequency)
 
 	// start the kubelet server
-	if *address != "" {
+	if *enableServer {
 		go util.Forever(func() {
 			kubelet.ListenAndServeKubeletServer(k, cfg.Channel("http"), http.DefaultServeMux, *address, *port)
 		}, 0)


### PR DESCRIPTION
Net result: kubelet's -address flag has clearer semantics and listens on localhost _and_ eth0.
