### PR TITLE
hack: add cluster in a pod manifest

### DIFF
--- a/hack/cluster-pod.yaml
+++ b/hack/cluster-pod.yaml
@@ -1,0 +1,36 @@
+version: v1beta1
+id: cluster-pod
+containers:
+  - name: etcd
+    image: coreos/etcd
+  - name: kubelet
+    image: kubernetes-kubelet
+    imagePullPolicy: never
+    volumeMounts:
+      - name: docker-socket
+        mountPath: /var/run/docker.sock
+  - name: apiserver
+    image: kubernetes-apiserver
+    imagePullPolicy: never
+    ports:
+      - name: apiserver-port
+        hostPort: 8080
+        containerPort: 8080
+        protocol: TCP
+    env:
+      - name: KUBE_MINIONS
+        value: 127.0.0.1
+  - name: controller-manager
+    image: kubernetes-controller-manager
+    imagePullPolicy: never
+  - name: proxy
+    image: kubernetes-proxy
+    imagePullPolicy: never
+  - name: scheduler
+    image: kubernetes-scheduler
+    imagePullPolicy: never
+volumes:
+  - name: docker-socket
+    source:
+      hostDir:
+        path: /var/run/docker.sock


### PR DESCRIPTION
Depends on #1669 #1670 #1671

Experimenting with running all the cluster component in a single pod.

That could be a nice alternative to the local provider for bootstrapping with `kubelet -runonce` in boot2docker

Will update with testing instructions, once I get the end to end tests to pass with it.
