### PR TITLE
Error when watching service endpoints across all namespaces

### DIFF
--- a/pkg/registry/etcd/etcd.go
+++ b/pkg/registry/etcd/etcd.go
@@ -575,11 +575,7 @@ func (r *Registry) WatchEndpoints(ctx api.Context, label, field labels.Selector,
 		return r.Watch(key, version), nil
 	}
 	if field.Empty() {
-		key, err := makeServiceEndpointsKey(ctx, "")
-		if err != nil {
-			return nil, err
-		}
-		return r.WatchList(key, version, tools.Everything)
+		return r.WatchList(makeServiceEndpointsListKey(ctx), version, tools.Everything)
 	}
 	return nil, fmt.Errorf("only the 'ID' and default (everything) field selectors are supported")
 }


### PR DESCRIPTION
This was a bug reported by @bketelsen who is using the proxy/config/api source channel.

A watch of service endpoints across all namespaces was throwing an error because it was using the older key method that was missed in an update of the enforce namespace PR.
