### PR TITLE
DO NOT MERGE: Namespace support (Part 2)

### DIFF
--- a/api/examples/external-service.json
+++ b/api/examples/external-service.json
@@ -1,5 +1,6 @@
 {
   "id": "example",
+  "namespace": "default",
   "kind": "Service",
   "apiVersion": "v1beta1",
   "port": 8000,

--- a/api/examples/service-list.json
+++ b/api/examples/service-list.json
@@ -4,6 +4,7 @@
     "items": [
         {
             "id": "example1",
+            "namespace": "default",
             "port": 8000,
             "labels": {
                 "name": "nginx"
@@ -14,6 +15,7 @@
         },
         {
             "id": "example2",
+            "namespace": "default",            
             "port": 8080,
             "labels": {
                 "env": "prod",

--- a/api/examples/service.json
+++ b/api/examples/service.json
@@ -2,6 +2,7 @@
   "kind": "Service",
   "apiVersion": "v1beta1",
   "id": "example",
+  "namespace": "default",
   "port": 8000,
   "labels": {
      "name": "nginx"

--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -126,7 +126,7 @@ func main() {
 		Port:   *minionPort,
 	}
 
-	client, err := client.New(net.JoinHostPort(*address, strconv.Itoa(int(*port))), *storageVersion, nil)
+	client, err := client.New(net.JoinHostPort(*address, strconv.Itoa(int(*port))), *storageVersion, nil, nil)
 	if err != nil {
 		glog.Fatalf("Invalid server address: %v", err)
 	}

--- a/cmd/controller-manager/controller-manager.go
+++ b/cmd/controller-manager/controller-manager.go
@@ -54,7 +54,7 @@ func main() {
 		glog.Fatal("usage: controller-manager -master <master>")
 	}
 
-	kubeClient, err := client.New(*master, latest.OldestVersion, nil)
+	kubeClient, err := client.New(*master, latest.OldestVersion, nil, nil)
 	if err != nil {
 		glog.Fatalf("Invalid -master: %v", err)
 	}

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -54,8 +54,8 @@ func main() {
 	// define api config source
 	if *master != "" {
 		glog.Infof("Using api calls to get config %v", *master)
-		//TODO: add auth info
-		client, err := client.New(*master, latest.OldestVersion, nil)
+		//TODO: add auth info, namespaceInfo
+		client, err := client.New(*master, latest.OldestVersion, nil, nil)
 		if err != nil {
 			glog.Fatalf("Invalid -master: %v", err)
 		}

--- a/examples/guestbook/frontend-service.json
+++ b/examples/guestbook/frontend-service.json
@@ -1,5 +1,6 @@
 {
   "id": "frontend",
+  "namespace": "default",
   "kind": "Service",
   "apiVersion": "v1beta1",
   "port": 9998,

--- a/examples/guestbook/redis-master-service.json
+++ b/examples/guestbook/redis-master-service.json
@@ -1,5 +1,6 @@
 {
   "id": "redismaster",
+  "namespace": "default",
   "kind": "Service",
   "apiVersion": "v1beta1",
   "port": 10000,

--- a/examples/guestbook/redis-slave-service.json
+++ b/examples/guestbook/redis-slave-service.json
@@ -1,5 +1,6 @@
 {
   "id": "redisslave",
+  "namespace": "default",
   "kind": "Service",
   "apiVersion": "v1beta1",
   "port": 10001,

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -233,11 +233,18 @@ type Event struct {
 type JSONBase struct {
 	Kind              string    `json:"kind,omitempty" yaml:"kind,omitempty"`
 	ID                string    `json:"id,omitempty" yaml:"id,omitempty"`
+	Namespace         string    `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	CreationTimestamp util.Time `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
 	SelfLink          string    `json:"selfLink,omitempty" yaml:"selfLink,omitempty"`
 	ResourceVersion   uint64    `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
 	APIVersion        string    `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
 }
+
+// This is the default namespace when not provided by clients
+const NamespaceDefault string = "default"
+
+// This is the default argument to pass when you want resources across all namespaces
+const NamespaceAll string = ""
 
 // PodStatus represents a status of a pod.
 type PodStatus string

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -244,6 +244,7 @@ type Event struct {
 type JSONBase struct {
 	Kind              string    `json:"kind,omitempty" yaml:"kind,omitempty"`
 	ID                string    `json:"id,omitempty" yaml:"id,omitempty"`
+	Namespace         string    `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	CreationTimestamp util.Time `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
 	SelfLink          string    `json:"selfLink,omitempty" yaml:"selfLink,omitempty"`
 	ResourceVersion   uint64    `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -242,6 +242,7 @@ type Event struct {
 type JSONBase struct {
 	Kind              string    `json:"kind,omitempty" yaml:"kind,omitempty"`
 	ID                string    `json:"id,omitempty" yaml:"id,omitempty"`
+	Namespace         string    `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	CreationTimestamp util.Time `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
 	SelfLink          string    `json:"selfLink,omitempty" yaml:"selfLink,omitempty"`
 	ResourceVersion   uint64    `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -233,6 +233,7 @@ type Event struct {
 type JSONBase struct {
 	Kind              string    `json:"kind,omitempty" yaml:"kind,omitempty"`
 	ID                string    `json:"id,omitempty" yaml:"id,omitempty"`
+	Namespace         string    `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	CreationTimestamp util.Time `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
 	SelfLink          string    `json:"selfLink,omitempty" yaml:"selfLink,omitempty"`
 	ResourceVersion   uint64    `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -366,7 +366,7 @@ func TestValidateManifest(t *testing.T) {
 
 func TestValidatePod(t *testing.T) {
 	errs := ValidatePod(&api.Pod{
-		JSONBase: api.JSONBase{ID: "foo"},
+		JSONBase: api.JSONBase{ID: "foo", Namespace: api.NamespaceDefault},
 		Labels: map[string]string{
 			"foo": "bar",
 		},
@@ -384,7 +384,7 @@ func TestValidatePod(t *testing.T) {
 		t.Errorf("Unexpected non-zero error list: %#v", errs)
 	}
 	errs = ValidatePod(&api.Pod{
-		JSONBase: api.JSONBase{ID: "foo"},
+		JSONBase: api.JSONBase{ID: "foo", Namespace: api.NamespaceDefault},
 		Labels: map[string]string{
 			"foo": "bar",
 		},
@@ -397,7 +397,7 @@ func TestValidatePod(t *testing.T) {
 	}
 
 	errs = ValidatePod(&api.Pod{
-		JSONBase: api.JSONBase{ID: "foo"},
+		JSONBase: api.JSONBase{ID: "foo", Namespace: api.NamespaceDefault},
 		Labels: map[string]string{
 			"foo": "bar",
 		},
@@ -424,6 +424,7 @@ func TestValidateService(t *testing.T) {
 		{
 			name: "missing id",
 			svc: api.Service{
+				JSONBase: api.JSONBase{Namespace: api.NamespaceDefault},
 				Port:     8675,
 				Selector: map[string]string{"foo": "bar"},
 			},
@@ -431,9 +432,19 @@ func TestValidateService(t *testing.T) {
 			numErrs: 1,
 		},
 		{
+			name: "missing namespace",
+			svc: api.Service{
+				JSONBase: api.JSONBase{ID: "abc123"},
+				Port:     8675,
+				Selector: map[string]string{"foo": "bar"},
+			},
+			// Should fail because the namespace is missing.
+			numErrs: 1,
+		},
+		{
 			name: "invalid id",
 			svc: api.Service{
-				JSONBase: api.JSONBase{ID: "123abc"},
+				JSONBase: api.JSONBase{ID: "123abc", Namespace: api.NamespaceDefault},
 				Port:     8675,
 				Selector: map[string]string{"foo": "bar"},
 			},
@@ -443,7 +454,7 @@ func TestValidateService(t *testing.T) {
 		{
 			name: "missing port",
 			svc: api.Service{
-				JSONBase: api.JSONBase{ID: "abc123"},
+				JSONBase: api.JSONBase{ID: "abc123", Namespace: api.NamespaceDefault},
 				Selector: map[string]string{"foo": "bar"},
 			},
 			// Should fail because the port number is missing/invalid.
@@ -452,7 +463,7 @@ func TestValidateService(t *testing.T) {
 		{
 			name: "invalid port",
 			svc: api.Service{
-				JSONBase: api.JSONBase{ID: "abc123"},
+				JSONBase: api.JSONBase{ID: "abc123", Namespace: api.NamespaceDefault},
 				Port:     65536,
 				Selector: map[string]string{"foo": "bar"},
 			},
@@ -462,7 +473,7 @@ func TestValidateService(t *testing.T) {
 		{
 			name: "invalid protocol",
 			svc: api.Service{
-				JSONBase: api.JSONBase{ID: "abc123"},
+				JSONBase: api.JSONBase{ID: "abc123", Namespace: api.NamespaceDefault},
 				Port:     8675,
 				Protocol: "INVALID",
 				Selector: map[string]string{"foo": "bar"},
@@ -473,7 +484,7 @@ func TestValidateService(t *testing.T) {
 		{
 			name: "missing selector",
 			svc: api.Service{
-				JSONBase: api.JSONBase{ID: "foo"},
+				JSONBase: api.JSONBase{ID: "foo", Namespace: api.NamespaceDefault},
 				Port:     8675,
 			},
 			// Should fail because the selector is missing.
@@ -482,7 +493,7 @@ func TestValidateService(t *testing.T) {
 		{
 			name: "valid 1",
 			svc: api.Service{
-				JSONBase: api.JSONBase{ID: "abc123"},
+				JSONBase: api.JSONBase{ID: "abc123", Namespace: api.NamespaceDefault},
 				Port:     1,
 				Protocol: "TCP",
 				Selector: map[string]string{"foo": "bar"},
@@ -492,7 +503,7 @@ func TestValidateService(t *testing.T) {
 		{
 			name: "valid 2",
 			svc: api.Service{
-				JSONBase: api.JSONBase{ID: "abc123"},
+				JSONBase: api.JSONBase{ID: "abc123", Namespace: api.NamespaceDefault},
 				Port:     65535,
 				Protocol: "UDP",
 				Selector: map[string]string{"foo": "bar"},
@@ -502,7 +513,7 @@ func TestValidateService(t *testing.T) {
 		{
 			name: "valid 3",
 			svc: api.Service{
-				JSONBase: api.JSONBase{ID: "abc123"},
+				JSONBase: api.JSONBase{ID: "abc123", Namespace: api.NamespaceDefault},
 				Port:     80,
 				Selector: map[string]string{"foo": "bar"},
 			},
@@ -519,7 +530,7 @@ func TestValidateService(t *testing.T) {
 
 	svc := api.Service{
 		Port:     6502,
-		JSONBase: api.JSONBase{ID: "foo"},
+		JSONBase: api.JSONBase{ID: "foo", Namespace: api.NamespaceDefault},
 		Selector: map[string]string{"foo": "bar"},
 	}
 	errs := ValidateService(&svc)
@@ -544,14 +555,14 @@ func TestValidateReplicationController(t *testing.T) {
 
 	successCases := []api.ReplicationController{
 		{
-			JSONBase: api.JSONBase{ID: "abc"},
+			JSONBase: api.JSONBase{ID: "abc", Namespace: api.NamespaceDefault},
 			DesiredState: api.ReplicationControllerState{
 				ReplicaSelector: validSelector,
 				PodTemplate:     validPodTemplate,
 			},
 		},
 		{
-			JSONBase: api.JSONBase{ID: "abc-123"},
+			JSONBase: api.JSONBase{ID: "abc-123", Namespace: api.NamespaceDefault},
 			DesiredState: api.ReplicationControllerState{
 				ReplicaSelector: validSelector,
 				PodTemplate:     validPodTemplate,
@@ -566,33 +577,33 @@ func TestValidateReplicationController(t *testing.T) {
 
 	errorCases := map[string]api.ReplicationController{
 		"zero-length ID": {
-			JSONBase: api.JSONBase{ID: ""},
+			JSONBase: api.JSONBase{ID: "", Namespace: api.NamespaceDefault},
 			DesiredState: api.ReplicationControllerState{
 				ReplicaSelector: validSelector,
 				PodTemplate:     validPodTemplate,
 			},
 		},
 		"empty selector": {
-			JSONBase: api.JSONBase{ID: "abc"},
+			JSONBase: api.JSONBase{ID: "abc", Namespace: api.NamespaceDefault},
 			DesiredState: api.ReplicationControllerState{
 				PodTemplate: validPodTemplate,
 			},
 		},
 		"selector_doesnt_match": {
-			JSONBase: api.JSONBase{ID: "abc"},
+			JSONBase: api.JSONBase{ID: "abc", Namespace: api.NamespaceDefault},
 			DesiredState: api.ReplicationControllerState{
 				ReplicaSelector: map[string]string{"foo": "bar"},
 				PodTemplate:     validPodTemplate,
 			},
 		},
 		"invalid manifest": {
-			JSONBase: api.JSONBase{ID: "abc"},
+			JSONBase: api.JSONBase{ID: "abc", Namespace: api.NamespaceDefault},
 			DesiredState: api.ReplicationControllerState{
 				ReplicaSelector: validSelector,
 			},
 		},
 		"negative_replicas": {
-			JSONBase: api.JSONBase{ID: "abc"},
+			JSONBase: api.JSONBase{ID: "abc", Namespace: api.NamespaceDefault},
 			DesiredState: api.ReplicationControllerState{
 				Replicas:        -1,
 				ReplicaSelector: validSelector,
@@ -607,7 +618,7 @@ func TestValidateReplicationController(t *testing.T) {
 		for i := range errs {
 			field := errs[i].(errors.ValidationError).Field
 			if !strings.HasPrefix(field, "desiredState.podTemplate.") &&
-				field != "id" &&
+				field != "ReplicationController.ID" &&
 				field != "desiredState.replicaSelector" &&
 				field != "desiredState.replicas" {
 				t.Errorf("%s: missing prefix for: %v", k, errs[i])

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -88,18 +88,18 @@ type SimpleRESTStorage struct {
 	injectedFunction func(obj runtime.Object) (returnObj runtime.Object, err error)
 }
 
-func (storage *SimpleRESTStorage) List(label, field labels.Selector) (runtime.Object, error) {
+func (storage *SimpleRESTStorage) List(namespace string, label, field labels.Selector) (runtime.Object, error) {
 	result := &SimpleList{
 		Items: storage.list,
 	}
 	return result, storage.errors["list"]
 }
 
-func (storage *SimpleRESTStorage) Get(id string) (runtime.Object, error) {
+func (storage *SimpleRESTStorage) Get(namespace string, id string) (runtime.Object, error) {
 	return api.Scheme.CopyOrDie(&storage.item), storage.errors["get"]
 }
 
-func (storage *SimpleRESTStorage) Delete(id string) (<-chan runtime.Object, error) {
+func (storage *SimpleRESTStorage) Delete(namespace string, id string) (<-chan runtime.Object, error) {
 	storage.deleted = id
 	if err := storage.errors["delete"]; err != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func (storage *SimpleRESTStorage) New() runtime.Object {
 	return &Simple{}
 }
 
-func (storage *SimpleRESTStorage) Create(obj runtime.Object) (<-chan runtime.Object, error) {
+func (storage *SimpleRESTStorage) Create(namespace string, obj runtime.Object) (<-chan runtime.Object, error) {
 	storage.created = obj.(*Simple)
 	if err := storage.errors["create"]; err != nil {
 		return nil, err
@@ -129,7 +129,7 @@ func (storage *SimpleRESTStorage) Create(obj runtime.Object) (<-chan runtime.Obj
 	}), nil
 }
 
-func (storage *SimpleRESTStorage) Update(obj runtime.Object) (<-chan runtime.Object, error) {
+func (storage *SimpleRESTStorage) Update(namespace string, obj runtime.Object) (<-chan runtime.Object, error) {
 	storage.updated = obj.(*Simple)
 	if err := storage.errors["update"]; err != nil {
 		return nil, err
@@ -155,7 +155,7 @@ func (storage *SimpleRESTStorage) Watch(label, field labels.Selector, resourceVe
 }
 
 // Implement Redirector.
-func (storage *SimpleRESTStorage) ResourceLocation(id string) (string, error) {
+func (storage *SimpleRESTStorage) ResourceLocation(namespace string, id string) (string, error) {
 	storage.requestedResourceLocationID = id
 	if err := storage.errors["resourceLocation"]; err != nil {
 		return "", err

--- a/pkg/apiserver/interfaces.go
+++ b/pkg/apiserver/interfaces.go
@@ -30,20 +30,20 @@ type RESTStorage interface {
 	New() runtime.Object
 
 	// List selects resources in the storage which match to the selector.
-	List(label, field labels.Selector) (runtime.Object, error)
+	List(namespace string, label, field labels.Selector) (runtime.Object, error)
 
 	// Get finds a resource in the storage by id and returns it.
 	// Although it can return an arbitrary error value, IsNotFound(err) is true for the
 	// returned error value err when the specified resource is not found.
-	Get(id string) (runtime.Object, error)
+	Get(namespace string, id string) (runtime.Object, error)
 
 	// Delete finds a resource in the storage and deletes it.
 	// Although it can return an arbitrary error value, IsNotFound(err) is true for the
 	// returned error value err when the specified resource is not found.
-	Delete(id string) (<-chan runtime.Object, error)
+	Delete(namespace string, id string) (<-chan runtime.Object, error)
 
-	Create(runtime.Object) (<-chan runtime.Object, error)
-	Update(runtime.Object) (<-chan runtime.Object, error)
+	Create(namespace string, obj runtime.Object) (<-chan runtime.Object, error)
+	Update(namespace string, obj runtime.Object) (<-chan runtime.Object, error)
 }
 
 // ResourceWatcher should be implemented by all RESTStorage objects that
@@ -59,5 +59,5 @@ type ResourceWatcher interface {
 // Redirector know how to return a remote resource's location.
 type Redirector interface {
 	// ResourceLocation should return the remote location of the given resource, or an error.
-	ResourceLocation(id string) (remoteLocation string, err error)
+	ResourceLocation(namespace string, id string) (remoteLocation string, err error)
 }

--- a/pkg/apiserver/proxy.go
+++ b/pkg/apiserver/proxy.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -76,6 +77,7 @@ type ProxyHandler struct {
 }
 
 func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	namespace := api.NamespaceDefault
 	parts := strings.SplitN(req.URL.Path, "/", 3)
 	if len(parts) < 2 {
 		notFound(w, req)
@@ -101,7 +103,7 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	location, err := redirector.ResourceLocation(id)
+	location, err := redirector.ResourceLocation(namespace, id)
 	if err != nil {
 		status := errToAPIStatus(err)
 		writeJSON(status.Code, r.codec, status, w)

--- a/pkg/apiserver/redirect.go
+++ b/pkg/apiserver/redirect.go
@@ -19,6 +19,7 @@ package apiserver
 import (
 	"net/http"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
@@ -29,6 +30,7 @@ type RedirectHandler struct {
 }
 
 func (r *RedirectHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	namespace := api.NamespaceDefault
 	parts := splitPath(req.URL.Path)
 	if len(parts) != 2 || req.Method != "GET" {
 		notFound(w, req)
@@ -50,7 +52,7 @@ func (r *RedirectHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	location, err := redirector.ResourceLocation(id)
+	location, err := redirector.ResourceLocation(namespace, id)
 	if err != nil {
 		status := errToAPIStatus(err)
 		writeJSON(status.Code, r.codec, status, w)

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiserver
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -66,7 +67,8 @@ func (h *RESTHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w http.ResponseWriter, storage RESTStorage) {
 	sync := req.URL.Query().Get("sync") == "true"
 	timeout := parseTimeout(req.URL.Query().Get("timeout"))
-	namespace := api.NamespaceDefault
+	namespace := req.URL.Query().Get("namespace")
+	fmt.Printf("Using namespace: %s", namespace)
 	switch req.Method {
 	case "GET":
 		switch len(parts) {

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -66,6 +66,7 @@ func (h *RESTHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w http.ResponseWriter, storage RESTStorage) {
 	sync := req.URL.Query().Get("sync") == "true"
 	timeout := parseTimeout(req.URL.Query().Get("timeout"))
+	namespace := api.NamespaceDefault
 	switch req.Method {
 	case "GET":
 		switch len(parts) {
@@ -80,14 +81,14 @@ func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w htt
 				errorJSON(err, h.codec, w)
 				return
 			}
-			list, err := storage.List(label, field)
+			list, err := storage.List(namespace, label, field)
 			if err != nil {
 				errorJSON(err, h.codec, w)
 				return
 			}
 			writeJSON(http.StatusOK, h.codec, list, w)
 		case 2:
-			item, err := storage.Get(parts[1])
+			item, err := storage.Get(namespace, parts[1])
 			if err != nil {
 				errorJSON(err, h.codec, w)
 				return
@@ -113,7 +114,7 @@ func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w htt
 			errorJSON(err, h.codec, w)
 			return
 		}
-		out, err := storage.Create(obj)
+		out, err := storage.Create(namespace, obj)
 		if err != nil {
 			errorJSON(err, h.codec, w)
 			return
@@ -126,7 +127,7 @@ func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w htt
 			notFound(w, req)
 			return
 		}
-		out, err := storage.Delete(parts[1])
+		out, err := storage.Delete(namespace, parts[1])
 		if err != nil {
 			errorJSON(err, h.codec, w)
 			return
@@ -150,7 +151,7 @@ func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w htt
 			errorJSON(err, h.codec, w)
 			return
 		}
-		out, err := storage.Update(obj)
+		out, err := storage.Update(namespace, obj)
 		if err != nil {
 			errorJSON(err, h.codec, w)
 			return

--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -59,6 +59,7 @@ func (r RealPodControl) createReplica(controllerSpec api.ReplicationController) 
 		labels["replicationController"] = controllerSpec.ID
 	}
 	pod := &api.Pod{
+		JSONBase:     api.JSONBase{Namespace: controllerSpec.Namespace},
 		DesiredState: controllerSpec.DesiredState.PodTemplate.DesiredState,
 		Labels:       controllerSpec.DesiredState.PodTemplate.Labels,
 	}

--- a/pkg/kubecfg/kubecfg.go
+++ b/pkg/kubecfg/kubecfg.go
@@ -75,6 +75,35 @@ func LoadAuthInfo(path string, r io.Reader) (*client.AuthInfo, error) {
 	return &auth, err
 }
 
+// LoadNamespaceInfo parses a NamespaceInfo object from a file path.  It creates a file at the specified path if it doesn't exist with the default namespace.
+func LoadNamespaceInfo(path string, r io.Reader) (*client.NamespaceInfo, error) {
+	var ns client.NamespaceInfo
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		ns.Namespace = api.NamespaceDefault
+		SaveNamespaceInfo(path, &ns)
+		return &ns, err
+	}
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(data, &ns)
+	if err != nil {
+		return nil, err
+	}
+	return &ns, err
+}
+
+// SaveNamespaceInfo saves a NamespaceInfo object at the specified file path.
+func SaveNamespaceInfo(path string, ns *client.NamespaceInfo) error {
+	if !util.IsDNSLabel(ns.Namespace) {
+		return fmt.Errorf("Namespace %s is not a valid DNS Label", ns.Namespace)
+	}
+	data, err := json.Marshal(ns)
+	err = ioutil.WriteFile(path, data, 0600)
+	return err
+}
+
 // Update performs a rolling update of a collection of pods.
 // 'name' points to a replication controller.
 // 'client' is used for updating pods.

--- a/pkg/master/pod_cache.go
+++ b/pkg/master/pod_cache.go
@@ -72,7 +72,7 @@ func (p *PodCache) updatePodInfo(host, id string) error {
 
 // UpdateAllContainers updates information about all containers.  Either called by Loop() below, or one-off.
 func (p *PodCache) UpdateAllContainers() {
-	pods, err := p.pods.ListPods(labels.Everything())
+	pods, err := p.pods.ListPods(api.NamespaceAll, labels.Everything())
 	if err != nil {
 		glog.Errorf("Error synchronizing container list: %v", err)
 		return

--- a/pkg/registry/binding/rest.go
+++ b/pkg/registry/binding/rest.go
@@ -41,17 +41,17 @@ func NewREST(bindingRegistry Registry) *REST {
 }
 
 // List returns an error because bindings are write-only objects.
-func (*REST) List(label, field labels.Selector) (runtime.Object, error) {
+func (*REST) List(namespace string, label, field labels.Selector) (runtime.Object, error) {
 	return nil, errors.NewNotFound("binding", "list")
 }
 
 // Get returns an error because bindings are write-only objects.
-func (*REST) Get(id string) (runtime.Object, error) {
+func (*REST) Get(namespace string, id string) (runtime.Object, error) {
 	return nil, errors.NewNotFound("binding", id)
 }
 
 // Delete returns an error because bindings are write-only objects.
-func (*REST) Delete(id string) (<-chan runtime.Object, error) {
+func (*REST) Delete(namespace string, id string) (<-chan runtime.Object, error) {
 	return nil, errors.NewNotFound("binding", id)
 }
 
@@ -61,10 +61,15 @@ func (*REST) New() runtime.Object {
 }
 
 // Create attempts to make the assignment indicated by the binding it recieves.
-func (b *REST) Create(obj runtime.Object) (<-chan runtime.Object, error) {
+func (b *REST) Create(namespace string, obj runtime.Object) (<-chan runtime.Object, error) {
 	binding, ok := obj.(*api.Binding)
+	// TODO find out if we have a nemspace
 	if !ok {
 		return nil, fmt.Errorf("incorrect type: %#v", obj)
+	}
+	// ensure the namespace is equal to the object
+	if len(namespace) > 0 {
+		binding.Namespace = namespace
 	}
 	return apiserver.MakeAsync(func() (runtime.Object, error) {
 		if err := b.registry.ApplyBinding(binding); err != nil {
@@ -75,6 +80,6 @@ func (b *REST) Create(obj runtime.Object) (<-chan runtime.Object, error) {
 }
 
 // Update returns an error-- this object may not be updated.
-func (b *REST) Update(obj runtime.Object) (<-chan runtime.Object, error) {
+func (b *REST) Update(namespace string, obj runtime.Object) (<-chan runtime.Object, error) {
 	return nil, fmt.Errorf("Bindings may not be changed.")
 }

--- a/pkg/registry/binding/rest_test.go
+++ b/pkg/registry/binding/rest_test.go
@@ -56,20 +56,20 @@ func TestRESTUnsupported(t *testing.T) {
 		OnApplyBinding: func(b *api.Binding) error { return nil },
 	}
 	b := NewREST(mockRegistry)
-	if _, err := b.Delete("binding id"); err == nil {
+	if _, err := b.Delete(api.NamespaceDefault, "binding id"); err == nil {
 		t.Errorf("unexpected non-error")
 	}
-	if _, err := b.Update(&api.Binding{PodID: "foo", Host: "new machine"}); err == nil {
+	if _, err := b.Update(api.NamespaceDefault, &api.Binding{PodID: "foo", Host: "new machine"}); err == nil {
 		t.Errorf("unexpected non-error")
 	}
-	if _, err := b.Get("binding id"); err == nil {
+	if _, err := b.Get(api.NamespaceDefault, "binding id"); err == nil {
 		t.Errorf("unexpected non-error")
 	}
-	if _, err := b.List(labels.Set{"name": "foo"}.AsSelector(), labels.Everything()); err == nil {
+	if _, err := b.List(api.NamespaceDefault, labels.Set{"name": "foo"}.AsSelector(), labels.Everything()); err == nil {
 		t.Errorf("unexpected non-error")
 	}
 	// Try sending wrong object just to get 100% coverage
-	if _, err := b.Create(&api.Pod{}); err == nil {
+	if _, err := b.Create(api.NamespaceDefault, &api.Pod{}); err == nil {
 		t.Errorf("unexpected non-error")
 	}
 }
@@ -94,7 +94,7 @@ func TestRESTPost(t *testing.T) {
 			},
 		}
 		b := NewREST(mockRegistry)
-		resultChan, err := b.Create(item.b)
+		resultChan, err := b.Create(api.NamespaceDefault, item.b)
 		if err != nil {
 			t.Errorf("Unexpected error %v", err)
 			continue

--- a/pkg/registry/controller/registry.go
+++ b/pkg/registry/controller/registry.go
@@ -23,10 +23,10 @@ import (
 
 // Registry is an interface for things that know how to store ReplicationControllers.
 type Registry interface {
-	ListControllers() (*api.ReplicationControllerList, error)
+	ListControllers(namespace string) (*api.ReplicationControllerList, error)
 	WatchControllers(resourceVersion uint64) (watch.Interface, error)
-	GetController(controllerID string) (*api.ReplicationController, error)
+	GetController(namespace string, controllerID string) (*api.ReplicationController, error)
 	CreateController(controller *api.ReplicationController) error
 	UpdateController(controller *api.ReplicationController) error
-	DeleteController(controllerID string) error
+	DeleteController(namespace string, controllerID string) error
 }

--- a/pkg/registry/endpoint/registry.go
+++ b/pkg/registry/endpoint/registry.go
@@ -24,8 +24,8 @@ import (
 
 // Registry is an interface for things that know how to store endpoints.
 type Registry interface {
-	ListEndpoints() (*api.EndpointsList, error)
-	GetEndpoints(name string) (*api.Endpoints, error)
+	ListEndpoints(namespace string) (*api.EndpointsList, error)
+	GetEndpoints(namespace string, name string) (*api.Endpoints, error)
 	WatchEndpoints(labels, fields labels.Selector, resourceVersion uint64) (watch.Interface, error)
 	UpdateEndpoints(e *api.Endpoints) error
 }

--- a/pkg/registry/endpoint/rest.go
+++ b/pkg/registry/endpoint/rest.go
@@ -38,16 +38,16 @@ func NewREST(registry Registry) *REST {
 }
 
 // Get satisfies the RESTStorage interface.
-func (rs *REST) Get(id string) (runtime.Object, error) {
-	return rs.registry.GetEndpoints(id)
+func (rs *REST) Get(namespace string, id string) (runtime.Object, error) {
+	return rs.registry.GetEndpoints(namespace, id)
 }
 
 // List satisfies the RESTStorage interface.
-func (rs *REST) List(label, field labels.Selector) (runtime.Object, error) {
+func (rs *REST) List(namespace string, label, field labels.Selector) (runtime.Object, error) {
 	if !label.Empty() || !field.Empty() {
 		return nil, errors.New("label/field selectors are not supported on endpoints")
 	}
-	return rs.registry.ListEndpoints()
+	return rs.registry.ListEndpoints(namespace)
 }
 
 // Watch returns Endpoint events via a watch.Interface.
@@ -57,17 +57,17 @@ func (rs *REST) Watch(label, field labels.Selector, resourceVersion uint64) (wat
 }
 
 // Create satisfies the RESTStorage interface but is unimplemented.
-func (rs *REST) Create(obj runtime.Object) (<-chan runtime.Object, error) {
+func (rs *REST) Create(namespace string, obj runtime.Object) (<-chan runtime.Object, error) {
 	return nil, errors.New("unimplemented")
 }
 
 // Update satisfies the RESTStorage interface but is unimplemented.
-func (rs *REST) Update(obj runtime.Object) (<-chan runtime.Object, error) {
+func (rs *REST) Update(namespace string, obj runtime.Object) (<-chan runtime.Object, error) {
 	return nil, errors.New("unimplemented")
 }
 
 // Delete satisfies the RESTStorage interface but is unimplemented.
-func (rs *REST) Delete(id string) (<-chan runtime.Object, error) {
+func (rs *REST) Delete(namespace string, id string) (<-chan runtime.Object, error) {
 	return nil, errors.New("unimplemented")
 }
 

--- a/pkg/registry/endpoint/rest_test.go
+++ b/pkg/registry/endpoint/rest_test.go
@@ -29,12 +29,12 @@ import (
 func TestGetEndpoints(t *testing.T) {
 	registry := &registrytest.ServiceRegistry{
 		Endpoints: api.Endpoints{
-			JSONBase:  api.JSONBase{ID: "foo"},
+			JSONBase:  api.JSONBase{ID: "foo", Namespace: api.NamespaceDefault},
 			Endpoints: []string{"127.0.0.1:9000"},
 		},
 	}
 	storage := NewREST(registry)
-	obj, err := storage.Get("foo")
+	obj, err := storage.Get(api.NamespaceDefault, "foo")
 	if err != nil {
 		t.Fatalf("unexpected error: %#v", err)
 	}
@@ -50,7 +50,7 @@ func TestGetEndpointsMissingService(t *testing.T) {
 	storage := NewREST(registry)
 
 	// returns service not found
-	_, err := storage.Get("foo")
+	_, err := storage.Get(api.NamespaceDefault, "foo")
 	if !errors.IsNotFound(err) || !reflect.DeepEqual(err, errors.NewNotFound("service", "foo")) {
 		t.Errorf("expected NotFound error, got %#v", err)
 	}
@@ -58,9 +58,9 @@ func TestGetEndpointsMissingService(t *testing.T) {
 	// returns empty endpoints
 	registry.Err = nil
 	registry.Service = &api.Service{
-		JSONBase: api.JSONBase{ID: "foo"},
+		JSONBase: api.JSONBase{ID: "foo", Namespace: api.NamespaceDefault},
 	}
-	obj, err := storage.Get("foo")
+	obj, err := storage.Get(api.NamespaceDefault, "foo")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -75,11 +75,11 @@ func TestEndpointsRegistryList(t *testing.T) {
 	registry.EndpointsList = api.EndpointsList{
 		JSONBase: api.JSONBase{ResourceVersion: 1},
 		Items: []api.Endpoints{
-			{JSONBase: api.JSONBase{ID: "foo"}},
-			{JSONBase: api.JSONBase{ID: "bar"}},
+			{JSONBase: api.JSONBase{ID: "foo", Namespace: api.NamespaceDefault}},
+			{JSONBase: api.JSONBase{ID: "bar", Namespace: api.NamespaceDefault}},
 		},
 	}
-	s, _ := storage.List(labels.Everything(), labels.Everything())
+	s, _ := storage.List(api.NamespaceDefault, labels.Everything(), labels.Everything())
 	sl := s.(*api.EndpointsList)
 	if len(sl.Items) != 2 {
 		t.Fatalf("Expected 2 endpoints, but got %v", len(sl.Items))

--- a/pkg/registry/etcd/etcd_test.go
+++ b/pkg/registry/etcd/etcd_test.go
@@ -41,28 +41,32 @@ func NewTestEtcdRegistry(client tools.EtcdClient) *Registry {
 
 func TestEtcdGetPod(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Set("/registry/pods/foo", runtime.EncodeOrDie(latest.Codec, &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	ns := api.NamespaceDefault
+	id := "foo"
+	fakeClient.Set(makePodKey(ns, id), runtime.EncodeOrDie(latest.Codec, &api.Pod{JSONBase: api.JSONBase{ID: id, Namespace: ns}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
-	pod, err := registry.GetPod("foo")
+	pod, err := registry.GetPod(ns, id)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if pod.ID != "foo" {
+	if pod.ID != id {
 		t.Errorf("Unexpected pod: %#v", pod)
 	}
 }
 
 func TestEtcdGetPodNotFound(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Data["/registry/pods/foo"] = tools.EtcdResponseWithError{
+	ns := api.NamespaceDefault
+	id := "foo"
+	fakeClient.Data[makePodKey(ns, id)] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
 		},
 		E: tools.EtcdErrorNotFound,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	_, err := registry.GetPod("foo")
+	_, err := registry.GetPod(ns, id)
 	if !errors.IsNotFound(err) {
 		t.Errorf("Unexpected error returned: %#v", err)
 	}
@@ -71,7 +75,9 @@ func TestEtcdGetPodNotFound(t *testing.T) {
 func TestEtcdCreatePod(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
-	fakeClient.Data["/registry/pods/foo"] = tools.EtcdResponseWithError{
+	ns := api.NamespaceDefault
+	id := "foo"
+	fakeClient.Data[makePodKey(ns, id)] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
 		},
@@ -81,7 +87,8 @@ func TestEtcdCreatePod(t *testing.T) {
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreatePod(&api.Pod{
 		JSONBase: api.JSONBase{
-			ID: "foo",
+			ID:        id,
+			Namespace: ns,
 		},
 		DesiredState: api.PodState{
 			Manifest: api.ContainerManifest{
@@ -98,12 +105,12 @@ func TestEtcdCreatePod(t *testing.T) {
 	}
 
 	// Suddenly, a wild scheduler appears:
-	err = registry.ApplyBinding(&api.Binding{PodID: "foo", Host: "machine"})
+	err = registry.ApplyBinding(&api.Binding{JSONBase: api.JSONBase{Namespace: ns}, PodID: id, Host: "machine"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	resp, err := fakeClient.Get("/registry/pods/foo", false, false)
+	resp, err := fakeClient.Get(makePodKey(ns, id), false, false)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
@@ -113,7 +120,7 @@ func TestEtcdCreatePod(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if pod.ID != "foo" {
+	if pod.ID != id {
 		t.Errorf("Unexpected pod: %#v %s", pod, resp.Node.Value)
 	}
 	var manifests api.ContainerManifestList
@@ -130,10 +137,12 @@ func TestEtcdCreatePod(t *testing.T) {
 
 func TestEtcdCreatePodAlreadyExisting(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Data["/registry/pods/foo"] = tools.EtcdResponseWithError{
+	ns := api.NamespaceDefault
+	id := "foo"
+	fakeClient.Data[makePodKey(ns, id)] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
-				Value: runtime.EncodeOrDie(latest.Codec, &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}),
+				Value: runtime.EncodeOrDie(latest.Codec, &api.Pod{JSONBase: api.JSONBase{ID: id, Namespace: ns}}),
 			},
 		},
 		E: nil,
@@ -141,7 +150,8 @@ func TestEtcdCreatePodAlreadyExisting(t *testing.T) {
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreatePod(&api.Pod{
 		JSONBase: api.JSONBase{
-			ID: "foo",
+			ID:        id,
+			Namespace: ns,
 		},
 	})
 	if !errors.IsAlreadyExists(err) {
@@ -152,7 +162,9 @@ func TestEtcdCreatePodAlreadyExisting(t *testing.T) {
 func TestEtcdCreatePodWithContainersError(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
-	fakeClient.Data["/registry/pods/foo"] = tools.EtcdResponseWithError{
+	ns := api.NamespaceDefault
+	id := "foo"
+	fakeClient.Data[makePodKey(ns, id)] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
 		},
@@ -167,7 +179,8 @@ func TestEtcdCreatePodWithContainersError(t *testing.T) {
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreatePod(&api.Pod{
 		JSONBase: api.JSONBase{
-			ID: "foo",
+			ID:        id,
+			Namespace: ns,
 		},
 	})
 	if err != nil {
@@ -175,12 +188,12 @@ func TestEtcdCreatePodWithContainersError(t *testing.T) {
 	}
 
 	// Suddenly, a wild scheduler appears:
-	err = registry.ApplyBinding(&api.Binding{PodID: "foo", Host: "machine"})
+	err = registry.ApplyBinding(&api.Binding{JSONBase: api.JSONBase{Namespace: ns}, PodID: id, Host: "machine"})
 	if !errors.IsAlreadyExists(err) {
 		t.Fatalf("Unexpected error returned: %#v", err)
 	}
 
-	existingPod, err := registry.GetPod("foo")
+	existingPod, err := registry.GetPod(api.NamespaceDefault, "foo")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -190,9 +203,12 @@ func TestEtcdCreatePodWithContainersError(t *testing.T) {
 }
 
 func TestEtcdCreatePodWithContainersNotFound(t *testing.T) {
+	id := "foo"
+	ns := api.NamespaceDefault
+	key := makePodKey(ns, id)
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
-	fakeClient.Data["/registry/pods/foo"] = tools.EtcdResponseWithError{
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
 		},
@@ -207,11 +223,12 @@ func TestEtcdCreatePodWithContainersNotFound(t *testing.T) {
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreatePod(&api.Pod{
 		JSONBase: api.JSONBase{
-			ID: "foo",
+			ID:        id,
+			Namespace: ns,
 		},
 		DesiredState: api.PodState{
 			Manifest: api.ContainerManifest{
-				ID: "foo",
+				ID: id,
 				Containers: []api.Container{
 					{
 						Name: "foo",
@@ -225,12 +242,12 @@ func TestEtcdCreatePodWithContainersNotFound(t *testing.T) {
 	}
 
 	// Suddenly, a wild scheduler appears:
-	err = registry.ApplyBinding(&api.Binding{PodID: "foo", Host: "machine"})
+	err = registry.ApplyBinding(&api.Binding{JSONBase: api.JSONBase{Namespace: ns}, PodID: id, Host: "machine"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	resp, err := fakeClient.Get("/registry/pods/foo", false, false)
+	resp, err := fakeClient.Get(key, false, false)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
@@ -240,7 +257,7 @@ func TestEtcdCreatePodWithContainersNotFound(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if pod.ID != "foo" {
+	if pod.ID != id {
 		t.Errorf("Unexpected pod: %#v %s", pod, resp.Node.Value)
 	}
 	var manifests api.ContainerManifestList
@@ -256,9 +273,12 @@ func TestEtcdCreatePodWithContainersNotFound(t *testing.T) {
 }
 
 func TestEtcdCreatePodWithExistingContainers(t *testing.T) {
+	id := "foo"
+	ns := api.NamespaceDefault
+	key := makePodKey(ns, id)
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
-	fakeClient.Data["/registry/pods/foo"] = tools.EtcdResponseWithError{
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
 		},
@@ -272,7 +292,8 @@ func TestEtcdCreatePodWithExistingContainers(t *testing.T) {
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreatePod(&api.Pod{
 		JSONBase: api.JSONBase{
-			ID: "foo",
+			ID:        id,
+			Namespace: ns,
 		},
 		DesiredState: api.PodState{
 			Manifest: api.ContainerManifest{
@@ -290,12 +311,12 @@ func TestEtcdCreatePodWithExistingContainers(t *testing.T) {
 	}
 
 	// Suddenly, a wild scheduler appears:
-	err = registry.ApplyBinding(&api.Binding{PodID: "foo", Host: "machine"})
+	err = registry.ApplyBinding(&api.Binding{JSONBase: api.JSONBase{Namespace: ns}, PodID: "foo", Host: "machine"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	resp, err := fakeClient.Get("/registry/pods/foo", false, false)
+	resp, err := fakeClient.Get(key, false, false)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
@@ -305,7 +326,7 @@ func TestEtcdCreatePodWithExistingContainers(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if pod.ID != "foo" {
+	if pod.ID != id {
 		t.Errorf("Unexpected pod: %#v %s", pod, resp.Node.Value)
 	}
 	var manifests api.ContainerManifestList
@@ -324,9 +345,12 @@ func TestEtcdDeletePod(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 
-	key := "/registry/pods/foo"
+	ns := api.NamespaceDefault
+	id := "foo"
+	key := makePodKey(ns, id)
+
 	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &api.Pod{
-		JSONBase:     api.JSONBase{ID: "foo"},
+		JSONBase:     api.JSONBase{ID: "foo", Namespace: api.NamespaceDefault},
 		DesiredState: api.PodState{Host: "machine"},
 	}), 0)
 	fakeClient.Set("/registry/hosts/machine/kubelet", runtime.EncodeOrDie(latest.Codec, &api.ContainerManifestList{
@@ -335,7 +359,7 @@ func TestEtcdDeletePod(t *testing.T) {
 		},
 	}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.DeletePod("foo")
+	err := registry.DeletePod(api.NamespaceDefault, "foo")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -360,9 +384,12 @@ func TestEtcdDeletePodMultipleContainers(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 
-	key := "/registry/pods/foo"
+	ns := api.NamespaceDefault
+	id := "foo"
+	key := makePodKey(ns, id)
+
 	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &api.Pod{
-		JSONBase:     api.JSONBase{ID: "foo"},
+		JSONBase:     api.JSONBase{ID: "foo", Namespace: api.NamespaceDefault},
 		DesiredState: api.PodState{Host: "machine"},
 	}), 0)
 	fakeClient.Set("/registry/hosts/machine/kubelet", runtime.EncodeOrDie(latest.Codec, &api.ContainerManifestList{
@@ -372,7 +399,7 @@ func TestEtcdDeletePodMultipleContainers(t *testing.T) {
 		},
 	}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.DeletePod("foo")
+	err := registry.DeletePod(api.NamespaceDefault, "foo")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -399,7 +426,8 @@ func TestEtcdDeletePodMultipleContainers(t *testing.T) {
 
 func TestEtcdEmptyListPods(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	key := "/registry/pods"
+	ns := api.NamespaceDefault
+	key := makePodKey(ns, "")
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
@@ -409,7 +437,7 @@ func TestEtcdEmptyListPods(t *testing.T) {
 		E: nil,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	pods, err := registry.ListPods(labels.Everything())
+	pods, err := registry.ListPods(ns, labels.Everything())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -421,13 +449,14 @@ func TestEtcdEmptyListPods(t *testing.T) {
 
 func TestEtcdListPodsNotFound(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	key := "/registry/pods"
+	ns := api.NamespaceDefault
+	key := makePodKey(ns, "")
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
 		E: tools.EtcdErrorNotFound,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	pods, err := registry.ListPods(labels.Everything())
+	pods, err := registry.ListPods(ns, labels.Everything())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -439,20 +468,21 @@ func TestEtcdListPodsNotFound(t *testing.T) {
 
 func TestEtcdListPods(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	key := "/registry/pods"
+	ns := api.NamespaceDefault
+	key := makePodKey(ns, "")
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
 					{
 						Value: runtime.EncodeOrDie(latest.Codec, &api.Pod{
-							JSONBase:     api.JSONBase{ID: "foo"},
+							JSONBase:     api.JSONBase{ID: "foo", Namespace: ns},
 							DesiredState: api.PodState{Host: "machine"},
 						}),
 					},
 					{
 						Value: runtime.EncodeOrDie(latest.Codec, &api.Pod{
-							JSONBase:     api.JSONBase{ID: "bar"},
+							JSONBase:     api.JSONBase{ID: "bar", Namespace: ns},
 							DesiredState: api.PodState{Host: "machine"},
 						}),
 					},
@@ -462,7 +492,7 @@ func TestEtcdListPods(t *testing.T) {
 		E: nil,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	pods, err := registry.ListPods(labels.Everything())
+	pods, err := registry.ListPods(ns, labels.Everything())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -478,13 +508,13 @@ func TestEtcdListPods(t *testing.T) {
 
 func TestEtcdListControllersNotFound(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	key := "/registry/controllers"
+	key := makeControllerKey(api.NamespaceDefault, "")
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
 		E: tools.EtcdErrorNotFound,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	controllers, err := registry.ListControllers()
+	controllers, err := registry.ListControllers(api.NamespaceDefault)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -496,13 +526,14 @@ func TestEtcdListControllersNotFound(t *testing.T) {
 
 func TestEtcdListServicesNotFound(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	key := "/registry/services/specs"
+	ns := api.NamespaceDefault
+	key := makeServiceKey(ns, "")
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
 		E: tools.EtcdErrorNotFound,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	services, err := registry.ListServices()
+	services, err := registry.ListServices(ns)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -514,24 +545,25 @@ func TestEtcdListServicesNotFound(t *testing.T) {
 
 func TestEtcdListControllers(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	key := "/registry/controllers"
+	registry := NewTestEtcdRegistry(fakeClient)
+	ns := api.NamespaceDefault
+	key := makeControllerKey(ns, "")
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
 					{
-						Value: runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}),
+						Value: runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: "foo", Namespace: ns}}),
 					},
 					{
-						Value: runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: "bar"}}),
+						Value: runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: "bar", Namespace: ns}}),
 					},
 				},
 			},
 		},
 		E: nil,
 	}
-	registry := NewTestEtcdRegistry(fakeClient)
-	controllers, err := registry.ListControllers()
+	controllers, err := registry.ListControllers(ns)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -542,29 +574,33 @@ func TestEtcdListControllers(t *testing.T) {
 }
 
 func TestEtcdGetController(t *testing.T) {
+	ns := api.NamespaceDefault
+	id := "foo"
+	key := makeControllerKey(ns, id)
+
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Set("/registry/controllers/foo", runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: id, Namespace: ns}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
-	ctrl, err := registry.GetController("foo")
+	ctrl, err := registry.GetController(ns, id)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if ctrl.ID != "foo" {
+	if ctrl.ID != id {
 		t.Errorf("Unexpected controller: %#v", ctrl)
 	}
 }
 
 func TestEtcdGetControllerNotFound(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Data["/registry/controllers/foo"] = tools.EtcdResponseWithError{
+	fakeClient.Data["/registry/controllers/"+api.NamespaceDefault+"/foo"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
 		},
 		E: tools.EtcdErrorNotFound,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	ctrl, err := registry.GetController("foo")
+	ctrl, err := registry.GetController(api.NamespaceDefault, "foo")
 	if ctrl != nil {
 		t.Errorf("Unexpected non-nil controller: %#v", ctrl)
 	}
@@ -574,35 +610,41 @@ func TestEtcdGetControllerNotFound(t *testing.T) {
 }
 
 func TestEtcdDeleteController(t *testing.T) {
+	ns := api.NamespaceDefault
+	id := "foo"
+	key := makeControllerKey(ns, id)
 	fakeClient := tools.NewFakeEtcdClient(t)
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.DeleteController("foo")
+	err := registry.DeleteController(ns, id)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-
 	if len(fakeClient.DeletedKeys) != 1 {
 		t.Errorf("Expected 1 delete, found %#v", fakeClient.DeletedKeys)
 	}
-	key := "/registry/controllers/foo"
 	if fakeClient.DeletedKeys[0] != key {
 		t.Errorf("Unexpected key: %s, expected %s", fakeClient.DeletedKeys[0], key)
 	}
 }
 
 func TestEtcdCreateController(t *testing.T) {
+	ns := api.NamespaceDefault
+	id := "foo"
+	key := makeControllerKey(ns, id)
+
 	fakeClient := tools.NewFakeEtcdClient(t)
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreateController(&api.ReplicationController{
 		JSONBase: api.JSONBase{
-			ID: "foo",
+			ID:        id,
+			Namespace: ns,
 		},
 	})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	resp, err := fakeClient.Get("/registry/controllers/foo", false, false)
+	resp, err := fakeClient.Get(key, false, false)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
@@ -618,13 +660,18 @@ func TestEtcdCreateController(t *testing.T) {
 }
 
 func TestEtcdCreateControllerAlreadyExisting(t *testing.T) {
+	ns := api.NamespaceDefault
+	id := "foo"
+	key := makeControllerKey(ns, id)
+
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Set("/registry/controllers/foo", runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: id, Namespace: ns}}), 0)
 
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreateController(&api.ReplicationController{
 		JSONBase: api.JSONBase{
-			ID: "foo",
+			ID:        id,
+			Namespace: ns,
 		},
 	})
 	if !errors.IsAlreadyExists(err) {
@@ -633,13 +680,17 @@ func TestEtcdCreateControllerAlreadyExisting(t *testing.T) {
 }
 
 func TestEtcdUpdateController(t *testing.T) {
+	ns := api.NamespaceDefault
+	id := "foo"
+	key := makeControllerKey(ns, id)
+
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 
-	resp, _ := fakeClient.Set("/registry/controllers/foo", runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	resp, _ := fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: id, Namespace: ns}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.UpdateController(&api.ReplicationController{
-		JSONBase: api.JSONBase{ID: "foo", ResourceVersion: resp.Node.ModifiedIndex},
+		JSONBase: api.JSONBase{ID: id, Namespace: ns, ResourceVersion: resp.Node.ModifiedIndex},
 		DesiredState: api.ReplicationControllerState{
 			Replicas: 2,
 		},
@@ -648,7 +699,7 @@ func TestEtcdUpdateController(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	ctrl, err := registry.GetController("foo")
+	ctrl, err := registry.GetController(ns, id)
 	if ctrl.DesiredState.Replicas != 2 {
 		t.Errorf("Unexpected controller: %#v", ctrl)
 	}
@@ -656,16 +707,17 @@ func TestEtcdUpdateController(t *testing.T) {
 
 func TestEtcdListServices(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	key := "/registry/services/specs"
+	ns := api.NamespaceDefault
+	key := makeServiceKey(ns, "")
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
 					{
-						Value: runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: "foo"}}),
+						Value: runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: "foo", Namespace: ns}}),
 					},
 					{
-						Value: runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: "bar"}}),
+						Value: runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: "bar", Namespace: ns}}),
 					},
 				},
 			},
@@ -673,7 +725,7 @@ func TestEtcdListServices(t *testing.T) {
 		E: nil,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	services, err := registry.ListServices()
+	services, err := registry.ListServices(ns)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -684,16 +736,20 @@ func TestEtcdListServices(t *testing.T) {
 }
 
 func TestEtcdCreateService(t *testing.T) {
+	ns := api.NamespaceDefault
+	id := "foo"
+	key := makeServiceKey(ns, id)
+
 	fakeClient := tools.NewFakeEtcdClient(t)
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreateService(&api.Service{
-		JSONBase: api.JSONBase{ID: "foo"},
+		JSONBase: api.JSONBase{ID: id, Namespace: ns},
 	})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	resp, err := fakeClient.Get("/registry/services/specs/foo", false, false)
+	resp, err := fakeClient.Get(key, false, false)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -704,17 +760,21 @@ func TestEtcdCreateService(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if service.ID != "foo" {
+	if service.ID != id {
 		t.Errorf("Unexpected service: %#v %s", service, resp.Node.Value)
 	}
 }
 
 func TestEtcdCreateServiceAlreadyExisting(t *testing.T) {
+	ns := api.NamespaceDefault
+	id := "foo"
+	key := makeServiceKey(ns, id)
+
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Set("/registry/services/specs/foo", runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: id, Namespace: ns}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreateService(&api.Service{
-		JSONBase: api.JSONBase{ID: "foo"},
+		JSONBase: api.JSONBase{ID: id, Namespace: ns},
 	})
 	if !errors.IsAlreadyExists(err) {
 		t.Errorf("expected already exists err, got %#v", err)
@@ -722,38 +782,50 @@ func TestEtcdCreateServiceAlreadyExisting(t *testing.T) {
 }
 
 func TestEtcdGetService(t *testing.T) {
+	ns := api.NamespaceDefault
+	id := "foo"
+	key := makeServiceKey(ns, id)
+
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Set("/registry/services/specs/foo", runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: id, Namespace: ns}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
-	service, err := registry.GetService("foo")
+	service, err := registry.GetService(ns, id)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if service.ID != "foo" {
+	if service.ID != id {
 		t.Errorf("Unexpected service: %#v", service)
 	}
 }
 
 func TestEtcdGetServiceNotFound(t *testing.T) {
+	ns := api.NamespaceDefault
+	id := "foo"
+	key := makeServiceKey(ns, id)
+
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.Data["/registry/services/specs/foo"] = tools.EtcdResponseWithError{
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
 		},
 		E: tools.EtcdErrorNotFound,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	_, err := registry.GetService("foo")
+	_, err := registry.GetService(ns, id)
 	if !errors.IsNotFound(err) {
 		t.Errorf("Unexpected error returned: %#v", err)
 	}
 }
 
 func TestEtcdDeleteService(t *testing.T) {
+	ns := api.NamespaceDefault
+	id := "foo"
+	key := makeServiceKey(ns, id)
+
 	fakeClient := tools.NewFakeEtcdClient(t)
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.DeleteService("foo")
+	err := registry.DeleteService(ns, id)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -761,24 +833,29 @@ func TestEtcdDeleteService(t *testing.T) {
 	if len(fakeClient.DeletedKeys) != 2 {
 		t.Errorf("Expected 2 delete, found %#v", fakeClient.DeletedKeys)
 	}
-	key := "/registry/services/specs/foo"
+
 	if fakeClient.DeletedKeys[0] != key {
 		t.Errorf("Unexpected key: %s, expected %s", fakeClient.DeletedKeys[0], key)
 	}
-	key = "/registry/services/endpoints/foo"
-	if fakeClient.DeletedKeys[1] != key {
+
+	endpointsKey := makeServiceEndpointsKey(ns, id)
+	if fakeClient.DeletedKeys[1] != endpointsKey {
 		t.Errorf("Unexpected key: %s, expected %s", fakeClient.DeletedKeys[1], key)
 	}
 }
 
 func TestEtcdUpdateService(t *testing.T) {
+	ns := api.NamespaceDefault
+	id := "foo"
+	key := makeServiceKey(ns, id)
+
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 
-	resp, _ := fakeClient.Set("/registry/services/specs/foo", runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
+	resp, _ := fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: id, Namespace: ns}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
 	testService := api.Service{
-		JSONBase: api.JSONBase{ID: "foo", ResourceVersion: resp.Node.ModifiedIndex},
+		JSONBase: api.JSONBase{ID: id, Namespace: ns, ResourceVersion: resp.Node.ModifiedIndex},
 		Labels: map[string]string{
 			"baz": "bar",
 		},
@@ -791,7 +868,7 @@ func TestEtcdUpdateService(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	svc, err := registry.GetService("foo")
+	svc, err := registry.GetService(ns, id)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -806,16 +883,17 @@ func TestEtcdUpdateService(t *testing.T) {
 
 func TestEtcdListEndpoints(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
-	key := "/registry/services/endpoints"
+	ns := api.NamespaceDefault
+	key := makeServiceEndpointsKey(ns, "")
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
 					{
-						Value: runtime.EncodeOrDie(latest.Codec, &api.Endpoints{JSONBase: api.JSONBase{ID: "foo"}, Endpoints: []string{"127.0.0.1:8345"}}),
+						Value: runtime.EncodeOrDie(latest.Codec, &api.Endpoints{JSONBase: api.JSONBase{ID: "foo", Namespace: ns}, Endpoints: []string{"127.0.0.1:8345"}}),
 					},
 					{
-						Value: runtime.EncodeOrDie(latest.Codec, &api.Endpoints{JSONBase: api.JSONBase{ID: "bar"}}),
+						Value: runtime.EncodeOrDie(latest.Codec, &api.Endpoints{JSONBase: api.JSONBase{ID: "bar", Namespace: ns}}),
 					},
 				},
 			},
@@ -823,7 +901,7 @@ func TestEtcdListEndpoints(t *testing.T) {
 		E: nil,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	services, err := registry.ListEndpoints()
+	services, err := registry.ListEndpoints(ns)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -834,16 +912,20 @@ func TestEtcdListEndpoints(t *testing.T) {
 }
 
 func TestEtcdGetEndpoints(t *testing.T) {
+	id := "foo"
+	ns := api.NamespaceDefault
+	key := makeServiceEndpointsKey(ns, id)
+
 	fakeClient := tools.NewFakeEtcdClient(t)
 	registry := NewTestEtcdRegistry(fakeClient)
 	endpoints := &api.Endpoints{
-		JSONBase:  api.JSONBase{ID: "foo"},
+		JSONBase:  api.JSONBase{ID: id, Namespace: ns},
 		Endpoints: []string{"127.0.0.1:34855"},
 	}
 
-	fakeClient.Set("/registry/services/endpoints/foo", runtime.EncodeOrDie(latest.Codec, endpoints), 0)
+	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, endpoints), 0)
 
-	got, err := registry.GetEndpoints("foo")
+	got, err := registry.GetEndpoints(ns, id)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -854,22 +936,26 @@ func TestEtcdGetEndpoints(t *testing.T) {
 }
 
 func TestEtcdUpdateEndpoints(t *testing.T) {
+	id := "foo"
+	ns := api.NamespaceDefault
+	key := makeServiceEndpointsKey(ns, id)
+
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 	registry := NewTestEtcdRegistry(fakeClient)
 	endpoints := api.Endpoints{
-		JSONBase:  api.JSONBase{ID: "foo"},
+		JSONBase:  api.JSONBase{ID: id, Namespace: ns},
 		Endpoints: []string{"baz", "bar"},
 	}
 
-	fakeClient.Set("/registry/services/endpoints/foo", runtime.EncodeOrDie(latest.Codec, &api.Endpoints{}), 0)
+	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &api.Endpoints{}), 0)
 
 	err := registry.UpdateEndpoints(&endpoints)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	response, err := fakeClient.Get("/registry/services/endpoints/foo", false, false)
+	response, err := fakeClient.Get(key, false, false)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}

--- a/pkg/registry/minion/rest.go
+++ b/pkg/registry/minion/rest.go
@@ -38,7 +38,7 @@ func NewREST(m Registry) *REST {
 	}
 }
 
-func (rs *REST) Create(obj runtime.Object) (<-chan runtime.Object, error) {
+func (rs *REST) Create(namespace string, obj runtime.Object) (<-chan runtime.Object, error) {
 	minion, ok := obj.(*api.Minion)
 	if !ok {
 		return nil, fmt.Errorf("not a minion: %#v", obj)
@@ -65,7 +65,7 @@ func (rs *REST) Create(obj runtime.Object) (<-chan runtime.Object, error) {
 	}), nil
 }
 
-func (rs *REST) Delete(id string) (<-chan runtime.Object, error) {
+func (rs *REST) Delete(namespace string, id string) (<-chan runtime.Object, error) {
 	exists, err := rs.registry.Contains(id)
 	if !exists {
 		return nil, ErrDoesNotExist
@@ -78,7 +78,7 @@ func (rs *REST) Delete(id string) (<-chan runtime.Object, error) {
 	}), nil
 }
 
-func (rs *REST) Get(id string) (runtime.Object, error) {
+func (rs *REST) Get(namespace string, id string) (runtime.Object, error) {
 	exists, err := rs.registry.Contains(id)
 	if !exists {
 		return nil, ErrDoesNotExist
@@ -86,7 +86,7 @@ func (rs *REST) Get(id string) (runtime.Object, error) {
 	return rs.toApiMinion(id), err
 }
 
-func (rs *REST) List(label, field labels.Selector) (runtime.Object, error) {
+func (rs *REST) List(namespace string, label, field labels.Selector) (runtime.Object, error) {
 	nameList, err := rs.registry.List()
 	if err != nil {
 		return nil, err
@@ -102,10 +102,10 @@ func (*REST) New() runtime.Object {
 	return &api.Minion{}
 }
 
-func (rs *REST) Update(minion runtime.Object) (<-chan runtime.Object, error) {
+func (rs *REST) Update(namespace string, minion runtime.Object) (<-chan runtime.Object, error) {
 	return nil, fmt.Errorf("Minions can only be created (inserted) and deleted.")
 }
 
 func (rs *REST) toApiMinion(name string) *api.Minion {
-	return &api.Minion{JSONBase: api.JSONBase{ID: name}}
+	return &api.Minion{JSONBase: api.JSONBase{ID: name, Namespace: api.NamespaceDefault}}
 }

--- a/pkg/registry/minion/rest_test.go
+++ b/pkg/registry/minion/rest_test.go
@@ -28,17 +28,17 @@ func TestMinionREST(t *testing.T) {
 	m := NewRegistry([]string{"foo", "bar"})
 	ms := NewREST(m)
 
-	if obj, err := ms.Get("foo"); err != nil || obj.(*api.Minion).ID != "foo" {
+	if obj, err := ms.Get(api.NamespaceDefault, "foo"); err != nil || obj.(*api.Minion).ID != "foo" {
 		t.Errorf("missing expected object")
 	}
-	if obj, err := ms.Get("bar"); err != nil || obj.(*api.Minion).ID != "bar" {
+	if obj, err := ms.Get(api.NamespaceDefault, "bar"); err != nil || obj.(*api.Minion).ID != "bar" {
 		t.Errorf("missing expected object")
 	}
-	if _, err := ms.Get("baz"); err != ErrDoesNotExist {
+	if _, err := ms.Get(api.NamespaceDefault, "baz"); err != ErrDoesNotExist {
 		t.Errorf("has unexpected object")
 	}
 
-	c, err := ms.Create(&api.Minion{JSONBase: api.JSONBase{ID: "baz"}})
+	c, err := ms.Create(api.NamespaceDefault, &api.Minion{JSONBase: api.JSONBase{ID: "baz", Namespace: api.NamespaceDefault}})
 	if err != nil {
 		t.Errorf("insert failed")
 	}
@@ -46,11 +46,12 @@ func TestMinionREST(t *testing.T) {
 	if m, ok := obj.(*api.Minion); !ok || m.ID != "baz" {
 		t.Errorf("insert return value was weird: %#v", obj)
 	}
-	if obj, err := ms.Get("baz"); err != nil || obj.(*api.Minion).ID != "baz" {
+
+	if obj, err := ms.Get(api.NamespaceDefault, "baz"); err != nil || obj.(*api.Minion).ID != "baz" {
 		t.Errorf("insert didn't actually insert")
 	}
 
-	c, err = ms.Delete("bar")
+	c, err = ms.Delete(api.NamespaceDefault, "bar")
 	if err != nil {
 		t.Errorf("delete failed")
 	}
@@ -58,24 +59,24 @@ func TestMinionREST(t *testing.T) {
 	if s, ok := obj.(*api.Status); !ok || s.Status != api.StatusSuccess {
 		t.Errorf("delete return value was weird: %#v", obj)
 	}
-	if _, err := ms.Get("bar"); err != ErrDoesNotExist {
+	if _, err := ms.Get(api.NamespaceDefault, "bar"); err != ErrDoesNotExist {
 		t.Errorf("delete didn't actually delete")
 	}
 
-	_, err = ms.Delete("bar")
+	_, err = ms.Delete(api.NamespaceDefault, "bar")
 	if err != ErrDoesNotExist {
 		t.Errorf("delete returned wrong error")
 	}
 
-	list, err := ms.List(labels.Everything(), labels.Everything())
+	list, err := ms.List(api.NamespaceDefault, labels.Everything(), labels.Everything())
 	if err != nil {
 		t.Errorf("got error calling List")
 	}
 	expect := []api.Minion{
 		{
-			JSONBase: api.JSONBase{ID: "baz"},
+			JSONBase: api.JSONBase{ID: "baz", Namespace: api.NamespaceDefault},
 		}, {
-			JSONBase: api.JSONBase{ID: "foo"},
+			JSONBase: api.JSONBase{ID: "foo", Namespace: api.NamespaceDefault},
 		},
 	}
 	if !reflect.DeepEqual(list.(*api.MinionList).Items, expect) {

--- a/pkg/registry/pod/registry.go
+++ b/pkg/registry/pod/registry.go
@@ -25,17 +25,17 @@ import (
 // Registry is an interface implemented by things that know how to store Pod objects.
 type Registry interface {
 	// ListPods obtains a list of pods having labels which match selector.
-	ListPods(selector labels.Selector) (*api.PodList, error)
+	ListPods(namespace string, selector labels.Selector) (*api.PodList, error)
 	// ListPodsPredicate obtains a list of pods for which filter returns true.
-	ListPodsPredicate(filter func(*api.Pod) bool) (*api.PodList, error)
+	ListPodsPredicate(namespace string, filter func(*api.Pod) bool) (*api.PodList, error)
 	// Watch for new/changed/deleted pods
 	WatchPods(resourceVersion uint64, filter func(*api.Pod) bool) (watch.Interface, error)
 	// Get a specific pod
-	GetPod(podID string) (*api.Pod, error)
+	GetPod(namespace string, podID string) (*api.Pod, error)
 	// Create a pod based on a specification.
 	CreatePod(pod *api.Pod) error
 	// Update an existing pod
 	UpdatePod(pod *api.Pod) error
 	// Delete an existing pod
-	DeletePod(podID string) error
+	DeletePod(namespace string, podID string) error
 }

--- a/pkg/registry/registrytest/controller.go
+++ b/pkg/registry/registrytest/controller.go
@@ -27,11 +27,11 @@ type ControllerRegistry struct {
 	Controllers *api.ReplicationControllerList
 }
 
-func (r *ControllerRegistry) ListControllers() (*api.ReplicationControllerList, error) {
+func (r *ControllerRegistry) ListControllers(namespace string) (*api.ReplicationControllerList, error) {
 	return r.Controllers, r.Err
 }
 
-func (r *ControllerRegistry) GetController(ID string) (*api.ReplicationController, error) {
+func (r *ControllerRegistry) GetController(namespace string, ID string) (*api.ReplicationController, error) {
 	return &api.ReplicationController{}, r.Err
 }
 
@@ -43,7 +43,7 @@ func (r *ControllerRegistry) UpdateController(controller *api.ReplicationControl
 	return r.Err
 }
 
-func (r *ControllerRegistry) DeleteController(ID string) error {
+func (r *ControllerRegistry) DeleteController(namespace string, ID string) error {
 	return r.Err
 }
 

--- a/pkg/registry/registrytest/pod.go
+++ b/pkg/registry/registrytest/pod.go
@@ -40,7 +40,7 @@ func NewPodRegistry(pods *api.PodList) *PodRegistry {
 	}
 }
 
-func (r *PodRegistry) ListPodsPredicate(filter func(*api.Pod) bool) (*api.PodList, error) {
+func (r *PodRegistry) ListPodsPredicate(namespace string, filter func(*api.Pod) bool) (*api.PodList, error) {
 	r.Lock()
 	defer r.Unlock()
 	if r.Err != nil {
@@ -57,8 +57,8 @@ func (r *PodRegistry) ListPodsPredicate(filter func(*api.Pod) bool) (*api.PodLis
 	return &pods, nil
 }
 
-func (r *PodRegistry) ListPods(selector labels.Selector) (*api.PodList, error) {
-	return r.ListPodsPredicate(func(pod *api.Pod) bool {
+func (r *PodRegistry) ListPods(namespace string, selector labels.Selector) (*api.PodList, error) {
+	return r.ListPodsPredicate(namespace, func(pod *api.Pod) bool {
 		return selector.Matches(labels.Set(pod.Labels))
 	})
 }
@@ -68,7 +68,7 @@ func (r *PodRegistry) WatchPods(resourceVersion uint64, filter func(*api.Pod) bo
 	return r.mux.Watch(), nil
 }
 
-func (r *PodRegistry) GetPod(podId string) (*api.Pod, error) {
+func (r *PodRegistry) GetPod(namespace string, podId string) (*api.Pod, error) {
 	r.Lock()
 	defer r.Unlock()
 	return r.Pod, r.Err
@@ -90,7 +90,7 @@ func (r *PodRegistry) UpdatePod(pod *api.Pod) error {
 	return r.Err
 }
 
-func (r *PodRegistry) DeletePod(podId string) error {
+func (r *PodRegistry) DeletePod(namespace string, podId string) error {
 	r.Lock()
 	defer r.Unlock()
 	r.mux.Action(watch.Deleted, r.Pod)

--- a/pkg/registry/registrytest/service.go
+++ b/pkg/registry/registrytest/service.go
@@ -38,7 +38,7 @@ type ServiceRegistry struct {
 	UpdatedID string
 }
 
-func (r *ServiceRegistry) ListServices() (*api.ServiceList, error) {
+func (r *ServiceRegistry) ListServices(namespace string) (*api.ServiceList, error) {
 	return &r.List, r.Err
 }
 
@@ -48,12 +48,12 @@ func (r *ServiceRegistry) CreateService(svc *api.Service) error {
 	return r.Err
 }
 
-func (r *ServiceRegistry) GetService(id string) (*api.Service, error) {
+func (r *ServiceRegistry) GetService(namespace string, id string) (*api.Service, error) {
 	r.GottenID = id
 	return r.Service, r.Err
 }
 
-func (r *ServiceRegistry) DeleteService(id string) error {
+func (r *ServiceRegistry) DeleteService(namespace string, id string) error {
 	r.DeletedID = id
 	return r.Err
 }
@@ -67,11 +67,11 @@ func (r *ServiceRegistry) WatchServices(label, field labels.Selector, resourceVe
 	return nil, r.Err
 }
 
-func (r *ServiceRegistry) ListEndpoints() (*api.EndpointsList, error) {
+func (r *ServiceRegistry) ListEndpoints(namespace string) (*api.EndpointsList, error) {
 	return &r.EndpointsList, r.Err
 }
 
-func (r *ServiceRegistry) GetEndpoints(id string) (*api.Endpoints, error) {
+func (r *ServiceRegistry) GetEndpoints(namespace string, id string) (*api.Endpoints, error) {
 	r.GottenID = id
 	return &r.Endpoints, r.Err
 }

--- a/pkg/registry/service/registry.go
+++ b/pkg/registry/service/registry.go
@@ -25,10 +25,10 @@ import (
 
 // Registry is an interface for things that know how to store services.
 type Registry interface {
-	ListServices() (*api.ServiceList, error)
+	ListServices(namespace string) (*api.ServiceList, error)
 	CreateService(svc *api.Service) error
-	GetService(name string) (*api.Service, error)
-	DeleteService(name string) error
+	GetService(namespace string, name string) (*api.Service, error)
+	DeleteService(namespace string, name string) error
 	UpdateService(svc *api.Service) error
 	WatchServices(labels, fields labels.Selector, resourceVersion uint64) (watch.Interface, error)
 

--- a/plugin/cmd/scheduler/scheduler.go
+++ b/plugin/cmd/scheduler/scheduler.go
@@ -47,7 +47,7 @@ func main() {
 	verflag.PrintAndExitIfRequested()
 
 	// TODO: security story for plugins!
-	kubeClient, err := client.New(*master, latest.OldestVersion, nil)
+	kubeClient, err := client.New(*master, latest.OldestVersion, nil, nil)
 	if err != nil {
 		glog.Fatalf("Invalid -master: %v", err)
 	}

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -231,6 +231,6 @@ type binder struct {
 func (b *binder) Bind(binding *api.Binding) error {
 	// TODO: Remove or reduce verbosity by sep 6th, 2014. Leave until then to
 	// make it easy to find scheduling problems.
-	glog.Infof("Attempting to bind %v to %v", binding.PodID, binding.Host)
+	glog.Infof("Attempting to bind %v / %v to %v", binding.Namespace, binding.PodID, binding.Host)
 	return b.Post().Path("bindings").Body(binding).Do().Error()
 }

--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -71,8 +71,9 @@ func (s *Scheduler) scheduleOne() {
 		return
 	}
 	b := &api.Binding{
-		PodID: pod.ID,
-		Host:  dest,
+		JSONBase: api.JSONBase{Namespace: pod.Namespace},
+		PodID:    pod.ID,
+		Host:     dest,
 	}
 	if err := s.config.Binder.Bind(b); err != nil {
 		s.config.Error(pod, err)

--- a/plugin/pkg/scheduler/scheduler_test.go
+++ b/plugin/pkg/scheduler/scheduler_test.go
@@ -32,7 +32,7 @@ type fakeBinder struct {
 func (fb fakeBinder) Bind(binding *api.Binding) error { return fb.b(binding) }
 
 func podWithID(id string) *api.Pod {
-	return &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}
+	return &api.Pod{JSONBase: api.JSONBase{ID: "foo", Namespace: api.NamespaceDefault}}
 }
 
 type mockScheduler struct {
@@ -60,7 +60,7 @@ func TestScheduler(t *testing.T) {
 		{
 			sendPod:    podWithID("foo"),
 			algo:       mockScheduler{"machine1", nil},
-			expectBind: &api.Binding{PodID: "foo", Host: "machine1"},
+			expectBind: &api.Binding{JSONBase: api.JSONBase{Namespace: api.NamespaceDefault}, PodID: "foo", Host: "machine1"},
 		}, {
 			sendPod:        podWithID("foo"),
 			algo:           mockScheduler{"machine1", errS},
@@ -69,7 +69,7 @@ func TestScheduler(t *testing.T) {
 		}, {
 			sendPod:         podWithID("foo"),
 			algo:            mockScheduler{"machine1", nil},
-			expectBind:      &api.Binding{PodID: "foo", Host: "machine1"},
+			expectBind:      &api.Binding{JSONBase: api.JSONBase{Namespace: api.NamespaceDefault}, PodID: "foo", Host: "machine1"},
 			injectBindError: errB,
 			expectError:     errB,
 			expectErrorPod:  podWithID("foo"),


### PR DESCRIPTION
This PR builds on #1241 by adding the following:
1. Ability to set the current ns of an operation using kubecfg ns <namespace> command
2. Modified client code to append ?namespace=<namespace> to API requests as a stop-gap before taking on the larger path modification change.

How to use:

```
$ cluster/kubecfg.sh ns 
$ Using namespace default
$ cluster/kubecfg.sh run openshift/hello-openshift 1 default-hi
$ cluster/kubecfg.sh list replicationControllers
see them in output
$ cluster/kubecfg.sh list pods
see them in output
$ cluster/kubecfg.sh ns other
Using namespace other
$ cluster/kubecfg.sh list pods
should now see no pods in that namespace
$ cluster/kubecfg.sh list replicationControllers
should now see no pods in that namespace
$ cluster/kubecfg.sh ns default
Using namespace default
$ cluster/kubecfg.sh list pods
original pods are now back
```

A future PR (once the v1beta3 stuff lands) will need to work out how to handle the new URL path structures instead of usage of a query parameter.
