### PR TITLE
Add a log when we drop a minion because of health checks.

### DIFF
--- a/pkg/registry/minion/healthy_registry.go
+++ b/pkg/registry/minion/healthy_registry.go
@@ -79,6 +79,8 @@ func (r *HealthyRegistry) List() (currentMinions []string, err error) {
 		}
 		if status == health.Healthy {
 			result = append(result, minion)
+		} else {
+			glog.Errorf("%s failed a health check, ignoring.", minion)
 		}
 	}
 	return result, nil


### PR DESCRIPTION
Closes https://github.com/GoogleCloudPlatform/kubernetes/issues/612
