### PR TITLE
Enforce namespace unique constraints

### DIFF
--- a/pkg/api/context.go
+++ b/pkg/api/context.go
@@ -63,6 +63,12 @@ func NamespaceFrom(ctx Context) (string, bool) {
 	return namespace, ok
 }
 
+// Namespace returns the value of the namespace key on the ctx, or the empty string if none
+func Namespace(ctx Context) string {
+	namespace, _ := NamespaceFrom(ctx)
+	return namespace
+}
+
 // ValidNamespace returns false if the namespace on the context differs from the resource.  If the resource has no namespace, it is set to the value in the context.
 func ValidNamespace(ctx Context, resource *TypeMeta) bool {
 	ns, ok := NamespaceFrom(ctx)
@@ -70,4 +76,13 @@ func ValidNamespace(ctx Context, resource *TypeMeta) bool {
 		resource.Namespace = ns
 	}
 	return ns == resource.Namespace && ok
+}
+
+// WithNamespaceDefaultIfNone returns a context whose namespace is the default if and only if the parent context has no namespace value
+func WithNamespaceDefaultIfNone(parent Context) Context {
+	namespace, ok := NamespaceFrom(parent)
+	if !ok || len(namespace) == 0 {
+		return WithNamespace(parent, NamespaceDefault)
+	}
+	return parent
 }

