### PR TITLE
Add and validate namespace to pod, service, replication controller objects

### DIFF
--- a/api/doc/controller-schema.json
+++ b/api/doc/controller-schema.json
@@ -12,6 +12,10 @@
       "type": "string",
       "required": false
     },
+    "namespace": {
+      "type": "string",
+      "required": false
+    },
     "creationTimestamp": {
       "type": "string",
       "required": false

--- a/api/doc/pod-schema.json
+++ b/api/doc/pod-schema.json
@@ -12,6 +12,10 @@
       "type": "string",
       "required": false
     },
+    "namespace": {
+      "type": "string",
+      "required": false
+    },    
     "creationTimestamp": {
       "type": "string",
       "required": false

--- a/api/doc/service-schema.json
+++ b/api/doc/service-schema.json
@@ -12,6 +12,10 @@
       "type": "string",
       "required": false
     },
+    "namespace": {
+      "type": "string",
+      "required": false
+    },    
     "creationTimestamp": {
       "type": "string",
       "required": false

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -41,14 +41,14 @@ func validateObject(obj runtime.Object) (errors []error) {
 			errors = append(errors, validateObject(&t.Items[i])...)
 		}
 	case *api.Service:
-		api.ValidNamespaceOnCreateOrUpdate(ctx, &t.JSONBase)
+		api.ValidNamespace(ctx, &t.JSONBase)
 		errors = validation.ValidateService(t)
 	case *api.ServiceList:
 		for i := range t.Items {
 			errors = append(errors, validateObject(&t.Items[i])...)
 		}
 	case *api.Pod:
-		api.ValidNamespaceOnCreateOrUpdate(ctx, &t.JSONBase)
+		api.ValidNamespace(ctx, &t.JSONBase)
 		errors = validation.ValidateManifest(&t.DesiredState.Manifest)
 	case *api.PodList:
 		for i := range t.Items {

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func validateObject(obj runtime.Object) (errors []error) {
+	ctx := api.NewDefaultContext()
 	switch t := obj.(type) {
 	case *api.ReplicationController:
 		errors = validation.ValidateManifest(&t.DesiredState.PodTemplate.DesiredState.Manifest)
@@ -40,12 +41,14 @@ func validateObject(obj runtime.Object) (errors []error) {
 			errors = append(errors, validateObject(&t.Items[i])...)
 		}
 	case *api.Service:
+		api.ValidNamespaceOnCreateOrUpdate(ctx, &t.JSONBase)
 		errors = validation.ValidateService(t)
 	case *api.ServiceList:
 		for i := range t.Items {
 			errors = append(errors, validateObject(&t.Items[i])...)
 		}
 	case *api.Pod:
+		api.ValidNamespaceOnCreateOrUpdate(ctx, &t.JSONBase)
 		errors = validation.ValidateManifest(&t.DesiredState.Manifest)
 	case *api.PodList:
 		for i := range t.Items {

--- a/pkg/api/context.go
+++ b/pkg/api/context.go
@@ -63,8 +63,8 @@ func NamespaceFrom(ctx Context) (string, bool) {
 	return namespace, ok
 }
 
-// ValidNamespaceOnCreateOrUpdate returns false if the namespace on the context differs from the resource.  If the resource has no namespace, it is set to the value in the context.
-func ValidNamespaceOnCreateOrUpdate(ctx Context, resource *JSONBase) bool {
+// ValidNamespace returns false if the namespace on the context differs from the resource.  If the resource has no namespace, it is set to the value in the context.
+func ValidNamespace(ctx Context, resource *JSONBase) bool {
 	ns, ok := NamespaceFrom(ctx)
 	if len(resource.Namespace) == 0 {
 		resource.Namespace = ns

--- a/pkg/api/context_test.go
+++ b/pkg/api/context_test.go
@@ -46,6 +46,10 @@ func TestValidNamespaceOnCreateOrUpdate(t *testing.T) {
 	}
 	resource = api.ReplicationController{JSONBase: api.JSONBase{Namespace: "other"}}
 	if api.ValidNamespaceOnCreateOrUpdate(ctx, &resource.JSONBase) {
-		t.Errorf("Expected error that resource and context errors do not match")
+		t.Errorf("Expected error that resource and context errors do not match because resource has different namespace")
+	}
+	ctx = api.NewContext()
+	if api.ValidNamespaceOnCreateOrUpdate(ctx, &resource.JSONBase) {
+		t.Errorf("Expected error that resource and context errors do not match since context has no namespace")
 	}
 }

--- a/pkg/api/context_test.go
+++ b/pkg/api/context_test.go
@@ -32,24 +32,31 @@ func TestNamespaceContext(t *testing.T) {
 	if api.NamespaceDefault != result {
 		t.Errorf("Expected: %v, Actual: %v", api.NamespaceDefault, result)
 	}
+
+	ctx = api.NewContext()
+	result, ok = api.NamespaceFrom(ctx)
+	if ok {
+		t.Errorf("Should not be ok because there is no namespace on the context")
+	}
 }
 
-func TestValidNamespaceOnCreateOrUpdate(t *testing.T) {
+// TestValidNamespace validates that namespace rules are enforced on a resource prior to create or update
+func TestValidNamespace(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	namespace, _ := api.NamespaceFrom(ctx)
 	resource := api.ReplicationController{}
-	if !api.ValidNamespaceOnCreateOrUpdate(ctx, &resource.JSONBase) {
+	if !api.ValidNamespace(ctx, &resource.JSONBase) {
 		t.Errorf("expected success")
 	}
 	if namespace != resource.Namespace {
 		t.Errorf("expected resource to have the default namespace assigned during validation")
 	}
 	resource = api.ReplicationController{JSONBase: api.JSONBase{Namespace: "other"}}
-	if api.ValidNamespaceOnCreateOrUpdate(ctx, &resource.JSONBase) {
+	if api.ValidNamespace(ctx, &resource.JSONBase) {
 		t.Errorf("Expected error that resource and context errors do not match because resource has different namespace")
 	}
 	ctx = api.NewContext()
-	if api.ValidNamespaceOnCreateOrUpdate(ctx, &resource.JSONBase) {
+	if api.ValidNamespace(ctx, &resource.JSONBase) {
 		t.Errorf("Expected error that resource and context errors do not match since context has no namespace")
 	}
 }

--- a/pkg/api/context_test.go
+++ b/pkg/api/context_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api_test
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+// TestNamespaceContext validates that a namespace can be get/set on a context object
+func TestNamespaceContext(t *testing.T) {
+	ctx := api.NewDefaultContext()
+	result, ok := api.NamespaceFrom(ctx)
+	if !ok {
+		t.Errorf("Error getting namespace")
+	}
+	if api.NamespaceDefault != result {
+		t.Errorf("Expected: %v, Actual: %v", api.NamespaceDefault, result)
+	}
+}
+
+func TestValidNamespaceOnCreateOrUpdate(t *testing.T) {
+	ctx := api.NewDefaultContext()
+	namespace, _ := api.NamespaceFrom(ctx)
+	resource := api.ReplicationController{}
+	if !api.ValidNamespaceOnCreateOrUpdate(ctx, &resource.JSONBase) {
+		t.Errorf("expected success")
+	}
+	if namespace != resource.Namespace {
+		t.Errorf("expected resource to have the default namespace assigned during validation")
+	}
+	resource = api.ReplicationController{JSONBase: api.JSONBase{Namespace: "other"}}
+	if api.ValidNamespaceOnCreateOrUpdate(ctx, &resource.JSONBase) {
+		t.Errorf("Expected error that resource and context errors do not match")
+	}
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -237,7 +237,15 @@ type JSONBase struct {
 	SelfLink          string    `json:"selfLink,omitempty" yaml:"selfLink,omitempty"`
 	ResourceVersion   uint64    `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
 	APIVersion        string    `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	Namespace         string    `json:"namespace",omitempty" yaml:"namespace,omitempty"`
 }
+
+const (
+	// NamespaceDefault means the object is in the default namespace which is applied when not specified by clients
+	NamespaceDefault string = "default"
+	// NamespaceAll is the default argument to specify on a context when you want to list or filter resources across all namespaces
+	NamespaceAll string = ""
+)
 
 // PodStatus represents a status of a pod.
 type PodStatus string

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -248,6 +248,7 @@ type JSONBase struct {
 	SelfLink          string    `json:"selfLink,omitempty" yaml:"selfLink,omitempty"`
 	ResourceVersion   uint64    `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
 	APIVersion        string    `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	Namespace         string    `json:"namespace",omitempty" yaml:"namespace,omitempty"`
 }
 
 func (*JSONBase) IsAnAPIObject() {}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -246,6 +246,7 @@ type JSONBase struct {
 	SelfLink          string    `json:"selfLink,omitempty" yaml:"selfLink,omitempty"`
 	ResourceVersion   uint64    `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
 	APIVersion        string    `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	Namespace         string    `json:"namespace",omitempty" yaml:"namespace,omitempty"`
 }
 
 // PodStatus represents a status of a pod.

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -313,7 +313,9 @@ func ValidatePod(pod *api.Pod) errs.ErrorList {
 	if len(pod.ID) == 0 {
 		allErrs = append(allErrs, errs.NewFieldRequired("id", pod.ID))
 	}
-	allErrs = append(allErrs, validateNotEmptyDNSSubdomain(pod.Namespace, "pod.Namespace")...)
+	if !util.IsDNSSubdomain(pod.Namespace) {
+		allErrs = append(allErrs, errs.NewFieldInvalid("pod.Namespace", pod.Namespace))
+	}
 	allErrs = append(allErrs, ValidatePodState(&pod.DesiredState).Prefix("desiredState")...)
 	return allErrs
 }
@@ -326,7 +328,9 @@ func ValidateService(service *api.Service) errs.ErrorList {
 	} else if !util.IsDNS952Label(service.ID) {
 		allErrs = append(allErrs, errs.NewFieldInvalid("id", service.ID))
 	}
-	allErrs = append(allErrs, validateNotEmptyDNSSubdomain(service.Namespace, "service.Namespace")...)
+	if !util.IsDNSSubdomain(service.Namespace) {
+		allErrs = append(allErrs, errs.NewFieldInvalid("service.Namespace", service.Namespace))
+	}
 	if !util.IsValidPortNum(service.Port) {
 		allErrs = append(allErrs, errs.NewFieldInvalid("Service.Port", service.Port))
 	}
@@ -347,7 +351,9 @@ func ValidateReplicationController(controller *api.ReplicationController) errs.E
 	if len(controller.ID) == 0 {
 		allErrs = append(allErrs, errs.NewFieldRequired("id", controller.ID))
 	}
-	allErrs = append(allErrs, validateNotEmptyDNSSubdomain(controller.Namespace, "controller.Namespace")...)
+	if !util.IsDNSSubdomain(controller.Namespace) {
+		allErrs = append(allErrs, errs.NewFieldInvalid("controller.Namespace", controller.Namespace))
+	}
 	allErrs = append(allErrs, ValidateReplicationControllerState(&controller.DesiredState).Prefix("desiredState")...)
 	return allErrs
 }
@@ -367,16 +373,5 @@ func ValidateReplicationControllerState(state *api.ReplicationControllerState) e
 		allErrs = append(allErrs, errs.NewFieldInvalid("replicas", state.Replicas))
 	}
 	allErrs = append(allErrs, ValidateManifest(&state.PodTemplate.DesiredState.Manifest).Prefix("podTemplate.desiredState.manifest")...)
-	return allErrs
-}
-
-// validateNotEmptyDNSSubdomain validates the provided value is not empty and is a dns subdomain.
-func validateNotEmptyDNSSubdomain(value string, label string) errs.ErrorList {
-	allErrs := errs.ErrorList{}
-	if value == "" {
-		allErrs = append(allErrs, errs.NewFieldInvalid(label, value))
-	} else if !util.IsDNSSubdomain(value) {
-		allErrs = append(allErrs, errs.NewFieldInvalid(label, value))
-	}
 	return allErrs
 }

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -100,7 +100,8 @@ func curry(f func(runtime.Object, *http.Request) error, req *http.Request) func(
 //    timeout=<duration> Timeout for synchronous requests, only applies if sync=true
 //    labels=<label-selector> Used for filtering list operations
 func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w http.ResponseWriter, storage RESTStorage) {
-	ctx := api.NewContext()
+	// TODO for now, we perform all operations in the default namespace
+	ctx := api.NewDefaultContext()
 	sync := req.URL.Query().Get("sync") == "true"
 	timeout := parseTimeout(req.URL.Query().Get("timeout"))
 	switch req.Method {

--- a/pkg/registry/controller/rest.go
+++ b/pkg/registry/controller/rest.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	stderrs "errors"
 	"fmt"
 	"time"
 
@@ -59,6 +60,10 @@ func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan runtime.Obje
 	if !ok {
 		return nil, fmt.Errorf("not a replication controller: %#v", obj)
 	}
+	if !api.ValidNamespaceOnCreateOrUpdate(ctx, &controller.JSONBase) {
+		return nil, errors.NewConflict("controller", controller.Namespace, stderrs.New("Controller.Namespace does not match the provided context"))
+	}
+
 	if len(controller.ID) == 0 {
 		controller.ID = uuid.NewUUID().String()
 	}
@@ -127,6 +132,9 @@ func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan runtime.Obje
 	controller, ok := obj.(*api.ReplicationController)
 	if !ok {
 		return nil, fmt.Errorf("not a replication controller: %#v", obj)
+	}
+	if !api.ValidNamespaceOnCreateOrUpdate(ctx, &controller.JSONBase) {
+		return nil, errors.NewConflict("controller", controller.Namespace, stderrs.New("Controller.Namespace does not match the provided context"))
 	}
 	if errs := validation.ValidateReplicationController(controller); len(errs) > 0 {
 		return nil, errors.NewInvalid("replicationController", controller.ID, errs)

--- a/pkg/registry/controller/rest.go
+++ b/pkg/registry/controller/rest.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controller
 
 import (
-	stderrs "errors"
 	"fmt"
 	"time"
 
@@ -60,8 +59,8 @@ func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan runtime.Obje
 	if !ok {
 		return nil, fmt.Errorf("not a replication controller: %#v", obj)
 	}
-	if !api.ValidNamespaceOnCreateOrUpdate(ctx, &controller.JSONBase) {
-		return nil, errors.NewConflict("controller", controller.Namespace, stderrs.New("Controller.Namespace does not match the provided context"))
+	if !api.ValidNamespace(ctx, &controller.JSONBase) {
+		return nil, errors.NewConflict("controller", controller.Namespace, fmt.Errorf("Controller.Namespace does not match the provided context"))
 	}
 
 	if len(controller.ID) == 0 {
@@ -133,8 +132,8 @@ func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan runtime.Obje
 	if !ok {
 		return nil, fmt.Errorf("not a replication controller: %#v", obj)
 	}
-	if !api.ValidNamespaceOnCreateOrUpdate(ctx, &controller.JSONBase) {
-		return nil, errors.NewConflict("controller", controller.Namespace, stderrs.New("Controller.Namespace does not match the provided context"))
+	if !api.ValidNamespace(ctx, &controller.JSONBase) {
+		return nil, errors.NewConflict("controller", controller.Namespace, fmt.Errorf("Controller.Namespace does not match the provided context"))
 	}
 	if errs := validation.ValidateReplicationController(controller); len(errs) > 0 {
 		return nil, errors.NewInvalid("replicationController", controller.ID, errs)

--- a/pkg/registry/controller/rest_test.go
+++ b/pkg/registry/controller/rest_test.go
@@ -243,7 +243,7 @@ func TestCreateController(t *testing.T) {
 			PodTemplate:     validPodTemplate,
 		},
 	}
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	channel, err := storage.Create(ctx, controller)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -279,8 +279,8 @@ func TestControllerStorageValidatesCreate(t *testing.T) {
 			DesiredState: api.ReplicationControllerState{},
 		},
 	}
+	ctx := api.NewDefaultContext()
 	for _, failureCase := range failureCases {
-		ctx := api.NewContext()
 		c, err := storage.Create(ctx, &failureCase)
 		if c != nil {
 			t.Errorf("Expected nil channel")
@@ -310,8 +310,8 @@ func TestControllerStorageValidatesUpdate(t *testing.T) {
 			DesiredState: api.ReplicationControllerState{},
 		},
 	}
+	ctx := api.NewDefaultContext()
 	for _, failureCase := range failureCases {
-		ctx := api.NewContext()
 		c, err := storage.Update(ctx, &failureCase)
 		if c != nil {
 			t.Errorf("Expected nil channel")

--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -17,7 +17,6 @@ limitations under the License.
 package pod
 
 import (
-	stderrs "errors"
 	"fmt"
 	"sync"
 	"time"
@@ -70,8 +69,8 @@ func NewREST(config *RESTConfig) *REST {
 
 func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan runtime.Object, error) {
 	pod := obj.(*api.Pod)
-	if !api.ValidNamespaceOnCreateOrUpdate(ctx, &pod.JSONBase) {
-		return nil, errors.NewConflict("pod", pod.Namespace, stderrs.New("Pod.Namespace does not match the provided context"))
+	if !api.ValidNamespace(ctx, &pod.JSONBase) {
+		return nil, errors.NewConflict("pod", pod.Namespace, fmt.Errorf("Pod.Namespace does not match the provided context"))
 	}
 	pod.DesiredState.Manifest.UUID = uuid.NewUUID().String()
 	if len(pod.ID) == 0 {
@@ -162,8 +161,8 @@ func (*REST) New() runtime.Object {
 
 func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan runtime.Object, error) {
 	pod := obj.(*api.Pod)
-	if !api.ValidNamespaceOnCreateOrUpdate(ctx, &pod.JSONBase) {
-		return nil, errors.NewConflict("pod", pod.Namespace, stderrs.New("Pod.Namespace does not match the provided context"))
+	if !api.ValidNamespace(ctx, &pod.JSONBase) {
+		return nil, errors.NewConflict("pod", pod.Namespace, fmt.Errorf("Pod.Namespace does not match the provided context"))
 	}
 	if errs := validation.ValidatePod(pod); len(errs) > 0 {
 		return nil, errors.NewInvalid("pod", pod.ID, errs)

--- a/pkg/registry/pod/rest_test.go
+++ b/pkg/registry/pod/rest_test.go
@@ -69,7 +69,7 @@ func TestCreatePodRegistryError(t *testing.T) {
 		},
 	}
 	pod := &api.Pod{DesiredState: desiredState}
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	ch, err := storage.Create(ctx, pod)
 	if err != nil {
 		t.Errorf("Expected %#v, Got %#v", nil, err)
@@ -89,7 +89,7 @@ func TestCreatePodSetsIds(t *testing.T) {
 		},
 	}
 	pod := &api.Pod{DesiredState: desiredState}
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	ch, err := storage.Create(ctx, pod)
 	if err != nil {
 		t.Errorf("Expected %#v, Got %#v", nil, err)
@@ -116,7 +116,7 @@ func TestCreatePodSetsUUIDs(t *testing.T) {
 		},
 	}
 	pod := &api.Pod{DesiredState: desiredState}
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	ch, err := storage.Create(ctx, pod)
 	if err != nil {
 		t.Errorf("Expected %#v, Got %#v", nil, err)
@@ -496,7 +496,7 @@ func TestPodStorageValidatesCreate(t *testing.T) {
 	storage := REST{
 		registry: podRegistry,
 	}
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	pod := &api.Pod{}
 	c, err := storage.Create(ctx, pod)
 	if c != nil {
@@ -513,7 +513,7 @@ func TestPodStorageValidatesUpdate(t *testing.T) {
 	storage := REST{
 		registry: podRegistry,
 	}
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	pod := &api.Pod{}
 	c, err := storage.Update(ctx, pod)
 	if c != nil {
@@ -545,7 +545,7 @@ func TestCreatePod(t *testing.T) {
 		JSONBase:     api.JSONBase{ID: "foo"},
 		DesiredState: desiredState,
 	}
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	channel, err := storage.Create(ctx, pod)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/pkg/registry/service/rest.go
+++ b/pkg/registry/service/rest.go
@@ -17,7 +17,6 @@ limitations under the License.
 package service
 
 import (
-	stderrs "errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -53,8 +52,8 @@ func NewREST(registry Registry, cloud cloudprovider.Interface, machines minion.R
 
 func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan runtime.Object, error) {
 	srv := obj.(*api.Service)
-	if !api.ValidNamespaceOnCreateOrUpdate(ctx, &srv.JSONBase) {
-		return nil, errors.NewConflict("service", srv.Namespace, stderrs.New("Service.Namespace does not match the provided context"))
+	if !api.ValidNamespace(ctx, &srv.JSONBase) {
+		return nil, errors.NewConflict("service", srv.Namespace, fmt.Errorf("Service.Namespace does not match the provided context"))
 	}
 	if errs := validation.ValidateService(srv); len(errs) > 0 {
 		return nil, errors.NewInvalid("service", srv.ID, errs)
@@ -169,8 +168,8 @@ func GetServiceEnvironmentVariables(ctx api.Context, registry Registry, machine 
 
 func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan runtime.Object, error) {
 	srv := obj.(*api.Service)
-	if !api.ValidNamespaceOnCreateOrUpdate(ctx, &srv.JSONBase) {
-		return nil, errors.NewConflict("service", srv.Namespace, stderrs.New("Service.Namespace does not match the provided context"))
+	if !api.ValidNamespace(ctx, &srv.JSONBase) {
+		return nil, errors.NewConflict("service", srv.Namespace, fmt.Errorf("Service.Namespace does not match the provided context"))
 	}
 	if errs := validation.ValidateService(srv); len(errs) > 0 {
 		return nil, errors.NewInvalid("service", srv.ID, errs)

--- a/pkg/registry/service/rest.go
+++ b/pkg/registry/service/rest.go
@@ -17,6 +17,7 @@ limitations under the License.
 package service
 
 import (
+	stderrs "errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -52,6 +53,9 @@ func NewREST(registry Registry, cloud cloudprovider.Interface, machines minion.R
 
 func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan runtime.Object, error) {
 	srv := obj.(*api.Service)
+	if !api.ValidNamespaceOnCreateOrUpdate(ctx, &srv.JSONBase) {
+		return nil, errors.NewConflict("service", srv.Namespace, stderrs.New("Service.Namespace does not match the provided context"))
+	}
 	if errs := validation.ValidateService(srv); len(errs) > 0 {
 		return nil, errors.NewInvalid("service", srv.ID, errs)
 	}
@@ -165,6 +169,9 @@ func GetServiceEnvironmentVariables(ctx api.Context, registry Registry, machine 
 
 func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan runtime.Object, error) {
 	srv := obj.(*api.Service)
+	if !api.ValidNamespaceOnCreateOrUpdate(ctx, &srv.JSONBase) {
+		return nil, errors.NewConflict("service", srv.Namespace, stderrs.New("Service.Namespace does not match the provided context"))
+	}
 	if errs := validation.ValidateService(srv); len(errs) > 0 {
 		return nil, errors.NewInvalid("service", srv.ID, errs)
 	}

--- a/pkg/registry/service/rest_test.go
+++ b/pkg/registry/service/rest_test.go
@@ -40,7 +40,7 @@ func TestServiceRegistryCreate(t *testing.T) {
 		JSONBase: api.JSONBase{ID: "foo"},
 		Selector: map[string]string{"bar": "baz"},
 	}
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	c, _ := storage.Create(ctx, svc)
 	created_svc := <-c
 	created_service := created_svc.(*api.Service)
@@ -76,7 +76,7 @@ func TestServiceStorageValidatesCreate(t *testing.T) {
 			Selector: map[string]string{},
 		},
 	}
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	for _, failureCase := range failureCases {
 		c, err := storage.Create(ctx, &failureCase)
 		if c != nil {
@@ -90,7 +90,7 @@ func TestServiceStorageValidatesCreate(t *testing.T) {
 }
 
 func TestServiceRegistryUpdate(t *testing.T) {
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	registry := registrytest.NewServiceRegistry()
 	registry.CreateService(ctx, &api.Service{
 		Port:     6502,
@@ -120,7 +120,7 @@ func TestServiceRegistryUpdate(t *testing.T) {
 }
 
 func TestServiceStorageValidatesUpdate(t *testing.T) {
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	registry := registrytest.NewServiceRegistry()
 	registry.CreateService(ctx, &api.Service{
 		Port:     6502,
@@ -152,7 +152,7 @@ func TestServiceStorageValidatesUpdate(t *testing.T) {
 }
 
 func TestServiceRegistryExternalService(t *testing.T) {
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	registry := registrytest.NewServiceRegistry()
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
@@ -190,7 +190,7 @@ func TestServiceRegistryExternalServiceError(t *testing.T) {
 		Selector:                   map[string]string{"bar": "baz"},
 		CreateExternalLoadBalancer: true,
 	}
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	c, _ := storage.Create(ctx, svc)
 	<-c
 	if len(fakeCloud.Calls) != 1 || fakeCloud.Calls[0] != "get-zone" {
@@ -202,7 +202,7 @@ func TestServiceRegistryExternalServiceError(t *testing.T) {
 }
 
 func TestServiceRegistryDelete(t *testing.T) {
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	registry := registrytest.NewServiceRegistry()
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
@@ -223,7 +223,7 @@ func TestServiceRegistryDelete(t *testing.T) {
 }
 
 func TestServiceRegistryDeleteExternal(t *testing.T) {
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	registry := registrytest.NewServiceRegistry()
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
@@ -245,7 +245,7 @@ func TestServiceRegistryDeleteExternal(t *testing.T) {
 }
 
 func TestServiceRegistryMakeLinkVariables(t *testing.T) {
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	registry := registrytest.NewServiceRegistry()
 	registry.List = api.ServiceList{
 		Items: []api.Service{
@@ -310,7 +310,7 @@ func TestServiceRegistryMakeLinkVariables(t *testing.T) {
 }
 
 func TestServiceRegistryGet(t *testing.T) {
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	registry := registrytest.NewServiceRegistry()
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
@@ -329,7 +329,7 @@ func TestServiceRegistryGet(t *testing.T) {
 }
 
 func TestServiceRegistryResourceLocation(t *testing.T) {
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	registry := registrytest.NewServiceRegistry()
 	registry.Endpoints = api.Endpoints{Endpoints: []string{"foo:80"}}
 	fakeCloud := &cloud.FakeCloud{}
@@ -359,7 +359,7 @@ func TestServiceRegistryResourceLocation(t *testing.T) {
 }
 
 func TestServiceRegistryList(t *testing.T) {
-	ctx := api.NewContext()
+	ctx := api.NewDefaultContext()
 	registry := registrytest.NewServiceRegistry()
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}


### PR DESCRIPTION
Next iteration in delivering code against the integrated namespaces proposal, the PR adds the following:
1. Add Namespace to Pod, Service, ReplicationController objects
2. Enforces Namespace is set prior to persistence
3. Enforces context.Namespace on create and update operations matches resource.Namespace

Feedback welcome.
