### PR TITLE
[WIP] Add support for Config{} to kubecfg

### DIFF
--- a/examples/config/guestbook.json
+++ b/examples/config/guestbook.json
@@ -1,0 +1,105 @@
+{
+  "services": [
+    {
+      "id": "frontend",
+      "kind": "Service",
+      "apiVersion": "v1beta1",
+      "port": 5432,
+      "selector": {
+        "name": "frontend"
+      }
+    },
+    {
+      "id": "redismaster",
+      "kind": "Service",
+      "apiVersion": "v1beta1",
+      "port": 10000,
+      "selector": {
+        "name": "redis-master"
+      }
+    },
+    {
+      "id": "redisslave",
+      "kind": "Service",
+      "apiVersion": "v1beta1",
+      "port": 10001,
+      "labels": {
+        "name": "redisslave"
+      },
+      "selector": {
+        "name": "redisslave"
+      }
+    }
+  ],
+  "pods": [
+    {
+      "id": "redis-master-2",
+      "kind": "Pod",
+      "apiVersion": "v1beta1",
+      "desiredState": {
+        "manifest": {
+          "version": "v1beta1",
+          "id": "redis-master-2",
+          "containers": [{
+            "name": "master",
+            "image": "dockerfile/redis",
+            "ports": [{
+              "containerPort": 6379
+            }]
+          }]
+        }
+      },
+      "labels": {
+        "name": "redis-master"
+      }
+    }
+  ],
+  "replicationControllers": [
+    {
+      "id": "frontendController",
+      "kind": "ReplicationController",
+      "apiVersion": "v1beta1",
+      "desiredState": {
+        "replicas": 3,
+        "replicaSelector": {"name": "frontend"},
+        "podTemplate": {
+          "desiredState": {
+            "manifest": {
+              "version": "v1beta1",
+              "id": "frontendController",
+              "containers": [{
+                "name": "php-redis",
+                "image": "brendanburns/php-redis",
+                "ports": [{"containerPort": 80, "hostPort": 8000}]
+              }]
+            }
+          },
+          "labels": {"name": "frontend"}
+        }},
+        "labels": {"name": "frontend"}
+    },
+    {
+      "id": "redisSlaveController",
+      "kind": "ReplicationController",
+      "apiVersion": "v1beta1",
+      "desiredState": {
+        "replicas": 2,
+        "replicaSelector": {"name": "redisslave"},
+        "podTemplate": {
+          "desiredState": {
+            "manifest": {
+              "version": "v1beta1",
+              "id": "redisSlaveController",
+              "containers": [{
+                "name": "slave",
+                "image": "brendanburns/redis-slave",
+                "ports": [{"containerPort": 6379, "hostPort": 6380}]
+              }]
+            }
+          },
+          "labels": {"name": "redisslave"}
+        }},
+        "labels": {"name": "redisslave"}
+    }
+  ]
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -478,3 +478,9 @@ type WatchEvent struct {
 type APIObject struct {
 	Object interface{}
 }
+
+type Config struct {
+	Services               []Service               `yaml:"services,omitempty" json:"services,omitempty"`
+	Pods                   []Pod                   `yaml:"pods,omitempty" json:"pods,omitempty"`
+	ReplicationControllers []ReplicationController `yaml:"replicationControllers,omitempty" json:"replicationControllers,omitempty"`
+}


### PR DESCRIPTION
This PR will allow users to use simple JSON file with arrays of Kubernetes objects (services, pods, replicationControllers) as a parameter for `kubecfg -c config.json apply` command.

The [example JSON](https://github.com/mfojtik/kubernetes/blob/config/examples/config/guestbook.json) file in `examples/config/guestbook.json` contains all objects required for deploying the [guestbook example](https://github.com/GoogleCloudPlatform/kubernetes/tree/master/examples/guestbook).
