### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ export PATH=$PATH:$GOPATH/bin
 ```
 
 #### Using godep
-Here is a quick summary of `godep`.  `godep` helps manage third party dependencies by copying known versions into Godep/_workspace.  You can use `godep` in three ways:
+Here is a quick summary of `godep`.  `godep` helps manage third party dependencies by copying known versions into Godeps/_workspace.  You can use `godep` in three ways:
 
 1. Use `godep` to call your `go` commands.  For example: `godep go test ./...`
 2. Use `godep` to modify your `$GOPATH` so that other tools know where to find the dependencies.  Specifically: `export GOPATH=$GOPATH:$(godep path)`
@@ -111,13 +111,10 @@ We recommend using options #1 or #2.
 Before committing any changes, please link/copy these hooks into your .git
 directory. This will keep you from accidentally committing non-gofmt'd go code.
 
-**NOTE:** The `../..` part seems odd but is correct, since the newly created
-links will be 2 levels down the tree.
-
 ```
 cd kubernetes
-ln -s ../../hooks/prepare-commit-msg .git/hooks/prepare-commit-msg
-ln -s ../../hooks/commit-msg .git/hooks/commit-msg
+ln -s hooks/prepare-commit-msg .git/hooks/prepare-commit-msg
+ln -s hooks/commit-msg .git/hooks/commit-msg
 ```
 
 ### Unit tests

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -59,7 +59,7 @@ function start_etcd {
 
   # Start etcd
   export ETCD_DIR=$(mktemp -d -t test-etcd.XXXXXX)
-  etcd -name test -data-dir ${ETCD_DIR} -bind-addr ${host}:${port} >/dev/null 2>/dev/null &
+  etcd -name test -data-dir ${ETCD_DIR} -addr ${host}:${port} >/dev/null 2>/dev/null &
   export ETCD_PID=$!
 
   wait_for_url "http://localhost:4001/v2/keys/" "etcd: "


### PR DESCRIPTION
Fixed a couple README.md typos and in order to run `hack/test-integration.sh` I had to use -addr instead of -bind-addr during etcd startup. Not sure if others have noticed the same thing but I wasn't able to curl etcd using -bind-addr.