--- a/pkg/api/context_test.go
+++ b/pkg/api/context_test.go
@@ -59,4 +59,10 @@ func TestValidNamespace(t *testing.T) {
 	if api.ValidNamespace(ctx, &resource.TypeMeta) {
 		t.Errorf("Expected error that resource and context errors do not match since context has no namespace")
 	}
+
+	ctx = api.NewContext()
+	ns := api.Namespace(ctx)
+	if ns != "" {
+		t.Errorf("Expected the empty string")
+	}
 }

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -100,10 +100,17 @@ func curry(f func(runtime.Object, *http.Request) error, req *http.Request) func(
 //    timeout=<duration> Timeout for synchronous requests, only applies if sync=true
 //    labels=<label-selector> Used for filtering list operations
 func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w http.ResponseWriter, storage RESTStorage) {
-	// TODO for now, we perform all operations in the default namespace
-	ctx := api.NewDefaultContext()
+	ctx := api.NewContext()
 	sync := req.URL.Query().Get("sync") == "true"
 	timeout := parseTimeout(req.URL.Query().Get("timeout"))
+	// TODO for now, we pull namespace from query parameter, but according to spec, it must go in resource path in future PR
+	// if a namespace if specified, it's always used.
+	// for list/watch operations, a namespace is not required if omitted.
+	// for all other operations, if namespace is omitted, we will default to default namespace.
+	namespace := req.URL.Query().Get("namespace")
+	if len(namespace) > 0 {
+		ctx = api.WithNamespace(ctx, namespace)
+	}
 	switch req.Method {
 	case "GET":
 		switch len(parts) {
@@ -129,7 +136,7 @@ func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w htt
 			}
 			writeJSON(http.StatusOK, h.codec, list, w)
 		case 2:
-			item, err := storage.Get(ctx, parts[1])
+			item, err := storage.Get(api.WithNamespaceDefaultIfNone(ctx), parts[1])
 			if err != nil {
 				errorJSON(err, h.codec, w)
 				return
@@ -159,7 +166,7 @@ func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w htt
 			errorJSON(err, h.codec, w)
 			return
 		}
-		out, err := storage.Create(ctx, obj)
+		out, err := storage.Create(api.WithNamespaceDefaultIfNone(ctx), obj)
 		if err != nil {
 			errorJSON(err, h.codec, w)
 			return
@@ -172,7 +179,7 @@ func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w htt
 			notFound(w, req)
 			return
 		}
-		out, err := storage.Delete(ctx, parts[1])
+		out, err := storage.Delete(api.WithNamespaceDefaultIfNone(ctx), parts[1])
 		if err != nil {
 			errorJSON(err, h.codec, w)
 			return
@@ -196,7 +203,7 @@ func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w htt
 			errorJSON(err, h.codec, w)
 			return
 		}
-		out, err := storage.Update(ctx, obj)
+		out, err := storage.Update(api.WithNamespaceDefaultIfNone(ctx), obj)
 		if err != nil {
 			errorJSON(err, h.codec, w)
 			return

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -104,26 +104,26 @@ type Client struct {
 // ListPods takes a selector, and returns the list of pods that match that selector.
 func (c *Client) ListPods(ctx api.Context, selector labels.Selector) (result *api.PodList, err error) {
 	result = &api.PodList{}
-	err = c.Get().Path("pods").SelectorParam("labels", selector).Do().Into(result)
+	err = c.Get().Namespace(api.Namespace(ctx)).Path("pods").SelectorParam("labels", selector).Do().Into(result)
 	return
 }
 
 // GetPod takes the id of the pod, and returns the corresponding Pod object, and an error if it occurs
 func (c *Client) GetPod(ctx api.Context, id string) (result *api.Pod, err error) {
 	result = &api.Pod{}
-	err = c.Get().Path("pods").Path(id).Do().Into(result)
+	err = c.Get().Namespace(api.Namespace(ctx)).Path("pods").Path(id).Do().Into(result)
 	return
 }
 
 // DeletePod takes the id of the pod, and returns an error if one occurs
 func (c *Client) DeletePod(ctx api.Context, id string) error {
-	return c.Delete().Path("pods").Path(id).Do().Error()
+	return c.Delete().Namespace(api.Namespace(ctx)).Path("pods").Path(id).Do().Error()
 }
 
 // CreatePod takes the representation of a pod.  Returns the server's representation of the pod, and an error, if it occurs.
 func (c *Client) CreatePod(ctx api.Context, pod *api.Pod) (result *api.Pod, err error) {
 	result = &api.Pod{}
-	err = c.Post().Path("pods").Body(pod).Do().Into(result)
+	err = c.Post().Namespace(api.Namespace(ctx)).Path("pods").Body(pod).Do().Into(result)
 	return
 }
 
@@ -134,28 +134,28 @@ func (c *Client) UpdatePod(ctx api.Context, pod *api.Pod) (result *api.Pod, err 
 		err = fmt.Errorf("invalid update object, missing resource version: %v", pod)
 		return
 	}
-	err = c.Put().Path("pods").Path(pod.ID).Body(pod).Do().Into(result)
+	err = c.Put().Namespace(api.Namespace(ctx)).Path("pods").Path(pod.ID).Body(pod).Do().Into(result)
 	return
 }
 
 // ListReplicationControllers takes a selector, and returns the list of replication controllers that match that selector.
 func (c *Client) ListReplicationControllers(ctx api.Context, selector labels.Selector) (result *api.ReplicationControllerList, err error) {
 	result = &api.ReplicationControllerList{}
-	err = c.Get().Path("replicationControllers").SelectorParam("labels", selector).Do().Into(result)
+	err = c.Get().Namespace(api.Namespace(ctx)).Path("replicationControllers").SelectorParam("labels", selector).Do().Into(result)
 	return
 }
 
 // GetReplicationController returns information about a particular replication controller.
 func (c *Client) GetReplicationController(ctx api.Context, id string) (result *api.ReplicationController, err error) {
 	result = &api.ReplicationController{}
-	err = c.Get().Path("replicationControllers").Path(id).Do().Into(result)
+	err = c.Get().Namespace(api.Namespace(ctx)).Path("replicationControllers").Path(id).Do().Into(result)
 	return
 }
 
 // CreateReplicationController creates a new replication controller.
 func (c *Client) CreateReplicationController(ctx api.Context, controller *api.ReplicationController) (result *api.ReplicationController, err error) {
 	result = &api.ReplicationController{}
-	err = c.Post().Path("replicationControllers").Body(controller).Do().Into(result)
+	err = c.Post().Namespace(api.Namespace(ctx)).Path("replicationControllers").Body(controller).Do().Into(result)
 	return
 }
 
@@ -166,18 +166,19 @@ func (c *Client) UpdateReplicationController(ctx api.Context, controller *api.Re
 		err = fmt.Errorf("invalid update object, missing resource version: %v", controller)
 		return
 	}
-	err = c.Put().Path("replicationControllers").Path(controller.ID).Body(controller).Do().Into(result)
+	err = c.Put().Namespace(api.Namespace(ctx)).Path("replicationControllers").Path(controller.ID).Body(controller).Do().Into(result)
 	return
 }
 
 // DeleteReplicationController deletes an existing replication controller.
 func (c *Client) DeleteReplicationController(ctx api.Context, id string) error {
-	return c.Delete().Path("replicationControllers").Path(id).Do().Error()
+	return c.Delete().Namespace(api.Namespace(ctx)).Path("replicationControllers").Path(id).Do().Error()
 }
 
 // WatchReplicationControllers returns a watch.Interface that watches the requested controllers.
 func (c *Client) WatchReplicationControllers(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.Get().
+		Namespace(api.Namespace(ctx)).
 		Path("watch").
 		Path("replicationControllers").
 		Param("resourceVersion", resourceVersion).
@@ -189,21 +190,21 @@ func (c *Client) WatchReplicationControllers(ctx api.Context, label, field label
 // ListServices takes a selector, and returns the list of services that match that selector
 func (c *Client) ListServices(ctx api.Context, selector labels.Selector) (result *api.ServiceList, err error) {
 	result = &api.ServiceList{}
-	err = c.Get().Path("services").SelectorParam("labels", selector).Do().Into(result)
+	err = c.Get().Namespace(api.Namespace(ctx)).Path("services").SelectorParam("labels", selector).Do().Into(result)
 	return
 }
 
 // GetService returns information about a particular service.
 func (c *Client) GetService(ctx api.Context, id string) (result *api.Service, err error) {
 	result = &api.Service{}
-	err = c.Get().Path("services").Path(id).Do().Into(result)
+	err = c.Get().Namespace(api.Namespace(ctx)).Path("services").Path(id).Do().Into(result)
 	return
 }
 
 // CreateService creates a new service.
 func (c *Client) CreateService(ctx api.Context, svc *api.Service) (result *api.Service, err error) {
 	result = &api.Service{}
-	err = c.Post().Path("services").Body(svc).Do().Into(result)
+	err = c.Post().Namespace(api.Namespace(ctx)).Path("services").Body(svc).Do().Into(result)
 	return
 }
 
@@ -214,18 +215,19 @@ func (c *Client) UpdateService(ctx api.Context, svc *api.Service) (result *api.S
 		err = fmt.Errorf("invalid update object, missing resource version: %v", svc)
 		return
 	}
-	err = c.Put().Path("services").Path(svc.ID).Body(svc).Do().Into(result)
+	err = c.Put().Namespace(api.Namespace(ctx)).Path("services").Path(svc.ID).Body(svc).Do().Into(result)
 	return
 }
 
 // DeleteService deletes an existing service.
 func (c *Client) DeleteService(ctx api.Context, id string) error {
-	return c.Delete().Path("services").Path(id).Do().Error()
+	return c.Delete().Namespace(api.Namespace(ctx)).Path("services").Path(id).Do().Error()
 }
 
 // WatchServices returns a watch.Interface that watches the requested services.
 func (c *Client) WatchServices(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.Get().
+		Namespace(api.Namespace(ctx)).
 		Path("watch").
 		Path("services").
 		Param("resourceVersion", resourceVersion).
@@ -237,20 +239,21 @@ func (c *Client) WatchServices(ctx api.Context, label, field labels.Selector, re
 // ListEndpoints takes a selector, and returns the list of endpoints that match that selector
 func (c *Client) ListEndpoints(ctx api.Context, selector labels.Selector) (result *api.EndpointsList, err error) {
 	result = &api.EndpointsList{}
-	err = c.Get().Path("endpoints").SelectorParam("labels", selector).Do().Into(result)
+	err = c.Get().Namespace(api.Namespace(ctx)).Path("endpoints").SelectorParam("labels", selector).Do().Into(result)
 	return
 }
 
 // GetEndpoints returns information about the endpoints for a particular service.
 func (c *Client) GetEndpoints(ctx api.Context, id string) (result *api.Endpoints, err error) {
 	result = &api.Endpoints{}
-	err = c.Get().Path("endpoints").Path(id).Do().Into(result)
+	err = c.Get().Namespace(api.Namespace(ctx)).Path("endpoints").Path(id).Do().Into(result)
 	return
 }
 
 // WatchEndpoints returns a watch.Interface that watches the requested endpoints for a service.
 func (c *Client) WatchEndpoints(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.Get().
+		Namespace(api.Namespace(ctx)).
 		Path("watch").
 		Path("endpoints").
 		Param("resourceVersion", resourceVersion).
@@ -261,7 +264,7 @@ func (c *Client) WatchEndpoints(ctx api.Context, label, field labels.Selector, r
 
 func (c *Client) CreateEndpoints(ctx api.Context, endpoints *api.Endpoints) (*api.Endpoints, error) {
 	result := &api.Endpoints{}
-	err := c.Post().Path("endpoints").Body(endpoints).Do().Into(result)
+	err := c.Post().Namespace(api.Namespace(ctx)).Path("endpoints").Body(endpoints).Do().Into(result)
 	return result, err
 }
 
@@ -271,6 +274,7 @@ func (c *Client) UpdateEndpoints(ctx api.Context, endpoints *api.Endpoints) (*ap
 		return nil, fmt.Errorf("invalid update object, missing resource version: %v", endpoints)
 	}
 	err := c.Put().
+		Namespace(api.Namespace(ctx)).
 		Path("endpoints").
 		Path(endpoints.ID).
 		Body(endpoints).

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -74,6 +74,14 @@ func (r *Request) Sync(sync bool) *Request {
 	return r
 }
 
+// Namespace applies the namespace scope to a request
+func (r *Request) Namespace(namespace string) *Request {
+	if len(namespace) > 0 {
+		return r.setParam("namespace", namespace)
+	}
+	return r
+}
+
 // AbsPath overwrites an existing path with the path parameter.
 func (r *Request) AbsPath(path string) *Request {
 	if r.err != nil {
@@ -196,6 +204,7 @@ func (r *Request) finalURL() string {
 	for key, value := range r.params {
 		query.Add(key, value)
 	}
+
 	// sync and timeout are handled specially here, to allow setting them
 	// in any order.
 	if r.sync {

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -215,7 +215,7 @@ func TestCreateReplica(t *testing.T) {
 		Labels:       controllerSpec.DesiredState.PodTemplate.Labels,
 		DesiredState: controllerSpec.DesiredState.PodTemplate.DesiredState,
 	}
-	fakeHandler.ValidateRequest(t, makeURL("/pods"), "POST", nil)
+	fakeHandler.ValidateRequest(t, makeURL("/pods?namespace=default"), "POST", nil)
 	actualPod := api.Pod{}
 	if err := json.Unmarshal([]byte(fakeHandler.RequestBody), &actualPod); err != nil {
 		t.Errorf("Unexpected error: %#v", err)

--- a/pkg/kubecfg/kubecfg.go
+++ b/pkg/kubecfg/kubecfg.go
@@ -60,6 +60,10 @@ type AuthInfo struct {
 	Insecure *bool
 }
 
+type NamespaceInfo struct {
+	Namespace string
+}
+
 // LoadAuthInfo parses an AuthInfo object from a file path. It prompts user and creates file if it doesn't exist.
 func LoadAuthInfo(path string, r io.Reader) (*AuthInfo, error) {
 	var auth AuthInfo
@@ -82,6 +86,35 @@ func LoadAuthInfo(path string, r io.Reader) (*AuthInfo, error) {
 		return nil, err
 	}
 	return &auth, err
+}
+
+// LoadNamespaceInfo parses a NamespaceInfo object from a file path. It creates a file at the specified path if it doesn't exist with the default namespace.
+func LoadNamespaceInfo(path string) (*NamespaceInfo, error) {
+	var ns NamespaceInfo
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		ns.Namespace = api.NamespaceDefault
+		err = SaveNamespaceInfo(path, &ns)
+		return &ns, err
+	}
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(data, &ns)
+	if err != nil {
+		return nil, err
+	}
+	return &ns, err
+}
+
+// SaveNamespaceInfo saves a NamespaceInfo object at the specified file path.
+func SaveNamespaceInfo(path string, ns *NamespaceInfo) error {
+	if !util.IsDNSLabel(ns.Namespace) {
+		return fmt.Errorf("Namespace %s is not a valid DNS Label", ns.Namespace)
+	}
+	data, err := json.Marshal(ns)
+	err = ioutil.WriteFile(path, data, 0600)
+	return err
 }
 
 // Update performs a rolling update of a collection of pods.

--- a/pkg/kubecfg/kubecfg_test.go
+++ b/pkg/kubecfg/kubecfg_test.go
@@ -240,6 +240,58 @@ func TestCloudCfgDeleteControllerWithReplicas(t *testing.T) {
 	}
 }
 
+func TestLoadNamespaceInfo(t *testing.T) {
+	loadNamespaceInfoTests := []struct {
+		nsData string
+		nsInfo *NamespaceInfo
+	}{
+		{
+			`{"Namespace":"test"}`,
+			&NamespaceInfo{Namespace: "test"},
+		},
+		{
+			"", nil,
+		},
+		{
+			"missing",
+			&NamespaceInfo{Namespace: "default"},
+		},
+	}
+	for _, loadNamespaceInfoTest := range loadNamespaceInfoTests {
+		tt := loadNamespaceInfoTest
+		nsfile, err := ioutil.TempFile("", "testNamespaceInfo")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if tt.nsData != "missing" {
+			defer os.Remove(nsfile.Name())
+			defer nsfile.Close()
+			_, err := nsfile.WriteString(tt.nsData)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		} else {
+			nsfile.Close()
+			os.Remove(nsfile.Name())
+		}
+		nsInfo, err := LoadNamespaceInfo(nsfile.Name())
+		if len(tt.nsData) == 0 && tt.nsData != "missing" {
+			if err == nil {
+				t.Error("LoadNamespaceInfo didn't fail on an empty file")
+			}
+			continue
+		}
+		if tt.nsData != "missing" {
+			if err != nil {
+				t.Errorf("Unexpected error: %v, %v", tt.nsData, err)
+			}
+			if !reflect.DeepEqual(nsInfo, tt.nsInfo) {
+				t.Errorf("Expected %v, got %v", tt.nsInfo, nsInfo)
+			}
+		}
+	}
+}
+
 func TestLoadAuthInfo(t *testing.T) {
 	loadAuthInfoTests := []struct {
 		authData string

--- a/pkg/tools/etcd_tools.go
+++ b/pkg/tools/etcd_tools.go
@@ -164,6 +164,12 @@ func (h *EtcdHelper) ExtractList(key string, slicePtr interface{}, resourceVersi
 	if err != nil {
 		return err
 	}
+	h.decodeNodeList(nodes, slicePtr)
+	return nil
+}
+
+// decodeNodeList walks the tree of each node in the list and decodes into the specified object
+func (h *EtcdHelper) decodeNodeList(nodes []*etcd.Node, slicePtr interface{}) error {
 	pv := reflect.ValueOf(slicePtr)
 	if pv.Type().Kind() != reflect.Ptr || pv.Type().Elem().Kind() != reflect.Slice {
 		// This should not happen at runtime.
@@ -171,16 +177,20 @@ func (h *EtcdHelper) ExtractList(key string, slicePtr interface{}, resourceVersi
 	}
 	v := pv.Elem()
 	for _, node := range nodes {
-		obj := reflect.New(v.Type().Elem())
-		err = h.Codec.DecodeInto([]byte(node.Value), obj.Interface().(runtime.Object))
-		if h.ResourceVersioner != nil {
-			_ = h.ResourceVersioner.SetResourceVersion(obj.Interface().(runtime.Object), node.ModifiedIndex)
-			// being unable to set the version does not prevent the object from being extracted
+		if node.Dir {
+			h.decodeNodeList(node.Nodes, slicePtr)
+		} else {
+			obj := reflect.New(v.Type().Elem())
+			err := h.Codec.DecodeInto([]byte(node.Value), obj.Interface().(runtime.Object))
+			if h.ResourceVersioner != nil {
+				_ = h.ResourceVersioner.SetResourceVersion(obj.Interface().(runtime.Object), node.ModifiedIndex)
+				// being unable to set the version does not prevent the object from being extracted
+			}
+			if err != nil {
+				return err
+			}
+			v.Set(reflect.Append(v, obj.Elem()))
 		}
-		if err != nil {
-			return err
-		}
-		v.Set(reflect.Append(v, obj.Elem()))
 	}
 	return nil
 }

--- a/pkg/tools/etcd_tools.go
+++ b/pkg/tools/etcd_tools.go
@@ -179,18 +179,18 @@ func (h *EtcdHelper) decodeNodeList(nodes []*etcd.Node, slicePtr interface{}) er
 	for _, node := range nodes {
 		if node.Dir {
 			h.decodeNodeList(node.Nodes, slicePtr)
-		} else {
-			obj := reflect.New(v.Type().Elem())
-			err := h.Codec.DecodeInto([]byte(node.Value), obj.Interface().(runtime.Object))
-			if h.ResourceVersioner != nil {
-				_ = h.ResourceVersioner.SetResourceVersion(obj.Interface().(runtime.Object), node.ModifiedIndex)
-				// being unable to set the version does not prevent the object from being extracted
-			}
-			if err != nil {
-				return err
-			}
-			v.Set(reflect.Append(v, obj.Elem()))
+			continue
 		}
+		obj := reflect.New(v.Type().Elem())
+		err := h.Codec.DecodeInto([]byte(node.Value), obj.Interface().(runtime.Object))
+		if h.ResourceVersioner != nil {
+			_ = h.ResourceVersioner.SetResourceVersion(obj.Interface().(runtime.Object), node.ModifiedIndex)
+			// being unable to set the version does not prevent the object from being extracted
+		}
+		if err != nil {
+			return err
+		}
+		v.Set(reflect.Append(v, obj.Elem()))
 	}
 	return nil
 }

--- a/pkg/tools/etcd_tools_test.go
+++ b/pkg/tools/etcd_tools_test.go
@@ -141,10 +141,10 @@ func TestExtractToListAcrossDirectories(t *testing.T) {
 		},
 	}
 	expect := api.PodList{
-		JSONBase: api.JSONBase{ResourceVersion: 10},
+		TypeMeta: api.TypeMeta{ResourceVersion: "10"},
 		Items: []api.Pod{
-			{JSONBase: api.JSONBase{ID: "foo", ResourceVersion: 1}},
-			{JSONBase: api.JSONBase{ID: "bar", ResourceVersion: 2}},
+			{TypeMeta: api.TypeMeta{ID: "foo", ResourceVersion: "1"}},
+			{TypeMeta: api.TypeMeta{ID: "bar", ResourceVersion: "2"}},
 		},
 	}
 
@@ -187,11 +187,11 @@ func TestExtractToListExcludesDirectories(t *testing.T) {
 		},
 	}
 	expect := api.PodList{
-		JSONBase: api.JSONBase{ResourceVersion: 10},
+		TypeMeta: api.TypeMeta{ResourceVersion: "10"},
 		Items: []api.Pod{
-			{JSONBase: api.JSONBase{ID: "foo", ResourceVersion: 1}},
-			{JSONBase: api.JSONBase{ID: "bar", ResourceVersion: 2}},
-			{JSONBase: api.JSONBase{ID: "baz", ResourceVersion: 3}},
+			{TypeMeta: api.TypeMeta{ID: "foo", ResourceVersion: "1"}},
+			{TypeMeta: api.TypeMeta{ID: "bar", ResourceVersion: "2"}},
+			{TypeMeta: api.TypeMeta{ID: "baz", ResourceVersion: "3"}},
 		},
 	}
 

--- a/pkg/tools/etcd_tools_test.go
+++ b/pkg/tools/etcd_tools_test.go
@@ -108,6 +108,104 @@ func TestExtractToList(t *testing.T) {
 	}
 }
 
+// TestExtractToListAcrossDirectories ensures that the client excludes directories and flattens tree-response - simulates cross-namespace query
+func TestExtractToListAcrossDirectories(t *testing.T) {
+	fakeClient := NewFakeEtcdClient(t)
+	fakeClient.Data["/some/key"] = EtcdResponseWithError{
+		R: &etcd.Response{
+			EtcdIndex: 10,
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{
+					{
+						Value: `{"id": "directory1"}`,
+						Dir:   true,
+						Nodes: []*etcd.Node{
+							{
+								Value:         `{"id":"foo"}`,
+								ModifiedIndex: 1,
+							},
+						},
+					},
+					{
+						Value: `{"id": "directory2"}`,
+						Dir:   true,
+						Nodes: []*etcd.Node{
+							{
+								Value:         `{"id":"bar"}`,
+								ModifiedIndex: 2,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	expect := api.PodList{
+		JSONBase: api.JSONBase{ResourceVersion: 10},
+		Items: []api.Pod{
+			{JSONBase: api.JSONBase{ID: "foo", ResourceVersion: 1}},
+			{JSONBase: api.JSONBase{ID: "bar", ResourceVersion: 2}},
+		},
+	}
+
+	var got api.PodList
+	helper := EtcdHelper{fakeClient, latest.Codec, versioner}
+	err := helper.ExtractToList("/some/key", &got)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	if e, a := expect, got; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+}
+
+func TestExtractToListExcludesDirectories(t *testing.T) {
+	fakeClient := NewFakeEtcdClient(t)
+	fakeClient.Data["/some/key"] = EtcdResponseWithError{
+		R: &etcd.Response{
+			EtcdIndex: 10,
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{
+					{
+						Value:         `{"id":"foo"}`,
+						ModifiedIndex: 1,
+					},
+					{
+						Value:         `{"id":"bar"}`,
+						ModifiedIndex: 2,
+					},
+					{
+						Value:         `{"id":"baz"}`,
+						ModifiedIndex: 3,
+					},
+					{
+						Value: `{"id": "directory"}`,
+						Dir:   true,
+					},
+				},
+			},
+		},
+	}
+	expect := api.PodList{
+		JSONBase: api.JSONBase{ResourceVersion: 10},
+		Items: []api.Pod{
+			{JSONBase: api.JSONBase{ID: "foo", ResourceVersion: 1}},
+			{JSONBase: api.JSONBase{ID: "bar", ResourceVersion: 2}},
+			{JSONBase: api.JSONBase{ID: "baz", ResourceVersion: 3}},
+		},
+	}
+
+	var got api.PodList
+	helper := EtcdHelper{fakeClient, latest.Codec, versioner}
+	err := helper.ExtractToList("/some/key", &got)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	if e, a := expect, got; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+}
+
 func TestExtractObj(t *testing.T) {
 	fakeClient := NewFakeEtcdClient(t)
 	expect := api.Pod{TypeMeta: api.TypeMeta{ID: "foo"}}

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -184,7 +184,8 @@ func (factory *ConfigFactory) makeDefaultErrorFunc(backoff *podBackoff, podQueue
 			backoff.wait(podID)
 			// Get the pod again; it may have changed/been scheduled already.
 			pod = &api.Pod{}
-			err := factory.Client.Get().Path("pods").Path(podID).Do().Into(pod)
+			ctx := api.WithNamespace(api.NewContext(), pod.Namespace)
+			err := factory.Client.Get().Namespace(api.Namespace(ctx)).Path("pods").Path(podID).Do().Into(pod)
 			if err != nil {
 				glog.Errorf("Error getting pod %v for retry: %v; abandoning", podID, err)
 				return
@@ -256,7 +257,8 @@ type binder struct {
 // Bind just does a POST binding RPC.
 func (b *binder) Bind(binding *api.Binding) error {
 	glog.V(2).Infof("Attempting to bind %v to %v", binding.PodID, binding.Host)
-	return b.Post().Path("bindings").Body(binding).Do().Error()
+	ctx := api.WithNamespace(api.NewContext(), binding.Namespace)
+	return b.Post().Namespace(api.Namespace(ctx)).Path("bindings").Body(binding).Do().Error()
 }
 
 type clock interface {

--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -73,8 +73,9 @@ func (s *Scheduler) scheduleOne() {
 		return
 	}
 	b := &api.Binding{
-		PodID: pod.ID,
-		Host:  dest,
+		TypeMeta: api.TypeMeta{Namespace: pod.Namespace},
+		PodID:    pod.ID,
+		Host:     dest,
 	}
 	if err := s.config.Binder.Bind(b); err != nil {
 		record.Eventf(pod, "", string(api.PodWaiting), "failedScheduling", "Binding rejected: %v", err)


### PR DESCRIPTION
This is the update to actually enable namespace support.

At the moment, I pass a namespace as a query parameter in order to support namespace scoping on the v1beta urls.  Once v1beta3 lands, I will modify to pass namespace in the path.  Note the client libraries were modified to make this easy to do, so should be a trivial change once ready.

I broke the commits into logical sections to improve readability.
