### PR TITLE
Move Policy test helpers into their own file

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"strings"
+)
+
+func IsPullAlways(p PullPolicy) bool {
+	// Default to pull always
+	if len(p) == 0 {
+		return true
+	}
+	return pullPoliciesEqual(p, PullAlways)
+}
+
+func IsPullNever(p PullPolicy) bool {
+	return pullPoliciesEqual(p, PullNever)
+}
+
+func IsPullIfNotPresent(p PullPolicy) bool {
+	return pullPoliciesEqual(p, PullIfNotPresent)
+}
+
+func pullPoliciesEqual(p1, p2 PullPolicy) bool {
+	return strings.ToLower(string(p1)) == strings.ToLower(string(p2))
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package api
 
 import (
-	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -194,26 +193,6 @@ const (
 	// Pull if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
 	PullIfNotPresent PullPolicy = "PullIfNotPresent"
 )
-
-func IsPullAlways(p PullPolicy) bool {
-	// Default to pull always
-	if len(p) == 0 {
-		return true
-	}
-	return pullPoliciesEqual(p, PullAlways)
-}
-
-func IsPullNever(p PullPolicy) bool {
-	return pullPoliciesEqual(p, PullNever)
-}
-
-func IsPullIfNotPresent(p PullPolicy) bool {
-	return pullPoliciesEqual(p, PullIfNotPresent)
-}
-
-func pullPoliciesEqual(p1, p2 PullPolicy) bool {
-	return strings.ToLower(string(p1)) == strings.ToLower(string(p2))
-}
 
 // Container represents a single container that is expected to be run on the host.
 type Container struct {


### PR DESCRIPTION
Since types.go should always be equal to latest API types.go, this
makes future cut and paste refactors easier.

Extracted from #1600
