### PR TITLE
Refactor kubelet access and add SSL

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -37,6 +37,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/controller"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/health"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/config"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools"
@@ -58,20 +59,20 @@ var (
 	fakeDocker1, fakeDocker2 dockertools.FakeDockerClient
 )
 
-type fakePodInfoGetter struct{}
+type fakeKubeletClient struct{}
 
-func (fakePodInfoGetter) GetPodInfo(host, podNamespace, podID string) (api.PodInfo, error) {
+func (fakeKubeletClient) GetPodInfo(host, podNamespace, podID string) (api.PodInfo, error) {
 	// This is a horrible hack to get around the fact that we can't provide
 	// different port numbers per kubelet...
 	var c client.PodInfoGetter
 	switch host {
 	case "localhost":
-		c = &client.HTTPPodInfoGetter{
+		c = &client.HTTPKubeletClient{
 			Client: http.DefaultClient,
 			Port:   10250,
 		}
 	case "machine":
-		c = &client.HTTPPodInfoGetter{
+		c = &client.HTTPKubeletClient{
 			Client: http.DefaultClient,
 			Port:   10251,
 		}
@@ -79,6 +80,10 @@ func (fakePodInfoGetter) GetPodInfo(host, podNamespace, podID string) (api.PodIn
 		glog.Fatalf("Can't get info for: '%v', '%v - %v'", host, podNamespace, podID)
 	}
 	return c.GetPodInfo("localhost", podNamespace, podID)
+}
+
+func (fakeKubeletClient) HealthCheck(host string) (health.Status, error) {
+	return health.Healthy, nil
 }
 
 type delegateHandler struct {
@@ -131,7 +136,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 		Client:        cl,
 		EtcdHelper:    helper,
 		Minions:       machineList,
-		PodInfoGetter: fakePodInfoGetter{},
+		KubeletClient: fakeKubeletClient{},
 		PortalNet:     portalNet,
 	})
 	mux := http.NewServeMux()
@@ -181,7 +186,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 
 // podsOnMinions returns true when all of the selected pods exist on a minion.
 func podsOnMinions(c *client.Client, pods api.PodList) wait.ConditionFunc {
-	podInfo := fakePodInfoGetter{}
+	podInfo := fakeKubeletClient{}
 	return func() (bool, error) {
 		for i := range pods.Items {
 			host, id, namespace := pods.Items[i].CurrentState.Host, pods.Items[i].Name, pods.Items[i].Namespace

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -71,8 +71,9 @@ ${GO_OUT}/apiserver \
   --port="${API_PORT}" \
   --etcd_servers="http://${ETCD_HOST}:${ETCD_PORT}" \
   --machines="127.0.0.1" \
-  --minion_port=${KUBELET_PORT} \
+  --kubelet_port=${KUBELET_PORT} \
   --portal_net="10.0.0.0/24" 1>&2 &
+
 APISERVER_PID=$!
 
 wait_for_url "http://127.0.0.1:${API_PORT}/healthz" "apiserver: "

--- a/pkg/client/flags.go
+++ b/pkg/client/flags.go
@@ -21,6 +21,7 @@ package client
 type FlagSet interface {
 	StringVar(p *string, name, value, usage string)
 	BoolVar(p *bool, name string, value bool, usage string)
+	UintVar(p *uint, name string, value uint, usage string)
 }
 
 // BindClientConfigFlags registers a standard set of CLI flags for connecting to a Kubernetes API server.
@@ -30,5 +31,13 @@ func BindClientConfigFlags(flags FlagSet, config *Config) {
 	flags.BoolVar(&config.Insecure, "insecure_skip_tls_verify", config.Insecure, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.")
 	flags.StringVar(&config.CertFile, "client_certificate", config.CertFile, "Path to a client key file for TLS.")
 	flags.StringVar(&config.KeyFile, "client_key", config.KeyFile, "Path to a client key file for TLS.")
-	flags.StringVar(&config.CAFile, "certificate_authority", config.CAFile, "Path to a cert. file for the certificate authority")
+	flags.StringVar(&config.CAFile, "certificate_authority", config.CAFile, "Path to a cert. file for the certificate authority.")
+}
+
+func BindKubeletClientConfigFlags(flags FlagSet, config *KubeletConfig) {
+	flags.BoolVar(&config.EnableHttps, "kubelet_https", config.EnableHttps, "Use https for kubelet connections")
+	flags.UintVar(&config.Port, "kubelet_port", config.Port, "Kubelet port")
+	flags.StringVar(&config.CertFile, "kubelet_client_certificate", config.CertFile, "Path to a client key file for TLS.")
+	flags.StringVar(&config.KeyFile, "kubelet_client_key", config.KeyFile, "Path to a client key file for TLS.")
+	flags.StringVar(&config.CAFile, "kubelet_certificate_authority", config.CAFile, "Path to a cert. file for the certificate authority.")
 }

--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -61,6 +61,19 @@ type Config struct {
 	Transport http.RoundTripper
 }
 
+type KubeletConfig struct {
+	// ToDo: Add support for different kubelet instances exposing different ports
+	Port        uint
+	EnableHttps bool
+
+	// TLS Configuration, only applies if EnableHttps is true.
+	CertFile string
+	// TLS Configuration, only applies if EnableHttps is true.
+	KeyFile string
+	// TLS Configuration, only applies if EnableHttps is true.
+	CAFile string
+}
+
 // New creates a Kubernetes client for the given config. This client works with pods,
 // replication controllers and services. It allows operations such as list, get, update
 // and delete on these objects. An error is returned if the provided configuration

--- a/pkg/client/kubelet_test.go
+++ b/pkg/client/kubelet_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
-func TestHTTPPodInfoGetter(t *testing.T) {
+func TestHTTPKubeletClient(t *testing.T) {
 	expectObj := api.PodInfo{
 		"myID": api.ContainerStatus{},
 	}
@@ -56,7 +56,7 @@ func TestHTTPPodInfoGetter(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	podInfoGetter := &HTTPPodInfoGetter{
+	podInfoGetter := &HTTPKubeletClient{
 		Client: http.DefaultClient,
 		Port:   uint(port),
 	}
@@ -71,7 +71,7 @@ func TestHTTPPodInfoGetter(t *testing.T) {
 	}
 }
 
-func TestHTTPPodInfoGetterNotFound(t *testing.T) {
+func TestHTTPKubeletClientNotFound(t *testing.T) {
 	expectObj := api.PodInfo{
 		"myID": api.ContainerStatus{},
 	}
@@ -98,7 +98,7 @@ func TestHTTPPodInfoGetterNotFound(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	podInfoGetter := &HTTPPodInfoGetter{
+	podInfoGetter := &HTTPKubeletClient{
 		Client: http.DefaultClient,
 		Port:   uint(port),
 	}

--- a/pkg/registry/minion/healthy_registry_test.go
+++ b/pkg/registry/minion/healthy_registry_test.go
@@ -17,27 +17,18 @@ limitations under the License.
 package minion
 
 import (
-	"bytes"
-	"io/ioutil"
-	"net/http"
 	"reflect"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/health"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
 )
 
 type alwaysYes struct{}
 
-func fakeHTTPResponse(status int) *http.Response {
-	return &http.Response{
-		StatusCode: status,
-		Body:       ioutil.NopCloser(&bytes.Buffer{}),
-	}
-}
-
-func (alwaysYes) Get(url string) (*http.Response, error) {
-	return fakeHTTPResponse(http.StatusOK), nil
+func (alwaysYes) HealthCheck(host string) (health.Status, error) {
+	return health.Healthy, nil
 }
 
 func TestBasicDelegation(t *testing.T) {
@@ -80,11 +71,11 @@ type notMinion struct {
 	minion string
 }
 
-func (n *notMinion) Get(url string) (*http.Response, error) {
-	if url != "http://"+n.minion+":10250/healthz" {
-		return fakeHTTPResponse(http.StatusOK), nil
+func (n *notMinion) HealthCheck(host string) (health.Status, error) {
+	if host != n.minion {
+		return health.Healthy, nil
 	} else {
-		return fakeHTTPResponse(http.StatusInternalServerError), nil
+		return health.Unhealthy, nil
 	}
 }
 
@@ -94,7 +85,6 @@ func TestFiltering(t *testing.T) {
 	healthy := HealthyRegistry{
 		delegate: mockMinionRegistry,
 		client:   &notMinion{minion: "m1"},
-		port:     10250,
 	}
 	expected := []string{"m2", "m3"}
 	list, err := healthy.ListMinions(ctx)


### PR DESCRIPTION
Overall goal of this is to add a way to configure ssl mutual auth for connections with the kubelet server. In order to do so, this tries to pull together the different places in the APIServer that access the kubelet, and add a single set of flags for configuring both port and ssl.

I'm fairly new to golang (and the k8s codebase), comments on everything extremely welcome.
