### PR TITLE
Demo files for logging for Fluentd and GCP

### DIFF
--- a/contrib/logging/fluentd-gcp/Makefile
+++ b/contrib/logging/fluentd-gcp/Makefile
@@ -1,0 +1,22 @@
+# Makefile for a synthetic logger to be logged
+# by GCP. The cluster must have been created with
+# the environment variable FLUENTD_GCP set to 'true'.
+
+.PHONY: up down logger-up logger-down get
+
+KUBECTL=kubectl.sh
+
+up:	logger-up
+
+down:	logger-down
+
+
+logger-up:
+	-${KUBECTL} create -f synthetic_0_25lps.yml
+
+logger-down:
+	-${KUBECTL} delete pods synthetic-logger-0.25lps-pod
+
+get:	
+	${KUBECTL} get pods
+

--- a/contrib/logging/fluentd-gcp/synthetic_0_25lps.yml
+++ b/contrib/logging/fluentd-gcp/synthetic_0_25lps.yml
@@ -1,0 +1,29 @@
+# This pod specification creates an instance of a synthetic logger. The logger
+# is simply a program that writes out the hostname of the pod, a count which increments
+# by one on each iteration (to help notice missing log enteries) and the date using
+# a long format (RFC-3339) to nano-second precision. This program logs at a frequency
+# of 0.25 lines per second. The shellscript program is given directly to bash as -c argument
+# and could have been written out as:
+#   i="0"
+#   while true
+#   do
+#     echo -n "`hostname`: $i: "
+#     date --rfc-3339 ns
+#     sleep 4
+#     i=$[$i+1]
+#   done
+
+apiVersion: v1beta1
+kind: Pod
+id: synthetic-logger-0.25lps-pod
+desiredState:
+  manifest:
+    version: v1beta1
+    id: synth-logger-0.25lps
+    containers:
+      - name: synth-lgr
+        image: ubuntu:14.04
+        command: ["bash", "-c", "i=\"0\"; while true; do echo -n \"`hostname`: $i: \"; date --rfc-3339 ns; sleep 4; i=$[$i+1]; done"]
+labels:
+  name: synth-logging-source
+ 


### PR DESCRIPTION
Right now I am proposing just to check in the demo files a user needs to quick off a synthetic logger on the assumption that the Fluentd + GCP configured on the cluster will collect without any further setup.
