### PR TITLE
Fix logic errors in validate cluster and make it work for vagrant again

### DIFF
--- a/cluster/kube-util.sh
+++ b/cluster/kube-util.sh
@@ -61,3 +61,8 @@ function test-setup {
 function test-teardown {
 	echo "TODO"
 }
+
+# Set the {user} and {password} environment values required to interact with provider
+function get-password {
+	echo "TODO"
+}

--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -27,4 +27,5 @@ export KUBERNETES_MASTER="https://10.245.1.2"
 MINION_IP_BASE="10.245.2."
 for (( i=0; i <${NUM_MINIONS}; i++)) do
 	KUBE_MINION_IP_ADDRESSES[$i]="${MINION_IP_BASE}$[$i+2]"
+	MINION_NAMES[$i]="${MINION_IP_BASE}$[$i+2]"
 done

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -67,3 +67,11 @@ function test-setup {
 function test-teardown {
 	echo "Vagrant ignores tear-down"
 }
+
+# Set the {user} and {password} environment values required to interact with provider
+function get-password {
+	export user=vagrant
+	export passwd=vagrant
+	echo "Using credentials: $user:$passwd"
+}
+

--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -34,9 +34,10 @@ MINIONS_FILE=/tmp/minions
 $(dirname $0)/kubecfg.sh -template '{{range.Items}}{{.ID}}:{{end}}' list minions > ${MINIONS_FILE}
 
 for (( i=0; i<${#MINION_NAMES[@]}; i++)); do
-    count=$(grep -c ${MINION_NAMES[i]} ${MINIONS_FILE})
+    # Grep returns an exit status of 1 when line is not found, so we need the : to always return a 0 exit status
+    count=$(grep -c ${MINION_NAMES[i]} ${MINIONS_FILE}) || :
     if [ "$count" == "0" ]; then
-	echo "Failed to find ${MINION_NAMES[i]}, cluster is probably broken."
+	    echo "Failed to find ${MINION_NAMES[i]}, cluster is probably broken."
         exit 1
     fi
 
@@ -46,9 +47,8 @@ for (( i=0; i<${#MINION_NAMES[@]}; i++)); do
         echo "Please run ./cluster/kube-down.sh and re-create the cluster. (sorry!)"
         exit 1
     else
-    echo "Kubelet is successfully installed on ${MINION_NAMES[$i]}"
-
-    fi
+        echo "Kubelet is successfully installed on ${MINION_NAMES[$i]}"
+    fi    
 done
 echo "Cluster validation succeeded"
 


### PR DESCRIPTION
There were a couple of issues this resolved:

function get-password 
was not abstracted into kube-util as a common top level function, so it had no implementation in the vagrant based functions.

the check on grep for count did not work when count == 0 because the script would exit out because grep returns an exit status of 1 when no match is found.  this caused the set -e to trigger, and script never proceeded.  modified to always || the output of grep with non-error result so script would proceed.
