### PR TITLE
Add Makefile shortcut to release with skip tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,3 +92,12 @@ vet:
 release:
 	build/release.sh
 .PHONY: release
+
+# Build a release, but skip tests
+# 
+# Example:
+#   make release-skip-tests
+release-skip-tests:
+	KUBE_RELEASE_RUN_TESTS=n build/release.sh
+.PHONY: release-skip-tests
+


### PR DESCRIPTION
I use this all the time, and would like it upstream so I do not need to remember the ENV var name.
