### PR TITLE
Detangle the use of a Red Hat OS family as requiring openvswitch

### DIFF
--- a/cluster/saltbase/salt/sdn/init.sls
+++ b/cluster/saltbase/salt/sdn/init.sls
@@ -1,4 +1,4 @@
-{% if grains['os_family'] == 'RedHat' %}
+{% if grains.network_mode is defined and grains.network_mode == 'openvswitch' %}
 
 openvswitch:
   pkg:

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -37,6 +37,7 @@ cat <<EOF >/etc/salt/minion.d/grains.conf
 grains:
   node_ip: $MASTER_IP
   master_ip: $MASTER_IP
+  network_mode: openvswitch
   etcd_servers: $MASTER_IP
   cloud_provider: vagrant
   roles:

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -44,6 +44,7 @@ echo "master: $MASTER_NAME" > /etc/salt/minion.d/master.conf
 # Our minions will have a pool role to distinguish them from the master.
 cat <<EOF >/etc/salt/minion.d/grains.conf
 grains:
+  network_mode: openvswitch
   node_ip: $MINION_IP
   etcd_servers: $MASTER_IP
   roles:

--- a/docs/salt.md
+++ b/docs/salt.md
@@ -59,6 +59,7 @@ hostnamef | (Optional) The full host name of the machine, i.e. hostname -f
 master_ip | (Optional) The IP address that the apiserver will bind against
 node_ip | (Optional) The IP address to use to address this node
 minion_ip | (Optional) Mapped to the kubelet hostname_override, K8S TODO - change this name
+network_mode | (Optional) Networking model to use among nodes: *openvswitch*
 roles | (Required) 1. **kubernetes-master** means this machine is the master in the kubernetes cluster.  2. **kubernetes-pool** means this machine is a kubernetes-minion.  Depending on the role, the Salt scripts will provision different resources on the machine.
 
 These keys may be leveraged by the Salt sls files to branch behavior.


### PR DESCRIPTION
The current Salt script hard-coded the use of openvswitch when installing on a Red Hat OS family.

This PR makes the use of openvswitch an explicit setting in the grains.conf file so it can be used by the Vagrant-based cluster for local development, but ignored when using a Red Hat based OS on an alternate cloud provider.

Closes #1152 
