### PR TITLE
Rework client.Interface

### DIFF
--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/proxy"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/proxy/config"
@@ -63,7 +64,8 @@ func main() {
 			glog.Fatalf("Invalid API configuration: %v", err)
 		}
 		config.NewSourceAPI(
-			client,
+			client.Services(api.NamespaceAll),
+			client.Endpoints(api.NamespaceAll),
 			30*time.Second,
 			serviceConfig.Channel("api"),
 			endpointsConfig.Channel("api"),

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -36,27 +36,27 @@ type Interface interface {
 }
 
 func (c *Client) ReplicationControllers(namespace string) ReplicationControllerInterface {
-	return NewReplicationControllersClient(c, namespace)
+	return newReplicationControllers(c, namespace)
 }
 
 func (c *Client) Minions() MinionInterface {
-	return NewMinionsClient(c)
+	return newMinions(c)
 }
 
 func (c *Client) Events() EventInterface {
-	return NewEventsClient(c)
+	return newEvents(c)
 }
 
 func (c *Client) Endpoints(namespace string) EndpointsInterface {
-	return NewEndpointsClient(c, namespace)
+	return newEndpoints(c, namespace)
 }
 
 func (c *Client) Pods(namespace string) PodInterface {
-	return NewPodsClient(c, namespace)
+	return newPods(c, namespace)
 }
 
 func (c *Client) Services(namespace string) ServiceInterface {
-	return NewServicesClient(c, namespace)
+	return newServices(c, namespace)
 }
 
 // VersionInterface has a method to retrieve the server version.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -21,75 +21,47 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
 // Interface holds the methods for clients of Kubernetes,
 // an interface to allow mock testing.
-// TODO: these should return/take pointers.
 type Interface interface {
-	PodInterface
-	ReplicationControllerInterface
-	ServiceInterface
+	PodsNamespacer
+	ReplicationControllersNamespacer
+	ServicesNamespacer
 	VersionInterface
-	MinionInterface
+	MinionsInterface
+	EventsInterface
 }
 
-// PodInterface has methods to work with Pod resources.
-type PodInterface interface {
-	ListPods(ctx api.Context, selector labels.Selector) (*api.PodList, error)
-	GetPod(ctx api.Context, id string) (*api.Pod, error)
-	DeletePod(ctx api.Context, id string) error
-	CreatePod(ctx api.Context, pod *api.Pod) (*api.Pod, error)
-	UpdatePod(ctx api.Context, pod *api.Pod) (*api.Pod, error)
+func (c *Client) ReplicationControllers(namespace string) ReplicationControllerInterface {
+	return NewReplicationControllersClient(c, namespace)
 }
 
-// ReplicationControllerInterface has methods to work with ReplicationController resources.
-type ReplicationControllerInterface interface {
-	ListReplicationControllers(ctx api.Context, selector labels.Selector) (*api.ReplicationControllerList, error)
-	GetReplicationController(ctx api.Context, id string) (*api.ReplicationController, error)
-	CreateReplicationController(ctx api.Context, ctrl *api.ReplicationController) (*api.ReplicationController, error)
-	UpdateReplicationController(ctx api.Context, ctrl *api.ReplicationController) (*api.ReplicationController, error)
-	DeleteReplicationController(ctx api.Context, id string) error
-	WatchReplicationControllers(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+func (c *Client) Minions() MinionInterface {
+	return NewMinionsClient(c)
 }
 
-// ServiceInterface has methods to work with Service resources.
-type ServiceInterface interface {
-	ListServices(ctx api.Context, selector labels.Selector) (*api.ServiceList, error)
-	GetService(ctx api.Context, id string) (*api.Service, error)
-	CreateService(ctx api.Context, srv *api.Service) (*api.Service, error)
-	UpdateService(ctx api.Context, srv *api.Service) (*api.Service, error)
-	DeleteService(ctx api.Context, id string) error
-	WatchServices(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+func (c *Client) Events() EventInterface {
+	return NewEventsClient(c)
 }
 
-// EndpointsInterface has methods to work with Endpoints resources
-type EndpointsInterface interface {
-	ListEndpoints(ctx api.Context, selector labels.Selector) (*api.EndpointsList, error)
-	GetEndpoints(ctx api.Context, id string) (*api.Endpoints, error)
-	WatchEndpoints(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+func (c *Client) Endpoints(namespace string) EndpointsInterface {
+	return NewEndpointsClient(c, namespace)
 }
 
-// EventInterface has methods to work with Event resources
-type EventInterface interface {
-	CreateEvent(event *api.Event) (*api.Event, error)
-	ListEvents(selector labels.Selector) (*api.EventList, error)
-	GetEvent(id string) (*api.Event, error)
-	WatchEvents(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+func (c *Client) Pods(namespace string) PodInterface {
+	return NewPodsClient(c, namespace)
+}
+
+func (c *Client) Services(namespace string) ServiceInterface {
+	return NewServicesClient(c, namespace)
 }
 
 // VersionInterface has a method to retrieve the server version.
 type VersionInterface interface {
 	ServerVersion() (*version.Info, error)
-}
-
-type MinionInterface interface {
-	CreateMinion(minion *api.Minion) (*api.Minion, error)
-	ListMinions() (*api.MinionList, error)
-	DeleteMinion(id string) error
 }
 
 // APIStatus is exposed by errors that can be converted to an api.Status object
@@ -101,190 +73,6 @@ type APIStatus interface {
 // Client is the implementation of a Kubernetes client.
 type Client struct {
 	*RESTClient
-}
-
-// ListPods takes a selector, and returns the list of pods that match that selector.
-func (c *Client) ListPods(ctx api.Context, selector labels.Selector) (result *api.PodList, err error) {
-	result = &api.PodList{}
-	err = c.Get().Namespace(api.Namespace(ctx)).Path("pods").SelectorParam("labels", selector).Do().Into(result)
-	return
-}
-
-// GetPod takes the id of the pod, and returns the corresponding Pod object, and an error if it occurs
-func (c *Client) GetPod(ctx api.Context, id string) (result *api.Pod, err error) {
-	result = &api.Pod{}
-	err = c.Get().Namespace(api.Namespace(ctx)).Path("pods").Path(id).Do().Into(result)
-	return
-}
-
-// DeletePod takes the id of the pod, and returns an error if one occurs
-func (c *Client) DeletePod(ctx api.Context, id string) error {
-	return c.Delete().Namespace(api.Namespace(ctx)).Path("pods").Path(id).Do().Error()
-}
-
-// CreatePod takes the representation of a pod.  Returns the server's representation of the pod, and an error, if it occurs.
-func (c *Client) CreatePod(ctx api.Context, pod *api.Pod) (result *api.Pod, err error) {
-	result = &api.Pod{}
-	err = c.Post().Namespace(api.Namespace(ctx)).Path("pods").Body(pod).Do().Into(result)
-	return
-}
-
-// UpdatePod takes the representation of a pod to update.  Returns the server's representation of the pod, and an error, if it occurs.
-func (c *Client) UpdatePod(ctx api.Context, pod *api.Pod) (result *api.Pod, err error) {
-	result = &api.Pod{}
-	if len(pod.ResourceVersion) == 0 {
-		err = fmt.Errorf("invalid update object, missing resource version: %v", pod)
-		return
-	}
-	err = c.Put().Namespace(api.Namespace(ctx)).Path("pods").Path(pod.Name).Body(pod).Do().Into(result)
-	return
-}
-
-// ListReplicationControllers takes a selector, and returns the list of replication controllers that match that selector.
-func (c *Client) ListReplicationControllers(ctx api.Context, selector labels.Selector) (result *api.ReplicationControllerList, err error) {
-	result = &api.ReplicationControllerList{}
-	err = c.Get().Namespace(api.Namespace(ctx)).Path("replicationControllers").SelectorParam("labels", selector).Do().Into(result)
-	return
-}
-
-// GetReplicationController returns information about a particular replication controller.
-func (c *Client) GetReplicationController(ctx api.Context, id string) (result *api.ReplicationController, err error) {
-	result = &api.ReplicationController{}
-	err = c.Get().Namespace(api.Namespace(ctx)).Path("replicationControllers").Path(id).Do().Into(result)
-	return
-}
-
-// CreateReplicationController creates a new replication controller.
-func (c *Client) CreateReplicationController(ctx api.Context, controller *api.ReplicationController) (result *api.ReplicationController, err error) {
-	result = &api.ReplicationController{}
-	err = c.Post().Namespace(api.Namespace(ctx)).Path("replicationControllers").Body(controller).Do().Into(result)
-	return
-}
-
-// UpdateReplicationController updates an existing replication controller.
-func (c *Client) UpdateReplicationController(ctx api.Context, controller *api.ReplicationController) (result *api.ReplicationController, err error) {
-	result = &api.ReplicationController{}
-	if len(controller.ResourceVersion) == 0 {
-		err = fmt.Errorf("invalid update object, missing resource version: %v", controller)
-		return
-	}
-	err = c.Put().Namespace(api.Namespace(ctx)).Path("replicationControllers").Path(controller.Name).Body(controller).Do().Into(result)
-	return
-}
-
-// DeleteReplicationController deletes an existing replication controller.
-func (c *Client) DeleteReplicationController(ctx api.Context, id string) error {
-	return c.Delete().Namespace(api.Namespace(ctx)).Path("replicationControllers").Path(id).Do().Error()
-}
-
-// WatchReplicationControllers returns a watch.Interface that watches the requested controllers.
-func (c *Client) WatchReplicationControllers(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	return c.Get().
-		Namespace(api.Namespace(ctx)).
-		Path("watch").
-		Path("replicationControllers").
-		Param("resourceVersion", resourceVersion).
-		SelectorParam("labels", label).
-		SelectorParam("fields", field).
-		Watch()
-}
-
-// ListServices takes a selector, and returns the list of services that match that selector
-func (c *Client) ListServices(ctx api.Context, selector labels.Selector) (result *api.ServiceList, err error) {
-	result = &api.ServiceList{}
-	err = c.Get().Namespace(api.Namespace(ctx)).Path("services").SelectorParam("labels", selector).Do().Into(result)
-	return
-}
-
-// GetService returns information about a particular service.
-func (c *Client) GetService(ctx api.Context, id string) (result *api.Service, err error) {
-	result = &api.Service{}
-	err = c.Get().Namespace(api.Namespace(ctx)).Path("services").Path(id).Do().Into(result)
-	return
-}
-
-// CreateService creates a new service.
-func (c *Client) CreateService(ctx api.Context, svc *api.Service) (result *api.Service, err error) {
-	result = &api.Service{}
-	err = c.Post().Namespace(api.Namespace(ctx)).Path("services").Body(svc).Do().Into(result)
-	return
-}
-
-// UpdateService updates an existing service.
-func (c *Client) UpdateService(ctx api.Context, svc *api.Service) (result *api.Service, err error) {
-	result = &api.Service{}
-	if len(svc.ResourceVersion) == 0 {
-		err = fmt.Errorf("invalid update object, missing resource version: %v", svc)
-		return
-	}
-	err = c.Put().Namespace(api.Namespace(ctx)).Path("services").Path(svc.Name).Body(svc).Do().Into(result)
-	return
-}
-
-// DeleteService deletes an existing service.
-func (c *Client) DeleteService(ctx api.Context, id string) error {
-	return c.Delete().Namespace(api.Namespace(ctx)).Path("services").Path(id).Do().Error()
-}
-
-// WatchServices returns a watch.Interface that watches the requested services.
-func (c *Client) WatchServices(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	return c.Get().
-		Namespace(api.Namespace(ctx)).
-		Path("watch").
-		Path("services").
-		Param("resourceVersion", resourceVersion).
-		SelectorParam("labels", label).
-		SelectorParam("fields", field).
-		Watch()
-}
-
-// ListEndpoints takes a selector, and returns the list of endpoints that match that selector
-func (c *Client) ListEndpoints(ctx api.Context, selector labels.Selector) (result *api.EndpointsList, err error) {
-	result = &api.EndpointsList{}
-	err = c.Get().Namespace(api.Namespace(ctx)).Path("endpoints").SelectorParam("labels", selector).Do().Into(result)
-	return
-}
-
-// GetEndpoints returns information about the endpoints for a particular service.
-func (c *Client) GetEndpoints(ctx api.Context, id string) (result *api.Endpoints, err error) {
-	result = &api.Endpoints{}
-	err = c.Get().Namespace(api.Namespace(ctx)).Path("endpoints").Path(id).Do().Into(result)
-	return
-}
-
-// WatchEndpoints returns a watch.Interface that watches the requested endpoints for a service.
-func (c *Client) WatchEndpoints(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	return c.Get().
-		Namespace(api.Namespace(ctx)).
-		Path("watch").
-		Path("endpoints").
-		Param("resourceVersion", resourceVersion).
-		SelectorParam("labels", label).
-		SelectorParam("fields", field).
-		Watch()
-}
-
-// CreateEndpoints creates a new endpoint.
-func (c *Client) CreateEndpoints(ctx api.Context, endpoints *api.Endpoints) (*api.Endpoints, error) {
-	result := &api.Endpoints{}
-	err := c.Post().Namespace(api.Namespace(ctx)).Path("endpoints").Body(endpoints).Do().Into(result)
-	return result, err
-}
-
-// UpdateEndpoints updates an existing endpoint.
-func (c *Client) UpdateEndpoints(ctx api.Context, endpoints *api.Endpoints) (*api.Endpoints, error) {
-	result := &api.Endpoints{}
-	if len(endpoints.ResourceVersion) == 0 {
-		return nil, fmt.Errorf("invalid update object, missing resource version: %v", endpoints)
-	}
-	err := c.Put().
-		Namespace(api.Namespace(ctx)).
-		Path("endpoints").
-		Path(endpoints.Name).
-		Body(endpoints).
-		Do().
-		Into(result)
-	return result, err
 }
 
 // ServerVersion retrieves and parses the server's version.
@@ -299,67 +87,4 @@ func (c *Client) ServerVersion() (*version.Info, error) {
 		return nil, fmt.Errorf("Got '%s': %v", string(body), err)
 	}
 	return &info, nil
-}
-
-// CreateMinion creates a new minion.
-func (c *Client) CreateMinion(minion *api.Minion) (*api.Minion, error) {
-	result := &api.Minion{}
-	err := c.Post().Path("minions").Body(minion).Do().Into(result)
-	return result, err
-}
-
-// ListMinions lists all the minions in the cluster.
-func (c *Client) ListMinions() (*api.MinionList, error) {
-	result := &api.MinionList{}
-	err := c.Get().Path("minions").Do().Into(result)
-	return result, err
-}
-
-// GetMinion returns information about a particular minion.
-func (c *Client) GetMinion(id string) (*api.Minion, error) {
-	result := &api.Minion{}
-	err := c.Get().Path("minions").Path(id).Do().Into(result)
-	return result, err
-}
-
-// DeleteMinion deletes an existing minion.
-func (c *Client) DeleteMinion(id string) error {
-	return c.Delete().Path("minions").Path(id).Do().Error()
-}
-
-// CreateEvent makes a new event. Returns the copy of the event the server returns, or an error.
-func (c *Client) CreateEvent(event *api.Event) (*api.Event, error) {
-	result := &api.Event{}
-	err := c.Post().Path("events").Body(event).Do().Into(result)
-	return result, err
-}
-
-// ListEvents returns a list of events matching the selectors.
-func (c *Client) ListEvents(label, field labels.Selector) (*api.EventList, error) {
-	result := &api.EventList{}
-	err := c.Get().
-		Path("events").
-		SelectorParam("labels", label).
-		SelectorParam("fields", field).
-		Do().
-		Into(result)
-	return result, err
-}
-
-// GetEvent returns the given event, or an error.
-func (c *Client) GetEvent(id string) (*api.Event, error) {
-	result := &api.Event{}
-	err := c.Get().Path("events").Path(id).Do().Into(result)
-	return result, err
-}
-
-// WatchEvents starts watching for events matching the given selectors.
-func (c *Client) WatchEvents(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	return c.Get().
-		Path("watch").
-		Path("events").
-		Param("resourceVersion", resourceVersion).
-		SelectorParam("labels", label).
-		SelectorParam("fields", field).
-		Watch()
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -146,17 +146,17 @@ func (c *testClient) ValidateCommon(t *testing.T, err error) {
 }
 
 func TestListEmptyPods(t *testing.T) {
-	ctx := api.NewContext()
+	ns := api.NamespaceDefault
 	c := &testClient{
 		Request:  testRequest{Method: "GET", Path: "/pods"},
 		Response: Response{StatusCode: 200, Body: &api.PodList{}},
 	}
-	podList, err := c.Setup().ListPods(ctx, labels.Everything())
+	podList, err := c.Setup().Pods(ns).List(labels.Everything())
 	c.Validate(t, podList, err)
 }
 
 func TestListPods(t *testing.T) {
-	ctx := api.NewDefaultContext()
+	ns := api.NamespaceDefault
 	c := &testClient{
 		Request: testRequest{Method: "GET", Path: "/pods"},
 		Response: Response{StatusCode: 200,
@@ -177,7 +177,7 @@ func TestListPods(t *testing.T) {
 			},
 		},
 	}
-	receivedPodList, err := c.Setup().ListPods(ctx, labels.Everything())
+	receivedPodList, err := c.Setup().Pods(ns).List(labels.Everything())
 	c.Validate(t, receivedPodList, err)
 }
 
@@ -188,7 +188,7 @@ func validateLabels(a, b string) bool {
 }
 
 func TestListPodsLabels(t *testing.T) {
-	ctx := api.NewDefaultContext()
+	ns := api.NamespaceDefault
 	c := &testClient{
 		Request: testRequest{Method: "GET", Path: "/pods", Query: url.Values{"labels": []string{"foo=bar,name=baz"}}},
 		Response: Response{
@@ -213,12 +213,12 @@ func TestListPodsLabels(t *testing.T) {
 	c.Setup()
 	c.QueryValidator["labels"] = validateLabels
 	selector := labels.Set{"foo": "bar", "name": "baz"}.AsSelector()
-	receivedPodList, err := c.ListPods(ctx, selector)
+	receivedPodList, err := c.Pods(ns).List(selector)
 	c.Validate(t, receivedPodList, err)
 }
 
 func TestGetPod(t *testing.T) {
-	ctx := api.NewDefaultContext()
+	ns := api.NamespaceDefault
 	c := &testClient{
 		Request: testRequest{Method: "GET", Path: "/pods/foo"},
 		Response: Response{
@@ -236,7 +236,7 @@ func TestGetPod(t *testing.T) {
 			},
 		},
 	}
-	receivedPod, err := c.Setup().GetPod(ctx, "foo")
+	receivedPod, err := c.Setup().Pods(ns).Get("foo")
 	c.Validate(t, receivedPod, err)
 }
 
@@ -245,7 +245,7 @@ func TestDeletePod(t *testing.T) {
 		Request:  testRequest{Method: "DELETE", Path: "/pods/foo"},
 		Response: Response{StatusCode: 200},
 	}
-	err := c.Setup().DeletePod(api.NewDefaultContext(), "foo")
+	err := c.Setup().Pods(api.NamespaceDefault).Delete("foo")
 	c.Validate(t, nil, err)
 }
 
@@ -268,7 +268,7 @@ func TestCreatePod(t *testing.T) {
 			Body:       requestPod,
 		},
 	}
-	receivedPod, err := c.Setup().CreatePod(api.NewDefaultContext(), requestPod)
+	receivedPod, err := c.Setup().Pods(api.NamespaceDefault).Create(requestPod)
 	c.Validate(t, receivedPod, err)
 }
 
@@ -290,7 +290,7 @@ func TestUpdatePod(t *testing.T) {
 		Request:  testRequest{Method: "PUT", Path: "/pods/foo"},
 		Response: Response{StatusCode: 200, Body: requestPod},
 	}
-	receivedPod, err := c.Setup().UpdatePod(api.NewDefaultContext(), requestPod)
+	receivedPod, err := c.Setup().Pods(api.NamespaceDefault).Update(requestPod)
 	c.Validate(t, receivedPod, err)
 }
 
@@ -316,7 +316,7 @@ func TestListControllers(t *testing.T) {
 			},
 		},
 	}
-	receivedControllerList, err := c.Setup().ListReplicationControllers(api.NewContext(), labels.Everything())
+	receivedControllerList, err := c.Setup().ReplicationControllers(api.NamespaceAll).List(labels.Everything())
 	c.Validate(t, receivedControllerList, err)
 
 }
@@ -340,7 +340,7 @@ func TestGetController(t *testing.T) {
 			},
 		},
 	}
-	receivedController, err := c.Setup().GetReplicationController(api.NewDefaultContext(), "foo")
+	receivedController, err := c.Setup().ReplicationControllers(api.NamespaceDefault).Get("foo")
 	c.Validate(t, receivedController, err)
 }
 
@@ -366,7 +366,7 @@ func TestUpdateController(t *testing.T) {
 			},
 		},
 	}
-	receivedController, err := c.Setup().UpdateReplicationController(api.NewDefaultContext(), requestController)
+	receivedController, err := c.Setup().ReplicationControllers(api.NamespaceDefault).Update(requestController)
 	c.Validate(t, receivedController, err)
 }
 
@@ -375,7 +375,7 @@ func TestDeleteController(t *testing.T) {
 		Request:  testRequest{Method: "DELETE", Path: "/replicationControllers/foo"},
 		Response: Response{StatusCode: 200},
 	}
-	err := c.Setup().DeleteReplicationController(api.NewDefaultContext(), "foo")
+	err := c.Setup().ReplicationControllers(api.NamespaceDefault).Delete("foo")
 	c.Validate(t, nil, err)
 }
 
