### PR TITLE
Handle invalid pod name

### DIFF
--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -362,7 +362,6 @@ func TestContainerLogs(t *testing.T) {
 	expectedContainerName := "baz"
 	expectedTail := ""
 	expectedFollow := false
-	// expected := api.Container{"goodpod": docker.Container{ID: "myContainerID"}}
 	fw.fakeKubelet.containerLogsFunc = func(podFullName, containerName, tail string, follow bool, stdout, stderr io.Writer) error {
 		if podFullName != expectedPodName {
 			t.Errorf("expected %s, got %s", expectedPodName, podFullName)


### PR DESCRIPTION
When entering invalid pod name for getting container logs, "Pod not found" will be returned.
