### PR TITLE
Fix a flake by extending the time out, so we don't race a go routine.

### DIFF
--- a/pkg/tools/etcd_tools_watch_test.go
+++ b/pkg/tools/etcd_tools_watch_test.go
@@ -425,7 +425,7 @@ func TestWatchFromOtherError(t *testing.T) {
 		if ok {
 			t.Fatalf("expected result channel to be closed")
 		}
-	case <-time.After(1 * time.Millisecond):
+	case <-time.After(1 * time.Second):
 		t.Fatalf("watch should have closed channel: %#v", watching)
 	}
 


### PR DESCRIPTION
Empirically this eliminates a flake (no flakes in > 1000 runs)

Closes https://github.com/GoogleCloudPlatform/kubernetes/issues/880
