### PR TITLE
Enforce -address flag is set on all Linux flavors

### DIFF
--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -9,9 +9,11 @@
   {% set etcd_servers = "-etcd_servers=http://" + ips[0][0] + ":4001" %}
 {% endif %}
 
+{% set address = "-address=0.0.0.0" %}
+{% set config = "-config=/etc/kubernetes/manifests" %}
 {% set hostname_override = "" %}
 {% if grains.minion_ip is defined %}
   {% set hostname_override = " -hostname_override=" + grains.minion_ip %}
 {% endif %}
 
-DAEMON_ARGS="{{daemon_args}} {{etcd_servers}} {{hostname_override}}"
+DAEMON_ARGS="{{daemon_args}} {{etcd_servers}} {{hostname_override}} {{address}} {{config}}"

--- a/cluster/saltbase/salt/kubelet/initd
+++ b/cluster/saltbase/salt/kubelet/initd
@@ -17,7 +17,7 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="The Kubernetes container manager"
 NAME=kubelet
 DAEMON=/usr/local/bin/kubelet
-DAEMON_ARGS="-config=/etc/kubernetes/manifests -address=0.0.0.0"
+DAEMON_ARGS=""
 DAEMON_LOG_FILE=/var/log/$NAME.log
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME


### PR DESCRIPTION
The change to only set this value in an initd file did not work when running on systemd linux distributions where the initd file is ignored in favor of the EnvironmentFile.  This broke the Vagrant cluster.  Moved the -address flag to be explicit in default file.

Moving forward, its best if we use fewer arguments in the init.d file (just like we avoid them in the .service files we generate) and instead, stick with making kubernetes process arguments explict in the default files.
