### PR TITLE
Compilation error on HEAD: Add JSONBase to v1beta3/types.go to prevent it

### DIFF
--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -836,8 +836,9 @@ type Event struct {
 
 // EventList is a list of events.
 type EventList struct {
-	JSONBase `json:",inline" yaml:",inline"`
-	Items    []Event `json:"items" yaml:"items"`
+	TypeMeta `json:",inline" yaml:",inline"`
+	Metadata ListMeta `json:"metadata,inline" yaml:"metadata,inline"`
+	Items    []Event  `json:"items" yaml:"items"`
 }
 
 // TODO: for readability


### PR DESCRIPTION
On a clean checkout (at https://github.com/GoogleCloudPlatform/kubernetes/commit/fd5a9080707fa871fb8b46d161816f84eb675b31), when I do `go build ./...`, I get a compilation error:

```
sghods-mba:kubernetes sam$ go build ./...
# github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3
pkg/api/v1beta3/types.go:839: undefined: JSONBase
```

I'm sure the intent was to fully remove JSONBase, but I don't know how to do that, so I did the minimal amount to just fix the build.
