### PR TITLE
hack: Switch some $(dirname $0)../blah to use ${KUBE_*} vars

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -18,6 +18,7 @@
 # simple scenarios.  It does not require Docker so it can run in travis.
 
 source $(dirname $0)/util.sh
+source $(dirname $0)/config-go.sh
 
 function cleanup()
 {
@@ -44,7 +45,7 @@ ETCD_PORT=${ETCD_PORT:-4001}
 API_PORT=${API_PORT:-8080}
 API_HOST=${API_HOST:-127.0.0.1}
 KUBELET_PORT=${KUBELET_PORT:-10250}
-GO_OUT=$(dirname $0)/../_output/go/bin
+GO_OUT=${KUBE_TARGET}/bin
 
 # Check kubecfg
 out=$(${GO_OUT}/kubecfg -version)

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 source $(dirname $0)/util.sh
+source $(dirname $0)/config-go.sh
 
 function cleanup()
 {
@@ -37,14 +38,14 @@ echo
 echo Integration test cases ...
 echo
 GOFLAGS="-tags 'integration no-docker'" \
-    $(dirname $0)/../hack/test-go.sh test/integration
+    ${KUBE_REPO_ROOT}/hack/test-go.sh test/integration
 # leave etcd running if integration tests fail
 trap "echo etcd still running" EXIT
 
 echo
 echo Integration scenario ...
 echo
-$(dirname $0)/../_output/go/bin/integration
+${KUBE_TARGET}/bin/integration
 
 # nuke etcd
 trap cleanup EXIT SIGINT


### PR DESCRIPTION
This doesn't fix anything broken. But we have config-go which exports
KUBE_REPO_ROOT and KUBE_TARGET.  Using those means the test scripts can
be more easily moved around the repo and still work.  Especially in
hack/test-integration.sh where we use hack/build-go.sh which is going
to use KUBE_TARGET to place the binary, then we use a different method
to find/execute the binary...

If the $(dirname $0)/../ method is prefered to sourcing config-go, feel free to just close this...
