### PR TITLE
Fix json serialization consistency

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -434,7 +434,7 @@ type PodList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
 	ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
-	Items []Pod `json:"items" yaml:"items,omitempty"`
+	Items []Pod `json:"items" yaml:"items"`
 }
 
 // Pod is a collection of containers, used as either input (create, update) or as output (list, get).
@@ -460,7 +460,7 @@ type ReplicationControllerList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
 	ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
-	Items []ReplicationController `json:"items,omitempty" yaml:"items,omitempty"`
+	Items []ReplicationController `json:"items" yaml:"items"`
 }
 
 // ReplicationController represents the configuration of a replication controller.
@@ -546,7 +546,7 @@ type EndpointsList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
 	ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
-	Items []Endpoints `json:"items,omitempty" yaml:"items,omitempty"`
+	Items []Endpoints `json:"items" yaml:"items"`
 }
 
 // NodeResources represents resources on a Kubernetes system node
@@ -580,7 +580,7 @@ type MinionList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
 	ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
-	Items []Minion `json:"items,omitempty" yaml:"items,omitempty"`
+	Items []Minion `json:"items" yaml:"items"`
 }
 
 // Binding is written by a scheduler to cause a pod to be bound to a host.
@@ -773,7 +773,7 @@ type ServerOpList struct {
 	TypeMeta `yaml:",inline" json:",inline"`
 	ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
-	Items []ServerOp `yaml:"items,omitempty" json:"items,omitempty"`
+	Items []ServerOp `yaml:"items" json:"items"`
 }
 
 // ObjectReference contains enough information to let you inspect or modify the referred object.
@@ -836,7 +836,7 @@ type EventList struct {
 	TypeMeta `yaml:",inline" json:",inline"`
 	ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
-	Items []Event `yaml:"items,omitempty" json:"items,omitempty"`
+	Items []Event `yaml:"items" json:"items"`
 }
 
 // ContainerManifest corresponds to the Container Manifest format, documented at:
@@ -864,7 +864,7 @@ type ContainerManifestList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
 	ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
-	Items []ContainerManifest `json:"items,omitempty" yaml:"items,omitempty"`
+	Items []ContainerManifest `json:"items" yaml:"items,omitempty"`
 }
 
 // Included in partial form from v1beta3 to replace ContainerManifest

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -66,7 +66,7 @@ type ContainerManifest struct {
 // ContainerManifestList is used to communicate container manifests to kubelet.
 type ContainerManifestList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
-	Items    []ContainerManifest `json:"items,omitempty" yaml:"items,omitempty"`
+	Items    []ContainerManifest `json:"items" yaml:"items"`
 }
 
 // Volume represents a named volume in a pod that may be accessed by any containers in the pod.
@@ -398,7 +398,7 @@ type PodState struct {
 // PodList is a list of Pods.
 type PodList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
-	Items    []Pod `json:"items" yaml:"items,omitempty"`
+	Items    []Pod `json:"items" yaml:"items"`
 }
 
 // Pod is a collection of containers, used as either input (create, update) or as output (list, get).
@@ -421,7 +421,7 @@ type ReplicationControllerState struct {
 // ReplicationControllerList is a collection of replication controllers.
 type ReplicationControllerList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
-	Items    []ReplicationController `json:"items,omitempty" yaml:"items,omitempty"`
+	Items    []ReplicationController `json:"items" yaml:"items"`
 }
 
 // ReplicationController represents the configuration of a replication controller.
@@ -485,7 +485,7 @@ type Endpoints struct {
 // EndpointsList is a list of endpoints.
 type EndpointsList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
-	Items    []Endpoints `json:"items,omitempty" yaml:"items,omitempty"`
+	Items    []Endpoints `json:"items" yaml:"items"`
 }
 
 // NodeResources represents resources on a Kubernetes system node
@@ -517,7 +517,7 @@ type MinionList struct {
 	// DEPRECATED: the below Minions is due to a naming mistake and
 	// will be replaced with Items in the future.
 	Minions []Minion `json:"minions,omitempty" yaml:"minions,omitempty"`
-	Items   []Minion `json:"items,omitempty" yaml:"items,omitempty"`
+	Items   []Minion `json:"items" yaml:"items"`
 }
 
 // Binding is written by a scheduler to cause a pod to be bound to a host.
