### PR TITLE
Adding GetEndpoints method to the client EndpointsInterface

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -78,6 +78,7 @@ type ServiceInterface interface {
 // EndpointsInterface has methods to work with Endpoints resources
 type EndpointsInterface interface {
 	ListEndpoints(selector labels.Selector) (*api.EndpointsList, error)
+	GetEndpoints(id string) (*api.Endpoints, error)
 	WatchEndpoints(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error)
 }
 
@@ -426,6 +427,13 @@ func (c *Client) WatchServices(label, field labels.Selector, resourceVersion uin
 func (c *Client) ListEndpoints(selector labels.Selector) (result *api.EndpointsList, err error) {
 	result = &api.EndpointsList{}
 	err = c.Get().Path("endpoints").SelectorParam("labels", selector).Do().Into(result)
+	return
+}
+
+// GetEndpoints returns information about the endpoints for a particular service.
+func (c *Client) GetEndpoints(id string) (result *api.Endpoints, err error) {
+	result = &api.Endpoints{}
+	err = c.Get().Path("endpoints").Path(id).Do().Into(result)
 	return
 }
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -541,6 +541,33 @@ func TestDeleteService(t *testing.T) {
 	c.Validate(t, nil, err)
 }
 
+func TestListEndpooints(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{Method: "GET", Path: "/endpoints"},
+		Response: Response{StatusCode: 200,
+			Body: &api.EndpointsList{
+				Items: []api.Endpoints{
+					{
+						JSONBase:  api.JSONBase{ID: "endpoint-1"},
+						Endpoints: []string{"10.245.1.2:8080", "10.245.1.3:8080"},
+					},
+				},
+			},
+		},
+	}
+	receivedEndpointsList, err := c.Setup().ListEndpoints(labels.Everything())
+	c.Validate(t, receivedEndpointsList, err)
+}
+
+func TestGetEndpoints(t *testing.T) {
+	c := &testClient{
+		Request:  testRequest{Method: "GET", Path: "/endpoints/endpoint-1"},
+		Response: Response{StatusCode: 200, Body: &api.Endpoints{JSONBase: api.JSONBase{ID: "endpoint-1"}}},
+	}
+	response, err := c.Setup().GetEndpoints("endpoint-1")
+	c.Validate(t, response, err)
+}
+
 func TestDoRequest(t *testing.T) {
 	invalid := "aaaaa"
 	testClients := []testClient{

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -132,6 +132,11 @@ func (c *Fake) ListEndpoints(selector labels.Selector) (*api.EndpointsList, erro
 	return api.Scheme.CopyOrDie(&c.EndpointsList).(*api.EndpointsList), c.Err
 }
 
+func (c *Fake) GetEndpoints(name string) (*api.Endpoints, error) {
+	c.Actions = append(c.Actions, FakeAction{Action: "get-endpoints"})
+	return &api.Endpoints{}, nil
+}
+
 func (c *Fake) WatchEndpoints(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
 	c.Actions = append(c.Actions, FakeAction{Action: "watch-endpoints", Value: resourceVersion})
 	return c.Watch, c.Err


### PR DESCRIPTION
I need to fetch the endpoints for a particular service from the client to be able to route / load balance to the endpoints independent of the kube proxy.

Adding the method to the fake client for consistency even though the APIs don't seem to be getting tested.
