### PR TITLE
Proposal for new kubecfg design (kubectl)

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -111,6 +111,13 @@
 			"ImportPath": "github.com/skratchdot/open-golang/open",
 			"Rev": "ba570a111973b539baf23c918213059543b5bb6e"
 		},
+			"ImportPath": "github.com/spf13/cobra",
+			"Rev": "b1e90a7943957b51bb96a13b44b844475bcf95c0"
+		},
+		{
+			"ImportPath": "github.com/spf13/pflag",
+			"Rev": "463bdc838f2b35e9307e91d480878bda5fff7232"
+		},
 		{
 			"ImportPath": "github.com/stretchr/objx",
 			"Rev": "d40df0cc104c06eae2dfe03d7dddb83802d52f9a"

--- a/Godeps/_workspace/src/github.com/spf13/cobra/.gitignore
+++ b/Godeps/_workspace/src/github.com/spf13/cobra/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+
+cobra.test

--- a/Godeps/_workspace/src/github.com/spf13/cobra/.travis.yml
+++ b/Godeps/_workspace/src/github.com/spf13/cobra/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+go:
+  - 1.1
+script:
+  - go test ./...
+  - go build

--- a/Godeps/_workspace/src/github.com/spf13/cobra/LICENSE.txt
+++ b/Godeps/_workspace/src/github.com/spf13/cobra/LICENSE.txt
@@ -1,0 +1,174 @@
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/Godeps/_workspace/src/github.com/spf13/cobra/README.md
+++ b/Godeps/_workspace/src/github.com/spf13/cobra/README.md
@@ -1,0 +1,397 @@
+# Cobra
+
+A Commander for modern go CLI interactions
+
+[![Build Status](https://travis-ci.org/spf13/cobra.png)](https://travis-ci.org/spf13/cobra)
+
+## Overview
+
+Cobra is a commander providing a simple interface to create powerful modern CLI
+interfaces similar to git & go tools. In addition to providing an interface, Cobra
+simultaneously provides a controller to organize your application code.
+
+Inspired by go, go-Commander, gh and subcommand, Cobra improves on these by
+providing **fully posix compliant flags** (including short & long versions),
+**nesting commands**, and the ability to **define your own help and usage** for any or
+all commands.
+
+Cobra has an exceptionally clean interface and simple design without needless
+constructors or initialization methods.
+
+Applications built with Cobra commands are designed to be as user friendly as
+possible. Flags can be placed before or after the command (as long as a
+confusing space isn’t provided). Both short and long flags can be used. A
+command need not even be fully typed. The shortest unambiguous string will
+suffice. Help is automatically generated and available for the application or
+for a specific command using either the help command or the --help flag.
+
+## Concepts
+
+Cobra is built on a structure of commands & flags.
+
+**Commands** represent actions and **Flags** are modifiers for those actions.
+
+In the following example 'server' is a command and 'port' is a flag.
+
+    hugo server --port=1313
+
+### Commands
+
+Command is the central point of the application. Each interaction that
+the application supports will be contained in a Command. A command can
+have children commands and optionally run an action.
+
+In the example above 'server' is the command
+
+A Command has the following structure:
+
+    type Command struct {
+        Use string // The one-line usage message.
+        Short string // The short description shown in the 'help' output.
+        Long string // The long message shown in the 'help <this-command>' output.
+        Run func(cmd *Command, args []string) // Run runs the command.
+    }
+
+### Flags
+
+A Flag is a way to modify the behavior of an command. Cobra supports
+fully posix compliant flags as well as the go flag package. 
+A Cobra command can define flags that persist through to children commands
+and flags that are only available to that command.
+
+In the example above 'port' is the flag.
+
+Flag functionality is provided by the [pflag
+libary](https://github.com/ogier/pflag), a fork of the flag standard library
+which maintains the same interface while adding posix compliance.
+
+## Usage
+
+Cobra works by creating a set of commands and then organizing them into a tree.
+The tree defines the structure of the application.
+
+Once each command is defined with it's corresponding flags, then the
+tree is assigned to the commander which is finally executed.
+
+### Installing
+Using Cobra is easy. First use go get to install the latest version
+of the library.
+
+    $ go get github.com/spf13/cobra
+
+Next include cobra in your application.
+
+    import "github.com/spf13/cobra"
+
+### Create the root command
+
+The root command represents your binary itself.
+
+Cobra doesn't require any special constructors. Simply create your commands.
+
+    var HugoCmd = &cobra.Command{
+        Use:   "hugo",
+        Short: "Hugo is a very fast static site generator",
+        Long: `A Fast and Flexible Static Site Generator built with
+                love by spf13 and friends in Go.
+                Complete documentation is available at http://hugo.spf13.com`,
+        Run: func(cmd *cobra.Command, args []string) {
+            // Do Stuff Here
+        },
+    }
+
+### Create additional commands
+
+Additional commands can be defined.
+
+    var versionCmd = &cobra.Command{
+        Use:   "version",
+        Short: "Print the version number of Hugo",
+        Long:  `All software has versions. This is Hugo's`,
+        Run: func(cmd *cobra.Command, args []string) {
+            fmt.Println("Hugo Static Site Generator v0.9 -- HEAD")
+        },
+    }
+
+### Attach command to its parent
+In this example we are attaching it to the root, but commands can be attached at any level.
+
+	HugoCmd.AddCommand(versionCmd)
+
+### Assign flags to a command
+
+Since the flags are defined and used in different locations, we need to define a variable outside with the correct scope to assign the flag to work with.
+
+    var Verbose bool
+    var Source string
+
+There are two different approaches to assign a flag.
+
+#### Persistent Flags
+
+A flag can be 'persistent' meaning that this flag will be available to the
+command it's assigned to as well as every command under that command. For
+global flags assign a flag as a persistent flag on the root.
+
+	HugoCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
+
+#### Local Flags
+
+A flag can also be assigned locally which will only apply to that specific command.
+
+	HugoCmd.Flags().StringVarP(&Source, "source", "s", "", "Source directory to read from")
+
+### Once all commands and flags are defined, Execute the commands
+
+Execute should be run on the root for clarity, though it can be called on any command.
+
+    HugoCmd.Execute()
+
+## Example
+
+In the example below we have defined three commands. Two are at the top level
+and one (cmdTimes) is a child of one of the top commands. In this case the root
+is not executable meaning that a subcommand is required. This is accomplished
+by not providing a 'Run' for the 'rootCmd'.
+
+We have only defined one flag for a single command.
+
+More documentation about flags is available at https://github.com/spf13/pflag
+
+    import(
+        "github.com/spf13/cobra"
+        "fmt"
+        "strings"
+    )
+
+    func main() {
+
+        var echoTimes int
+
+        var cmdPrint = &cobra.Command{
+            Use:   "print [string to print]",
+            Short: "Print anything to the screen",
+            Long:  `print is for printing anything back to the screen.
+            For many years people have printed back to the screen.
+            `,
+            Run: func(cmd *cobra.Command, args []string) {
+                fmt.Println("Print: " + strings.Join(args, " "))
+            },
+        }
+
+        var cmdEcho = &cobra.Command{
+            Use:   "echo [string to echo]",
+            Short: "Echo anything to the screen",
+            Long:  `echo is for echoing anything back.
+            Echo works a lot like print, except it has a child command.
+            `,
+            Run: func(cmd *cobra.Command, args []string) {
+                fmt.Println("Print: " + strings.Join(args, " "))
+            },
+        }
+
+        var cmdTimes = &cobra.Command{
+            Use:   "times [# times] [string to echo]",
+            Short: "Echo anything to the screen more times",
+            Long:  `echo things multiple times back to the user by providing
+            a count and a string.`,
+            Run: func(cmd *cobra.Command, args []string) {
+                for i:=0; i < echoTimes; i++ {
+                    fmt.Println("Echo: " + strings.Join(args, " "))
+                }
+            },
+        }
+
+        cmdTimes.Flags().IntVarP(&echoTimes, "times", "t", 1, "times to echo the input")
+
+        var rootCmd = &cobra.Command{Use: "app"}
+        rootCmd.AddCommand(cmdPrint, cmdEcho)
+        cmdEcho.AddCommand(cmdTimes)
+        rootCmd.Execute()
+    }
+
+For a more complete example of a larger application, please checkout [Hugo](http://hugo.spf13.com)
+
+## The Help Command
+
+Cobra automatically adds a help command to your application.
+This will be called when a user runs 'app help'. Additionally help will also
+support all other commands as input. Say for instance you have a command called
+'create' without any additional configuration cobra will work when 'app help
+create' is called.
+
+### Example
+
+The following output is automatically generated by cobra. Nothing beyond the
+command and flag definitions are needed.
+
+    > hugo help
+
+    A Fast and Flexible Static Site Generator built with
+    love by spf13 and friends in Go.
+
+    Complete documentation is available at http://hugo.spf13.com
+
+    Usage:
+      hugo [flags]
+      hugo [command]
+
+    Available Commands:
+      server          :: Hugo runs it's own a webserver to render the files
+      version         :: Print the version number of Hugo
+      check           :: Check content in the source directory
+      benchmark       :: Benchmark hugo by building a site a number of times
+      help [command]  :: Help about any command
+
+     Available Flags:
+      -b, --base-url="": hostname (and path) to the root eg. http://spf13.com/
+      -D, --build-drafts=false: include content marked as draft
+          --config="": config file (default is path/config.yaml|json|toml)
+      -d, --destination="": filesystem path to write files to
+      -s, --source="": filesystem path to read files relative from
+          --stepAnalysis=false: display memory and timing of different steps of the program
+          --uglyurls=false: if true, use /filename.html instead of /filename/
+      -v, --verbose=false: verbose output
+      -w, --watch=false: watch filesystem for changes and recreate as needed
+
+    Use "hugo help [command]" for more information about that command.
+
+
+
+Help is just a command like any other. There is no special logic or behavior
+around it. In fact you can provide your own if you want.
+
+### Defining your own help
+
+You can provide your own Help command or you own template for the default command to use.
+
+The default help command is 
+
+    func (c *Command) initHelp() {
+        if c.helpCommand == nil {
+            c.helpCommand = &Command{
+                Use:   "help [command]",
+                Short: "Help about any command",
+                Long: `Help provides help for any command in the application.
+        Simply type ` + c.Name() + ` help [path to command] for full details.`,
+                Run: c.HelpFunc(),
+            }
+        }
+        c.AddCommand(c.helpCommand)
+    }
+
+You can provide your own command, function or template through the following methods.
+
+    command.SetHelpCommand(cmd *Command)
+
+    command.SetHelpFunc(f func(*Command, []string))
+
+    command.SetHelpTemplate(s string)
+
+The latter two will also apply to any children commands.
+
+## Usage
+
+When the user provides an invalid flag or invalid command Cobra responds by
+showing the user the 'usage'
+
+### Example
+You may recognize this from the help above. That's because the default help
+embeds the usage as part of it's output.
+
+    Usage:
+      hugo [flags]
+      hugo [command]
+
+    Available Commands:
+      server          Hugo runs it's own a webserver to render the files
+      version         Print the version number of Hugo
+      check           Check content in the source directory
+      benchmark       Benchmark hugo by building a site a number of times
+      help [command]  Help about any command
+
+     Available Flags:
+      -b, --base-url="": hostname (and path) to the root eg. http://spf13.com/
+      -D, --build-drafts=false: include content marked as draft
+          --config="": config file (default is path/config.yaml|json|toml)
+      -d, --destination="": filesystem path to write files to
+      -s, --source="": filesystem path to read files relative from
+          --stepAnalysis=false: display memory and timing of different steps of the program
+          --uglyurls=false: if true, use /filename.html instead of /filename/
+      -v, --verbose=false: verbose output
+      -w, --watch=false: watch filesystem for changes and recreate as needed
+
+### Defining your own usage
+You can provide your own usage function or template for cobra to use.
+
+The default usage function is
+
+		return func(c *Command) error {
+			err := tmpl(c.Out(), c.UsageTemplate(), c)
+			return err
+		}
+
+Like help the function and template are over ridable through public methods.
+
+    command.SetUsageFunc(f func(*Command) error)
+
+    command.SetUsageTemplate(s string)
+
+
+## Debugging
+
+Cobra provides a ‘DebugFlags’ method on a command which when called will print
+out everything Cobra knows about the flags for each command
+
+### Example
+
+    command.DebugFlags()
+
+## Release Notes
+* **0.9.0** June 17, 2014
+  * flags can appears anywhere in the args (provided they are unambiguous)
+  * --help prints usage screen for app or command
+  * Prefix matching for commands
+  * Cleaner looking help and usage output
+  * Extensive test suite
+* **0.8.0** Nov 5, 2013
+  * Reworked interface to remove commander completely
+  * Command now primary structure
+  * No initialization needed
+  * Usage & Help templates & functions definable at any level
+  * Updated Readme
+* **0.7.0** Sept 24, 2013
+  * Needs more eyes
+  * Test suite
+  * Support for automatic error messages
+  * Support for help command
+  * Support for printing to any io.Writer instead of os.Stderr
+  * Support for persistent flags which cascade down tree
+  * Ready for integration into Hugo
+* **0.1.0** Sept 3, 2013
+  * Implement first draft
+
+## ToDo
+* Launch proper documentation site
+
+## Contributing
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request
+
+## Contributors
+
+Names in no particular order:
+
+* [spf13](https://github.com/spf13)
+
+## License
+
+Cobra is released under the Apache 2.0 license. See [LICENSE.txt](https://github.com/spf13/cobra/blob/master/LICENSE.txt)
+
+
+[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/spf13/cobra/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+

--- a/Godeps/_workspace/src/github.com/spf13/cobra/cobra.go
+++ b/Godeps/_workspace/src/github.com/spf13/cobra/cobra.go
@@ -1,0 +1,98 @@
+// Copyright © 2013 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Commands similar to git, go tools and other modern CLI tools
+// inspired by go, go-Commander, gh and subcommand
+
+package cobra
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+var initializers []func()
+
+// automatic prefix matching can be a dangerous thing to automatically enable in CLI tools.
+// Set this to true to enable it
+var EnablePrefixMatching bool = false
+
+func OnInitialize(y ...func()) {
+	for _, x := range y {
+		initializers = append(initializers, x)
+	}
+}
+
+func Gt(a interface{}, b interface{}) bool {
+	var left, right int64
+	av := reflect.ValueOf(a)
+
+	switch av.Kind() {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice:
+		left = int64(av.Len())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		left = av.Int()
+	case reflect.String:
+		left, _ = strconv.ParseInt(av.String(), 10, 64)
+	}
+
+	bv := reflect.ValueOf(b)
+
+	switch bv.Kind() {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice:
+		right = int64(bv.Len())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		right = bv.Int()
+	case reflect.String:
+		right, _ = strconv.ParseInt(bv.String(), 10, 64)
+	}
+
+	return left > right
+}
+
+func Eq(a interface{}, b interface{}) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+
+	switch av.Kind() {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice:
+		panic("Eq called on unsupported type")
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return av.Int() == bv.Int()
+	case reflect.String:
+		return av.String() == bv.String()
+	}
+	return false
+}
+
+func rpad(s string, padding int) string {
+	template := fmt.Sprintf("%%-%ds", padding)
+	return fmt.Sprintf(template, s)
+}
+
+// tmpl executes the given template text on data, writing the result to w.
+func tmpl(w io.Writer, text string, data interface{}) error {
+	t := template.New("top")
+	t.Funcs(template.FuncMap{
+		"trim": strings.TrimSpace,
+		"rpad": rpad,
+		"gt":   Gt,
+		"eq":   Eq,
+	})
+	template.Must(t.Parse(text))
+	return t.Execute(w, data)
+}

--- a/Godeps/_workspace/src/github.com/spf13/cobra/cobra_test.go
+++ b/Godeps/_workspace/src/github.com/spf13/cobra/cobra_test.go
@@ -1,0 +1,507 @@
+package cobra
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var _ = fmt.Println
+
+var tp, te, tt, t1 []string
+var flagb1, flagb2, flagb3, flagbr bool
+var flags1, flags2, flags3 string
+var flagi1, flagi2, flagi3, flagir int
+var globalFlag1 bool
+var flagEcho, rootcalled bool
+
+var cmdPrint = &Command{
+	Use:   "print [string to print]",
+	Short: "Print anything to the screen",
+	Long:  `an utterly useless command for testing.`,
+	Run: func(cmd *Command, args []string) {
+		tp = args
+	},
+}
+
+var cmdEcho = &Command{
+	Use:     "echo [string to echo]",
+	Aliases: []string{"say"},
+	Short:   "Echo anything to the screen",
+	Long:    `an utterly useless command for testing.`,
+	Run: func(cmd *Command, args []string) {
+		te = args
+	},
+}
+
+var cmdTimes = &Command{
+	Use:   "times [# times] [string to echo]",
+	Short: "Echo anything to the screen more times",
+	Long:  `an slightly useless command for testing.`,
+	Run: func(cmd *Command, args []string) {
+		tt = args
+	},
+}
+
+var cmdRootNoRun = &Command{
+	Use:   "cobra-test",
+	Short: "The root can run it's own function",
+	Long:  "The root description for help",
+}
+
+var cmdRootSameName = &Command{
+	Use:   "print",
+	Short: "Root with the same name as a subcommand",
+	Long:  "The root description for help",
+}
+
+var cmdRootWithRun = &Command{
+	Use:   "cobra-test",
+	Short: "The root can run it's own function",
+	Long:  "The root description for help",
+	Run: func(cmd *Command, args []string) {
+		rootcalled = true
+	},
+}
+
+func flagInit() {
+	cmdEcho.ResetFlags()
+	cmdPrint.ResetFlags()
+	cmdTimes.ResetFlags()
+	cmdRootNoRun.ResetFlags()
+	cmdRootSameName.ResetFlags()
+	cmdRootWithRun.ResetFlags()
+	cmdEcho.Flags().IntVarP(&flagi1, "intone", "i", 123, "help message for flag intone")
+	cmdTimes.Flags().IntVarP(&flagi2, "inttwo", "j", 234, "help message for flag inttwo")
+	cmdPrint.Flags().IntVarP(&flagi3, "intthree", "i", 345, "help message for flag intthree")
+	cmdEcho.PersistentFlags().StringVarP(&flags1, "strone", "s", "one", "help message for flag strone")
+	cmdTimes.PersistentFlags().StringVarP(&flags2, "strtwo", "t", "two", "help message for flag strtwo")
+	cmdPrint.PersistentFlags().StringVarP(&flags3, "strthree", "s", "three", "help message for flag strthree")
+	cmdEcho.Flags().BoolVarP(&flagb1, "boolone", "b", true, "help message for flag boolone")
+	cmdTimes.Flags().BoolVarP(&flagb2, "booltwo", "c", false, "help message for flag booltwo")
+	cmdPrint.Flags().BoolVarP(&flagb3, "boolthree", "b", true, "help message for flag boolthree")
+}
+
+func commandInit() {
+	cmdEcho.ResetCommands()
+	cmdPrint.ResetCommands()
+	cmdTimes.ResetCommands()
+	cmdRootNoRun.ResetCommands()
+	cmdRootSameName.ResetCommands()
+	cmdRootWithRun.ResetCommands()
+}
+
+func initialize() *Command {
+	tt, tp, te = nil, nil, nil
+	var c = cmdRootNoRun
+	flagInit()
+	commandInit()
+	return c
+}
+
+func initializeWithSameName() *Command {
+	tt, tp, te = nil, nil, nil
+	var c = cmdRootSameName
+	flagInit()
+	commandInit()
+	return c
+}
+
+func initializeWithRootCmd() *Command {
+	cmdRootWithRun.ResetCommands()
+	tt, tp, te, rootcalled = nil, nil, nil, false
+	flagInit()
+	cmdRootWithRun.Flags().BoolVarP(&flagbr, "boolroot", "b", false, "help message for flag boolroot")
+	cmdRootWithRun.Flags().IntVarP(&flagir, "introot", "i", 321, "help message for flag introot")
+	commandInit()
+	return cmdRootWithRun
+}
+
+type resulter struct {
+	Error   error
+	Output  string
+	Command *Command
+}
+
+func fullSetupTest(input string) resulter {
+	c := initializeWithRootCmd()
+
+	return fullTester(c, input)
+}
+
+func noRRSetupTest(input string) resulter {
+	c := initialize()
+
+	return fullTester(c, input)
+}
+
+func fullTester(c *Command, input string) resulter {
+	buf := new(bytes.Buffer)
+	// Testing flag with invalid input
+	c.SetOutput(buf)
+	cmdEcho.AddCommand(cmdTimes)
+	c.AddCommand(cmdPrint, cmdEcho)
+	c.SetArgs(strings.Split(input, " "))
+
+	err := c.Execute()
+	output := buf.String()
+
+	return resulter{err, output, c}
+}
+
+func checkResultContains(t *testing.T, x resulter, check string) {
+	if !strings.Contains(x.Output, check) {
+		t.Errorf("Unexpected response.\nExpecting to contain: \n %q\nGot:\n %q\n", check, x.Output)
+	}
+}
+
+func checkOutputContains(t *testing.T, c *Command, check string) {
+	buf := new(bytes.Buffer)
+	c.SetOutput(buf)
+	c.Execute()
+
+	if !strings.Contains(buf.String(), check) {
+		t.Errorf("Unexpected response.\nExpecting to contain: \n %q\nGot:\n %q\n", check, buf.String())
+	}
+}
+
+func TestSingleCommand(t *testing.T) {
+	noRRSetupTest("print one two")
+
+	if te != nil || tt != nil {
+		t.Error("Wrong command called")
+	}
+	if tp == nil {
+		t.Error("Wrong command called")
+	}
+	if strings.Join(tp, " ") != "one two" {
+		t.Error("Command didn't parse correctly")
+	}
+}
+
+func TestChildCommand(t *testing.T) {
+	noRRSetupTest("echo times one two")
+
+	if te != nil || tp != nil {
+		t.Error("Wrong command called")
+	}
+	if tt == nil {
+		t.Error("Wrong command called")
+	}
+	if strings.Join(tt, " ") != "one two" {
+		t.Error("Command didn't parse correctly")
+	}
+}
+
+func TestCommandAlias(t *testing.T) {
+	noRRSetupTest("say times one two")
+
+	if te != nil || tp != nil {
+		t.Error("Wrong command called")
+	}
+	if tt == nil {
+		t.Error("Wrong command called")
+	}
+	if strings.Join(tt, " ") != "one two" {
+		t.Error("Command didn't parse correctly")
+	}
+}
+
+func TestPrefixMatching(t *testing.T) {
+	EnablePrefixMatching = true
+	noRRSetupTest("ech times one two")
+
+	if te != nil || tp != nil {
+		t.Error("Wrong command called")
+	}
+	if tt == nil {
+		t.Error("Wrong command called")
+	}
+	if strings.Join(tt, " ") != "one two" {
+		t.Error("Command didn't parse correctly")
+	}
+
+	EnablePrefixMatching = false
+}
+
+func TestNoPrefixMatching(t *testing.T) {
+	EnablePrefixMatching = false
+
+	noRRSetupTest("ech times one two")
+
+	if !(tt == nil && te == nil && tp == nil) {
+		t.Error("Wrong command called")
+	}
+}
+
+func TestAliasPrefixMatching(t *testing.T) {
+	EnablePrefixMatching = true
+	noRRSetupTest("sa times one two")
+
+	if te != nil || tp != nil {
+		t.Error("Wrong command called")
+	}
+	if tt == nil {
+		t.Error("Wrong command called")
+	}
+	if strings.Join(tt, " ") != "one two" {
+		t.Error("Command didn't parse correctly")
+	}
+	EnablePrefixMatching = false
+}
+
+func TestChildSameName(t *testing.T) {
+	c := initializeWithSameName()
+	c.AddCommand(cmdPrint, cmdEcho)
+	c.SetArgs(strings.Split("print one two", " "))
+	c.Execute()
+
+	if te != nil || tt != nil {
+		t.Error("Wrong command called")
+	}
+	if tp == nil {
+		t.Error("Wrong command called")
+	}
+	if strings.Join(tp, " ") != "one two" {
+		t.Error("Command didn't parse correctly")
+	}
+}
+
+func TestFlagLong(t *testing.T) {
+	noRRSetupTest("echo --intone=13 something here")
+
+	if strings.Join(te, " ") != "something here" {
+		t.Errorf("flags didn't leave proper args remaining..%s given", te)
+	}
+	if flagi1 != 13 {
+		t.Errorf("int flag didn't get correct value, had %d", flagi1)
+	}
+	if flagi2 != 234 {
+		t.Errorf("default flag value changed, 234 expected, %d given", flagi2)
+	}
+}
+
+func TestFlagShort(t *testing.T) {
+	noRRSetupTest("echo -i13 something here")
+
+	if strings.Join(te, " ") != "something here" {
+		t.Errorf("flags didn't leave proper args remaining..%s given", te)
+	}
+	if flagi1 != 13 {
+		t.Errorf("int flag didn't get correct value, had %d", flagi1)
+	}
+	if flagi2 != 234 {
+		t.Errorf("default flag value changed, 234 expected, %d given", flagi2)
+	}
+
+	noRRSetupTest("echo -i 13 something here")
+
+	if strings.Join(te, " ") != "something here" {
+		t.Errorf("flags didn't leave proper args remaining..%s given", te)
+	}
+	if flagi1 != 13 {
+		t.Errorf("int flag didn't get correct value, had %d", flagi1)
+	}
+	if flagi2 != 234 {
+		t.Errorf("default flag value changed, 234 expected, %d given", flagi2)
+	}
+
+	noRRSetupTest("print -i99 one two")
+
+	if strings.Join(tp, " ") != "one two" {
+		t.Errorf("flags didn't leave proper args remaining..%s given", tp)
+	}
+	if flagi3 != 99 {
+		t.Errorf("int flag didn't get correct value, had %d", flagi3)
+	}
+	if flagi1 != 123 {
+		t.Errorf("default flag value changed on different command with same shortname, 234 expected, %d given", flagi2)
+	}
+}
+
+func TestChildCommandFlags(t *testing.T) {
+	noRRSetupTest("echo times -j 99 one two")
+
+	if strings.Join(tt, " ") != "one two" {
+		t.Errorf("flags didn't leave proper args remaining..%s given", tt)
+	}
+
+	// Testing with flag that shouldn't be persistent
+	r := noRRSetupTest("echo times -j 99 -i77 one two")
+
+	if r.Error == nil {
+		t.Errorf("invalid flag should generate error")
+	}
+
+	if !strings.Contains(r.Output, "unknown shorthand") {
+		t.Errorf("Wrong error message displayed, \n %s", r.Output)
+	}
+
+	if flagi2 != 99 {
+		t.Errorf("flag value should be 99, %d given", flagi2)
+	}
+
+	if flagi1 != 123 {
+		t.Errorf("unset flag should have default value, expecting 123, given %d", flagi1)
+	}
+
+	// Testing with flag only existing on child
+	r = noRRSetupTest("echo -j 99 -i77 one two")
+
+	if r.Error == nil {
+		t.Errorf("invalid flag should generate error")
+	}
+
+	if !strings.Contains(r.Output, "intone=123") {
+		t.Errorf("Wrong error message displayed, \n %s", r.Output)
+	}
+
+	// Testing flag with invalid input
+	r = noRRSetupTest("echo -i10E")
+
+	if r.Error == nil {
+		t.Errorf("invalid input should generate error")
+	}
+
+	if !strings.Contains(r.Output, "invalid argument \"10E\" for -i10E") {
+		t.Errorf("Wrong error message displayed, \n %s", r.Output)
+	}
+}
+
+func TestTrailingCommandFlags(t *testing.T) {
+	x := fullSetupTest("echo two -x")
+
+	if x.Error == nil {
+		t.Errorf("invalid flag should generate error")
+	}
+}
+
+func TestPersistentFlags(t *testing.T) {
+	fullSetupTest("echo -s something more here")
+
+	// persistentFlag should act like normal flag on it's own command
+	if strings.Join(te, " ") != "more here" {
+		t.Errorf("flags didn't leave proper args remaining..%s given", te)
+	}
+
+	// persistentFlag should act like normal flag on it's own command
+	if flags1 != "something" {
+		t.Errorf("string flag didn't get correct value, had %v", flags1)
+	}
+
+	fullSetupTest("echo times -s again -c test here")
+
+	if strings.Join(tt, " ") != "test here" {
+		t.Errorf("flags didn't leave proper args remaining..%s given", tt)
+	}
+
+	if flags1 != "again" {
+		t.Errorf("string flag didn't get correct value, had %v", flags1)
+	}
+
+	if flagb2 != true {
+		t.Errorf("local flag not parsed correctly. Expected false, had %v", flagb2)
+	}
+}
+
+func TestHelpCommand(t *testing.T) {
+	c := fullSetupTest("help echo")
+	checkResultContains(t, c, cmdEcho.Long)
+
+	r := fullSetupTest("help echo times")
+	checkResultContains(t, r, cmdTimes.Long)
+}
+
+func TestRunnableRootCommand(t *testing.T) {
+	fullSetupTest("")
+
+	if rootcalled != true {
+		t.Errorf("Root Function was not called")
+	}
+}
+
+func TestRootFlags(t *testing.T) {
+	fullSetupTest("-i 17 -b")
+
+	if flagbr != true {
+		t.Errorf("flag value should be true, %v given", flagbr)
+	}
+
+	if flagir != 17 {
+		t.Errorf("flag value should be 17, %d given", flagir)
+	}
+}
+
+func TestRootHelp(t *testing.T) {
+	x := fullSetupTest("--help")
+
+	checkResultContains(t, x, "Available Commands:")
+
+	if strings.Contains(x.Output, "unknown flag: --help") {
+		t.Errorf("--help shouldn't trigger an error, Got: \n %s", x.Output)
+	}
+
+	x = fullSetupTest("echo --help")
+
+	checkResultContains(t, x, "Available Commands:")
+
+	if strings.Contains(x.Output, "unknown flag: --help") {
+		t.Errorf("--help shouldn't trigger an error, Got: \n %s", x.Output)
+	}
+
+}
+
+func TestFlagsBeforeCommand(t *testing.T) {
+	// short without space
+	x := fullSetupTest("-i10 echo")
+	if x.Error != nil {
+		t.Errorf("Valid Input shouldn't have errors, got:\n %q", x.Error)
+	}
+
+	// short (int) with equals
+	// It appears that pflags doesn't support this...
+	// Commenting out until support can be added
+
+	//x = noRRSetupTest("echo -i=10")
+	//if x.Error != nil {
+	//t.Errorf("Valid Input shouldn't have errors, got:\n %s", x.Error)
+	//}
+
+	// long with equals
+	x = noRRSetupTest("--intone=123 echo one two")
+	if x.Error != nil {
+		t.Errorf("Valid Input shouldn't have errors, got:\n %s", x.Error)
+	}
+
+	// With parsing error properly reported
+	x = fullSetupTest("-i10E echo")
+	if !strings.Contains(x.Output, "invalid argument \"10E\" for -i10E") {
+		t.Errorf("Wrong error message displayed, \n %s", x.Output)
+	}
+
+	//With quotes
+	x = fullSetupTest("-s=\"walking\" echo")
+	if x.Error != nil {
+		t.Errorf("Valid Input shouldn't have errors, got:\n %q", x.Error)
+	}
+
+	//With quotes and space
+	x = fullSetupTest("-s=\"walking fast\" echo")
+	if x.Error != nil {
+		t.Errorf("Valid Input shouldn't have errors, got:\n %q", x.Error)
+	}
+
+	//With inner quote
+	x = fullSetupTest("-s=\"walking \\\"Inner Quote\\\" fast\" echo")
+	if x.Error != nil {
+		t.Errorf("Valid Input shouldn't have errors, got:\n %q", x.Error)
+	}
+
+	//With quotes and space
+	x = fullSetupTest("-s=\"walking \\\"Inner Quote\\\" fast\" echo")
+	if x.Error != nil {
+		t.Errorf("Valid Input shouldn't have errors, got:\n %q", x.Error)
+	}
+
+}

--- a/Godeps/_workspace/src/github.com/spf13/cobra/command.go
+++ b/Godeps/_workspace/src/github.com/spf13/cobra/command.go
@@ -1,0 +1,764 @@
+// Copyright © 2013 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Commands similar to git, go tools and other modern CLI tools
+// inspired by go, go-Commander, gh and subcommand
+
+package cobra
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	flag "github.com/spf13/pflag"
+)
+
+// Command is just that, a command for your application.
+// eg.  'go run' ... 'run' is the command. Cobra requires
+// you to define the usage and description as part of your command
+// definition to ensure usability.
+type Command struct {
+	// Name is the command name, usually the executable's name.
+	name string
+	// The one-line usage message.
+	Use string
+	// An array of aliases that can be used instead of the first word in Use.
+	Aliases []string
+	// The short description shown in the 'help' output.
+	Short string
+	// The long message shown in the 'help <this-command>' output.
+	Long string
+	// Set of flags specific to this command.
+	flags *flag.FlagSet
+	// Set of flags children commands will inherit
+	pflags *flag.FlagSet
+	// Run runs the command.
+	// The args are the arguments after the command name.
+	Run func(cmd *Command, args []string)
+	// Commands is the list of commands supported by this program.
+	commands []*Command
+	// Parent Command for this command
+	parent *Command
+	// max lengths of commands' string lengths for use in padding
+	commandsMaxUseLen         int
+	commandsMaxCommandPathLen int
+
+	flagErrorBuf *bytes.Buffer
+
+	args          []string
+	output        *io.Writer               // nil means stderr; use Out() method instead
+	usageFunc     func(*Command) error     // Usage can be defined by application
+	usageTemplate string                   // Can be defined by Application
+	helpTemplate  string                   // Can be defined by Application
+	helpFunc      func(*Command, []string) // Help can be defined by application
+	helpCommand   *Command                 // The help command
+	helpFlagVal   bool
+}
+
+// os.Args[1:] by default, if desired, can be overridden
+// particularly useful when testing.
+func (c *Command) SetArgs(a []string) {
+	c.args = a
+}
+
+func (c *Command) Out() io.Writer {
+	if c.output != nil {
+		return *c.output
+	}
+
+	if c.HasParent() {
+		return c.parent.Out()
+	} else {
+		return os.Stderr
+	}
+}
+
+// SetOutput sets the destination for usage and error messages.
+// If output is nil, os.Stderr is used.
+func (c *Command) SetOutput(output io.Writer) {
+	c.output = &output
+}
+
+// Usage can be defined by application
+func (c *Command) SetUsageFunc(f func(*Command) error) {
+	c.usageFunc = f
+}
+
+// Can be defined by Application
+func (c *Command) SetUsageTemplate(s string) {
+	c.usageTemplate = s
+}
+
+// Can be defined by Application
+func (c *Command) SetHelpFunc(f func(*Command, []string)) {
+	c.helpFunc = f
+}
+
+func (c *Command) SetHelpCommand(cmd *Command) {
+	c.helpCommand = cmd
+}
+
+// Can be defined by Application
+func (c *Command) SetHelpTemplate(s string) {
+	c.helpTemplate = s
+}
+
+func (c *Command) UsageFunc() (f func(*Command) error) {
+	if c.usageFunc != nil {
+		return c.usageFunc
+	}
+
+	if c.HasParent() {
+		return c.parent.UsageFunc()
+	} else {
+		return func(c *Command) error {
+			err := tmpl(c.Out(), c.UsageTemplate(), c)
+			return err
+		}
+	}
+}
+func (c *Command) HelpFunc() func(*Command, []string) {
+	if c.helpFunc != nil {
+		return c.helpFunc
+	}
+
+	if c.HasParent() {
+		return c.parent.HelpFunc()
+	} else {
+		return func(c *Command, args []string) {
+			if len(args) == 0 {
+				// Help called without any topic, calling on root
+				c.Root().Help()
+				return
+			}
+
+			cmd, _, e := c.Root().Find(args)
+			if cmd == nil || e != nil {
+				c.Printf("Unknown help topic %#q.", args)
+
+				c.Root().Usage()
+			} else {
+				err := cmd.Help()
+				if err != nil {
+					c.Println(err)
+				}
+			}
+		}
+	}
+}
+
+var minUsagePadding int = 25
+
+func (c *Command) UsagePadding() int {
+	if c.parent == nil || minUsagePadding > c.parent.commandsMaxUseLen {
+		return minUsagePadding
+	} else {
+		return c.parent.commandsMaxUseLen
+	}
+}
+
+var minCommandPathPadding int = 11
+
+func (c *Command) CommandPathPadding() int {
+	if c.parent == nil || minCommandPathPadding > c.parent.commandsMaxCommandPathLen {
+		return minCommandPathPadding
+	} else {
+		return c.parent.commandsMaxCommandPathLen
+	}
+}
+
+func (c *Command) UsageTemplate() string {
+	if c.usageTemplate != "" {
+		return c.usageTemplate
+	}
+
+	if c.HasParent() {
+		return c.parent.UsageTemplate()
+	} else {
+		return `{{ $cmd := . }}
+Usage: {{if .Runnable}}
+  {{.UseLine}}{{if .HasFlags}} [flags]{{end}}{{end}}{{if .HasSubCommands}}
+  {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}
+{{ if .HasSubCommands}}
+Available Commands: {{range .Commands}}{{if .Runnable}}
+  {{rpad .Use .UsagePadding }} {{.Short}}{{end}}{{end}}
+{{end}}
+{{ if .HasFlags}} Available Flags:
+{{.Flags.FlagUsages}}{{end}}{{if .HasParent}}{{if and (gt .Commands 0) (gt .Parent.Commands 1) }}
+Additional help topics: {{if gt .Commands 0 }}{{range .Commands}}{{if not .Runnable}} {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if gt .Parent.Commands 1 }}{{range .Parent.Commands}}{{if .Runnable}}{{if not (eq .Name $cmd.Name) }}{{end}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{end}}
+{{end}}
+Use "{{.Root.Name}} help [command]" for more information about that command.
+`
+	}
+}
+
+func (c *Command) HelpTemplate() string {
+	if c.helpTemplate != "" {
+		return c.helpTemplate
+	}
+
+	if c.HasParent() {
+		return c.parent.HelpTemplate()
+	} else {
+		return `{{.Long | trim}}
+{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}
+`
+	}
+}
+
+// Really only used when casting a command to a commander
+func (c *Command) resetChildrensParents() {
+	for _, x := range c.commands {
+		x.parent = c
+	}
+}
+
+func stripFlags(args []string) []string {
+	if len(args) < 1 {
+		return args
+	}
+
+	commands := []string{}
+
+	inQuote := false
+	for _, y := range args {
+		if !inQuote {
+			switch {
+			case strings.HasPrefix(y, "\""):
+				inQuote = true
+			case strings.Contains(y, "=\""):
+				inQuote = true
+			case !strings.HasPrefix(y, "-"):
+				commands = append(commands, y)
+			}
+		}
+
+		if strings.HasSuffix(y, "\"") && !strings.HasSuffix(y, "\\\"") {
+			inQuote = false
+		}
+	}
+
+	return commands
+}
+
+func argsMinusX(args []string, x string) []string {
+	newargs := []string{}
+
+	for _, y := range args {
+		if x != y {
+			newargs = append(newargs, y)
+		}
+	}
+	return newargs
+}
+
+// find the target command given the args and command tree
+// Meant to be run on the highest node. Only searches down.
+func (c *Command) Find(arrs []string) (*Command, []string, error) {
+	if c == nil {
+		return nil, nil, fmt.Errorf("Called find() on a nil Command")
+	}
+
+	if len(arrs) == 0 {
+		return c.Root(), arrs, nil
+	}
+
+	var innerfind func(*Command, []string) (*Command, []string)
+
+	innerfind = func(c *Command, args []string) (*Command, []string) {
+		if len(args) > 0 && c.HasSubCommands() {
+			argsWOflags := stripFlags(args)
+			if len(argsWOflags) > 0 {
+				matches := make([]*Command, 0)
+				for _, cmd := range c.commands {
+					if cmd.Name() == argsWOflags[0] || cmd.HasAlias(argsWOflags[0]) { // exact name or alias match
+						return innerfind(cmd, argsMinusX(args, argsWOflags[0]))
+					} else if EnablePrefixMatching {
+						if strings.HasPrefix(cmd.Name(), argsWOflags[0]) { // prefix match
+							matches = append(matches, cmd)
+						}
+						for _, x := range cmd.Aliases {
+							if strings.HasPrefix(x, argsWOflags[0]) {
+								matches = append(matches, cmd)
+							}
+						}
+					}
+				}
+
+				// only accept a single prefix match - multiple matches would be ambiguous
+				if len(matches) == 1 {
+					return innerfind(matches[0], argsMinusX(args, argsWOflags[0]))
+				}
+			}
+		}
+
+		return c, args
+	}
+
+	commandFound, a := innerfind(c, arrs)
+
+	// if commander returned and the first argument (if it exists) doesn't
+	// match the command name, return nil & error
+	if commandFound.Name() == c.Name() && len(arrs[0]) > 0 && commandFound.Name() != arrs[0] {
+		return nil, a, fmt.Errorf("unknown command %q\nRun 'help' for usage.\n", a[0])
+	}
+
+	return commandFound, a, nil
+}
+
+func (c *Command) Root() *Command {
+	var findRoot func(*Command) *Command
+
+	findRoot = func(x *Command) *Command {
+		if x.HasParent() {
+			return findRoot(x.parent)
+		} else {
+			return x
+		}
+	}
+
+	return findRoot(c)
+}
+
+// execute the command determined by args and the command tree
+func (c *Command) findAndExecute(args []string) (err error) {
+
+	cmd, a, e := c.Find(args)
+	if e != nil {
+		return e
+	}
+	return cmd.execute(a)
+}
+
+func (c *Command) execute(a []string) (err error) {
+	if c == nil {
+		return fmt.Errorf("Called Execute() on a nil Command")
+	}
+
+	err = c.ParseFlags(a)
+
+	if err != nil {
+		return err
+	} else {
+		// If help is called, regardless of other flags, we print that
+		if c.helpFlagVal {
+			c.Help()
+			return nil
+		}
+
+		c.preRun()
+		argWoFlags := c.Flags().Args()
+		c.Run(c, argWoFlags)
+		return nil
+	}
+}
+
+func (c *Command) preRun() {
+	for _, x := range initializers {
+		x()
+	}
+}
+
+func (c *Command) errorMsgFromParse() string {
+	s := c.flagErrorBuf.String()
+
+	x := strings.Split(s, "\n")
+
+	if len(x) > 0 {
+		return x[0]
+	} else {
+		return ""
+	}
+}
+
+// Call execute to use the args (os.Args[1:] by default)
+// and run through the command tree finding appropriate matches
+// for commands and then corresponding flags.
+func (c *Command) Execute() (err error) {
+
+	// Regardless of what command execute is called on, run on Root only
+	if c.HasParent() {
+		return c.Root().Execute()
+	}
+
+	// initialize help as the last point possible to allow for user
+	// overriding
+	c.initHelp()
+
+	var args []string
+
+	if len(c.args) == 0 {
+		args = os.Args[1:]
+	} else {
+		args = c.args
+	}
+
+	if len(args) == 0 {
+		// Only the executable is called and the root is runnable, run it
+		if c.Runnable() {
+			err = c.execute([]string(nil))
+		} else {
+			c.Help()
+		}
+	} else {
+		err = c.findAndExecute(args)
+	}
+
+	// Now handle the case where the root is runnable and only flags are provided
+	if err != nil && c.Runnable() {
+		// This is pretty much a custom version of the *Command.execute method
+		// with a few differences because it's the final command (no fall back)
+		e := c.ParseFlags(args)
+		if e != nil {
+			// Flags parsing had an error.
+			// If an error happens here, we have to report it to the user
+			c.Println(c.errorMsgFromParse())
+			c.Usage()
+			return e
+		} else {
+			// If help is called, regardless of other flags, we print that
+			if c.helpFlagVal {
+				c.Help()
+				return nil
+			}
+
+			argWoFlags := c.Flags().Args()
+			if len(argWoFlags) > 0 {
+				// If there are arguments (not flags) one of the earlier
+				// cases should have caught it.. It means invalid usage
+				// print the usage
+				c.Usage()
+			} else {
+				// Only flags left... Call root.Run
+				c.preRun()
+				c.Run(c, argWoFlags)
+				err = nil
+			}
+		}
+	}
+
+	if err != nil {
+		c.Println("Error:", err.Error())
+		c.Printf("%v: invalid command %#q\n", c.Root().Name(), os.Args[1:])
+		c.Printf("Run '%v help' for usage\n", c.Root().Name())
+	}
+
+	return
+}
+
+func (c *Command) initHelp() {
+	if c.helpCommand == nil {
+		c.helpCommand = &Command{
+			Use:   "help [command]",
+			Short: "Help about any command",
+			Long: `Help provides help for any command in the application.
+    Simply type ` + c.Name() + ` help [path to command] for full details.`,
+			Run: c.HelpFunc(),
+		}
+	}
+	c.AddCommand(c.helpCommand)
+}
+
+// Used for testing
+func (c *Command) ResetCommands() {
+	c.commands = nil
+}
+
+func (c *Command) Commands() []*Command {
+	return c.commands
+}
+
+// Add one or many commands as children of this
+func (c *Command) AddCommand(cmds ...*Command) {
+	for i, x := range cmds {
+		if cmds[i] == c {
+			panic("Command can't be a child of itself")
+		}
+		cmds[i].parent = c
+		// update max lengths
+		usageLen := len(x.Use)
+		if usageLen > c.commandsMaxUseLen {
+			c.commandsMaxUseLen = usageLen
+		}
+		commandPathLen := len(x.CommandPath())
+		if commandPathLen > c.commandsMaxCommandPathLen {
+			c.commandsMaxCommandPathLen = commandPathLen
+		}
+		c.commands = append(c.commands, x)
+	}
+}
+
+// Convenience method to Print to the defined output
+func (c *Command) Print(i ...interface{}) {
+	fmt.Fprint(c.Out(), i...)
+}
+
+// Convenience method to Println to the defined output
+func (c *Command) Println(i ...interface{}) {
+	str := fmt.Sprintln(i...)
+	c.Print(str)
+}
+
+// Convenience method to Printf to the defined output
+func (c *Command) Printf(format string, i ...interface{}) {
+	str := fmt.Sprintf(format, i...)
+	c.Print(str)
+}
+
+// Output the usage for the command
+// Used when a user provides invalid input
+// Can be defined by user by overriding UsageFunc
+func (c *Command) Usage() error {
+	c.mergePersistentFlags()
+	err := c.UsageFunc()(c)
+	return err
+}
+
+// Output the help for the command
+// Used when a user calls help [command]
+// by the default HelpFunc in the commander
+func (c *Command) Help() error {
+	c.mergePersistentFlags()
+	err := tmpl(c.Out(), c.HelpTemplate(), c)
+	return err
+}
+
+func (c *Command) UsageString() string {
+	tmpOutput := c.output
+	bb := new(bytes.Buffer)
+	c.SetOutput(bb)
+	c.Usage()
+	c.output = tmpOutput
+	return bb.String()
+}
+
+// The full path to this command
+func (c *Command) CommandPath() string {
+	str := c.Name()
+	x := c
+	for x.HasParent() {
+		str = x.parent.Name() + " " + str
+		x = x.parent
+	}
+	return str
+}
+
+//The full usage for a given command (including parents)
+func (c *Command) UseLine() string {
+	str := ""
+	if c.HasParent() {
+		str = c.parent.CommandPath() + " "
+	}
+	return str + c.Use
+}
+
+// For use in determining which flags have been assigned to which commands
+// and which persist
+func (c *Command) DebugFlags() {
+	c.Println("DebugFlags called on", c.Name())
+	var debugflags func(*Command)
+
+	debugflags = func(x *Command) {
+		if x.HasFlags() || x.HasPersistentFlags() {
+			c.Println(x.Name())
+		}
+		if x.HasFlags() {
+			x.flags.VisitAll(func(f *flag.Flag) {
+				if x.HasPersistentFlags() {
+					if x.persistentFlag(f.Name) == nil {
+						c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [L]")
+					} else {
+						c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [LP]")
+					}
+				} else {
+					c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [L]")
+				}
+			})
+		}
+		if x.HasPersistentFlags() {
+			x.pflags.VisitAll(func(f *flag.Flag) {
+				if x.HasFlags() {
+					if x.flags.Lookup(f.Name) == nil {
+						c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [P]")
+					}
+				} else {
+					c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [P]")
+				}
+			})
+		}
+		c.Println(x.flagErrorBuf)
+		if x.HasSubCommands() {
+			for _, y := range x.commands {
+				debugflags(y)
+			}
+		}
+	}
+
+	debugflags(c)
+}
+
+// Name returns the command's name: the first word in the use line.
+func (c *Command) Name() string {
+	if c.name != "" {
+		return c.name
+	}
+	name := c.Use
+	i := strings.Index(name, " ")
+	if i >= 0 {
+		name = name[:i]
+	}
+	return name
+}
+
+// Determine if a given string is an alias of the command.
+func (c *Command) HasAlias(s string) bool {
+	for _, a := range c.Aliases {
+		if a == s {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Command) NameAndAliases() string {
+	return strings.Join(append([]string{c.Name()}, c.Aliases...), ", ")
+}
+
+// Determine if the command is itself runnable
+func (c *Command) Runnable() bool {
+	return c.Run != nil
+}
+
+// Determine if the command has children commands
+func (c *Command) HasSubCommands() bool {
+	return len(c.commands) > 0
+}
+
+// Determine if the command is a child command
+func (c *Command) HasParent() bool {
+	return c.parent != nil
+}
+
+// Get the Commands FlagSet
+func (c *Command) Flags() *flag.FlagSet {
+	if c.flags == nil {
+		c.flags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+		if c.flagErrorBuf == nil {
+			c.flagErrorBuf = new(bytes.Buffer)
+		}
+		c.flags.SetOutput(c.flagErrorBuf)
+		c.PersistentFlags().BoolVarP(&c.helpFlagVal, "help", "h", false, "help for "+c.Name())
+	}
+	return c.flags
+}
+
+// Get the Commands Persistent FlagSet
+func (c *Command) PersistentFlags() *flag.FlagSet {
+	if c.pflags == nil {
+		c.pflags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+		if c.flagErrorBuf == nil {
+			c.flagErrorBuf = new(bytes.Buffer)
+		}
+		c.pflags.SetOutput(c.flagErrorBuf)
+	}
+	return c.pflags
+}
+
+// For use in testing
+func (c *Command) ResetFlags() {
+	c.flagErrorBuf = new(bytes.Buffer)
+	c.flagErrorBuf.Reset()
+	c.flags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+	c.flags.SetOutput(c.flagErrorBuf)
+	c.pflags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+	c.pflags.SetOutput(c.flagErrorBuf)
+}
+
+// Does the command contain flags (local not persistent)
+func (c *Command) HasFlags() bool {
+	return c.Flags().HasFlags()
+}
+
+// Does the command contain persistent flags
+func (c *Command) HasPersistentFlags() bool {
+	return c.PersistentFlags().HasFlags()
+}
+
+// Climbs up the command tree looking for matching flag
+func (c *Command) Flag(name string) (flag *flag.Flag) {
+	flag = c.Flags().Lookup(name)
+
+	if flag == nil {
+		flag = c.persistentFlag(name)
+	}
+
+	return
+}
+
+// recursively find matching persistent flag
+func (c *Command) persistentFlag(name string) (flag *flag.Flag) {
+	if c.HasPersistentFlags() {
+		flag = c.PersistentFlags().Lookup(name)
+	}
+
+	if flag == nil && c.HasParent() {
+		flag = c.parent.persistentFlag(name)
+	}
+	return
+}
+
+// Parses persistent flag tree & local flags
+func (c *Command) ParseFlags(args []string) (err error) {
+	c.mergePersistentFlags()
+	err = c.Flags().Parse(args)
+
+	// The upstream library adds spaces to the error
+	// response regardless of success.
+	// Handling it here until fixing upstream
+	if len(strings.TrimSpace(c.flagErrorBuf.String())) > 1 {
+		return fmt.Errorf("%s", c.flagErrorBuf.String())
+	}
+
+	//always return nil because upstream library is inconsistent & we always check the error buffer anyway
+	return nil
+}
+
+func (c *Command) mergePersistentFlags() {
+	var rmerge func(x *Command)
+
+	rmerge = func(x *Command) {
+		if x.HasPersistentFlags() {
+			x.PersistentFlags().VisitAll(func(f *flag.Flag) {
+				if c.Flags().Lookup(f.Name) == nil {
+					c.Flags().AddFlag(f)
+				}
+			})
+		}
+		if x.HasParent() {
+			rmerge(x.parent)
+		}
+	}
+
+	rmerge(c)
+}
+
+func (c *Command) Parent() *Command {
+	return c.parent
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/LICENSE
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2012 Alex Ogier. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Godeps/_workspace/src/github.com/spf13/pflag/README.md
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/README.md
@@ -1,0 +1,155 @@
+## Description
+
+pflag is a drop-in replacement for Go's flag package, implementing
+POSIX/GNU-style --flags.
+
+pflag is compatible with the [GNU extensions to the POSIX recommendations
+for command-line options][1]. For a more precise description, see the
+"Command-line flag syntax" section below.
+
+[1]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+
+pflag is available under the same style of BSD license as the Go language,
+which can be found in the LICENSE file.
+
+## Installation
+
+pflag is available using the standard `go get` command.
+
+Install by running:
+
+    go get github.com/ogier/pflag
+
+Run tests by running:
+
+    go test github.com/ogier/pflag
+
+## Usage
+
+pflag is a drop-in replacement of Go's native flag package. If you import
+pflag under the name "flag" then all code should continue to function
+with no changes.
+
+``` go
+import flag "github.com/ogier/pflag"
+```
+
+There is one exception to this: if you directly instantiate the Flag struct
+there is one more field "Shorthand" that you will need to set.
+Most code never instantiates this struct directly, and instead uses
+functions such as String(), BoolVar(), and Var(), and is therefore
+unaffected.
+
+Define flags using flag.String(), Bool(), Int(), etc.
+
+This declares an integer flag, -flagname, stored in the pointer ip, with type *int.
+
+``` go
+var ip *int = flag.Int("flagname", 1234, "help message for flagname")
+```
+
+If you like, you can bind the flag to a variable using the Var() functions.
+
+``` go
+var flagvar int
+func init() {
+    flag.IntVar(&flagvar, "flagname", 1234, "help message for flagname")
+}
+```
+
+Or you can create custom flags that satisfy the Value interface (with
+pointer receivers) and couple them to flag parsing by
+
+``` go
+flag.Var(&flagVal, "name", "help message for flagname")
+```
+
+For such flags, the default value is just the initial value of the variable.
+
+After all flags are defined, call
+
+``` go
+flag.Parse()
+```
+
+to parse the command line into the defined flags.
+
+Flags may then be used directly. If you're using the flags themselves,
+they are all pointers; if you bind to variables, they're values.
+
+``` go
+fmt.Println("ip has value ", *ip)
+fmt.Println("flagvar has value ", flagvar)
+```
+
+After parsing, the arguments after the flag are available as the
+slice flag.Args() or individually as flag.Arg(i).
+The arguments are indexed from 0 through flag.NArg()-1.
+
+The pflag package also defines some new functions that are not in flag,
+that give one-letter shorthands for flags. You can use these by appending
+'P' to the name of any function that defines a flag.
+
+``` go
+var ip = flag.IntP("flagname", "f", 1234, "help message")
+var flagvar bool
+func init() {
+    flag.BoolVarP("boolname", "b", true, "help message")
+}
+flag.VarP(&flagVar, "varname", "v", 1234, "help message")
+```
+
+Shorthand letters can be used with single dashes on the command line.
+Boolean shorthand flags can be combined with other shorthand flags.
+
+The default set of command-line flags is controlled by
+top-level functions.  The FlagSet type allows one to define
+independent sets of flags, such as to implement subcommands
+in a command-line interface. The methods of FlagSet are
+analogous to the top-level functions for the command-line
+flag set.
+
+## Command line flag syntax
+
+```
+--flag    // boolean flags only
+--flag=x
+```
+
+Unlike the flag package, a single dash before an option means something
+different than a double dash. Single dashes signify a series of shorthand
+letters for flags. All but the last shorthand letter must be boolean flags.
+
+```
+// boolean flags
+-f
+-abc
+
+// non-boolean flags
+-n 1234
+-Ifile
+
+// mixed
+-abcs "hello"
+-abcn1234
+```
+
+Flag parsing stops after the terminator "--". Unlike the flag package,
+flags can be interspersed with arguments anywhere on the command line
+before this terminator.
+
+Integer flags accept 1234, 0664, 0x1234 and may be negative.
+Boolean flags (in their long form) accept 1, 0, t, f, true, false,
+TRUE, FALSE, True, False.
+Duration flags accept any input valid for time.ParseDuration.
+
+## More info
+
+You can see the full reference documentation of the pflag package
+[at godoc.org][3], or through go's standard documentation system by
+running `godoc -http=:6060` and browsing to
+[http://localhost:6060/pkg/github.com/ogier/pflag][2] after
+installation.
+
+[2]: http://localhost:6060/pkg/github.com/ogier/pflag
+[3]: http://godoc.org/github.com/ogier/pflag

--- a/Godeps/_workspace/src/github.com/spf13/pflag/bool.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/bool.go
@@ -1,0 +1,74 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- bool Value
+type boolValue bool
+
+func newBoolValue(val bool, p *bool) *boolValue {
+	*p = val
+	return (*boolValue)(p)
+}
+
+func (b *boolValue) Set(s string) error {
+	v, err := strconv.ParseBool(s)
+	*b = boolValue(v)
+	return err
+}
+
+func (b *boolValue) Type() string {
+	return "bool"
+}
+
+func (b *boolValue) String() string { return fmt.Sprintf("%v", *b) }
+
+// BoolVar defines a bool flag with specified name, default value, and usage string.
+// The argument p points to a bool variable in which to store the value of the flag.
+func (f *FlagSet) BoolVar(p *bool, name string, value bool, usage string) {
+	f.VarP(newBoolValue(value, p), name, "", usage)
+}
+
+// Like BoolVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
+	f.VarP(newBoolValue(value, p), name, shorthand, usage)
+}
+
+// BoolVar defines a bool flag with specified name, default value, and usage string.
+// The argument p points to a bool variable in which to store the value of the flag.
+func BoolVar(p *bool, name string, value bool, usage string) {
+	CommandLine.VarP(newBoolValue(value, p), name, "", usage)
+}
+
+// Like BoolVar, but accepts a shorthand letter that can be used after a single dash.
+func BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
+	CommandLine.VarP(newBoolValue(value, p), name, shorthand, usage)
+}
+
+// Bool defines a bool flag with specified name, default value, and usage string.
+// The return value is the address of a bool variable that stores the value of the flag.
+func (f *FlagSet) Bool(name string, value bool, usage string) *bool {
+	p := new(bool)
+	f.BoolVarP(p, name, "", value, usage)
+	return p
+}
+
+// Like Bool, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) BoolP(name, shorthand string, value bool, usage string) *bool {
+	p := new(bool)
+	f.BoolVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Bool defines a bool flag with specified name, default value, and usage string.
+// The return value is the address of a bool variable that stores the value of the flag.
+func Bool(name string, value bool, usage string) *bool {
+	return CommandLine.BoolP(name, "", value, usage)
+}
+
+// Like Bool, but accepts a shorthand letter that can be used after a single dash.
+func BoolP(name, shorthand string, value bool, usage string) *bool {
+	return CommandLine.BoolP(name, shorthand, value, usage)
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/duration.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/duration.go
@@ -1,0 +1,71 @@
+package pflag
+
+import "time"
+
+// -- time.Duration Value
+type durationValue time.Duration
+
+func newDurationValue(val time.Duration, p *time.Duration) *durationValue {
+	*p = val
+	return (*durationValue)(p)
+}
+
+func (d *durationValue) Set(s string) error {
+	v, err := time.ParseDuration(s)
+	*d = durationValue(v)
+	return err
+}
+
+func (d *durationValue) Type() string {
+	return "duration"
+}
+
+func (d *durationValue) String() string { return (*time.Duration)(d).String() }
+
+// DurationVar defines a time.Duration flag with specified name, default value, and usage string.
+// The argument p points to a time.Duration variable in which to store the value of the flag.
+func (f *FlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
+	f.VarP(newDurationValue(value, p), name, "", usage)
+}
+
+// Like DurationVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string) {
+	f.VarP(newDurationValue(value, p), name, shorthand, usage)
+}
+
+// DurationVar defines a time.Duration flag with specified name, default value, and usage string.
+// The argument p points to a time.Duration variable in which to store the value of the flag.
+func DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
+	CommandLine.VarP(newDurationValue(value, p), name, "", usage)
+}
+
+// Like DurationVar, but accepts a shorthand letter that can be used after a single dash.
+func DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string) {
+	CommandLine.VarP(newDurationValue(value, p), name, shorthand, usage)
+}
+
+// Duration defines a time.Duration flag with specified name, default value, and usage string.
+// The return value is the address of a time.Duration variable that stores the value of the flag.
+func (f *FlagSet) Duration(name string, value time.Duration, usage string) *time.Duration {
+	p := new(time.Duration)
+	f.DurationVarP(p, name, "", value, usage)
+	return p
+}
+
+// Like Duration, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) DurationP(name, shorthand string, value time.Duration, usage string) *time.Duration {
+	p := new(time.Duration)
+	f.DurationVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Duration defines a time.Duration flag with specified name, default value, and usage string.
+// The return value is the address of a time.Duration variable that stores the value of the flag.
+func Duration(name string, value time.Duration, usage string) *time.Duration {
+	return CommandLine.DurationP(name, "", value, usage)
+}
+
+// Like Duration, but accepts a shorthand letter that can be used after a single dash.
+func DurationP(name, shorthand string, value time.Duration, usage string) *time.Duration {
+	return CommandLine.DurationP(name, shorthand, value, usage)
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/example_test.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/example_test.go
@@ -1,0 +1,73 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// These examples demonstrate more intricate uses of the flag package.
+package pflag_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	flag "github.com/ogier/pflag"
+)
+
+// Example 1: A single string flag called "species" with default value "gopher".
+var species = flag.String("species", "gopher", "the species we are studying")
+
+// Example 2: A flag with a shorthand letter.
+var gopherType = flag.StringP("gopher_type", "g", "pocket", "the variety of gopher")
+
+// Example 3: A user-defined flag type, a slice of durations.
+type interval []time.Duration
+
+// String is the method to format the flag's value, part of the flag.Value interface.
+// The String method's output will be used in diagnostics.
+func (i *interval) String() string {
+	return fmt.Sprint(*i)
+}
+
+// Set is the method to set the flag value, part of the flag.Value interface.
+// Set's argument is a string to be parsed to set the flag.
+// It's a comma-separated list, so we split it.
+func (i *interval) Set(value string) error {
+	// If we wanted to allow the flag to be set multiple times,
+	// accumulating values, we would delete this if statement.
+	// That would permit usages such as
+	//	-deltaT 10s -deltaT 15s
+	// and other combinations.
+	if len(*i) > 0 {
+		return errors.New("interval flag already set")
+	}
+	for _, dt := range strings.Split(value, ",") {
+		duration, err := time.ParseDuration(dt)
+		if err != nil {
+			return err
+		}
+		*i = append(*i, duration)
+	}
+	return nil
+}
+
+// Define a flag to accumulate durations. Because it has a special type,
+// we need to use the Var function and therefore create the flag during
+// init.
+
+var intervalFlag interval
+
+func init() {
+	// Tie the command-line flag to the intervalFlag variable and
+	// set a usage message.
+	flag.Var(&intervalFlag, "deltaT", "comma-separated list of intervals to use between events")
+}
+
+func Example() {
+	// All the interesting pieces are with the variables declared above, but
+	// to enable the flag package to see the flags defined there, one must
+	// execute, typically at the start of main (not init!):
+	//	flag.Parse()
+	// We don't run it here because this is not a main function and
+	// the testing suite has already parsed the flags.
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/export_test.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/export_test.go
@@ -1,0 +1,29 @@
+// Copyright 2010 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pflag
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+// Additional routines compiled into the package only during testing.
+
+// ResetForTesting clears all flag state and sets the usage function as directed.
+// After calling ResetForTesting, parse errors in flag handling will not
+// exit the program.
+func ResetForTesting(usage func()) {
+	CommandLine = &FlagSet{
+		name:          os.Args[0],
+		errorHandling: ContinueOnError,
+		output:        ioutil.Discard,
+	}
+	Usage = usage
+}
+
+// GetCommandLine returns the default FlagSet.
+func GetCommandLine() *FlagSet {
+	return CommandLine
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/flag.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/flag.go
@@ -1,0 +1,621 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+	pflag is a drop-in replacement for Go's flag package, implementing
+	POSIX/GNU-style --flags.
+
+	pflag is compatible with the GNU extensions to the POSIX recommendations
+	for command-line options. See
+	http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+
+	Usage:
+
+	pflag is a drop-in replacement of Go's native flag package. If you import
+	pflag under the name "flag" then all code should continue to function
+	with no changes.
+
+		import flag "github.com/ogier/pflag"
+
+	There is one exception to this: if you directly instantiate the Flag struct
+	there is one more field "Shorthand" that you will need to set.
+	Most code never instantiates this struct directly, and instead uses
+	functions such as String(), BoolVar(), and Var(), and is therefore
+	unaffected.
+
+	Define flags using flag.String(), Bool(), Int(), etc.
+
+	This declares an integer flag, -flagname, stored in the pointer ip, with type *int.
+		var ip = flag.Int("flagname", 1234, "help message for flagname")
+	If you like, you can bind the flag to a variable using the Var() functions.
+		var flagvar int
+		func init() {
+			flag.IntVar(&flagvar, "flagname", 1234, "help message for flagname")
+		}
+	Or you can create custom flags that satisfy the Value interface (with
+	pointer receivers) and couple them to flag parsing by
+		flag.Var(&flagVal, "name", "help message for flagname")
+	For such flags, the default value is just the initial value of the variable.
+
+	After all flags are defined, call
+		flag.Parse()
+	to parse the command line into the defined flags.
+
+	Flags may then be used directly. If you're using the flags themselves,
+	they are all pointers; if you bind to variables, they're values.
+		fmt.Println("ip has value ", *ip)
+		fmt.Println("flagvar has value ", flagvar)
+
+	After parsing, the arguments after the flag are available as the
+	slice flag.Args() or individually as flag.Arg(i).
+	The arguments are indexed from 0 through flag.NArg()-1.
+
+	The pflag package also defines some new functions that are not in flag,
+	that give one-letter shorthands for flags. You can use these by appending
+	'P' to the name of any function that defines a flag.
+		var ip = flag.IntP("flagname", "f", 1234, "help message")
+		var flagvar bool
+		func init() {
+			flag.BoolVarP("boolname", "b", true, "help message")
+		}
+		flag.VarP(&flagVar, "varname", "v", 1234, "help message")
+	Shorthand letters can be used with single dashes on the command line.
+	Boolean shorthand flags can be combined with other shorthand flags.
+
+	Command line flag syntax:
+		--flag    // boolean flags only
+		--flag=x
+
+	Unlike the flag package, a single dash before an option means something
+	different than a double dash. Single dashes signify a series of shorthand
+	letters for flags. All but the last shorthand letter must be boolean flags.
+		// boolean flags
+		-f
+		-abc
+		// non-boolean flags
+		-n 1234
+		-Ifile
+		// mixed
+		-abcs "hello"
+		-abcn1234
+
+	Flag parsing stops after the terminator "--". Unlike the flag package,
+	flags can be interspersed with arguments anywhere on the command line
+	before this terminator.
+
+	Integer flags accept 1234, 0664, 0x1234 and may be negative.
+	Boolean flags (in their long form) accept 1, 0, t, f, true, false,
+	TRUE, FALSE, True, False.
+	Duration flags accept any input valid for time.ParseDuration.
+
+	The default set of command-line flags is controlled by
+	top-level functions.  The FlagSet type allows one to define
+	independent sets of flags, such as to implement subcommands
+	in a command-line interface. The methods of FlagSet are
+	analogous to the top-level functions for the command-line
+	flag set.
+*/
+package pflag
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+// ErrHelp is the error returned if the flag -help is invoked but no such flag is defined.
+var ErrHelp = errors.New("pflag: help requested")
+
+// ErrorHandling defines how to handle flag parsing errors.
+type ErrorHandling int
+
+const (
+	ContinueOnError ErrorHandling = iota
+	ExitOnError
+	PanicOnError
+)
+
+// A FlagSet represents a set of defined flags.
+type FlagSet struct {
+	// Usage is the function called when an error occurs while parsing flags.
+	// The field is a function (not a method) that may be changed to point to
+	// a custom error handler.
+	Usage func()
+
+	name          string
+	parsed        bool
+	actual        map[string]*Flag
+	formal        map[string]*Flag
+	shorthands    map[byte]*Flag
+	args          []string // arguments after flags
+	exitOnError   bool     // does the program exit if there's an error?
+	errorHandling ErrorHandling
+	output        io.Writer // nil means stderr; use out() accessor
+	interspersed  bool      // allow interspersed option/non-option args
+}
+
+// A Flag represents the state of a flag.
+type Flag struct {
+	Name      string // name as it appears on command line
+	Shorthand string // one-letter abbreviated flag
+	Usage     string // help message
+	Value     Value  // value as set
+	DefValue  string // default value (as text); for usage message
+	Changed   bool   // If the user set the value (or if left to default)
+}
+
+// Value is the interface to the dynamic value stored in a flag.
+// (The default value is represented as a string.)
+type Value interface {
+	String() string
+	Set(string) error
+	Type() string
+}
+
+// sortFlags returns the flags as a slice in lexicographical sorted order.
+func sortFlags(flags map[string]*Flag) []*Flag {
+	list := make(sort.StringSlice, len(flags))
+	i := 0
+	for _, f := range flags {
+		list[i] = f.Name
+		i++
+	}
+	list.Sort()
+	result := make([]*Flag, len(list))
+	for i, name := range list {
+		result[i] = flags[name]
+	}
+	return result
+}
+
+func (f *FlagSet) out() io.Writer {
+	if f.output == nil {
+		return os.Stderr
+	}
+	return f.output
+}
+
+// SetOutput sets the destination for usage and error messages.
+// If output is nil, os.Stderr is used.
+func (f *FlagSet) SetOutput(output io.Writer) {
+	f.output = output
+}
+
+// VisitAll visits the flags in lexicographical order, calling fn for each.
+// It visits all flags, even those not set.
+func (f *FlagSet) VisitAll(fn func(*Flag)) {
+	for _, flag := range sortFlags(f.formal) {
+		fn(flag)
+	}
+}
+
+func (f *FlagSet) HasFlags() bool {
+	return len(f.formal) > 0
+}
+
+// VisitAll visits the command-line flags in lexicographical order, calling
+// fn for each.  It visits all flags, even those not set.
+func VisitAll(fn func(*Flag)) {
+	CommandLine.VisitAll(fn)
+}
+
+// Visit visits the flags in lexicographical order, calling fn for each.
+// It visits only those flags that have been set.
+func (f *FlagSet) Visit(fn func(*Flag)) {
+	for _, flag := range sortFlags(f.actual) {
+		fn(flag)
+	}
+}
+
+// Visit visits the command-line flags in lexicographical order, calling fn
+// for each.  It visits only those flags that have been set.
+func Visit(fn func(*Flag)) {
+	CommandLine.Visit(fn)
+}
+
+// Lookup returns the Flag structure of the named flag, returning nil if none exists.
+func (f *FlagSet) Lookup(name string) *Flag {
+	return f.formal[name]
+}
+
+// Lookup returns the Flag structure of the named command-line flag,
+// returning nil if none exists.
+func Lookup(name string) *Flag {
+	return CommandLine.formal[name]
+}
+
+// Set sets the value of the named flag.
+func (f *FlagSet) Set(name, value string) error {
+	flag, ok := f.formal[name]
+	if !ok {
+		return fmt.Errorf("no such flag -%v", name)
+	}
+	err := flag.Value.Set(value)
+	if err != nil {
+		return err
+	}
+	if f.actual == nil {
+		f.actual = make(map[string]*Flag)
+	}
+	f.actual[name] = flag
+	f.Lookup(name).Changed = true
+	return nil
+}
+
+// Set sets the value of the named command-line flag.
+func Set(name, value string) error {
+	return CommandLine.Set(name, value)
+}
+
+// PrintDefaults prints, to standard error unless configured
+// otherwise, the default values of all defined flags in the set.
+func (f *FlagSet) PrintDefaults() {
+	f.VisitAll(func(flag *Flag) {
+		format := "--%s=%s: %s\n"
+		if _, ok := flag.Value.(*stringValue); ok {
+			// put quotes on the value
+			format = "--%s=%q: %s\n"
+		}
+		if len(flag.Shorthand) > 0 {
+			format = "  -%s, " + format
+		} else {
+			format = "   %s   " + format
+		}
+		fmt.Fprintf(f.out(), format, flag.Shorthand, flag.Name, flag.DefValue, flag.Usage)
+	})
+}
+
+func (f *FlagSet) FlagUsages() string {
+	x := new(bytes.Buffer)
+
+	f.VisitAll(func(flag *Flag) {
+		format := "--%s=%s: %s\n"
+		if _, ok := flag.Value.(*stringValue); ok {
+			// put quotes on the value
+			format = "--%s=%q: %s\n"
+		}
+		if len(flag.Shorthand) > 0 {
+			format = "  -%s, " + format
+		} else {
+			format = "   %s   " + format
+		}
+		fmt.Fprintf(x, format, flag.Shorthand, flag.Name, flag.DefValue, flag.Usage)
+	})
+
+	return x.String()
+}
+
+// PrintDefaults prints to standard error the default values of all defined command-line flags.
+func PrintDefaults() {
+	CommandLine.PrintDefaults()
+}
+
+// defaultUsage is the default function to print a usage message.
+func defaultUsage(f *FlagSet) {
+	fmt.Fprintf(f.out(), "Usage of %s:\n", f.name)
+	f.PrintDefaults()
+}
+
+// NOTE: Usage is not just defaultUsage(CommandLine)
+// because it serves (via godoc flag Usage) as the example
+// for how to write your own usage function.
+
+// Usage prints to standard error a usage message documenting all defined command-line flags.
+// The function is a variable that may be changed to point to a custom function.
+var Usage = func() {
+	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+	PrintDefaults()
+}
+
+// NFlag returns the number of flags that have been set.
+func (f *FlagSet) NFlag() int { return len(f.actual) }
+
+// NFlag returns the number of command-line flags that have been set.
+func NFlag() int { return len(CommandLine.actual) }
+
+// Arg returns the i'th argument.  Arg(0) is the first remaining argument
+// after flags have been processed.
+func (f *FlagSet) Arg(i int) string {
+	if i < 0 || i >= len(f.args) {
+		return ""
+	}
+	return f.args[i]
+}
+
+// Arg returns the i'th command-line argument.  Arg(0) is the first remaining argument
+// after flags have been processed.
+func Arg(i int) string {
+	return CommandLine.Arg(i)
+}
+
+// NArg is the number of arguments remaining after flags have been processed.
+func (f *FlagSet) NArg() int { return len(f.args) }
+
+// NArg is the number of arguments remaining after flags have been processed.
+func NArg() int { return len(CommandLine.args) }
+
+// Args returns the non-flag arguments.
+func (f *FlagSet) Args() []string { return f.args }
+
+// Args returns the non-flag command-line arguments.
+func Args() []string { return CommandLine.args }
+
+// Var defines a flag with the specified name and usage string. The type and
+// value of the flag are represented by the first argument, of type Value, which
+// typically holds a user-defined implementation of Value. For instance, the
+// caller could create a flag that turns a comma-separated string into a slice
+// of strings by giving the slice the methods of Value; in particular, Set would
+// decompose the comma-separated string into the slice.
+func (f *FlagSet) Var(value Value, name string, usage string) {
+	f.VarP(value, name, "", usage)
+}
+
+// Like Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) VarP(value Value, name, shorthand, usage string) {
+	// Remember the default value as a string; it won't change.
+	flag := &Flag{name, shorthand, usage, value, value.String(), false}
+	f.AddFlag(flag)
+}
+
+func (f *FlagSet) AddFlag(flag *Flag) {
+	_, alreadythere := f.formal[flag.Name]
+	if alreadythere {
+		msg := fmt.Sprintf("%s flag redefined: %s", f.name, flag.Name)
+		fmt.Fprintln(f.out(), msg)
+		panic(msg) // Happens only if flags are declared with identical names
+	}
+	if f.formal == nil {
+		f.formal = make(map[string]*Flag)
+	}
+	f.formal[flag.Name] = flag
+
+	if len(flag.Shorthand) == 0 {
+		return
+	}
+	if len(flag.Shorthand) > 1 {
+		fmt.Fprintf(f.out(), "%s shorthand more than ASCII character: %s\n", f.name, flag.Shorthand)
+		panic("shorthand is more than one character")
+	}
+	if f.shorthands == nil {
+		f.shorthands = make(map[byte]*Flag)
+	}
+	c := flag.Shorthand[0]
+	old, alreadythere := f.shorthands[c]
+	if alreadythere {
+		fmt.Fprintf(f.out(), "%s shorthand reused: %q for %s already used for %s\n", f.name, c, flag.Name, old.Name)
+		panic("shorthand redefinition")
+	}
+	f.shorthands[c] = flag
+}
+
+// Var defines a flag with the specified name and usage string. The type and
+// value of the flag are represented by the first argument, of type Value, which
+// typically holds a user-defined implementation of Value. For instance, the
+// caller could create a flag that turns a comma-separated string into a slice
+// of strings by giving the slice the methods of Value; in particular, Set would
+// decompose the comma-separated string into the slice.
+func Var(value Value, name string, usage string) {
+	CommandLine.VarP(value, name, "", usage)
+}
+
+// Like Var, but accepts a shorthand letter that can be used after a single dash.
+func VarP(value Value, name, shorthand, usage string) {
+	CommandLine.VarP(value, name, shorthand, usage)
+}
+
+// failf prints to standard error a formatted error and usage message and
+// returns the error.
+func (f *FlagSet) failf(format string, a ...interface{}) error {
+	err := fmt.Errorf(format, a...)
+	fmt.Fprintln(f.out(), err)
+	f.usage()
+	return err
+}
+
+// usage calls the Usage method for the flag set, or the usage function if
+// the flag set is CommandLine.
+func (f *FlagSet) usage() {
+	if f == CommandLine {
+		Usage()
+	} else if f.Usage == nil {
+		defaultUsage(f)
+	} else {
+		f.Usage()
+	}
+}
+
+func (f *FlagSet) setFlag(flag *Flag, value string, origArg string) error {
+	if err := flag.Value.Set(value); err != nil {
+		return f.failf("invalid argument %q for %s: %v", value, origArg, err)
+	}
+	// mark as visited for Visit()
+	if f.actual == nil {
+		f.actual = make(map[string]*Flag)
+	}
+	f.actual[flag.Name] = flag
+	flag.Changed = true
+	return nil
+}
+
+func (f *FlagSet) parseLongArg(s string, args []string) (a []string, err error) {
+	a = args
+	if len(s) == 2 { // "--" terminates the flags
+		f.args = append(f.args, args...)
+		return
+	}
+	name := s[2:]
+	if len(name) == 0 || name[0] == '-' || name[0] == '=' {
+		err = f.failf("bad flag syntax: %s", s)
+		return
+	}
+	split := strings.SplitN(name, "=", 2)
+	name = split[0]
+	m := f.formal
+	flag, alreadythere := m[name] // BUG
+	if !alreadythere {
+		if name == "help" { // special case for nice help message.
+			f.usage()
+			return args, ErrHelp
+		}
+		err = f.failf("unknown flag: --%s", name)
+		return
+	}
+	if len(split) == 1 {
+		if _, ok := flag.Value.(*boolValue); !ok {
+			err = f.failf("flag needs an argument: %s", s)
+			return
+		}
+		f.setFlag(flag, "true", s)
+	} else {
+		if e := f.setFlag(flag, split[1], s); e != nil {
+			err = e
+			return
+		}
+	}
+	return args, nil
+}
+
+func (f *FlagSet) parseShortArg(s string, args []string) (a []string, err error) {
+	a = args
+	shorthands := s[1:]
+
+	for i := 0; i < len(shorthands); i++ {
+		c := shorthands[i]
+		flag, alreadythere := f.shorthands[c]
+		if !alreadythere {
+			if c == 'h' { // special case for nice help message.
+				f.usage()
+				err = ErrHelp
+				return
+			}
+			//TODO continue on error
+			err = f.failf("unknown shorthand flag: %q in -%s", c, shorthands)
+			if len(args) == 0 {
+				return
+			}
+		}
+		if alreadythere {
+			if _, ok := flag.Value.(*boolValue); ok {
+				f.setFlag(flag, "true", s)
+				continue
+			}
+			if i < len(shorthands)-1 {
+				if e := f.setFlag(flag, shorthands[i+1:], s); e != nil {
+					err = e
+					return
+				}
+				break
+			}
+			if len(args) == 0 {
+				err = f.failf("flag needs an argument: %q in -%s", c, shorthands)
+				return
+			}
+			if e := f.setFlag(flag, args[0], s); e != nil {
+				err = e
+				return
+			}
+		}
+		a = args[1:]
+		break // should be unnecessary
+	}
+
+	return
+}
+
+func (f *FlagSet) parseArgs(args []string) (err error) {
+	for len(args) > 0 {
+		s := args[0]
+		args = args[1:]
+		if len(s) == 0 || s[0] != '-' || len(s) == 1 {
+			if !f.interspersed {
+				f.args = append(f.args, s)
+				f.args = append(f.args, args...)
+				return nil
+			}
+			f.args = append(f.args, s)
+			continue
+		}
+
+		if s[1] == '-' {
+			args, err = f.parseLongArg(s, args)
+		} else {
+			args, err = f.parseShortArg(s, args)
+		}
+	}
+	return
+}
+
+// Parse parses flag definitions from the argument list, which should not
+// include the command name.  Must be called after all flags in the FlagSet
+// are defined and before flags are accessed by the program.
+// The return value will be ErrHelp if -help was set but not defined.
+func (f *FlagSet) Parse(arguments []string) error {
+	f.parsed = true
+	f.args = make([]string, 0, len(arguments))
+	err := f.parseArgs(arguments)
+	if err != nil {
+		switch f.errorHandling {
+		case ContinueOnError:
+			return err
+		case ExitOnError:
+			os.Exit(2)
+		case PanicOnError:
+			panic(err)
+		}
+	}
+	return nil
+}
+
+// Parsed reports whether f.Parse has been called.
+func (f *FlagSet) Parsed() bool {
+	return f.parsed
+}
+
+// Parse parses the command-line flags from os.Args[1:].  Must be called
+// after all flags are defined and before flags are accessed by the program.
+func Parse() {
+	// Ignore errors; CommandLine is set for ExitOnError.
+	CommandLine.Parse(os.Args[1:])
+}
+
+// Whether to support interspersed option/non-option arguments.
+func SetInterspersed(interspersed bool) {
+	CommandLine.SetInterspersed(interspersed)
+}
+
+// Parsed returns true if the command-line flags have been parsed.
+func Parsed() bool {
+	return CommandLine.Parsed()
+}
+
+// The default set of command-line flags, parsed from os.Args.
+var CommandLine = NewFlagSet(os.Args[0], ExitOnError)
+
+// NewFlagSet returns a new, empty flag set with the specified name and
+// error handling property.
+func NewFlagSet(name string, errorHandling ErrorHandling) *FlagSet {
+	f := &FlagSet{
+		name:          name,
+		errorHandling: errorHandling,
+		interspersed:  true,
+	}
+	return f
+}
+
+// Whether to support interspersed option/non-option arguments.
+func (f *FlagSet) SetInterspersed(interspersed bool) {
+	f.interspersed = interspersed
+}
+
+// Init sets the name and error handling property for a flag set.
+// By default, the zero FlagSet uses an empty name and the
+// ContinueOnError error handling policy.
+func (f *FlagSet) Init(name string, errorHandling ErrorHandling) {
+	f.name = name
+	f.errorHandling = errorHandling
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/flag_test.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/flag_test.go
@@ -1,0 +1,354 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pflag_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/spf13/pflag"
+)
+
+var (
+	test_bool     = Bool("test_bool", false, "bool value")
+	test_int      = Int("test_int", 0, "int value")
+	test_int64    = Int64("test_int64", 0, "int64 value")
+	test_uint     = Uint("test_uint", 0, "uint value")
+	test_uint64   = Uint64("test_uint64", 0, "uint64 value")
+	test_string   = String("test_string", "0", "string value")
+	test_float64  = Float64("test_float64", 0, "float64 value")
+	test_duration = Duration("test_duration", 0, "time.Duration value")
+)
+
+func boolString(s string) string {
+	if s == "0" {
+		return "false"
+	}
+	return "true"
+}
+
+func TestEverything(t *testing.T) {
+	m := make(map[string]*Flag)
+	desired := "0"
+	visitor := func(f *Flag) {
+		if len(f.Name) > 5 && f.Name[0:5] == "test_" {
+			m[f.Name] = f
+			ok := false
+			switch {
+			case f.Value.String() == desired:
+				ok = true
+			case f.Name == "test_bool" && f.Value.String() == boolString(desired):
+				ok = true
+			case f.Name == "test_duration" && f.Value.String() == desired+"s":
+				ok = true
+			}
+			if !ok {
+				t.Error("Visit: bad value", f.Value.String(), "for", f.Name)
+			}
+		}
+	}
+	VisitAll(visitor)
+	if len(m) != 8 {
+		t.Error("VisitAll misses some flags")
+		for k, v := range m {
+			t.Log(k, *v)
+		}
+	}
+	m = make(map[string]*Flag)
+	Visit(visitor)
+	if len(m) != 0 {
+		t.Errorf("Visit sees unset flags")
+		for k, v := range m {
+			t.Log(k, *v)
+		}
+	}
+	// Now set all flags
+	Set("test_bool", "true")
+	Set("test_int", "1")
+	Set("test_int64", "1")
+	Set("test_uint", "1")
+	Set("test_uint64", "1")
+	Set("test_string", "1")
+	Set("test_float64", "1")
+	Set("test_duration", "1s")
+	desired = "1"
+	Visit(visitor)
+	if len(m) != 8 {
+		t.Error("Visit fails after set")
+		for k, v := range m {
+			t.Log(k, *v)
+		}
+	}
+	// Now test they're visited in sort order.
+	var flagNames []string
+	Visit(func(f *Flag) { flagNames = append(flagNames, f.Name) })
+	if !sort.StringsAreSorted(flagNames) {
+		t.Errorf("flag names not sorted: %v", flagNames)
+	}
+}
+
+func TestUsage(t *testing.T) {
+	called := false
+	ResetForTesting(func() { called = true })
+	if GetCommandLine().Parse([]string{"--x"}) == nil {
+		t.Error("parse did not fail for unknown flag")
+	}
+	if !called {
+		t.Error("did not call Usage for unknown flag")
+	}
+}
+
+func testParse(f *FlagSet, t *testing.T) {
+	if f.Parsed() {
+		t.Error("f.Parse() = true before Parse")
+	}
+	boolFlag := f.Bool("bool", false, "bool value")
+	bool2Flag := f.Bool("bool2", false, "bool2 value")
+	bool3Flag := f.Bool("bool3", false, "bool3 value")
+	intFlag := f.Int("int", 0, "int value")
+	int64Flag := f.Int64("int64", 0, "int64 value")
+	uintFlag := f.Uint("uint", 0, "uint value")
+	uint64Flag := f.Uint64("uint64", 0, "uint64 value")
+	stringFlag := f.String("string", "0", "string value")
+	float64Flag := f.Float64("float64", 0, "float64 value")
+	durationFlag := f.Duration("duration", 5*time.Second, "time.Duration value")
+	extra := "one-extra-argument"
+	args := []string{
+		"--bool",
+		"--bool2=true",
+		"--bool3=false",
+		"--int=22",
+		"--int64=0x23",
+		"--uint=24",
+		"--uint64=25",
+		"--string=hello",
+		"--float64=2718e28",
+		"--duration=2m",
+		extra,
+	}
+	if err := f.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	if !f.Parsed() {
+		t.Error("f.Parse() = false after Parse")
+	}
+	if *boolFlag != true {
+		t.Error("bool flag should be true, is ", *boolFlag)
+	}
+	if *bool2Flag != true {
+		t.Error("bool2 flag should be true, is ", *bool2Flag)
+	}
+	if *bool3Flag != false {
+		t.Error("bool3 flag should be false, is ", *bool2Flag)
+	}
+	if *intFlag != 22 {
+		t.Error("int flag should be 22, is ", *intFlag)
+	}
+	if *int64Flag != 0x23 {
+		t.Error("int64 flag should be 0x23, is ", *int64Flag)
+	}
+	if *uintFlag != 24 {
+		t.Error("uint flag should be 24, is ", *uintFlag)
+	}
+	if *uint64Flag != 25 {
+		t.Error("uint64 flag should be 25, is ", *uint64Flag)
+	}
+	if *stringFlag != "hello" {
+		t.Error("string flag should be `hello`, is ", *stringFlag)
+	}
+	if *float64Flag != 2718e28 {
+		t.Error("float64 flag should be 2718e28, is ", *float64Flag)
+	}
+	if *durationFlag != 2*time.Minute {
+		t.Error("duration flag should be 2m, is ", *durationFlag)
+	}
+	if len(f.Args()) != 1 {
+		t.Error("expected one argument, got", len(f.Args()))
+	} else if f.Args()[0] != extra {
+		t.Errorf("expected argument %q got %q", extra, f.Args()[0])
+	}
+}
+
+func TestShorthand(t *testing.T) {
+	f := NewFlagSet("shorthand", ContinueOnError)
+	if f.Parsed() {
+		t.Error("f.Parse() = true before Parse")
+	}
+	boolaFlag := f.BoolP("boola", "a", false, "bool value")
+	boolbFlag := f.BoolP("boolb", "b", false, "bool2 value")
+	boolcFlag := f.BoolP("boolc", "c", false, "bool3 value")
+	stringFlag := f.StringP("string", "s", "0", "string value")
+	extra := "interspersed-argument"
+	notaflag := "--i-look-like-a-flag"
+	args := []string{
+		"-ab",
+		extra,
+		"-cs",
+		"hello",
+		"--",
+		notaflag,
+	}
+	f.SetOutput(ioutil.Discard)
+	if err := f.Parse(args); err == nil {
+		t.Error("--i-look-like-a-flag should throw an error")
+	}
+	if !f.Parsed() {
+		t.Error("f.Parse() = false after Parse")
+	}
+	if *boolaFlag != true {
+		t.Error("boola flag should be true, is ", *boolaFlag)
+	}
+	if *boolbFlag != true {
+		t.Error("boolb flag should be true, is ", *boolbFlag)
+	}
+	if *boolcFlag != true {
+		t.Error("boolc flag should be true, is ", *boolcFlag)
+	}
+	if *stringFlag != "hello" {
+		t.Error("string flag should be `hello`, is ", *stringFlag)
+	}
+	if len(f.Args()) != 2 {
+		t.Error("expected one argument, got", len(f.Args()))
+	} else if f.Args()[0] != extra {
+		t.Errorf("expected argument %q got %q", extra, f.Args()[0])
+	} else if f.Args()[1] != notaflag {
+		t.Errorf("expected argument %q got %q", notaflag, f.Args()[1])
+	}
+}
+
+func TestParse(t *testing.T) {
+	ResetForTesting(func() { t.Error("bad parse") })
+	testParse(GetCommandLine(), t)
+}
+
+func TestFlagSetParse(t *testing.T) {
+	testParse(NewFlagSet("test", ContinueOnError), t)
+}
+
+// Declare a user-defined flag type.
+type flagVar []string
+
+func (f *flagVar) String() string {
+	return fmt.Sprint([]string(*f))
+}
+
+func (f *flagVar) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
+func TestUserDefined(t *testing.T) {
+	var flags FlagSet
+	flags.Init("test", ContinueOnError)
+	var v flagVar
+	flags.VarP(&v, "v", "v", "usage")
+	if err := flags.Parse([]string{"--v=1", "-v2", "-v", "3"}); err != nil {
+		t.Error(err)
+	}
+	if len(v) != 3 {
+		t.Fatal("expected 3 args; got ", len(v))
+	}
+	expect := "[1 2 3]"
+	if v.String() != expect {
+		t.Errorf("expected value %q got %q", expect, v.String())
+	}
+}
+
+func TestSetOutput(t *testing.T) {
+	var flags FlagSet
+	var buf bytes.Buffer
+	flags.SetOutput(&buf)
+	flags.Init("test", ContinueOnError)
+	flags.Parse([]string{"--unknown"})
+	if out := buf.String(); !strings.Contains(out, "--unknown") {
+		t.Logf("expected output mentioning unknown; got %q", out)
+	}
+}
+
+// This tests that one can reset the flags. This still works but not well, and is
+// superseded by FlagSet.
+func TestChangingArgs(t *testing.T) {
+	ResetForTesting(func() { t.Fatal("bad parse") })
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"cmd", "--before", "subcmd"}
+	before := Bool("before", false, "")
+	if err := GetCommandLine().Parse(os.Args[1:]); err != nil {
+		t.Fatal(err)
+	}
+	cmd := Arg(0)
+	os.Args = []string{"subcmd", "--after", "args"}
+	after := Bool("after", false, "")
+	Parse()
+	args := Args()
+
+	if !*before || cmd != "subcmd" || !*after || len(args) != 1 || args[0] != "args" {
+		t.Fatalf("expected true subcmd true [args] got %v %v %v %v", *before, cmd, *after, args)
+	}
+}
+
+// Test that -help invokes the usage message and returns ErrHelp.
+func TestHelp(t *testing.T) {
+	var helpCalled = false
+	fs := NewFlagSet("help test", ContinueOnError)
+	fs.Usage = func() { helpCalled = true }
+	var flag bool
+	fs.BoolVar(&flag, "flag", false, "regular flag")
+	// Regular flag invocation should work
+	err := fs.Parse([]string{"--flag=true"})
+	if err != nil {
+		t.Fatal("expected no error; got ", err)
+	}
+	if !flag {
+		t.Error("flag was not set by --flag")
+	}
+	if helpCalled {
+		t.Error("help called for regular flag")
+		helpCalled = false // reset for next test
+	}
+	// Help flag should work as expected.
+	err = fs.Parse([]string{"--help"})
+	if err == nil {
+		t.Fatal("error expected")
+	}
+	if err != ErrHelp {
+		t.Fatal("expected ErrHelp; got ", err)
+	}
+	if !helpCalled {
+		t.Fatal("help was not called")
+	}
+	// If we define a help flag, that should override.
+	var help bool
+	fs.BoolVar(&help, "help", false, "help flag")
+	helpCalled = false
+	err = fs.Parse([]string{"--help"})
+	if err != nil {
+		t.Fatal("expected no error for defined --help; got ", err)
+	}
+	if helpCalled {
+		t.Fatal("help was called; should not have been for defined help flag")
+	}
+}
+
+func TestNoInterspersed(t *testing.T) {
+	f := NewFlagSet("test", ContinueOnError)
+	f.SetInterspersed(false)
+	f.Bool("true", true, "always true")
+	f.Bool("false", false, "always false")
+	err := f.Parse([]string{"--true", "break", "--false"})
+	if err != nil {
+		t.Fatal("expected no error; got ", err)
+	}
+	args := f.Args()
+	if len(args) != 2 || args[0] != "break" || args[1] != "--false" {
+		t.Fatal("expected interspersed options/non-options to fail")
+	}
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/float32.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/float32.go
@@ -1,0 +1,74 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- float32 Value
+type float32Value float32
+
+func newFloat32Value(val float32, p *float32) *float32Value {
+	*p = val
+	return (*float32Value)(p)
+}
+
+func (f *float32Value) Set(s string) error {
+	v, err := strconv.ParseFloat(s, 32)
+	*f = float32Value(v)
+	return err
+}
+
+func (f *float32Value) Type() string {
+	return "float32"
+}
+
+func (f *float32Value) String() string { return fmt.Sprintf("%v", *f) }
+
+// Float32Var defines a float32 flag with specified name, default value, and usage string.
+// The argument p points to a float32 variable in which to store the value of the flag.
+func (f *FlagSet) Float32Var(p *float32, name string, value float32, usage string) {
+	f.VarP(newFloat32Value(value, p), name, "", usage)
+}
+
+// Like Float32Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Float32VarP(p *float32, name, shorthand string, value float32, usage string) {
+	f.VarP(newFloat32Value(value, p), name, shorthand, usage)
+}
+
+// Float32Var defines a float32 flag with specified name, default value, and usage string.
+// The argument p points to a float32 variable in which to store the value of the flag.
+func Float32Var(p *float32, name string, value float32, usage string) {
+	CommandLine.VarP(newFloat32Value(value, p), name, "", usage)
+}
+
+// Like Float32Var, but accepts a shorthand letter that can be used after a single dash.
+func Float32VarP(p *float32, name, shorthand string, value float32, usage string) {
+	CommandLine.VarP(newFloat32Value(value, p), name, shorthand, usage)
+}
+
+// Float32 defines a float32 flag with specified name, default value, and usage string.
+// The return value is the address of a float32 variable that stores the value of the flag.
+func (f *FlagSet) Float32(name string, value float32, usage string) *float32 {
+	p := new(float32)
+	f.Float32VarP(p, name, "", value, usage)
+	return p
+}
+
+// Like Float32, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Float32P(name, shorthand string, value float32, usage string) *float32 {
+	p := new(float32)
+	f.Float32VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Float32 defines a float32 flag with specified name, default value, and usage string.
+// The return value is the address of a float32 variable that stores the value of the flag.
+func Float32(name string, value float32, usage string) *float32 {
+	return CommandLine.Float32P(name, "", value, usage)
+}
+
+// Like Float32, but accepts a shorthand letter that can be used after a single dash.
+func Float32P(name, shorthand string, value float32, usage string) *float32 {
+	return CommandLine.Float32P(name, shorthand, value, usage)
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/float64.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/float64.go
@@ -1,0 +1,74 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- float64 Value
+type float64Value float64
+
+func newFloat64Value(val float64, p *float64) *float64Value {
+	*p = val
+	return (*float64Value)(p)
+}
+
+func (f *float64Value) Set(s string) error {
+	v, err := strconv.ParseFloat(s, 64)
+	*f = float64Value(v)
+	return err
+}
+
+func (f *float64Value) Type() string {
+	return "float64"
+}
+
+func (f *float64Value) String() string { return fmt.Sprintf("%v", *f) }
+
+// Float64Var defines a float64 flag with specified name, default value, and usage string.
+// The argument p points to a float64 variable in which to store the value of the flag.
+func (f *FlagSet) Float64Var(p *float64, name string, value float64, usage string) {
+	f.VarP(newFloat64Value(value, p), name, "", usage)
+}
+
+// Like Float64Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Float64VarP(p *float64, name, shorthand string, value float64, usage string) {
+	f.VarP(newFloat64Value(value, p), name, shorthand, usage)
+}
+
+// Float64Var defines a float64 flag with specified name, default value, and usage string.
+// The argument p points to a float64 variable in which to store the value of the flag.
+func Float64Var(p *float64, name string, value float64, usage string) {
+	CommandLine.VarP(newFloat64Value(value, p), name, "", usage)
+}
+
+// Like Float64Var, but accepts a shorthand letter that can be used after a single dash.
+func Float64VarP(p *float64, name, shorthand string, value float64, usage string) {
+	CommandLine.VarP(newFloat64Value(value, p), name, shorthand, usage)
+}
+
+// Float64 defines a float64 flag with specified name, default value, and usage string.
+// The return value is the address of a float64 variable that stores the value of the flag.
+func (f *FlagSet) Float64(name string, value float64, usage string) *float64 {
+	p := new(float64)
+	f.Float64VarP(p, name, "", value, usage)
+	return p
+}
+
+// Like Float64, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Float64P(name, shorthand string, value float64, usage string) *float64 {
+	p := new(float64)
+	f.Float64VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Float64 defines a float64 flag with specified name, default value, and usage string.
+// The return value is the address of a float64 variable that stores the value of the flag.
+func Float64(name string, value float64, usage string) *float64 {
+	return CommandLine.Float64P(name, "", value, usage)
+}
+
+// Like Float64, but accepts a shorthand letter that can be used after a single dash.
+func Float64P(name, shorthand string, value float64, usage string) *float64 {
+	return CommandLine.Float64P(name, shorthand, value, usage)
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/int.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/int.go
@@ -1,0 +1,74 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- int Value
+type intValue int
+
+func newIntValue(val int, p *int) *intValue {
+	*p = val
+	return (*intValue)(p)
+}
+
+func (i *intValue) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 64)
+	*i = intValue(v)
+	return err
+}
+
+func (i *intValue) Type() string {
+	return "int"
+}
+
+func (i *intValue) String() string { return fmt.Sprintf("%v", *i) }
+
+// IntVar defines an int flag with specified name, default value, and usage string.
+// The argument p points to an int variable in which to store the value of the flag.
+func (f *FlagSet) IntVar(p *int, name string, value int, usage string) {
+	f.VarP(newIntValue(value, p), name, "", usage)
+}
+
+// Like IntVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IntVarP(p *int, name, shorthand string, value int, usage string) {
+	f.VarP(newIntValue(value, p), name, shorthand, usage)
+}
+
+// IntVar defines an int flag with specified name, default value, and usage string.
+// The argument p points to an int variable in which to store the value of the flag.
+func IntVar(p *int, name string, value int, usage string) {
+	CommandLine.VarP(newIntValue(value, p), name, "", usage)
+}
+
+// Like IntVar, but accepts a shorthand letter that can be used after a single dash.
+func IntVarP(p *int, name, shorthand string, value int, usage string) {
+	CommandLine.VarP(newIntValue(value, p), name, shorthand, usage)
+}
+
+// Int defines an int flag with specified name, default value, and usage string.
+// The return value is the address of an int variable that stores the value of the flag.
+func (f *FlagSet) Int(name string, value int, usage string) *int {
+	p := new(int)
+	f.IntVarP(p, name, "", value, usage)
+	return p
+}
+
+// Like Int, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IntP(name, shorthand string, value int, usage string) *int {
+	p := new(int)
+	f.IntVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Int defines an int flag with specified name, default value, and usage string.
+// The return value is the address of an int variable that stores the value of the flag.
+func Int(name string, value int, usage string) *int {
+	return CommandLine.IntP(name, "", value, usage)
+}
+
+// Like Int, but accepts a shorthand letter that can be used after a single dash.
+func IntP(name, shorthand string, value int, usage string) *int {
+	return CommandLine.IntP(name, shorthand, value, usage)
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/int32.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/int32.go
@@ -1,0 +1,74 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- int32 Value
+type int32Value int32
+
+func newInt32Value(val int32, p *int32) *int32Value {
+	*p = val
+	return (*int32Value)(p)
+}
+
+func (i *int32Value) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 32)
+	*i = int32Value(v)
+	return err
+}
+
+func (i *int32Value) Type() string {
+	return "int32"
+}
+
+func (i *int32Value) String() string { return fmt.Sprintf("%v", *i) }
+
+// Int32Var defines an int32 flag with specified name, default value, and usage string.
+// The argument p points to an int32 variable in which to store the value of the flag.
+func (f *FlagSet) Int32Var(p *int32, name string, value int32, usage string) {
+	f.VarP(newInt32Value(value, p), name, "", usage)
+}
+
+// Like Int32Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int32VarP(p *int32, name, shorthand string, value int32, usage string) {
+	f.VarP(newInt32Value(value, p), name, shorthand, usage)
+}
+
+// Int32Var defines an int32 flag with specified name, default value, and usage string.
+// The argument p points to an int32 variable in which to store the value of the flag.
+func Int32Var(p *int32, name string, value int32, usage string) {
+	CommandLine.VarP(newInt32Value(value, p), name, "", usage)
+}
+
+// Like Int32Var, but accepts a shorthand letter that can be used after a single dash.
+func Int32VarP(p *int32, name, shorthand string, value int32, usage string) {
+	CommandLine.VarP(newInt32Value(value, p), name, shorthand, usage)
+}
+
+// Int32 defines an int32 flag with specified name, default value, and usage string.
+// The return value is the address of an int32 variable that stores the value of the flag.
+func (f *FlagSet) Int32(name string, value int32, usage string) *int32 {
+	p := new(int32)
+	f.Int32VarP(p, name, "", value, usage)
+	return p
+}
+
+// Like Int32, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int32P(name, shorthand string, value int32, usage string) *int32 {
+	p := new(int32)
+	f.Int32VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Int32 defines an int32 flag with specified name, default value, and usage string.
+// The return value is the address of an int32 variable that stores the value of the flag.
+func Int32(name string, value int32, usage string) *int32 {
+	return CommandLine.Int32P(name, "", value, usage)
+}
+
+// Like Int32, but accepts a shorthand letter that can be used after a single dash.
+func Int32P(name, shorthand string, value int32, usage string) *int32 {
+	return CommandLine.Int32P(name, shorthand, value, usage)
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/int64.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/int64.go
@@ -1,0 +1,74 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- int64 Value
+type int64Value int64
+
+func newInt64Value(val int64, p *int64) *int64Value {
+	*p = val
+	return (*int64Value)(p)
+}
+
+func (i *int64Value) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 64)
+	*i = int64Value(v)
+	return err
+}
+
+func (i *int64Value) Type() string {
+	return "int64"
+}
+
+func (i *int64Value) String() string { return fmt.Sprintf("%v", *i) }
+
+// Int64Var defines an int64 flag with specified name, default value, and usage string.
+// The argument p points to an int64 variable in which to store the value of the flag.
+func (f *FlagSet) Int64Var(p *int64, name string, value int64, usage string) {
+	f.VarP(newInt64Value(value, p), name, "", usage)
+}
+
+// Like Int64Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int64VarP(p *int64, name, shorthand string, value int64, usage string) {
+	f.VarP(newInt64Value(value, p), name, shorthand, usage)
+}
+
+// Int64Var defines an int64 flag with specified name, default value, and usage string.
+// The argument p points to an int64 variable in which to store the value of the flag.
+func Int64Var(p *int64, name string, value int64, usage string) {
+	CommandLine.VarP(newInt64Value(value, p), name, "", usage)
+}
+
+// Like Int64Var, but accepts a shorthand letter that can be used after a single dash.
+func Int64VarP(p *int64, name, shorthand string, value int64, usage string) {
+	CommandLine.VarP(newInt64Value(value, p), name, shorthand, usage)
+}
+
+// Int64 defines an int64 flag with specified name, default value, and usage string.
+// The return value is the address of an int64 variable that stores the value of the flag.
+func (f *FlagSet) Int64(name string, value int64, usage string) *int64 {
+	p := new(int64)
+	f.Int64VarP(p, name, "", value, usage)
+	return p
+}
+
+// Like Int64, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int64P(name, shorthand string, value int64, usage string) *int64 {
+	p := new(int64)
+	f.Int64VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Int64 defines an int64 flag with specified name, default value, and usage string.
+// The return value is the address of an int64 variable that stores the value of the flag.
+func Int64(name string, value int64, usage string) *int64 {
+	return CommandLine.Int64P(name, "", value, usage)
+}
+
+// Like Int64, but accepts a shorthand letter that can be used after a single dash.
+func Int64P(name, shorthand string, value int64, usage string) *int64 {
+	return CommandLine.Int64P(name, shorthand, value, usage)
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/int8.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/int8.go
@@ -1,0 +1,74 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- int8 Value
+type int8Value int8
+
+func newInt8Value(val int8, p *int8) *int8Value {
+	*p = val
+	return (*int8Value)(p)
+}
+
+func (i *int8Value) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 8)
+	*i = int8Value(v)
+	return err
+}
+
+func (i *int8Value) Type() string {
+	return "int8"
+}
+
+func (i *int8Value) String() string { return fmt.Sprintf("%v", *i) }
+
+// Int8Var defines an int8 flag with specified name, default value, and usage string.
+// The argument p points to an int8 variable in which to store the value of the flag.
+func (f *FlagSet) Int8Var(p *int8, name string, value int8, usage string) {
+	f.VarP(newInt8Value(value, p), name, "", usage)
+}
+
+// Like Int8Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int8VarP(p *int8, name, shorthand string, value int8, usage string) {
+	f.VarP(newInt8Value(value, p), name, shorthand, usage)
+}
+
+// Int8Var defines an int8 flag with specified name, default value, and usage string.
+// The argument p points to an int8 variable in which to store the value of the flag.
+func Int8Var(p *int8, name string, value int8, usage string) {
+	CommandLine.VarP(newInt8Value(value, p), name, "", usage)
+}
+
+// Like Int8Var, but accepts a shorthand letter that can be used after a single dash.
+func Int8VarP(p *int8, name, shorthand string, value int8, usage string) {
+	CommandLine.VarP(newInt8Value(value, p), name, shorthand, usage)
+}
+
+// Int8 defines an int8 flag with specified name, default value, and usage string.
+// The return value is the address of an int8 variable that stores the value of the flag.
+func (f *FlagSet) Int8(name string, value int8, usage string) *int8 {
+	p := new(int8)
+	f.Int8VarP(p, name, "", value, usage)
+	return p
+}
+
+// Like Int8, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int8P(name, shorthand string, value int8, usage string) *int8 {
+	p := new(int8)
+	f.Int8VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Int8 defines an int8 flag with specified name, default value, and usage string.
+// The return value is the address of an int8 variable that stores the value of the flag.
+func Int8(name string, value int8, usage string) *int8 {
+	return CommandLine.Int8P(name, "", value, usage)
+}
+
+// Like Int8, but accepts a shorthand letter that can be used after a single dash.
+func Int8P(name, shorthand string, value int8, usage string) *int8 {
+	return CommandLine.Int8P(name, shorthand, value, usage)
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/ip.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/ip.go
@@ -1,0 +1,79 @@
+package pflag
+
+import (
+	"fmt"
+	"net"
+)
+
+// -- net.IP value
+type ipValue net.IP
+
+func newIPValue(val net.IP, p *net.IP) *ipValue {
+	*p = val
+	return (*ipValue)(p)
+}
+
+func (i *ipValue) String() string { return net.IP(*i).String() }
+func (i *ipValue) Set(s string) error {
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return fmt.Errorf("failed to parse IP: %q", s)
+	}
+	*i = ipValue(ip)
+	return nil
+}
+func (i *ipValue) Get() interface{} {
+	return net.IP(*i)
+}
+
+func (i *ipValue) Type() string {
+	return "ip"
+}
+
+// IPVar defines an net.IP flag with specified name, default value, and usage string.
+// The argument p points to an net.IP variable in which to store the value of the flag.
+func (f *FlagSet) IPVar(p *net.IP, name string, value net.IP, usage string) {
+	f.VarP(newIPValue(value, p), name, "", usage)
+}
+
+// Like IPVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string) {
+	f.VarP(newIPValue(value, p), name, shorthand, usage)
+}
+
+// IPVar defines an net.IP flag with specified name, default value, and usage string.
+// The argument p points to an net.IP variable in which to store the value of the flag.
+func IPVar(p *net.IP, name string, value net.IP, usage string) {
+	CommandLine.VarP(newIPValue(value, p), name, "", usage)
+}
+
+// Like IPVar, but accepts a shorthand letter that can be used after a single dash.
+func IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string) {
+	CommandLine.VarP(newIPValue(value, p), name, shorthand, usage)
+}
+
+// IP defines an net.IP flag with specified name, default value, and usage string.
+// The return value is the address of an net.IP variable that stores the value of the flag.
+func (f *FlagSet) IP(name string, value net.IP, usage string) *net.IP {
+	p := new(net.IP)
+	f.IPVarP(p, name, "", value, usage)
+	return p
+}
+
+// Like IP, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IPP(name, shorthand string, value net.IP, usage string) *net.IP {
+	p := new(net.IP)
+	f.IPVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// IP defines an net.IP flag with specified name, default value, and usage string.
+// The return value is the address of an net.IP variable that stores the value of the flag.
+func IP(name string, value net.IP, usage string) *net.IP {
+	return CommandLine.IPP(name, "", value, usage)
+}
+
+// Like IP, but accepts a shorthand letter that can be used after a single dash.
+func IPP(name, shorthand string, value net.IP, usage string) *net.IP {
+	return CommandLine.IPP(name, shorthand, value, usage)
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/ipmask.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/ipmask.go
@@ -1,0 +1,89 @@
+package pflag
+
+import (
+	"fmt"
+	"net"
+)
+
+// -- net.IPMask value
+type ipMaskValue net.IPMask
+
+func newIPMaskValue(val net.IPMask, p *net.IPMask) *ipMaskValue {
+	*p = val
+	return (*ipMaskValue)(p)
+}
+
+func (i *ipMaskValue) String() string { return net.IPMask(*i).String() }
+func (i *ipMaskValue) Set(s string) error {
+	ip := ParseIPv4Mask(s)
+	if ip == nil {
+		return fmt.Errorf("failed to parse IP mask: %q", s)
+	}
+	*i = ipMaskValue(ip)
+	return nil
+}
+func (i *ipMaskValue) Get() interface{} {
+	return net.IPMask(*i)
+}
+
+func (i *ipMaskValue) Type() string {
+	return "ipMask"
+}
+
+// Parse IPv4 netmask written in IP form (e.g. 255.255.255.0).
+// This function should really belong to the net package.
+func ParseIPv4Mask(s string) net.IPMask {
+	mask := net.ParseIP(s)
+	if mask == nil {
+		return nil
+	}
+	return net.IPv4Mask(mask[12], mask[13], mask[14], mask[15])
+}
+
+// IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
+// The argument p points to an net.IPMask variable in which to store the value of the flag.
+func (f *FlagSet) IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string) {
+	f.VarP(newIPMaskValue(value, p), name, "", usage)
+}
+
+// Like IPMaskVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string) {
+	f.VarP(newIPMaskValue(value, p), name, shorthand, usage)
+}
+
+// IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
+// The argument p points to an net.IPMask variable in which to store the value of the flag.
+func IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string) {
+	CommandLine.VarP(newIPMaskValue(value, p), name, "", usage)
+}
+
+// Like IPMaskVar, but accepts a shorthand letter that can be used after a single dash.
+func IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string) {
+	CommandLine.VarP(newIPMaskValue(value, p), name, shorthand, usage)
+}
+
+// IPMask defines an net.IPMask flag with specified name, default value, and usage string.
+// The return value is the address of an net.IPMask variable that stores the value of the flag.
+func (f *FlagSet) IPMask(name string, value net.IPMask, usage string) *net.IPMask {
+	p := new(net.IPMask)
+	f.IPMaskVarP(p, name, "", value, usage)
+	return p
+}
+
+// Like IPMask, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IPMaskP(name, shorthand string, value net.IPMask, usage string) *net.IPMask {
+	p := new(net.IPMask)
+	f.IPMaskVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// IPMask defines an net.IPMask flag with specified name, default value, and usage string.
+// The return value is the address of an net.IPMask variable that stores the value of the flag.
+func IPMask(name string, value net.IPMask, usage string) *net.IPMask {
+	return CommandLine.IPMaskP(name, "", value, usage)
+}
+
+// Like IP, but accepts a shorthand letter that can be used after a single dash.
+func IPMaskP(name, shorthand string, value net.IPMask, usage string) *net.IPMask {
+	return CommandLine.IPMaskP(name, shorthand, value, usage)
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/string.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/string.go
@@ -1,0 +1,69 @@
+package pflag
+
+import "fmt"
+
+// -- string Value
+type stringValue string
+
+func newStringValue(val string, p *string) *stringValue {
+	*p = val
+	return (*stringValue)(p)
+}
+
+func (s *stringValue) Set(val string) error {
+	*s = stringValue(val)
+	return nil
+}
+func (s *stringValue) Type() string {
+	return "string"
+}
+
+func (s *stringValue) String() string { return fmt.Sprintf("%s", *s) }
+
+// StringVar defines a string flag with specified name, default value, and usage string.
+// The argument p points to a string variable in which to store the value of the flag.
+func (f *FlagSet) StringVar(p *string, name string, value string, usage string) {
+	f.VarP(newStringValue(value, p), name, "", usage)
+}
+
+// Like StringVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) StringVarP(p *string, name, shorthand string, value string, usage string) {
+	f.VarP(newStringValue(value, p), name, shorthand, usage)
+}
+
+// StringVar defines a string flag with specified name, default value, and usage string.
+// The argument p points to a string variable in which to store the value of the flag.
+func StringVar(p *string, name string, value string, usage string) {
+	CommandLine.VarP(newStringValue(value, p), name, "", usage)
+}
+
+// Like StringVar, but accepts a shorthand letter that can be used after a single dash.
+func StringVarP(p *string, name, shorthand string, value string, usage string) {
+	CommandLine.VarP(newStringValue(value, p), name, shorthand, usage)
+}
+
+// String defines a string flag with specified name, default value, and usage string.
+// The return value is the address of a string variable that stores the value of the flag.
+func (f *FlagSet) String(name string, value string, usage string) *string {
+	p := new(string)
+	f.StringVarP(p, name, "", value, usage)
+	return p
+}
+
+// Like String, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) StringP(name, shorthand string, value string, usage string) *string {
+	p := new(string)
+	f.StringVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// String defines a string flag with specified name, default value, and usage string.
+// The return value is the address of a string variable that stores the value of the flag.
+func String(name string, value string, usage string) *string {
+	return CommandLine.StringP(name, "", value, usage)
+}
+
+// Like String, but accepts a shorthand letter that can be used after a single dash.
+func StringP(name, shorthand string, value string, usage string) *string {
+	return CommandLine.StringP(name, shorthand, value, usage)
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/uint.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/uint.go
@@ -1,0 +1,74 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- uint Value
+type uintValue uint
+
+func newUintValue(val uint, p *uint) *uintValue {
+	*p = val
+	return (*uintValue)(p)
+}
+
+func (i *uintValue) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 64)
+	*i = uintValue(v)
+	return err
+}
+
+func (i *uintValue) Type() string {
+	return "uint"
+}
+
+func (i *uintValue) String() string { return fmt.Sprintf("%v", *i) }
+
+// UintVar defines a uint flag with specified name, default value, and usage string.
+// The argument p points to a uint variable in which to store the value of the flag.
+func (f *FlagSet) UintVar(p *uint, name string, value uint, usage string) {
+	f.VarP(newUintValue(value, p), name, "", usage)
+}
+
+// Like UintVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) UintVarP(p *uint, name, shorthand string, value uint, usage string) {
+	f.VarP(newUintValue(value, p), name, shorthand, usage)
+}
+
+// UintVar defines a uint flag with specified name, default value, and usage string.
+// The argument p points to a uint  variable in which to store the value of the flag.
+func UintVar(p *uint, name string, value uint, usage string) {
+	CommandLine.VarP(newUintValue(value, p), name, "", usage)
+}
+
+// Like UintVar, but accepts a shorthand letter that can be used after a single dash.
+func UintVarP(p *uint, name, shorthand string, value uint, usage string) {
+	CommandLine.VarP(newUintValue(value, p), name, shorthand, usage)
+}
+
+// Uint defines a uint flag with specified name, default value, and usage string.
+// The return value is the address of a uint  variable that stores the value of the flag.
+func (f *FlagSet) Uint(name string, value uint, usage string) *uint {
+	p := new(uint)
+	f.UintVarP(p, name, "", value, usage)
+	return p
+}
+
+// Like Uint, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) UintP(name, shorthand string, value uint, usage string) *uint {
+	p := new(uint)
+	f.UintVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Uint defines a uint flag with specified name, default value, and usage string.
+// The return value is the address of a uint  variable that stores the value of the flag.
+func Uint(name string, value uint, usage string) *uint {
+	return CommandLine.UintP(name, "", value, usage)
+}
+
+// Like Uint, but accepts a shorthand letter that can be used after a single dash.
+func UintP(name, shorthand string, value uint, usage string) *uint {
+	return CommandLine.UintP(name, shorthand, value, usage)
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/uint16.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/uint16.go
@@ -1,0 +1,76 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- uint16 value
+type uint16Value uint16
+
+func newUint16Value(val uint16, p *uint16) *uint16Value {
+	*p = val
+	return (*uint16Value)(p)
+}
+func (i *uint16Value) String() string { return fmt.Sprintf("%d", *i) }
+func (i *uint16Value) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 16)
+	*i = uint16Value(v)
+	return err
+}
+
+func (i *uint16Value) Get() interface{} {
+	return uint16(*i)
+}
+
+func (i *uint16Value) Type() string {
+	return "uint16"
+}
+
+// Uint16Var defines a uint flag with specified name, default value, and usage string.
+// The argument p points to a uint variable in which to store the value of the flag.
+func (f *FlagSet) Uint16Var(p *uint16, name string, value uint16, usage string) {
+	f.VarP(newUint16Value(value, p), name, "", usage)
+}
+
+// Like Uint16Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string) {
+	f.VarP(newUint16Value(value, p), name, shorthand, usage)
+}
+
+// Uint16Var defines a uint flag with specified name, default value, and usage string.
+// The argument p points to a uint  variable in which to store the value of the flag.
+func Uint16Var(p *uint16, name string, value uint16, usage string) {
+	CommandLine.VarP(newUint16Value(value, p), name, "", usage)
+}
+
+// Like Uint16Var, but accepts a shorthand letter that can be used after a single dash.
+func Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string) {
+	CommandLine.VarP(newUint16Value(value, p), name, shorthand, usage)
+}
+
+// Uint16 defines a uint flag with specified name, default value, and usage string.
+// The return value is the address of a uint  variable that stores the value of the flag.
+func (f *FlagSet) Uint16(name string, value uint16, usage string) *uint16 {
+	p := new(uint16)
+	f.Uint16VarP(p, name, "", value, usage)
+	return p
+}
+
+// Like Uint16, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint16P(name, shorthand string, value uint16, usage string) *uint16 {
+	p := new(uint16)
+	f.Uint16VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Uint16 defines a uint flag with specified name, default value, and usage string.
+// The return value is the address of a uint  variable that stores the value of the flag.
+func Uint16(name string, value uint16, usage string) *uint16 {
+	return CommandLine.Uint16P(name, "", value, usage)
+}
+
+// Like Uint16, but accepts a shorthand letter that can be used after a single dash.
+func Uint16P(name, shorthand string, value uint16, usage string) *uint16 {
+	return CommandLine.Uint16P(name, shorthand, value, usage)
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/uint32.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/uint32.go
@@ -1,0 +1,75 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- uint16 value
+type uint32Value uint32
+
+func newUint32Value(val uint32, p *uint32) *uint32Value {
+	*p = val
+	return (*uint32Value)(p)
+}
+func (i *uint32Value) String() string { return fmt.Sprintf("%d", *i) }
+func (i *uint32Value) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 32)
+	*i = uint32Value(v)
+	return err
+}
+func (i *uint32Value) Get() interface{} {
+	return uint32(*i)
+}
+
+func (i *uint32Value) Type() string {
+	return "uint32"
+}
+
+// Uint32Var defines a uint32 flag with specified name, default value, and usage string.
+// The argument p points to a uint32 variable in which to store the value of the flag.
+func (f *FlagSet) Uint32Var(p *uint32, name string, value uint32, usage string) {
+	f.VarP(newUint32Value(value, p), name, "", usage)
+}
+
+// Like Uint32Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string) {
+	f.VarP(newUint32Value(value, p), name, shorthand, usage)
+}
+
+// Uint32Var defines a uint32 flag with specified name, default value, and usage string.
+// The argument p points to a uint32  variable in which to store the value of the flag.
+func Uint32Var(p *uint32, name string, value uint32, usage string) {
+	CommandLine.VarP(newUint32Value(value, p), name, "", usage)
+}
+
+// Like Uint32Var, but accepts a shorthand letter that can be used after a single dash.
+func Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string) {
+	CommandLine.VarP(newUint32Value(value, p), name, shorthand, usage)
+}
+
+// Uint32 defines a uint32 flag with specified name, default value, and usage string.
+// The return value is the address of a uint32  variable that stores the value of the flag.
+func (f *FlagSet) Uint32(name string, value uint32, usage string) *uint32 {
+	p := new(uint32)
+	f.Uint32VarP(p, name, "", value, usage)
+	return p
+}
+
+// Like Uint32, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint32P(name, shorthand string, value uint32, usage string) *uint32 {
+	p := new(uint32)
+	f.Uint32VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Uint32 defines a uint32 flag with specified name, default value, and usage string.
+// The return value is the address of a uint32  variable that stores the value of the flag.
+func Uint32(name string, value uint32, usage string) *uint32 {
+	return CommandLine.Uint32P(name, "", value, usage)
+}
+
+// Like Uint32, but accepts a shorthand letter that can be used after a single dash.
+func Uint32P(name, shorthand string, value uint32, usage string) *uint32 {
+	return CommandLine.Uint32P(name, shorthand, value, usage)
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/uint64.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/uint64.go
@@ -1,0 +1,74 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- uint64 Value
+type uint64Value uint64
+
+func newUint64Value(val uint64, p *uint64) *uint64Value {
+	*p = val
+	return (*uint64Value)(p)
+}
+
+func (i *uint64Value) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 64)
+	*i = uint64Value(v)
+	return err
+}
+
+func (i *uint64Value) Type() string {
+	return "uint64"
+}
+
+func (i *uint64Value) String() string { return fmt.Sprintf("%v", *i) }
+
+// Uint64Var defines a uint64 flag with specified name, default value, and usage string.
+// The argument p points to a uint64 variable in which to store the value of the flag.
+func (f *FlagSet) Uint64Var(p *uint64, name string, value uint64, usage string) {
+	f.VarP(newUint64Value(value, p), name, "", usage)
+}
+
+// Like Uint64Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string) {
+	f.VarP(newUint64Value(value, p), name, shorthand, usage)
+}
+
+// Uint64Var defines a uint64 flag with specified name, default value, and usage string.
+// The argument p points to a uint64 variable in which to store the value of the flag.
+func Uint64Var(p *uint64, name string, value uint64, usage string) {
+	CommandLine.VarP(newUint64Value(value, p), name, "", usage)
+}
+
+// Like Uint64Var, but accepts a shorthand letter that can be used after a single dash.
+func Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string) {
+	CommandLine.VarP(newUint64Value(value, p), name, shorthand, usage)
+}
+
+// Uint64 defines a uint64 flag with specified name, default value, and usage string.
+// The return value is the address of a uint64 variable that stores the value of the flag.
+func (f *FlagSet) Uint64(name string, value uint64, usage string) *uint64 {
+	p := new(uint64)
+	f.Uint64VarP(p, name, "", value, usage)
+	return p
+}
+
+// Like Uint64, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint64P(name, shorthand string, value uint64, usage string) *uint64 {
+	p := new(uint64)
+	f.Uint64VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Uint64 defines a uint64 flag with specified name, default value, and usage string.
+// The return value is the address of a uint64 variable that stores the value of the flag.
+func Uint64(name string, value uint64, usage string) *uint64 {
+	return CommandLine.Uint64P(name, "", value, usage)
+}
+
+// Like Uint64, but accepts a shorthand letter that can be used after a single dash.
+func Uint64P(name, shorthand string, value uint64, usage string) *uint64 {
+	return CommandLine.Uint64P(name, shorthand, value, usage)
+}

