### PR TITLE
Authenticated docker pulls

### DIFF
--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -56,6 +56,9 @@ var (
 	port               = flag.Uint("port", 10250, "The port for the info server to serve on")
 	hostnameOverride   = flag.String("hostname_override", "", "If non-empty, will use this string as identification instead of the actual hostname.")
 	dockerEndpoint     = flag.String("docker_endpoint", "", "If non-empty, use this for the docker endpoint to communicate with")
+	dockerAuthUsername = flag.String("docker_auth_username", "", "Use this username to authenticate docker pulls.")
+	dockerAuthPassword = flag.String("docker_auth_password", "", "Use this password to authenticate docker pulls.")
+	dockerAuthEmail    = flag.String("docker_auth_email", "", "Use this email address to authenticate docker pulls.")
 	etcdServerList     util.StringList
 	rootDirectory      = flag.String("root_dir", defaultRootDir, "Directory path for managing kubelet files (volume mounts,etc).")
 )
@@ -107,6 +110,12 @@ func main() {
 		glog.Fatal("Couldn't connect to docker.")
 	}
 
+	dockerAuth := docker.AuthConfiguration{
+		Username: *dockerAuthUsername,
+		Password: *dockerAuthPassword,
+		Email:    *dockerAuthEmail,
+	}
+
 	cadvisorClient, err := cadvisor.NewClient("http://127.0.0.1:4194")
 	if err != nil {
 		glog.Errorf("Error on creating cadvisor client: %v", err)
@@ -147,6 +156,7 @@ func main() {
 	k := kubelet.NewMainKubelet(
 		getHostname(),
 		dockerClient,
+		dockerAuth,
 		cadvisorClient,
 		etcdClient,
 		*rootDirectory,

--- a/pkg/kubelet/docker.go
+++ b/pkg/kubelet/docker.go
@@ -58,12 +58,14 @@ type DockerPuller interface {
 // dockerPuller is the default implementation of DockerPuller.
 type dockerPuller struct {
 	client DockerInterface
+	auth   docker.AuthConfiguration
 }
 
 // NewDockerPuller creates a new instance of the default implementation of DockerPuller.
-func NewDockerPuller(client DockerInterface) DockerPuller {
+func NewDockerPuller(client DockerInterface, auth docker.AuthConfiguration) DockerPuller {
 	return dockerPuller{
 		client: client,
+		auth:   auth,
 	}
 }
 
@@ -103,7 +105,7 @@ func (p dockerPuller) Pull(image string) error {
 		Repository: image,
 		Tag:        tag,
 	}
-	return p.client.PullImage(opts, docker.AuthConfiguration{})
+	return p.client.PullImage(opts, p.auth)
 }
 
 // DockerContainers is a map of containers

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -62,6 +62,7 @@ type volumeMap map[string]volume.Interface
 func NewMainKubelet(
 	hn string,
 	dc DockerInterface,
+	da docker.AuthConfiguration,
 	cc CadvisorInterface,
 	ec tools.EtcdClient,
 	rd string,
@@ -69,6 +70,7 @@ func NewMainKubelet(
 	return &Kubelet{
 		hostname:       hn,
 		dockerClient:   dc,
+		dockerAuth:     da,
 		cadvisorClient: cc,
 		etcdClient:     ec,
 		rootDirectory:  rd,
@@ -98,6 +100,7 @@ type ContainerCommandRunner interface {
 type Kubelet struct {
 	hostname       string
 	dockerClient   DockerInterface
+	dockerAuth     docker.AuthConfiguration
 	rootDirectory  string
 	podWorkers     podWorkers
 	resyncInterval time.Duration
@@ -122,7 +125,7 @@ func (kl *Kubelet) Run(updates <-chan PodUpdate) {
 		kl.logServer = http.StripPrefix("/logs/", http.FileServer(http.Dir("/var/log/")))
 	}
 	if kl.dockerPuller == nil {
-		kl.dockerPuller = NewDockerPuller(kl.dockerClient)
+		kl.dockerPuller = NewDockerPuller(kl.dockerClient, kl.dockerAuth)
 	}
 	if kl.healthChecker == nil {
 		kl.healthChecker = health.NewHealthChecker()


### PR DESCRIPTION
This is just a strawman to get the conversation going. While this PR is functional, I don't think this is the right solution.

I've only got one major requirement for this feature, and it is not accomplished in this PR: the kubelet must be able to pull from multiple registries, each with their own set of credentials.

To meet this requirement, I see three reasonable options:
1. configure kubelet from dockercfg
2. configure kubelet from CLI flags
3. add docker creds to container manifest

Any thoughts out there?
