### PR TITLE
Start kubelet watch index at zero

### DIFF
--- a/pkg/kubelet/config/etcd.go
+++ b/pkg/kubelet/config/etcd.go
@@ -59,48 +59,72 @@ func NewSourceEtcd(key string, client tools.EtcdClient, updates chan<- interface
 	return config
 }
 
-// run loops forever looking for changes to a key in etcd
+// run fetches the current state of the config from etcd before establishing
+// a long-running etcd watcher. run will exit only when an unrecoverable error occurs.
 func (s *SourceEtcd) run() {
-	index := uint64(0)
+	response, err := s.getCurrentState()
+	if err != nil {
+		glog.Errorf("Unexpected error from etcd (%s): %v", s.key, err)
+		return
+	}
+	if response == nil {
+		return
+	}
+
+	err = s.handleResponse(response)
+	if err != nil {
+		glog.Errorf("Failed parsing response from etcd (%s): %v", s.key, err)
+		return
+	}
+
 	for {
-		nextIndex, err := s.fetchNextState(index)
+		response, err = s.watchForNextState(response.Node.ModifiedIndex + 1)
 		if err != nil {
-			if !tools.IsEtcdNotFound(err) {
-				glog.Errorf("Unable to extract from the response (%s): %%v", s.key, err)
-			}
+			glog.Errorf("Unexpected error from etcd watch (%s): %v", s.key, err)
+			break
+		}
+		if response == nil {
 			return
 		}
-		index = nextIndex
+
+		err = s.handleResponse(response)
+		if err != nil {
+			glog.Errorf("Failed parsing response from etcd watch (%s): %v", s.key, err)
+			return
+		}
 	}
 }
 
-// fetchNextState fetches the key (or waits for a change to a key) and then returns
-// the nextIndex to read.  It will watch no longer than s.waitDuration and then return
-func (s *SourceEtcd) fetchNextState(fromIndex uint64) (nextIndex uint64, err error) {
-	var response *etcd.Response
-
-	if fromIndex == 0 {
-		response, err = s.client.Get(s.key, true, false)
-	} else {
-		response, err = s.client.Watch(s.key, fromIndex, false, nil, stopChannel(s.timeout))
-		if tools.IsEtcdWatchStoppedByUser(err) {
-			return fromIndex, nil
-		}
-	}
-	if err != nil {
-		return fromIndex, err
+func (s *SourceEtcd) getCurrentState() (response *etcd.Response, err error) {
+	response, err = s.client.Get(s.key, true, false)
+	if err != nil && tools.IsEtcdNotFound(err) {
+		response = nil
+		err = nil
 	}
 
+	return
+}
+
+func (s *SourceEtcd) watchForNextState(watchIndex uint64) (response *etcd.Response, err error) {
+	response, err = s.client.Watch(s.key, watchIndex, false, nil, stopChannel(s.timeout))
+	if err != nil && (tools.IsEtcdNotFound(err) || tools.IsEtcdWatchStoppedByUser(err)) {
+		response = nil
+		err = nil
+	}
+
+	return
+}
+
+func (s *SourceEtcd) handleResponse(response *etcd.Response) error {
 	pods, err := responseToPods(response)
 	if err != nil {
-		glog.Infof("Response was in error: %#v", response)
-		return 0, fmt.Errorf("error parsing response: %#v", err)
+		return fmt.Errorf("error parsing response: %#v", err)
 	}
 
 	glog.Infof("Got state from etcd: %+v", pods)
 	s.updates <- kubelet.PodUpdate{pods, kubelet.SET}
 
-	return response.Node.ModifiedIndex + 1, nil
+	return nil
 }
 
 // responseToPods takes an etcd Response object, and turns it into a structured list of containers.

--- a/pkg/kubelet/config/etcd.go
+++ b/pkg/kubelet/config/etcd.go
@@ -77,8 +77,11 @@ func (s *SourceEtcd) run() {
 		return
 	}
 
+	// watch must start from zero since the ModifiedIndex of the state may
+	// already be too far in the past for the etcd event queue
+	watchIndex := uint64(0)
 	for {
-		response, err = s.watchForNextState(response.Node.ModifiedIndex + 1)
+		response, err = s.watchForNextState(watchIndex)
 		if err != nil {
 			glog.Errorf("Unexpected error from etcd watch (%s): %v", s.key, err)
 			break
@@ -92,6 +95,8 @@ func (s *SourceEtcd) run() {
 			glog.Errorf("Failed parsing response from etcd watch (%s): %v", s.key, err)
 			return
 		}
+
+		watchIndex = response.Node.ModifiedIndex + 1
 	}
 }
 


### PR DESCRIPTION
1. Start up a cluster
2. Wait a long enough time for 1000+ etcd writes to happen in your cluster outside of the kubernetes keyspace
3. Restart a kubelet

The kubelet will repeatedly log something like this:

```
I0828 16:29:06.188275 00008 logs.go:39] etcd DEBUG: recv.response.fromhttp://127.0.0.1:4001/v2/keys/registry/hosts/10.141.164.134/kubelet?consistent=true&wait=true&waitIndex=253363
I0828 16:29:06.188435 00008 logs.go:39] etcd DEBUG: recv.success.http://127.0.0.1:4001/v2/keys/registry/hosts/10.141.164.134/kubelet?consistent=true&wait=true&waitIndex=253363
E0828 16:29:06.188933 00008 etcd.go:69] Unable to extract from the response (/registry/hosts/10.141.164.134/kubelet): %v%!(EXTRA *etcd.EtcdError=401: The event in requested index is outdated and cleared (the requested history has been cleared [254788/253363]) [255787])
```

This etcd error occurs when a user attempts to establish an watch with an index that is 1000 or more behind the current cluster-wide index. Here's what the kubelet is currently doing:
1. on startup, GET the kubelet config without `wait=true`
2. establish a watcher on the kubelet config key with `wait=true` and `waitIndex` equal to the ModifiedIndex of the etcd Node returned in step 1

The ModifiedIndex ends up being more than 1000 behind the current cluster index and the watch immediately fails. To work around this, we should just start the watcher using `waitIndex=0`.
