### PR TITLE
ListContainer filter

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -176,10 +176,11 @@ func (c DockerContainers) FindContainersByPodFullName(podFullName string) map[st
 	return containers
 }
 
-// GetKubeletDockerContainers returns a map of docker containers that we manage. The map key is the docker container ID
-func GetKubeletDockerContainers(client DockerInterface) (DockerContainers, error) {
+// GetKubeletDockerContainers takes client and boolean whether to list all container or just the running ones.
+// Returns a map of docker containers that we manage. The map key is the docker container ID
+func GetKubeletDockerContainers(client DockerInterface, allContainers bool) (DockerContainers, error) {
 	result := make(DockerContainers)
-	containers, err := client.ListContainers(docker.ListContainersOptions{})
+	containers, err := client.ListContainers(docker.ListContainersOptions{All: allContainers})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -62,7 +62,7 @@ func TestGetContainerID(t *testing.T) {
 		ID: "foobar",
 	}
 
-	dockerContainers, err := GetKubeletDockerContainers(fakeDocker)
+	dockerContainers, err := GetKubeletDockerContainers(fakeDocker, false)
 	if err != nil {
 		t.Errorf("Expected no error, Got %#v", err)
 	}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -448,7 +448,7 @@ func (kl *Kubelet) syncPod(pod *Pod, dockerContainers dockertools.DockerContaine
 		netID = dockerNetworkID
 		if count > 0 {
 			// relist everything, otherwise we'll think we're ok
-			dockerContainers, err = dockertools.GetKubeletDockerContainers(kl.dockerClient)
+			dockerContainers, err = dockertools.GetKubeletDockerContainers(kl.dockerClient, false)
 			if err != nil {
 				glog.Errorf("Error listing containers %#v", dockerContainers)
 				return err
@@ -606,7 +606,7 @@ func (kl *Kubelet) SyncPods(pods []Pod) error {
 	var err error
 	desiredContainers := make(map[podContainer]empty)
 
-	dockerContainers, err := dockertools.GetKubeletDockerContainers(kl.dockerClient)
+	dockerContainers, err := dockertools.GetKubeletDockerContainers(kl.dockerClient, false)
 	if err != nil {
 		glog.Errorf("Error listing containers %#v", dockerContainers)
 		return err
@@ -634,7 +634,7 @@ func (kl *Kubelet) SyncPods(pods []Pod) error {
 	}
 
 	// Kill any containers we don't need
-	existingContainers, err := dockertools.GetKubeletDockerContainers(kl.dockerClient)
+	existingContainers, err := dockertools.GetKubeletDockerContainers(kl.dockerClient, false)
 	if err != nil {
 		glog.Errorf("Error listing containers: %v", err)
 		return err
@@ -736,7 +736,7 @@ func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName, tail stri
 	if err == dockertools.ErrNoContainersInPod {
 		return fmt.Errorf("Pod not found (%s)\n", podFullName)
 	}
-	dockerContainers, err := dockertools.GetKubeletDockerContainers(kl.dockerClient)
+	dockerContainers, err := dockertools.GetKubeletDockerContainers(kl.dockerClient, true)
 	if err != nil {
 		return err
 	}
@@ -757,7 +757,7 @@ func (kl *Kubelet) GetContainerInfo(podFullName, uuid, containerName string, req
 	if kl.cadvisorClient == nil {
 		return nil, nil
 	}
-	dockerContainers, err := dockertools.GetKubeletDockerContainers(kl.dockerClient)
+	dockerContainers, err := dockertools.GetKubeletDockerContainers(kl.dockerClient, false)
 	if err != nil {
 		return nil, err
 	}
@@ -802,7 +802,7 @@ func (kl *Kubelet) RunInContainer(podFullName, uuid, container string, cmd []str
 	if kl.runner == nil {
 		return nil, fmt.Errorf("no runner specified.")
 	}
-	dockerContainers, err := dockertools.GetKubeletDockerContainers(kl.dockerClient)
+	dockerContainers, err := dockertools.GetKubeletDockerContainers(kl.dockerClient, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`func GetKubeletDockerContainers`,  unfortunately returns only running containers. There should be possibility to get also containers which are stopped by defining `docker.ListContainersOptions`. There is also `func GetRecentDockerContainersWithNameAndUUID` but that returns only stopped  containers.

There are several possible approaches:
1. The one presented in this PR.
2. Add function similar to the `GetKubeletDockerContainers` that will search in all the containers,  something like `GetAllKubeletDockerContainers`, so the API will be untouched.
