### PR TITLE
Add unit test for namespace aware proxy

### DIFF
--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -83,6 +83,7 @@ type SimpleRESTStorage struct {
 	// The id requested, and location to return for ResourceLocation
 	requestedResourceLocationID string
 	resourceLocation            string
+	expectedResourceNamespace   string
 
 	// If non-nil, called inside the WorkFunc when answering update, delete, create.
 	// obj receives the original input to the update, delete, or create call.
@@ -157,6 +158,11 @@ func (storage *SimpleRESTStorage) Watch(ctx api.Context, label, field labels.Sel
 
 // Implement Redirector.
 func (storage *SimpleRESTStorage) ResourceLocation(ctx api.Context, id string) (string, error) {
+	// validate that the namespace context on the request matches the expected input
+	requestedResourceNamespace := api.Namespace(ctx)
+	if storage.expectedResourceNamespace != requestedResourceNamespace {
+		return "", fmt.Errorf("Expected request namespace %s, but got namespace %s", storage.expectedResourceNamespace, requestedResourceNamespace)
+	}
 	storage.requestedResourceLocationID = id
 	if err := storage.errors["resourceLocation"]; err != nil {
 		return "", err

--- a/pkg/apiserver/proxy_test.go
+++ b/pkg/apiserver/proxy_test.go
@@ -132,15 +132,17 @@ func TestProxyTransport_fixLinks(t *testing.T) {
 
 func TestProxy(t *testing.T) {
 	table := []struct {
-		method   string
-		path     string
-		reqBody  string
-		respBody string
+		method       string
+		path         string
+		reqBody      string
+		respBody     string
+		reqNamespace string
 	}{
-		{"GET", "/some/dir", "", "answer"},
-		{"POST", "/some/other/dir", "question", "answer"},
-		{"PUT", "/some/dir/id", "different question", "answer"},
-		{"DELETE", "/some/dir/id", "", "ok"},
+		{"GET", "/some/dir", "", "answer", "default"},
+		{"POST", "/some/other/dir", "question", "answer", "default"},
+		{"PUT", "/some/dir/id", "different question", "answer", "default"},
+		{"DELETE", "/some/dir/id", "", "ok", "default"},
+		{"GET", "/some/dir/id?namespace=other", "", "answer", "other"},
 	}
 
 	for _, item := range table {
@@ -156,8 +158,9 @@ func TestProxy(t *testing.T) {
 		}))
 
 		simpleStorage := &SimpleRESTStorage{
-			errors:           map[string]error{},
-			resourceLocation: proxyServer.URL,
+			errors:                    map[string]error{},
+			resourceLocation:          proxyServer.URL,
+			expectedResourceNamespace: item.reqNamespace,
 		}
 		handler := Handle(map[string]RESTStorage{
 			"foo": simpleStorage,


### PR DESCRIPTION
This is a follow-on to #1868 with the promised unit test to validate that the storage object is provided a namespace in the context that was requested.
