### PR TITLE
Use go build, not go install because of golang issue

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -49,7 +49,9 @@ eval "goflags=(${GOFLAGS:-})"
 
 binaries=()
 for arg; do
-  if [[ "${arg}" == -* ]]; then
+  if [[ "${arg}" == "--build" ]]; then
+    USE_BUILD=true
+  elif [[ "${arg}" == -* ]]; then
     # Assume arguments starting with a dash are flags to pass to go.
     goflags+=("${arg}")
   else
@@ -61,6 +63,17 @@ done
 # (release/build-release.sh) for our cluster deploy.  If we add more command
 # line options to our standard build we'll want to duplicate them there.  As we
 # move to distributing pre- built binaries we can eliminate this duplication.
-go install "${goflags[@]:+${goflags[@]}}" \
-    -ldflags "${version_ldflags}" \
-    "${binaries[@]}"
+if [[ -n ${USE_BUILD-} ]]; then
+  for bin in "${binaries[@]}"; do
+    echo "+++ Building ${bin}"
+    binary_name=$(basename "${bin}")
+    go build -o "${KUBE_TARGET}/bin/${binary_name}" \
+	    "${goflags[@]:+${goflags[@]}}" \
+	    -ldflags "${version_ldflags}" \
+	    "${bin}"
+  done
+else
+  go install "${goflags[@]:+${goflags[@]}}" \
+      -ldflags "${version_ldflags}" \
+      "${binaries[@]}"
+fi


### PR DESCRIPTION
If you don't have write permission to the location of the 3rd party
deps, you can't use go install
  https://code.google.com/p/go/issues/detail?id=8521
