### PR TITLE
use `go build` instead of `go install`

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -41,4 +41,10 @@ for arg; do
   binaries+=("${KUBE_GO_PACKAGE}/${arg}")
 done
 
-go install "${binaries[@]}"
+# accomplishes the same as `go install`, but does not attempt to build and
+# install dependencies that are on the system, for the use-case of limit user
+# builds.
+mkdir -o ${KUBE_TARGET}/bin
+pushd ${KUBE_TARGET}/bin
+  go build "${binaries[@]}"
+popd


### PR DESCRIPTION
go install does build and install for all dependencies, and for
packaging these dependencies are in a system directory owned by root,
and the build is done as a limited user. Permission denied.

Signed-off-by: Vincent Batts vbatts@redhat.com
