### PR TITLE
Sketch of idea for package to index data in etcd.  DO NOT MERGE

### DIFF
--- a/pkg/etcdex/doc.go
+++ b/pkg/etcdex/doc.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package etcdex provides a read-only "coherent" in-memory content-addressible cache of etcd content.
+//
+// It assumes that etcd is being according to the following extended analogy:
+// Etcd concept                 : Relation Database Concept :: 
+// 
+// tree rooted at "dir"         : Table ::
+// etcd file part after "dir"   : Primary Key ::
+// etcd value (must be JSON)    : Row (except Primary Key) ::
+// union of all fully qualified 
+// JSON property names of etcd 
+// values in "dir"              : Columns of a Table ::
+//
+// It provides for the creation of "indexes" of "tables" stored in etcd.
+// The name is a contraction of etcd and index.
+// It is not intended to be a completehttp://en.wikipedia.org/wiki/Object-relational_mapping
+// It watches etcd to keep its indexes up to date.
+//

--- a/pkg/etcdex/doc.go
+++ b/pkg/etcdex/doc.go
@@ -16,18 +16,19 @@ limitations under the License.
 
 // Package etcdex provides a read-only "coherent" in-memory content-addressible cache of etcd content.
 //
-// It assumes that etcd is being according to the following extended analogy:
-// Etcd concept                 : Relation Database Concept :: 
-// 
+// It assumes that etcd is being used according to the following extended analogy:
+// Etcd concept                 : Relational Database Concept ::
+//
 // tree rooted at "dir"         : Table ::
 // etcd file part after "dir"   : Primary Key ::
 // etcd value (must be JSON)    : Row (except Primary Key) ::
-// union of all fully qualified 
-// JSON property names of etcd 
-// values in "dir"              : Columns of a Table ::
+// union of all fully qualified
+// JSON property names of etcd
+// values in "dir"              : Columns of a Table
 //
 // It provides for the creation of "indexes" of "tables" stored in etcd.
 // The name is a contraction of etcd and index.
 // It is not intended to be a completehttp://en.wikipedia.org/wiki/Object-relational_mapping
 // It watches etcd to keep its indexes up to date.
-//
+
+package etcdex

--- a/pkg/etcdex/etcdex.go
+++ b/pkg/etcdex/etcdex.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcdex
+
+// Types of indexes that etcdex can maintain.
+
+// Set holds a read-only set of strings with efficient membership checking.
+// Membership is maintained by hidden goroutines.
+type Set interface {
+  Contains(key string) bool
+}
+
+// Map holds a read-only map[string]string.
+// Membership is maintained by hidden goroutines.
+type Map interface {
+  Get(key string) string
+}
+
+// MultiMap holds a read-only map[string](map[string]string]).
+// Membership is maintained by hidden goroutines.
+type MultiMap interface {
+  Get(key string) Set
+}
+
+type Client inteface {
+  // IndexKeys creates, or returns a reference to an existing, Set of all the keys under etcdPathPfx. 
+  // It also causes the membership of the Set to be maintained by goroutines that watch etcd.
+  IndexKeys(etcdPathPfx string) *Set
+
+  // IndexKeysAndValues creates, or returns a reference to an existing, Map of all the keys and values under etcdPathPfx. 
+  // It also causes the membership of the Map to be maintained by goroutines that watch etcd.
+  IndexKeysAndValues(etcdPathPfx string) *Map
+
+  // IndexKeysAndSubValues creates, or returns a reference to an existing, Map of all the keys under etcdPathPfx,
+  // and a part of each key's value.
+  // It also causes the membership of the Map to be maintained by goroutines that watch etcd.
+  // The value in the Map is a single field of the etcd value type, where the latter must be a JSON string.
+  // IndexKeysAndSubValues is less CPU effiicent than IndexKeysAndValues since it has to decode JSON,
+  // but more memory efficient since it discards parts of the value type that are not needed.
+  IndexKeysAndSubValues(etcdPathPfx string, subValueProjectionExpression string) *Map
+
+  // InvertedIndex creates, or returns a reference to an existing, MultiMap.
+  // The Multimap's keys are unique values of property names of (JSON) etcd values.
+  // The Multimap's value-Set contains all the etcd keys with that sub-value.
+  InvertedIndex(etcdPathPfx string, subValueProjectionExpression string) *MulitMap
+}
+
+// New makes a new Client to etcd and allow for creation of, and holds, indexes.
+// TODO: be able to dedup redundant Clients and/or Indexes at the go Package Level
+ func newConnection(p etcdConnectionParams) Connection
+
+// TODO: make a transaction object, and have any index lookups done while that transaction is open
+// cause the indexes state to be recorded, and then at commit time, do writes to etcd conditional 
+// on the state of the indexes not having changed.
+
+
+/**** Implementation ****/
+
+
+type client struct {
+
+  // collection of Indexes
+
+  // connection to etcd, and watches on all relevant "dirs".
+}
+
+func (*client) IndexKeys(etcdPatchPfx string) *Set {
+  // Create a type set.  
+
+  // Start a goroutine to Watch this path prefix if not already watched.
+
+  // Start a goroutine to subscribe to that Watch and to insert/delete changes into this particular set.
+
+  // return pointer to set as Set interface.
+}
+// Similarly for other methods of Client ...
+
+type set struct {
+  data map[string]bool
+
+}
+// Similarly for Map and MultiMap ...
+
+func (*set) Contains(key string) {
+  // Acquire lock.
+  return data[key]
+}
+// Similarly for Map and MultiMap ...
+
+// Alternate more-go-ish implementation:
+// - actual storage (e.g. map[string]string) is private to an index object.
+// - index object listens on channel for read/write requests and handles in series.
+// - The Set/Map/MultiMap object returned to the user sends read requests over a that channel.
+
+// TODO: transactions:
+// This would appear to require that all etcd writers to tables requiring transactions should
+// use some kind of synchronization.  That is beyond the scope of this sketch, but appears needed
+// regardless of whether this sketch is expanded to a full implementation.

