### PR TITLE
Add continuation to conversion routines

### DIFF
--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -19,22 +19,20 @@ package v1beta1
 import (
 	// Alias this so it can be easily changed when we cut the next version.
 	newer "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
 func init() {
-	// Shortcut for sub-conversions. TODO: This should possibly be refactored
-	// such that this convert function is passed to each conversion func.
-	Convert := runtime.Convert
 	runtime.AddConversionFuncs(
 		// EnvVar's Key is deprecated in favor of Name.
-		func(in *newer.EnvVar, out *EnvVar) error {
+		func(in *newer.EnvVar, out *EnvVar, s conversion.Scope) error {
 			out.Value = in.Value
 			out.Key = in.Name
 			out.Name = in.Name
 			return nil
 		},
-		func(in *EnvVar, out *newer.EnvVar) error {
+		func(in *EnvVar, out *newer.EnvVar, s conversion.Scope) error {
 			out.Value = in.Value
 			if in.Name != "" {
 				out.Name = in.Name
@@ -45,7 +43,7 @@ func init() {
 		},
 
 		// Path & MountType are deprecated.
-		func(in *newer.VolumeMount, out *VolumeMount) error {
+		func(in *newer.VolumeMount, out *VolumeMount, s conversion.Scope) error {
 			out.Name = in.Name
 			out.ReadOnly = in.ReadOnly
 			out.MountPath = in.MountPath
@@ -53,7 +51,7 @@ func init() {
 			out.MountType = "" // MountType is ignored.
 			return nil
 		},
-		func(in *VolumeMount, out *newer.VolumeMount) error {
+		func(in *VolumeMount, out *newer.VolumeMount, s conversion.Scope) error {
 			out.Name = in.Name
 			out.ReadOnly = in.ReadOnly
 			if in.MountPath == "" {
@@ -65,18 +63,18 @@ func init() {
 		},
 
 		// MinionList.Items had a wrong name in v1beta1
-		func(in *newer.MinionList, out *MinionList) error {
-			Convert(&in.JSONBase, &out.JSONBase)
-			Convert(&in.Items, &out.Items)
+		func(in *newer.MinionList, out *MinionList, s conversion.Scope) error {
+			s.Convert(&in.JSONBase, &out.JSONBase, 0)
+			s.Convert(&in.Items, &out.Items, 0)
 			out.Minions = out.Items
 			return nil
 		},
-		func(in *MinionList, out *newer.MinionList) error {
-			Convert(&in.JSONBase, &out.JSONBase)
+		func(in *MinionList, out *newer.MinionList, s conversion.Scope) error {
+			s.Convert(&in.JSONBase, &out.JSONBase, 0)
 			if len(in.Items) == 0 {
-				Convert(&in.Minions, &out.Items)
+				s.Convert(&in.Minions, &out.Items, 0)
 			} else {
-				Convert(&in.Items, &out.Items)
+				s.Convert(&in.Items, &out.Items, 0)
 			}
 			return nil
 		},

--- a/pkg/conversion/converter_test.go
+++ b/pkg/conversion/converter_test.go
@@ -27,28 +27,30 @@ import (
 func TestConverter_CallsRegisteredFunctions(t *testing.T) {
 	type A struct {
 		Foo string
+		Baz int
 	}
 	type B struct {
 		Bar string
+		Baz int
 	}
 	type C struct{}
 	c := NewConverter()
-	err := c.Register(func(in *A, out *B) error {
+	err := c.Register(func(in *A, out *B, s Scope) error {
 		out.Bar = in.Foo
-		return nil
+		return s.Convert(&in.Baz, &out.Baz, 0)
 	})
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
-	err = c.Register(func(in *B, out *A) error {
+	err = c.Register(func(in *B, out *A, s Scope) error {
 		out.Foo = in.Bar
-		return nil
+		return s.Convert(&in.Baz, &out.Baz, 0)
 	})
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 
-	x := A{"hello, intrepid test reader!"}
+	x := A{"hello, intrepid test reader!", 3}
 	y := B{}
 
 	err = c.Convert(&x, &y, 0)
@@ -58,8 +60,11 @@ func TestConverter_CallsRegisteredFunctions(t *testing.T) {
 	if e, a := x.Foo, y.Bar; e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
+	if e, a := x.Baz, y.Baz; e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
 
-	z := B{"all your test are belong to us"}
+	z := B{"all your test are belong to us", 42}
 	w := A{}
 
 	err = c.Convert(&z, &w, 0)
@@ -69,8 +74,11 @@ func TestConverter_CallsRegisteredFunctions(t *testing.T) {
 	if e, a := z.Bar, w.Foo; e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
+	if e, a := z.Baz, w.Baz; e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
 
-	err = c.Register(func(in *A, out *C) error {
+	err = c.Register(func(in *A, out *C, s Scope) error {
 		return fmt.Errorf("C can't store an A, silly")
 	})
 	if err != nil {


### PR DESCRIPTION
This is necessary to make sure that conversion functions use the correct scheme-- will be necessary when we have more than one scheme. Also gives them the chance to pass flags to Convert().
