### PR TITLE
Fix docker-links-style env vars for services

### DIFF
--- a/pkg/registry/pod/manifest_factory_test.go
+++ b/pkg/registry/pod/manifest_factory_test.go
@@ -107,19 +107,19 @@ func TestMakeManifestServices(t *testing.T) {
 			Value: "tcp://machine:8080",
 		},
 		{
-			Name:  "TEST_PORT_900_TCP",
+			Name:  "TEST_PORT_8080_TCP",
 			Value: "tcp://machine:8080",
 		},
 		{
-			Name:  "TEST_PORT_900_TCP_PROTO",
+			Name:  "TEST_PORT_8080_TCP_PROTO",
 			Value: "tcp",
 		},
 		{
-			Name:  "TEST_PORT_900_TCP_PORT",
+			Name:  "TEST_PORT_8080_TCP_PORT",
 			Value: "8080",
 		},
 		{
-			Name:  "TEST_PORT_900_TCP_ADDR",
+			Name:  "TEST_PORT_8080_TCP_ADDR",
 			Value: "machine",
 		},
 		{
@@ -197,19 +197,19 @@ func TestMakeManifestServicesExistingEnvVar(t *testing.T) {
 			Value: "tcp://machine:8080",
 		},
 		{
-			Name:  "TEST_PORT_900_TCP",
+			Name:  "TEST_PORT_8080_TCP",
 			Value: "tcp://machine:8080",
 		},
 		{
-			Name:  "TEST_PORT_900_TCP_PROTO",
+			Name:  "TEST_PORT_8080_TCP_PROTO",
 			Value: "tcp",
 		},
 		{
-			Name:  "TEST_PORT_900_TCP_PORT",
+			Name:  "TEST_PORT_8080_TCP_PORT",
 			Value: "8080",
 		},
 		{
-			Name:  "TEST_PORT_900_TCP_ADDR",
+			Name:  "TEST_PORT_8080_TCP_ADDR",
 			Value: "machine",
 		},
 		{

--- a/pkg/registry/service/rest.go
+++ b/pkg/registry/service/rest.go
@@ -222,25 +222,23 @@ func makeEnvVariableName(str string) string {
 
 func makeLinkVariables(service api.Service, machine string) []api.EnvVar {
 	prefix := makeEnvVariableName(service.ID)
-	var port string
-	if service.ContainerPort.Kind == util.IntstrString {
-		port = service.ContainerPort.StrVal
-	} else {
-		port = strconv.Itoa(service.ContainerPort.IntVal)
+	protocol := "TCP"
+	if service.Protocol != "" {
+		protocol = service.Protocol
 	}
-	portPrefix := prefix + "_PORT_" + makeEnvVariableName(port) + "_TCP"
+	portPrefix := fmt.Sprintf("%s_PORT_%d_%s", prefix, service.Port, strings.ToUpper(protocol))
 	return []api.EnvVar{
 		{
 			Name:  prefix + "_PORT",
-			Value: fmt.Sprintf("tcp://%s:%d", machine, service.Port),
+			Value: fmt.Sprintf("%s://%s:%d", strings.ToLower(protocol), machine, service.Port),
 		},
 		{
 			Name:  portPrefix,
-			Value: fmt.Sprintf("tcp://%s:%d", machine, service.Port),
+			Value: fmt.Sprintf("%s://%s:%d", strings.ToLower(protocol), machine, service.Port),
 		},
 		{
 			Name:  portPrefix + "_PROTO",
-			Value: "tcp",
+			Value: strings.ToLower(protocol),
 		},
 		{
 			Name:  portPrefix + "_PORT",


### PR DESCRIPTION
This includes 3 changes:

1) Use the Service.Protocol field, rather than hardcoding TCP.
2) Use Service.Port rather than ContainerPort - ContainerPort can be a string
   and has absolutely no meaning to consumers.
3) Beef up tests for these env vars.
