### PR TITLE
cmd: build minimal docker images for all cmds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Godeps/_workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.3
+
+RUN go get github.com/tools/godep
+
+WORKDIR /go/src/github.com/GoogleCloudPlatform/kubernetes
+ADD Godeps/Godeps.json $GOPATH/src/github.com/GoogleCloudPlatform/kubernetes/Godeps/Godeps.json
+RUN godep restore
+ADD . $GOPATH/src/github.com/GoogleCloudPlatform/kubernetes
+RUN CGO_ENABLED=0 godep go install -a -ldflags '-s' -tags netgo github.com/GoogleCloudPlatform/kubernetes/cmd/...
+RUN echo \
+'FROM scratch\n'\
+'ADD cmd /bin/cmd\n'\
+'ENTRYPOINT ["/bin/cmd"]' > Dockerfile.cmd
+CMD tar cvzhf - $GOPATH/bin/$cmd Dockerfile.cmd --transform="s,Dockerfile.cmd,Dockerfile,;s,go/bin/$cmd,cmd," --show-transformed-names

--- a/hack/build-docker-images.sh
+++ b/hack/build-docker-images.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+CONTEXT=$(readlink -f $(dirname ${BASH_SOURCE[0]})/..)
+
+docker build -t kube-builder ${CONTEXT}
+for dir in ${CONTEXT}/cmd/*; do
+    cmd=$(basename ${dir})
+    docker run -e cmd=${cmd} kube-builder | docker build -t kubernetes/${cmd} -
+done
+
+docker images | grep kubernetes


### PR DESCRIPTION
Build the images using context tar injection (see https://github.com/docker/docker/pull/5715) on top of `FROM scratch`.

This could be cleaner (and work with the hub!) once https://github.com/docker/docker/pull/8021 is merged.

```
$ ./hack/build-docker-images.sh
...
kubernetes/proxy                latest                c8ecf48b90e2        4 days ago          6.073 MB
kubernetes/kubelet              latest                e0aa1bbef6f0        4 days ago          6.946 MB
kubernetes/kubecfg              latest                310aef0bed1c        4 days ago          6.398 MB
kubernetes/integration          latest                d7e55ac70f5d        4 days ago          7.614 MB
kubernetes/controller-manager   latest                0bc6f96a1151        4 days ago          6.094 MB
kubernetes/apiserver            latest                cd8907e1464f        4 days ago          8.945 MB
```

Note: because `scratch` doesn't have `hostname` you have to pass `--hostname_overide` to the `kubelet` when starting.

/cc @gbin
