### PR TITLE
Fix `which salt-master` warning in Vagrant startup

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -61,7 +61,7 @@ MASTER_HTPASSWD=$(cat ${KUBE_TEMP}/htpasswd)
 echo $MASTER_HTPASSWD > /srv/salt/nginx/htpasswd
 
 # we will run provision to update code each time we test, so we do not want to do salt install each time
-if [ ! $(which salt-master) ]; then
+if ! which salt-master >/dev/null 2>&1; then
 
   # Configure the salt-api
   cat <<EOF >/etc/salt/master.d/salt-api.conf

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -41,7 +41,7 @@ grains:
 EOF
 
 # we will run provision to update code each time we test, so we do not want to do salt install each time
-if [ ! $(which salt-minion) ]; then
+if ! which salt-minion >/dev/null 2>&1; then
   # Install Salt
   #
   # We specify -X to avoid a race condition that can cause minion failure to


### PR DESCRIPTION
The `which` command in Fedora 20 (differently from the one in Debian)
prints to stderr when the binary is not found. Redirect both stdout and
stderr to /dev/null to prevent messages from being printed by `which`.

Check whether the binary exists or not by the exit status of `which`
(non-zero means the binary does not exist) instead of checking for empty
output.

Tested:
- Started a Vagrant cluster with `vagrant up` and confirmed these
  messages were gone. Checked master and minions for Kubernetes
  components using the systemd status commands.

Fixes: Issue #1079

Signed-off-by: Filipe Brandenburger filbranden@google.com
