### PR TITLE
Allow Kube proxy to watch for service/endpoint changes

### DIFF
--- a/cmd/controller-manager/controller-manager.go
+++ b/cmd/controller-manager/controller-manager.go
@@ -47,7 +47,7 @@ func main() {
 	}
 
 	controllerManager := controller.NewReplicationManager(
-		client.New("http://"+*master, nil))
+		client.New(*master, nil))
 
 	controllerManager.Run(10 * time.Second)
 	select {}

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -66,7 +66,7 @@ KUBELET_PID=$!
 
 PROXY_LOG=/tmp/kube-proxy.log
 ${GO_OUT}/proxy \
-  --etcd_servers="http://127.0.0.1:4001" &> ${PROXY_LOG} &
+  --master="http://${API_HOST}:${API_PORT}" &> ${PROXY_LOG} &
 PROXY_PID=$!
 
 echo "Local Kubernetes cluster is running. Press Ctrl-C to shut it down."

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -37,6 +37,33 @@ func makeURL(suffix string) string {
 	return apiPath + suffix
 }
 
+func TestValidatesHostParameter(t *testing.T) {
+	testCases := map[string]struct {
+		Value string
+		Err   bool
+	}{
+		"foo.bar.com":        {"http://foo.bar.com/api/v1beta1/", false},
+		"http://host/server": {"http://host/server/api/v1beta1/", false},
+		"host/server":        {"", true},
+	}
+	for k, expected := range testCases {
+		c := RESTClient{host: k, Prefix: "/api/v1beta1/"}
+		actual, err := c.makeURL("")
+		switch {
+		case err == nil && expected.Err:
+			t.Errorf("expected error but was nil")
+			continue
+		case err != nil && !expected.Err:
+			t.Errorf("unexpected error %v", err)
+			continue
+		}
+		if expected.Value != actual {
+			t.Errorf("%s: expected %s, got %s", k, expected.Value, actual)
+			continue
+		}
+	}
+}
+
 func TestListEmptyPods(t *testing.T) {
 	c := &testClient{
 		Request:  testRequest{Method: "GET", Path: "/pods"},

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -35,6 +35,7 @@ type Fake struct {
 	Actions []FakeAction
 	Pods    api.PodList
 	Ctrl    api.ReplicationController
+	Watch   watch.Interface
 }
 
 func (c *Fake) ListPods(selector labels.Selector) (api.PodList, error) {
@@ -88,8 +89,8 @@ func (c *Fake) DeleteReplicationController(controller string) error {
 }
 
 func (c *Fake) WatchReplicationControllers(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "watch-controllers"})
-	return watch.NewFake(), nil
+	c.Actions = append(c.Actions, FakeAction{Action: "watch-controllers", Value: resourceVersion})
+	return c.Watch, nil
 }
 
 func (c *Fake) GetService(name string) (api.Service, error) {
@@ -110,6 +111,16 @@ func (c *Fake) UpdateService(service api.Service) (api.Service, error) {
 func (c *Fake) DeleteService(service string) error {
 	c.Actions = append(c.Actions, FakeAction{Action: "delete-service", Value: service})
 	return nil
+}
+
+func (c *Fake) WatchServices(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+	c.Actions = append(c.Actions, FakeAction{Action: "watch-services", Value: resourceVersion})
+	return c.Watch, nil
+}
+
+func (c *Fake) WatchEndpoints(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+	c.Actions = append(c.Actions, FakeAction{Action: "watch-endpoints", Value: resourceVersion})
+	return c.Watch, nil
 }
 
 func (c *Fake) ServerVersion() (*version.Info, error) {

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/binding"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/controller"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/endpoint"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/etcd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/minion"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/pod"
@@ -54,6 +55,7 @@ type Master struct {
 	podRegistry        pod.Registry
 	controllerRegistry controller.Registry
 	serviceRegistry    service.Registry
+	endpointRegistry   endpoint.Registry
 	minionRegistry     minion.Registry
 	bindingRegistry    binding.Registry
 	storage            map[string]apiserver.RESTStorage
@@ -68,6 +70,7 @@ func New(c *Config) *Master {
 		podRegistry:        etcd.NewRegistry(etcdClient, minionRegistry),
 		controllerRegistry: etcd.NewRegistry(etcdClient, minionRegistry),
 		serviceRegistry:    etcd.NewRegistry(etcdClient, minionRegistry),
+		endpointRegistry:   etcd.NewRegistry(etcdClient, minionRegistry),
 		bindingRegistry:    etcd.NewRegistry(etcdClient, minionRegistry),
 		minionRegistry:     minionRegistry,
 		client:             c.Client,
@@ -118,6 +121,7 @@ func (m *Master) init(cloud cloudprovider.Interface, podInfoGetter client.PodInf
 		}),
 		"replicationControllers": controller.NewRegistryStorage(m.controllerRegistry, m.podRegistry),
 		"services":               service.NewRegistryStorage(m.serviceRegistry, cloud, m.minionRegistry),
+		"endpoints":              endpoint.NewStorage(m.endpointRegistry),
 		"minions":                minion.NewRegistryStorage(m.minionRegistry),
 
 		// TODO: should appear only in scheduler API group.

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -26,11 +26,11 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/binding"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/controller"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/endpoint"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/etcd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/minion"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/pod"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service"
+	servicecontroller "github.com/GoogleCloudPlatform/kubernetes/pkg/service"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	goetcd "github.com/coreos/go-etcd/etcd"
@@ -106,7 +106,7 @@ func (m *Master) init(cloud cloudprovider.Interface, podInfoGetter client.PodInf
 	podCache := NewPodCache(podInfoGetter, m.podRegistry)
 	go util.Forever(func() { podCache.UpdateAllContainers() }, time.Second*30)
 
-	endpoints := endpoint.NewEndpointController(m.serviceRegistry, m.client)
+	endpoints := servicecontroller.NewEndpointController(m.serviceRegistry, m.client)
 	go util.Forever(func() { endpoints.SyncServiceEndpoints() }, time.Second*10)
 
 	m.storage = map[string]apiserver.RESTStorage{

--- a/pkg/proxy/config/api.go
+++ b/pkg/proxy/config/api.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/wait"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+	"github.com/golang/glog"
+)
+
+// Watcher is the interface needed to receive changes to services and endpoints
+type Watcher interface {
+	WatchServices(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error)
+	WatchEndpoints(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error)
+}
+
+// SourceAPI implements a configuration source for services and endpoints that
+// uses the client watch API to efficiently detect changes.
+type SourceAPI struct {
+	client    Watcher
+	services  chan<- ServiceUpdate
+	endpoints chan<- EndpointsUpdate
+
+	waitDuration      time.Duration
+	reconnectDuration time.Duration
+}
+
+// NewSourceAPI creates a config source that watches for changes to the services and endpoints
+func NewSourceAPI(client Watcher, period time.Duration, services chan<- ServiceUpdate, endpoints chan<- EndpointsUpdate) *SourceAPI {
+	config := &SourceAPI{
+		client:    client,
+		services:  services,
+		endpoints: endpoints,
+
+		waitDuration: period,
+		// prevent hot loops if the server starts to misbehave
+		reconnectDuration: time.Second * 1,
+	}
+	serviceVersion := uint64(0)
+	go util.Forever(func() {
+		config.runServices(&serviceVersion)
+		time.Sleep(wait.Jitter(config.reconnectDuration, 0.0))
+	}, period)
+	endpointVersion := uint64(0)
+	go util.Forever(func() {
+		config.runEndpoints(&endpointVersion)
+		time.Sleep(wait.Jitter(config.reconnectDuration, 0.0))
+	}, period)
+	return config
+}
+
+// runServices loops forever looking for changes to services
+func (s *SourceAPI) runServices(resourceVersion *uint64) {
+	watcher, err := s.client.WatchServices(labels.Everything(), labels.Everything(), *resourceVersion)
+	if err != nil {
+		glog.Errorf("Unable to watch for services changes: %v", err)
+		time.Sleep(wait.Jitter(s.waitDuration, 0.0))
+		return
+	}
+	defer watcher.Stop()
+
+	ch := watcher.ResultChan()
+	handleServicesWatch(resourceVersion, ch, s.services)
+}
+
+// handleServicesWatch loops over an event channel and delivers config changes to an update channel
+func handleServicesWatch(resourceVersion *uint64, ch <-chan watch.Event, updates chan<- ServiceUpdate) {
+	for {
+		select {
+		case event, ok := <-ch:
+			if !ok {
+				glog.V(2).Infof("WatchServices channel closed")
+				return
+			}
+
+			service := event.Object.(*api.Service)
+			*resourceVersion = service.ResourceVersion + 1
+
+			switch event.Type {
+			case watch.Added, watch.Modified:
+				updates <- ServiceUpdate{Op: SET, Services: []api.Service{*service}}
+
+			case watch.Deleted:
+				updates <- ServiceUpdate{Op: SET}
+			}
+		}
+	}
+}
+
+// runEndpoints loops forever looking for changes to endpoints
+func (s *SourceAPI) runEndpoints(resourceVersion *uint64) {
+	watcher, err := s.client.WatchEndpoints(labels.Everything(), labels.Everything(), *resourceVersion)
+	if err != nil {
+		glog.Errorf("Unable to watch for endpoints changes: %v", err)
+		time.Sleep(wait.Jitter(s.waitDuration, 0.0))
+		return
+	}
+	defer watcher.Stop()
+
+	ch := watcher.ResultChan()
+	handleEndpointsWatch(resourceVersion, ch, s.endpoints)
+}
+
+// handleEndpointsWatch loops over an event channel and delivers config changes to an update channel
+func handleEndpointsWatch(resourceVersion *uint64, ch <-chan watch.Event, updates chan<- EndpointsUpdate) {
+	for {
+		select {
+		case event, ok := <-ch:
+			if !ok {
+				glog.V(2).Infof("WatchEndpoints channel closed")
+				return
+			}
+
+			endpoints := event.Object.(*api.Endpoints)
+			*resourceVersion = endpoints.ResourceVersion + 1
+
+			switch event.Type {
+			case watch.Added, watch.Modified:
+				updates <- EndpointsUpdate{Op: SET, Endpoints: []api.Endpoints{*endpoints}}
+
+			case watch.Deleted:
+				updates <- EndpointsUpdate{Op: SET}
+			}
+		}
+	}
+}

--- a/pkg/proxy/config/api_test.go
+++ b/pkg/proxy/config/api_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+func TestServices(t *testing.T) {
+	service := api.Service{JSONBase: api.JSONBase{ID: "bar", ResourceVersion: uint64(2)}}
+
+	fakeWatch := watch.NewFake()
+	fakeClient := &client.Fake{Watch: fakeWatch}
+	services := make(chan ServiceUpdate)
+	source := SourceAPI{client: fakeClient, services: services}
+	resourceVersion := uint64(0)
+	go func() {
+		// called twice
+		source.runServices(&resourceVersion)
+		source.runServices(&resourceVersion)
+	}()
+
+	// test adding a service to the watch
+	fakeWatch.Add(&service)
+	if !reflect.DeepEqual(fakeClient.Actions, []client.FakeAction{{"watch-services", uint64(0)}}) {
+		t.Errorf("expected call to watch-services, got %#v", fakeClient)
+	}
+
+	actual := <-services
+	expected := ServiceUpdate{Op: SET, Services: []api.Service{service}}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected %#v, got %#v", expected, actual)
+	}
+
+	// verify that a delete results in a config change
+	fakeWatch.Delete(&service)
+	actual = <-services
+	expected = ServiceUpdate{Op: SET}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected %#v, got %#v", expected, actual)
+	}
+
+	// verify that closing the channel results in a new call to WatchServices with a higher resource version
+	newFakeWatch := watch.NewFake()
+	fakeClient.Watch = newFakeWatch
+	fakeWatch.Stop()
+
+	newFakeWatch.Add(&service)
+	if !reflect.DeepEqual(fakeClient.Actions, []client.FakeAction{{"watch-services", uint64(0)}, {"watch-services", uint64(3)}}) {
+		t.Errorf("expected call to watch-endpoints, got %#v", fakeClient)
+	}
+}
+
+func TestEndpoints(t *testing.T) {
+	endpoint := api.Endpoints{JSONBase: api.JSONBase{ID: "bar", ResourceVersion: uint64(2)}, Endpoints: []string{"127.0.0.1:9000"}}
+
+	fakeWatch := watch.NewFake()
+	fakeClient := &client.Fake{Watch: fakeWatch}
+	endpoints := make(chan EndpointsUpdate)
+	source := SourceAPI{client: fakeClient, endpoints: endpoints}
+	resourceVersion := uint64(0)
+	go func() {
+		// called twice
+		source.runEndpoints(&resourceVersion)
+		source.runEndpoints(&resourceVersion)
+	}()
+
+	// test adding an endpoint to the watch
+	fakeWatch.Add(&endpoint)
+	if !reflect.DeepEqual(fakeClient.Actions, []client.FakeAction{{"watch-endpoints", uint64(0)}}) {
+		t.Errorf("expected call to watch-endpoints, got %#v", fakeClient)
+	}
+
+	actual := <-endpoints
+	expected := EndpointsUpdate{Op: SET, Endpoints: []api.Endpoints{endpoint}}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected %#v, got %#v", expected, actual)
+	}
+
+	// verify that a delete results in a config change
+	fakeWatch.Delete(&endpoint)
+	actual = <-endpoints
+	expected = EndpointsUpdate{Op: SET}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected %#v, got %#v", expected, actual)
+	}
+
+	// verify that closing the channel results in a new call to WatchEndpoints with a higher resource version
+	newFakeWatch := watch.NewFake()
+	fakeClient.Watch = newFakeWatch
+	fakeWatch.Stop()
+
+	newFakeWatch.Add(&endpoint)
+	if !reflect.DeepEqual(fakeClient.Actions, []client.FakeAction{{"watch-endpoints", uint64(0)}, {"watch-endpoints", uint64(3)}}) {
+		t.Errorf("expected call to watch-endpoints, got %#v", fakeClient)
+	}
+}

--- a/pkg/registry/endpoint/registry.go
+++ b/pkg/registry/endpoint/registry.go
@@ -14,25 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package service
+package endpoint
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/endpoint"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
-// Registry is an interface for things that know how to store services.
+// Registry is an interface for things that know how to store endpoints.
 type Registry interface {
-	ListServices() (api.ServiceList, error)
-	CreateService(svc api.Service) error
-	GetService(name string) (*api.Service, error)
-	DeleteService(name string) error
-	UpdateService(svc api.Service) error
-	WatchServices(labels, fields labels.Selector, resourceVersion uint64) (watch.Interface, error)
-
-	// TODO: endpoints and their implementation should be separated, setting endpoints should be
-	// supported via the API, and the endpoints-controller should use the API to update endpoints.
-	endpoint.Registry
+	GetEndpoints(name string) (*api.Endpoints, error)
+	WatchEndpoints(labels, fields labels.Selector, resourceVersion uint64) (watch.Interface, error)
+	UpdateEndpoints(e api.Endpoints) error
 }

--- a/pkg/registry/endpoint/storage.go
+++ b/pkg/registry/endpoint/storage.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"errors"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// Storage adapts endpoints into apiserver's RESTStorage model.
+type Storage struct {
+	registry Registry
+}
+
+// NewStorage returns a new Storage implementation for endpoints
+func NewStorage(registry Registry) apiserver.RESTStorage {
+	return &Storage{
+		registry: registry,
+	}
+}
+
+// Get satisfies the RESTStorage interface but is unimplemented
+func (rs *Storage) Get(id string) (interface{}, error) {
+	return rs.registry.GetEndpoints(id)
+}
+
+// List satisfies the RESTStorage interface but is unimplemented
+func (rs *Storage) List(selector labels.Selector) (interface{}, error) {
+	return nil, errors.New("unimplemented")
+}
+
+// Watch returns Endpoint events via a watch.Interface.
+// It implements apiserver.ResourceWatcher.
+func (rs *Storage) Watch(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+	return rs.registry.WatchEndpoints(label, field, resourceVersion)
+}
+
+// Create satisfies the RESTStorage interface but is unimplemented
+func (rs *Storage) Create(obj interface{}) (<-chan interface{}, error) {
+	return nil, errors.New("unimplemented")
+}
+
+// Update satisfies the RESTStorage interface but is unimplemented
+func (rs *Storage) Update(obj interface{}) (<-chan interface{}, error) {
+	return nil, errors.New("unimplemented")
+}
+
+// Delete satisfies the RESTStorage interface but is unimplemented
+func (rs *Storage) Delete(id string) (<-chan interface{}, error) {
+	return nil, errors.New("unimplemented")
+}
+
+// New implements the RESTStorage interface
+func (rs Storage) New() interface{} {
+	return &api.Endpoints{}
+}

--- a/pkg/registry/endpoint/storage_test.go
+++ b/pkg/registry/endpoint/storage_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
+)
+
+func TestGetEndpoints(t *testing.T) {
+	registry := &registrytest.ServiceRegistry{
+		Endpoints: api.Endpoints{
+			JSONBase:  api.JSONBase{ID: "foo"},
+			Endpoints: []string{"127.0.0.1:9000"},
+		},
+	}
+	storage := NewStorage(registry)
+	obj, err := storage.Get("foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	}
+	if !reflect.DeepEqual([]string{"127.0.0.1:9000"}, obj.(*api.Endpoints).Endpoints) {
+		t.Errorf("unexpected endpoints: %#v", obj)
+	}
+}
+
+func TestGetEndpointsMissingService(t *testing.T) {
+	registry := &registrytest.ServiceRegistry{
+		Err: apiserver.NewNotFoundErr("service", "foo"),
+	}
+	storage := NewStorage(registry)
+
+	// returns service not found
+	_, err := storage.Get("foo")
+	if !apiserver.IsNotFound(err) || !reflect.DeepEqual(err, apiserver.NewNotFoundErr("service", "foo")) {
+		t.Errorf("expected NotFound error, got %#v", err)
+	}
+
+	// returns empty endpoints
+	registry.Err = nil
+	registry.Service = &api.Service{
+		JSONBase: api.JSONBase{ID: "foo"},
+	}
+	obj, err := storage.Get("foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if obj.(*api.Endpoints).Endpoints != nil {
+		t.Errorf("unexpected endpoints: %#v", obj)
+	}
+}

--- a/pkg/registry/registrytest/service.go
+++ b/pkg/registry/registrytest/service.go
@@ -18,6 +18,8 @@ package registrytest
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
 func NewServiceRegistry() *ServiceRegistry {
@@ -60,7 +62,19 @@ func (r *ServiceRegistry) UpdateService(svc api.Service) error {
 	return r.Err
 }
 
+func (r *ServiceRegistry) WatchServices(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+	return nil, r.Err
+}
+
+func (r *ServiceRegistry) GetEndpoints(name string) (*api.Endpoints, error) {
+	return &r.Endpoints, r.Err
+}
+
 func (r *ServiceRegistry) UpdateEndpoints(e api.Endpoints) error {
 	r.Endpoints = e
 	return r.Err
+}
+
+func (r *ServiceRegistry) WatchEndpoints(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+	return nil, r.Err
 }

--- a/pkg/registry/service/storage.go
+++ b/pkg/registry/service/storage.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/minion"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
 // RegistryStorage adapts a service registry into apiserver's RESTStorage model.
@@ -121,6 +122,12 @@ func (rs *RegistryStorage) List(selector labels.Selector) (interface{}, error) {
 	}
 	list.Items = filtered
 	return list, err
+}
+
+// Watch returns Services events via a watch.Interface.
+// It implements apiserver.ResourceWatcher.
+func (rs *RegistryStorage) Watch(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+	return rs.registry.WatchServices(label, field, resourceVersion)
 }
 
 func (rs RegistryStorage) New() interface{} {

--- a/pkg/service/endpoints_controller.go
+++ b/pkg/service/endpoints_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package endpoint
+package service
 
 import (
 	"fmt"

--- a/pkg/service/endpoints_controller_test.go
+++ b/pkg/service/endpoints_controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package endpoint
+package service
 
 import (
 	"encoding/json"

--- a/pkg/util/wait/wait.go
+++ b/pkg/util/wait/wait.go
@@ -18,8 +18,20 @@ package wait
 
 import (
 	"errors"
+	"math/rand"
 	"time"
 )
+
+// Jitter returns a time.Duration between duration and duration + maxFactor * duration,
+// to allow clients to avoid converging on periodic behavior.  If maxFactor is 0.0, a
+// suggested default value will be chosen.
+func Jitter(duration time.Duration, maxFactor float64) time.Duration {
+	if maxFactor <= 0.0 {
+		maxFactor = 1.0
+	}
+	wait := duration + time.Duration(rand.Float64()*maxFactor*float64(duration))
+	return wait
+}
 
 // ErrWaitTimeout is returned when the condition exited without success
 var ErrWaitTimeout = errors.New("timed out waiting for the condition")


### PR DESCRIPTION
Expose `GET /endpoints/<serviceName>`.  Allow watch on endpoints and with services with `fields=Name%3D<serviceName>`
