### PR TITLE
Do not always look for latest pkg on salt-updates

### DIFF
--- a/cluster/saltbase/salt/base.sls
+++ b/cluster/saltbase/salt/base.sls
@@ -1,5 +1,5 @@
 pkg-core:
-  pkg.latest:
+  pkg.installed:
     - names:
 {% if grains['os_family'] == 'RedHat' %}
       - python

--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -26,7 +26,7 @@ net.ipv4.ip_forward:
     - value: 1
 
 bridge-utils:
-  pkg.latest
+  pkg.installed
 
 cbr0:
   container_bridge.ensure:
@@ -59,7 +59,7 @@ docker:
     - makedirs: true
 
 lxc-docker:
-  pkg.latest
+  pkg.installed
 
 # There is a race here, I think.  As the package is installed, it will start
 # docker.  If it doesn't write its pid file fast enough then this next stanza


### PR DESCRIPTION
A few of our Salt states used pkg.latest module which requires every invocation of salt-call state.highstate to result in a network request to the underlying package-manager (yum, apt-get, etc.) to check if there are updates.

Given the infrequency of changes to python, git, bridge-utils, and docker, I think it should be fine to just use pkg.installed and pick up the latest when first creating the cluster, but then not using salt to peform subsequent package updates on each cluster/kube-push.sh.

This makes all of our pushes faster.