--- a/Godeps/_workspace/src/github.com/spf13/pflag/uint8.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/uint8.go
@@ -1,0 +1,74 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- uint8 Value
+type uint8Value uint8
+
+func newUint8Value(val uint8, p *uint8) *uint8Value {
+	*p = val
+	return (*uint8Value)(p)
+}
+
+func (i *uint8Value) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 8)
+	*i = uint8Value(v)
+	return err
+}
+
+func (i *uint8Value) Type() string {
+	return "uint8"
+}
+
+func (i *uint8Value) String() string { return fmt.Sprintf("%v", *i) }
+
+// Uint8Var defines a uint8 flag with specified name, default value, and usage string.
+// The argument p points to a uint8 variable in which to store the value of the flag.
+func (f *FlagSet) Uint8Var(p *uint8, name string, value uint8, usage string) {
+	f.VarP(newUint8Value(value, p), name, "", usage)
+}
+
+// Like Uint8Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string) {
+	f.VarP(newUint8Value(value, p), name, shorthand, usage)
+}
+
+// Uint8Var defines a uint8 flag with specified name, default value, and usage string.
+// The argument p points to a uint8 variable in which to store the value of the flag.
+func Uint8Var(p *uint8, name string, value uint8, usage string) {
+	CommandLine.VarP(newUint8Value(value, p), name, "", usage)
+}
+
+// Like Uint8Var, but accepts a shorthand letter that can be used after a single dash.
+func Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string) {
+	CommandLine.VarP(newUint8Value(value, p), name, shorthand, usage)
+}
+
+// Uint8 defines a uint8 flag with specified name, default value, and usage string.
+// The return value is the address of a uint8 variable that stores the value of the flag.
+func (f *FlagSet) Uint8(name string, value uint8, usage string) *uint8 {
+	p := new(uint8)
+	f.Uint8VarP(p, name, "", value, usage)
+	return p
+}
+
+// Like Uint8, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint8P(name, shorthand string, value uint8, usage string) *uint8 {
+	p := new(uint8)
+	f.Uint8VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Uint8 defines a uint8 flag with specified name, default value, and usage string.
+// The return value is the address of a uint8 variable that stores the value of the flag.
+func Uint8(name string, value uint8, usage string) *uint8 {
+	return CommandLine.Uint8P(name, "", value, usage)
+}
+
+// Like Uint8, but accepts a shorthand letter that can be used after a single dash.
+func Uint8P(name, shorthand string, value uint8, usage string) *uint8 {
+	return CommandLine.Uint8P(name, shorthand, value, usage)
+}

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
+)
+
+func main() {
+	cmd.RunKubectl(os.Stdout)
+}

