### PR TITLE
Add ctx object to kubecfg and client

### DIFF
--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/capabilities"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
@@ -126,7 +127,8 @@ func main() {
 		Port:   *minionPort,
 	}
 
-	client, err := client.New(net.JoinHostPort(*address, strconv.Itoa(int(*port))), *storageVersion, nil)
+	ctx := api.NewContext()
+	client, err := client.New(ctx, net.JoinHostPort(*address, strconv.Itoa(int(*port))), *storageVersion, nil)
 	if err != nil {
 		glog.Fatalf("Invalid server address: %v", err)
 	}

--- a/cmd/controller-manager/controller-manager.go
+++ b/cmd/controller-manager/controller-manager.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/controller"
@@ -53,8 +54,8 @@ func main() {
 	if len(*master) == 0 {
 		glog.Fatal("usage: controller-manager -master <master>")
 	}
-
-	kubeClient, err := client.New(*master, latest.OldestVersion, nil)
+	ctx := api.NewContext()
+	kubeClient, err := client.New(ctx, *master, latest.OldestVersion, nil)
 	if err != nil {
 		glog.Fatalf("Invalid -master: %v", err)
 	}

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -106,7 +106,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 		}
 	}
 
-	cl := client.NewOrDie(apiServer.URL, "", nil)
+	cl := client.NewOrDie(api.NewContext(), apiServer.URL, "", nil)
 	cl.PollPeriod = time.Second * 1
 	cl.Sync = true
 
