### PR TITLE
Fix minion registry test insert.

### DIFF
--- a/pkg/registry/registrytest/minion.go
+++ b/pkg/registry/registrytest/minion.go
@@ -41,6 +41,7 @@ func (r *MinionRegistry) Insert(minion string) error {
 	r.Lock()
 	defer r.Unlock()
 	r.Minion = minion
+	r.Minions = append(r.Minions, minion)
 	return r.Err
 }
 


### PR DESCRIPTION
Only caching registry test uses the Insert method, and since we don't update r.Minions, it is always compare with old entries (which are the same)
