### PR TITLE
Split log statements into more buckets for better control

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,25 @@
+Logging Conventions
+===================
+
+The following conventions for the glog levels to use.  glog is globally prefered to "log" for better runtime control.
+
+* glog.Errorf() - Always an error
+* glog.Warningf() - Something unexpected, but probably not an error
+* glog.Infof / glog.V(0) - Generally useful for this to ALWAYS be visible to an operator
+ * Programmer errors
+ * Logging extra info about a panic
+ * CLI argument handling
+* glog.V(1) - A reasonable default log level if you don't want verbosity.
+ * Information about config (listening on X, watching Y)
+  * Errors that repeat frequently that relate to conditions that can be corrected (pod detected as unhealthy)
+* glog.V(2) - Useful steady state information about the service and important log messages that may correlate to significant changes in the system.  This is the recommended default log level for most systems.
+ * Logging HTTP requests and their exit code
+ * System state changing (killing pod)
+ * Controller state change events (starting pods)
+ * Scheduler log messages
+* glog.V(3) - Extended information about changes
+  * More info about system state changes
+* glog.V(4) - Debug level verbosity (for now)
+ * Logging in particularly thorny parts of code where you may want to come back later and check it
+
+As per the comments, the practical default level is V(2).  Developers and QE environments may wish to run at V(3) or V(4).

--- a/pkg/apiserver/errors.go
+++ b/pkg/apiserver/errors.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/golang/glog"
 )
 
 // statusError is an object that can be converted into an api.Status
@@ -44,6 +45,11 @@ func errToAPIStatus(err error) *api.Status {
 		case tools.IsEtcdTestFailed(err):
 			status = http.StatusConflict
 		}
+		// Log errors that were not converted to an error status
+		// by REST storage - these typically indicate programmer
+		// error by not using pkg/api/errors, or unexpected failure
+		// cases.
+		glog.V(1).Infof("An unchecked error was received: %v", err)
 		return &api.Status{
 			Status:  api.StatusFailure,
 			Code:    status,

--- a/pkg/client/cache/reflector.go
+++ b/pkg/client/cache/reflector.go
@@ -166,6 +166,6 @@ func (r *Reflector) watchHandler(w watch.Interface, resourceVersion *uint64) err
 		glog.Errorf("unexpected watch close - watch lasted less than a second and no items received")
 		return errors.New("very short watch")
 	}
-	glog.Infof("watch close - %v total items received", eventCount)
+	glog.V(4).Infof("watch close - %v total items received", eventCount)
 	return nil
 }

--- a/pkg/cloudprovider/plugins.go
+++ b/pkg/cloudprovider/plugins.go
@@ -42,7 +42,7 @@ func RegisterCloudProvider(name string, cloud Factory) {
 	if found {
 		glog.Fatalf("Cloud provider %q was registered twice", name)
 	}
-	glog.Infof("Registered cloud provider %q", name)
+	glog.V(1).Infof("Registered cloud provider %q", name)
 	providers[name] = cloud
 }
 

--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -115,7 +115,7 @@ func (rm *ReplicationManager) watchControllers(resourceVersion *uint64) {
 				// that called us call us again.
 				return
 			}
-			glog.Infof("Got watch: %#v", event)
+			glog.V(4).Infof("Got watch: %#v", event)
 			rc, ok := event.Object.(*api.ReplicationController)
 			if !ok {
 				glog.Errorf("unexpected object: %#v", event.Object)
@@ -125,7 +125,7 @@ func (rm *ReplicationManager) watchControllers(resourceVersion *uint64) {
 			*resourceVersion = rc.ResourceVersion + 1
 			// Sync even if this is a deletion event, to ensure that we leave
 			// it in the desired state.
-			glog.Infof("About to sync from watch: %v", rc.ID)
+			glog.V(4).Infof("About to sync from watch: %v", rc.ID)
 			rm.syncHandler(*rc)
 		}
 	}
