### PR TITLE
Fix pod status error with List method.

### DIFF
--- a/pkg/registry/pod/storage.go
+++ b/pkg/registry/pod/storage.go
@@ -108,7 +108,10 @@ func (rs *RegistryStorage) List(selector labels.Selector) (interface{}, error) {
 	pods, err := rs.registry.ListPods(selector)
 	if err == nil {
 		for i := range pods.Items {
-			rs.fillPodInfo(&pods.Items[i])
+			pod := &pods.Items[i]
+			rs.fillPodInfo(pod)
+			pod.CurrentState.Status = getPodStatus(pod)
+			pod.CurrentState.HostIP = getInstanceIP(rs.cloudProvider, pod.CurrentState.Host)
 		}
 	}
 	return pods, err


### PR DESCRIPTION
Fix for issue #1109.  This PR populate pod current status and hostIP by adding two extra method call, though I think we can combine them into fillPodInfo, so Get and List will have the same code path.
