### PR TITLE
fix unit tests broken in 5cb3c10289f79238a04b777143eed8ab970a6177

### DIFF
--- a/pkg/registry/service/rest_test.go
+++ b/pkg/registry/service/rest_test.go
@@ -456,7 +456,7 @@ func TestServiceRegistryIPAllocation(t *testing.T) {
 	ctx = api.NewDefaultContext()
 	c3, _ := rest.Create(ctx, svc3)
 	created_svc3 := <-c3
-	created_service_3 := created_svc3.(*api.Service)
+	created_service_3 := created_svc3.Object.(*api.Service)
 	if created_service_3.PortalIP != "1.2.3.93" { // specific IP
 		t.Errorf("Unexpected PortalIP: %s", created_service_3.PortalIP)
 	}
@@ -550,7 +550,7 @@ func TestServiceRegistryIPUpdate(t *testing.T) {
 
 	c, _ = rest.Update(ctx, update)
 	result := <-c
-	st := result.(*api.Status)
+	st := result.Object.(*api.Status)
 	if st.Reason != api.StatusReasonInvalid {
 		t.Errorf("Expected to get an invalid error, got %v", st)
 	}


### PR DESCRIPTION
After fetching 5cb3c10289f79238a04b777143eed8ab970a6177, I suffered failures in unit tests for pkg/registry/service/rest_test.go.  
# github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service

src/github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service/rest_test.go:459: invalid type assertion: created_svc3.(_api.Service) (non-interface type apiserver.RESTResult on left)
src/github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service/rest_test.go:553: invalid type assertion: result.(_api.Status) (non-interface type apiserver.RESTResult on left)
FAIL    github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service [build failed]

This eliminates those errors.

@smarterclayton looks like 5cb3c10289f79238a04b777143eed8ab970a6177 was yours can review?
