### PR TITLE
Refactor kubelet to use http.ServeMux

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -118,7 +118,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	myKubelet := kubelet.NewIntegrationTestKubelet(machineList[0], &fakeDocker1)
 	go util.Forever(func() { myKubelet.Run(cfg1.Updates()) }, 0)
 	go util.Forever(func() {
-		kubelet.ListenAndServeKubeletServer(myKubelet, cfg1.Channel("http"), http.DefaultServeMux, "localhost", 10250)
+		kubelet.ListenAndServeKubeletServer(myKubelet, cfg1.Channel("http"), "localhost", 10250)
 	}, 0)
 
 	// Kubelet (machine)
@@ -129,7 +129,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	otherKubelet := kubelet.NewIntegrationTestKubelet(machineList[1], &fakeDocker2)
 	go util.Forever(func() { otherKubelet.Run(cfg2.Updates()) }, 0)
 	go util.Forever(func() {
-		kubelet.ListenAndServeKubeletServer(otherKubelet, cfg2.Channel("http"), http.DefaultServeMux, "localhost", 10251)
+		kubelet.ListenAndServeKubeletServer(otherKubelet, cfg2.Channel("http"), "localhost", 10251)
 	}, 0)
 
 	return apiServer.URL

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -162,7 +162,7 @@ func main() {
 	// start the kubelet server
 	if *enableServer {
 		go util.Forever(func() {
-			kubelet.ListenAndServeKubeletServer(k, cfg.Channel("http"), http.DefaultServeMux, *address, *port)
+			kubelet.ListenAndServeKubeletServer(k, cfg.Channel("http"), *address, *port)
 		}, 0)
 	}
 

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -76,10 +76,8 @@ func makeServerTest() *serverTestFramework {
 	}
 	fw.updateReader = startReading(fw.updateChan)
 	fw.fakeKubelet = &fakeKubelet{}
-	fw.serverUnderTest = &Server{
-		host:    fw.fakeKubelet,
-		updates: fw.updateChan,
-	}
+	server := NewServer(fw.fakeKubelet, fw.updateChan)
+	fw.serverUnderTest = &server
 	fw.testHTTPServer = httptest.NewServer(fw.serverUnderTest)
 	return fw
 }


### PR DESCRIPTION
Initial implementation that helps clarify what the actual REST API is provided by the Kubelet versus the current switch/case logic.

closes #959
