### PR TITLE
Remove Godeps build artifacts on clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 #   clean: Clean up.
 
 OUT_DIR = _output
+GODEPS_PKG_DIR = Godeps/_workspace/pkg
 
 export GOFLAGS
 
@@ -48,4 +49,5 @@ check test:
 #   make clean
 clean:
 	rm -rf $(OUT_DIR)
+	rm -rf $(GODEPS_PKG_DIR)
 .PHONY: clean


### PR DESCRIPTION
This was causing test breaks for me.  Maybe we should move the 'rm' into a hack/clean.sh ?  Sort of pointless, imo, but could do.

@filbranden 
