### PR TITLE
In hack/test-go.sh, treat arguments that start with a dash as go flags.

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -44,13 +44,18 @@ if [[ $# == 0 ]]; then
       plugin/cmd/scheduler
 fi
 
-binaries=()
-for arg; do
-  binaries+=("${KUBE_GO_PACKAGE}/${arg}")
-done
-
 # Use eval to preserve embedded quoted strings.
 eval "goflags=(${GOFLAGS:-})"
+
+binaries=()
+for arg; do
+  if [[ "${arg}" == -* ]]; then
+    # Assume arguments starting with a dash are flags to pass to go.
+    goflags+=("${arg}")
+  else
+    binaries+=("${KUBE_GO_PACKAGE}/${arg}")
+  fi
+done
 
 # Note that the flags to 'go build' are duplicated in the salt build setup
 # (release/build-release.sh) for our cluster deploy.  If we add more command

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -94,6 +94,17 @@ shift $((OPTIND - 1))
 # Use eval to preserve embedded quoted strings.
 eval "goflags=(${GOFLAGS:-})"
 
+# Filter out arguments that start with "-" and move them to goflags.
+testcases=()
+for arg; do
+  if [[ "${arg}" == -* ]]; then
+    goflags+=("${arg}")
+  else
+    testcases+=("${arg}")
+  fi
+done
+set -- ${testcases[@]+"${testcases[@]}"}
+
 if [[ "${iterations}" -gt 1 ]]; then
   if [[ $# -eq 0 ]]; then
     set -- $(find_test_dirs)


### PR DESCRIPTION
This fixes `hack/test-go.sh pkg/apiserver -test.run=<a_specific_test_name>`
which was broken by PR #1116.

@thockin 
@smarterclayton 
