### PR TITLE
Add plugin/ to build dir

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -127,6 +127,7 @@ function build-image() {
     LICENSE
     README.md
     pkg
+    plugin
     third_party
   "
   mkdir -p ${BUILD_CONTEXT_DIR}


### PR DESCRIPTION
./build/make-binaries.sh fails with the following output:

```
$ ./build/make-binaries.sh
+++ Building Docker image kube-build:registry-auth. This can take a while.
+++ Building proxy for linux/amd64
+++ Building integration for linux/amd64
cmd/integration/integration.go:41:2: cannot find package "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler" in any of:
    /usr/local/go/src/pkg/github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler (from $GOROOT)
    /go/src/github.com/GoogleCloudPlatform/kubernetes/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler (from $GOPATH)
    /go/src/github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler
cmd/integration/integration.go:42:2: cannot find package "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/factory" in any of:
    /usr/local/go/src/pkg/github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/factory (from $GOROOT)
    /go/src/github.com/GoogleCloudPlatform/kubernetes/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/factory (from $GOPATH)
    /go/src/github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/factory
godep: go exit status 1
```

It turns out that the ./plugin/ dir is just missing from kube-source.tar.gz.
