### PR TITLE
Client should validate the incoming host value

### DIFF
--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -92,7 +92,10 @@ func main() {
 		Port:   *minionPort,
 	}
 
-	client := client.New("http://"+net.JoinHostPort(*address, strconv.Itoa(int(*port))), nil)
+	client, err := client.New(net.JoinHostPort(*address, strconv.Itoa(int(*port))), nil)
+	if err != nil {
+		glog.Fatalf("Invalid server address: %v", err)
+	}
 
 	m := master.New(&master.Config{
 		Client:             client,

--- a/cmd/controller-manager/controller-manager.go
+++ b/cmd/controller-manager/controller-manager.go
@@ -46,9 +46,12 @@ func main() {
 		glog.Fatal("usage: controller-manager -master <master>")
 	}
 
-	controllerManager := controller.NewReplicationManager(
-		client.New("http://"+*master, nil))
+	kubeClient, err := client.New(*master, nil)
+	if err != nil {
+		glog.Fatalf("Invalid -master: %v", err)
+	}
 
+	controllerManager := controller.NewReplicationManager(kubeClient)
 	controllerManager.Run(10 * time.Second)
 	select {}
 }

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -104,7 +104,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 		}
 	}
 
-	cl := client.New(apiServer.URL, nil)
+	cl := client.NewOrDie(apiServer.URL, nil)
 	cl.PollPeriod = time.Second * 1
 	cl.Sync = true
 
