### PR TITLE
Rackspace: fix apiserver salt config

### DIFF
--- a/cluster/rackspace/cloud-config/master-cloud-config.yaml
+++ b/cluster/rackspace/cloud-config/master-cloud-config.yaml
@@ -6,6 +6,7 @@ write_files:
       roles:
         - kubernetes-master
       cloud: rackspace
+      etcd_servers: KUBE_MASTER
   path: /etc/salt/minion.d/grains.conf
 - content: |
     auto_accept: True

--- a/cluster/rackspace/kube-up.sh
+++ b/cluster/rackspace/kube-up.sh
@@ -31,6 +31,7 @@ echo "Starting cluster using provider: $KUBERNETES_PROVIDER"
 verify-prereqs
 kube-up
 
-source $(dirname $0)/validate-cluster.sh
+# skipping validation for now until since machines show up as private IPs
+# source $(dirname $0)/validate-cluster.sh
 
 echo "Done"

--- a/cluster/saltbase/salt/apiserver/default
+++ b/cluster/saltbase/salt/apiserver/default
@@ -28,7 +28,7 @@
   MACHINES="{{ salt['mine.get']('roles:kubernetes-pool', 'grains.items', expr_form='grain').values()|join(',', attribute='hostnamef') }}"
   {% set machines = "-machines $MACHINES" %}
 {% endif %}
-{% if grains.cloud == 'rackspace' or grains.cloud == 'vsphere' %}
+{% if grains.cloud == 'vsphere' %}
   # Collect IPs of minions as machines list.
   #
   # Use a bash array to build the value we need. Jinja 2.7 does support a 'map'
@@ -40,6 +40,15 @@
   {% endfor %}
   {% set machines = "-machines=$(echo ${MACHINE_IPS[@]} | xargs -n1 echo | paste -sd,)" %}
   {% set minion_regexp = "" %}
+{% endif %}
+{%- if grains.cloud == 'rackspace' %}
+  {%- set ip_addrs = [] %}
+  {%- for addrs in salt['mine.get']('roles:kubernetes-pool', 'grains.items', expr_form='grain').values() %}
+    {%- do ip_addrs.append(addrs.ip_interfaces.eth2[0]) %}
+  {%- endfor %}
+    MACHINES="{{ip_addrs|join(',')}}"
+  {%- set machines = "-machines=$MACHINES" %}
+  {%- set minion_regexp = "" %}
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
This is the fix for issue https://github.com/GoogleCloudPlatform/kubernetes/issues/1089 which broke the Rackspace configuration. This PR is restoring working functionality and making a few additional changes:
1. Use minion's ip addresses from eth2 for apiserver
2. Complete the basic sanity checking
3. move etcd communication off eth0 and onto eth2

NOTE: I used a non-standard jinja function, `do` to avoid the bash array. I tested this on our Wheezy image and didn't see a problem but please confirm this doesn't cause any jinja template problems on GCE:

``` python
{%- if grains.cloud == 'rackspace' %}
  {%- set ip_addrs = [] %}
  {%- for addrs in salt['mine.get']('roles:kubernetes-pool', 'grains.items', expr_form='grain').values() %}
    {%- do ip_addrs.append(addrs.ip_interfaces.eth2[0]) %}
  {%- endfor %}
    MACHINES="{{ip_addrs|join(',')}}"
  {%- set machines = "-machines=$MACHINES" %}
  {%- set minion_regexp = "" %}
{% endif %}
```

Any comments welcome.

This isn't a rush so we can wait till Monday seeing as it's late Friday afternoon.
