### PR TITLE
Pod cache needs to be namespace-aware

### DIFF
--- a/pkg/client/podinfo.go
+++ b/pkg/client/podinfo.go
@@ -36,7 +36,7 @@ var ErrPodInfoNotAvailable = errors.New("no pod info available")
 type PodInfoGetter interface {
 	// GetPodInfo returns information about all containers which are part
 	// Returns an api.PodInfo, or an error if one occurs.
-	GetPodInfo(host, podID string) (api.PodInfo, error)
+	GetPodInfo(host, podNamespace, podID string) (api.PodInfo, error)
 }
 
 // HTTPPodInfoGetter is the default implementation of PodInfoGetter, accesses the kubelet over HTTP.
@@ -46,13 +46,14 @@ type HTTPPodInfoGetter struct {
 }
 
 // GetPodInfo gets information about the specified pod.
-func (c *HTTPPodInfoGetter) GetPodInfo(host, podID string) (api.PodInfo, error) {
+func (c *HTTPPodInfoGetter) GetPodInfo(host, podNamespace, podID string) (api.PodInfo, error) {
 	request, err := http.NewRequest(
 		"GET",
 		fmt.Sprintf(
-			"http://%s/podInfo?podID=%s",
+			"http://%s/podInfo?podID=%s&podNamespace=%s",
 			net.JoinHostPort(host, strconv.FormatUint(uint64(c.Port), 10)),
-			podID),
+			podID,
+			podNamespace),
 		nil)
 	if err != nil {
 		return nil, err
@@ -85,6 +86,6 @@ type FakePodInfoGetter struct {
 }
 
 // GetPodInfo is a fake implementation of PodInfoGetter.GetPodInfo.
-func (c *FakePodInfoGetter) GetPodInfo(host, podID string) (api.PodInfo, error) {
+func (c *FakePodInfoGetter) GetPodInfo(host, podNamespace string, podID string) (api.PodInfo, error) {
 	return c.data, c.err
 }

--- a/pkg/client/podinfo_test.go
+++ b/pkg/client/podinfo_test.go
@@ -60,7 +60,7 @@ func TestHTTPPodInfoGetter(t *testing.T) {
 		Client: http.DefaultClient,
 		Port:   uint(port),
 	}
-	gotObj, err := podInfoGetter.GetPodInfo(parts[0], "foo")
+	gotObj, err := podInfoGetter.GetPodInfo(parts[0], api.NamespaceDefault, "foo")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestHTTPPodInfoGetterNotFound(t *testing.T) {
 		Client: http.DefaultClient,
 		Port:   uint(port),
 	}
-	_, err = podInfoGetter.GetPodInfo(parts[0], "foo")
+	_, err = podInfoGetter.GetPodInfo(parts[0], api.NamespaceDefault, "foo")
 	if err != ErrPodInfoNotAvailable {
 		t.Errorf("Expected %#v, Got %#v", ErrPodInfoNotAvailable, err)
 	}

--- a/pkg/master/pod_cache.go
+++ b/pkg/master/pod_cache.go
@@ -46,33 +46,38 @@ func NewPodCache(info client.PodInfoGetter, pods pod.Registry) *PodCache {
 	}
 }
 
+// makePodCacheKey constructs a key for use in a map to address a pod with specified namespace and id
+func makePodCacheKey(podNamespace, podID string) string {
+	return podNamespace + "." + podID
+}
+
 // GetPodInfo implements the PodInfoGetter.GetPodInfo.
 // The returned value should be treated as read-only.
 // TODO: Remove the host from this call, it's totally unnecessary.
-func (p *PodCache) GetPodInfo(host, podID string) (api.PodInfo, error) {
+func (p *PodCache) GetPodInfo(host, podNamespace, podID string) (api.PodInfo, error) {
 	p.podLock.Lock()
 	defer p.podLock.Unlock()
-	value, ok := p.podInfo[podID]
+	value, ok := p.podInfo[makePodCacheKey(podNamespace, podID)]
 	if !ok {
 		return nil, client.ErrPodInfoNotAvailable
 	}
 	return value, nil
 }
 
-func (p *PodCache) updatePodInfo(host, id string) error {
-	info, err := p.containerInfo.GetPodInfo(host, id)
+func (p *PodCache) updatePodInfo(host, podNamespace, podID string) error {
+	info, err := p.containerInfo.GetPodInfo(host, podNamespace, podID)
 	if err != nil {
 		return err
 	}
 	p.podLock.Lock()
 	defer p.podLock.Unlock()
-	p.podInfo[id] = info
+	p.podInfo[makePodCacheKey(podNamespace, podID)] = info
 	return nil
 }
 
 // UpdateAllContainers updates information about all containers.  Either called by Loop() below, or one-off.
 func (p *PodCache) UpdateAllContainers() {
-	var ctx api.Context
+	ctx := api.NewContext()
 	pods, err := p.pods.ListPods(ctx, labels.Everything())
 	if err != nil {
 		glog.Errorf("Error synchronizing container list: %v", err)
@@ -82,7 +87,7 @@ func (p *PodCache) UpdateAllContainers() {
 		if pod.CurrentState.Host == "" {
 			continue
 		}
-		err := p.updatePodInfo(pod.CurrentState.Host, pod.ID)
+		err := p.updatePodInfo(pod.CurrentState.Host, pod.Namespace, pod.ID)
 		if err != nil && err != client.ErrPodInfoNotAvailable {
 			glog.Errorf("Error synchronizing container: %v", err)
 		}

--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -208,13 +208,13 @@ func (rs *REST) fillPodInfo(pod *api.Pod) {
 	// Get cached info for the list currently.
 	// TODO: Optionally use fresh info
 	if rs.podCache != nil {
-		info, err := rs.podCache.GetPodInfo(pod.CurrentState.Host, pod.ID)
+		info, err := rs.podCache.GetPodInfo(pod.CurrentState.Host, pod.Namespace, pod.ID)
 		if err != nil {
 			if err != client.ErrPodInfoNotAvailable {
 				glog.Errorf("Error getting container info from cache: %#v", err)
 			}
 			if rs.podInfoGetter != nil {
-				info, err = rs.podInfoGetter.GetPodInfo(pod.CurrentState.Host, pod.ID)
+				info, err = rs.podInfoGetter.GetPodInfo(pod.CurrentState.Host, pod.Namespace, pod.ID)
 			}
 			if err != nil {
 				if err != client.ErrPodInfoNotAvailable {

--- a/pkg/registry/pod/rest_test.go
+++ b/pkg/registry/pod/rest_test.go
@@ -597,7 +597,7 @@ type FakePodInfoGetter struct {
 	err  error
 }
 
-func (f *FakePodInfoGetter) GetPodInfo(host, podID string) (api.PodInfo, error) {
+func (f *FakePodInfoGetter) GetPodInfo(host, podNamespace string, podID string) (api.PodInfo, error) {
 	return f.info, f.err
 }
 


### PR DESCRIPTION
This handles the front-end piece of making pod_cache namespace aware.  The kubelet podInfo operation will need a corresponding update, but @smarterclayton is refactoring that piece in a separate PR.  Once that is done, the corresponding update can be made in kubelet server.go as a follow-on PR.
