### PR TITLE
Fix `line 55: ldflags[*]: unbound variable`

### DIFF
--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -52,7 +52,7 @@ kube::version_ldflags() {
     fi
 
     # The -ldflags parameter takes a single string, so join the output.
-    echo "${ldflags[*]}"
+    echo "${ldflags[*]-}"
   )
 }
 


### PR DESCRIPTION
This is caused by bash thinking that an empty array is the same as an
undefined variable and `set -o nounset` treating that as an error.

Fix that by using an empty string as the default for the expansion.

Fixes PR #1069 (6e25f602882196d22340a31fb05b24384e907d71).

Tested:
- Before this patch:
  $ mv .git .gitbackup
  $ hack/build-go.sh
  /home/filbranden/devel/kubernetes/hack/config-go.sh: line 55: ldflags[*]: unbound variable
- After this patch:
  $ mv .git .gitbackup
  $ rm -rf output/
  $ hack/build-go.sh
  $ output/go/bin/kubelet -version
  Kubernetes version 0.1+, build (unknown)

Signed-off-by: Filipe Brandenburger filbranden@google.com
