### PR TITLE
WIP: Versioning Kubernetes (see PR #1251 [and PR #1056] instead)

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,10 +16,6 @@ limitations under the License.
 
 package version
 
-import (
-	"fmt"
-)
-
 // Info contains versioning information.
 // TODO: Add []string of api versions supported? It's still unclear
 // how we'll want to distribute that information.
@@ -47,9 +43,5 @@ func Get() Info {
 
 // String returns info as a human-friendly version string.
 func (info Info) String() string {
-	commit := info.GitCommit
-	if commit == "" {
-		commit = "(unknown)"
-	}
-	return fmt.Sprintf("version %s.%s, build %s", info.Major, info.Minor, commit)
+	return info.GitVersion
 }


### PR DESCRIPTION
Hi,

This is an early draft, but I thought I'd put it out there for review...

This is not a PR meant for merging, it should go in the top of the tree (with a `git push`) **AND** we should tag it as v0.2 when we do it. In other words, this should be the first released version of Kubernetes, v0.2. We need to release a version, otherwise "git describe" doesn't work and that's pretty much required to do versioning.

I'm trying to address issue #1018 with this patch set.

I tried building it in several different modes and they all worked as expected. I couldn't manage to build it with godep but I imagine that's because my tree doesn't match what's "expected" from a Go point of view. (@monnand can you please take a look?)

Let me know what you think of the output of -version in the case we build from out of a git tree and when we do not inject the git version info through ldflags...

Any other feedback is of course welcome!

I plan to add more documentation and comments, so please take this as just a proof of concept draft, right now I'm more concerned about comments regarding the idea itself, the -version output, etc. and not about the code. I'll do another round of commits where I expect to deliver better code, but I want to make sure the architecture makes sense before I do.

Cheers!
Filipe
