### PR TITLE
Man pages - initial release

### DIFF
--- a/docs/man/Dockerfile
+++ b/docs/man/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.3
+RUN mkdir -p /go/src/github.com/cpuguy83
+RUN mkdir -p /go/src/github.com/cpuguy83 \
+    && git clone -b v1 https://github.com/cpuguy83/go-md2man.git /go/src/github.com/cpuguy83/go-md2man \
+    && cd /go/src/github.com/cpuguy83/go-md2man \
+    && go get -v ./...
+CMD ["/go/bin/go-md2man", "--help"]

--- a/docs/man/README.md
+++ b/docs/man/README.md
@@ -1,0 +1,41 @@
+Kubernetes Documentation
+====================
+
+This directory contains the Docker user manual in the Markdown format.
+Do *not* edit the man pages in the man1 directory. Instead, amend the
+Markdown (*.md) files.
+
+# File List
+
+    kubecfg.md
+    docker-attach.md
+    docker-build.md
+    Dockerfile
+    md2man-all.sh
+
+# Generating man pages from the Markdown files
+
+The recommended approach for generating the man pages is via a Docker
+container using the supplied `Dockerfile` to create an image with the correct
+environment. This uses `go-md2man`, a pure Go Markdown to man page generator.
+
+## Building the md2man image
+
+There is a `Dockerfile` provided in the `docker/docs/man` directory.
+
+Using this `Dockerfile`, create a Docker image tagged `docker/md2man`:
+
+    docker build -t docker/md2man .
+
+## Utilizing the image
+
+Once the image is built, run a container using the image with *volumes*:
+
+    docker run -v /<path-to-git-dir>/kubernetes/docs/man:/docs:rw \
+    -w /docs -i docker/md2man /docs/md2man-all.sh
+
+The `md2man` Docker container will process the Markdown files and generate
+the man pages inside the `docker/docs/man/man1` directory using
+Docker volumes. For more information on Docker volumes see the man page for
+`docker run` and also look at the article [Sharing Directories via Volumes]
+(http://docs.docker.com/use/working_with_volumes/).

--- a/docs/man/kube-apiserver.1.md
+++ b/docs/man/kube-apiserver.1.md
@@ -1,0 +1,115 @@
+% KUBERNETES(1) kubernetes User Manuals
+% Scott Collier
+% October 2014
+# NAME
+kube-apiserver \- Provides the API for kubernetes orchestration.
+
+# SYNOPSIS
+**kube-apiserver** [OPTIONS]
+
+# DESCRIPTION
+
+The **kubernetes** API server validates and configures data for 3 types of objects: pods, services, and replicationControllers. Beyond just servicing REST operations, the API Server does two other things as well: 1. Schedules pods to worker nodes. Right now the scheduler is very simple. 2. Synchronize pod information (where they are, what ports they are exposing) with the service configuration.
+
+The the kube-apiserver several options. 
+
+# OPTIONS
+**-address**=""
+	The address on the local server to listen to. Default 127.0.0.1
+
+**-allow_privileged**=""
+	If true, allow privileged containers.
+
+**-alsologtostderr**=
+	log to standard error as well as files. Default is false.
+
+**-api_prefix**="/api"
+	The prefix for API requests on the server. Default '/api'
+
+**-cloud_config**=""
+	The path to the cloud provider configuration file. Empty string for no configuration file.
+
+**-cloud_provider**=""
+	The provider for cloud services. Empty string for no provider.
+
+**-cors_allowed_origins**=[]
+	List of allowed origins for CORS, comma separated. An allowed origin can be a regular expression to support subdomain matching. If this list is empty CORS will not be enabled.
+
+**-etcd_servers**=[]
+	List of etcd servers to watch (http://ip:port), comma separated
+
+**-health_check_minions**=
+	If true, health check minions and filter unhealthy ones. Default true.
+
+**-log_backtrace_at=**:0
+	when logging hits line file:N, emit a stack trace
+
+**-log_dir**=""
+	If non-empty, write log files in this directory
+
+**-log_flush_frequency**=5s
+	Maximum number of seconds between log flushes. Default is 5 seconds.
+
+**-logtostderr**=
+	log to standard error instead of files. Default is false.
+
+**-machines**=[]
+	List of machines to schedule onto, comma separated.
+
+**-minion_cache_ttl**=30s
+	Duration of time to cache minion information. Default 30 seconds.
+
+**-minion_port**=10250
+	The port at which kubelet will be listening on the minions. Default is 10250.
+
+**-minion_regexp**=""
+	If non empty, and -cloud_provider is specified, a regular expression for matching minion VMs.
+
+**-port**=8080
+	The port to listen on. Default is 8080.
+
+**-stderrthreshold**=0
+	logs at or above this threshold go to stderr. Default is 0.
+
+**-storage_version**=""
+	The version to store resources with. Defaults to server preferred.
+
+**-v**=0
+	Log level for V logs.
+
+**-version**=false
+	Print version information and quit. Default is false.
+
+**-vmodule**=
+	comma-separated list of pattern=N settings for file-filtered logging
+
+# EXAMPLES
+
+The kube-apiserver can be called manually or from systemd. An example unit file looks as such:
+
+	[Unit]
+	Description=Kubernetes API Server
+	
+	[Service]
+	EnvironmentFile=/etc/kubernetes/config
+	EnvironmentFile=/etc/kubernetes/apiserver
+	User=kube
+	ExecStart=/usr/bin/kube-apiserver \
+	        --logtostderr=${KUBE_LOGTOSTDERR} \
+	        --v=${KUBE_LOG_LEVEL} \
+	        --etcd_servers=${KUBE_ETCD_SERVERS} \
+	        --address=${KUBE_API_ADDRESS} \
+	        --port=${KUBE_API_PORT} \
+	        --machines=${MINION_ADDRESSES} \
+	        --minion_port=${MINION_PORT} \
+	        --allow_privileged=${KUBE_ALLOW_PRIV}
+	Restart=on-failure
+	
+	[Install]
+	WantedBy=multi-user.target
+
+Where the variables are stored in the /etc/kubernetes/ environment files.
+
+# HISTORY
+October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
+ on the kubernetes source material and internal work.

--- a/docs/man/kube-controller-manager.1.md
+++ b/docs/man/kube-controller-manager.1.md
@@ -1,0 +1,91 @@
+% KUBERNETES(1) kubernetes User Manuals
+% Scott Collier
+% October 2014
+# NAME
+kube-controller-manager \- Enforces kubernetes services.
+
+# SYNOPSIS
+**kube-controller-manager** [OPTIONS]
+
+# DESCRIPTION
+
+The **kubernetes** controller manager is really a service that is layered on top of the simple pod API. To enforce this layering, the logic for the replicationController is actually broken out into another server. This server watches etcd for changes to replicationController objects and then uses the public Kubernetes API to implement the replication algorithm.
+
+The kube-controller-manager has several options.
+
+# OPTIONS
+**-address**=""
+	The address on the local server to listen to. Default 127.0.0.1.
+
+**-allow_privileged**="false"
+	If true, allow privileged containers.
+
+**-address=**"127.0.0.1"
+	The address to serve from.
+
+**-alsologtostderr**=false
+	log to standard error as well as files.
+
+**-api_version**=""
+	The API version to use when talking to the server.
+
+**-insecure_skip_tls_verify**=false
+	If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+**-log_backtrace_at**=:0
+	when logging hits line file:N, emit a stack trace.
+
+**-log_dir**=""
+	If non-empty, write log files in this directory.
+
+**-log_flush_frequency**=5s
+	Maximum number of seconds between log flushes.
+
+**-logtostderr**=false
+	log to standard error instead of files.
+
+**-master**=""
+	The address of the Kubernetes API server.
+
+**-port**=10252
+	The port that the controller-manager's http service runs on.
+
+**-stderrthreshold**=0
+	logs at or above this threshold go to stderr.
+
+**-v**=0
+	log level for V logs.
+
+**-version**=false
+	Print version information and quit.
+
+**-vmodule**=
+	comma-separated list of pattern=N settings for file-filtered logging.
+
+# EXAMPLES
+
+The kube-controller-manager can be called manually or from systemd. An example unit file looks as such:
+
+	[Unit]
+	Description=Kubernetes Controller Manager
+	
+	[Service]
+	EnvironmentFile=/etc/kubernetes/config
+	EnvironmentFile=/etc/kubernetes/apiserver
+	EnvironmentFile=/etc/kubernetes/controller-manager
+	User=kube
+	ExecStart=/usr/bin/kube-controller-manager \
+	    --logtostderr=${KUBE_LOGTOSTDERR} \
+	    --v=${KUBE_LOG_LEVEL} \
+	    --master=${KUBE_MASTER}
+	Restart=on-failure
+
+	[Install]
+	WantedBy=multi-user.target
+
+
+Where the variables are stored in the /etc/kubernetes/ enfironment files.
+
+# HISTORY
+October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
+ on the kubernetes source material and internal work.

--- a/docs/man/kube-proxy.1.md
+++ b/docs/man/kube-proxy.1.md
@@ -1,0 +1,89 @@
+% KUBERNETES(1) kubernetes User Manuals
+% Scott Collier
+% October 2014
+# NAME
+kube-proxy \- Provides network proxy services.
+
+# SYNOPSIS
+**kube-proxy** [OPTIONS]
+
+# DESCRIPTION
+
+The **kubernetes** network proxy runs on each node. This reflects services as defined in the Kubernetes API on each node and can do simple TCP stream forwarding or round robin TCP forwarding across a set of backends. Service endpoints are currently found through Docker-links-compatible environment variables specifying ports opened by the service proxy. Currently the user must select a port to expose the service on on the proxy, as well as the container's port to target.
+
+The kube-proxy takes several options.
+
+# OPTIONS
+**-alsologtostderr**=false
+	log to standard error as well as files
+
+**-api_version=**""
+	The API version to use when talking to the server
+
+**-bindaddress**="0.0.0.0"
+	The address for the proxy server to serve on (set to 0.0.0.0 or "" for all interfaces)
+
+**-configfile**="/tmp/proxy_config"
+	Configuration file for the proxy
+
+**-etcd_servers**=[]
+	List of etcd servers to watch (http://ip:port), comma separated (optional)
+
+**-insecure_skip_tls_verify**=false
+	If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+**-log_backtrace_at**=:0
+	when logging hits line file:N, emit a stack trace
+
+**-log_dir**=""
+	If non-empty, write log files in this directory
+
+**-log_flush_frequency**=5s
+	Maximum number of seconds between log flushes
+
+**-logtostderr**=false
+	log to standard error instead of files
+
+**-master**=""
+	The address of the Kubernetes API server
+
+**-stderrthreshold**=0
+	logs at or above this threshold go to stderr
+
+**-v**=0
+	log level for V logs
+
+**-version**=false
+	Print version information and quit
+
+**-vmodule**=
+	comma-separated list of pattern=N settings for file-filtered logging
+
+
+# EXAMPLES
+
+The kube-proxy can be called manually or from systemd. An example unit file looks as such:
+
+	[Unit]
+	Description=Kubernetes Proxy
+	# the proxy crashes if etcd isn't reachable.
+	# https://github.com/GoogleCloudPlatform/kubernetes/issues/1206
+	After=network.target
+	
+	[Service]
+	EnvironmentFile=/etc/kubernetes/config
+	EnvironmentFile=/etc/kubernetes/proxy
+	ExecStart=/usr/bin/kube-proxy \
+		--logtostderr=${KUBE_LOGTOSTDERR} \
+		--v=${KUBE_LOG_LEVEL} \
+		--etcd_servers=${KUBE_ETCD_SERVERS}
+	Restart=on-failure
+	
+	[Install]
+	WantedBy=multi-user.target
+
+Where the variables are stored in the /etc/kubernetes/ directory.
+
+# HISTORY
+October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
+ on the kubernetes source material and internal work.

--- a/docs/man/kube-scheduler.1.md
+++ b/docs/man/kube-scheduler.1.md
@@ -1,0 +1,84 @@
+% KUBERNETES(1) kubernetes User Manuals
+% Scott Collier
+% October 2014
+# NAME
+kube-scheduler \- Schedules containers on hosts.
+
+# SYNOPSIS
+**kube-scheduler** [OPTIONS]
+
+# DESCRIPTION
+
+The **kubernetes** scheduler is a policy-rich, topology-aware, workload-specific function that significantly impacts availability, performance, and capacity. The scheduler needs to take into account individual and collective resource requirements, quality of service requirements, hardware/software/policy constraints, affinity and anti-affinity specifications, data locality, inter-workload interference, deadlines, and so on. Workload-specific requirements will be exposed through the API as necessary.
+
+The kube-scheduler can take several options.
+
+# OPTIONS
+**-address=**"127.0.0.1"
+	The address to serve from.
+
+**-alsologtostderr=**false
+	log to standard error as well as files.
+
+**-api_version=**""
+	The API version to use when talking to the server.
+
+**-insecure_skip_tls_verify**=false
+	If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+**-log_backtrace_at=**:0
+	when logging hits line file:N, emit a stack trace.
+
+**-log_dir=**""
+	If non-empty, write log files in this directory.
+
+**-log_flush_frequency**=5s
+	Maximum number of seconds between log flushes.
+
+**-logtostderr**=false
+	log to standard error instead of files.
+
+**-master=**""
+	The address of the Kubernetes API server.
+
+**-port=**10251
+	The port that the scheduler's http service runs on.
+
+**-stderrthreshold**=0
+	logs at or above this threshold go to stderr.
+
+**-v**=0
+	log level for V logs.
+
+**-version**=false
+	Print version information and quit.
+
+**-vmodule**=
+	comma-separated list of pattern=N settings for file-filtered logging.
+
+# EXAMPLES
+
+The kube-scheduler can be called manually or from systemd. An example unit file looks as such:
+
+	[Unit]
+	Description=Kubernetes Scheduler
+	
+	[Service]
+	EnvironmentFile=/etc/kubernetes/config
+	EnvironmentFile=/etc/kubernetes/apiserver
+	EnvironmentFile=/etc/kubernetes/scheduler
+	ExecStart=/usr/bin/kube-scheduler \
+	    --logtostderr=${KUBE_LOGTOSTDERR} \
+	    --v=${KUBE_LOG_LEVEL} \
+	    --master=${KUBE_MASTER}
+	Restart=on-failure
+
+	[Install]
+	WantedBy=multi-user.target
+
+
+Where the variables are stored in the /etc/kubernetes/ environment files.
+
+# HISTORY
+October 2014, Originally compiled by Scott Collier (scollier@redhat.com) based
+ on the kubernetes source material and internal work.

--- a/docs/man/kubelet.1.md
+++ b/docs/man/kubelet.1.md
@@ -1,0 +1,128 @@
+% KUBERNETES(1) kubernetes User Manuals
+% Scott Collier
+% October 2014
+# NAME
+kubelet \- Processes a container manifest so the containers are launched according to how they are described.
+
+# SYNOPSIS
+**kubelet** [OPTIONS]
+
+# DESCRIPTION
+
+The **kubernetes** kubelet runs on each node. The Kubelet works in terms of a container manifest. A container manifest is a YAML or JSON file that describes a pod. The Kubelet takes a set of manifests that are provided in various mechanisms and ensures that the containers described in those manifests are started and continue running.
+
+There are 4 ways that a container manifest can be provided to the Kubelet:
+
+    File Path passed as a flag on the command line. This file is rechecked every 20 seconds (configurable with a flag).
+    HTTP endpoint HTTP endpoint passed as a parameter on the command line. This endpoint is checked every 20 seconds (also configurable with a flag).
+    etcd server The Kubelet will reach out and do a watch on an etcd server. The etcd path that is watched is /registry/hosts/$(hostname -f). As this is a watch, changes are noticed and acted upon very quickly.
+    HTTP server The kubelet can also listen for HTTP and respond to a simple API (underspec'd currently) to submit a new manifest.
+ 
+
+# OPTIONS
+**-address**="127.0.0.1"
+	The address for the info server to serve on (set to 0.0.0.0 or "" for all interfaces).
+
+**-allow_privileged**=false
+	If true, allow containers to request privileged mode. [default=false].
+
+**-alsologtostderr**=false
+	log to standard error as well as files.
+
+**-config**=""
+	Path to the config file or directory of files.
+
+**-docker_endpoint**=""
+	If non-empty, use this for the docker endpoint to communicate with.
+
+**-enable_server**=true
+	Enable the info server.
+
+**-etcd_servers**=[]
+	List of etcd servers to watch (http://ip:port), comma separated.
+
+**-file_check_frequency**=20s
+	Duration between checking config files for new data.
+
+**-hostname_override**=""
+	If non-empty, will use this string as identification instead of the actual hostname.
+
+**-http_check_frequency**=20s
+	Duration between checking http for new data.
+
+**-log_backtrace_at**=:0
+	when logging hits line file:N, emit a stack trace.
+
+**-log_dir**=""
+	If non-empty, write log files in this directory.
+
+**-log_flush_frequency**=5s
+	Maximum number of seconds between log flushes.
+
+**-logtostderr**=false
+	log to standard error instead of files.
+
+**-manifest_url**=""
+	URL for accessing the container manifest.
+
+**-network_container_image**="kubernetes/pause:latest"
+	The image that network containers in each pod will use.
+
+**-port**=10250
+	The port for the info server to serve on.
+
+**-registry_burst**=10
+	Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry_qps. Only used if --registry_qps > 0.
+
+**-registry_qps**=0
+	If > 0, limit registry pull QPS to this value. If 0, unlimited. [default=0.0].
+
+**-root_dir**="/var/lib/kubelet"
+	Directory path for managing kubelet files (volume mounts,etc).
+
+**-stderrthreshold**=0
+	logs at or above this threshold go to stderr.
+
+**-sync_frequency**=10s
+	Max period between synchronizing running containers and config.
+
+**-v**=0
+	log level for V logs.
+
+**-version**=false
+	Print version information and quit.
+
+**-vmodule**=
+	comma-separated list of pattern=N settings for file-filtered logging.
+
+
+# EXAMPLES
+
+The kubelet can be called manually or from systemd. An example unit file looks as such:
+
+	[Unit]
+	Description=Kubernetes Kubelet
+	After=docker.socket cadvisor.service
+	Requires=docker.socket
+	
+	[Service]
+	EnvironmentFile=/etc/kubernetes/config
+	EnvironmentFile=/etc/kubernetes/kubelet
+	ExecStart=/usr/bin/kubelet \
+		--logtostderr=${KUBE_LOGTOSTDERR} \
+		--v=${KUBE_LOG_LEVEL} \
+		--etcd_servers=${KUBE_ETCD_SERVERS} \
+		--address=${MINION_ADDRESS} \
+		--port=${MINION_PORT} \
+	    --hostname_override=${MINION_HOSTNAME} \
+	    --allow_privileged=${KUBE_ALLOW_PRIV}
+	Restart=on-failure
+	
+	[Install]
+	WantedBy=multi-user.target
+
+Where the variables are stored in the /etc/kubernetes/ environment files.
+
+# HISTORY
+October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
+ on the kubernetes source material and internal work.

--- a/docs/man/man1/kube-apiserver.1
+++ b/docs/man/man1/kube-apiserver.1
@@ -1,0 +1,149 @@
+.TH "KUBERNETES" "1" " kubernetes User Manuals" "Scott Collier" "October 2014"  ""
+
+.SH NAME
+.PP
+kube\-apiserver \- Provides the API for kubernetes orchestration.
+
+.SH SYNOPSIS
+.PP
+\fBkube\-apiserver\fP [OPTIONS]
+
+.SH DESCRIPTION
+.PP
+The \fBkubernetes\fP API server validates and configures data for 3 types of objects: pods, services, and replicationControllers. Beyond just servicing REST operations, the API Server does two other things as well: 1. Schedules pods to worker nodes. Right now the scheduler is very simple. 2. Synchronize pod information (where they are, what ports they are exposing) with the service configuration.
+
+.PP
+The the kube\-apiserver several options.
+
+.SH OPTIONS
+.PP
+\fB\-address\fP=""
+    The address on the local server to listen to. Default 127.0.0.1
+
+.PP
+\fB\-allow\_privileged\fP=""
+    If true, allow privileged containers.
+
+.PP
+\fB\-alsologtostderr\fP=
+    log to standard error as well as files. Default is false.
+
+.PP
+\fB\-api\_prefix\fP="/api"
+    The prefix for API requests on the server. Default '/api'
+
+.PP
+\fB\-cloud\_config\fP=""
+    The path to the cloud provider configuration file. Empty string for no configuration file.
+
+.PP
+\fB\-cloud\_provider\fP=""
+    The provider for cloud services. Empty string for no provider.
+
+.PP
+\fB\-cors\_allowed\_origins\fP=[]
+    List of allowed origins for CORS, comma separated. An allowed origin can be a regular expression to support subdomain matching. If this list is empty CORS will not be enabled.
+
+.PP
+\fB\-etcd\_servers\fP=[]
+    List of etcd servers to watch (
+\[la]http://ip:port\[ra]), comma separated
+
+.PP
+\fB\-health\_check\_minions\fP=
+    If true, health check minions and filter unhealthy ones. Default true.
+
+.PP
+\fB\-log\_backtrace\_at=\fP:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes. Default is 5 seconds.
+
+.PP
+\fB\-logtostderr\fP=
+    log to standard error instead of files. Default is false.
+
+.PP
+\fB\-machines\fP=[]
+    List of machines to schedule onto, comma separated.
+
+.PP
+\fB\-minion\_cache\_ttl\fP=30s
+    Duration of time to cache minion information. Default 30 seconds.
+
+.PP
+\fB\-minion\_port\fP=10250
+    The port at which kubelet will be listening on the minions. Default is 10250.
+
+.PP
+\fB\-minion\_regexp\fP=""
+    If non empty, and \-cloud\_provider is specified, a regular expression for matching minion VMs.
+
+.PP
+\fB\-port\fP=8080
+    The port to listen on. Default is 8080.
+
+.PP
+\fB\-stderrthreshold\fP=0
+    logs at or above this threshold go to stderr. Default is 0.
+
+.PP
+\fB\-storage\_version\fP=""
+    The version to store resources with. Defaults to server preferred.
+
+.PP
+\fB\-v\fP=0
+    Log level for V logs.
+
+.PP
+\fB\-version\fP=false
+    Print version information and quit. Default is false.
+
+.PP
+\fB\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+.SH EXAMPLES
+.PP
+The kube\-apiserver can be called manually or from systemd. An example unit file looks as such:
+
+.PP
+.RS
+
+.nf
+[Unit]
+Description=Kubernetes API Server
+
+[Service]
+EnvironmentFile=/etc/kubernetes/config
+EnvironmentFile=/etc/kubernetes/apiserver
+User=kube
+ExecStart=/usr/bin/kube\-apiserver \\
+        \-\-logtostderr=\$\{KUBE\_LOGTOSTDERR\} \\
+        \-\-v=\$\{KUBE\_LOG\_LEVEL\} \\
+        \-\-etcd\_servers=\$\{KUBE\_ETCD\_SERVERS\} \\
+        \-\-address=\$\{KUBE\_API\_ADDRESS\} \\
+        \-\-port=\$\{KUBE\_API\_PORT\} \\
+        \-\-machines=\$\{MINION\_ADDRESSES\} \\
+        \-\-minion\_port=\$\{MINION\_PORT\} \\
+        \-\-allow\_privileged=\$\{KUBE\_ALLOW\_PRIV\}
+Restart=on\-failure
+
+[Install]
+WantedBy=multi\-user.target
+
+.fi
+
+.PP
+Where the variables are stored in the /etc/kubernetes/ environment files.
+
+.SH HISTORY
+.PP
+October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
+ on the kubernetes source material and internal work.

--- a/docs/man/man1/kube-controller-manager.1
+++ b/docs/man/man1/kube-controller-manager.1
@@ -1,0 +1,116 @@
+.TH "KUBERNETES" "1" " kubernetes User Manuals" "Scott Collier" "October 2014"  ""
+
+.SH NAME
+.PP
+kube\-controller\-manager \- Enforces kubernetes services.
+
+.SH SYNOPSIS
+.PP
+\fBkube\-controller\-manager\fP [OPTIONS]
+
+.SH DESCRIPTION
+.PP
+The \fBkubernetes\fP controller manager is really a service that is layered on top of the simple pod API. To enforce this layering, the logic for the replicationController is actually broken out into another server. This server watches etcd for changes to replicationController objects and then uses the public Kubernetes API to implement the replication algorithm.
+
+.PP
+The kube\-controller\-manager has several options.
+
+.SH OPTIONS
+.PP
+\fB\-address\fP=""
+    The address on the local server to listen to. Default 127.0.0.1.
+
+.PP
+\fB\-allow\_privileged\fP="false"
+    If true, allow privileged containers.
+
+.PP
+\fB\-address=\fP"127.0.0.1"
+    The address to serve from.
+
+.PP
+\fB\-alsologtostderr\fP=false
+    log to standard error as well as files.
+
+.PP
+\fB\-api\_version\fP=""
+    The API version to use when talking to the server.
+
+.PP
+\fB\-insecure\_skip\_tls\_verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace.
+
+.PP
+\fB\-log\_dir\fP=""
+    If non\-empty, write log files in this directory.
+
+.PP
+\fB\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes.
+
+.PP
+\fB\-logtostderr\fP=false
+    log to standard error instead of files.
+
+.PP
+\fB\-master\fP=""
+    The address of the Kubernetes API server.
+
+.PP
+\fB\-port\fP=10252
+    The port that the controller\-manager's http service runs on.
+
+.PP
+\fB\-stderrthreshold\fP=0
+    logs at or above this threshold go to stderr.
+
+.PP
+\fB\-v\fP=0
+    log level for V logs.
+
+.PP
+\fB\-version\fP=false
+    Print version information and quit.
+
+.PP
+\fB\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging.
+
+.SH EXAMPLES
+.PP
+The kube\-controller\-manager can be called manually or from systemd. An example unit file looks as such:
+
+.PP
+.RS
+
+.nf
+[Unit]
+Description=Kubernetes Controller Manager
+
+[Service]
+EnvironmentFile=/etc/kubernetes/config
+EnvironmentFile=/etc/kubernetes/apiserver
+EnvironmentFile=/etc/kubernetes/controller\-manager
+User=kube
+ExecStart=/usr/bin/kube\-controller\-manager \\
+    \-\-logtostderr=\$\{KUBE\_LOGTOSTDERR\} \\
+    \-\-v=\$\{KUBE\_LOG\_LEVEL\} \\
+    \-\-master=\$\{KUBE\_MASTER\}
+Restart=on\-failure
+
+[Install]
+WantedBy=multi\-user.target
+
+.fi
+
+.PP
+Where the variables are stored in the /etc/kubernetes/ enfironment files.
+
+.SH HISTORY
+.PP
+October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
+ on the kubernetes source material and internal work.

--- a/docs/man/man1/kube-proxy.1
+++ b/docs/man/man1/kube-proxy.1
@@ -1,0 +1,114 @@
+.TH "KUBERNETES" "1" " kubernetes User Manuals" "Scott Collier" "October 2014"  ""
+
+.SH NAME
+.PP
+kube\-proxy \- Provides network proxy services.
+
+.SH SYNOPSIS
+.PP
+\fBkube\-proxy\fP [OPTIONS]
+
+.SH DESCRIPTION
+.PP
+The \fBkubernetes\fP network proxy runs on each node. This reflects services as defined in the Kubernetes API on each node and can do simple TCP stream forwarding or round robin TCP forwarding across a set of backends. Service endpoints are currently found through Docker\-links\-compatible environment variables specifying ports opened by the service proxy. Currently the user must select a port to expose the service on on the proxy, as well as the container's port to target.
+
+.PP
+The kube\-proxy takes several options.
+
+.SH OPTIONS
+.PP
+\fB\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-api\_version=\fP""
+    The API version to use when talking to the server
+
+.PP
+\fB\-bindaddress\fP="0.0.0.0"
+    The address for the proxy server to serve on (set to 0.0.0.0 or "" for all interfaces)
+
+.PP
+\fB\-configfile\fP="/tmp/proxy\_config"
+    Configuration file for the proxy
+
+.PP
+\fB\-etcd\_servers\fP=[]
+    List of etcd servers to watch (
+\[la]http://ip:port\[ra]), comma separated (optional)
+
+.PP
+\fB\-insecure\_skip\_tls\_verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-logtostderr\fP=false
+    log to standard error instead of files
+
+.PP
+\fB\-master\fP=""
+    The address of the Kubernetes API server
+
+.PP
+\fB\-stderrthreshold\fP=0
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-version\fP=false
+    Print version information and quit
+
+.PP
+\fB\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+.SH EXAMPLES
+.PP
+The kube\-proxy can be called manually or from systemd. An example unit file looks as such:
+
+.PP
+.RS
+
+.nf
+[Unit]
+Description=Kubernetes Proxy
+# the proxy crashes if etcd isn't reachable.
+# https://github.com/GoogleCloudPlatform/kubernetes/issues/1206
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/kubernetes/config
+EnvironmentFile=/etc/kubernetes/proxy
+ExecStart=/usr/bin/kube\-proxy \\
+    \-\-logtostderr=\$\{KUBE\_LOGTOSTDERR\} \\
+    \-\-v=\$\{KUBE\_LOG\_LEVEL\} \\
+    \-\-etcd\_servers=\$\{KUBE\_ETCD\_SERVERS\}
+Restart=on\-failure
+
+[Install]
+WantedBy=multi\-user.target
+
+.fi
+
+.PP
+Where the variables are stored in the /etc/kubernetes/ directory.
+
+.SH HISTORY
+.PP
+October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
+ on the kubernetes source material and internal work.

--- a/docs/man/man1/kube-scheduler.1
+++ b/docs/man/man1/kube-scheduler.1
@@ -1,0 +1,107 @@
+.TH "KUBERNETES" "1" " kubernetes User Manuals" "Scott Collier" "October 2014"  ""
+
+.SH NAME
+.PP
+kube\-scheduler \- Schedules containers on hosts.
+
+.SH SYNOPSIS
+.PP
+\fBkube\-scheduler\fP [OPTIONS]
+
+.SH DESCRIPTION
+.PP
+The \fBkubernetes\fP scheduler is a policy\-rich, topology\-aware, workload\-specific function that significantly impacts availability, performance, and capacity. The scheduler needs to take into account individual and collective resource requirements, quality of service requirements, hardware/software/policy constraints, affinity and anti\-affinity specifications, data locality, inter\-workload interference, deadlines, and so on. Workload\-specific requirements will be exposed through the API as necessary.
+
+.PP
+The kube\-scheduler can take several options.
+
+.SH OPTIONS
+.PP
+\fB\-address=\fP"127.0.0.1"
+    The address to serve from.
+
+.PP
+\fB\-alsologtostderr=\fPfalse
+    log to standard error as well as files.
+
+.PP
+\fB\-api\_version=\fP""
+    The API version to use when talking to the server.
+
+.PP
+\fB\-insecure\_skip\_tls\_verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-log\_backtrace\_at=\fP:0
+    when logging hits line file:N, emit a stack trace.
+
+.PP
+\fB\-log\_dir=\fP""
+    If non\-empty, write log files in this directory.
+
+.PP
+\fB\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes.
+
+.PP
+\fB\-logtostderr\fP=false
+    log to standard error instead of files.
+
+.PP
+\fB\-master=\fP""
+    The address of the Kubernetes API server.
+
+.PP
+\fB\-port=\fP10251
+    The port that the scheduler's http service runs on.
+
+.PP
+\fB\-stderrthreshold\fP=0
+    logs at or above this threshold go to stderr.
+
+.PP
+\fB\-v\fP=0
+    log level for V logs.
+
+.PP
+\fB\-version\fP=false
+    Print version information and quit.
+
+.PP
+\fB\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging.
+
+.SH EXAMPLES
+.PP
+The kube\-scheduler can be called manually or from systemd. An example unit file looks as such:
+
+.PP
+.RS
+
+.nf
+[Unit]
+Description=Kubernetes Scheduler
+
+[Service]
+EnvironmentFile=/etc/kubernetes/config
+EnvironmentFile=/etc/kubernetes/apiserver
+EnvironmentFile=/etc/kubernetes/scheduler
+ExecStart=/usr/bin/kube\-scheduler \\
+    \-\-logtostderr=\$\{KUBE\_LOGTOSTDERR\} \\
+    \-\-v=\$\{KUBE\_LOG\_LEVEL\} \\
+    \-\-master=\$\{KUBE\_MASTER\}
+Restart=on\-failure
+
+[Install]
+WantedBy=multi\-user.target
+
+.fi
+
+.PP
+Where the variables are stored in the /etc/kubernetes/ environment files.
+
+.SH HISTORY
+.PP
+October 2014, Originally compiled by Scott Collier (scollier@redhat.com) based
+ on the kubernetes source material and internal work.

--- a/docs/man/man1/kubelet.1
+++ b/docs/man/man1/kubelet.1
@@ -1,0 +1,168 @@
+.TH "KUBERNETES" "1" " kubernetes User Manuals" "Scott Collier" "October 2014"  ""
+
+.SH NAME
+.PP
+kubelet \- Processes a container manifest so the containers are launched according to how they are described.
+
+.SH SYNOPSIS
+.PP
+\fBkubelet\fP [OPTIONS]
+
+.SH DESCRIPTION
+.PP
+The \fBkubernetes\fP kubelet runs on each node. The Kubelet works in terms of a container manifest. A container manifest is a YAML or JSON file that describes a pod. The Kubelet takes a set of manifests that are provided in various mechanisms and ensures that the containers described in those manifests are started and continue running.
+
+.PP
+There are 4 ways that a container manifest can be provided to the Kubelet:
+
+.PP
+.RS
+
+.nf
+File Path passed as a flag on the command line. This file is rechecked every 20 seconds (configurable with a flag).
+HTTP endpoint HTTP endpoint passed as a parameter on the command line. This endpoint is checked every 20 seconds (also configurable with a flag).
+etcd server The Kubelet will reach out and do a watch on an etcd server. The etcd path that is watched is /registry/hosts/\$(hostname \-f). As this is a watch, changes are noticed and acted upon very quickly.
+HTTP server The kubelet can also listen for HTTP and respond to a simple API (underspec'd currently) to submit a new manifest.
+
+.fi
+
+.SH OPTIONS
+.PP
+\fB\-address\fP="127.0.0.1"
+    The address for the info server to serve on (set to 0.0.0.0 or "" for all interfaces).
+
+.PP
+\fB\-allow\_privileged\fP=false
+    If true, allow containers to request privileged mode. [default=false].
+
+.PP
+\fB\-alsologtostderr\fP=false
+    log to standard error as well as files.
+
+.PP
+\fB\-config\fP=""
+    Path to the config file or directory of files.
+
+.PP
+\fB\-docker\_endpoint\fP=""
+    If non\-empty, use this for the docker endpoint to communicate with.
+
+.PP
+\fB\-enable\_server\fP=true
+    Enable the info server.
+
+.PP
+\fB\-etcd\_servers\fP=[]
+    List of etcd servers to watch (
+\[la]http://ip:port\[ra]), comma separated.
+
+.PP
+\fB\-file\_check\_frequency\fP=20s
+    Duration between checking config files for new data.
+
+.PP
+\fB\-hostname\_override\fP=""
+    If non\-empty, will use this string as identification instead of the actual hostname.
+
+.PP
+\fB\-http\_check\_frequency\fP=20s
+    Duration between checking http for new data.
+
+.PP
+\fB\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace.
+
+.PP
+\fB\-log\_dir\fP=""
+    If non\-empty, write log files in this directory.
+
+.PP
+\fB\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes.
+
+.PP
+\fB\-logtostderr\fP=false
+    log to standard error instead of files.
+
+.PP
+\fB\-manifest\_url\fP=""
+    URL for accessing the container manifest.
+
+.PP
+\fB\-network\_container\_image\fP="kubernetes/pause:latest"
+    The image that network containers in each pod will use.
+
+.PP
+\fB\-port\fP=10250
+    The port for the info server to serve on.
+
+.PP
+\fB\-registry\_burst\fP=10
+    Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry\_qps. Only used if \-\-registry\_qps > 0.
+
+.PP
+\fB\-registry\_qps\fP=0
+    If > 0, limit registry pull QPS to this value. If 0, unlimited. [default=0.0].
+
+.PP
+\fB\-root\_dir\fP="/var/lib/kubelet"
+    Directory path for managing kubelet files (volume mounts,etc).
+
+.PP
+\fB\-stderrthreshold\fP=0
+    logs at or above this threshold go to stderr.
+
+.PP
+\fB\-sync\_frequency\fP=10s
+    Max period between synchronizing running containers and config.
+
+.PP
+\fB\-v\fP=0
+    log level for V logs.
+
+.PP
+\fB\-version\fP=false
+    Print version information and quit.
+
+.PP
+\fB\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging.
+
+.SH EXAMPLES
+.PP
+The kubelet can be called manually or from systemd. An example unit file looks as such:
+
+.PP
+.RS
+
+.nf
+[Unit]
+Description=Kubernetes Kubelet
+After=docker.socket cadvisor.service
+Requires=docker.socket
+
+[Service]
+EnvironmentFile=/etc/kubernetes/config
+EnvironmentFile=/etc/kubernetes/kubelet
+ExecStart=/usr/bin/kubelet \\
+    \-\-logtostderr=\$\{KUBE\_LOGTOSTDERR\} \\
+    \-\-v=\$\{KUBE\_LOG\_LEVEL\} \\
+    \-\-etcd\_servers=\$\{KUBE\_ETCD\_SERVERS\} \\
+    \-\-address=\$\{MINION\_ADDRESS\} \\
+    \-\-port=\$\{MINION\_PORT\} \\
+    \-\-hostname\_override=\$\{MINION\_HOSTNAME\} \\
+    \-\-allow\_privileged=\$\{KUBE\_ALLOW\_PRIV\}
+Restart=on\-failure
+
+[Install]
+WantedBy=multi\-user.target
+
+.fi
+
+.PP
+Where the variables are stored in the /etc/kubernetes/ environment files.
+
+.SH HISTORY
+.PP
+October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
+ on the kubernetes source material and internal work.

--- a/docs/man/md2man-all.sh
+++ b/docs/man/md2man-all.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright 2014 Red Hat Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [[ -z ${GO_MD2MAN} ]]; then
+	GO_MD2MAN="go-md2man"
+fi
+
+# get into this script's directory
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+[ "$1" = '-q' ] || {
+	set -x
+	pwd
+}
+
+for FILE in *.md; do
+	base="$(basename "$FILE")"
+	name="${base%.md}"
+	num="${name##*.}"
+	if [ -z "$num" -o "$name" = "$num" ]; then
+		# skip files that aren't of the format xxxx.N.md (like README.md)
+		continue
+	fi
+	mkdir -p "./man${num}"
+	${GO_MD2MAN} -in "$FILE" -out "./man${num}/${name}"
+done


### PR DESCRIPTION
This is an initial release of man pages.  I have added pages for: 

kube-apiserver
kube-controller-manager
kubelet
kube-proxy
kube-scheduler

These man pages are written in markdown and converted into man pages by md2man via a docker container.  See the README.md for instructions on how to do this.  Hopefully this is a good start.  
