### PR TITLE
Remove unnecessary parameter from NewRegistry

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -67,11 +67,11 @@ func New(c *Config) *Master {
 	etcdClient := goetcd.NewClient(c.EtcdServers)
 	minionRegistry := makeMinionRegistry(c)
 	m := &Master{
-		podRegistry:        etcd.NewRegistry(etcdClient, minionRegistry),
-		controllerRegistry: etcd.NewRegistry(etcdClient, minionRegistry),
-		serviceRegistry:    etcd.NewRegistry(etcdClient, minionRegistry),
-		endpointRegistry:   etcd.NewRegistry(etcdClient, minionRegistry),
-		bindingRegistry:    etcd.NewRegistry(etcdClient, minionRegistry),
+		podRegistry:        etcd.NewRegistry(etcdClient),
+		controllerRegistry: etcd.NewRegistry(etcdClient),
+		serviceRegistry:    etcd.NewRegistry(etcdClient),
+		endpointRegistry:   etcd.NewRegistry(etcdClient),
+		bindingRegistry:    etcd.NewRegistry(etcdClient),
 		minionRegistry:     minionRegistry,
 		client:             c.Client,
 	}

--- a/pkg/registry/etcd/etcd.go
+++ b/pkg/registry/etcd/etcd.go
@@ -23,7 +23,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/constraint"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/minion"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
@@ -41,7 +40,7 @@ type Registry struct {
 }
 
 // NewRegistry creates an etcd registry.
-func NewRegistry(client tools.EtcdClient, machines minion.Registry) *Registry {
+func NewRegistry(client tools.EtcdClient) *Registry {
 	registry := &Registry{
 		EtcdHelper: tools.EtcdHelper{
 			client,


### PR DESCRIPTION
NewRegistry's `machines minion.Registry` parameter is not used
