### PR TITLE
Podex handling multiple images

### DIFF
--- a/contrib/podex/podex.go
+++ b/contrib/podex/podex.go
@@ -40,10 +40,11 @@ import (
 	"gopkg.in/v1/yaml"
 )
 
-const usage = "usage: podex [-json|-yaml] <repo/dockerimage>"
+const usage = "usage: podex [-json|-yaml] -id=ID username/image1 ... username/imageN"
 
 var generateJSON = flag.Bool("json", false, "generate json manifest")
 var generateYAML = flag.Bool("yaml", false, "generate yaml manifest")
+var podName = flag.String("id", "", "set pod name")
 
 func main() {
 	flag.Parse()
@@ -51,60 +52,64 @@ func main() {
 	if flag.NArg() < 1 {
 		log.Fatal(usage)
 	}
-
-	imageName := flag.Arg(0)
-	if len(imageName) == 0 {
-		log.Fatal(usage)
+	if *podName == "" {
+		if flag.NArg() > 1 {
+			log.Fatal(usage)
+		}
+		_, *podName = parseDockerImage(flag.Arg(0))
 	}
 
 	if (!*generateJSON && !*generateYAML) || (*generateJSON && *generateYAML) {
 		log.Fatal(usage)
 	}
 
-	// Parse docker image name
-	// IMAGE: [REGISTRYHOST/][USERNAME/]NAME[:TAG]
-	// NAME: [a-z0-9-_.]
-	parts := strings.Split(imageName, "/")
-	baseName := parts[len(parts)-1]
-
 	dockerHost := os.Getenv("DOCKER_HOST")
 	if dockerHost == "" {
 		log.Fatalf("DOCKER_HOST is not set")
 	}
-
 	docker, err := dockerclient.NewClient(dockerHost)
 	if err != nil {
 		log.Fatalf("failed to connect to %q: %v", dockerHost, err)
 	}
 
-	// TODO(proppy): use the regitry API instead of the remote API to get image metadata.
-	img, err := docker.InspectImage(imageName)
-	if err != nil {
-		log.Fatalf("failed to inspect image %q: %v", imageName, err)
-	}
-	// TODO(proppy): add flag to handle multiple version
-	manifest := v1beta1.ContainerManifest{
-		Version: "v1beta1",
-		ID:      baseName + "-pod",
-		Containers: []v1beta1.Container{{
+	podContainers := []v1beta1.Container{}
+
+	for _, imageName := range flag.Args() {
+		parts, baseName := parseDockerImage(imageName)
+		container := v1beta1.Container{
 			Name:  baseName,
 			Image: imageName,
-		}},
+		}
+
+		// TODO(proppy): use the regitry API instead of the remote API to get image metadata.
+		img, err := docker.InspectImage(imageName)
+		if err != nil {
+			log.Fatalf("failed to inspect image %q: %v", imageName, err)
+		}
+		for p := range img.Config.ExposedPorts {
+			port, err := strconv.Atoi(p.Port())
+			if err != nil {
+				log.Fatalf("failed to parse port %q: %v", parts[0], err)
+			}
+			container.Ports = append(container.Ports, v1beta1.Port{
+				Name:          strings.Join([]string{baseName, p.Proto(), p.Port()}, "-"),
+				ContainerPort: port,
+				Protocol:      v1beta1.Protocol(strings.ToUpper(p.Proto())),
+			})
+		}
+		podContainers = append(podContainers, container)
+	}
+
+	// TODO(proppy): add flag to handle multiple version
+	manifest := v1beta1.ContainerManifest{
+		Version:    "v1beta1",
+		ID:         *podName + "-pod",
+		Containers: podContainers,
 		RestartPolicy: v1beta1.RestartPolicy{
 			Always: &v1beta1.RestartPolicyAlways{},
 		},
 	}
-	for p := range img.Config.ExposedPorts {
-		port, err := strconv.Atoi(p.Port())
-		if err != nil {
-			log.Fatalf("failed to parse port %q: %v", parts[0], err)
-		}
-		manifest.Containers[0].Ports = append(manifest.Containers[0].Ports, v1beta1.Port{
-			Name:          strings.Join([]string{baseName, p.Proto(), p.Port()}, "-"),
-			ContainerPort: port,
-			Protocol:      v1beta1.Protocol(strings.ToUpper(p.Proto())),
-		})
-	}
+
 	if *generateJSON {
 		bs, err := json.MarshalIndent(manifest, "", "  ")
 		if err != nil {
@@ -119,4 +124,16 @@ func main() {
 		}
 		os.Stdout.Write(bs)
 	}
+}
+
+// parseDockerImage split a docker image name of the form [REGISTRYHOST/][USERNAME/]NAME[:TAG]
+// TODO: handle the TAG
+// Returns array of images name parts and base image name
+func parseDockerImage(imageName string) (parts []string, baseName string) {
+	// Parse docker image name
+	// IMAGE: [REGISTRYHOST/][USERNAME/]NAME[:TAG]
+	// NAME: [a-z0-9-_.]
+	parts = strings.Split(imageName, "/")
+	baseName = parts[len(parts)-1]
+	return
 }


### PR DESCRIPTION
Podex can now handle multiple images.
Also adding `podID` flag, with which user can specify the pod ID.
eg:
   `podex -json -podID=nodejs dockerfile/redis google/nodejs-hello`

In case the command will take only one image the `podID` is optional and image base-name will be used for as a podID 
