### PR TITLE
Don't write password in get-password

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -192,15 +192,6 @@ function get-password {
   fi
   KUBE_USER=admin
   KUBE_PASSWORD=$(python -c 'import string,random; print "".join(random.SystemRandom().choice(string.ascii_letters + string.digits) for _ in range(16))')
-
-  # Store password for reuse.
-  cat << EOF > "$file"
-{
-  "User": "$KUBE_USER",
-  "Password": "$KUBE_PASSWORD"
-}
-EOF
-  chmod 0600 "$file"
 }
 
 # Instantiate a kubernetes cluster

--- a/icebox/cluster/azure/util.sh
+++ b/icebox/cluster/azure/util.sh
@@ -41,15 +41,6 @@ function get-password {
     fi
     user=admin
     passwd=$(python -c 'import string,random; print "".join(random.SystemRandom().choice(string.ascii_letters + string.digits) for _ in range(16))')
-
-    # Store password for reuse.
-    cat << EOF > ~/.kubernetes_auth
-{
-  "User": "$user",
-  "Password": "$passwd"
-}
-EOF
-    chmod 0600 ~/.kubernetes_auth
 }
 
 # Verify prereqs
@@ -199,6 +190,8 @@ function kube-up {
             exit 1
         fi
     done
+
+    # TODO: write .kubernetes_auth file with user/pass/certs/key
 
     echo
     echo "Kubernetes cluster is running.  The master is running at:"

--- a/icebox/cluster/rackspace/util.sh
+++ b/icebox/cluster/rackspace/util.sh
@@ -241,6 +241,8 @@ kube-up() {
 
   detect-minions
 
+  # TODO: write .kubernetes_auth file with user/pass/certs/key
+
   echo "All minions may not be online yet, this is okay."
   echo
   echo "Kubernetes cluster is running.  The master is running at:"

--- a/icebox/cluster/vsphere/util.sh
+++ b/icebox/cluster/vsphere/util.sh
@@ -217,6 +217,7 @@ function kube-up {
       fi
   done
 
+  # TODO: write .kubernetes_auth file with user/pass/certs/key
   echo
   echo "Kubernetes cluster is running. The master is running at:"
   echo


### PR DESCRIPTION
get-password overwrites the .kubernetes_auth,
without respecting some added fields.

For GCE, it is not necessary to write in
the file in kube-up() because the file
is written later in the function.

In kube-push, it is not necessary to write
since the cluster is already created.

For vagrant, it was not saving them, so no change.

Other providers are in the "icebox".  Added todos to those.
