### PR TITLE
Fluentd example with Elasticsearch and Kibana in separate pods

### DIFF
--- a/contrib/logging/fluentd-ek/Makefile
+++ b/contrib/logging/fluentd-ek/Makefile
@@ -1,0 +1,56 @@
+# Makefile for Fluentd to Elastiscsearch and Kibana configured
+# in separate pods.
+
+
+.PHONY: up dow es-up kibana-up es-down kibana-down update \
+        logger-up logger-down get net firewall rmfirewall
+
+KUBECTL=kubectl.sh
+
+up:	logger-up es-up kibana-up
+
+down:	logger-down es-down kibana-down
+
+
+es-up:	
+	-${KUBECTL} create -f es-pod.yml
+	-${KUBECTL} create -f es-service.yml
+
+kibana-up:
+	-${KUBECTL} create -f kibana-pod.yml
+	-${KUBECTL} create -f kibana-service.yml
+
+es-down:
+	-${KUBECTL} delete pods elasticsearch-pod
+	-${KUBECTL} delete service elasticsearch
+
+kibana-down:
+	-${KUBECTL} delete pods kibana-pod
+	-${KUBECTL} delete service kibana
+
+
+update:	
+	-${KUBECTL} delete pods kibana-pod
+	-${KUBECTL} create -f kibana-pod.yml
+
+logger-up:
+	-${KUBECTL} create -f synthetic_0_25lps.yml
+
+logger-down:
+	-${KUBECTL} delete pods synthetic-logger-0.25lps-pod
+
+get:	
+	${KUBECTL} get pods
+	${KUBECTL} get services
+
+net:	
+	gcutil getforwardingrule elasticsearch
+	gcutil getforwardingrule kibana
+
+firewall:	
+	gcutil addfirewall --allowed=tcp:5601,tcp:9200,tcp:9300 --target_tags=kubernetes-minion kubernetes-elk-example
+ 
+
+rmfirewall:
+	gcutil deletefirewall -f kubernetes-elk-example
+

--- a/contrib/logging/fluentd-ek/es-pod.yml
+++ b/contrib/logging/fluentd-ek/es-pod.yml
@@ -1,0 +1,25 @@
+apiVersion: v1beta1
+kind: Pod
+id: elasticsearch-pod
+desiredState:
+  manifest:
+    version: v1beta1
+    id: es
+    containers:
+      - name: elasticsearch
+        image: dockerfile/elasticsearch
+        ports:
+          - name: es-port
+            containerPort: 9200
+          - name: es-transport-port
+            containerPort: 9300
+        volumeMounts:
+          - name: es-persistent-storage
+            mountPath: /data
+    volumes:
+      - name: es-persistent-storage
+        source:
+          emptyDir: {}
+labels:
+  app: elasticsearch
+ 

--- a/contrib/logging/fluentd-ek/es-service.yml
+++ b/contrib/logging/fluentd-ek/es-service.yml
@@ -1,0 +1,8 @@
+apiVersion: v1beta1
+kind: Service
+id: elasticsearch
+containerPort: es-port
+port: 9200
+selector:
+  app: elasticsearch
+createExternalLoadBalancer: true

--- a/contrib/logging/fluentd-ek/kibana-pod.yml
+++ b/contrib/logging/fluentd-ek/kibana-pod.yml
@@ -1,0 +1,15 @@
+apiVersion: v1beta1
+kind: Pod
+id: kibana-pod
+desiredState:
+  manifest:
+    version: v1beta1
+    id: kibana-server
+    containers:
+      - name: kibana-image
+        image: kubernetes/kibana:latest
+        ports:
+          - name: kibana-port
+            containerPort: 80
+labels:
+  app: kibana-viewer

--- a/contrib/logging/fluentd-ek/kibana-service.yml
+++ b/contrib/logging/fluentd-ek/kibana-service.yml
@@ -1,0 +1,9 @@
+apiVersion: v1beta1
+kind: Service
+id: kibana
+containerPort: kibana-port
+port: 5601
+selector:
+  app: kibana-viewer
+createExternalLoadBalancer: true
+ 

--- a/contrib/logging/fluentd-ek/synthetic_0_25lps.yml
+++ b/contrib/logging/fluentd-ek/synthetic_0_25lps.yml
@@ -1,0 +1,29 @@
+# This pod specification creates an instance of a synthetic logger. The logger
+# is simply a program that writes out the hostname of the pod, a count which increments
+# by one on each iteration (to help notice missing log enteries) and the date using
+# a long format (RFC-3339) to nano-second precision. This program logs at a frequency
+# of 0.25 lines per second. The shellscript program is given directly to bash as -c argument
+# and could have been written out as:
+#   i="0"
+#   while true
+#   do
+#     echo -n "`hostname`: $i: "
+#     date --rfc-3339 ns
+#     sleep 4
+#     i=$[$i+1]
+#   done
+
+apiVersion: v1beta1
+kind: Pod
+id: synthetic-logger-0.25lps-pod
+desiredState:
+  manifest:
+    version: v1beta1
+    id: synth-logger-0.25lps
+    containers:
+      - name: synth-lgr
+        image: ubuntu:14.04
+        command: ["bash", "-c", "i=\"0\"; while true; do echo -n \"`hostname`: $i: \"; date --rfc-3339 ns; sleep 4; i=$[$i+1]; done"]
+labels:
+  name: synth-logging-source
+ 


### PR DESCRIPTION
This pull requests shows how Elasticsearch and Kibana can be placed in separate pods and use to log the behaviour of a synthetic logging program.
