### PR TITLE
Fix bug in minion registrytest.

### DIFF
--- a/pkg/registry/registrytest/minion.go
+++ b/pkg/registry/registrytest/minion.go
@@ -76,7 +76,7 @@ func (r *MinionRegistry) Delete(minion string) error {
 	var newList []api.Minion
 	for _, node := range r.Minions.Items {
 		if node.ID != minion {
-			newList = append(newList, api.Minion{JSONBase: api.JSONBase{ID: minion}})
+			newList = append(newList, api.Minion{JSONBase: api.JSONBase{ID: node.ID}})
 		}
 	}
 	r.Minions.Items = newList


### PR DESCRIPTION
I think this is introduced in #1474. 

The error didn't surface because Delete is not used apart from caching registry, and which only test cache layer instead of underline registry.
