### PR TITLE
guard reference to grains.cloud

### DIFF
--- a/cluster/kube-env.sh
+++ b/cluster/kube-env.sh
@@ -20,4 +20,4 @@
 #
 # The valid values: 'gce', 'azure', 'vagrant', 'local', 'vsphere'
 
-KUBERNETES_PROVIDER=${KUBERNETES_PROVIDER:-gce}
+KUBERNETES_PROVIDER=${KUBERNETES_PROVIDER:-vagrant}

--- a/cluster/saltbase/salt/nginx/init.sls
+++ b/cluster/saltbase/salt/nginx/init.sls
@@ -10,6 +10,7 @@ nginx:
       - file: /usr/share/nginx/htpasswd
       - cmd: /usr/share/nginx/server.cert
 
+{% if grains.cloud is defined %}
 {% if grains.cloud == 'gce' %}
   {% set cert_ip='_use_gce_external_ip_' %}
 {% endif %}
@@ -19,6 +20,7 @@ nginx:
 # If there is a pillar defined, override any defaults.
 {% if pillar['cert_ip'] is defined %}
   {% set cert_ip=pillar['cert_ip'] %}
+{% endif %}
 {% endif %}
 
 {% set certgen="make-cert.sh" %}

--- a/cluster/saltbase/salt/nginx/init.sls
+++ b/cluster/saltbase/salt/nginx/init.sls
@@ -17,10 +17,11 @@ nginx:
 {% if grains.cloud == 'vagrant' %}
   {% set cert_ip=grains.fqdn_ip4 %}
 {% endif %}
+{% endif %}
+
 # If there is a pillar defined, override any defaults.
 {% if pillar['cert_ip'] is defined %}
   {% set cert_ip=pillar['cert_ip'] %}
-{% endif %}
 {% endif %}
 
 {% set certgen="make-cert.sh" %}


### PR DESCRIPTION
Prevent errors during provisioning if grains.cloud has not been initialized.
