### PR TITLE
Allow option to not build cmd/integration

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -28,7 +28,10 @@ function cleanup()
 
 # Stop right away if the build fails
 set -e
-$(dirname $0)/build-go.sh cmd/integration
+
+if [[ -z $KUBE_NO_BUILD_INTEGRATION ]]; then
+    $(dirname $0)/build-go.sh cmd/integration
+fi
 
 start_etcd
 


### PR DESCRIPTION
In case it was built seperately (as in, on Fedora, we cannot use go
install as we do not have write permission to portions of the GOPATH)

@filbranden