--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -160,6 +160,7 @@ kube::default_build_targets() {
   echo "cmd/e2e"
   echo "cmd/kubelet"
   echo "cmd/kubecfg"
+  echo "cmd/kubectl"
   echo "plugin/cmd/scheduler"
 }
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -51,9 +51,9 @@ API_HOST=${API_HOST:-127.0.0.1}
 KUBELET_PORT=${KUBELET_PORT:-10250}
 GO_OUT=${KUBE_TARGET}/bin
 
-# Check kubecfg
-out=$("${GO_OUT}/kubecfg" -version)
-echo kubecfg: $out
+# Check kubectl
+out=$("${GO_OUT}/kubectl")
+echo kubectl: $out
 
 # Start kubelet
 ${GO_OUT}/kubelet \
@@ -76,19 +76,20 @@ APISERVER_PID=$!
 
 wait_for_url "http://127.0.0.1:${API_PORT}/healthz" "apiserver: "
 
-KUBE_CMD="${GO_OUT}/kubecfg -h http://127.0.0.1:${API_PORT} -expect_version_match"
+KUBE_CMD="${GO_OUT}/kubectl"
+KUBE_FLAGS="-s http://127.0.0.1:${API_PORT} --match-server-version"
 
-${KUBE_CMD} list pods
-echo "kubecfg(pods): ok"
+${KUBE_CMD} get pods ${KUBE_FLAGS}
+echo "kubectl(pods): ok"
 
