### PR TITLE
Add explicit instruction to vagrant example docs

### DIFF
--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -82,6 +82,9 @@ cd kubernetes
 modify cluster/kube-env.sh:
   KUBERNETES_PROVIDER="vagrant"
 
+## build the binary required by kubecfg.sh
+hack/build-go.sh
+
 cluster/kube-up.sh => brings up a vagrant cluster
 cluster/kube-down.sh => destroys a vagrant cluster
 cluster/kube-push.sh => updates a vagrant cluster


### PR DESCRIPTION
Building kubecfg is required for kubecfg.sh. kubecfg.sh will warn
of this if it hasn't been built, but it's a better user experience
to make people explicitly aware of all required steps.
