### PR TITLE
Improve test script

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -49,10 +49,13 @@ for arg; do
   binaries+=("${KUBE_GO_PACKAGE}/${arg}")
 done
 
+# Use eval to preserve embedded quoted strings.
+eval "goflags=(${GOFLAGS:-})"
+
 # Note that the flags to 'go build' are duplicated in the salt build setup
 # (release/build-release.sh) for our cluster deploy.  If we add more command
 # line options to our standard build we'll want to duplicate them there.  As we
 # move to distributing pre- built binaries we can eliminate this duplication.
-go install ${GOFLAGS:-} \
+go install "${goflags[@]:+${goflags[@]}}" \
     -ldflags "${version_ldflags}" \
     "${binaries[@]}"

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -36,7 +36,8 @@ trap cleanup EXIT SIGINT
 echo
 echo Integration test cases ...
 echo
-$(dirname $0)/../hack/test-go.sh test/integration -tags 'integration no-docker'
+GOFLAGS="-tags 'integration no-docker'" \
+    $(dirname $0)/../hack/test-go.sh test/integration
 # leave etcd running if integration tests fail
 trap "echo etcd still running" EXIT
 


### PR DESCRIPTION
add usage
verify flag value for -i is numeric
allow multiple targets on the command line
actually capture coverage output
fix lingering GOFLAGS undef issue
fix issue with -i not working at all: ((x++)) returns 1 when x is 0, which is
  incompatible with "set -e"

@filbranden 
