### PR TITLE
Push major and minor versions from git

### DIFF
--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -47,6 +47,12 @@ kube::version_ldflags() {
 
       # Use git describe to find the version based on annotated tags.
       if git_version=$(git describe --abbrev=14 "${git_commit}^{commit}" 2>/dev/null); then
+        if [[ "${git_tree_state}" == "dirty" ]]; then
+          # git describe --dirty only considers changes to existing files, but
+          # that is problematic since new untracked .go files affect the build,
+          # so use our idea of "dirty" from git status instead.
+          git_version+="-dirty"
+        fi
         ldflags+=(-X "${KUBE_GO_PACKAGE}/pkg/version.gitVersion" "${git_version}")
       fi
     fi

--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -54,6 +54,21 @@ kube::version_ldflags() {
           git_version+="-dirty"
         fi
         ldflags+=(-X "${KUBE_GO_PACKAGE}/pkg/version.gitVersion" "${git_version}")
+
+        # Try to match the "git describe" output to a regex to try to extract
+        # the "major" and "minor" versions and whether this is the exact tagged
+        # version or whether the tree is between two tagged versions.
+        if [[ "${git_version}" =~ ^v([0-9]+)\.([0-9]+)([.-].*)?$ ]]; then
+          git_major=${BASH_REMATCH[1]}
+          git_minor=${BASH_REMATCH[2]}
+          if [[ -n "${BASH_REMATCH[3]}" ]]; then
+            git_minor+="+"
+          fi
+          ldflags+=(
+            -X "${KUBE_GO_PACKAGE}/pkg/version.gitMajor" "${git_major}"
+            -X "${KUBE_GO_PACKAGE}/pkg/version.gitMinor" "${git_minor}"
+          )
+        fi
       fi
     fi
 


### PR DESCRIPTION
Use the output of "git describe" (which bases it on annotated tags) to define the major and minor versions in the version.Info.

The minor version includes a "+" suffix whenever the version doesn't match a tag exactly, to indicate that modifications exist from that exact version, but it's a good approximation of the version being between X.Y and X.(Y+1)

Tested with a bunch of annotated tags and in cases where the tree is clean or dirty.

(This patchset also includes the patches in #1121, just because I used them to test these... I'll lock this merge until that one has been resolved. Let me know if you'd like me to rebase these without those, that would be possible as there's really no dependency between them.)
