### PR TITLE
Improve pkg/registry/service code coverage.

### DIFF
--- a/pkg/registry/registrytest/service.go
+++ b/pkg/registry/registrytest/service.go
@@ -32,6 +32,7 @@ type ServiceRegistry struct {
 
 	DeletedID string
 	GottenID  string
+	UpdatedID string
 }
 
 func (r *ServiceRegistry) ListServices() (api.ServiceList, error) {
@@ -40,6 +41,7 @@ func (r *ServiceRegistry) ListServices() (api.ServiceList, error) {
 
 func (r *ServiceRegistry) CreateService(svc api.Service) error {
 	r.Service = &svc
+	r.List.Items = append(r.List.Items, svc)
 	return r.Err
 }
 
@@ -54,6 +56,7 @@ func (r *ServiceRegistry) DeleteService(id string) error {
 }
 
 func (r *ServiceRegistry) UpdateService(svc api.Service) error {
+	r.UpdatedID = svc.ID
 	return r.Err
 }
 


### PR DESCRIPTION
As per #917, I'm trying to learn kubernetes code base by improving pkg/registry/service code coverage.

This commit increase coverage of the package to around 81%.  There are quite a few small branch tests that accumulate to 10%+, I don't if it worth the effort to test.

One more thing about the function TestServiceRegistryList, do I need to test various cases for different labels? since now it only covers labels.Everything()...  It might be necessary unless it is covered by integration test.

Any comments are welcome :)
