### PR TITLE
Convert minion_ to kubelet_ in numerous docs

### DIFF
--- a/contrib/init/systemd/README.md
+++ b/contrib/init/systemd/README.md
@@ -23,8 +23,8 @@ Assumptions of the service files
 Non kubernetes defaults in the environment files
 ------------------------------------------------
 1. Default to log to stdout/journald instead of directly to disk, see: [KUBE_LOGTOSTDERR](environ/config)
-2. Node list of 127.0.0.1 forced instead of relying on cloud provider, see: [MINION_ADDRESSES](environ/apiserver)
-3. Explicitly set the minion hostname to 127.0.0.1, see: [MINION_HOSTNAME](environ/kubelet)
+2. Node list of 127.0.0.1 forced instead of relying on cloud provider, see: [KUBELET_ADDRESSES](environ/apiserver)
+3. Explicitly set the minion hostname to 127.0.0.1, see: [KUBELET_HOSTNAME](environ/kubelet)
 4. There is no default for the IP address range of services.  This uses 10.254.0.0/16 see: [KUBE_SERVICE_ADDRESSES](environ/apiserver)
 
 Notes

--- a/contrib/init/systemd/environ/apiserver
+++ b/contrib/init/systemd/environ/apiserver
@@ -14,10 +14,10 @@ KUBE_API_PORT="--port=8080"
 KUBE_MASTER="--master=127.0.0.1:8080"
 
 # Comma seperated list of minions
-MINION_ADDRESSES="--machines=127.0.0.1"
+KUBELET_ADDRESSES="--machines=127.0.0.1"
 
 # Port minions listen on
-MINION_PORT="--kubelet_port=10250"
+KUBELET_PORT="--kubelet_port=10250"
 
 # Address range to use for services
 KUBE_SERVICE_ADDRESSES="--portal_net=10.254.0.0/16"

--- a/contrib/init/systemd/environ/kubelet
+++ b/contrib/init/systemd/environ/kubelet
@@ -1,14 +1,14 @@
 ###
-# kubernetes kublet (minion) config
+# kubernetes kubelet (minion) config
 
 # The address for the info server to serve on (set to 0.0.0.0 or "" for all interfaces)
-MINION_ADDRESS="--address=127.0.0.1"
+KUBELET_ADDRESS="--address=127.0.0.1"
 
 # The port for the info server to serve on
-MINION_PORT="--port=10250"
+KUBELET_PORT="--port=10250"
 
 # You may leave this blank to use the actual hostname
-MINION_HOSTNAME="--hostname_override=127.0.0.1"
+KUBELET_HOSTNAME="--hostname_override=127.0.0.1"
 
 # Add your own!
-MINION_ARGS=""
+KUBELET_ARGS=""

--- a/contrib/init/systemd/kube-apiserver.service
+++ b/contrib/init/systemd/kube-apiserver.service
@@ -12,8 +12,8 @@ ExecStart=/usr/bin/kube-apiserver \
 	    ${KUBE_ETCD_SERVERS} \
 	    ${KUBE_API_ADDRESS} \
 	    ${KUBE_API_PORT} \
-	    ${MINION_ADDRESSES} \
-	    ${MINION_PORT} \
+	    ${KUBELET_ADDRESSES} \
+	    ${KUBELET_PORT} \
 	    ${KUBE_ALLOW_PRIV} \
 	    ${KUBE_SERVICE_ADDRESSES} \
 	    ${KUBE_API_ARGS}

--- a/contrib/init/systemd/kubelet.service
+++ b/contrib/init/systemd/kubelet.service
@@ -11,11 +11,11 @@ ExecStart=/usr/bin/kubelet \
 	    ${KUBE_LOGTOSTDERR} \
 	    ${KUBE_LOG_LEVEL} \
 	    ${KUBE_ETCD_SERVERS} \
-	    ${MINION_ADDRESS} \
-	    ${MINION_PORT} \
-	    ${MINION_HOSTNAME} \
+	    ${KUBELET_ADDRESS} \
+	    ${KUBELET_PORT} \
+	    ${KUBELET_HOSTNAME} \
 	    ${KUBE_ALLOW_PRIV} \
-	    ${MINION_ARGS}
+	    ${KUBELET_ARGS}
 Restart=on-failure
 
 [Install]

--- a/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -103,10 +103,10 @@ KUBE_API_PORT="--port=8080"
 KUBE_MASTER="--master=fed-master:8080"
 
 # Comma seperated list of minions
-MINION_ADDRESSES="--machines=fed-minion"
+KUBELET_ADDRESSES="--machines=fed-minion"
 
 # Port minions listen on
-MINION_PORT="--kubelet_port=10250"
+KUBELET_PORT="--kubelet_port=10250"
 
 # Address range to use for services
 KUBE_SERVICE_ADDRESSES="--portal_net=10.254.0.0/16"
@@ -155,19 +155,19 @@ curl -s -L http://fed-master:8080/api/v1beta1/services | python -mjson.tool
 
 ```       
 ###
-# kubernetes kublet (minion) config
+# kubernetes kubelet (minion) config
 
 # The address for the info server to serve on
-MINION_ADDRESS="--address=fed-minion"
+KUBELET_ADDRESS="--address=fed-minion"
 
 # The port for the info server to serve on
-MINION_PORT="--port=10250"
+KUBELET_PORT="--port=10250"
 
 # You may leave this blank to use the actual hostname
-MINION_HOSTNAME="--hostname_override=fed-minion"
+KUBELET_HOSTNAME="--hostname_override=fed-minion"
 
 # Add your won!
-MINION_ARGS=""
+KUBELET_ARGS=""
 ```       
 
 * Start the appropriate services on minion (fed-minion).


### PR DESCRIPTION
The example systemd services files, environment files, and the fedora
manual config doc all used numerous references to minion_.  Many of
these are better named kubelet_.  Convert them.
