### PR TITLE
Add simple service redirection

### DIFF
--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -71,6 +71,9 @@ type SimpleRESTStorage struct {
 	requestedFieldSelector   labels.Selector
 	requestedResourceVersion uint64
 
+	// The location
+	requestedResourceLocationID string
+
 	// If non-nil, called inside the WorkFunc when answering update, delete, create.
 	// obj receives the original input to the update, delete, or create call.
 	injectedFunction func(obj interface{}) (returnObj interface{}, err error)
@@ -140,6 +143,15 @@ func (storage *SimpleRESTStorage) Watch(label, field labels.Selector, resourceVe
 	}
 	storage.fakeWatch = watch.NewFake()
 	return storage.fakeWatch, nil
+}
+
+// Implement Redirector.
+func (storage *SimpleRESTStorage) ResourceLocation(id string) (string, error) {
+	storage.requestedResourceLocationID = id
+	if err := storage.errors["resourceLocation"]; err != nil {
+		return "", err
+	}
+	return id, nil
 }
 
 func extractBody(response *http.Response, object interface{}) (string, error) {

--- a/pkg/apiserver/interfaces.go
+++ b/pkg/apiserver/interfaces.go
@@ -55,3 +55,9 @@ type ResourceWatcher interface {
 	// particular version.
 	Watch(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error)
 }
+
+// Redirectors know how to return a remote resource's location.
+type Redirector interface {
+	// ResourceLocation should return the remote location of the given resource, or an error.
+	ResourceLocation(id string) (remoteLocation string, err error)
+}

--- a/pkg/apiserver/redirect.go
+++ b/pkg/apiserver/redirect.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
+)
+
+type RedirectHandler struct {
+	storage map[string]RESTStorage
+	codec   Codec
+}
+
+func (r *RedirectHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	parts := splitPath(req.URL.Path)
+	if len(parts) != 2 || req.Method != "GET" {
+		notFound(w, req)
+		return
+	}
+	resourceName := parts[0]
+	id := parts[1]
+	storage, ok := r.storage[resourceName]
+	if !ok {
+		httplog.LogOf(w).Addf("'%v' has no storage object", resourceName)
+		notFound(w, req)
+		return
+	}
+
+	redirector, ok := storage.(Redirector)
+	if !ok {
+		httplog.LogOf(w).Addf("'%v' is not a redirector", resourceName)
+		notFound(w, req)
+		return
+	}
+
+	location, err := redirector.ResourceLocation(id)
+	if err != nil {
+		status := errToAPIStatus(err)
+		writeJSON(status.Code, r.codec, status, w)
+		return
+	}
+
+	w.Header().Set("Location", location)
+	w.WriteHeader(http.StatusTemporaryRedirect)
+}

--- a/pkg/apiserver/redirect_test.go
+++ b/pkg/apiserver/redirect_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestRedirect(t *testing.T) {
+	simpleStorage := &SimpleRESTStorage{
+		errors: map[string]error{},
+	}
+	handler := Handle(map[string]RESTStorage{
+		"foo": simpleStorage,
+	}, codec, "/prefix/version")
+	server := httptest.NewServer(handler)
+
+	dontFollow := errors.New("don't follow")
+	client := http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return dontFollow
+		},
+	}
+
+	table := []struct {
+		id   string
+		err  error
+		code int
+	}{
+		{"cozy", nil, http.StatusTemporaryRedirect},
+		{"horse", errors.New("no such id"), http.StatusInternalServerError},
+	}
+
+	for _, item := range table {
+		simpleStorage.errors["resourceLocation"] = item.err
+		resp, err := client.Get(server.URL + "/prefix/version/redirect/foo/" + item.id)
+		if resp == nil {
+			t.Fatalf("Unexpected nil resp")
+		}
+		resp.Body.Close()
+		if e, a := item.code, resp.StatusCode; e != a {
+			t.Errorf("Expected %v, got %v", e, a)
+		}
+		if e, a := item.id, simpleStorage.requestedResourceLocationID; e != a {
+			t.Errorf("Expected %v, got %v", e, a)
+		}
+		if item.err != nil {
+			continue
+		}
+		if err == nil || err.(*url.Error).Err != dontFollow {
+			t.Errorf("Unexpected err %#v", err)
+		}
+		if e, a := item.id, resp.Header.Get("Location"); e != a {
+			t.Errorf("Expected %v, got %v", e, a)
+		}
+	}
+}

