### PR TITLE
Proposed ContainerStatus for each individual Container in a Pod.

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -268,7 +268,7 @@ type ContainerStateTerminated struct {
 
 type ContainerState struct {
 	// Only one of the following ContainerState may be specified.
-	// If none of them is specified, the default on is ContainerStateWaiting.
+	// If none of them is specified, the default one is ContainerStateWaiting.
 	Waiting     *ContainerStateWaiting    `json:"waiting,omitempty" yaml:"waiting,omitempty"`
 	Running     *ContainerStateRunning    `json:"running,omitempty" yaml:"running,omitempty"`
 	Termination *ContainerStateTerminated `json:"termination,omitempty" yaml:"termination,omitempty"`

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -253,6 +253,8 @@ const (
 )
 
 type ContainerStateWaiting struct {
+	// Reason could be pulling image,
+	Reason string `json:"reason,omitempty" yaml:"reason,omitempty"`
 }
 
 type ContainerStateRunning struct {
@@ -276,16 +278,20 @@ type ContainerStatus struct {
 	// TODO(dchen1107): Should we rename PodStatus to a more generic name or have a separate states
 	// defined for container?
 	State        ContainerState `json:"state,omitempty" yaml:"state,omitempty"`
-	RestartCount int            `json:"restartCount,omitempty" yaml:"restartCount,omitempty"`
-	// TODO(dchen1107): In long run, I think we should replace this with our own struct to remove
-	// the dependency on docker. Also once we have done with integration with cadvisor, resource
+	RestartCount int            `json:"restartCount" yaml:"restartCount"`
+	// TODO(dchen1107): Introduce our own NetworkSettings struct here?
+	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
 	// usage should be included.
+	// TODO(dchen1107):  In long run, I think we should replace this with our own struct to remove
+	// the dependency on docker.
 	DetailInfo docker.Container `json:"detailInfo,omitempty" yaml:"detailInfo,omitempty"`
 }
 
 // PodInfo contains one entry for every container with available info.
 // TODO(dchen1107): Replace docker.Container below with ContainerStatus defined above.
 type PodInfo map[string]docker.Container
+
+//type PodInfo map[string]docker.Container
 
 type RestartPolicyAlways struct{}
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -252,7 +252,39 @@ const (
 	PodTerminated PodStatus = "Terminated"
 )
 
+type ContainerStateWaiting struct {
+}
+
+type ContainerStateRunning struct {
+}
+
+type ContainerStateTerminated struct {
+	ExitCode int    `json:"exitCode,omitempty" yaml:"exitCode,omitempty"`
+	Signal   int    `json:"signal,omitempty" yaml:"signal,omitempty"`
+	Reason   string `json:"reason,omitempty" yaml:"reason,omitempty"`
+}
+
+type ContainerState struct {
+	// Only one of the following ContainerState may be specified.
+	// If none of them is specified, the default on is ContainerStateWaiting.
+	Waiting     *ContainerStateWaiting    `json:"waiting,omitempty" yaml:"waiting,omitempty"`
+	Running     *ContainerStateRunning    `json:"running,omitempty" yaml:"running,omitempty"`
+	Termination *ContainerStateTerminated `json:"termination,omitempty" yaml:"termination,omitempty"`
+}
+
+type ContainerStatus struct {
+	// TODO(dchen1107): Should we rename PodStatus to a more generic name or have a separate states
+	// defined for container?
+	State        ContainerState `json:"state,omitempty" yaml:"state,omitempty"`
+	RestartCount int            `json:"restartCount,omitempty" yaml:"restartCount,omitempty"`
+	// TODO(dchen1107): In long run, I think we should replace this with our own struct to remove
+	// the dependency on docker. Also once we have done with integration with cadvisor, resource
+	// usage should be included.
+	DetailInfo docker.Container `json:"detailInfo,omitempty" yaml:"detailInfo,omitempty"`
+}
+
 // PodInfo contains one entry for every container with available info.
+// TODO(dchen1107): Replace docker.Container below with ContainerStatus defined above.
 type PodInfo map[string]docker.Container
 
 type RestartPolicyAlways struct{}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -291,8 +291,6 @@ type ContainerStatus struct {
 // TODO(dchen1107): Replace docker.Container below with ContainerStatus defined above.
 type PodInfo map[string]docker.Container
 
-//type PodInfo map[string]docker.Container
-
 type RestartPolicyAlways struct{}
 
 // TODO(dchen1107): Define what kinds of failures should restart.

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -281,7 +281,7 @@ type ContainerStateTerminated struct {
 
 type ContainerState struct {
 	// Only one of the following ContainerState may be specified.
-	// If none of them is specified, the default on is ContainerStateWaiting.
+	// If none of them is specified, the default one is ContainerStateWaiting.
 	Waiting     *ContainerStateWaiting    `json:"waiting,omitempty" yaml:"waiting,omitempty"`
 	Running     *ContainerStateRunning    `json:"running,omitempty" yaml:"running,omitempty"`
 	Termination *ContainerStateTerminated `json:"termination,omitempty" yaml:"termination,omitempty"`

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -265,6 +265,41 @@ const (
 	PodTerminated PodStatus = "Terminated"
 )
 
+type ContainerStateWaiting struct {
+	// Reason could be pulling image,
+	Reason string `json:"reason,omitempty" yaml:"reason,omitempty"`
+}
+
+type ContainerStateRunning struct {
+}
+
+type ContainerStateTerminated struct {
+	ExitCode int    `json:"exitCode,omitempty" yaml:"exitCode,omitempty"`
+	Signal   int    `json:"signal,omitempty" yaml:"signal,omitempty"`
+	Reason   string `json:"reason,omitempty" yaml:"reason,omitempty"`
+}
+
+type ContainerState struct {
+	// Only one of the following ContainerState may be specified.
+	// If none of them is specified, the default on is ContainerStateWaiting.
+	Waiting     *ContainerStateWaiting    `json:"waiting,omitempty" yaml:"waiting,omitempty"`
+	Running     *ContainerStateRunning    `json:"running,omitempty" yaml:"running,omitempty"`
+	Termination *ContainerStateTerminated `json:"termination,omitempty" yaml:"termination,omitempty"`
+}
+
+type ContainerStatus struct {
+	// TODO(dchen1107): Should we rename PodStatus to a more generic name or have a separate states
+	// defined for container?
+	State        ContainerState `json:"state,omitempty" yaml:"state,omitempty"`
+	RestartCount int            `json:"restartCount" yaml:"restartCount"`
+	// TODO(dchen1107): Introduce our own NetworkSettings struct here?
+	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
+	// usage should be included.
+	// TODO(dchen1107):  In long run, I think we should replace this with our own struct to remove
+	// the dependency on docker.
+	DetailInfo docker.Container `json:"detailInfo,omitempty" yaml:"detailInfo,omitempty"`
+}
+
 // PodInfo contains one entry for every container with available info.
 type PodInfo map[string]docker.Container
 


### PR DESCRIPTION
@smarterclayton @thockin @bgrant0607 @brendandburns 

I started to work on termination reasons #137. Before I go crazy, I would like to propose a new struct to our API, which hold all information of a container related to a BoundPod. This PR does nothing with many TODOs
for further discussion. 

@smarterclayton I mentioned this to you in one of your v1beta3 API proposal (#1225). But I think we could have this in now without breaking any clients. Without my PR #1199 and #1262 in, we don't have correct PodInfo anyway. 
