### PR TITLE
Check to see if FLUENTD_GCP is defined before use

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -287,7 +287,7 @@ function kube-up {
   ) > "${KUBE_TEMP}/master-start.sh"
 
   # For logging to GCP we need to enable some minion scopes.
-  if [ $FLUENTD_GCP == "true" ]; then
+  if [ -n "$FLUENTD_GCP" ] && [ "$FLUENTD_GCP" = "true" ]; then
      MINION_SCOPES="${MINION_SCOPES}, https://www.googleapis.com/auth/logging.write"
   fi
 


### PR DESCRIPTION
Fix breakage I introduced by not checking to see if FLUENTD_GCP existed before using it.
