### PR TITLE
Fix label query in e2e basic.sh

### DIFF
--- a/hack/e2e-suite/basic.sh
+++ b/hack/e2e-suite/basic.sh
@@ -41,7 +41,7 @@ function teardown() {
 
 trap "teardown" EXIT
 
-POD_ID_LIST=$($KUBECFG '-template={{range.Items}}{{.ID}} {{end}}' -l name=myNginx list pods)
+POD_ID_LIST=$($KUBECFG '-template={{range.Items}}{{.ID}} {{end}}' -l replicationController=myNginx list pods)
 # Container turn up on a clean cluster can take a while for the docker image pull.
 ALL_RUNNING=0
 while [ $ALL_RUNNING -ne 1 ]; do


### PR DESCRIPTION
Giving this another try.  I changed the labels applied with `kubecfg run` and didn't fix up all the tests.  My set up was fast enough that things still worked.
