### PR TITLE
Don't include '.' in release tars.

### DIFF
--- a/docs/getting-started-guides/binary_release.md
+++ b/docs/getting-started-guides/binary_release.md
@@ -6,7 +6,7 @@ You can either build a release from sources or download a pre-built release.  If
 
 Soon, we will have a list of numbered and nightly releases.  Until then, you can download a development release/snapshot from [here](http://storage.googleapis.com/kubernetes-releases-56726/devel/kubernetes.tar.gz).
 
-Unpack this tar file on Linux or OS X.  Most guides assume you are in the `kubernetes/` directory.
+Unpack this tar file on Linux or OS X.  Unpack this tar file on Linux or OS X, cd to the created `kubernetes/` directory, and then follow the getting started guide for your cloud.
 
 ### Building from source
 


### PR DESCRIPTION
Also make ownership, by default, be root.  This won't work on systems that don't have GNU tar so we warn.

Fixes: #1902
