### PR TITLE
systemd example unit and environment files

### DIFF
--- a/contrib/init/systemd/README.md
+++ b/contrib/init/systemd/README.md
@@ -1,0 +1,36 @@
+What these give you
+------------------------------------
+
+These 'config' files default to launch a single master/node on the same system talking to each
+other via 127.0.0.1.
+
+They require that etcd be available at 127.0.0.1:4001.
+
+Daemons may have multiple config files.  An example is that the scheduler will pull in 'config', 'apiserver', and 'scheduler'.  In that order.  Each file may overwrite the values of the previous file.  The 'config' file is sourced by all daemons.  The apiserver config file is sourced by those daemons which must know how to reach the apiserver.  Each daemon has its own config file for configuration specific to that daemon.
+
+Commenting out all values or removing all environment files will launch the daemons with no command line options.
+
+Assumptions of the service files
+--------------------------------
+
+1. All binaries live in /usr/bin.
+2. All binaries (except kubelet) are prefixed with kube-
+   * Ex. the apiserver binary should be /usr/bin/kube-apiserver
+3. There is a user named 'kube' on the system.
+   * apiserver, controller-manager, and scheduler are run as kube, not root
+4. Configuration is done in via environment files in /etc/kubernetes/
+
+Non kubernetes defaults in the environment files
+------------------------------------------------
+1. Default to log to stdout/journald instead of directly to disk, see: [KUBE_LOGTOSTDERR](environ/config)
+2. Node list of 127.0.0.1 forced instead of relying on cloud provider, see: [MINION_ADDRESSES](environ/apiserver)
+3. Explicitly set the minion hostname to 127.0.0.1, see: [MINION_HOSTNAME](environ/kubelet)
+4. There is no default for the IP address range of services.  This uses 10.254.0.0/16 see: [KUBE_SERVICE_ADDRESSES](environ/apiserver)
+
+Notes
+-----
+It may seem reasonable to use --option=${OPTION} in the .service file instead of only putting the command line option in the environment file.  However this results in the possiblity of daemons being called with --option= if the environment file does not define a value.  Whereas including the --option string inside the environment file means that nothing will be passed to the daemon.  So the daemon default will be used for things unset by the environment files.
+
+While some command line options to the daemons use the default when passed an empty option some cause the daemon to fail to launch.  --allow_privileged= (without a value of true/false) will cause the apiserver and kubelet to refuse to launch.
+
+It also may seem reasonable to just use ${DAEMON_ARGS} and string all of these into one line in the environment file.  While that makes the .service file simple it makes the admin job more difficult to locate and make appropriate changes to the config.  This is a tradeoff between having to update the .service file to add new options or having the config files easy for an admin to work with.  I choose: "easy for adminmost of the time".

--- a/contrib/init/systemd/environ/apiserver
+++ b/contrib/init/systemd/environ/apiserver
@@ -1,0 +1,26 @@
+###
+# kubernetes system config
+#
+# The following values are used to configure the kubernetes-apiserver
+#
+
+# The address on the local server to listen to.
+KUBE_API_ADDRESS="--address=127.0.0.1"
+
+# The port on the local server to listen on.
+KUBE_API_PORT="--port=8080"
+
+# How the replication controller and scheduler find the apiserver
+KUBE_MASTER="--master=127.0.0.1:8080"
+
+# Comma seperated list of minions
+MINION_ADDRESSES="--machines=127.0.0.1"
+
+# Port minions listen on
+MINION_PORT="--minion_port=10250"
+
+# Address range to use for services
+KUBE_SERVICE_ADDRESSES="--portal_net=10.254.0.0/16"
+
+# Add you own!
+KUBE_API_ARGS=""

--- a/contrib/init/systemd/environ/config
+++ b/contrib/init/systemd/environ/config
@@ -1,0 +1,23 @@
+###
+# kubernetes system config
+#
+# The following values are used to configure various aspects of all
+# kubernetes services, including
+#
+#   kubernetes-apiserver.service
+#   kubernetes-controller-manager.service
+#   kubernetes-scheduler.service
+#   kubelet.service
+#   kubernetes-proxy.service
+
+# Comma seperated list of nodes in the etcd cluster
+KUBE_ETCD_SERVERS="--etcd_servers=http://127.0.0.1:4001"
+
+# logging to stderr means we get it in the systemd journal
+KUBE_LOGTOSTDERR="--logtostderr=true"
+
+# journal message level, 0 is debug
+KUBE_LOG_LEVEL="--v=0"
+
+# Should this cluster be allowed to run privleged docker containers
+KUBE_ALLOW_PRIV="--allow_privileged=false"

--- a/contrib/init/systemd/environ/controller-manager
+++ b/contrib/init/systemd/environ/controller-manager
@@ -1,0 +1,7 @@
+###
+# The following values are used to configure the kubernetes controller-manager
+
+# defaults from config and apiserver should be adequate
+
+# Add you own!
+KUBE_CONTROLLER_MANAGER_ARGS=""

