### PR TITLE
Redirect output of `systemctl enable` to stdout

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -86,7 +86,9 @@ EOF
   #
   # This is used to inform the cloud provider used in the vagrant cluster
   yum install -y salt-api
-  systemctl enable salt-api
+  # Set log level to a level higher than "info" to prevent the message about
+  # enabling the service (which is not an error) from being printed to stderr.
+  SYSTEMD_LOG_LEVEL=notice systemctl enable salt-api
   systemctl start salt-api
 
 fi


### PR DESCRIPTION
The `systemctl enable` command ordinarily prints the `ln` command used to enable the unit to stderr, but that's not ideal in the vagrant setup because it gets printed in red, which should be reserved for errors, but
it's not a real error.

Redirect its stderr to stdout to get it printed in green and reserve red for real error messages.

I looked into the `systemctl` calls happening from the Salt setup script to understand why they were not going to stderr, and it turns out the Salt script will redirect all messages to stdout so they will all be green regardless...

Tested:
- Started a fresh Vagrant cluster, confirmed no red messages in output
  when creating the cluster successfully. Successfully started nginx
  through Kubernetes using cluster/kubecfg.sh.
- Confirmed that the message is still there, only now it's green.
