### PR TITLE
Refactor the client (again) to better support auth

### DIFF
--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/capabilities"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
@@ -127,8 +126,12 @@ func main() {
 		Port:   *minionPort,
 	}
 
-	ctx := api.NewContext()
-	client, err := client.New(ctx, net.JoinHostPort(*address, strconv.Itoa(int(*port))), *storageVersion, nil)
+	// TODO: expose same flags as client.BindClientConfigFlags but for a server
+	clientConfig := &client.Config{
+		Host:    net.JoinHostPort(*address, strconv.Itoa(int(*port))),
+		Version: *storageVersion,
+	}
+	client, err := client.New(clientConfig)
 	if err != nil {
 		glog.Fatalf("Invalid server address: %v", err)
 	}

--- a/pkg/api/testapi/testapi.go
+++ b/pkg/api/testapi/testapi.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testapi provides a helper for retrieving the KUBE_API_VERSION environment variable.
+package testapi
+
+import (
+	"os"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+)
+
+// Version returns the API version to test against as set by the KUBE_API_VERSION env var.
+func Version() string {
+	version := os.Getenv("KUBE_API_VERSION")
+	if version == "" {
+		version = latest.Version
+	}
+	return version
+}
+
+func CodecForVersionOrDie() runtime.Codec {
+	interfaces, err := latest.InterfacesFor(Version())
+	if err != nil {
+		panic(err)
+	}
+	return interfaces.Codec
+}

--- a/pkg/client/doc.go
+++ b/pkg/client/doc.go
@@ -14,6 +14,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package client contains the implementation of the client side communication with the
-// Kubernetes master.
+/*
+Package client contains the implementation of the client side communication with the
+Kubernetes master. The Client class provides methods for reading, creating, updating,
+and deleting pods, replication controllers, services, and minions.
+
+Most consumers should use the Config object to create a Client:
+
+    config := &client.Config{
+      Host:     "http://localhost:8080",
+      Username: "test",
+      Password: "password",
+    }
+    client, err := client.New(&config)
+    if err != nil {
+      // handle error
+    }
+    client.ListPods()
+
+More advanced consumers may wish to provide their own transport via a http.RoundTripper:
+
+    config := &client.Config{
+      Host:      "https://localhost:8080",
+      Transport: oauthclient.Transport(),
+    }
+    client, err := client.New(&config)
+
+The RESTClient type implements the Kubernetes API conventions (see `docs/api-conventions.md`)
+for a given API path and is intended for use by consumers implementing their own Kubernetes
+compatible APIs.
+*/
 package client

--- a/pkg/client/flags.go
+++ b/pkg/client/flags.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+// FlagSet abstracts the flag interface for compatibility with both Golang "flag"
+// and cobra pflags (Posix style).
+type FlagSet interface {
+	StringVar(p *string, name, value, usage string)
+}
+
+// BindClientConfigFlags registers a standard set of CLI flags for connecting to a Kubernetes API server.
+func BindClientConfigFlags(flags FlagSet, config *Config) {
+	flags.StringVar(&config.Host, "master", config.Host, "The address of the Kubernetes API server")
+	flags.StringVar(&config.Version, "api_version", config.Version, "The API version to use when talking to the server")
+}

