### PR TITLE
Pass arguments to td-agent with unquoted spaces

### DIFF
--- a/contrib/logging/fluentd-es-image/run.sh
+++ b/contrib/logging/fluentd-es-image/run.sh
@@ -26,4 +26,4 @@ OUTER_HOST=`tail -n 1 /outerhost | awk '{print $3}'`
 # service IPs are done.
 # Adjust the name of the host machine for %ES_HOST%. HACK!
 sed -i -e "s/\%ES_HOST\%/${OUTER_HOST}/" /etc/td-agent/td-agent.conf
-/usr/sbin/td-agent $@
+/usr/sbin/td-agent "$@"


### PR DESCRIPTION
The original form pass arguments like "alpha beta gamma" (i.e. as one argument) but we should pass them through as separate arguments i.e. "alpha" "beta" "gamma" (accomplished by double quotes around $@).