@@ -401,7 +401,7 @@ func TestCreateController(t *testing.T) {
 			},
 		},
 	}
-	receivedController, err := c.Setup().CreateReplicationController(api.NewDefaultContext(), requestController)
+	receivedController, err := c.Setup().ReplicationControllers(api.NamespaceDefault).Create(requestController)
 	c.Validate(t, receivedController, err)
 }
 
@@ -436,7 +436,7 @@ func TestListServices(t *testing.T) {
 			},
 		},
 	}
-	receivedServiceList, err := c.Setup().ListServices(api.NewDefaultContext(), labels.Everything())
+	receivedServiceList, err := c.Setup().Services(api.NamespaceDefault).List(labels.Everything())
 	t.Logf("received services: %v %#v", err, receivedServiceList)
 	c.Validate(t, receivedServiceList, err)
 }
@@ -466,7 +466,7 @@ func TestListServicesLabels(t *testing.T) {
 	c.Setup()
 	c.QueryValidator["labels"] = validateLabels
 	selector := labels.Set{"foo": "bar", "name": "baz"}.AsSelector()
-	receivedServiceList, err := c.ListServices(api.NewDefaultContext(), selector)
+	receivedServiceList, err := c.Services(api.NamespaceDefault).List(selector)
 	c.Validate(t, receivedServiceList, err)
 }
 
