### PR TITLE
Use codec to encode/decode api objects in client and kubecfg parser

### DIFF
--- a/cmd/kubecfg/kubecfg.go
+++ b/cmd/kubecfg/kubecfg.go
@@ -105,7 +105,7 @@ func readConfig(storage string) []byte {
 	if err != nil {
 		glog.Fatalf("Unable to read %v: %v\n", *config, err)
 	}
-	data, err = parser.ToWireFormat(data, storage)
+	data, err = parser.ToWireFormat(data, storage, runtime.DefaultCodec)
 	if err != nil {
 		glog.Fatalf("Error parsing %v as an object for %v: %v\n", *config, storage, err)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -99,7 +99,7 @@ type Client struct {
 // to a URL will prepend the server path. Returns an error if host cannot be converted to a
 // valid URL.
 func New(host string, auth *AuthInfo) (*Client, error) {
-	restClient, err := NewRESTClient(host, auth, "/api/v1beta1/")
+	restClient, err := NewRESTClient(host, auth, "/api/v1beta1/", runtime.DefaultCodec)
 	if err != nil {
 		return nil, err
 	}
@@ -143,11 +143,12 @@ type RESTClient struct {
 	Sync       bool
 	PollPeriod time.Duration
 	Timeout    time.Duration
+	Codec      runtime.Codec
 }
 
 // NewRESTClient creates a new RESTClient. This client performs generic REST functions
 // such as Get, Put, Post, and Delete on specified paths.
-func NewRESTClient(host string, auth *AuthInfo, path string) (*RESTClient, error) {
+func NewRESTClient(host string, auth *AuthInfo, path string, c runtime.Codec) (*RESTClient, error) {
 	prefix, err := normalizePrefix(host, path)
 	if err != nil {
 		return nil, err
@@ -171,6 +172,7 @@ func NewRESTClient(host string, auth *AuthInfo, path string) (*RESTClient, error
 		Sync:       false,
 		PollPeriod: time.Second * 2,
 		Timeout:    time.Second * 20,
+		Codec:      c,
 	}, nil
 }
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -48,7 +48,7 @@ func TestValidatesHostParameter(t *testing.T) {
 		"host/server":        {"", "", true},
 	}
 	for k, expected := range testCases {
-		c, err := NewRESTClient(k, nil, "/api/v1beta1/")
+		c, err := NewRESTClient(k, nil, "/api/v1beta1/", runtime.DefaultCodec)
 		switch {
 		case err == nil && expected.Err:
 			t.Errorf("expected error but was nil")

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -206,7 +206,7 @@ func (r *Request) Body(obj interface{}) *Request {
 	case io.Reader:
 		r.body = t
 	case runtime.Object:
-		data, err := runtime.DefaultCodec.Encode(t)
+		data, err := r.c.Codec.Encode(t)
 		if err != nil {
 			r.err = err
 			return r
@@ -301,14 +301,15 @@ func (r *Request) Do() Result {
 				}
 			}
 		}
-		return Result{respBody, err}
+		return Result{respBody, err, r.c.Codec}
 	}
 }
 
 // Result contains the result of calling Request.Do().
 type Result struct {
-	body []byte
-	err  error
+	body  []byte
+	err   error
+	codec runtime.Codec
 }
 
 // Raw returns the raw result.
@@ -321,7 +322,7 @@ func (r Result) Get() (runtime.Object, error) {
 	if r.err != nil {
 		return nil, r.err
 	}
-	return runtime.DefaultCodec.Decode(r.body)
+	return r.codec.Decode(r.body)
 }
 
 // Into stores the result into obj, if possible.
@@ -329,7 +330,7 @@ func (r Result) Into(obj runtime.Object) error {
 	if r.err != nil {
 		return r.err
 	}
-	return runtime.DefaultCodec.DecodeInto(r.body, obj)
+	return r.codec.DecodeInto(r.body, obj)
 }
 
 // Error returns the error executing the request, nil if no error occurred.

--- a/pkg/kubecfg/parse.go
+++ b/pkg/kubecfg/parse.go
@@ -38,18 +38,18 @@ func NewParser(objectMap map[string]runtime.Object) *Parser {
 
 // ToWireFormat takes input 'data' as either json or yaml, checks that it parses as the
 // appropriate object type, and returns json for sending to the API or an error.
-func (p *Parser) ToWireFormat(data []byte, storage string) ([]byte, error) {
+func (p *Parser) ToWireFormat(data []byte, storage string, c runtime.Codec) ([]byte, error) {
 	prototypeType, found := p.storageToType[storage]
 	if !found {
 		return nil, fmt.Errorf("unknown storage type: %v", storage)
 	}
 
 	obj := reflect.New(prototypeType).Interface().(runtime.Object)
-	err := runtime.DefaultCodec.DecodeInto(data, obj)
+	err := c.DecodeInto(data, obj)
 	if err != nil {
 		return nil, err
 	}
-	return runtime.DefaultCodec.Encode(obj)
+	return c.Encode(obj)
 }
 
 func (p *Parser) SupportedWireStorage() []string {

--- a/pkg/kubecfg/parse_test.go
+++ b/pkg/kubecfg/parse_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestParseBadStorage(t *testing.T) {
 	p := NewParser(map[string]runtime.Object{})
-	_, err := p.ToWireFormat([]byte("{}"), "badstorage")
+	_, err := p.ToWireFormat([]byte("{}"), "badstorage", runtime.DefaultCodec)
 	if err == nil {
 		t.Errorf("Expected error, received none")
 	}
@@ -37,8 +37,8 @@ func DoParseTest(t *testing.T, storage string, obj runtime.Object, p *Parser) {
 	yamlData, _ := yaml.Marshal(obj)
 	t.Logf("Intermediate yaml:\n%v\n", string(yamlData))
 	t.Logf("Intermediate json:\n%v\n", string(jsonData))
-	jsonGot, jsonErr := p.ToWireFormat(jsonData, storage)
-	yamlGot, yamlErr := p.ToWireFormat(yamlData, storage)
+	jsonGot, jsonErr := p.ToWireFormat(jsonData, storage, runtime.DefaultCodec)
+	yamlGot, yamlErr := p.ToWireFormat(yamlData, storage, runtime.DefaultCodec)
 
 	if jsonErr != nil {
 		t.Errorf("json err: %#v", jsonErr)


### PR DESCRIPTION
The purpose of this change is to allow core parser and client to work with other resource codecs that know how to encode/decode custom types.
