### PR TITLE
Config gopath overrides

### DIFF
--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -110,8 +110,11 @@ kube::setup_go_environment() {
   if [[ -n ${KUBE_EXTRA_GOPATH:-} ]]; then
     GOPATH=${GOPATH}:${KUBE_EXTRA_GOPATH}
   fi
-  # Set GOPATH to point to the tree maintained by `godep`.
-  GOPATH="${GOPATH}:${KUBE_REPO_ROOT}/Godeps/_workspace"
+  # Append the tree maintained by `godep` to the GOPATH unless KUBE_NO_GODEPS
+  # is defined.
+  if [[ -z ${KUBE_NO_GODEPS:-} ]]; then
+    GOPATH="${GOPATH}:${KUBE_REPO_ROOT}/Godeps/_workspace"
+  fi
   export GOPATH
 
   # Unset GOBIN in case it already exists in the current session.

--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -105,8 +105,13 @@ kube::setup_go_environment() {
     fi
   fi
 
+  GOPATH=${KUBE_TARGET}
+  # Append KUBE_EXTRA_GOPATH to the GOPATH if it is defined.
+  if [[ -n ${KUBE_EXTRA_GOPATH:-} ]]; then
+    GOPATH=${GOPATH}:${KUBE_EXTRA_GOPATH}
+  fi
   # Set GOPATH to point to the tree maintained by `godep`.
-  GOPATH="${KUBE_TARGET}:${KUBE_REPO_ROOT}/Godeps/_workspace"
+  GOPATH="${GOPATH}:${KUBE_REPO_ROOT}/Godeps/_workspace"
   export GOPATH
 
   # Unset GOBIN in case it already exists in the current session.


### PR DESCRIPTION
adds two new shell variables which are respected

KUBE_EXTRA_GOPATH and KUBE_NO_GODEPS

The first will be added to the final GOPATH.  The later will cause the Godeps directory to not be added to the final GOPATH.  Used in conjunction these can be used to replace the Godeps with something outside of the tree.