@@ -475,7 +475,7 @@ func TestGetService(t *testing.T) {
 		Request:  testRequest{Method: "GET", Path: "/services/1"},
 		Response: Response{StatusCode: 200, Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
 	}
-	response, err := c.Setup().GetService(api.NewDefaultContext(), "1")
+	response, err := c.Setup().Services(api.NamespaceDefault).Get("1")
 	c.Validate(t, response, err)
 }
 
@@ -484,7 +484,7 @@ func TestCreateService(t *testing.T) {
 		Request:  testRequest{Method: "POST", Path: "/services", Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
 		Response: Response{StatusCode: 200, Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
 	}
-	response, err := c.Setup().CreateService(api.NewDefaultContext(), &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}})
+	response, err := c.Setup().Services(api.NamespaceDefault).Create(&api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}})
 	c.Validate(t, response, err)
 }
 
@@ -494,7 +494,7 @@ func TestUpdateService(t *testing.T) {
 		Request:  testRequest{Method: "PUT", Path: "/services/service-1", Body: svc},
 		Response: Response{StatusCode: 200, Body: svc},
 	}
-	response, err := c.Setup().UpdateService(api.NewDefaultContext(), svc)
+	response, err := c.Setup().Services(api.NamespaceDefault).Update(svc)
 	c.Validate(t, response, err)
 }
 
@@ -503,7 +503,7 @@ func TestDeleteService(t *testing.T) {
 		Request:  testRequest{Method: "DELETE", Path: "/services/1"},
 		Response: Response{StatusCode: 200},
 	}
-	err := c.Setup().DeleteService(api.NewDefaultContext(), "1")
+	err := c.Setup().Services(api.NamespaceDefault).Delete("1")
 	c.Validate(t, nil, err)
 }
 
@@ -521,7 +521,7 @@ func TestListEndpooints(t *testing.T) {
 			},
 		},
 	}
-	receivedEndpointsList, err := c.Setup().ListEndpoints(api.NewDefaultContext(), labels.Everything())
+	receivedEndpointsList, err := c.Setup().Endpoints(api.NamespaceDefault).List(labels.Everything())
 	c.Validate(t, receivedEndpointsList, err)
 }
 
@@ -530,7 +530,7 @@ func TestGetEndpoints(t *testing.T) {
 		Request:  testRequest{Method: "GET", Path: "/endpoints/endpoint-1"},
 		Response: Response{StatusCode: 200, Body: &api.Endpoints{ObjectMeta: api.ObjectMeta{Name: "endpoint-1"}}},
 	}
-	response, err := c.Setup().GetEndpoints(api.NewDefaultContext(), "endpoint-1")
+	response, err := c.Setup().Endpoints(api.NamespaceDefault).Get("endpoint-1")
 	c.Validate(t, response, err)
 }
 
@@ -566,7 +566,7 @@ func TestListMinions(t *testing.T) {
 		Request:  testRequest{Method: "GET", Path: "/minions"},
 		Response: Response{StatusCode: 200, Body: &api.MinionList{ListMeta: api.ListMeta{ResourceVersion: "1"}}},
 	}
-	response, err := c.Setup().ListMinions()
+	response, err := c.Setup().Minions().List()
 	c.Validate(t, response, err)
 }
 
@@ -590,7 +590,7 @@ func TestCreateMinion(t *testing.T) {
 			Body:       requestMinion,
 		},
 	}
-	receivedMinion, err := c.Setup().CreateMinion(requestMinion)
+	receivedMinion, err := c.Setup().Minions().Create(requestMinion)
 	c.Validate(t, receivedMinion, err)
 }
 
@@ -599,6 +599,6 @@ func TestDeleteMinion(t *testing.T) {
 		Request:  testRequest{Method: "DELETE", Path: "/minions/foo"},
 		Response: Response{StatusCode: 200},
 	}
