### PR TITLE
small docs fixes

### DIFF
--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -62,9 +62,9 @@ Before committing any changes, please link/copy these hooks into your .git
 directory. This will keep you from accidentally committing non-gofmt'd go code.
 
 ```
-cd kubernetes
-ln -s hooks/prepare-commit-msg .git/hooks/prepare-commit-msg
-ln -s hooks/commit-msg .git/hooks/commit-msg
+cd kubernetes/.git/hooks/
+ln -s ../../hooks/prepare-commit-msg .
+ln -s ../../hooks/commit-msg .
 ```
 
 ## Unit tests

--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -169,7 +169,7 @@ ID                  Image(s)            Selector            Replicas
 Start a container running nginx with a replication controller and three replicas:
 
 ```
-$cluster/kubecfg.sh -p 8080:80 run dockerfile/nginx 3 myNginx
+$ cluster/kubecfg.sh -p 8080:80 run dockerfile/nginx 3 myNginx
 ```
 
 When listing the pods, you will see that three containers have been started and are in Waiting state:
@@ -226,7 +226,7 @@ myNginx             dockerfile/nginx    replicationController=myNginx   3
 ```
 
 We did not start any services, hence there is none listed. But we see three replicas displayed properly.
-Check the [guestbook](examples/guestbook/README.md) application to learn how to create a service.
+Check the [guestbook](../../examples/guestbook/README.md) application to learn how to create a service.
 You can already play with resizing the replicas with:
 
 ```


### PR DESCRIPTION
This patch fixes:
- example showing how to create links to git hooks
- link to guestbook docs
