### PR TITLE
Revert to latest salt bootstrap and force SSL

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -69,14 +69,7 @@ if [ ! $(which salt-master) ]; then
   # install.  See https://github.com/saltstack/salt-bootstrap/issues/270
   #
   # -M installs the master
-  # FIXME: The following line should be replaced with:
-  # curl -L http://bootstrap.saltstack.com | sh -s -- -M
-  # when the merged salt-api service is included in the fedora salt-master rpm
-  # Merge is here: https://github.com/saltstack/salt/pull/13554
-  # Fedora git repository is here: http://pkgs.fedoraproject.org/cgit/salt.git/
-  # (a new service file needs to be added for salt-api)
-  curl -sS -L https://raw.githubusercontent.com/saltstack/salt-bootstrap/v2014.06.30/bootstrap-salt.sh | sh -s -- -M
-
+  curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -M
 fi
 
 # Build release

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -46,7 +46,7 @@ if [ ! $(which salt-minion) ]; then
   #
   # We specify -X to avoid a race condition that can cause minion failure to
   # install.  See https://github.com/saltstack/salt-bootstrap/issues/270
-  curl -sS -L http://bootstrap.saltstack.com | sh -s -- -X
+  curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -X
 
   ## TODO this only works on systemd distros, need to find a work-around as removing -X above fails to start the services installed
   systemctl enable salt-minion


### PR DESCRIPTION
Salt bootstrap errors have been fixed upstream on fedora.
Force SSL on minion install.
Improve reliability via retry logic.

closes #923
