### PR TITLE
Flunentd to GCP logging node level configuration

### DIFF
--- a/cluster/gce/templates/create-dynamic-salt-files.sh
+++ b/cluster/gce/templates/create-dynamic-salt-files.sh
@@ -23,6 +23,7 @@ cat <<EOF >/srv/salt-overlay/pillar/cluster-params.sls
 node_instance_prefix: $NODE_INSTANCE_PREFIX
 portal_net: $PORTAL_NET
 use-fluentd-es: $FLUENTD_ELASTICSEARCH
+use-fluentd-gcp: $FLUENTD_GCP
 EOF
 
 mkdir -p /srv/salt-overlay/salt/nginx

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -265,10 +265,16 @@ function kube-up {
     echo "readonly MASTER_HTPASSWD='${htpasswd}'"
     echo "readonly PORTAL_NET='${PORTAL_NET}'"
     echo "readonly FLUENTD_ELASTICSEARCH='${FLUENTD_ELASTICSEARCH:-false}'"
+    echo "readonly FLUENTD_GCP='${FLUENTD_GCP:-false}'"
     grep -v "^#" "${KUBE_ROOT}/cluster/gce/templates/create-dynamic-salt-files.sh"
     grep -v "^#" "${KUBE_ROOT}/cluster/gce/templates/download-release.sh"
     grep -v "^#" "${KUBE_ROOT}/cluster/gce/templates/salt-master.sh"
   ) > "${KUBE_TEMP}/master-start.sh"
+
+  # For logging to GCP we need to enable some minion scopes.
+  if [ $FLUENTD_GCP == "true" ]; then
+     MINION_SCOPES="${MINION_SCOPES}, https://www.googleapis.com/auth/logging.write"
+  fi
 
   gcutil addinstance "${MASTER_NAME}" \
     --project "${PROJECT}" \

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.manifest
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.manifest
@@ -1,0 +1,14 @@
+version: v1beta2
+id: fluentd-to-gcp
+containers:
+  - name: fluentd-gcp-container
+    image: kubernetes/fluentd-gcp
+    volumeMounts:
+      - name: containers
+        mountPath: /var/lib/docker/containers
+        readOnly: true
+volumes:
+  - name: containers
+    source:
+      hostDir:
+        path: /var/lib/docker/containers

--- a/cluster/saltbase/salt/fluentd-gcp/init.sls
+++ b/cluster/saltbase/salt/fluentd-gcp/init.sls
@@ -1,0 +1,8 @@
+/etc/kubernetes/manifests/fluentd-gcp.manifest:
+  file.managed:
+    - source: salt://fluentd-gcp/fluentd-gcp.manifest
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: true
+    - dir_mode: 755

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -11,6 +11,9 @@ base:
 {% if pillar['use-fluentd-es'] is defined and pillar['use-fluentd-es'] %}
     - fluentd-es
 {% endif %}
+{% if pillar['use-fluentd-gcp'] is defined and pillar['use-fluentd-gcp'] %}
+    - fluentd-gcp
+{% endif %}
     # We need a binary release of nsinit
     # - nsinit
     - logrotate

--- a/docs/getting-started-guides/logging.md
+++ b/docs/getting-started-guides/logging.md
@@ -16,3 +16,8 @@ be targetted at an [Elasticsearch](http://www.elasticsearch.org/) instance assum
 local node and accepting log information on port 9200. This can be accomplished
 by writing a pod specification and service sepecificaiton to define an
 Elasticsearch service (more informaiton to follow shortly in the contrib directory).
+
+### Logging with Fluentd and Google Compute Platform
+
+To enable logging of Docker contains in a cluster using Google Compute
+Platfrom set the shell environment variable ``FLUENTD_GCP`` to ``true``.


### PR DESCRIPTION
This is the setup to conditionally support logging using Fluentd and GCP. If enabled with FLUENTD_GCP=true then this will install a manifest on each node which will instantiate a Fluentd instance (in a Docker container) on each node which causes logging data to be ingested into Google Compute Platform. When this option is enabled the minion are created with extra scopes to allow the required logging API calls to be authenticated.
