### PR TITLE
Centralize path magic in apiserver into the New method

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"path"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -48,12 +49,11 @@ type Codec interface {
 //
 // TODO: consider migrating this to go-restful which is a more full-featured version of the same thing.
 type APIServer struct {
-	prefix      string
 	storage     map[string]RESTStorage
 	codec       Codec
 	ops         *Operations
-	mux         *http.ServeMux
 	asyncOpWait time.Duration
+	handler     http.Handler
 }
 
 // New creates a new APIServer object. 'storage' contains a map of handlers. 'codec'
@@ -65,31 +65,43 @@ type APIServer struct {
 // TODO: add multitype codec serialization
 func New(storage map[string]RESTStorage, codec Codec, prefix string) *APIServer {
 	s := &APIServer{
-		prefix:  strings.TrimRight(prefix, "/"),
 		storage: storage,
 		codec:   codec,
 		ops:     NewOperations(),
-		mux:     http.NewServeMux(),
 		// Delay just long enough to handle most simple write operations
 		asyncOpWait: time.Millisecond * 25,
 	}
 
-	// Primary API methods
-	s.mux.HandleFunc(s.prefix+"/", s.handleREST)
-	s.mux.HandleFunc(s.watchPrefix()+"/", s.handleWatch)
+	mux := http.NewServeMux()
+
+	prefix = strings.TrimRight(prefix, "/")
+
+	// Primary API handlers
+	restPrefix := prefix + "/"
+	mux.Handle(restPrefix, http.StripPrefix(restPrefix, http.HandlerFunc(s.handleREST)))
+
+	// Watch API handlers
+	watchPrefix := path.Join(prefix, "watch") + "/"
+	mux.Handle(watchPrefix, http.StripPrefix(watchPrefix, &WatchHandler{storage}))
 
 	// Support services for the apiserver
-	s.mux.Handle("/logs/", http.StripPrefix("/logs/", http.FileServer(http.Dir("/var/log/"))))
-	healthz.InstallHandler(s.mux)
-	s.mux.HandleFunc("/version", handleVersion)
-	s.mux.HandleFunc("/", handleIndex)
+	logsPrefix := "/logs/"
+	mux.Handle(logsPrefix, http.StripPrefix(logsPrefix, http.FileServer(http.Dir("/var/log/"))))
+	healthz.InstallHandler(mux)
+	mux.HandleFunc("/version", handleVersion)
+	mux.HandleFunc("/", handleIndex)
 
 	// Handle both operations and operations/* with the same handler
-	s.mux.HandleFunc(s.operationPrefix(), s.handleOperation)
-	s.mux.HandleFunc(s.operationPrefix()+"/", s.handleOperation)
+	handler := &OperationHandler{s.ops, s.codec}
+	operationPrefix := path.Join(prefix, "operations")
+	mux.Handle(operationPrefix, http.StripPrefix(operationPrefix, handler))
+	operationsPrefix := operationPrefix + "/"
+	mux.Handle(operationsPrefix, http.StripPrefix(operationsPrefix, handler))
 
 	// Proxy minion requests
-	s.mux.Handle("/proxy/minion/", http.StripPrefix("/proxy/minion", http.HandlerFunc(handleProxyMinion)))
+	mux.Handle("/proxy/minion/", http.StripPrefix("/proxy/minion", http.HandlerFunc(handleProxyMinion)))
+
+	s.handler = mux
 
 	return s
 }
@@ -112,29 +124,25 @@ func (s *APIServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		),
 	).Log()
 
-	// Dispatch via our mux.
-	s.mux.ServeHTTP(w, req)
+	// Dispatch to the internal handler
+	s.handler.ServeHTTP(w, req)
 }
 
 // handleREST handles requests to all our RESTStorage objects.
 func (s *APIServer) handleREST(w http.ResponseWriter, req *http.Request) {
-	if !strings.HasPrefix(req.URL.Path, s.prefix) {
+	parts := splitPath(req.URL.Path)
+	if len(parts) < 1 {
 		notFound(w, req)
 		return
 	}
-	requestParts := strings.Split(req.URL.Path[len(s.prefix):], "/")[1:]
-	if len(requestParts) < 1 {
-		notFound(w, req)
-		return
-	}
-	storage := s.storage[requestParts[0]]
+	storage := s.storage[parts[0]]
 	if storage == nil {
-		httplog.LogOf(w).Addf("'%v' has no storage object", requestParts[0])
+		httplog.LogOf(w).Addf("'%v' has no storage object", parts[0])
 		notFound(w, req)
 		return
 	}
 
-	s.handleRESTStorage(requestParts, req, w, storage)
+	s.handleRESTStorage(parts, req, w, storage)
 }
 
 // handleRESTStorage is the main dispatcher for a storage object.  It switches on the HTTP method, and then
@@ -346,4 +354,13 @@ func parseTimeout(str string) time.Duration {
 func readBody(req *http.Request) ([]byte, error) {
 	defer req.Body.Close()
 	return ioutil.ReadAll(req.Body)
+}
+
+// splitPath returns the segments for a URL path
+func splitPath(path string) []string {
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return []string{}
+	}
+	return strings.Split(path, "/")
 }


### PR DESCRIPTION
Make OperationHandler and WatchHandler properly encapsulate their
concerns and make them not depend on the global path

Handles the non-url encoding parts of #811
