### PR TITLE
Fix hack/local-up-cluster.sh to ensure apiserver comes up

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -54,6 +54,9 @@ APISERVER_LOG=/tmp/apiserver.log
   --cors_allowed_origins="${API_CORS_ALLOWED_ORIGINS}" >"${APISERVER_LOG}" 2>&1 &
 APISERVER_PID=$!
 
+# Wait for apiserver to come up before launching the rest of the components.
+wait_for_url "http://$API_HOST:$API_PORT/api/v1beta1/pods" "apiserver: "
+
 CTLRMGR_LOG=/tmp/controller-manager.log
 "${GO_OUT}/controller-manager" \
   --master="${API_HOST}:${API_PORT}" >"${CTLRMGR_LOG}" 2>&1 &


### PR DESCRIPTION
Currently, `scheduler` requires `apiserver` to be up before starting up. This PR ensures that, when running `hack/local-up-cluster.sh`, `apiserver` is up before starting subsequent components. Without this, `hack/local-up-cluster.sh` causes `scheduler` to abort most of the time.
