### PR TITLE
Rename a bunch of "Make" functions to "New"

### DIFF
--- a/cmd/controller-manager/controller-manager.go
+++ b/cmd/controller-manager/controller-manager.go
@@ -46,7 +46,7 @@ func main() {
 		glog.Fatal("usage: controller-manager -master <master>")
 	}
 
-	controllerManager := controller.MakeReplicationManager(
+	controllerManager := controller.NewReplicationManager(
 		client.New("http://"+*master, nil))
 
 	controllerManager.Run(10 * time.Second)

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -105,7 +105,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	storage, codec := m.API_v1beta1()
 	handler.delegate = apiserver.Handle(storage, codec, "/api/v1beta1")
 
-	controllerManager := controller.MakeReplicationManager(cl)
+	controllerManager := controller.NewReplicationManager(cl)
 
 	// Prove that controllerManager's watch works by making it not sync until after this
 	// test is over. (Hopefully we don't take 10 minutes!)

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -125,7 +125,7 @@ func RecoverPanics(handler http.Handler) http.Handler {
 				glog.Infof("APIServer panic'd on %v %v: %#v\n%s\n", req.Method, req.RequestURI, x, debug.Stack())
 			}
 		}()
-		defer httplog.MakeLogged(req, &w).StacktraceWhen(
+		defer httplog.NewLogged(req, &w).StacktraceWhen(
 			httplog.StatusIsNot(
 				http.StatusOK,
 				http.StatusAccepted,

--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -72,8 +72,8 @@ func (r RealPodControl) deletePod(podID string) error {
 	return r.kubeClient.DeletePod(podID)
 }
 
-// MakeReplicationManager creates a new ReplicationManager.
-func MakeReplicationManager(kubeClient client.Interface) *ReplicationManager {
+// NewReplicationManager creates a new ReplicationManager.
+func NewReplicationManager(kubeClient client.Interface) *ReplicationManager {
 	rm := &ReplicationManager{
 		kubeClient: kubeClient,
 		podControl: RealPodControl{

--- a/pkg/election/etcd_master_test.go
+++ b/pkg/election/etcd_master_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestEtcdMasterOther(t *testing.T) {
 	path := "foo"
-	etcd := tools.MakeFakeEtcdClient(t)
+	etcd := tools.NewFakeEtcdClient(t)
 	etcd.Set(path, "baz", 0)
 	master := NewEtcdMasterElector(etcd)
 	w := master.Elect(path, "bar")
@@ -39,7 +39,7 @@ func TestEtcdMasterOther(t *testing.T) {
 
 func TestEtcdMasterNoOther(t *testing.T) {
 	path := "foo"
-	e := tools.MakeFakeEtcdClient(t)
+	e := tools.NewFakeEtcdClient(t)
 	e.TestIndex = true
 	e.Data["foo"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
@@ -60,7 +60,7 @@ func TestEtcdMasterNoOther(t *testing.T) {
 
 func TestEtcdMasterNoOtherThenConflict(t *testing.T) {
 	path := "foo"
-	e := tools.MakeFakeEtcdClient(t)
+	e := tools.NewFakeEtcdClient(t)
 	e.TestIndex = true
 	// Ok, so we set up a chain of responses from etcd:
 	//   1) Nothing there

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -60,7 +60,7 @@ func TestHealthChecker(t *testing.T) {
 		container := api.Container{
 			LivenessProbe: &api.LivenessProbe{
 				HTTPGet: &api.HTTPGetProbe{
-					Port: util.MakeIntOrStringFromString(port),
+					Port: util.NewIntOrStringFromString(port),
 					Path: "/foo/bar",
 					Host: host,
 				},
@@ -132,7 +132,7 @@ func TestMuxHealthChecker(t *testing.T) {
 			},
 		}
 		container.LivenessProbe.Type = tt.probeType
-		container.LivenessProbe.HTTPGet.Port = util.MakeIntOrStringFromString(port)
+		container.LivenessProbe.HTTPGet.Port = util.NewIntOrStringFromString(port)
 		container.LivenessProbe.HTTPGet.Host = host
 		health, err := mc.HealthCheck("test", api.PodState{}, container)
 		if err != nil {

--- a/pkg/health/http_test.go
+++ b/pkg/health/http_test.go
@@ -35,14 +35,14 @@ func TestGetURLParts(t *testing.T) {
 		port  int
 		path  string
 	}{
-		{&api.HTTPGetProbe{Host: "", Port: util.MakeIntOrStringFromInt(-1), Path: ""}, false, "", -1, ""},
-		{&api.HTTPGetProbe{Host: "", Port: util.MakeIntOrStringFromString(""), Path: ""}, false, "", -1, ""},
-		{&api.HTTPGetProbe{Host: "", Port: util.MakeIntOrStringFromString("-1"), Path: ""}, false, "", -1, ""},
-		{&api.HTTPGetProbe{Host: "", Port: util.MakeIntOrStringFromString("not-found"), Path: ""}, false, "", -1, ""},
-		{&api.HTTPGetProbe{Host: "", Port: util.MakeIntOrStringFromString("found"), Path: ""}, true, "127.0.0.1", 93, ""},
-		{&api.HTTPGetProbe{Host: "", Port: util.MakeIntOrStringFromInt(76), Path: ""}, true, "127.0.0.1", 76, ""},
-		{&api.HTTPGetProbe{Host: "", Port: util.MakeIntOrStringFromString("118"), Path: ""}, true, "127.0.0.1", 118, ""},
-		{&api.HTTPGetProbe{Host: "hostname", Port: util.MakeIntOrStringFromInt(76), Path: "path"}, true, "hostname", 76, "path"},
+		{&api.HTTPGetProbe{Host: "", Port: util.NewIntOrStringFromInt(-1), Path: ""}, false, "", -1, ""},
+		{&api.HTTPGetProbe{Host: "", Port: util.NewIntOrStringFromString(""), Path: ""}, false, "", -1, ""},
+		{&api.HTTPGetProbe{Host: "", Port: util.NewIntOrStringFromString("-1"), Path: ""}, false, "", -1, ""},
+		{&api.HTTPGetProbe{Host: "", Port: util.NewIntOrStringFromString("not-found"), Path: ""}, false, "", -1, ""},
+		{&api.HTTPGetProbe{Host: "", Port: util.NewIntOrStringFromString("found"), Path: ""}, true, "127.0.0.1", 93, ""},
+		{&api.HTTPGetProbe{Host: "", Port: util.NewIntOrStringFromInt(76), Path: ""}, true, "127.0.0.1", 76, ""},
+		{&api.HTTPGetProbe{Host: "", Port: util.NewIntOrStringFromString("118"), Path: ""}, true, "127.0.0.1", 118, ""},
+		{&api.HTTPGetProbe{Host: "hostname", Port: util.NewIntOrStringFromInt(76), Path: "path"}, true, "hostname", 76, "path"},
 	}
 
 	for _, test := range testCases {
@@ -122,7 +122,7 @@ func TestHTTPHealthChecker(t *testing.T) {
 		}
 		params := container.LivenessProbe.HTTPGet
 		if params != nil {
-			params.Port = util.MakeIntOrStringFromString(port)
+			params.Port = util.NewIntOrStringFromString(port)
 			params.Host = host
 		}
 		health, err := hc.HealthCheck("test", api.PodState{PodIP: host}, container)

--- a/pkg/health/tcp_test.go
+++ b/pkg/health/tcp_test.go
@@ -34,13 +34,13 @@ func TestGetTCPAddrParts(t *testing.T) {
 		host  string
 		port  int
 	}{
-		{&api.TCPSocketProbe{Port: util.MakeIntOrStringFromInt(-1)}, false, "", -1},
-		{&api.TCPSocketProbe{Port: util.MakeIntOrStringFromString("")}, false, "", -1},
-		{&api.TCPSocketProbe{Port: util.MakeIntOrStringFromString("-1")}, false, "", -1},
-		{&api.TCPSocketProbe{Port: util.MakeIntOrStringFromString("not-found")}, false, "", -1},
-		{&api.TCPSocketProbe{Port: util.MakeIntOrStringFromString("found")}, true, "1.2.3.4", 93},
-		{&api.TCPSocketProbe{Port: util.MakeIntOrStringFromInt(76)}, true, "1.2.3.4", 76},
-		{&api.TCPSocketProbe{Port: util.MakeIntOrStringFromString("118")}, true, "1.2.3.4", 118},
+		{&api.TCPSocketProbe{Port: util.NewIntOrStringFromInt(-1)}, false, "", -1},
+		{&api.TCPSocketProbe{Port: util.NewIntOrStringFromString("")}, false, "", -1},
+		{&api.TCPSocketProbe{Port: util.NewIntOrStringFromString("-1")}, false, "", -1},
+		{&api.TCPSocketProbe{Port: util.NewIntOrStringFromString("not-found")}, false, "", -1},
+		{&api.TCPSocketProbe{Port: util.NewIntOrStringFromString("found")}, true, "1.2.3.4", 93},
+		{&api.TCPSocketProbe{Port: util.NewIntOrStringFromInt(76)}, true, "1.2.3.4", 76},
+		{&api.TCPSocketProbe{Port: util.NewIntOrStringFromString("118")}, true, "1.2.3.4", 118},
 	}
 
 	for _, test := range testCases {
@@ -100,7 +100,7 @@ func TestTcpHealthChecker(t *testing.T) {
 		}
 		params := container.LivenessProbe.TCPSocket
 		if params != nil && test.expectedStatus == Healthy {
-			params.Port = util.MakeIntOrStringFromString(port)
+			params.Port = util.NewIntOrStringFromString(port)
 		}
 		status, err := checker.HealthCheck("test", api.PodState{PodIP: host}, container)
 		if status != test.expectedStatus {

--- a/pkg/httplog/log.go
+++ b/pkg/httplog/log.go
@@ -32,7 +32,7 @@ import (
 // Intended to wrap calls to your ServeMux.
 func Handler(delegate http.Handler, pred StacktracePred) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		defer MakeLogged(req, &w).StacktraceWhen(pred).Log()
+		defer NewLogged(req, &w).StacktraceWhen(pred).Log()
 		delegate.ServeHTTP(w, req)
 	})
 }
@@ -59,11 +59,11 @@ func DefaultStacktracePred(status int) bool {
 	return status < http.StatusOK || status >= http.StatusBadRequest
 }
 
-// MakeLogged turns a normal response writer into a logged response writer.
+// NewLogged turns a normal response writer into a logged response writer.
 //
 // Usage:
 //
-// defer MakeLogged(req, &w).StacktraceWhen(StatusIsNot(200, 202)).Log()
+// defer NewLogged(req, &w).StacktraceWhen(StatusIsNot(200, 202)).Log()
 //
 // (Only the call to Log() is defered, so you can set everything up in one line!)
 //
@@ -71,10 +71,10 @@ func DefaultStacktracePred(status int) bool {
 // through the logger.
 //
 // Use LogOf(w).Addf(...) to log something along with the response result.
-func MakeLogged(req *http.Request, w *http.ResponseWriter) *respLogger {
+func NewLogged(req *http.Request, w *http.ResponseWriter) *respLogger {
 	if _, ok := (*w).(*respLogger); ok {
 		// Don't double-wrap!
-		panic("multiple MakeLogged calls!")
+		panic("multiple NewLogged calls!")
 	}
 	rl := &respLogger{
 		startTime:         time.Now(),
@@ -87,7 +87,7 @@ func MakeLogged(req *http.Request, w *http.ResponseWriter) *respLogger {
 }
 
 // LogOf returns the logger hiding in w. Panics if there isn't such a logger,
-// because MakeLogged() must have been previously called for the log to work.
+// because NewLogged() must have been previously called for the log to work.
 func LogOf(w http.ResponseWriter) *respLogger {
 	if rl, ok := w.(*respLogger); ok {
 		return rl

--- a/pkg/httplog/log_test.go
+++ b/pkg/httplog/log_test.go
@@ -65,19 +65,19 @@ func TestStatusIsNot(t *testing.T) {
 	}
 }
 
-func TestMakeLogged(t *testing.T) {
+func TestNewLogged(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		MakeLogged(req, &w)
+		NewLogged(req, &w)
 		defer func() {
 			if r := recover(); r == nil {
-				t.Errorf("Expected MakeLogged to panic")
+				t.Errorf("Expected NewLogged to panic")
 			}
 		}()
-		MakeLogged(req, &w)
+		NewLogged(req, &w)
 	}
 	w := httptest.NewRecorder()
 	handler(w, req)
@@ -93,7 +93,7 @@ func TestLogOf(t *testing.T) {
 		handler := func(w http.ResponseWriter, r *http.Request) {
 			var want *respLogger
 			if makeLogger {
-				want = MakeLogged(req, &w)
+				want = NewLogged(req, &w)
 			} else {
 				defer func() {
 					if r := recover(); r == nil {
@@ -121,7 +121,7 @@ func TestUnlogged(t *testing.T) {
 		handler := func(w http.ResponseWriter, r *http.Request) {
 			want := w
 			if makeLogger {
-				MakeLogged(req, &w)
+				NewLogged(req, &w)
 			}
 			got := Unlogged(w)
 			if want != got {

--- a/pkg/kubecfg/kubecfg.go
+++ b/pkg/kubecfg/kubecfg.go
@@ -129,7 +129,7 @@ func ResizeController(name string, replicas int, client client.Interface) error 
 	return nil
 }
 
-func makePorts(spec string) []api.Port {
+func portsFromString(spec string) []api.Port {
 	parts := strings.Split(spec, ",")
 	var result []api.Port
 	for _, part := range parts {
@@ -172,7 +172,7 @@ func RunController(image, name string, replicas int, client client.Interface, po
 							{
 								Name:  strings.ToLower(name),
 								Image: image,
-								Ports: makePorts(portSpec),
+								Ports: portsFromString(portSpec),
 							},
 						},
 					},

--- a/pkg/kubecfg/kubecfg_test.go
+++ b/pkg/kubecfg/kubecfg_test.go
@@ -233,7 +233,7 @@ func TestLoadAuthInfo(t *testing.T) {
 }
 
 func TestMakePorts(t *testing.T) {
-	var makePortsTests = []struct {
+	var testCases = []struct {
 		spec  string
 		ports []api.Port
 	}{
@@ -246,8 +246,8 @@ func TestMakePorts(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range makePortsTests {
-		ports := makePorts(tt.spec)
+	for _, tt := range testCases {
+		ports := portsFromString(tt.spec)
 		if !reflect.DeepEqual(ports, tt.ports) {
 			t.Errorf("Expected %#v, got %#v", tt.ports, ports)
 		}

--- a/pkg/kubecfg/proxy_server.go
+++ b/pkg/kubecfg/proxy_server.go
@@ -31,7 +31,7 @@ type ProxyServer struct {
 	Client *client.Client
 }
 
-func makeFileHandler(prefix, base string) http.Handler {
+func newFileHandler(prefix, base string) http.Handler {
 	return http.StripPrefix(prefix, http.FileServer(http.Dir(base)))
 }
 
@@ -44,7 +44,7 @@ func NewProxyServer(filebase, host string, auth *client.AuthInfo) *ProxyServer {
 		Client: client.New(host, auth),
 	}
 	http.Handle("/api/", server)
-	http.Handle("/static/", makeFileHandler("/static/", filebase))
+	http.Handle("/static/", newFileHandler("/static/", filebase))
 	return server
 }
 

--- a/pkg/kubecfg/proxy_server_test.go
+++ b/pkg/kubecfg/proxy_server_test.go
@@ -34,7 +34,7 @@ func TestFileServing(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	prefix := "/foo/"
-	handler := makeFileHandler(prefix, dir)
+	handler := newFileHandler(prefix, dir)
 	server := httptest.NewServer(handler)
 	client := http.Client{}
 	req, err := http.NewRequest("GET", server.URL+prefix+"test.txt", nil)

--- a/pkg/kubelet/config/etcd_test.go
+++ b/pkg/kubelet/config/etcd_test.go
@@ -30,7 +30,7 @@ import (
 // TODO(lavalamp): Use the etcd watcher from the tools package, and make sure all test cases here are tested there.
 
 func TestGetEtcdData(t *testing.T) {
-	fakeClient := tools.MakeFakeEtcdClient(t)
+	fakeClient := tools.NewFakeEtcdClient(t)
 	ch := make(chan interface{})
 	fakeClient.Data["/registry/hosts/machine/kubelet"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
@@ -57,7 +57,7 @@ func TestGetEtcdData(t *testing.T) {
 }
 
 func TestGetEtcdNoData(t *testing.T) {
-	fakeClient := tools.MakeFakeEtcdClient(t)
+	fakeClient := tools.NewFakeEtcdClient(t)
 	ch := make(chan interface{}, 1)
 	fakeClient.Data["/registry/hosts/machine/kubelet"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
@@ -72,7 +72,7 @@ func TestGetEtcdNoData(t *testing.T) {
 }
 
 func TestGetEtcd(t *testing.T) {
-	fakeClient := tools.MakeFakeEtcdClient(t)
+	fakeClient := tools.NewFakeEtcdClient(t)
 	ch := make(chan interface{}, 1)
 	manifest := api.ContainerManifest{ID: "foo", Version: "v1beta1", Containers: []api.Container{{Name: "1", Image: "foo"}}}
 	fakeClient.Data["/registry/hosts/machine/kubelet"] = tools.EtcdResponseWithError{
@@ -107,7 +107,7 @@ func TestGetEtcd(t *testing.T) {
 }
 
 func TestWatchEtcd(t *testing.T) {
-	fakeClient := tools.MakeFakeEtcdClient(t)
+	fakeClient := tools.NewFakeEtcdClient(t)
 	ch := make(chan interface{}, 1)
 	fakeClient.Data["/registry/hosts/machine/kubelet"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
@@ -134,7 +134,7 @@ func TestWatchEtcd(t *testing.T) {
 }
 
 func TestGetEtcdNotFound(t *testing.T) {
-	fakeClient := tools.MakeFakeEtcdClient(t)
+	fakeClient := tools.NewFakeEtcdClient(t)
 	ch := make(chan interface{}, 1)
 	fakeClient.Data["/registry/hosts/machine/kubelet"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
@@ -149,7 +149,7 @@ func TestGetEtcdNotFound(t *testing.T) {
 }
 
 func TestGetEtcdError(t *testing.T) {
-	fakeClient := tools.MakeFakeEtcdClient(t)
+	fakeClient := tools.NewFakeEtcdClient(t)
 	ch := make(chan interface{}, 1)
 	fakeClient.Data["/registry/hosts/machine/kubelet"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},

--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -206,7 +206,7 @@ func (s *Server) handleSpec(w http.ResponseWriter, req *http.Request) {
 
 // ServeHTTP responds to HTTP requests on the Kubelet
 func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	defer httplog.MakeLogged(req, &w).StacktraceWhen(
+	defer httplog.NewLogged(req, &w).StacktraceWhen(
 		httplog.StatusIsNot(
 			http.StatusOK,
 			http.StatusNotFound,

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -70,7 +70,7 @@ type serverTestFramework struct {
 	testHTTPServer  *httptest.Server
 }
 
-func makeServerTest() *serverTestFramework {
+func newServerTest() *serverTestFramework {
 	fw := &serverTestFramework{
 		updateChan: make(chan interface{}),
 	}
@@ -89,11 +89,11 @@ func readResp(resp *http.Response) (string, error) {
 }
 
 func TestContainer(t *testing.T) {
-	fw := makeServerTest()
+	fw := newServerTest()
 	expected := []api.ContainerManifest{
 		{ID: "test_manifest"},
 	}
-	body := bytes.NewBuffer([]byte(util.MakeJSONString(expected[0]))) // Only send a single ContainerManifest
+	body := bytes.NewBuffer([]byte(util.EncodeJSON(expected[0]))) // Only send a single ContainerManifest
 	resp, err := http.Post(fw.testHTTPServer.URL+"/container", "application/json", body)
 	if err != nil {
 		t.Errorf("Post returned: %v", err)
@@ -111,12 +111,12 @@ func TestContainer(t *testing.T) {
 }
 
 func TestContainers(t *testing.T) {
-	fw := makeServerTest()
+	fw := newServerTest()
 	expected := []api.ContainerManifest{
 		{ID: "test_manifest_1"},
 		{ID: "test_manifest_2"},
 	}
-	body := bytes.NewBuffer([]byte(util.MakeJSONString(expected)))
+	body := bytes.NewBuffer([]byte(util.EncodeJSON(expected)))
 	resp, err := http.Post(fw.testHTTPServer.URL+"/containers", "application/json", body)
 	if err != nil {
 		t.Errorf("Post returned: %v", err)
@@ -134,7 +134,7 @@ func TestContainers(t *testing.T) {
 }
 
 func TestPodInfo(t *testing.T) {
-	fw := makeServerTest()
+	fw := newServerTest()
 	expected := api.PodInfo{"goodpod": docker.Container{ID: "myContainerID"}}
 	fw.fakeKubelet.infoFunc = func(name string) (api.PodInfo, error) {
 		if name == "goodpod.etcd" {
@@ -160,7 +160,7 @@ func TestPodInfo(t *testing.T) {
 }
 
 func TestContainerInfo(t *testing.T) {
-	fw := makeServerTest()
+	fw := newServerTest()
 	expectedInfo := &info.ContainerInfo{
 		StatsPercentiles: &info.ContainerStatsPercentiles{
 			MaxMemoryUsage: 1024001,
@@ -201,7 +201,7 @@ func TestContainerInfo(t *testing.T) {
 }
 
 func TestRootInfo(t *testing.T) {
-	fw := makeServerTest()
+	fw := newServerTest()
 	expectedInfo := &info.ContainerInfo{
 		StatsPercentiles: &info.ContainerStatsPercentiles{
 			MaxMemoryUsage: 1024001,
@@ -237,7 +237,7 @@ func TestRootInfo(t *testing.T) {
 }
 
 func TestMachineInfo(t *testing.T) {
-	fw := makeServerTest()
+	fw := newServerTest()
 	expectedInfo := &info.MachineInfo{
 		NumCores:       4,
 		MemoryCapacity: 1024,
@@ -262,7 +262,7 @@ func TestMachineInfo(t *testing.T) {
 }
 
 func TestServeLogs(t *testing.T) {
-	fw := makeServerTest()
+	fw := newServerTest()
 
 	content := string(`<pre><a href="kubelet.log">kubelet.log</a><a href="google.log">google.log</a></pre>`)
 

--- a/pkg/registry/endpoint/endpoints_test.go
+++ b/pkg/registry/endpoint/endpoints_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
-func makePodList(count int) api.PodList {
+func newPodList(count int) api.PodList {
 	pods := []api.Pod{}
 	for i := 0; i < count; i++ {
 		pods = append(pods, api.Pod{
@@ -122,7 +122,7 @@ func TestFindPort(t *testing.T) {
 }
 
 func TestSyncEndpointsEmpty(t *testing.T) {
-	body, _ := json.Marshal(makePodList(0))
+	body, _ := json.Marshal(newPodList(0))
 	fakeHandler := util.FakeHandler{
 		StatusCode:   200,
 		ResponseBody: string(body),
@@ -139,7 +139,7 @@ func TestSyncEndpointsEmpty(t *testing.T) {
 }
 
 func TestSyncEndpointsError(t *testing.T) {
-	body, _ := json.Marshal(makePodList(0))
+	body, _ := json.Marshal(newPodList(0))
 	fakeHandler := util.FakeHandler{
 		StatusCode:   200,
 		ResponseBody: string(body),
@@ -157,7 +157,7 @@ func TestSyncEndpointsError(t *testing.T) {
 }
 
 func TestSyncEndpointsItems(t *testing.T) {
-	body, _ := json.Marshal(makePodList(1))
+	body, _ := json.Marshal(newPodList(1))
 	fakeHandler := util.FakeHandler{
 		StatusCode:   200,
 		ResponseBody: string(body),

--- a/pkg/registry/pod/storage.go
+++ b/pkg/registry/pod/storage.go
@@ -105,7 +105,7 @@ func (rs *RegistryStorage) Get(id string) (interface{}, error) {
 	}
 	if rs.podCache != nil || rs.podInfoGetter != nil {
 		rs.fillPodInfo(pod)
-		pod.CurrentState.Status = makePodStatus(pod)
+		pod.CurrentState.Status = getPodStatus(pod)
 	}
 	pod.CurrentState.HostIP = getInstanceIP(rs.cloudProvider, pod.CurrentState.Host)
 	return pod, err
@@ -210,7 +210,7 @@ func getInstanceIP(cloud cloudprovider.Interface, host string) string {
 	return addr.String()
 }
 
-func makePodStatus(pod *api.Pod) api.PodStatus {
+func getPodStatus(pod *api.Pod) api.PodStatus {
 	if pod.CurrentState.Info == nil || pod.CurrentState.Host == "" {
 		return api.PodWaiting
 	}

--- a/pkg/registry/pod/storage_test.go
+++ b/pkg/registry/pod/storage_test.go
@@ -263,7 +263,7 @@ func TestMakePodStatus(t *testing.T) {
 		Host: "machine",
 	}
 	pod := &api.Pod{DesiredState: desiredState, CurrentState: currentState}
-	status := makePodStatus(pod)
+	status := getPodStatus(pod)
 	if status != api.PodWaiting {
 		t.Errorf("Expected 'Waiting', got '%s'", status)
 	}
@@ -290,7 +290,7 @@ func TestMakePodStatus(t *testing.T) {
 			Host: "machine",
 		},
 	}
-	status = makePodStatus(pod)
+	status = getPodStatus(pod)
 	if status != api.PodRunning {
 		t.Errorf("Expected 'Running', got '%s'", status)
 	}
@@ -306,7 +306,7 @@ func TestMakePodStatus(t *testing.T) {
 			Host: "machine",
 		},
 	}
-	status = makePodStatus(pod)
+	status = getPodStatus(pod)
 	if status != api.PodTerminated {
 		t.Errorf("Expected 'Terminated', got '%s'", status)
 	}
@@ -322,7 +322,7 @@ func TestMakePodStatus(t *testing.T) {
 			Host: "machine",
 		},
 	}
-	status = makePodStatus(pod)
+	status = getPodStatus(pod)
 	if status != api.PodWaiting {
 		t.Errorf("Expected 'Waiting', got '%s'", status)
 	}
@@ -337,7 +337,7 @@ func TestMakePodStatus(t *testing.T) {
 			Host: "machine",
 		},
 	}
-	status = makePodStatus(pod)
+	status = getPodStatus(pod)
 	if status != api.PodWaiting {
 		t.Errorf("Expected 'Waiting', got '%s'", status)
 	}
@@ -388,7 +388,7 @@ func TestCreatePod(t *testing.T) {
 	storage := RegistryStorage{
 		registry:      podRegistry,
 		podPollPeriod: time.Millisecond * 100,
-		scheduler:     scheduler.MakeRoundRobinScheduler(),
+		scheduler:     scheduler.NewRoundRobinScheduler(),
 		minionLister:  minion.NewRegistry([]string{"machine"}),
 	}
 	desiredState := api.PodState{

--- a/pkg/scheduler/random.go
+++ b/pkg/scheduler/random.go
@@ -29,7 +29,7 @@ type RandomScheduler struct {
 	randomLock sync.Mutex
 }
 
-func MakeRandomScheduler(random *rand.Rand) Scheduler {
+func NewRandomScheduler(random *rand.Rand) Scheduler {
 	return &RandomScheduler{
 		random: random,
 	}

--- a/pkg/scheduler/random_test.go
+++ b/pkg/scheduler/random_test.go
@@ -27,7 +27,7 @@ func TestRandomScheduler(t *testing.T) {
 	random := rand.New(rand.NewSource(0))
 	st := schedulerTester{
 		t:            t,
-		scheduler:    MakeRandomScheduler(random),
+		scheduler:    NewRandomScheduler(random),
 		minionLister: FakeMinionLister{"m1", "m2", "m3", "m4"},
 	}
 	st.expectSuccess(api.Pod{})

--- a/pkg/scheduler/randomfit_test.go
+++ b/pkg/scheduler/randomfit_test.go
@@ -36,7 +36,7 @@ func TestRandomFitSchedulerNothingScheduled(t *testing.T) {
 
 func TestRandomFitSchedulerFirstScheduled(t *testing.T) {
 	fakeRegistry := FakePodLister{
-		makePod("m1", 8080),
+		newPod("m1", 8080),
 	}
 	r := rand.New(rand.NewSource(0))
 	st := schedulerTester{
@@ -44,14 +44,14 @@ func TestRandomFitSchedulerFirstScheduled(t *testing.T) {
 		scheduler:    NewRandomFitScheduler(fakeRegistry, r),
 		minionLister: FakeMinionLister{"m1", "m2", "m3"},
 	}
-	st.expectSchedule(makePod("", 8080), "m3")
+	st.expectSchedule(newPod("", 8080), "m3")
 }
 
 func TestRandomFitSchedulerFirstScheduledComplicated(t *testing.T) {
 	fakeRegistry := FakePodLister{
-		makePod("m1", 80, 8080),
-		makePod("m2", 8081, 8082, 8083),
-		makePod("m3", 80, 443, 8085),
+		newPod("m1", 80, 8080),
+		newPod("m2", 8081, 8082, 8083),
+		newPod("m3", 80, 443, 8085),
 	}
 	r := rand.New(rand.NewSource(0))
 	st := schedulerTester{
@@ -59,14 +59,14 @@ func TestRandomFitSchedulerFirstScheduledComplicated(t *testing.T) {
 		scheduler:    NewRandomFitScheduler(fakeRegistry, r),
 		minionLister: FakeMinionLister{"m1", "m2", "m3"},
 	}
-	st.expectSchedule(makePod("", 8080, 8081), "m3")
+	st.expectSchedule(newPod("", 8080, 8081), "m3")
 }
 
 func TestRandomFitSchedulerFirstScheduledImpossible(t *testing.T) {
 	fakeRegistry := FakePodLister{
-		makePod("m1", 8080),
-		makePod("m2", 8081),
-		makePod("m3", 8080),
+		newPod("m1", 8080),
+		newPod("m2", 8081),
+		newPod("m3", 8080),
 	}
 	r := rand.New(rand.NewSource(0))
 	st := schedulerTester{
@@ -74,5 +74,5 @@ func TestRandomFitSchedulerFirstScheduledImpossible(t *testing.T) {
 		scheduler:    NewRandomFitScheduler(fakeRegistry, r),
 		minionLister: FakeMinionLister{"m1", "m2", "m3"},
 	}
-	st.expectFailure(makePod("", 8080, 8081))
+	st.expectFailure(newPod("", 8080, 8081))
 }

--- a/pkg/scheduler/roundrobin.go
+++ b/pkg/scheduler/roundrobin.go
@@ -25,7 +25,7 @@ type RoundRobinScheduler struct {
 	currentIndex int
 }
 
-func MakeRoundRobinScheduler() Scheduler {
+func NewRoundRobinScheduler() Scheduler {
 	return &RoundRobinScheduler{
 		currentIndex: -1,
 	}

--- a/pkg/scheduler/roundrobin_test.go
+++ b/pkg/scheduler/roundrobin_test.go
@@ -25,7 +25,7 @@ import (
 func TestRoundRobinScheduler(t *testing.T) {
 	st := schedulerTester{
 		t:            t,
-		scheduler:    MakeRoundRobinScheduler(),
+		scheduler:    NewRoundRobinScheduler(),
 		minionLister: FakeMinionLister{"m1", "m2", "m3", "m4"},
 	}
 	st.expectSchedule(api.Pod{}, "m1")

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -59,7 +59,7 @@ func (st *schedulerTester) expectFailure(pod api.Pod) {
 	}
 }
 
-func makePod(host string, hostPorts ...int) api.Pod {
+func newPod(host string, hostPorts ...int) api.Pod {
 	networkPorts := []api.Port{}
 	for _, port := range hostPorts {
 		networkPorts = append(networkPorts, api.Port{HostPort: port})

--- a/pkg/tools/etcd_tools_test.go
+++ b/pkg/tools/etcd_tools_test.go
@@ -65,7 +65,7 @@ func TestIsEtcdNotFound(t *testing.T) {
 }
 
 func TestExtractList(t *testing.T) {
-	fakeClient := MakeFakeEtcdClient(t)
+	fakeClient := NewFakeEtcdClient(t)
 	fakeClient.Data["/some/key"] = EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
@@ -107,9 +107,9 @@ func TestExtractList(t *testing.T) {
 }
 
 func TestExtractObj(t *testing.T) {
-	fakeClient := MakeFakeEtcdClient(t)
+	fakeClient := NewFakeEtcdClient(t)
 	expect := api.Pod{JSONBase: api.JSONBase{ID: "foo"}}
-	fakeClient.Set("/some/key", util.MakeJSONString(expect), 0)
+	fakeClient.Set("/some/key", util.EncodeJSON(expect), 0)
 	helper := EtcdHelper{fakeClient, codec, versioner}
 	var got api.Pod
 	err := helper.ExtractObj("/some/key", &got, false)
@@ -122,7 +122,7 @@ func TestExtractObj(t *testing.T) {
 }
 
 func TestExtractObjNotFoundErr(t *testing.T) {
-	fakeClient := MakeFakeEtcdClient(t)
+	fakeClient := NewFakeEtcdClient(t)
 	fakeClient.Data["/some/key"] = EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
@@ -163,7 +163,7 @@ func TestExtractObjNotFoundErr(t *testing.T) {
 
 func TestSetObj(t *testing.T) {
 	obj := api.Pod{JSONBase: api.JSONBase{ID: "foo"}}
-	fakeClient := MakeFakeEtcdClient(t)
+	fakeClient := NewFakeEtcdClient(t)
 	helper := EtcdHelper{fakeClient, codec, versioner}
 	err := helper.SetObj("/some/key", obj)
 	if err != nil {
@@ -182,7 +182,7 @@ func TestSetObj(t *testing.T) {
 
 func TestSetObjWithVersion(t *testing.T) {
 	obj := api.Pod{JSONBase: api.JSONBase{ID: "foo", ResourceVersion: 1}}
-	fakeClient := MakeFakeEtcdClient(t)
+	fakeClient := NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 	fakeClient.Data["/some/key"] = EtcdResponseWithError{
 		R: &etcd.Response{
@@ -211,7 +211,7 @@ func TestSetObjWithVersion(t *testing.T) {
 
 func TestSetObjWithoutResourceVersioner(t *testing.T) {
 	obj := api.Pod{JSONBase: api.JSONBase{ID: "foo"}}
-	fakeClient := MakeFakeEtcdClient(t)
+	fakeClient := NewFakeEtcdClient(t)
 	helper := EtcdHelper{fakeClient, codec, nil}
 	err := helper.SetObj("/some/key", obj)
 	if err != nil {
@@ -229,7 +229,7 @@ func TestSetObjWithoutResourceVersioner(t *testing.T) {
 }
 
 func TestAtomicUpdate(t *testing.T) {
-	fakeClient := MakeFakeEtcdClient(t)
+	fakeClient := NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 	codec := scheme
 	helper := EtcdHelper{fakeClient, codec, api.NewJSONBaseResourceVersioner()}
@@ -284,7 +284,7 @@ func TestAtomicUpdate(t *testing.T) {
 }
 
 func TestAtomicUpdateNoChange(t *testing.T) {
-	fakeClient := MakeFakeEtcdClient(t)
+	fakeClient := NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 	helper := EtcdHelper{fakeClient, scheme, api.NewJSONBaseResourceVersioner()}
 
@@ -315,7 +315,7 @@ func TestAtomicUpdateNoChange(t *testing.T) {
 }
 
 func TestAtomicUpdate_CreateCollision(t *testing.T) {
-	fakeClient := MakeFakeEtcdClient(t)
+	fakeClient := NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 	codec := scheme
 	helper := EtcdHelper{fakeClient, codec, api.NewJSONBaseResourceVersioner()}
@@ -486,7 +486,7 @@ func TestWatchInterpretation_ResponseBadData(t *testing.T) {
 }
 
 func TestWatch(t *testing.T) {
-	fakeClient := MakeFakeEtcdClient(t)
+	fakeClient := NewFakeEtcdClient(t)
 	fakeClient.expectNotFoundGetSet["/some/key"] = struct{}{}
 	h := EtcdHelper{fakeClient, codec, versioner}
 
@@ -572,7 +572,7 @@ func TestWatchFromZeroIndex(t *testing.T) {
 	}
 
 	for k, testCase := range testCases {
-		fakeClient := MakeFakeEtcdClient(t)
+		fakeClient := NewFakeEtcdClient(t)
 		fakeClient.Data["/some/key"] = testCase.Response
 		h := EtcdHelper{fakeClient, codec, versioner}
 
@@ -609,7 +609,7 @@ func TestWatchFromZeroIndex(t *testing.T) {
 func TestWatchListFromZeroIndex(t *testing.T) {
 	pod := &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}
 
-	fakeClient := MakeFakeEtcdClient(t)
+	fakeClient := NewFakeEtcdClient(t)
 	fakeClient.Data["/some/key"] = EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
@@ -662,7 +662,7 @@ func TestWatchListFromZeroIndex(t *testing.T) {
 }
 
 func TestWatchFromNotFound(t *testing.T) {
-	fakeClient := MakeFakeEtcdClient(t)
+	fakeClient := NewFakeEtcdClient(t)
 	fakeClient.Data["/some/key"] = EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
@@ -688,7 +688,7 @@ func TestWatchFromNotFound(t *testing.T) {
 }
 
 func TestWatchFromOtherError(t *testing.T) {
-	fakeClient := MakeFakeEtcdClient(t)
+	fakeClient := NewFakeEtcdClient(t)
 	fakeClient.Data["/some/key"] = EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
@@ -720,7 +720,7 @@ func TestWatchFromOtherError(t *testing.T) {
 }
 
 func TestWatchPurposefulShutdown(t *testing.T) {
-	fakeClient := MakeFakeEtcdClient(t)
+	fakeClient := NewFakeEtcdClient(t)
 	h := EtcdHelper{fakeClient, codec, versioner}
 	fakeClient.expectNotFoundGetSet["/some/key"] = struct{}{}
 

--- a/pkg/tools/fake_etcd_client.go
+++ b/pkg/tools/fake_etcd_client.go
@@ -59,7 +59,7 @@ type FakeEtcdClient struct {
 	WatchStop        chan<- bool
 }
 
-func MakeFakeEtcdClient(t TestLogger) *FakeEtcdClient {
+func NewFakeEtcdClient(t TestLogger) *FakeEtcdClient {
 	ret := &FakeEtcdClient{
 		t:                    t,
 		expectNotFoundGetSet: map[string]struct{}{},

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -59,8 +59,8 @@ func Forever(f func(), period time.Duration) {
 	}
 }
 
-// MakeJSONString returns obj marshalled as a JSON string, ignoring any errors.
-func MakeJSONString(obj interface{}) string {
+// EncodeJSON returns obj marshalled as a JSON string, ignoring any errors.
+func EncodeJSON(obj interface{}) string {
 	data, _ := json.Marshal(obj)
 	return string(data)
 }
@@ -83,13 +83,13 @@ const (
 	IntstrString                   // The IntOrString holds a string.
 )
 
-// MakeIntOrStringFromInt creates an IntOrString object with an int value.
-func MakeIntOrStringFromInt(val int) IntOrString {
+// NewIntOrStringFromInt creates an IntOrString object with an int value.
+func NewIntOrStringFromInt(val int) IntOrString {
 	return IntOrString{Kind: IntstrInt, IntVal: val}
 }
 
-// MakeIntOrStringFromInt creates an IntOrString object with a string value.
-func MakeIntOrStringFromString(val string) IntOrString {
+// NewIntOrStringFromInt creates an IntOrString object with a string value.
+func NewIntOrStringFromString(val string) IntOrString {
 	return IntOrString{Kind: IntstrString, StrVal: val}
 }
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -34,7 +34,7 @@ type FakePod struct {
 	Str          string
 }
 
-func TestMakeJSONString(t *testing.T) {
+func TestEncodeJSON(t *testing.T) {
 	pod := FakePod{
 		FakeJSONBase: FakeJSONBase{ID: "foo"},
 		Labels: map[string]string{
@@ -45,7 +45,7 @@ func TestMakeJSONString(t *testing.T) {
 		Str: "a string",
 	}
 
-	body := MakeJSONString(pod)
+	body := EncodeJSON(pod)
 
 	expectedBody, err := json.Marshal(pod)
 	if err != nil {
@@ -72,15 +72,15 @@ func TestHandleCrash(t *testing.T) {
 	}
 }
 
-func TestMakeIntOrStringFromInt(t *testing.T) {
-	i := MakeIntOrStringFromInt(93)
+func TestNewIntOrStringFromInt(t *testing.T) {
+	i := NewIntOrStringFromInt(93)
 	if i.Kind != IntstrInt || i.IntVal != 93 {
 		t.Errorf("Expected IntVal=93, got %+v", i)
 	}
 }
 
-func TestMakeIntOrStringFromString(t *testing.T) {
-	i := MakeIntOrStringFromString("76")
+func TestNewIntOrStringFromString(t *testing.T) {
+	i := NewIntOrStringFromString("76")
 	if i.Kind != IntstrString || i.StrVal != "76" {
 		t.Errorf("Expected StrVal=\"76\", got %+v", i)
 	}


### PR DESCRIPTION
Also rename some to other names that make better reading.  There are still a
bunch of "make" functions but they do things like assemble a string from parts
or build an array of things.  It seemed that "make" there seemed fine.  "New"
is for "constructors".