@@ -676,7 +676,7 @@ type ServerOp struct {
 // ServerOpList is a list of operations, as delivered to API clients.
 type ServerOpList struct {
 	TypeMeta `yaml:",inline" json:",inline"`
-	Items    []ServerOp `yaml:"items,omitempty" json:"items,omitempty"`
+	Items    []ServerOp `yaml:"items" json:"items"`
 }
 
 // ObjectReference contains enough information to let you inspect or modify the referred object.
@@ -736,7 +736,7 @@ type Event struct {
 // EventList is a list of events.
 type EventList struct {
 	TypeMeta `yaml:",inline" json:",inline"`
-	Items    []Event `yaml:"items,omitempty" json:"items,omitempty"`
+	Items    []Event `yaml:"items" json:"items"`
 }
 
 // Backported from v1beta3 to replace ContainerManifest

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -363,7 +363,7 @@ type PodState struct {
 // PodList is a list of Pods.
 type PodList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
-	Items    []Pod `json:"items" yaml:"items,omitempty"`
+	Items    []Pod `json:"items" yaml:"items"`
 }
 
 // Pod is a collection of containers, used as either input (create, update) or as output (list, get).
@@ -386,7 +386,7 @@ type ReplicationControllerState struct {
 // ReplicationControllerList is a collection of replication controllers.
 type ReplicationControllerList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
-	Items    []ReplicationController `json:"items,omitempty" yaml:"items,omitempty"`
+	Items    []ReplicationController `json:"items" yaml:"items"`
 }
 
 // ReplicationController represents the configuration of a replication controller.
@@ -450,7 +450,7 @@ type Endpoints struct {
 // EndpointsList is a list of endpoints.
 type EndpointsList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
-	Items    []Endpoints `json:"items,omitempty" yaml:"items,omitempty"`
+	Items    []Endpoints `json:"items" yaml:"items"`
 }
 
 // NodeResources represents resources on a Kubernetes system node
@@ -479,7 +479,7 @@ type Minion struct {
 // MinionList is a list of minions.
 type MinionList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
-	Items    []Minion `json:"items,omitempty" yaml:"items,omitempty"`
+	Items    []Minion `json:"items" yaml:"items"`
 }
 
 // Binding is written by a scheduler to cause a pod to be bound to a host.
@@ -651,7 +651,7 @@ type ServerOp struct {
 // ServerOpList is a list of operations, as delivered to API clients.
 type ServerOpList struct {
 	TypeMeta `yaml:",inline" json:",inline"`
-	Items    []ServerOp `yaml:"items,omitempty" json:"items,omitempty"`
+	Items    []ServerOp `yaml:"items" json:"items"`
 }
 
 // ObjectReference contains enough information to let you inspect or modify the referred object.
@@ -711,7 +711,7 @@ type Event struct {
 // EventList is a list of events.
 type EventList struct {
 	TypeMeta `yaml:",inline" json:",inline"`
-	Items    []Event `yaml:"items,omitempty" json:"items,omitempty"`
+	Items    []Event `yaml:"items" json:"items"`
 }
 
 // ContainerManifest corresponds to the Container Manifest format, documented at:
@@ -737,7 +737,7 @@ type ContainerManifest struct {
 // DEPRECATED: Replaced with BoundPods
 type ContainerManifestList struct {
 	TypeMeta `json:",inline" yaml:",inline"`
-	Items    []ContainerManifest `json:"items,omitempty" yaml:"items,omitempty"`
+	Items    []ContainerManifest `json:"items" yaml:"items,omitempty"`
 }
 
 // Backported from v1beta3 to replace ContainerManifest


### PR DESCRIPTION
Fixes #2070 

We were not consistent with how we treated serializing items array in JSON.

Doing an omitempty is harder for clients to parse as it requires them to special case nil checks in code versus just iterating empty arrays.
