### PR TITLE
Fix up source install instructions for VSphere

### DIFF
--- a/docs/getting-started-guides/vsphere.md
+++ b/docs/getting-started-guides/vsphere.md
@@ -23,8 +23,9 @@
 6. Get the Kubernetes source:
 
    ```sh
-   go get github.com/GoogleCloudPlatform/kubernetes
-   cd $GOPATH/src/github.com/GoogleCloudPlatform/kubernetes
+   mkdir -p $GOPATH/src/github.com/GoogleCloudPlatform
+   git clone https://github.com/GoogleCloudPlatform/kubernetes.git
+   cd kubernetes
    ```
 
 ### Setup


### PR DESCRIPTION
I skip using `go get` as it downloads all of the dependencies. But since we are vendoring using godep without rewriting imports, this means we download a bunch of stuff we don't use.  Instead, just clone the repo directly.

Fixes #1360.
