### PR TITLE
stdout/stderr writer container log stream

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -208,13 +208,13 @@ func GetRecentDockerContainersWithNameAndUUID(client DockerInterface, podFullNam
 // By default the function will return snapshot of the container log
 // Log streaming is possible if 'follow' param is set to true
 // Log tailing is possible when number of tailed lines are set and only if 'follow' is false
-func GetKubeletDockerContainerLogs(client DockerInterface, containerID, tail string, follow bool, writer io.Writer) (err error) {
+func GetKubeletDockerContainerLogs(client DockerInterface, containerID, tail string, follow bool, stdout, stderr io.Writer) (err error) {
 	opts := docker.LogsOptions{
 		Container:    containerID,
 		Stdout:       true,
 		Stderr:       true,
-		OutputStream: writer,
-		ErrorStream:  writer,
+		OutputStream: stdout,
+		ErrorStream:  stderr,
 		Timestamps:   true,
 		RawTerminal:  true,
 		Follow:       follow,

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -753,7 +753,7 @@ func (kl *Kubelet) statsFromContainerPath(containerPath string, req *info.Contai
 }
 
 // GetKubeletContainerLogs returns logs from the container
-func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName, tail string, follow bool, writer io.Writer) error {
+func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName, tail string, follow bool, stdout, stderr io.Writer) error {
 	dockerContainers, err := dockertools.GetKubeletDockerContainers(kl.dockerClient)
 	if err != nil {
 		return err
@@ -763,7 +763,7 @@ func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName, tail stri
 	if !found {
 		return fmt.Errorf("container not found (%s)\n", containerName)
 	}
-	return dockertools.GetKubeletDockerContainerLogs(kl.dockerClient, dockerContainer.ID, tail , follow, writer)
+	return dockertools.GetKubeletDockerContainerLogs(kl.dockerClient, dockerContainer.ID, tail , follow, stdout, stderr)
 }
 
 // GetPodInfo returns information from Docker about the containers in a pod

--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -68,7 +68,7 @@ type HostInterface interface {
 	GetMachineInfo() (*info.MachineInfo, error)
 	GetPodInfo(name, uuid string) (api.PodInfo, error)
 	RunInContainer(name, uuid, container string, cmd []string) ([]byte, error)
-	GetKubeletContainerLogs(podFullName, containerName, tail string, follow bool, writer io.Writer) error
+	GetKubeletContainerLogs(podFullName, containerName, tail string, follow bool, stdout, stderr io.Writer) error
 	ServeLogs(w http.ResponseWriter, req *http.Request)
 }
 
@@ -185,7 +185,7 @@ func (s *Server) handleContainerLogs(w http.ResponseWriter, req *http.Request) {
 	}
 	w.Header().Set("Transfer-Encoding", "chunked")
 	w.WriteHeader(http.StatusOK)
-	err = s.host.GetKubeletContainerLogs(podFullName, containerName, tail, follow, &fw)
+	err = s.host.GetKubeletContainerLogs(podFullName, containerName, tail, follow, &fw, &fw)
 	if err != nil {
 		s.error(w, err)
 		return

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -42,7 +42,7 @@ type fakeKubelet struct {
 	machineInfoFunc    func() (*info.MachineInfo, error)
 	logFunc            func(w http.ResponseWriter, req *http.Request)
 	runFunc            func(podFullName, uuid, containerName string, cmd []string) ([]byte, error)
-	containerLogsFunc  func(podFullName, containerName, tail string, follow bool, writer io.Writer)  error
+	containerLogsFunc  func(podFullName, containerName, tail string, follow bool, stdout, stderr io.Writer)  error
 }
 
 func (fk *fakeKubelet) GetPodInfo(name, uuid string) (api.PodInfo, error) {
@@ -65,8 +65,8 @@ func (fk *fakeKubelet) ServeLogs(w http.ResponseWriter, req *http.Request) {
 	fk.logFunc(w, req)
 }
 
-func (fk *fakeKubelet) GetKubeletContainerLogs(podFullName, containerName, tail string, follow bool, writer io.Writer) error {
-	return fk.containerLogsFunc(podFullName, containerName, tail, follow, writer)
+func (fk *fakeKubelet) GetKubeletContainerLogs(podFullName, containerName, tail string, follow bool, stdout, stderr io.Writer) error {
+	return fk.containerLogsFunc(podFullName, containerName, tail, follow, stdout, stderr)
 }
 
 func (fk *fakeKubelet) RunInContainer(podFullName, uuid, containerName string, cmd []string) ([]byte, error) {
@@ -391,7 +391,7 @@ func TestContainerLogs(t *testing.T) {
     expectedTail := ""
     expectedFollow := false
     // expected := api.Container{"goodpod": docker.Container{ID: "myContainerID"}}
-    fw.fakeKubelet.containerLogsFunc = func(podFullName, containerName, tail string, follow bool, writer io.Writer) error {
+    fw.fakeKubelet.containerLogsFunc = func(podFullName, containerName, tail string, follow bool, stdout, stderr io.Writer) error {
             if podFullName != expectedPodName {
                     t.Errorf("expected %s, got %s", expectedPodName, podFullName)
             }
@@ -430,7 +430,7 @@ func TestContainerLogsWithTail(t *testing.T) {
     expectedContainerName := "baz"
     expectedTail := "5"
     expectedFollow := false
-    fw.fakeKubelet.containerLogsFunc = func(podFullName, containerName, tail string, follow bool, writer io.Writer) error {
+    fw.fakeKubelet.containerLogsFunc = func(podFullName, containerName, tail string, follow bool, stdout, stderr io.Writer) error {
             if podFullName != expectedPodName {
                     t.Errorf("expected %s, got %s", expectedPodName, podFullName)
             }
@@ -469,7 +469,7 @@ func TestContainerLogsWithFollow(t *testing.T) {
     expectedContainerName := "baz"
     expectedTail := ""
     expectedFollow := true
-    fw.fakeKubelet.containerLogsFunc = func(podFullName, containerName, tail string, follow bool, writer io.Writer) error {
+    fw.fakeKubelet.containerLogsFunc = func(podFullName, containerName, tail string, follow bool, stdout, stderr io.Writer) error {
             if podFullName != expectedPodName {
                     t.Errorf("expected %s, got %s", expectedPodName, podFullName)
             }


### PR DESCRIPTION
Adding possibility to differentiate between stdout/stderr, by passing extra io.Writer to the `GetKubeletDockerContainerLogs` and making it more general.
