### PR TITLE
Disable docker restarts, for now

### DIFF
--- a/cluster/saltbase/salt/docker/docker-defaults
+++ b/cluster/saltbase/salt/docker/docker-defaults
@@ -1,1 +1,1 @@
-DOCKER_OPTS="--bridge cbr0 --iptables=false"
+DOCKER_OPTS="--bridge cbr0 --iptables=false -r=false"


### PR DESCRIPTION
If the docker daemon goes down and comes up, it will try to restart
containers.  This will race with our own restart loop.  Only one loop should
be controlling restarts, probably.
