### PR TITLE
Remove unreachable code.

### DIFF
--- a/pkg/tools/fake_etcd_client.go
+++ b/pkg/tools/fake_etcd_client.go
@@ -257,6 +257,4 @@ func (f *FakeEtcdClient) Watch(prefix string, waitIndex uint64, recursive bool, 
 	case err := <-injectedError:
 		return nil, err
 	}
-	// Never get here.
-	return nil, nil
 }


### PR DESCRIPTION
Go compiler will not allow you to write a function with a path that fails to return something.  So, this extra code is not needed.
