### PR TITLE
Initial support to propagating the termination reasons and image failures. 

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package api
 
 import (
+	"time"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/fsouza/go-dockerclient"
 )
 
 // Common string formats
@@ -250,12 +251,15 @@ type ContainerStateWaiting struct {
 }
 
 type ContainerStateRunning struct {
+	StartedAt time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
 }
 
 type ContainerStateTerminated struct {
-	ExitCode int    `json:"exitCode,omitempty" yaml:"exitCode,omitempty"`
-	Signal   int    `json:"signal,omitempty" yaml:"signal,omitempty"`
-	Reason   string `json:"reason,omitempty" yaml:"reason,omitempty"`
+	ExitCode   int       `json:"exitCode" yaml:"exitCode"`
+	Signal     int       `json:"signal,omitempty" yaml:"signal,omitempty"`
+	Reason     string    `json:"reason,omitempty" yaml:"reason,omitempty"`
+	StartedAt  time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
+	FinishedAt time.Time `json:"finishedAt,omitempty" yaml:"finishedAt,omitempty"`
 }
 
 type ContainerState struct {
@@ -271,12 +275,11 @@ type ContainerStatus struct {
 	// defined for container?
 	State        ContainerState `json:"state,omitempty" yaml:"state,omitempty"`
 	RestartCount int            `json:"restartCount" yaml:"restartCount"`
-	// TODO(dchen1107): Introduce our own NetworkSettings struct here?
+	// TODO(dchen1107): Deprecated this soon once we pull entire PodStatus from node,
+	// not just PodInfo. Now we need this to remove docker.Container from API
+	PodIP string `json:"podIP,omitempty" yaml:"podIP,omitempty"`
 	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
 	// usage should be included.
-	// TODO(dchen1107):  In long run, I think we should replace this with our own struct to remove
-	// the dependency on docker.
-	DetailInfo docker.Container `json:"detailInfo,omitempty" yaml:"detailInfo,omitempty"`
 }
 
 // PodInfo contains one entry for every container with available info.

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	"time"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/fsouza/go-dockerclient"
 )
 
 // Common string formats
