### PR TITLE
Fix a wrong explaining text about running command to create replication controllers.

### DIFF
--- a/examples/guestbook/README.md
+++ b/examples/guestbook/README.md
@@ -131,7 +131,7 @@ Use the file `examples/guestbook/redis-slave-controller.json`
 }
 ```
 
-to create the service by running:
+to create the replication controller by running:
 
 ```shell
 $ cluster/kubecfg.sh -c examples/guestbook/redis-slave-controller.json create replicationControllers


### PR DESCRIPTION
At [Step Three Turn up the replicated slave pods.](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/examples/guestbook/README.md#step-three-turn-up-the-replicated-slave-pods), 

It is described like below, 

```
to create the service by running:
$ cluster/kubecfg.sh -c examples/guestbook/redis-slave-controller.json create replicationControllers
```

But in this place,  create a replication controller, I guess should be like below.

```
to create the replication controller by running:
```
