### PR TITLE
Adding a CloudStack deployment page with initial documentation and place...

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,3 +17,4 @@ least one maintainer on relevant issues and PRs.
 * oVirt: [Federico Simoncelli](https://github.com/simon3z)
 * Local: [Derek Carr](https://github.com/derekwaynecarr)
 * Vagrant: [Derek Carr](https://github.com/derekwaynecarr)
+* CloudStack: [Sebastien Goasguen](https://github.com/runseb)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ While the concepts and architecture in Kubernetes represent years of experience 
   * [Digital Ocean](https://github.com/bketelsen/coreos-kubernetes-digitalocean)
   * [CoreOS](docs/getting-started-guides/coreos.md)
   * [OpenStack](https://developer.rackspace.com/blog/running-coreos-and-kubernetes/)
+  * [CloudStack](docs/getting-started-guides/cloudstack.md)
 * The following clouds are currently broken at Kubernetes head.  Please sync your client to `v0.3` (`git checkout v0.3`) to use these:
   * [Locally](docs/getting-started-guides/locally.md)
   * [vSphere](docs/getting-started-guides/vsphere.md)

--- a/docs/getting-started-guides/cloudstack.md
+++ b/docs/getting-started-guides/cloudstack.md
@@ -1,0 +1,8 @@
+## Deploying Kubernetes on [CloudStack](http://cloudstack.apache.org)
+
+CloudStack is software to build public and private clouds based on hardware virtualization principles (traditional IaaS). To deploy Kubernetes on CloudStack there are several possibilities depending on the Cloud being used and what images are made available. [Exoscale](http://exoscale.ch) for instance makes a [CoreOS](http://coreos.com) template available, therefore instructions to deploy Kubernetes on coreOS can be used. CloudStack also has a vagrant plugin available, hence Vagrant could be used to deploy Kubernetes either using the existing shell provisioner or using new Salt based recipes.
+
+Here we introduce the existing documentation.
+
+* [Kubernetes on Exoscale](https://github.com/runseb/kubernetes-exoscale)
+


### PR DESCRIPTION
This adds a page for CloudStack deployments documentation.

I am not sure how you would to handle this, but I check the coreOS page which lists several links.
The main idea is that there are many different ways to do this and I just want to have a basic place holders to add documentation.
I am happy to send a pr for https://github.com/runseb/kubernetes-exoscale but I will also start working on a pure vagrant setup to deploy on CloudStack and that could be linked from the cloudstack page in the getting started guides.
