### PR TITLE
remove systemd example files from man pages

### DIFF
--- a/docs/man/kube-apiserver.1.md
+++ b/docs/man/kube-apiserver.1.md
@@ -84,32 +84,9 @@ The the kube-apiserver several options.
 	comma-separated list of pattern=N settings for file-filtered logging
 
 # EXAMPLES
-
-The kube-apiserver can be called manually or from systemd. An example unit file looks as such:
-
-	[Unit]
-	Description=Kubernetes API Server
-	
-	[Service]
-	EnvironmentFile=/etc/kubernetes/config
-	EnvironmentFile=/etc/kubernetes/apiserver
-	User=kube
-	ExecStart=/usr/bin/kube-apiserver \
-	        --logtostderr=${KUBE_LOGTOSTDERR} \
-	        --v=${KUBE_LOG_LEVEL} \
-	        --etcd_servers=${KUBE_ETCD_SERVERS} \
-	        --address=${KUBE_API_ADDRESS} \
-	        --port=${KUBE_API_PORT} \
-	        --machines=${MINION_ADDRESSES} \
-	        --minion_port=${MINION_PORT} \
-	        --allow_privileged=${KUBE_ALLOW_PRIV}
-	Restart=on-failure
-	
-	[Install]
-	WantedBy=multi-user.target
-
-Where the variables are stored in the /etc/kubernetes/ environment files.
-
+```
+/usr/bin/kube-apiserver --logtostderr=true --v=0 --etcd_servers=http://127.0.0.1:4001 --address=0.0.0.0 --port=8080 --machines=127.0.0.1 --kubelet_port=10250 --allow_privileged=false
+```
 # HISTORY
 October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
  on the kubernetes source material and internal work.

--- a/docs/man/kube-controller-manager.1.md
+++ b/docs/man/kube-controller-manager.1.md
@@ -63,29 +63,9 @@ The kube-controller-manager has several options.
 	comma-separated list of pattern=N settings for file-filtered logging.
 
 # EXAMPLES
-
-The kube-controller-manager can be called manually or from systemd. An example unit file looks as such:
-
-	[Unit]
-	Description=Kubernetes Controller Manager
-	
-	[Service]
-	EnvironmentFile=/etc/kubernetes/config
-	EnvironmentFile=/etc/kubernetes/apiserver
-	EnvironmentFile=/etc/kubernetes/controller-manager
-	User=kube
-	ExecStart=/usr/bin/kube-controller-manager \
-	    --logtostderr=${KUBE_LOGTOSTDERR} \
-	    --v=${KUBE_LOG_LEVEL} \
-	    --master=${KUBE_MASTER}
-	Restart=on-failure
-
-	[Install]
-	WantedBy=multi-user.target
-
-
-Where the variables are stored in the /etc/kubernetes/ enfironment files.
-
+```
+/usr/bin/kube-controller-manager --logtostderr=true --v=0 --master=127.0.0.1:8080
+```
 # HISTORY
 October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
  on the kubernetes source material and internal work.

--- a/docs/man/kube-proxy.1.md
+++ b/docs/man/kube-proxy.1.md
@@ -58,29 +58,9 @@ The kube-proxy takes several options.
 
 
 # EXAMPLES
-
-The kube-proxy can be called manually or from systemd. An example unit file looks as such:
-
-	[Unit]
-	Description=Kubernetes Proxy
-	# the proxy crashes if etcd isn't reachable.
-	# https://github.com/GoogleCloudPlatform/kubernetes/issues/1206
-	After=network.target
-	
-	[Service]
-	EnvironmentFile=/etc/kubernetes/config
-	EnvironmentFile=/etc/kubernetes/proxy
-	ExecStart=/usr/bin/kube-proxy \
-		--logtostderr=${KUBE_LOGTOSTDERR} \
-		--v=${KUBE_LOG_LEVEL} \
-		--etcd_servers=${KUBE_ETCD_SERVERS}
-	Restart=on-failure
-	
-	[Install]
-	WantedBy=multi-user.target
-
-Where the variables are stored in the /etc/kubernetes/ directory.
-
+```
+/usr/bin/kube-proxy --logtostderr=true --v=0 --etcd_servers=http://127.0.0.1:4001
+```
 # HISTORY
 October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
  on the kubernetes source material and internal work.

--- a/docs/man/kube-scheduler.1.md
+++ b/docs/man/kube-scheduler.1.md
@@ -57,28 +57,9 @@ The kube-scheduler can take several options.
 	comma-separated list of pattern=N settings for file-filtered logging.
 
 # EXAMPLES
-
-The kube-scheduler can be called manually or from systemd. An example unit file looks as such:
-
-	[Unit]
-	Description=Kubernetes Scheduler
-	
-	[Service]
-	EnvironmentFile=/etc/kubernetes/config
-	EnvironmentFile=/etc/kubernetes/apiserver
-	EnvironmentFile=/etc/kubernetes/scheduler
-	ExecStart=/usr/bin/kube-scheduler \
-	    --logtostderr=${KUBE_LOGTOSTDERR} \
-	    --v=${KUBE_LOG_LEVEL} \
-	    --master=${KUBE_MASTER}
-	Restart=on-failure
-
-	[Install]
-	WantedBy=multi-user.target
-
-
-Where the variables are stored in the /etc/kubernetes/ environment files.
-
+```
+/usr/bin/kube-scheduler --logtostderr=true --v=0 --master=127.0.0.1:8080
+```
 # HISTORY
 October 2014, Originally compiled by Scott Collier (scollier@redhat.com) based
  on the kubernetes source material and internal work.

