### PR TITLE
Update version to use -dev suffix

### DIFF
--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -23,9 +23,10 @@ package version
 // version for ad-hoc builds (e.g. `go build`) that cannot get the version
 // information from git.
 //
-// The "+" in the version info indicates that fact, and it means the current
-// build is from a version greater or equal to that version.
-// (e.g. v0.7+ means version >= 0.7 and < 0.8)
+// The "-dev" suffix in the version info indicates that fact, and it means the
+// current build is from a version greater that version. For example, v0.7-dev
+// means version > 0.7 and < 0.8. (There's exceptions to this rule, see
+// docs/releasing.md for more details.)
 //
 // When releasing a new Kubernetes version, this file should be updated to
 // reflect the new version, and then a git annotated tag (using format vX.Y
@@ -33,9 +34,10 @@ package version
 // to the commit that updates pkg/version/base.go
 
 var (
+	// TODO: Deprecate gitMajor and gitMinor, use only gitVersion instead.
 	gitMajor     string = "0"              // major version, always numeric
 	gitMinor     string = "2+"             // minor version, numeric possibly followed by "+"
-	gitVersion   string = "v0.2+"          // version from git, output of $(git describe)
+	gitVersion   string = "v0.2-dev"       // version from git, output of $(git describe)
 	gitCommit    string = ""               // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 )


### PR DESCRIPTION
According to the plan listed in docs/releasing.md.

The gitMinor will keep using a "+" suffix instead for now.

Added a //TODO to deprecate gitMajor and gitMinor in a follow up.
