### PR TITLE
Make "kubecfg -s <port> run ..." select correctly

### DIFF
--- a/hack/e2e-suite/update.sh
+++ b/hack/e2e-suite/update.sh
@@ -30,7 +30,7 @@ CONTROLLER_NAME=update-demo
 function validate() {
   NUM_REPLICAS=$1
   CONTAINER_IMAGE_VERSION=$2
-  POD_ID_LIST=$($KUBECFG '-template={{range.Items}}{{.ID}} {{end}}' -l replicationController=${CONTROLLER_NAME} list pods)
+  POD_ID_LIST=$($KUBECFG '-template={{range.Items}}{{.ID}} {{end}}' -l simpleService=${CONTROLLER_NAME} list pods)
   # Container turn up on a clean cluster can take a while for the docker image pull.
   ALL_RUNNING=0
   while [ $ALL_RUNNING -ne 1 ]; do

--- a/pkg/kubecfg/kubecfg.go
+++ b/pkg/kubecfg/kubecfg.go
@@ -201,7 +201,7 @@ func RunController(image, name string, replicas int, client client.Interface, po
 		DesiredState: api.ReplicationControllerState{
 			Replicas: replicas,
 			ReplicaSelector: map[string]string{
-				"replicationController": name,
+				"simpleService": name,
 			},
 			PodTemplate: api.PodTemplate{
 				DesiredState: api.PodState{
@@ -217,7 +217,7 @@ func RunController(image, name string, replicas int, client client.Interface, po
 					},
 				},
 				Labels: map[string]string{
-					"replicationController": name,
+					"simpleService": name,
 				},
 			},
 		},
@@ -252,10 +252,10 @@ func createService(name string, port int, client client.Interface) (*api.Service
 		JSONBase: api.JSONBase{ID: name},
 		Port:     port,
 		Labels: map[string]string{
-			"name": name,
+			"simpleService": name,
 		},
 		Selector: map[string]string{
-			"replicationController": name,
+			"simpleService": name,
 		},
 	}
 	svc, err := client.CreateService(svc)

--- a/pkg/kubecfg/kubecfg.go
+++ b/pkg/kubecfg/kubecfg.go
@@ -255,7 +255,7 @@ func createService(name string, port int, client client.Interface) (*api.Service
 			"name": name,
 		},
 		Selector: map[string]string{
-			"name": name,
+			"replicationController": name,
 		},
 	}
 	svc, err := client.CreateService(svc)


### PR DESCRIPTION
kubecfg run creates a replication controller which sets all pods with a
replicationController= label, but then sets up a service selecting on name=
instead.  This fixes that.  kubecfg -s <port> run ... can now actually work.
