### PR TITLE
(Re)generate the build version when preparing a release

### DIFF
--- a/release/build-release.sh
+++ b/release/build-release.sh
@@ -27,7 +27,11 @@ INSTANCE_PREFIX=$1
 
 KUBE_DIR=$SCRIPT_DIR/..
 
-# First build the release tar.  This gets copied on to the master and installed
+# First ensure the version pkg is complete and is up to date
+HACK_DIR=$KUBE_DIR/hack
+$HACK_DIR/version-gen.sh
+
+# Next build the release tar.  This gets copied on to the master and installed
 # from there.  It includes the go source for the necessary servers along with
 # the salt configs.
 rm -rf $KUBE_DIR/output/release/*


### PR DESCRIPTION
If hack/build-go.sh has never been run before release/build-release.sh
(used by provision-\* scripts) the subsequent build will fail. Also, when
preparing builds the version should be forced to be up to date with the
current checkout.
