### PR TITLE
No DNS in vagrant cross minions, need explicit IP as host

### DIFF
--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -27,12 +27,14 @@ INSTANCE_PREFIX=kubernetes
 MASTER_NAME="${INSTANCE_PREFIX}-master"
 MASTER_TAG="${INSTANCE_PREFIX}-master"
 MINION_TAG="${INSTANCE_PREFIX}-minion"
-MINION_NAMES=($(eval echo ${INSTANCE_PREFIX}-minion-{1..${NUM_MINIONS}}))
+# Unable to use hostnames yet because DNS is not in cluster, so we revert external look-up name to use the minion IP
+#MINION_NAMES=($(eval echo ${INSTANCE_PREFIX}-minion-{1..${NUM_MINIONS}}))
 
 # IP LOCATIONS FOR INTERACTING WITH THE MINIONS
 MINION_IP_BASE="10.245.2."
 for (( i=0; i <${NUM_MINIONS}; i++)) do
   KUBE_MINION_IP_ADDRESSES[$i]="${MINION_IP_BASE}$[$i+2]"
   MINION_IP[$i]="${MINION_IP_BASE}$[$i+2]"
+  MINION_NAMES[$i]="${MINION_IP[$i]}"
   VAGRANT_MINION_NAMES[$i]="minion-$[$i+1]"
 done

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -50,6 +50,7 @@ grains:
   roles:
     - kubernetes-pool
   cbr-cidr: $MINION_IP_RANGE
+  minion_ip: $MINION_IP
 EOF
 
 # we will run provision to update code each time we test, so we do not want to do salt install each time

--- a/pkg/cloudprovider/vagrant/vagrant.go
+++ b/pkg/cloudprovider/vagrant/vagrant.go
@@ -106,8 +106,8 @@ func (v *VagrantCloud) IPAddress(instance string) (net.IP, error) {
 	}
 	filteredMinions := v.saltMinionsByRole(minions, "kubernetes-pool")
 	for _, minion := range filteredMinions {
-		fmt.Println("Minion: ", minion.Host, " , ", instance, " IP: ", minion.IP)
-		if minion.Host == instance {
+		// Due to vagrant not running with a dedicated DNS setup, we return the IP address of a minion as its hostname at this time
+		if minion.IP == instance {
 			return net.ParseIP(minion.IP), nil
 		}
 	}
@@ -203,7 +203,8 @@ func (v *VagrantCloud) List(filter string) ([]string, error) {
 	filteredMinions := v.saltMinionsByRole(minions, "kubernetes-pool")
 	var instances []string
 	for _, instance := range filteredMinions {
-		instances = append(instances, instance.Host)
+		// With no dedicated DNS setup in cluster, IP address is used as hostname
+		instances = append(instances, instance.IP)
 	}
 
 	return instances, nil

--- a/pkg/cloudprovider/vagrant/vagrant_test.go
+++ b/pkg/cloudprovider/vagrant/vagrant_test.go
@@ -73,7 +73,11 @@ func TestVagrantCloud(t *testing.T) {
 		t.Fatalf("Incorrect number of instances returned")
 	}
 
-	if instances[0] != "kubernetes-minion-1" {
+	// no DNS in vagrant cluster, so we return IP as hostname
+	expectedInstanceHost := "10.245.2.2"
+	expectedInstanceIP := "10.245.2.2"
+
+	if instances[0] != expectedInstanceHost {
 		t.Fatalf("Invalid instance returned")
 	}
 
@@ -82,7 +86,7 @@ func TestVagrantCloud(t *testing.T) {
 		t.Fatalf("Unexpected error, should have returned a valid IP address: %s", err)
 	}
 
-	if ip.String() != "10.245.2.2" {
+	if ip.String() != expectedInstanceIP {
 		t.Fatalf("Invalid IP address returned")
 	}
 }

--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -18,7 +18,6 @@ package pod
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -194,10 +193,6 @@ func getInstanceIP(cloud cloudprovider.Interface, host string) string {
 	instances, ok := cloud.Instances()
 	if instances == nil || !ok {
 		return ""
-	}
-	ix := strings.Index(host, ".")
-	if ix != -1 {
-		host = host[:ix]
 	}
 	addr, err := instances.IPAddress(host)
 	if err != nil {


### PR DESCRIPTION
Closes #1233 

Issue is that the running container could not ping the other minions by hostname in the vagrant environment because minion hostnames were only routable via /etc/hosts

There was some code that made other parts of the experience not work when getting pod data because k8s was modifying the self reported host name from a cloud provider prior to requesting the machines IP.  Fixed that issue up so k8s does not modify the hostname reported by the cloud_provider.