-	err := c.Setup().DeleteMinion("foo")
+	err := c.Setup().Minions().Delete("foo")
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/conditions.go
+++ b/pkg/client/conditions.go
@@ -26,8 +26,7 @@ import (
 // for a controller's ReplicaSelector equals the Replicas count.
 func (c *Client) ControllerHasDesiredReplicas(controller api.ReplicationController) wait.ConditionFunc {
 	return func() (bool, error) {
-		ctx := api.WithNamespace(api.NewContext(), controller.Namespace)
-		pods, err := c.ListPods(ctx, labels.Set(controller.DesiredState.ReplicaSelector).AsSelector())
+		pods, err := c.Pods(controller.Namespace).List(labels.Set(controller.DesiredState.ReplicaSelector).AsSelector())
 		if err != nil {
 			return false, err
 		}

--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -38,40 +38,40 @@ type EndpointsInterface interface {
 	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
 }
 
-// EndpointsClient implements EndpointsNamespacer interface
-type EndpointsClient struct {
+// endpoints implements EndpointsNamespacer interface
+type endpoints struct {
 	r  *Client
 	ns string
 }
 
-// NewEndpointsClient returns a EndpointsClient
-func NewEndpointsClient(c *Client, namespace string) *EndpointsClient {
-	return &EndpointsClient{c, namespace}
+// newEndpoints returns a endpoints
+func newEndpoints(c *Client, namespace string) *endpoints {
+	return &endpoints{c, namespace}
 }
 
 // Create creates a new endpoint.
-func (c *EndpointsClient) Create(endpoints *api.Endpoints) (*api.Endpoints, error) {
+func (c *endpoints) Create(endpoints *api.Endpoints) (*api.Endpoints, error) {
 	result := &api.Endpoints{}
 	err := c.r.Post().Namespace(c.ns).Path("endpoints").Body(endpoints).Do().Into(result)
 	return result, err
 }
 
 // List takes a selector, and returns the list of endpoints that match that selector
-func (c *EndpointsClient) List(selector labels.Selector) (result *api.EndpointsList, err error) {
+func (c *endpoints) List(selector labels.Selector) (result *api.EndpointsList, err error) {
 	result = &api.EndpointsList{}
 	err = c.r.Get().Namespace(c.ns).Path("endpoints").SelectorParam("labels", selector).Do().Into(result)
 	return
 }
 
 // Get returns information about the endpoints for a particular service.
-func (c *EndpointsClient) Get(id string) (result *api.Endpoints, err error) {
+func (c *endpoints) Get(id string) (result *api.Endpoints, err error) {
 	result = &api.Endpoints{}
 	err = c.r.Get().Namespace(c.ns).Path("endpoints").Path(id).Do().Into(result)
 	return
 }
 
 // Watch returns a watch.Interface that watches the requested endpoints for a service.
-func (c *EndpointsClient) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *endpoints) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
 		Namespace(c.ns).
 		Path("watch").
@@ -82,7 +82,7 @@ func (c *EndpointsClient) Watch(label, field labels.Selector, resourceVersion st
 		Watch()
 }
 
-func (c *EndpointsClient) Update(endpoints *api.Endpoints) (*api.Endpoints, error) {
+func (c *endpoints) Update(endpoints *api.Endpoints) (*api.Endpoints, error) {
 	result := &api.Endpoints{}
 	if len(endpoints.ResourceVersion) == 0 {
 		return nil, fmt.Errorf("invalid update object, missing resource version: %v", endpoints)

--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// EndpointsNamespacer has methods to work with Endpoint resources in a namespace
+type EndpointsNamespacer interface {
+	Endpoint(namespace string) EndpointsInterface
+}
+
+// EndpointsInterface has methods to work with Endpoints resources
+type EndpointsInterface interface {
+	Create(endpoints *api.Endpoints) (*api.Endpoints, error)
+	List(selector labels.Selector) (*api.EndpointsList, error)
+	Get(id string) (*api.Endpoints, error)
+	Update(endpoints *api.Endpoints) (*api.Endpoints, error)
+	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// EndpointsClient implements EndpointsNamespacer interface
+type EndpointsClient struct {
+	r  *Client
+	ns string
+}
+
+// NewEndpointsClient returns a EndpointsClient
+func NewEndpointsClient(c *Client, namespace string) *EndpointsClient {
+	return &EndpointsClient{c, namespace}
+}
+
+// Create creates a new endpoint.
+func (c *EndpointsClient) Create(endpoints *api.Endpoints) (*api.Endpoints, error) {
+	result := &api.Endpoints{}
+	err := c.r.Post().Namespace(c.ns).Path("endpoints").Body(endpoints).Do().Into(result)
+	return result, err
+}
+
+// List takes a selector, and returns the list of endpoints that match that selector
+func (c *EndpointsClient) List(selector labels.Selector) (result *api.EndpointsList, err error) {
+	result = &api.EndpointsList{}
+	err = c.r.Get().Namespace(c.ns).Path("endpoints").SelectorParam("labels", selector).Do().Into(result)
+	return
+}
+
+// Get returns information about the endpoints for a particular service.
+func (c *EndpointsClient) Get(id string) (result *api.Endpoints, err error) {
+	result = &api.Endpoints{}
+	err = c.r.Get().Namespace(c.ns).Path("endpoints").Path(id).Do().Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested endpoints for a service.
+func (c *EndpointsClient) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Namespace(c.ns).
+		Path("watch").
+		Path("endpoints").
+		Param("resourceVersion", resourceVersion).
+		SelectorParam("labels", label).
+		SelectorParam("fields", field).
+		Watch()
+}
+
+func (c *EndpointsClient) Update(endpoints *api.Endpoints) (*api.Endpoints, error) {
+	result := &api.Endpoints{}
+	if len(endpoints.ResourceVersion) == 0 {
+		return nil, fmt.Errorf("invalid update object, missing resource version: %v", endpoints)
+	}
+	err := c.r.Put().
+		Namespace(c.ns).
+		Path("endpoints").
+		Path(endpoints.Name).
+		Body(endpoints).
+		Do().
+		Into(result)
+	return result, err
+}

--- a/pkg/client/events.go
+++ b/pkg/client/events.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// Events has methods to work with Event resources
+type EventsInterface interface {
+	Events() EventInterface
+}
+
+// EventInterface has methods to work with Event resources
+type EventInterface interface {
+	Create(event *api.Event) (*api.Event, error)
+	List(label, field labels.Selector) (*api.EventList, error)
+	Get(id string) (*api.Event, error)
+	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// EventsClient implements Events interface
+type EventsClient struct {
+	r *Client
+}
+
+// NewEventsClient returns a EventsClient
+func NewEventsClient(c *Client) *EventsClient {
+	return &EventsClient{
+		r: c,
+	}
+}
+
+// Create makes a new event. Returns the copy of the event the server returns, or an error.
+func (c *EventsClient) Create(event *api.Event) (*api.Event, error) {
+	result := &api.Event{}
+	err := c.r.Post().Path("events").Body(event).Do().Into(result)
+	return result, err
+}
+
+// List returns a list of events matching the selectors.
+func (c *EventsClient) List(label, field labels.Selector) (*api.EventList, error) {
+	result := &api.EventList{}
+	err := c.r.Get().
+		Path("events").
+		SelectorParam("labels", label).
+		SelectorParam("fields", field).
+		Do().
+		Into(result)
+	return result, err
+}
+
+// Get returns the given event, or an error.
+func (c *EventsClient) Get(id string) (*api.Event, error) {
+	result := &api.Event{}
+	err := c.r.Get().Path("events").Path(id).Do().Into(result)
+	return result, err
+}
+
+// Watch starts watching for events matching the given selectors.
+func (c *EventsClient) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Path("watch").
+		Path("events").
+		Param("resourceVersion", resourceVersion).
+		SelectorParam("labels", label).
+		SelectorParam("fields", field).
+		Watch()
+}

--- a/pkg/client/events.go
+++ b/pkg/client/events.go
@@ -35,27 +35,27 @@ type EventInterface interface {
 	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
 }
 
-// EventsClient implements Events interface
-type EventsClient struct {
+// events implements Events interface
+type events struct {
 	r *Client
 }
 
-// NewEventsClient returns a EventsClient
-func NewEventsClient(c *Client) *EventsClient {
-	return &EventsClient{
+// newEvents returns a events
+func newEvents(c *Client) *events {
+	return &events{
 		r: c,
 	}
 }
 
 // Create makes a new event. Returns the copy of the event the server returns, or an error.
-func (c *EventsClient) Create(event *api.Event) (*api.Event, error) {
+func (c *events) Create(event *api.Event) (*api.Event, error) {
 	result := &api.Event{}
 	err := c.r.Post().Path("events").Body(event).Do().Into(result)
 	return result, err
 }
 
 // List returns a list of events matching the selectors.
-func (c *EventsClient) List(label, field labels.Selector) (*api.EventList, error) {
+func (c *events) List(label, field labels.Selector) (*api.EventList, error) {
 	result := &api.EventList{}
 	err := c.r.Get().
 		Path("events").
@@ -67,14 +67,14 @@ func (c *EventsClient) List(label, field labels.Selector) (*api.EventList, error
 }
 
 // Get returns the given event, or an error.
-func (c *EventsClient) Get(id string) (*api.Event, error) {
+func (c *events) Get(id string) (*api.Event, error) {
 	result := &api.Event{}
 	err := c.r.Get().Path("events").Path(id).Do().Into(result)
 	return result, err
 }
 
 // Watch starts watching for events matching the given selectors.
-func (c *EventsClient) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *events) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
 		Path("watch").
 		Path("events").

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -18,7 +18,6 @@ package client
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -31,159 +30,43 @@ type FakeAction struct {
 // Fake implements Interface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the method you want to test easier.
 type Fake struct {
-	// Fake by default keeps a simple list of the methods that have been called.
 	Actions       []FakeAction
-	Pods          api.PodList
+	PodsList      api.PodList
 	Ctrl          api.ReplicationController
 	ServiceList   api.ServiceList
 	EndpointsList api.EndpointsList
-	Minions       api.MinionList
-	Events        api.EventList
+	MinionsList   api.MinionList
+	EventsList    api.EventList
 	Err           error
 	Watch         watch.Interface
 }
 
-func (c *Fake) ListPods(ctx api.Context, selector labels.Selector) (*api.PodList, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "list-pods"})
-	return api.Scheme.CopyOrDie(&c.Pods).(*api.PodList), nil
+func (c *Fake) ReplicationControllers(namespace string) ReplicationControllerInterface {
+	return &FakeReplicationControllers{Fake: c, Namespace: namespace}
 }
 
-func (c *Fake) GetPod(ctx api.Context, name string) (*api.Pod, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "get-pod", Value: name})
-	return &api.Pod{}, nil
+func (c *Fake) Minions() MinionInterface {
+	return &FakeMinions{Fake: c}
 }
 
-func (c *Fake) DeletePod(ctx api.Context, name string) error {
-	c.Actions = append(c.Actions, FakeAction{Action: "delete-pod", Value: name})
-	return nil
+func (c *Fake) Events() EventInterface {
+	return &FakeEvents{Fake: c}
 }
 
-func (c *Fake) CreatePod(ctx api.Context, pod *api.Pod) (*api.Pod, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "create-pod"})
-	return &api.Pod{}, nil
+func (c *Fake) Endpoints(namespace string) EndpointsInterface {
+	return &FakeEndpoints{Fake: c, Namespace: namespace}
 }
 
-func (c *Fake) UpdatePod(ctx api.Context, pod *api.Pod) (*api.Pod, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "update-pod", Value: pod.Name})
-	return &api.Pod{}, nil
+func (c *Fake) Pods(namespace string) PodInterface {
+	return &FakePods{Fake: c, Namespace: namespace}
 }
 
-func (c *Fake) ListReplicationControllers(ctx api.Context, selector labels.Selector) (*api.ReplicationControllerList, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "list-controllers"})
-	return &api.ReplicationControllerList{}, nil
-}
-
-func (c *Fake) GetReplicationController(ctx api.Context, name string) (*api.ReplicationController, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "get-controller", Value: name})
-	return api.Scheme.CopyOrDie(&c.Ctrl).(*api.ReplicationController), nil
-}
-
-func (c *Fake) CreateReplicationController(ctx api.Context, controller *api.ReplicationController) (*api.ReplicationController, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "create-controller", Value: controller})
-	return &api.ReplicationController{}, nil
-}
-
-func (c *Fake) UpdateReplicationController(ctx api.Context, controller *api.ReplicationController) (*api.ReplicationController, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "update-controller", Value: controller})
-	return &api.ReplicationController{}, nil
-}
-
-func (c *Fake) DeleteReplicationController(ctx api.Context, controller string) error {
-	c.Actions = append(c.Actions, FakeAction{Action: "delete-controller", Value: controller})
-	return nil
-}
-
-func (c *Fake) WatchReplicationControllers(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "watch-controllers", Value: resourceVersion})
-	return c.Watch, nil
-}
-
-func (c *Fake) ListServices(ctx api.Context, selector labels.Selector) (*api.ServiceList, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "list-services"})
-	return &c.ServiceList, c.Err
-}
-
-func (c *Fake) GetService(ctx api.Context, name string) (*api.Service, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "get-service", Value: name})
-	return &api.Service{}, nil
-}
-
-func (c *Fake) CreateService(ctx api.Context, service *api.Service) (*api.Service, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "create-service", Value: service})
-	return &api.Service{}, nil
-}
-
-func (c *Fake) UpdateService(ctx api.Context, service *api.Service) (*api.Service, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "update-service", Value: service})
-	return &api.Service{}, nil
-}
-
-func (c *Fake) DeleteService(ctx api.Context, service string) error {
-	c.Actions = append(c.Actions, FakeAction{Action: "delete-service", Value: service})
-	return nil
-}
-
-func (c *Fake) WatchServices(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "watch-services", Value: resourceVersion})
-	return c.Watch, c.Err
-}
-
-func (c *Fake) ListEndpoints(ctx api.Context, selector labels.Selector) (*api.EndpointsList, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "list-endpoints"})
-	return api.Scheme.CopyOrDie(&c.EndpointsList).(*api.EndpointsList), c.Err
-}
-
-func (c *Fake) GetEndpoints(ctx api.Context, name string) (*api.Endpoints, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "get-endpoints"})
-	return &api.Endpoints{}, nil
-}
-
-func (c *Fake) WatchEndpoints(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "watch-endpoints", Value: resourceVersion})
-	return c.Watch, c.Err
+func (c *Fake) Services(namespace string) ServiceInterface {
+	return &FakeServices{Fake: c, Namespace: namespace}
 }
 
 func (c *Fake) ServerVersion() (*version.Info, error) {
 	c.Actions = append(c.Actions, FakeAction{Action: "get-version", Value: nil})
 	versionInfo := version.Get()
 	return &versionInfo, nil
-}
-
-func (c *Fake) ListMinions() (*api.MinionList, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "list-minions", Value: nil})
-	return &c.Minions, nil
-}
-
-func (c *Fake) CreateMinion(minion *api.Minion) (*api.Minion, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "create-minion", Value: minion})
-	return &api.Minion{}, nil
-}
-
-func (c *Fake) DeleteMinion(id string) error {
-	c.Actions = append(c.Actions, FakeAction{Action: "delete-minion", Value: id})
-	return nil
-}
-
-// CreateEvent makes a new event. Returns the copy of the event the server returns, or an error.
-func (c *Fake) CreateEvent(event *api.Event) (*api.Event, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "get-event", Value: event.Name})
-	return &api.Event{}, nil
-}
-
-// ListEvents returns a list of events matching the selectors.
-func (c *Fake) ListEvents(label, field labels.Selector) (*api.EventList, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "list-events"})
-	return &c.Events, nil
-}
-
-// GetEvent returns the given event, or an error.
-func (c *Fake) GetEvent(id string) (*api.Event, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "get-event", Value: id})
-	return &api.Event{}, nil
-}
-
-// WatchEvents starts watching for events matching the given selectors.
-func (c *Fake) WatchEvents(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Actions = append(c.Actions, FakeAction{Action: "watch-events", Value: resourceVersion})
-	return c.Watch, c.Err
 }

