### PR TITLE
Authenticated docker pulls, pt. I

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -34,6 +34,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/controller"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/config"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -46,7 +47,7 @@ import (
 )
 
 var (
-	fakeDocker1, fakeDocker2 kubelet.FakeDockerClient
+	fakeDocker1, fakeDocker2 dockertools.FakeDockerClient
 )
 
 type fakePodInfoGetter struct{}

--- a/pkg/kubelet/dockertools/config.go
+++ b/pkg/kubelet/dockertools/config.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockertools
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"strings"
+
+	"github.com/fsouza/go-dockerclient"
+	"github.com/golang/glog"
+)
+
+const (
+	dockerConfigFileLocation = ".dockercfg"
+)
+
+func readDockerConfigFile() (cfg dockerConfig, err error) {
+	contents, err := ioutil.ReadFile(dockerConfigFileLocation)
+	err = json.Unmarshal(contents, &cfg)
+	return
+}
+
+// dockerConfig represents the config file used by the docker CLI.
+// This config that represents the credentials that should be used
+// when pulling images from specific image repositories.
+type dockerConfig map[string]dockerConfigEntry
+
+func (dc dockerConfig) addToKeyring(dk *dockerKeyring) {
+	for loc, ident := range dc {
+		creds := docker.AuthConfiguration{
+			Username: ident.Username,
+			Password: ident.Password,
+			Email:    ident.Email,
+		}
+
+		parsed, err := url.Parse(loc)
+		if err != nil {
+			glog.Errorf("Entry %q in dockercfg invalid (%v), ignoring", loc, err)
+			continue
+		}
+
+		dk.add(parsed.Host+parsed.Path, creds)
+	}
+}
+
+type dockerConfigEntry struct {
+	Username string
+	Password string
+	Email    string
+}
+
+// dockerConfigEntryWithAuth is used solely for deserializing the Auth field
+// into a dockerConfigEntry during JSON deserialization.
+type dockerConfigEntryWithAuth struct {
+	Username string
+	Password string
+	Email    string
+	Auth     string
+}
+
+func (ident *dockerConfigEntry) UnmarshalJSON(data []byte) error {
+	var tmp dockerConfigEntryWithAuth
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+
+	ident.Username = tmp.Username
+	ident.Password = tmp.Password
+	ident.Email = tmp.Email
+
+	if len(tmp.Auth) == 0 {
+		return nil
+	}
+
+	ident.Username, ident.Password, err = decodeDockerConfigFieldAuth(tmp.Auth)
+	return err
+}
+
+// decodeDockerConfigFieldAuth deserializes the "auth" field from dockercfg into a
+// username and a password. The format of the auth field is base64(<username>:<password>).
+func decodeDockerConfigFieldAuth(field string) (username, password string, err error) {
+	decoded, err := base64.StdEncoding.DecodeString(field)
+	if err != nil {
+		return
+	}
+
+	parts := strings.SplitN(string(decoded), ":", 2)
+	if len(parts) != 2 {
+		err = fmt.Errorf("unable to parse auth field")
+		return
+	}
+
+	username = parts[0]
+	password = parts[1]
+
+	return
+}

