### PR TITLE
Fix reflect panic in runtime/conversion

### DIFF
--- a/pkg/api/meta/meta.go
+++ b/pkg/api/meta/meta.go
@@ -224,11 +224,10 @@ func fieldPtr(v reflect.Value, fieldName string, dest interface{}) error {
 	if !field.IsValid() {
 		return fmt.Errorf("Couldn't find %v field in %#v", fieldName, v.Interface())
 	}
-	v = reflect.ValueOf(dest)
-	if v.Kind() != reflect.Ptr {
-		return fmt.Errorf("dest should be ptr")
+	v, err := conversion.EnforcePtr(dest)
+	if err != nil {
+		return err
 	}
-	v = v.Elem()
 	field = field.Addr()
 	if field.Type().AssignableTo(v.Type()) {
 		v.Set(field)

--- a/pkg/conversion/converter.go
+++ b/pkg/conversion/converter.go
@@ -213,17 +213,16 @@ func (f FieldMatchingFlags) IsSet(flag FieldMatchingFlags) bool {
 // it is not used by Convert() other than storing it in the scope.
 // Not safe for objects with cyclic references!
 func (c *Converter) Convert(src, dest interface{}, flags FieldMatchingFlags, meta *Meta) error {
-	dv, sv := reflect.ValueOf(dest), reflect.ValueOf(src)
-	if dv.Kind() != reflect.Ptr {
-		return fmt.Errorf("Need pointer, but got %#v", dest)
+	dv, err := EnforcePtr(dest)
+	if err != nil {
+		return err
 	}
-	if sv.Kind() != reflect.Ptr {
-		return fmt.Errorf("Need pointer, but got %#v", src)
-	}
-	dv = dv.Elem()
-	sv = sv.Elem()
 	if !dv.CanAddr() {
 		return fmt.Errorf("Can't write to dest")
+	}
+	sv, err := EnforcePtr(src)
+	if err != nil {
+		return err
 	}
 	s := &scope{
 		converter: c,

--- a/pkg/conversion/meta.go
+++ b/pkg/conversion/meta.go
@@ -113,7 +113,10 @@ func UpdateVersionAndKind(baseFields []string, versionField, version, kindField,
 func EnforcePtr(obj interface{}) (reflect.Value, error) {
 	v := reflect.ValueOf(obj)
 	if v.Kind() != reflect.Ptr {
-		return reflect.Value{}, fmt.Errorf("expected pointer, but got %v", v.Type().Name())
+		if v.Kind() == reflect.Invalid {
+			return reflect.Value{}, fmt.Errorf("expected pointer, but got invalid kind")
+		}
+		return reflect.Value{}, fmt.Errorf("expected pointer, but got %v type", v.Type().Name())
 	}
 	return v.Elem(), nil
 }

--- a/pkg/conversion/meta.go
+++ b/pkg/conversion/meta.go
@@ -118,5 +118,8 @@ func EnforcePtr(obj interface{}) (reflect.Value, error) {
 		}
 		return reflect.Value{}, fmt.Errorf("expected pointer, but got %v type", v.Type().Name())
 	}
+	if v.IsNil() {
+		return reflect.Value{}, fmt.Errorf("expected pointer, but got nil")
+	}
 	return v.Elem(), nil
 }

--- a/pkg/conversion/meta_test.go
+++ b/pkg/conversion/meta_test.go
@@ -253,3 +253,11 @@ func TestInvalidPtrValueKind(t *testing.T) {
 		}
 	}
 }
+
+func TestEnforceNilPtr(t *testing.T) {
+	var nilPtr *struct{}
+	_, err := EnforcePtr(nilPtr)
+	if err == nil {
+		t.Errorf("Expected error on nil pointer")
+	}
+}

--- a/pkg/conversion/meta_test.go
+++ b/pkg/conversion/meta_test.go
@@ -242,3 +242,14 @@ func TestMetaValuesUnregisteredConvert(t *testing.T) {
 		t.Errorf("Expected %v, got %v", e, a)
 	}
 }
+
+func TestInvalidPtrValueKind(t *testing.T) {
+	var simple interface{}
+	switch obj := simple.(type) {
+	default:
+		_, err := EnforcePtr(obj)
+		if err == nil {
+			t.Errorf("Expected error on invalid kind")
+		}
+	}
+}

--- a/pkg/resources/resources_test.go
+++ b/pkg/resources/resources_test.go
@@ -130,7 +130,7 @@ func TestGetFloat(t *testing.T) {
 	for _, test := range tests {
 		val := GetFloatResource(test.res, test.name, test.def)
 		if val != test.expected {
-			t.Errorf("%expected: %d found %d", test.expected, val)
+			t.Errorf("expected: %d found %d", test.expected, val)
 		}
 	}
 }

--- a/pkg/runtime/scheme_test.go
+++ b/pkg/runtime/scheme_test.go
@@ -123,6 +123,20 @@ func TestScheme(t *testing.T) {
 	}
 }
 
+func TestInvalidObjectValueKind(t *testing.T) {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName("", "Simple", &InternalSimple{})
+
+	embedded := &runtime.EmbeddedObject{}
+	switch obj := embedded.Object.(type) {
+	default:
+		_, _, err := scheme.ObjectVersionAndKind(obj)
+		if err == nil {
+			t.Errorf("Expected error on invalid kind")
+		}
+	}
+}
+
 func TestBadJSONRejection(t *testing.T) {
 	scheme := runtime.NewScheme()
 	badJSONMissingKind := []byte(`{ }`)


### PR DESCRIPTION
Fixes `panic: reflect: call of reflect.Value.Type on zero Value`
when calling conversion.EnforcePtr() or
runtime.Scheme.ObjectVersionAndKind() from default type switch.

Signed-off-by: Vojtech Vitek (V-Teq) vvitek@redhat.com
