### PR TITLE
Make DataVersionAndKind public on runtime.Scheme

### DIFF
--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -33,6 +33,13 @@ type Codec interface {
 	Encoder
 }
 
+// ObjectTyper contains methods for extracting the APIVersion and Kind
+// of objects.
+type ObjectTyper interface {
+	DataVersionAndKind([]byte) (version, kind string, err error)
+	ObjectVersionAndKind(Object) (version, kind string, err error)
+}
+
 // ResourceVersioner provides methods for setting and retrieving
 // the resource version from an API object.
 type ResourceVersioner interface {

--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -174,6 +174,12 @@ func (s *Scheme) KnownTypes(version string) map[string]reflect.Type {
 	return s.raw.KnownTypes(version)
 }
 
+// DataVersionAndKind will return the APIVersion and Kind of the given wire-format
+// enconding of an API Object, or an error.
+func (s *Scheme) DataVersionAndKind(data []byte) (version, kind string, err error) {
+	return s.raw.DataVersionAndKind(data)
+}
+
 // ObjectVersionAndKind returns the version and kind of the given Object.
 func (s *Scheme) ObjectVersionAndKind(obj Object) (version, kind string, err error) {
 	return s.raw.ObjectVersionAndKind(obj)

--- a/pkg/runtime/scheme_test.go
+++ b/pkg/runtime/scheme_test.go
@@ -47,6 +47,9 @@ func TestScheme(t *testing.T) {
 	scheme.AddKnownTypeWithName("", "Simple", &InternalSimple{})
 	scheme.AddKnownTypeWithName("externalVersion", "Simple", &ExternalSimple{})
 
+	// test that scheme is an ObjectTyper
+	var _ runtime.ObjectTyper = scheme
+
 	internalToExternalCalls := 0
 	externalToInternalCalls := 0
 


### PR DESCRIPTION
Add a new ObjectTyper interface that clients can depend on for
converting between data and object to version and kind.

Extracted from #2000 to support #1958