-${KUBE_CMD} list services
-${KUBE_CMD} -c examples/guestbook/frontend-service.json create services
-${KUBE_CMD} delete services/frontend
-echo "kubecfg(services): ok"
+${KUBE_CMD} get services ${KUBE_FLAGS}
+${KUBE_CMD} create -f examples/guestbook/frontend-service.json ${KUBE_FLAGS}
+${KUBE_CMD} delete service frontend ${KUBE_FLAGS}
+echo "kubectl(services): ok"
 
-${KUBE_CMD} list minions
-${KUBE_CMD} get minions/127.0.0.1
-echo "kubecfg(minions): ok"
+${KUBE_CMD} get minions ${KUBE_FLAGS}
+${KUBE_CMD} get minions 127.0.0.1 ${KUBE_FLAGS}
+echo "kubectl(minions): ok"
 
 # Start controller manager
 #${GO_OUT}/controller-manager \

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+)
+
+func RunKubectl(out io.Writer) {
+	// Parent command to which all subcommands are added.
+	cmds := &cobra.Command{
+		Use:   "kubectl",
+		Short: "kubectl controls the Kubernetes cluster manager",
+		Long: `kubectl controls the Kubernetes cluster manager.
+
+Find more information at https://github.com/GoogleCloudPlatform/kubernetes.`,
+		Run: runHelp,
+	}
+
+	// Globally persistent flags across all subcommands.
+	// TODO Change flag names to consts to allow safer lookup from subcommands.
+	// TODO Add a verbose flag that turns on glog logging. Probably need a way
+	// to do that automatically for every subcommand.
+	cmds.PersistentFlags().StringP("server", "s", "", "Kubernetes apiserver to connect to")
+	cmds.PersistentFlags().StringP("auth-path", "a", os.Getenv("HOME")+"/.kubernetes_auth", "Path to the auth info file. If missing, prompt the user. Only used if using https.")
+	cmds.PersistentFlags().Bool("match-server-version", false, "Require server version to match client version")
+	cmds.PersistentFlags().String("api-version", latest.Version, "The version of the API to use against the server (used for viewing resources only)")
+	cmds.PersistentFlags().String("certificate-authority", "", "Path to a certificate file for the certificate authority")
+	cmds.PersistentFlags().String("client-certificate", "", "Path to a client certificate for TLS.")
+	cmds.PersistentFlags().String("client-key", "", "Path to a client key file for TLS.")
+	cmds.PersistentFlags().Bool("insecure-skip-tls-verify", false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.")
+
+	cmds.AddCommand(NewCmdVersion(out))
+	cmds.AddCommand(NewCmdProxy(out))
+	cmds.AddCommand(NewCmdGet(out))
+	cmds.AddCommand(NewCmdDescribe(out))
+	cmds.AddCommand(NewCmdCreate(out))
+	cmds.AddCommand(NewCmdUpdate(out))
+	cmds.AddCommand(NewCmdDelete(out))
+
+	if err := cmds.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func checkErr(err error) {
+	if err != nil {
+		glog.Fatalf("%v", err)
+	}
+}
+
+func usageError(cmd *cobra.Command, format string, args ...interface{}) {
+	glog.Errorf(format, args...)
+	glog.Errorf("See '%s -h' for help.", cmd.CommandPath())
+	os.Exit(1)
+}
+
+func runHelp(cmd *cobra.Command, args []string) {
+	cmd.Help()
+}
+
+func getFlagString(cmd *cobra.Command, flag string) string {
+	f := cmd.Flags().Lookup(flag)
+	if f == nil {
+		glog.Fatalf("Flag accessed but not defined for command %s: %s", cmd.Name(), flag)
+	}
+	return f.Value.String()
+}
+
+func getFlagBool(cmd *cobra.Command, flag string) bool {
+	f := cmd.Flags().Lookup(flag)
+	if f == nil {
+		glog.Fatalf("Flag accessed but not defined for command %s: %s", cmd.Name(), flag)
+	}
+	// Caseless compare.
+	if strings.ToLower(f.Value.String()) == "true" {
+		return true
+	}
+	return false
+}
+
+// Returns nil if the flag wasn't set.
+func getFlagBoolPtr(cmd *cobra.Command, flag string) *bool {
+	f := cmd.Flags().Lookup(flag)
+	if f == nil {
+		glog.Fatalf("Flag accessed but not defined for command %s: %s", cmd.Name(), flag)
+	}
+	// Check if flag was not set at all.
+	if !f.Changed && f.DefValue == f.Value.String() {
+		return nil
+	}
+	var ret bool
+	// Caseless compare.
+	if strings.ToLower(f.Value.String()) == "true" {
+		ret = true
+	} else {
+		ret = false
+	}
+	return &ret
+}
+
+// Assumes the flag has a default value.
+func getFlagInt(cmd *cobra.Command, flag string) int {
+	f := cmd.Flags().Lookup(flag)
+	if f == nil {
+		glog.Fatalf("Flag accessed but not defined for command %s: %s", cmd.Name(), flag)
+	}
+	v, err := strconv.Atoi(f.Value.String())
+	// This is likely not a sufficiently friendly error message, but cobra
+	// should prevent non-integer values from reaching here.
+	checkErr(err)
+	return v
+}
+
+func getKubeClient(cmd *cobra.Command) *client.Client {
+	config := &client.Config{}
+
+	var host string
+	if hostFlag := getFlagString(cmd, "server"); len(hostFlag) > 0 {
+		host = hostFlag
+		glog.V(2).Infof("Using server from -s flag: %s", host)
+	} else if len(os.Getenv("KUBERNETES_MASTER")) > 0 {
+		host = os.Getenv("KUBERNETES_MASTER")
+		glog.V(2).Infof("Using server from env var KUBERNETES_MASTER: %s", host)
+	} else {
+		// TODO: eventually apiserver should start on 443 and be secure by default
+		host = "http://localhost:8080"
+		glog.V(2).Infof("No server found in flag or env var, using default: %s", host)
+	}
+	config.Host = host
+
+	if client.IsConfigTransportSecure(config) {
+		// Get the values from the file on disk (or from the user at the
+		// command line). Override them with the command line parameters, if
+		// provided.
+		authPath := getFlagString(cmd, "auth-path")
+		authInfo, err := kubectl.LoadAuthInfo(authPath, os.Stdin)
+		if err != nil {
+			glog.Fatalf("Error loading auth: %v", err)
+		}
+
+		config.Username = authInfo.User
+		config.Password = authInfo.Password
+		// First priority is flag, then file.
+		config.CAFile = firstNonEmptyString(getFlagString(cmd, "certificate-authority"), authInfo.CAFile)
+		config.CertFile = firstNonEmptyString(getFlagString(cmd, "client-certificate"), authInfo.CertFile)
+		config.KeyFile = firstNonEmptyString(getFlagString(cmd, "client-key"), authInfo.KeyFile)
+		// For config.Insecure, the command line ALWAYS overrides the authInfo
+		// file, regardless of its setting.
+		if insecureFlag := getFlagBoolPtr(cmd, "insecure-skip-tls-verify"); insecureFlag != nil {
+			config.Insecure = *insecureFlag
+		} else if authInfo.Insecure != nil {
+			config.Insecure = *authInfo.Insecure
+		}
+	}
+
+	// The API version (e.g. v1beta1), not the binary version.
+	config.Version = getFlagString(cmd, "api-version")
+
+	// The binary version.
+	matchVersion := getFlagBool(cmd, "match-server-version")
+
+	c, err := kubectl.GetKubeClient(config, matchVersion)
+	if err != nil {
+		glog.Fatalf("Error creating kubernetes client: %v", err)
+	}
+	return c
+}
+
+// Returns the first non-empty string out of the ones provided. If all
+// strings are empty, returns an empty string.
+func firstNonEmptyString(args ...string) string {
+	for _, s := range args {
+		if len(s) > 0 {
+			return s
+		}
+	}
+	return ""
+}
+
+// readConfigData reads the bytes from the specified filesytem or network
+// location or from stdin if location == "-".
+func readConfigData(location string) ([]byte, error) {
+	if len(location) == 0 {
+		return nil, fmt.Errorf("Location given but empty")
+	}
+
+	if location == "-" {
+		// Read from stdin.
+		data, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(data) == 0 {
+			return nil, fmt.Errorf(`Read from stdin specified ("-") but no data found`)
+		}
+
+		return data, nil
+	}
+
+	// Use the location as a file path or URL.
+	return readConfigDataFromLocation(location)
+}
+
+func readConfigDataFromLocation(location string) ([]byte, error) {
+	// we look for http:// or https:// to determine if valid URL, otherwise do normal file IO
+	if strings.Index(location, "http://") == 0 || strings.Index(location, "https://") == 0 {
+		resp, err := http.Get(location)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to access URL %s: %v\n", location, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			return nil, fmt.Errorf("Unable to read URL, server reported %d %s", resp.StatusCode, resp.Status)
+		}
+		data, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to read URL %s: %v\n", location, err)
+		}
+		return data, nil
+	} else {
+		data, err := ioutil.ReadFile(location)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to read %s: %v\n", location, err)
+		}
+		return data, nil
+	}
+}

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"io"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdCreate(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create -f filename",
+		Short: "Create a resource by filename or stdin",
+		Long: `Create a resource by filename or stdin.
+
+JSON and YAML formats are accepted.
+
+Examples:
+  $ kubectl create -f pod.json
+  <create a pod using the data in pod.json>
+
+  $ cat pod.json | kubectl create -f -
+  <create a pod based on the json passed into stdin>`,
+		Run: func(cmd *cobra.Command, args []string) {
+			filename := getFlagString(cmd, "filename")
+			if len(filename) == 0 {
+				usageError(cmd, "Must pass a filename to update")
+			}
+			data, err := readConfigData(filename)
+			checkErr(err)
+
+			err = kubectl.Modify(out, getKubeClient(cmd).RESTClient, kubectl.ModifyCreate, data)
+			checkErr(err)
+		},
+	}
+	cmd.Flags().StringP("filename", "f", "", "Filename or URL to file to use to create the resource")
+	return cmd
+}

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"io"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdDelete(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete ([-f filename] | (<resource> <id>))",
+		Short: "Delete a resource by filename, stdin or resource and id",
+		Long: `Delete a resource by filename, stdin or resource and id.
+
+JSON and YAML formats are accepted.
+
+If both a filename and command line arguments are passed, the command line
+arguments are used and the filename is ignored.
+
+Note that the delete command does NOT do resource version checks, so if someone
+submits an update to a resource right when you submit a delete, their update
+will be lost along with the rest of the resource.
+
+Examples:
+  $ kubectl delete -f pod.json
+  <delete a pod using the type and id pod.json>
+
+  $ cat pod.json | kubectl delete -f -
+  <delete a pod based on the type and id in the json passed into stdin>
+
+  $ kubectl delete pod 1234-56-7890-234234-456456
+  <delete a pod with ID 1234-56-7890-234234-456456>`,
+		Run: func(cmd *cobra.Command, args []string) {
+			// If command line args are passed in, use those preferentially.
+			if len(args) > 0 && len(args) != 2 {
+				usageError(cmd, "If passing in command line parameters, must be resource and id")
+			}
+
+			var data []byte
+			var err error
+
+			if len(args) == 2 {
+				data, err = kubectl.CreateResource(args[0], args[1])
+			} else {
+				filename := getFlagString(cmd, "filename")
+				if len(filename) > 0 {
+					data, err = readConfigData(getFlagString(cmd, "filename"))
+				}
+			}
+			checkErr(err)
+
+			if len(data) == 0 {
+				usageError(cmd, "Must specify filename or command line params")
+			}
+
+			// TODO Add ability to require a resource-version check for delete.
+			err = kubectl.Modify(out, getKubeClient(cmd).RESTClient, kubectl.ModifyDelete, data)
+			checkErr(err)
+		},
+	}
+	cmd.Flags().StringP("filename", "f", "", "Filename or URL to file to use to delete the resource")
+	return cmd
+}

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"io"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdDescribe(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "describe <resource> <id>",
+		Short: "Show details of a specific resource",
+		Long: `Show details of a specific resource.
+
+This command joins many API calls together to form a detailed description of a
+given resource.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) < 2 {
+				usageError(cmd, "Need to supply a resource and an ID")
+			}
+			resource := args[0]
+			id := args[1]
+			err := kubectl.Describe(out, getKubeClient(cmd), resource, id)
+			checkErr(err)
+		},
+	}
+	return cmd
+}

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"io"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdGet(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get [(-o|--output=)table|json|yaml|template] [-t <file>|--template=<file>] <resource> [<id>]",
+		Short: "Display one or many resources",
+		Long: `Display one or many resources.
+
+Possible resources include pods (po), replication controllers (rc), services
+(se) or minions (mi).
+
+If you specify a Go template, you can use any field defined in pkg/api/types.go.
+
+Examples:
+  $ kubectl get pods
+  <list all pods in ps output format>
+
+  $ kubectl get replicationController 1234-56-7890-234234-456456
+  <list single repliaction controller in ps output format>
+
+  $ kubectl get -f json pod 1234-56-7890-234234-456456
+  <list single pod in json output format>`,
+		Run: func(cmd *cobra.Command, args []string) {
+			var resource, id string
+			if len(args) == 0 {
+				usageError(cmd, "Need to supply a resource.")
+			}
+			if len(args) >= 1 {
+				resource = args[0]
+			}
+			if len(args) >= 2 {
+				id = args[1]
+			}
+			outputFormat := getFlagString(cmd, "output")
+			templateFile := getFlagString(cmd, "template")
+			selector := getFlagString(cmd, "selector")
+			err := kubectl.Get(out, getKubeClient(cmd).RESTClient, resource, id, selector, outputFormat, templateFile)
+			checkErr(err)
+		},
+	}
+	// TODO Add an --output-version lock which can ensure that regardless of the
+	// server version, the client output stays the same.
+	cmd.Flags().StringP("output", "o", "console", "Output format: console|json|yaml|template")
+	cmd.Flags().StringP("template", "t", "", "Path to template file to use when --output=template")
+	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on")
+	return cmd
+}

--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"io"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdProxy(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "proxy",
+		Short: "Run a proxy to the Kubernetes API server",
+		Long:  `Run a proxy to the Kubernetes API server.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			port := getFlagInt(cmd, "port")
+			glog.Infof("Starting to serve on localhost:%d", port)
+			server := kubectl.NewProxyServer(getFlagString(cmd, "www"), getKubeClient(cmd), port)
+			glog.Fatal(server.Serve())
+		},
+	}
+	cmd.Flags().StringP("www", "w", "", "Also serve static files from the given directory under the prefix /static")
+	cmd.Flags().IntP("port", "p", 8001, "The port on which to run the proxy")
+	return cmd
+}

