### PR TITLE
Rename all XStorage types to REST for clarity

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -114,19 +114,19 @@ func (m *Master) init(cloud cloudprovider.Interface, podInfoGetter client.PodInf
 	go util.Forever(func() { endpoints.SyncServiceEndpoints() }, time.Second*10)
 
 	m.storage = map[string]apiserver.RESTStorage{
-		"pods": pod.NewRegistryStorage(&pod.RegistryStorageConfig{
+		"pods": pod.NewREST(&pod.RESTConfig{
 			CloudProvider: cloud,
 			PodCache:      podCache,
 			PodInfoGetter: podInfoGetter,
 			Registry:      m.podRegistry,
 		}),
-		"replicationControllers": controller.NewRegistryStorage(m.controllerRegistry, m.podRegistry),
-		"services":               service.NewRegistryStorage(m.serviceRegistry, cloud, m.minionRegistry),
-		"endpoints":              endpoint.NewStorage(m.endpointRegistry),
-		"minions":                minion.NewRegistryStorage(m.minionRegistry),
+		"replicationControllers": controller.NewREST(m.controllerRegistry, m.podRegistry),
+		"services":               service.NewREST(m.serviceRegistry, cloud, m.minionRegistry),
+		"endpoints":              endpoint.NewREST(m.endpointRegistry),
+		"minions":                minion.NewREST(m.minionRegistry),
 
 		// TODO: should appear only in scheduler API group.
-		"bindings": binding.NewBindingStorage(m.bindingRegistry),
+		"bindings": binding.NewREST(m.bindingRegistry),
 	}
 }
 

--- a/pkg/registry/binding/rest.go
+++ b/pkg/registry/binding/rest.go
@@ -26,42 +26,42 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
-// BindingStorage implements the RESTStorage interface. When bindings are written, it
+// REST implements the RESTStorage interface for bindings. When bindings are written, it
 // changes the location of the affected pods. This information is eventually reflected
 // in the pod's CurrentState.Host field.
-type BindingStorage struct {
+type REST struct {
 	registry Registry
 }
 
-// NewBindingStorage creates a new BindingStorage backed by the given bindingRegistry.
-func NewBindingStorage(bindingRegistry Registry) *BindingStorage {
-	return &BindingStorage{
+// NewREST creates a new REST backed by the given bindingRegistry.
+func NewREST(bindingRegistry Registry) *REST {
+	return &REST{
 		registry: bindingRegistry,
 	}
 }
 
 // List returns an error because bindings are write-only objects.
-func (*BindingStorage) List(selector labels.Selector) (runtime.Object, error) {
+func (*REST) List(selector labels.Selector) (runtime.Object, error) {
 	return nil, errors.NewNotFound("binding", "list")
 }
 
 // Get returns an error because bindings are write-only objects.
-func (*BindingStorage) Get(id string) (runtime.Object, error) {
+func (*REST) Get(id string) (runtime.Object, error) {
 	return nil, errors.NewNotFound("binding", id)
 }
 
 // Delete returns an error because bindings are write-only objects.
-func (*BindingStorage) Delete(id string) (<-chan runtime.Object, error) {
+func (*REST) Delete(id string) (<-chan runtime.Object, error) {
 	return nil, errors.NewNotFound("binding", id)
 }
 
 // New returns a new binding object fit for having data unmarshalled into it.
-func (*BindingStorage) New() runtime.Object {
+func (*REST) New() runtime.Object {
 	return &api.Binding{}
 }
 
 // Create attempts to make the assignment indicated by the binding it recieves.
-func (b *BindingStorage) Create(obj runtime.Object) (<-chan runtime.Object, error) {
+func (b *REST) Create(obj runtime.Object) (<-chan runtime.Object, error) {
 	binding, ok := obj.(*api.Binding)
 	if !ok {
 		return nil, fmt.Errorf("incorrect type: %#v", obj)
@@ -75,6 +75,6 @@ func (b *BindingStorage) Create(obj runtime.Object) (<-chan runtime.Object, erro
 }
 
 // Update returns an error-- this object may not be updated.
-func (b *BindingStorage) Update(obj runtime.Object) (<-chan runtime.Object, error) {
+func (b *REST) Update(obj runtime.Object) (<-chan runtime.Object, error) {
 	return nil, fmt.Errorf("Bindings may not be changed.")
 }

--- a/pkg/registry/binding/rest_test.go
+++ b/pkg/registry/binding/rest_test.go
@@ -28,11 +28,11 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
-func TestNewBindingStorage(t *testing.T) {
+func TestNewREST(t *testing.T) {
 	mockRegistry := MockRegistry{
 		OnApplyBinding: func(b *api.Binding) error { return nil },
 	}
-	b := NewBindingStorage(mockRegistry)
+	b := NewREST(mockRegistry)
 
 	binding := &api.Binding{
 		PodID: "foo",
@@ -52,11 +52,11 @@ func TestNewBindingStorage(t *testing.T) {
 	}
 }
 
-func TestBindingStorageUnsupported(t *testing.T) {
+func TestRESTUnsupported(t *testing.T) {
 	mockRegistry := MockRegistry{
 		OnApplyBinding: func(b *api.Binding) error { return nil },
 	}
-	b := NewBindingStorage(mockRegistry)
+	b := NewREST(mockRegistry)
 	if _, err := b.Delete("binding id"); err == nil {
 		t.Errorf("unexpected non-error")
 	}
@@ -75,7 +75,7 @@ func TestBindingStorageUnsupported(t *testing.T) {
 	}
 }
 
-func TestBindingStoragePost(t *testing.T) {
+func TestRESTPost(t *testing.T) {
 	table := []struct {
 		b   *api.Binding
 		err error
@@ -94,7 +94,7 @@ func TestBindingStoragePost(t *testing.T) {
 				return item.err
 			},
 		}
-		b := NewBindingStorage(mockRegistry)
+		b := NewREST(mockRegistry)
 		resultChan, err := b.Create(item.b)
 		if err != nil {
 			t.Errorf("Unexpected error %v", err)

--- a/pkg/registry/controller/rest_test.go
+++ b/pkg/registry/controller/rest_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
@@ -35,7 +36,7 @@ func TestListControllersError(t *testing.T) {
 	mockRegistry := registrytest.ControllerRegistry{
 		Err: fmt.Errorf("test error"),
 	}
-	storage := RegistryStorage{
+	storage := REST{
 		registry: &mockRegistry,
 	}
 	controllers, err := storage.List(nil)
@@ -49,7 +50,7 @@ func TestListControllersError(t *testing.T) {
 
 func TestListEmptyControllerList(t *testing.T) {
 	mockRegistry := registrytest.ControllerRegistry{nil, &api.ReplicationControllerList{JSONBase: api.JSONBase{ResourceVersion: 1}}}
-	storage := RegistryStorage{
+	storage := REST{
 		registry: &mockRegistry,
 	}
 	controllers, err := storage.List(labels.Everything())
@@ -82,7 +83,7 @@ func TestListControllerList(t *testing.T) {
 			},
 		},
 	}
-	storage := RegistryStorage{
+	storage := REST{
 		registry: &mockRegistry,
 	}
 	controllersObj, err := storage.List(labels.Everything())
@@ -104,7 +105,7 @@ func TestListControllerList(t *testing.T) {
 
 func TestControllerDecode(t *testing.T) {
 	mockRegistry := registrytest.ControllerRegistry{}
-	storage := RegistryStorage{
+	storage := REST{
 		registry: &mockRegistry,
 	}
 	controller := &api.ReplicationController{
@@ -226,10 +227,10 @@ func TestCreateController(t *testing.T) {
 			},
 		},
 	}
-	storage := RegistryStorage{
-		registry:    &mockRegistry,
-		podRegistry: &mockPodRegistry,
-		pollPeriod:  time.Millisecond * 1,
+	storage := REST{
+		registry:   &mockRegistry,
+		podLister:  &mockPodRegistry,
+		pollPeriod: time.Millisecond * 1,
 	}
 	controller := &api.ReplicationController{
 		JSONBase: api.JSONBase{ID: "test"},
@@ -257,10 +258,10 @@ func TestCreateController(t *testing.T) {
 
 func TestControllerStorageValidatesCreate(t *testing.T) {
 	mockRegistry := registrytest.ControllerRegistry{}
-	storage := RegistryStorage{
-		registry:    &mockRegistry,
-		podRegistry: nil,
-		pollPeriod:  time.Millisecond * 1,
+	storage := REST{
+		registry:   &mockRegistry,
+		podLister:  nil,
+		pollPeriod: time.Millisecond * 1,
 	}
 
 	failureCases := map[string]api.ReplicationController{
@@ -288,10 +289,10 @@ func TestControllerStorageValidatesCreate(t *testing.T) {
 
 func TestControllerStorageValidatesUpdate(t *testing.T) {
 	mockRegistry := registrytest.ControllerRegistry{}
-	storage := RegistryStorage{
-		registry:    &mockRegistry,
-		podRegistry: nil,
-		pollPeriod:  time.Millisecond * 1,
+	storage := REST{
+		registry:   &mockRegistry,
+		podLister:  nil,
+		pollPeriod: time.Millisecond * 1,
 	}
 	failureCases := map[string]api.ReplicationController{
 		"empty ID": {

--- a/pkg/registry/endpoint/rest.go
+++ b/pkg/registry/endpoint/rest.go
@@ -20,31 +20,30 @@ import (
 	"errors"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
-// Storage adapts endpoints into apiserver's RESTStorage model.
-type Storage struct {
+// REST adapts endpoints into apiserver's RESTStorage model.
+type REST struct {
 	registry Registry
 }
 
-// NewStorage returns a new Storage implementation for endpoints
-func NewStorage(registry Registry) apiserver.RESTStorage {
-	return &Storage{
+// NewREST returns a new apiserver.RESTStorage implementation for endpoints
+func NewREST(registry Registry) *REST {
+	return &REST{
 		registry: registry,
 	}
 }
 
 // Get satisfies the RESTStorage interface.
-func (rs *Storage) Get(id string) (runtime.Object, error) {
+func (rs *REST) Get(id string) (runtime.Object, error) {
 	return rs.registry.GetEndpoints(id)
 }
 
 // List satisfies the RESTStorage interface.
-func (rs *Storage) List(selector labels.Selector) (runtime.Object, error) {
+func (rs *REST) List(selector labels.Selector) (runtime.Object, error) {
 	if !selector.Empty() {
 		return nil, errors.New("label selectors are not supported on endpoints")
 	}
@@ -53,26 +52,26 @@ func (rs *Storage) List(selector labels.Selector) (runtime.Object, error) {
 
 // Watch returns Endpoint events via a watch.Interface.
 // It implements apiserver.ResourceWatcher.
-func (rs *Storage) Watch(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+func (rs *REST) Watch(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
 	return rs.registry.WatchEndpoints(label, field, resourceVersion)
 }
 
 // Create satisfies the RESTStorage interface but is unimplemented.
-func (rs *Storage) Create(obj runtime.Object) (<-chan runtime.Object, error) {
+func (rs *REST) Create(obj runtime.Object) (<-chan runtime.Object, error) {
 	return nil, errors.New("unimplemented")
 }
 
 // Update satisfies the RESTStorage interface but is unimplemented.
-func (rs *Storage) Update(obj runtime.Object) (<-chan runtime.Object, error) {
+func (rs *REST) Update(obj runtime.Object) (<-chan runtime.Object, error) {
 	return nil, errors.New("unimplemented")
 }
 
 // Delete satisfies the RESTStorage interface but is unimplemented.
-func (rs *Storage) Delete(id string) (<-chan runtime.Object, error) {
+func (rs *REST) Delete(id string) (<-chan runtime.Object, error) {
 	return nil, errors.New("unimplemented")
 }
 
 // New implements the RESTStorage interface.
-func (rs Storage) New() runtime.Object {
+func (rs REST) New() runtime.Object {
 	return &api.Endpoints{}
 }

--- a/pkg/registry/endpoint/rest_test.go
+++ b/pkg/registry/endpoint/rest_test.go
@@ -33,7 +33,7 @@ func TestGetEndpoints(t *testing.T) {
 			Endpoints: []string{"127.0.0.1:9000"},
 		},
 	}
-	storage := NewStorage(registry)
+	storage := NewREST(registry)
 	obj, err := storage.Get("foo")
 	if err != nil {
 		t.Fatalf("unexpected error: %#v", err)
@@ -47,7 +47,7 @@ func TestGetEndpointsMissingService(t *testing.T) {
 	registry := &registrytest.ServiceRegistry{
 		Err: errors.NewNotFound("service", "foo"),
 	}
-	storage := NewStorage(registry)
+	storage := NewREST(registry)
 
 	// returns service not found
 	_, err := storage.Get("foo")
@@ -71,7 +71,7 @@ func TestGetEndpointsMissingService(t *testing.T) {
 
 func TestEndpointsRegistryList(t *testing.T) {
 	registry := registrytest.NewServiceRegistry()
-	storage := NewStorage(registry)
+	storage := NewREST(registry)
 	registry.EndpointsList = api.EndpointsList{
 		JSONBase: api.JSONBase{ResourceVersion: 1},
 		Items: []api.Endpoints{

--- a/pkg/registry/minion/rest.go
+++ b/pkg/registry/minion/rest.go
@@ -26,19 +26,19 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
-// RegistryStorage implements the RESTStorage interface, backed by a MinionRegistry.
-type RegistryStorage struct {
+// REST implements the RESTStorage interface, backed by a MinionRegistry.
+type REST struct {
 	registry Registry
 }
 
-// NewRegistryStorage returns a new RegistryStorage.
-func NewRegistryStorage(m Registry) apiserver.RESTStorage {
-	return &RegistryStorage{
+// NewREST returns a new REST.
+func NewREST(m Registry) *REST {
+	return &REST{
 		registry: m,
 	}
 }
 
-func (rs *RegistryStorage) Create(obj runtime.Object) (<-chan runtime.Object, error) {
+func (rs *REST) Create(obj runtime.Object) (<-chan runtime.Object, error) {
 	minion, ok := obj.(*api.Minion)
 	if !ok {
 		return nil, fmt.Errorf("not a minion: %#v", obj)
@@ -65,7 +65,7 @@ func (rs *RegistryStorage) Create(obj runtime.Object) (<-chan runtime.Object, er
 	}), nil
 }
 
-func (rs *RegistryStorage) Delete(id string) (<-chan runtime.Object, error) {
+func (rs *REST) Delete(id string) (<-chan runtime.Object, error) {
 	exists, err := rs.registry.Contains(id)
 	if !exists {
 		return nil, ErrDoesNotExist
@@ -78,7 +78,7 @@ func (rs *RegistryStorage) Delete(id string) (<-chan runtime.Object, error) {
 	}), nil
 }
 
-func (rs *RegistryStorage) Get(id string) (runtime.Object, error) {
+func (rs *REST) Get(id string) (runtime.Object, error) {
 	exists, err := rs.registry.Contains(id)
 	if !exists {
 		return nil, ErrDoesNotExist
@@ -86,7 +86,7 @@ func (rs *RegistryStorage) Get(id string) (runtime.Object, error) {
 	return rs.toApiMinion(id), err
 }
 
-func (rs *RegistryStorage) List(selector labels.Selector) (runtime.Object, error) {
+func (rs *REST) List(selector labels.Selector) (runtime.Object, error) {
 	nameList, err := rs.registry.List()
 	if err != nil {
 		return nil, err
@@ -98,14 +98,14 @@ func (rs *RegistryStorage) List(selector labels.Selector) (runtime.Object, error
 	return &list, nil
 }
 
-func (rs RegistryStorage) New() runtime.Object {
+func (*REST) New() runtime.Object {
 	return &api.Minion{}
 }
 
-func (rs *RegistryStorage) Update(minion runtime.Object) (<-chan runtime.Object, error) {
+func (rs *REST) Update(minion runtime.Object) (<-chan runtime.Object, error) {
 	return nil, fmt.Errorf("Minions can only be created (inserted) and deleted.")
 }
 
-func (rs *RegistryStorage) toApiMinion(name string) *api.Minion {
+func (rs *REST) toApiMinion(name string) *api.Minion {
 	return &api.Minion{JSONBase: api.JSONBase{ID: name}}
 }

--- a/pkg/registry/minion/rest_test.go
+++ b/pkg/registry/minion/rest_test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 )
 
-func TestMinionRegistryStorage(t *testing.T) {
+func TestMinionREST(t *testing.T) {
 	m := NewRegistry([]string{"foo", "bar"})
-	ms := NewRegistryStorage(m)
+	ms := NewREST(m)
 
 	if obj, err := ms.Get("foo"); err != nil || obj.(*api.Minion).ID != "foo" {
 		t.Errorf("missing expected object")

--- a/pkg/registry/pod/rest_test.go
+++ b/pkg/registry/pod/rest_test.go
@@ -57,7 +57,7 @@ func expectPod(t *testing.T, ch <-chan runtime.Object) (*api.Pod, bool) {
 func TestCreatePodRegistryError(t *testing.T) {
 	podRegistry := registrytest.NewPodRegistry(nil)
 	podRegistry.Err = fmt.Errorf("test error")
-	storage := RegistryStorage{
+	storage := REST{
 		registry: podRegistry,
 	}
 	desiredState := api.PodState{
@@ -76,7 +76,7 @@ func TestCreatePodRegistryError(t *testing.T) {
 func TestCreatePodSetsIds(t *testing.T) {
 	podRegistry := registrytest.NewPodRegistry(nil)
 	podRegistry.Err = fmt.Errorf("test error")
-	storage := RegistryStorage{
+	storage := REST{
 		registry: podRegistry,
 	}
 	desiredState := api.PodState{
@@ -102,7 +102,7 @@ func TestCreatePodSetsIds(t *testing.T) {
 func TestCreatePodSetsUUIDs(t *testing.T) {
 	podRegistry := registrytest.NewPodRegistry(nil)
 	podRegistry.Err = fmt.Errorf("test error")
-	storage := RegistryStorage{
+	storage := REST{
 		registry: podRegistry,
 	}
 	desiredState := api.PodState{
@@ -125,7 +125,7 @@ func TestCreatePodSetsUUIDs(t *testing.T) {
 func TestListPodsError(t *testing.T) {
 	podRegistry := registrytest.NewPodRegistry(nil)
 	podRegistry.Err = fmt.Errorf("test error")
-	storage := RegistryStorage{
+	storage := REST{
 		registry: podRegistry,
 	}
 	pods, err := storage.List(labels.Everything())
@@ -139,7 +139,7 @@ func TestListPodsError(t *testing.T) {
 
 func TestListEmptyPodList(t *testing.T) {
 	podRegistry := registrytest.NewPodRegistry(&api.PodList{JSONBase: api.JSONBase{ResourceVersion: 1}})
-	storage := RegistryStorage{
+	storage := REST{
 		registry: podRegistry,
 	}
 	pods, err := storage.List(labels.Everything())
@@ -171,7 +171,7 @@ func TestListPodList(t *testing.T) {
 			},
 		},
 	}
-	storage := RegistryStorage{
+	storage := REST{
 		registry: podRegistry,
 	}
 	podsObj, err := storage.List(labels.Everything())
@@ -193,7 +193,7 @@ func TestListPodList(t *testing.T) {
 
 func TestPodDecode(t *testing.T) {
 	podRegistry := registrytest.NewPodRegistry(nil)
-	storage := RegistryStorage{
+	storage := REST{
 		registry: podRegistry,
 	}
 	expected := &api.Pod{
@@ -219,7 +219,7 @@ func TestPodDecode(t *testing.T) {
 func TestGetPod(t *testing.T) {
 	podRegistry := registrytest.NewPodRegistry(nil)
 	podRegistry.Pod = &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}
-	storage := RegistryStorage{
+	storage := REST{
 		registry: podRegistry,
 	}
 	obj, err := storage.Get("foo")
@@ -237,7 +237,7 @@ func TestGetPodCloud(t *testing.T) {
 	fakeCloud := &fake_cloud.FakeCloud{}
 	podRegistry := registrytest.NewPodRegistry(nil)
 	podRegistry.Pod = &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}
-	storage := RegistryStorage{
+	storage := REST{
 		registry:      podRegistry,
 		cloudProvider: fakeCloud,
 	}
@@ -352,7 +352,7 @@ func TestMakePodStatus(t *testing.T) {
 func TestPodStorageValidatesCreate(t *testing.T) {
 	podRegistry := registrytest.NewPodRegistry(nil)
 	podRegistry.Err = fmt.Errorf("test error")
-	storage := RegistryStorage{
+	storage := REST{
 		registry: podRegistry,
 	}
 	pod := &api.Pod{}
@@ -368,7 +368,7 @@ func TestPodStorageValidatesCreate(t *testing.T) {
 func TestPodStorageValidatesUpdate(t *testing.T) {
 	podRegistry := registrytest.NewPodRegistry(nil)
 	podRegistry.Err = fmt.Errorf("test error")
-	storage := RegistryStorage{
+	storage := REST{
 		registry: podRegistry,
 	}
 	pod := &api.Pod{}
@@ -389,7 +389,7 @@ func TestCreatePod(t *testing.T) {
 			Host: "machine",
 		},
 	}
-	storage := RegistryStorage{
+	storage := REST{
 		registry:      podRegistry,
 		podPollPeriod: time.Millisecond * 100,
 	}
@@ -437,7 +437,7 @@ func TestFillPodInfo(t *testing.T) {
 			},
 		},
 	}
-	storage := RegistryStorage{
+	storage := REST{
 		podCache: &fakeGetter,
 	}
 	pod := api.Pod{DesiredState: api.PodState{Host: "foo"}}
@@ -460,7 +460,7 @@ func TestFillPodInfoNoData(t *testing.T) {
 			},
 		},
 	}
-	storage := RegistryStorage{
+	storage := REST{
 		podCache: &fakeGetter,
 	}
 	pod := api.Pod{DesiredState: api.PodState{Host: "foo"}}

--- a/pkg/registry/service/rest_test.go
+++ b/pkg/registry/service/rest_test.go
@@ -34,7 +34,7 @@ func TestServiceRegistryCreate(t *testing.T) {
 	registry := registrytest.NewServiceRegistry()
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
-	storage := NewRegistryStorage(registry, fakeCloud, minion.NewRegistry(machines))
+	storage := NewREST(registry, fakeCloud, minion.NewRegistry(machines))
 	svc := &api.Service{
 		Port:     6502,
 		JSONBase: api.JSONBase{ID: "foo"},
@@ -63,7 +63,7 @@ func TestServiceRegistryCreate(t *testing.T) {
 
 func TestServiceStorageValidatesCreate(t *testing.T) {
 	registry := registrytest.NewServiceRegistry()
-	storage := NewRegistryStorage(registry, nil, nil)
+	storage := NewREST(registry, nil, nil)
 	failureCases := map[string]api.Service{
 		"empty ID": {
 			Port:     6502,
@@ -94,7 +94,7 @@ func TestServiceRegistryUpdate(t *testing.T) {
 		JSONBase: api.JSONBase{ID: "foo"},
 		Selector: map[string]string{"bar": "baz1"},
 	})
-	storage := NewRegistryStorage(registry, nil, nil)
+	storage := NewREST(registry, nil, nil)
 	c, err := storage.Update(&api.Service{
 		Port:     6502,
 		JSONBase: api.JSONBase{ID: "foo"},
@@ -123,7 +123,7 @@ func TestServiceStorageValidatesUpdate(t *testing.T) {
 		JSONBase: api.JSONBase{ID: "foo"},
 		Selector: map[string]string{"bar": "baz"},
 	})
-	storage := NewRegistryStorage(registry, nil, nil)
+	storage := NewREST(registry, nil, nil)
 	failureCases := map[string]api.Service{
 		"empty ID": {
 			Port:     6502,
@@ -151,7 +151,7 @@ func TestServiceRegistryExternalService(t *testing.T) {
 	registry := registrytest.NewServiceRegistry()
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
-	storage := NewRegistryStorage(registry, fakeCloud, minion.NewRegistry(machines))
+	storage := NewREST(registry, fakeCloud, minion.NewRegistry(machines))
 	svc := &api.Service{
 		Port:                       6502,
 		JSONBase:                   api.JSONBase{ID: "foo"},
@@ -178,7 +178,7 @@ func TestServiceRegistryExternalServiceError(t *testing.T) {
 		Err: fmt.Errorf("test error"),
 	}
 	machines := []string{"foo", "bar", "baz"}
-	storage := NewRegistryStorage(registry, fakeCloud, minion.NewRegistry(machines))
+	storage := NewREST(registry, fakeCloud, minion.NewRegistry(machines))
 	svc := &api.Service{
 		Port:                       6502,
 		JSONBase:                   api.JSONBase{ID: "foo"},
@@ -199,7 +199,7 @@ func TestServiceRegistryDelete(t *testing.T) {
 	registry := registrytest.NewServiceRegistry()
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
-	storage := NewRegistryStorage(registry, fakeCloud, minion.NewRegistry(machines))
+	storage := NewREST(registry, fakeCloud, minion.NewRegistry(machines))
 	svc := &api.Service{
 		JSONBase: api.JSONBase{ID: "foo"},
 		Selector: map[string]string{"bar": "baz"},
@@ -219,7 +219,7 @@ func TestServiceRegistryDeleteExternal(t *testing.T) {
 	registry := registrytest.NewServiceRegistry()
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
-	storage := NewRegistryStorage(registry, fakeCloud, minion.NewRegistry(machines))
+	storage := NewREST(registry, fakeCloud, minion.NewRegistry(machines))
 	svc := &api.Service{
 		JSONBase:                   api.JSONBase{ID: "foo"},
 		Selector:                   map[string]string{"bar": "baz"},
@@ -262,7 +262,7 @@ func TestServiceRegistryGet(t *testing.T) {
 	registry := registrytest.NewServiceRegistry()
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
-	storage := NewRegistryStorage(registry, fakeCloud, minion.NewRegistry(machines))
+	storage := NewREST(registry, fakeCloud, minion.NewRegistry(machines))
 	registry.CreateService(&api.Service{
 		JSONBase: api.JSONBase{ID: "foo"},
 		Selector: map[string]string{"bar": "baz"},
@@ -281,12 +281,12 @@ func TestServiceRegistryResourceLocation(t *testing.T) {
 	registry.Endpoints = api.Endpoints{Endpoints: []string{"foo:80"}}
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
-	storage := NewRegistryStorage(registry, fakeCloud, minion.NewRegistry(machines))
+	storage := NewREST(registry, fakeCloud, minion.NewRegistry(machines))
 	registry.CreateService(&api.Service{
 		JSONBase: api.JSONBase{ID: "foo"},
 		Selector: map[string]string{"bar": "baz"},
 	})
-	redirector := storage.(apiserver.Redirector)
+	redirector := apiserver.Redirector(storage)
 	location, err := redirector.ResourceLocation("foo")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -309,7 +309,7 @@ func TestServiceRegistryList(t *testing.T) {
 	registry := registrytest.NewServiceRegistry()
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
-	storage := NewRegistryStorage(registry, fakeCloud, minion.NewRegistry(machines))
+	storage := NewREST(registry, fakeCloud, minion.NewRegistry(machines))
 	registry.CreateService(&api.Service{
 		JSONBase: api.JSONBase{ID: "foo"},
 		Selector: map[string]string{"bar": "baz"},


### PR DESCRIPTION
Using the name "Storage" is very misleading as these objects don't store anything, they pass through to the registry layer.
