### PR TITLE
Add codec to restlient test.

### DIFF
--- a/pkg/client/restclient_test.go
+++ b/pkg/client/restclient_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta2"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
@@ -105,10 +106,10 @@ func TestDoRequest(t *testing.T) {
 	testClients := []testClient{
 		{Request: testRequest{Method: "GET", Path: "good"}, Response: Response{StatusCode: 200}},
 		{Request: testRequest{Method: "GET", Path: "bad%ZZ"}, Error: true},
-		{Client: &Client{&RESTClient{baseURL: uri}}, Request: testRequest{Method: "GET", Path: "nocertificate"}, Error: true},
 		{Request: testRequest{Method: "GET", Path: "error"}, Response: Response{StatusCode: 500}, Error: true},
 		{Request: testRequest{Method: "POST", Path: "faildecode"}, Response: Response{StatusCode: 200, RawBody: &invalid}},
 		{Request: testRequest{Method: "GET", Path: "failread"}, Response: Response{StatusCode: 200, RawBody: &invalid}},
+		{Client: &Client{&RESTClient{baseURL: uri, Codec: testapi.CodecForVersionOrDie()}}, Request: testRequest{Method: "GET", Path: "nocertificate"}, Error: true},
 	}
 	for _, c := range testClients {
 		client := c.Setup()


### PR DESCRIPTION
I've seen the error recently:

```
--- FAIL: TestDoRequest (0.00 seconds)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x28 pc=0x44fe39]
```

After some dig in, I find that Codec is nil, but I don't know why travis is passing, am i missing something?