--- a/pkg/kubelet/dockertools/config_test.go
+++ b/pkg/kubelet/dockertools/config_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockertools
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/fsouza/go-dockerclient"
+)
+
+func TestDockerConfigJSONDecode(t *testing.T) {
+	input := []byte(`{"http://foo.example.com":{"username": "foo", "password": "bar", "email": "foo@example.com"}, "http://bar.example.com":{"username": "bar", "password": "baz", "email": "bar@example.com"}}`)
+
+	expect := dockerConfig(map[string]dockerConfigEntry{
+		"http://foo.example.com": dockerConfigEntry{
+			Username: "foo",
+			Password: "bar",
+			Email:    "foo@example.com",
+		},
+		"http://bar.example.com": dockerConfigEntry{
+			Username: "bar",
+			Password: "baz",
+			Email:    "bar@example.com",
+		},
+	})
+
+	var output dockerConfig
+	err := json.Unmarshal(input, &output)
+	if err != nil {
+		t.Errorf("Received unexpected error: %v", err)
+	}
+
+	if !reflect.DeepEqual(expect, output) {
+		t.Errorf("Received unexpected output. Expected %#v, got %#v", expect, output)
+	}
+}
+
+func TestDockerConfigEntryJSONDecode(t *testing.T) {
+	tests := []struct {
+		input  []byte
+		expect dockerConfigEntry
+		fail   bool
+	}{
+		// simple case, just decode the fields
+		{
+			input: []byte(`{"username": "foo", "password": "bar", "email": "foo@example.com"}`),
+			expect: dockerConfigEntry{
+				Username: "foo",
+				Password: "bar",
+				Email:    "foo@example.com",
+			},
+			fail: false,
+		},
+
+		// auth field decodes to username & password
+		{
+			input: []byte(`{"auth": "Zm9vOmJhcg==", "email": "foo@example.com"}`),
+			expect: dockerConfigEntry{
+				Username: "foo",
+				Password: "bar",
+				Email:    "foo@example.com",
+			},
+			fail: false,
+		},
+
+		// auth field overrides username & password
+		{
+			input: []byte(`{"username": "foo", "password": "bar", "auth": "cGluZzpwb25n", "email": "foo@example.com"}`),
+			expect: dockerConfigEntry{
+				Username: "ping",
+				Password: "pong",
+				Email:    "foo@example.com",
+			},
+			fail: false,
+		},
+
+		// poorly-formatted auth causes failure
+		{
+			input: []byte(`{"auth": "pants", "email": "foo@example.com"}`),
+			expect: dockerConfigEntry{
+				Username: "",
+				Password: "",
+				Email:    "foo@example.com",
+			},
+			fail: true,
+		},
+
+		// invalid JSON causes failure
+		{
+			input: []byte(`{"email": false}`),
+			expect: dockerConfigEntry{
+				Username: "",
+				Password: "",
+				Email:    "",
+			},
+			fail: true,
+		},
+	}
+
+	for i, tt := range tests {
+		var output dockerConfigEntry
+		err := json.Unmarshal(tt.input, &output)
+		if (err != nil) != tt.fail {
+			t.Errorf("case %d: expected fail=%t, got err=%v", i, tt.fail, err)
+		}
+
+		if !reflect.DeepEqual(tt.expect, output) {
+			t.Errorf("case %d: expected output %#v, got %#v", i, tt.expect, output)
+		}
+	}
+}
+
+func TestDecodeDockerConfigFieldAuth(t *testing.T) {
+	tests := []struct {
+		input    string
+		username string
+		password string
+		fail     bool
+	}{
+		// auth field decodes to username & password
+		{
+			input:    "Zm9vOmJhcg==",
+			username: "foo",
+			password: "bar",
+		},
+
+		// good base64 data, but no colon separating username & password
+		{
+			input: "cGFudHM=",
+			fail:  true,
+		},
+
+		// bad base64 data
+		{
+			input: "pants",
+			fail:  true,
+		},
+	}
+
+	for i, tt := range tests {
+		username, password, err := decodeDockerConfigFieldAuth(tt.input)
+		if (err != nil) != tt.fail {
+			t.Errorf("case %d: expected fail=%t, got err=%v", i, tt.fail, err)
+		}
+
+		if tt.username != username {
+			t.Errorf("case %d: expected username %q, got %q", i, tt.username, username)
+		}
+
+		if tt.password != password {
+			t.Errorf("case %d: expected password %q, got %q", i, tt.password, password)
+		}
+	}
+}
+
+func TestDockerKeyringFromConfig(t *testing.T) {
+	cfg := dockerConfig(map[string]dockerConfigEntry{
+		"http://foo.example.com": dockerConfigEntry{
+			Username: "foo",
+			Password: "bar",
+			Email:    "foo@example.com",
+		},
+		"https://bar.example.com": dockerConfigEntry{
+			Username: "bar",
+			Password: "baz",
+			Email:    "bar@example.com",
+		},
+	})
+
+	dk := newDockerKeyring()
+	cfg.addToKeyring(dk)
+
+	expect := newDockerKeyring()
+	expect.add("foo.example.com",
+		docker.AuthConfiguration{
+			Username: "foo",
+			Password: "bar",
+			Email:    "foo@example.com",
+		},
+	)
+	expect.add("bar.example.com",
+		docker.AuthConfiguration{
+			Username: "bar",
+			Password: "baz",
+			Email:    "bar@example.com",
+		},
+	)
+
+	if !reflect.DeepEqual(expect, dk) {
+		t.Errorf("Received unexpected output. Expected %#v, got %#v", expect, dk)
+	}
+}

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockertools
+
+import (
+	"fmt"
+	"hash/adler32"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/fsouza/go-dockerclient"
+)
+
+func verifyCalls(t *testing.T, fakeDocker *FakeDockerClient, calls []string) {
+	fakeDocker.Lock()
+	defer fakeDocker.Unlock()
+	verifyStringArrayEquals(t, fakeDocker.called, calls)
+}
+
+func verifyStringArrayEquals(t *testing.T, actual, expected []string) {
+	invalid := len(actual) != len(expected)
+	if !invalid {
+		for ix, value := range actual {
+			if expected[ix] != value {
+				invalid = true
+			}
+		}
+	}
+	if invalid {
+		t.Errorf("Expected: %#v, Actual: %#v", expected, actual)
+	}
+}
+
+func TestGetContainerID(t *testing.T) {
+	fakeDocker := &FakeDockerClient{}
+	fakeDocker.ContainerList = []docker.APIContainers{
+		{
+			ID:    "foobar",
+			Names: []string{"/k8s--foo--qux--1234"},
+		},
+		{
+			ID:    "barbar",
+			Names: []string{"/k8s--bar--qux--2565"},
+		},
+	}
+	fakeDocker.Container = &docker.Container{
+		ID: "foobar",
+	}
+
+	dockerContainers, err := GetKubeletDockerContainers(fakeDocker)
+	if err != nil {
+		t.Errorf("Expected no error, Got %#v", err)
+	}
+	if len(dockerContainers) != 2 {
+		t.Errorf("Expected %#v, Got %#v", fakeDocker.ContainerList, dockerContainers)
+	}
+	verifyCalls(t, fakeDocker, []string{"list"})
+	dockerContainer, found, _ := dockerContainers.FindPodContainer("qux", "", "foo")
+	if dockerContainer == nil || !found {
+		t.Errorf("Failed to find container %#v", dockerContainer)
+	}
+
+	fakeDocker.clearCalls()
+	dockerContainer, found, _ = dockerContainers.FindPodContainer("foobar", "", "foo")
+	verifyCalls(t, fakeDocker, []string{})
+	if dockerContainer != nil || found {
+		t.Errorf("Should not have found container %#v", dockerContainer)
+	}
+}
+
+func verifyPackUnpack(t *testing.T, podNamespace, podName, containerName string) {
+	container := &api.Container{Name: containerName}
+	hasher := adler32.New()
+	data := fmt.Sprintf("%#v", *container)
+	hasher.Write([]byte(data))
+	computedHash := uint64(hasher.Sum32())
+	podFullName := fmt.Sprintf("%s.%s", podName, podNamespace)
+	name := BuildDockerName("", podFullName, container)
+	returnedPodFullName, _, returnedContainerName, hash := ParseDockerName(name)
+	if podFullName != returnedPodFullName || containerName != returnedContainerName || computedHash != hash {
+		t.Errorf("For (%s, %s, %d), unpacked (%s, %s, %d)", podFullName, containerName, computedHash, returnedPodFullName, returnedContainerName, hash)
+	}
+}
+
+func TestContainerManifestNaming(t *testing.T) {
+	verifyPackUnpack(t, "file", "manifest1234", "container5678")
+	verifyPackUnpack(t, "file", "manifest--", "container__")
+	verifyPackUnpack(t, "file", "--manifest", "__container")
+	verifyPackUnpack(t, "", "m___anifest_", "container-_-")
+	verifyPackUnpack(t, "other", "_m___anifest", "-_-container")
+
+	container := &api.Container{Name: "container"}
+	podName := "foo"
+	podNamespace := "test"
+	name := fmt.Sprintf("k8s--%s--%s.%s--12345", container.Name, podName, podNamespace)
+
+	podFullName := fmt.Sprintf("%s.%s", podName, podNamespace)
+	returnedPodFullName, _, returnedContainerName, hash := ParseDockerName(name)
+	if returnedPodFullName != podFullName || returnedContainerName != container.Name || hash != 0 {
+		t.Errorf("unexpected parse: %s %s %d", returnedPodFullName, returnedContainerName, hash)
+	}
+}
+
+func TestDockerContainerCommand(t *testing.T) {
+	runner := dockerContainerCommandRunner{}
+	containerID := "1234"
+	command := []string{"ls"}
+	cmd, _ := runner.getRunInContainerCommand(containerID, command)
+	if cmd.Dir != "/var/lib/docker/execdriver/native/"+containerID {
+		t.Errorf("unexpected command CWD: %s", cmd.Dir)
+	}
+	if !reflect.DeepEqual(cmd.Args, []string{"/usr/sbin/nsinit", "exec", "ls"}) {
+		t.Errorf("unexpectd command args: %s", cmd.Args)
+	}
+}
+
+var parseImageNameTests = []struct {
+	imageName string
+	name      string
+	tag       string
+}{
+	{"ubuntu", "ubuntu", ""},
+	{"ubuntu:2342", "ubuntu", "2342"},
+	{"ubuntu:latest", "ubuntu", "latest"},
+	{"foo/bar:445566", "foo/bar", "445566"},
+	{"registry.example.com:5000/foobar", "registry.example.com:5000/foobar", ""},
+	{"registry.example.com:5000/foobar:5342", "registry.example.com:5000/foobar", "5342"},
+	{"registry.example.com:5000/foobar:latest", "registry.example.com:5000/foobar", "latest"},
+}
+
+func TestParseImageName(t *testing.T) {
+	for _, tt := range parseImageNameTests {
+		name, tag := parseImageName(tt.imageName)
+		if name != tt.name || tag != tt.tag {
+			t.Errorf("Expected name/tag: %s/%s, got %s/%s", tt.name, tt.tag, name, tag)
+		}
+	}
+}

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubelet
+package dockertools
 
 import (
 	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/fsouza/go-dockerclient"
@@ -25,93 +26,105 @@ import (
 
 // FakeDockerClient is a simple fake docker client, so that kubelet can be run for testing without requiring a real docker setup.
 type FakeDockerClient struct {
-	lock          sync.Mutex
-	containerList []docker.APIContainers
-	container     *docker.Container
-	err           error
+	sync.Mutex
+	ContainerList []docker.APIContainers
+	Container     *docker.Container
+	Err           error
 	called        []string
-	stopped       []string
+	Stopped       []string
 	pulled        []string
 	Created       []string
 }
 
 func (f *FakeDockerClient) clearCalls() {
-	f.lock.Lock()
-	defer f.lock.Unlock()
+	f.Lock()
+	defer f.Unlock()
 	f.called = []string{}
+}
+
+func (f *FakeDockerClient) AssertCalls(calls []string) (err error) {
+	f.Lock()
+	defer f.Unlock()
+
+	if !reflect.DeepEqual(calls, f.called) {
+		err = fmt.Errorf("expected %#v, got %#v", calls, f.called)
+	}
+
+	return
 }
 
 // ListContainers is a test-spy implementation of DockerInterface.ListContainers.
 // It adds an entry "list" to the internal method call record.
 func (f *FakeDockerClient) ListContainers(options docker.ListContainersOptions) ([]docker.APIContainers, error) {
-	f.lock.Lock()
-	defer f.lock.Unlock()
+	f.Lock()
+	defer f.Unlock()
 	f.called = append(f.called, "list")
-	return f.containerList, f.err
+	return f.ContainerList, f.Err
 }
 
 // InspectContainer is a test-spy implementation of DockerInterface.InspectContainer.
 // It adds an entry "inspect" to the internal method call record.
 func (f *FakeDockerClient) InspectContainer(id string) (*docker.Container, error) {
-	f.lock.Lock()
-	defer f.lock.Unlock()
+	f.Lock()
+	defer f.Unlock()
 	f.called = append(f.called, "inspect")
-	return f.container, f.err
+	return f.Container, f.Err
 }
 
 // CreateContainer is a test-spy implementation of DockerInterface.CreateContainer.
 // It adds an entry "create" to the internal method call record.
 func (f *FakeDockerClient) CreateContainer(c docker.CreateContainerOptions) (*docker.Container, error) {
-	f.lock.Lock()
-	defer f.lock.Unlock()
+	f.Lock()
+	defer f.Unlock()
 	f.called = append(f.called, "create")
 	f.Created = append(f.Created, c.Name)
 	// This is not a very good fake. We'll just add this container's name to the list.
 	// Docker likes to add a '/', so copy that behavior.
 	name := "/" + c.Name
-	f.containerList = append(f.containerList, docker.APIContainers{ID: name, Names: []string{name}})
+	f.ContainerList = append(f.ContainerList, docker.APIContainers{ID: name, Names: []string{name}})
 	return &docker.Container{ID: name}, nil
 }
 
 // StartContainer is a test-spy implementation of DockerInterface.StartContainer.
 // It adds an entry "start" to the internal method call record.
 func (f *FakeDockerClient) StartContainer(id string, hostConfig *docker.HostConfig) error {
-	f.lock.Lock()
-	defer f.lock.Unlock()
+	f.Lock()
+	defer f.Unlock()
 	f.called = append(f.called, "start")
-	return f.err
+	return f.Err
 }
 
 // StopContainer is a test-spy implementation of DockerInterface.StopContainer.
 // It adds an entry "stop" to the internal method call record.
 func (f *FakeDockerClient) StopContainer(id string, timeout uint) error {
-	f.lock.Lock()
-	defer f.lock.Unlock()
+	f.Lock()
+	defer f.Unlock()
 	f.called = append(f.called, "stop")
-	f.stopped = append(f.stopped, id)
+	f.Stopped = append(f.Stopped, id)
 	var newList []docker.APIContainers
-	for _, container := range f.containerList {
+	for _, container := range f.ContainerList {
 		if container.ID != id {
 			newList = append(newList, container)
 		}
 	}
-	f.containerList = newList
-	return f.err
+	f.ContainerList = newList
+	return f.Err
 }
 
 // PullImage is a test-spy implementation of DockerInterface.StopContainer.
 // It adds an entry "pull" to the internal method call record.
 func (f *FakeDockerClient) PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error {
-	f.lock.Lock()
-	defer f.lock.Unlock()
+	f.Lock()
+	defer f.Unlock()
 	f.called = append(f.called, "pull")
 	f.pulled = append(f.pulled, fmt.Sprintf("%s/%s:%s", opts.Repository, opts.Registry, opts.Tag))
-	return f.err
+	return f.Err
 }
 
 // FakeDockerPuller is a stub implementation of DockerPuller.
 type FakeDockerPuller struct {
-	lock         sync.Mutex
+	sync.Mutex
+
 	ImagesPulled []string
 
 	// Every pull will return the first error here, and then reslice
@@ -121,8 +134,8 @@ type FakeDockerPuller struct {
 
 // Pull records the image pull attempt, and optionally injects an error.
 func (f *FakeDockerPuller) Pull(image string) (err error) {
-	f.lock.Lock()
-	defer f.lock.Unlock()
+	f.Lock()
+	defer f.Unlock()
 	f.ImagesPulled = append(f.ImagesPulled, image)
 
 	if len(f.ErrorsToInject) > 0 {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -19,7 +19,6 @@ package kubelet
 import (
 	"encoding/json"
 	"fmt"
-	"hash/adler32"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -30,6 +29,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/health"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
@@ -38,25 +38,24 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func newTestKubelet(t *testing.T) (*Kubelet, *tools.FakeEtcdClient, *FakeDockerClient) {
+func newTestKubelet(t *testing.T) (*Kubelet, *tools.FakeEtcdClient, *dockertools.FakeDockerClient) {
 	fakeEtcdClient := tools.NewFakeEtcdClient(t)
-	fakeDocker := &FakeDockerClient{
-		err: nil,
-	}
+	fakeDocker := &dockertools.FakeDockerClient{}
 
 	kubelet := &Kubelet{}
 	kubelet.dockerClient = fakeDocker
-	kubelet.dockerPuller = &FakeDockerPuller{}
+	kubelet.dockerPuller = &dockertools.FakeDockerPuller{}
 	kubelet.etcdClient = fakeEtcdClient
 	kubelet.rootDirectory = "/tmp/kubelet"
 	kubelet.podWorkers = newPodWorkers()
 	return kubelet, fakeEtcdClient, fakeDocker
 }
 
-func verifyCalls(t *testing.T, fakeDocker *FakeDockerClient, calls []string) {
-	fakeDocker.lock.Lock()
-	defer fakeDocker.lock.Unlock()
-	verifyStringArrayEquals(t, fakeDocker.called, calls)
+func verifyCalls(t *testing.T, fakeDocker *dockertools.FakeDockerClient, calls []string) {
+	err := fakeDocker.AssertCalls(calls)
+	if err != nil {
+		t.Error(err)
+	}
 }
 
 func verifyStringArrayEquals(t *testing.T, actual, expected []string) {
@@ -73,89 +72,16 @@ func verifyStringArrayEquals(t *testing.T, actual, expected []string) {
 	}
 }
 
-func verifyPackUnpack(t *testing.T, podNamespace, podName, containerName string) {
-	container := &api.Container{Name: containerName}
-	hasher := adler32.New()
-	data := fmt.Sprintf("%#v", *container)
-	hasher.Write([]byte(data))
-	computedHash := uint64(hasher.Sum32())
-	name := buildDockerName(
-		&Pod{Name: podName, Namespace: podNamespace},
-		container,
-	)
-	podFullName := fmt.Sprintf("%s.%s", podName, podNamespace)
-	returnedPodFullName, _, returnedContainerName, hash := parseDockerName(name)
-	if podFullName != returnedPodFullName || containerName != returnedContainerName || computedHash != hash {
-		t.Errorf("For (%s, %s, %d), unpacked (%s, %s, %d)", podFullName, containerName, computedHash, returnedPodFullName, returnedContainerName, hash)
-	}
-}
-
 func verifyBoolean(t *testing.T, expected, value bool) {
 	if expected != value {
 		t.Errorf("Unexpected boolean.  Expected %t.  Found %t", expected, value)
 	}
 }
 
-func TestContainerManifestNaming(t *testing.T) {
-	verifyPackUnpack(t, "file", "manifest1234", "container5678")
-	verifyPackUnpack(t, "file", "manifest--", "container__")
-	verifyPackUnpack(t, "file", "--manifest", "__container")
-	verifyPackUnpack(t, "", "m___anifest_", "container-_-")
-	verifyPackUnpack(t, "other", "_m___anifest", "-_-container")
-
-	container := &api.Container{Name: "container"}
-	pod := &Pod{Name: "foo", Namespace: "test"}
-	name := fmt.Sprintf("k8s--%s--%s.%s--12345", container.Name, pod.Name, pod.Namespace)
-
-	podFullName := fmt.Sprintf("%s.%s", pod.Name, pod.Namespace)
-	returnedPodFullName, _, returnedContainerName, hash := parseDockerName(name)
-	if returnedPodFullName != podFullName || returnedContainerName != container.Name || hash != 0 {
-		t.Errorf("unexpected parse: %s %s %d", returnedPodFullName, returnedContainerName, hash)
-	}
-
-}
-
-func TestGetContainerID(t *testing.T) {
-	_, _, fakeDocker := newTestKubelet(t)
-	fakeDocker.containerList = []docker.APIContainers{
-		{
-			ID:    "foobar",
-			Names: []string{"/k8s--foo--qux--1234"},
-		},
-		{
-			ID:    "barbar",
-			Names: []string{"/k8s--bar--qux--2565"},
-		},
-	}
-	fakeDocker.container = &docker.Container{
-		ID: "foobar",
-	}
-
-	dockerContainers, err := getKubeletDockerContainers(fakeDocker)
-	if err != nil {
-		t.Errorf("Expected no error, Got %#v", err)
-	}
-	if len(dockerContainers) != 2 {
-		t.Errorf("Expected %#v, Got %#v", fakeDocker.containerList, dockerContainers)
-	}
-	verifyCalls(t, fakeDocker, []string{"list"})
-	dockerContainer, found, _ := dockerContainers.FindPodContainer("qux", "", "foo")
-	if dockerContainer == nil || !found {
-		t.Errorf("Failed to find container %#v", dockerContainer)
-	}
-
-	fakeDocker.clearCalls()
-	dockerContainer, found, _ = dockerContainers.FindPodContainer("foobar", "", "foo")
-	verifyCalls(t, fakeDocker, []string{})
-	if dockerContainer != nil || found {
-		t.Errorf("Should not have found container %#v", dockerContainer)
-	}
-}
-
 func TestKillContainerWithError(t *testing.T) {
-	fakeDocker := &FakeDockerClient{
-		err: fmt.Errorf("sample error"),
-		containerList: []docker.APIContainers{
+	fakeDocker := &dockertools.FakeDockerClient{
+		Err: fmt.Errorf("sample error"),
+		ContainerList: []docker.APIContainers{
 			{
 				ID:    "1234",
 				Names: []string{"/k8s--foo--qux--1234"},
@@ -168,7 +94,7 @@ func TestKillContainerWithError(t *testing.T) {
 	}
 	kubelet, _, _ := newTestKubelet(t)
 	kubelet.dockerClient = fakeDocker
-	err := kubelet.killContainer(&fakeDocker.containerList[0])
+	err := kubelet.killContainer(&fakeDocker.ContainerList[0])
 	if err == nil {
 		t.Errorf("expected error, found nil")
 	}
@@ -177,7 +103,7 @@ func TestKillContainerWithError(t *testing.T) {
 
 func TestKillContainer(t *testing.T) {
 	kubelet, _, fakeDocker := newTestKubelet(t)
-	fakeDocker.containerList = []docker.APIContainers{
+	fakeDocker.ContainerList = []docker.APIContainers{
 		{
 			ID:    "1234",
 			Names: []string{"/k8s--foo--qux--1234"},
@@ -187,11 +113,11 @@ func TestKillContainer(t *testing.T) {
 			Names: []string{"/k8s--bar--qux--5678"},
 		},
 	}
-	fakeDocker.container = &docker.Container{
+	fakeDocker.Container = &docker.Container{
 		ID: "foobar",
 	}
 
-	err := kubelet.killContainer(&fakeDocker.containerList[0])
+	err := kubelet.killContainer(&fakeDocker.ContainerList[0])
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -227,10 +153,10 @@ func (cr *channelReader) GetList() [][]Pod {
 func TestSyncPodsDoesNothing(t *testing.T) {
 	kubelet, _, fakeDocker := newTestKubelet(t)
 	container := api.Container{Name: "bar"}
-	fakeDocker.containerList = []docker.APIContainers{
+	fakeDocker.ContainerList = []docker.APIContainers{
 		{
 			// format is k8s--<container-id>--<pod-fullname>
-			Names: []string{"/k8s--bar." + strconv.FormatUint(hashContainer(&container), 16) + "--foo.test"},
+			Names: []string{"/k8s--bar." + strconv.FormatUint(dockertools.HashContainer(&container), 16) + "--foo.test"},
 			ID:    "1234",
 		},
 		{
@@ -281,7 +207,7 @@ func matchString(t *testing.T, pattern, str string) bool {
 
 func TestSyncPodsCreatesNetAndContainer(t *testing.T) {
 	kubelet, _, fakeDocker := newTestKubelet(t)
-	fakeDocker.containerList = []docker.APIContainers{}
+	fakeDocker.ContainerList = []docker.APIContainers{}
 	err := kubelet.SyncPods([]Pod{
 		{
 			Name:      "foo",
@@ -302,18 +228,18 @@ func TestSyncPodsCreatesNetAndContainer(t *testing.T) {
 	verifyCalls(t, fakeDocker, []string{
 		"list", "list", "create", "start", "list", "inspect", "list", "create", "start"})
 
-	fakeDocker.lock.Lock()
+	fakeDocker.Lock()
 	if len(fakeDocker.Created) != 2 ||
 		!matchString(t, "k8s--net\\.[a-f0-9]+--foo.test--", fakeDocker.Created[0]) ||
 		!matchString(t, "k8s--bar\\.[a-f0-9]+--foo.test--", fakeDocker.Created[1]) {
 		t.Errorf("Unexpected containers created %v", fakeDocker.Created)
 	}
-	fakeDocker.lock.Unlock()
+	fakeDocker.Unlock()
 }
 
 func TestSyncPodsWithNetCreatesContainer(t *testing.T) {
 	kubelet, _, fakeDocker := newTestKubelet(t)
-	fakeDocker.containerList = []docker.APIContainers{
+	fakeDocker.ContainerList = []docker.APIContainers{
 		{
 			// network container
 			Names: []string{"/k8s--net--foo.test--"},
@@ -340,19 +266,19 @@ func TestSyncPodsWithNetCreatesContainer(t *testing.T) {
 	verifyCalls(t, fakeDocker, []string{
 		"list", "list", "list", "inspect", "list", "create", "start"})
 
-	fakeDocker.lock.Lock()
+	fakeDocker.Lock()
 	if len(fakeDocker.Created) != 1 ||
 		!matchString(t, "k8s--bar\\.[a-f0-9]+--foo.test--", fakeDocker.Created[0]) {
 		t.Errorf("Unexpected containers created %v", fakeDocker.Created)
 	}
-	fakeDocker.lock.Unlock()
+	fakeDocker.Unlock()
 }
 
 func TestSyncPodsWithNetCreatesContainerCallsHandler(t *testing.T) {
 	kubelet, _, fakeDocker := newTestKubelet(t)
 	fakeHttp := fakeHTTP{}
 	kubelet.httpClient = &fakeHttp
-	fakeDocker.containerList = []docker.APIContainers{
+	fakeDocker.ContainerList = []docker.APIContainers{
 		{
 			// network container
 			Names: []string{"/k8s--net--foo.test--"},
@@ -390,12 +316,12 @@ func TestSyncPodsWithNetCreatesContainerCallsHandler(t *testing.T) {
 	verifyCalls(t, fakeDocker, []string{
 		"list", "list", "list", "inspect", "list", "create", "start"})
 
-	fakeDocker.lock.Lock()
+	fakeDocker.Lock()
 	if len(fakeDocker.Created) != 1 ||
 		!matchString(t, "k8s--bar\\.[a-f0-9]+--foo.test--", fakeDocker.Created[0]) {
 		t.Errorf("Unexpected containers created %v", fakeDocker.Created)
 	}
-	fakeDocker.lock.Unlock()
+	fakeDocker.Unlock()
 	if fakeHttp.url != "http://foo:8080/bar" {
 		t.Errorf("Unexpected handler: %s", fakeHttp.url)
 	}
@@ -403,7 +329,7 @@ func TestSyncPodsWithNetCreatesContainerCallsHandler(t *testing.T) {
 
 func TestSyncPodsDeletesWithNoNetContainer(t *testing.T) {
 	kubelet, _, fakeDocker := newTestKubelet(t)
-	fakeDocker.containerList = []docker.APIContainers{
+	fakeDocker.ContainerList = []docker.APIContainers{
 		{
 			// format is k8s--<container-id>--<pod-fullname>
 			Names: []string{"/k8s--bar--foo.test"},
@@ -435,16 +361,16 @@ func TestSyncPodsDeletesWithNoNetContainer(t *testing.T) {
 	expectedToStop := map[string]bool{
 		"1234": true,
 	}
-	fakeDocker.lock.Lock()
-	if len(fakeDocker.stopped) != 1 || !expectedToStop[fakeDocker.stopped[0]] {
-		t.Errorf("Wrong containers were stopped: %v", fakeDocker.stopped)
+	fakeDocker.Lock()
+	if len(fakeDocker.Stopped) != 1 || !expectedToStop[fakeDocker.Stopped[0]] {
+		t.Errorf("Wrong containers were stopped: %v", fakeDocker.Stopped)
 	}
-	fakeDocker.lock.Unlock()
+	fakeDocker.Unlock()
 }
 
 func TestSyncPodsDeletes(t *testing.T) {
 	kubelet, _, fakeDocker := newTestKubelet(t)
-	fakeDocker.containerList = []docker.APIContainers{
+	fakeDocker.ContainerList = []docker.APIContainers{
 		{
 			// the k8s prefix is required for the kubelet to manage the container
 			Names: []string{"/k8s--foo--bar.test"},
@@ -473,16 +399,16 @@ func TestSyncPodsDeletes(t *testing.T) {
 		"1234": true,
 		"9876": true,
 	}
-	if len(fakeDocker.stopped) != 2 ||
-		!expectedToStop[fakeDocker.stopped[0]] ||
-		!expectedToStop[fakeDocker.stopped[1]] {
-		t.Errorf("Wrong containers were stopped: %v", fakeDocker.stopped)
+	if len(fakeDocker.Stopped) != 2 ||
+		!expectedToStop[fakeDocker.Stopped[0]] ||
+		!expectedToStop[fakeDocker.Stopped[1]] {
+		t.Errorf("Wrong containers were stopped: %v", fakeDocker.Stopped)
 	}
 }
 
 func TestSyncPodDeletesDuplicate(t *testing.T) {
 	kubelet, _, fakeDocker := newTestKubelet(t)
-	dockerContainers := DockerContainers{
+	dockerContainers := dockertools.DockerContainers{
 		"1234": &docker.APIContainers{
 			// the k8s prefix is required for the kubelet to manage the container
 			Names: []string{"/k8s--foo--bar.test--1"},
@@ -521,8 +447,8 @@ func TestSyncPodDeletesDuplicate(t *testing.T) {
 	verifyCalls(t, fakeDocker, []string{"list", "stop"})
 
 	// Expect one of the duplicates to be killed.
-	if len(fakeDocker.stopped) != 1 || (len(fakeDocker.stopped) != 0 && fakeDocker.stopped[0] != "1234" && fakeDocker.stopped[0] != "4567") {
-		t.Errorf("Wrong containers were stopped: %v", fakeDocker.stopped)
+	if len(fakeDocker.Stopped) != 1 || (len(fakeDocker.Stopped) != 0 && fakeDocker.Stopped[0] != "1234" && fakeDocker.Stopped[0] != "4567") {
+		t.Errorf("Wrong containers were stopped: %v", fakeDocker.Stopped)
 	}
 }
 
@@ -535,7 +461,7 @@ func (f *FalseHealthChecker) HealthCheck(podFullName string, state api.PodState,
 func TestSyncPodBadHash(t *testing.T) {
 	kubelet, _, fakeDocker := newTestKubelet(t)
 	kubelet.healthChecker = &FalseHealthChecker{}
-	dockerContainers := DockerContainers{
+	dockerContainers := dockertools.DockerContainers{
 		"1234": &docker.APIContainers{
 			// the k8s prefix is required for the kubelet to manage the container
 			Names: []string{"/k8s--bar.1234--foo.test"},
@@ -568,16 +494,16 @@ func TestSyncPodBadHash(t *testing.T) {
 	expectedToStop := map[string]bool{
 		"1234": true,
 	}
-	if len(fakeDocker.stopped) != 1 ||
-		!expectedToStop[fakeDocker.stopped[0]] {
-		t.Errorf("Wrong containers were stopped: %v", fakeDocker.stopped)
+	if len(fakeDocker.Stopped) != 1 ||
+		!expectedToStop[fakeDocker.Stopped[0]] {
+		t.Errorf("Wrong containers were stopped: %v", fakeDocker.Stopped)
 	}
 }
 
 func TestSyncPodUnhealthy(t *testing.T) {
 	kubelet, _, fakeDocker := newTestKubelet(t)
 	kubelet.healthChecker = &FalseHealthChecker{}
-	dockerContainers := DockerContainers{
+	dockerContainers := dockertools.DockerContainers{
 		"1234": &docker.APIContainers{
 			// the k8s prefix is required for the kubelet to manage the container
 			Names: []string{"/k8s--bar--foo.test"},
@@ -615,9 +541,9 @@ func TestSyncPodUnhealthy(t *testing.T) {
 	expectedToStop := map[string]bool{
 		"1234": true,
 	}
-	if len(fakeDocker.stopped) != 1 ||
-		!expectedToStop[fakeDocker.stopped[0]] {
-		t.Errorf("Wrong containers were stopped: %v", fakeDocker.stopped)
+	if len(fakeDocker.Stopped) != 1 ||
+		!expectedToStop[fakeDocker.Stopped[0]] {
+		t.Errorf("Wrong containers were stopped: %v", fakeDocker.Stopped)
 	}
 }
 
@@ -934,7 +860,7 @@ func TestGetContainerInfo(t *testing.T) {
 
 	kubelet, _, fakeDocker := newTestKubelet(t)
 	kubelet.cadvisorClient = mockCadvisor
-	fakeDocker.containerList = []docker.APIContainers{
+	fakeDocker.ContainerList = []docker.APIContainers{
 		{
 			ID: containerID,
 			// pod id: qux
@@ -958,7 +884,7 @@ func TestGetContainerInfo(t *testing.T) {
 	mockCadvisor.AssertExpectations(t)
 }
 
-func TestGetRooInfo(t *testing.T) {
+func TestGetRootInfo(t *testing.T) {
 	containerPath := "/"
 	containerInfo := &info.ContainerInfo{
 		ContainerReference: info.ContainerReference{
@@ -973,9 +899,7 @@ func TestGetRooInfo(t *testing.T) {
 			},
 		},
 	}
-	fakeDocker := FakeDockerClient{
-		err: nil,
-	}
+	fakeDocker := dockertools.FakeDockerClient{}
 
 	mockCadvisor := &mockCadvisorClient{}
 	req := &info.ContainerInfoRequest{}
@@ -984,7 +908,7 @@ func TestGetRooInfo(t *testing.T) {
 
 	kubelet := Kubelet{
 		dockerClient:   &fakeDocker,
-		dockerPuller:   &FakeDockerPuller{},
+		dockerPuller:   &dockertools.FakeDockerPuller{},
 		cadvisorClient: mockCadvisor,
 		podWorkers:     newPodWorkers(),
 	}
@@ -1004,7 +928,7 @@ func TestGetRooInfo(t *testing.T) {
 
 func TestGetContainerInfoWithoutCadvisor(t *testing.T) {
 	kubelet, _, fakeDocker := newTestKubelet(t)
-	fakeDocker.containerList = []docker.APIContainers{
+	fakeDocker.ContainerList = []docker.APIContainers{
 		{
 			ID: "foobar",
 			// pod id: qux
@@ -1042,7 +966,7 @@ func TestGetContainerInfoWhenCadvisorFailed(t *testing.T) {
 
 	kubelet, _, fakeDocker := newTestKubelet(t)
 	kubelet.cadvisorClient = mockCadvisor
-	fakeDocker.containerList = []docker.APIContainers{
+	fakeDocker.ContainerList = []docker.APIContainers{
 		{
 			ID: containerID,
 			// pod id: qux
@@ -1070,7 +994,7 @@ func TestGetContainerInfoOnNonExistContainer(t *testing.T) {
 
 	kubelet, _, fakeDocker := newTestKubelet(t)
 	kubelet.cadvisorClient = mockCadvisor
-	fakeDocker.containerList = []docker.APIContainers{}
+	fakeDocker.ContainerList = []docker.APIContainers{}
 
 	stats, _ := kubelet.GetContainerInfo("qux", "", "foo", nil)
 	if stats != nil {
@@ -1094,7 +1018,7 @@ func (f *fakeContainerCommandRunner) RunInContainer(id string, cmd []string) ([]
 func TestRunInContainerNoSuchPod(t *testing.T) {
 	fakeCommandRunner := fakeContainerCommandRunner{}
 	kubelet, _, fakeDocker := newTestKubelet(t)
-	fakeDocker.containerList = []docker.APIContainers{}
+	fakeDocker.ContainerList = []docker.APIContainers{}
 	kubelet.runner = &fakeCommandRunner
 
 	podName := "podFoo"
@@ -1123,7 +1047,7 @@ func TestRunInContainer(t *testing.T) {
 	podNamespace := "etcd"
 	containerName := "containerFoo"
 
-	fakeDocker.containerList = []docker.APIContainers{
+	fakeDocker.ContainerList = []docker.APIContainers{
 		{
 			ID:    containerID,
 			Names: []string{"/k8s--" + containerName + "--" + podName + "." + podNamespace + "--1234"},
@@ -1147,43 +1071,6 @@ func TestRunInContainer(t *testing.T) {
 	}
 }
 
-func TestDockerContainerCommand(t *testing.T) {
-	runner := dockerContainerCommandRunner{}
-	containerID := "1234"
-	command := []string{"ls"}
-	cmd, _ := runner.getRunInContainerCommand(containerID, command)
-	if cmd.Dir != "/var/lib/docker/execdriver/native/"+containerID {
-		t.Errorf("unexpected command CWD: %s", cmd.Dir)
-	}
-	if !reflect.DeepEqual(cmd.Args, []string{"/usr/sbin/nsinit", "exec", "ls"}) {
-		t.Errorf("unexpectd command args: %s", cmd.Args)
-	}
-
-}
-
-var parseImageNameTests = []struct {
-	imageName string
-	name      string
-	tag       string
-}{
-	{"ubuntu", "ubuntu", ""},
-	{"ubuntu:2342", "ubuntu", "2342"},
-	{"ubuntu:latest", "ubuntu", "latest"},
-	{"foo/bar:445566", "foo/bar", "445566"},
-	{"registry.example.com:5000/foobar", "registry.example.com:5000/foobar", ""},
-	{"registry.example.com:5000/foobar:5342", "registry.example.com:5000/foobar", "5342"},
-	{"registry.example.com:5000/foobar:latest", "registry.example.com:5000/foobar", "latest"},
-}
-
-func TestParseImageName(t *testing.T) {
-	for _, tt := range parseImageNameTests {
-		name, tag := parseImageName(tt.imageName)
-		if name != tt.name || tag != tt.tag {
-			t.Errorf("Expected name/tag: %s/%s, got %s/%s", tt.name, tt.tag, name, tag)
-		}
-	}
-}
-
 func TestRunHandlerExec(t *testing.T) {
 	fakeCommandRunner := fakeContainerCommandRunner{}
 	kubelet, _, fakeDocker := newTestKubelet(t)
@@ -1194,7 +1081,7 @@ func TestRunHandlerExec(t *testing.T) {
 	podNamespace := "etcd"
 	containerName := "containerFoo"
 
-	fakeDocker.containerList = []docker.APIContainers{
+	fakeDocker.ContainerList = []docker.APIContainers{
 		{
 			ID:    containerID,
 			Names: []string{"/k8s--" + containerName + "--" + podName + "." + podNamespace + "--1234"},
@@ -1298,7 +1185,7 @@ func TestSyncPodEventHandlerFails(t *testing.T) {
 	kubelet.httpClient = &fakeHTTP{
 		err: fmt.Errorf("test error"),
 	}
-	dockerContainers := DockerContainers{
+	dockerContainers := dockertools.DockerContainers{
 		"9876": &docker.APIContainers{
 			// network container
 			Names: []string{"/k8s--net--foo.test--"},
@@ -1331,7 +1218,7 @@ func TestSyncPodEventHandlerFails(t *testing.T) {
 
 	verifyCalls(t, fakeDocker, []string{"list", "list", "create", "start", "stop"})
 
-	if len(fakeDocker.stopped) != 1 {
-		t.Errorf("Wrong containers were stopped: %v", fakeDocker.stopped)
+	if len(fakeDocker.Stopped) != 1 {
+		t.Errorf("Wrong containers were stopped: %v", fakeDocker.Stopped)
 	}
 }

--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools"
 	"github.com/golang/glog"
 	"github.com/google/cadvisor/info"
 	"gopkg.in/v1/yaml"
@@ -159,7 +160,7 @@ func (s *Server) handlePodInfo(w http.ResponseWriter, req *http.Request) {
 	// TODO: backwards compatibility with existing API, needs API change
 	podFullName := GetPodFullName(&Pod{Name: podID, Namespace: "etcd"})
 	info, err := s.host.GetPodInfo(podFullName, podUUID)
-	if err == ErrNoContainersInPod {
+	if err == dockertools.ErrNoContainersInPod {
 		http.Error(w, "Pod does not exist", http.StatusNotFound)
 		return
 	}


### PR DESCRIPTION
The simplest reasonable thing to do here is to read the `.dockercfg` files that are already available to the kubelets. This only happens on startup, so any changes the user makes  to `.dockercfg` will only be applied after a service restart.
