### PR TITLE
avoid dumping error pages into error messages

### DIFF
--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -62,6 +62,9 @@ func (s *SourceURL) extractFromURL() error {
 	if err != nil {
 		return err
 	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("%v: %v", s.url, resp.Status)
+	}
 	if len(data) == 0 {
 		return fmt.Errorf("zero-length data received from %v", s.url)
 	}


### PR DESCRIPTION
kubelet.log filled my disk with the metadata server's 404 error page because I started a container-optimized GCE VM without a google-container-manifest metadata.  In general, for a non-200 response, maybe we can just log the URL and the status code.