--- a/pkg/kubectl/cmd/update.go
+++ b/pkg/kubectl/cmd/update.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"io"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdUpdate(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update -f filename",
+		Short: "Update a resource by filename or stdin",
+		Long: `Update a resource by filename or stdin.
+
+JSON and YAML formats are accepted.
+
+Examples:
+  $ kubectl update -f pod.json
+  <update a pod using the data in pod.json>
+
+  $ cat pod.json | kubectl update -f -
+  <update a pod based on the json passed into stdin>`,
+		Run: func(cmd *cobra.Command, args []string) {
+			filename := getFlagString(cmd, "filename")
+			if len(filename) == 0 {
+				usageError(cmd, "Must pass a filename to update")
+			}
+
+			data, err := readConfigData(filename)
+			checkErr(err)
+
+			err = kubectl.Modify(out, getKubeClient(cmd).RESTClient, kubectl.ModifyUpdate, data)
+			checkErr(err)
+		},
+	}
+	cmd.Flags().StringP("filename", "f", "", "Filename or URL to file to use to update the resource")
+	return cmd
+}

--- a/pkg/kubectl/cmd/version.go
+++ b/pkg/kubectl/cmd/version.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"io"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdVersion(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print version of client and server",
+		Run: func(cmd *cobra.Command, args []string) {
+			if getFlagBool(cmd, "client") {
+				kubectl.GetClientVersion(out)
+			} else {
+				kubectl.GetVersion(out, getKubeClient(cmd))
+			}
+		},
+	}
+	cmd.Flags().BoolP("client", "c", false, "Client version only (no server required)")
+	return cmd
+}

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/golang/glog"
+)
+
+func Describe(w io.Writer, c client.Interface, resource, id string) error {
+	var str string
+	var err error
+	path, err := resolveResource(resolveToPath, resource)
+	if err != nil {
+		return err
+	}
+	switch path {
+	case "pods":
+		str, err = describePod(w, c, id)
+	case "replicationControllers":
+		str, err = describeReplicationController(w, c, id)
+	case "services":
+		str, err = describeService(w, c, id)
+	case "minions":
+		str, err = describeMinion(w, c, id)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(w, str)
+	return err
+}
+
+func describePod(w io.Writer, c client.Interface, id string) (string, error) {
+	pod, err := c.GetPod(api.NewDefaultContext(), id)
+	if err != nil {
+		return "", err
+	}
+
+	return tabbedString(func(out *tabwriter.Writer) error {
+		fmt.Fprintf(out, "ID:\t%s\n", pod.ID)
+		fmt.Fprintf(out, "Image(s):\t%s\n", makeImageList(pod.DesiredState.Manifest))
+		fmt.Fprintf(out, "Host:\t%s\n", pod.CurrentState.Host+"/"+pod.CurrentState.HostIP)
+		fmt.Fprintf(out, "Labels:\t%s\n", formatLabels(pod.Labels))
+		fmt.Fprintf(out, "Status:\t%s\n", string(pod.CurrentState.Status))
+		fmt.Fprintf(out, "Replication Controllers:\t%s\n", getReplicationControllersForLabels(c, labels.Set(pod.Labels)))
+		return nil
+	})
+}
+
+func describeReplicationController(w io.Writer, c client.Interface, id string) (string, error) {
+	rc, err := c.GetReplicationController(api.NewDefaultContext(), id)
+	if err != nil {
+		return "", err
+	}
+
+	running, waiting, terminated, err := getPodStatusForReplicationController(c, rc)
+	if err != nil {
+		return "", err
+	}
+
+	return tabbedString(func(out *tabwriter.Writer) error {
+		fmt.Fprintf(out, "ID:\t%s\n", rc.ID)
+		fmt.Fprintf(out, "Image(s):\t%s\n", makeImageList(rc.DesiredState.PodTemplate.DesiredState.Manifest))
+		fmt.Fprintf(out, "Selector:\t%s\n", formatLabels(rc.DesiredState.ReplicaSelector))
+		fmt.Fprintf(out, "Labels:\t%s\n", formatLabels(rc.Labels))
+		fmt.Fprintf(out, "Replicas:\t%d current / %d desired\n", rc.CurrentState.Replicas, rc.DesiredState.Replicas)
+		fmt.Fprintf(out, "Pods Status:\t%d Running / %d Waiting / %d Terminated\n", running, waiting, terminated)
+		return nil
+	})
+}
+
+func describeService(w io.Writer, c client.Interface, id string) (string, error) {
+	s, err := c.GetService(api.NewDefaultContext(), id)
+	if err != nil {
+		return "", err
+	}
+
+	return tabbedString(func(out *tabwriter.Writer) error {
+		fmt.Fprintf(out, "ID:\t%s\n", s.ID)
+		fmt.Fprintf(out, "Labels:\t%s\n", formatLabels(s.Labels))
+		fmt.Fprintf(out, "Selector:\t%s\n", formatLabels(s.Selector))
+		fmt.Fprintf(out, "Port:\t%d\n", s.Port)
+		return nil
+	})
+}
+
+func describeMinion(w io.Writer, c client.Interface, id string) (string, error) {
+	m, err := getMinion(c, id)
+	if err != nil {
+		return "", err
+	}
+
+	return tabbedString(func(out *tabwriter.Writer) error {
+		fmt.Fprintf(out, "ID:\t%s\n", m.ID)
+		return nil
+	})
+}
+
+// client.Interface doesn't have GetMinion(id) yet so we hack it up.
+func getMinion(c client.Interface, id string) (*api.Minion, error) {
+	minionList, err := c.ListMinions()
+	if err != nil {
+		glog.Fatalf("Error getting minion info: %v\n", err)
+	}
+
+	for _, m := range minionList.Items {
+		if id == m.TypeMeta.ID {
+			return &m, nil
+		}
+	}
+	return nil, fmt.Errorf("Minion %s not found", id)
+}
+
+// Get all replication controllers whose selectors would match a given set of
+// labels.
+// TODO Move this to pkg/client and ideally implement it server-side (instead
+// of getting all RC's and searching through them manually).
+func getReplicationControllersForLabels(c client.Interface, labelsToMatch labels.Labels) string {
+	// Get all replication controllers.
+	rcs, err := c.ListReplicationControllers(api.NewDefaultContext(), labels.Everything())
+	if err != nil {
+		glog.Fatalf("Error getting replication controllers: %v\n", err)
+	}
+
+	// Find the ones that match labelsToMatch.
+	var matchingRCs []api.ReplicationController
+	for _, rc := range rcs.Items {
+		selector := labels.SelectorFromSet(rc.DesiredState.ReplicaSelector)
+		if selector.Matches(labelsToMatch) {
+			matchingRCs = append(matchingRCs, rc)
+		}
+	}
+
+	// Format the matching RC's into strings.
+	var rcStrings []string
+	for _, rc := range matchingRCs {
+		rcStrings = append(rcStrings, fmt.Sprintf("%s (%d/%d replicas created)", rc.ID, rc.CurrentState.Replicas, rc.DesiredState.Replicas))
+	}
+
+	list := strings.Join(rcStrings, ", ")
+	if list == "" {
+		return "<none>"
+	}
+	return list
+}
+
+func getPodStatusForReplicationController(kubeClient client.Interface, rc *api.ReplicationController) (running, waiting, terminated int, err error) {
+	rcPods, err := kubeClient.ListPods(api.NewDefaultContext(), labels.SelectorFromSet(rc.DesiredState.ReplicaSelector))
+	if err != nil {
+		return
+	}
+	for _, pod := range rcPods.Items {
+		if pod.CurrentState.Status == api.PodRunning {
+			running++
+		} else if pod.CurrentState.Status == api.PodWaiting {
+			waiting++
+		} else if pod.CurrentState.Status == api.PodTerminated {
+			terminated++
+		}
+	}
+	return
+}

--- a/pkg/kubectl/doc.go
+++ b/pkg/kubectl/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kubectl is a set of libraries that are used by the kubectl command line tool.
+// They are separated out into a library to support unit testing.  Most functionality should
+// be included in this package, and the main kubectl should really just be an entry point.
+package kubectl

--- a/pkg/kubectl/get.go
+++ b/pkg/kubectl/get.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+)
+
+func Get(w io.Writer, c *client.RESTClient, resource, id, selector, format, templateFile string) error {
+	path, err := resolveResource(resolveToPath, resource)
+	if err != nil {
+		return err
+	}
+
+	r := c.Verb("GET").Path(path)
+	if len(id) > 0 {
+		r.Path(id)
+	}
+	if len(selector) > 0 {
+		r.ParseSelectorParam("labels", selector)
+	}
+	result := r.Do()
+	obj, err := result.Get()
+	if err != nil {
+		return err
+	}
+
+	printer, err := getPrinter(format, templateFile)
+	if err != nil {
+		return err
+	}
+
+	if err = printer.PrintObj(obj, w); err != nil {
+		body, _ := result.Raw()
+		return fmt.Errorf("Failed to print: %v\nRaw received object:\n%#v\n\nBody received: %v", err, obj, string(body))
+	}
+
+	return nil
+}

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// A set of common functions needed by cmd/kubectl and pkg/kubectl packages.
+package kubectl
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
+	"gopkg.in/v1/yaml"
+)
+
+var apiVersionToUse = "v1beta1"
+
+func GetKubeClient(config *client.Config, matchVersion bool) (*client.Client, error) {
+	// TODO: get the namespace context when kubectl ns is completed
+	c, err := client.New(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if matchVersion {
+		clientVersion := version.Get()
+		serverVersion, err := c.ServerVersion()
+		if err != nil {
+			return nil, fmt.Errorf("Couldn't read version from server: %v\n", err)
+		}
+		if s := *serverVersion; !reflect.DeepEqual(clientVersion, s) {
+			return nil, fmt.Errorf("Server version (%#v) differs from client version (%#v)!\n", s, clientVersion)
+		}
+	}
+
+	return c, nil
+}
+
+type AuthInfo struct {
+	User     string
+	Password string
+	CAFile   string
+	CertFile string
+	KeyFile  string
+	Insecure *bool
+}
+
+// LoadAuthInfo parses an AuthInfo object from a file path. It prompts user and creates file if it doesn't exist.
+func LoadAuthInfo(path string, r io.Reader) (*AuthInfo, error) {
+	var auth AuthInfo
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		auth.User = promptForString("Username", r)
+		auth.Password = promptForString("Password", r)
+		data, err := json.Marshal(auth)
+		if err != nil {
+			return &auth, err
+		}
+		err = ioutil.WriteFile(path, data, 0600)
+		return &auth, err
+	}
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(data, &auth)
+	if err != nil {
+		return nil, err
+	}
+	return &auth, err
+}
+
+func promptForString(field string, r io.Reader) string {
+	fmt.Printf("Please enter %s: ", field)
+	var result string
+	fmt.Fscan(r, &result)
+	return result
+}
+
+func CreateResource(resource, id string) ([]byte, error) {
+	kind, err := resolveResource(resolveToKind, resource)
+	if err != nil {
+		return nil, err
+	}
+
+	s := fmt.Sprintf(`{"kind": "%s", "apiVersion": "%s", "id": "%s"}`, kind, apiVersionToUse, id)
+	return []byte(s), nil
+}
+
+// TODO Move to labels package.
+func formatLabels(labelMap map[string]string) string {
+	l := labels.Set(labelMap).String()
+	if l == "" {
+		l = "<none>"
+	}
+	return l
+}
+
+func makeImageList(manifest api.ContainerManifest) string {
+	var images []string
+	for _, container := range manifest.Containers {
+		images = append(images, container.Image)
+	}
+	return strings.Join(images, ",")
+}
+
+// Takes input 'data' as either json or yaml and attemps to decode it into the
+// supplied object.
+func dataToObject(data []byte) (runtime.Object, error) {
+	// This seems hacky but we can't get the codec from kubeClient.
+	versionInterfaces, err := latest.InterfacesFor(apiVersionToUse)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := versionInterfaces.Codec.Decode(data)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+const (
+	resolveToPath = "path"
+	resolveToKind = "kind"
+)
+
+// Takes a human-friendly reference to a resource and converts it to either a
+// resource path for an API call or to a Kind to construct a JSON definition.
+// See usages of the function for more context.
+//
+// target is one of the above constants ("path" or "kind") to determine what to
+// resolve the resource to.
+//
+// resource is the human-friendly reference to the resource you want to
+// convert.
+func resolveResource(target, resource string) (string, error) {
+	if target != resolveToPath && target != resolveToKind {
+		return "", fmt.Errorf("Unrecognized target to convert to: %s", target)
+	}
+
+	var resolved string
+	var err error
+	// Caseless comparison.
+	resource = strings.ToLower(resource)
+	switch resource {
+	case "pods", "pod", "po":
+		if target == resolveToPath {
+			resolved = "pods"
+		} else {
+			resolved = "Pod"
+		}
+	case "replicationcontrollers", "replicationcontroller", "rc":
+		if target == resolveToPath {
+			resolved = "replicationControllers"
+		} else {
+			resolved = "ReplicationController"
+		}
+	case "services", "service", "se":
+		if target == resolveToPath {
+			resolved = "services"
+		} else {
+			resolved = "Service"
+		}
+	case "minions", "minion", "mi":
+		if target == resolveToPath {
+			resolved = "minions"
+		} else {
+			resolved = "Minion"
+		}
+	default:
+		// It might be a GUID, but we don't know how to handle those for now.
+		err = fmt.Errorf("Resource %s not recognized; need pods, replicationContollers, services or minions.", resource)
+	}
+	return resolved, err
+}
+
+func resolveKindToResource(kind string) (resource string, err error) {
+	// Determine the REST resource according to the type in data.
+	switch kind {
+	case "Pod":
+		resource = "pods"
+	case "ReplicationController":
+		resource = "replicationControllers"
+	case "Service":
+		resource = "services"
+	default:
+		err = fmt.Errorf("Object %s not recognized", kind)
+	}
+	return
+}
+
+// versionAndKind will return the APIVersion and Kind of the given wire-format
+// enconding of an APIObject, or an error. This is hacked in until the
+// migration to v1beta3.
+func versionAndKind(data []byte) (version, kind string, err error) {
+	findKind := struct {
+		Kind       string `json:"kind,omitempty" yaml:"kind,omitempty"`
+		APIVersion string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	}{}
+	// yaml is a superset of json, so we use it to decode here. That way,
+	// we understand both.
+	err = yaml.Unmarshal(data, &findKind)
+	if err != nil {
+		return "", "", fmt.Errorf("couldn't get version/kind: %v", err)
+	}
+	return findKind.APIVersion, findKind.Kind, nil
+}

--- a/pkg/kubectl/kubectl_test.go
+++ b/pkg/kubectl/kubectl_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+)
+
+func validateAction(expectedAction, actualAction client.FakeAction, t *testing.T) {
+	if !reflect.DeepEqual(expectedAction, actualAction) {
+		t.Errorf("Unexpected Action: %#v, expected: %#v", actualAction, expectedAction)
+	}
+}
+
+func TestLoadAuthInfo(t *testing.T) {
+	loadAuthInfoTests := []struct {
+		authData string
+		authInfo *AuthInfo
+		r        io.Reader
+	}{
+		{
+			`{"user": "user", "password": "pass"}`,
+			&AuthInfo{User: "user", Password: "pass"},
+			nil,
+		},
+		{
+			"", nil, nil,
+		},
+		{
+			"missing",
+			&AuthInfo{User: "user", Password: "pass"},
+			bytes.NewBufferString("user\npass"),
+		},
+	}
+	for _, loadAuthInfoTest := range loadAuthInfoTests {
+		tt := loadAuthInfoTest
+		aifile, err := ioutil.TempFile("", "testAuthInfo")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if tt.authData != "missing" {
+			defer os.Remove(aifile.Name())
+			defer aifile.Close()
+			_, err = aifile.WriteString(tt.authData)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		} else {
+			aifile.Close()
+			os.Remove(aifile.Name())
+		}
+		authInfo, err := LoadAuthInfo(aifile.Name(), tt.r)
+		if len(tt.authData) == 0 && tt.authData != "missing" {
+			if err == nil {
+				t.Error("LoadAuthInfo didn't fail on empty file")
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(authInfo, tt.authInfo) {
+			t.Errorf("Expected %v, got %v", tt.authInfo, authInfo)
+		}
+	}
+}

--- a/pkg/kubectl/modify.go
+++ b/pkg/kubectl/modify.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+)
+
+type ModifyAction string
+
+const (
+	ModifyCreate = ModifyAction("create")
+	ModifyUpdate = ModifyAction("update")
+	ModifyDelete = ModifyAction("delete")
+)
+
+func Modify(w io.Writer, c *client.RESTClient, action ModifyAction, data []byte) error {
+	if action != ModifyCreate && action != ModifyUpdate && action != ModifyDelete {
+		return fmt.Errorf("Action not recognized")
+	}
+
+	// TODO Support multiple API versions.
+	version, kind, err := versionAndKind(data)
+	if err != nil {
+		return err
+	}
+
+	if version != apiVersionToUse {
+		return fmt.Errorf("Only supporting API version '%s' for now (version '%s' specified)", apiVersionToUse, version)
+	}
+
+	obj, err := dataToObject(data)
+	if err != nil {
+		if err.Error() == "No type '' for version ''" {
+			return fmt.Errorf("Object could not be decoded. Make sure it has the Kind field defined.")
+		}
+		return err
+	}
+
+	resource, err := resolveKindToResource(kind)
+	if err != nil {
+		return err
+	}
+
+	var id string
+	switch action {
+	case "create":
+		id, err = doCreate(c, resource, data)
+	case "update":
+		id, err = doUpdate(c, resource, obj)
+	case "delete":
+		id, err = doDelete(c, resource, obj)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(w, "%s\n", id)
+	return nil
+}
+
+// Creates the object then returns the ID of the newly created object.
+func doCreate(c *client.RESTClient, resource string, data []byte) (string, error) {
+	obj, err := c.Post().Path(resource).Body(data).Do().Get()
+	if err != nil {
+		return "", err
+	}
+	return getIDFromObj(obj)
+}
+
+// Creates the object then returns the ID of the newly created object.
+func doUpdate(c *client.RESTClient, resource string, obj runtime.Object) (string, error) {
+	// Figure out the ID of the object to update by introspecting into the
+	// object.
+	id, err := getIDFromObj(obj)
+	if err != nil {
+		return "", fmt.Errorf("ID not retrievable from object for update: %v", err)
+	}
+
+	// Get the object from the server to find out its current resource
+	// version to prevent race conditions in updating the object.
+	serverObj, err := c.Get().Path(resource).Path(id).Do().Get()
+	if err != nil {
+		return "", fmt.Errorf("Item ID %s does not exist for update: %v", id, err)
+	}
+	version, err := getResourceVersionFromObj(serverObj)
+	if err != nil {
+		return "", err
+	}
+
+	// Update the object we are trying to send to the server with the
+	// correct resource version.
+	typeMeta, err := runtime.FindTypeMeta(obj)
+	if err != nil {
+		return "", err
+	}
+	typeMeta.SetResourceVersion(version)
+
+	// Convert object with updated resourceVersion to data for PUT.
+	data, err := c.Codec.Encode(obj)
+	if err != nil {
+		return "", err
+	}
+
+	// Do the update.
+	err = c.Put().Path(resource).Path(id).Body(data).Do().Error()
+	fmt.Printf("r: %q, i: %q, d: %s", resource, id, data)
+	if err != nil {
+		return "", err
+	}
+
+	return id, nil
+}
+
+func doDelete(c *client.RESTClient, resource string, obj runtime.Object) (string, error) {
+	id, err := getIDFromObj(obj)
+	if err != nil {
+		return "", fmt.Errorf("ID not retrievable from object for update: %v", err)
+	}
+
+	err = c.Delete().Path(resource).Path(id).Do().Error()
+	if err != nil {
+		return "", err
+	}
+
+	return id, nil
+}
+
+func getIDFromObj(obj runtime.Object) (string, error) {
+	typeMeta, err := runtime.FindTypeMeta(obj)
+	if err != nil {
+		return "", err
+	}
+	return typeMeta.ID(), nil
+}
+
+func getResourceVersionFromObj(obj runtime.Object) (string, error) {
+	typeMeta, err := runtime.FindTypeMeta(obj)
+	if err != nil {
+		return "", err
+	}
+	return typeMeta.ResourceVersion(), nil
+}

--- a/pkg/kubectl/proxy_server.go
+++ b/pkg/kubectl/proxy_server.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+)
+
+// ProxyServer is a http.Handler which proxies Kubernetes APIs to remote API server.
+type ProxyServer struct {
+	Client *client.Client
+	Port   int
+}
+
+func newFileHandler(prefix, base string) http.Handler {
+	return http.StripPrefix(prefix, http.FileServer(http.Dir(base)))
+}
+
+// NewProxyServer creates and installs a new ProxyServer.
+// It automatically registers the created ProxyServer to http.DefaultServeMux.
+func NewProxyServer(filebase string, kubeClient *client.Client, port int) *ProxyServer {
+	server := &ProxyServer{
+		Client: kubeClient,
+		Port:   port,
+	}
+	http.Handle("/api/", server)
+	http.Handle("/static/", newFileHandler("/static/", filebase))
+	return server
+}
+
+// Serve starts the server (http.DefaultServeMux) on TCP port 8001, loops forever.
+func (s *ProxyServer) Serve() error {
+	addr := fmt.Sprintf(":%d", s.Port)
+	return http.ListenAndServe(addr, nil)
+}
+
+func (s *ProxyServer) doError(w http.ResponseWriter, err error) {
+	w.WriteHeader(http.StatusInternalServerError)
+	w.Header().Add("Content-type", "application/json")
+	data, _ := latest.Codec.Encode(&api.Status{
+		Status:  api.StatusFailure,
+		Message: fmt.Sprintf("internal error: %#v", err),
+	})
+	w.Write(data)
+}
+
+func (s *ProxyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	url := r.URL
+	selector := url.Query().Get("labels")
+	fieldSelector := url.Query().Get("fields")
+	result := s.Client.
+		Verb(r.Method).
+		AbsPath(r.URL.Path).
+		ParseSelectorParam("labels", selector).
+		ParseSelectorParam("fields", fieldSelector).
+		Body(r.Body).
+		Do()
+	if result.Error() != nil {
+		s.doError(w, result.Error())
+		return
+	}
+	data, err := result.Raw()
+	if err != nil {
+		s.doError(w, err)
+		return
+	}
+	w.Header().Add("Content-type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(data)
+}

--- a/pkg/kubectl/proxy_server_test.go
+++ b/pkg/kubectl/proxy_server_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFileServing(t *testing.T) {
+	data := "This is test data"
+	dir, err := ioutil.TempDir("", "data")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	err = ioutil.WriteFile(dir+"/test.txt", []byte(data), 0755)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	prefix := "/foo/"
+	handler := newFileHandler(prefix, dir)
+	server := httptest.NewServer(handler)
+	client := http.Client{}
+	req, err := http.NewRequest("GET", server.URL+prefix+"test.txt", nil)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	defer res.Body.Close()
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("Unexpected status: %d", res.StatusCode)
+	}
+	if string(b) != data {
+		t.Errorf("Data doesn't match: %s vs %s", string(b), data)
+	}
+}

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"reflect"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/golang/glog"
+	"gopkg.in/v1/yaml"
+)
+
+func getPrinter(format, templateFile string) (ResourcePrinter, error) {
+	var printer ResourcePrinter
+	switch format {
+	case "json":
+		printer = &JSONPrinter{}
+	case "yaml":
+		printer = &YAMLPrinter{}
+	case "template":
+		var data []byte
+		if len(templateFile) > 0 {
+			var err error
+			data, err = ioutil.ReadFile(templateFile)
+			if err != nil {
+				return printer, fmt.Errorf("Error reading template %s, %v\n", templateFile, err)
+			}
+		} else {
+			return printer, fmt.Errorf("template format specified but no template file given")
+		}
+		tmpl, err := template.New("output").Parse(string(data))
+		if err != nil {
+			return printer, fmt.Errorf("Error parsing template %s, %v\n", string(data), err)
+		}
+		printer = &TemplatePrinter{
+			Template: tmpl,
+		}
+	default:
+		printer = NewHumanReadablePrinter()
+	}
+	return printer, nil
+}
+
+// ResourcePrinter is an interface that knows how to print API resources.
+type ResourcePrinter interface {
+	// Print receives an arbitrary JSON body, formats it and prints it to a writer.
+	PrintObj(runtime.Object, io.Writer) error
+}
+
+// IdentityPrinter is an implementation of ResourcePrinter which simply copies the body out to the output stream.
+type JSONPrinter struct{}
+
+// PrintObj is an implementation of ResourcePrinter.PrintObj which simply writes the object to the Writer.
+func (i *JSONPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	output, err := json.MarshalIndent(obj, "", "    ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(w, string(output)+"\n")
+	return err
+}
+
+// YAMLPrinter is an implementation of ResourcePrinter which parsess JSON, and re-formats as YAML.
+type YAMLPrinter struct{}
+
+// PrintObj prints the data as YAML.
+func (y *YAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	output, err := yaml.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(w, string(output))
+	return err
+}
+
+type handlerEntry struct {
+	columns   []string
+	printFunc reflect.Value
+}
+
+// HumanReadablePrinter is an implementation of ResourcePrinter which attempts to provide more elegant output.
+type HumanReadablePrinter struct {
+	handlerMap map[reflect.Type]*handlerEntry
+}
+
+// NewHumanReadablePrinter creates a HumanReadablePrinter.
+func NewHumanReadablePrinter() *HumanReadablePrinter {
+	printer := &HumanReadablePrinter{make(map[reflect.Type]*handlerEntry)}
+	printer.addDefaultHandlers()
+	return printer
+}
+
+// Handler adds a print handler with a given set of columns to HumanReadablePrinter instance.
+// printFunc is the function that will be called to print an object.
+// It must be of the following type:
+//  func printFunc(object ObjectType, w io.Writer) error
+// where ObjectType is the type of the object that will be printed.
+func (h *HumanReadablePrinter) Handler(columns []string, printFunc interface{}) error {
+	printFuncValue := reflect.ValueOf(printFunc)
+	if err := h.validatePrintHandlerFunc(printFuncValue); err != nil {
+		glog.Errorf("Unable to add print handler: %v", err)
+		return err
+	}
+	objType := printFuncValue.Type().In(0)
+	h.handlerMap[objType] = &handlerEntry{
+		columns:   columns,
+		printFunc: printFuncValue,
+	}
+	return nil
+}
+
+func (h *HumanReadablePrinter) validatePrintHandlerFunc(printFunc reflect.Value) error {
+	if printFunc.Kind() != reflect.Func {
+		return fmt.Errorf("Invalid print handler. %#v is not a function.", printFunc)
+	}
+	funcType := printFunc.Type()
+	if funcType.NumIn() != 2 || funcType.NumOut() != 1 {
+		return fmt.Errorf("Invalid print handler." +
+			"Must accept 2 parameters and return 1 value.")
+	}
+	if funcType.In(1) != reflect.TypeOf((*io.Writer)(nil)).Elem() ||
+		funcType.Out(0) != reflect.TypeOf((*error)(nil)).Elem() {
+		return fmt.Errorf("Invalid print handler. The expected signature is: "+
+			"func handler(obj %v, w io.Writer) error", funcType.In(0))
+	}
+	return nil
+}
+
+var podColumns = []string{"ID", "IMAGE(S)", "HOST", "LABELS", "STATUS"}
+var replicationControllerColumns = []string{"ID", "IMAGE(S)", "SELECTOR", "REPLICAS"}
+var serviceColumns = []string{"ID", "LABELS", "SELECTOR", "PORT"}
+var minionColumns = []string{"ID"}
+var statusColumns = []string{"STATUS"}
+
+// addDefaultHandlers adds print handlers for default Kubernetes types.
+func (h *HumanReadablePrinter) addDefaultHandlers() {
+	h.Handler(podColumns, printPod)
+	h.Handler(podColumns, printPodList)
+	h.Handler(replicationControllerColumns, printReplicationController)
+	h.Handler(replicationControllerColumns, printReplicationControllerList)
+	h.Handler(serviceColumns, printService)
+	h.Handler(serviceColumns, printServiceList)
+	h.Handler(minionColumns, printMinion)
+	h.Handler(minionColumns, printMinionList)
+	h.Handler(statusColumns, printStatus)
+}
+
+func (h *HumanReadablePrinter) unknown(data []byte, w io.Writer) error {
+	_, err := fmt.Fprintf(w, "Unknown object: %s", string(data))
+	return err
+}
+
+func (h *HumanReadablePrinter) printHeader(columnNames []string, w io.Writer) error {
+	if _, err := fmt.Fprintf(w, "%s\n", strings.Join(columnNames, "\t")); err != nil {
+		return err
+	}
+	return nil
+}
+
+func podHostString(host, ip string) string {
+	if host == "" && ip == "" {
+		return "<unassigned>"
+	}
+	return host + "/" + ip
+}
+
+func printPod(pod *api.Pod, w io.Writer) error {
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+		pod.ID, makeImageList(pod.DesiredState.Manifest),
+		podHostString(pod.CurrentState.Host, pod.CurrentState.HostIP),
+		labels.Set(pod.Labels), pod.CurrentState.Status)
+	return err
+}
+
+func printPodList(podList *api.PodList, w io.Writer) error {
+	for _, pod := range podList.Items {
+		if err := printPod(&pod, w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printReplicationController(ctrl *api.ReplicationController, w io.Writer) error {
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%d\n",
+		ctrl.ID, makeImageList(ctrl.DesiredState.PodTemplate.DesiredState.Manifest),
+		labels.Set(ctrl.DesiredState.ReplicaSelector), ctrl.DesiredState.Replicas)
+	return err
+}
+
+func printReplicationControllerList(list *api.ReplicationControllerList, w io.Writer) error {
+	for _, ctrl := range list.Items {
+		if err := printReplicationController(&ctrl, w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printService(svc *api.Service, w io.Writer) error {
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%d\n", svc.ID, labels.Set(svc.Labels),
+		labels.Set(svc.Selector), svc.Port)
+	return err
+}
+
+func printServiceList(list *api.ServiceList, w io.Writer) error {
+	for _, svc := range list.Items {
+		if err := printService(&svc, w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printMinion(minion *api.Minion, w io.Writer) error {
+	_, err := fmt.Fprintf(w, "%s\n", minion.ID)
+	return err
+}
+
+func printMinionList(list *api.MinionList, w io.Writer) error {
+	for _, minion := range list.Items {
+		if err := printMinion(&minion, w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printStatus(status *api.Status, w io.Writer) error {
+	_, err := fmt.Fprintf(w, "%v\n", status.Status)
+	return err
+}
+
+// PrintObj prints the obj in a human-friendly format according to the type of the obj.
+func (h *HumanReadablePrinter) PrintObj(obj runtime.Object, output io.Writer) error {
+	w := tabwriter.NewWriter(output, 20, 5, 3, ' ', 0)
+	defer w.Flush()
+	if handler := h.handlerMap[reflect.TypeOf(obj)]; handler != nil {
+		h.printHeader(handler.columns, w)
+		args := []reflect.Value{reflect.ValueOf(obj), reflect.ValueOf(w)}
+		resultValue := handler.printFunc.Call(args)[0]
+		if resultValue.IsNil() {
+			return nil
+		} else {
+			return resultValue.Interface().(error)
+		}
+	} else {
+		return fmt.Errorf("Error: unknown type %#v", obj)
+	}
+}
+
+// TemplatePrinter is an implementation of ResourcePrinter which formats data with a Go Template.
+type TemplatePrinter struct {
+	Template *template.Template
+}
+
+// PrintObj formats the obj with the Go Template.
+func (t *TemplatePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	return t.Template.Execute(w, obj)
+}
+
+func tabbedString(f func(*tabwriter.Writer) error) (string, error) {
+	out := new(tabwriter.Writer)
+	b := make([]byte, 1024)
+	buf := bytes.NewBuffer(b)
+	out.Init(buf, 0, 8, 1, '\t', 0)
+
+	err := f(out)
+	if err != nil {
+		return "", err
+	}
+
+	out.Flush()
+	str := string(buf.String())
+	return str, nil
+}

--- a/pkg/kubectl/resource_printer_test.go
+++ b/pkg/kubectl/resource_printer_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"gopkg.in/v1/yaml"
+)
+
+type testStruct struct {
+	Key        string         `yaml:"Key" json:"Key"`
+	Map        map[string]int `yaml:"Map" json:"Map"`
+	StringList []string       `yaml:"StringList" json:"StringList"`
+	IntList    []int          `yaml:"IntList" json:"IntList"`
+}
+
+func (ts *testStruct) IsAnAPIObject() {}
+
+var testData = testStruct{
+	"testValue",
+	map[string]int{"TestSubkey": 1},
+	[]string{"a", "b", "c"},
+	[]int{1, 2, 3},
+}
+
+func TestYAMLPrinter(t *testing.T) {
+	testPrinter(t, &YAMLPrinter{}, yaml.Unmarshal)
+}
+
+func TestJSONPrinter(t *testing.T) {
+	testPrinter(t, &JSONPrinter{}, json.Unmarshal)
+}
+
+func testPrinter(t *testing.T, printer ResourcePrinter, unmarshalFunc func(data []byte, v interface{}) error) {
+	buf := bytes.NewBuffer([]byte{})
+
+	err := printer.PrintObj(&testData, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var poutput testStruct
+	err = yaml.Unmarshal(buf.Bytes(), &poutput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(testData, poutput) {
+		t.Errorf("Test data and unmarshaled data are not equal: %#v vs %#v", poutput, testData)
+	}
+
+	obj := &api.Pod{
+		TypeMeta: api.TypeMeta{ID: "foo"},
+	}
+	buf.Reset()
+	printer.PrintObj(obj, buf)
+	var objOut api.Pod
+	err = yaml.Unmarshal([]byte(buf.String()), &objOut)
+	if err != nil {
+		t.Errorf("Unexpeted error: %#v", err)
+	}
+	if !reflect.DeepEqual(obj, &objOut) {
+		t.Errorf("Unexpected inequality: %#v vs %#v", obj, &objOut)
+	}
+}
+
+type TestPrintType struct {
+	Data string
+}
+
+func (*TestPrintType) IsAnAPIObject() {}
+
+type TestUnknownType struct{}
+
+func (*TestUnknownType) IsAnAPIObject() {}
+
+func PrintCustomType(obj *TestPrintType, w io.Writer) error {
+	_, err := fmt.Fprintf(w, "%s", obj.Data)
+	return err
+}
+
+func ErrorPrintHandler(obj *TestPrintType, w io.Writer) error {
+	return fmt.Errorf("ErrorPrintHandler error")
+}
+
+func TestCustomTypePrinting(t *testing.T) {
+	columns := []string{"Data"}
+	printer := NewHumanReadablePrinter()
+	printer.Handler(columns, PrintCustomType)
+
+	obj := TestPrintType{"test object"}
+	buffer := &bytes.Buffer{}
+	err := printer.PrintObj(&obj, buffer)
+	if err != nil {
+		t.Errorf("An error occurred printing the custom type: %#v", err)
+	}
+	expectedOutput := "Data\ntest object"
+	if buffer.String() != expectedOutput {
+		t.Errorf("The data was not printed as expected. Expected:\n%s\nGot:\n%s", expectedOutput, buffer.String())
+	}
+}
+
+func TestPrintHandlerError(t *testing.T) {
+	columns := []string{"Data"}
+	printer := NewHumanReadablePrinter()
+	printer.Handler(columns, ErrorPrintHandler)
+	obj := TestPrintType{"test object"}
+	buffer := &bytes.Buffer{}
+	err := printer.PrintObj(&obj, buffer)
+	if err == nil || err.Error() != "ErrorPrintHandler error" {
+		t.Errorf("Did not get the expected error: %#v", err)
+	}
+}
+
+func TestUnknownTypePrinting(t *testing.T) {
+	printer := NewHumanReadablePrinter()
+	buffer := &bytes.Buffer{}
+	err := printer.PrintObj(&TestUnknownType{}, buffer)
+	if err == nil {
+		t.Errorf("An error was expected from printing unknown type")
+	}
+}

--- a/pkg/kubectl/version.go
+++ b/pkg/kubectl/version.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
+)
+
+func GetVersion(w io.Writer, kubeClient client.Interface) {
+	serverVersion, err := kubeClient.ServerVersion()
+	if err != nil {
+		fmt.Printf("Couldn't read version from server: %v\n", err)
+		os.Exit(1)
+	}
+
+	GetClientVersion(w)
+	fmt.Fprintf(w, "Server Version: %#v\n", serverVersion)
+}
+
+func GetClientVersion(w io.Writer) {
+	fmt.Fprintf(w, "Client Version: %#v\n", version.Get())
+}


### PR DESCRIPTION
**_UPDATE: This proposal was reworked many times throughout this PR. I am keeping this parent message the same for historical purposes, but you can find the closest description of the final design in [this comment](https://github.com/GoogleCloudPlatform/kubernetes/pull/1325#issuecomment-57416174) (with the exception that `inspect` became `describe`).**_
### Intent

The intent of this pull request is to propose a design for the present and future of kubecfg. The conversation from #1167 was the primary input into this design. The idea is to have kubecfg solve two use cases:
1. Provide a great user experience to view the current status of a Kubernetes cluster and to execute simple commands on the cluster.
2. Provide a tool which will accept configuration with generic resources to submit changes to and diff against a Kubernetes cluster.

The problem with the current design is that it is too generic to effectively support (1). The proposed redesign enables custom commands per resource (e.g. kubecfg pods, kubecfg services, etc.) but generic subcommands to satisfy (2) (kubecfg submit, kubecfg diff, kubecfg reconcile, etc.).
### Proposed set of subcommands

_Only a subset of these have been implemented in the attached commit._
- `kubecfg2` - Parent command.
  - `pods`
    - `list [<id>]` - List pods in a column-oriented view (see [Examples](#examples) below). By default, the first argument passed in acts as a filter by ID.
    - `get <id>` - List info about a pod in a row-oriented view. Designed to show more metadata about a given pod, and over time can be enhanced to make navigating the cluster from a given pod very easy. Currently I'm adding a list of any replication controllers whose selectors match (and therefore who control) the selected pod.
    - `delete <id>` - Delete a pod.
    - `create [-f <filename>]` - In the future we can accept directories or even data from stdin.
  - `rc` - For replication controllers. Happy to use a different abbreviation but replicationControllers seemed too long.
    - `list [<id>]`
    - `get <id>` - RC's `get` command could become extremely rich. For now I've added Pods Status which queries for pods under this replication controller and shows counts for running, waiting and terminated, but in the future you could do diffs against the controller's PodTemplate and show counts for matching and non-matching pods. You could also show the first 3-4 pod ID's per category and then show &lt;X more ...&gt;, making debugging even easier.
    - `create [-f <filename>]`
    - `update [-f <filename>]`
    - `delete <id>` - I have removed the delete/stop/rm replication controller confusion in favor of just `delete` and `resize`, where delete takes an optional --force flag if replicas > 0.
    - `resize <id> <replicas>`
    - _Removed_ `rollingupdate <controller> <image> <time>` - I've included this here for parity but I would like to propose taking it out. This is the one command that I don't think belongs in kubecfg ... it's too long-running, fraught with edge cases, and in reality would probably want to take more into consideration (like fluctuations in metrics, % of pods that come up successfully, etc.). I think this level of functionality belongs in an independent client that uses the API that can look at more components in the infrastructure than just kubernetes.
  - `minions`
    - `list [<id>]`
    - `get <id>`
  - `services`
    - `list [<id>]`
    - `get <id>`
    - `create [-f <filename>]`
    - `update [-f <filename>]`
    - `delete <id>`
    - _Postponed_ `resolve <id>` - Just an idea, but it could give you a random IP/port combination to connect to. May be useful for quickly locating a node to test for a given service.
  - _Postponed_ `submit [<filename>...]` - This command exists to satisfy the second use case above. Reconcile and submit any changes from a given set of config(s), from files or from stdin. If you had an entire directory tree of files that had configs that represented your cluster state, you could use this command to submit them all to either create or update your cluster.
  - _Postponed_ `diff [<filename>...]` - A dry-run version of `submit`.
  - `run [-p <port spec>] <image> <replicas> <controller>` - Same as today.
### Examples

Here is what the current commit produces:

_These examples are out of date - see [this comment](https://github.com/GoogleCloudPlatform/kubernetes/pull/1325#issuecomment-56786115) for the latest._

```
$ kubecfg2
kubecfg2 controls the Kubernetes cluster manager.

Find more information at https://github.com/GoogleCloudPlatform/kubernetes.

Usage:
  kubecfg2 [command]

Available Commands:
  version                   Print version of client and server
  pods                      List, inspect and modify pods
  rc                        List, inspect and modify replication controllers
  help [command]            Help about any command

 Available Flags:
  -a, --auth="/Users/sam/.kubernetes_auth": Path to the auth info file. If missing, prompt the user. Only used if doing https.
      --help=false: help for kubecfg2
  -h, --host="": Kubernetes apiserver to connect to
  -m, --match-version=false: Require server version to match client version

Use "kubecfg2 help [command]" for more information about that command.

```

```
$ kubecfg2 help pods list
List one or more pods. Pass in an ID to filter.

Usage:
  kubecfg2 pods list [<id>] [flags]

 Available Flags:
  -a, --auth="/Users/sam/.kubernetes_auth": Path to the auth info file. If missing, prompt the user. Only used if doing https.
      --help=false: help for list
  -h, --host="": Kubernetes apiserver to connect to
  -m, --match-version=false: Require server version to match client version
  -l, --selector="": Selector (label query) to filter on


Use "kubecfg2 help [command]" for more information about that command.

```

```
$ kubecfg2 pods list
ID                                      IMAGE(S)                HOST            LABELS                                  STATUS
4893ea09-3d0d-11e4-b3ad-0800279696e1    dockerfile/nginx        127.0.0.1/      replicationController=MyNginxController Running
48943371-3d0d-11e4-b3ad-0800279696e1    dockerfile/nginx        127.0.0.1/      replicationController=MyNginxController Running
```

```
$ kubecfg2 pods list 4893ea09-3d0d-11e4-b3ad-0800279696e1
ID                                      IMAGE(S)                HOST            LABELS                                  STATUS
4893ea09-3d0d-11e4-b3ad-0800279696e1    dockerfile/nginx        127.0.0.1/      replicationController=MyNginxController Running
```

```
$ kubecfg2 pods get 4893ea09-3d0d-11e4-b3ad-0800279696e1
ID:                             4893ea09-3d0d-11e4-b3ad-0800279696e1
Image(s):                       dockerfile/nginx
Host:                           127.0.0.1/
Labels:                         replicationController=MyNginxController
Status:                         Running
Replication Controllers:        MyNginxController (2/2 replicas created)
```

```
$ kubecfg2 rc list
ID                      IMAGE(S)                SELECTOR                                REPLICAS
MyNginxController       dockerfile/nginx        replicationController=MyNginxController 2
```

```
$ kubecfg2 rc get MyNginxController
ID:             MyNginxController
Image(s):       dockerfile/nginx
Selector:       replicationController=MyNginxController
Labels:         <none>
Replicas:       2 current / 2 desired
Pods Status:    2 running / 0 waiting / 0 terminated
```
### Other notes
- I am currently using [spf13/cobra](https://github.com/spf13/cobra) but am also considering [codegangsta/cli](https://github.com/codegangsta/cli). The latter may allow us to write out the command definitions in a cleaner way and support bash autocompletion, but the former allows persistent flags. Open to using either one.
- Some of these commands (especially `get` commands that show a lot of info) may result in lots of queries to the server. There are several ways to handle this: (1) don't consider it an issue, (2) offer a "succinct mode" that tries to do as little as possible and (3) over time backport functionality that is particularly useful directly into apiserver as new API endpoints. Especially with (3), you could consider kubecfg a proving ground for new convenience functionality to see whether it's worth implementing in apiserver directly.
### File layout
- cmd/kubecfg2/kubecfg2.go - All cobra and CLI-related code remains in this file/package.
- pkg/kubecfg2/&lt;subcommand&gt;.go - All logic per subcommand lives in one file per subcommand.
- pkg/kubecfg2/kubecfg2.go - Common functions used by cmd/kubecfg2 and pkg/kubecfg2 packages.
### Open Questions
- Can we leave rollingupdate out of this version for the merge? If it's needed for demo purposes, can it be reimplemented somewhere outside of this tool?
- @erictune pointed out that `get` is not the best name for above. `info` and `details` are other options but ideas here are welcome.
