### PR TITLE
apiserver does not require a cloud provider or machine list

### DIFF
--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -60,7 +60,7 @@ func init() {
 func verifyMinionFlags() {
 	if *cloudProvider == "" || *minionRegexp == "" {
 		if len(machineList) == 0 {
-			glog.Fatal("No machines specified!")
+			glog.Info("No machines specified!")
 		}
 		return
 	}


### PR DESCRIPTION
Currently the apiserver will not start unless a machine list or a
valid cloud provider is specified. This prevents a workflow that
manages machines solely through the minions API.

Fix the issue by changing the apiserver to only log a message that
the apiserver is being started with an empty machine list.

This patch results in a change in behavior. The apiserver will no
longer exit non-zero if a cloud provider or machine list is not
configured.