--- a/pkg/client/fake_endpoints.go
+++ b/pkg/client/fake_endpoints.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// FakeEndpoints implements EndpointInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeEndpoints struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakeEndpoints) Create(endpoints *api.Endpoints) (*api.Endpoints, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "create-endpoints"})
+	return &api.Endpoints{}, nil
+}
+
+func (c *FakeEndpoints) List(selector labels.Selector) (*api.EndpointsList, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "list-endpoints"})
+	return api.Scheme.CopyOrDie(&c.Fake.EndpointsList).(*api.EndpointsList), c.Fake.Err
+}
+
+func (c *FakeEndpoints) Get(name string) (*api.Endpoints, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-endpoints"})
+	return &api.Endpoints{}, nil
+}
+
+func (c *FakeEndpoints) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-endpoints", Value: resourceVersion})
+	return c.Fake.Watch, c.Fake.Err
+}
+
+func (c *FakeEndpoints) Update(endpoints *api.Endpoints) (*api.Endpoints, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "update-endpoints", Value: endpoints.Name})
+	return &api.Endpoints{}, nil
+}

--- a/pkg/client/fake_events.go
+++ b/pkg/client/fake_events.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// FakeEvents implements EventInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeEvents struct {
+	Fake *Fake
+}
+
+// Create makes a new event. Returns the copy of the event the server returns, or an error.
+func (c *FakeEvents) Create(event *api.Event) (*api.Event, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-event", Value: event.Name})
+	return &api.Event{}, nil
+}
+
+// List returns a list of events matching the selectors.
+func (c *FakeEvents) List(label, field labels.Selector) (*api.EventList, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "list-events"})
+	return &c.Fake.EventsList, nil
+}
+
+// Get returns the given event, or an error.
+func (c *FakeEvents) Get(id string) (*api.Event, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-event", Value: id})
+	return &api.Event{}, nil
+}
+
+// Watch starts watching for events matching the given selectors.
+func (c *FakeEvents) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-events", Value: resourceVersion})
+	return c.Fake.Watch, c.Fake.Err
+}

--- a/pkg/client/fake_minions.go
+++ b/pkg/client/fake_minions.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+// FakeMinions implements MinionInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeMinions struct {
+	Fake *Fake
+}
+
+func (c *FakeMinions) Get(name string) (*api.Minion, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-minion", Value: name})
+	return &api.Minion{}, nil
+}
+
+func (c *FakeMinions) List() (*api.MinionList, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "list-minions", Value: nil})
+	return &c.Fake.MinionsList, nil
+}
+
+func (c *FakeMinions) Create(minion *api.Minion) (*api.Minion, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "create-minion", Value: minion})
+	return &api.Minion{}, nil
+}
+
+func (c *FakeMinions) Delete(id string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-minion", Value: id})
+	return nil
+}

--- a/pkg/client/fake_pods.go
+++ b/pkg/client/fake_pods.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+)
+
+// FakePods implements PodsInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakePods struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakePods) List(selector labels.Selector) (*api.PodList, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "list-pods"})
+	return api.Scheme.CopyOrDie(&c.Fake.PodsList).(*api.PodList), nil
+}
+
+func (c *FakePods) Get(name string) (*api.Pod, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-pod", Value: name})
+	return &api.Pod{}, nil
+}
+
+func (c *FakePods) Delete(name string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-pod", Value: name})
+	return nil
+}
+
+func (c *FakePods) Create(pod *api.Pod) (*api.Pod, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "create-pod"})
+	return &api.Pod{}, nil
+}
+
+func (c *FakePods) Update(pod *api.Pod) (*api.Pod, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "update-pod", Value: pod.Name})
+	return &api.Pod{}, nil
+}

--- a/pkg/client/fake_replication_controllers.go
+++ b/pkg/client/fake_replication_controllers.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// FakeReplicationControllers implements ReplicationControllerInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeReplicationControllers struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakeReplicationControllers) List(selector labels.Selector) (*api.ReplicationControllerList, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "list-controllers"})
+	return &api.ReplicationControllerList{}, nil
+}
+
+func (c *FakeReplicationControllers) Get(name string) (*api.ReplicationController, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-controller", Value: name})
+	return api.Scheme.CopyOrDie(&c.Fake.Ctrl).(*api.ReplicationController), nil
+}
+
+func (c *FakeReplicationControllers) Create(controller *api.ReplicationController) (*api.ReplicationController, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "create-controller", Value: controller})
+	return &api.ReplicationController{}, nil
+}
+
+func (c *FakeReplicationControllers) Update(controller *api.ReplicationController) (*api.ReplicationController, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "update-controller", Value: controller})
+	return &api.ReplicationController{}, nil
+}
+
+func (c *FakeReplicationControllers) Delete(controller string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-controller", Value: controller})
+	return nil
+}
+
+func (c *FakeReplicationControllers) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-controllers", Value: resourceVersion})
+	return c.Fake.Watch, nil
+}

--- a/pkg/client/fake_services.go
+++ b/pkg/client/fake_services.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// Fake implements ServiceInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeServices struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakeServices) List(selector labels.Selector) (*api.ServiceList, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "list-services"})
+	return &c.Fake.ServiceList, c.Fake.Err
+}
+
+func (c *FakeServices) Get(name string) (*api.Service, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-service", Value: name})
+	return &api.Service{}, nil
+}
+
+func (c *FakeServices) Create(service *api.Service) (*api.Service, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "create-service", Value: service})
+	return &api.Service{}, nil
+}
+
+func (c *FakeServices) Update(service *api.Service) (*api.Service, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "update-service", Value: service})
+	return &api.Service{}, nil
+}
+
+func (c *FakeServices) Delete(service string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-service", Value: service})
+	return nil
+}
+
+func (c *FakeServices) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-services", Value: resourceVersion})
+	return c.Fake.Watch, c.Fake.Err
+}

--- a/pkg/client/minions.go
+++ b/pkg/client/minions.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+type MinionsInterface interface {
+	Minions() MinionInterface
+}
+
+type MinionInterface interface {
+	Get(id string) (result *api.Minion, err error)
+	Create(minion *api.Minion) (*api.Minion, error)
+	List() (*api.MinionList, error)
+	Delete(id string) error
+}
+
+// MinionsClient implements Minions interface
+type MinionsClient struct {
+	r *Client
+}
+
+// NewMinionsClient returns a MinionsClient
+func NewMinionsClient(c *Client) *MinionsClient {
+	return &MinionsClient{c}
+}
+
+// Create creates a new minion.
+func (c *MinionsClient) Create(minion *api.Minion) (*api.Minion, error) {
+	result := &api.Minion{}
+	err := c.r.Post().Path("minions").Body(minion).Do().Into(result)
+	return result, err
+}
+
+// List lists all the minions in the cluster.
+func (c *MinionsClient) List() (result *api.MinionList, err error) {
+	result = &api.MinionList{}
+	err = c.r.Get().Path("minions").Do().Into(result)
+	return
+}
+
+// Get gets an existing minion
+func (c *MinionsClient) Get(id string) (result *api.Minion, err error) {
+	result = &api.Minion{}
+	err = c.r.Get().Path("minions").Path(id).Do().Into(result)
+	return
+}
+
+// Delete deletes an existing minion.
+func (c *MinionsClient) Delete(id string) error {
+	return c.r.Delete().Path("minions").Path(id).Do().Error()
+}

--- a/pkg/client/minions.go
+++ b/pkg/client/minions.go
@@ -31,38 +31,38 @@ type MinionInterface interface {
 	Delete(id string) error
 }
 
