### PR TITLE
Fix race condition in start-up of salt-minion and salt-master

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -113,7 +113,7 @@ python "${KUBE_ROOT}/third_party/htpasswd/htpasswd.py" -b -c "${KUBE_TEMP}/htpas
 MASTER_HTPASSWD=$(cat "${KUBE_TEMP}/htpasswd")
 echo $MASTER_HTPASSWD > /srv/salt/nginx/htpasswd
 
-# we will run provision to update code each time we test, so we do not want to do salt install each time
+# we will run provision to update code each time we test, so we do not want to do salt installs each time
 if ! which salt-master >/dev/null 2>&1; then
 
   # Configure the salt-api
@@ -130,10 +130,12 @@ rest_cherrypy:
   webhook_disable_auth: True
 EOF
 
-  # Install Salt
+
+  # Install Salt Master
   #
   # -M installs the master
-  curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -M
+  # -N does not install the minion
+  curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -M -N
 
   # Install salt-api
   #
@@ -144,6 +146,13 @@ EOF
   SYSTEMD_LOG_LEVEL=notice systemctl enable salt-api
   systemctl start salt-api
 
+fi
+
+if ! which salt-minion >/dev/null 2>&1; then
+
+  # Install Salt minion
+  curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s
+  
 else
   # Only run highstate when updating the config.  In the first-run case, Salt is
   # set up to run highstate as new minions join for the first time.


### PR DESCRIPTION
The last few days, I have been getting errors intermittently when using the salt bootstrap scripts where when it checks if both the salt-master and salt-minion are running when installed together on the master VM, one of the two daemons fails to start-up complaining that /var/log/salt already exists when it attempts to create /var/log/salt/minion or /var/log/salt/master directory.

To get around this issue, I install the salt-master and salt-minion in separate steps.  It has proven more reliable.
