### PR TITLE
Clean-up docker configuration changes for openvswitch

### DIFF
--- a/cluster/saltbase/salt/sdn/init.sls
+++ b/cluster/saltbase/salt/sdn/init.sls
@@ -12,5 +12,4 @@ sdn:
     - watch:
       - pkg: docker-io
       - pkg: openvswitch
-
 {% endif %}


### PR DESCRIPTION
The old code was always adding the docker command line arguments to the .service file and was therefore getting duplicates.  

There was an occasional race-condition where on a particular minion you could end up with two .service files - one docker.service and other docker.servicee - and systemd appeared to get confused and refuse to start docker.

In the end, cleaned this code up to actually stick the options for docker in the Docker options file, and only set them once versus every update to the cluster.