--- a/pkg/registry/etcd/etcd_test.go
+++ b/pkg/registry/etcd/etcd_test.go
@@ -805,18 +805,21 @@ func TestEtcdUpdateService(t *testing.T) {
 
 func TestEtcdGetEndpoints(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Set("/registry/services/endpoints/foo", api.EncodeOrDie(api.Endpoints{
+	registry := NewTestEtcdRegistry(fakeClient, []string{"machine"})
+	endpoints := &api.Endpoints{
 		JSONBase:  api.JSONBase{ID: "foo"},
 		Endpoints: []string{"127.0.0.1:34855"},
-	}), 0)
-	registry := NewTestEtcdRegistry(fakeClient, []string{"machine"})
-	endpoints, err := registry.GetEndpoints("foo")
+	}
+
+	fakeClient.Set("/registry/services/endpoints/foo", api.EncodeOrDie(endpoints), 0)
+
+	got, err := registry.GetEndpoints("foo")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if endpoints.ID != "foo" || !reflect.DeepEqual(endpoints.Endpoints, []string{"127.0.0.1:34855"}) {
-		t.Errorf("Unexpected endpoints: %#v", endpoints)
+	if e, a := endpoints, got; !reflect.DeepEqual(e, a) {
+		t.Errorf("Unexpected endpoints: %#v, expected %#v", e, a)
 	}
 }
 

--- a/pkg/registry/registrytest/service.go
+++ b/pkg/registry/registrytest/service.go
@@ -66,7 +66,8 @@ func (r *ServiceRegistry) WatchServices(label, field labels.Selector, resourceVe
 	return nil, r.Err
 }
 
-func (r *ServiceRegistry) GetEndpoints(name string) (*api.Endpoints, error) {
+func (r *ServiceRegistry) GetEndpoints(id string) (*api.Endpoints, error) {
+	r.GottenID = id
 	return &r.Endpoints, r.Err
 }
 

--- a/pkg/registry/service/storage.go
+++ b/pkg/registry/service/storage.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"fmt"
+	"math/rand"
 	"strconv"
 	"strings"
 
@@ -165,6 +166,18 @@ func (rs *RegistryStorage) Update(obj interface{}) (<-chan interface{}, error) {
 		}
 		return rs.registry.GetService(srv.ID)
 	}), nil
+}
+
+// ResourceLocation returns a URL to which one can send traffic for the specified service.
+func (rs *RegistryStorage) ResourceLocation(id string) (string, error) {
+	e, err := rs.registry.GetEndpoints(id)
+	if err != nil {
+		return "", err
+	}
+	if len(e.Endpoints) == 0 {
+		return "", fmt.Errorf("no endpoints available for %v", id)
+	}
+	return e.Endpoints[rand.Intn(len(e.Endpoints))], nil
 }
 
 func (rs *RegistryStorage) deleteExternalLoadBalancer(service *api.Service) error {

--- a/pkg/service/endpoints_controller.go
+++ b/pkg/service/endpoints_controller.go
@@ -72,6 +72,7 @@ func (e *EndpointController) SyncServiceEndpoints() error {
 			}
 			endpoints[ix] = net.JoinHostPort(pod.CurrentState.PodIP, strconv.Itoa(port))
 		}
+		// TODO: this is totally broken, we need to compute this and store inside an AtomicUpdate loop.
 		err = e.serviceRegistry.UpdateEndpoints(api.Endpoints{
 			JSONBase:  api.JSONBase{ID: service.ID},
 			Endpoints: endpoints,


### PR DESCRIPTION
This adds a simple redirection handler, so that you can call `GET /api/v1beta1/redirect/services/myService` and get back a 307 and a Location header set with an IP:port that will let you talk to myService. This is a very rudimentary form of discovery that is inferior to our final solution in every way except for existing.

@smarterclayton This is a simple idea about how to send requests to a service running in a k8s cluster from outside of that cluster, inspired by the conversation about having a build system. This would NOT be the way I expect to talk to actual k8s plugins.
