### PR TITLE
Apply resource versioning to list extractions from etcd

### DIFF
--- a/pkg/tools/etcd_tools.go
+++ b/pkg/tools/etcd_tools.go
@@ -140,6 +140,10 @@ func (h *EtcdHelper) ExtractList(key string, slicePtr interface{}) error {
 	for _, node := range nodes {
 		obj := reflect.New(v.Type().Elem())
 		err = h.Codec.DecodeInto([]byte(node.Value), obj.Interface())
+		if h.ResourceVersioner != nil {
+			_ = h.ResourceVersioner.SetResourceVersion(obj.Interface(), node.ModifiedIndex)
+			// being unable to set the version does not prevent the object from being extracted
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/tools/etcd_tools_test.go
+++ b/pkg/tools/etcd_tools_test.go
@@ -70,30 +70,37 @@ func TestExtractList(t *testing.T) {
 				Nodes: []*etcd.Node{
 					{
 						Value: `{"id":"foo"}`,
+						ModifiedIndex: 1,
 					},
 					{
 						Value: `{"id":"bar"}`,
+						ModifiedIndex: 2,
 					},
 					{
 						Value: `{"id":"baz"}`,
+						ModifiedIndex: 3,
 					},
 				},
 			},
 		},
 	}
 	expect := []api.Pod{
-		{JSONBase: api.JSONBase{ID: "foo"}},
-		{JSONBase: api.JSONBase{ID: "bar"}},
-		{JSONBase: api.JSONBase{ID: "baz"}},
+		{JSONBase: api.JSONBase{ID: "foo", ResourceVersion: 1}},
+		{JSONBase: api.JSONBase{ID: "bar", ResourceVersion: 2}},
+		{JSONBase: api.JSONBase{ID: "baz", ResourceVersion: 3}},
 	}
+
 	var got []api.Pod
 	helper := EtcdHelper{fakeClient, codec, versioner}
 	err := helper.ExtractList("/some/key", &got)
 	if err != nil {
 		t.Errorf("Unexpected error %#v", err)
 	}
-	if !reflect.DeepEqual(got, expect) {
-		t.Errorf("Wanted %#v, got %#v", expect, got)
+
+	for i := 0; i < len(expect); i++ {
+		if !reflect.DeepEqual(got[i], expect[i]) {
+			t.Errorf("\nWanted:\n%#v\nGot:\n%#v\n", expect[i], got[i])
+		}
 	}
 }
 


### PR DESCRIPTION
Set the resource version on lists of objects extracted from etcd to prevent
them from always being interpreted as new during updates.
