### PR TITLE
state-based parser for multi-valued set selector syntax

### DIFF
--- a/pkg/labels/selector_test.go
+++ b/pkg/labels/selector_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package labels
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -212,6 +213,8 @@ func TestRequirementConstructor(t *testing.T) {
 		{"x", In, util.NewStringSet("foo"), true},
 		{"x", NotIn, util.NewStringSet("foo"), true},
 		{"x", Exists, nil, true},
+		{"abcdefghijklmnopqrstuvwxy", Exists, nil, false}, //breaks DNS952 rule that len(key) < 25
+		{"1foo", In, util.NewStringSet("bar"), false},     //breaks DNS952 rule that keys start with [a-z]
 	}
 	for _, rc := range requirementConstructorTests {
 		if _, err := NewRequirement(rc.Key, rc.Op, rc.Vals); err == nil && !rc.Success {
@@ -285,6 +288,67 @@ func TestRequirementLabelSelectorMatching(t *testing.T) {
 			t.Errorf("%+v.Matches(%#v) => %v, expected no error", lsm.Sel, lsm.Set, err)
 		} else if match != lsm.Match {
 			t.Errorf("%+v.Matches(%#v) => %v, want %v", lsm.Sel, lsm.Set, match, lsm.Match)
+		}
+	}
+}
+
+func TestSetSelectorParser(t *testing.T) {
+	setSelectorParserTests := []struct {
+		In    string
+		Out   SetBasedSelector
+		Match bool
+		Valid bool
+	}{
+		{"", &LabelSelector{Requirements: nil}, true, true},
+		{"x", &LabelSelector{Requirements: []Requirement{
+			getRequirement("x", Exists, nil, t),
+		}}, true, true},
+		{"foo in (abc)", &LabelSelector{Requirements: []Requirement{
+			getRequirement("foo", In, util.NewStringSet("abc"), t),
+		}}, true, true},
+		{"x not in (abc)", &LabelSelector{Requirements: []Requirement{
+			getRequirement("x", NotIn, util.NewStringSet("abc"), t),
+		}}, true, true},
+		{"x not in (abc,def)", &LabelSelector{Requirements: []Requirement{
+			getRequirement("x", NotIn, util.NewStringSet("abc", "def"), t),
+		}}, true, true},
+		{"x in (abc,def)", &LabelSelector{Requirements: []Requirement{
+			getRequirement("x", In, util.NewStringSet("abc", "def"), t),
+		}}, true, true},
+		{"x in (abc,)", &LabelSelector{Requirements: []Requirement{
+			getRequirement("x", In, util.NewStringSet("abc", ""), t),
+		}}, true, true},
+		{"x in ()", &LabelSelector{Requirements: []Requirement{
+			getRequirement("x", In, util.NewStringSet(""), t),
+		}}, true, true},
+		{"x not in (abc,,def),bar,z in (),w", &LabelSelector{Requirements: []Requirement{
+			getRequirement("x", NotIn, util.NewStringSet("abc", "", "def"), t),
+			getRequirement("bar", Exists, nil, t),
+			getRequirement("z", In, util.NewStringSet(""), t),
+			getRequirement("w", Exists, nil, t),
+		}}, true, true},
+		{"x,y in (a)", &LabelSelector{Requirements: []Requirement{
+			getRequirement("y", In, util.NewStringSet("a"), t),
+			getRequirement("x", Exists, nil, t),
+		}}, false, true},
+		{"x,,y", nil, true, false},
+		{",x,y", nil, true, false},
+		{"x, y", nil, true, false},
+		{"x nott in (y)", nil, true, false},
+		{"x not in ( )", nil, true, false},
+		{"x not in (, a)", nil, true, false},
+		{"a in (xyz),", nil, true, false},
+		{"a in (xyz)b not in ()", nil, true, false},
+		{"a ", nil, true, false},
+		{"a not in(", nil, true, false},
+	}
+	for _, ssp := range setSelectorParserTests {
+		if sel, err := Parse(ssp.In); err != nil && ssp.Valid {
+			t.Errorf("Parse(%s) => %v expected no error", ssp.In, err)
+		} else if err == nil && !ssp.Valid {
+			t.Errorf("Parse(%s) => %+v expected error", ssp.In, sel)
+		} else if ssp.Match && !reflect.DeepEqual(sel, ssp.Out) {
+			t.Errorf("parse output %+v doesn't match %+v, expected match", sel, ssp.Out)
 		}
 	}
 }


### PR DESCRIPTION
Continuation of the work done [here](https://github.com/GoogleCloudPlatform/kubernetes/pull/951). Whereas previous work expanded the struct and went from object to string, this goes from string to object.