@@ -153,7 +153,7 @@ func (rm *ReplicationManager) syncReplicationController(controllerSpec api.Repli
 		diff *= -1
 		wait := sync.WaitGroup{}
 		wait.Add(diff)
-		glog.Infof("Too few replicas, creating %d\n", diff)
+		glog.V(2).Infof("Too few replicas, creating %d\n", diff)
 		for i := 0; i < diff; i++ {
 			go func() {
 				defer wait.Done()
@@ -162,7 +162,7 @@ func (rm *ReplicationManager) syncReplicationController(controllerSpec api.Repli
 		}
 		wait.Wait()
 	} else if diff > 0 {
-		glog.Infof("Too many replicas, deleting %d\n", diff)
+		glog.V(2).Infof("Too many replicas, deleting %d\n", diff)
 		wait := sync.WaitGroup{}
 		wait.Add(diff)
 		for i := 0; i < diff; i++ {
@@ -191,7 +191,7 @@ func (rm *ReplicationManager) synchronize() {
 	for ix := range controllerSpecs {
 		go func(ix int) {
 			defer wg.Done()
-			glog.Infof("periodic sync of %v", controllerSpecs[ix].ID)
+			glog.V(4).Infof("periodic sync of %v", controllerSpecs[ix].ID)
 			err := rm.syncHandler(controllerSpecs[ix])
 			if err != nil {
 				glog.Errorf("Error synchronizing: %#v", err)

--- a/pkg/httplog/log.go
+++ b/pkg/httplog/log.go
@@ -148,7 +148,7 @@ func (rl *respLogger) Addf(format string, data ...interface{}) {
 // Log is intended to be called once at the end of your request handler, via defer
 func (rl *respLogger) Log() {
 	latency := time.Since(rl.startTime)
-	glog.Infof("%s %s: (%v) %v%v%v", rl.req.Method, rl.req.RequestURI, latency, rl.status, rl.statusStack, rl.addedInfo)
+	glog.V(2).Infof("%s %s: (%v) %v%v%v", rl.req.Method, rl.req.RequestURI, latency, rl.status, rl.statusStack, rl.addedInfo)
 }
 
 // Header implements http.ResponseWriter.

--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -168,9 +168,9 @@ func (s *podStorage) merge(source string, change interface{}) (adds, updates, de
 	switch update.Op {
 	case kubelet.ADD, kubelet.UPDATE:
 		if update.Op == kubelet.ADD {
-			glog.Infof("Adding new pods from source %s : %v", source, update.Pods)
+			glog.V(4).Infof("Adding new pods from source %s : %v", source, update.Pods)
 		} else {
-			glog.Infof("Updating pods from source %s : %v", source, update.Pods)
+			glog.V(4).Infof("Updating pods from source %s : %v", source, update.Pods)
 		}
 
 		filtered := filterInvalidPods(update.Pods, source)
@@ -193,7 +193,7 @@ func (s *podStorage) merge(source string, change interface{}) (adds, updates, de
 		}
 
 	case kubelet.REMOVE:
-		glog.Infof("Removing a pod %v", update)
+		glog.V(4).Infof("Removing a pod %v", update)
 		for _, value := range update.Pods {
 			name := value.Name
 			if existing, found := pods[name]; found {
@@ -206,7 +206,7 @@ func (s *podStorage) merge(source string, change interface{}) (adds, updates, de
 		}
 
 	case kubelet.SET:
-		glog.Infof("Setting pods for source %s : %v", source, update)
+		glog.V(4).Infof("Setting pods for source %s : %v", source, update)
 		// Clear the old map entries by just creating a new map
 		oldPods := pods
 		pods = make(map[string]*kubelet.Pod)
@@ -238,7 +238,7 @@ func (s *podStorage) merge(source string, change interface{}) (adds, updates, de
 		}
 
 	default:
-		glog.Infof("Received invalid update type: %v", update)
+		glog.Warningf("Received invalid update type: %v", update)
 
 	}
 
@@ -259,7 +259,7 @@ func filterInvalidPods(pods []kubelet.Pod, source string) (filtered []*kubelet.P
 			errors = append(errors, errs...)
 		}
 		if len(errors) > 0 {
-			glog.Warningf("Pod %d from %s failed validation, ignoring: %v", i+1, source, errors)
+			glog.Warningf("Pod %d (%s) from %s failed validation, ignoring: %v", i+1, pods[i].Name, source, errors)
 			continue
 		}
 		filtered = append(filtered, &pods[i])

--- a/pkg/kubelet/config/etcd.go
+++ b/pkg/kubelet/config/etcd.go
@@ -54,7 +54,7 @@ func NewSourceEtcd(key string, client tools.EtcdClient, updates chan<- interface
 		helper:  helper,
 		updates: updates,
 	}
-	glog.Infof("Watching etcd for %s", key)
+	glog.V(1).Infof("Watching etcd for %s", key)
 	go util.Forever(source.run, time.Second)
 	return source
 }
@@ -78,7 +78,7 @@ func (s *SourceEtcd) run() {
 				continue
 			}
 
-			glog.Infof("Received state from etcd watch: %+v", pods)
+			glog.V(4).Infof("Received state from etcd watch: %+v", pods)
 			s.updates <- kubelet.PodUpdate{pods, kubelet.SET}
 		}
 	}

--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -45,7 +45,7 @@ func NewSourceFile(path string, period time.Duration, updates chan<- interface{}
 		path:    path,
 		updates: updates,
 	}
-	glog.Infof("Watching file %s", path)
+	glog.V(1).Infof("Watching file %s", path)
 	go util.Forever(config.run, period)
 	return config
 }

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -44,7 +44,7 @@ func NewSourceURL(url string, period time.Duration, updates chan<- interface{}) 
 		updates: updates,
 		data:    nil,
 	}
-	glog.Infof("Watching URL %s", url)
+	glog.V(1).Infof("Watching URL %s", url)
 	go util.Forever(config.run, period)
 	return config
 }

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -75,11 +75,11 @@ func NewDockerPuller(client DockerInterface) DockerPuller {
 	if err == nil {
 		cfg.addToKeyring(dp.keyring)
 	} else {
-		glog.Errorf("Unable to parse docker config file: %v", err)
+		glog.Errorf("Unable to parse Docker config file: %v", err)
 	}
 
 	if dp.keyring.count() == 0 {
-		glog.Infof("Continuing with empty docker keyring")
+		glog.V(1).Infof("Continuing with empty Docker keyring")
 	}
 
 	return dp
@@ -348,7 +348,7 @@ func ParseDockerName(name string) (podFullName, uuid, containerName string, hash
 			var err error
 			hash, err = strconv.ParseUint(pieces[1], 16, 32)
 			if err != nil {
-				glog.Infof("invalid container hash: %s", pieces[1])
+				glog.Warningf("invalid container hash: %s", pieces[1])
 			}
 		}
 	}

--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -48,7 +48,7 @@ type Server struct {
 
 // ListenAndServeKubeletServer initializes a server to respond to HTTP network requests on the Kubelet.
 func ListenAndServeKubeletServer(host HostInterface, updates chan<- interface{}, address string, port uint) {
-	glog.Infof("Starting to listen on %s:%d", address, port)
+	glog.V(1).Infof("Starting to listen on %s:%d", address, port)
 	handler := NewServer(host, updates)
 	s := &http.Server{
 		Addr:           net.JoinHostPort(address, strconv.FormatUint(uint64(port), 10)),

--- a/pkg/proxy/config/api.go
+++ b/pkg/proxy/config/api.go
@@ -101,7 +101,7 @@ func handleServicesWatch(resourceVersion *uint64, ch <-chan watch.Event, updates
 		select {
 		case event, ok := <-ch:
 			if !ok {
-				glog.V(2).Infof("WatchServices channel closed")
+				glog.V(4).Infof("WatchServices channel closed")
 				return
 			}
 
@@ -150,7 +150,7 @@ func handleEndpointsWatch(resourceVersion *uint64, ch <-chan watch.Event, update
 		select {
 		case event, ok := <-ch:
 			if !ok {
-				glog.V(2).Infof("WatchEndpoints channel closed")
+				glog.V(4).Infof("WatchEndpoints channel closed")
 				return
 			}
 

--- a/pkg/proxy/config/config.go
+++ b/pkg/proxy/config/config.go
@@ -125,24 +125,24 @@ func (s *endpointsStore) Merge(source string, change interface{}) error {
 	update := change.(EndpointsUpdate)
 	switch update.Op {
 	case ADD:
-		glog.Infof("Adding new endpoint from source %s : %v", source, update.Endpoints)
+		glog.V(4).Infof("Adding new endpoint from source %s : %v", source, update.Endpoints)
 		for _, value := range update.Endpoints {
 			endpoints[value.ID] = value
 		}
 	case REMOVE:
-		glog.Infof("Removing an endpoint %v", update)
+		glog.V(4).Infof("Removing an endpoint %v", update)
 		for _, value := range update.Endpoints {
 			delete(endpoints, value.ID)
 		}
 	case SET:
-		glog.Infof("Setting endpoints %v", update)
+		glog.V(4).Infof("Setting endpoints %v", update)
 		// Clear the old map entries by just creating a new map
 		endpoints = make(map[string]api.Endpoints)
 		for _, value := range update.Endpoints {
 			endpoints[value.ID] = value
 		}
 	default:
-		glog.Infof("Received invalid update type: %v", update)
+		glog.V(4).Infof("Received invalid update type: %v", update)
 	}
 	s.endpoints[source] = endpoints
 	s.endpointLock.Unlock()
@@ -220,24 +220,24 @@ func (s *serviceStore) Merge(source string, change interface{}) error {
 	update := change.(ServiceUpdate)
 	switch update.Op {
 	case ADD:
-		glog.Infof("Adding new service from source %s : %v", source, update.Services)
+		glog.V(4).Infof("Adding new service from source %s : %v", source, update.Services)
 		for _, value := range update.Services {
 			services[value.ID] = value
 		}
 	case REMOVE:
-		glog.Infof("Removing a service %v", update)
+		glog.V(4).Infof("Removing a service %v", update)
 		for _, value := range update.Services {
 			delete(services, value.ID)
 		}
 	case SET:
-		glog.Infof("Setting services %v", update)
+		glog.V(4).Infof("Setting services %v", update)
 		// Clear the old map entries by just creating a new map
 		services = make(map[string]api.Service)
 		for _, value := range update.Services {
 			services[value.ID] = value
 		}
 	default:
-		glog.Infof("Received invalid update type: %v", update)
+		glog.V(4).Infof("Received invalid update type: %v", update)
 	}
 	s.services[source] = services
 	s.serviceLock.Unlock()

--- a/pkg/proxy/config/file.go
+++ b/pkg/proxy/config/file.go
@@ -72,7 +72,7 @@ func NewConfigSourceFile(filename string, serviceChannel chan ServiceUpdate, end
 
 // Run begins watching the config file.
 func (s ConfigSourceFile) Run() {
-	glog.Infof("Watching file %s", s.filename)
+	glog.V(1).Infof("Watching file %s", s.filename)
 	var lastData []byte
 	var lastServices []api.Service
 	var lastEndpoints []api.Endpoints

--- a/pkg/proxy/roundrobin.go
+++ b/pkg/proxy/roundrobin.go
@@ -101,7 +101,7 @@ func (lb *LoadBalancerRR) OnUpdate(endpoints []api.Endpoints) {
 		existingEndpoints, exists := lb.endpointsMap[endpoint.ID]
 		validEndpoints := filterValidEndpoints(endpoint.Endpoints)
 		if !exists || !reflect.DeepEqual(existingEndpoints, validEndpoints) {
-			glog.Infof("LoadBalancerRR: Setting endpoints for %s to %+v", endpoint.ID, endpoint.Endpoints)
+			glog.V(3).Infof("LoadBalancerRR: Setting endpoints for %s to %+v", endpoint.ID, endpoint.Endpoints)
 			lb.endpointsMap[endpoint.ID] = validEndpoints
 			// Reset the round-robin index.
 			lb.rrIndex[endpoint.ID] = 0
@@ -111,7 +111,7 @@ func (lb *LoadBalancerRR) OnUpdate(endpoints []api.Endpoints) {
 	// Remove endpoints missing from the update.
 	for k, v := range lb.endpointsMap {
 		if _, exists := registeredEndpoints[k]; !exists {
-			glog.Infof("LoadBalancerRR: Removing endpoints for %s -> %+v", k, v)
+			glog.V(3).Infof("LoadBalancerRR: Removing endpoints for %s -> %+v", k, v)
 			delete(lb.endpointsMap, k)
 		}
 	}

--- a/pkg/registry/etcd/etcd.go
+++ b/pkg/registry/etcd/etcd.go
@@ -218,7 +218,7 @@ func (r *Registry) DeletePod(podID string) error {
 			// This really shouldn't happen, it indicates something is broken, and likely
 			// there is a lost pod somewhere.
 			// However it is "deleted" so log it and move on
-			glog.Infof("Couldn't find: %s in %#v", podID, manifests)
+			glog.Warningf("Couldn't find: %s in %#v", podID, manifests)
 		}
 		manifests.Items = newManifests
 		return manifests, nil

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -71,9 +71,7 @@ func (factory *ConfigFactory) Create() *scheduler.Config {
 		Binder:       &binder{factory.Client},
 		NextPod: func() *api.Pod {
 			pod := podQueue.Pop().(*api.Pod)
-			// TODO: Remove or reduce verbosity by sep 6th, 2014. Leave until then to
-			// make it easy to find scheduling problems.
-			glog.Infof("About to try and schedule pod %v\n"+
+			glog.V(2).Infof("About to try and schedule pod %v\n"+
 				"\tknown minions: %v\n"+
 				"\tknown scheduled pods: %v\n",
 				pod.ID, minionCache.Contains(), podCache.Contains())
@@ -229,8 +227,6 @@ type binder struct {
 
 // Bind just does a POST binding RPC.
 func (b *binder) Bind(binding *api.Binding) error {
-	// TODO: Remove or reduce verbosity by sep 6th, 2014. Leave until then to
-	// make it easy to find scheduling problems.
-	glog.Infof("Attempting to bind %v to %v", binding.PodID, binding.Host)
+	glog.V(2).Infof("Attempting to bind %v to %v", binding.PodID, binding.Host)
 	return b.Post().Path("bindings").Body(binding).Do().Error()
 }


### PR DESCRIPTION
Move a lot of common error logging into better buckets:
- glog.Errorf() - Always an error
- glog.Warningf() - Something unexpected, but probably not an error
- glog.Infof / glog.V(0) - Generally useful for this to ALWAYS be visible to an operator
  - Programmer errors
  - Logging extra info about a panic
  - CLI argument handling
- glog.V(1) - A reasonable default log level if you don't want verbosity.
  - Information about config (listening on X, watching Y)
  - Errors that repeat frequently that relate to conditions that can be corrected (pod detected as unhealthy)
- glog.V(2) - Useful steady state information about the service and important log messages that may correlate to significant changes in the system.  This is the recommended default log level for most systems.
  - Logging HTTP requests and their exit code
  - System state changing (killing pod)
  - Controller state change events (starting pods)
  - Scheduler log messages
- glog.V(3) - Extended information about changes
  - More info about system state changes
- glog.V(4) - Debug level verbosity (for now)
  - Logging in particularly thorny parts of code where you may want to come back later and check it

As per the comments, the practical default level is V(2).  Developers and QE environments would run at V(3) or V(4).

I just started at one and tried to create buckets - we could space them out more so we have better control in the future (i.e. make 10 debug, 3 or 4 be default).
