### PR TITLE
Separate minion controller from master.

### DIFF
--- a/cluster/saltbase/salt/apiserver/default
+++ b/cluster/saltbase/salt/apiserver/default
@@ -3,18 +3,12 @@
 	{% set daemon_args = "" %}
 {% endif %}
 
-{% set machines = ""%}
 {% set cloud_provider = "" %}
-{% set minion_regexp = "-minion_regexp=.*" %}
 {% if grains.cloud_provider is defined %}
   {% set cloud_provider = "-cloud_provider=" + grains.cloud_provider %}
 {% endif %}
 
 {% set address = "-address=127.0.0.1" %}
-
-{% if pillar['node_instance_prefix'] is defined %}
-  {% set minion_regexp = "-minion_regexp='" + pillar['node_instance_prefix'] + ".*'" %}
-{% endif %}
 
 {% if grains.etcd_servers is defined %}
   {% set etcd_servers = "-etcd_servers=http://" + grains.etcd_servers + ":4001" %}
@@ -26,28 +20,11 @@
 {% if grains.cloud is defined %}
 {% if grains.cloud == 'gce' %}
   {% set cloud_provider = "-cloud_provider=gce" %}
-  {% set machines = "-machines=" + ','.join(salt['mine.get']('roles:kubernetes-pool', 'network.ip_addrs', expr_form='grain').keys()) %}
-{% endif %}
-{% if grains.cloud == 'azure' %}
-  MACHINES="{{ salt['mine.get']('roles:kubernetes-pool', 'grains.items', expr_form='grain').values()|join(',', attribute='hostnamef') }}"
-  {% set machines = "-machines=$MACHINES" %}
-{% endif %}
-{% if grains.cloud == 'vsphere' %}
-  # Collect IPs of minions as machines list.
-  #
-  # Use a bash array to build the value we need. Jinja 2.7 does support a 'map'
-  # filter that would simplify this.  However, some installations (specifically
-  # Debian Wheezy) only install Jinja 2.6.
-  MACHINE_IPS=()
-  {% for addrs in salt['mine.get']('roles:kubernetes-pool', 'network.ip_addrs', expr_form='grain').values() %}
-  MACHINE_IPS+=( {{ addrs[0] }} )
-  {% endfor %}
-  {% set machines = "-machines=$(echo ${MACHINE_IPS[@]} | xargs -n1 echo | paste -sd,)" %}
-  {% set minion_regexp = "" %}
 {% endif %}
 {% endif %}
+
 {% if pillar['portal_net'] is defined %}
   {% set portal_net = "-portal_net=" + pillar['portal_net'] %}
 {% endif %}
 
-DAEMON_ARGS="{{daemon_args}} {{address}} {{machines}} {{etcd_servers}} {{ minion_regexp }} {{ cloud_provider }} --allow_privileged={{pillar['allow_privileged']}} {{portal_net}}"
+DAEMON_ARGS="{{daemon_args}} {{address}} {{etcd_servers}} {{ cloud_provider }} --allow_privileged={{pillar['allow_privileged']}} {{portal_net}}"

--- a/cluster/saltbase/salt/controller-manager/default
+++ b/cluster/saltbase/salt/controller-manager/default
@@ -2,5 +2,42 @@
 {% if grains['os_family'] == 'RedHat' %}
 	{% set daemon_args = "" %}
 {% endif %}
+
 {% set master="-master=127.0.0.1:8080" %}
-DAEMON_ARGS="{{daemon_args}} {{master}}"
+
+{% set machines = ""%}
+{% set cloud_provider = "" %}
+{% set minion_regexp = "-minion_regexp=.*" %}
+{% if grains.cloud_provider is defined %}
+  {% set cloud_provider = "-cloud_provider=" + grains.cloud_provider %}
+{% endif %}
+
+{% if pillar['node_instance_prefix'] is defined %}
+  {% set minion_regexp = "-minion_regexp='" + pillar['node_instance_prefix'] + ".*'" %}
+{% endif %}
+
+{% if grains.cloud is defined %}
+{% if grains.cloud == 'gce' %}
+  {% set cloud_provider = "-cloud_provider=gce" %}
+  {% set machines = "-machines=" + ','.join(salt['mine.get']('roles:kubernetes-pool', 'network.ip_addrs', expr_form='grain').keys()) %}
+{% endif %}
+{% if grains.cloud == 'azure' %}
+  MACHINES="{{ salt['mine.get']('roles:kubernetes-pool', 'grains.items', expr_form='grain').values()|join(',', attribute='hostnamef') }}"
+  {% set machines = "-machines=$MACHINES" %}
+{% endif %}
+{% if grains.cloud == 'vsphere' %}
+  # Collect IPs of minions as machines list.
+  #
+  # Use a bash array to build the value we need. Jinja 2.7 does support a 'map'
+  # filter that would simplify this.  However, some installations (specifically
+  # Debian Wheezy) only install Jinja 2.6.
+  MACHINE_IPS=()
+  {% for addrs in salt['mine.get']('roles:kubernetes-pool', 'network.ip_addrs', expr_form='grain').values() %}
+  MACHINE_IPS+=( {{ addrs[0] }} )
+  {% endfor %}
+  {% set machines = "-machines=$(echo ${MACHINE_IPS[@]} | xargs -n1 echo | paste -sd,)" %}
+  {% set minion_regexp = "" %}
+{% endif %}
+{% endif %}
+
+DAEMON_ARGS="{{daemon_args}} {{master}} {{machines}} {{ minion_regexp }} {{ cloud_provider }}"

--- a/cmd/controller-manager/plugins.go
+++ b/cmd/controller-manager/plugins.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// This file exists to force the desired plugin implementations to be linked.
+// This should probably be part of some configuration fed into the build for a
+// given binary target.
+import (
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/aws"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/gce"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/openstack"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/ovirt"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/vagrant"
+)

--- a/pkg/client/minions.go
+++ b/pkg/client/minions.go
@@ -16,9 +16,7 @@ limitations under the License.
 
 package client
 
-import (
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-)
+import "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 
 type MinionsInterface interface {
 	Minions() MinionInterface
@@ -49,17 +47,17 @@ func (c *minions) Create(minion *api.Minion) (*api.Minion, error) {
 }
 
 // List lists all the minions in the cluster.
-func (c *minions) List() (result *api.MinionList, err error) {
-	result = &api.MinionList{}
-	err = c.r.Get().Path("minions").Do().Into(result)
-	return
+func (c *minions) List() (*api.MinionList, error) {
+	result := &api.MinionList{}
+	err := c.r.Get().Path("minions").Do().Into(result)
+	return result, err
 }
 
 // Get gets an existing minion
-func (c *minions) Get(id string) (result *api.Minion, err error) {
-	result = &api.Minion{}
-	err = c.r.Get().Path("minions").Path(id).Do().Into(result)
-	return
+func (c *minions) Get(id string) (*api.Minion, error) {
+	result := &api.Minion{}
+	err := c.r.Get().Path("minions").Path(id).Do().Into(result)
+	return result, err
 }
 
 // Delete deletes an existing minion.


### PR DESCRIPTION
There is some restrictions with our test utilities.  The pkg/util/fake_handler only handles one request/response.  I want to expand the fake_handler, so it's possible to write a more thorough test on minion controller; maybe in another PR.
