### PR TITLE
Add kubectl to build/release scripts.

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -18,10 +18,10 @@ There is also early support for building Docker "run" containers
 
 ## Key scripts
 
-* `make-binaries.sh`: This will compile all of the Kubernetes binaries
+* `make-server.sh`: This will compile all of the Kubernetes server binaries for linux/amd64
+* `make-client.sh`: This will make all cross-compiled client binaries
 * `run-tests.sh`: This will run the Kubernetes unit tests
 * `run-integration.sh`: This will build and run the integration test
-* `make-cross.sh`: This will make all cross-compiled binaries (currently just `kubecfg`)
 * `copy-output.sh`: This will copy the contents of `_output/build` from any remote Docker container to the local `_output/build`.  Right now this is only necessary on Mac OS X with `boot2docker`.
 * `make-clean.sh`: Clean out the contents of `_output/build` and remove any local built container images.
 * `shell.sh`: Drop into a `bash` shell in a build container with a snapshot of the current repo code.

--- a/build/build-image/common.sh
+++ b/build/build-image/common.sh
@@ -23,6 +23,19 @@ cd "${KUBE_ROOT}"
 readonly KUBE_TARGET="${KUBE_ROOT}/_output/build"
 readonly KUBE_GO_PACKAGE=github.com/GoogleCloudPlatform/kubernetes
 
+server_targets=(
+  cmd/proxy
+  cmd/apiserver
+  cmd/controller-manager
+  cmd/kubelet
+  plugin/cmd/scheduler
+)
+
+client_targets=(
+  cmd/kubecfg
+  cmd/kubectl
+)
+
 mkdir -p "${KUBE_TARGET}"
 
 if [[ ! -f "/kube-build-image" ]]; then
@@ -46,19 +59,11 @@ function kube::build::make_binary() {
 }
 
 function kube::build::make_binaries() {
-  local -a targets=(
-    cmd/proxy
-    cmd/apiserver
-    cmd/controller-manager
-    cmd/kubelet
-    cmd/kubecfg
-    plugin/cmd/scheduler
-  )
+  [[ $# -gt 0 ]] || {
+    echo "!!! Internal error. kube::build::make_binaries called with no targets."
+  }
 
-  if [[ -n "${1-}" ]]; then
-    targets=("$1")
-  fi
-
+  local -a targets=("$@")
   local -a binaries=()
   local target
   for target in "${targets[@]}"; do

--- a/build/build-image/make-client.sh
+++ b/build/build-image/make-client.sh
@@ -21,16 +21,19 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${KUBE_ROOT}/build/build-image/common.sh"
 
-readonly CROSS_BINARIES=(
-  ./cmd/kubecfg
-  )
+platforms=(linux/amd64 $KUBE_CROSSPLATFORMS)
+targets=("${client_targets[@]}")
 
-for platform in ${KUBE_CROSSPLATFORMS}; do
+if [[ $# -gt 0 ]]; then
+  targets=("$@")
+fi
+
+for platform in "${platforms[@]}"; do
   (
+    # Subshell to contain these exports
     export GOOS=${platform%/*}
     export GOARCH=${platform##*/}
-    for binary in "${CROSS_BINARIES[@]}"; do
-      kube::build::make_binaries "${binary}"
-    done
+
+    kube::build::make_binaries "${targets[@]}"
   )
 done

--- a/build/build-image/make-server.sh
+++ b/build/build-image/make-server.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 # Copyright 2014 Google Inc. All rights reserved.
 #
@@ -14,19 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make all of the Kubernetes binaries for cross compile targets
-#
-# This makes the docker build image, builds the cross binaries and copies them
-# out of the docker container.
-
 set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "$KUBE_ROOT/build/common.sh"
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${KUBE_ROOT}/build/build-image/common.sh"
 
-kube::build::verify_prereqs
-kube::build::build_image
-kube::build::run_build_command build/build-image/make-cross.sh
-kube::build::copy_output
+targets=("${server_targets[@]}")
+if [[ $# -gt 0 ]]; then
+  targets=("$@")
+fi
+
+kube::build::make_binaries "${targets[@]}"

--- a/build/common.sh
+++ b/build/common.sh
@@ -63,6 +63,7 @@ readonly DOCKER_MOUNT_ARGS=(--volume "${LOCAL_OUTPUT_BUILD}:${REMOTE_OUTPUT_DIR}
 
 readonly KUBE_CLIENT_BINARIES=(
   kubecfg
+  kubectl
 )
 
 readonly KUBE_SERVER_BINARIES=(

--- a/build/make-client.sh
+++ b/build/make-client.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /bin/bash
 
 # Copyright 2014 Google Inc. All rights reserved.
 #
@@ -14,11 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Make all of the client Kubernetes binaries for cross compile targets
+#
+# This makes the docker build image, builds the cross binaries and copies them
+# out of the docker container.
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${KUBE_ROOT}/build/build-image/common.sh"
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "$KUBE_ROOT/build/common.sh"
 
-kube::build::make_binaries "$@"
+kube::build::verify_prereqs
+kube::build::build_image
+kube::build::run_build_command build/build-image/make-client.sh "$@"
+kube::build::copy_output

--- a/build/make-server.sh
+++ b/build/make-server.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make all of the Kubernetes binaries.
+# Make all of the Kubernetes server binaries.
 #
 # This makes the docker build image, builds the binaries and copies them out
 # of the docker container.
@@ -27,5 +27,5 @@ source "$KUBE_ROOT/build/common.sh"
 
 kube::build::verify_prereqs
 kube::build::build_image
-kube::build::run_build_command build/build-image/make-binaries.sh "$@"
+kube::build::run_build_command build/build-image/make-server.sh "$@"
 kube::build::copy_output

--- a/build/release.sh
+++ b/build/release.sh
@@ -29,8 +29,8 @@ KUBE_RELEASE_RUN_TESTS=${KUBE_RELEASE_RUN_TESTS-y}
 
 kube::build::verify_prereqs
 kube::build::build_image
-kube::build::run_build_command build/build-image/make-binaries.sh
-kube::build::run_build_command build/build-image/make-cross.sh
+kube::build::run_build_command build/build-image/make-client.sh
+kube::build::run_build_command build/build-image/make-server.sh
 
 if [[ $KUBE_RELEASE_RUN_TESTS =~ ^[yY]$ ]]; then
   kube::build::run_build_command build/build-image/run-tests.sh

--- a/cluster/kubecfg.sh
+++ b/cluster/kubecfg.sh
@@ -68,7 +68,7 @@ if [[ ! -x "$kubecfg" ]]; then
     echo "It looks as if you don't have a compiled kubecfg binary."
     echo
     echo "If you are running from a clone of the git repo, please run"
-    echo "'./build/make-cross.sh'. Note that this requires having Docker installed."
+    echo "'./build/make-client.sh'. Note that this requires having Docker installed."
     echo
     echo "If you are running from a binary release tarball, something is wrong. "
     echo "Look at http://kubernetes.io/ for information on how to contact the "


### PR DESCRIPTION
Also Refactor build helpers into client/cross and server/linux.  This make it easier to tell users what to build to get just the client binaries.
