### PR TITLE
Make storage.Delete return *api.Status instead of api.Status

### DIFF
--- a/pkg/registry/controllerstorage.go
+++ b/pkg/registry/controllerstorage.go
@@ -69,7 +69,7 @@ func (storage *ControllerRegistryStorage) Get(id string) (interface{}, error) {
 // Delete asynchronously deletes the ReplicationController specified by its id.
 func (storage *ControllerRegistryStorage) Delete(id string) (<-chan interface{}, error) {
 	return apiserver.MakeAsync(func() (interface{}, error) {
-		return api.Status{Status: api.StatusSuccess}, storage.registry.DeleteController(id)
+		return &api.Status{Status: api.StatusSuccess}, storage.registry.DeleteController(id)
 	}), nil
 }
 

--- a/pkg/registry/minionstorage.go
+++ b/pkg/registry/minionstorage.go
@@ -100,6 +100,6 @@ func (storage *MinionRegistryStorage) Delete(id string) (<-chan interface{}, err
 		return nil, err
 	}
 	return apiserver.MakeAsync(func() (interface{}, error) {
-		return api.Status{Status: api.StatusSuccess}, storage.registry.Delete(id)
+		return &api.Status{Status: api.StatusSuccess}, storage.registry.Delete(id)
 	}), nil
 }

--- a/pkg/registry/minionstorage_test.go
+++ b/pkg/registry/minionstorage_test.go
@@ -55,7 +55,7 @@ func TestMinionRegistryStorage(t *testing.T) {
 		t.Errorf("delete failed")
 	}
 	obj = <-c
-	if s, ok := obj.(api.Status); !ok || s.Status != api.StatusSuccess {
+	if s, ok := obj.(*api.Status); !ok || s.Status != api.StatusSuccess {
 		t.Errorf("delete return value was weird: %#v", obj)
 	}
 	if _, err := ms.Get("bar"); err != ErrDoesNotExist {

--- a/pkg/registry/podstorage.go
+++ b/pkg/registry/podstorage.go
@@ -185,7 +185,7 @@ func (storage *PodRegistryStorage) Get(id string) (interface{}, error) {
 
 func (storage *PodRegistryStorage) Delete(id string) (<-chan interface{}, error) {
 	return apiserver.MakeAsync(func() (interface{}, error) {
-		return api.Status{Status: api.StatusSuccess}, storage.registry.DeletePod(id)
+		return &api.Status{Status: api.StatusSuccess}, storage.registry.DeletePod(id)
 	}), nil
 }
 

--- a/pkg/registry/servicestorage.go
+++ b/pkg/registry/servicestorage.go
@@ -156,7 +156,7 @@ func (sr *ServiceRegistryStorage) Delete(id string) (<-chan interface{}, error) 
 	}
 	return apiserver.MakeAsync(func() (interface{}, error) {
 		sr.deleteExternalLoadBalancer(service)
-		return api.Status{Status: api.StatusSuccess}, sr.registry.DeleteService(id)
+		return &api.Status{Status: api.StatusSuccess}, sr.registry.DeleteService(id)
 	}), nil
 }
 


### PR DESCRIPTION
as apiserver.APIServer.finishReq expects.

This solves the warning in finishReq:
"programmer error: use *api.Status as a result, not api.Status."
