### PR TITLE
Fix verify-boilerplate

### DIFF
--- a/build/hello-kubernetes/hello.go
+++ b/build/hello-kubernetes/hello.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -18,7 +18,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/../" && pwd -P)"
 
 result=0
 
-gofiles="$(find ${REPO_ROOT} -type f | grep "[.]go$" | grep -v "third_party/\|release/\|output/\|target/")"
+gofiles="$(find ${REPO_ROOT} -type f | grep "[.]go$" | grep -v "Godeps/\|third_party/\|release/\|output/\|target/")"
 for file in ${gofiles}; do
   if [[ "$(${REPO_ROOT}/hooks/boilerplate.sh "${file}")" -eq "0" ]]; then
     echo "Boilerplate header is wrong for: ${file}"

--- a/hooks/boilerplate.sh
+++ b/hooks/boilerplate.sh
@@ -16,11 +16,11 @@
 
 # Print 1 if the file in $1 has the correct boilerplate header, 0 otherwise.
 FILE=$1
-EXT=${FILE#*.}
+EXT=${FILE##*.}
 
 REF_FILE="$(dirname $0)/boilerplate.${EXT}.txt"
 
-if [[ ! -e "${REF_FILE}" ]]; then
+if [ ! -e $REF_FILE ]; then
   echo "1"
   exit 0
 fi

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (


### PR DESCRIPTION
The old verify boilerplate did not determine file extension correctly.
In addition, it did not ignore files that we have as a go dependency.
Updated script and confirmed its behavior by flagging these modified files and added required boilerplate.