--- a/docs/man/kubelet.1.md
+++ b/docs/man/kubelet.1.md
@@ -97,32 +97,9 @@ There are 4 ways that a container manifest can be provided to the Kubelet:
 
 
 # EXAMPLES
-
-The kubelet can be called manually or from systemd. An example unit file looks as such:
-
-	[Unit]
-	Description=Kubernetes Kubelet
-	After=docker.socket cadvisor.service
-	Requires=docker.socket
-	
-	[Service]
-	EnvironmentFile=/etc/kubernetes/config
-	EnvironmentFile=/etc/kubernetes/kubelet
-	ExecStart=/usr/bin/kubelet \
-		--logtostderr=${KUBE_LOGTOSTDERR} \
-		--v=${KUBE_LOG_LEVEL} \
-		--etcd_servers=${KUBE_ETCD_SERVERS} \
-		--address=${MINION_ADDRESS} \
-		--port=${MINION_PORT} \
-	    --hostname_override=${MINION_HOSTNAME} \
-	    --allow_privileged=${KUBE_ALLOW_PRIV}
-	Restart=on-failure
-	
-	[Install]
-	WantedBy=multi-user.target
-
-Where the variables are stored in the /etc/kubernetes/ environment files.
-
+```
+/usr/bin/kubelet --logtostderr=true --v=0 --etcd_servers=http://127.0.0.1:4001 --address=127.0.0.1 --port=10250 --hostname_override=127.0.0.1 --allow_privileged=false
+```
 # HISTORY
 October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
  on the kubernetes source material and internal work.

--- a/docs/man/man1/kube-apiserver.1
+++ b/docs/man/man1/kube-apiserver.1
@@ -78,7 +78,7 @@ The the kube\-apiserver several options.
     Duration of time to cache minion information. Default 30 seconds.
 
 .PP
-\fB\-minion\_port\fP=10250
+\fB\-kubelet\_port\fP=10250
     The port at which kubelet will be listening on the minions. Default is 10250.
 
 .PP
@@ -111,37 +111,12 @@ The the kube\-apiserver several options.
 
 .SH EXAMPLES
 .PP
-The kube\-apiserver can be called manually or from systemd. An example unit file looks as such:
-
-.PP
 .RS
 
 .nf
-[Unit]
-Description=Kubernetes API Server
-
-[Service]
-EnvironmentFile=/etc/kubernetes/config
-EnvironmentFile=/etc/kubernetes/apiserver
-User=kube
-ExecStart=/usr/bin/kube\-apiserver \\
-        \-\-logtostderr=\$\{KUBE\_LOGTOSTDERR\} \\
-        \-\-v=\$\{KUBE\_LOG\_LEVEL\} \\
-        \-\-etcd\_servers=\$\{KUBE\_ETCD\_SERVERS\} \\
-        \-\-address=\$\{KUBE\_API\_ADDRESS\} \\
-        \-\-port=\$\{KUBE\_API\_PORT\} \\
-        \-\-machines=\$\{MINION\_ADDRESSES\} \\
-        \-\-minion\_port=\$\{MINION\_PORT\} \\
-        \-\-allow\_privileged=\$\{KUBE\_ALLOW\_PRIV\}
-Restart=on\-failure
-
-[Install]
-WantedBy=multi\-user.target
+/usr/bin/kube\-apiserver \-\-logtostderr=true \-\-v=0 \-\-etcd\_servers=http://127.0.0.1:4001 \-\-address=0.0.0.0 \-\-port=8080 \-\-machines=127.0.0.1 \-\-kubelet\_port=10250 \-\-allow\_privileged=false
 
 .fi
-
-.PP
-Where the variables are stored in the /etc/kubernetes/ environment files.
 
 .SH HISTORY
 .PP

--- a/docs/man/man1/kube-controller-manager.1
+++ b/docs/man/man1/kube-controller-manager.1
@@ -82,33 +82,12 @@ The kube\-controller\-manager has several options.
 
 .SH EXAMPLES
 .PP
-The kube\-controller\-manager can be called manually or from systemd. An example unit file looks as such:
-
-.PP
 .RS
 
 .nf
-[Unit]
-Description=Kubernetes Controller Manager
-
-[Service]
-EnvironmentFile=/etc/kubernetes/config
-EnvironmentFile=/etc/kubernetes/apiserver
-EnvironmentFile=/etc/kubernetes/controller\-manager
-User=kube
-ExecStart=/usr/bin/kube\-controller\-manager \\
-    \-\-logtostderr=\$\{KUBE\_LOGTOSTDERR\} \\
-    \-\-v=\$\{KUBE\_LOG\_LEVEL\} \\
-    \-\-master=\$\{KUBE\_MASTER\}
-Restart=on\-failure
-
-[Install]
-WantedBy=multi\-user.target
+/usr/bin/kube\-controller\-manager \-\-logtostderr=true \-\-v=0 \-\-master=127.0.0.1:8080
 
 .fi
