### PR TITLE
Move specification of minion-regexp to deploy-time rather than build-time.

### DIFF
--- a/cluster/azure/templates/salt-master.sh
+++ b/cluster/azure/templates/salt-master.sh
@@ -25,6 +25,11 @@ grains:
   cloud: azure
 EOF
 
+# Specify the minion prefix
+cat <<EOF >>/srv/pillar/common.sls
+instance_prefix: $MINION_PREFIX
+EOF
+
 # Auto accept all keys from minions that try to join
 mkdir -p /etc/salt/master.d
 cat <<EOF >/etc/salt/master.d/auto-accept.conf

--- a/cluster/azure/util.sh
+++ b/cluster/azure/util.sh
@@ -108,6 +108,7 @@ function kube-up {
         echo "MASTER_NAME=${MASTER_NAME}"
         echo "MASTER_RELEASE_TAR=${FULL_URL}"
         echo "MASTER_HTPASSWD='${HTPASSWD}'"
+        echo "MINION_PREFIX=${INSTANCE_PREFIX}-minion"
         echo "CA_CRT=\"$(cat ${KUBE_TEMP}/ca.crt)\""
         echo "SERVER_CRT=\"$(cat ${KUBE_TEMP}/server.crt)\""
         echo "SERVER_KEY=\"$(cat ${KUBE_TEMP}/server.key)\""

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -176,6 +176,7 @@ function kube-up {
     echo "MASTER_NAME='${MASTER_NAME}'"
     echo "MASTER_RELEASE_TAR=${RELEASE_NORMALIZED}/master-release.tgz"
     echo "MASTER_HTPASSWD='${HTPASSWD}'"
+    echo "MINION_PREFIX=${INSTANCE_PREFIX}-minion"
     grep -v "^#" "${base_dir}/cluster/templates/download-release.sh"
     grep -v "^#" "${base_dir}/cluster/templates/salt-master.sh"
   ) > "${KUBE_TEMP}/master-start.sh"

--- a/cluster/templates/salt-master.sh
+++ b/cluster/templates/salt-master.sh
@@ -28,6 +28,11 @@ grains:
   cloud: gce
 EOF
 
+# Specify the minion prefix
+cat <<EOF >>/srv/pillar/common.sls
+instance_prefix: $MINION_PREFIX
+EOF
+
 # Auto accept all keys from minions that try to join
 mkdir -p /etc/salt/master.d
 cat <<EOF >/etc/salt/master.d/auto-accept.conf

--- a/cluster/vagrant/provision-config.sh
+++ b/cluster/vagrant/provision-config.sh
@@ -26,6 +26,7 @@ MINION_TAG="${INSTANCE_PREFIX}-minion"
 MINION_NAMES=($(eval echo ${INSTANCE_PREFIX}-minion-{1..${NUM_MINIONS}}))
 MINION_IP_RANGES=($(eval echo "10.245.{2..${NUM_MINIONS}}.2/24"))
 MINION_SCOPES=""
+MINION_PREFIX="${INSTANCE_PREFIX}-minion"
 
 # simplified setup for local vagrant 2 node cluster
 MASTER_USER=vagrant

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -44,6 +44,11 @@ grains:
     - kubernetes-master
 EOF
 
+# Specify the minion prefix
+cat <<EOF >>/srv/pillar/common.sls
+instance_prefix: $MINION_PREFIX
+EOF
+
 # Configure the salt-master
 # Auto accept all keys from minions that try to join
 mkdir -p /etc/salt/master.d

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -115,7 +115,7 @@ fi
 # Build release
 echo "Building release"
 pushd /vagrant
-  ./release/build-release.sh kubernetes
+  ./release/build-release.sh
 popd
 
 echo "Running release install script"

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -45,6 +45,7 @@ grains:
 EOF
 
 # Specify the minion prefix
+mkdir -p /srv/pillar/
 cat <<EOF >>/srv/pillar/common.sls
 instance_prefix: $MINION_PREFIX
 EOF

--- a/cluster/vsphere/templates/salt-master.sh
+++ b/cluster/vsphere/templates/salt-master.sh
@@ -28,6 +28,11 @@ grains:
   cloud: vsphere
 EOF
 
+# Specify the minion prefix
+cat <<EOF >/srv/pillar/common.sls
+instance_prefix: $MINION_PREFIX
+EOF
+
 # Auto accept all keys from minions that try to join
 mkdir -p /etc/salt/master.d
 cat <<EOF >/etc/salt/master.d/auto-accept.conf

--- a/cluster/vsphere/util.sh
+++ b/cluster/vsphere/util.sh
@@ -166,6 +166,7 @@ function kube-up {
     grep -v "^#" $(dirname $0)/vsphere/templates/hostname.sh
     echo "MASTER_NAME=${MASTER_NAME}"
     echo "MASTER_HTPASSWD='${HTPASSWD}'"
+    echo "MINION_PREFIX=${INSTANCE_PREFIX}-minion"
     grep -v "^#" $(dirname $0)/vsphere/templates/install-release.sh
     grep -v "^#" $(dirname $0)/vsphere/templates/salt-master.sh
   ) > ${KUBE_TEMP}/master-start.sh

--- a/docs/getting-started-guides/vsphere.md
+++ b/docs/getting-started-guides/vsphere.md
@@ -66,8 +66,8 @@ cd kubernetes
 # Build source
 hack/build-go.sh
 
-# Build a release (argument is the instance prefix)
-release/build-release.sh kubernetes
+# Build a release
+release/build-release.sh
 
 # Deploy Kubernetes (takes ~5 minutes, provided everything works out)
 export KUBERNETES_PROVIDER=vsphere

--- a/release/azure/release.sh
+++ b/release/azure/release.sh
@@ -27,7 +27,7 @@ function json_val () {
 
 source $SCRIPT_DIR/config.sh
 
-$SCRIPT_DIR/../build-release.sh $INSTANCE_PREFIX
+$SCRIPT_DIR/../build-release.sh
 
 if [ -z "$(azure storage account show $AZ_STG 2>/dev/null | \
     grep data)" ]; then

--- a/release/build-release.sh
+++ b/release/build-release.sh
@@ -22,8 +22,6 @@ set -o pipefail
 
 SCRIPT_DIR=$(CDPATH="" cd $(dirname $0); pwd)
 
-INSTANCE_PREFIX=$1
-
 KUBE_DIR=$SCRIPT_DIR/..
 
 . "${KUBE_DIR}/hack/config-go.sh"

--- a/release/build-release.sh
+++ b/release/build-release.sh
@@ -47,7 +47,6 @@ version_ldflags=$(kube::version_ldflags)
 
 # Note: go_opt must stay in sync with the flags in hack/build-go.sh.
 cat << EOF > $MASTER_RELEASE_DIR/src/saltbase/pillar/common.sls
-instance_prefix: $INSTANCE_PREFIX-minion
 go_opt: -ldflags '${version_ldflags}'
 EOF
 

--- a/release/rackspace/release.sh
+++ b/release/rackspace/release.sh
@@ -32,7 +32,7 @@ source "${KUBE_REPO_ROOT}/cluster/kube-env.sh"
 source $SCRIPT_DIR/../../cluster/rackspace/${KUBE_CONFIG_FILE-"config-default.sh"}
 source $SCRIPT_DIR/../../cluster/rackspace/util.sh
 
-$SCRIPT_DIR/../build-release.sh $INSTANCE_PREFIX
+$SCRIPT_DIR/../build-release.sh
 
 # Copy everything up to swift object store
 echo "release/rackspace/release.sh: Uploading to Cloud Files"

--- a/release/release.sh
+++ b/release/release.sh
@@ -43,7 +43,7 @@ source $(dirname ${BASH_SOURCE})/../cluster/${KUBERNETES_PROVIDER}/${KUBE_CONFIG
 
 cd $SCRIPT_DIR/..
 
-$SCRIPT_DIR/build-release.sh $INSTANCE_PREFIX
+$SCRIPT_DIR/build-release.sh
 
 echo "Building launch script"
 # Create the local install script.  These are the tools to install the local


### PR DESCRIPTION
Currently, /srv/pillar/common.sls is generated at build time and "instance_prefix" is set to whatever config-default.sh currently says it should be. This makes it impossible for the same release to be used to create clusters with different names.

This change moves the setting of "instance_prefix" to the deploy-time startup scripts (allowing $INSTANCE_PREFIX in config-default.sh to be changed without creating a broken cluster).

I've made corresponding changes in other providers where the flow was the same, but I have only tested on gce. Please feel free to yell at me if this breaks one of the other providers.
