### PR TITLE
Using containervm image for gce by default

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -19,8 +19,10 @@ ZONE=us-central1-b
 MASTER_SIZE=n1-standard-1
 MINION_SIZE=n1-standard-1
 NUM_MINIONS=4
-# gcloud/gcutil will expand this to the latest supported image.
-IMAGE=backports-debian-7-wheezy
+# TODO(dchen1107): Filed an internal issue to create an alias
+# for containervm image, so that gcloud/gcutil will expand this
+# to the latest supported image.
+IMAGE=container-vm-v20141016
 NETWORK=default
 INSTANCE_PREFIX=kubernetes
 MASTER_NAME="${INSTANCE_PREFIX}-master"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -19,8 +19,10 @@ ZONE=us-central1-b
 MASTER_SIZE=g1-small
 MINION_SIZE=g1-small
 NUM_MINIONS=2
-# gcloud/gcutil will expand this to the latest supported image.
-IMAGE=backports-debian-7-wheezy
+# TODO(dchen1107): Filed an internal issue to create an alias
+# for containervm image, so that gcloud/gcutil will expand this
+# to the latest supported image.
+IMAGE=container-vm-v20141016
 NETWORK=e2e
 INSTANCE_PREFIX="e2e-test-${USER}"
 MASTER_NAME="${INSTANCE_PREFIX}-master"

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -239,6 +239,13 @@ function kube-up {
   local htpasswd
   htpasswd=$(cat "${KUBE_TEMP}/htpasswd")
 
+  if ! gcutil getimage "${IMAGE}" > /dev/null 2>&1; then
+    echo "Adding new image: ${IMAGE}"
+    gcutil addimage "${IMAGE}" \
+      "gs://gcp-containers-images/${IMAGE}.tar.gz" \
+      --project "${PROJECT}"
+  fi
+
   if ! gcutil getnetwork "${NETWORK}" >/dev/null 2>&1; then
     echo "Creating new network for: ${NETWORK}"
     # The network needs to be created synchronously or we have a race. The


### PR DESCRIPTION
Have done a lot of tests against this change: 

1) Verified with kube-up.sh, and both docker and kubernetes binary are upgraded properly:

On master node: 
root@kubernetes-master:/var/log# /usr/local/bin/apiserver --version
Kubernetes 3f52a97052dd1b2880e2fae0e41338f852d32a41-311-gdcd454374fe4e1-dirty

On minion node:
root@kubernetes-minion-1:/var/log# /usr/local/bin/kubelet --version
Kubernetes 3f52a97052dd1b2880e2fae0e41338f852d32a41-311-gdcd454374fe4e1-dirty
root@kubernetes-minion-1:/var/log# /usr/bin/docker --version
Docker version 1.3.0, build c78088f

2) With #2042 merged, e2e tests are passed:
2014/10/28 15:29:39 Passed tests: [update.sh guestbook.sh services.sh goe2e.sh basic.sh]
2014/10/28 15:29:39 Failed tests: []
- exit 0

3) ran replication controller example by following examples/guestbook:

$ cluster/kubecfg.sh list pods
Name                                   Image(s)                   Host                                                               Labels              Status

---

redis-master-2                         dockerfile/redis           kubernetes-minion-1.c.golden-system-455.internal/146.148.52.185    name=redis-master   Running
12ca8706-5efe-11e4-b6bd-42010af0091c   brendanburns/redis-slave   kubernetes-minion-4.c.golden-system-455.internal/130.211.121.128   name=redisslave     Running
12cbf5f5-5efe-11e4-b6bd-42010af0091c   brendanburns/redis-slave   kubernetes-minion-2.c.golden-system-455.internal/107.178.223.69    name=redisslave     Running
41141971-5efe-11e4-b6bd-42010af0091c   brendanburns/php-redis     kubernetes-minion-3.c.golden-system-455.internal/130.211.119.51    name=frontend       Running
41144698-5efe-11e4-b6bd-42010af0091c   brendanburns/php-redis     kubernetes-minion-1.c.golden-system-455.internal/146.148.52.185    name=frontend       Running
41149190-5efe-11e4-b6bd-42010af0091c   brendanburns/php-redis     kubernetes-minion-4.c.golden-system-455.internal/130.211.121.128   name=frontend       Running
