### PR TITLE
Fix an issue on GetContainerInfo.

### DIFF
--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -318,9 +318,11 @@ func (s *Server) serveStats(w http.ResponseWriter, req *http.Request) {
 		errors.New("pod level status currently unimplemented")
 	case 3:
 		// Backward compatibility without uuid information
-		stats, err = s.host.GetContainerInfo(components[1], "", components[2], &query)
+		podFullName := GetPodFullName(&Pod{Name: components[1], Namespace: "etcd"})
+		stats, err = s.host.GetContainerInfo(podFullName, "", components[2], &query)
 	case 4:
-		stats, err = s.host.GetContainerInfo(components[1], components[2], components[2], &query)
+		podFullName := GetPodFullName(&Pod{Name: components[1], Namespace: "etcd"})
+		stats, err = s.host.GetContainerInfo(podFullName, components[2], components[2], &query)
 	default:
 		http.Error(w, "unknown resource.", http.StatusNotFound)
 		return

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -174,7 +174,8 @@ func TestPodInfo(t *testing.T) {
 func TestContainerInfo(t *testing.T) {
 	fw := newServerTest()
 	expectedInfo := &info.ContainerInfo{}
-	expectedPodID := "somepod"
+	podID := "somepod"
+	expectedPodID := "somepod" + ".etcd"
 	expectedContainerName := "goodcontainer"
 	fw.fakeKubelet.containerInfoFunc = func(podID, containerName string, req *info.ContainerInfoRequest) (*info.ContainerInfo, error) {
 		if podID != expectedPodID || containerName != expectedContainerName {
@@ -183,7 +184,7 @@ func TestContainerInfo(t *testing.T) {
 		return expectedInfo, nil
 	}
 
-	resp, err := http.Get(fw.testHTTPServer.URL + fmt.Sprintf("/stats/%v/%v", expectedPodID, expectedContainerName))
+	resp, err := http.Get(fw.testHTTPServer.URL + fmt.Sprintf("/stats/%v/%v", podID, expectedContainerName))
 	if err != nil {
 		t.Fatalf("Got error GETing: %v", err)
 	}


### PR DESCRIPTION
I believe the issue was first introduced when we append namespace to docker
container's name. This is a temporary fix for #160.

@brendandburns 