@@ -301,7 +301,7 @@ func main() {
 	// Wait for the synchronization threads to come up.
 	time.Sleep(time.Second * 10)
 
-	kubeClient := client.New(apiServerURL, nil)
+	kubeClient := client.NewOrDie(apiServerURL, nil)
 
 	// Run tests in parallel
 	testFuncs := []testFunc{

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -53,7 +53,10 @@ func main() {
 	if *master != "" {
 		glog.Infof("Using api calls to get config %v", *master)
 		//TODO: add auth info
-		client := client.New(*master, nil)
+		client, err := client.New(*master, nil)
+		if err != nil {
+			glog.Fatalf("Invalid -master: %v", err)
+		}
 		config.NewSourceAPI(
 			client,
 			30*time.Second,

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -56,7 +56,7 @@ func (c *RESTClient) Verb(verb string) *Request {
 	return &Request{
 		verb:       verb,
 		c:          c,
-		path:       c.Prefix,
+		path:       c.prefix,
 		sync:       c.Sync,
 		timeout:    c.Timeout,
 		params:     map[string]string{},

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -114,7 +114,7 @@ func TestSyncReplicationControllerDoesNothing(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewTLSServer(&fakeHandler)
-	client := client.New(testServer.URL, nil)
+	client := client.NewOrDie(testServer.URL, nil)
 
 	fakePodControl := FakePodControl{}
 
@@ -134,7 +134,7 @@ func TestSyncReplicationControllerDeletes(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewTLSServer(&fakeHandler)
-	client := client.New(testServer.URL, nil)
+	client := client.NewOrDie(testServer.URL, nil)
 
 	fakePodControl := FakePodControl{}
 
@@ -154,7 +154,7 @@ func TestSyncReplicationControllerCreates(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewTLSServer(&fakeHandler)
-	client := client.New(testServer.URL, nil)
+	client := client.NewOrDie(testServer.URL, nil)
 
 	fakePodControl := FakePodControl{}
 
@@ -174,7 +174,7 @@ func TestCreateReplica(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewTLSServer(&fakeHandler)
-	client := client.New(testServer.URL, nil)
+	client := client.NewOrDie(testServer.URL, nil)
 
 	podControl := RealPodControl{
 		kubeClient: client,
@@ -307,7 +307,7 @@ func TestSyncronize(t *testing.T) {
 		t.Errorf("Unexpected request for %v", req.RequestURI)
 	})
 	testServer := httptest.NewServer(mux)
-	client := client.New(testServer.URL, nil)
+	client := client.NewOrDie(testServer.URL, nil)
 	manager := NewReplicationManager(client)
 	fakePodControl := FakePodControl{}
 	manager.podControl = &fakePodControl

--- a/pkg/kubecfg/proxy_server.go
+++ b/pkg/kubecfg/proxy_server.go
@@ -26,8 +26,6 @@ import (
 
 // ProxyServer is a http.Handler which proxies Kubernetes APIs to remote API server.
 type ProxyServer struct {
-	Host   string
-	Auth   *client.AuthInfo
 	Client *client.Client
 }
 
@@ -37,11 +35,9 @@ func newFileHandler(prefix, base string) http.Handler {
 
 // NewProxyServer creates and installs a new ProxyServer.
 // It automatically registers the created ProxyServer to http.DefaultServeMux.
-func NewProxyServer(filebase, host string, auth *client.AuthInfo) *ProxyServer {
+func NewProxyServer(filebase string, kubeClient *client.Client) *ProxyServer {
 	server := &ProxyServer{
-		Host:   host,
-		Auth:   auth,
-		Client: client.New(host, auth),
+		Client: kubeClient,
 	}
 	http.Handle("/api/", server)
 	http.Handle("/static/", newFileHandler("/static/", filebase))

--- a/pkg/service/endpoints_controller_test.go
+++ b/pkg/service/endpoints_controller_test.go
@@ -128,14 +128,12 @@ func TestSyncEndpointsEmpty(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewTLSServer(&fakeHandler)
-	client := client.New(testServer.URL, nil)
+	client := client.NewOrDie(testServer.URL, nil)
 	serviceRegistry := registrytest.ServiceRegistry{}
 	endpoints := NewEndpointController(&serviceRegistry, client)
-	err := endpoints.SyncServiceEndpoints()
-	if err != nil {
+	if err := endpoints.SyncServiceEndpoints(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-
 }
 
 func TestSyncEndpointsError(t *testing.T) {
@@ -145,13 +143,12 @@ func TestSyncEndpointsError(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewTLSServer(&fakeHandler)
-	client := client.New(testServer.URL, nil)
+	client := client.NewOrDie(testServer.URL, nil)
 	serviceRegistry := registrytest.ServiceRegistry{
 		Err: fmt.Errorf("test error"),
 	}
 	endpoints := NewEndpointController(&serviceRegistry, client)
-	err := endpoints.SyncServiceEndpoints()
-	if err != serviceRegistry.Err {
+	if err := endpoints.SyncServiceEndpoints(); err != serviceRegistry.Err {
 		t.Errorf("Errors don't match: %#v %#v", err, serviceRegistry.Err)
 	}
 }
@@ -163,7 +160,7 @@ func TestSyncEndpointsItems(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewTLSServer(&fakeHandler)
-	client := client.New(testServer.URL, nil)
+	client := client.NewOrDie(testServer.URL, nil)
 	serviceRegistry := registrytest.ServiceRegistry{
 		List: api.ServiceList{
 			Items: []api.Service{
@@ -176,8 +173,7 @@ func TestSyncEndpointsItems(t *testing.T) {
 		},
 	}
 	endpoints := NewEndpointController(&serviceRegistry, client)
-	err := endpoints.SyncServiceEndpoints()
-	if err != nil {
+	if err := endpoints.SyncServiceEndpoints(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if len(serviceRegistry.Endpoints.Endpoints) != 1 {
@@ -190,7 +186,7 @@ func TestSyncEndpointsPodError(t *testing.T) {
 		StatusCode: 500,
 	}
 	testServer := httptest.NewTLSServer(&fakeHandler)
-	client := client.New(testServer.URL, nil)
+	client := client.NewOrDie(testServer.URL, nil)
 	serviceRegistry := registrytest.ServiceRegistry{
 		List: api.ServiceList{
 			Items: []api.Service{
@@ -203,8 +199,7 @@ func TestSyncEndpointsPodError(t *testing.T) {
 		},
 	}
 	endpoints := NewEndpointController(&serviceRegistry, client)
-	err := endpoints.SyncServiceEndpoints()
-	if err == nil {
+	if err := endpoints.SyncServiceEndpoints(); err == nil {
 		t.Error("Unexpected non-error")
 	}
 }

--- a/plugin/cmd/scheduler/scheduler.go
+++ b/plugin/cmd/scheduler/scheduler.go
@@ -24,6 +24,7 @@ import (
 	verflag "github.com/GoogleCloudPlatform/kubernetes/pkg/version/flag"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/factory"
+	"github.com/golang/glog"
 )
 
 var (
@@ -38,7 +39,10 @@ func main() {
 	verflag.PrintAndExitIfRequested()
 
 	// TODO: security story for plugins!
-	kubeClient := client.New("http://"+*master, nil)
+	kubeClient, err := client.New(*master, nil)
+	if err != nil {
+		glog.Fatalf("Invalid -master: %v", err)
+	}
 
 	configFactory := &factory.ConfigFactory{Client: kubeClient}
 	config := configFactory.Create()

--- a/plugin/pkg/scheduler/factory/factory_test.go
+++ b/plugin/pkg/scheduler/factory/factory_test.go
@@ -37,7 +37,8 @@ func TestCreate(t *testing.T) {
 		T:            t,
 	}
 	server := httptest.NewServer(&handler)
-	factory := ConfigFactory{client.New(server.URL, nil)}
+	client := client.NewOrDie(server.URL, nil)
+	factory := ConfigFactory{client}
 	factory.Create()
 }
 
@@ -87,7 +88,7 @@ func TestCreateWatches(t *testing.T) {
 			T:            t,
 		}
 		server := httptest.NewServer(&handler)
-		factory.Client = client.New(server.URL, nil)
+		factory.Client = client.NewOrDie(server.URL, nil)
 		// This test merely tests that the correct request is made.
 		item.watchFactory(item.rv)
 		handler.ValidateRequest(t, item.location, "GET", nil)
@@ -114,7 +115,8 @@ func TestPollMinions(t *testing.T) {
 			T:            t,
 		}
 		server := httptest.NewServer(&handler)
-		cf := ConfigFactory{client.New(server.URL, nil)}
+		client := client.NewOrDie(server.URL, nil)
+		cf := ConfigFactory{client}
 
 		ce, err := cf.pollMinions()
 		if err != nil {
@@ -137,7 +139,7 @@ func TestDefaultErrorFunc(t *testing.T) {
 		T:            t,
 	}
 	server := httptest.NewServer(&handler)
-	factory := ConfigFactory{client.New(server.URL, nil)}
+	factory := ConfigFactory{client.NewOrDie(server.URL, nil)}
 	queue := cache.NewFIFO()
 	errFunc := factory.makeDefaultErrorFunc(queue)
 
@@ -242,10 +244,10 @@ func TestBind(t *testing.T) {
 			T:            t,
 		}
 		server := httptest.NewServer(&handler)
-		b := binder{client.New(server.URL, nil)}
+		client := client.NewOrDie(server.URL, nil)
+		b := binder{client}
 
-		err := b.Bind(item.binding)
-		if err != nil {
+		if err := b.Bind(item.binding); err != nil {
 			t.Errorf("Unexpected error: %v", err)
 			continue
 		}

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -43,7 +43,7 @@ func TestClient(t *testing.T) {
 	storage, codec := m.API_v1beta1()
 	s := httptest.NewServer(apiserver.Handle(storage, codec, "/api/v1beta1/"))
 
-	client := client.New(s.URL, nil)
+	client := client.NewOrDie(s.URL, nil)
 
 	info, err := client.ServerVersion()
 	if err != nil {


### PR DESCRIPTION
Convert host:port and URLs passed to client.New() into the proper values, and return an error if the value is invalid.  Change CLI to return an error if -master is invalid.  Remove Client.rawRequest which was not referenced, and fix the involved tests.

Preserves the behavior of the client to not auth when a non-https URL is passed (although in the future this should be corrected).
