### PR TITLE
Add ctx object to registry interface

### DIFF
--- a/pkg/registry/binding/mock.go
+++ b/pkg/registry/binding/mock.go
@@ -25,6 +25,6 @@ type MockRegistry struct {
 	OnApplyBinding func(binding *api.Binding) error
 }
 
-func (mr MockRegistry) ApplyBinding(binding *api.Binding) error {
+func (mr MockRegistry) ApplyBinding(ctx api.Context, binding *api.Binding) error {
 	return mr.OnApplyBinding(binding)
 }

--- a/pkg/registry/binding/registry.go
+++ b/pkg/registry/binding/registry.go
@@ -24,5 +24,5 @@ import (
 type Registry interface {
 	// ApplyBinding should apply the binding. That is, it should actually
 	// assign or place pod binding.PodID on machine binding.Host.
-	ApplyBinding(binding *api.Binding) error
+	ApplyBinding(ctx api.Context, binding *api.Binding) error
 }

--- a/pkg/registry/binding/rest.go
+++ b/pkg/registry/binding/rest.go
@@ -67,7 +67,7 @@ func (b *REST) Create(ctx api.Context, obj runtime.Object) (<-chan runtime.Objec
 		return nil, fmt.Errorf("incorrect type: %#v", obj)
 	}
 	return apiserver.MakeAsync(func() (runtime.Object, error) {
-		if err := b.registry.ApplyBinding(binding); err != nil {
+		if err := b.registry.ApplyBinding(ctx, binding); err != nil {
 			return nil, err
 		}
 		return &api.Status{Status: api.StatusSuccess}, nil

--- a/pkg/registry/controller/registry.go
+++ b/pkg/registry/controller/registry.go
@@ -23,10 +23,10 @@ import (
 
 // Registry is an interface for things that know how to store ReplicationControllers.
 type Registry interface {
-	ListControllers() (*api.ReplicationControllerList, error)
-	WatchControllers(resourceVersion uint64) (watch.Interface, error)
-	GetController(controllerID string) (*api.ReplicationController, error)
-	CreateController(controller *api.ReplicationController) error
-	UpdateController(controller *api.ReplicationController) error
-	DeleteController(controllerID string) error
+	ListControllers(ctx api.Context) (*api.ReplicationControllerList, error)
+	WatchControllers(ctx api.Context, resourceVersion uint64) (watch.Interface, error)
+	GetController(ctx api.Context, controllerID string) (*api.ReplicationController, error)
+	CreateController(ctx api.Context, controller *api.ReplicationController) error
+	UpdateController(ctx api.Context, controller *api.ReplicationController) error
+	DeleteController(ctx api.Context, controllerID string) error
 }

--- a/pkg/registry/controller/rest.go
+++ b/pkg/registry/controller/rest.go
@@ -71,24 +71,24 @@ func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan runtime.Obje
 	controller.CreationTimestamp = util.Now()
 
 	return apiserver.MakeAsync(func() (runtime.Object, error) {
-		err := rs.registry.CreateController(controller)
+		err := rs.registry.CreateController(ctx, controller)
 		if err != nil {
 			return nil, err
 		}
-		return rs.registry.GetController(controller.ID)
+		return rs.registry.GetController(ctx, controller.ID)
 	}), nil
 }
 
 // Delete asynchronously deletes the ReplicationController specified by its id.
 func (rs *REST) Delete(ctx api.Context, id string) (<-chan runtime.Object, error) {
 	return apiserver.MakeAsync(func() (runtime.Object, error) {
-		return &api.Status{Status: api.StatusSuccess}, rs.registry.DeleteController(id)
+		return &api.Status{Status: api.StatusSuccess}, rs.registry.DeleteController(ctx, id)
 	}), nil
 }
 
 // Get obtains the ReplicationController specified by its id.
 func (rs *REST) Get(ctx api.Context, id string) (runtime.Object, error) {
-	controller, err := rs.registry.GetController(id)
+	controller, err := rs.registry.GetController(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (rs *REST) List(ctx api.Context, label, field labels.Selector) (runtime.Obj
 	if !field.Empty() {
 		return nil, fmt.Errorf("field selector not supported yet")
 	}
-	controllers, err := rs.registry.ListControllers()
+	controllers, err := rs.registry.ListControllers(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -132,11 +132,11 @@ func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan runtime.Obje
 		return nil, errors.NewInvalid("replicationController", controller.ID, errs)
 	}
 	return apiserver.MakeAsync(func() (runtime.Object, error) {
-		err := rs.registry.UpdateController(controller)
+		err := rs.registry.UpdateController(ctx, controller)
 		if err != nil {
 			return nil, err
 		}
-		return rs.registry.GetController(controller.ID)
+		return rs.registry.GetController(ctx, controller.ID)
 	}), nil
 }
 
@@ -146,7 +146,7 @@ func (rs *REST) Watch(ctx api.Context, label, field labels.Selector, resourceVer
 	if !field.Empty() {
 		return nil, fmt.Errorf("no field selector implemented for controllers")
 	}
-	incoming, err := rs.registry.WatchControllers(resourceVersion)
+	incoming, err := rs.registry.WatchControllers(ctx, resourceVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/endpoint/registry.go
+++ b/pkg/registry/endpoint/registry.go
@@ -24,8 +24,8 @@ import (
 
 // Registry is an interface for things that know how to store endpoints.
 type Registry interface {
-	ListEndpoints() (*api.EndpointsList, error)
-	GetEndpoints(name string) (*api.Endpoints, error)
-	WatchEndpoints(labels, fields labels.Selector, resourceVersion uint64) (watch.Interface, error)
-	UpdateEndpoints(e *api.Endpoints) error
+	ListEndpoints(ctx api.Context) (*api.EndpointsList, error)
+	GetEndpoints(ctx api.Context, name string) (*api.Endpoints, error)
+	WatchEndpoints(ctx api.Context, labels, fields labels.Selector, resourceVersion uint64) (watch.Interface, error)
+	UpdateEndpoints(ctx api.Context, e *api.Endpoints) error
 }

--- a/pkg/registry/endpoint/rest.go
+++ b/pkg/registry/endpoint/rest.go
@@ -39,7 +39,7 @@ func NewREST(registry Registry) *REST {
 
 // Get satisfies the RESTStorage interface.
 func (rs *REST) Get(ctx api.Context, id string) (runtime.Object, error) {
-	return rs.registry.GetEndpoints(id)
+	return rs.registry.GetEndpoints(ctx, id)
 }
 
 // List satisfies the RESTStorage interface.
@@ -47,13 +47,13 @@ func (rs *REST) List(ctx api.Context, label, field labels.Selector) (runtime.Obj
 	if !label.Empty() || !field.Empty() {
 		return nil, errors.New("label/field selectors are not supported on endpoints")
 	}
-	return rs.registry.ListEndpoints()
+	return rs.registry.ListEndpoints(ctx)
 }
 
 // Watch returns Endpoint events via a watch.Interface.
 // It implements apiserver.ResourceWatcher.
 func (rs *REST) Watch(ctx api.Context, label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
-	return rs.registry.WatchEndpoints(label, field, resourceVersion)
+	return rs.registry.WatchEndpoints(ctx, label, field, resourceVersion)
 }
 
 // Create satisfies the RESTStorage interface but is unimplemented.

--- a/pkg/registry/etcd/etcd_test.go
+++ b/pkg/registry/etcd/etcd_test.go
@@ -41,10 +41,11 @@ func NewTestEtcdRegistry(client tools.EtcdClient) *Registry {
 }
 
 func TestEtcdGetPod(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.Set("/registry/pods/foo", runtime.EncodeOrDie(latest.Codec, &api.Pod{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
-	pod, err := registry.GetPod("foo")
+	pod, err := registry.GetPod(ctx, "foo")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -55,6 +56,7 @@ func TestEtcdGetPod(t *testing.T) {
 }
 
 func TestEtcdGetPodNotFound(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.Data["/registry/pods/foo"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
@@ -63,13 +65,14 @@ func TestEtcdGetPodNotFound(t *testing.T) {
 		E: tools.EtcdErrorNotFound,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	_, err := registry.GetPod("foo")
+	_, err := registry.GetPod(ctx, "foo")
 	if !errors.IsNotFound(err) {
 		t.Errorf("Unexpected error returned: %#v", err)
 	}
 }
 
 func TestEtcdCreatePod(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 	fakeClient.Data["/registry/pods/foo"] = tools.EtcdResponseWithError{
@@ -80,7 +83,7 @@ func TestEtcdCreatePod(t *testing.T) {
 	}
 	fakeClient.Set("/registry/hosts/machine/kubelet", runtime.EncodeOrDie(latest.Codec, &api.ContainerManifestList{}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.CreatePod(&api.Pod{
+	err := registry.CreatePod(ctx, &api.Pod{
 		JSONBase: api.JSONBase{
 			ID: "foo",
 		},
@@ -99,7 +102,7 @@ func TestEtcdCreatePod(t *testing.T) {
 	}
 
 	// Suddenly, a wild scheduler appears:
-	err = registry.ApplyBinding(&api.Binding{PodID: "foo", Host: "machine"})
+	err = registry.ApplyBinding(ctx, &api.Binding{PodID: "foo", Host: "machine"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -130,6 +133,7 @@ func TestEtcdCreatePod(t *testing.T) {
 }
 
 func TestEtcdCreatePodAlreadyExisting(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.Data["/registry/pods/foo"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
@@ -140,7 +144,7 @@ func TestEtcdCreatePodAlreadyExisting(t *testing.T) {
 		E: nil,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.CreatePod(&api.Pod{
+	err := registry.CreatePod(ctx, &api.Pod{
 		JSONBase: api.JSONBase{
 			ID: "foo",
 		},
@@ -151,6 +155,7 @@ func TestEtcdCreatePodAlreadyExisting(t *testing.T) {
 }
 
 func TestEtcdCreatePodWithContainersError(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 	fakeClient.Data["/registry/pods/foo"] = tools.EtcdResponseWithError{
@@ -166,7 +171,7 @@ func TestEtcdCreatePodWithContainersError(t *testing.T) {
 		E: tools.EtcdErrorNodeExist, // validate that ApplyBinding is translating Create errors
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.CreatePod(&api.Pod{
+	err := registry.CreatePod(ctx, &api.Pod{
 		JSONBase: api.JSONBase{
 			ID: "foo",
 		},
@@ -176,12 +181,12 @@ func TestEtcdCreatePodWithContainersError(t *testing.T) {
 	}
 
 	// Suddenly, a wild scheduler appears:
-	err = registry.ApplyBinding(&api.Binding{PodID: "foo", Host: "machine"})
+	err = registry.ApplyBinding(ctx, &api.Binding{PodID: "foo", Host: "machine"})
 	if !errors.IsAlreadyExists(err) {
 		t.Fatalf("Unexpected error returned: %#v", err)
 	}
 
-	existingPod, err := registry.GetPod("foo")
+	existingPod, err := registry.GetPod(ctx, "foo")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -191,6 +196,7 @@ func TestEtcdCreatePodWithContainersError(t *testing.T) {
 }
 
 func TestEtcdCreatePodWithContainersNotFound(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 	fakeClient.Data["/registry/pods/foo"] = tools.EtcdResponseWithError{
@@ -206,7 +212,7 @@ func TestEtcdCreatePodWithContainersNotFound(t *testing.T) {
 		E: tools.EtcdErrorNotFound,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.CreatePod(&api.Pod{
+	err := registry.CreatePod(ctx, &api.Pod{
 		JSONBase: api.JSONBase{
 			ID: "foo",
 		},
@@ -226,7 +232,7 @@ func TestEtcdCreatePodWithContainersNotFound(t *testing.T) {
 	}
 
 	// Suddenly, a wild scheduler appears:
-	err = registry.ApplyBinding(&api.Binding{PodID: "foo", Host: "machine"})
+	err = registry.ApplyBinding(ctx, &api.Binding{PodID: "foo", Host: "machine"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -257,6 +263,7 @@ func TestEtcdCreatePodWithContainersNotFound(t *testing.T) {
 }
 
 func TestEtcdCreatePodWithExistingContainers(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 	fakeClient.Data["/registry/pods/foo"] = tools.EtcdResponseWithError{
@@ -271,7 +278,7 @@ func TestEtcdCreatePodWithExistingContainers(t *testing.T) {
 		},
 	}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.CreatePod(&api.Pod{
+	err := registry.CreatePod(ctx, &api.Pod{
 		JSONBase: api.JSONBase{
 			ID: "foo",
 		},
@@ -291,7 +298,7 @@ func TestEtcdCreatePodWithExistingContainers(t *testing.T) {
 	}
 
 	// Suddenly, a wild scheduler appears:
-	err = registry.ApplyBinding(&api.Binding{PodID: "foo", Host: "machine"})
+	err = registry.ApplyBinding(ctx, &api.Binding{PodID: "foo", Host: "machine"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -322,6 +329,7 @@ func TestEtcdCreatePodWithExistingContainers(t *testing.T) {
 }
 
 func TestEtcdDeletePod(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 
@@ -336,7 +344,7 @@ func TestEtcdDeletePod(t *testing.T) {
 		},
 	}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.DeletePod("foo")
+	err := registry.DeletePod(ctx, "foo")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -358,6 +366,7 @@ func TestEtcdDeletePod(t *testing.T) {
 }
 
 func TestEtcdDeletePodMultipleContainers(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 
@@ -373,7 +382,7 @@ func TestEtcdDeletePodMultipleContainers(t *testing.T) {
 		},
 	}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.DeletePod("foo")
+	err := registry.DeletePod(ctx, "foo")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -481,6 +490,7 @@ func TestEtcdListPods(t *testing.T) {
 }
 
 func TestEtcdListControllersNotFound(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	key := "/registry/controllers"
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
@@ -488,7 +498,7 @@ func TestEtcdListControllersNotFound(t *testing.T) {
 		E: tools.EtcdErrorNotFound,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	controllers, err := registry.ListControllers()
+	controllers, err := registry.ListControllers(ctx)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -499,6 +509,7 @@ func TestEtcdListControllersNotFound(t *testing.T) {
 }
 
 func TestEtcdListServicesNotFound(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	key := "/registry/services/specs"
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
@@ -506,7 +517,7 @@ func TestEtcdListServicesNotFound(t *testing.T) {
 		E: tools.EtcdErrorNotFound,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	services, err := registry.ListServices()
+	services, err := registry.ListServices(ctx)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -517,6 +528,7 @@ func TestEtcdListServicesNotFound(t *testing.T) {
 }
 
 func TestEtcdListControllers(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	key := "/registry/controllers"
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
@@ -535,7 +547,7 @@ func TestEtcdListControllers(t *testing.T) {
 		E: nil,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	controllers, err := registry.ListControllers()
+	controllers, err := registry.ListControllers(ctx)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -546,10 +558,11 @@ func TestEtcdListControllers(t *testing.T) {
 }
 
 func TestEtcdGetController(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.Set("/registry/controllers/foo", runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
-	ctrl, err := registry.GetController("foo")
+	ctrl, err := registry.GetController(ctx, "foo")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -560,6 +573,7 @@ func TestEtcdGetController(t *testing.T) {
 }
 
 func TestEtcdGetControllerNotFound(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.Data["/registry/controllers/foo"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
@@ -568,7 +582,7 @@ func TestEtcdGetControllerNotFound(t *testing.T) {
 		E: tools.EtcdErrorNotFound,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	ctrl, err := registry.GetController("foo")
+	ctrl, err := registry.GetController(ctx, "foo")
 	if ctrl != nil {
 		t.Errorf("Unexpected non-nil controller: %#v", ctrl)
 	}
@@ -578,9 +592,10 @@ func TestEtcdGetControllerNotFound(t *testing.T) {
 }
 
 func TestEtcdDeleteController(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.DeleteController("foo")
+	err := registry.DeleteController(ctx, "foo")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -595,9 +610,10 @@ func TestEtcdDeleteController(t *testing.T) {
 }
 
 func TestEtcdCreateController(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.CreateController(&api.ReplicationController{
+	err := registry.CreateController(ctx, &api.ReplicationController{
 		JSONBase: api.JSONBase{
 			ID: "foo",
 		},
@@ -622,11 +638,12 @@ func TestEtcdCreateController(t *testing.T) {
 }
 
 func TestEtcdCreateControllerAlreadyExisting(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.Set("/registry/controllers/foo", runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.CreateController(&api.ReplicationController{
+	err := registry.CreateController(ctx, &api.ReplicationController{
 		JSONBase: api.JSONBase{
 			ID: "foo",
 		},
@@ -637,12 +654,13 @@ func TestEtcdCreateControllerAlreadyExisting(t *testing.T) {
 }
 
 func TestEtcdUpdateController(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 
 	resp, _ := fakeClient.Set("/registry/controllers/foo", runtime.EncodeOrDie(latest.Codec, &api.ReplicationController{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.UpdateController(&api.ReplicationController{
+	err := registry.UpdateController(ctx, &api.ReplicationController{
 		JSONBase: api.JSONBase{ID: "foo", ResourceVersion: resp.Node.ModifiedIndex},
 		DesiredState: api.ReplicationControllerState{
 			Replicas: 2,
@@ -652,13 +670,14 @@ func TestEtcdUpdateController(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	ctrl, err := registry.GetController("foo")
+	ctrl, err := registry.GetController(ctx, "foo")
 	if ctrl.DesiredState.Replicas != 2 {
 		t.Errorf("Unexpected controller: %#v", ctrl)
 	}
 }
 
 func TestEtcdListServices(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	key := "/registry/services/specs"
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
@@ -677,7 +696,7 @@ func TestEtcdListServices(t *testing.T) {
 		E: nil,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	services, err := registry.ListServices()
+	services, err := registry.ListServices(ctx)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -688,9 +707,10 @@ func TestEtcdListServices(t *testing.T) {
 }
 
 func TestEtcdCreateService(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.CreateService(&api.Service{
+	err := registry.CreateService(ctx, &api.Service{
 		JSONBase: api.JSONBase{ID: "foo"},
 	})
 	if err != nil {
@@ -714,10 +734,11 @@ func TestEtcdCreateService(t *testing.T) {
 }
 
 func TestEtcdCreateServiceAlreadyExisting(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.Set("/registry/services/specs/foo", runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.CreateService(&api.Service{
+	err := registry.CreateService(ctx, &api.Service{
 		JSONBase: api.JSONBase{ID: "foo"},
 	})
 	if !errors.IsAlreadyExists(err) {
@@ -726,10 +747,11 @@ func TestEtcdCreateServiceAlreadyExisting(t *testing.T) {
 }
 
 func TestEtcdGetService(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.Set("/registry/services/specs/foo", runtime.EncodeOrDie(latest.Codec, &api.Service{JSONBase: api.JSONBase{ID: "foo"}}), 0)
 	registry := NewTestEtcdRegistry(fakeClient)
-	service, err := registry.GetService("foo")
+	service, err := registry.GetService(ctx, "foo")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -740,6 +762,7 @@ func TestEtcdGetService(t *testing.T) {
 }
 
 func TestEtcdGetServiceNotFound(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.Data["/registry/services/specs/foo"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
@@ -748,16 +771,17 @@ func TestEtcdGetServiceNotFound(t *testing.T) {
 		E: tools.EtcdErrorNotFound,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	_, err := registry.GetService("foo")
+	_, err := registry.GetService(ctx, "foo")
 	if !errors.IsNotFound(err) {
 		t.Errorf("Unexpected error returned: %#v", err)
 	}
 }
 
 func TestEtcdDeleteService(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	registry := NewTestEtcdRegistry(fakeClient)
-	err := registry.DeleteService("foo")
+	err := registry.DeleteService(ctx, "foo")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -776,6 +800,7 @@ func TestEtcdDeleteService(t *testing.T) {
 }
 
 func TestEtcdUpdateService(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 
@@ -790,12 +815,12 @@ func TestEtcdUpdateService(t *testing.T) {
 			"baz": "bar",
 		},
 	}
-	err := registry.UpdateService(&testService)
+	err := registry.UpdateService(ctx, &testService)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	svc, err := registry.GetService("foo")
+	svc, err := registry.GetService(ctx, "foo")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -809,6 +834,7 @@ func TestEtcdUpdateService(t *testing.T) {
 }
 
 func TestEtcdListEndpoints(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	key := "/registry/services/endpoints"
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
@@ -827,7 +853,7 @@ func TestEtcdListEndpoints(t *testing.T) {
 		E: nil,
 	}
 	registry := NewTestEtcdRegistry(fakeClient)
-	services, err := registry.ListEndpoints()
+	services, err := registry.ListEndpoints(ctx)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -838,6 +864,7 @@ func TestEtcdListEndpoints(t *testing.T) {
 }
 
 func TestEtcdGetEndpoints(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	registry := NewTestEtcdRegistry(fakeClient)
 	endpoints := &api.Endpoints{
@@ -847,7 +874,7 @@ func TestEtcdGetEndpoints(t *testing.T) {
 
 	fakeClient.Set("/registry/services/endpoints/foo", runtime.EncodeOrDie(latest.Codec, endpoints), 0)
 
-	got, err := registry.GetEndpoints("foo")
+	got, err := registry.GetEndpoints(ctx, "foo")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -858,6 +885,7 @@ func TestEtcdGetEndpoints(t *testing.T) {
 }
 
 func TestEtcdUpdateEndpoints(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
 	registry := NewTestEtcdRegistry(fakeClient)
@@ -868,7 +896,7 @@ func TestEtcdUpdateEndpoints(t *testing.T) {
 
 	fakeClient.Set("/registry/services/endpoints/foo", runtime.EncodeOrDie(latest.Codec, &api.Endpoints{}), 0)
 
-	err := registry.UpdateEndpoints(&endpoints)
+	err := registry.UpdateEndpoints(ctx, &endpoints)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -885,9 +913,10 @@ func TestEtcdUpdateEndpoints(t *testing.T) {
 }
 
 func TestEtcdWatchServices(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	registry := NewTestEtcdRegistry(fakeClient)
-	watching, err := registry.WatchServices(
+	watching, err := registry.WatchServices(ctx,
 		labels.Everything(),
 		labels.SelectorFromSet(labels.Set{"ID": "foo"}),
 		1,
@@ -912,9 +941,11 @@ func TestEtcdWatchServices(t *testing.T) {
 }
 
 func TestEtcdWatchServicesBadSelector(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	registry := NewTestEtcdRegistry(fakeClient)
 	_, err := registry.WatchServices(
+		ctx,
 		labels.Everything(),
 		labels.SelectorFromSet(labels.Set{"Field.Selector": "foo"}),
 		0,
@@ -924,6 +955,7 @@ func TestEtcdWatchServicesBadSelector(t *testing.T) {
 	}
 
 	_, err = registry.WatchServices(
+		ctx,
 		labels.SelectorFromSet(labels.Set{"Label.Selector": "foo"}),
 		labels.Everything(),
 		0,
@@ -934,9 +966,11 @@ func TestEtcdWatchServicesBadSelector(t *testing.T) {
 }
 
 func TestEtcdWatchEndpoints(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	registry := NewTestEtcdRegistry(fakeClient)
 	watching, err := registry.WatchEndpoints(
+		ctx,
 		labels.Everything(),
 		labels.SelectorFromSet(labels.Set{"ID": "foo"}),
 		1,
@@ -961,9 +995,11 @@ func TestEtcdWatchEndpoints(t *testing.T) {
 }
 
 func TestEtcdWatchEndpointsBadSelector(t *testing.T) {
+	ctx := api.NewContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
 	registry := NewTestEtcdRegistry(fakeClient)
 	_, err := registry.WatchEndpoints(
+		ctx,
 		labels.Everything(),
 		labels.SelectorFromSet(labels.Set{"Field.Selector": "foo"}),
 		0,
@@ -973,6 +1009,7 @@ func TestEtcdWatchEndpointsBadSelector(t *testing.T) {
 	}
 
 	_, err = registry.WatchEndpoints(
+		ctx,
 		labels.SelectorFromSet(labels.Set{"Label.Selector": "foo"}),
 		labels.Everything(),
 		0,

--- a/pkg/registry/pod/manifest_factory.go
+++ b/pkg/registry/pod/manifest_factory.go
@@ -32,7 +32,7 @@ type BasicManifestFactory struct {
 }
 
 func (b *BasicManifestFactory) MakeManifest(machine string, pod api.Pod) (api.ContainerManifest, error) {
-	envVars, err := service.GetServiceEnvironmentVariables(b.ServiceRegistry, machine)
+	envVars, err := service.GetServiceEnvironmentVariables(api.NewContext(), b.ServiceRegistry, machine)
 	if err != nil {
 		return api.ContainerManifest{}, err
 	}

--- a/pkg/registry/pod/registry.go
+++ b/pkg/registry/pod/registry.go
@@ -27,15 +27,15 @@ type Registry interface {
 	// ListPods obtains a list of pods having labels which match selector.
 	ListPods(ctx api.Context, selector labels.Selector) (*api.PodList, error)
 	// ListPodsPredicate obtains a list of pods for which filter returns true.
-	ListPodsPredicate(filter func(*api.Pod) bool) (*api.PodList, error)
+	ListPodsPredicate(ctx api.Context, filter func(*api.Pod) bool) (*api.PodList, error)
 	// Watch for new/changed/deleted pods
-	WatchPods(resourceVersion uint64, filter func(*api.Pod) bool) (watch.Interface, error)
+	WatchPods(ctx api.Context, resourceVersion uint64, filter func(*api.Pod) bool) (watch.Interface, error)
 	// Get a specific pod
-	GetPod(podID string) (*api.Pod, error)
+	GetPod(ctx api.Context, podID string) (*api.Pod, error)
 	// Create a pod based on a specification.
-	CreatePod(pod *api.Pod) error
+	CreatePod(ctx api.Context, pod *api.Pod) error
 	// Update an existing pod
-	UpdatePod(pod *api.Pod) error
+	UpdatePod(ctx api.Context, pod *api.Pod) error
 	// Delete an existing pod
-	DeletePod(podID string) error
+	DeletePod(ctx api.Context, podID string) error
 }

--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -81,21 +81,21 @@ func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan runtime.Obje
 	pod.CreationTimestamp = util.Now()
 
 	return apiserver.MakeAsync(func() (runtime.Object, error) {
-		if err := rs.registry.CreatePod(pod); err != nil {
+		if err := rs.registry.CreatePod(ctx, pod); err != nil {
 			return nil, err
 		}
-		return rs.registry.GetPod(pod.ID)
+		return rs.registry.GetPod(ctx, pod.ID)
 	}), nil
 }
 
 func (rs *REST) Delete(ctx api.Context, id string) (<-chan runtime.Object, error) {
 	return apiserver.MakeAsync(func() (runtime.Object, error) {
-		return &api.Status{Status: api.StatusSuccess}, rs.registry.DeletePod(id)
+		return &api.Status{Status: api.StatusSuccess}, rs.registry.DeletePod(ctx, id)
 	}), nil
 }
 
 func (rs *REST) Get(ctx api.Context, id string) (runtime.Object, error) {
-	pod, err := rs.registry.GetPod(id)
+	pod, err := rs.registry.GetPod(ctx, id)
 	if err != nil {
 		return pod, err
 	}
@@ -132,7 +132,7 @@ func (rs *REST) filterFunc(label, field labels.Selector) func(*api.Pod) bool {
 }
 
 func (rs *REST) List(ctx api.Context, label, field labels.Selector) (runtime.Object, error) {
-	pods, err := rs.registry.ListPodsPredicate(rs.filterFunc(label, field))
+	pods, err := rs.registry.ListPodsPredicate(ctx, rs.filterFunc(label, field))
 	if err == nil {
 		for i := range pods.Items {
 			pod := &pods.Items[i]
@@ -150,7 +150,7 @@ func (rs *REST) List(ctx api.Context, label, field labels.Selector) (runtime.Obj
 
 // Watch begins watching for new, changed, or deleted pods.
 func (rs *REST) Watch(ctx api.Context, label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
-	return rs.registry.WatchPods(resourceVersion, rs.filterFunc(label, field))
+	return rs.registry.WatchPods(ctx, resourceVersion, rs.filterFunc(label, field))
 }
 
 func (*REST) New() runtime.Object {
@@ -163,10 +163,10 @@ func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan runtime.Obje
 		return nil, errors.NewInvalid("pod", pod.ID, errs)
 	}
 	return apiserver.MakeAsync(func() (runtime.Object, error) {
-		if err := rs.registry.UpdatePod(pod); err != nil {
+		if err := rs.registry.UpdatePod(ctx, pod); err != nil {
 			return nil, err
 		}
-		return rs.registry.GetPod(pod.ID)
+		return rs.registry.GetPod(ctx, pod.ID)
 	}), nil
 }
 

--- a/pkg/registry/registrytest/controller.go
+++ b/pkg/registry/registrytest/controller.go
@@ -27,26 +27,26 @@ type ControllerRegistry struct {
 	Controllers *api.ReplicationControllerList
 }
 
-func (r *ControllerRegistry) ListControllers() (*api.ReplicationControllerList, error) {
+func (r *ControllerRegistry) ListControllers(ctx api.Context) (*api.ReplicationControllerList, error) {
 	return r.Controllers, r.Err
 }
 
-func (r *ControllerRegistry) GetController(ID string) (*api.ReplicationController, error) {
+func (r *ControllerRegistry) GetController(ctx api.Context, ID string) (*api.ReplicationController, error) {
 	return &api.ReplicationController{}, r.Err
 }
 
-func (r *ControllerRegistry) CreateController(controller *api.ReplicationController) error {
+func (r *ControllerRegistry) CreateController(ctx api.Context, controller *api.ReplicationController) error {
 	return r.Err
 }
 
-func (r *ControllerRegistry) UpdateController(controller *api.ReplicationController) error {
+func (r *ControllerRegistry) UpdateController(ctx api.Context, controller *api.ReplicationController) error {
 	return r.Err
 }
 
-func (r *ControllerRegistry) DeleteController(ID string) error {
+func (r *ControllerRegistry) DeleteController(ctx api.Context, ID string) error {
 	return r.Err
 }
 
-func (r *ControllerRegistry) WatchControllers(resourceVersion uint64) (watch.Interface, error) {
+func (r *ControllerRegistry) WatchControllers(ctx api.Context, resourceVersion uint64) (watch.Interface, error) {
 	return nil, r.Err
 }

--- a/pkg/registry/registrytest/pod.go
+++ b/pkg/registry/registrytest/pod.go
@@ -40,7 +40,7 @@ func NewPodRegistry(pods *api.PodList) *PodRegistry {
 	}
 }
 
-func (r *PodRegistry) ListPodsPredicate(filter func(*api.Pod) bool) (*api.PodList, error) {
+func (r *PodRegistry) ListPodsPredicate(ctx api.Context, filter func(*api.Pod) bool) (*api.PodList, error) {
 	r.Lock()
 	defer r.Unlock()
 	if r.Err != nil {
@@ -58,23 +58,23 @@ func (r *PodRegistry) ListPodsPredicate(filter func(*api.Pod) bool) (*api.PodLis
 }
 
 func (r *PodRegistry) ListPods(ctx api.Context, selector labels.Selector) (*api.PodList, error) {
-	return r.ListPodsPredicate(func(pod *api.Pod) bool {
+	return r.ListPodsPredicate(ctx, func(pod *api.Pod) bool {
 		return selector.Matches(labels.Set(pod.Labels))
 	})
 }
 
-func (r *PodRegistry) WatchPods(resourceVersion uint64, filter func(*api.Pod) bool) (watch.Interface, error) {
+func (r *PodRegistry) WatchPods(ctx api.Context, resourceVersion uint64, filter func(*api.Pod) bool) (watch.Interface, error) {
 	// TODO: wire filter down into the mux; it needs access to current and previous state :(
 	return r.mux.Watch(), nil
 }
 
-func (r *PodRegistry) GetPod(podId string) (*api.Pod, error) {
+func (r *PodRegistry) GetPod(ctx api.Context, podId string) (*api.Pod, error) {
 	r.Lock()
 	defer r.Unlock()
 	return r.Pod, r.Err
 }
 
-func (r *PodRegistry) CreatePod(pod *api.Pod) error {
+func (r *PodRegistry) CreatePod(ctx api.Context, pod *api.Pod) error {
 	r.Lock()
 	defer r.Unlock()
 	r.Pod = pod
@@ -82,7 +82,7 @@ func (r *PodRegistry) CreatePod(pod *api.Pod) error {
 	return r.Err
 }
 
-func (r *PodRegistry) UpdatePod(pod *api.Pod) error {
+func (r *PodRegistry) UpdatePod(ctx api.Context, pod *api.Pod) error {
 	r.Lock()
 	defer r.Unlock()
 	r.Pod = pod
@@ -90,7 +90,7 @@ func (r *PodRegistry) UpdatePod(pod *api.Pod) error {
 	return r.Err
 }
 
-func (r *PodRegistry) DeletePod(podId string) error {
+func (r *PodRegistry) DeletePod(ctx api.Context, podId string) error {
 	r.Lock()
 	defer r.Unlock()
 	r.mux.Action(watch.Deleted, r.Pod)

--- a/pkg/registry/registrytest/service.go
+++ b/pkg/registry/registrytest/service.go
@@ -38,49 +38,49 @@ type ServiceRegistry struct {
 	UpdatedID string
 }
 
-func (r *ServiceRegistry) ListServices() (*api.ServiceList, error) {
+func (r *ServiceRegistry) ListServices(ctx api.Context) (*api.ServiceList, error) {
 	return &r.List, r.Err
 }
 
-func (r *ServiceRegistry) CreateService(svc *api.Service) error {
+func (r *ServiceRegistry) CreateService(ctx api.Context, svc *api.Service) error {
 	r.Service = svc
 	r.List.Items = append(r.List.Items, *svc)
 	return r.Err
 }
 
-func (r *ServiceRegistry) GetService(id string) (*api.Service, error) {
+func (r *ServiceRegistry) GetService(ctx api.Context, id string) (*api.Service, error) {
 	r.GottenID = id
 	return r.Service, r.Err
 }
 
-func (r *ServiceRegistry) DeleteService(id string) error {
+func (r *ServiceRegistry) DeleteService(ctx api.Context, id string) error {
 	r.DeletedID = id
 	return r.Err
 }
 
-func (r *ServiceRegistry) UpdateService(svc *api.Service) error {
+func (r *ServiceRegistry) UpdateService(ctx api.Context, svc *api.Service) error {
 	r.UpdatedID = svc.ID
 	return r.Err
 }
 
-func (r *ServiceRegistry) WatchServices(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+func (r *ServiceRegistry) WatchServices(ctx api.Context, label labels.Selector, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
 	return nil, r.Err
 }
 
-func (r *ServiceRegistry) ListEndpoints() (*api.EndpointsList, error) {
+func (r *ServiceRegistry) ListEndpoints(ctx api.Context) (*api.EndpointsList, error) {
 	return &r.EndpointsList, r.Err
 }
 
-func (r *ServiceRegistry) GetEndpoints(id string) (*api.Endpoints, error) {
+func (r *ServiceRegistry) GetEndpoints(ctx api.Context, id string) (*api.Endpoints, error) {
 	r.GottenID = id
 	return &r.Endpoints, r.Err
 }
 
-func (r *ServiceRegistry) UpdateEndpoints(e *api.Endpoints) error {
+func (r *ServiceRegistry) UpdateEndpoints(ctx api.Context, e *api.Endpoints) error {
 	r.Endpoints = *e
 	return r.Err
 }
 
-func (r *ServiceRegistry) WatchEndpoints(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+func (r *ServiceRegistry) WatchEndpoints(ctx api.Context, label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
 	return nil, r.Err
 }

--- a/pkg/registry/service/registry.go
+++ b/pkg/registry/service/registry.go
@@ -25,12 +25,12 @@ import (
 
 // Registry is an interface for things that know how to store services.
 type Registry interface {
-	ListServices() (*api.ServiceList, error)
-	CreateService(svc *api.Service) error
-	GetService(name string) (*api.Service, error)
-	DeleteService(name string) error
-	UpdateService(svc *api.Service) error
-	WatchServices(labels, fields labels.Selector, resourceVersion uint64) (watch.Interface, error)
+	ListServices(ctx api.Context) (*api.ServiceList, error)
+	CreateService(ctx api.Context, svc *api.Service) error
+	GetService(ctx api.Context, name string) (*api.Service, error)
+	DeleteService(ctx api.Context, name string) error
+	UpdateService(ctx api.Context, svc *api.Service) error
+	WatchServices(ctx api.Context, labels, fields labels.Selector, resourceVersion uint64) (watch.Interface, error)
 
 	// TODO: endpoints and their implementation should be separated, setting endpoints should be
 	// supported via the API, and the endpoints-controller should use the API to update endpoints.

--- a/pkg/service/endpoints_controller.go
+++ b/pkg/service/endpoints_controller.go
@@ -73,7 +73,7 @@ func (e *EndpointController) SyncServiceEndpoints() error {
 			endpoints[ix] = net.JoinHostPort(pod.CurrentState.PodIP, strconv.Itoa(port))
 		}
 		// TODO: this is totally broken, we need to compute this and store inside an AtomicUpdate loop.
-		err = e.serviceRegistry.UpdateEndpoints(&api.Endpoints{
+		err = e.serviceRegistry.UpdateEndpoints(api.NewContext(), &api.Endpoints{
 			JSONBase:  api.JSONBase{ID: service.ID},
 			Endpoints: endpoints,
 		})


### PR DESCRIPTION
This is the next step in enabling that a ctx is passed down from the RESTStorage interface to the Registry code paths.

Nothing is done with the context yet.
