### PR TITLE
Refactor HealthCheck to take podUUID as its own argument

### DIFF
--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -35,11 +35,31 @@ func init() {
 		&Status{},
 		&ServerOpList{},
 		&ServerOp{},
-		&ContainerManifestList{},
 		&Endpoints{},
 		&EndpointsList{},
 		&Binding{},
 		&Event{},
 		&EventList{},
+		&ContainerManifestList{},
+		&BoundPods{},
 	)
 }
+
+func (*Pod) IsAnAPIObject()                       {}
+func (*PodList) IsAnAPIObject()                   {}
+func (*ReplicationController) IsAnAPIObject()     {}
+func (*ReplicationControllerList) IsAnAPIObject() {}
+func (*Service) IsAnAPIObject()                   {}
+func (*ServiceList) IsAnAPIObject()               {}
+func (*Endpoints) IsAnAPIObject()                 {}
+func (*EndpointsList) IsAnAPIObject()             {}
+func (*Minion) IsAnAPIObject()                    {}
+func (*MinionList) IsAnAPIObject()                {}
+func (*Binding) IsAnAPIObject()                   {}
+func (*Status) IsAnAPIObject()                    {}
+func (*ServerOp) IsAnAPIObject()                  {}
+func (*ServerOpList) IsAnAPIObject()              {}
+func (*Event) IsAnAPIObject()                     {}
+func (*EventList) IsAnAPIObject()                 {}
+func (*ContainerManifestList) IsAnAPIObject()     {}
+func (*BoundPods) IsAnAPIObject()                 {}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -45,32 +45,6 @@ import (
 //     or more simply:
 //         DNS_LABEL(\.DNS_LABEL)*
 
-// ContainerManifest corresponds to the Container Manifest format, documented at:
-// https://developers.google.com/compute/docs/containers/container_vms#container_manifest
-// This is used as the representation of Kubernetes workloads.
-type ContainerManifest struct {
-	// Required: This must be a supported version string, such as "v1beta1".
-	Version string `yaml:"version" json:"version"`
-	// Required: This must be a DNS_SUBDOMAIN.
-	// TODO: ID on Manifest is deprecated and will be removed in the future.
-	ID string `yaml:"id" json:"id"`
-	// TODO: UUID on Manifest is deprecated in the future once we are done
-	// with the API refactoring. It is required for now to determine the instance
-	// of a Pod.
-	UUID          string        `yaml:"uuid,omitempty" json:"uuid,omitempty"`
-	Volumes       []Volume      `yaml:"volumes" json:"volumes"`
-	Containers    []Container   `yaml:"containers" json:"containers"`
-	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty" yaml:"restartPolicy,omitempty"`
-}
-
-// ContainerManifestList is used to communicate container manifests to kubelet.
-type ContainerManifestList struct {
-	TypeMeta `json:",inline" yaml:",inline"`
-	Items    []ContainerManifest `json:"items,omitempty" yaml:"items,omitempty"`
-}
-
-func (*ContainerManifestList) IsAnAPIObject() {}
-
 // Volume represents a named volume in a pod that may be accessed by any containers in the pod.
 type Volume struct {
 	// Required: This must be a DNS_LABEL.  Each volume in a pod must have
@@ -387,8 +361,6 @@ type PodList struct {
 	Items    []Pod `json:"items" yaml:"items,omitempty"`
 }
 
-func (*PodList) IsAnAPIObject() {}
-
 // Pod is a collection of containers, used as either input (create, update) or as output (list, get).
 type Pod struct {
 	TypeMeta     `json:",inline" yaml:",inline"`
@@ -396,8 +368,6 @@ type Pod struct {
 	DesiredState PodState          `json:"desiredState,omitempty" yaml:"desiredState,omitempty"`
 	CurrentState PodState          `json:"currentState,omitempty" yaml:"currentState,omitempty"`
 }
-
-func (*Pod) IsAnAPIObject() {}
 
 // ReplicationControllerState is the state of a replication controller, either input (create, update) or as output (list, get).
 type ReplicationControllerState struct {
@@ -412,8 +382,6 @@ type ReplicationControllerList struct {
 	Items    []ReplicationController `json:"items,omitempty" yaml:"items,omitempty"`
 }
 
-func (*ReplicationControllerList) IsAnAPIObject() {}
-
 // ReplicationController represents the configuration of a replication controller.
 type ReplicationController struct {
 	TypeMeta     `json:",inline" yaml:",inline"`
@@ -421,8 +389,6 @@ type ReplicationController struct {
 	CurrentState ReplicationControllerState `json:"currentState,omitempty" yaml:"currentState,omitempty"`
 	Labels       map[string]string          `json:"labels,omitempty" yaml:"labels,omitempty"`
 }
-
-func (*ReplicationController) IsAnAPIObject() {}
 
 // PodTemplate holds the information used for creating pods.
 type PodTemplate struct {
@@ -435,8 +401,6 @@ type ServiceList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
 	Items    []Service `json:"items" yaml:"items"`
 }
-
-func (*ServiceList) IsAnAPIObject() {}
 
 // Service is a named abstraction of software service (for example, mysql) consisting of local port
 // (for example 3306) that the proxy listens on, and the selector that determines which pods
@@ -461,8 +425,6 @@ type Service struct {
 	ContainerPort util.IntOrString `json:"containerPort,omitempty" yaml:"containerPort,omitempty"`
 }
 
-func (*Service) IsAnAPIObject() {}
-
 // Endpoints is a collection of endpoints that implement the actual service, for example:
 // Name: "mysql", Endpoints: ["10.10.1.1:1909", "10.10.2.2:8834"]
 type Endpoints struct {
@@ -470,15 +432,11 @@ type Endpoints struct {
 	Endpoints []string `json:"endpoints,omitempty" yaml:"endpoints,omitempty"`
 }
 
-func (*Endpoints) IsAnAPIObject() {}
-
 // EndpointsList is a list of endpoints.
 type EndpointsList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
 	Items    []Endpoints `json:"items,omitempty" yaml:"items,omitempty"`
 }
-
-func (*EndpointsList) IsAnAPIObject() {}
 
 // NodeResources represents resources on a Kubernetes system node
 // see https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/resources.md for more details.
@@ -502,15 +460,11 @@ type Minion struct {
 	NodeResources NodeResources `json:"resources,omitempty" yaml:"resources,omitempty"`
 }
 
-func (*Minion) IsAnAPIObject() {}
-
 // MinionList is a list of minions.
 type MinionList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
 	Items    []Minion `json:"items,omitempty" yaml:"items,omitempty"`
 }
-
-func (*MinionList) IsAnAPIObject() {}
 
 // Binding is written by a scheduler to cause a pod to be bound to a host.
 type Binding struct {
@@ -518,8 +472,6 @@ type Binding struct {
 	PodID    string `json:"podID" yaml:"podID"`
 	Host     string `json:"host" yaml:"host"`
 }
-
-func (*Binding) IsAnAPIObject() {}
 
 // Status is a return value for calls that don't return other objects.
 // TODO: this could go in apiserver, but I'm including it here so clients needn't
@@ -543,8 +495,6 @@ type Status struct {
 	// Suggested HTTP return code for this status, 0 if not set.
 	Code int `json:"code,omitempty" yaml:"code,omitempty"`
 }
-
-func (*Status) IsAnAPIObject() {}
 
 // StatusDetails is a set of additional properties that MAY be set by the
 // server to provide additional information about a response. The Reason
@@ -682,15 +632,11 @@ type ServerOp struct {
 	TypeMeta `yaml:",inline" json:",inline"`
 }
 
-func (*ServerOp) IsAnAPIObject() {}
-
 // ServerOpList is a list of operations, as delivered to API clients.
 type ServerOpList struct {
 	TypeMeta `yaml:",inline" json:",inline"`
 	Items    []ServerOp `yaml:"items,omitempty" json:"items,omitempty"`
 }
-
-func (*ServerOpList) IsAnAPIObject() {}
 
 // ObjectReference contains enough information to let you inspect or modify the referred object.
 type ObjectReference struct {
@@ -743,12 +689,65 @@ type Event struct {
 	Source string `json:"source,omitempty" yaml:"source,omitempty"`
 }
 
-func (*Event) IsAnAPIObject() {}
-
 // EventList is a list of events.
 type EventList struct {
 	TypeMeta `yaml:",inline" json:",inline"`
 	Items    []Event `yaml:"items,omitempty" json:"items,omitempty"`
 }
 
-func (*EventList) IsAnAPIObject() {}
+// ContainerManifest corresponds to the Container Manifest format, documented at:
+// https://developers.google.com/compute/docs/containers/container_vms#container_manifest
+// This is used as the representation of Kubernetes workloads.
+// DEPRECATED: Replaced with BoundPod
+type ContainerManifest struct {
+	// Required: This must be a supported version string, such as "v1beta1".
+	Version string `yaml:"version" json:"version"`
+	// Required: This must be a DNS_SUBDOMAIN.
+	// TODO: ID on Manifest is deprecated and will be removed in the future.
+	ID string `yaml:"id" json:"id"`
+	// TODO: UUID on Manifest is deprecated in the future once we are done
+	// with the API refactoring. It is required for now to determine the instance
+	// of a Pod.
+	UUID          string        `yaml:"uuid,omitempty" json:"uuid,omitempty"`
+	Volumes       []Volume      `yaml:"volumes" json:"volumes"`
+	Containers    []Container   `yaml:"containers" json:"containers"`
+	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty" yaml:"restartPolicy,omitempty"`
+}
+
+// ContainerManifestList is used to communicate container manifests to kubelet.
+// DEPRECATED: Replaced with BoundPods
+type ContainerManifestList struct {
+	TypeMeta `json:",inline" yaml:",inline"`
+	Items    []ContainerManifest `json:"items,omitempty" yaml:"items,omitempty"`
+}
+
+// Included in partial form from v1beta3 to replace ContainerManifest
+
+// PodSpec is a description of a pod
+type PodSpec struct {
+	Volumes       []Volume      `json:"volumes" yaml:"volumes"`
+	Containers    []Container   `json:"containers" yaml:"containers"`
+	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty" yaml:"restartPolicy,omitempty"`
+}
+
+// BoundPod is a collection of containers that should be run on a host. A BoundPod
+// defines how a Pod may change after a Binding is created. A Pod is a request to
+// execute a pod, whereas a BoundPod is the specification that would be run on a server.
+type BoundPod struct {
+	TypeMeta `json:",inline" yaml:",inline"`
+
+	// Spec defines the behavior of a pod.
+	Spec PodSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
+}
+
+// BoundPods is a list of Pods bound to a common server. The resource version of
+// the pod list is guaranteed to only change when the list of bound pods changes.
+type BoundPods struct {
+	TypeMeta `json:",inline" yaml:",inline"`
+
+	// Host is the name of a node that these pods were bound to.
+	Host string `json:"host" yaml:"host"`
+
+	// Items is the list of all pods bound to a given host.
+	Items []BoundPod `json:"items" yaml:"items"`
+}

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -43,6 +43,7 @@ func init() {
 		&Event{},
 		&EventList{},
 		&ContainerManifestList{},
+		&BoundPods{},
 	)
 }
 
@@ -63,3 +64,4 @@ func (*ServerOpList) IsAnAPIObject()              {}
 func (*Event) IsAnAPIObject()                     {}
 func (*EventList) IsAnAPIObject()                 {}
 func (*ContainerManifestList) IsAnAPIObject()     {}
+func (*BoundPods) IsAnAPIObject()                 {}

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -711,3 +711,34 @@ type EventList struct {
 	TypeMeta `yaml:",inline" json:",inline"`
 	Items    []Event `yaml:"items,omitempty" json:"items,omitempty"`
 }
+
+// Backported from v1beta3 to replace ContainerManifest
+
+// PodSpec is a description of a pod
+type PodSpec struct {
+	Volumes       []Volume      `json:"volumes" yaml:"volumes"`
+	Containers    []Container   `json:"containers" yaml:"containers"`
+	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty" yaml:"restartPolicy,omitempty"`
+}
+
+// BoundPod is a collection of containers that should be run on a host. A BoundPod
+// defines how a Pod may change after a Binding is created. A Pod is a request to
+// execute a pod, whereas a BoundPod is the specification that would be run on a server.
+type BoundPod struct {
+	TypeMeta `json:",inline" yaml:",inline"`
+
+	// Spec defines the behavior of a pod.
+	Spec PodSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
+}
+
+// BoundPods is a list of Pods bound to a common server. The resource version of
+// the pod list is guaranteed to only change when the list of bound pods changes.
+type BoundPods struct {
+	TypeMeta `json:",inline" yaml:",inline"`
+
+	// Host is the name of a node that these pods were bound to.
+	Host string `json:"host" yaml:"host"`
+
+	// Items is the list of all pods bound to a given host.
+	Items []BoundPod `json:"items" yaml:"items"`
+}

--- a/pkg/api/v1beta2/register.go
+++ b/pkg/api/v1beta2/register.go
@@ -43,6 +43,7 @@ func init() {
 		&Event{},
 		&EventList{},
 		&ContainerManifestList{},
+		&BoundPods{},
 	)
 }
 
@@ -63,3 +64,4 @@ func (*ServerOpList) IsAnAPIObject()              {}
 func (*Event) IsAnAPIObject()                     {}
 func (*EventList) IsAnAPIObject()                 {}
 func (*ContainerManifestList) IsAnAPIObject()     {}
+func (*BoundPods) IsAnAPIObject()                 {}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -45,30 +45,6 @@ import (
 //     or more simply:
 //         DNS_LABEL(\.DNS_LABEL)*
 
-// ContainerManifest corresponds to the Container Manifest format, documented at:
-// https://developers.google.com/compute/docs/containers/container_vms#container_manifest
-// This is used as the representation of Kubernetes workloads.
-type ContainerManifest struct {
-	// Required: This must be a supported version string, such as "v1beta1".
-	Version string `yaml:"version" json:"version"`
-	// Required: This must be a DNS_SUBDOMAIN.
-	// TODO: ID on Manifest is deprecated and will be removed in the future.
-	ID string `yaml:"id" json:"id"`
-	// TODO: UUID on Manifest is deprecated in the future once we are done
-	// with the API refactoring. It is required for now to determine the instance
-	// of a Pod.
-	UUID          string        `yaml:"uuid,omitempty" json:"uuid,omitempty"`
-	Volumes       []Volume      `yaml:"volumes" json:"volumes"`
-	Containers    []Container   `yaml:"containers" json:"containers"`
-	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty" yaml:"restartPolicy,omitempty"`
-}
-
-// ContainerManifestList is used to communicate container manifests to kubelet.
-type ContainerManifestList struct {
-	TypeMeta `json:",inline" yaml:",inline"`
-	Items    []ContainerManifest `json:"items,omitempty" yaml:"items,omitempty"`
-}
-
 // Volume represents a named volume in a pod that may be accessed by any containers in the pod.
 type Volume struct {
 	// Required: This must be a DNS_LABEL.  Each volume in a pod must have
@@ -709,4 +685,61 @@ type Event struct {
 type EventList struct {
 	TypeMeta `yaml:",inline" json:",inline"`
 	Items    []Event `yaml:"items,omitempty" json:"items,omitempty"`
+}
+
+// ContainerManifest corresponds to the Container Manifest format, documented at:
+// https://developers.google.com/compute/docs/containers/container_vms#container_manifest
+// This is used as the representation of Kubernetes workloads.
+// DEPRECATED: Replaced with BoundPod
+type ContainerManifest struct {
+	// Required: This must be a supported version string, such as "v1beta1".
+	Version string `yaml:"version" json:"version"`
+	// Required: This must be a DNS_SUBDOMAIN.
+	// TODO: ID on Manifest is deprecated and will be removed in the future.
+	ID string `yaml:"id" json:"id"`
+	// TODO: UUID on Manifest is deprecated in the future once we are done
+	// with the API refactoring. It is required for now to determine the instance
+	// of a Pod.
+	UUID          string        `yaml:"uuid,omitempty" json:"uuid,omitempty"`
+	Volumes       []Volume      `yaml:"volumes" json:"volumes"`
+	Containers    []Container   `yaml:"containers" json:"containers"`
+	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty" yaml:"restartPolicy,omitempty"`
+}
+
+// ContainerManifestList is used to communicate container manifests to kubelet.
+// DEPRECATED: Replaced with BoundPods
+type ContainerManifestList struct {
+	TypeMeta `json:",inline" yaml:",inline"`
+	Items    []ContainerManifest `json:"items,omitempty" yaml:"items,omitempty"`
+}
+
+// Backported from v1beta3 to replace ContainerManifest
+
+// PodSpec is a description of a pod
+type PodSpec struct {
+	Volumes       []Volume      `json:"volumes" yaml:"volumes"`
+	Containers    []Container   `json:"containers" yaml:"containers"`
+	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty" yaml:"restartPolicy,omitempty"`
+}
+
+// BoundPod is a collection of containers that should be run on a host. A BoundPod
+// defines how a Pod may change after a Binding is created. A Pod is a request to
+// execute a pod, whereas a BoundPod is the specification that would be run on a server.
+type BoundPod struct {
+	TypeMeta `json:",inline" yaml:",inline"`
+
+	// Spec defines the behavior of a pod.
+	Spec PodSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
+}
+
+// BoundPods is a list of Pods bound to a common server. The resource version of
+// the pod list is guaranteed to only change when the list of bound pods changes.
+type BoundPods struct {
+	TypeMeta `json:",inline" yaml:",inline"`
+
+	// Host is the name of a node that these pods were bound to.
+	Host string `json:"host" yaml:"host"`
+
+	// Items is the list of all pods bound to a given host.
+	Items []BoundPod `json:"items" yaml:"items"`
 }

--- a/pkg/health/exec.go
+++ b/pkg/health/exec.go
@@ -43,11 +43,11 @@ func IsExitError(err error) bool {
 	return ok
 }
 
-func (e *ExecHealthChecker) HealthCheck(podFullName string, currentState api.PodState, container api.Container) (Status, error) {
+func (e *ExecHealthChecker) HealthCheck(podFullName, podUUID string, currentState api.PodState, container api.Container) (Status, error) {
 	if container.LivenessProbe.Exec == nil {
 		return Unknown, fmt.Errorf("Missing exec parameters")
 	}
-	data, err := e.runner.RunInContainer(podFullName, currentState.Manifest.UUID, container.Name, container.LivenessProbe.Exec.Command)
+	data, err := e.runner.RunInContainer(podFullName, podUUID, container.Name, container.LivenessProbe.Exec.Command)
 	glog.V(1).Infof("container %s failed health check: %s", podFullName, string(data))
 	if err != nil {
 		if IsExitError(err) {

--- a/pkg/health/exec_test.go
+++ b/pkg/health/exec_test.go
@@ -70,7 +70,7 @@ func TestExec(t *testing.T) {
 	for _, test := range tests {
 		fake.out = test.output
 		fake.err = test.err
-		status, err := checker.HealthCheck("test", api.PodState{}, api.Container{LivenessProbe: test.probe})
+		status, err := checker.HealthCheck("test", "", api.PodState{}, api.Container{LivenessProbe: test.probe})
 		if status != test.expectedStatus {
 			t.Errorf("expected %v, got %v", test.expectedStatus, status)
 		}

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -35,7 +35,7 @@ const (
 
 // HealthChecker defines an abstract interface for checking container health.
 type HealthChecker interface {
-	HealthCheck(podFullName string, currentState api.PodState, container api.Container) (Status, error)
+	HealthCheck(podFullName, podUUID string, currentState api.PodState, container api.Container) (Status, error)
 	CanCheck(probe *api.LivenessProbe) bool
 }
 
@@ -78,13 +78,13 @@ func (m *muxHealthChecker) findCheckerFor(probe *api.LivenessProbe) HealthChecke
 
 // HealthCheck delegates the health-checking of the container to one of the bundled implementations.
 // If there is no health checker that can check container it returns Unknown, nil.
-func (m *muxHealthChecker) HealthCheck(podFullName string, currentState api.PodState, container api.Container) (Status, error) {
+func (m *muxHealthChecker) HealthCheck(podFullName, podUUID string, currentState api.PodState, container api.Container) (Status, error) {
 	checker := m.findCheckerFor(container.LivenessProbe)
 	if checker == nil {
 		glog.Warningf("Failed to find health checker for %s %+v", container.Name, container.LivenessProbe)
 		return Unknown, nil
 	}
-	return checker.HealthCheck(podFullName, currentState, container)
+	return checker.HealthCheck(podFullName, podUUID, currentState, container)
 }
 
 func (m *muxHealthChecker) CanCheck(probe *api.LivenessProbe) bool {

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -67,7 +67,7 @@ func TestHealthChecker(t *testing.T) {
 			},
 		}
 		hc := NewHealthChecker()
-		health, err := hc.HealthCheck("test", api.PodState{}, container)
+		health, err := hc.HealthCheck("test", "", api.PodState{}, container)
 		if err != nil && tt.health != Unknown {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -129,7 +129,7 @@ func TestMuxHealthChecker(t *testing.T) {
 		}
 		container.LivenessProbe.HTTPGet.Port = util.NewIntOrStringFromString(port)
 		container.LivenessProbe.HTTPGet.Host = host
-		health, err := mc.HealthCheck("test", api.PodState{}, container)
+		health, err := mc.HealthCheck("test", "", api.PodState{}, container)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}

--- a/pkg/health/http.go
+++ b/pkg/health/http.go
@@ -98,7 +98,7 @@ func DoHTTPCheck(url string, client HTTPGetInterface) (Status, error) {
 }
 
 // HealthCheck checks if the container is healthy by trying sending HTTP Get requests to the container.
-func (h *HTTPHealthChecker) HealthCheck(podFullName string, currentState api.PodState, container api.Container) (Status, error) {
+func (h *HTTPHealthChecker) HealthCheck(podFullName, podUUID string, currentState api.PodState, container api.Container) (Status, error) {
 	host, port, path, err := getURLParts(currentState, container)
 	if err != nil {
 		return Unknown, err

--- a/pkg/health/http_test.go
+++ b/pkg/health/http_test.go
@@ -123,7 +123,7 @@ func TestHTTPHealthChecker(t *testing.T) {
 			params.Port = util.NewIntOrStringFromString(port)
 			params.Host = host
 		}
-		health, err := hc.HealthCheck("test", api.PodState{PodIP: host}, container)
+		health, err := hc.HealthCheck("test", "", api.PodState{PodIP: host}, container)
 		if test.health == Unknown && err == nil {
 			t.Errorf("Expected error")
 		}

--- a/pkg/health/tcp.go
+++ b/pkg/health/tcp.go
@@ -74,7 +74,7 @@ func DoTCPCheck(addr string) (Status, error) {
 	return Healthy, nil
 }
 
-func (t *TCPHealthChecker) HealthCheck(podFullName string, currentState api.PodState, container api.Container) (Status, error) {
+func (t *TCPHealthChecker) HealthCheck(podFullName, podUUID string, currentState api.PodState, container api.Container) (Status, error) {
 	host, port, err := getTCPAddrParts(currentState, container)
 	if err != nil {
 		return Unknown, err

--- a/pkg/health/tcp_test.go
+++ b/pkg/health/tcp_test.go
@@ -100,7 +100,7 @@ func TestTcpHealthChecker(t *testing.T) {
 		if params != nil && test.expectedStatus == Healthy {
 			params.Port = util.NewIntOrStringFromString(port)
 		}
-		status, err := checker.HealthCheck("test", api.PodState{PodIP: host}, container)
+		status, err := checker.HealthCheck("test", "", api.PodState{PodIP: host}, container)
 		if status != test.expectedStatus {
 			t.Errorf("expected: %v, got: %v", test.expectedStatus, status)
 		}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -490,7 +490,7 @@ func (kl *Kubelet) syncPod(pod *Pod, dockerContainers dockertools.DockerContaine
 		return err
 	}
 
-	podState := api.PodState{Manifest: api.ContainerManifest{UUID: uuid}}
+	podState := api.PodState{}
 	info, err := kl.GetPodInfo(podFullName, uuid)
 	if err != nil {
 		glog.Errorf("Unable to get pod with name %s and uuid %s info, health checks may be invalid.",
@@ -510,7 +510,7 @@ func (kl *Kubelet) syncPod(pod *Pod, dockerContainers dockertools.DockerContaine
 			// look for changes in the container.
 			if hash == 0 || hash == expectedHash {
 				// TODO: This should probably be separated out into a separate goroutine.
-				healthy, err := kl.healthy(podFullName, podState, container, dockerContainer)
+				healthy, err := kl.healthy(podFullName, uuid, podState, container, dockerContainer)
 				if err != nil {
 					glog.V(1).Infof("health check errored: %v", err)
 					containersToKeep[containerID] = empty{}
@@ -828,7 +828,7 @@ func (kl *Kubelet) GetMachineInfo() (*info.MachineInfo, error) {
 	return cc.MachineInfo()
 }
 
-func (kl *Kubelet) healthy(podFullName string, currentState api.PodState, container api.Container, dockerContainer *docker.APIContainers) (health.Status, error) {
+func (kl *Kubelet) healthy(podFullName, podUUID string, currentState api.PodState, container api.Container, dockerContainer *docker.APIContainers) (health.Status, error) {
 	// Give the container 60 seconds to start up.
 	if container.LivenessProbe == nil {
 		return health.Healthy, nil
@@ -839,7 +839,7 @@ func (kl *Kubelet) healthy(podFullName string, currentState api.PodState, contai
 	if kl.healthChecker == nil {
 		return health.Healthy, nil
 	}
-	return kl.healthChecker.HealthCheck(podFullName, currentState, container)
+	return kl.healthChecker.HealthCheck(podFullName, podUUID, currentState, container)
 }
 
 // Returns logs of current machine.

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -506,7 +506,7 @@ func TestSyncPodDeletesDuplicate(t *testing.T) {
 
 type FalseHealthChecker struct{}
 
-func (f *FalseHealthChecker) HealthCheck(podFullName string, state api.PodState, container api.Container) (health.Status, error) {
+func (f *FalseHealthChecker) HealthCheck(podFullName, podUUID string, state api.PodState, container api.Container) (health.Status, error) {
 	return health.Unhealthy, nil
 }
 


### PR DESCRIPTION
PodState will be going away and won't have access to the manifest UUID (also going away, but replaced by the pod UID), which means that HealthCheck needs to take the podFullName and podUUID as distinct arguments.

Extracted from #1600
