### PR TITLE
Versioning fixes

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -45,4 +45,4 @@ done
 # our cluster deploy.  If we add more command line options to our standard build
 # we'll want to duplicate them there.  As we move to distributing pre- built
 # binaries we can eliminate this duplication.
-go install -ldflags "-X github.com/GoogleCloudPlatform/kubernetes/pkg/version.commitFromGit '${version}'" "${binaries[@]}"
+go install -ldflags "-X github.com/GoogleCloudPlatform/kubernetes/pkg/version.gitCommit '${version}'" "${binaries[@]}"

--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -31,6 +31,8 @@ function gitcommit() {
     # Check if the tree is dirty.
     if ! dirty_tree=$(git status --porcelain) || [[ -n "${dirty_tree}" ]]; then
       echo "${git_commit}-dirty"
+    else
+      echo "${git_commit}"
     fi
   else
     echo "(none)"

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+// Base version information.
+//
+// This is the fallback data used when version information from git is not
+// provided via go ldflags. It provides an approximation of the Kubernetes
+// version for ad-hoc builds (e.g. `go build`) that cannot get the version
+// information from git.
+//
+// The "+" in the version info indicates that fact, and it means the current
+// build is from a version greater or equal to that version.
+// (e.g. v0.7+ means version >= 0.7 and < 0.8)
+//
+// When releasing a new Kubernetes version, this file should be updated to
+// reflect the new version, and then a git annotated tag (using format vX.Y
+// where X == Major version and Y == Minor version) should be created to point
+// to the commit that updates pkg/version/base.go
+
+var (
+	gitMajor     string = "0"              // major version, always numeric
+	gitMinor     string = "1+"             // minor version, numeric possibly followed by "+"
+	gitVersion   string = "v0.1+"          // version from git, output of $(git describe)
+	gitCommit    string = ""               // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
+)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,26 +20,28 @@ import (
 	"fmt"
 )
 
-// commitFromGit is a constant representing the source version that
-// generated this build. It should be set during build via -ldflags.
-var commitFromGit string
-
 // Info contains versioning information.
 // TODO: Add []string of api versions supported? It's still unclear
 // how we'll want to distribute that information.
 type Info struct {
-	Major     string `json:"major" yaml:"major"`
-	Minor     string `json:"minor" yaml:"minor"`
-	GitCommit string `json:"gitCommit" yaml:"gitCommit"`
+	Major        string `json:"major" yaml:"major"`
+	Minor        string `json:"minor" yaml:"minor"`
+	GitVersion   string `json:"gitVersion" yaml:"gitVersion"`
+	GitCommit    string `json:"gitCommit" yaml:"gitCommit"`
+	GitTreeState string `json:"gitTreeState" yaml:"gitTreeState"`
 }
 
 // Get returns the overall codebase version. It's for detecting
 // what code a binary was built from.
 func Get() Info {
+	// These variables typically come from -ldflags settings and in
+	// their absence fallback to the settings in pkg/version/base.go
 	return Info{
-		Major:     "0",
-		Minor:     "1",
-		GitCommit: commitFromGit,
+		Major:        gitMajor,
+		Minor:        gitMinor,
+		GitVersion:   gitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
 	}
 }
 


### PR DESCRIPTION
Hi,

Here's a first set of commits to do versioning (see PR #1025 for a draft of where I'm planning to take it next.)

Right now it's still not relying on command such as "git describe" but its building the internal infrastructure for it.

I'm also fixing a bug from PR #1045 where the git sha1 was only being generated when the tree was clean (please take a look @smarterclayton)

I'll try to do this in small steps, so let's get this one figured out first and I'll send a PR for the next step.

@lavalamp Can you please take a look? I think you're probably the best reviewer for this PR...

Thanks,
Filipe
