### PR TITLE
Small clean up in validation.

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -228,8 +228,8 @@ func ValidateManifest(manifest *api.ContainerManifest) errs.ErrorList {
 	} else if !supportedManifestVersions.Has(strings.ToLower(manifest.Version)) {
 		allErrs = append(allErrs, errs.NewFieldNotSupported("version", manifest.Version))
 	}
-	allVolumes, errs := validateVolumes(manifest.Volumes)
-	allErrs = append(allErrs, errs.Prefix("volumes")...)
+	allVolumes, vErrs := validateVolumes(manifest.Volumes)
+	allErrs = append(allErrs, vErrs.Prefix("volumes")...)
 	allErrs = append(allErrs, validateContainers(manifest.Containers, allVolumes).Prefix("containers")...)
 	return allErrs
 }


### PR DESCRIPTION
 errs is used as import path alias in validation.go, but it is reused as a variable in ValidateManifest.
