### PR TITLE
Fix GCE since KUBE_ADMIN_TOKEN is never set,

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -410,8 +410,7 @@ function kube-up {
   "Password": "$KUBE_PASSWORD",
   "CAFile": "$HOME/$ca_cert",
   "CertFile": "$HOME/$kube_cert",
-  "KeyFile": "$HOME/$kube_key",
-  "BearerToken": "$KUBE_ADMIN_TOKEN"
+  "KeyFile": "$HOME/$kube_key"
 }
 EOF
 


### PR DESCRIPTION
 since get-admin-token is never called.
