### PR TITLE
make api match intent with less specific type

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -165,7 +165,7 @@ func StringDiff(a, b string) string {
 }
 
 // Takes a list of strings and compiles them into a list of regular expressions
-func CompileRegexps(regexpStrings StringList) ([]*regexp.Regexp, error) {
+func CompileRegexps(regexpStrings []string) ([]*regexp.Regexp, error) {
 	regexps := []*regexp.Regexp{}
 	for _, regexpStr := range regexpStrings {
 		r, err := regexp.Compile(regexpStr)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -206,3 +206,28 @@ func TestStringDiff(t *testing.T) {
 		t.Errorf("diff returned %v", diff)
 	}
 }
+
+func TestCompileRegex(t *testing.T) {
+	uncompiledRegexes := []string{"endsWithMe$", "^startingWithMe"}
+	regexes, err := CompileRegexps(uncompiledRegexes)
+
+	if err != nil {
+		t.Errorf("Failed to compile legal regexes: '%v': %v", uncompiledRegexes, err)
+	}
+	if len(regexes) != len(uncompiledRegexes) {
+		t.Errorf("Wrong number of regexes returned: '%v': %v", uncompiledRegexes, regexes)
+	}
+
+	if !regexes[0].MatchString("Something that endsWithMe") {
+		t.Errorf("Wrong regex returned: '%v': %v", uncompiledRegexes[0], regexes[0])
+	}
+	if regexes[0].MatchString("Something that doesn't endsWithMe.") {
+		t.Errorf("Wrong regex returned: '%v': %v", uncompiledRegexes[0], regexes[0])
+	}
+	if !regexes[1].MatchString("startingWithMe is very important") {
+		t.Errorf("Wrong regex returned: '%v': %v", uncompiledRegexes[1], regexes[1])
+	}
+	if regexes[1].MatchString("not startingWithMe should fail") {
+		t.Errorf("Wrong regex returned: '%v': %v", uncompiledRegexes[1], regexes[1])
+	}
+}


### PR DESCRIPTION
The intent of this API is to take a list of regular expression strings and return a slice of Regexps.  The type "StringList" is unnecessarily restrictive and prevents other callers from using simple slice of strings.  This change just relaxes the type to match the comment and the intent.
