### PR TITLE
docs/getting-started-guides/locally.md: note linux dependency

### DIFF
--- a/docs/getting-started-guides/locally.md
+++ b/docs/getting-started-guides/locally.md
@@ -1,5 +1,12 @@
 ## Getting started locally
 
+### Requirements 
+
+ - Linux 
+ - Docker 1.0.0+
+
+Not running Linux? Consider running Linux in a local virtual machine with [Vagrant](vagrant.md), or on a cloud provider like [Google Compute Engine](gce.md)
+
 In a separate tab of your terminal, run:
 
 ```


### PR DESCRIPTION
While the linux dependency is obvious with a moment's thought, some users (especially on *nix) might plow ahead before realizing their system isn't supported. This points them in the direction of guides more likely to work for them.
