### PR TITLE
Allocate mux in master.New()

### DIFF
--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -197,7 +197,6 @@ func main() {
 	}
 
 	n := net.IPNet(portalNet)
-	mux := http.NewServeMux()
 	config := &master.Config{
 		Client:             client,
 		Cloud:              cloud,
@@ -215,7 +214,6 @@ func main() {
 			},
 		},
 		PortalNet:             &n,
-		Mux:                   mux,
 		EnableLogsSupport:     *enableLogsSupport,
 		EnableUISupport:       true,
 		APIPrefix:             *apiPrefix,

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -137,14 +137,12 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	if err != nil {
 		glog.Fatalf("Nonnumeric port? %v", err)
 	}
-	mux := http.NewServeMux()
 	// Create a master and install handlers into mux.
-	master.New(&master.Config{
+	m := master.New(&master.Config{
 		Client:            cl,
 		EtcdHelper:        helper,
 		Minions:           machineList,
 		KubeletClient:     fakeKubeletClient{},
-		Mux:               mux,
 		EnableLogsSupport: false,
 		APIPrefix:         "/api",
 
@@ -152,7 +150,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 		ReadOnlyPort:  portNumber,
 		PublicAddress: host,
 	})
-	handler.delegate = mux
+	handler.delegate = m.Handler
 
 	// Scheduler
 	schedulerConfigFactory := &factory.ConfigFactory{cl}

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -180,7 +180,28 @@ func setDefaults(c *Config) {
 	}
 }
 
-// New returns a new instance of Master connected to the given etcd server.
+// New returns a new instance of Master from the given config.
+// Certain config fields will be set to a default value if unset,
+// including:
+//   PortalNet
+//   MasterCount
+//   ReadOnlyPort
+//   ReadWritePort
+//   PublicAddress
+// Certain config fields must be specified, including:
+//   KubeletClient
+// Public fields:
+//   Handler -- The returned master has a field TopHandler which is an
+//   http.Handler which handles all the endpoints provided by the master,
+//   including the API, the UI, and miscelaneous debugging endpoints.  All
+//   these are subject to authorization and authentication.
+// Public methods:
+//   HandleWithAuth -- Allows caller to add an http.Handler for an endpoint
+//   that uses the same authentication and authorization (if any is configured)
+//   as the master's built-in endpoints.
+//   If the caller wants to add additional endpoints not using the master's
+//   auth, then the caller should create a handler for those endpoints, which delegates the
+//   any unhandled paths to "Handler".
 func New(c *Config) *Master {
 	setDefaults(c)
 	minionRegistry := makeMinionRegistry(c)
@@ -198,7 +219,7 @@ func New(c *Config) *Master {
 		minionRegistry:        minionRegistry,
 		client:                c.Client,
 		portalNet:             c.PortalNet,
-		mux:                   c.Mux,
+		mux:                   http.NewServeMux(),
 		enableLogsSupport:     c.EnableLogsSupport,
 		enableUISupport:       c.EnableUISupport,
 		apiPrefix:             c.APIPrefix,
@@ -211,6 +232,24 @@ func New(c *Config) *Master {
 	m.masterServices = util.NewRunner(m.serviceWriterLoop, m.roServiceWriterLoop)
 	m.init(c)
 	return m
+}
+
+// HandleWithAuth adds an http.Handler for pattern to an http.ServeMux
+// Applies the same authentication and authorization (if any is configured)
+// to the request is used for the master's built-in endpoints.
+func (m *Master) HandleWithAuth(pattern string, handler http.Handler) {
+	// TODO: Add a way for plugged-in endpoints to translate their
+	// URLs into attributes that an Authorizer can understand, and have
+	// sensible policy defaults for plugged-in endpoints.  This will be different
+	// for generic endpoints versus REST object endpoints.
+	m.mux.Handle(pattern, handler)
+}
+
+// HandleFuncWithAuth adds an http.Handler for pattern to an http.ServeMux
+// Applies the same authentication and authorization (if any is configured)
+// to the request is used for the master's built-in endpoints.
+func (m *Master) HandleFuncWithAuth(pattern string, handler func(http.ResponseWriter, *http.Request)) {
+	m.mux.HandleFunc(pattern, handler)
 }
 
 func makeMinionRegistry(c *Config) minion.Registry {

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package integration
 
 import (
-	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
@@ -40,17 +39,14 @@ func TestClient(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	mux := http.NewServeMux()
-
-	master.New(&master.Config{
+	m := master.New(&master.Config{
 		EtcdHelper:        helper,
-		Mux:               mux,
 		EnableLogsSupport: false,
 		EnableUISupport:   false,
 		APIPrefix:         "/api",
 	})
 
-	s := httptest.NewServer(mux)
+	s := httptest.NewServer(m.Handler)
 
 	testCases := []string{
 		"v1beta1",


### PR DESCRIPTION
Master installs auth in front of other handlers,
but code that uses the master was not giving
this handler to the http servers.
Fix test, now that /_whoami sits behind auth.
