### PR TITLE
Invert api and api/v1beta1 dependencies

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/golang/glog"
 )
 

--- a/pkg/api/helper.go
+++ b/pkg/api/helper.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
 	"gopkg.in/v1/yaml"
 )
@@ -64,22 +63,6 @@ func init() {
 		ContainerManifestList{},
 		Endpoints{},
 		Binding{},
-	)
-	AddKnownTypes("v1beta1",
-		v1beta1.PodList{},
-		v1beta1.Pod{},
-		v1beta1.ReplicationControllerList{},
-		v1beta1.ReplicationController{},
-		v1beta1.ServiceList{},
-		v1beta1.Service{},
-		v1beta1.MinionList{},
-		v1beta1.Minion{},
-		v1beta1.Status{},
-		v1beta1.ServerOpList{},
-		v1beta1.ServerOp{},
-		v1beta1.ContainerManifestList{},
-		v1beta1.Endpoints{},
-		v1beta1.Binding{},
 	)
 
 	Codec = conversionScheme

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -14,25 +14,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package api
+package v1beta1
 
 import (
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
+	// Alias this so it can be easily changed when we cut the next version.
+	newer "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	// Also import under original name for Convert and AddConversionFuncs.
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 )
 
 func init() {
-	// TODO: Consider inverting dependency chain-- imagine v1beta1 package
-	// registering all of these functions. Then, if you want to be able to understand
-	// v1beta1 objects, you just import that package for its side effects.
-	AddConversionFuncs(
+	// Shortcut for sub-conversions. TODO: This should possibly be refactored
+	// such that this convert function is passed to each conversion func.
+	Convert := api.Convert
+	api.AddConversionFuncs(
 		// EnvVar's Key is deprecated in favor of Name.
-		func(in *EnvVar, out *v1beta1.EnvVar) error {
+		func(in *newer.EnvVar, out *EnvVar) error {
 			out.Value = in.Value
 			out.Key = in.Name
 			out.Name = in.Name
 			return nil
 		},
-		func(in *v1beta1.EnvVar, out *EnvVar) error {
+		func(in *EnvVar, out *newer.EnvVar) error {
 			out.Value = in.Value
 			if in.Name != "" {
 				out.Name = in.Name
@@ -43,7 +46,7 @@ func init() {
 		},
 
 		// Path & MountType are deprecated.
-		func(in *VolumeMount, out *v1beta1.VolumeMount) error {
+		func(in *newer.VolumeMount, out *VolumeMount) error {
 			out.Name = in.Name
 			out.ReadOnly = in.ReadOnly
 			out.MountPath = in.MountPath
@@ -51,7 +54,7 @@ func init() {
 			out.MountType = "" // MountType is ignored.
 			return nil
 		},
-		func(in *v1beta1.VolumeMount, out *VolumeMount) error {
+		func(in *VolumeMount, out *newer.VolumeMount) error {
 			out.Name = in.Name
 			out.ReadOnly = in.ReadOnly
 			if in.MountPath == "" {
@@ -63,13 +66,13 @@ func init() {
 		},
 
 		// MinionList.Items had a wrong name in v1beta1
-		func(in *MinionList, out *v1beta1.MinionList) error {
+		func(in *newer.MinionList, out *MinionList) error {
 			Convert(&in.JSONBase, &out.JSONBase)
 			Convert(&in.Items, &out.Items)
 			out.Minions = out.Items
 			return nil
 		},
-		func(in *v1beta1.MinionList, out *MinionList) error {
+		func(in *MinionList, out *newer.MinionList) error {
 			Convert(&in.JSONBase, &out.JSONBase)
 			if len(in.Items) == 0 {
 				Convert(&in.Minions, &out.Items)

--- a/pkg/api/v1beta1/conversion_test.go
+++ b/pkg/api/v1beta1/conversion_test.go
@@ -14,26 +14,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package api
+package v1beta1_test
 
 import (
 	"reflect"
 	"testing"
 
+	newer "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 )
+
+var Convert = newer.Convert
 
 func TestEnvConversion(t *testing.T) {
 	nonCanonical := []v1beta1.EnvVar{
 		{Key: "EV"},
 		{Key: "EV", Name: "EX"},
 	}
-	canonical := []EnvVar{
+	canonical := []newer.EnvVar{
 		{Name: "EV"},
 		{Name: "EX"},
 	}
 	for i := range nonCanonical {
-		var got EnvVar
+		var got newer.EnvVar
 		err := Convert(&nonCanonical[i], &got)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -61,11 +64,11 @@ func TestEnvConversion(t *testing.T) {
 
 func TestVolumeMountConversionToOld(t *testing.T) {
 	table := []struct {
-		in  VolumeMount
+		in  newer.VolumeMount
 		out v1beta1.VolumeMount
 	}{
 		{
-			in:  VolumeMount{Name: "foo", MountPath: "/dev/foo", ReadOnly: true},
+			in:  newer.VolumeMount{Name: "foo", MountPath: "/dev/foo", ReadOnly: true},
 			out: v1beta1.VolumeMount{Name: "foo", MountPath: "/dev/foo", Path: "/dev/foo", ReadOnly: true},
 		},
 	}
@@ -85,21 +88,21 @@ func TestVolumeMountConversionToOld(t *testing.T) {
 func TestVolumeMountConversionToNew(t *testing.T) {
 	table := []struct {
 		in  v1beta1.VolumeMount
-		out VolumeMount
+		out newer.VolumeMount
 	}{
 		{
 			in:  v1beta1.VolumeMount{Name: "foo", MountPath: "/dev/foo", ReadOnly: true},
-			out: VolumeMount{Name: "foo", MountPath: "/dev/foo", ReadOnly: true},
+			out: newer.VolumeMount{Name: "foo", MountPath: "/dev/foo", ReadOnly: true},
 		}, {
 			in:  v1beta1.VolumeMount{Name: "foo", MountPath: "/dev/foo", Path: "/dev/bar", ReadOnly: true},
-			out: VolumeMount{Name: "foo", MountPath: "/dev/foo", ReadOnly: true},
+			out: newer.VolumeMount{Name: "foo", MountPath: "/dev/foo", ReadOnly: true},
 		}, {
 			in:  v1beta1.VolumeMount{Name: "foo", Path: "/dev/bar", ReadOnly: true},
-			out: VolumeMount{Name: "foo", MountPath: "/dev/bar", ReadOnly: true},
+			out: newer.VolumeMount{Name: "foo", MountPath: "/dev/bar", ReadOnly: true},
 		},
 	}
 	for _, item := range table {
-		got := VolumeMount{}
+		got := newer.VolumeMount{}
 		err := Convert(&item.in, &got)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
@@ -115,39 +118,39 @@ func TestMinionListConversionToNew(t *testing.T) {
 	oldMinion := func(id string) v1beta1.Minion {
 		return v1beta1.Minion{JSONBase: v1beta1.JSONBase{ID: id}}
 	}
-	newMinion := func(id string) Minion {
-		return Minion{JSONBase: JSONBase{ID: id}}
+	newMinion := func(id string) newer.Minion {
+		return newer.Minion{JSONBase: newer.JSONBase{ID: id}}
 	}
 	oldMinions := []v1beta1.Minion{
 		oldMinion("foo"),
 		oldMinion("bar"),
 	}
-	newMinions := []Minion{
+	newMinions := []newer.Minion{
 		newMinion("foo"),
 		newMinion("bar"),
 	}
 
 	table := []struct {
 		oldML *v1beta1.MinionList
-		newML *MinionList
+		newML *newer.MinionList
 	}{
 		{
 			oldML: &v1beta1.MinionList{Items: oldMinions},
-			newML: &MinionList{Items: newMinions},
+			newML: &newer.MinionList{Items: newMinions},
 		}, {
 			oldML: &v1beta1.MinionList{Minions: oldMinions},
-			newML: &MinionList{Items: newMinions},
+			newML: &newer.MinionList{Items: newMinions},
 		}, {
 			oldML: &v1beta1.MinionList{
 				Items:   oldMinions,
 				Minions: []v1beta1.Minion{oldMinion("baz")},
 			},
-			newML: &MinionList{Items: newMinions},
+			newML: &newer.MinionList{Items: newMinions},
 		},
 	}
 
 	for _, item := range table {
-		got := &MinionList{}
+		got := &newer.MinionList{}
 		err := Convert(item.oldML, got)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
@@ -162,19 +165,19 @@ func TestMinionListConversionToOld(t *testing.T) {
 	oldMinion := func(id string) v1beta1.Minion {
 		return v1beta1.Minion{JSONBase: v1beta1.JSONBase{ID: id}}
 	}
-	newMinion := func(id string) Minion {
-		return Minion{JSONBase: JSONBase{ID: id}}
+	newMinion := func(id string) newer.Minion {
+		return newer.Minion{JSONBase: newer.JSONBase{ID: id}}
 	}
 	oldMinions := []v1beta1.Minion{
 		oldMinion("foo"),
 		oldMinion("bar"),
 	}
-	newMinions := []Minion{
+	newMinions := []newer.Minion{
 		newMinion("foo"),
 		newMinion("bar"),
 	}
 
-	newML := &MinionList{Items: newMinions}
+	newML := &newer.MinionList{Items: newMinions}
 	oldML := &v1beta1.MinionList{
 		Items:   oldMinions,
 		Minions: oldMinions,

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+func init() {
+	api.AddKnownTypes("v1beta1",
+		PodList{},
+		Pod{},
+		ReplicationControllerList{},
+		ReplicationController{},
+		ServiceList{},
+		Service{},
+		MinionList{},
+		Minion{},
+		Status{},
+		ServerOpList{},
+		ServerOp{},
+		ContainerManifestList{},
+		Endpoints{},
+		Binding{},
+	)
+}

--- a/pkg/apiserver/operation_test.go
+++ b/pkg/apiserver/operation_test.go
@@ -25,7 +25,9 @@ import (
 	"testing"
 	"time"
 
+	// TODO: remove dependency on api, apiserver should be generic
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 )
 
 func TestOperation(t *testing.T) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"

--- a/pkg/kubelet/config/etcd.go
+++ b/pkg/kubelet/config/etcd.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"

--- a/pkg/registry/binding/storage_test.go
+++ b/pkg/registry/binding/storage_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 )
 

--- a/pkg/registry/etcd/etcd_test.go
+++ b/pkg/registry/etcd/etcd_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"

--- a/pkg/tools/decoder_test.go
+++ b/pkg/tools/decoder_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 


### PR DESCRIPTION
This is some cleanup that has been needed for a while.
There's still one more step that could usefully be done, which is to
split up our api package into the part that provides the helper
functions and the part that provides the internal types. That can come
later.

The v1beta1 package is now a good example of what an api plugin should
do to version its types.
