### PR TITLE
Allow watch operations to run longer than the http.Server timeout

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -86,6 +86,8 @@ func NewAPIGroup(storage map[string]RESTStorage, codec Codec) *APIGroup {
 		ops:     NewOperations(),
 		// Delay just long enough to handle most simple write operations
 		asyncOpWait: time.Millisecond * 25,
+		// The idle timeout for a watch connection
+		watchTimeout: time.Second * 60,
 	}}
 }
 
@@ -94,7 +96,7 @@ func NewAPIGroup(storage map[string]RESTStorage, codec Codec) *APIGroup {
 // in a slash.
 func (g *APIGroup) InstallREST(mux mux, paths ...string) {
 	restHandler := &g.handler
-	watchHandler := &WatchHandler{g.handler.storage, g.handler.codec}
+	watchHandler := &WatchHandler{g.handler.storage, g.handler.codec, g.handler.watchTimeout}
 	opHandler := &OperationHandler{g.handler.ops, g.handler.codec}
 
 	for _, prefix := range paths {

--- a/pkg/apiserver/chunked_http.go
+++ b/pkg/apiserver/chunked_http.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+)
+
+// hijackHTTPChunked hijacks an http.ResponseWriter as a flushable, chunked writer and returns
+// the connection so that write deadlines can be set. Clients MUST close the writer AND the
+// connection.
+func hijackHTTPChunked(w http.ResponseWriter) (io.WriteCloser, net.Conn, http.Flusher, error) {
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		return nil, nil, nil, errors.New("does not implement http.Hijacker")
+	}
+	conn, rw, err := hijacker.Hijack()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return httputil.NewChunkedWriter(rw.Writer), conn, noReturnFlusher{rw.Writer}, nil
+}
+
+// noReturnFlusher implements http.Flusher around a bufio.Writer
+type noReturnFlusher struct {
+	w *bufio.Writer
+}
+
+// Flush implements http.Flusher
+func (f noReturnFlusher) Flush() {
+	f.w.Flush()
+}

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -26,10 +26,11 @@ import (
 )
 
 type RESTHandler struct {
-	storage     map[string]RESTStorage
-	codec       Codec
-	ops         *Operations
-	asyncOpWait time.Duration
+	storage      map[string]RESTStorage
+	codec        Codec
+	ops          *Operations
+	asyncOpWait  time.Duration
+	watchTimeout time.Duration
 }
 
 // ServeHTTP handles requests to all RESTStorage objects.


### PR DESCRIPTION
The default http.Server implementation sets a global write deadline on all handled responses.  Watches depend on waiting for long periods before returning.  A watch implementation should be able to wait
longer than the default server timeout.

This commit alters watch to hijack the http response writer, gain access to the underlying connection for setting the write deadline (which must be reset after every write), and also properly handle chunked encoding of the http response (it's not possible to game the write deadline via the ResponseWriter by writing empty lines because we don't know what the servers deadline is set to).