--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+)
+
+// Config holds the common attributes that can be passed to a Kubernetes client on
+// initialization.
+type Config struct {
+	// Host must be a host string, a host:port pair, or a URL to the base of the API.
+	Host    string
+	Version string
+
+	// Server requires Basic authentication
+	Username string
+	Password string
+
+	// Server requires Bearer authentication. This client will not attempt to use
+	// refresh tokens for an OAuth2 flow.
+	// TODO: demonstrate an OAuth2 compatible client.
+	BearerToken string
+
+	// Server requires TLS client certificate authentication
+	CertFile string
+	KeyFile  string
+	CAFile   string
+
+	// Server should be accessed without verifying the TLS
+	// certificate. For testing only.
+	Insecure bool
+
+	// Transport may be used for custom HTTP behavior. This attribute may not
+	// be specified with the TLS client certificate options.
+	Transport http.RoundTripper
+
+	// Context is the context that should be passed down to the server. If nil, the
+	// context will be set to the appropriate default.
+	Context api.Context
+}
+
+// New creates a Kubernetes client for the given config. This client works with pods,
+// replication controllers and services. It allows operations such as list, get, update
+// and delete on these objects. An error is returned if the provided configuration
+// is not valid.
+func New(c *Config) (*Client, error) {
+	client, err := RESTClientFor(c)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{client}, nil
+}
+
+// NewOrDie creates a Kubernetes client and panics if the provided API version is not recognized.
+func NewOrDie(c *Config) *Client {
+	client, err := New(c)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+// RESTClientFor returns a RESTClient that satisfies the requested attributes on a client Config
+// object.
+func RESTClientFor(config *Config) (*RESTClient, error) {
+	version := defaultVersionFor(config)
+
+	// Set version
+	versionInterfaces, err := latest.InterfacesFor(version)
+	if err != nil {
+		return nil, fmt.Errorf("API version '%s' is not recognized (valid values: %s)", version, strings.Join(latest.Versions, ", "))
+	}
+
+	baseURL, err := defaultServerUrlFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	client := NewRESTClient(baseURL, versionInterfaces.Codec)
+
+	transport, err := TransportFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if transport != http.DefaultTransport {
+		client.Client = &http.Client{Transport: transport}
+	}
+	return client, nil
+}
+
+// TransportFor returns an http.RoundTripper that will provide the authentication
+// or transport level security defined by the provided Config. Will return the
+// default http.DefaultTransport if no special case behavior is needed.
+func TransportFor(config *Config) (http.RoundTripper, error) {
+	// Set transport level security
+	if config.Transport != nil && (config.CertFile != "" || config.Insecure) {
+		return nil, fmt.Errorf("using a custom transport with TLS certificate options or the insecure flag is not allowed")
+	}
+	var transport http.RoundTripper
+	switch {
+	case config.Transport != nil:
+		transport = config.Transport
+	case config.CertFile != "":
+		t, err := NewClientCertTLSTransport(config.CertFile, config.KeyFile, config.CAFile)
+		if err != nil {
+			return nil, err
+		}
+		transport = t
+	case config.Insecure:
+		transport = NewUnsafeTLSTransport()
+	default:
+		transport = http.DefaultTransport
+	}
+
+	// Set authentication wrappers
+	hasBasicAuth := config.Username != "" || config.Password != ""
+	if hasBasicAuth && config.BearerToken != "" {
+		return nil, fmt.Errorf("username/password or bearer token may be set, but not both")
+	}
+	switch {
+	case config.BearerToken != "":
+		transport = NewBearerAuthRoundTripper(config.BearerToken, transport)
+	case hasBasicAuth:
+		transport = NewBasicAuthRoundTripper(config.Username, config.Password, transport)
+	}
+
+	// TODO: use the config context to wrap a transport
+
+	return transport, nil
+}
+
+// DefaultServerURL converts a host, host:port, or URL string to the default base server API path
+// to use with a Client at a given API version following the standard conventions for a
+// Kubernetes API.
+func DefaultServerURL(host, version string, defaultSecure bool) (*url.URL, error) {
+	if host == "" {
+		return nil, fmt.Errorf("host must be a URL or a host:port pair")
+	}
+	if version == "" {
+		return nil, fmt.Errorf("version must be set")
+	}
+	base := host
+	hostURL, err := url.Parse(base)
+	if err != nil {
+		return nil, err
+	}
+	if hostURL.Scheme == "" {
+		scheme := "http://"
+		if defaultSecure {
+			scheme = "https://"
+		}
+		hostURL, err = url.Parse(scheme + base)
+		if err != nil {
+			return nil, err
+		}
+		if hostURL.Path != "" && hostURL.Path != "/" {
+			return nil, fmt.Errorf("host must be a URL or a host:port pair: %s", base)
+		}
+	}
+
+	// If the user specified a URL without a path component (http://server.com), automatically
+	// append the default API prefix
+	if hostURL.Path == "" {
+		hostURL.Path = "/api"
+	}
+
+	// Add the version to the end of the path
+	hostURL.Path = path.Join(hostURL.Path, version)
+
+	return hostURL, nil
+}
+
+// IsConfigTransportSecure returns true iff the provided config will result in a protected
+// connection to the server when it is passed to client.New() or client.RESTClientFor().
+// Use to determine when to send credentials over the wire.
+//
+// Note: the Insecure flag is ignored when testing for this value, so MITM attacks are
+// still possible.
+func IsConfigTransportSecure(config *Config) bool {
+	baseURL, err := defaultServerUrlFor(config)
+	if err != nil {
+		return false
+	}
+	return baseURL.Scheme == "https"
+}
+
+// defaultServerUrlFor is shared between IsConfigSecure and RESTClientFor
+func defaultServerUrlFor(config *Config) (*url.URL, error) {
+	version := defaultVersionFor(config)
+	// TODO: move the default to secure when the apiserver supports TLS by default
+	defaultSecure := config.CertFile != ""
+	host := config.Host
+	if host == "" {
+		host = "localhost"
+	}
+	return DefaultServerURL(host, version, defaultSecure)
+}
+
+// defaultVersionFor is shared between defaultServerUrlFor and RESTClientFor
+func defaultVersionFor(config *Config) string {
+	version := config.Version
+	if version == "" {
+		// Clients default to the preferred code API version
+		// TODO: implement version negotiation (highest version supported by server)
+		version = latest.Version
+	}
+	return version
+}

--- a/pkg/client/helper_test.go
+++ b/pkg/client/helper_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestTransportFor(t *testing.T) {
+	testCases := map[string]struct {
+		Config  *Config
+		Err     bool
+		Default bool
+	}{
+		"default transport": {
+			Config: &Config{},
+		},
+	}
+	for k, testCase := range testCases {
+		transport, err := TransportFor(testCase.Config)
+		switch {
+		case testCase.Err && err == nil:
+			t.Errorf("%s: unexpected non-error", k)
+			continue
+		case !testCase.Err && err != nil:
+			t.Errorf("%s: unexpected error: %v", k, err)
+			continue
+		}
+		if testCase.Default && transport != http.DefaultTransport {
+			t.Errorf("%s: expected the default transport, got %#v", k, transport)
+		}
+	}
+}
+
+func TestIsConfigTransportSecure(t *testing.T) {
+	testCases := []struct {
+		Config *Config
+		Secure bool
+	}{
+		{
+			Config: &Config{},
+			Secure: false,
+		},
+		{
+			Config: &Config{
+				Host: "https://localhost",
+			},
+			Secure: true,
+		},
+		{
+			Config: &Config{
+				Host:     "localhost",
+				CertFile: "foo",
+			},
+			Secure: true,
+		},
+		{
+			Config: &Config{
+				Host:     "///:://localhost",
+				CertFile: "foo",
+			},
+			Secure: false,
+		},
+	}
+	for _, testCase := range testCases {
+		secure := IsConfigTransportSecure(testCase.Config)
+		if testCase.Secure != secure {
+			t.Errorf("expected %d for %#v", testCase.Secure, testCase.Config)
+		}
+	}
+}

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -40,56 +40,6 @@ import (
 // are therefore not allowed to set manually.
 var specialParams = util.NewStringSet("sync", "timeout")
 
-// Verb begins a request with a verb (GET, POST, PUT, DELETE).
-//
-// Example usage of Client's request building interface:
-// auth, err := LoadAuth(filename)
-// c := New(url, auth)
-// resp, err := c.Verb("GET").
-//	Path("pods").
-//	SelectorParam("labels", "area=staging").
-//	Timeout(10*time.Second).
-//	Do()
-// if err != nil { ... }
-// list, ok := resp.(*api.PodList)
-//
-func (c *RESTClient) Verb(verb string) *Request {
-	return &Request{
-		verb:       verb,
-		c:          c,
-		path:       c.prefix,
-		sync:       c.Sync,
-		timeout:    c.Timeout,
-		params:     map[string]string{},
-		pollPeriod: c.PollPeriod,
-	}
-}
-
-// Post begins a POST request. Short for c.Verb("POST").
-func (c *RESTClient) Post() *Request {
-	return c.Verb("POST")
-}
-
-// Put begins a PUT request. Short for c.Verb("PUT").
-func (c *RESTClient) Put() *Request {
-	return c.Verb("PUT")
-}
-
-// Get begins a GET request. Short for c.Verb("GET").
-func (c *RESTClient) Get() *Request {
-	return c.Verb("GET")
-}
-
-// Delete begins a DELETE request. Short for c.Verb("DELETE").
-func (c *RESTClient) Delete() *Request {
-	return c.Verb("DELETE")
-}
-
-// PollFor makes a request to do a single poll of the completion of the given operation.
-func (c *RESTClient) PollFor(operationID string) *Request {
-	return c.Get().Path("operations").Path(operationID).Sync(false).PollPeriod(0)
-}
-
 // Request allows for building up a request to a server in a chained fashion.
 // Any errors are stored until the end of your call, so you only have to
 // check once.
@@ -232,7 +182,8 @@ func (r *Request) PollPeriod(d time.Duration) *Request {
 }
 
 func (r *Request) finalURL() string {
-	finalURL := r.c.host + r.path
+	finalURL := *r.c.baseURL
+	finalURL.Path = r.path
 	query := url.Values{}
 	for key, value := range r.params {
 		query.Add(key, value)
@@ -245,8 +196,8 @@ func (r *Request) finalURL() string {
 			query.Add("timeout", r.timeout.String())
 		}
 	}
-	finalURL += "?" + query.Encode()
-	return finalURL
+	finalURL.RawQuery = query.Encode()
+	return finalURL.String()
 }
 
 // Watch attempts to begin watching the requested location.
@@ -259,10 +210,11 @@ func (r *Request) Watch() (watch.Interface, error) {
 	if err != nil {
 		return nil, err
 	}
-	if r.c.auth != nil {
-		req.SetBasicAuth(r.c.auth.User, r.c.auth.Password)
+	client := r.c.Client
+	if client == nil {
+		client = http.DefaultClient
 	}
-	response, err := r.c.httpClient.Do(req)
+	response, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -284,10 +236,11 @@ func (r *Request) Do() Result {
 		}
 		respBody, err := r.c.doRequest(req)
 		if err != nil {
-			if statusErr, ok := err.(*StatusErr); ok {
-				if statusErr.Status.Status == api.StatusWorking && r.pollPeriod != 0 {
-					if statusErr.Status.Details != nil {
-						id := statusErr.Status.Details.ID
+			if s, ok := err.(APIStatus); ok {
+				status := s.Status()
+				if status.Status == api.StatusWorking && r.pollPeriod != 0 {
+					if status.Details != nil {
+						id := status.Details.ID
 						if len(id) > 0 {
 							glog.Infof("Waiting for completion of /operations/%s", id)
 							time.Sleep(r.pollPeriod)

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -48,9 +48,7 @@ func TestDoRequestNewWay(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	auth := AuthInfo{User: "user", Password: "pass"}
-	ctx := api.NewContext()
-	c := NewOrDie(ctx, testServer.URL, "v1beta2", &auth)
+	c := NewOrDie(&Config{Host: testServer.URL, Version: "v1beta2", Username: "user", Password: "pass"})
 	obj, err := c.Verb("POST").
 		Path("foo/bar").
 		Path("baz").
@@ -84,9 +82,7 @@ func TestDoRequestNewWayReader(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	auth := AuthInfo{User: "user", Password: "pass"}
-	ctx := api.NewContext()
-	c := NewOrDie(ctx, testServer.URL, "v1beta1", &auth)
+	c := NewOrDie(&Config{Host: testServer.URL, Version: "v1beta1", Username: "user", Password: "pass"})
 	obj, err := c.Verb("POST").
 		Path("foo/bar").
 		Path("baz").
@@ -122,9 +118,7 @@ func TestDoRequestNewWayObj(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	auth := AuthInfo{User: "user", Password: "pass"}
-	ctx := api.NewContext()
-	c := NewOrDie(ctx, testServer.URL, "v1beta2", &auth)
+	c := NewOrDie(&Config{Host: testServer.URL, Version: "v1beta2", Username: "user", Password: "pass"})
 	obj, err := c.Verb("POST").
 		Path("foo/bar").
 		Path("baz").
@@ -173,9 +167,7 @@ func TestDoRequestNewWayFile(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	auth := AuthInfo{User: "user", Password: "pass"}
-	ctx := api.NewContext()
-	c := NewOrDie(ctx, testServer.URL, "v1beta1", &auth)
+	c := NewOrDie(&Config{Host: testServer.URL, Version: "v1beta1", Username: "user", Password: "pass"})
 	obj, err := c.Verb("POST").
 		Path("foo/bar").
 		Path("baz").
@@ -200,8 +192,7 @@ func TestDoRequestNewWayFile(t *testing.T) {
 }
 
 func TestVerbs(t *testing.T) {
-	ctx := api.NewContext()
-	c := NewOrDie(ctx, "localhost", "", nil)
+	c := NewOrDie(&Config{})
 	if r := c.Post(); r.verb != "POST" {
 		t.Errorf("Post verb is wrong")
 	}
@@ -217,9 +208,8 @@ func TestVerbs(t *testing.T) {
 }
 
 func TestAbsPath(t *testing.T) {
-	ctx := api.NewContext()
 	expectedPath := "/bar/foo"
-	c := NewOrDie(ctx, "localhost", "", nil)
+	c := NewOrDie(&Config{})
 	r := c.Post().Path("/foo").AbsPath(expectedPath)
 	if r.path != expectedPath {
 		t.Errorf("unexpected path: %s, expected %s", r.path, expectedPath)
@@ -227,8 +217,7 @@ func TestAbsPath(t *testing.T) {
 }
 
 func TestSync(t *testing.T) {
-	ctx := api.NewContext()
-	c := NewOrDie(ctx, "localhost", "", nil)
+	c := NewOrDie(&Config{})
 	r := c.Get()
 	if r.sync {
 		t.Errorf("sync has wrong default")
@@ -254,9 +243,8 @@ func TestUintParam(t *testing.T) {
 		{"baz", 0, "http://localhost?baz=0"},
 	}
 
-	ctx := api.NewContext()
 	for _, item := range table {
-		c := NewOrDie(ctx, "localhost", "", nil)
+		c := NewOrDie(&Config{})
 		r := c.Get().AbsPath("").UintParam(item.name, item.testVal)
 		if e, a := item.expectStr, r.finalURL(); e != a {
 			t.Errorf("expected %v, got %v", e, a)
@@ -273,9 +261,9 @@ func TestUnacceptableParamNames(t *testing.T) {
 		{"sync", "foo", false},
 		{"timeout", "42", false},
 	}
-	ctx := api.NewContext()
+
 	for _, item := range table {
-		c := NewOrDie(ctx, "localhost", "", nil)
+		c := NewOrDie(&Config{})
 		r := c.Get().setParam(item.name, item.testVal)
 		if e, a := item.expectSuccess, r.err == nil; e != a {
 			t.Errorf("expected %v, got %v (%v)", e, a, r.err)
@@ -284,8 +272,7 @@ func TestUnacceptableParamNames(t *testing.T) {
 }
 
 func TestSetPollPeriod(t *testing.T) {
-	ctx := api.NewContext()
-	c := NewOrDie(ctx, "localhost", "", nil)
+	c := NewOrDie(&Config{})
 	r := c.Get()
 	if r.pollPeriod == 0 {
 		t.Errorf("polling should be on by default")
@@ -315,9 +302,7 @@ func TestPolling(t *testing.T) {
 		w.Write(data)
 	}))
 
-	auth := AuthInfo{User: "user", Password: "pass"}
-	ctx := api.NewContext()
-	c := NewOrDie(ctx, testServer.URL, "v1beta1", &auth)
+	c := NewOrDie(&Config{Host: testServer.URL, Version: "v1beta1", Username: "user", Password: "pass"})
 
 	trials := []func(){
 		func() {
@@ -342,7 +327,7 @@ func TestPolling(t *testing.T) {
 				t.Errorf("Unexpected non error: %v", obj)
 				return
 			}
-			if se, ok := err.(*StatusErr); !ok || se.Status.Status != api.StatusWorking {
+			if se, ok := err.(APIStatus); !ok || se.Status().Status != api.StatusWorking {
 				t.Errorf("Unexpected kind of error: %#v", err)
 				return
 			}
@@ -357,7 +342,7 @@ func TestPolling(t *testing.T) {
 	}
 }
 
-func authFromReq(r *http.Request) (*AuthInfo, bool) {
+func authFromReq(r *http.Request) (*Config, bool) {
 	auth, ok := r.Header["Authorization"]
 	if !ok {
 		return nil, false
@@ -376,16 +361,16 @@ func authFromReq(r *http.Request) (*AuthInfo, bool) {
 	if len(parts) != 2 {
 		return nil, false
 	}
-	return &AuthInfo{User: parts[0], Password: parts[1]}, true
+	return &Config{Username: parts[0], Password: parts[1]}, true
 }
 
 // checkAuth sets errors if the auth found in r doesn't match the expectation.
 // TODO: Move to util, test in more places.
-func checkAuth(t *testing.T, expect AuthInfo, r *http.Request) {
+func checkAuth(t *testing.T, expect *Config, r *http.Request) {
 	foundAuth, found := authFromReq(r)
 	if !found {
 		t.Errorf("no auth found")
-	} else if e, a := expect, *foundAuth; !reflect.DeepEqual(e, a) {
+	} else if e, a := expect, foundAuth; !reflect.DeepEqual(e, a) {
 		t.Fatalf("Wrong basic auth: wanted %#v, got %#v", e, a)
 	}
 }
@@ -400,7 +385,7 @@ func TestWatch(t *testing.T) {
 		{watch.Deleted, &api.Pod{JSONBase: api.JSONBase{ID: "last"}}},
 	}
 
-	auth := AuthInfo{User: "user", Password: "pass"}
+	auth := &Config{Username: "user", Password: "pass"}
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		checkAuth(t, auth, r)
 		flusher, ok := w.(http.Flusher)
@@ -421,8 +406,12 @@ func TestWatch(t *testing.T) {
 		}
 	}))
 
-	ctx := api.NewContext()
-	s, err := New(ctx, testServer.URL, "v1beta1", &auth)
+	s, err := New(&Config{
+		Host:     testServer.URL,
+		Version:  "v1beta1",
+		Username: "user",
+		Password: "pass",
+	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/client/restclient.go
+++ b/pkg/client/restclient.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+)
+
+// RESTClient imposes common Kubernetes API conventions on a set of resource paths.
+// The baseURL is expected to point to an HTTP or HTTPS path that is the parent
+// of one or more resources.  The server should return a decodable API resource
+// object, or an api.Status object which contains information about the reason for
+// any failure.
+//
+// Most consumers should use client.New() to get a Kubernetes API client.
+type RESTClient struct {
+	baseURL *url.URL
+
+	// Codec is the encoding and decoding scheme that applies to a particular set of
+	// REST resources.
+	Codec runtime.Codec
+
+	// Set specific behavior of the client.  If not set http.DefaultClient will be
+	// used.
+	Client *http.Client
+
+	Sync       bool
+	PollPeriod time.Duration
+	Timeout    time.Duration
+}
+
+// NewRESTClient creates a new RESTClient. This client performs generic REST functions
+// such as Get, Put, Post, and Delete on specified paths.  Codec controls encoding and
+// decoding of responses from the server.
+func NewRESTClient(baseURL *url.URL, c runtime.Codec) *RESTClient {
+	base := *baseURL
+	if !strings.HasSuffix(base.Path, "/") {
+		base.Path += "/"
+	}
+	base.RawQuery = ""
+	base.Fragment = ""
+
+	return &RESTClient{
+		baseURL: &base,
+		Codec:   c,
+
+		// Make asynchronous requests by default
+		// TODO: flip me to the default
+		Sync: false,
+		// Poll frequently when asynchronous requests are provided
+		PollPeriod: time.Second * 2,
+	}
+}
+
+// doRequest executes a request against a server
+func (c *RESTClient) doRequest(request *http.Request) ([]byte, error) {
+	client := c.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return body, err
+	}
+
+	// Did the server give us a status response?
+	isStatusResponse := false
+	var status api.Status
+	if err := c.Codec.DecodeInto(body, &status); err == nil && status.Status != "" {
+		isStatusResponse = true
+	}
+
+	switch {
+	case response.StatusCode < http.StatusOK || response.StatusCode > http.StatusPartialContent:
+		if !isStatusResponse {
+			return nil, fmt.Errorf("request [%#v] failed (%d) %s: %s", request, response.StatusCode, response.Status, string(body))
+		}
+		return nil, errors.FromObject(&status)
+	}
+
+	// If the server gave us a status back, look at what it was.
+	if isStatusResponse && status.Status != api.StatusSuccess {
+		// "Working" requests need to be handled specially.
+		// "Failed" requests are clearly just an error and it makes sense to return them as such.
+		return nil, errors.FromObject(&status)
+	}
+
+	return body, err
+}
+
+// Verb begins a request with a verb (GET, POST, PUT, DELETE).
+//
+// Example usage of RESTClient's request building interface:
+// c := NewRESTClient(url, codec)
+// resp, err := c.Verb("GET").
+//  Path("pods").
+//  SelectorParam("labels", "area=staging").
+//  Timeout(10*time.Second).
+//  Do()
+// if err != nil { ... }
+// list, ok := resp.(*api.PodList)
+//
+func (c *RESTClient) Verb(verb string) *Request {
+	// TODO: uncomment when Go 1.2 support is dropped
+	//var timeout time.Duration = 0
+	// if c.Client != nil {
+	// 	timeout = c.Client.Timeout
+	// }
+	return &Request{
+		verb:       verb,
+		c:          c,
+		path:       c.baseURL.Path,
+		sync:       c.Sync,
+		timeout:    c.Timeout,
+		params:     map[string]string{},
+		pollPeriod: c.PollPeriod,
+	}
+}
+
+// Post begins a POST request. Short for c.Verb("POST").
+func (c *RESTClient) Post() *Request {
+	return c.Verb("POST")
+}
+
+// Put begins a PUT request. Short for c.Verb("PUT").
+func (c *RESTClient) Put() *Request {
+	return c.Verb("PUT")
+}
+
+// Get begins a GET request. Short for c.Verb("GET").
+func (c *RESTClient) Get() *Request {
+	return c.Verb("GET")
+}
+
+// Delete begins a DELETE request. Short for c.Verb("DELETE").
+func (c *RESTClient) Delete() *Request {
+	return c.Verb("DELETE")
+}
+
+// PollFor makes a request to do a single poll of the completion of the given operation.
+func (c *RESTClient) PollFor(operationID string) *Request {
+	return c.Get().Path("operations").Path(operationID).Sync(false).PollPeriod(0)
+}

--- a/pkg/client/restclient_test.go
+++ b/pkg/client/restclient_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta2"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+func TestChecksCodec(t *testing.T) {
+	testCases := map[string]struct {
+		Err    bool
+		Prefix string
+		Codec  runtime.Codec
+	}{
+		"v1beta1": {false, "/api/v1beta1/", v1beta1.Codec},
+		"":        {false, "/api/v1beta1/", v1beta1.Codec},
+		"v1beta2": {false, "/api/v1beta2/", v1beta2.Codec},
+		"v1beta3": {true, "", nil},
+	}
+	for version, expected := range testCases {
+		client, err := RESTClientFor(&Config{Host: "127.0.0.1", Version: version})
+		switch {
+		case err == nil && expected.Err:
+			t.Errorf("expected error but was nil")
+			continue
+		case err != nil && !expected.Err:
+			t.Errorf("unexpected error %v", err)
+			continue
+		case err != nil:
+			continue
+		}
+		if e, a := expected.Prefix, client.baseURL.Path; e != a {
+			t.Errorf("expected %#v, got %#v", e, a)
+		}
+		if e, a := expected.Codec, client.Codec; e != a {
+			t.Errorf("expected %#v, got %#v", e, a)
+		}
+	}
+}
+
+func TestValidatesHostParameter(t *testing.T) {
+	testCases := map[string]struct {
+		URL string
+		Err bool
+	}{
+		"127.0.0.1":          {"http://127.0.0.1/api/v1beta1/", false},
+		"127.0.0.1:8080":     {"http://127.0.0.1:8080/api/v1beta1/", false},
+		"foo.bar.com":        {"http://foo.bar.com/api/v1beta1/", false},
+		"http://host/prefix": {"http://host/prefix/v1beta1/", false},
+		"http://host":        {"http://host/api/v1beta1/", false},
+		"host/server":        {"", true},
+	}
+	for k, expected := range testCases {
+		c, err := RESTClientFor(&Config{Host: k, Version: "v1beta1"})
+		switch {
+		case err == nil && expected.Err:
+			t.Errorf("expected error but was nil")
+			continue
+		case err != nil && !expected.Err:
+			t.Errorf("unexpected error %v", err)
+			continue
+		case err != nil:
+			continue
+		}
+		if e, a := expected.URL, c.baseURL.String(); e != a {
+			t.Errorf("%s: expected host %s, got %s", k, e, a)
+			continue
+		}
+	}
+}
+
+func TestDoRequest(t *testing.T) {
+	invalid := "aaaaa"
+	uri, _ := url.Parse("http://localhost")
+	testClients := []testClient{
+		{Request: testRequest{Method: "GET", Path: "good"}, Response: Response{StatusCode: 200}},
+		{Request: testRequest{Method: "GET", Path: "bad%ZZ"}, Error: true},
+		{Client: &Client{&RESTClient{baseURL: uri}}, Request: testRequest{Method: "GET", Path: "nocertificate"}, Error: true},
+		{Request: testRequest{Method: "GET", Path: "error"}, Response: Response{StatusCode: 500}, Error: true},
+		{Request: testRequest{Method: "POST", Path: "faildecode"}, Response: Response{StatusCode: 200, RawBody: &invalid}},
+		{Request: testRequest{Method: "GET", Path: "failread"}, Response: Response{StatusCode: 200, RawBody: &invalid}},
+	}
+	for _, c := range testClients {
+		client := c.Setup()
+		prefix := *client.baseURL
+		prefix.Path += c.Request.Path
+		request := &http.Request{
+			Method: c.Request.Method,
+			Header: make(http.Header),
+			URL:    &prefix,
+		}
+		response, err := client.doRequest(request)
+		//t.Logf("dorequest: %#v\n%#v\n%v", request.URL, response, err)
+		c.ValidateRaw(t, response, err)
+	}
+}
+
+func TestDoRequestBearer(t *testing.T) {
+	status := &api.Status{Status: api.StatusWorking}
+	expectedBody, _ := latest.Codec.Encode(status)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   202,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	request, _ := http.NewRequest("GET", testServer.URL+"/foo/bar", nil)
+	c, err := RESTClientFor(&Config{Host: testServer.URL, BearerToken: "test"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c.doRequest(request)
+	if fakeHandler.RequestReceived.Header.Get("Authorization") != "Bearer test" {
+		t.Errorf("Request is missing authorization header: %#v", *request)
+	}
+}
+
+func TestDoRequestAccepted(t *testing.T) {
+	status := &api.Status{Status: api.StatusWorking}
+	expectedBody, _ := latest.Codec.Encode(status)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   202,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	request, _ := http.NewRequest("GET", testServer.URL+"/foo/bar", nil)
+	c, err := RESTClientFor(&Config{Host: testServer.URL, Username: "test"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, err := c.doRequest(request)
+	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
+		t.Errorf("Request is missing authorization header: %#v", *request)
+	}
+	if err == nil {
+		t.Error("Unexpected non-error")
+		return
+	}
+	se, ok := err.(APIStatus)
+	if !ok {
+		t.Errorf("Unexpected kind of error: %#v", err)
+		return
+	}
+	if !reflect.DeepEqual(se.Status(), *status) {
+		t.Errorf("Unexpected status: %#v %#v", se.Status(), status)
+	}
+	if body != nil {
+		t.Errorf("Expected nil body, but saw: '%s'", body)
+	}
+	fakeHandler.ValidateRequest(t, "/foo/bar", "GET", nil)
+}
+
+func TestDoRequestAcceptedSuccess(t *testing.T) {
+	status := &api.Status{Status: api.StatusSuccess}
+	expectedBody, _ := latest.Codec.Encode(status)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   202,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	request, _ := http.NewRequest("GET", testServer.URL+"/foo/bar", nil)
+	c, err := RESTClientFor(&Config{Host: testServer.URL, Username: "user", Password: "pass"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, err := c.doRequest(request)
+	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
+		t.Errorf("Request is missing authorization header: %#v", *request)
+	}
+	if err != nil {
+		t.Errorf("Unexpected error %#v", err)
+	}
+	statusOut, err := latest.Codec.Decode(body)
+	if err != nil {
+		t.Errorf("Unexpected error %#v", err)
+	}
+	if !reflect.DeepEqual(status, statusOut) {
+		t.Errorf("Unexpected mis-match. Expected %#v.  Saw %#v", status, statusOut)
+	}
+	fakeHandler.ValidateRequest(t, "/foo/bar", "GET", nil)
+}
+
+func TestDoRequestFailed(t *testing.T) {
+	status := &api.Status{Status: api.StatusFailure, Reason: api.StatusReasonInvalid, Details: &api.StatusDetails{ID: "test", Kind: "test"}}
+	expectedBody, _ := latest.Codec.Encode(status)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   404,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	request, _ := http.NewRequest("GET", testServer.URL+"/foo/bar", nil)
+	c, err := RESTClientFor(&Config{Host: testServer.URL})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, err := c.doRequest(request)
+	if err == nil || body != nil {
+		t.Errorf("unexpected non-error: %#v", body)
+	}
+	ss, ok := err.(APIStatus)
+	if !ok {
+		t.Errorf("unexpected error type %v", err)
+	}
+	actual := ss.Status()
+	if !reflect.DeepEqual(status, &actual) {
+		t.Errorf("Unexpected mis-match. Expected %#v.  Saw %#v", status, actual)
+	}
+}

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type basicAuthRoundTripper struct {
+	username string
+	password string
+	rt       http.RoundTripper
+}
+
+func NewBasicAuthRoundTripper(username, password string, rt http.RoundTripper) http.RoundTripper {
+	return &basicAuthRoundTripper{username, password, rt}
+}
+
+func (rt *basicAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = cloneRequest(req)
+	req.SetBasicAuth(rt.username, rt.password)
+	return rt.rt.RoundTrip(req)
+}
+
+type bearerAuthRoundTripper struct {
+	bearer string
+	rt     http.RoundTripper
+}
+
+func NewBearerAuthRoundTripper(bearer string, rt http.RoundTripper) http.RoundTripper {
+	return &bearerAuthRoundTripper{bearer, rt}
+}
+
+func (rt *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = cloneRequest(req)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", rt.bearer))
+	return rt.rt.RoundTrip(req)
+}
+
+func NewClientCertTLSTransport(certFile, keyFile, caFile string) (*http.Transport, error) {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+	data, err := ioutil.ReadFile(caFile)
+	if err != nil {
+		return nil, err
+	}
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(data)
+	return &http.Transport{
+		TLSClientConfig: &tls.Config{
+			Certificates: []tls.Certificate{
+				cert,
+			},
+			RootCAs:    certPool,
+			ClientCAs:  certPool,
+			ClientAuth: tls.RequireAndVerifyClientCert,
+		},
+	}, nil
+}
+
+func NewUnsafeTLSTransport() *http.Transport {
+	return &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+}
+
+// cloneRequest returns a clone of the provided *http.Request.
+// The clone is a shallow copy of the struct and its Header map.
+func cloneRequest(r *http.Request) *http.Request {
+	// shallow copy of the struct
+	r2 := new(http.Request)
+	*r2 = *r
+	// deep copy of the Header
+	r2.Header = make(http.Header)
+	for k, s := range r.Header {
+		r2.Header[k] = s
+	}
+	return r2
+}

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/base64"
+	"net/http"
+	"testing"
+)
+
+func TestUnsecuredTLSTransport(t *testing.T) {
+	transport := NewUnsafeTLSTransport()
+	if !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Errorf("expected transport to be insecure")
+	}
+}
+
+type testRoundTripper struct {
+	Request  *http.Request
+	Response *http.Response
+	Err      error
+}
+
+func (rt *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.Request = req
+	return rt.Response, rt.Err
+}
+
+func TestBearerAuthRoundTripper(t *testing.T) {
+	rt := &testRoundTripper{}
+	req := &http.Request{}
+	NewBearerAuthRoundTripper("test", rt).RoundTrip(req)
+	if rt.Request == nil {
+		t.Fatalf("unexpected nil request", rt)
+	}
+	if rt.Request == req {
+		t.Fatalf("round tripper should have copied request object: %#v", rt.Request)
+	}
+	if rt.Request.Header.Get("Authorization") != "Bearer test" {
+		t.Errorf("unexpected authorization header: %#v", rt.Request)
+	}
+}
+
+func TestBasicAuthRoundTripper(t *testing.T) {
+	rt := &testRoundTripper{}
+	req := &http.Request{}
+	NewBasicAuthRoundTripper("user", "pass", rt).RoundTrip(req)
+	if rt.Request == nil {
+		t.Fatalf("unexpected nil request", rt)
+	}
+	if rt.Request == req {
+		t.Fatalf("round tripper should have copied request object: %#v", rt.Request)
+	}
+	if rt.Request.Header.Get("Authorization") != "Basic "+base64.StdEncoding.EncodeToString([]byte("user:pass")) {
+		t.Errorf("unexpected authorization header: %#v", rt.Request)
+	}
+}

--- a/pkg/kubecfg/kubecfg.go
+++ b/pkg/kubecfg/kubecfg.go
@@ -51,9 +51,14 @@ func promptForString(field string, r io.Reader) string {
 	return result
 }
 
+type AuthInfo struct {
+	User     string
+	Password string
+}
+
 // LoadAuthInfo parses an AuthInfo object from a file path. It prompts user and creates file if it doesn't exist.
-func LoadAuthInfo(path string, r io.Reader) (*client.AuthInfo, error) {
-	var auth client.AuthInfo
+func LoadAuthInfo(path string, r io.Reader) (*AuthInfo, error) {
+	var auth AuthInfo
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		auth.User = promptForString("Username", r)
 		auth.Password = promptForString("Password", r)

--- a/pkg/kubecfg/kubecfg_test.go
+++ b/pkg/kubecfg/kubecfg_test.go
@@ -222,12 +222,12 @@ func TestCloudCfgDeleteControllerWithReplicas(t *testing.T) {
 func TestLoadAuthInfo(t *testing.T) {
 	loadAuthInfoTests := []struct {
 		authData string
-		authInfo *client.AuthInfo
+		authInfo *AuthInfo
 		r        io.Reader
 	}{
 		{
 			`{"user": "user", "password": "pass"}`,
-			&client.AuthInfo{User: "user", Password: "pass"},
+			&AuthInfo{User: "user", Password: "pass"},
 			nil,
 		},
 		{
@@ -235,7 +235,7 @@ func TestLoadAuthInfo(t *testing.T) {
 		},
 		{
 			"missing",
-			&client.AuthInfo{User: "user", Password: "pass"},
+			&AuthInfo{User: "user", Password: "pass"},
 			bytes.NewBufferString("user\npass"),
 		},
 	}

--- a/pkg/util/fake_handler.go
+++ b/pkg/util/fake_handler.go
@@ -65,6 +65,10 @@ func (f FakeHandler) ValidateRequest(t TestInterface, expectedPath, expectedMeth
 	if err != nil {
 		t.Errorf("Couldn't parse %v as a URL.", expectedPath)
 	}
+	if f.RequestReceived == nil {
+		t.Errorf("Unexpected nil request received for %s", expectedPath)
+		return
+	}
 	if f.RequestReceived.URL.Path != expectURL.Path {
 		t.Errorf("Unexpected request path for request %#v, received: %q, expected: %q", f.RequestReceived, f.RequestReceived.URL.Path, expectURL.Path)
 	}

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -61,7 +61,7 @@ func TestClient(t *testing.T) {
 	for apiVersion, values := range testCases {
 		deleteAllEtcdKeys()
 		s := httptest.NewServer(apiserver.Handle(values.Storage, values.Codec, fmt.Sprintf("/api/%s/", apiVersion), values.selfLinker))
-		client := client.NewOrDie(api.NewContext(), s.URL, apiVersion, nil)
+		client := client.NewOrDie(&client.Config{Host: s.URL, Version: apiVersion})
 
 		info, err := client.ServerVersion()
 		if err != nil {


### PR DESCRIPTION
Allows consumers to provide their own transports for common cases.

Fixes #1499
Adds basic support for #1473
