### PR TITLE
build: exclude Godeps/_workspace/pkg from docker build

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -160,8 +160,11 @@ function kube::build::build_image() {
     README.md
     third_party
   )
+  local -r exclude=(
+    Godeps/_workspace/pkg
+  )
   mkdir -p "${build_context_dir}"
-  tar czf "${build_context_dir}/kube-source.tar.gz" "${source[@]}"
+  tar czf "${build_context_dir}/kube-source.tar.gz" "${source[@]}" --exclude "${exclude[@]}"
   cat >"${build_context_dir}/kube-version-defs" <<EOF
 KUBE_LD_FLAGS="$(kube::version_ldflags)"
 EOF


### PR DESCRIPTION
Since go version on the host and and go version in the `golang:1.3` image might not match.