-// MinionsClient implements Minions interface
-type MinionsClient struct {
+// minions implements Minions interface
+type minions struct {
 	r *Client
 }
 
-// NewMinionsClient returns a MinionsClient
-func NewMinionsClient(c *Client) *MinionsClient {
-	return &MinionsClient{c}
+// newMinions returns a minions
+func newMinions(c *Client) *minions {
+	return &minions{c}
 }
 
 // Create creates a new minion.
-func (c *MinionsClient) Create(minion *api.Minion) (*api.Minion, error) {
+func (c *minions) Create(minion *api.Minion) (*api.Minion, error) {
 	result := &api.Minion{}
 	err := c.r.Post().Path("minions").Body(minion).Do().Into(result)
 	return result, err
 }
 
 // List lists all the minions in the cluster.
-func (c *MinionsClient) List() (result *api.MinionList, err error) {
+func (c *minions) List() (result *api.MinionList, err error) {
 	result = &api.MinionList{}
 	err = c.r.Get().Path("minions").Do().Into(result)
 	return
 }
 
 // Get gets an existing minion
-func (c *MinionsClient) Get(id string) (result *api.Minion, err error) {
+func (c *minions) Get(id string) (result *api.Minion, err error) {
 	result = &api.Minion{}
 	err = c.r.Get().Path("minions").Path(id).Do().Into(result)
 	return
 }
 
 // Delete deletes an existing minion.
-func (c *MinionsClient) Delete(id string) error {
+func (c *minions) Delete(id string) error {
 	return c.r.Delete().Path("minions").Path(id).Do().Error()
 }

--- a/pkg/client/pods.go
+++ b/pkg/client/pods.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+)
+
+// PodsNamespacer has methods to work with Pod resources in a namespace
+type PodsNamespacer interface {
+	Pods(namespace string) PodInterface
+}
+
+// PodInterface has methods to work with Pod resources.
+type PodInterface interface {
+	List(selector labels.Selector) (*api.PodList, error)
+	Get(name string) (*api.Pod, error)
+	Delete(name string) error
+	Create(pod *api.Pod) (*api.Pod, error)
+	Update(pod *api.Pod) (*api.Pod, error)
+}
+
+// PodsClient implements PodsNamespacer interface
+type PodsClient struct {
+	r  *Client
+	ns string
+}
+
+// NewPodsClient returns a PodsClient
+func NewPodsClient(c *Client, namespace string) *PodsClient {
+	return &PodsClient{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+// ListPods takes a selector, and returns the list of pods that match that selector.
+func (c *PodsClient) List(selector labels.Selector) (result *api.PodList, err error) {
+	result = &api.PodList{}
+	err = c.r.Get().Namespace(c.ns).Path("pods").SelectorParam("labels", selector).Do().Into(result)
+	return
+}
+
+// GetPod takes the name of the pod, and returns the corresponding Pod object, and an error if it occurs
+func (c *PodsClient) Get(name string) (result *api.Pod, err error) {
+	result = &api.Pod{}
+	err = c.r.Get().Namespace(c.ns).Path("pods").Path(name).Do().Into(result)
+	return
+}
+
+// DeletePod takes the name of the pod, and returns an error if one occurs
+func (c *PodsClient) Delete(name string) error {
+	return c.r.Delete().Namespace(c.ns).Path("pods").Path(name).Do().Error()
+}
+
+// CreatePod takes the representation of a pod.  Returns the server's representation of the pod, and an error, if it occurs.
+func (c *PodsClient) Create(pod *api.Pod) (result *api.Pod, err error) {
+	result = &api.Pod{}
+	err = c.r.Post().Namespace(c.ns).Path("pods").Body(pod).Do().Into(result)
+	return
+}
+
+// UpdatePod takes the representation of a pod to update.  Returns the server's representation of the pod, and an error, if it occurs.
+func (c *PodsClient) Update(pod *api.Pod) (result *api.Pod, err error) {
+	result = &api.Pod{}
+	if len(pod.ResourceVersion) == 0 {
+		err = fmt.Errorf("invalid update object, missing resource version: %v", pod)
+		return
+	}
+	err = c.r.Put().Namespace(c.ns).Path("pods").Path(pod.Name).Body(pod).Do().Into(result)
+	return
+}

--- a/pkg/client/pods.go
+++ b/pkg/client/pods.go
@@ -37,48 +37,48 @@ type PodInterface interface {
 	Update(pod *api.Pod) (*api.Pod, error)
 }
 
-// PodsClient implements PodsNamespacer interface
-type PodsClient struct {
+// pods implements PodsNamespacer interface
+type pods struct {
 	r  *Client
 	ns string
 }
 
-// NewPodsClient returns a PodsClient
-func NewPodsClient(c *Client, namespace string) *PodsClient {
-	return &PodsClient{
+// newPods returns a pods
+func newPods(c *Client, namespace string) *pods {
+	return &pods{
 		r:  c,
 		ns: namespace,
 	}
 }
 
 // ListPods takes a selector, and returns the list of pods that match that selector.
-func (c *PodsClient) List(selector labels.Selector) (result *api.PodList, err error) {
+func (c *pods) List(selector labels.Selector) (result *api.PodList, err error) {
 	result = &api.PodList{}
 	err = c.r.Get().Namespace(c.ns).Path("pods").SelectorParam("labels", selector).Do().Into(result)
 	return
 }
 
 // GetPod takes the name of the pod, and returns the corresponding Pod object, and an error if it occurs
-func (c *PodsClient) Get(name string) (result *api.Pod, err error) {
+func (c *pods) Get(name string) (result *api.Pod, err error) {
 	result = &api.Pod{}
 	err = c.r.Get().Namespace(c.ns).Path("pods").Path(name).Do().Into(result)
 	return
 }
 
 // DeletePod takes the name of the pod, and returns an error if one occurs
-func (c *PodsClient) Delete(name string) error {
+func (c *pods) Delete(name string) error {
 	return c.r.Delete().Namespace(c.ns).Path("pods").Path(name).Do().Error()
 }
 
 // CreatePod takes the representation of a pod.  Returns the server's representation of the pod, and an error, if it occurs.
-func (c *PodsClient) Create(pod *api.Pod) (result *api.Pod, err error) {
+func (c *pods) Create(pod *api.Pod) (result *api.Pod, err error) {
 	result = &api.Pod{}
 	err = c.r.Post().Namespace(c.ns).Path("pods").Body(pod).Do().Into(result)
 	return
 }
 
 // UpdatePod takes the representation of a pod to update.  Returns the server's representation of the pod, and an error, if it occurs.
-func (c *PodsClient) Update(pod *api.Pod) (result *api.Pod, err error) {
+func (c *pods) Update(pod *api.Pod) (result *api.Pod, err error) {
 	result = &api.Pod{}
 	if len(pod.ResourceVersion) == 0 {
 		err = fmt.Errorf("invalid update object, missing resource version: %v", pod)

--- a/pkg/client/record/event.go
+++ b/pkg/client/record/event.go
@@ -30,7 +30,7 @@ import (
 
 // EventRecorder knows how to store events (client.Client implements it.)
 type EventRecorder interface {
-	CreateEvent(event *api.Event) (*api.Event, error)
+	Create(event *api.Event) (*api.Event, error)
 }
 
 // StartRecording starts sending events to recorder. Call once while initializing
@@ -44,7 +44,7 @@ func StartRecording(recorder EventRecorder, sourceName string) watch.Interface {
 		event = &eventCopy
 		event.Source = sourceName
 		for {
-			_, err := recorder.CreateEvent(event)
+			_, err := recorder.Create(event)
 			if err == nil {
 				break
 			}

--- a/pkg/client/record/event_test.go
+++ b/pkg/client/record/event_test.go
@@ -32,7 +32,7 @@ type testEventRecorder struct {
 }
 
 // CreateEvent records the event for testing.
-func (t *testEventRecorder) CreateEvent(e *api.Event) (*api.Event, error) {
+func (t *testEventRecorder) Create(e *api.Event) (*api.Event, error) {
 	if t.OnEvent != nil {
 		return t.OnEvent(e)
 	}

--- a/pkg/client/replication_controllers.go
+++ b/pkg/client/replication_controllers.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// ReplicationControllersNamespacer has methods to work with ReplicationController resources in a namespace
+type ReplicationControllersNamespacer interface {
+	ReplicationControllers(namespace string) ReplicationControllerInterface
+}
+
+// ReplicationControllerInterface has methods to work with ReplicationController resources.
+type ReplicationControllerInterface interface {
+	List(selector labels.Selector) (*api.ReplicationControllerList, error)
+	Get(name string) (*api.ReplicationController, error)
+	Create(ctrl *api.ReplicationController) (*api.ReplicationController, error)
+	Update(ctrl *api.ReplicationController) (*api.ReplicationController, error)
+	Delete(name string) error
+	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// ReplicationControllersClient implements ReplicationControllersNamespacer interface
+type ReplicationControllersClient struct {
+	r  *Client
+	ns string
+}
+
+// NewReplicationControllersClient returns a PodsClient
+func NewReplicationControllersClient(c *Client, namespace string) *ReplicationControllersClient {
+	return &ReplicationControllersClient{c, namespace}
+}
+
+// List takes a selector, and returns the list of replication controllers that match that selector.
+func (c *ReplicationControllersClient) List(selector labels.Selector) (result *api.ReplicationControllerList, err error) {
+	result = &api.ReplicationControllerList{}
+	err = c.r.Get().Namespace(c.ns).Path("replicationControllers").SelectorParam("labels", selector).Do().Into(result)
+	return
+}
+
+// Get returns information about a particular replication controller.
+func (c *ReplicationControllersClient) Get(name string) (result *api.ReplicationController, err error) {
+	result = &api.ReplicationController{}
+	err = c.r.Get().Namespace(c.ns).Path("replicationControllers").Path(name).Do().Into(result)
+	return
+}
+
+// Create creates a new replication controller.
+func (c *ReplicationControllersClient) Create(controller *api.ReplicationController) (result *api.ReplicationController, err error) {
+	result = &api.ReplicationController{}
+	err = c.r.Post().Namespace(c.ns).Path("replicationControllers").Body(controller).Do().Into(result)
+	return
+}
+
+// Update updates an existing replication controller.
+func (c *ReplicationControllersClient) Update(controller *api.ReplicationController) (result *api.ReplicationController, err error) {
+	result = &api.ReplicationController{}
+	if len(controller.ResourceVersion) == 0 {
+		err = fmt.Errorf("invalid update object, missing resource version: %v", controller)
+		return
+	}
+	err = c.r.Put().Namespace(c.ns).Path("replicationControllers").Path(controller.Name).Body(controller).Do().Into(result)
+	return
+}
+
+// Delete deletes an existing replication controller.
+func (c *ReplicationControllersClient) Delete(name string) error {
+	return c.r.Delete().Namespace(c.ns).Path("replicationControllers").Path(name).Do().Error()
+}
+
+// Watch returns a watch.Interface that watches the requested controllers.
+func (c *ReplicationControllersClient) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Namespace(c.ns).
+		Path("watch").
+		Path("replicationControllers").
+		Param("resourceVersion", resourceVersion).
+		SelectorParam("labels", label).
+		SelectorParam("fields", field).
+		Watch()
+}

--- a/pkg/client/replication_controllers.go
+++ b/pkg/client/replication_controllers.go
@@ -39,40 +39,40 @@ type ReplicationControllerInterface interface {
 	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
 }
 
-// ReplicationControllersClient implements ReplicationControllersNamespacer interface
-type ReplicationControllersClient struct {
+// replicationControllers implements ReplicationControllersNamespacer interface
+type replicationControllers struct {
 	r  *Client
 	ns string
 }
 
-// NewReplicationControllersClient returns a PodsClient
-func NewReplicationControllersClient(c *Client, namespace string) *ReplicationControllersClient {
-	return &ReplicationControllersClient{c, namespace}
+// newReplicationControllers returns a PodsClient
+func newReplicationControllers(c *Client, namespace string) *replicationControllers {
+	return &replicationControllers{c, namespace}
 }
 
 // List takes a selector, and returns the list of replication controllers that match that selector.
-func (c *ReplicationControllersClient) List(selector labels.Selector) (result *api.ReplicationControllerList, err error) {
+func (c *replicationControllers) List(selector labels.Selector) (result *api.ReplicationControllerList, err error) {
 	result = &api.ReplicationControllerList{}
 	err = c.r.Get().Namespace(c.ns).Path("replicationControllers").SelectorParam("labels", selector).Do().Into(result)
 	return
 }
 
 // Get returns information about a particular replication controller.
-func (c *ReplicationControllersClient) Get(name string) (result *api.ReplicationController, err error) {
+func (c *replicationControllers) Get(name string) (result *api.ReplicationController, err error) {
 	result = &api.ReplicationController{}
 	err = c.r.Get().Namespace(c.ns).Path("replicationControllers").Path(name).Do().Into(result)
 	return
 }
 
 // Create creates a new replication controller.
-func (c *ReplicationControllersClient) Create(controller *api.ReplicationController) (result *api.ReplicationController, err error) {
+func (c *replicationControllers) Create(controller *api.ReplicationController) (result *api.ReplicationController, err error) {
 	result = &api.ReplicationController{}
 	err = c.r.Post().Namespace(c.ns).Path("replicationControllers").Body(controller).Do().Into(result)
 	return
 }
 
 // Update updates an existing replication controller.
-func (c *ReplicationControllersClient) Update(controller *api.ReplicationController) (result *api.ReplicationController, err error) {
+func (c *replicationControllers) Update(controller *api.ReplicationController) (result *api.ReplicationController, err error) {
 	result = &api.ReplicationController{}
 	if len(controller.ResourceVersion) == 0 {
 		err = fmt.Errorf("invalid update object, missing resource version: %v", controller)
@@ -83,12 +83,12 @@ func (c *ReplicationControllersClient) Update(controller *api.ReplicationControl
 }
 
 // Delete deletes an existing replication controller.
-func (c *ReplicationControllersClient) Delete(name string) error {
+func (c *replicationControllers) Delete(name string) error {
 	return c.r.Delete().Namespace(c.ns).Path("replicationControllers").Path(name).Do().Error()
 }
 
 // Watch returns a watch.Interface that watches the requested controllers.
-func (c *ReplicationControllersClient) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *replicationControllers) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
 		Namespace(c.ns).
 		Path("watch").

--- a/pkg/client/services.go
+++ b/pkg/client/services.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// ServicesNamespacer has methods to work with Service resources in a namespace
+type ServicesNamespacer interface {
+	Services(namespace string) ServiceInterface
+}
+
+// ServiceInterface has methods to work with Service resources.
+type ServiceInterface interface {
+	List(selector labels.Selector) (*api.ServiceList, error)
+	Get(name string) (*api.Service, error)
+	Create(srv *api.Service) (*api.Service, error)
+	Update(srv *api.Service) (*api.Service, error)
+	Delete(name string) error
+	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// ServicesClient implements PodsNamespacer interface
+type ServicesClient struct {
+	r  *Client
+	ns string
+}
+
+// NewServicesClient returns a PodsClient
+func NewServicesClient(c *Client, namespace string) *ServicesClient {
+	return &ServicesClient{c, namespace}
+}
+
+// List takes a selector, and returns the list of services that match that selector
+func (c *ServicesClient) List(selector labels.Selector) (result *api.ServiceList, err error) {
+	result = &api.ServiceList{}
+	err = c.r.Get().Namespace(c.ns).Path("services").SelectorParam("labels", selector).Do().Into(result)
+	return
+}
+
+// Get returns information about a particular service.
+func (c *ServicesClient) Get(name string) (result *api.Service, err error) {
+	result = &api.Service{}
+	err = c.r.Get().Namespace(c.ns).Path("services").Path(name).Do().Into(result)
+	return
+}
+
+// Create creates a new service.
+func (c *ServicesClient) Create(svc *api.Service) (result *api.Service, err error) {
+	result = &api.Service{}
+	err = c.r.Post().Namespace(c.ns).Path("services").Body(svc).Do().Into(result)
+	return
+}
+
+// Update updates an existing service.
+func (c *ServicesClient) Update(svc *api.Service) (result *api.Service, err error) {
+	result = &api.Service{}
+	if len(svc.ResourceVersion) == 0 {
+		err = fmt.Errorf("invalid update object, missing resource version: %v", svc)
+		return
+	}
+	err = c.r.Put().Namespace(c.ns).Path("services").Path(svc.Name).Body(svc).Do().Into(result)
+	return
+}
+
+// Delete deletes an existing service.
+func (c *ServicesClient) Delete(name string) error {
+	return c.r.Delete().Namespace(c.ns).Path("services").Path(name).Do().Error()
+}
+
+// Watch returns a watch.Interface that watches the requested services.
+func (c *ServicesClient) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Namespace(c.ns).
+		Path("watch").
+		Path("services").
+		Param("resourceVersion", resourceVersion).
+		SelectorParam("labels", label).
+		SelectorParam("fields", field).
+		Watch()
+}

--- a/pkg/client/services.go
+++ b/pkg/client/services.go
@@ -39,40 +39,40 @@ type ServiceInterface interface {
 	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
 }
 
-// ServicesClient implements PodsNamespacer interface
-type ServicesClient struct {
+// services implements PodsNamespacer interface
+type services struct {
 	r  *Client
 	ns string
 }
 
-// NewServicesClient returns a PodsClient
-func NewServicesClient(c *Client, namespace string) *ServicesClient {
-	return &ServicesClient{c, namespace}
+// newServices returns a PodsClient
+func newServices(c *Client, namespace string) *services {
+	return &services{c, namespace}
 }
 
 // List takes a selector, and returns the list of services that match that selector
-func (c *ServicesClient) List(selector labels.Selector) (result *api.ServiceList, err error) {
+func (c *services) List(selector labels.Selector) (result *api.ServiceList, err error) {
 	result = &api.ServiceList{}
 	err = c.r.Get().Namespace(c.ns).Path("services").SelectorParam("labels", selector).Do().Into(result)
 	return
 }
 
 // Get returns information about a particular service.
-func (c *ServicesClient) Get(name string) (result *api.Service, err error) {
+func (c *services) Get(name string) (result *api.Service, err error) {
 	result = &api.Service{}
 	err = c.r.Get().Namespace(c.ns).Path("services").Path(name).Do().Into(result)
 	return
 }
 
 // Create creates a new service.
-func (c *ServicesClient) Create(svc *api.Service) (result *api.Service, err error) {
+func (c *services) Create(svc *api.Service) (result *api.Service, err error) {
 	result = &api.Service{}
 	err = c.r.Post().Namespace(c.ns).Path("services").Body(svc).Do().Into(result)
 	return
 }
 
 // Update updates an existing service.
-func (c *ServicesClient) Update(svc *api.Service) (result *api.Service, err error) {
+func (c *services) Update(svc *api.Service) (result *api.Service, err error) {
 	result = &api.Service{}
 	if len(svc.ResourceVersion) == 0 {
 		err = fmt.Errorf("invalid update object, missing resource version: %v", svc)
@@ -83,12 +83,12 @@ func (c *ServicesClient) Update(svc *api.Service) (result *api.Service, err erro
 }
 
 // Delete deletes an existing service.
-func (c *ServicesClient) Delete(name string) error {
+func (c *services) Delete(name string) error {
 	return c.r.Delete().Namespace(c.ns).Path("services").Path(name).Do().Error()
 }
 
 // Watch returns a watch.Interface that watches the requested services.
-func (c *ServicesClient) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *services) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
 		Namespace(c.ns).
 		Path("watch").

--- a/pkg/kubecfg/kubecfg_test.go
+++ b/pkg/kubecfg/kubecfg_test.go
@@ -36,7 +36,7 @@ func validateAction(expectedAction, actualAction client.FakeAction, t *testing.T
 
 func TestUpdateWithPods(t *testing.T) {
 	fakeClient := client.Fake{
-		Pods: api.PodList{
+		PodsList: api.PodList{
 			Items: []api.Pod{
 				{ObjectMeta: api.ObjectMeta{Name: "pod-1"}},
 				{ObjectMeta: api.ObjectMeta{Name: "pod-2"}},
@@ -67,7 +67,7 @@ func TestUpdateNoPods(t *testing.T) {
 
 func TestUpdateWithNewImage(t *testing.T) {
 	fakeClient := client.Fake{
-		Pods: api.PodList{
+		PodsList: api.PodList{
 			Items: []api.Pod{
 				{ObjectMeta: api.ObjectMeta{Name: "pod-1"}},
 				{ObjectMeta: api.ObjectMeta{Name: "pod-2"}},

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -55,7 +55,8 @@ func Describe(w io.Writer, c client.Interface, resource, id string) error {
 }
 
 func describePod(w io.Writer, c client.Interface, id string) (string, error) {
-	pod, err := c.GetPod(api.NewDefaultContext(), id)
+	// TODO this needs proper namespace support
+	pod, err := c.Pods(api.NamespaceDefault).Get(id)
 	if err != nil {
 		return "", err
 	}
@@ -72,7 +73,8 @@ func describePod(w io.Writer, c client.Interface, id string) (string, error) {
 }
 
 func describeReplicationController(w io.Writer, c client.Interface, id string) (string, error) {
-	controller, err := c.GetReplicationController(api.NewDefaultContext(), id)
+	// TODO this needs proper namespace support
+	controller, err := c.ReplicationControllers(api.NamespaceDefault).Get(id)
 	if err != nil {
 		return "", err
 	}
@@ -94,7 +96,7 @@ func describeReplicationController(w io.Writer, c client.Interface, id string) (
 }
 
 func describeService(w io.Writer, c client.Interface, id string) (string, error) {
-	service, err := c.GetService(api.NewDefaultContext(), id)
+	service, err := c.Services(api.NamespaceDefault).Get(id)
 	if err != nil {
 		return "", err
 	}
@@ -122,7 +124,7 @@ func describeMinion(w io.Writer, c client.Interface, id string) (string, error) 
 
 // client.Interface doesn't have GetMinion(id) yet so we hack it up.
 func getMinion(c client.Interface, id string) (*api.Minion, error) {
-	minionList, err := c.ListMinions()
+	minionList, err := c.Minions().List()
 	if err != nil {
 		glog.Fatalf("Error getting minion info: %v\n", err)
 	}
@@ -141,7 +143,8 @@ func getMinion(c client.Interface, id string) (*api.Minion, error) {
 // of getting all RC's and searching through them manually).
 func getReplicationControllersForLabels(c client.Interface, labelsToMatch labels.Labels) string {
 	// Get all replication controllers.
-	rcs, err := c.ListReplicationControllers(api.NewDefaultContext(), labels.Everything())
+	// TODO this needs a namespace scope as argument
+	rcs, err := c.ReplicationControllers(api.NamespaceDefault).List(labels.Everything())
 	if err != nil {
 		glog.Fatalf("Error getting replication controllers: %v\n", err)
 	}
@@ -169,7 +172,7 @@ func getReplicationControllersForLabels(c client.Interface, labelsToMatch labels
 }
 
 func getPodStatusForReplicationController(kubeClient client.Interface, controller *api.ReplicationController) (running, waiting, terminated int, err error) {
-	rcPods, err := kubeClient.ListPods(api.NewDefaultContext(), labels.SelectorFromSet(controller.DesiredState.ReplicaSelector))
+	rcPods, err := kubeClient.Pods(controller.Namespace).List(labels.SelectorFromSet(controller.DesiredState.ReplicaSelector))
 	if err != nil {
 		return
 	}

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -137,7 +137,7 @@ func (m *Master) init(c *Config) {
 			PodCache:      podCache,
 			PodInfoGetter: c.KubeletClient,
 			Registry:      m.podRegistry,
-			Minions:       m.client,
+			Minions:       m.client.Minions(),
 		}),
 		"replicationControllers": controller.NewREST(m.controllerRegistry, m.podRegistry),
 		"services":               service.NewREST(m.serviceRegistry, c.Cloud, m.minionRegistry, m.portalNet),

--- a/pkg/proxy/config/api_test.go
+++ b/pkg/proxy/config/api_test.go
@@ -32,7 +32,7 @@ func TestServices(t *testing.T) {
 	fakeWatch := watch.NewFake()
 	fakeClient := &client.Fake{Watch: fakeWatch}
 	services := make(chan ServiceUpdate)
-	source := SourceAPI{client: fakeClient, services: services}
+	source := SourceAPI{servicesWatcher: fakeClient.Services(api.NamespaceAll), endpointsWatcher: fakeClient.Endpoints(api.NamespaceAll), services: services}
 	resourceVersion := "1"
 	go func() {
 		// called twice
@@ -84,7 +84,7 @@ func TestServicesFromZero(t *testing.T) {
 		},
 	}
 	services := make(chan ServiceUpdate)
-	source := SourceAPI{client: fakeClient, services: services}
+	source := SourceAPI{servicesWatcher: fakeClient.Services(api.NamespaceAll), endpointsWatcher: fakeClient.Endpoints(api.NamespaceAll), services: services}
 	resourceVersion := ""
 	ch := make(chan struct{})
 	go func() {
@@ -112,7 +112,7 @@ func TestServicesFromZero(t *testing.T) {
 func TestServicesError(t *testing.T) {
 	fakeClient := &client.Fake{Err: errors.New("test")}
 	services := make(chan ServiceUpdate)
-	source := SourceAPI{client: fakeClient, services: services}
+	source := SourceAPI{servicesWatcher: fakeClient.Services(api.NamespaceAll), endpointsWatcher: fakeClient.Endpoints(api.NamespaceAll), services: services}
 	resourceVersion := "1"
 	ch := make(chan struct{})
 	go func() {
@@ -133,7 +133,7 @@ func TestServicesError(t *testing.T) {
 func TestServicesFromZeroError(t *testing.T) {
 	fakeClient := &client.Fake{Err: errors.New("test")}
 	services := make(chan ServiceUpdate)
-	source := SourceAPI{client: fakeClient, services: services}
+	source := SourceAPI{servicesWatcher: fakeClient.Services(api.NamespaceAll), endpointsWatcher: fakeClient.Endpoints(api.NamespaceAll), services: services}
 	resourceVersion := ""
 	ch := make(chan struct{})
 	go func() {
@@ -157,7 +157,7 @@ func TestEndpoints(t *testing.T) {
 	fakeWatch := watch.NewFake()
 	fakeClient := &client.Fake{Watch: fakeWatch}
 	endpoints := make(chan EndpointsUpdate)
-	source := SourceAPI{client: fakeClient, endpoints: endpoints}
+	source := SourceAPI{servicesWatcher: fakeClient.Services(api.NamespaceAll), endpointsWatcher: fakeClient.Endpoints(api.NamespaceAll), endpoints: endpoints}
 	resourceVersion := "1"
 	go func() {
 		// called twice
@@ -209,7 +209,7 @@ func TestEndpointsFromZero(t *testing.T) {
 		},
 	}
 	endpoints := make(chan EndpointsUpdate)
-	source := SourceAPI{client: fakeClient, endpoints: endpoints}
+	source := SourceAPI{servicesWatcher: fakeClient.Services(api.NamespaceAll), endpointsWatcher: fakeClient.Endpoints(api.NamespaceAll), endpoints: endpoints}
 	resourceVersion := ""
 	ch := make(chan struct{})
 	go func() {
@@ -237,7 +237,7 @@ func TestEndpointsFromZero(t *testing.T) {
 func TestEndpointsError(t *testing.T) {
 	fakeClient := &client.Fake{Err: errors.New("test")}
 	endpoints := make(chan EndpointsUpdate)
-	source := SourceAPI{client: fakeClient, endpoints: endpoints}
+	source := SourceAPI{servicesWatcher: fakeClient.Services(api.NamespaceAll), endpointsWatcher: fakeClient.Endpoints(api.NamespaceAll), endpoints: endpoints}
 	resourceVersion := "1"
 	ch := make(chan struct{})
 	go func() {
@@ -258,7 +258,7 @@ func TestEndpointsError(t *testing.T) {
 func TestEndpointsFromZeroError(t *testing.T) {
 	fakeClient := &client.Fake{Err: errors.New("test")}
 	endpoints := make(chan EndpointsUpdate)
-	source := SourceAPI{client: fakeClient, endpoints: endpoints}
+	source := SourceAPI{servicesWatcher: fakeClient.Services(api.NamespaceAll), endpointsWatcher: fakeClient.Endpoints(api.NamespaceAll), endpoints: endpoints}
 	resourceVersion := ""
 	ch := make(chan struct{})
 	go func() {

--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -273,7 +273,7 @@ func getPodStatus(pod *api.Pod, minions client.MinionInterface) (api.PodStatus, 
 		return api.PodWaiting, nil
 	}
 	if minions != nil {
-		res, err := minions.ListMinions()
+		res, err := minions.List()
 		if err != nil {
 			glog.Errorf("Error listing minions: %v", err)
 			return "", err

--- a/pkg/registry/pod/rest_test.go
+++ b/pkg/registry/pod/rest_test.go
@@ -385,7 +385,7 @@ func TestGetPodCloud(t *testing.T) {
 
 func TestMakePodStatus(t *testing.T) {
 	fakeClient := client.Fake{
-		Minions: api.MinionList{
+		MinionsList: api.MinionList{
 			Items: []api.Minion{
 				{
 					ObjectMeta: api.ObjectMeta{Name: "machine"},
@@ -517,7 +517,7 @@ func TestMakePodStatus(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		if status, err := getPodStatus(test.pod, &fakeClient); status != test.status {
+		if status, err := getPodStatus(test.pod, fakeClient.Minions()); status != test.status {
 			t.Errorf("In test %s, expected %v, got %v", test.test, test.status, status)
 			if err != nil {
 				t.Errorf("In test %s, unexpected error: %v", test.test, err)

--- a/pkg/scheduler/predicates.go
+++ b/pkg/scheduler/predicates.go
@@ -48,7 +48,7 @@ type ClientNodeInfo struct {
 }
 
 func (nodes ClientNodeInfo) GetNodeInfo(nodeID string) (*api.Minion, error) {
-	return nodes.GetMinion(nodeID)
+	return nodes.Minions().Get(nodeID)
 }
 
 func isVolumeConflict(volume api.Volume, pod *api.Pod) bool {

--- a/pkg/service/endpoints_controller.go
+++ b/pkg/service/endpoints_controller.go
@@ -44,16 +44,14 @@ func NewEndpointController(client *client.Client) *EndpointController {
 
 // SyncServiceEndpoints syncs service endpoints.
 func (e *EndpointController) SyncServiceEndpoints() error {
-	ctx := api.NewContext()
-	services, err := e.client.ListServices(ctx, labels.Everything())
+	services, err := e.client.Services(api.NamespaceAll).List(labels.Everything())
 	if err != nil {
 		glog.Errorf("Failed to list services: %v", err)
 		return err
 	}
 	var resultErr error
 	for _, service := range services.Items {
-		nsCtx := api.WithNamespace(ctx, service.Namespace)
-		pods, err := e.client.ListPods(nsCtx, labels.Set(service.Selector).AsSelector())
+		pods, err := e.client.Pods(service.Namespace).List(labels.Set(service.Selector).AsSelector())
 		if err != nil {
 			glog.Errorf("Error syncing service: %#v, skipping.", service)
 			resultErr = err
@@ -72,7 +70,7 @@ func (e *EndpointController) SyncServiceEndpoints() error {
 			}
 			endpoints = append(endpoints, net.JoinHostPort(pod.CurrentState.PodIP, strconv.Itoa(port)))
 		}
-		currentEndpoints, err := e.client.GetEndpoints(nsCtx, service.Name)
+		currentEndpoints, err := e.client.Endpoints(service.Namespace).Get(service.Namespace)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				currentEndpoints = &api.Endpoints{
@@ -91,14 +89,14 @@ func (e *EndpointController) SyncServiceEndpoints() error {
 
 		if len(currentEndpoints.ResourceVersion) == 0 {
 			// No previous endpoints, create them
-			_, err = e.client.CreateEndpoints(nsCtx, newEndpoints)
+			_, err = e.client.Endpoints(service.Namespace).Create(newEndpoints)
 		} else {
 			// Pre-existing
 			if endpointsEqual(currentEndpoints, endpoints) {
 				glog.V(2).Infof("endpoints are equal for %s, skipping update", service.Name)
 				continue
 			}
-			_, err = e.client.UpdateEndpoints(nsCtx, newEndpoints)
+			_, err = e.client.Endpoints(service.Namespace).Update(newEndpoints)
 		}
 		if err != nil {
 			glog.Errorf("Error updating endpoints: %#v", err)

--- a/pkg/service/endpoints_controller.go
+++ b/pkg/service/endpoints_controller.go
@@ -70,7 +70,7 @@ func (e *EndpointController) SyncServiceEndpoints() error {
 			}
 			endpoints = append(endpoints, net.JoinHostPort(pod.CurrentState.PodIP, strconv.Itoa(port)))
 		}
-		currentEndpoints, err := e.client.Endpoints(service.Namespace).Get(service.Namespace)
+		currentEndpoints, err := e.client.Endpoints(service.Namespace).Get(service.Name)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				currentEndpoints = &api.Endpoints{

--- a/plugin/cmd/scheduler/scheduler.go
+++ b/plugin/cmd/scheduler/scheduler.go
@@ -56,7 +56,7 @@ func main() {
 		glog.Fatalf("Invalid API configuration: %v", err)
 	}
 
-	record.StartRecording(kubeClient, "scheduler")
+	record.StartRecording(kubeClient.Events(), "scheduler")
 
 	go http.ListenAndServe(net.JoinHostPort(address.String(), strconv.Itoa(*port)), nil)
 

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -59,7 +59,7 @@ func TestClient(t *testing.T) {
 	}
 
 	for apiVersion, values := range testCases {
-		ctx := api.NewDefaultContext()
+		ns := api.NamespaceDefault
 		deleteAllEtcdKeys()
 		s := httptest.NewServer(apiserver.Handle(values.Storage, values.Codec, fmt.Sprintf("/api/%s/", apiVersion), values.selfLinker))
 		client := client.NewOrDie(&client.Config{Host: s.URL, Version: apiVersion})
@@ -72,7 +72,7 @@ func TestClient(t *testing.T) {
 			t.Errorf("expected %#v, got %#v", e, a)
 		}
 
-		pods, err := client.ListPods(ctx, labels.Everything())
+		pods, err := client.Pods(ns).List(labels.Everything())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -93,14 +93,14 @@ func TestClient(t *testing.T) {
 				},
 			},
 		}
-		got, err := client.CreatePod(ctx, pod)
+		got, err := client.Pods(ns).Create(pod)
 		if err == nil {
 			t.Fatalf("unexpected non-error: %v", err)
 		}
 
 		// get a created pod
 		pod.DesiredState.Manifest.Containers[0].Image = "an-image"
-		got, err = client.CreatePod(ctx, pod)
+		got, err = client.Pods(ns).Create(pod)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -109,7 +109,7 @@ func TestClient(t *testing.T) {
 		}
 
 		// pod is shown, but not scheduled
-		pods, err = client.ListPods(ctx, labels.Everything())
+		pods, err = client.Pods(ns).List(labels.Everything())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
Fixes #1708 

This is a WIP proposal for how we could have an alternate client pattern.

Goals:
1. Keep client stateless
2. Make client operate in a Noun -> Verb style
3. Make code clear when client namespace switches

Sample Code:

```
client := ...

// list pods across all namespaces
pods, err := client.Pods("*").List(selector)
// list pods in the default namespace
pods, err := client.Pods("default").List(selector)
// create a pod in default namespace
pod, err := client.Pods("default").Create(pod)

// work with services
services, err := client.Services("*").List(selector)
services, err := client.Services("default").List(selector)
...

// work with minions
minions, err := client.Minions().List()
```

Please provide feedback, as I will not make rest of this change until we agree on pattern.
