### PR TITLE
Initial support to propagating the termination reasons and image failures

### DIFF
--- a/hack/e2e-suite/basic.sh
+++ b/hack/e2e-suite/basic.sh
@@ -50,7 +50,7 @@ while [ $ALL_RUNNING -ne 1 ]; do
   ALL_RUNNING=1
   for id in $POD_ID_LIST; do
     CURRENT_STATUS=$($KUBECFG -template '{{and .CurrentState.Info.mynginx.State.Running .CurrentState.Info.net.State.Running}}' get pods/$id)
-    if [ "$CURRENT_STATUS" != "{}" ]; then
+    if [ "$CURRENT_STATUS" != "{0001-01-01 00:00:00 +0000 UTC}" ]; then
       ALL_RUNNING=0
     fi
   done

--- a/hack/e2e-suite/update.sh
+++ b/hack/e2e-suite/update.sh
@@ -47,12 +47,12 @@ function validate() {
       local template_string current_status current_image host_ip
       template_string="{{and ((index .CurrentState.Info \"${CONTROLLER_NAME}\").State.Running) .CurrentState.Info.net.State.Running}}"
       current_status=$($KUBECFG -template="${template_string}" get "pods/$id")
-      if [[ "$current_status" != "{}" ]]; then
+      if [ "$current_status" != "{0001-01-01 00:00:00 +0000 UTC}" ]; then
         echo "  $id is created but not running"
         continue
       fi
 
-      template_string="{{(index .CurrentState.Info \"${CONTROLLER_NAME}\").DetailInfo.Config.Image}}"
+      template_string="{{(index .CurrentState.Info \"${CONTROLLER_NAME}\").Image}}"
       current_image=$($KUBECFG -template="${template_string}" get "pods/$id")
       if [[ "$current_image" != "${DOCKER_HUB_USER}/update-demo:${container_image_version}" ]]; then
         echo "  ${id} is created but running wrong image"

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -18,9 +18,9 @@ package api
 
 import (
 	"strings"
+	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/fsouza/go-dockerclient"
 )
 
 // Common string formats
@@ -302,12 +302,15 @@ type ContainerStateWaiting struct {
 }
 
 type ContainerStateRunning struct {
+	StartedAt time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
 }
 
 type ContainerStateTerminated struct {
-	ExitCode int    `json:"exitCode,omitempty" yaml:"exitCode,omitempty"`
-	Signal   int    `json:"signal,omitempty" yaml:"signal,omitempty"`
-	Reason   string `json:"reason,omitempty" yaml:"reason,omitempty"`
+	ExitCode   int       `json:"exitCode" yaml:"exitCode"`
+	Signal     int       `json:"signal,omitempty" yaml:"signal,omitempty"`
+	Reason     string    `json:"reason,omitempty" yaml:"reason,omitempty"`
+	StartedAt  time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
+	FinishedAt time.Time `json:"finishedAt,omitempty" yaml:"finishedAt,omitempty"`
 }
 
 type ContainerState struct {
@@ -323,12 +326,11 @@ type ContainerStatus struct {
 	// defined for container?
 	State        ContainerState `json:"state,omitempty" yaml:"state,omitempty"`
 	RestartCount int            `json:"restartCount" yaml:"restartCount"`
-	// TODO(dchen1107): Introduce our own NetworkSettings struct here?
+	// TODO(dchen1107): Deprecated this soon once we pull entire PodStatus from node,
+	// not just PodInfo. Now we need this to remove docker.Container from API
+	PodIP string `json:"podIP,omitempty" yaml:"podIP,omitempty"`
 	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
 	// usage should be included.
-	// TODO(dchen1107):  In long run, I think we should replace this with our own struct to remove
-	// the dependency on docker.
-	DetailInfo docker.Container `json:"detailInfo,omitempty" yaml:"detailInfo,omitempty"`
 }
 
 // PodInfo contains one entry for every container with available info.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -329,6 +329,8 @@ type ContainerStatus struct {
 	// TODO(dchen1107): Deprecated this soon once we pull entire PodStatus from node,
 	// not just PodInfo. Now we need this to remove docker.Container from API
 	PodIP string `json:"podIP,omitempty" yaml:"podIP,omitempty"`
+	// TODO(dchen1107): Need to decide how to reprensent this in v1beta3
+	Image string `yaml:"image" json:"image"`
 	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
 	// usage should be included.
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -329,7 +329,7 @@ type ContainerStatus struct {
 	// TODO(dchen1107): Deprecated this soon once we pull entire PodStatus from node,
 	// not just PodInfo. Now we need this to remove docker.Container from API
 	PodIP string `json:"podIP,omitempty" yaml:"podIP,omitempty"`
-	// TODO(dchen1107): Need to decide how to reprensent this in v1beta3
+	// TODO(dchen1107): Need to decide how to represent this in v1beta3
 	Image string `yaml:"image" json:"image"`
 	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
 	// usage should be included.

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	"time"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/fsouza/go-dockerclient"
 )
 
 // Common string formats
@@ -286,12 +287,15 @@ type ContainerStateWaiting struct {
 }
 
 type ContainerStateRunning struct {
+	StartedAt time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
 }
 
 type ContainerStateTerminated struct {
-	ExitCode int    `json:"exitCode,omitempty" yaml:"exitCode,omitempty"`
-	Signal   int    `json:"signal,omitempty" yaml:"signal,omitempty"`
-	Reason   string `json:"reason,omitempty" yaml:"reason,omitempty"`
+	ExitCode   int       `json:"exitCode" yaml:"exitCode"`
+	Signal     int       `json:"signal,omitempty" yaml:"signal,omitempty"`
+	Reason     string    `json:"reason,omitempty" yaml:"reason,omitempty"`
+	StartedAt  time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
+	FinishedAt time.Time `json:"finishedAt,omitempty" yaml:"finishedAt,omitempty"`
 }
 
 type ContainerState struct {
@@ -307,12 +311,11 @@ type ContainerStatus struct {
 	// defined for container?
 	State        ContainerState `json:"state,omitempty" yaml:"state,omitempty"`
 	RestartCount int            `json:"restartCount" yaml:"restartCount"`
-	// TODO(dchen1107): Introduce our own NetworkSettings struct here?
+	// TODO(dchen1107): Deprecated this soon once we pull entire PodStatus from node,
+	// not just PodInfo. Now we need this to remove docker.Container from API
+	PodIP string `json:"podIP,omitempty" yaml:"podIP,omitempty"`
 	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
 	// usage should be included.
-	// TODO(dchen1107):  In long run, I think we should replace this with our own struct to remove
-	// the dependency on docker.
-	DetailInfo docker.Container `json:"detailInfo,omitempty" yaml:"detailInfo,omitempty"`
 }
 
 // PodInfo contains one entry for every container with available info.

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -314,6 +314,8 @@ type ContainerStatus struct {
 	// TODO(dchen1107): Deprecated this soon once we pull entire PodStatus from node,
 	// not just PodInfo. Now we need this to remove docker.Container from API
 	PodIP string `json:"podIP,omitempty" yaml:"podIP,omitempty"`
+	// TODO(dchen1107): Need to decide how to reprensent this in v1beta3
+	Image string `yaml:"image" json:"image"`
 	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
 	// usage should be included.
 }

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1beta2
 
 import (
+	"time"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/fsouza/go-dockerclient"
 )
 
 // Common string formats
@@ -282,12 +283,15 @@ type ContainerStateWaiting struct {
 }
 
 type ContainerStateRunning struct {
+	StartedAt time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
 }
 
 type ContainerStateTerminated struct {
-	ExitCode int    `json:"exitCode,omitempty" yaml:"exitCode,omitempty"`
-	Signal   int    `json:"signal,omitempty" yaml:"signal,omitempty"`
-	Reason   string `json:"reason,omitempty" yaml:"reason,omitempty"`
+	ExitCode   int       `json:"exitCode" yaml:"exitCode"`
+	Signal     int       `json:"signal,omitempty" yaml:"signal,omitempty"`
+	Reason     string    `json:"reason,omitempty" yaml:"reason,omitempty"`
+	StartedAt  time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
+	FinishedAt time.Time `json:"finishedAt,omitempty" yaml:"finishedAt,omitempty"`
 }
 
 type ContainerState struct {
@@ -303,16 +307,14 @@ type ContainerStatus struct {
 	// defined for container?
 	State        ContainerState `json:"state,omitempty" yaml:"state,omitempty"`
 	RestartCount int            `json:"restartCount" yaml:"restartCount"`
-	// TODO(dchen1107): Introduce our own NetworkSettings struct here?
+	// TODO(dchen1107): Deprecated this soon once we pull entire PodStatus from node,
+	// not just PodInfo. Now we need this to remove docker.Container from API
+	PodIP string `json:"podIP,omitempty" yaml:"podIP,omitempty"`
 	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
 	// usage should be included.
-	// TODO(dchen1107):  In long run, I think we should replace this with our own struct to remove
-	// the dependency on docker.
-	DetailInfo docker.Container `json:"detailInfo,omitempty" yaml:"detailInfo,omitempty"`
 }
 
 // PodInfo contains one entry for every container with available info.
-// TODO(dchen1107): Replace docker.Container below with ContainerStatus defined above.
 type PodInfo map[string]ContainerStatus
 
 type RestartPolicyAlways struct{}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -310,6 +310,8 @@ type ContainerStatus struct {
 	// TODO(dchen1107): Deprecated this soon once we pull entire PodStatus from node,
 	// not just PodInfo. Now we need this to remove docker.Container from API
 	PodIP string `json:"podIP,omitempty" yaml:"podIP,omitempty"`
+	// TODO(dchen1107): Need to decide how to reprensent this in v1beta3
+	Image string `yaml:"image" json:"image"`
 	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
 	// usage should be included.
 }

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1beta3
 
 import (
+	"time"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/fsouza/go-dockerclient"
 )
 
 // Common string formats
@@ -312,12 +313,15 @@ type ContainerStateWaiting struct {
 }
 
 type ContainerStateRunning struct {
+	StartedAt time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
 }
 
 type ContainerStateTerminated struct {
-	ExitCode int    `json:"exitCode,omitempty" yaml:"exitCode,omitempty"`
-	Signal   int    `json:"signal,omitempty" yaml:"signal,omitempty"`
-	Reason   string `json:"reason,omitempty" yaml:"reason,omitempty"`
+	ExitCode   int       `json:"exitCode" yaml:"exitCode"`
+	Signal     int       `json:"signal,omitempty" yaml:"signal,omitempty"`
+	Reason     string    `json:"reason,omitempty" yaml:"reason,omitempty"`
+	StartedAt  time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
+	FinishedAt time.Time `json:"finishedAt,omitempty" yaml:"finishedAt,omitempty"`
 }
 
 type ContainerState struct {
@@ -336,14 +340,11 @@ type ContainerStatus struct {
 	// TODO(dchen1107): Introduce our own NetworkSettings struct here?
 	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
 	// usage should be included.
-	// TODO(dchen1107):  In long run, I think we should replace this with our own struct to remove
-	// the dependency on docker.
-	DetailInfo docker.Container `json:"detailInfo,omitempty" yaml:"detailInfo,omitempty"`
 }
 
 // PodInfo contains one entry for every container with available info.
 // TODO(dchen1107): Replace docker.Container below with ContainerStatus defined above.
-type PodInfo map[string]docker.Container
+type PodInfo map[string]ContainerStatus
 
 type RestartPolicyAlways struct{}
 

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -338,6 +338,7 @@ type ContainerStatus struct {
 	State        ContainerState `json:"state,omitempty" yaml:"state,omitempty"`
 	RestartCount int            `json:"restartCount" yaml:"restartCount"`
 	// TODO(dchen1107): Introduce our own NetworkSettings struct here?
+	// TODO(dchen1107): Which image the container is running with?
 	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
 	// usage should be included.
 }

--- a/pkg/client/podinfo_test.go
+++ b/pkg/client/podinfo_test.go
@@ -27,14 +27,11 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/fsouza/go-dockerclient"
 )
 
 func TestHTTPPodInfoGetter(t *testing.T) {
 	expectObj := api.PodInfo{
-		"myID": api.ContainerStatus{
-			DetailInfo: docker.Container{ID: "myID"},
-		},
+		"myID": api.ContainerStatus{},
 	}
 	body, err := json.Marshal(expectObj)
 	if err != nil {
@@ -69,17 +66,14 @@ func TestHTTPPodInfoGetter(t *testing.T) {
 	}
 
 	// reflect.DeepEqual(expectObj, gotObj) doesn't handle blank times well
-	if len(gotObj) != len(expectObj) ||
-		expectObj["myID"].DetailInfo.ID != gotObj["myID"].DetailInfo.ID {
+	if len(gotObj) != len(expectObj) {
 		t.Errorf("Unexpected response.  Expected: %#v, received %#v", expectObj, gotObj)
 	}
 }
 
 func TestHTTPPodInfoGetterNotFound(t *testing.T) {
 	expectObj := api.PodInfo{
-		"myID": api.ContainerStatus{
-			DetailInfo: docker.Container{ID: "myID"},
-		},
+		"myID": api.ContainerStatus{},
 	}
 	_, err := json.Marshal(expectObj)
 	if err != nil {

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -293,8 +293,9 @@ func inspectContainer(client DockerInterface, dockerID, containerName string) (*
 
 	glog.V(3).Infof("Container: %s [%s] inspect result %+v", *inspectResult)
 	var containerStatus api.ContainerStatus
-	waiting := true
+	containerStatus.Image = inspectResult.Config.Image
 
+	waiting := true
 	if inspectResult.State.Running {
 		containerStatus.State.Running = &api.ContainerStateRunning{
 			StartedAt: inspectResult.State.StartedAt,

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -44,7 +44,6 @@ type DockerContainerData struct {
 type DockerInterface interface {
 	ListContainers(options docker.ListContainersOptions) ([]docker.APIContainers, error)
 	InspectContainer(id string) (*docker.Container, error)
-	InspectImage(name string) (*docker.Image, error)
 	CreateContainer(docker.CreateContainerOptions) (*docker.Container, error)
 	StartContainer(id string, hostConfig *docker.HostConfig) error
 	StopContainer(id string, timeout uint) error

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -29,6 +29,7 @@ type FakeDockerClient struct {
 	sync.Mutex
 	ContainerList []docker.APIContainers
 	Container     *docker.Container
+	Image         *docker.Image
 	Err           error
 	called        []string
 	Stopped       []string
@@ -67,8 +68,17 @@ func (f *FakeDockerClient) ListContainers(options docker.ListContainersOptions) 
 func (f *FakeDockerClient) InspectContainer(id string) (*docker.Container, error) {
 	f.Lock()
 	defer f.Unlock()
-	f.called = append(f.called, "inspect")
+	f.called = append(f.called, "inspect_container")
 	return f.Container, f.Err
+}
+
+// InspectImage is a test-spy implementation of DockerInterface.InspectImage.
+// It adds an entry "inspect" to the internal method call record.
+func (f *FakeDockerClient) InspectImage(name string) (*docker.Image, error) {
+	f.Lock()
+	defer f.Unlock()
+	f.called = append(f.called, "inspect_image")
+	return f.Image, f.Err
 }
 
 // CreateContainer is a test-spy implementation of DockerInterface.CreateContainer.

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -140,10 +140,6 @@ func (f *FakeDockerClient) PullImage(opts docker.PullImageOptions, auth docker.A
 	return f.Err
 }
 
-func (f *FakeDockerClient) InspectImage(name string) (*docker.Image, error) {
-	return nil, f.Err
-}
-
 // FakeDockerPuller is a stub implementation of DockerPuller.
 type FakeDockerPuller struct {
 	sync.Mutex

--- a/pkg/kubelet/handlers.go
+++ b/pkg/kubelet/handlers.go
@@ -77,8 +77,8 @@ func (h *httpActionHandler) Run(podFullName, uuid string, container *api.Contain
 			return err
 		}
 		netInfo, found := info[networkContainerName]
-		if found && netInfo.DetailInfo.NetworkSettings != nil {
-			host = netInfo.DetailInfo.NetworkSettings.IPAddress
+		if found {
+			host = netInfo.PodIP
 		} else {
 			return fmt.Errorf("failed to find networking container: %v", info)
 		}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -771,8 +771,7 @@ func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName, tail stri
 func (kl *Kubelet) GetPodInfo(podFullName, uuid string) (api.PodInfo, error) {
 	var manifest api.ContainerManifest
 	for _, pod := range kl.pods {
-		fullName := fmt.Sprintf("%s.%s", pod.Name, pod.Namespace)
-		if fullName == podFullName {
+		if GetPodFullName(&pod) == podFullName {
 			manifest = pod.Manifest
 			break
 		}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -227,7 +227,7 @@ func TestSyncPodsCreatesNetAndContainer(t *testing.T) {
 	kubelet.drainWorkers()
 
 	verifyCalls(t, fakeDocker, []string{
-		"list", "list", "create", "start", "list", "inspect", "list", "create", "start"})
+		"list", "list", "create", "start", "list", "inspect_container", "list", "create", "start"})
 
 	fakeDocker.Lock()
 
@@ -316,7 +316,7 @@ func TestSyncPodsWithNetCreatesContainer(t *testing.T) {
 	kubelet.drainWorkers()
 
 	verifyCalls(t, fakeDocker, []string{
-		"list", "list", "list", "inspect", "list", "create", "start"})
+		"list", "list", "list", "inspect_container", "list", "create", "start"})
 
 	fakeDocker.Lock()
 	if len(fakeDocker.Created) != 1 ||
@@ -366,7 +366,7 @@ func TestSyncPodsWithNetCreatesContainerCallsHandler(t *testing.T) {
 	kubelet.drainWorkers()
 
 	verifyCalls(t, fakeDocker, []string{
-		"list", "list", "list", "inspect", "list", "create", "start"})
+		"list", "list", "list", "inspect_container", "list", "create", "start"})
 
 	fakeDocker.Lock()
 	if len(fakeDocker.Created) != 1 ||
@@ -406,7 +406,7 @@ func TestSyncPodsDeletesWithNoNetContainer(t *testing.T) {
 	kubelet.drainWorkers()
 
 	verifyCalls(t, fakeDocker, []string{
-		"list", "list", "stop", "create", "start", "list", "list", "inspect", "list", "create", "start"})
+		"list", "list", "stop", "create", "start", "list", "list", "inspect_container", "list", "create", "start"})
 
 	// A map iteration is used to delete containers, so must not depend on
 	// order here.

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -273,7 +273,7 @@ func TestSyncPodsCreatesNetAndContainerPullsImage(t *testing.T) {
 	kubelet.drainWorkers()
 
 	verifyCalls(t, fakeDocker, []string{
-		"list", "list", "create", "start", "list", "inspect", "list", "create", "start"})
+		"list", "list", "create", "start", "list", "inspect_container", "list", "create", "start"})
 
 	fakeDocker.Lock()
 

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -85,8 +85,20 @@ func TestRunOnce(t *testing.T) {
 			}},
 		},
 		inspectContainersResults: []inspectContainersResult{
-			{label: "syncPod", container: docker.Container{State: docker.State{Running: true}}},
-			{label: "syncPod", container: docker.Container{State: docker.State{Running: true}}},
+			{
+				label: "syncPod",
+				container: docker.Container{
+					Config: &docker.Config{Image: "someimage"},
+					State:  docker.State{Running: true},
+				},
+			},
+			{
+				label: "syncPod",
+				container: docker.Container{
+					Config: &docker.Config{Image: "someimage"},
+					State:  docker.State{Running: true},
+				},
+			},
 		},
 		t: t,
 	}

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/fsouza/go-dockerclient"
 	"github.com/google/cadvisor/info"
 )
 
@@ -147,9 +146,7 @@ func TestContainers(t *testing.T) {
 func TestPodInfo(t *testing.T) {
 	fw := newServerTest()
 	expected := api.PodInfo{
-		"goodpod": api.ContainerStatus{
-			DetailInfo: docker.Container{ID: "myContainerID"},
-		},
+		"goodpod": api.ContainerStatus{},
 	}
 	fw.fakeKubelet.infoFunc = func(name string) (api.PodInfo, error) {
 		if name == "goodpod.etcd" {

--- a/pkg/master/pod_cache_test.go
+++ b/pkg/master/pod_cache_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
-	"github.com/fsouza/go-dockerclient"
 )
 
 type FakePodInfoGetter struct {
@@ -42,9 +41,7 @@ func TestPodCacheGet(t *testing.T) {
 	cache := NewPodCache(nil, nil)
 
 	expected := api.PodInfo{
-		"foo": api.ContainerStatus{
-			DetailInfo: docker.Container{ID: "foo"},
-		},
+		"foo": api.ContainerStatus{},
 	}
 	cache.podInfo["foo"] = expected
 
@@ -71,9 +68,7 @@ func TestPodCacheGetMissing(t *testing.T) {
 
 func TestPodGetPodInfoGetter(t *testing.T) {
 	expected := api.PodInfo{
-		"foo": api.ContainerStatus{
-			DetailInfo: docker.Container{ID: "foo"},
-		},
+		"foo": api.ContainerStatus{},
 	}
 	fake := FakePodInfoGetter{
 		data: expected,
@@ -107,9 +102,7 @@ func TestPodUpdateAllContainers(t *testing.T) {
 	mockRegistry := registrytest.NewPodRegistry(&api.PodList{Items: pods})
 
 	expected := api.PodInfo{
-		"foo": api.ContainerStatus{
-			DetailInfo: docker.Container{ID: "foo"},
-		},
+		"foo": api.ContainerStatus{},
 	}
 	fake := FakePodInfoGetter{
 		data: expected,

--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -226,8 +226,8 @@ func (rs *REST) fillPodInfo(pod *api.Pod) {
 		pod.CurrentState.Info = info
 		netContainerInfo, ok := info["net"]
 		if ok {
-			if netContainerInfo.DetailInfo.NetworkSettings != nil {
-				pod.CurrentState.PodIP = netContainerInfo.DetailInfo.NetworkSettings.IPAddress
+			if netContainerInfo.PodIP != "" {
+				pod.CurrentState.PodIP = netContainerInfo.PodIP
 			} else {
 				glog.Warningf("No network settings: %#v", netContainerInfo)
 			}

--- a/pkg/registry/pod/rest_test.go
+++ b/pkg/registry/pod/rest_test.go
@@ -31,8 +31,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-
-	"github.com/fsouza/go-dockerclient"
 )
 
 func expectApiStatusError(t *testing.T, ch <-chan runtime.Object, msg string) {
@@ -605,16 +603,17 @@ func (f *FakePodInfoGetter) GetPodInfo(host, podID string) (api.PodInfo, error) 
 
 func TestFillPodInfo(t *testing.T) {
 	expectedIP := "1.2.3.4"
+	expectedTime, _ := time.Parse("2013-Feb-03", "2013-Feb-03")
 	fakeGetter := FakePodInfoGetter{
 		info: map[string]api.ContainerStatus{
 			"net": {
-				DetailInfo: docker.Container{
-					ID:   "foobar",
-					Path: "bin/run.sh",
-					NetworkSettings: &docker.NetworkSettings{
-						IPAddress: expectedIP,
+				State: api.ContainerState{
+					Running: &api.ContainerStateRunning{
+						StartedAt: expectedTime,
 					},
 				},
+				RestartCount: 1,
+				PodIP:        expectedIP,
 			},
 		},
 	}
@@ -636,10 +635,7 @@ func TestFillPodInfoNoData(t *testing.T) {
 	fakeGetter := FakePodInfoGetter{
 		info: map[string]api.ContainerStatus{
 			"net": {
-				DetailInfo: docker.Container{
-					ID:   "foobar",
-					Path: "bin/run.sh",
-				},
+				State: api.ContainerState{},
 			},
 		},
 	}


### PR DESCRIPTION
Resent ... :-)

I still need to fix e2e tests. Unfortunately everytime I ran e2e, it ran into a weird issue. Will update this PR once e2e is fixed.

With this PR, docker.Container is retired completely from our API. But to achieve that, I have to introduce some to be deprecated field, such as PodIP for now. Once below TODO 1) is handled, those fields will be removed. (#137)

Also why container is waiting is added in this PR. (#941) Currently only two possible causes: 
1) The request image is not ready (The reasons can be categorized into 2, one is still pulling, another one is pulling failure. Filed an issue to docker, but it should be ok for now since we already have creation timestamp, and real container state reported)
2) Failed to run the container (Current I just guess it based on available data, but a pending PR to resolve docker/docker#8294 should give us more detail information)

All those information are not comprehensive

There are many TODOs following:
1) I tried to propagate then entire CurrentState back, but that requires more changes, especially v1beta3 we retired PodState, and introduced PodStatus. We can handle that separately when starting to support v1beta3.
2) Several docker issues filed against docker, and some are fixed and should be available in v1.3 release.
3) Arbitrary termination reasons initiated by the user or management system will be handled separately through #1462
4) Need to decide how to integrate with events next to make termination reasons more comprehensive.