--- a/contrib/init/systemd/environ/kubelet
+++ b/contrib/init/systemd/environ/kubelet
@@ -1,0 +1,14 @@
+###
+# kubernetes kublet (minion) config
+
+# The address for the info server to serve on (set to 0.0.0.0 or "" for all interfaces)
+MINION_ADDRESS="--address=127.0.0.1"
+
+# The port for the info server to serve on
+MINION_PORT="--port=10250"
+
+# You may leave this blank to use the actual hostname
+MINION_HOSTNAME="--hostname_override=127.0.0.1"
+
+# Add your own!
+MINION_ARGS=""

--- a/contrib/init/systemd/environ/proxy
+++ b/contrib/init/systemd/environ/proxy
@@ -1,0 +1,7 @@
+###
+# kubernetes proxy config
+
+# default config should be adequate
+
+# Add your own!
+KUBE_PROXY_ARGS=""

--- a/contrib/init/systemd/environ/scheduler
+++ b/contrib/init/systemd/environ/scheduler
@@ -1,0 +1,7 @@
+###
+# kubernetes scheduler config
+
+# default config should be adequate
+
+# Add your own!
+KUBE_SCHEDULER_ARGS=""

--- a/contrib/init/systemd/kube-apiserver.service
+++ b/contrib/init/systemd/kube-apiserver.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Kubernetes API Server
+Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+
+[Service]
+EnvironmentFile=-/etc/kubernetes/config
+EnvironmentFile=-/etc/kubernetes/apiserver
+User=kube
+ExecStart=/usr/bin/kube-apiserver \
+	    ${KUBE_LOGTOSTDERR} \
+	    ${KUBE_LOG_LEVEL} \
+	    ${KUBE_ETCD_SERVERS} \
+	    ${KUBE_API_ADDRESS} \
+	    ${KUBE_API_PORT} \
+	    ${MINION_ADDRESSES} \
+	    ${MINION_PORT} \
+	    ${KUBE_ALLOW_PRIV} \
+	    ${KUBE_SERVICE_ADDRESSES} \
+	    ${KUBE_API_ARGS}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/init/systemd/kube-controller-manager.service
+++ b/contrib/init/systemd/kube-controller-manager.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Kubernetes Controller Manager
+Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+
+[Service]
+EnvironmentFile=-/etc/kubernetes/config
+EnvironmentFile=-/etc/kubernetes/apiserver
+EnvironmentFile=-/etc/kubernetes/controller-manager
+User=kube
+ExecStart=/usr/bin/kube-controller-manager \
+	    ${KUBE_LOGTOSTDERR} \
+	    ${KUBE_LOG_LEVEL} \
+	    ${KUBE_MASTER} \
+	    ${KUBE_CONTROLLER_MANAGER_ARGS}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/init/systemd/kube-proxy.service
+++ b/contrib/init/systemd/kube-proxy.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Kubernetes Kube-Proxy Server
+Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+
+[Service]
+EnvironmentFile=-/etc/kubernetes/config
+EnvironmentFile=-/etc/kubernetes/proxy
+ExecStart=/usr/bin/kube-proxy \
+	    ${KUBE_LOGTOSTDERR} \
+	    ${KUBE_LOG_LEVEL} \
+	    ${KUBE_ETCD_SERVERS} \
+	    ${KUBE_PROXY_ARGS}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/init/systemd/kube-scheduler.service
+++ b/contrib/init/systemd/kube-scheduler.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Kubernetes Scheduler Plugin
+Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+
+[Service]
+EnvironmentFile=-/etc/kubernetes/config
+EnvironmentFile=-/etc/kubernetes/apiserver
+EnvironmentFile=-/etc/kubernetes/scheduler
+ExecStart=/usr/bin/kube-scheduler \
+	    ${KUBE_LOGTOSTDERR} \
+	    ${KUBE_LOG_LEVEL} \
+	    ${KUBE_MASTER} \
+	    ${KUBE_SCHEDULER_ARGS}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/init/systemd/kubelet.service
+++ b/contrib/init/systemd/kubelet.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Kubernetes Kubelet Server
+Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+After=docker.socket cadvisor.service
+Requires=docker.socket
+
+[Service]
+EnvironmentFile=-/etc/kubernetes/config
+EnvironmentFile=-/etc/kubernetes/kubelet
+ExecStart=/usr/bin/kubelet \
+	    ${KUBE_LOGTOSTDERR} \
+	    ${KUBE_LOG_LEVEL} \
+	    ${KUBE_ETCD_SERVERS} \
+	    ${MINION_ADDRESS} \
+	    ${MINION_PORT} \
+	    ${MINION_HOSTNAME} \
+	    ${KUBE_ALLOW_PRIV} \
+	    ${MINION_ARGS}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The binary names in these are

kube-apiserver
kube-controller-manager
kube-scheduler
kube-proxy
kubelet

The environment/config files need to live in /etc/kubernetes/

I personally like the namespaced binaries a lot more than just 'apiserver' etc.  I wouldn't mind if we switched the binary names to something namespaced in the in project build...
