### PR TITLE
Use DesiredState.Host in scheduler predicate

### DIFF
--- a/pkg/scheduler/predicates.go
+++ b/pkg/scheduler/predicates.go
@@ -143,7 +143,7 @@ func MapPodsToMachines(lister PodLister) (map[string][]api.Pod, error) {
 		return map[string][]api.Pod{}, err
 	}
 	for _, scheduledPod := range pods {
-		host := scheduledPod.CurrentState.Host
+		host := scheduledPod.DesiredState.Host
 		machineToPods[host] = append(machineToPods[host], scheduledPod)
 	}
 	return machineToPods, nil

--- a/pkg/scheduler/priorities_test.go
+++ b/pkg/scheduler/priorities_test.go
@@ -59,6 +59,7 @@ func TestLeastRequested(t *testing.T) {
 				{CPU: 2000},
 			},
 		},
+		Host: "machine1",
 	}
 	cpuAndMemory := api.PodState{
 		Manifest: api.ContainerManifest{
@@ -67,6 +68,7 @@ func TestLeastRequested(t *testing.T) {
 				{CPU: 2000, Memory: 3000},
 			},
 		},
+		Host: "machine2",
 	}
 	tests := []struct {
 		pod          api.Pod
@@ -85,10 +87,10 @@ func TestLeastRequested(t *testing.T) {
 			expectedList: []HostPriority{{"machine1", 0}, {"machine2", 0}},
 			test:         "no resources requested",
 			pods: []api.Pod{
-				{CurrentState: machine1State, Labels: labels2},
-				{CurrentState: machine1State, Labels: labels1},
-				{CurrentState: machine2State, Labels: labels1},
-				{CurrentState: machine2State, Labels: labels1},
+				{DesiredState: machine1State, Labels: labels2},
+				{DesiredState: machine1State, Labels: labels1},
+				{DesiredState: machine2State, Labels: labels1},
+				{DesiredState: machine2State, Labels: labels1},
 			},
 		},
 		{
@@ -96,8 +98,8 @@ func TestLeastRequested(t *testing.T) {
 			expectedList: []HostPriority{{"machine1", 37 /* int(75% / 2) */}, {"machine2", 62 /* int( 75% + 50% / 2) */}},
 			test:         "no resources requested",
 			pods: []api.Pod{
-				{DesiredState: cpuOnly, CurrentState: machine1State},
-				{DesiredState: cpuAndMemory, CurrentState: machine2State},
+				{DesiredState: cpuOnly},
+				{DesiredState: cpuAndMemory},
 			},
 		},
 		{
@@ -105,8 +107,8 @@ func TestLeastRequested(t *testing.T) {
 			expectedList: []HostPriority{{"machine1", 0}, {"machine2", 0}},
 			test:         "zero minion resources",
 			pods: []api.Pod{
-				{DesiredState: cpuOnly, CurrentState: machine1State},
-				{DesiredState: cpuAndMemory, CurrentState: machine2State},
+				{DesiredState: cpuOnly},
+				{DesiredState: cpuAndMemory},
 			},
 		},
 	}


### PR DESCRIPTION
This is an attempt to fix #1751

Method MapPodsToMachines always returns a map of empty host to a list of pods, thus when passing existing pods to predicate, predicate will always get an empty list.  In this case, all predicates will return true, even if there is an existing port conflict. If we get unlucky, the node that has the highest priority (least used resources) is the node has port conflict, then scheduler will do a retry but still use the same wrong node.

The problems seems to be that MapPodsToMachines use CurrentState.Host, which is only set in GetPod and ListPods.  However, Scheduler uses a PodLister, which is a podCache using Reflector (List and Watch).  After initial List, podCache will watch on Pod changs, which won't have the CurrentState.Host correctly set.

This is what I've diagonsed so far, the problem seems to go away (Run 200+ times without error).  However, I believe there is a reason for using CurrentState, if so, then this may not be the right fix.