@@ -263,12 +264,15 @@ type ContainerStateWaiting struct {
 }
 
 type ContainerStateRunning struct {
+	StartedAt time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
 }
 
 type ContainerStateTerminated struct {
-	ExitCode int    `json:"exitCode,omitempty" yaml:"exitCode,omitempty"`
-	Signal   int    `json:"signal,omitempty" yaml:"signal,omitempty"`
-	Reason   string `json:"reason,omitempty" yaml:"reason,omitempty"`
+	ExitCode   int       `json:"exitCode" yaml:"exitCode"`
+	Signal     int       `json:"signal,omitempty" yaml:"signal,omitempty"`
+	Reason     string    `json:"reason,omitempty" yaml:"reason,omitempty"`
+	StartedAt  time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
+	FinishedAt time.Time `json:"finishedAt,omitempty" yaml:"finishedAt,omitempty"`
 }
 
 type ContainerState struct {
@@ -284,12 +288,11 @@ type ContainerStatus struct {
 	// defined for container?
 	State        ContainerState `json:"state,omitempty" yaml:"state,omitempty"`
 	RestartCount int            `json:"restartCount" yaml:"restartCount"`
-	// TODO(dchen1107): Introduce our own NetworkSettings struct here?
+	// TODO(dchen1107): Deprecated this soon once we pull entire PodStatus from node,
+	// not just PodInfo. Now we need this to remove docker.Container from API
+	PodIP string `json:"podIP,omitempty" yaml:"podIP,omitempty"`
 	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
 	// usage should be included.
-	// TODO(dchen1107):  In long run, I think we should replace this with our own struct to remove
-	// the dependency on docker.
-	DetailInfo docker.Container `json:"detailInfo,omitempty" yaml:"detailInfo,omitempty"`
 }
 
 // PodInfo contains one entry for every container with available info.

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1beta2
 
 import (
+	"time"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/fsouza/go-dockerclient"
 )
 
 // Common string formats
@@ -259,12 +260,15 @@ type ContainerStateWaiting struct {
 }
 
 type ContainerStateRunning struct {
+	StartedAt time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
 }
 
 type ContainerStateTerminated struct {
-	ExitCode int    `json:"exitCode,omitempty" yaml:"exitCode,omitempty"`
-	Signal   int    `json:"signal,omitempty" yaml:"signal,omitempty"`
-	Reason   string `json:"reason,omitempty" yaml:"reason,omitempty"`
+	ExitCode   int       `json:"exitCode" yaml:"exitCode"`
+	Signal     int       `json:"signal,omitempty" yaml:"signal,omitempty"`
+	Reason     string    `json:"reason,omitempty" yaml:"reason,omitempty"`
+	StartedAt  time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
+	FinishedAt time.Time `json:"finishedAt,omitempty" yaml:"finishedAt,omitempty"`
 }
 
 type ContainerState struct {
@@ -280,16 +284,14 @@ type ContainerStatus struct {
 	// defined for container?
 	State        ContainerState `json:"state,omitempty" yaml:"state,omitempty"`
 	RestartCount int            `json:"restartCount" yaml:"restartCount"`
-	// TODO(dchen1107): Introduce our own NetworkSettings struct here?
+	// TODO(dchen1107): Deprecated this soon once we pull entire PodStatus from node,
+	// not just PodInfo. Now we need this to remove docker.Container from API
+	PodIP string `json:"podIP,omitempty" yaml:"podIP,omitempty"`
 	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
 	// usage should be included.
-	// TODO(dchen1107):  In long run, I think we should replace this with our own struct to remove
-	// the dependency on docker.
-	DetailInfo docker.Container `json:"detailInfo,omitempty" yaml:"detailInfo,omitempty"`
 }
 
 // PodInfo contains one entry for every container with available info.
-// TODO(dchen1107): Replace docker.Container below with ContainerStatus defined above.
 type PodInfo map[string]ContainerStatus
 
 type RestartPolicyAlways struct{}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1beta3
 
 import (
+	"time"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/fsouza/go-dockerclient"
 )
 
 // Common string formats
@@ -258,12 +259,15 @@ type ContainerStateWaiting struct {
 }
 
 type ContainerStateRunning struct {
+	StartedAt time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
 }
 
 type ContainerStateTerminated struct {
-	ExitCode int    `json:"exitCode,omitempty" yaml:"exitCode,omitempty"`
-	Signal   int    `json:"signal,omitempty" yaml:"signal,omitempty"`
-	Reason   string `json:"reason,omitempty" yaml:"reason,omitempty"`
+	ExitCode   int       `json:"exitCode" yaml:"exitCode"`
+	Signal     int       `json:"signal,omitempty" yaml:"signal,omitempty"`
+	Reason     string    `json:"reason,omitempty" yaml:"reason,omitempty"`
+	StartedAt  time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
+	FinishedAt time.Time `json:"finishedAt,omitempty" yaml:"finishedAt,omitempty"`
 }
 
 type ContainerState struct {
@@ -282,14 +286,11 @@ type ContainerStatus struct {
 	// TODO(dchen1107): Introduce our own NetworkSettings struct here?
 	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
 	// usage should be included.
-	// TODO(dchen1107):  In long run, I think we should replace this with our own struct to remove
-	// the dependency on docker.
-	DetailInfo docker.Container `json:"detailInfo,omitempty" yaml:"detailInfo,omitempty"`
 }
 
 // PodInfo contains one entry for every container with available info.
 // TODO(dchen1107): Replace docker.Container below with ContainerStatus defined above.
-type PodInfo map[string]docker.Container
+type PodInfo map[string]ContainerStatus
 
 type RestartPolicyAlways struct{}
 

--- a/pkg/client/podinfo_test.go
+++ b/pkg/client/podinfo_test.go
@@ -27,14 +27,11 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/fsouza/go-dockerclient"
 )
 
 func TestHTTPPodInfoGetter(t *testing.T) {
 	expectObj := api.PodInfo{
-		"myID": api.ContainerStatus{
-			DetailInfo: docker.Container{ID: "myID"},
-		},
+		"myID": api.ContainerStatus{},
 	}
 	body, err := json.Marshal(expectObj)
 	if err != nil {
@@ -69,17 +66,14 @@ func TestHTTPPodInfoGetter(t *testing.T) {
 	}
 
 	// reflect.DeepEqual(expectObj, gotObj) doesn't handle blank times well
-	if len(gotObj) != len(expectObj) ||
-		expectObj["myID"].DetailInfo.ID != gotObj["myID"].DetailInfo.ID {
+	if len(gotObj) != len(expectObj) {
 		t.Errorf("Unexpected response.  Expected: %#v, received %#v", expectObj, gotObj)
 	}
 }
 
 func TestHTTPPodInfoGetterNotFound(t *testing.T) {
 	expectObj := api.PodInfo{
-		"myID": api.ContainerStatus{
-			DetailInfo: docker.Container{ID: "myID"},
-		},
+		"myID": api.ContainerStatus{},
 	}
 	_, err := json.Marshal(expectObj)
 	if err != nil {

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -43,6 +43,7 @@ type DockerContainerData struct {
 type DockerInterface interface {
 	ListContainers(options docker.ListContainersOptions) ([]docker.APIContainers, error)
 	InspectContainer(id string) (*docker.Container, error)
+	InspectImage(name string) (*docker.Image, error)
 	CreateContainer(docker.CreateContainerOptions) (*docker.Container, error)
 	StartContainer(id string, hostConfig *docker.HostConfig) error
 	StopContainer(id string, timeout uint) error
@@ -231,30 +232,64 @@ func GetKubeletDockerContainerLogs(client DockerInterface, containerID, tail str
 	return
 }
 
-func generateContainerStatus(inspectResult *docker.Container) api.ContainerStatus {
+var (
+	// ErrNoContainersInPod is returned when there are no containers for a given pod
+	ErrNoContainersInPod = errors.New("no containers exist for this pod")
+
+	// ErrNoNetworkContainerInPod is returned when there is no network container for a given pod
+	ErrNoNetworkContainerInPod = errors.New("No network container exist for this pod")
+
+	// ErrContainerCannotRun is returned when a container is created, but cannot run properly
+	ErrContainerCannotRun = errors.New("Container cannot run")
+)
+
+func inspectContainer(client DockerInterface, dockerID, containerName string) (*api.ContainerStatus, error) {
+	inspectResult, err := client.InspectContainer(dockerID)
+	if err != nil {
+		return nil, err
+	}
 	if inspectResult == nil {
 		// Why did we not get an error?
-		return api.ContainerStatus{}
+		return &api.ContainerStatus{}, nil
 	}
 
+	glog.V(3).Infof("Container: %s [%s] inspect result %+v", *inspectResult)
 	var containerStatus api.ContainerStatus
+	waiting := true
 
 	if inspectResult.State.Running {
-		containerStatus.State.Running = &api.ContainerStateRunning{}
-	} else {
+		containerStatus.State.Running = &api.ContainerStateRunning{
+			StartedAt: inspectResult.State.StartedAt,
+		}
+		if containerName == "net" && inspectResult.NetworkSettings != nil {
+			containerStatus.PodIP = inspectResult.NetworkSettings.IPAddress
+		}
+		waiting = false
+	} else if !inspectResult.State.FinishedAt.IsZero() {
+		// TODO(dchen1107): Integrate with event to provide a better reason
 		containerStatus.State.Termination = &api.ContainerStateTerminated{
-			ExitCode: inspectResult.State.ExitCode,
+			ExitCode:   inspectResult.State.ExitCode,
+			Reason:     "",
+			StartedAt:  inspectResult.State.StartedAt,
+			FinishedAt: inspectResult.State.FinishedAt,
+		}
+		waiting = false
+	}
+
+	if waiting {
+		// TODO(dchen1107): Separate issue docker/docker#8294 was filed
+		// TODO(dchen1107): Need to figure out why we are still waiting
+		// Check any issue to run container
+		containerStatus.State.Waiting = &api.ContainerStateWaiting{
+			Reason: ErrContainerCannotRun.Error(),
 		}
 	}
-	containerStatus.DetailInfo = *inspectResult
-	return containerStatus
+
+	return &containerStatus, nil
 }
 
-// ErrNoContainersInPod is returned when there are no containers for a given pod
-var ErrNoContainersInPod = errors.New("no containers exist for this pod")
-
 // GetDockerPodInfo returns docker info for all containers in the pod/manifest.
-func GetDockerPodInfo(client DockerInterface, podFullName, uuid string) (api.PodInfo, error) {
+func GetDockerPodInfo(client DockerInterface, manifest api.ContainerManifest, podFullName, uuid string) (api.PodInfo, error) {
 	info := api.PodInfo{}
 
 	containers, err := client.ListContainers(docker.ListContainersOptions{All: true})
@@ -277,14 +312,47 @@ func GetDockerPodInfo(client DockerInterface, podFullName, uuid string) (api.Pod
 			continue
 		}
 
-		inspectResult, err := client.InspectContainer(value.ID)
+		containerStatus, err := inspectContainer(client, value.ID, dockerContainerName)
 		if err != nil {
 			return nil, err
 		}
-		info[dockerContainerName] = generateContainerStatus(inspectResult)
+		info[dockerContainerName] = *containerStatus
 	}
+
 	if len(info) == 0 {
 		return nil, ErrNoContainersInPod
+	}
+
+	// First make sure we are not missing network container
+	if _, found := info["net"]; !found {
+		return nil, ErrNoNetworkContainerInPod
+	}
+
+	if len(info) < (len(manifest.Containers) + 1) {
+		var containerStatus api.ContainerStatus
+		// Not all containers expected are created, verify if there are
+		// image related issues
+		for _, container := range manifest.Containers {
+			if _, found := info[container.Name]; found {
+				continue
+			}
+
+			image := container.Image
+			containerStatus.State.Waiting = &api.ContainerStateWaiting{}
+			// Check image is ready on the node or not
+			// TODO(dchen1107): docker/docker/issues/8365 to figure out if the image exists
+			_, err := client.InspectImage(image)
+			if err != nil && err == docker.ErrNoSuchImage {
+				if err == docker.ErrNoSuchImage {
+					containerStatus.State.Waiting.Reason = fmt.Sprintf("Image: %s is not ready on the node", image)
+				} else {
+					containerStatus.State.Waiting.Reason = err.Error()
+				}
+			} else {
+				containerStatus.State.Waiting.Reason = fmt.Sprintf("Image: %s is ready, container is creating", image)
+			}
+			info[container.Name] = containerStatus
+		}
 	}
 
 	return info, nil

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -29,6 +29,7 @@ type FakeDockerClient struct {
 	sync.Mutex
 	ContainerList []docker.APIContainers
 	Container     *docker.Container
+	Image         *docker.Image
 	Err           error
 	called        []string
 	Stopped       []string
@@ -67,8 +68,17 @@ func (f *FakeDockerClient) ListContainers(options docker.ListContainersOptions) 
 func (f *FakeDockerClient) InspectContainer(id string) (*docker.Container, error) {
 	f.Lock()
 	defer f.Unlock()
-	f.called = append(f.called, "inspect")
+	f.called = append(f.called, "inspect_container")
 	return f.Container, f.Err
+}
+
+// InspectImage is a test-spy implementation of DockerInterface.InspectImage.
+// It adds an entry "inspect" to the internal method call record.
+func (f *FakeDockerClient) InspectImage(name string) (*docker.Image, error) {
+	f.Lock()
+	defer f.Unlock()
+	f.called = append(f.called, "inspect_image")
+	return f.Image, f.Err
 }
 
 // CreateContainer is a test-spy implementation of DockerInterface.CreateContainer.

--- a/pkg/kubelet/handlers.go
+++ b/pkg/kubelet/handlers.go
@@ -77,8 +77,8 @@ func (h *httpActionHandler) Run(podFullName, uuid string, container *api.Contain
 			return err
 		}
 		netInfo, found := info[networkContainerName]
-		if found && netInfo.DetailInfo.NetworkSettings != nil {
-			host = netInfo.DetailInfo.NetworkSettings.IPAddress
+		if found {
+			host = netInfo.PodIP
 		} else {
 			return fmt.Errorf("failed to find networking container: %v", info)
 		}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -104,6 +104,7 @@ type Kubelet struct {
 	rootDirectory  string
 	podWorkers     podWorkers
 	resyncInterval time.Duration
+	pods           []Pod
 
 	// Optional, no events will be sent without it
 	etcdClient tools.EtcdClient
@@ -460,8 +461,8 @@ func (kl *Kubelet) syncPod(pod *Pod, dockerContainers dockertools.DockerContaine
 			podFullName, uuid)
 	}
 	netInfo, found := info[networkContainerName]
-	if found && netInfo.DetailInfo.NetworkSettings != nil {
-		podState.PodIP = netInfo.DetailInfo.NetworkSettings.IPAddress
+	if found {
+		podState.PodIP = netInfo.PodIP
 	}
 
 	for _, container := range pod.Manifest.Containers {
@@ -669,15 +670,14 @@ func filterHostPortConflicts(pods []Pod) []Pod {
 // no changes are seen to the configuration, will synchronize the last known desired
 // state every sync_frequency seconds. Never returns.
 func (kl *Kubelet) syncLoop(updates <-chan PodUpdate, handler SyncHandler) {
-	var pods []Pod
 	for {
 		select {
 		case u := <-updates:
 			switch u.Op {
 			case SET:
 				glog.V(3).Infof("Containers changed [%s]", kl.hostname)
-				pods = u.Pods
-				pods = filterHostPortConflicts(pods)
+				kl.pods = u.Pods
+				kl.pods = filterHostPortConflicts(kl.pods)
 
 			case UPDATE:
 				//TODO: implement updates of containers
@@ -688,12 +688,12 @@ func (kl *Kubelet) syncLoop(updates <-chan PodUpdate, handler SyncHandler) {
 				panic("syncLoop does not support incremental changes")
 			}
 		case <-time.After(kl.resyncInterval):
-			if pods == nil {
+			if kl.pods == nil {
 				continue
 			}
 		}
 
-		err := handler.SyncPods(pods)
+		err := handler.SyncPods(kl.pods)
 		if err != nil {
 			glog.Errorf("Couldn't sync containers : %v", err)
 		}
@@ -739,7 +739,15 @@ func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName, tail stri
 
 // GetPodInfo returns information from Docker about the containers in a pod
 func (kl *Kubelet) GetPodInfo(podFullName, uuid string) (api.PodInfo, error) {
-	return dockertools.GetDockerPodInfo(kl.dockerClient, podFullName, uuid)
+	var manifest api.ContainerManifest
+	for _, pod := range kl.pods {
+		fullName := fmt.Sprintf("%s.%s", pod.Name, pod.Namespace)
+		if fullName == podFullName {
+			manifest = pod.Manifest
+			break
+		}
+	}
+	return dockertools.GetDockerPodInfo(kl.dockerClient, manifest, podFullName, uuid)
 }
 
 // GetContainerInfo returns stats (from Cadvisor) for a container.

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -225,7 +225,7 @@ func TestSyncPodsCreatesNetAndContainer(t *testing.T) {
 	kubelet.drainWorkers()
 
 	verifyCalls(t, fakeDocker, []string{
-		"list", "list", "create", "start", "list", "inspect", "list", "create", "start"})
+		"list", "list", "create", "start", "list", "inspect_container", "list", "create", "start"})
 
 	fakeDocker.Lock()
 	if len(fakeDocker.Created) != 2 ||
@@ -263,7 +263,7 @@ func TestSyncPodsWithNetCreatesContainer(t *testing.T) {
 	kubelet.drainWorkers()
 
 	verifyCalls(t, fakeDocker, []string{
-		"list", "list", "list", "inspect", "list", "create", "start"})
+		"list", "list", "list", "inspect_container", "list", "create", "start"})
 
 	fakeDocker.Lock()
 	if len(fakeDocker.Created) != 1 ||
@@ -313,7 +313,7 @@ func TestSyncPodsWithNetCreatesContainerCallsHandler(t *testing.T) {
 	kubelet.drainWorkers()
 
 	verifyCalls(t, fakeDocker, []string{
-		"list", "list", "list", "inspect", "list", "create", "start"})
+		"list", "list", "list", "inspect_container", "list", "create", "start"})
 
 	fakeDocker.Lock()
 	if len(fakeDocker.Created) != 1 ||
@@ -353,7 +353,7 @@ func TestSyncPodsDeletesWithNoNetContainer(t *testing.T) {
 	kubelet.drainWorkers()
 
 	verifyCalls(t, fakeDocker, []string{
-		"list", "list", "stop", "create", "start", "list", "list", "inspect", "list", "create", "start"})
+		"list", "list", "stop", "create", "start", "list", "list", "inspect_container", "list", "create", "start"})
 
 	// A map iteration is used to delete containers, so must not depend on
 	// order here.

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/fsouza/go-dockerclient"
 	"github.com/google/cadvisor/info"
 )
 
@@ -147,9 +146,7 @@ func TestContainers(t *testing.T) {
 func TestPodInfo(t *testing.T) {
 	fw := newServerTest()
 	expected := api.PodInfo{
-		"goodpod": api.ContainerStatus{
-			DetailInfo: docker.Container{ID: "myContainerID"},
-		},
+		"goodpod": api.ContainerStatus{},
 	}
 	fw.fakeKubelet.infoFunc = func(name string) (api.PodInfo, error) {
 		if name == "goodpod.etcd" {

--- a/pkg/master/pod_cache_test.go
+++ b/pkg/master/pod_cache_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
-	"github.com/fsouza/go-dockerclient"
 )
 
 type FakePodInfoGetter struct {
@@ -42,9 +41,7 @@ func TestPodCacheGet(t *testing.T) {
 	cache := NewPodCache(nil, nil)
 
 	expected := api.PodInfo{
-		"foo": api.ContainerStatus{
-			DetailInfo: docker.Container{ID: "foo"},
-		},
+		"foo": api.ContainerStatus{},
 	}
 	cache.podInfo["foo"] = expected
 
@@ -71,9 +68,7 @@ func TestPodCacheGetMissing(t *testing.T) {
 
 func TestPodGetPodInfoGetter(t *testing.T) {
 	expected := api.PodInfo{
-		"foo": api.ContainerStatus{
-			DetailInfo: docker.Container{ID: "foo"},
-		},
+		"foo": api.ContainerStatus{},
 	}
 	fake := FakePodInfoGetter{
 		data: expected,
@@ -107,9 +102,7 @@ func TestPodUpdateAllContainers(t *testing.T) {
 	mockRegistry := registrytest.NewPodRegistry(&api.PodList{Items: pods})
 
 	expected := api.PodInfo{
-		"foo": api.ContainerStatus{
-			DetailInfo: docker.Container{ID: "foo"},
-		},
+		"foo": api.ContainerStatus{},
 	}
 	fake := FakePodInfoGetter{
 		data: expected,

--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -196,8 +196,8 @@ func (rs *REST) fillPodInfo(pod *api.Pod) {
 		pod.CurrentState.Info = info
 		netContainerInfo, ok := info["net"]
 		if ok {
-			if netContainerInfo.DetailInfo.NetworkSettings != nil {
-				pod.CurrentState.PodIP = netContainerInfo.DetailInfo.NetworkSettings.IPAddress
+			if netContainerInfo.PodIP != "" {
+				pod.CurrentState.PodIP = netContainerInfo.PodIP
 			} else {
 				glog.Warningf("No network settings: %#v", netContainerInfo)
 			}

--- a/pkg/registry/pod/rest_test.go
+++ b/pkg/registry/pod/rest_test.go
@@ -31,8 +31,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-
-	"github.com/fsouza/go-dockerclient"
 )
 
 func expectApiStatusError(t *testing.T, ch <-chan runtime.Object, msg string) {
@@ -570,16 +568,17 @@ func (f *FakePodInfoGetter) GetPodInfo(host, podID string) (api.PodInfo, error) 
 
 func TestFillPodInfo(t *testing.T) {
 	expectedIP := "1.2.3.4"
+	expectedTime, _ := time.Parse("2013-Feb-03", "2013-Feb-03")
 	fakeGetter := FakePodInfoGetter{
 		info: map[string]api.ContainerStatus{
 			"net": {
-				DetailInfo: docker.Container{
-					ID:   "foobar",
-					Path: "bin/run.sh",
-					NetworkSettings: &docker.NetworkSettings{
-						IPAddress: expectedIP,
+				State: api.ContainerState{
+					Running: &api.ContainerStateRunning{
+						StartedAt: expectedTime,
 					},
 				},
+				RestartCount: 1,
+				PodIP:        expectedIP,
 			},
 		},
 	}
@@ -601,10 +600,7 @@ func TestFillPodInfoNoData(t *testing.T) {
 	fakeGetter := FakePodInfoGetter{
 		info: map[string]api.ContainerStatus{
 			"net": {
-				DetailInfo: docker.Container{
-					ID:   "foobar",
-					Path: "bin/run.sh",
-				},
+				State: api.ContainerState{},
 			},
 		},
 	}


### PR DESCRIPTION
I still need to fix e2e tests. Unfortunately everytime I ran e2e, it ran into a weird issue. Will update this PR once e2e is fixed.  

With this PR, docker.Container is retired completely from our API. But to achieve that, I have to introduce some to be deprecated field, such as PodIP for now. Once below TODO 1) is handled, those fields will be removed. (#137)

Also why container is waiting is added in this PR. (#941) Currently only two possible causes: 
1) The request image is not ready (The reasons can be categorized into 2, one is still pulling, another one is pulling failure. Filed an issue to docker, but it should be ok for now since we already have creation timestamp, and real container state reported)
2) Failed to run the container (Current I just guess it based on available data, but a pending PR to resolve docker/docker/issues/8294 should give us more detail information)

All those information are not comprehensive 

There are many TODOs following:
1) I tried to propagate then entire CurrentState back, but that requires more changes, especially v1beta3 we retired PodState, and introduced PodStatus. We can handle that separately when starting to support v1beta3.
2) Several docker issues filed against docker, and some are fixed and should be available in v1.3 release.
3) Arbitrary termination reasons initiated by the user or management system will be handled separately through #1462
4) Need to decide how to integrate with events next to make termination reasons more comprehensive. 
