### PR TITLE
Break up API client into per-resource client and common code

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -415,7 +415,7 @@ func TestMakeRequest(t *testing.T) {
 		{Request: testRequest{Method: "GET", Path: "/good"}, Response: Response{StatusCode: 200}},
 		{Request: testRequest{Method: "GET", Path: "/bad%ZZ"}, Error: true},
 		{Client: New("", &AuthInfo{"foo", "bar"}), Request: testRequest{Method: "GET", Path: "/auth", Header: "Authorization"}, Response: Response{StatusCode: 200}},
-		{Client: &Client{httpClient: http.DefaultClient}, Request: testRequest{Method: "GET", Path: "/nocertificate"}, Error: true},
+		{Client: &Client{&RESTClient{httpClient: http.DefaultClient}}, Request: testRequest{Method: "GET", Path: "/nocertificate"}, Error: true},
 		{Request: testRequest{Method: "GET", Path: "/error"}, Response: Response{StatusCode: 500}, Error: true},
 		{Request: testRequest{Method: "POST", Path: "/faildecode"}, Response: Response{StatusCode: 200, Body: "aaaaa"}, Target: &struct{}{}, Error: true},
 		{Request: testRequest{Method: "GET", Path: "/failread"}, Response: Response{StatusCode: 200, Body: "aaaaa"}, Target: &struct{}{}, Error: true},

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -19,6 +19,7 @@ package client
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
@@ -109,4 +110,10 @@ func (c *Fake) UpdateService(service api.Service) (api.Service, error) {
 func (c *Fake) DeleteService(service string) error {
 	c.Actions = append(c.Actions, FakeAction{Action: "delete-service", Value: service})
 	return nil
+}
+
+func (c *Fake) ServerVersion() (*version.Info, error) {
+	c.Actions = append(c.Actions, FakeAction{Action: "get-version", Value: nil})
+	versionInfo := version.Get()
+	return &versionInfo, nil
 }

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -52,11 +52,11 @@ var specialParams = util.NewStringSet("sync", "timeout")
 // if err != nil { ... }
 // list, ok := resp.(*api.PodList)
 //
-func (c *Client) Verb(verb string) *Request {
+func (c *RESTClient) Verb(verb string) *Request {
 	return &Request{
 		verb:       verb,
 		c:          c,
-		path:       "/api/v1beta1",
+		path:       c.Prefix,
 		sync:       c.Sync,
 		timeout:    c.Timeout,
 		params:     map[string]string{},
@@ -65,27 +65,27 @@ func (c *Client) Verb(verb string) *Request {
 }
 
 // Post begins a POST request. Short for c.Verb("POST").
-func (c *Client) Post() *Request {
+func (c *RESTClient) Post() *Request {
 	return c.Verb("POST")
 }
 
 // Put begins a PUT request. Short for c.Verb("PUT").
-func (c *Client) Put() *Request {
+func (c *RESTClient) Put() *Request {
 	return c.Verb("PUT")
 }
 
 // Get begins a GET request. Short for c.Verb("GET").
-func (c *Client) Get() *Request {
+func (c *RESTClient) Get() *Request {
 	return c.Verb("GET")
 }
 
 // Delete begins a DELETE request. Short for c.Verb("DELETE").
-func (c *Client) Delete() *Request {
+func (c *RESTClient) Delete() *Request {
 	return c.Verb("DELETE")
 }
 
 // PollFor makes a request to do a single poll of the completion of the given operation.
-func (c *Client) PollFor(operationID string) *Request {
+func (c *RESTClient) PollFor(operationID string) *Request {
 	return c.Get().Path("operations").Path(operationID).Sync(false).PollPeriod(0)
 }
 
@@ -93,7 +93,7 @@ func (c *Client) PollFor(operationID string) *Request {
 // Any errors are stored until the end of your call, so you only have to
 // check once.
 type Request struct {
-	c          *Client
+	c          *RESTClient
 	err        error
 	verb       string
 	path       string

--- a/pkg/kubecfg/kubecfg.go
+++ b/pkg/kubecfg/kubecfg.go
@@ -36,16 +36,11 @@ import (
 )
 
 func GetServerVersion(client *client.Client) (*version.Info, error) {
-	body, err := client.Get().AbsPath("/version").Do().Raw()
+	info, err := client.ServerVersion()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Got error: %v", err)
 	}
-	var info version.Info
-	err = json.Unmarshal(body, &info)
-	if err != nil {
-		return nil, fmt.Errorf("Got '%s': %v", string(body), err)
-	}
-	return &info, nil
+	return info, nil
 }
 
 func promptForString(field string, r io.Reader) string {


### PR DESCRIPTION
Refactor client code into per-resource client objects and a common client core. The purpose of this is to allow future composition of clients that access both Kubernetes resources as well as plugin custom resources.
