### PR TITLE
Remove workaround for salt-minion startup in vagrant/provision-minion.sh

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -79,9 +79,6 @@ EOF
 
   # Install Salt
   #
-  # We specify -X to avoid a race condition that can cause minion failure to
-  # install.  See https://github.com/saltstack/salt-bootstrap/issues/270
-  #
   # -M installs the master
   curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -M
 

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -43,14 +43,7 @@ EOF
 # we will run provision to update code each time we test, so we do not want to do salt install each time
 if ! which salt-minion >/dev/null 2>&1; then
   # Install Salt
-  #
-  # We specify -X to avoid a race condition that can cause minion failure to
-  # install.  See https://github.com/saltstack/salt-bootstrap/issues/270
-  curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -X
-
-  ## TODO this only works on systemd distros, need to find a work-around as removing -X above fails to start the services installed
-  systemctl enable salt-minion
-  systemctl start salt-minion
+  curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s
 fi
 
 # run the networking setup


### PR DESCRIPTION
The workaround was not needed, as salt-minion was always correctly started in the Vagrant minion setup.

The issue reported in #270 was clearly specific do System V style init scripts and will not affect systemd.

Also remove the inaccurate comment from provision-master.sh, since -X was not even really in use there.

Tested:
- Performed 3 full `vagrant up` and `vagrant destroy -f` cycles with at
  least 3 minions and up to 6 minions in one case. Checked that
  salt-minion was up in each of the minions using a `systemctl status
  salt-minion` command.
- Started nginx on the cluster using cluster/kubecfg.sh, confirmed it
  was up with `list /pods` and confirmed it was reachable using wget on
  port 8080 of the minions.
