### PR TITLE
expose ParseWatchResourceVersion for downstream use

### DIFF
--- a/pkg/registry/etcd/etcd.go
+++ b/pkg/registry/etcd/etcd.go
@@ -97,11 +97,11 @@ func makePodKey(ctx api.Context, id string) (string, error) {
 	return MakeEtcdItemKey(ctx, PodPath, id)
 }
 
-// parseWatchResourceVersion takes a resource version argument and converts it to
+// ParseWatchResourceVersion takes a resource version argument and converts it to
 // the etcd version we should pass to helper.Watch(). Because resourceVersion is
 // an opaque value, the default watch behavior for non-zero watch is to watch
 // the next value (if you pass "1", you will see updates from "2" onwards).
-func parseWatchResourceVersion(resourceVersion, kind string) (uint64, error) {
+func ParseWatchResourceVersion(resourceVersion, kind string) (uint64, error) {
 	if resourceVersion == "" || resourceVersion == "0" {
 		return 0, nil
 	}
@@ -143,7 +143,7 @@ func (r *Registry) ListPodsPredicate(ctx api.Context, filter func(*api.Pod) bool
 
 // WatchPods begins watching for new, changed, or deleted pods.
 func (r *Registry) WatchPods(ctx api.Context, resourceVersion string, filter func(*api.Pod) bool) (watch.Interface, error) {
-	version, err := parseWatchResourceVersion(resourceVersion, "pod")
+	version, err := ParseWatchResourceVersion(resourceVersion, "pod")
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +353,7 @@ func (r *Registry) ListControllers(ctx api.Context) (*api.ReplicationControllerL
 
 // WatchControllers begins watching for new, changed, or deleted controllers.
 func (r *Registry) WatchControllers(ctx api.Context, resourceVersion string) (watch.Interface, error) {
-	version, err := parseWatchResourceVersion(resourceVersion, "replicationControllers")
+	version, err := ParseWatchResourceVersion(resourceVersion, "replicationControllers")
 	if err != nil {
 		return nil, err
 	}
@@ -515,7 +515,7 @@ func (r *Registry) UpdateService(ctx api.Context, svc *api.Service) error {
 
 // WatchServices begins watching for new, changed, or deleted service configurations.
 func (r *Registry) WatchServices(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	version, err := parseWatchResourceVersion(resourceVersion, "service")
+	version, err := ParseWatchResourceVersion(resourceVersion, "service")
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +560,7 @@ func (r *Registry) UpdateEndpoints(ctx api.Context, endpoints *api.Endpoints) er
 
 // WatchEndpoints begins watching for new, changed, or deleted endpoint configurations.
 func (r *Registry) WatchEndpoints(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	version, err := parseWatchResourceVersion(resourceVersion, "endpoints")
+	version, err := ParseWatchResourceVersion(resourceVersion, "endpoints")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/etcd/etcd_test.go
+++ b/pkg/registry/etcd/etcd_test.go
@@ -56,7 +56,7 @@ func TestEtcdParseWatchResourceVersion(t *testing.T) {
 		{Version: "10", ExpectVersion: 11},
 	}
 	for _, testCase := range testCases {
-		version, err := parseWatchResourceVersion(testCase.Version, testCase.Kind)
+		version, err := ParseWatchResourceVersion(testCase.Version, testCase.Kind)
 		switch {
 		case testCase.Err:
 			if err == nil {


### PR DESCRIPTION
The parseWatchResourceVersion is important for anyone wanting to create a pkg/client/cache/ListerWatcher backed by etcd where the resourceVersion is uint64.  This simply exposes it.
