### PR TITLE
Add per-service env vars for *_SERVICE_HOST

### DIFF
--- a/examples/guestbook/README.md
+++ b/examples/guestbook/README.md
@@ -149,7 +149,7 @@ redisSlaveController   brendanburns/redis-slave   name=redisslave     2
 The redis slave configures itself by looking for the Kubernetes service environment variables in the container environment.  In particular, the redis slave is started with the following command:
 
 ```shell
-redis-server --slaveof $SERVICE_HOST $REDISMASTER_SERVICE_PORT
+redis-server --slaveof ${REDISMASTER_SERVICE_HOST:-$SERVICE_HOST} $REDISMASTER_SERVICE_PORT
 ```
 
 Once that's up you can list the pods in the cluster, to verify that the master and slaves are running:
@@ -270,7 +270,7 @@ if (isset($_GET['cmd']) === true) {
   if ($_GET['cmd'] == 'set') {
     $client = new Predis\Client([
       'scheme' => 'tcp',
-      'host'   => getenv('SERVICE_HOST'),
+      'host'   => getenv('REDISMASTER_SERVICE_HOST') ?: getenv('SERVICE_HOST'),
       'port'   => getenv('REDISMASTER_SERVICE_PORT'),
     ]);
     $client->set($_GET['key'], $_GET['value']);
@@ -283,7 +283,7 @@ if (isset($_GET['cmd']) === true) {
     }
     $client = new Predis\Client([
       'scheme' => 'tcp',
-      'host'   => getenv('SERVICE_HOST'),
+      'host'   => getenv('REDISMASTER_SERVICE_HOST') ?: getenv('SERVICE_HOST'),
       'port'   => $read_port,
     ]);
 

--- a/examples/guestbook/index.php
+++ b/examples/guestbook/index.php
@@ -12,7 +12,7 @@ if (isset($_GET['cmd']) === true) {
   if ($_GET['cmd'] == 'set') {
     $client = new Predis\Client([
       'scheme' => 'tcp',
-      'host'   => getenv('SERVICE_HOST'),
+      'host'   => getenv('REDISMASTER_SERVICE_HOST') ?: getenv('SERVICE_HOST'),
       'port'   => getenv('REDISMASTER_SERVICE_PORT'),
     ]);
     $client->set($_GET['key'], $_GET['value']);
@@ -25,7 +25,7 @@ if (isset($_GET['cmd']) === true) {
     }
     $client = new Predis\Client([
       'scheme' => 'tcp',
-      'host'   => getenv('SERVICE_HOST'),
+      'host'   => getenv('REDISMASTER_SERVICE_HOST') ?: getenv('SERVICE_HOST'),
       'port'   => $read_port,
     ]);
 

--- a/examples/guestbook/php-redis/index.php
+++ b/examples/guestbook/php-redis/index.php
@@ -12,7 +12,7 @@ if (isset($_GET['cmd']) === true) {
   if ($_GET['cmd'] == 'set') {
     $client = new Predis\Client([
       'scheme' => 'tcp',
-      'host'   => getenv('SERVICE_HOST'),
+      'host'   => getenv('REDISMASTER_SERVICE_HOST') ?: getenv('SERVICE_HOST'),
       'port'   => getenv('REDISMASTER_SERVICE_PORT'),
     ]);
     $client->set($_GET['key'], $_GET['value']);
@@ -25,7 +25,7 @@ if (isset($_GET['cmd']) === true) {
     }
     $client = new Predis\Client([
       'scheme' => 'tcp',
-      'host'   => getenv('SERVICE_HOST'),
+      'host'   => getenv('REDISMASTER_SERVICE_HOST') ?: getenv('SERVICE_HOST'),
       'port'   => $read_port,
     ]);
 

--- a/examples/guestbook/redis-slave/run.sh
+++ b/examples/guestbook/redis-slave/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-redis-server --slaveof $SERVICE_HOST $REDISMASTER_SERVICE_PORT
+redis-server --slaveof ${REDISMASTER_SERVICE_HOST:-$SERVICE_HOST} $REDISMASTER_SERVICE_PORT

--- a/pkg/registry/pod/manifest_factory_test.go
+++ b/pkg/registry/pod/manifest_factory_test.go
@@ -95,6 +95,10 @@ func TestMakeManifestServices(t *testing.T) {
 	container := manifest.Containers[0]
 	envs := []api.EnvVar{
 		{
+			Name:  "TEST_SERVICE_HOST",
+			Value: "machine",
+		},
+		{
 			Name:  "TEST_SERVICE_PORT",
 			Value: "8080",
 		},
@@ -123,8 +127,8 @@ func TestMakeManifestServices(t *testing.T) {
 			Value: "machine",
 		},
 	}
-	if len(container.Env) != 7 {
-		t.Errorf("Expected 7 env vars, got %d: %#v", len(container.Env), manifest)
+	if len(container.Env) != len(envs) {
+		t.Errorf("Expected %d env vars, got %d: %#v", len(envs), len(container.Env), manifest)
 		return
 	}
 	for ix := range container.Env {
@@ -181,6 +185,10 @@ func TestMakeManifestServicesExistingEnvVar(t *testing.T) {
 			Value: "bar",
 		},
 		{
+			Name:  "TEST_SERVICE_HOST",
+			Value: "machine",
+		},
+		{
 			Name:  "TEST_SERVICE_PORT",
 			Value: "8080",
 		},
@@ -209,8 +217,8 @@ func TestMakeManifestServicesExistingEnvVar(t *testing.T) {
 			Value: "machine",
 		},
 	}
-	if len(container.Env) != 8 {
-		t.Errorf("Expected 8 env vars, got: %#v", manifest)
+	if len(container.Env) != len(envs) {
+		t.Errorf("Expected %d env vars, got: %#v", len(envs), manifest)
 		return
 	}
 	for ix := range container.Env {

--- a/pkg/registry/service/rest.go
+++ b/pkg/registry/service/rest.go
@@ -148,11 +148,17 @@ func GetServiceEnvironmentVariables(registry Registry, machine string) ([]api.En
 		return result, err
 	}
 	for _, service := range services.Items {
-		name := makeEnvVariableName(service.ID) + "_SERVICE_PORT"
-		value := strconv.Itoa(service.Port)
-		result = append(result, api.EnvVar{Name: name, Value: value})
+		// Host
+		name := makeEnvVariableName(service.ID) + "_SERVICE_HOST"
+		result = append(result, api.EnvVar{Name: name, Value: machine})
+		// Port
+		name = makeEnvVariableName(service.ID) + "_SERVICE_PORT"
+		result = append(result, api.EnvVar{Name: name, Value: strconv.Itoa(service.Port)})
+		// Docker-compatible vars.
 		result = append(result, makeLinkVariables(service, machine)...)
 	}
+	// The 'SERVICE_HOST' variable is deprecated.
+	// TODO(thockin): get rid of it once ip-per-service is in and "deployed".
 	result = append(result, api.EnvVar{Name: "SERVICE_HOST", Value: machine})
 	return result, nil
 }


### PR DESCRIPTION
As a replacement of a single SERVICE_HOST variable, offer a FOO_SERVICE_HOST
variable.  This will help ease the transition to ip-per-service, where there
is no longer a single service host.
