### PR TITLE
Add small image to use for e2e-testing and getting started examples

### DIFF
--- a/build/hello-kubernetes/Dockerfile
+++ b/build/hello-kubernetes/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+ADD hello /
+EXPOSE 8080
+ENTRYPOINT ["/hello"]

--- a/build/hello-kubernetes/hello.go
+++ b/build/hello-kubernetes/hello.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func helloFromKubernetes(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, "Hello World! -- Kubernetes")
+}
+
+func main() {
+	http.HandleFunc("/", helloFromKubernetes)
+	err := http.ListenAndServe(":8080", nil)
+	if err != nil {
+		panic("ListenAndServe: " + err.Error())
+	}
+}

--- a/build/hello-kubernetes/prepare.sh
+++ b/build/hello-kubernetes/prepare.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+set -x
+
+CGO_ENABLED=0 go build  -a -ldflags '-extldflags "-static" -s' hello.go


### PR DESCRIPTION
The images we use in our Getting Started example, and more important to me, our end-to-end testing scripts are very large.  This makes testing our cluster's basic function really slow as each minion after provisioning has to download ~600 MB dockerfile/nginx images just to curl it and get a response.

I put together a simple image that when built is ~3MB in size that I would like us to publish on Docker Hub under the kubernetes namespace that we can use for getting started guides and the basic e2e test.

The image enables the end-user Getting Started examples to drastically reduce in total-time .
