### PR TITLE
Fixup apiserver proxy to be namespace aware

### DIFF
--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -116,6 +116,8 @@ The k8s API server will associate a resource with a *Namespace* if not populated
 of the incoming request.  If the *Namespace* of the resource being created, or updated does not match the *Namespace* on the request,
 then the k8s API server will reject the request.
 
+TODO: Update to discuss k8s api server proxy patterns
+
 ## k8s storage
 
 A namespace provides a unique identifier space and therefore must be in the storage path of a resource.

--- a/pkg/apiserver/proxy.go
+++ b/pkg/apiserver/proxy.go
@@ -77,7 +77,14 @@ type ProxyHandler struct {
 }
 
 func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	ctx := api.NewContext()
+	// use the default namespace to address the service
+	ctx := api.NewDefaultContext()
+	// if not in default namespace, provide the query parameter
+	// TODO this will need to go in the path in the future and not as a query parameter
+	namespace := req.URL.Query().Get("namespace")
+	if len(namespace) > 0 {
+		ctx = api.WithNamespace(ctx, namespace)
+	}
 	parts := strings.SplitN(req.URL.Path, "/", 3)
 	if len(parts) < 2 {
 		notFound(w, req)


### PR DESCRIPTION
The apiserver was not setting a proper namespace value for a request.

```
curl -s --insecure -u vagrant:vagrant https://10.245.1.2/api/v1beta1/proxy/services/db | python -m json.tool | more{
    "apiVersion": "v1beta1",
    "code": 500,
    "creationTimestamp": null,
    "kind": "Status",
    "message": "Invalid request.  Unable to address and item without a namespace
on context",
    "status": "Failure"
}
```

The fix is to assume the default namespace, unless an alternative is provided in the query parameter of the URL.

Added a placeholder TODO for the namespaces.md spec to address path structures for this when we move to make the namespace part of the URL path.
