### PR TITLE
Make kubelet handleRun work for pods in non-default namespace

### DIFF
--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -296,23 +296,24 @@ func (s *Server) handleRun(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	parts := strings.Split(u.Path, "/")
-	var podID, uuid, container string
-	if len(parts) == 4 {
-		podID = parts[2]
-		container = parts[3]
-	} else if len(parts) == 5 {
-		podID = parts[2]
-		uuid = parts[3]
+	var podNamespace, podID, uuid, container string
+	if len(parts) == 5 {
+		podNamespace = parts[2]
+		podID = parts[3]
 		container = parts[4]
+	} else if len(parts) == 6 {
+		podNamespace = parts[2]
+		podID = parts[3]
+		uuid = parts[4]
+		container = parts[5]
 	} else {
 		http.Error(w, "Unexpected path for command running", http.StatusBadRequest)
 		return
 	}
 	podFullName := GetPodFullName(&api.BoundPod{
 		TypeMeta: api.TypeMeta{
-			ID: podID,
-			// TODO: I am broken
-			Namespace:   api.NamespaceDefault,
+			ID:          podID,
+			Namespace:   podNamespace,
 			Annotations: map[string]string{ConfigSourceAnnotationKey: "etcd"},
 		},
 	})

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -386,8 +386,9 @@ func TestServeLogs(t *testing.T) {
 func TestServeRunInContainer(t *testing.T) {
 	fw := newServerTest()
 	output := "foo bar"
+	podNamespace := "other"
 	podName := "foo"
-	expectedPodName := podName + ".default.etcd"
+	expectedPodName := podName + "." + podNamespace + ".etcd"
 	expectedContainerName := "baz"
 	expectedCommand := "ls -a"
 	fw.fakeKubelet.runFunc = func(podFullName, uuid, containerName string, cmd []string) ([]byte, error) {
@@ -404,7 +405,7 @@ func TestServeRunInContainer(t *testing.T) {
 		return []byte(output), nil
 	}
 
-	resp, err := http.Get(fw.testHTTPServer.URL + "/run/" + podName + "/" + expectedContainerName + "?cmd=ls%20-a")
+	resp, err := http.Get(fw.testHTTPServer.URL + "/run/" + podNamespace + "/" + podName + "/" + expectedContainerName + "?cmd=ls%20-a")
 
 	if err != nil {
 		t.Fatalf("Got error GETing: %v", err)
@@ -425,8 +426,9 @@ func TestServeRunInContainer(t *testing.T) {
 func TestServeRunInContainerWithUUID(t *testing.T) {
 	fw := newServerTest()
 	output := "foo bar"
+	podNamespace := "other"
 	podName := "foo"
-	expectedPodName := podName + ".default.etcd"
+	expectedPodName := podName + "." + podNamespace + ".etcd"
 	expectedUuid := "7e00838d_-_3523_-_11e4_-_8421_-_42010af0a720"
 	expectedContainerName := "baz"
 	expectedCommand := "ls -a"
@@ -447,7 +449,7 @@ func TestServeRunInContainerWithUUID(t *testing.T) {
 		return []byte(output), nil
 	}
 
-	resp, err := http.Get(fw.testHTTPServer.URL + "/run/" + podName + "/" + expectedUuid + "/" + expectedContainerName + "?cmd=ls%20-a")
+	resp, err := http.Get(fw.testHTTPServer.URL + "/run/" + podNamespace + "/" + podName + "/" + expectedUuid + "/" + expectedContainerName + "?cmd=ls%20-a")
 
 	if err != nil {
 		t.Fatalf("Got error GETing: %v", err)


### PR DESCRIPTION
Updated kubelet server to take a podNamespace as input.

Did not find any other internal callers of this in k8s, but if reviewer is aware of some, I can update.
