### PR TITLE
Passing pod UUID to Kubelet.

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -54,7 +54,11 @@ type ContainerManifest struct {
 	Version string `yaml:"version" json:"version"`
 	// Required: This must be a DNS_SUBDOMAIN.
 	// TODO: ID on Manifest is deprecated and will be removed in the future.
-	ID         string      `yaml:"id" json:"id"`
+	ID string `yaml:"id" json:"id"`
+	// TODO: UUID on Manifest is deprecated in the future once we are done
+	// with the API refactoring. It is required for now to determine the instance
+	// of a Pod.
+	UUID       string      `yaml:"uuid,omitempty" json:"uuid,omitempty"`
 	Volumes    []Volume    `yaml:"volumes" json:"volumes"`
 	Containers []Container `yaml:"containers" json:"containers"`
 }

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -54,7 +54,11 @@ type ContainerManifest struct {
 	Version string `yaml:"version" json:"version"`
 	// Required: This must be a DNS_SUBDOMAIN.
 	// TODO: ID on Manifest is deprecated and will be removed in the future.
-	ID         string      `yaml:"id" json:"id"`
+	ID string `yaml:"id" json:"id"`
+	// TODO: UUID on Manifext is deprecated in the future once we are done
+	// with the API refactory. It is required for now to determine the instance
+	// of a Pod.
+	UUID       string      `yaml:"uuid,omitempty" json:"uuid,omitempty"`
 	Volumes    []Volume    `yaml:"volumes" json:"volumes"`
 	Containers []Container `yaml:"containers" json:"containers"`
 }

--- a/pkg/health/exec.go
+++ b/pkg/health/exec.go
@@ -27,7 +27,7 @@ import (
 const defaultHealthyRegex = "^OK$"
 
 type CommandRunner interface {
-	RunInContainer(podFullName, containerName string, cmd []string) ([]byte, error)
+	RunInContainer(podFullName, uuid, containerName string, cmd []string) ([]byte, error)
 }
 
 type ExecHealthChecker struct {
@@ -47,7 +47,7 @@ func (e *ExecHealthChecker) HealthCheck(podFullName string, currentState api.Pod
 	if container.LivenessProbe.Exec == nil {
 		return Unknown, fmt.Errorf("Missing exec parameters")
 	}
-	data, err := e.runner.RunInContainer(podFullName, container.Name, container.LivenessProbe.Exec.Command)
+	data, err := e.runner.RunInContainer(podFullName, currentState.Manifest.UUID, container.Name, container.LivenessProbe.Exec.Command)
 	glog.V(1).Infof("container %s failed health check: %s", podFullName, string(data))
 	if err != nil {
 		if IsExitError(err) {

--- a/pkg/health/exec_test.go
+++ b/pkg/health/exec_test.go
@@ -31,7 +31,7 @@ type FakeExec struct {
 	err error
 }
 
-func (f *FakeExec) RunInContainer(podFullName, container string, cmd []string) ([]byte, error) {
+func (f *FakeExec) RunInContainer(podFullName, uuid, container string, cmd []string) ([]byte, error) {
 	f.cmd = cmd
 	return f.out, f.err
 }

--- a/pkg/kubelet/config/etcd.go
+++ b/pkg/kubelet/config/etcd.go
@@ -99,7 +99,9 @@ func eventToPods(ev watch.Event) ([]kubelet.Pod, error) {
 		if name == "" {
 			name = fmt.Sprintf("%d", i+1)
 		}
-		pods = append(pods, kubelet.Pod{Name: name, Manifest: manifest})
+		pods = append(pods, kubelet.Pod{
+			Name:     name,
+			Manifest: manifest})
 	}
 
 	return pods, nil

--- a/pkg/kubelet/handlers.go
+++ b/pkg/kubelet/handlers.go
@@ -30,8 +30,8 @@ type execActionHandler struct {
 	kubelet *Kubelet
 }
 
-func (e *execActionHandler) Run(podFullName string, container *api.Container, handler *api.Handler) error {
-	_, err := e.kubelet.RunInContainer(podFullName, container.Name, handler.Exec.Command)
+func (e *execActionHandler) Run(podFullName, uuid string, container *api.Container, handler *api.Handler) error {
+	_, err := e.kubelet.RunInContainer(podFullName, uuid, container.Name, handler.Exec.Command)
 	return err
 }
 
@@ -65,11 +65,11 @@ func ResolvePort(portReference util.IntOrString, container *api.Container) (int,
 	return -1, fmt.Errorf("couldn't find port: %v in %v", portReference, container)
 }
 
-func (h *httpActionHandler) Run(podFullName string, container *api.Container, handler *api.Handler) error {
+func (h *httpActionHandler) Run(podFullName, uuid string, container *api.Container, handler *api.Handler) error {
 	host := handler.HTTPGet.Host
 	if len(host) == 0 {
 		var info api.PodInfo
-		info, err := h.kubelet.GetPodInfo(podFullName)
+		info, err := h.kubelet.GetPodInfo(podFullName, uuid)
 		if err != nil {
 			glog.Errorf("unable to get pod info, event handlers may be invalid.")
 			return err

--- a/pkg/registry/pod/storage.go
+++ b/pkg/registry/pod/storage.go
@@ -67,8 +67,9 @@ func NewRegistryStorage(config *RegistryStorageConfig) apiserver.RESTStorage {
 
 func (rs *RegistryStorage) Create(obj runtime.Object) (<-chan runtime.Object, error) {
 	pod := obj.(*api.Pod)
+	pod.DesiredState.Manifest.UUID = uuid.NewUUID().String()
 	if len(pod.ID) == 0 {
-		pod.ID = uuid.NewUUID().String()
+		pod.ID = pod.DesiredState.Manifest.UUID
 	}
 	pod.DesiredState.Manifest.ID = pod.ID
 	if errs := validation.ValidatePod(pod); len(errs) > 0 {

--- a/pkg/registry/pod/storage_test.go
+++ b/pkg/registry/pod/storage_test.go
@@ -99,6 +99,29 @@ func TestCreatePodSetsIds(t *testing.T) {
 	}
 }
 
+func TestCreatePodSetsUUIDs(t *testing.T) {
+	podRegistry := registrytest.NewPodRegistry(nil)
+	podRegistry.Err = fmt.Errorf("test error")
+	storage := RegistryStorage{
+		registry: podRegistry,
+	}
+	desiredState := api.PodState{
+		Manifest: api.ContainerManifest{
+			Version: "v1beta1",
+		},
+	}
+	pod := &api.Pod{DesiredState: desiredState}
+	ch, err := storage.Create(pod)
+	if err != nil {
+		t.Errorf("Expected %#v, Got %#v", nil, err)
+	}
+	expectApiStatusError(t, ch, podRegistry.Err.Error())
+
+	if len(podRegistry.Pod.DesiredState.Manifest.UUID) == 0 {
+		t.Errorf("Expected pod UUID to be set, Got %#v", pod)
+	}
+}
+
 func TestListPodsError(t *testing.T) {
 	podRegistry := registrytest.NewPodRegistry(nil)
 	podRegistry.Err = fmt.Errorf("test error")


### PR DESCRIPTION
We need UUID to indicate the instance of a Pod to make restart work. 
