### PR TITLE
Fix a problem with for loops, copy semantics and async routines.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -635,8 +635,9 @@ func (kl *Kubelet) SyncPods(pods []Pod) error {
 	}
 
 	// Check for any containers that need starting
-	for _, pod := range pods {
-		podFullName := GetPodFullName(&pod)
+	for ix := range pods {
+		pod := &pods[ix]
+		podFullName := GetPodFullName(pod)
 		uuid := pod.Manifest.UUID
 
 		// Add all containers (including net) to the map.
@@ -647,7 +648,7 @@ func (kl *Kubelet) SyncPods(pods []Pod) error {
 
 		// Run the sync in an async manifest worker.
 		kl.podWorkers.Run(podFullName, func() {
-			err := kl.syncPod(&pod, dockerContainers)
+			err := kl.syncPod(pod, dockerContainers)
 			if err != nil {
 				glog.Errorf("Error syncing pod: %v skipping.", err)
 			}


### PR DESCRIPTION
@proppy @bgrant0607 Fixes a bug introduced by https://github.com/GoogleCloudPlatform/kubernetes/commit/f91162cf789ac6742e4aa822a2542ab14454f909#diff-bf28da68f62a8df6e99e447c4351122dR637

Go lang for loop copy semantics and async routines are _not_ friends.
