### PR TITLE
Create v1beta2 and allow multiple Codec encodings to exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - ./hack/build-go.sh
 
 script:
-  - ./hack/test-go.sh
+  - KUBE_TIMEOUT='-timeout 60s' ./hack/test-go.sh
   - PATH=$HOME/gopath/bin:./third_party/etcd/bin:$PATH ./hack/test-cmd.sh
   - PATH=$HOME/gopath/bin:./third_party/etcd/bin:$PATH ./hack/test-integration.sh
 

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/controller"
@@ -206,7 +207,7 @@ func runAtomicPutTest(c *client.Client) {
 	var svc api.Service
 	err := c.Post().Path("services").Body(
 		&api.Service{
-			JSONBase: api.JSONBase{ID: "atomicservice", APIVersion: "v1beta1"},
+			JSONBase: api.JSONBase{ID: "atomicservice", APIVersion: latest.Version},
 			Port:     12345,
 			Labels: map[string]string{
 				"name": "atomicService",

--- a/cmd/kubecfg/kubecfg.go
+++ b/cmd/kubecfg/kubecfg.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubecfg"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"

--- a/cmd/kubecfg/kubecfg.go
+++ b/cmd/kubecfg/kubecfg.go
@@ -129,7 +129,7 @@ func readConfig(storage string) []byte {
 		glog.Fatal("Need config file (-c)")
 	}
 
-	data, err := parser.ToWireFormat(readConfigData(), storage, runtime.DefaultCodec)
+	data, err := parser.ToWireFormat(readConfigData(), storage, latest.Codec)
 
 	if err != nil {
 		glog.Fatalf("Error parsing %v as an object for %v: %v\n", *config, storage, err)
@@ -296,7 +296,7 @@ func executeAPIRequest(method string, c *client.Client) bool {
 	if setBody {
 		if version != 0 {
 			data := readConfig(storage)
-			obj, err := runtime.DefaultCodec.Decode(data)
+			obj, err := latest.Codec.Decode(data)
 			if err != nil {
 				glog.Fatalf("error setting resource version: %v", err)
 			}
@@ -305,7 +305,7 @@ func executeAPIRequest(method string, c *client.Client) bool {
 				glog.Fatalf("error setting resource version: %v", err)
 			}
 			jsonBase.SetResourceVersion(version)
-			data, err = runtime.DefaultCodec.Encode(obj)
+			data, err = latest.Codec.Encode(obj)
 			if err != nil {
 				glog.Fatalf("error setting resource version: %v", err)
 			}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/golang/glog"

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -103,7 +103,7 @@ func TestApiExamples(t *testing.T) {
 			return
 		}
 		tested += 1
-		if err := runtime.DefaultCodec.DecodeInto(data, expectedType); err != nil {
+		if err := latest.Codec.DecodeInto(data, expectedType); err != nil {
 			t.Errorf("%s did not decode correctly: %v\n%s", path, err, string(data))
 			return
 		}
@@ -137,7 +137,7 @@ func TestExamples(t *testing.T) {
 			return
 		}
 		tested += 1
-		if err := runtime.DefaultCodec.DecodeInto(data, expectedType); err != nil {
+		if err := latest.Codec.DecodeInto(data, expectedType); err != nil {
 			t.Errorf("%s did not decode correctly: %v\n%s", path, err, string(data))
 			return
 		}
@@ -168,14 +168,14 @@ func TestReadme(t *testing.T) {
 	}
 	for _, json := range match[1:] {
 		expectedType := &api.Pod{}
-		if err := runtime.DefaultCodec.DecodeInto([]byte(json), expectedType); err != nil {
+		if err := latest.Codec.DecodeInto([]byte(json), expectedType); err != nil {
 			t.Errorf("%s did not decode correctly: %v\n%s", path, err, string(data))
 			return
 		}
 		if errors := validateObject(expectedType); len(errors) > 0 {
 			t.Errorf("%s did not validate correctly: %v", path, errors)
 		}
-		encoded, err := runtime.DefaultCodec.Encode(expectedType)
+		encoded, err := latest.Codec.Encode(expectedType)
 		if err != nil {
 			t.Errorf("Could not encode object: %v", err)
 			continue

--- a/pkg/api/conversion.go
+++ b/pkg/api/conversion.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+)
+
+// Codec is the identity codec for this package - it can only convert itself
+// to itself.
+var Codec = runtime.CodecFor(Scheme, "")
+
+// EmbeddedObject implements a Codec specific version of an
+// embedded object.
+type EmbeddedObject struct {
+	runtime.Object
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (a *EmbeddedObject) UnmarshalJSON(b []byte) error {
+	obj, err := runtime.CodecUnmarshalJSON(Codec, b)
+	a.Object = obj
+	return err
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (a EmbeddedObject) MarshalJSON() ([]byte, error) {
+	return runtime.CodecMarshalJSON(Codec, a.Object)
+}
+
+// SetYAML implements the yaml.Setter interface.
+func (a *EmbeddedObject) SetYAML(tag string, value interface{}) bool {
+	obj, ok := runtime.CodecSetYAML(Codec, tag, value)
+	a.Object = obj
+	return ok
+}
+
+// GetYAML implements the yaml.Getter interface.
+func (a EmbeddedObject) GetYAML() (tag string, value interface{}) {
+	return runtime.CodecGetYAML(Codec, a.Object)
+}

--- a/pkg/api/latest/doc.go
+++ b/pkg/api/latest/doc.go
@@ -14,30 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package api
-
-import (
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-)
-
-var Scheme = runtime.NewScheme()
-
-func init() {
-	Scheme.AddKnownTypes("",
-		&PodList{},
-		&Pod{},
-		&ReplicationControllerList{},
-		&ReplicationController{},
-		&ServiceList{},
-		&Service{},
-		&MinionList{},
-		&Minion{},
-		&Status{},
-		&ServerOpList{},
-		&ServerOp{},
-		&ContainerManifestList{},
-		&Endpoints{},
-		&EndpointsList{},
-		&Binding{},
-	)
-}
+// Package latest defines the default output serializations that code should
+// use and imports the required schemas.  It also ensures all previously known
+// and supported API versions are available for conversion.
+package latest

--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latest
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta2"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+)
+
+// Version is the string that represents the current external default version
+var Version = "v1beta1"
+
+// Codec is the default codec for serializing output that should use
+// the latest supported version.  Use this Codec when writing to
+// disk, a data store that is not dynamically versioned, or in tests.
+// This codec can decode any object that Kubernetes is aware of.
+var Codec = v1beta1.Codec
+
+// ResourceVersioner describes a default versioner that can handle all types
+// of versioning.
+// TODO: when versioning changes, make this part of each API definition.
+var ResourceVersioner = runtime.NewJSONBaseResourceVersioner()

--- a/pkg/api/latest/latest_test.go
+++ b/pkg/api/latest/latest_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latest
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	internal "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta2"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/fsouza/go-dockerclient"
+	"github.com/google/gofuzz"
+)
+
+// apiObjectFuzzer can randomly populate api objects.
+var apiObjectFuzzer = fuzz.New().NilChance(.5).NumElements(1, 1).Funcs(
+	func(j *internal.JSONBase, c fuzz.Continue) {
+		// We have to customize the randomization of JSONBases because their
+		// APIVersion and Kind must remain blank in memory.
+		j.APIVersion = ""
+		j.Kind = ""
+		j.ID = c.RandString()
+		// TODO: Fix JSON/YAML packages and/or write custom encoding
+		// for uint64's. Somehow the LS *byte* of this is lost, but
+		// only when all 8 bytes are set.
+		j.ResourceVersion = c.RandUint64() >> 8
+		j.SelfLink = c.RandString()
+
+		var sec, nsec int64
+		c.Fuzz(&sec)
+		c.Fuzz(&nsec)
+		j.CreationTimestamp = util.Unix(sec, nsec).Rfc3339Copy()
+	},
+	func(intstr *util.IntOrString, c fuzz.Continue) {
+		// util.IntOrString will panic if its kind is set wrong.
+		if c.RandBool() {
+			intstr.Kind = util.IntstrInt
+			intstr.IntVal = int(c.RandUint64())
+			intstr.StrVal = ""
+		} else {
+			intstr.Kind = util.IntstrString
+			intstr.IntVal = 0
+			intstr.StrVal = c.RandString()
+		}
+	},
+	func(u64 *uint64, c fuzz.Continue) {
+		// TODO: uint64's are NOT handled right.
+		*u64 = c.RandUint64() >> 8
+	},
+	func(pb map[docker.Port][]docker.PortBinding, c fuzz.Continue) {
+		// This is necessary because keys with nil values get omitted.
+		// TODO: Is this a bug?
+		pb[docker.Port(c.RandString())] = []docker.PortBinding{
+			{c.RandString(), c.RandString()},
+			{c.RandString(), c.RandString()},
+		}
+	},
+	func(pm map[string]docker.PortMapping, c fuzz.Continue) {
+		// This is necessary because keys with nil values get omitted.
+		// TODO: Is this a bug?
+		pm[c.RandString()] = docker.PortMapping{
+			c.RandString(): c.RandString(),
+		}
+	},
+)
+
+func TestInternalRoundTrip(t *testing.T) {
+	latest := "v1beta2"
+
+	for k, _ := range internal.Scheme.KnownTypes("") {
+		obj, err := internal.Scheme.New("", k)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", k, err)
+			continue
+		}
+		apiObjectFuzzer.Fuzz(obj)
+
+		newer, err := internal.Scheme.New(latest, k)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", k, err)
+			continue
+		}
+
+		if err := internal.Scheme.Convert(obj, newer); err != nil {
+			t.Errorf("unable to convert %#v to %#v: %v", obj, newer, err)
+		}
+
+		actual, err := internal.Scheme.New("", k)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", k, err)
+			continue
+		}
+
+		if err := internal.Scheme.Convert(newer, actual); err != nil {
+			t.Errorf("unable to convert %#v to %#v: %v", newer, actual, err)
+		}
+
+		if !reflect.DeepEqual(obj, actual) {
+			t.Errorf("%s: diff %s", k, runtime.ObjectDiff(obj, actual))
+		}
+	}
+}
+
+func TestResourceVersioner(t *testing.T) {
+	pod := internal.Pod{JSONBase: internal.JSONBase{ResourceVersion: 10}}
+	version, err := ResourceVersioner.ResourceVersion(&pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if version != 10 {
+		t.Errorf("unexpected version %d", version)
+	}
+}
+
+func TestCodec(t *testing.T) {
+	pod := internal.Pod{}
+	data, err := Codec.Encode(&pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	other := internal.Pod{}
+	if err := json.Unmarshal(data, &other); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if other.APIVersion != Version || other.Kind != "Pod" {
+		t.Errorf("unexpected unmarshalled object %#v", other)
+	}
+}

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -135,13 +135,13 @@ func runTest(t *testing.T, source runtime.Object) {
 	j.SetKind("")
 	j.SetAPIVersion("")
 
-	data, err := runtime.DefaultCodec.Encode(source)
+	data, err := latest.Codec.Encode(source)
 	if err != nil {
 		t.Errorf("%v: %v (%#v)", name, err, source)
 		return
 	}
 
-	obj2, err := runtime.DefaultCodec.Decode(data)
+	obj2, err := latest.Codec.Decode(data)
 	if err != nil {
 		t.Errorf("%v: %v", name, err)
 		return
@@ -152,7 +152,7 @@ func runTest(t *testing.T, source runtime.Object) {
 		}
 	}
 	obj3 := reflect.New(reflect.TypeOf(source).Elem()).Interface().(runtime.Object)
-	err = runtime.DefaultCodec.DecodeInto(data, obj3)
+	err = latest.Codec.DecodeInto(data, obj3)
 	if err != nil {
 		t.Errorf("2: %v: %v", name, err)
 		return
@@ -194,8 +194,8 @@ func TestEncode_Ptr(t *testing.T) {
 		Labels: map[string]string{"name": "foo"},
 	}
 	obj := runtime.Object(pod)
-	data, err := runtime.DefaultCodec.Encode(obj)
-	obj2, err2 := runtime.DefaultCodec.Decode(data)
+	data, err := latest.Codec.Encode(obj)
+	obj2, err2 := latest.Codec.Decode(data)
 	if err != nil || err2 != nil {
 		t.Fatalf("Failure: '%v' '%v'", err, err2)
 	}
@@ -209,11 +209,11 @@ func TestEncode_Ptr(t *testing.T) {
 
 func TestBadJSONRejection(t *testing.T) {
 	badJSONMissingKind := []byte(`{ }`)
-	if _, err := runtime.DefaultCodec.Decode(badJSONMissingKind); err == nil {
+	if _, err := latest.Codec.Decode(badJSONMissingKind); err == nil {
 		t.Errorf("Did not reject despite lack of kind field: %s", badJSONMissingKind)
 	}
 	badJSONUnknownType := []byte(`{"kind": "bar"}`)
-	if _, err1 := runtime.DefaultCodec.Decode(badJSONUnknownType); err1 == nil {
+	if _, err1 := latest.Codec.Decode(badJSONUnknownType); err1 == nil {
 		t.Errorf("Did not reject despite use of unknown type: %s", badJSONUnknownType)
 	}
 	/*badJSONKindMismatch := []byte(`{"kind": "Pod"}`)

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/google/gofuzz"
 )
 
-var fuzzIters = flag.Int("fuzz_iters", 50, "How many fuzzing iterations to do.")
+var fuzzIters = flag.Int("fuzz_iters", 40, "How many fuzzing iterations to do.")
 
 // apiObjectFuzzer can randomly populate api objects.
 var apiObjectFuzzer = fuzz.New().NilChance(.5).NumElements(1, 1).Funcs(
@@ -166,6 +166,7 @@ func TestTypes(t *testing.T) {
 		for i := 0; i < *fuzzIters; i++ {
 			runTest(t, v1beta1.Codec, item)
 			runTest(t, v1beta2.Codec, item)
+			runTest(t, api.Codec, item)
 		}
 	}
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -17,9 +17,7 @@ limitations under the License.
 package api
 
 import (
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/fsouza/go-dockerclient"
 )
 
@@ -623,13 +621,3 @@ type ServerOpList struct {
 }
 
 func (*ServerOpList) IsAnAPIObject() {}
-
-// WatchEvent objects are streamed from the api server in response to a watch request.
-type WatchEvent struct {
-	// The type of the watch event; added, modified, or deleted.
-	Type watch.EventType
-
-	// For added or modified objects, this is the new object; for deleted objects,
-	// it's the state of the object immediately prior to its deletion.
-	Object runtime.EmbeddedObject
-}

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -17,14 +17,13 @@ limitations under the License.
 package v1beta1
 
 import (
-	// Alias this so it can be easily changed when we cut the next version.
 	newer "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
 func init() {
-	runtime.DefaultScheme.AddConversionFuncs(
+	newer.Scheme.AddConversionFuncs(
 		// EnvVar's Key is deprecated in favor of Name.
 		func(in *newer.EnvVar, out *EnvVar, s conversion.Scope) error {
 			out.Value = in.Value
@@ -80,4 +79,34 @@ func init() {
 		},
 	)
 
+}
+
+// EmbeddedObject implements a Codec specific version of an
+// embedded object.
+type EmbeddedObject struct {
+	runtime.Object
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (a *EmbeddedObject) UnmarshalJSON(b []byte) error {
+	obj, err := runtime.CodecUnmarshalJSON(Codec, b)
+	a.Object = obj
+	return err
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (a EmbeddedObject) MarshalJSON() ([]byte, error) {
+	return runtime.CodecMarshalJSON(Codec, a.Object)
+}
+
+// SetYAML implements the yaml.Setter interface.
+func (a *EmbeddedObject) SetYAML(tag string, value interface{}) bool {
+	obj, ok := runtime.CodecSetYAML(Codec, tag, value)
+	a.Object = obj
+	return ok
+}
+
+// GetYAML implements the yaml.Getter interface.
+func (a EmbeddedObject) GetYAML() (tag string, value interface{}) {
+	return runtime.CodecGetYAML(Codec, a.Object)
 }

--- a/pkg/api/v1beta1/conversion_test.go
+++ b/pkg/api/v1beta1/conversion_test.go
@@ -22,10 +22,9 @@ import (
 
 	newer "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
-var Convert = runtime.DefaultScheme.Convert
+var Convert = newer.Scheme.Convert
 
 func TestEnvConversion(t *testing.T) {
 	nonCanonical := []v1beta1.EnvVar{

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -17,11 +17,15 @@ limitations under the License.
 package v1beta1
 
 import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
+// Codec encodes internal objects to the v1beta1 scheme
+var Codec = runtime.CodecFor(api.Scheme, "v1beta1")
+
 func init() {
-	runtime.DefaultScheme.AddKnownTypes("v1beta1",
+	api.Scheme.AddKnownTypes("v1beta1",
 		&PodList{},
 		&Pod{},
 		&ReplicationControllerList{},

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -17,9 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/fsouza/go-dockerclient"
 )
 
@@ -625,13 +623,3 @@ type ServerOpList struct {
 }
 
 func (*ServerOpList) IsAnAPIObject() {}
-
-// WatchEvent objects are streamed from the api server in response to a watch request.
-type WatchEvent struct {
-	// The type of the watch event; added, modified, or deleted.
-	Type watch.EventType
-
-	// For added or modified objects, this is the new object; for deleted objects,
-	// it's the state of the object immediately prior to its deletion.
-	Object runtime.EmbeddedObject
-}

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+)
+
+func init() {
+	runtime.DefaultScheme.AddConversionFuncs()
+}
+
+// EmbeddedObject implements a Codec specific version of an
+// embedded object.
+type EmbeddedObject struct {
+	runtime.Object
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (a *EmbeddedObject) UnmarshalJSON(b []byte) error {
+	obj, err := runtime.CodecUnmarshalJSON(Codec, b)
+	a.Object = obj
+	return err
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (a EmbeddedObject) MarshalJSON() ([]byte, error) {
+	return runtime.CodecMarshalJSON(Codec, a.Object)
+}
+
+// SetYAML implements the yaml.Setter interface.
+func (a *EmbeddedObject) SetYAML(tag string, value interface{}) bool {
+	obj, ok := runtime.CodecSetYAML(Codec, tag, value)
+	a.Object = obj
+	return ok
+}
+
+// GetYAML implements the yaml.Getter interface.
+func (a EmbeddedObject) GetYAML() (tag string, value interface{}) {
+	return runtime.CodecGetYAML(Codec, a.Object)
+}

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -17,11 +17,67 @@ limitations under the License.
 package v1beta2
 
 import (
+	newer "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
 func init() {
-	runtime.DefaultScheme.AddConversionFuncs()
+	newer.Scheme.AddConversionFuncs(
+		// EnvVar's Key is deprecated in favor of Name.
+		func(in *newer.EnvVar, out *EnvVar, s conversion.Scope) error {
+			out.Value = in.Value
+			out.Key = in.Name
+			out.Name = in.Name
+			return nil
+		},
+		func(in *EnvVar, out *newer.EnvVar, s conversion.Scope) error {
+			out.Value = in.Value
+			if in.Name != "" {
+				out.Name = in.Name
+			} else {
+				out.Name = in.Key
+			}
+			return nil
+		},
+
+		// Path & MountType are deprecated.
+		func(in *newer.VolumeMount, out *VolumeMount, s conversion.Scope) error {
+			out.Name = in.Name
+			out.ReadOnly = in.ReadOnly
+			out.MountPath = in.MountPath
+			out.Path = in.MountPath
+			out.MountType = "" // MountType is ignored.
+			return nil
+		},
+		func(in *VolumeMount, out *newer.VolumeMount, s conversion.Scope) error {
+			out.Name = in.Name
+			out.ReadOnly = in.ReadOnly
+			if in.MountPath == "" {
+				out.MountPath = in.Path
+			} else {
+				out.MountPath = in.MountPath
+			}
+			return nil
+		},
+
+		// MinionList.Items had a wrong name in v1beta1
+		func(in *newer.MinionList, out *MinionList, s conversion.Scope) error {
+			s.Convert(&in.JSONBase, &out.JSONBase, 0)
+			s.Convert(&in.Items, &out.Items, 0)
+			out.Minions = out.Items
+			return nil
+		},
+		func(in *MinionList, out *newer.MinionList, s conversion.Scope) error {
+			s.Convert(&in.JSONBase, &out.JSONBase, 0)
+			if len(in.Items) == 0 {
+				s.Convert(&in.Minions, &out.Items, 0)
+			} else {
+				s.Convert(&in.Items, &out.Items, 0)
+			}
+			return nil
+		},
+	)
 }
 
 // EmbeddedObject implements a Codec specific version of an

--- a/pkg/api/v1beta2/conversion_test.go
+++ b/pkg/api/v1beta2/conversion_test.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2_test
+
+import ()

--- a/pkg/api/v1beta2/doc.go
+++ b/pkg/api/v1beta2/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1beta2 is the v1beta2 version of the API.
+package v1beta2

--- a/pkg/api/v1beta2/register.go
+++ b/pkg/api/v1beta2/register.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+)
+
+// Codec encodes runtime objects to the v1beta2 scheme
+var Codec = runtime.CodecFor(runtime.DefaultScheme, "v1beta2")
+
+func init() {
+	runtime.DefaultScheme.AddKnownTypes("v1beta2",
+		&PodList{},
+		&Pod{},
+		&ReplicationControllerList{},
+		&ReplicationController{},
+		&ServiceList{},
+		&Service{},
+		&MinionList{},
+		&Minion{},
+		&Status{},
+		&ServerOpList{},
+		&ServerOp{},
+		&ContainerManifestList{},
+		&Endpoints{},
+		&EndpointsList{},
+		&Binding{},
+	)
+}

--- a/pkg/api/v1beta2/register.go
+++ b/pkg/api/v1beta2/register.go
@@ -17,14 +17,15 @@ limitations under the License.
 package v1beta2
 
 import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
-// Codec encodes runtime objects to the v1beta2 scheme
-var Codec = runtime.CodecFor(runtime.DefaultScheme, "v1beta2")
+// Codec encodes internal objects to the v1beta2 scheme
+var Codec = runtime.CodecFor(api.Scheme, "v1beta2")
 
 func init() {
-	runtime.DefaultScheme.AddKnownTypes("v1beta2",
+	api.Scheme.AddKnownTypes("v1beta2",
 		&PodList{},
 		&Pod{},
 		&ReplicationControllerList{},

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -1,0 +1,637 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+	"github.com/fsouza/go-dockerclient"
+)
+
+// Common string formats
+// ---------------------
+// Many fields in this API have formatting requirements.  The commonly used
+// formats are defined here.
+//
+// C_IDENTIFIER:  This is a string that conforms the definition of an "identifier"
+//     in the C language.  This is captured by the following regex:
+//         [A-Za-z_][A-Za-z0-9_]*
+//     This defines the format, but not the length restriction, which should be
+//     specified at the definition of any field of this type.
+//
+// DNS_LABEL:  This is a string, no more than 63 characters long, that conforms
+//     to the definition of a "label" in RFCs 1035 and 1123.  This is captured
+//     by the following regex:
+//         [a-z0-9]([-a-z0-9]*[a-z0-9])?
+//
+// DNS_SUBDOMAIN:  This is a string, no more than 253 characters long, that conforms
+//      to the definition of a "subdomain" in RFCs 1035 and 1123.  This is captured
+//      by the following regex:
+//         [a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
+//     or more simply:
+//         DNS_LABEL(\.DNS_LABEL)*
+
+// ContainerManifest corresponds to the Container Manifest format, documented at:
+// https://developers.google.com/compute/docs/containers/container_vms#container_manifest
+// This is used as the representation of Kubernetes workloads.
+type ContainerManifest struct {
+	// Required: This must be a supported version string, such as "v1beta1".
+	Version string `yaml:"version" json:"version"`
+	// Required: This must be a DNS_SUBDOMAIN.
+	// TODO: ID on Manifest is deprecated and will be removed in the future.
+	ID string `yaml:"id" json:"id"`
+	// TODO: UUID on Manifext is deprecated in the future once we are done
+	// with the API refactory. It is required for now to determine the instance
+	// of a Pod.
+	UUID          string        `yaml:"uuid,omitempty" json:"uuid,omitempty"`
+	Volumes       []Volume      `yaml:"volumes" json:"volumes"`
+	Containers    []Container   `yaml:"containers" json:"containers"`
+	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty" yaml:"restartPolicy,omitempty"`
+}
+
+// ContainerManifestList is used to communicate container manifests to kubelet.
+type ContainerManifestList struct {
+	JSONBase `json:",inline" yaml:",inline"`
+	Items    []ContainerManifest `json:"items,omitempty" yaml:"items,omitempty"`
+}
+
+func (*ContainerManifestList) IsAnAPIObject() {}
+
+// Volume represents a named volume in a pod that may be accessed by any containers in the pod.
+type Volume struct {
+	// Required: This must be a DNS_LABEL.  Each volume in a pod must have
+	// a unique name.
+	Name string `yaml:"name" json:"name"`
+	// Source represents the location and type of a volume to mount.
+	// This is optional for now. If not specified, the Volume is implied to be an EmptyDir.
+	// This implied behavior is deprecated and will be removed in a future version.
+	Source *VolumeSource `yaml:"source" json:"source"`
+}
+
+type VolumeSource struct {
+	// Only one of the following sources may be specified
+	// HostDirectory represents a pre-existing directory on the host machine that is directly
+	// exposed to the container. This is generally used for system agents or other privileged
+	// things that are allowed to see the host machine. Most containers will NOT need this.
+	// TODO(jonesdl) We need to restrict who can use host directory mounts and
+	// who can/can not mount host directories as read/write.
+	HostDirectory *HostDirectory `yaml:"hostDir" json:"hostDir"`
+	// EmptyDirectory represents a temporary directory that shares a pod's lifetime.
+	EmptyDirectory *EmptyDirectory `yaml:"emptyDir" json:"emptyDir"`
+}
+
+// HostDirectory represents bare host directory volume.
+type HostDirectory struct {
+	Path string `yaml:"path" json:"path"`
+}
+
+type EmptyDirectory struct{}
+
+// Port represents a network port in a single container.
+type Port struct {
+	// Optional: If specified, this must be a DNS_LABEL.  Each named port
+	// in a pod must have a unique name.
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+	// Optional: If specified, this must be a valid port number, 0 < x < 65536.
+	HostPort int `yaml:"hostPort,omitempty" json:"hostPort,omitempty"`
+	// Required: This must be a valid port number, 0 < x < 65536.
+	ContainerPort int `yaml:"containerPort" json:"containerPort"`
+	// Optional: Supports "TCP" and "UDP".  Defaults to "TCP".
+	Protocol string `yaml:"protocol,omitempty" json:"protocol,omitempty"`
+	// Optional: What host IP to bind the external port to.
+	HostIP string `yaml:"hostIP,omitempty" json:"hostIP,omitempty"`
+}
+
+// VolumeMount describes a mounting of a Volume within a container.
+type VolumeMount struct {
+	// Required: This must match the Name of a Volume [above].
+	Name string `yaml:"name" json:"name"`
+	// Optional: Defaults to false (read-write).
+	ReadOnly bool `yaml:"readOnly,omitempty" json:"readOnly,omitempty"`
+	// Required.
+	// Exactly one of the following must be set.  If both are set, prefer MountPath.
+	// DEPRECATED: Path will be removed in a future version of the API.
+	MountPath string `yaml:"mountPath,omitempty" json:"mountPath,omitempty"`
+	Path      string `yaml:"path,omitempty" json:"path,omitempty"`
+	// One of: "LOCAL" (local volume) or "HOST" (external mount from the host). Default: LOCAL.
+	// DEPRECATED: MountType will be removed in a future version of the API.
+	MountType string `yaml:"mountType,omitempty" json:"mountType,omitempty"`
+}
+
+// EnvVar represents an environment variable present in a Container.
+type EnvVar struct {
+	// Required: This must be a C_IDENTIFIER.
+	// Exactly one of the following must be set.  If both are set, prefer Name.
+	// DEPRECATED: EnvVar.Key will be removed in a future version of the API.
+	Name string `yaml:"name" json:"name"`
+	Key  string `yaml:"key,omitempty" json:"key,omitempty"`
+	// Optional: defaults to "".
+	Value string `yaml:"value,omitempty" json:"value,omitempty"`
+}
+
+// HTTPGetAction describes an action based on HTTP Get requests.
+type HTTPGetAction struct {
+	// Optional: Path to access on the HTTP server.
+	Path string `yaml:"path,omitempty" json:"path,omitempty"`
+	// Required: Name or number of the port to access on the container.
+	Port util.IntOrString `yaml:"port,omitempty" json:"port,omitempty"`
+	// Optional: Host name to connect to, defaults to the pod IP.
+	Host string `yaml:"host,omitempty" json:"host,omitempty"`
+}
+
+// TCPSocketAction describes an action based on opening a socket
+type TCPSocketAction struct {
+	// Required: Port to connect to.
+	Port util.IntOrString `yaml:"port,omitempty" json:"port,omitempty"`
+}
+
+// ExecAction describes a "run in container" action.
+type ExecAction struct {
+	// Command is the command line to execute inside the container, the working directory for the
+	// command  is root ('/') in the container's filesystem.  The command is simply exec'd, it is
+	// not run inside a shell, so traditional shell instructions ('|', etc) won't work.  To use
+	// a shell, you need to explicitly call out to that shell.
+	// A return code of zero is treated as 'Healthy', non-zero is 'Unhealthy'
+	Command []string `yaml:"command,omitempty" json:"command,omitempty"`
+}
+
+// LivenessProbe describes a liveness probe to be examined to the container.
+// TODO: pass structured data to the actions, and document that data here.
+type LivenessProbe struct {
+	// Type of liveness probe.  Current legal values "http", "tcp"
+	Type string `yaml:"type,omitempty" json:"type,omitempty"`
+	// HTTPGetProbe parameters, required if Type == 'http'
+	HTTPGet *HTTPGetAction `yaml:"httpGet,omitempty" json:"httpGet,omitempty"`
+	// TCPSocketProbe parameter, required if Type == 'tcp'
+	TCPSocket *TCPSocketAction `yaml:"tcpSocket,omitempty" json:"tcpSocket,omitempty"`
+	// ExecProbe parameter, required if Type == 'exec'
+	Exec *ExecAction `yaml:"exec,omitempty" json:"exec,omitempty"`
+	// Length of time before health checking is activated.  In seconds.
+	InitialDelaySeconds int64 `yaml:"initialDelaySeconds,omitempty" json:"initialDelaySeconds,omitempty"`
+}
+
+// Container represents a single container that is expected to be run on the host.
+type Container struct {
+	// Required: This must be a DNS_LABEL.  Each container in a pod must
+	// have a unique name.
+	Name string `yaml:"name" json:"name"`
+	// Required.
+	Image string `yaml:"image" json:"image"`
+	// Optional: Defaults to whatever is defined in the image.
+	Command []string `yaml:"command,omitempty" json:"command,omitempty"`
+	// Optional: Defaults to Docker's default.
+	WorkingDir string   `yaml:"workingDir,omitempty" json:"workingDir,omitempty"`
+	Ports      []Port   `yaml:"ports,omitempty" json:"ports,omitempty"`
+	Env        []EnvVar `yaml:"env,omitempty" json:"env,omitempty"`
+	// Optional: Defaults to unlimited.
+	Memory int `yaml:"memory,omitempty" json:"memory,omitempty"`
+	// Optional: Defaults to unlimited.
+	CPU           int            `yaml:"cpu,omitempty" json:"cpu,omitempty"`
+	VolumeMounts  []VolumeMount  `yaml:"volumeMounts,omitempty" json:"volumeMounts,omitempty"`
+	LivenessProbe *LivenessProbe `yaml:"livenessProbe,omitempty" json:"livenessProbe,omitempty"`
+	Lifecycle     *Lifecycle     `yaml:"lifecycle,omitempty" json:"lifecycle,omitempty"`
+	// Optional: Default to false.
+	Privileged bool `json:"privileged,omitempty" yaml:"privileged,omitempty"`
+}
+
+// Handler defines a specific action that should be taken
+// TODO: merge this with liveness probing?
+// TODO: pass structured data to these actions, and document that data here.
+type Handler struct {
+	// One and only one of the following should be specified.
+	// Exec specifies the action to take.
+	Exec *ExecAction `yaml:"exec,omitempty" json:"exec,omitempty"`
+	// HTTPGet specifies the http request to perform.
+	HTTPGet *HTTPGetAction `yaml:"httpGet,omitempty" json:"httpGet,omitempty"`
+}
+
+// Lifecycle describes actions that the management system should take in response to container lifecycle
+// events.  For the PostStart and PreStop lifecycle handlers, management of the container blocks
+// until the action is complete, unless the container process fails, in which case the handler is aborted.
+type Lifecycle struct {
+	// PostStart is called immediately after a container is created.  If the handler fails, the container
+	// is terminated and restarted.
+	PostStart *Handler `yaml:"postStart,omitempty" json:"postStart,omitempty"`
+	// PreStop is called immediately before a container is terminated.  The reason for termination is
+	// passed to the handler.  Regardless of the outcome of the handler, the container is eventually terminated.
+	PreStop *Handler `yaml:"preStop,omitempty" json:"preStop,omitempty"`
+}
+
+// Event is the representation of an event logged to etcd backends.
+type Event struct {
+	Event     string             `json:"event,omitempty"`
+	Manifest  *ContainerManifest `json:"manifest,omitempty"`
+	Container *Container         `json:"container,omitempty"`
+	Timestamp int64              `json:"timestamp"`
+}
+
+// The below types are used by kube_client and api_server.
+
+// JSONBase is shared by all objects sent to, or returned from the client.
+type JSONBase struct {
+	Kind              string    `json:"kind,omitempty" yaml:"kind,omitempty"`
+	ID                string    `json:"id,omitempty" yaml:"id,omitempty"`
+	CreationTimestamp util.Time `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
+	SelfLink          string    `json:"selfLink,omitempty" yaml:"selfLink,omitempty"`
+	ResourceVersion   uint64    `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
+	APIVersion        string    `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+}
+
+func (*JSONBase) IsAnAPIObject() {}
+
+// PodStatus represents a status of a pod.
+type PodStatus string
+
+// These are the valid statuses of pods.
+const (
+	// PodWaiting means that we're waiting for the pod to begin running.
+	PodWaiting PodStatus = "Waiting"
+	// PodRunning means that the pod is up and running.
+	PodRunning PodStatus = "Running"
+	// PodTerminated means that the pod has stopped.
+	PodTerminated PodStatus = "Terminated"
+)
+
+type ContainerStateWaiting struct {
+	// Reason could be pulling image,
+	Reason string `json:"reason,omitempty" yaml:"reason,omitempty"`
+}
+
+type ContainerStateRunning struct {
+}
+
+type ContainerStateTerminated struct {
+	ExitCode int    `json:"exitCode,omitempty" yaml:"exitCode,omitempty"`
+	Signal   int    `json:"signal,omitempty" yaml:"signal,omitempty"`
+	Reason   string `json:"reason,omitempty" yaml:"reason,omitempty"`
+}
+
+type ContainerState struct {
+	// Only one of the following ContainerState may be specified.
+	// If none of them is specified, the default one is ContainerStateWaiting.
+	Waiting     *ContainerStateWaiting    `json:"waiting,omitempty" yaml:"waiting,omitempty"`
+	Running     *ContainerStateRunning    `json:"running,omitempty" yaml:"running,omitempty"`
+	Termination *ContainerStateTerminated `json:"termination,omitempty" yaml:"termination,omitempty"`
+}
+
+type ContainerStatus struct {
+	// TODO(dchen1107): Should we rename PodStatus to a more generic name or have a separate states
+	// defined for container?
+	State        ContainerState `json:"state,omitempty" yaml:"state,omitempty"`
+	RestartCount int            `json:"restartCount" yaml:"restartCount"`
+	// TODO(dchen1107): Introduce our own NetworkSettings struct here?
+	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
+	// usage should be included.
+	// TODO(dchen1107):  In long run, I think we should replace this with our own struct to remove
+	// the dependency on docker.
+	DetailInfo docker.Container `json:"detailInfo,omitempty" yaml:"detailInfo,omitempty"`
+}
+
+// PodInfo contains one entry for every container with available info.
+type PodInfo map[string]docker.Container
+
+type RestartPolicyAlways struct{}
+
+// TODO(dchen1107): Define what kinds of failures should restart
+// TODO(dchen1107): Decide whether to support policy knobs, and, if so, which ones.
+type RestartPolicyOnFailure struct{}
+
+type RestartPolicyNever struct{}
+
+type RestartPolicy struct {
+	// Only one of the following restart policy may be specified.
+	// If none of the following policies is specified, the default one
+	// is RestartPolicyAlways.
+	Always    *RestartPolicyAlways    `json:"always,omitempty" yaml:"always,omitempty"`
+	OnFailure *RestartPolicyOnFailure `json:"onFailure,omitempty" yaml:"onFailure,omitempty"`
+	Never     *RestartPolicyNever     `json:"never,omitempty" yaml:"never,omitempty"`
+}
+
+// PodState is the state of a pod, used as either input (desired state) or output (current state).
+type PodState struct {
+	Manifest ContainerManifest `json:"manifest,omitempty" yaml:"manifest,omitempty"`
+	Status   PodStatus         `json:"status,omitempty" yaml:"status,omitempty"`
+	Host     string            `json:"host,omitempty" yaml:"host,omitempty"`
+	HostIP   string            `json:"hostIP,omitempty" yaml:"hostIP,omitempty"`
+	PodIP    string            `json:"podIP,omitempty" yaml:"podIP,omitempty"`
+
+	// The key of this map is the *name* of the container within the manifest; it has one
+	// entry per container in the manifest. The value of this map is currently the output
+	// of `docker inspect`. This output format is *not* final and should not be relied
+	// upon. To allow marshalling/unmarshalling, we copied the client's structs and added
+	// json/yaml tags.
+	// TODO: Make real decisions about what our info should look like.
+	Info PodInfo `json:"info,omitempty" yaml:"info,omitempty"`
+}
+
+// PodList is a list of Pods.
+type PodList struct {
+	JSONBase `json:",inline" yaml:",inline"`
+	Items    []Pod `json:"items" yaml:"items,omitempty"`
+}
+
+func (*PodList) IsAnAPIObject() {}
+
+// Pod is a collection of containers, used as either input (create, update) or as output (list, get).
+type Pod struct {
+	JSONBase     `json:",inline" yaml:",inline"`
+	Labels       map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	DesiredState PodState          `json:"desiredState,omitempty" yaml:"desiredState,omitempty"`
+	CurrentState PodState          `json:"currentState,omitempty" yaml:"currentState,omitempty"`
+}
+
+func (*Pod) IsAnAPIObject() {}
+
+// ReplicationControllerState is the state of a replication controller, either input (create, update) or as output (list, get).
+type ReplicationControllerState struct {
+	Replicas        int               `json:"replicas" yaml:"replicas"`
+	ReplicaSelector map[string]string `json:"replicaSelector,omitempty" yaml:"replicaSelector,omitempty"`
+	PodTemplate     PodTemplate       `json:"podTemplate,omitempty" yaml:"podTemplate,omitempty"`
+}
+
+// ReplicationControllerList is a collection of replication controllers.
+type ReplicationControllerList struct {
+	JSONBase `json:",inline" yaml:",inline"`
+	Items    []ReplicationController `json:"items,omitempty" yaml:"items,omitempty"`
+}
+
+func (*ReplicationControllerList) IsAnAPIObject() {}
+
+// ReplicationController represents the configuration of a replication controller.
+type ReplicationController struct {
+	JSONBase     `json:",inline" yaml:",inline"`
+	DesiredState ReplicationControllerState `json:"desiredState,omitempty" yaml:"desiredState,omitempty"`
+	CurrentState ReplicationControllerState `json:"currentState,omitempty" yaml:"currentState,omitempty"`
+	Labels       map[string]string          `json:"labels,omitempty" yaml:"labels,omitempty"`
+}
+
+func (*ReplicationController) IsAnAPIObject() {}
+
+// PodTemplate holds the information used for creating pods.
+type PodTemplate struct {
+	DesiredState PodState          `json:"desiredState,omitempty" yaml:"desiredState,omitempty"`
+	Labels       map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+}
+
+// ServiceList holds a list of services.
+type ServiceList struct {
+	JSONBase `json:",inline" yaml:",inline"`
+	Items    []Service `json:"items" yaml:"items"`
+}
+
+func (*ServiceList) IsAnAPIObject() {}
+
+// Service is a named abstraction of software service (for example, mysql) consisting of local port
+// (for example 3306) that the proxy listens on, and the selector that determines which pods
+// will answer requests sent through the proxy.
+type Service struct {
+	JSONBase `json:",inline" yaml:",inline"`
+
+	// Required.
+	Port int `json:"port" yaml:"port"`
+	// Optional: Supports "TCP" and "UDP".  Defaults to "TCP".
+	Protocol string `yaml:"protocol,omitempty" json:"protocol,omitempty"`
+
+	// This service's labels.
+	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+
+	// This service will route traffic to pods having labels matching this selector.
+	Selector                   map[string]string `json:"selector,omitempty" yaml:"selector,omitempty"`
+	CreateExternalLoadBalancer bool              `json:"createExternalLoadBalancer,omitempty" yaml:"createExternalLoadBalancer,omitempty"`
+
+	// ContainerPort is the name of the port on the container to direct traffic to.
+	// Optional, if unspecified use the first port on the container.
+	ContainerPort util.IntOrString `json:"containerPort,omitempty" yaml:"containerPort,omitempty"`
+}
+
+func (*Service) IsAnAPIObject() {}
+
+// Endpoints is a collection of endpoints that implement the actual service, for example:
+// Name: "mysql", Endpoints: ["10.10.1.1:1909", "10.10.2.2:8834"]
+type Endpoints struct {
+	JSONBase  `json:",inline" yaml:",inline"`
+	Endpoints []string `json:"endpoints,omitempty" yaml:"endpoints,omitempty"`
+}
+
+func (*Endpoints) IsAnAPIObject() {}
+
+// EndpointsList is a list of endpoints.
+type EndpointsList struct {
+	JSONBase `json:",inline" yaml:",inline"`
+	Items    []Endpoints `json:"items,omitempty" yaml:"items,omitempty"`
+}
+
+func (*EndpointsList) IsAnAPIObject() {}
+
+// Minion is a worker node in Kubernetenes.
+// The name of the minion according to etcd is in JSONBase.ID.
+type Minion struct {
+	JSONBase `json:",inline" yaml:",inline"`
+	// Queried from cloud provider, if available.
+	HostIP string `json:"hostIP,omitempty" yaml:"hostIP,omitempty"`
+}
+
+func (*Minion) IsAnAPIObject() {}
+
+// MinionList is a list of minions.
+type MinionList struct {
+	JSONBase `json:",inline" yaml:",inline"`
+	// DEPRECATED: the below Minions is due to a naming mistake and
+	// will be replaced with Items in the future.
+	Minions []Minion `json:"minions,omitempty" yaml:"minions,omitempty"`
+	Items   []Minion `json:"items,omitempty" yaml:"items,omitempty"`
+}
+
+func (*MinionList) IsAnAPIObject() {}
+
+// Binding is written by a scheduler to cause a pod to be bound to a host.
+type Binding struct {
+	JSONBase `json:",inline" yaml:",inline"`
+	PodID    string `json:"podID" yaml:"podID"`
+	Host     string `json:"host" yaml:"host"`
+}
+
+func (*Binding) IsAnAPIObject() {}
+
+// Status is a return value for calls that don't return other objects.
+// TODO: this could go in apiserver, but I'm including it here so clients needn't
+// import both.
+type Status struct {
+	JSONBase `json:",inline" yaml:",inline"`
+	// One of: "success", "failure", "working" (for operations not yet completed)
+	Status string `json:"status,omitempty" yaml:"status,omitempty"`
+	// A human-readable description of the status of this operation.
+	Message string `json:"message,omitempty" yaml:"message,omitempty"`
+	// A machine-readable description of why this operation is in the
+	// "failure" or "working" status. If this value is empty there
+	// is no information available. A Reason clarifies an HTTP status
+	// code but does not override it.
+	Reason StatusReason `json:"reason,omitempty" yaml:"reason,omitempty"`
+	// Extended data associated with the reason.  Each reason may define its
+	// own extended details. This field is optional and the data returned
+	// is not guaranteed to conform to any schema except that defined by
+	// the reason type.
+	Details *StatusDetails `json:"details,omitempty" yaml:"details,omitempty"`
+	// Suggested HTTP return code for this status, 0 if not set.
+	Code int `json:"code,omitempty" yaml:"code,omitempty"`
+}
+
+func (*Status) IsAnAPIObject() {}
+
+// StatusDetails is a set of additional properties that MAY be set by the
+// server to provide additional information about a response. The Reason
+// field of a Status object defines what attributes will be set. Clients
+// must ignore fields that do not match the defined type of each attribute,
+// and should assume that any attribute may be empty, invalid, or under
+// defined.
+type StatusDetails struct {
+	// The ID attribute of the resource associated with the status StatusReason
+	// (when there is a single ID which can be described).
+	ID string `json:"id,omitempty" yaml:"id,omitempty"`
+	// The kind attribute of the resource associated with the status StatusReason.
+	// On some operations may differ from the requested resource Kind.
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+	// The Causes array includes more details associated with the StatusReason
+	// failure. Not all StatusReasons may provide detailed causes.
+	Causes []StatusCause `json:"causes,omitempty" yaml:"causes,omitempty"`
+}
+
+// Values of Status.Status
+const (
+	StatusSuccess = "success"
+	StatusFailure = "failure"
+	StatusWorking = "working"
+)
+
+// StatusReason is an enumeration of possible failure causes.  Each StatusReason
+// must map to a single HTTP status code, but multiple reasons may map
+// to the same HTTP status code.
+// TODO: move to apiserver
+type StatusReason string
+
+const (
+	// StatusReasonUnknown means the server has declined to indicate a specific reason.
+	// The details field may contain other information about this error.
+	// Status code 500.
+	StatusReasonUnknown StatusReason = ""
+
+	// StatusReasonWorking means the server is processing this request and will complete
+	// at a future time.
+	// Details (optional):
+	//   "kind" string - the name of the resource being referenced ("operation" today)
+	//   "id"   string - the identifier of the Operation resource where updates
+	//                   will be returned
+	// Headers (optional):
+	//   "Location" - HTTP header populated with a URL that can retrieved the final
+	//                status of this operation.
+	// Status code 202
+	StatusReasonWorking StatusReason = "working"
+
+	// StatusReasonNotFound means one or more resources required for this operation
+	// could not be found.
+	// Details (optional):
+	//   "kind" string - the kind attribute of the missing resource
+	//                   on some operations may differ from the requested
+	//                   resource.
+	//   "id"   string - the identifier of the missing resource
+	// Status code 404
+	StatusReasonNotFound StatusReason = "notFound"
+
+	// StatusReasonAlreadyExists means the resource you are creating already exists.
+	// Details (optional):
+	//   "kind" string - the kind attribute of the conflicting resource
+	//   "id"   string - the identifier of the conflicting resource
+	// Status code 409
+	StatusReasonAlreadyExists StatusReason = "alreadyExists"
+
+	// StatusReasonConflict means the requested update operation cannot be completed
+	// due to a conflict in the operation. The client may need to alter the request.
+	// Each resource may define custom details that indicate the nature of the
+	// conflict.
+	// Status code 409
+	StatusReasonConflict StatusReason = "conflict"
+)
+
+// StatusCause provides more information about an api.Status failure, including
+// cases when multiple errors are encountered.
+type StatusCause struct {
+	// A machine-readable description of the cause of the error. If this value is
+	// empty there is no information available.
+	Type CauseType `json:"reason,omitempty" yaml:"reason,omitempty"`
+	// A human-readable description of the cause of the error.  This field may be
+	// presented as-is to a reader.
+	Message string `json:"message,omitempty" yaml:"message,omitempty"`
+	// The field of the resource that has caused this error, as named by its JSON
+	// serialization. May include dot and postfix notation for nested attributes.
+	// Arrays are zero-indexed.  Fields may appear more than once in an array of
+	// causes due to fields having multiple errors.
+	// Optional.
+	//
+	// Examples:
+	//   "name" - the field "name" on the current resource
+	//   "items[0].name" - the field "name" on the first array entry in "items"
+	Field string `json:"field,omitempty" yaml:"field,omitempty"`
+}
+
+// CauseType is a machine readable value providing more detail about what
+// occured in a status response. An operation may have multiple causes for a
+// status (whether failure, success, or working).
+type CauseType string
+
+const (
+	// CauseTypeFieldValueNotFound is used to report failure to find a requested value
+	// (e.g. looking up an ID).
+	CauseTypeFieldValueNotFound CauseType = "fieldValueNotFound"
+	// CauseTypeFieldValueInvalid is used to report required values that are not
+	// provided (e.g. empty strings, null values, or empty arrays).
+	CauseTypeFieldValueRequired CauseType = "fieldValueRequired"
+	// CauseTypeFieldValueDuplicate is used to report collisions of values that must be
+	// unique (e.g. unique IDs).
+	CauseTypeFieldValueDuplicate CauseType = "fieldValueDuplicate"
+	// CauseTypeFieldValueInvalid is used to report malformed values (e.g. failed regex
+	// match).
+	CauseTypeFieldValueInvalid CauseType = "fieldValueInvalid"
+	// CauseTypeFieldValueNotSupported is used to report valid (as per formatting rules)
+	// values that can not be handled (e.g. an enumerated string).
+	CauseTypeFieldValueNotSupported CauseType = "fieldValueNotSupported"
+)
+
+// ServerOp is an operation delivered to API clients.
+type ServerOp struct {
+	JSONBase `yaml:",inline" json:",inline"`
+}
+
+func (*ServerOp) IsAnAPIObject() {}
+
+// ServerOpList is a list of operations, as delivered to API clients.
+type ServerOpList struct {
+	JSONBase `yaml:",inline" json:",inline"`
+	Items    []ServerOp `yaml:"items,omitempty" json:"items,omitempty"`
+}
+
+func (*ServerOpList) IsAnAPIObject() {}
+
+// WatchEvent objects are streamed from the api server in response to a watch request.
+type WatchEvent struct {
+	// The type of the watch event; added, modified, or deleted.
+	Type watch.EventType
+
+	// For added or modified objects, this is the new object; for deleted objects,
+	// it's the state of the object immediately prior to its deletion.
+	Object runtime.EmbeddedObject
+}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -17,9 +17,7 @@ limitations under the License.
 package v1beta2
 
 import (
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/fsouza/go-dockerclient"
 )
 
@@ -55,8 +53,8 @@ type ContainerManifest struct {
 	// Required: This must be a DNS_SUBDOMAIN.
 	// TODO: ID on Manifest is deprecated and will be removed in the future.
 	ID string `yaml:"id" json:"id"`
-	// TODO: UUID on Manifext is deprecated in the future once we are done
-	// with the API refactory. It is required for now to determine the instance
+	// TODO: UUID on Manifest is deprecated in the future once we are done
+	// with the API refactoring. It is required for now to determine the instance
 	// of a Pod.
 	UUID          string        `yaml:"uuid,omitempty" json:"uuid,omitempty"`
 	Volumes       []Volume      `yaml:"volumes" json:"volumes"`
@@ -166,7 +164,6 @@ type ExecAction struct {
 	// command  is root ('/') in the container's filesystem.  The command is simply exec'd, it is
 	// not run inside a shell, so traditional shell instructions ('|', etc) won't work.  To use
 	// a shell, you need to explicitly call out to that shell.
-	// A return code of zero is treated as 'Healthy', non-zero is 'Unhealthy'
 	Command []string `yaml:"command,omitempty" json:"command,omitempty"`
 }
 
@@ -210,7 +207,6 @@ type Container struct {
 }
 
 // Handler defines a specific action that should be taken
-// TODO: merge this with liveness probing?
 // TODO: pass structured data to these actions, and document that data here.
 type Handler struct {
 	// One and only one of the following should be specified.
@@ -251,8 +247,6 @@ type JSONBase struct {
 	ResourceVersion   uint64    `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
 	APIVersion        string    `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
 }
-
-func (*JSONBase) IsAnAPIObject() {}
 
 // PodStatus represents a status of a pod.
 type PodStatus string
@@ -303,18 +297,19 @@ type ContainerStatus struct {
 }
 
 // PodInfo contains one entry for every container with available info.
+// TODO(dchen1107): Replace docker.Container below with ContainerStatus defined above.
 type PodInfo map[string]docker.Container
 
 type RestartPolicyAlways struct{}
 
-// TODO(dchen1107): Define what kinds of failures should restart
+// TODO(dchen1107): Define what kinds of failures should restart.
 // TODO(dchen1107): Decide whether to support policy knobs, and, if so, which ones.
 type RestartPolicyOnFailure struct{}
 
 type RestartPolicyNever struct{}
 
 type RestartPolicy struct {
-	// Only one of the following restart policy may be specified.
+	// Only one of the following restart policies may be specified.
 	// If none of the following policies is specified, the default one
 	// is RestartPolicyAlways.
 	Always    *RestartPolicyAlways    `json:"always,omitempty" yaml:"always,omitempty"`
@@ -333,9 +328,9 @@ type PodState struct {
 	// The key of this map is the *name* of the container within the manifest; it has one
 	// entry per container in the manifest. The value of this map is currently the output
 	// of `docker inspect`. This output format is *not* final and should not be relied
-	// upon. To allow marshalling/unmarshalling, we copied the client's structs and added
-	// json/yaml tags.
-	// TODO: Make real decisions about what our info should look like.
+	// upon.
+	// TODO: Make real decisions about what our info should look like. Re-enable fuzz test
+	// when we have done this.
 	Info PodInfo `json:"info,omitempty" yaml:"info,omitempty"`
 }
 
@@ -550,14 +545,14 @@ const (
 	//                   resource.
 	//   "id"   string - the identifier of the missing resource
 	// Status code 404
-	StatusReasonNotFound StatusReason = "notFound"
+	StatusReasonNotFound StatusReason = "not_found"
 
 	// StatusReasonAlreadyExists means the resource you are creating already exists.
 	// Details (optional):
 	//   "kind" string - the kind attribute of the conflicting resource
 	//   "id"   string - the identifier of the conflicting resource
 	// Status code 409
-	StatusReasonAlreadyExists StatusReason = "alreadyExists"
+	StatusReasonAlreadyExists StatusReason = "already_exists"
 
 	// StatusReasonConflict means the requested update operation cannot be completed
 	// due to a conflict in the operation. The client may need to alter the request.
@@ -565,6 +560,19 @@ const (
 	// conflict.
 	// Status code 409
 	StatusReasonConflict StatusReason = "conflict"
+
+	// StatusReasonInvalid means the requested create or update operation cannot be
+	// completed due to invalid data provided as part of the request. The client may
+	// need to alter the request. When set, the client may use the StatusDetails
+	// message field as a summary of the issues encountered.
+	// Details (optional):
+	//   "kind" string - the kind attribute of the invalid resource
+	//   "id"   string - the identifier of the invalid resource
+	//   "causes"      - one or more StatusCause entries indicating the data in the
+	//                   provided resource that was invalid.  The code, message, and
+	//                   field attributes will be set.
+	// Status code 422
+	StatusReasonInvalid StatusReason = "invalid"
 )
 
 // StatusCause provides more information about an api.Status failure, including
@@ -625,13 +633,3 @@ type ServerOpList struct {
 }
 
 func (*ServerOpList) IsAnAPIObject() {}
-
-// WatchEvent objects are streamed from the api server in response to a watch request.
-type WatchEvent struct {
-	// The type of the watch event; added, modified, or deleted.
-	Type watch.EventType
-
-	// For added or modified objects, this is the new object; for deleted objects,
-	// it's the state of the object immediately prior to its deletion.
-	Object runtime.EmbeddedObject
-}

--- a/pkg/api/watch.go
+++ b/pkg/api/watch.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// WatchEvent objects are streamed from the api server in response to a watch request.
+// These are not API objects and are unversioned today.
+type WatchEvent struct {
+	// The type of the watch event; added, modified, or deleted.
+	Type watch.EventType
+
+	// For added or modified objects, this is the new object; for deleted objects,
+	// it's the state of the object immediately prior to its deletion.
+	Object EmbeddedObject
+}
+
+// watchSerialization defines the JSON wire equivalent of watch.Event
+type watchSerialization struct {
+	Type   watch.EventType
+	Object json.RawMessage
+}
+
+// NewJSONWatcHEvent returns an object that will serialize to JSON and back
+// to a WatchEvent.
+func NewJSONWatchEvent(codec runtime.Codec, event watch.Event) (interface{}, error) {
+	obj, ok := event.Object.(runtime.Object)
+	if !ok {
+		return nil, fmt.Errorf("The event object cannot be safely converted to JSON: %v", reflect.TypeOf(event.Object).Name())
+	}
+	data, err := codec.Encode(obj)
+	if err != nil {
+		return nil, err
+	}
+	return &watchSerialization{event.Type, json.RawMessage(data)}, nil
+}

--- a/pkg/api/watch_test.go
+++ b/pkg/api/watch_test.go
@@ -17,27 +17,27 @@ limitations under the License.
 package api
 
 import (
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"encoding/json"
+	"reflect"
+	"testing"
 )
 
-var Scheme = runtime.NewScheme()
+func TestEmbeddedDefaultSerialization(t *testing.T) {
+	expected := WatchEvent{
+		Type:   "foo",
+		Object: EmbeddedObject{&Pod{}},
+	}
+	data, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 
-func init() {
-	Scheme.AddKnownTypes("",
-		&PodList{},
-		&Pod{},
-		&ReplicationControllerList{},
-		&ReplicationController{},
-		&ServiceList{},
-		&Service{},
-		&MinionList{},
-		&Minion{},
-		&Status{},
-		&ServerOpList{},
-		&ServerOp{},
-		&ContainerManifestList{},
-		&Endpoints{},
-		&EndpointsList{},
-		&Binding{},
-	)
+	actual := WatchEvent{}
+	if err := json.Unmarshal(data, &actual); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Expected %#v, Got %#v", expected, actual)
+	}
 }

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	apierrs "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -46,8 +47,8 @@ func convert(obj runtime.Object) (runtime.Object, error) {
 var codec = latest.Codec
 
 func init() {
-	latest.Codec.AddKnownTypes("", &Simple{}, &SimpleList{})
-	latest.Codec.AddKnownTypes("v1beta1", &Simple{}, &SimpleList{})
+	api.Scheme.AddKnownTypes("", &Simple{}, &SimpleList{})
+	api.Scheme.AddKnownTypes(latest.Version, &Simple{}, &SimpleList{})
 }
 
 type Simple struct {
@@ -95,7 +96,7 @@ func (storage *SimpleRESTStorage) List(labels.Selector) (runtime.Object, error) 
 }
 
 func (storage *SimpleRESTStorage) Get(id string) (runtime.Object, error) {
-	return latest.Codec.CopyOrDie(&storage.item), storage.errors["get"]
+	return api.Scheme.CopyOrDie(&storage.item), storage.errors["get"]
 }
 
 func (storage *SimpleRESTStorage) Delete(id string) (<-chan runtime.Object, error) {

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -46,8 +46,8 @@ func convert(obj runtime.Object) (runtime.Object, error) {
 var codec = latest.Codec
 
 func init() {
-	runtime.DefaultScheme.AddKnownTypes("", &Simple{}, &SimpleList{})
-	runtime.DefaultScheme.AddKnownTypes("v1beta1", &Simple{}, &SimpleList{})
+	latest.Codec.AddKnownTypes("", &Simple{}, &SimpleList{})
+	latest.Codec.AddKnownTypes("v1beta1", &Simple{}, &SimpleList{})
 }
 
 type Simple struct {
@@ -95,7 +95,7 @@ func (storage *SimpleRESTStorage) List(labels.Selector) (runtime.Object, error) 
 }
 
 func (storage *SimpleRESTStorage) Get(id string) (runtime.Object, error) {
-	return runtime.DefaultScheme.CopyOrDie(&storage.item), storage.errors["get"]
+	return latest.Codec.CopyOrDie(&storage.item), storage.errors["get"]
 }
 
 func (storage *SimpleRESTStorage) Delete(id string) (<-chan runtime.Object, error) {

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -43,7 +43,7 @@ func convert(obj runtime.Object) (runtime.Object, error) {
 	return obj, nil
 }
 
-var codec = runtime.DefaultCodec
+var codec = latest.Codec
 
 func init() {
 	runtime.DefaultScheme.AddKnownTypes("", &Simple{}, &SimpleList{})
@@ -676,7 +676,7 @@ func (*UnregisteredAPIObject) IsAnAPIObject() {}
 
 func TestWriteJSONDecodeError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		writeJSON(http.StatusOK, runtime.DefaultCodec, &UnregisteredAPIObject{"Undecodable"}, w)
+		writeJSON(http.StatusOK, latest.Codec, &UnregisteredAPIObject{"Undecodable"}, w)
 	}))
 	status := expectApiStatus(t, "GET", server.URL, nil, http.StatusInternalServerError)
 	if status.Reason != api.StatusReasonUnknown {

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -114,25 +114,21 @@ func TestWatchHTTP(t *testing.T) {
 
 	decoder := json.NewDecoder(response.Body)
 
-	try := func(action watch.EventType, object runtime.Object) {
+	for i, item := range watchTestTable {
 		// Send
-		simpleStorage.fakeWatch.Action(action, object)
+		simpleStorage.fakeWatch.Action(item.t, item.obj)
 		// Test receive
 		var got api.WatchEvent
 		err := decoder.Decode(&got)
 		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
+			t.Fatalf("%d: Unexpected error: %v", i, err)
 		}
-		if got.Type != action {
-			t.Errorf("Unexpected type: %v", got.Type)
+		if got.Type != item.t {
+			t.Errorf("%d: Unexpected type: %v", i, got.Type)
 		}
-		if e, a := object, got.Object.Object; !reflect.DeepEqual(e, a) {
-			t.Errorf("Expected %v, got %v", e, a)
+		if e, a := item.obj, got.Object.Object; !reflect.DeepEqual(e, a) {
+			t.Errorf("%d: Expected %v, got %v", i, e, a)
 		}
-	}
-
-	for _, item := range watchTestTable {
-		try(item.t, item.obj)
 	}
 	simpleStorage.fakeWatch.Stop()
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -99,7 +99,7 @@ type Client struct {
 // to a URL will prepend the server path. Returns an error if host cannot be converted to a
 // valid URL.
 func New(host string, auth *AuthInfo) (*Client, error) {
-	restClient, err := NewRESTClient(host, auth, "/api/v1beta1/", runtime.DefaultCodec)
+	restClient, err := NewRESTClient(host, auth, "/api/v1beta1/", latest.Codec)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +224,7 @@ func (c *RESTClient) doRequest(request *http.Request) ([]byte, error) {
 	// Did the server give us a status response?
 	isStatusResponse := false
 	var status api.Status
-	if err := runtime.DefaultCodec.DecodeInto(body, &status); err == nil && status.Status != "" {
+	if err := latest.Codec.DecodeInto(body, &status); err == nil && status.Status != "" {
 		isStatusResponse = true
 	}
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -48,7 +48,7 @@ func TestValidatesHostParameter(t *testing.T) {
 		"host/server":        {"", "", true},
 	}
 	for k, expected := range testCases {
-		c, err := NewRESTClient(k, nil, "/api/v1beta1/", runtime.DefaultCodec)
+		c, err := NewRESTClient(k, nil, "/api/v1beta1/", latest.Codec)
 		switch {
 		case err == nil && expected.Err:
 			t.Errorf("expected error but was nil")
@@ -309,7 +309,7 @@ func TestCreateController(t *testing.T) {
 
 func body(obj runtime.Object, raw *string) *string {
 	if obj != nil {
-		bs, _ := runtime.DefaultCodec.Encode(obj)
+		bs, _ := latest.Codec.Encode(obj)
 		body := string(bs)
 		return &body
 	}
@@ -533,7 +533,7 @@ func TestDoRequest(t *testing.T) {
 
 func TestDoRequestAccepted(t *testing.T) {
 	status := &api.Status{Status: api.StatusWorking}
-	expectedBody, _ := runtime.DefaultCodec.Encode(status)
+	expectedBody, _ := latest.Codec.Encode(status)
 	fakeHandler := util.FakeHandler{
 		StatusCode:   202,
 		ResponseBody: string(expectedBody),
@@ -570,7 +570,7 @@ func TestDoRequestAccepted(t *testing.T) {
 
 func TestDoRequestAcceptedSuccess(t *testing.T) {
 	status := &api.Status{Status: api.StatusSuccess}
-	expectedBody, _ := runtime.DefaultCodec.Encode(status)
+	expectedBody, _ := latest.Codec.Encode(status)
 	fakeHandler := util.FakeHandler{
 		StatusCode:   202,
 		ResponseBody: string(expectedBody),
@@ -590,7 +590,7 @@ func TestDoRequestAcceptedSuccess(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error %#v", err)
 	}
-	statusOut, err := runtime.DefaultCodec.Decode(body)
+	statusOut, err := latest.Codec.Decode(body)
 	if err != nil {
 		t.Errorf("Unexpected error %#v", err)
 	}

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -19,7 +19,6 @@ package client
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -44,7 +43,7 @@ type Fake struct {
 
 func (c *Fake) ListPods(selector labels.Selector) (*api.PodList, error) {
 	c.Actions = append(c.Actions, FakeAction{Action: "list-pods"})
-	return runtime.DefaultScheme.CopyOrDie(&c.Pods).(*api.PodList), nil
+	return api.Scheme.CopyOrDie(&c.Pods).(*api.PodList), nil
 }
 
 func (c *Fake) GetPod(name string) (*api.Pod, error) {
@@ -74,7 +73,7 @@ func (c *Fake) ListReplicationControllers(selector labels.Selector) (*api.Replic
 
 func (c *Fake) GetReplicationController(name string) (*api.ReplicationController, error) {
 	c.Actions = append(c.Actions, FakeAction{Action: "get-controller", Value: name})
-	return runtime.DefaultScheme.CopyOrDie(&c.Ctrl).(*api.ReplicationController), nil
+	return api.Scheme.CopyOrDie(&c.Ctrl).(*api.ReplicationController), nil
 }
 
 func (c *Fake) CreateReplicationController(controller *api.ReplicationController) (*api.ReplicationController, error) {
@@ -129,7 +128,7 @@ func (c *Fake) WatchServices(label, field labels.Selector, resourceVersion uint6
 
 func (c *Fake) ListEndpoints(selector labels.Selector) (*api.EndpointsList, error) {
 	c.Actions = append(c.Actions, FakeAction{Action: "list-endpoints"})
-	return runtime.DefaultScheme.CopyOrDie(&c.EndpointsList).(*api.EndpointsList), c.Err
+	return api.Scheme.CopyOrDie(&c.EndpointsList).(*api.EndpointsList), c.Err
 }
 
 func (c *Fake) WatchEndpoints(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -28,9 +28,9 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	cwatch "github.com/GoogleCloudPlatform/kubernetes/pkg/client/watch"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/golang/glog"
@@ -269,7 +269,7 @@ func (r *Request) Watch() (watch.Interface, error) {
 	if response.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("Got status: %v", response.StatusCode)
 	}
-	return watch.NewStreamWatcher(tools.NewAPIEventDecoder(response.Body)), nil
+	return watch.NewStreamWatcher(cwatch.NewAPIEventDecoder(response.Body)), nil
 }
 
 // Do formats and executes the request. Returns the API object received, or an error.

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -401,7 +402,13 @@ func TestWatch(t *testing.T) {
 
 		encoder := json.NewEncoder(w)
 		for _, item := range table {
-			encoder.Encode(&api.WatchEvent{item.t, runtime.EmbeddedObject{item.obj}})
+			data, err := api.NewJSONWatchEvent(latest.Codec, watch.Event{item.t, item.obj})
+			if err != nil {
+				panic(err)
+			}
+			if err := encoder.Encode(data); err != nil {
+				panic(err)
+			}
 			flusher.Flush()
 		}
 	}))

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -38,7 +38,7 @@ import (
 func TestDoRequestNewWay(t *testing.T) {
 	reqBody := "request body"
 	expectedObj := &api.Service{Port: 12345}
-	expectedBody, _ := runtime.DefaultCodec.Encode(expectedObj)
+	expectedBody, _ := latest.Codec.Encode(expectedObj)
 	fakeHandler := util.FakeHandler{
 		StatusCode:   200,
 		ResponseBody: string(expectedBody),
@@ -71,9 +71,9 @@ func TestDoRequestNewWay(t *testing.T) {
 
 func TestDoRequestNewWayReader(t *testing.T) {
 	reqObj := &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}
-	reqBodyExpected, _ := runtime.DefaultCodec.Encode(reqObj)
+	reqBodyExpected, _ := latest.Codec.Encode(reqObj)
 	expectedObj := &api.Service{Port: 12345}
-	expectedBody, _ := runtime.DefaultCodec.Encode(expectedObj)
+	expectedBody, _ := latest.Codec.Encode(expectedObj)
 	fakeHandler := util.FakeHandler{
 		StatusCode:   200,
 		ResponseBody: string(expectedBody),
@@ -108,9 +108,9 @@ func TestDoRequestNewWayReader(t *testing.T) {
 
 func TestDoRequestNewWayObj(t *testing.T) {
 	reqObj := &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}
-	reqBodyExpected, _ := runtime.DefaultCodec.Encode(reqObj)
+	reqBodyExpected, _ := latest.Codec.Encode(reqObj)
 	expectedObj := &api.Service{Port: 12345}
-	expectedBody, _ := runtime.DefaultCodec.Encode(expectedObj)
+	expectedBody, _ := latest.Codec.Encode(expectedObj)
 	fakeHandler := util.FakeHandler{
 		StatusCode:   200,
 		ResponseBody: string(expectedBody),
@@ -144,7 +144,7 @@ func TestDoRequestNewWayObj(t *testing.T) {
 
 func TestDoRequestNewWayFile(t *testing.T) {
 	reqObj := &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}
-	reqBodyExpected, err := runtime.DefaultCodec.Encode(reqObj)
+	reqBodyExpected, err := latest.Codec.Encode(reqObj)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -160,7 +160,7 @@ func TestDoRequestNewWayFile(t *testing.T) {
 	}
 
 	expectedObj := &api.Service{Port: 12345}
-	expectedBody, _ := runtime.DefaultCodec.Encode(expectedObj)
+	expectedBody, _ := latest.Codec.Encode(expectedObj)
 	fakeHandler := util.FakeHandler{
 		StatusCode:   200,
 		ResponseBody: string(expectedBody),
@@ -295,7 +295,7 @@ func TestPolling(t *testing.T) {
 
 	callNumber := 0
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		data, err := runtime.DefaultCodec.Encode(objects[callNumber])
+		data, err := latest.Codec.Encode(objects[callNumber])
 		if err != nil {
 			t.Errorf("Unexpected encode error")
 		}

--- a/pkg/client/watch/decoder.go
+++ b/pkg/client/watch/decoder.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tools
+package watch
 
 import (
 	"encoding/json"
@@ -28,6 +28,8 @@ import (
 
 // APIEventDecoder implements the watch.Decoder interface for io.ReadClosers that
 // have contents which consist of a series of api.WatchEvent objects encoded via JSON.
+// It will decode any object which is registered to convert to api.WatchEvent via
+// api.Scheme
 type APIEventDecoder struct {
 	stream  io.ReadCloser
 	decoder *json.Decoder

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -27,6 +27,8 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
@@ -169,7 +171,7 @@ func TestSyncReplicationControllerCreates(t *testing.T) {
 }
 
 func TestCreateReplica(t *testing.T) {
-	body, _ := latest.Codec.Encode(&api.Pod{})
+	body, _ := v1beta1.Codec.Encode(&api.Pod{})
 	fakeHandler := util.FakeHandler{
 		StatusCode:   200,
 		ResponseBody: string(body),
@@ -209,7 +211,7 @@ func TestCreateReplica(t *testing.T) {
 	expectedPod := api.Pod{
 		JSONBase: api.JSONBase{
 			Kind:       "Pod",
-			APIVersion: "v1beta1",
+			APIVersion: latest.Version,
 		},
 		Labels:       controllerSpec.DesiredState.PodTemplate.Labels,
 		DesiredState: controllerSpec.DesiredState.PodTemplate.DesiredState,
@@ -287,12 +289,12 @@ func TestSyncronize(t *testing.T) {
 
 	fakePodHandler := util.FakeHandler{
 		StatusCode:   200,
-		ResponseBody: "{\"apiVersion\": \"v1beta1\", \"kind\": \"PodList\"}",
+		ResponseBody: "{\"apiVersion\": \"" + latest.Version + "\", \"kind\": \"PodList\"}",
 		T:            t,
 	}
 	fakeControllerHandler := util.FakeHandler{
 		StatusCode: 200,
-		ResponseBody: latest.Codec.EncodeOrDie(&api.ReplicationControllerList{
+		ResponseBody: runtime.EncodeOrDie(latest.Codec, &api.ReplicationControllerList{
 			Items: []api.ReplicationController{
 				controllerSpec1,
 				controllerSpec2,

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -292,7 +292,7 @@ func TestSyncronize(t *testing.T) {
 	}
 	fakeControllerHandler := util.FakeHandler{
 		StatusCode: 200,
-		ResponseBody: runtime.DefaultScheme.EncodeOrDie(&api.ReplicationControllerList{
+		ResponseBody: latest.Codec.EncodeOrDie(&api.ReplicationControllerList{
 			Items: []api.ReplicationController{
 				controllerSpec1,
 				controllerSpec2,

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -109,7 +109,7 @@ func validateSyncReplication(t *testing.T, fakePodControl *FakePodControl, expec
 }
 
 func TestSyncReplicationControllerDoesNothing(t *testing.T) {
-	body, _ := runtime.DefaultCodec.Encode(newPodList(2))
+	body, _ := latest.Codec.Encode(newPodList(2))
 	fakeHandler := util.FakeHandler{
 		StatusCode:   200,
 		ResponseBody: string(body),
@@ -129,7 +129,7 @@ func TestSyncReplicationControllerDoesNothing(t *testing.T) {
 }
 
 func TestSyncReplicationControllerDeletes(t *testing.T) {
-	body, _ := runtime.DefaultCodec.Encode(newPodList(2))
+	body, _ := latest.Codec.Encode(newPodList(2))
 	fakeHandler := util.FakeHandler{
 		StatusCode:   200,
 		ResponseBody: string(body),
@@ -149,7 +149,7 @@ func TestSyncReplicationControllerDeletes(t *testing.T) {
 }
 
 func TestSyncReplicationControllerCreates(t *testing.T) {
-	body, _ := runtime.DefaultCodec.Encode(newPodList(0))
+	body, _ := latest.Codec.Encode(newPodList(0))
 	fakeHandler := util.FakeHandler{
 		StatusCode:   200,
 		ResponseBody: string(body),
@@ -169,7 +169,7 @@ func TestSyncReplicationControllerCreates(t *testing.T) {
 }
 
 func TestCreateReplica(t *testing.T) {
-	body, _ := runtime.DefaultCodec.Encode(&api.Pod{})
+	body, _ := latest.Codec.Encode(&api.Pod{})
 	fakeHandler := util.FakeHandler{
 		StatusCode:   200,
 		ResponseBody: string(body),

--- a/pkg/conversion/decode.go
+++ b/pkg/conversion/decode.go
@@ -25,14 +25,14 @@ import (
 // Decode converts a YAML or JSON string back into a pointer to an api object.
 // Deduces the type based upon the fields added by the MetaInsertionFactory
 // technique. The object will be converted, if necessary, into the
-// s.InternalVersion type before being returned. Decode will refuse to decode
-// objects without a version, because that's probably an error.
+// s.InternalVersion type before being returned. Decode will not decode
+// objects without version set unless InternalVersion is also "".
 func (s *Scheme) Decode(data []byte) (interface{}, error) {
 	version, kind, err := s.DataVersionAndKind(data)
 	if err != nil {
 		return nil, err
 	}
-	if version == "" {
+	if version == "" && s.InternalVersion != "" {
 		return nil, fmt.Errorf("version not set in '%s'", string(data))
 	}
 	obj, err := s.NewObject(version, kind)

--- a/pkg/conversion/encode.go
+++ b/pkg/conversion/encode.go
@@ -21,16 +21,7 @@ import (
 	"fmt"
 )
 
-// EncodeOrDie is a version of Encode which will panic instead of returning an error. For tests.
-func (s *Scheme) EncodeOrDie(obj interface{}) string {
-	bytes, err := s.Encode(obj)
-	if err != nil {
-		panic(err)
-	}
-	return string(bytes)
-}
-
-// Encode turns the given api object into an appropriate JSON string.
+// EncodeToVersion turns the given api object into an appropriate JSON string.
 // Obj may be a pointer to a struct, or a struct. If a struct, a copy
 // will be made, therefore it's recommended to pass a pointer to a
 // struct. The type must have been registered.
@@ -58,11 +49,6 @@ func (s *Scheme) EncodeOrDie(obj interface{}) string {
 // objects, whether they be in our storage layer (e.g., etcd), or in user's
 // config files.
 //
-func (s *Scheme) Encode(obj interface{}) (data []byte, err error) {
-	return s.EncodeToVersion(obj, s.ExternalVersion)
-}
-
-// EncodeToVersion is like Encode, but you may choose the version.
 func (s *Scheme) EncodeToVersion(obj interface{}, destVersion string) (data []byte, err error) {
 	obj = maybeCopy(obj)
 	v, _ := enforcePtr(obj) // maybeCopy guarantees a pointer

--- a/pkg/conversion/scheme.go
+++ b/pkg/conversion/scheme.go
@@ -66,9 +66,6 @@ type Scheme struct {
 	// you use "" for the internal version.
 	InternalVersion string
 
-	// ExternalVersion is the default external version.
-	ExternalVersion string
-
 	// MetaInsertionFactory is used to create an object to store and retrieve
 	// the version and kind information for all objects. The default uses the
 	// keys "version" and "kind" respectively.
@@ -83,7 +80,6 @@ func NewScheme() *Scheme {
 		typeToKind:           map[reflect.Type]string{},
 		converter:            NewConverter(),
 		InternalVersion:      "",
-		ExternalVersion:      "v1",
 		MetaInsertionFactory: metaInsertion{},
 	}
 	s.converter.NameFunc = s.nameFunc
@@ -144,6 +140,19 @@ func (s *Scheme) AddKnownTypeWithName(version, kind string, obj interface{}) {
 	knownTypes[kind] = t
 	s.typeToVersion[t] = version
 	s.typeToKind[t] = kind
+}
+
+// KnownTypes returns an array of the types that are known for a particular version.
+func (s *Scheme) KnownTypes(version string) map[string]reflect.Type {
+	all, ok := s.versionMap[version]
+	if !ok {
+		return map[string]reflect.Type{}
+	}
+	types := make(map[string]reflect.Type)
+	for k, v := range all {
+		types[k] = v
+	}
+	return types
 }
 
 // NewObject returns a new object of the given version and name,

--- a/pkg/kubecfg/kubecfg_test.go
+++ b/pkg/kubecfg/kubecfg_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
 func validateAction(expectedAction, actualAction client.FakeAction, t *testing.T) {
@@ -94,7 +93,7 @@ func TestUpdateWithNewImage(t *testing.T) {
 	}
 	validateAction(client.FakeAction{Action: "get-controller", Value: "foo"}, fakeClient.Actions[0], t)
 
-	newCtrl := runtime.DefaultScheme.CopyOrDie(&fakeClient.Ctrl).(*api.ReplicationController)
+	newCtrl := api.Scheme.CopyOrDie(&fakeClient.Ctrl).(*api.ReplicationController)
 	newCtrl.DesiredState.PodTemplate.DesiredState.Manifest.Containers[0].Image = "fooImage:2"
 	validateAction(client.FakeAction{Action: "update-controller", Value: newCtrl}, fakeClient.Actions[1], t)
 

--- a/pkg/kubecfg/parse_test.go
+++ b/pkg/kubecfg/parse_test.go
@@ -125,8 +125,8 @@ type TestParseType struct {
 func (*TestParseType) IsAnAPIObject() {}
 
 func TestParseCustomType(t *testing.T) {
-	runtime.DefaultScheme.AddKnownTypes("", &TestParseType{})
-	runtime.DefaultScheme.AddKnownTypes("v1beta1", &TestParseType{})
+	latest.Codec.AddKnownTypes("", &TestParseType{})
+	latest.Codec.AddKnownTypes("v1beta1", &TestParseType{})
 	parser := NewParser(map[string]runtime.Object{
 		"custom": &TestParseType{},
 	})

--- a/pkg/kubecfg/parse_test.go
+++ b/pkg/kubecfg/parse_test.go
@@ -27,21 +27,21 @@ import (
 
 func TestParseBadStorage(t *testing.T) {
 	p := NewParser(map[string]runtime.Object{})
-	_, err := p.ToWireFormat([]byte("{}"), "badstorage", runtime.DefaultCodec)
+	_, err := p.ToWireFormat([]byte("{}"), "badstorage", latest.Codec)
 	if err == nil {
 		t.Errorf("Expected error, received none")
 	}
 }
 
 func DoParseTest(t *testing.T, storage string, obj runtime.Object, p *Parser) {
-	jsonData, _ := runtime.DefaultCodec.Encode(obj)
+	jsonData, _ := latest.Codec.Encode(obj)
 	var tmp map[string]interface{}
 	json.Unmarshal(jsonData, &tmp)
 	yamlData, _ := yaml.Marshal(tmp)
 	t.Logf("Intermediate yaml:\n%v\n", string(yamlData))
 	t.Logf("Intermediate json:\n%v\n", string(jsonData))
-	jsonGot, jsonErr := p.ToWireFormat(jsonData, storage, runtime.DefaultCodec)
-	yamlGot, yamlErr := p.ToWireFormat(yamlData, storage, runtime.DefaultCodec)
+	jsonGot, jsonErr := p.ToWireFormat(jsonData, storage, latest.Codec)
+	yamlGot, yamlErr := p.ToWireFormat(yamlData, storage, latest.Codec)
 
 	if jsonErr != nil {
 		t.Errorf("json err: %#v", jsonErr)

--- a/pkg/kubecfg/parse_test.go
+++ b/pkg/kubecfg/parse_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"gopkg.in/v1/yaml"
 )
@@ -125,8 +127,9 @@ type TestParseType struct {
 func (*TestParseType) IsAnAPIObject() {}
 
 func TestParseCustomType(t *testing.T) {
-	latest.Codec.AddKnownTypes("", &TestParseType{})
-	latest.Codec.AddKnownTypes("v1beta1", &TestParseType{})
+	api.Scheme.AddKnownTypes("", &TestParseType{})
+	api.Scheme.AddKnownTypes("v1beta1", &TestParseType{})
+	api.Scheme.AddKnownTypes("v1beta2", &TestParseType{})
 	parser := NewParser(map[string]runtime.Object{
 		"custom": &TestParseType{},
 	})

--- a/pkg/kubecfg/proxy_server.go
+++ b/pkg/kubecfg/proxy_server.go
@@ -21,8 +21,8 @@ import (
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
 // ProxyServer is a http.Handler which proxies Kubernetes APIs to remote API server.

--- a/pkg/kubecfg/proxy_server.go
+++ b/pkg/kubecfg/proxy_server.go
@@ -53,7 +53,7 @@ func (s *ProxyServer) Serve() error {
 func (s *ProxyServer) doError(w http.ResponseWriter, err error) {
 	w.WriteHeader(http.StatusInternalServerError)
 	w.Header().Add("Content-type", "application/json")
-	data, _ := runtime.DefaultCodec.Encode(&api.Status{
+	data, _ := latest.Codec.Encode(&api.Status{
 		Status:  api.StatusFailure,
 		Message: fmt.Sprintf("internal error: %#v", err),
 	})

--- a/pkg/kubecfg/resource_printer.go
+++ b/pkg/kubecfg/resource_printer.go
@@ -26,6 +26,7 @@ import (
 	"text/template"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/golang/glog"

--- a/pkg/kubecfg/resource_printer.go
+++ b/pkg/kubecfg/resource_printer.go
@@ -50,7 +50,7 @@ func (i *IdentityPrinter) Print(data []byte, w io.Writer) error {
 
 // PrintObj is an implementation of ResourcePrinter.PrintObj which simply writes the object to the Writer.
 func (i *IdentityPrinter) PrintObj(obj runtime.Object, output io.Writer) error {
-	data, err := runtime.DefaultCodec.Encode(obj)
+	data, err := latest.Codec.Encode(obj)
 	if err != nil {
 		return err
 	}
@@ -260,7 +260,7 @@ func (h *HumanReadablePrinter) Print(data []byte, output io.Writer) error {
 		return fmt.Errorf("unexpected object with no 'kind' field: %s", data)
 	}
 
-	obj, err := runtime.DefaultCodec.Decode(data)
+	obj, err := latest.Codec.Decode(data)
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ type TemplatePrinter struct {
 
 // Print parses the data as JSON, and re-formats it with the Go Template.
 func (t *TemplatePrinter) Print(data []byte, w io.Writer) error {
-	obj, err := runtime.DefaultCodec.Decode(data)
+	obj, err := latest.Codec.Decode(data)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubecfg/resource_printer_test.go
+++ b/pkg/kubecfg/resource_printer_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"gopkg.in/v1/yaml"
 )
 

--- a/pkg/kubecfg/resource_printer_test.go
+++ b/pkg/kubecfg/resource_printer_test.go
@@ -96,7 +96,7 @@ func TestIdentityPrinter(t *testing.T) {
 	}
 	buff.Reset()
 	printer.PrintObj(obj, buff)
-	objOut, err := runtime.DefaultCodec.Decode([]byte(buff.String()))
+	objOut, err := latest.Codec.Decode([]byte(buff.String()))
 	if err != nil {
 		t.Errorf("Unexpeted error: %#v", err)
 	}

--- a/pkg/kubelet/config/etcd.go
+++ b/pkg/kubelet/config/etcd.go
@@ -24,9 +24,8 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -48,7 +47,7 @@ func NewSourceEtcd(key string, client tools.EtcdClient, updates chan<- interface
 	helper := tools.EtcdHelper{
 		client,
 		latest.Codec,
-		runtime.DefaultResourceVersioner,
+		latest.ResourceVersioner,
 	}
 	source := &SourceEtcd{
 		key:     key,

--- a/pkg/kubelet/config/etcd.go
+++ b/pkg/kubelet/config/etcd.go
@@ -47,7 +47,7 @@ type SourceEtcd struct {
 func NewSourceEtcd(key string, client tools.EtcdClient, updates chan<- interface{}) *SourceEtcd {
 	helper := tools.EtcdHelper{
 		client,
-		runtime.DefaultCodec,
+		latest.Codec,
 		runtime.DefaultResourceVersioner,
 	}
 	source := &SourceEtcd{

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"time"
 
-	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
@@ -136,5 +136,5 @@ func (m *Master) API_v1beta1() (map[string]apiserver.RESTStorage, runtime.Codec)
 	for k, v := range m.storage {
 		storage[k] = v
 	}
-	return storage, runtime.DefaultCodec
+	return storage, v1beta1.Codec
 }

--- a/pkg/proxy/config/etcd.go
+++ b/pkg/proxy/config/etcd.go
@@ -135,7 +135,7 @@ func (s ConfigSourceEtcd) GetServices() ([]api.Service, []api.Endpoints, error) 
 		// and create a Service entry for it.
 		for i, node := range response.Node.Nodes {
 			var svc api.Service
-			err = runtime.DefaultCodec.DecodeInto([]byte(node.Value), &svc)
+			err = latest.Codec.DecodeInto([]byte(node.Value), &svc)
 			if err != nil {
 				glog.Errorf("Failed to load Service: %s (%#v)", node.Value, err)
 				continue
@@ -168,7 +168,7 @@ func (s ConfigSourceEtcd) GetEndpoints(service string) (api.Endpoints, error) {
 	}
 	// Parse all the endpoint specifications in this value.
 	var e api.Endpoints
-	err = runtime.DefaultCodec.DecodeInto([]byte(response.Node.Value), &e)
+	err = latest.Codec.DecodeInto([]byte(response.Node.Value), &e)
 	return e, err
 }
 
@@ -178,7 +178,7 @@ func etcdResponseToService(response *etcd.Response) (*api.Service, error) {
 		return nil, fmt.Errorf("invalid response from etcd: %#v", response)
 	}
 	var svc api.Service
-	err := runtime.DefaultCodec.DecodeInto([]byte(response.Node.Value), &svc)
+	err := latest.Codec.DecodeInto([]byte(response.Node.Value), &svc)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func (s ConfigSourceEtcd) ProcessChange(response *etcd.Response) {
 func (s ConfigSourceEtcd) ProcessEndpointResponse(response *etcd.Response) {
 	glog.Infof("Processing a change in endpoint configuration... %s", *response)
 	var endpoints api.Endpoints
-	err := runtime.DefaultCodec.DecodeInto([]byte(response.Node.Value), &endpoints)
+	err := latest.Codec.DecodeInto([]byte(response.Node.Value), &endpoints)
 	if err != nil {
 		glog.Errorf("Failed to parse service out of etcd key: %v : %+v", response.Node.Value, err)
 		return

--- a/pkg/proxy/config/etcd.go
+++ b/pkg/proxy/config/etcd.go
@@ -39,7 +39,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/coreos/go-etcd/etcd"

--- a/pkg/registry/binding/rest_test.go
+++ b/pkg/registry/binding/rest_test.go
@@ -38,12 +38,12 @@ func TestNewREST(t *testing.T) {
 		PodID: "foo",
 		Host:  "bar",
 	}
-	body, err := runtime.DefaultCodec.Encode(binding)
+	body, err := latest.Codec.Encode(binding)
 	if err != nil {
 		t.Fatalf("Unexpected encode error %v", err)
 	}
 	obj := b.New()
-	err = runtime.DefaultCodec.DecodeInto(body, obj)
+	err = latest.Codec.DecodeInto(body, obj)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}

--- a/pkg/registry/binding/rest_test.go
+++ b/pkg/registry/binding/rest_test.go
@@ -23,9 +23,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
 func TestNewREST(t *testing.T) {

--- a/pkg/registry/controller/rest_test.go
+++ b/pkg/registry/controller/rest_test.go
@@ -113,13 +113,13 @@ func TestControllerDecode(t *testing.T) {
 			ID: "foo",
 		},
 	}
-	body, err := runtime.DefaultCodec.Encode(controller)
+	body, err := latest.Codec.Encode(controller)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
 	controllerOut := storage.New()
-	if err := runtime.DefaultCodec.DecodeInto(body, controllerOut); err != nil {
+	if err := latest.Codec.DecodeInto(body, controllerOut); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 

--- a/pkg/registry/controller/rest_test.go
+++ b/pkg/registry/controller/rest_test.go
@@ -26,10 +26,10 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
 func TestListControllersError(t *testing.T) {

--- a/pkg/registry/etcd/etcd.go
+++ b/pkg/registry/etcd/etcd.go
@@ -45,7 +45,7 @@ func NewRegistry(client tools.EtcdClient) *Registry {
 	registry := &Registry{
 		EtcdHelper: tools.EtcdHelper{
 			client,
-			runtime.DefaultCodec,
+			latest.Codec,
 			runtime.DefaultResourceVersioner,
 		},
 	}

--- a/pkg/registry/etcd/etcd.go
+++ b/pkg/registry/etcd/etcd.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	etcderr "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/constraint"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
@@ -46,7 +47,7 @@ func NewRegistry(client tools.EtcdClient) *Registry {
 		EtcdHelper: tools.EtcdHelper{
 			client,
 			latest.Codec,
-			runtime.DefaultResourceVersioner,
+			latest.ResourceVersioner,
 		},
 	}
 	registry.manifestFactory = &BasicManifestFactory{

--- a/pkg/registry/etcd/etcd_test.go
+++ b/pkg/registry/etcd/etcd_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
-	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
@@ -41,7 +41,7 @@ func NewTestEtcdRegistry(client tools.EtcdClient) *Registry {
 
 func TestEtcdGetPod(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Set("/registry/pods/foo", latest.Codec.EncodeOrDie(&api.Pod{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	fakeClient.Set("/registry/pods/foo", runtime.EncodeOrDie(latest.Codec, &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	pod, err := registry.GetPod("foo")
 	if err != nil {
@@ -77,7 +77,7 @@ func TestEtcdCreatePod(t *testing.T) {
 		},
 		E: tools.EtcdErrorNotFound,
 	}
-	fakeClient.Set("/registry/hosts/machine/kubelet", latest.Codec.EncodeOrDie(&api.ContainerManifestList{}), 0)
+	fakeClient.Set("/registry/hosts/machine/kubelet", runtime.EncodeOrDie(latest.Codec, &api.ContainerManifestList{}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreatePod(&api.Pod{
 		JSONBase: api.JSONBase{
@@ -133,7 +133,7 @@ func TestEtcdCreatePodAlreadyExisting(t *testing.T) {
 	fakeClient.Data["/registry/pods/foo"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
-				Value: latest.Codec.EncodeOrDie(&api.Pod{JSONBase: api.JSONBase{ID: "foo"}}),
+				Value: runtime.EncodeOrDie(latest.Codec, &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}),
 			},
 		},
 		E: nil,
@@ -264,7 +264,7 @@ func TestEtcdCreatePodWithExistingContainers(t *testing.T) {
 		},
 		E: tools.EtcdErrorNotFound,
 	}
-	fakeClient.Set("/registry/hosts/machine/kubelet", latest.Codec.EncodeOrDie(&api.ContainerManifestList{
+	fakeClient.Set("/registry/hosts/machine/kubelet", runtime.EncodeOrDie(latest.Codec, &api.ContainerManifestList{
 		Items: []api.ContainerManifest{
 			{ID: "bar"},
 		},
@@ -325,11 +325,11 @@ func TestEtcdDeletePod(t *testing.T) {
 	fakeClient.TestIndex = true
 
 	key := "/registry/pods/foo"
-	fakeClient.Set(key, latest.Codec.EncodeOrDie(&api.Pod{
+	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &api.Pod{
 		JSONBase:     api.JSONBase{ID: "foo"},
 		DesiredState: api.PodState{Host: "machine"},
 	}), 0)
-	fakeClient.Set("/registry/hosts/machine/kubelet", latest.Codec.EncodeOrDie(&api.ContainerManifestList{
+	fakeClient.Set("/registry/hosts/machine/kubelet", runtime.EncodeOrDie(latest.Codec, &api.ContainerManifestList{
 		Items: []api.ContainerManifest{
 			{ID: "foo"},
 		},
@@ -361,11 +361,11 @@ func TestEtcdDeletePodMultipleContainers(t *testing.T) {
 	fakeClient.TestIndex = true
 
 	key := "/registry/pods/foo"
-	fakeClient.Set(key, latest.Codec.EncodeOrDie(&api.Pod{
+	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &api.Pod{
 		JSONBase:     api.JSONBase{ID: "foo"},
 		DesiredState: api.PodState{Host: "machine"},
 	}), 0)
-	fakeClient.Set("/registry/hosts/machine/kubelet", latest.Codec.EncodeOrDie(&api.ContainerManifestList{
+	fakeClient.Set("/registry/hosts/machine/kubelet", runtime.EncodeOrDie(latest.Codec, &api.ContainerManifestList{
 		Items: []api.ContainerManifest{
 			{ID: "foo"},
 			{ID: "bar"},
@@ -445,13 +445,13 @@ func TestEtcdListPods(t *testing.T) {
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
 					{
-						Value: latest.Codec.EncodeOrDie(&api.Pod{
+						Value: runtime.EncodeOrDie(latest.Codec, &api.Pod{
 							JSONBase:     api.JSONBase{ID: "foo"},
 							DesiredState: api.PodState{Host: "machine"},
 						}),
 					},
 					{
-						Value: latest.Codec.EncodeOrDie(&api.Pod{
+						Value: runtime.EncodeOrDie(latest.Codec, &api.Pod{
 							JSONBase:     api.JSONBase{ID: "bar"},
 							DesiredState: api.PodState{Host: "machine"},
 						}),
@@ -520,10 +520,10 @@ func TestEtcdListControllers(t *testing.T) {
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
 					{
-						Value: latest.Codec.EncodeOrDie(&api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}),
+						Value: runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}),
 					},
 					{
-						Value: latest.Codec.EncodeOrDie(&api.ReplicationController{JSONBase: api.JSONBase{ID: "bar"}}),
+						Value: runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: "bar"}}),
 					},
 				},
 			},
@@ -543,7 +543,7 @@ func TestEtcdListControllers(t *testing.T) {
 
 func TestEtcdGetController(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Set("/registry/controllers/foo", latest.Codec.EncodeOrDie(&api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	fakeClient.Set("/registry/controllers/foo", runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	ctrl, err := registry.GetController("foo")
 	if err != nil {
@@ -619,7 +619,7 @@ func TestEtcdCreateController(t *testing.T) {
 
 func TestEtcdCreateControllerAlreadyExisting(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Set("/registry/controllers/foo", latest.Codec.EncodeOrDie(&api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	fakeClient.Set("/registry/controllers/foo", runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreateController(&api.ReplicationController{
@@ -636,7 +636,7 @@ func TestEtcdUpdateController(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 
-	resp, _ := fakeClient.Set("/registry/controllers/foo", latest.Codec.EncodeOrDie(&api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	resp, _ := fakeClient.Set("/registry/controllers/foo", runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.UpdateController(&api.ReplicationController{
 		JSONBase: api.JSONBase{ID: "foo", ResourceVersion: resp.Node.ModifiedIndex},
@@ -662,10 +662,10 @@ func TestEtcdListServices(t *testing.T) {
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
 					{
-						Value: latest.Codec.EncodeOrDie(&api.Service{JSONBase: api.JSONBase{ID: "foo"}}),
+						Value: runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: "foo"}}),
 					},
 					{
-						Value: latest.Codec.EncodeOrDie(&api.Service{JSONBase: api.JSONBase{ID: "bar"}}),
+						Value: runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: "bar"}}),
 					},
 				},
 			},
@@ -711,7 +711,7 @@ func TestEtcdCreateService(t *testing.T) {
 
 func TestEtcdCreateServiceAlreadyExisting(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Set("/registry/services/specs/foo", latest.Codec.EncodeOrDie(&api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	fakeClient.Set("/registry/services/specs/foo", runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreateService(&api.Service{
 		JSONBase: api.JSONBase{ID: "foo"},
@@ -723,7 +723,7 @@ func TestEtcdCreateServiceAlreadyExisting(t *testing.T) {
 
 func TestEtcdGetService(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Set("/registry/services/specs/foo", latest.Codec.EncodeOrDie(&api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	fakeClient.Set("/registry/services/specs/foo", runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	service, err := registry.GetService("foo")
 	if err != nil {
@@ -775,7 +775,7 @@ func TestEtcdUpdateService(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 
-	resp, _ := fakeClient.Set("/registry/services/specs/foo", latest.Codec.EncodeOrDie(&api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	resp, _ := fakeClient.Set("/registry/services/specs/foo", runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	testService := api.Service{
 		JSONBase: api.JSONBase{ID: "foo", ResourceVersion: resp.Node.ModifiedIndex},
@@ -812,10 +812,10 @@ func TestEtcdListEndpoints(t *testing.T) {
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
 					{
-						Value: latest.Codec.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{"127.0.0.1:8345"}}),
+						Value: runtime.EncodeOrDie(latest.Codec, &api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{"127.0.0.1:8345"}}),
 					},
 					{
-						Value: latest.Codec.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "bar"}}),
+						Value: runtime.EncodeOrDie(latest.Codec, &api.Endpoints{JSONBase: api.JSONBase{ID: "bar"}}),
 					},
 				},
 			},
@@ -841,7 +841,7 @@ func TestEtcdGetEndpoints(t *testing.T) {
 		Endpoints: []string{"127.0.0.1:34855"},
 	}
 
-	fakeClient.Set("/registry/services/endpoints/foo", latest.Codec.EncodeOrDie(endpoints), 0)
+	fakeClient.Set("/registry/services/endpoints/foo", runtime.EncodeOrDie(latest.Codec, endpoints), 0)
 
 	got, err := registry.GetEndpoints("foo")
 	if err != nil {
@@ -862,7 +862,7 @@ func TestEtcdUpdateEndpoints(t *testing.T) {
 		Endpoints: []string{"baz", "bar"},
 	}
 
-	fakeClient.Set("/registry/services/endpoints/foo", latest.Codec.EncodeOrDie(&api.Endpoints{}), 0)
+	fakeClient.Set("/registry/services/endpoints/foo", runtime.EncodeOrDie(latest.Codec, &api.Endpoints{}), 0)
 
 	err := registry.UpdateEndpoints(&endpoints)
 	if err != nil {

--- a/pkg/registry/etcd/etcd_test.go
+++ b/pkg/registry/etcd/etcd_test.go
@@ -41,7 +41,7 @@ func NewTestEtcdRegistry(client tools.EtcdClient) *Registry {
 
 func TestEtcdGetPod(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Set("/registry/pods/foo", runtime.DefaultScheme.EncodeOrDie(&api.Pod{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	fakeClient.Set("/registry/pods/foo", latest.Codec.EncodeOrDie(&api.Pod{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	pod, err := registry.GetPod("foo")
 	if err != nil {
@@ -77,7 +77,7 @@ func TestEtcdCreatePod(t *testing.T) {
 		},
 		E: tools.EtcdErrorNotFound,
 	}
-	fakeClient.Set("/registry/hosts/machine/kubelet", runtime.DefaultScheme.EncodeOrDie(&api.ContainerManifestList{}), 0)
+	fakeClient.Set("/registry/hosts/machine/kubelet", latest.Codec.EncodeOrDie(&api.ContainerManifestList{}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreatePod(&api.Pod{
 		JSONBase: api.JSONBase{
@@ -133,7 +133,7 @@ func TestEtcdCreatePodAlreadyExisting(t *testing.T) {
 	fakeClient.Data["/registry/pods/foo"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
-				Value: runtime.DefaultScheme.EncodeOrDie(&api.Pod{JSONBase: api.JSONBase{ID: "foo"}}),
+				Value: latest.Codec.EncodeOrDie(&api.Pod{JSONBase: api.JSONBase{ID: "foo"}}),
 			},
 		},
 		E: nil,
@@ -264,7 +264,7 @@ func TestEtcdCreatePodWithExistingContainers(t *testing.T) {
 		},
 		E: tools.EtcdErrorNotFound,
 	}
-	fakeClient.Set("/registry/hosts/machine/kubelet", runtime.DefaultScheme.EncodeOrDie(&api.ContainerManifestList{
+	fakeClient.Set("/registry/hosts/machine/kubelet", latest.Codec.EncodeOrDie(&api.ContainerManifestList{
 		Items: []api.ContainerManifest{
 			{ID: "bar"},
 		},
@@ -325,11 +325,11 @@ func TestEtcdDeletePod(t *testing.T) {
 	fakeClient.TestIndex = true
 
 	key := "/registry/pods/foo"
-	fakeClient.Set(key, runtime.DefaultScheme.EncodeOrDie(&api.Pod{
+	fakeClient.Set(key, latest.Codec.EncodeOrDie(&api.Pod{
 		JSONBase:     api.JSONBase{ID: "foo"},
 		DesiredState: api.PodState{Host: "machine"},
 	}), 0)
-	fakeClient.Set("/registry/hosts/machine/kubelet", runtime.DefaultScheme.EncodeOrDie(&api.ContainerManifestList{
+	fakeClient.Set("/registry/hosts/machine/kubelet", latest.Codec.EncodeOrDie(&api.ContainerManifestList{
 		Items: []api.ContainerManifest{
 			{ID: "foo"},
 		},
@@ -361,11 +361,11 @@ func TestEtcdDeletePodMultipleContainers(t *testing.T) {
 	fakeClient.TestIndex = true
 
 	key := "/registry/pods/foo"
-	fakeClient.Set(key, runtime.DefaultScheme.EncodeOrDie(&api.Pod{
+	fakeClient.Set(key, latest.Codec.EncodeOrDie(&api.Pod{
 		JSONBase:     api.JSONBase{ID: "foo"},
 		DesiredState: api.PodState{Host: "machine"},
 	}), 0)
-	fakeClient.Set("/registry/hosts/machine/kubelet", runtime.DefaultScheme.EncodeOrDie(&api.ContainerManifestList{
+	fakeClient.Set("/registry/hosts/machine/kubelet", latest.Codec.EncodeOrDie(&api.ContainerManifestList{
 		Items: []api.ContainerManifest{
 			{ID: "foo"},
 			{ID: "bar"},
@@ -445,13 +445,13 @@ func TestEtcdListPods(t *testing.T) {
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
 					{
-						Value: runtime.DefaultScheme.EncodeOrDie(&api.Pod{
+						Value: latest.Codec.EncodeOrDie(&api.Pod{
 							JSONBase:     api.JSONBase{ID: "foo"},
 							DesiredState: api.PodState{Host: "machine"},
 						}),
 					},
 					{
-						Value: runtime.DefaultScheme.EncodeOrDie(&api.Pod{
+						Value: latest.Codec.EncodeOrDie(&api.Pod{
 							JSONBase:     api.JSONBase{ID: "bar"},
 							DesiredState: api.PodState{Host: "machine"},
 						}),
@@ -520,10 +520,10 @@ func TestEtcdListControllers(t *testing.T) {
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
 					{
-						Value: runtime.DefaultScheme.EncodeOrDie(&api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}),
+						Value: latest.Codec.EncodeOrDie(&api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}),
 					},
 					{
-						Value: runtime.DefaultScheme.EncodeOrDie(&api.ReplicationController{JSONBase: api.JSONBase{ID: "bar"}}),
+						Value: latest.Codec.EncodeOrDie(&api.ReplicationController{JSONBase: api.JSONBase{ID: "bar"}}),
 					},
 				},
 			},
@@ -543,7 +543,7 @@ func TestEtcdListControllers(t *testing.T) {
 
 func TestEtcdGetController(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Set("/registry/controllers/foo", runtime.DefaultScheme.EncodeOrDie(&api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	fakeClient.Set("/registry/controllers/foo", latest.Codec.EncodeOrDie(&api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	ctrl, err := registry.GetController("foo")
 	if err != nil {
@@ -619,7 +619,7 @@ func TestEtcdCreateController(t *testing.T) {
 
 func TestEtcdCreateControllerAlreadyExisting(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Set("/registry/controllers/foo", runtime.DefaultScheme.EncodeOrDie(&api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	fakeClient.Set("/registry/controllers/foo", latest.Codec.EncodeOrDie(&api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreateController(&api.ReplicationController{
@@ -636,7 +636,7 @@ func TestEtcdUpdateController(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 
-	resp, _ := fakeClient.Set("/registry/controllers/foo", runtime.DefaultScheme.EncodeOrDie(&api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	resp, _ := fakeClient.Set("/registry/controllers/foo", latest.Codec.EncodeOrDie(&api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.UpdateController(&api.ReplicationController{
 		JSONBase: api.JSONBase{ID: "foo", ResourceVersion: resp.Node.ModifiedIndex},
@@ -662,10 +662,10 @@ func TestEtcdListServices(t *testing.T) {
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
 					{
-						Value: runtime.DefaultScheme.EncodeOrDie(&api.Service{JSONBase: api.JSONBase{ID: "foo"}}),
+						Value: latest.Codec.EncodeOrDie(&api.Service{JSONBase: api.JSONBase{ID: "foo"}}),
 					},
 					{
-						Value: runtime.DefaultScheme.EncodeOrDie(&api.Service{JSONBase: api.JSONBase{ID: "bar"}}),
+						Value: latest.Codec.EncodeOrDie(&api.Service{JSONBase: api.JSONBase{ID: "bar"}}),
 					},
 				},
 			},
@@ -711,7 +711,7 @@ func TestEtcdCreateService(t *testing.T) {
 
 func TestEtcdCreateServiceAlreadyExisting(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Set("/registry/services/specs/foo", runtime.DefaultScheme.EncodeOrDie(&api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	fakeClient.Set("/registry/services/specs/foo", latest.Codec.EncodeOrDie(&api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreateService(&api.Service{
 		JSONBase: api.JSONBase{ID: "foo"},
@@ -723,7 +723,7 @@ func TestEtcdCreateServiceAlreadyExisting(t *testing.T) {
 
 func TestEtcdGetService(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Set("/registry/services/specs/foo", runtime.DefaultScheme.EncodeOrDie(&api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	fakeClient.Set("/registry/services/specs/foo", latest.Codec.EncodeOrDie(&api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	service, err := registry.GetService("foo")
 	if err != nil {
@@ -775,7 +775,7 @@ func TestEtcdUpdateService(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 
-	resp, _ := fakeClient.Set("/registry/services/specs/foo", runtime.DefaultScheme.EncodeOrDie(&api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	resp, _ := fakeClient.Set("/registry/services/specs/foo", latest.Codec.EncodeOrDie(&api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	testService := api.Service{
 		JSONBase: api.JSONBase{ID: "foo", ResourceVersion: resp.Node.ModifiedIndex},
@@ -812,10 +812,10 @@ func TestEtcdListEndpoints(t *testing.T) {
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
 					{
-						Value: runtime.DefaultScheme.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{"127.0.0.1:8345"}}),
+						Value: latest.Codec.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{"127.0.0.1:8345"}}),
 					},
 					{
-						Value: runtime.DefaultScheme.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "bar"}}),
+						Value: latest.Codec.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "bar"}}),
 					},
 				},
 			},
@@ -841,7 +841,7 @@ func TestEtcdGetEndpoints(t *testing.T) {
 		Endpoints: []string{"127.0.0.1:34855"},
 	}
 
-	fakeClient.Set("/registry/services/endpoints/foo", runtime.DefaultScheme.EncodeOrDie(endpoints), 0)
+	fakeClient.Set("/registry/services/endpoints/foo", latest.Codec.EncodeOrDie(endpoints), 0)
 
 	got, err := registry.GetEndpoints("foo")
 	if err != nil {
@@ -862,7 +862,7 @@ func TestEtcdUpdateEndpoints(t *testing.T) {
 		Endpoints: []string{"baz", "bar"},
 	}
 
-	fakeClient.Set("/registry/services/endpoints/foo", runtime.DefaultScheme.EncodeOrDie(&api.Endpoints{}), 0)
+	fakeClient.Set("/registry/services/endpoints/foo", latest.Codec.EncodeOrDie(&api.Endpoints{}), 0)
 
 	err := registry.UpdateEndpoints(&endpoints)
 	if err != nil {

--- a/pkg/registry/etcd/etcd_test.go
+++ b/pkg/registry/etcd/etcd_test.go
@@ -108,7 +108,7 @@ func TestEtcdCreatePod(t *testing.T) {
 		t.Fatalf("Unexpected error %v", err)
 	}
 	var pod api.Pod
-	err = runtime.DefaultCodec.DecodeInto([]byte(resp.Node.Value), &pod)
+	err = latest.Codec.DecodeInto([]byte(resp.Node.Value), &pod)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestEtcdCreatePod(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	err = runtime.DefaultCodec.DecodeInto([]byte(resp.Node.Value), &manifests)
+	err = latest.Codec.DecodeInto([]byte(resp.Node.Value), &manifests)
 	if len(manifests.Items) != 1 || manifests.Items[0].ID != "foo" {
 		t.Errorf("Unexpected manifest list: %#v", manifests)
 	}
@@ -235,7 +235,7 @@ func TestEtcdCreatePodWithContainersNotFound(t *testing.T) {
 		t.Fatalf("Unexpected error %v", err)
 	}
 	var pod api.Pod
-	err = runtime.DefaultCodec.DecodeInto([]byte(resp.Node.Value), &pod)
+	err = latest.Codec.DecodeInto([]byte(resp.Node.Value), &pod)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestEtcdCreatePodWithContainersNotFound(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	err = runtime.DefaultCodec.DecodeInto([]byte(resp.Node.Value), &manifests)
+	err = latest.Codec.DecodeInto([]byte(resp.Node.Value), &manifests)
 	if len(manifests.Items) != 1 || manifests.Items[0].ID != "foo" {
 		t.Errorf("Unexpected manifest list: %#v", manifests)
 	}
@@ -300,7 +300,7 @@ func TestEtcdCreatePodWithExistingContainers(t *testing.T) {
 		t.Fatalf("Unexpected error %v", err)
 	}
 	var pod api.Pod
-	err = runtime.DefaultCodec.DecodeInto([]byte(resp.Node.Value), &pod)
+	err = latest.Codec.DecodeInto([]byte(resp.Node.Value), &pod)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -314,7 +314,7 @@ func TestEtcdCreatePodWithExistingContainers(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	err = runtime.DefaultCodec.DecodeInto([]byte(resp.Node.Value), &manifests)
+	err = latest.Codec.DecodeInto([]byte(resp.Node.Value), &manifests)
 	if len(manifests.Items) != 2 || manifests.Items[1].ID != "foo" {
 		t.Errorf("Unexpected manifest list: %#v", manifests)
 	}
@@ -350,7 +350,7 @@ func TestEtcdDeletePod(t *testing.T) {
 		t.Fatalf("Unexpected error %v", err)
 	}
 	var manifests api.ContainerManifestList
-	runtime.DefaultCodec.DecodeInto([]byte(response.Node.Value), &manifests)
+	latest.Codec.DecodeInto([]byte(response.Node.Value), &manifests)
 	if len(manifests.Items) != 0 {
 		t.Errorf("Unexpected container set: %s, expected empty", response.Node.Value)
 	}
@@ -388,7 +388,7 @@ func TestEtcdDeletePodMultipleContainers(t *testing.T) {
 		t.Fatalf("Unexpected error %v", err)
 	}
 	var manifests api.ContainerManifestList
-	runtime.DefaultCodec.DecodeInto([]byte(response.Node.Value), &manifests)
+	latest.Codec.DecodeInto([]byte(response.Node.Value), &manifests)
 	if len(manifests.Items) != 1 {
 		t.Fatalf("Unexpected manifest set: %#v, expected empty", manifests)
 	}
@@ -607,7 +607,7 @@ func TestEtcdCreateController(t *testing.T) {
 		t.Fatalf("Unexpected error %v", err)
 	}
 	var ctrl api.ReplicationController
-	err = runtime.DefaultCodec.DecodeInto([]byte(resp.Node.Value), &ctrl)
+	err = latest.Codec.DecodeInto([]byte(resp.Node.Value), &ctrl)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -699,7 +699,7 @@ func TestEtcdCreateService(t *testing.T) {
 	}
 
 	var service api.Service
-	err = runtime.DefaultCodec.DecodeInto([]byte(resp.Node.Value), &service)
+	err = latest.Codec.DecodeInto([]byte(resp.Node.Value), &service)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -874,7 +874,7 @@ func TestEtcdUpdateEndpoints(t *testing.T) {
 		t.Fatalf("Unexpected error %v", err)
 	}
 	var endpointsOut api.Endpoints
-	err = runtime.DefaultCodec.DecodeInto([]byte(response.Node.Value), &endpointsOut)
+	err = latest.Codec.DecodeInto([]byte(response.Node.Value), &endpointsOut)
 	if !reflect.DeepEqual(endpoints, endpointsOut) {
 		t.Errorf("Unexpected endpoints: %#v, expected %#v", endpointsOut, endpoints)
 	}

--- a/pkg/registry/pod/rest_test.go
+++ b/pkg/registry/pod/rest_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/fake"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"

--- a/pkg/registry/pod/rest_test.go
+++ b/pkg/registry/pod/rest_test.go
@@ -201,13 +201,13 @@ func TestPodDecode(t *testing.T) {
 			ID: "foo",
 		},
 	}
-	body, err := runtime.DefaultCodec.Encode(expected)
+	body, err := latest.Codec.Encode(expected)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
 	actual := storage.New()
-	if err := runtime.DefaultCodec.DecodeInto(body, actual); err != nil {
+	if err := latest.Codec.DecodeInto(body, actual); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 

--- a/pkg/runtime/embedded.go
+++ b/pkg/runtime/embedded.go
@@ -20,42 +20,80 @@ import (
 	"gopkg.in/v1/yaml"
 )
 
+// EmbeddedObject must have an appropriate encoder and decoder functions, such that on the
+// wire, it's stored as a []byte, but in memory, the contained object is accessable as an
+// Object via the Get() function. Only valid API objects may be stored via EmbeddedObject.
+// The purpose of this is to allow an API object of type known only at runtime to be
+// embedded within other API objects.
+//
+// Define a Codec variable in your package and import the runtime package and
+// then use the commented section below
+
+/*
+// EmbeddedObject implements a Codec specific version of an
+// embedded object.
+type EmbeddedObject struct {
+	runtime.Object
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (a *EmbeddedObject) UnmarshalJSON(b []byte) error {
+	obj, err := runtime.CodecUnmarshalJSON(Codec, b)
+	a.Object = obj
+	return err
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (a EmbeddedObject) MarshalJSON() ([]byte, error) {
+	return runtime.CodecMarshalJSON(Codec, a.Object)
+}
+
+// SetYAML implements the yaml.Setter interface.
+func (a *EmbeddedObject) SetYAML(tag string, value interface{}) bool {
+	obj, ok := runtime.CodecSetYAML(Codec, tag, value)
+	a.Object = obj
+	return ok
+}
+
+// GetYAML implements the yaml.Getter interface.
+func (a EmbeddedObject) GetYAML() (tag string, value interface{}) {
+	return runtime.CodecGetYAML(Codec, a.Object)
+}
+*/
+
 // Encode()/Decode() are the canonical way of converting an API object to/from
 // wire format. This file provides utility functions which permit doing so
 // recursively, such that API objects of types known only at run time can be
 // embedded within other API types.
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
-func (a *EmbeddedObject) UnmarshalJSON(b []byte) error {
+func CodecUnmarshalJSON(codec Codec, b []byte) (Object, error) {
 	// Handle JSON's "null": Decode() doesn't expect it.
 	if len(b) == 4 && string(b) == "null" {
-		a.Object = nil
-		return nil
+		return nil, nil
 	}
 
-	obj, err := DefaultCodec.Decode(b)
+	obj, err := codec.Decode(b)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	a.Object = obj
-	return nil
+	return obj, nil
 }
 
 // MarshalJSON implements the json.Marshaler interface.
-func (a EmbeddedObject) MarshalJSON() ([]byte, error) {
-	if a.Object == nil {
+func CodecMarshalJSON(codec Codec, obj Object) ([]byte, error) {
+	if obj == nil {
 		// Encode unset/nil objects as JSON's "null".
 		return []byte("null"), nil
 	}
 
-	return DefaultCodec.Encode(a.Object)
+	return codec.Encode(obj)
 }
 
 // SetYAML implements the yaml.Setter interface.
-func (a *EmbeddedObject) SetYAML(tag string, value interface{}) bool {
+func CodecSetYAML(codec Codec, tag string, value interface{}) (Object, bool) {
 	if value == nil {
-		a.Object = nil
-		return true
+		return nil, true
 	}
 	// Why does the yaml package send value as a map[interface{}]interface{}?
 	// It's especially frustrating because encoding/json does the right thing
@@ -67,22 +105,21 @@ func (a *EmbeddedObject) SetYAML(tag string, value interface{}) bool {
 	if err != nil {
 		panic("yaml can't reverse its own object")
 	}
-	obj, err := DefaultCodec.Decode(b)
+	obj, err := codec.Decode(b)
 	if err != nil {
-		return false
+		return nil, false
 	}
-	a.Object = obj
-	return true
+	return obj, true
 }
 
 // GetYAML implements the yaml.Getter interface.
-func (a EmbeddedObject) GetYAML() (tag string, value interface{}) {
-	if a.Object == nil {
+func CodecGetYAML(codec Codec, obj Object) (tag string, value interface{}) {
+	if obj == nil {
 		value = "null"
 		return
 	}
 	// Encode returns JSON, which is conveniently a subset of YAML.
-	v, err := DefaultCodec.Encode(a.Object)
+	v, err := codec.Encode(obj)
 	if err != nil {
 		panic("impossible to encode API object!")
 	}

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -16,11 +16,21 @@ limitations under the License.
 
 package runtime
 
-// Codec defines methods for serializing and deserializing API objects.
-type Codec interface {
-	Encode(obj Object) (data []byte, err error)
+// Decoder defines methods for deserializing API objects into a given type
+type Decoder interface {
 	Decode(data []byte) (Object, error)
 	DecodeInto(data []byte, obj Object) error
+}
+
+// Encoder defines methods for serializing API objects into bytes
+type Encoder interface {
+	Encode(obj Object) (data []byte, err error)
+}
+
+// Codec defines methods for serializing and deserializing API objects.
+type Codec interface {
+	Decoder
+	Encoder
 }
 
 // ResourceVersioner provides methods for setting and retrieving

--- a/pkg/runtime/scheme_test.go
+++ b/pkg/runtime/scheme_test.go
@@ -43,14 +43,15 @@ func (*InternalSimple) IsAnAPIObject() {}
 func (*ExternalSimple) IsAnAPIObject() {}
 
 func TestScheme(t *testing.T) {
-	runtime.DefaultScheme.AddKnownTypeWithName("", "Simple", &InternalSimple{})
-	runtime.DefaultScheme.AddKnownTypeWithName("externalVersion", "Simple", &ExternalSimple{})
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName("", "Simple", &InternalSimple{})
+	scheme.AddKnownTypeWithName("externalVersion", "Simple", &ExternalSimple{})
 
 	internalToExternalCalls := 0
 	externalToInternalCalls := 0
 
 	// Register functions to verify that scope.Meta() gets set correctly.
-	err := runtime.DefaultScheme.AddConversionFuncs(
+	err := scheme.AddConversionFuncs(
 		func(in *InternalSimple, out *ExternalSimple, scope conversion.Scope) error {
 			if e, a := "", scope.Meta().SrcVersion; e != a {
 				t.Errorf("Expected '%v', got '%v'", e, a)
@@ -85,10 +86,10 @@ func TestScheme(t *testing.T) {
 
 	// Test Encode, Decode, and DecodeInto
 	obj := runtime.Object(simple)
-	data, err := runtime.DefaultScheme.EncodeToVersion(obj, "externalVersion")
-	obj2, err2 := runtime.DefaultScheme.Decode(data)
+	data, err := scheme.EncodeToVersion(obj, "externalVersion")
+	obj2, err2 := scheme.Decode(data)
 	obj3 := &InternalSimple{}
-	err3 := runtime.DefaultScheme.DecodeInto(data, obj3)
+	err3 := scheme.DecodeInto(data, obj3)
 	if err != nil || err2 != nil {
 		t.Fatalf("Failure: '%v' '%v' '%v'", err, err2, err3)
 	}
@@ -104,7 +105,7 @@ func TestScheme(t *testing.T) {
 
 	// Test Convert
 	external := &ExternalSimple{}
-	err = runtime.DefaultScheme.Convert(simple, external)
+	err = scheme.Convert(simple, external)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -123,12 +124,13 @@ func TestScheme(t *testing.T) {
 }
 
 func TestBadJSONRejection(t *testing.T) {
+	scheme := runtime.NewScheme()
 	badJSONMissingKind := []byte(`{ }`)
-	if _, err := runtime.DefaultScheme.Decode(badJSONMissingKind); err == nil {
+	if _, err := scheme.Decode(badJSONMissingKind); err == nil {
 		t.Errorf("Did not reject despite lack of kind field: %s", badJSONMissingKind)
 	}
 	badJSONUnknownType := []byte(`{"kind": "bar"}`)
-	if _, err1 := runtime.DefaultScheme.Decode(badJSONUnknownType); err1 == nil {
+	if _, err1 := scheme.Decode(badJSONUnknownType); err1 == nil {
 		t.Errorf("Did not reject despite use of unknown type: %s", badJSONUnknownType)
 	}
 	/*badJSONKindMismatch := []byte(`{"kind": "Pod"}`)
@@ -163,12 +165,13 @@ func (*ExternalExtensionType) IsAnAPIObject() {}
 func (*InternalExtensionType) IsAnAPIObject() {}
 
 func TestExtensionMapping(t *testing.T) {
-	runtime.DefaultScheme.AddKnownTypeWithName("", "ExtensionType", &InternalExtensionType{})
-	runtime.DefaultScheme.AddKnownTypeWithName("", "A", &ExtensionA{})
-	runtime.DefaultScheme.AddKnownTypeWithName("", "B", &ExtensionB{})
-	runtime.DefaultScheme.AddKnownTypeWithName("testExternal", "ExtensionType", &ExternalExtensionType{})
-	runtime.DefaultScheme.AddKnownTypeWithName("testExternal", "A", &ExtensionA{})
-	runtime.DefaultScheme.AddKnownTypeWithName("testExternal", "B", &ExtensionB{})
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName("", "ExtensionType", &InternalExtensionType{})
+	scheme.AddKnownTypeWithName("", "A", &ExtensionA{})
+	scheme.AddKnownTypeWithName("", "B", &ExtensionB{})
+	scheme.AddKnownTypeWithName("testExternal", "ExtensionType", &ExternalExtensionType{})
+	scheme.AddKnownTypeWithName("testExternal", "A", &ExtensionA{})
+	scheme.AddKnownTypeWithName("testExternal", "B", &ExtensionB{})
 
 	table := []struct {
 		obj     runtime.Object
@@ -187,14 +190,14 @@ func TestExtensionMapping(t *testing.T) {
 	}
 
 	for _, item := range table {
-		gotEncoded, err := runtime.DefaultScheme.EncodeToVersion(item.obj, "testExternal")
+		gotEncoded, err := scheme.EncodeToVersion(item.obj, "testExternal")
 		if err != nil {
 			t.Errorf("unexpected error '%v' (%#v)", err, item.obj)
 		} else if e, a := item.encoded, string(gotEncoded); e != a {
 			t.Errorf("expected %v, got %v", e, a)
 		}
 
-		gotDecoded, err := runtime.DefaultScheme.Decode([]byte(item.encoded))
+		gotDecoded, err := scheme.Decode([]byte(item.encoded))
 		if err != nil {
 			t.Errorf("unexpected error '%v' (%v)", err, item.encoded)
 		} else if e, a := item.obj, gotDecoded; !reflect.DeepEqual(e, a) {
@@ -207,5 +210,27 @@ func TestExtensionMapping(t *testing.T) {
 			}
 			t.Errorf("expected %#v, got %#v (%#v, %#v)", e, a, eEx, aEx)
 		}
+	}
+}
+
+func TestEncode(t *testing.T) {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName("", "Simple", &InternalSimple{})
+	scheme.AddKnownTypeWithName("externalVersion", "Simple", &ExternalSimple{})
+	codec := runtime.CodecFor(scheme, "externalVersion")
+	test := &InternalSimple{
+		TestString: "I'm the same",
+	}
+	obj := runtime.Object(test)
+	data, err := codec.Encode(obj)
+	obj2, err2 := codec.Decode(data)
+	if err != nil || err2 != nil {
+		t.Fatalf("Failure: '%v' '%v'", err, err2)
+	}
+	if _, ok := obj2.(*InternalSimple); !ok {
+		t.Fatalf("Got wrong type")
+	}
+	if !reflect.DeepEqual(obj2, test) {
+		t.Errorf("Expected:\n %#v,\n Got:\n %#v", &test, obj2)
 	}
 }

--- a/pkg/service/endpoints_controller_test.go
+++ b/pkg/service/endpoints_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"

--- a/pkg/tools/etcd_tools_test.go
+++ b/pkg/tools/etcd_tools_test.go
@@ -42,7 +42,7 @@ type TestResource struct {
 func (*TestResource) IsAnAPIObject() {}
 
 var scheme *runtime.Scheme
-var codec = runtime.DefaultCodec
+var codec = latest.Codec
 var versioner = runtime.DefaultResourceVersioner
 
 func init() {

--- a/pkg/tools/etcd_tools_test.go
+++ b/pkg/tools/etcd_tools_test.go
@@ -191,7 +191,7 @@ func TestSetObjWithVersion(t *testing.T) {
 	fakeClient.Data["/some/key"] = EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
-				Value:         runtime.DefaultScheme.EncodeOrDie(obj),
+				Value:         latest.Codec.EncodeOrDie(obj),
 				ModifiedIndex: 1,
 			},
 		},

--- a/pkg/tools/etcd_tools_watch_test.go
+++ b/pkg/tools/etcd_tools_watch_test.go
@@ -48,62 +48,62 @@ func TestWatchInterpretations(t *testing.T) {
 	}{
 		"create": {
 			actions:      []string{"create", "get"},
-			nodeValue:    runtime.DefaultScheme.EncodeOrDie(podBar),
+			nodeValue:    latest.Codec.EncodeOrDie(podBar),
 			expectEmit:   true,
 			expectType:   watch.Added,
 			expectObject: podBar,
 		},
 		"create but filter blocks": {
 			actions:    []string{"create", "get"},
-			nodeValue:  runtime.DefaultScheme.EncodeOrDie(podFoo),
+			nodeValue:  latest.Codec.EncodeOrDie(podFoo),
 			expectEmit: false,
 		},
 		"delete": {
 			actions:       []string{"delete"},
-			prevNodeValue: runtime.DefaultScheme.EncodeOrDie(podBar),
+			prevNodeValue: latest.Codec.EncodeOrDie(podBar),
 			expectEmit:    true,
 			expectType:    watch.Deleted,
 			expectObject:  podBar,
 		},
 		"delete but filter blocks": {
 			actions:    []string{"delete"},
-			nodeValue:  runtime.DefaultScheme.EncodeOrDie(podFoo),
+			nodeValue:  latest.Codec.EncodeOrDie(podFoo),
 			expectEmit: false,
 		},
 		"modify appears to create 1": {
 			actions:      []string{"set", "compareAndSwap"},
-			nodeValue:    runtime.DefaultScheme.EncodeOrDie(podBar),
+			nodeValue:    latest.Codec.EncodeOrDie(podBar),
 			expectEmit:   true,
 			expectType:   watch.Added,
 			expectObject: podBar,
 		},
 		"modify appears to create 2": {
 			actions:       []string{"set", "compareAndSwap"},
-			prevNodeValue: runtime.DefaultScheme.EncodeOrDie(podFoo),
-			nodeValue:     runtime.DefaultScheme.EncodeOrDie(podBar),
+			prevNodeValue: latest.Codec.EncodeOrDie(podFoo),
+			nodeValue:     latest.Codec.EncodeOrDie(podBar),
 			expectEmit:    true,
 			expectType:    watch.Added,
 			expectObject:  podBar,
 		},
 		"modify appears to delete": {
 			actions:       []string{"set", "compareAndSwap"},
-			prevNodeValue: runtime.DefaultScheme.EncodeOrDie(podBar),
-			nodeValue:     runtime.DefaultScheme.EncodeOrDie(podFoo),
+			prevNodeValue: latest.Codec.EncodeOrDie(podBar),
+			nodeValue:     latest.Codec.EncodeOrDie(podFoo),
 			expectEmit:    true,
 			expectType:    watch.Deleted,
 			expectObject:  podBar, // Should return last state that passed the filter!
 		},
 		"modify modifies": {
 			actions:       []string{"set", "compareAndSwap"},
-			prevNodeValue: runtime.DefaultScheme.EncodeOrDie(podBar),
-			nodeValue:     runtime.DefaultScheme.EncodeOrDie(podBaz),
+			prevNodeValue: latest.Codec.EncodeOrDie(podBar),
+			nodeValue:     latest.Codec.EncodeOrDie(podBaz),
 			expectEmit:    true,
 			expectType:    watch.Modified,
 			expectObject:  podBaz,
 		},
 		"modify ignores": {
 			actions:    []string{"set", "compareAndSwap"},
-			nodeValue:  runtime.DefaultScheme.EncodeOrDie(podFoo),
+			nodeValue:  latest.Codec.EncodeOrDie(podFoo),
 			expectEmit: false,
 		},
 	}
@@ -259,7 +259,7 @@ func TestWatchEtcdState(t *testing.T) {
 				{
 					Action: "create",
 					Node: &etcd.Node{
-						Value: string(runtime.DefaultScheme.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{}})),
+						Value: string(latest.Codec.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{}})),
 					},
 				},
 			},
@@ -273,12 +273,12 @@ func TestWatchEtcdState(t *testing.T) {
 				{
 					Action: "compareAndSwap",
 					Node: &etcd.Node{
-						Value:         string(runtime.DefaultScheme.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{"127.0.0.1:9000"}})),
+						Value:         string(latest.Codec.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{"127.0.0.1:9000"}})),
 						CreatedIndex:  1,
 						ModifiedIndex: 2,
 					},
 					PrevNode: &etcd.Node{
-						Value:         string(runtime.DefaultScheme.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{}})),
+						Value:         string(latest.Codec.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{}})),
 						CreatedIndex:  1,
 						ModifiedIndex: 1,
 					},
@@ -295,7 +295,7 @@ func TestWatchEtcdState(t *testing.T) {
 					R: &etcd.Response{
 						Action: "get",
 						Node: &etcd.Node{
-							Value:         string(runtime.DefaultScheme.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{}})),
+							Value:         string(latest.Codec.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{}})),
 							CreatedIndex:  1,
 							ModifiedIndex: 1,
 						},
@@ -308,12 +308,12 @@ func TestWatchEtcdState(t *testing.T) {
 				{
 					Action: "compareAndSwap",
 					Node: &etcd.Node{
-						Value:         string(runtime.DefaultScheme.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{"127.0.0.1:9000"}})),
+						Value:         string(latest.Codec.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{"127.0.0.1:9000"}})),
 						CreatedIndex:  1,
 						ModifiedIndex: 2,
 					},
 					PrevNode: &etcd.Node{
-						Value:         string(runtime.DefaultScheme.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{}})),
+						Value:         string(latest.Codec.EncodeOrDie(&api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{}})),
 						CreatedIndex:  1,
 						ModifiedIndex: 1,
 					},
@@ -370,7 +370,7 @@ func TestWatchFromZeroIndex(t *testing.T) {
 			EtcdResponseWithError{
 				R: &etcd.Response{
 					Node: &etcd.Node{
-						Value:         runtime.DefaultScheme.EncodeOrDie(pod),
+						Value:         latest.Codec.EncodeOrDie(pod),
 						CreatedIndex:  1,
 						ModifiedIndex: 1,
 					},
@@ -385,7 +385,7 @@ func TestWatchFromZeroIndex(t *testing.T) {
 			EtcdResponseWithError{
 				R: &etcd.Response{
 					Node: &etcd.Node{
-						Value:         runtime.DefaultScheme.EncodeOrDie(pod),
+						Value:         latest.Codec.EncodeOrDie(pod),
 						CreatedIndex:  1,
 						ModifiedIndex: 2,
 					},
@@ -443,13 +443,13 @@ func TestWatchListFromZeroIndex(t *testing.T) {
 				Dir: true,
 				Nodes: etcd.Nodes{
 					&etcd.Node{
-						Value:         runtime.DefaultScheme.EncodeOrDie(pod),
+						Value:         latest.Codec.EncodeOrDie(pod),
 						CreatedIndex:  1,
 						ModifiedIndex: 1,
 						Nodes:         etcd.Nodes{},
 					},
 					&etcd.Node{
-						Value:         runtime.DefaultScheme.EncodeOrDie(pod),
+						Value:         latest.Codec.EncodeOrDie(pod),
 						CreatedIndex:  2,
 						ModifiedIndex: 2,
 						Nodes:         etcd.Nodes{},

--- a/plugin/pkg/scheduler/factory/factory_test.go
+++ b/plugin/pkg/scheduler/factory/factory_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
@@ -113,7 +114,7 @@ func TestPollMinions(t *testing.T) {
 		ml := &api.MinionList{Items: item.minions}
 		handler := util.FakeHandler{
 			StatusCode:   200,
-			ResponseBody: latest.Codec.EncodeOrDie(ml),
+			ResponseBody: runtime.EncodeOrDie(latest.Codec, ml),
 			T:            t,
 		}
 		mux := http.NewServeMux()
@@ -140,7 +141,7 @@ func TestDefaultErrorFunc(t *testing.T) {
 	testPod := &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}
 	handler := util.FakeHandler{
 		StatusCode:   200,
-		ResponseBody: latest.Codec.EncodeOrDie(testPod),
+		ResponseBody: runtime.EncodeOrDie(latest.Codec, testPod),
 		T:            t,
 	}
 	mux := http.NewServeMux()
@@ -259,7 +260,7 @@ func TestBind(t *testing.T) {
 			t.Errorf("Unexpected error: %v", err)
 			continue
 		}
-		expectedBody := latest.Codec.EncodeOrDie(item.binding)
+		expectedBody := runtime.EncodeOrDie(latest.Codec, item.binding)
 		handler.ValidateRequest(t, "/api/v1beta1/bindings", "POST", &expectedBody)
 	}
 }

--- a/plugin/pkg/scheduler/factory/factory_test.go
+++ b/plugin/pkg/scheduler/factory/factory_test.go
@@ -113,7 +113,7 @@ func TestPollMinions(t *testing.T) {
 		ml := &api.MinionList{Items: item.minions}
 		handler := util.FakeHandler{
 			StatusCode:   200,
-			ResponseBody: runtime.DefaultScheme.EncodeOrDie(ml),
+			ResponseBody: latest.Codec.EncodeOrDie(ml),
 			T:            t,
 		}
 		mux := http.NewServeMux()
@@ -140,7 +140,7 @@ func TestDefaultErrorFunc(t *testing.T) {
 	testPod := &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}
 	handler := util.FakeHandler{
 		StatusCode:   200,
-		ResponseBody: runtime.DefaultScheme.EncodeOrDie(testPod),
+		ResponseBody: latest.Codec.EncodeOrDie(testPod),
 		T:            t,
 	}
 	mux := http.NewServeMux()
@@ -259,7 +259,7 @@ func TestBind(t *testing.T) {
 			t.Errorf("Unexpected error: %v", err)
 			continue
 		}
-		expectedBody := runtime.DefaultScheme.EncodeOrDie(item.binding)
+		expectedBody := latest.Codec.EncodeOrDie(item.binding)
 		handler.ValidateRequest(t, "/api/v1beta1/bindings", "POST", &expectedBody)
 	}
 }

--- a/test/integration/etcd_tools_test.go
+++ b/test/integration/etcd_tools_test.go
@@ -90,7 +90,7 @@ func TestExtractObj(t *testing.T) {
 
 func TestWatch(t *testing.T) {
 	client := newEtcdClient()
-	helper := tools.EtcdHelper{Client: client, Codec: runtime.DefaultCodec, ResourceVersioner: runtime.DefaultResourceVersioner}
+	helper := tools.EtcdHelper{Client: client, Codec: latest.Codec, ResourceVersioner: runtime.DefaultResourceVersioner}
 	withEtcdKey(func(key string) {
 		resp, err := client.Set(key, runtime.DefaultScheme.EncodeOrDie(&api.Pod{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 		if err != nil {

--- a/test/integration/etcd_tools_test.go
+++ b/test/integration/etcd_tools_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -90,9 +92,9 @@ func TestExtractObj(t *testing.T) {
 
 func TestWatch(t *testing.T) {
 	client := newEtcdClient()
-	helper := tools.EtcdHelper{Client: client, Codec: latest.Codec, ResourceVersioner: runtime.DefaultResourceVersioner}
+	helper := tools.EtcdHelper{Client: client, Codec: latest.Codec, ResourceVersioner: latest.ResourceVersioner}
 	withEtcdKey(func(key string) {
-		resp, err := client.Set(key, latest.Codec.EncodeOrDie(&api.Pod{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+		resp, err := client.Set(key, runtime.EncodeOrDie(v1beta1.Codec, &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/test/integration/etcd_tools_test.go
+++ b/test/integration/etcd_tools_test.go
@@ -92,7 +92,7 @@ func TestWatch(t *testing.T) {
 	client := newEtcdClient()
 	helper := tools.EtcdHelper{Client: client, Codec: latest.Codec, ResourceVersioner: runtime.DefaultResourceVersioner}
 	withEtcdKey(func(key string) {
-		resp, err := client.Set(key, runtime.DefaultScheme.EncodeOrDie(&api.Pod{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+		resp, err := client.Set(key, latest.Codec.EncodeOrDie(&api.Pod{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
@lavalamp see changes related to killing DefaultCodec + EmbeddedObject being
package specific.

Key changes here are that the "latest" package has a Codec that defines the
default encoding.  Code that doesn't care about what it encodes to should use
that.  Code that must version bind still needs to use a specific packages Codec.
