### PR TITLE
proxy: Attempt to reconnect on connection errors

### DIFF
--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -57,6 +57,9 @@ func (si *serviceInfo) setActive(val bool) bool {
 // How long we wait for a connection to a backend.
 const endpointDialTimeout = 5 * time.Second
 
+// How long we retry when opening a listening socket.
+const listenTimeout = 5 * time.Second
+
 // Abstraction over TCP/UDP sockets which are proxied.
 type proxySocket interface {
 	// Addr gets the net.Addr for a proxySocket.
@@ -72,6 +75,24 @@ type proxySocket interface {
 // no new connections are allowed but existing connections are left untouched.
 type tcpProxySocket struct {
 	net.Listener
+}
+
+func retryDial(network, address string, timeout time.Duration) (net.Conn, error) {
+	endTime := time.Now().Add(timeout)
+	for {
+		remaining := endTime.Sub(time.Now())
+		outConn, err := net.DialTimeout(network, address, remaining)
+		if err != nil {
+			if endTime.After(time.Now()) {
+				glog.Infof("Dial retrying on error for %s: %v", remaining, err)
+				time.Sleep(100 * time.Millisecond)
+				continue
+			} else {
+				return nil, fmt.Errorf("Dial retry timed out")
+			}
+		}
+		return outConn, err
+	}
 }
 
 func (tcp *tcpProxySocket) ProxyLoop(service string, proxier *Proxier) {
@@ -101,7 +122,7 @@ func (tcp *tcpProxySocket) ProxyLoop(service string, proxier *Proxier) {
 		glog.Infof("Mapped service %s to endpoint %s", service, endpoint)
 		// TODO: This could spin up a new goroutine to make the outbound connection,
 		// and keep accepting inbound traffic.
-		outConn, err := net.DialTimeout("tcp", endpoint, endpointDialTimeout)
+		outConn, err := retryDial("tcp", endpoint, endpointDialTimeout)
 		if err != nil {
 			// TODO: Try another endpoint?
 			glog.Errorf("Dial failed: %v", err)
@@ -206,7 +227,7 @@ func (udp *udpProxySocket) getBackendConn(activeClients *clientCache, cliAddr ne
 			return nil, err
 		}
 		glog.Infof("Mapped service %s to endpoint %s", service, endpoint)
-		svrConn, err = net.DialTimeout("udp", endpoint, endpointDialTimeout)
+		svrConn, err = retryDial("udp", endpoint, endpointDialTimeout)
 		if err != nil {
 			// TODO: Try another endpoint?
 			glog.Errorf("Dial failed: %v", err)
@@ -262,6 +283,26 @@ func logTimeout(err error) bool {
 }
 
 func newProxySocket(protocol string, host string, port int) (proxySocket, error) {
+	endTime := time.Now().Add(listenTimeout)
+	for {
+		remaining := endTime.Sub(time.Now())
+		sock, err := innerProxySocket(protocol, host, port)
+		if err != nil {
+			// TODO(vish): don't retry if the socket is in use
+			if endTime.After(time.Now()) {
+				glog.Infof("ProxySocket retrying on error for %v: %v", remaining, err)
+				time.Sleep(100 * time.Millisecond)
+				continue
+			} else {
+				return nil, fmt.Errorf("ProxySocket retry timed out")
+			}
+		}
+		return sock, err
+	}
+
+}
+
+func innerProxySocket(protocol string, host string, port int) (proxySocket, error) {
 	switch strings.ToUpper(protocol) {
 	case "TCP":
 		listener, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(port)))


### PR DESCRIPTION
This modifies the proxy dial command to retry to retry if it hits an
error. Previously it would pass a timeout, but not retry if there
is a connection error of some sort. It also adds a similar retry
for the listening socket.
