### PR TITLE
Fix e2e tests w/ http prefix in kube client init

### DIFF
--- a/cmd/controller-manager/controller-manager.go
+++ b/cmd/controller-manager/controller-manager.go
@@ -47,7 +47,7 @@ func main() {
 	}
 
 	controllerManager := controller.NewReplicationManager(
-		client.New(*master, nil))
+		client.New("http://"+*master, nil))
 
 	controllerManager.Run(10 * time.Second)
 	select {}


### PR DESCRIPTION
cc @smarterclayton 
