### PR TITLE
Add third_party/etcd to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ network_closure.sh
 
 # compiled binaries in third_party
 /third_party/pkg
+
+# also ignore etcd installed by hack/install-etcd.sh
+/third_party/etcd


### PR DESCRIPTION
Otherwise the tree looks "dirty" after hack/install-etcd.sh is executed.

Tested:
- Ran `git status` after running `hack/install-etcd.sh`.

Signed-off-by: Filipe Brandenburger filbranden@google.com
