### PR TITLE
Increase the hack/test-go.sh timeout to account for more fuzzing

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -46,7 +46,7 @@ find_test_pkgs() {
 
 # -covermode=atomic becomes default with -race in Go >=1.3
 KUBE_COVER=${KUBE_COVER:--cover -covermode=atomic}
-KUBE_TIMEOUT=${KUBE_TIMEOUT:--timeout 30s}
+KUBE_TIMEOUT=${KUBE_TIMEOUT:--timeout 60s}
 
 cd "${KUBE_TARGET}"
 


### PR DESCRIPTION
We fuzz v1beta1 and v1beta2 now, so fuzzer takes twice as long.
