### PR TITLE
Allow clients to skip TLS verification

### DIFF
--- a/cmd/kubecfg/kubecfg.go
+++ b/cmd/kubecfg/kubecfg.go
@@ -66,6 +66,7 @@ func init() {
 	flag.StringVar(&clientConfig.CAFile, "certificate_authority", "", "Path to a cert. file for the certificate authority")
 	flag.StringVar(&clientConfig.CertFile, "client_certificate", "", "Path to a client certificate for TLS.")
 	flag.StringVar(&clientConfig.KeyFile, "client_key", "", "Path to a client key file for TLS.")
+	flag.BoolVar(&clientConfig.Insecure, "insecure_skip_tls_verify", clientConfig.Insecure, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.")
 }
 
 var parser = kubecfg.NewParser(map[string]runtime.Object{
@@ -196,6 +197,9 @@ func main() {
 		}
 		if auth.KeyFile != "" {
 			clientConfig.KeyFile = auth.KeyFile
+		}
+		if auth.Insecure != nil {
+			clientConfig.Insecure = *auth.Insecure
 		}
 	}
 	kubeClient, err := client.New(clientConfig)

--- a/pkg/client/flags.go
+++ b/pkg/client/flags.go
@@ -20,10 +20,12 @@ package client
 // and cobra pflags (Posix style).
 type FlagSet interface {
 	StringVar(p *string, name, value, usage string)
+	BoolVar(p *bool, name string, value bool, usage string)
 }
 
 // BindClientConfigFlags registers a standard set of CLI flags for connecting to a Kubernetes API server.
 func BindClientConfigFlags(flags FlagSet, config *Config) {
 	flags.StringVar(&config.Host, "master", config.Host, "The address of the Kubernetes API server")
 	flags.StringVar(&config.Version, "api_version", config.Version, "The API version to use when talking to the server")
+	flags.BoolVar(&config.Insecure, "insecure_skip_tls_verify", config.Insecure, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.")
 }

--- a/pkg/kubecfg/kubecfg.go
+++ b/pkg/kubecfg/kubecfg.go
@@ -57,6 +57,7 @@ type AuthInfo struct {
 	CAFile   string
 	CertFile string
 	KeyFile  string
+	Insecure *bool
 }
 
 // LoadAuthInfo parses an AuthInfo object from a file path. It prompts user and creates file if it doesn't exist.


### PR DESCRIPTION
Adds -skip_tls_verify to any API server client.
