### PR TITLE
Move targets and packages from build-go to config-go

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -48,14 +48,7 @@ for arg; do
 done
 
 if [[ ${#targets[@]} -eq 0 ]]; then
-  targets=(
-    cmd/proxy
-    cmd/apiserver
-    cmd/controller-manager
-    cmd/kubelet
-    cmd/kubecfg
-    plugin/cmd/scheduler
-  )
+  targets=($(kube::default_build_targets))
 fi
 
 binaries=()

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -51,10 +51,7 @@ if [[ ${#targets[@]} -eq 0 ]]; then
   targets=($(kube::default_build_targets))
 fi
 
-binaries=()
-for target in ${targets[@]}; do
-  binaries+=("${KUBE_GO_PACKAGE}/${target}")
-done
+binaries=($(kube::binaries_from_targets "${targets[@]}"))
 
 echo "Building local go components"
 # Note that the flags to 'go build' are duplicated in the salt build setup

--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -123,6 +123,15 @@ kube::default_build_targets() {
   echo "cmd/kubecfg"
   echo "plugin/cmd/scheduler"
 }
+
+# kube::binaries_from_targets take a list of build targets and return the
+# full go package to be built
+kube::binaries_from_targets() {
+  local target
+  for target; do
+    echo "${KUBE_GO_PACKAGE}/${target}"
+  done
+}
 # --- Environment Variables ---
 
 # KUBE_REPO_ROOT  - Path to the top of the build tree.

--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -114,6 +114,15 @@ kube::setup_go_environment() {
 }
 
 
+# kube::default_build_targets return list of all build targets
+kube::default_build_targets() {
+  echo "cmd/proxy"
+  echo "cmd/apiserver"
+  echo "cmd/controller-manager"
+  echo "cmd/kubelet"
+  echo "cmd/kubecfg"
+  echo "plugin/cmd/scheduler"
+}
 # --- Environment Variables ---
 
 # KUBE_REPO_ROOT  - Path to the top of the build tree.


### PR DESCRIPTION
@filbranden This should help with building things not using the build-go script and doing it by hand.  This should be the last of the 'brains' in build-go.sh
