### PR TITLE
Step #1 in migrating the service controller away from the apiserver.

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -317,6 +317,11 @@ func (c *Client) WatchReplicationControllers(label, field labels.Selector, resou
 		Watch()
 }
 
+func (c *Client) ListServices(selector labels.Selector) (list api.ServiceList, err error) {
+	err = c.Get().Path("services").SelectorParam("labels", selector).Do().Into(&list)
+	return
+}
+
 // GetService returns information about a particular service.
 func (c *Client) GetService(name string) (result api.Service, err error) {
 	err = c.Get().Path("services").Path(name).Do().Into(&result)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -406,6 +406,57 @@ func (c *testClient) Validate(t *testing.T, received interface{}, err error) {
 	}
 }
 
+func TestListServices(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{Method: "GET", Path: "/services"},
+		Response: Response{StatusCode: 200,
+			Body: api.ServiceList{
+				Items: []api.Service{
+					{
+						JSONBase: api.JSONBase{ID: "name"},
+						Labels: map[string]string{
+							"foo":  "bar",
+							"name": "baz",
+						},
+						Selector: map[string]string{
+							"one": "two",
+						},
+					},
+				},
+			},
+		},
+	}
+	receivedServiceList, err := c.Setup().ListServices(labels.Everything())
+	c.Validate(t, receivedServiceList, err)
+}
+
+func TestListServicesLabels(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{Method: "GET", Path: "/services", Query: url.Values{"labels": []string{"foo=bar,name=baz"}}},
+		Response: Response{StatusCode: 200,
+			Body: api.ServiceList{
+				Items: []api.Service{
+					{
+						JSONBase: api.JSONBase{ID: "name"},
+						Labels: map[string]string{
+							"foo":  "bar",
+							"name": "baz",
+						},
+						Selector: map[string]string{
+							"one": "two",
+						},
+					},
+				},
+			},
+		},
+	}
+	c.Setup()
+	c.QueryValidator["labels"] = validateLabels
+	selector := labels.Set{"foo": "bar", "name": "baz"}.AsSelector()
+	receivedServiceList, err := c.ListServices(selector)
+	c.Validate(t, receivedServiceList, err)
+}
+
 func TestGetService(t *testing.T) {
 	c := &testClient{
 		Request:  testRequest{Method: "GET", Path: "/services/1"},

--- a/pkg/service/endpoints_controller.go
+++ b/pkg/service/endpoints_controller.go
@@ -46,9 +46,9 @@ func NewEndpointController(serviceRegistry service.Registry, client *client.Clie
 
 // SyncServiceEndpoints syncs service endpoints.
 func (e *EndpointController) SyncServiceEndpoints() error {
-	services, err := e.serviceRegistry.ListServices()
+	services, err := e.client.ListServices(labels.Everything())
 	if err != nil {
-		glog.Errorf("Failed to list services!")
+		glog.Errorf("Failed to list services: %v", err)
 		return err
 	}
 	var resultErr error


### PR DESCRIPTION
Start using the API server for listing services.
