### PR TITLE
Add create/delete minion to client interface.

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -87,7 +87,9 @@ type VersionInterface interface {
 }
 
 type MinionInterface interface {
+	CreateMinion(minion *api.Minion) (*api.Minion, error)
 	ListMinions() (*api.MinionList, error)
+	DeleteMinion(id string) error
 }
 
 // APIStatus is exposed by errors that can be converted to an api.Status object
@@ -262,12 +264,14 @@ func (c *Client) WatchEndpoints(ctx api.Context, label, field labels.Selector, r
 		Watch()
 }
 
+// CreateEndpoints creates a new endpoint.
 func (c *Client) CreateEndpoints(ctx api.Context, endpoints *api.Endpoints) (*api.Endpoints, error) {
 	result := &api.Endpoints{}
 	err := c.Post().Namespace(api.Namespace(ctx)).Path("endpoints").Body(endpoints).Do().Into(result)
 	return result, err
 }
 
+// UpdateEndpoints updates an existing endpoint.
 func (c *Client) UpdateEndpoints(ctx api.Context, endpoints *api.Endpoints) (*api.Endpoints, error) {
 	result := &api.Endpoints{}
 	if len(endpoints.ResourceVersion) == 0 {
@@ -297,17 +301,30 @@ func (c *Client) ServerVersion() (*version.Info, error) {
 	return &info, nil
 }
 
-// ListMinions lists all the minions in the cluster.
-func (c *Client) ListMinions() (result *api.MinionList, err error) {
-	result = &api.MinionList{}
-	err = c.Get().Path("minions").Do().Into(result)
-	return
+// CreateMinion creates a new minion.
+func (c *Client) CreateMinion(minion *api.Minion) (*api.Minion, error) {
+	result := &api.Minion{}
+	err := c.Post().Path("minions").Body(minion).Do().Into(result)
+	return result, err
 }
 
-func (c *Client) GetMinion(id string) (result *api.Minion, err error) {
-	result = &api.Minion{}
-	err = c.Get().Path("minions").Path(id).Do().Into(result)
-	return
+// ListMinions lists all the minions in the cluster.
+func (c *Client) ListMinions() (*api.MinionList, error) {
+	result := &api.MinionList{}
+	err := c.Get().Path("minions").Do().Into(result)
+	return result, err
+}
+
+// GetMinion returns information about a particular minion.
+func (c *Client) GetMinion(id string) (*api.Minion, error) {
+	result := &api.Minion{}
+	err := c.Get().Path("minions").Path(id).Do().Into(result)
+	return result, err
+}
+
+// DeleteMinion deletes an existing minion.
+func (c *Client) DeleteMinion(id string) error {
+	return c.Delete().Path("minions").Path(id).Do().Error()
 }
 
 // CreateEvent makes a new event. Returns the copy of the event the server returns, or an error.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/resources"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
@@ -543,4 +544,37 @@ func TestListMinions(t *testing.T) {
 	}
 	response, err := c.Setup().ListMinions()
 	c.Validate(t, response, err)
+}
+
+func TestCreateMinion(t *testing.T) {
+	requestMinion := &api.Minion{
+		TypeMeta: api.TypeMeta{
+			ID: "minion-1",
+		},
+		HostIP: "123.321.456.654",
+		NodeResources: api.NodeResources{
+			Capacity: api.ResourceList{
+				resources.CPU:    util.NewIntOrStringFromInt(1000),
+				resources.Memory: util.NewIntOrStringFromInt(1024 * 1024),
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{Method: "POST", Path: "/minions", Body: requestMinion},
+		Response: Response{
+			StatusCode: 200,
+			Body:       requestMinion,
+		},
+	}
+	receivedMinion, err := c.Setup().CreateMinion(requestMinion)
+	c.Validate(t, receivedMinion, err)
+}
+
+func TestDeleteMinion(t *testing.T) {
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: "/minions/foo"},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup().DeleteMinion("foo")
+	c.Validate(t, nil, err)
 }

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -154,6 +154,16 @@ func (c *Fake) ListMinions() (*api.MinionList, error) {
 	return &c.Minions, nil
 }
 
+func (c *Fake) CreateMinion(minion *api.Minion) (*api.Minion, error) {
+	c.Actions = append(c.Actions, FakeAction{Action: "create-minion", Value: minion})
+	return &api.Minion{}, nil
+}
+
+func (c *Fake) DeleteMinion(id string) error {
+	c.Actions = append(c.Actions, FakeAction{Action: "delete-minion", Value: id})
+	return nil
+}
+
 // CreateEvent makes a new event. Returns the copy of the event the server returns, or an error.
 func (c *Fake) CreateEvent(event *api.Event) (*api.Event, error) {
 	c.Actions = append(c.Actions, FakeAction{Action: "get-event", Value: event.ID})


### PR DESCRIPTION
Add two methods to client interface for minion controller.   Should only have a little conflict with #1937
