### PR TITLE
Increase logging levels in hack/local-up-cluster.sh

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -5,21 +5,22 @@ The following conventions for the glog levels to use.  glog is globally prefered
 
 * glog.Errorf() - Always an error
 * glog.Warningf() - Something unexpected, but probably not an error
-* glog.Infof / glog.V(0) - Generally useful for this to ALWAYS be visible to an operator
- * Programmer errors
- * Logging extra info about a panic
- * CLI argument handling
-* glog.V(1) - A reasonable default log level if you don't want verbosity.
- * Information about config (listening on X, watching Y)
-  * Errors that repeat frequently that relate to conditions that can be corrected (pod detected as unhealthy)
-* glog.V(2) - Useful steady state information about the service and important log messages that may correlate to significant changes in the system.  This is the recommended default log level for most systems.
- * Logging HTTP requests and their exit code
- * System state changing (killing pod)
- * Controller state change events (starting pods)
- * Scheduler log messages
-* glog.V(3) - Extended information about changes
-  * More info about system state changes
-* glog.V(4) - Debug level verbosity (for now)
- * Logging in particularly thorny parts of code where you may want to come back later and check it
+* glog.Infof() has multiple levels:
+  * glog.V(0) - Generally useful for this to ALWAYS be visible to an operator
+    * Programmer errors
+    * Logging extra info about a panic
+    * CLI argument handling
+  * glog.V(1) - A reasonable default log level if you don't want verbosity.
+    * Information about config (listening on X, watching Y)
+    * Errors that repeat frequently that relate to conditions that can be corrected (pod detected as unhealthy)
+  * glog.V(2) - Useful steady state information about the service and important log messages that may correlate to significant changes in the system.  This is the recommended default log level for most systems.
+    * Logging HTTP requests and their exit code
+    * System state changing (killing pod)
+    * Controller state change events (starting pods)
+    * Scheduler log messages
+  * glog.V(3) - Extended information about changes
+    * More info about system state changes
+  * glog.V(4) - Debug level verbosity (for now)
+    * Logging in particularly thorny parts of code where you may want to come back later and check it
 
-As per the comments, the practical default level is V(2).  Developers and QE environments may wish to run at V(3) or V(4).
+As per the comments, the practical default level is V(2).  Developers and QE environments may wish to run at V(3) or V(4). If you wish to change the log level, you can pass in `-v=X` where X is the desired maximum level to log.

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -42,11 +42,13 @@ API_HOST=${API_HOST:-127.0.0.1}
 # By default only allow CORS for requests on localhost
 API_CORS_ALLOWED_ORIGINS=${API_CORS_ALLOWED_ORIGINS:-"/127.0.0.1(:[0-9]+)?$,/localhost(:[0-9]+)?$"}
 KUBELET_PORT=${KUBELET_PORT:-10250}
+LOG_LEVEL=${LOG_LEVEL:-3}
 
 GO_OUT=$(dirname $0)/../_output/go/bin
 
 APISERVER_LOG=/tmp/apiserver.log
 "${GO_OUT}/apiserver" \
+  -v=${LOG_LEVEL} \
   --address="${API_HOST}" \
   --port="${API_PORT}" \
   --etcd_servers="http://127.0.0.1:4001" \
@@ -59,11 +61,13 @@ wait_for_url "http://$API_HOST:$API_PORT/api/v1beta1/pods" "apiserver: "
 
 CTLRMGR_LOG=/tmp/controller-manager.log
 "${GO_OUT}/controller-manager" \
+  -v=${LOG_LEVEL} \
   --master="${API_HOST}:${API_PORT}" >"${CTLRMGR_LOG}" 2>&1 &
 CTLRMGR_PID=$!
 
 KUBELET_LOG=/tmp/kubelet.log
 "${GO_OUT}/kubelet" \
+  -v=${LOG_LEVEL} \
   --etcd_servers="http://127.0.0.1:4001" \
   --hostname_override="127.0.0.1" \
   --address="127.0.0.1" \
@@ -72,11 +76,13 @@ KUBELET_PID=$!
 
 PROXY_LOG=/tmp/kube-proxy.log
 "${GO_OUT}/proxy" \
+  -v=${LOG_LEVEL} \
   --master="http://${API_HOST}:${API_PORT}" >"${PROXY_LOG}" 2>&1 &
 PROXY_PID=$!
 
 SCHEDULER_LOG=/tmp/k8s-scheduler.log
 "${GO_OUT}/scheduler" \
+  -v=${LOG_LEVEL} \
   --master="http://${API_HOST}:${API_PORT}" >"${SCHEDULER_LOG}" 2>&1 &
 SCHEDULER_PID=$!
 


### PR DESCRIPTION
As per the suggestion in docs/logging.md, increase log levels in development up to 3. You could argue for 4 but that might be too much for average development, and the env var LOG_LEVEL can be specified as well. Also changed the indentation in docs/logging.md to make it a little clearer what's going on.

(This was triggered by me no longer seeing HTTP requests in apiserver logs when running hack/local-up-cluster.sh and not understanding why.)