-
-.PP
-Where the variables are stored in the /etc/kubernetes/ enfironment files.
 
 .SH HISTORY
 .PP

--- a/docs/man/man1/kube-proxy.1
+++ b/docs/man/man1/kube-proxy.1
@@ -75,34 +75,12 @@ The kube\-proxy takes several options.
 
 .SH EXAMPLES
 .PP
-The kube\-proxy can be called manually or from systemd. An example unit file looks as such:
-
-.PP
 .RS
 
 .nf
-[Unit]
-Description=Kubernetes Proxy
-# the proxy crashes if etcd isn't reachable.
-# https://github.com/GoogleCloudPlatform/kubernetes/issues/1206
-After=network.target
-
-[Service]
-EnvironmentFile=/etc/kubernetes/config
-EnvironmentFile=/etc/kubernetes/proxy
-ExecStart=/usr/bin/kube\-proxy \\
-    \-\-logtostderr=\$\{KUBE\_LOGTOSTDERR\} \\
-    \-\-v=\$\{KUBE\_LOG\_LEVEL\} \\
-    \-\-etcd\_servers=\$\{KUBE\_ETCD\_SERVERS\}
-Restart=on\-failure
-
-[Install]
-WantedBy=multi\-user.target
+/usr/bin/kube\-proxy \-\-logtostderr=true \-\-v=0 \-\-etcd\_servers=http://127.0.0.1:4001
 
 .fi
-
-.PP
-Where the variables are stored in the /etc/kubernetes/ directory.
 
 .SH HISTORY
 .PP

--- a/docs/man/man1/kube-scheduler.1
+++ b/docs/man/man1/kube-scheduler.1
@@ -74,32 +74,12 @@ The kube\-scheduler can take several options.
 
 .SH EXAMPLES
 .PP
-The kube\-scheduler can be called manually or from systemd. An example unit file looks as such:
-
-.PP
 .RS
 
 .nf
-[Unit]
-Description=Kubernetes Scheduler
-
-[Service]
-EnvironmentFile=/etc/kubernetes/config
-EnvironmentFile=/etc/kubernetes/apiserver
-EnvironmentFile=/etc/kubernetes/scheduler
-ExecStart=/usr/bin/kube\-scheduler \\
-    \-\-logtostderr=\$\{KUBE\_LOGTOSTDERR\} \\
-    \-\-v=\$\{KUBE\_LOG\_LEVEL\} \\
-    \-\-master=\$\{KUBE\_MASTER\}
-Restart=on\-failure
-
-[Install]
-WantedBy=multi\-user.target
+/usr/bin/kube\-scheduler \-\-logtostderr=true \-\-v=0 \-\-master=127.0.0.1:8080
 
 .fi
-
-.PP
-Where the variables are stored in the /etc/kubernetes/ environment files.
 
 .SH HISTORY
 .PP

--- a/docs/man/man1/kubelet.1
+++ b/docs/man/man1/kubelet.1
@@ -130,37 +130,12 @@ HTTP server The kubelet can also listen for HTTP and respond to a simple API (un
 
 .SH EXAMPLES
 .PP
-The kubelet can be called manually or from systemd. An example unit file looks as such:
-
-.PP
 .RS
 
 .nf
-[Unit]
-Description=Kubernetes Kubelet
-After=docker.socket cadvisor.service
-Requires=docker.socket
-
-[Service]
-EnvironmentFile=/etc/kubernetes/config
-EnvironmentFile=/etc/kubernetes/kubelet
-ExecStart=/usr/bin/kubelet \\
-    \-\-logtostderr=\$\{KUBE\_LOGTOSTDERR\} \\
-    \-\-v=\$\{KUBE\_LOG\_LEVEL\} \\
-    \-\-etcd\_servers=\$\{KUBE\_ETCD\_SERVERS\} \\
-    \-\-address=\$\{MINION\_ADDRESS\} \\
-    \-\-port=\$\{MINION\_PORT\} \\
-    \-\-hostname\_override=\$\{MINION\_HOSTNAME\} \\
-    \-\-allow\_privileged=\$\{KUBE\_ALLOW\_PRIV\}
-Restart=on\-failure
-
-[Install]
-WantedBy=multi\-user.target
+/usr/bin/kubelet \-\-logtostderr=true \-\-v=0 \-\-etcd\_servers=http://127.0.0.1:4001 \-\-address=127.0.0.1 \-\-port=10250 \-\-hostname\_override=127.0.0.1 \-\-allow\_privileged=false
 
 .fi
-
-.PP
-Where the variables are stored in the /etc/kubernetes/ environment files.
 
 .SH HISTORY
 .PP


### PR DESCRIPTION
We have contrib/init to talk about how to set up init systems.  Do not
include it in the man page.  Instead give an actual example.
