### PR TITLE
Extract RESTHandler and allow API groupings

### DIFF
--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
@@ -114,5 +115,13 @@ func main() {
 		})
 	}
 
-	glog.Fatal(m.Run(net.JoinHostPort(*address, strconv.Itoa(int(*port))), *apiPrefix))
+	storage, codec := m.API_v1beta1()
+	s := &http.Server{
+		Addr:           net.JoinHostPort(*address, strconv.Itoa(int(*port))),
+		Handler:        apiserver.Handle(storage, codec, *apiPrefix),
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   10 * time.Second,
+		MaxHeaderBytes: 1 << 20,
+	}
+	glog.Fatal(s.ListenAndServe())
 }

--- a/pkg/apiserver/minionproxy_test.go
+++ b/pkg/apiserver/minionproxy_test.go
@@ -127,7 +127,7 @@ func TestApiServerMinionProxy(t *testing.T) {
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte(req.URL.Path))
 	}))
-	server := httptest.NewServer(New(nil, nil, "/prefix"))
+	server := httptest.NewServer(Handle(nil, nil, "/prefix"))
 	proxy, _ := url.Parse(proxyServer.URL)
 	resp, err := http.Get(fmt.Sprintf("%s/proxy/minion/%s%s", server.URL, proxy.Host, "/test"))
 	if err != nil {

--- a/pkg/apiserver/operation_test.go
+++ b/pkg/apiserver/operation_test.go
@@ -93,10 +93,10 @@ func TestOperation(t *testing.T) {
 
 func TestOperationsList(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
-	handler := New(map[string]RESTStorage{
+	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
 	}, codec, "/prefix/version")
-	handler.asyncOpWait = 0
+	handler.(*defaultAPIServer).group.handler.asyncOpWait = 0
 	server := httptest.NewServer(handler)
 	client := http.Client{}
 
@@ -105,26 +105,26 @@ func TestOperationsList(t *testing.T) {
 	}
 	data, err := codec.Encode(simple)
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	response, err := client.Post(server.URL+"/prefix/version/foo", "application/json", bytes.NewBuffer(data))
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if response.StatusCode != http.StatusAccepted {
-		t.Errorf("Unexpected response %#v", response)
+		t.Fatalf("Unexpected response %#v", response)
 	}
 
 	response, err = client.Get(server.URL + "/prefix/version/operations")
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("unexpected status code %#v", response)
 	}
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	obj, err := codec.Decode(body)
 	if err != nil {
@@ -149,10 +149,10 @@ func TestOpGet(t *testing.T) {
 			return obj, nil
 		},
 	}
-	handler := New(map[string]RESTStorage{
+	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
 	}, codec, "/prefix/version")
-	handler.asyncOpWait = 0
+	handler.(*defaultAPIServer).group.handler.asyncOpWait = 0
 	server := httptest.NewServer(handler)
 	client := http.Client{}
 
@@ -162,27 +162,27 @@ func TestOpGet(t *testing.T) {
 	data, err := codec.Encode(simple)
 	t.Log(string(data))
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	request, err := http.NewRequest("POST", server.URL+"/prefix/version/foo", bytes.NewBuffer(data))
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	response, err := client.Do(request)
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if response.StatusCode != http.StatusAccepted {
-		t.Errorf("Unexpected response %#v", response)
+		t.Fatalf("Unexpected response %#v", response)
 	}
 
 	var itemOut api.Status
 	body, err := extractBody(response, &itemOut)
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if itemOut.Status != api.StatusWorking || itemOut.Details == nil || itemOut.Details.ID == "" {
@@ -191,12 +191,12 @@ func TestOpGet(t *testing.T) {
 
 	req2, err := http.NewRequest("GET", server.URL+"/prefix/version/operations/"+itemOut.Details.ID, nil)
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	_, err = client.Do(req2)
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if response.StatusCode != http.StatusAccepted {

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+)
+
+type RESTHandler struct {
+	storage     map[string]RESTStorage
+	codec       Codec
+	ops         *Operations
+	asyncOpWait time.Duration
+}
+
+// ServeHTTP handles requests to all RESTStorage objects.
+func (h *RESTHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	parts := splitPath(req.URL.Path)
+	if len(parts) < 1 {
+		notFound(w, req)
+		return
+	}
+	storage := h.storage[parts[0]]
+	if storage == nil {
+		httplog.LogOf(w).Addf("'%v' has no storage object", parts[0])
+		notFound(w, req)
+		return
+	}
+
+	h.handleRESTStorage(parts, req, w, storage)
+}
+
+// handleRESTStorage is the main dispatcher for a storage object.  It switches on the HTTP method, and then
+// on path length, according to the following table:
+//   Method     Path          Action
+//   GET        /foo          list
+//   GET        /foo/bar      get 'bar'
+//   POST       /foo          create
+//   PUT        /foo/bar      update 'bar'
+//   DELETE     /foo/bar      delete 'bar'
+// Returns 404 if the method/pattern doesn't match one of these entries
+// The s accepts several query parameters:
+//    sync=[false|true] Synchronous request (only applies to create, update, delete operations)
+//    timeout=<duration> Timeout for synchronous requests, only applies if sync=true
+//    labels=<label-selector> Used for filtering list operations
+func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w http.ResponseWriter, storage RESTStorage) {
+	sync := req.URL.Query().Get("sync") == "true"
+	timeout := parseTimeout(req.URL.Query().Get("timeout"))
+	switch req.Method {
+	case "GET":
+		switch len(parts) {
+		case 1:
+			selector, err := labels.ParseSelector(req.URL.Query().Get("labels"))
+			if err != nil {
+				errorJSON(err, h.codec, w)
+				return
+			}
+			list, err := storage.List(selector)
+			if err != nil {
+				errorJSON(err, h.codec, w)
+				return
+			}
+			writeJSON(http.StatusOK, h.codec, list, w)
+		case 2:
+			item, err := storage.Get(parts[1])
+			if err != nil {
+				errorJSON(err, h.codec, w)
+				return
+			}
+			writeJSON(http.StatusOK, h.codec, item, w)
+		default:
+			notFound(w, req)
+		}
+
+	case "POST":
+		if len(parts) != 1 {
+			notFound(w, req)
+			return
+		}
+		body, err := readBody(req)
+		if err != nil {
+			errorJSON(err, h.codec, w)
+			return
+		}
+		obj := storage.New()
+		err = h.codec.DecodeInto(body, obj)
+		if err != nil {
+			errorJSON(err, h.codec, w)
+			return
+		}
+		out, err := storage.Create(obj)
+		if err != nil {
+			errorJSON(err, h.codec, w)
+			return
+		}
+		op := h.createOperation(out, sync, timeout)
+		h.finishReq(op, w)
+
+	case "DELETE":
+		if len(parts) != 2 {
+			notFound(w, req)
+			return
+		}
+		out, err := storage.Delete(parts[1])
+		if err != nil {
+			errorJSON(err, h.codec, w)
+			return
+		}
+		op := h.createOperation(out, sync, timeout)
+		h.finishReq(op, w)
+
+	case "PUT":
+		if len(parts) != 2 {
+			notFound(w, req)
+			return
+		}
+		body, err := readBody(req)
+		if err != nil {
+			errorJSON(err, h.codec, w)
+			return
+		}
+		obj := storage.New()
+		err = h.codec.DecodeInto(body, obj)
+		if err != nil {
+			errorJSON(err, h.codec, w)
+			return
+		}
+		out, err := storage.Update(obj)
+		if err != nil {
+			errorJSON(err, h.codec, w)
+			return
+		}
+		op := h.createOperation(out, sync, timeout)
+		h.finishReq(op, w)
+
+	default:
+		notFound(w, req)
+	}
+}
+
+// createOperation creates an operation to process a channel response
+func (h *RESTHandler) createOperation(out <-chan interface{}, sync bool, timeout time.Duration) *Operation {
+	op := h.ops.NewOperation(out)
+	if sync {
+		op.WaitFor(timeout)
+	} else if h.asyncOpWait != 0 {
+		op.WaitFor(h.asyncOpWait)
+	}
+	return op
+}
+
+// finishReq finishes up a request, waiting until the operation finishes or, after a timeout, creating an
+// Operation to receive the result and returning its ID down the writer.
+func (h *RESTHandler) finishReq(op *Operation, w http.ResponseWriter) {
+	obj, complete := op.StatusOrResult()
+	if complete {
+		status := http.StatusOK
+		switch stat := obj.(type) {
+		case api.Status:
+			httplog.LogOf(w).Addf("programmer error: use *api.Status as a result, not api.Status.")
+			if stat.Code != 0 {
+				status = stat.Code
+			}
+		case *api.Status:
+			if stat.Code != 0 {
+				status = stat.Code
+			}
+		}
+		writeJSON(status, h.codec, obj, w)
+	} else {
+		writeJSON(http.StatusAccepted, h.codec, obj, w)
+	}
+}

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -41,7 +41,7 @@ var watchTestTable = []struct {
 func TestWatchWebsocket(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
 	_ = ResourceWatcher(simpleStorage) // Give compile error if this doesn't work.
-	handler := New(map[string]RESTStorage{
+	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
 	}, codec, "/prefix/version")
 	server := httptest.NewServer(handler)
@@ -87,7 +87,7 @@ func TestWatchWebsocket(t *testing.T) {
 
 func TestWatchHTTP(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
-	handler := New(map[string]RESTStorage{
+	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
 	}, codec, "/prefix/version")
 	server := httptest.NewServer(handler)
@@ -144,7 +144,7 @@ func TestWatchHTTP(t *testing.T) {
 
 func TestWatchParamParsing(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
-	handler := New(map[string]RESTStorage{
+	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
 	}, codec, "/prefix/version")
 	server := httptest.NewServer(handler)

--- a/pkg/healthz/healthz.go
+++ b/pkg/healthz/healthz.go
@@ -20,6 +20,11 @@ import (
 	"net/http"
 )
 
+// mux is an interface describing the methods InstallHandler requires.
+type mux interface {
+	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))
+}
+
 func init() {
 	http.HandleFunc("/healthz", handleHealthz)
 }
@@ -31,6 +36,6 @@ func handleHealthz(w http.ResponseWriter, r *http.Request) {
 }
 
 // InstallHandler registers a handler for health checking on the path "/healthz" to mux.
-func InstallHandler(mux *http.ServeMux) {
+func InstallHandler(mux mux) {
 	mux.HandleFunc("/healthz", handleHealthz)
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -139,21 +139,11 @@ func (m *Master) init(cloud cloudprovider.Interface, podInfoGetter client.PodInf
 	}
 }
 
-// Run begins serving the Kubernetes API. It never returns.
-func (m *Master) Run(myAddress, apiPrefix string) error {
-	s := &http.Server{
-		Addr:           myAddress,
-		Handler:        m.ConstructHandler(apiPrefix),
-		ReadTimeout:    10 * time.Second,
-		WriteTimeout:   10 * time.Second,
-		MaxHeaderBytes: 1 << 20,
+// API_v1beta1 returns the resources and codec for API version v1beta1
+func (m *Master) API_v1beta1() (map[string]apiserver.RESTStorage, apiserver.Codec) {
+	storage := make(map[string]apiserver.RESTStorage)
+	for k, v := range m.storage {
+		storage[k] = v
 	}
-	return s.ListenAndServe()
-}
-
-// ConstructHandler returns an http.Handler which serves the Kubernetes API.
-// Instead of calling Run, you can call this function to get a handler for your own server.
-// It is intended for testing. Only call once.
-func (m *Master) ConstructHandler(apiPrefix string) http.Handler {
-	return apiserver.New(m.storage, api.Codec, apiPrefix)
+	return storage, api.Codec
 }


### PR DESCRIPTION
Prepare for running multiple API versions on the same HTTP server by decoupling some of the mechanics of apiserver.  Define a new APIGroup object which represents a version of the API.

@brendandburns this is a variant of the earlier pull but will allow multiple apigroups.  Let me know if you need something different.

Supports #635
