### PR TITLE
More config-go.sh cleanup

### DIFF
--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -97,6 +97,12 @@ kube::setup_go_environment() {
 }
 
 
+# --- Environment Variables ---
+
+# KUBE_REPO_ROOT  - Path to the top of the build tree.
+# KUBE_TARGET     - Path where output Go files are saved.
+# KUBE_GO_PACKAGE - Full name of the Kubernetes Go package.
+
 KUBE_REPO_ROOT=$(dirname "${BASH_SOURCE:-$0}")/..
 if [[ "${OSTYPE:-}" == *darwin* ]]; then
   # Make the path absolute if it is not.
@@ -107,11 +113,15 @@ else
   # Resolve symlinks.
   KUBE_REPO_ROOT=$(readlink -f "${KUBE_REPO_ROOT}")
 fi
+export KUBE_REPO_ROOT
 
 KUBE_TARGET="${KUBE_REPO_ROOT}/output/go"
 mkdir -p "${KUBE_TARGET}"
+export KUBE_TARGET
 
 KUBE_GO_PACKAGE=github.com/GoogleCloudPlatform/kubernetes
+export KUBE_GO_PACKAGE
+
 KUBE_GO_PACKAGE_DIR="${KUBE_TARGET}/src/${KUBE_GO_PACKAGE}"
 
 KUBE_GO_PACKAGE_BASEDIR=$(dirname "${KUBE_GO_PACKAGE_DIR}")

--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -103,16 +103,15 @@ kube::setup_go_environment() {
 # KUBE_TARGET     - Path where output Go files are saved.
 # KUBE_GO_PACKAGE - Full name of the Kubernetes Go package.
 
-KUBE_REPO_ROOT=$(dirname "${BASH_SOURCE:-$0}")/..
-if [[ "${OSTYPE:-}" == *darwin* ]]; then
-  # Make the path absolute if it is not.
-  if [[ "${KUBE_REPO_ROOT}" != /* ]]; then
-    KUBE_REPO_ROOT=${PWD}/${KUBE_REPO_ROOT}
-  fi
-else
-  # Resolve symlinks.
-  KUBE_REPO_ROOT=$(readlink -f "${KUBE_REPO_ROOT}")
-fi
+# Make ${KUBE_REPO_ROOT} an absolute path.
+KUBE_REPO_ROOT=$(
+  set -eu
+  unset CDPATH
+  scripts_dir=$(dirname "${BASH_SOURCE[0]}")
+  cd "${scripts_dir}"
+  cd ..
+  pwd
+)
 export KUBE_REPO_ROOT
 
 KUBE_TARGET="${KUBE_REPO_ROOT}/output/go"

--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -121,10 +121,17 @@ export KUBE_TARGET
 KUBE_GO_PACKAGE=github.com/GoogleCloudPlatform/kubernetes
 export KUBE_GO_PACKAGE
 
-KUBE_GO_PACKAGE_DIR="${KUBE_TARGET}/src/${KUBE_GO_PACKAGE}"
+(
+  # Create symlink named ${KUBE_GO_PACKAGE} under output/go/src.
+  # So that Go knows how to import Kubernetes sources by full path.
+  # Use a subshell to avoid leaking these variables.
 
-KUBE_GO_PACKAGE_BASEDIR=$(dirname "${KUBE_GO_PACKAGE_DIR}")
-mkdir -p "${KUBE_GO_PACKAGE_BASEDIR}"
+  set -eu
+  go_pkg_dir="${KUBE_TARGET}/src/${KUBE_GO_PACKAGE}"
+  go_pkg_basedir=$(dirname "${go_pkg_dir}")
+  mkdir -p "${go_pkg_basedir}"
+  rm -f "${go_pkg_dir}"
+  # TODO: This symlink should be relative.
+  ln -s "${KUBE_REPO_ROOT}" "${go_pkg_dir}"
+)
 
-# Create symlink under output/go/src.
-ln -snf "${KUBE_REPO_ROOT}" "${KUBE_GO_PACKAGE_DIR}"


### PR DESCRIPTION
Now the environment variables.

Document the ones that are supposed to be public, make sure they're exported.

Run setup of output/go/ tree in a subshell to avoid leaking the variables.

Simplify finding absolute path to the top of the tree (`${KUBE_REPO_ROOT}`) by using cd & pwd in a subshell instead of using readlink on Linux and a hack on Mac.
