### PR TITLE
The default client poll interval is extremely long

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -96,7 +96,7 @@ func New(host string, auth *AuthInfo) *Client {
 			},
 		},
 		Sync:       false,
-		PollPeriod: time.Second * 20,
+		PollPeriod: time.Second * 2,
 		Timeout:    time.Second * 20,
 	}
 }


### PR DESCRIPTION
Most operations complete much more quickly than 20s, and those that
do take longer are going to be fixed to make them take less time
(#353)
