### PR TITLE
build/run-images: switch base to busybox+libc

### DIFF
--- a/build/run-images/base/Dockerfile
+++ b/build/run-images/base/Dockerfile
@@ -14,7 +14,7 @@
 
 # This file creates a minimal container for running Kubernetes binaries
 
-FROM google/debian:wheezy
+FROM progrium/busybox
 MAINTAINER  Joe Beda <jbeda@google.com>
 
 WORKDIR /kubernetes


### PR DESCRIPTION
```
kubernetes-bootstrap                               latest                f7319a2945f1        3 minutes ago       56.39 MB
kubernetes-kubelet                                 latest                bd89cfebb960        3 minutes ago       56.39 MB
kubernetes-scheduler                               latest                05e140fa86ce        3 minutes ago       56.39 MB
kubernetes-proxy                                   latest                a60a0603c99b        3 minutes ago       56.39 MB
kubernetes-apiserver                               latest                7268af915b2d        3 minutes ago       56.39 MB
kubernetes-controller-manager                      latest                ef7661dd1313        3 minutes ago       56.39 MB
kubernetes                                         latest                cbd25d7c708b        3 minutes ago       56.39 MB
```

This [base](https://github.com/progrium/busybox) include glibc, so no need for `-static` build.
