### PR TITLE
Make global http timeout longer than most operations

### DIFF
--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -113,8 +113,8 @@ func main() {
 	s := &http.Server{
 		Addr:           net.JoinHostPort(*address, strconv.Itoa(int(*port))),
 		Handler:        apiserver.Handle(storage, codec, *apiPrefix),
-		ReadTimeout:    10 * time.Second,
-		WriteTimeout:   10 * time.Second,
+		ReadTimeout:    5 * time.Minute,
+		WriteTimeout:   5 * time.Minute,
 		MaxHeaderBytes: 1 << 20,
 	}
 	glog.Fatal(s.ListenAndServe())


### PR DESCRIPTION
We have a few long running operations today (sync=true, watch) that
exceed the original default http.Server timeout.  We should set the
timeout to a high enough limit that more granular controls can be
implemented.
