### PR TITLE
Fix broken link in GuestBook example, remove unnecessary content.

### DIFF
--- a/examples/guestbook/README.md
+++ b/examples/guestbook/README.md
@@ -10,7 +10,7 @@ This example assumes that you have forked the repository and [turned up a Kubern
 
 ### Step One: Turn up the redis master.
 
-Use the file `examples/guestbook/redis-master.json` which describes a single podrunning a redis key-value server in a container.
+Use the file `examples/guestbook/redis-master.json` which describes a single pod running a redis key-value server in a container.
 
 ```javascript
 {

--- a/examples/guestbook/README.md
+++ b/examples/guestbook/README.md
@@ -6,11 +6,7 @@ The example combines a web frontend, a redis master for storage and a replicated
 
 ### Step Zero: Prerequisites
 
-This example assumes that you have forked the repository and [turned up a Kubernetes cluster](https://github.com/GoogleCloudPlatform/kubernetes-new#setup):
-
-    $ cd kubernetes
-    $ hack/dev-build-and-up.sh
-    $ hack/build-go.sh
+This example assumes that you have forked the repository and [turned up a Kubernetes cluster](https://github.com/GoogleCloudPlatform/kubernetes-new#contents):
 
 ### Step One: Turn up the redis master.
 


### PR DESCRIPTION
There is no longer a #setup anchor in home page, though i don't if #content is the right one.  Also, the three lines of commands are kind of misleading, I think the example should also work for vagrant. Is it?
