### PR TITLE
Use pointer for struct holding lock.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -111,7 +111,7 @@ type Kubelet struct {
 	dockerClient          dockertools.DockerInterface
 	rootDirectory         string
 	networkContainerImage string
-	podWorkers            podWorkers
+	podWorkers            *podWorkers
 	resyncInterval        time.Duration
 	pods                  []Pod
 
@@ -157,8 +157,8 @@ type podWorkers struct {
 	workers util.StringSet
 }
 
-func newPodWorkers() podWorkers {
-	return podWorkers{
+func newPodWorkers() *podWorkers {
+	return &podWorkers{
 		workers: util.NewStringSet(),
 	}
 }


### PR DESCRIPTION
The current code is correct, since the copy only occurs at allocation time, before concurrency.
However, I changed the new function to return a pointer to silence the go vet warning and to remind users to use a pointer to this type.
