### PR TITLE
Allow STDIN to kubecfg via `-c -`.

### DIFF
--- a/cmd/kubecfg/kubecfg.go
+++ b/cmd/kubecfg/kubecfg.go
@@ -44,7 +44,7 @@ var (
 	serverVersion = verflag.Version("server_version", verflag.VersionFalse, "Print the server's version information and quit")
 	preventSkew   = flag.Bool("expect_version_match", false, "Fail if server's version doesn't match own version.")
 	httpServer    = flag.String("h", "", "The host to connect to.")
-	config        = flag.String("c", "", "Path or URL to the config file.")
+	config        = flag.String("c", "", "Path or URL to the config file, or '-' to read from STDIN")
 	selector      = flag.String("l", "", "Selector (label query) to use for listing")
 	updatePeriod  = flag.Duration("u", 60*time.Second, "Update interval period")
 	portSpec      = flag.String("p", "", "The port spec, comma-separated list of <external>:<internal>,...")
@@ -72,7 +72,7 @@ var parser = kubecfg.NewParser(map[string]runtime.Object{
 })
 
 func usage() {
-	fmt.Fprintf(os.Stderr, `Usage: kubecfg -h [-c config/file.json] <method>
+	fmt.Fprintf(os.Stderr, `Usage: kubecfg -h [-c config/file.json|url|-] <method>
 
 Kubernetes REST API:
 
@@ -103,6 +103,15 @@ func prettyWireStorage() string {
 
 // readConfigData reads the bytes from the specified filesytem or network location associated with the *config flag
 func readConfigData() []byte {
+	// read from STDIN
+	if *config == "-" {
+		data, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			glog.Fatalf("Unable to read from STDIN: %v\n", err)
+		}
+		return data
+	}
+
 	// we look for http:// or https:// to determine if valid URL, otherwise do normal file IO
 	if strings.Index(*config, "http://") == 0 || strings.Index(*config, "https://") == 0 {
 		resp, err := http.Get(*config)
@@ -118,13 +127,13 @@ func readConfigData() []byte {
 			glog.Fatalf("Unable to read URL %v: %v\n", *config, err)
 		}
 		return data
-	} else {
-		data, err := ioutil.ReadFile(*config)
-		if err != nil {
-			glog.Fatalf("Unable to read %v: %v\n", *config, err)
-		}
-		return data
 	}
+
+	data, err := ioutil.ReadFile(*config)
+	if err != nil {
+		glog.Fatalf("Unable to read %v: %v\n", *config, err)
+	}
+	return data
 }
 
 // readConfig reads and parses pod, replicationController, and service


### PR DESCRIPTION
Follows the `tar xvf -` convention (because all the other conventions
are crazier?). Tried `--` at the end or a separate arg and all of them
felt worse.
