### PR TITLE
Do not set IFS to the wrong value

### DIFF
--- a/release/build-release.sh
+++ b/release/build-release.sh
@@ -19,7 +19,6 @@
 # exit on any error
 set -eu
 set -o pipefail
-IFS=$'\n\t'
 
 SCRIPT_DIR=$(CDPATH="" cd $(dirname $0); pwd)
 


### PR DESCRIPTION
The correct way to reset it to the default would be `IFS=$' \t\n'`, but
there's no reason to assume a wrong setting here, in fact, nothing this
script does should depend on an IFS setting, so let's just drop this
line altogether.

Tested:
- Ran "release/build-release.sh <instance>" before and after this
  change. Compared the two trees for differences, only difference was
  the SHA1 in output/release/master-release/src/saltbase/pillar/common.sls

```
    $ diff -Naur output.orig/release/master-release/ output/release/master-release/
    diff -Naur output.orig/release/master-release/src/saltbase/pillar/common.sls output/release/master-release/src/saltbase/pillar/common.sls
    --- output.orig/release/master-release/src/saltbase/pillar/common.sls   2014-08-27 13:28:52.104241577 -0700
    +++ output/release/master-release/src/saltbase/pillar/common.sls        2014-08-27 13:29:28.296087806 -0700
    @@ -1,2 +1,2 @@
     instance_prefix: MY_INSTANCE_NAME-minion
    -go_opt: -ldflags "-X github.com/GoogleCloudPlatform/kubernetes/pkg/version.commitFromGit 'e169da2abfbf'"
    +go_opt: -ldflags "-X github.com/GoogleCloudPlatform/kubernetes/pkg/version.commitFromGit '8aea0d85e447-dirty'"
```
