### PR TITLE
Add etcd cloud provider

### DIFF
--- a/cmd/apiserver/plugins.go
+++ b/cmd/apiserver/plugins.go
@@ -20,6 +20,7 @@ package main
 // This should probably be part of some configuration fed into the build for a
 // given binary target.
 import (
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/etcd"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/gce"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/vagrant"
 )

--- a/pkg/cloudprovider/etcd/etcd.go
+++ b/pkg/cloudprovider/etcd/etcd.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package etcd_cloud implements the cloudprovider interface. It aims to
+leverage the etcd data store for retrieving k8s minions.
+
+Each minion must have an entry under the /minions etcd directory and
+the value must be the IP address of the minion.
+*/
+package etcd_cloud
+
+import (
+	"net"
+	"regexp"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
+
+	"github.com/coreos/go-etcd/etcd"
+)
+
+var etcdServerList = []string{
+	"http://127.0.0.1:4001",
+}
+
+// EtcdClient is an injectable interface for testing.
+type EtcdClient interface {
+	Get(key string, sort, recursive bool) (*etcd.Response, error)
+}
+
+func init() {
+	cloudprovider.RegisterCloudProvider("etcd", func() (cloudprovider.Interface, error) { return newEtcdCloud() })
+}
+
+// EtcdCloud is an implementation of Interface, TCPLoadBalancer and Instances
+// for etcd.
+type EtcdCloud struct {
+	client EtcdClient
+}
+
+// newEtcdCloud creates a new instance of EtcdCloud.
+func newEtcdCloud() (*EtcdCloud, error) {
+	return &EtcdCloud{
+		client: etcd.NewClient(etcdServerList),
+	}, nil
+}
+
+// Instances returns an implementation of Instances for etcd.
+func (c *EtcdCloud) Instances() (cloudprovider.Instances, bool) {
+	return c, true
+}
+
+// IPAddress returns an net.IP for the given instance.
+func (c *EtcdCloud) IPAddress(instance string) (net.IP, error) {
+	return net.ParseIP(instance), nil
+}
+
+// List returns a list of minions.
+// List searches the etcd /minions directory for registred minions. Each
+// minion is represented by a /minions/<minion> key and the minion's IP
+// address as the value.
+func (c *EtcdCloud) List(filter string) ([]string, error) {
+	instances := make([]string, 0)
+	matcher, err := regexp.Compile(filter)
+	if err != nil {
+		return instances, err
+	}
+	response, err := c.client.Get("/minions", false, true)
+	if err != nil {
+		return instances, err
+	}
+	for _, node := range response.Node.Nodes {
+		if matcher.MatchString(node.Value) {
+			instances = append(instances, node.Value)
+		}
+	}
+	return instances, nil
+}
+
+// TCPLoadBalancer returns an implementation of TCPLoadBalancer for etcd.
+func (c *EtcdCloud) TCPLoadBalancer() (cloudprovider.TCPLoadBalancer, bool) {
+	return nil, false
+}
+
+// Zones returns an implementation of Zones for etcd.
+func (c *EtcdCloud) Zones() (cloudprovider.Zones, bool) {
+	return nil, false
+}

--- a/pkg/cloudprovider/etcd/etcd_test.go
+++ b/pkg/cloudprovider/etcd/etcd_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd_cloud
+
+import (
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+
+	"github.com/coreos/go-etcd/etcd"
+)
+
+func TestList(t *testing.T) {
+	c, err := newEtcdCloud()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	etcdClient := tools.NewFakeEtcdClient(t)
+	etcdClient.Data["/minions"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{
+					{Value: "203.0.113.10", ModifiedIndex: 1},
+					{Value: "203.0.113.11", ModifiedIndex: 2},
+				},
+			},
+		},
+	}
+	c.client = etcdClient
+	instances, _ := c.Instances()
+	got, err := instances.List(".*")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	want := []string{
+		"203.0.113.10",
+		"203.0.113.11",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Expected: %v, got %v", want, got)
+	}
+}
+
+func TestIPAddress(t *testing.T) {
+	c, err := newEtcdCloud()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	instances, _ := c.Instances()
+	want := net.ParseIP("203.0.113.10")
+	got, err := instances.IPAddress("203.0.113.10")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Expected: %v, got %v", want, got)
+	}
+}
+
+func TestInstances(t *testing.T) {
+	c, err := newEtcdCloud()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	instances, implemented := c.Instances()
+	if !implemented {
+		t.Errorf("Exected Instances to be implemented.")
+	}
+	if !reflect.DeepEqual(c, instances) {
+		t.Errorf("Expected: %v, got %v", c, instances)
+	}
+}
+
+func TestTCPLoadBalancer(t *testing.T) {
+	c, err := newEtcdCloud()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	_, implemented := c.TCPLoadBalancer()
+	if implemented {
+		t.Errorf("Exected TCPLoadBalancer not to be implemented.")
+	}
+}
+
+func TestZones(t *testing.T) {
+	c, err := newEtcdCloud()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	_, implemented := c.Zones()
+	if implemented {
+		t.Errorf("Exected Zones not to be implemented")
+	}
+}


### PR DESCRIPTION
Minions can be discovered via etcd. The etcd cloud provider searches for
minions under the "/minions" etcd directory. Each minion must have a key
"/minions/<host>" with the minion's IP address as the value.

Minions must be added to etcd through a separate process. For example
using the etcdctl command:

```
etcdctl set /minions/minion0.example.com 203.0.113.100
```

The etcd cloud provider can be activated using the following flags:

```
apiserver --cloud_provider=etcd --minion_regexp=".*"
```

Minions are filtered using the regular expression specified by the
--minion_regexp flag. To match all minions found under the "/minions"
etcd directory use a wild card pattern such as ".*".

If the --minion_regexp is ommited or set to an empty string, the etcd
cloud provider will not return any minions.

The etcd cloud provider does not implement the Zones or TCPLoadBalancer
interfaces.
