### PR TITLE
Grab complete version information from git

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -32,7 +32,7 @@ cd "${KUBE_REPO_ROOT}"
 kube::setup_go_environment
 
 # Fetch the version.
-version=$(gitcommit)
+version_ldflags=$(kube::version_ldflags)
 
 if [[ $# == 0 ]]; then
   # Update $@ with the default list of targets to build.
@@ -48,4 +48,4 @@ done
 # our cluster deploy.  If we add more command line options to our standard build
 # we'll want to duplicate them there.  As we move to distributing pre- built
 # binaries we can eliminate this duplication.
-go install -ldflags "-X github.com/GoogleCloudPlatform/kubernetes/pkg/version.gitCommit '${version}'" "${binaries[@]}"
+go install -ldflags "${version_ldflags}" "${binaries[@]}"

--- a/release/build-release.sh
+++ b/release/build-release.sh
@@ -26,6 +26,8 @@ INSTANCE_PREFIX=$1
 
 KUBE_DIR=$SCRIPT_DIR/..
 
+. "${KUBE_DIR}/hack/config-go.sh"
+
 # Next build the release tar.  This gets copied on to the master and installed
 # from there.  It includes the go source for the necessary servers along with
 # the salt configs.
@@ -41,15 +43,11 @@ cp -r $KUBE_DIR/cluster/saltbase $MASTER_RELEASE_DIR/src/saltbase
 
 # Capture the same version we are using to build the client tools and pass that
 # on.
-version=$(
-  unset IFS
-  source $KUBE_DIR/hack/config-go.sh
-  gitcommit
-)
+version_ldflags=$(kube::version_ldflags)
 
 cat << EOF > $MASTER_RELEASE_DIR/src/saltbase/pillar/common.sls
 instance_prefix: $INSTANCE_PREFIX-minion
-go_opt: -ldflags "-X github.com/GoogleCloudPlatform/kubernetes/pkg/version.gitCommit '$version'"
+go_opt: -ldflags '${version_ldflags}'
 EOF
 
 function find_go_files() {


### PR DESCRIPTION
This is a follow up to PR #1056 which introduced the more complete version field from git.

In this PR I'm populating more git fields using Go's ldflags.

They're still not fully reported in -version, that will follow up in an upcoming commit.

I'm also not yet pushing gitMajor and gitMinor from git, that will also follow. (We need annotated tags for that to work though...)

I also made sure to fix the `release/build-release.sh` script to make sure I won't break Jenkins again since it expects the client (built locally with hack/build.sh) and the server (built from that release script) to have exactly matching versions...

Cheers,
Filipe
