### PR TITLE
Rename Object to EmbeddedObject

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -552,5 +552,5 @@ type WatchEvent struct {
 
 	// For added or modified objects, this is the new object; for deleted objects,
 	// it's the state of the object immediately prior to its deletion.
-	Object runtime.Object
+	Object runtime.EmbeddedObject
 }

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -553,5 +553,5 @@ type WatchEvent struct {
 
 	// For added or modified objects, this is the new object; for deleted objects,
 	// it's the state of the object immediately prior to its deletion.
-	Object runtime.Object
+	Object runtime.EmbeddedObject
 }

--- a/pkg/apiserver/watch.go
+++ b/pkg/apiserver/watch.go
@@ -113,7 +113,7 @@ func (w *WatchServer) HandleWS(ws *websocket.Conn) {
 			}
 			err := websocket.JSON.Send(ws, &api.WatchEvent{
 				Type:   event.Type,
-				Object: runtime.Object{event.Object},
+				Object: runtime.EmbeddedObject{event.Object},
 			})
 			if err != nil {
 				// Client disconnect.
@@ -160,7 +160,7 @@ func (self *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			}
 			err := encoder.Encode(&api.WatchEvent{
 				Type:   event.Type,
-				Object: runtime.Object{event.Object},
+				Object: runtime.EmbeddedObject{event.Object},
 			})
 			if err != nil {
 				// Client disconnect.

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -401,7 +401,7 @@ func TestWatch(t *testing.T) {
 
 		encoder := json.NewEncoder(w)
 		for _, item := range table {
-			encoder.Encode(&api.WatchEvent{item.t, runtime.Object{item.obj}})
+			encoder.Encode(&api.WatchEvent{item.t, runtime.EmbeddedObject{item.obj}})
 			flusher.Flush()
 		}
 	}))

--- a/pkg/kubelet/config/etcd_test.go
+++ b/pkg/kubelet/config/etcd_test.go
@@ -45,14 +45,14 @@ func TestEventToPods(t *testing.T) {
 			input: watch.Event{
 				Object: &api.ContainerManifestList{
 					Items: []api.ContainerManifest{
-						api.ContainerManifest{ID: "foo"},
-						api.ContainerManifest{ID: "bar"},
+						{ID: "foo"},
+						{ID: "bar"},
 					},
 				},
 			},
 			pods: []kubelet.Pod{
-				kubelet.Pod{Name: "foo", Manifest: api.ContainerManifest{ID: "foo"}},
-				kubelet.Pod{Name: "bar", Manifest: api.ContainerManifest{ID: "bar"}},
+				{Name: "foo", Manifest: api.ContainerManifest{ID: "foo"}},
+				{Name: "bar", Manifest: api.ContainerManifest{ID: "bar"}},
 			},
 			fail: false,
 		},
@@ -60,14 +60,14 @@ func TestEventToPods(t *testing.T) {
 			input: watch.Event{
 				Object: &api.ContainerManifestList{
 					Items: []api.ContainerManifest{
-						api.ContainerManifest{ID: ""},
-						api.ContainerManifest{ID: ""},
+						{ID: ""},
+						{ID: ""},
 					},
 				},
 			},
 			pods: []kubelet.Pod{
-				kubelet.Pod{Name: "1", Manifest: api.ContainerManifest{ID: ""}},
-				kubelet.Pod{Name: "2", Manifest: api.ContainerManifest{ID: ""}},
+				{Name: "1", Manifest: api.ContainerManifest{ID: ""}},
+				{Name: "2", Manifest: api.ContainerManifest{ID: ""}},
 			},
 			fail: false,
 		},

