### PR TITLE
report originating error for GetReference failure

### DIFF
--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -34,7 +34,7 @@ func RecoverPanics(handler http.Handler) http.Handler {
 			if x := recover(); x != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				fmt.Fprint(w, "apis panic. Look in log for details.")
-				glog.Infof("APIServer panic'd on %v %v: %#v\n%s\n", req.Method, req.RequestURI, x, debug.Stack())
+				glog.Infof("APIServer panic'd on %v %v: %v\n%s\n", req.Method, req.RequestURI, x, debug.Stack())
 			}
 		}()
 		defer httplog.NewLogged(req, &w).StacktraceWhen(

--- a/pkg/client/record/event.go
+++ b/pkg/client/record/event.go
@@ -99,7 +99,7 @@ var events = watch.NewMux(queueLen)
 func Event(object runtime.Object, fieldPath, status, reason, message string) {
 	ref, err := api.GetReference(object)
 	if err != nil {
-		glog.Errorf("Could not construct reference to: %#v", object)
+		glog.Errorf("Could not construct reference to: %#v due to: %v", object, err)
 		return
 	}
 	ref.FieldPath = fieldPath


### PR DESCRIPTION
When there is an error getting the reference, the originating error is suppressed making it difficult to debug.  This simply adds the originating error to the existing error message.
