### PR TITLE
Control use of HostDir

### DIFF
--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -64,6 +64,7 @@ var (
 	machineList           util.StringList
 	corsAllowedOriginList util.StringList
 	allowPrivileged       = flag.Bool("allow_privileged", false, "If true, allow privileged containers.")
+	allowEscapeChroot     = flag.Bool("allow_escape_chroot", false, "If true, allow HostDir volume types, which expose the node filesystem.")
 	// TODO: Discover these by pinging the host machines, and rip out these flags.
 	nodeMilliCPU      = flag.Int("node_milli_cpu", 1000, "The amount of MilliCPU provisioned on each node")
 	nodeMemory        = flag.Int("node_memory", 3*1024*1024*1024, "The amount of memory (in bytes) provisioned on each node")
@@ -147,7 +148,8 @@ func main() {
 	}
 
 	capabilities.Initialize(capabilities.Capabilities{
-		AllowPrivileged: *allowPrivileged,
+		AllowPrivileged:   *allowPrivileged,
+		AllowEscapeChroot: *allowEscapeChroot,
 	})
 
 	cloud := initCloudProvider(*cloudProvider, *cloudConfigFile)

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -63,6 +63,7 @@ var (
 	etcdConfigFile          = flag.String("etcd_config", "", "The config file for the etcd client. Mutually exclusive with -etcd_servers")
 	rootDirectory           = flag.String("root_dir", defaultRootDir, "Directory path for managing kubelet files (volume mounts,etc).")
 	allowPrivileged         = flag.Bool("allow_privileged", false, "If true, allow containers to request privileged mode. [default=false]")
+	allowEscapeChroot       = flag.Bool("allow_escape_chroot", true, "If true, allow pods to mount node directories as volumes.  [default=true]")
 	registryPullQPS         = flag.Float64("registry_qps", 0.0, "If > 0, limit registry pull QPS to this value.  If 0, unlimited. [default=0.0]")
 	registryBurst           = flag.Int("registry_burst", 10, "Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry_qps.  Only used if --registry_qps > 0")
 	runonce                 = flag.Bool("runonce", false, "If true, exit after spawning pods from local manifests or remote urls. Exclusive with --etcd_servers and --enable-server")
@@ -124,7 +125,8 @@ func main() {
 	etcd.SetLogger(util.NewLogger("etcd "))
 
 	capabilities.Initialize(capabilities.Capabilities{
-		AllowPrivileged: *allowPrivileged,
+		AllowPrivileged:   *allowPrivileged,
+		AllowEscapeChroot: *allowEscapeChroot,
 	})
 
 	dockerClient, err := docker.NewClient(getDockerEndpoint())

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -63,6 +63,11 @@ func validateSource(source *api.VolumeSource) errs.ErrorList {
 	if source.HostDir != nil {
 		numVolumes++
 		allErrs = append(allErrs, validateHostDir(source.HostDir).Prefix("hostDirectory")...)
+		capabilities := capabilities.Get()
+		if !capabilities.AllowEscapeChroot {
+			allErrs = append(allErrs, errs.NewFieldInvalid("hostDir", source.HostDir))
+
+		}
 	}
 	if source.EmptyDir != nil {
 		numVolumes++

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -23,7 +23,8 @@ import (
 // Capabilities defines the set of capabilities available within the system.
 // For now these are global.  Eventually they may be per-user
 type Capabilities struct {
-	AllowPrivileged bool
+	AllowEscapeChroot bool
+	AllowPrivileged   bool
 }
 
 var once sync.Once
@@ -46,7 +47,8 @@ func SetForTests(c Capabilities) {
 func Get() Capabilities {
 	if capabilities == nil {
 		Initialize(Capabilities{
-			AllowPrivileged: false,
+			AllowPrivileged:   false,
+			AllowEscapeChroot: false,
 		})
 	}
 	return *capabilities


### PR DESCRIPTION
A flag on kubelet and apiserver controls use of the HostDir volume type.
Default is to allow since there may be existing use cases.
When prohibited, pods that request HostDir will fail validation.