--- a/pkg/runtime/embedded.go
+++ b/pkg/runtime/embedded.go
@@ -26,7 +26,7 @@ import (
 // embedded within other API types.
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
-func (a *Object) UnmarshalJSON(b []byte) error {
+func (a *EmbeddedObject) UnmarshalJSON(b []byte) error {
 	// Handle JSON's "null": Decode() doesn't expect it.
 	if len(b) == 4 && string(b) == "null" {
 		a.Object = nil
@@ -42,7 +42,7 @@ func (a *Object) UnmarshalJSON(b []byte) error {
 }
 
 // MarshalJSON implements the json.Marshaler interface.
-func (a Object) MarshalJSON() ([]byte, error) {
+func (a EmbeddedObject) MarshalJSON() ([]byte, error) {
 	if a.Object == nil {
 		// Encode unset/nil objects as JSON's "null".
 		return []byte("null"), nil
@@ -52,7 +52,7 @@ func (a Object) MarshalJSON() ([]byte, error) {
 }
 
 // SetYAML implements the yaml.Setter interface.
-func (a *Object) SetYAML(tag string, value interface{}) bool {
+func (a *EmbeddedObject) SetYAML(tag string, value interface{}) bool {
 	if value == nil {
 		a.Object = nil
 		return true
@@ -76,7 +76,7 @@ func (a *Object) SetYAML(tag string, value interface{}) bool {
 }
 
 // GetYAML implements the yaml.Getter interface.
-func (a Object) GetYAML() (tag string, value interface{}) {
+func (a EmbeddedObject) GetYAML() (tag string, value interface{}) {
 	if a.Object == nil {
 		value = "null"
 		return

--- a/pkg/runtime/embedded_test.go
+++ b/pkg/runtime/embedded_test.go
@@ -22,18 +22,18 @@ import (
 	"testing"
 )
 
-func TestObject(t *testing.T) {
+func TestEmbeddedObject(t *testing.T) {
 	type EmbeddedTest struct {
 		JSONBase    `yaml:",inline" json:",inline"`
-		Object      Object `yaml:"object,omitempty" json:"object,omitempty"`
-		EmptyObject Object `yaml:"emptyObject,omitempty" json:"emptyObject,omitempty"`
+		Object      EmbeddedObject `yaml:"object,omitempty" json:"object,omitempty"`
+		EmptyObject EmbeddedObject `yaml:"emptyObject,omitempty" json:"emptyObject,omitempty"`
 	}
 	AddKnownTypes("", EmbeddedTest{})
 	AddKnownTypes("v1beta1", EmbeddedTest{})
 
 	outer := &EmbeddedTest{
 		JSONBase: JSONBase{ID: "outer"},
-		Object: Object{
+		Object: EmbeddedObject{
 			&EmbeddedTest{
 				JSONBase: JSONBase{ID: "inner"},
 			},

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -42,7 +42,7 @@ type JSONBase struct {
 	APIVersion        string    `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
 }
 
-// Object has appropriate encoder and decoder functions, such that on the wire, it's
+// EmbeddedObject has appropriate encoder and decoder functions, such that on the wire, it's
 // stored as a []byte, but in memory, the contained object is accessable as an interface{}
 // via the Get() function. Only objects having a JSONBase may be stored via Object.
 // The purpose of this is to allow an API object of type known only at runtime to be
@@ -52,7 +52,7 @@ type JSONBase struct {
 //
 // Note that objects will be serialized into the api package's default external versioned type;
 // this should be fixed in the future to use the version of the current Codec instead.
-type Object struct {
+type EmbeddedObject struct {
 	Object interface{}
 }
 

--- a/pkg/tools/decoder_test.go
+++ b/pkg/tools/decoder_test.go
@@ -36,7 +36,7 @@ func TestDecoder(t *testing.T) {
 
 	expect := &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}
 	go func() {
-		err := encoder.Encode(api.WatchEvent{watch.Added, runtime.Object{expect}})
+		err := encoder.Encode(api.WatchEvent{watch.Added, runtime.EmbeddedObject{expect}})
 		if err != nil {
 			t.Errorf("Unexpected error %v", err)
 		}


### PR DESCRIPTION
This is to free up runtime.Object to be used by a new type which will keep us from storing everything in interface{}.
