### PR TITLE
Introduce the simplest RestartPolicy and handling.

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -58,9 +58,10 @@ type ContainerManifest struct {
 	// TODO: UUID on Manifest is deprecated in the future once we are done
 	// with the API refactoring. It is required for now to determine the instance
 	// of a Pod.
-	UUID       string      `yaml:"uuid,omitempty" json:"uuid,omitempty"`
-	Volumes    []Volume    `yaml:"volumes" json:"volumes"`
-	Containers []Container `yaml:"containers" json:"containers"`
+	UUID          string        `yaml:"uuid,omitempty" json:"uuid,omitempty"`
+	Volumes       []Volume      `yaml:"volumes" json:"volumes"`
+	Containers    []Container   `yaml:"containers" json:"containers"`
+	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty" yaml:"restartPolicy,omitempty"`
 }
 
 // ContainerManifestList is used to communicate container manifests to kubelet.
@@ -254,19 +255,21 @@ const (
 // PodInfo contains one entry for every container with available info.
 type PodInfo map[string]docker.Container
 
-// RestartPolicyType represents a restart policy for a pod.
-type RestartPolicyType string
+type RestartPolicyAlways struct{}
 
-// Valid restart policies defined for a PodState.RestartPolicy.
-const (
-	RestartAlways    RestartPolicyType = "RestartAlways"
-	RestartOnFailure RestartPolicyType = "RestartOnFailure"
-	RestartNever     RestartPolicyType = "RestartNever"
-)
+// TODO(dchen1107): Define what kinds of failures should restart.
+// TODO(dchen1107): Decide whether to support policy knobs, and, if so, which ones.
+type RestartPolicyOnFailure struct{}
+
+type RestartPolicyNever struct{}
 
 type RestartPolicy struct {
-	// Optional: Defaults to "RestartAlways".
-	Type RestartPolicyType `yaml:"type,omitempty" json:"type,omitempty"`
+	// Only one of the following restart policies may be specified.
+	// If none of the following policies is specified, the default one
+	// is RestartPolicyAlways.
+	Always    *RestartPolicyAlways    `json:"always,omitempty" yaml:"always,omitempty"`
+	OnFailure *RestartPolicyOnFailure `json:"onFailure,omitempty" yaml:"onFailure,omitempty"`
+	Never     *RestartPolicyNever     `json:"never,omitempty" yaml:"never,omitempty"`
 }
 
 // PodState is the state of a pod, used as either input (desired state) or output (current state).
@@ -283,8 +286,7 @@ type PodState struct {
 	// upon.
 	// TODO: Make real decisions about what our info should look like. Re-enable fuzz test
 	// when we have done this.
-	Info          PodInfo       `json:"info,omitempty" yaml:"info,omitempty"`
-	RestartPolicy RestartPolicy `json:"restartpolicy,omitempty" yaml:"restartpolicy,omitempty"`
+	Info PodInfo `json:"info,omitempty" yaml:"info,omitempty"`
 }
 
 // PodList is a list of Pods.

--- a/pkg/kubelet/config/config_test.go
+++ b/pkg/kubelet/config/config_test.go
@@ -52,7 +52,8 @@ func CreateValidPod(name, namespace string) kubelet.Pod {
 		Name:      name,
 		Namespace: namespace,
 		Manifest: api.ContainerManifest{
-			Version: "v1beta1",
+			Version:       "v1beta1",
+			RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
 		},
 	}
 }

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -105,8 +105,12 @@ func TestExtractFromHTTP(t *testing.T) {
 			manifests: api.ContainerManifest{Version: "v1beta1", ID: "foo"},
 			expected: CreatePodUpdate(kubelet.SET,
 				kubelet.Pod{
-					Name:     "foo",
-					Manifest: api.ContainerManifest{Version: "v1beta1", ID: "foo"},
+					Name: "foo",
+					Manifest: api.ContainerManifest{
+						Version:       "v1beta1",
+						ID:            "foo",
+						RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+					},
 				}),
 		},
 		{

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -300,7 +300,7 @@ func TestSyncPodsCreatesNetAndContainer(t *testing.T) {
 	kubelet.drainWorkers()
 
 	verifyCalls(t, fakeDocker, []string{
-		"list", "list", "create", "start", "list", "inspect", "create", "start"})
+		"list", "list", "create", "start", "list", "inspect", "list", "create", "start"})
 
 	fakeDocker.lock.Lock()
 	if len(fakeDocker.Created) != 2 ||
