### PR TITLE
Update apiserver defaults template

### DIFF
--- a/cluster/saltbase/salt/apiserver/default
+++ b/cluster/saltbase/salt/apiserver/default
@@ -18,16 +18,18 @@
   {% set ips = salt['mine.get']('roles:kubernetes-master', 'network.ip_addrs', 'grain').values() %}
   {% set etcd_servers = "-etcd_servers=http://" + ips[0][0] + ":4001" %}
 {% endif %}
-{% if grains.minion_ips is defined %}
-  {% set machines = "-machines " + grains.minion_ips %}
-{% elif grains.cloud is defined and grains.cloud == 'gce' %}
+
+{% if grains.cloud is defined %}
+{% if grains.cloud == 'gce' %}
   {% set cloud_provider = "-cloud_provider=gce" %}
   {% set machines = "-machines " + ','.join(salt['mine.get']('roles:kubernetes-pool', 'network.ip_addrs', expr_form='grain').keys()) %}
-{% elif grains.cloud is defined and grains.cloud == 'azure' %}
-  MACHINES="{{ salt['mine.get']('roles:kubernetes-pool', 'grains.items', expr_form='grain').values()|join(',', attribute='hostnamef') }}" 
+{% endif %}
+{% if grains.cloud == 'azure' %}
+  MACHINES="{{ salt['mine.get']('roles:kubernetes-pool', 'grains.items', expr_form='grain').values()|join(',', attribute='hostnamef') }}"
   {% set machines = "-machines $MACHINES" %}
-{% else %}
-  # No cloud defined, collect IPs of minions as machines list.
+{% endif %}
+{% if grains.cloud == 'vsphere' %}
+  # Collect IPs of minions as machines list.
   # Use a bash array to build the value we need. It doesn't appear to be
   # possible call functions map or zip, or use lambda's from Jinja.
   MACHINE_IPS=()
@@ -35,6 +37,7 @@
   MACHINE_IPS+=( {{ addrs[0] }} )
   {% endfor %}
   {% set machines = "-machines=$(echo ${MACHINE_IPS[@]} | xargs -n1 echo | paste -sd,)" %}
+{% endif %}
 {% endif %}
 
 DAEMON_ARGS="{{daemon_args}} {{address}} {{machines}} {{etcd_servers}} {{ minion_regexp }} {{ cloud_provider }}"

--- a/cluster/vsphere/templates/salt-master.sh
+++ b/cluster/vsphere/templates/salt-master.sh
@@ -25,6 +25,7 @@ cat <<EOF >/etc/salt/minion.d/grains.conf
 grains:
   roles:
     - kubernetes-master
+  cloud: vsphere
 EOF
 
 # Auto accept all keys from minions that try to join


### PR DESCRIPTION
Set "cloud" grain to "vsphere".

The "minion_ips" grain doesn't seem to be used anymore.

I changed the "if defined && equal, elseif" paradigm to a set of explicit ifs, to try and make more clear that these cases really are independent, and that there shouldn't be an "else" case.
