### PR TITLE
After all containers in a pod started, If any one container is still run...

### DIFF
--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -311,7 +311,7 @@ func getPodStatus(pod *api.Pod, minions client.MinionInterface) (api.PodStatus, 
 		}
 	}
 	switch {
-	case running > 0 && stopped == 0 && unknown == 0:
+	case running > 0 && unknown == 0:
 		return api.PodRunning, nil
 	case running == 0 && stopped > 0 && unknown == 0:
 		return api.PodTerminated, nil

--- a/pkg/registry/pod/rest_test.go
+++ b/pkg/registry/pod/rest_test.go
@@ -496,7 +496,7 @@ func TestMakePodStatus(t *testing.T) {
 					Host: "machine",
 				},
 			},
-			api.PodWaiting,
+			api.PodRunning,
 			"mixed state #1",
 		},
 		{


### PR DESCRIPTION
...ning, or in the process of restarting, mark pod status running.

Fix #1758.
