### PR TITLE
build: cleaner `docker rmi`

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -346,7 +346,7 @@ function kube::build::clean_images() {
   done
 
   echo "+++ Cleaning all other untagged docker images"
-  docker rmi $(docker images | awk '/^<none>/ {print $3}') 2> /dev/null || true
+  docker rmi $(docker images -q --filter 'dangling=true') 2> /dev/null || true
 }
 
 # Run a command in the kube-build image.  This assumes that the image has


### PR DESCRIPTION
no need to pipe to awk for orphan images

Signed-off-by: Vincent Batts vbatts@redhat.com
