### PR TITLE
Fix nsinit on Vagrant

### DIFF
--- a/cluster/saltbase/salt/nsinit/init.sls
+++ b/cluster/saltbase/salt/nsinit/init.sls
@@ -1,3 +1,9 @@
+{% if grains['os_family'] != 'RedHat' %}
+build-essential:
+  pkg:
+    - installed
+{% endif %}
+
 nsinit:
   cmd.script:
     - user: root

--- a/cluster/saltbase/salt/nsinit/install.sh
+++ b/cluster/saltbase/salt/nsinit/install.sh
@@ -16,7 +16,6 @@
 
 export GOPATH=/var/nsinit
 mkdir -p $GOPATH
-apt-get install -y -qq build-essential
 go get github.com/docker/docker/vendor/src/github.com/docker/libcontainer/nsinit/nsinit
 if [ ! -e /usr/sbin/nsinit ]; then
   ln -s /var/nsinit/bin/nsinit /usr/sbin/nsinit


### PR DESCRIPTION
The nsinit state that was added in commit:

https://github.com/GoogleCloudPlatform/kubernetes/commit/abb754c00d479e4a4a98d82b497dbcd073251a69

did not work in Vagrant cluster (Fedora based).

Changed the instruction to install build-essential using Salt when not in Red Hat family of OS (where package does not exist) and modified the shell script as appropriate.  

Validated that nsinit is installed on each minion in Vagrant setup as a result.