--- a/pkg/etcdex/etcdex.go
+++ b/pkg/etcdex/etcdex.go
@@ -61,7 +61,7 @@ type Client inteface {
 
 // New makes a new Client to etcd and allow for creation of, and holds, indexes.
 // TODO: be able to dedup redundant Clients and/or Indexes at the go Package Level
- func newConnection(p etcdConnectionParams) Connection
+ func NewConnection(p etcdConnectionParams) Connection
 
 // TODO: make a transaction object, and have any index lookups done while that transaction is open
 // cause the indexes state to be recorded, and then at commit time, do writes to etcd conditional 
@@ -91,12 +91,12 @@ func (*client) IndexKeys(etcdPatchPfx string) *Set {
 
 type set struct {
   data map[string]bool
-
 }
 // Similarly for Map and MultiMap ...
 
 func (*set) Contains(key string) {
   // Acquire lock.
+  // defer release lock.
   return data[key]
 }
 // Similarly for Map and MultiMap ...

--- a/pkg/etcdex/etcdex_example.go
+++ b/pkg/etcdex/etcdex_example.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package example
+
+import (
+	"fmt"
+
+    "github.com/GoogleCloudPlatform/kubernetes/etcdex"
+    )
+
+edex = etcdex.NewClient()
+
+services = edex.IndexKeys("/registry/service")
+pod_labels = edex.IndexKeysAndValues("/registry/pods", "Labels")
+service_ports = edex.InvertedIndex("/registry/service", "Port")
+
+func CreateService(serviceToCreate) {
+  if services.contains(servicetocreate.id) {
+    fmt.Println("internal error: duplicate service id.")
+   }
+
+  service_id, err = service_ports.Get(servicetocreate.Port)
+  if err != nil {
+    fmt.Println("Warning: Service %s is already using port %d", service_id, serviceToCreate.Port)
+   }
+
+  pods_involved := 0
+  // TODO: think about how I am going to iterate over a list of keys from an index that is changing underneath.
+  for label in pod_labels {
+    if Match(pod_labels, serviceToCreate.Selector) {
+       pods_involved += 1
+    }
+  }
+  fmt.Println("Info: %d pod match selector for new service %s", pods_involved, serviceToCreate.Id)
+}
+


### PR DESCRIPTION
There are several components (apiserver, controller, scheduler) where we will want to:
- lookup an API object by key efficiently (without calling etcd).
- lookup an API object efficiently by something other than its key in etcd

This is a sketch of a more general mechanism.

Feedback of any sort welcomed.  I'm particularly thinking of @lavalamp and @smarterclayton who understand the etcd Watch interface well, which this would interact with.

Alternatives Considered:

We could write custom code for this in each binary that needs to do this.
That seems bad.

We could push changes into etcd to help us with indexing.
However, doing it in a go library allows:
- faster prototyping, without ruling out eventual contrib back to etcd
- control of memory size is responsibility of each go program, rather than etcd
- short-circuits the network path for mostly-read operations, with optimistic concurrency.
