### PR TITLE
Adjust the logic, so that if the apiserver restarts, or has no pod info

### DIFF
--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -214,7 +214,7 @@ func getInstanceIP(cloud cloudprovider.Interface, host string) string {
 }
 
 func getPodStatus(pod *api.Pod, minions client.MinionInterface) (api.PodStatus, error) {
-	if pod.CurrentState.Info == nil || pod.CurrentState.Host == "" {
+	if pod.CurrentState.Host == "" {
 		return api.PodWaiting, nil
 	}
 	res, err := minions.ListMinions()
@@ -231,6 +231,9 @@ func getPodStatus(pod *api.Pod, minions client.MinionInterface) (api.PodStatus, 
 	}
 	if !found {
 		return api.PodTerminated, nil
+	}
+	if pod.CurrentState.Info == nil {
+		return api.PodWaiting, nil
 	}
 	running := 0
 	stopped := 0

--- a/pkg/registry/pod/rest_test.go
+++ b/pkg/registry/pod/rest_test.go
@@ -300,6 +300,16 @@ func TestMakePodStatus(t *testing.T) {
 			&api.Pod{
 				DesiredState: desiredState,
 				CurrentState: api.PodState{
+					Host: "machine-2",
+				},
+			},
+			api.PodTerminated,
+			"no info, but bad machine",
+		},
+		{
+			&api.Pod{
+				DesiredState: desiredState,
+				CurrentState: api.PodState{
 					Info: map[string]docker.Container{
 						"containerA": runningState,
 						"containerB": runningState,


### PR DESCRIPTION
for some other reason, pods on missing machines are still 'terminated'

Closes #1346 
