### PR TITLE
Prevent scheduler from crashing infinitely if apiserver is unreachable

### DIFF
--- a/plugin/cmd/scheduler/scheduler.go
+++ b/plugin/cmd/scheduler/scheduler.go
@@ -58,7 +58,10 @@ func main() {
 	go http.ListenAndServe(net.JoinHostPort(address.String(), strconv.Itoa(*port)), nil)
 
 	configFactory := &factory.ConfigFactory{Client: kubeClient}
-	config := configFactory.Create()
+	config, err := configFactory.Create()
+	if err != nil {
+		glog.Fatalf("Can't create scheduler config: %v", err)
+	}
 	s := scheduler.New(config)
 	s.Run()
 

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -42,7 +42,7 @@ type ConfigFactory struct {
 }
 
 // Create creates a scheduler and all support functions.
-func (factory *ConfigFactory) Create() *scheduler.Config {
+func (factory *ConfigFactory) Create() (*scheduler.Config, error) {
 	// Watch and queue pods that need scheduling.
 	podQueue := cache.NewFIFO()
 	cache.NewReflector(factory.createUnassignedPodLW(), &api.Pod{}, podQueue).Run()
@@ -66,8 +66,7 @@ func (factory *ConfigFactory) Create() *scheduler.Config {
 
 	nodes, err := factory.Client.ListMinions()
 	if err != nil {
-		glog.Errorf("failed to obtain minion information, aborting")
-		return nil
+		return nil, err
 	}
 	algo := algorithm.NewGenericScheduler(
 		[]algorithm.FitPredicate{
@@ -98,7 +97,7 @@ func (factory *ConfigFactory) Create() *scheduler.Config {
 			return pod
 		},
 		Error: factory.makeDefaultErrorFunc(&podBackoff, podQueue),
-	}
+	}, nil
 }
 
 type listWatch struct {


### PR DESCRIPTION
Currently the `scheduler` binary will enter an infinite nil pointer reference loop if `apiserver` is not ready to accept requests when `scheduler` starts up. (This happens in hack/local-up-cluster.sh, which will be fixed in a separate PR.) This PR fixes it to just abort immediately.

Better would be another PR which cleans this up to do some retries... the minion information should likely be injected into the CreateConfig() function. For now this has been coded up just to prevent my disk from filling up with log messages every time I run hack/local-up-cluster.sh.

FTR one should never return nil for a reference without a corresponding error param. `if err != nil` is the only way that nil pointer references are conventionally avoided in Go.
