### PR TITLE
Use just GitVersion for the -version output

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,10 +16,6 @@ limitations under the License.
 
 package version
 
-import (
-	"fmt"
-)
-
 // Info contains versioning information.
 // TODO: Add []string of api versions supported? It's still unclear
 // how we'll want to distribute that information.
@@ -47,9 +43,5 @@ func Get() Info {
 
 // String returns info as a human-friendly version string.
 func (info Info) String() string {
-	commit := info.GitCommit
-	if commit == "" {
-		commit = "(unknown)"
-	}
-	return fmt.Sprintf("version %s.%s, build %s", info.Major, info.Minor, commit)
+	return info.GitVersion
 }


### PR DESCRIPTION
It turns out that that's simply the most useful information about the version that was built.

For a git tree, it includes information about the closest release, number of commits since the release, enough of the SHA1 to find the exact commit and whether the tree was clean or dirty at build time.

For a build from tarball, it will include information of which release was built and, when using a tarball from a not released commit (e.g. downloading "master.tar.gz" from GitHub, not recommended!) it will include the -dev prefix to indicate that was not an official release. (That's as good as we can get with it.)

If additional information is required, it can be found with -version=raw.

I tested most use cases, I didn't test tarball with official version since that requires additional commits, at the time we release v0.3 I'll have a chance to experiment with that in my fork before we push the tag upstream.

Cheers,
Filipe
