### PR TITLE
Look at all tags when looking for version.

### DIFF
--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -78,7 +78,7 @@ kube::version_ldflags() {
       ldflags+=(-X "${KUBE_GO_PACKAGE}/pkg/version.gitTreeState" "${KUBE_GIT_TREE_STATE}")
 
       # Use git describe to find the version based on annotated tags.
-      if [[ -n ${KUBE_GIT_VERSION-} ]] || KUBE_GIT_VERSION=$(git describe --abbrev=14 "${KUBE_GIT_COMMIT}^{commit}" 2>/dev/null); then
+      if [[ -n ${KUBE_GIT_VERSION-} ]] || KUBE_GIT_VERSION=$(git describe --tag --abbrev=14 "${KUBE_GIT_COMMIT}^{commit}" 2>/dev/null); then
         if [[ "${KUBE_GIT_TREE_STATE}" == "dirty" ]]; then
           # git describe --dirty only considers changes to existing files, but
           # that is problematic since new untracked .go files affect the build,


### PR DESCRIPTION
'git describe' uses only annotated tags by default.  We want to use all tags as we can only create 'lightweight' tags in the GitHub UI.
