### PR TITLE
Fluentd example with Elasticsearch and Kibana in the same pod

### DIFF
--- a/contrib/logging/fluentd-ek-colo/Makefile
+++ b/contrib/logging/fluentd-ek-colo/Makefile
@@ -1,0 +1,45 @@
+# Makefile for scenario where the Elasticsearch and Kibana containers
+# have to be co-located inside the same pod.
+
+KUBECTL=kubectl.sh
+
+up:	logger-up es-kibana-up
+
+down:	logger-down es-kibana-down
+
+
+es-kibana-up:	
+	-${KUBECTL} create -f es-kibana-pod.yml
+	-${KUBECTL} create -f es-service.yml
+	-${KUBECTL} create -f kibana-service.yml
+
+es-kibana-down:
+	-${KUBECTL} delete pods elasticsearch-kibana-pod
+	-${KUBECTL} delete service kibana-colo
+	-${KUBECTL} delete service elasticsearch-colo
+
+update:	
+	-${KUBECTL} delete pods elasticsearch-kibana-pod
+	-${KUBECTL} create -f es-kibana-pod.yml
+
+logger-up:
+	-${KUBECTL} create -f synthetic_0_25lps.yml
+
+logger-down:
+	-${KUBECTL} delete pods synthetic-logger-0.25lps-pod
+
+get:	
+	${KUBECTL} get pods
+	${KUBECTL} get services
+
+net:	
+	gcutil getforwardingrule elasticsearch-colo
+	gcutil getforwardingrule kibana-colo
+
+firewall:	
+	gcutil addfirewall --allowed=tcp:5601,tcp:9200,tcp:9300 --target_tags=kubernetes-minion kubernetes-elk-example
+
+
+rmfirewall:
+	gcutil deletefirewall -f kubernetes-elk-example
+

--- a/contrib/logging/fluentd-ek-colo/es-kibana-pod.yml
+++ b/contrib/logging/fluentd-ek-colo/es-kibana-pod.yml
@@ -1,0 +1,29 @@
+apiVersion: v1beta1
+kind: Pod
+id: elasticsearch-kibana-pod
+desiredState:
+  manifest:
+    version: v1beta1
+    id: es
+    containers:
+      - name: elasticsearch
+        image: dockerfile/elasticsearch
+        ports:
+          - name: es-port
+            containerPort: 9200
+          - name: es-transport-port
+            containerPort: 9300
+        volumeMounts:
+          - name: es-persistent-storage
+            mountPath: /data
+    volumes:
+      - name: es-persistent-storage
+        source:
+          emptyDir: {}
+      - name: kibana-image
+        image: kubernetes/kibana
+        ports:
+          - name: kibana-port
+            containerPort: 80
+labels:
+  app: elasticsearch-kibana

--- a/contrib/logging/fluentd-ek-colo/es-service.yml
+++ b/contrib/logging/fluentd-ek-colo/es-service.yml
@@ -1,0 +1,8 @@
+apiVersion: v1beta1
+kind: Service
+id: elasticsearch-colo
+containerPort: es-port
+port: 9200
+selector:
+  app: elasticsearch-kibana
+createExternalLoadBalancer: true

--- a/contrib/logging/fluentd-ek-colo/kibana-service.yml
+++ b/contrib/logging/fluentd-ek-colo/kibana-service.yml
@@ -1,0 +1,8 @@
+apiVersion: v1beta1
+kind: Service
+id: kibana-colo
+containerPort: kibana-port
+port: 5601
+selector:
+  app: elasticsearch-kibana
+createExternalLoadBalancer: true

--- a/contrib/logging/fluentd-ek-colo/synthetic_0_25lps.yml
+++ b/contrib/logging/fluentd-ek-colo/synthetic_0_25lps.yml
@@ -1,0 +1,14 @@
+apiVersion: v1beta1
+kind: Pod
+id: synthetic-logger-0.25lps-pod
+desiredState:
+  manifest:
+    version: v1beta1
+    id: synth-logger-0.25lps
+    containers:
+      - name: synth-lgr
+        image: ubuntu:14.04
+        command: ["bash", "-c", "i=\"0\"; while true; do echo -n \"`hostname`: $i: \"; date --rfc-3339 ns; sleep 4; i=$[$i+1]; done"]
+labels:
+  name: synth-logging-source
+ 


### PR DESCRIPTION
This example shows how Elasticsearch and Fluentd can be co-located in the same pod to log the behaviour of a synthetic logging program.
