### PR TITLE
Build without godep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,13 @@ go:
 install: 
   - go get code.google.com/p/go.tools/cmd/cover
   - go get github.com/coreos/etcd
-  - go get github.com/tools/godep
   - ./hack/verify-gofmt.sh
   - ./hack/verify-boilerplate.sh
   - ./hack/install-std-race.sh
-  - PATH=$HOME/gopath/bin:$PATH ./hack/build-go.sh
+  - ./hack/build-go.sh
 
 script:
-  - PATH=$HOME/gopath/bin:$PATH ./hack/test-go.sh
+  - ./hack/test-go.sh
   - PATH=$HOME/gopath/bin:$PATH ./hack/test-cmd.sh
   - PATH=$HOME/gopath/bin:$PATH ./hack/test-integration.sh
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The commands above will not work if there are more than one directory in ``$GOPA
 
 ### godep and dependency management
 
-Kubernetes uses [godep](https://github.com/tools/godep) to manage dependencies. Please make sure that ``godep`` is installed and in your ``$PATH``.
+Kubernetes uses [godep](https://github.com/tools/godep) to manage dependencies. It is not required for building Kubernetes but it is required when managing dependencies under the Godeps/ tree. Please make sure that ``godep`` is installed and in your ``$PATH``.
 
 #### Installing godep
 There are many ways to build and host go binaries. Here is an easy way to get utilities like ```godep``` installed:

--- a/docs/getting-started-guides/gce.md
+++ b/docs/getting-started-guides/gce.md
@@ -9,7 +9,7 @@
 4. You must have Go (version 1.2 or later) installed: [www.golang.org](http://www.golang.org).
 5. You must have the [`gcloud` components](https://developers.google.com/cloud/sdk/) installed.
 6. Ensure that your `gcloud` components are up-to-date by running `gcloud components update`.
-7. Install godep. [Instructions here](https://github.com/GoogleCloudPlatform/kubernetes#installing-godep)
+7. Install godep (optional, only required when modifying package dependencies). [Instructions here](https://github.com/GoogleCloudPlatform/kubernetes#installing-godep)
 8. Get the Kubernetes source:
 
         git clone https://github.com/GoogleCloudPlatform/kubernetes.git

--- a/docs/getting-started-guides/vsphere.md
+++ b/docs/getting-started-guides/vsphere.md
@@ -18,7 +18,7 @@
    go get github.com/vmware/govmomi/govc
    ```
 
-5. Install godep. [Instructions here](https://github.com/GoogleCloudPlatform/kubernetes#installing-godep)
+5. Install godep (optional, only required when modifying package dependencies). [Instructions here](https://github.com/GoogleCloudPlatform/kubernetes#installing-godep)
 
 6. Get the Kubernetes source:
 

--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -40,21 +40,15 @@ function gitcommit() {
   return 0
 }
 
-# kube::setup_go_environment will check that `go` and `godep` commands are
-# available in ${PATH}. If not running on Travis, it will also check that the Go
-# version is good enough for the Kubernetes build.
+# kube::setup_go_environment will check that the `go` commands is available in
+# ${PATH}. If not running on Travis, it will also check that the Go version is
+# good enough for the Kubernetes build.
 #
 # Also set ${GOPATH} and environment variables needed by Go.
 kube::setup_go_environment() {
   if [[ -z "$(which go)" ]]; then
     echo "Can't find 'go' in PATH, please fix and retry." >&2
     echo "See http://golang.org/doc/install for installation instructions." >&2
-    exit 1
-  fi
-
-  if [[ -z "$(which godep)" ]]; then
-    echo "Can't find 'godep' in PATH, please fix and retry." >&2
-    echo "See https://github.com/GoogleCloudPlatform/kubernetes#godep-and-dependency-management" >&2
     exit 1
   fi
 
@@ -72,8 +66,8 @@ kube::setup_go_environment() {
     fi
   fi
 
-  # TODO: get rid of this after PR #1054 gets rid of godep.
-  GOPATH="${KUBE_TARGET}:$(godep path)"
+  # Set GOPATH to point to the tree maintained by `godep`.
+  GOPATH="${KUBE_TARGET}:${KUBE_REPO_ROOT}/Godeps/_workspace"
   export GOPATH
 
   # Unset GOBIN in case it already exsits in the current session.


### PR DESCRIPTION
Here's a commit to remove dependency on `godep` when **building** Kubernetes. You still use it to manage to Godeps/ tree.

I'm also reverting the Travis change that pulls `godep` into the CI environment, so Travis will let us know that that works for it too.

I also updated the docs to indicate that `godep` is optional and not required for building.

Cheers,
Filipe
