### PR TITLE
Support configurations for cloudproviders

### DIFF
--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -18,6 +18,7 @@ package gce_cloud
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -40,7 +41,7 @@ type GCECloud struct {
 }
 
 func init() {
-	cloudprovider.RegisterCloudProvider("gce", func() (cloudprovider.Interface, error) { return newGCECloud() })
+	cloudprovider.RegisterCloudProvider("gce", func(config io.Reader) (cloudprovider.Interface, error) { return newGCECloud() })
 }
 
 func getProjectAndZone() (string, string, error) {

--- a/pkg/cloudprovider/plugins.go
+++ b/pkg/cloudprovider/plugins.go
@@ -17,13 +17,17 @@ limitations under the License.
 package cloudprovider
 
 import (
+	"io"
 	"sync"
 
 	"github.com/golang/glog"
 )
 
 // Factory is a function that returns a cloudprovider.Interface.
-type Factory func() (Interface, error)
+// The config parameter provides an io.Reader handler to the factory in
+// order to load specific configurations. If no configuration is provided
+// the parameter is nil.
+type Factory func(config io.Reader) (Interface, error)
 
 // All registered cloud providers.
 var providersMutex sync.Mutex
@@ -44,13 +48,15 @@ func RegisterCloudProvider(name string, cloud Factory) {
 
 // GetCloudProvider creates an instance of the named cloud provider, or nil if
 // the name is not known.  The error return is only used if the named provider
-// was known but failed to initialize.
-func GetCloudProvider(name string) (Interface, error) {
+// was known but failed to initialize. The config parameter specifies the
+// io.Reader handler of the configuration file for the cloud provider, or nil
+// for no configuation.
+func GetCloudProvider(name string, config io.Reader) (Interface, error) {
 	providersMutex.Lock()
 	defer providersMutex.Unlock()
 	f, found := providers[name]
 	if !found {
 		return nil, nil
 	}
-	return f()
+	return f(config)
 }

--- a/pkg/cloudprovider/vagrant/vagrant.go
+++ b/pkg/cloudprovider/vagrant/vagrant.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -38,7 +39,7 @@ type VagrantCloud struct {
 }
 
 func init() {
-	cloudprovider.RegisterCloudProvider("vagrant", func() (cloudprovider.Interface, error) { return newVagrantCloud() })
+	cloudprovider.RegisterCloudProvider("vagrant", func(config io.Reader) (cloudprovider.Interface, error) { return newVagrantCloud() })
 }
 
 // SaltToken is an authorization token required by Salt REST API.


### PR DESCRIPTION
Cloud providers may need specific configurations to run properly (e.g. authentication parameters, uri, etc.).

This patch adds the simplest implementation for passing configurations to cloudproviders: a new apiserver -cloud_config flag to specify the path to an arbitrary configuration file.
