### PR TITLE
Fix vagrant set up.

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -23,7 +23,8 @@ set -o pipefail
 hackdir=$(CDPATH="" cd $(dirname $0); pwd)
 
 # Set the environment variables required by the build.
-. "${hackdir}/config-go.sh"
+source "${hackdir}/config-go.sh"
+source "${hackdir}/util.sh"
 
 # Go to the top of the tree.
 cd "${KUBE_REPO_ROOT}"

--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -17,29 +17,6 @@
 # This script sets up a go workspace locally and builds all go components.
 # You can 'source' this file if you want to set up GOPATH in your local shell.
 
-# gitcommit prints the current Git commit information
-function gitcommit() {
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  topdir=$(dirname "$0")/..
-  cd "${topdir}"
-
-  # TODO: when we start making tags, switch to git describe?
-  if git_commit=$(git rev-parse --short "HEAD^{commit}" 2>/dev/null); then
-    # Check if the tree is dirty.
-    if ! dirty_tree=$(git status --porcelain) || [[ -n "${dirty_tree}" ]]; then
-      echo "${git_commit}-dirty"
-    else
-      echo "${git_commit}"
-    fi
-  else
-    echo "(none)"
-  fi
-  return 0
-}
-
 if [[ -z "$(which go)" ]]; then
   echo "Can't find 'go' in PATH, please fix and retry." >&2
   echo "See http://golang.org/doc/install for installation instructions." >&2

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -64,3 +64,26 @@ function start_etcd {
 
   wait_for_url "http://localhost:4001/v2/keys/" "etcd: "
 }
+
+# gitcommit prints the current Git commit information
+function gitcommit() {
+  set -o errexit
+  set -o nounset
+  set -o pipefail
+
+  topdir=$(dirname "$0")/..
+  cd "${topdir}"
+
+  # TODO: when we start making tags, switch to git describe?
+  if git_commit=$(git rev-parse --short "HEAD^{commit}" 2>/dev/null); then
+    # Check if the tree is dirty.
+    if ! dirty_tree=$(git status --porcelain) || [[ -n "${dirty_tree}" ]]; then
+      echo "${git_commit}-dirty"
+    else
+      echo "${git_commit}"
+    fi
+  else
+    echo "(none)"
+  fi
+  return 0
+}

--- a/release/build-release.sh
+++ b/release/build-release.sh
@@ -42,8 +42,7 @@ cp -r $KUBE_DIR/cluster/saltbase $MASTER_RELEASE_DIR/src/saltbase
 # Capture the same version we are using to build the client tools and pass that
 # on.
 version=$(
-  unset IFS
-  source $KUBE_DIR/hack/config-go.sh
+  source $KUBE_DIR/hack/util.sh
   gitcommit
 )
 


### PR DESCRIPTION
Move the gitversion function out of hack/config-go.sh to hack/util.sh so that we can build a release without having go installed.

Fixes #1057