@@ -311,7 +311,7 @@ func main() {
 	// Wait for the synchronization threads to come up.
 	time.Sleep(time.Second * 10)
 
-	kubeClient := client.NewOrDie(apiServerURL, "", nil)
+	kubeClient := client.NewOrDie(api.NewContext(), apiServerURL, "", nil)
 
 	// Run tests in parallel
 	testFuncs := []testFunc{

--- a/cmd/kubecfg/kubecfg.go
+++ b/cmd/kubecfg/kubecfg.go
@@ -173,7 +173,11 @@ func main() {
 	} else {
 		masterServer = "http://localhost:8080"
 	}
-	kubeClient, err := client.New(masterServer, *apiVersion, nil)
+
+	// TODO: get the namespace context when kubecfg ns is completed
+	ctx := api.NewContext()
+
+	kubeClient, err := client.New(ctx, masterServer, *apiVersion, nil)
 	if err != nil {
 		glog.Fatalf("Can't configure client: %v", err)
 	}
@@ -194,7 +198,7 @@ func main() {
 		if *keyFile != "" {
 			auth.KeyFile = *keyFile
 		}
-		kubeClient, err = client.New(masterServer, *apiVersion, auth)
+		kubeClient, err = client.New(ctx, masterServer, *apiVersion, auth)
 		if err != nil {
 			glog.Fatalf("Can't configure client: %v", err)
 		}

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"time"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/proxy"
@@ -54,8 +55,9 @@ func main() {
 	// define api config source
 	if *master != "" {
 		glog.Infof("Using api calls to get config %v", *master)
+		ctx := api.NewContext()
 		//TODO: add auth info
-		client, err := client.New(*master, latest.OldestVersion, nil)
+		client, err := client.New(ctx, *master, latest.OldestVersion, nil)
 		if err != nil {
 			glog.Fatalf("Invalid -master: %v", err)
 		}

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -49,7 +49,8 @@ func TestDoRequestNewWay(t *testing.T) {
 	}
 	testServer := httptest.NewServer(&fakeHandler)
 	auth := AuthInfo{User: "user", Password: "pass"}
-	c := NewOrDie(testServer.URL, "v1beta2", &auth)
+	ctx := api.NewContext()
+	c := NewOrDie(ctx, testServer.URL, "v1beta2", &auth)
 	obj, err := c.Verb("POST").
 		Path("foo/bar").
 		Path("baz").
@@ -84,7 +85,8 @@ func TestDoRequestNewWayReader(t *testing.T) {
 	}
 	testServer := httptest.NewServer(&fakeHandler)
 	auth := AuthInfo{User: "user", Password: "pass"}
-	c := NewOrDie(testServer.URL, "v1beta1", &auth)
+	ctx := api.NewContext()
+	c := NewOrDie(ctx, testServer.URL, "v1beta1", &auth)
 	obj, err := c.Verb("POST").
 		Path("foo/bar").
 		Path("baz").
@@ -121,7 +123,8 @@ func TestDoRequestNewWayObj(t *testing.T) {
 	}
 	testServer := httptest.NewServer(&fakeHandler)
 	auth := AuthInfo{User: "user", Password: "pass"}
-	c := NewOrDie(testServer.URL, "v1beta2", &auth)
+	ctx := api.NewContext()
+	c := NewOrDie(ctx, testServer.URL, "v1beta2", &auth)
 	obj, err := c.Verb("POST").
 		Path("foo/bar").
 		Path("baz").
@@ -171,7 +174,8 @@ func TestDoRequestNewWayFile(t *testing.T) {
 	}
 	testServer := httptest.NewServer(&fakeHandler)
 	auth := AuthInfo{User: "user", Password: "pass"}
-	c := NewOrDie(testServer.URL, "v1beta1", &auth)
+	ctx := api.NewContext()
+	c := NewOrDie(ctx, testServer.URL, "v1beta1", &auth)
 	obj, err := c.Verb("POST").
 		Path("foo/bar").
 		Path("baz").
@@ -196,7 +200,8 @@ func TestDoRequestNewWayFile(t *testing.T) {
 }
 
 func TestVerbs(t *testing.T) {
-	c := NewOrDie("localhost", "", nil)
+	ctx := api.NewContext()
+	c := NewOrDie(ctx, "localhost", "", nil)
 	if r := c.Post(); r.verb != "POST" {
 		t.Errorf("Post verb is wrong")
 	}
@@ -212,8 +217,9 @@ func TestVerbs(t *testing.T) {
 }
 
 func TestAbsPath(t *testing.T) {
+	ctx := api.NewContext()
 	expectedPath := "/bar/foo"
-	c := NewOrDie("localhost", "", nil)
+	c := NewOrDie(ctx, "localhost", "", nil)
 	r := c.Post().Path("/foo").AbsPath(expectedPath)
 	if r.path != expectedPath {
 		t.Errorf("unexpected path: %s, expected %s", r.path, expectedPath)
@@ -221,7 +227,8 @@ func TestAbsPath(t *testing.T) {
 }
 
 func TestSync(t *testing.T) {
-	c := NewOrDie("localhost", "", nil)
+	ctx := api.NewContext()
+	c := NewOrDie(ctx, "localhost", "", nil)
 	r := c.Get()
 	if r.sync {
 		t.Errorf("sync has wrong default")
@@ -247,8 +254,9 @@ func TestUintParam(t *testing.T) {
 		{"baz", 0, "http://localhost?baz=0"},
 	}
 
+	ctx := api.NewContext()
 	for _, item := range table {
-		c := NewOrDie("localhost", "", nil)
+		c := NewOrDie(ctx, "localhost", "", nil)
 		r := c.Get().AbsPath("").UintParam(item.name, item.testVal)
 		if e, a := item.expectStr, r.finalURL(); e != a {
 			t.Errorf("expected %v, got %v", e, a)
@@ -265,9 +273,9 @@ func TestUnacceptableParamNames(t *testing.T) {
 		{"sync", "foo", false},
 		{"timeout", "42", false},
 	}
-
+	ctx := api.NewContext()
 	for _, item := range table {
-		c := NewOrDie("localhost", "", nil)
+		c := NewOrDie(ctx, "localhost", "", nil)
 		r := c.Get().setParam(item.name, item.testVal)
 		if e, a := item.expectSuccess, r.err == nil; e != a {
 			t.Errorf("expected %v, got %v (%v)", e, a, r.err)
@@ -276,7 +284,8 @@ func TestUnacceptableParamNames(t *testing.T) {
 }
 
 func TestSetPollPeriod(t *testing.T) {
-	c := NewOrDie("localhost", "", nil)
+	ctx := api.NewContext()
+	c := NewOrDie(ctx, "localhost", "", nil)
 	r := c.Get()
 	if r.pollPeriod == 0 {
 		t.Errorf("polling should be on by default")
@@ -307,7 +316,8 @@ func TestPolling(t *testing.T) {
 	}))
 
 	auth := AuthInfo{User: "user", Password: "pass"}
-	c := NewOrDie(testServer.URL, "v1beta1", &auth)
+	ctx := api.NewContext()
+	c := NewOrDie(ctx, testServer.URL, "v1beta1", &auth)
 
 	trials := []func(){
 		func() {
@@ -411,7 +421,8 @@ func TestWatch(t *testing.T) {
 		}
 	}))
 
-	s, err := New(testServer.URL, "v1beta1", &auth)
+	ctx := api.NewContext()
+	s, err := New(ctx, testServer.URL, "v1beta1", &auth)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -117,7 +117,7 @@ func TestSyncReplicationControllerDoesNothing(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewTLSServer(&fakeHandler)
-	client := client.NewOrDie(testServer.URL, "v1beta1", nil)
+	client := client.NewOrDie(api.NewContext(), testServer.URL, "v1beta1", nil)
 
 	fakePodControl := FakePodControl{}
 
@@ -137,7 +137,7 @@ func TestSyncReplicationControllerDeletes(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewTLSServer(&fakeHandler)
-	client := client.NewOrDie(testServer.URL, "v1beta1", nil)
+	client := client.NewOrDie(api.NewContext(), testServer.URL, "v1beta1", nil)
 
 	fakePodControl := FakePodControl{}
 
@@ -157,7 +157,7 @@ func TestSyncReplicationControllerCreates(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewTLSServer(&fakeHandler)
-	client := client.NewOrDie(testServer.URL, "v1beta1", nil)
+	client := client.NewOrDie(api.NewContext(), testServer.URL, "v1beta1", nil)
 
 	fakePodControl := FakePodControl{}
 
@@ -177,7 +177,7 @@ func TestCreateReplica(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewTLSServer(&fakeHandler)
-	client := client.NewOrDie(testServer.URL, "v1beta1", nil)
+	client := client.NewOrDie(api.NewContext(), testServer.URL, "v1beta1", nil)
 
 	podControl := RealPodControl{
 		kubeClient: client,
@@ -310,7 +310,7 @@ func TestSynchonize(t *testing.T) {
 		t.Errorf("Unexpected request for %v", req.RequestURI)
 	})
 	testServer := httptest.NewServer(mux)
-	client := client.NewOrDie(testServer.URL, "v1beta1", nil)
+	client := client.NewOrDie(api.NewContext(), testServer.URL, "v1beta1", nil)
 	manager := NewReplicationManager(client)
 	fakePodControl := FakePodControl{}
 	manager.podControl = &fakePodControl

--- a/pkg/service/endpoints_controller_test.go
+++ b/pkg/service/endpoints_controller_test.go
@@ -159,7 +159,7 @@ func TestSyncEndpointsEmpty(t *testing.T) {
 		serverResponse{http.StatusOK, newPodList(0)},
 		serverResponse{http.StatusOK, api.ServiceList{}},
 		serverResponse{http.StatusOK, api.Endpoints{}})
-	client := client.NewOrDie(testServer.URL, "v1beta1", nil)
+	client := client.NewOrDie(api.NewContext(), testServer.URL, "v1beta1", nil)
 	serviceRegistry := registrytest.ServiceRegistry{}
 	endpoints := NewEndpointController(&serviceRegistry, client)
 	if err := endpoints.SyncServiceEndpoints(); err != nil {
@@ -172,7 +172,7 @@ func TestSyncEndpointsError(t *testing.T) {
 		serverResponse{http.StatusOK, newPodList(0)},
 		serverResponse{http.StatusInternalServerError, api.ServiceList{}},
 		serverResponse{http.StatusOK, api.Endpoints{}})
-	client := client.NewOrDie(testServer.URL, "v1beta1", nil)
+	client := client.NewOrDie(api.NewContext(), testServer.URL, "v1beta1", nil)
 	serviceRegistry := registrytest.ServiceRegistry{
 		Err: fmt.Errorf("test error"),
 	}
@@ -203,7 +203,7 @@ func TestSyncEndpointsItemsPreexisting(t *testing.T) {
 			},
 			Endpoints: []string{"6.7.8.9:1000"},
 		}})
-	client := client.NewOrDie(testServer.URL, "v1beta1", nil)
+	client := client.NewOrDie(api.NewContext(), testServer.URL, "v1beta1", nil)
 	serviceRegistry := registrytest.ServiceRegistry{}
 	endpoints := NewEndpointController(&serviceRegistry, client)
 	if err := endpoints.SyncServiceEndpoints(); err != nil {
@@ -239,7 +239,7 @@ func TestSyncEndpointsItemsPreexistingIdentical(t *testing.T) {
 			},
 			Endpoints: []string{"1.2.3.4:8080"},
 		}})
-	client := client.NewOrDie(testServer.URL, "v1beta1", nil)
+	client := client.NewOrDie(api.NewContext(), testServer.URL, "v1beta1", nil)
 	serviceRegistry := registrytest.ServiceRegistry{}
 	endpoints := NewEndpointController(&serviceRegistry, client)
 	if err := endpoints.SyncServiceEndpoints(); err != nil {
@@ -263,7 +263,7 @@ func TestSyncEndpointsItems(t *testing.T) {
 		serverResponse{http.StatusOK, newPodList(1)},
 		serverResponse{http.StatusOK, serviceList},
 		serverResponse{http.StatusOK, api.Endpoints{}})
-	client := client.NewOrDie(testServer.URL, "v1beta1", nil)
+	client := client.NewOrDie(api.NewContext(), testServer.URL, "v1beta1", nil)
 	serviceRegistry := registrytest.ServiceRegistry{}
 	endpoints := NewEndpointController(&serviceRegistry, client)
 	if err := endpoints.SyncServiceEndpoints(); err != nil {
@@ -292,7 +292,7 @@ func TestSyncEndpointsPodError(t *testing.T) {
 		serverResponse{http.StatusInternalServerError, api.PodList{}},
 		serverResponse{http.StatusOK, serviceList},
 		serverResponse{http.StatusOK, api.Endpoints{}})
-	client := client.NewOrDie(testServer.URL, "v1beta1", nil)
+	client := client.NewOrDie(api.NewContext(), testServer.URL, "v1beta1", nil)
 	serviceRegistry := registrytest.ServiceRegistry{
 		List: api.ServiceList{
 			Items: []api.Service{

--- a/plugin/cmd/scheduler/scheduler.go
+++ b/plugin/cmd/scheduler/scheduler.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
@@ -47,7 +48,8 @@ func main() {
 	verflag.PrintAndExitIfRequested()
 
 	// TODO: security story for plugins!
-	kubeClient, err := client.New(*master, latest.OldestVersion, nil)
+	ctx := api.NewContext()
+	kubeClient, err := client.New(ctx, *master, latest.OldestVersion, nil)
 	if err != nil {
 		glog.Fatalf("Invalid -master: %v", err)
 	}

--- a/plugin/pkg/scheduler/factory/factory_test.go
+++ b/plugin/pkg/scheduler/factory/factory_test.go
@@ -39,7 +39,7 @@ func TestCreate(t *testing.T) {
 		T:            t,
 	}
 	server := httptest.NewServer(&handler)
-	client := client.NewOrDie(server.URL, "", nil)
+	client := client.NewOrDie(api.NewContext(), server.URL, "", nil)
 	factory := ConfigFactory{client}
 	factory.Create()
 }
@@ -74,7 +74,7 @@ func TestCreateLists(t *testing.T) {
 			T:            t,
 		}
 		server := httptest.NewServer(&handler)
-		factory.Client = client.NewOrDie(server.URL, latest.OldestVersion, nil)
+		factory.Client = client.NewOrDie(api.NewContext(), server.URL, latest.OldestVersion, nil)
 		// This test merely tests that the correct request is made.
 		item.factory().List()
 		handler.ValidateRequest(t, item.location, "GET", nil)
@@ -127,7 +127,7 @@ func TestCreateWatches(t *testing.T) {
 			T:            t,
 		}
 		server := httptest.NewServer(&handler)
-		factory.Client = client.NewOrDie(server.URL, "v1beta1", nil)
+		factory.Client = client.NewOrDie(api.NewContext(), server.URL, "v1beta1", nil)
 		// This test merely tests that the correct request is made.
 		item.factory().Watch(item.rv)
 		handler.ValidateRequest(t, item.location, "GET", nil)
@@ -157,7 +157,7 @@ func TestPollMinions(t *testing.T) {
 		// FakeHandler musn't be sent requests other than the one you want to test.
 		mux.Handle("/api/v1beta1/minions", &handler)
 		server := httptest.NewServer(mux)
-		client := client.NewOrDie(server.URL, "v1beta1", nil)
+		client := client.NewOrDie(api.NewContext(), server.URL, "v1beta1", nil)
 		cf := ConfigFactory{client}
 
 		ce, err := cf.pollMinions()
@@ -184,7 +184,7 @@ func TestDefaultErrorFunc(t *testing.T) {
 	// FakeHandler musn't be sent requests other than the one you want to test.
 	mux.Handle("/api/v1beta1/pods/foo", &handler)
 	server := httptest.NewServer(mux)
-	factory := ConfigFactory{client.NewOrDie(server.URL, "", nil)}
+	factory := ConfigFactory{client.NewOrDie(api.NewContext(), server.URL, "", nil)}
 	queue := cache.NewFIFO()
 	errFunc := factory.makeDefaultErrorFunc(queue)
 
@@ -289,7 +289,7 @@ func TestBind(t *testing.T) {
 			T:            t,
 		}
 		server := httptest.NewServer(&handler)
-		client := client.NewOrDie(server.URL, "", nil)
+		client := client.NewOrDie(api.NewContext(), server.URL, "", nil)
 		b := binder{client}
 
 		if err := b.Bind(item.binding); err != nil {

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -61,7 +61,7 @@ func TestClient(t *testing.T) {
 	for apiVersion, values := range testCases {
 		deleteAllEtcdKeys()
 		s := httptest.NewServer(apiserver.Handle(values.Storage, values.Codec, fmt.Sprintf("/api/%s/", apiVersion), values.selfLinker))
-		client := client.NewOrDie(s.URL, apiVersion, nil)
+		client := client.NewOrDie(api.NewContext(), s.URL, apiVersion, nil)
 
 		info, err := client.ServerVersion()
 		if err != nil {


### PR DESCRIPTION
This is a prerequisite for namespace support similar to what has already been merged for the server.

The context object will hold the namespace for a request in a subsequent PR.
