### PR TITLE
Allow etcd config file to be passed to apiserver, kubelet, and proxy

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -117,7 +117,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	cl.PollPeriod = time.Second * 1
 	cl.Sync = true
 
-	helper, err := master.NewEtcdHelper(servers, "")
+	helper, err := master.NewEtcdHelper(etcdClient, "")
 	if err != nil {
 		glog.Fatalf("Unable to get etcd helper: %v", err)
 	}

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -38,7 +38,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
-	goetcd "github.com/coreos/go-etcd/etcd"
 	"github.com/golang/glog"
 )
 
@@ -69,8 +68,7 @@ type Master struct {
 
 // NewEtcdHelper returns an EtcdHelper for the provided arguments or an error if the version
 // is incorrect.
-func NewEtcdHelper(etcdServers []string, version string) (helper tools.EtcdHelper, err error) {
-	client := goetcd.NewClient(etcdServers)
+func NewEtcdHelper(client tools.EtcdGetSet, version string) (helper tools.EtcdHelper, err error) {
 	if version == "" {
 		version = latest.Version
 	}

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 func TestClient(t *testing.T) {
-	helper, err := master.NewEtcdHelper(newEtcdClient().GetCluster(), "v1beta1")
+	helper, err := master.NewEtcdHelper(newEtcdClient(), "v1beta1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
This is meant to fix #1338 .

I'm a relative golang newbie, so let me know where I'm going wrong here.
