### PR TITLE
Add a teardown option to the e2e, that just tears down the cluster, also make gce teardown synchronous.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -357,7 +357,8 @@ function test-teardown {
     --project ${PROJECT} \
     --norespect_terminal_width \
     --force \
-    ${MINION_TAG}-http-alt &
-  $(dirname $0)/../cluster/kube-down.sh > /dev/null &
+    ${MINION_TAG}-http-alt
+  $(dirname $0)/../cluster/kube-down.sh > /dev/null
 }
+
 

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -24,6 +24,7 @@ source $(dirname $0)/../cluster/$KUBERNETES_PROVIDER/util.sh
 # cluster running.
 ALREADY_UP=${1:-0}
 LEAVE_UP=${2:-0}
+TEAR_DOWN=${3:-0}
 
 HAVE_JQ=$(which jq)
 if [[ -z ${HAVE_JQ} ]]; then
@@ -40,6 +41,11 @@ set -e
 export KUBE_CONFIG_FILE="config-test.sh"
 export KUBE_REPO_ROOT="$(dirname $0)/.."
 export CLOUDCFG="${KUBE_REPO_ROOT}/cluster/kubecfg.sh -expect_version_match"
+
+if [[ $TEAR_DOWN -ne 0 ]]; then
+  trap test-teardown EXIT
+  exit 0
+fi
 
 # Build a release required by the test provider [if any]
 test-build-release


### PR DESCRIPTION
Useful for cleaning state after failed runs.