@@ -338,7 +338,7 @@ func TestSyncPodsWithNetCreatesContainer(t *testing.T) {
 	kubelet.drainWorkers()
 
 	verifyCalls(t, fakeDocker, []string{
-		"list", "list", "list", "inspect", "create", "start"})
+		"list", "list", "list", "inspect", "list", "create", "start"})
 
 	fakeDocker.lock.Lock()
 	if len(fakeDocker.Created) != 1 ||
@@ -388,7 +388,7 @@ func TestSyncPodsWithNetCreatesContainerCallsHandler(t *testing.T) {
 	kubelet.drainWorkers()
 
 	verifyCalls(t, fakeDocker, []string{
-		"list", "list", "list", "inspect", "create", "start"})
+		"list", "list", "list", "inspect", "list", "create", "start"})
 
 	fakeDocker.lock.Lock()
 	if len(fakeDocker.Created) != 1 ||
@@ -428,7 +428,7 @@ func TestSyncPodsDeletesWithNoNetContainer(t *testing.T) {
 	kubelet.drainWorkers()
 
 	verifyCalls(t, fakeDocker, []string{
-		"list", "list", "stop", "create", "start", "list", "list", "inspect", "create", "start"})
+		"list", "list", "stop", "create", "start", "list", "list", "inspect", "list", "create", "start"})
 
 	// A map iteration is used to delete containers, so must not depend on
 	// order here.
@@ -561,7 +561,7 @@ func TestSyncPodBadHash(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	verifyCalls(t, fakeDocker, []string{"list", "stop", "create", "start"})
+	verifyCalls(t, fakeDocker, []string{"list", "stop", "list", "create", "start"})
 
 	// A map interation is used to delete containers, so must not depend on
 	// order here.
@@ -608,7 +608,7 @@ func TestSyncPodUnhealthy(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	verifyCalls(t, fakeDocker, []string{"list", "stop", "create", "start"})
+	verifyCalls(t, fakeDocker, []string{"list", "stop", "list", "create", "start"})
 
 	// A map interation is used to delete containers, so must not depend on
 	// order here.
@@ -1329,7 +1329,7 @@ func TestSyncPodEventHandlerFails(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	verifyCalls(t, fakeDocker, []string{"list", "create", "start", "stop"})
+	verifyCalls(t, fakeDocker, []string{"list", "list", "create", "start", "stop"})
 
 	if len(fakeDocker.stopped) != 1 {
 		t.Errorf("Wrong containers were stopped: %v", fakeDocker.stopped)


### PR DESCRIPTION
I am still adding unittests to the PR. But since I have hold this PR for too long, and know someone are waiting for this, I decided to cut it simple and sent it out for the initial review. I ran manual tests with all three different restart policy: Never, Always, and OnFailure, all are working. 

Besides unittests, to make sure the whole workflow with restart work fine, there are TODOs listed below, and I will include them in separate PRs:

1) Status defined for Pod only have 3 types: Running, Waiting and Terminated. When a container in Pod are failed, and shouldn't restart based on RestartPolicy, the Status of Pod is changed to Waiting from Running, which is wrong. Should we introduce a new Status type, such as Error here?

2) GetPodStatus only gets current running Container info from Docker. We should include previous failed container info too.

3) Pod's CurrentState should have how many attempts on restart.

4) When kubecfg delete pods, it should call DockerClient.RemoveContainer too; otherwise the GetRecentDockerContainersWithName will include previous dead containers, and mess up maxAttempts logic.

5) DelaySeconds should be checked before running a container
