### PR TITLE
WIP: add kubernetes_nginx to contrib/

### DIFF
--- a/contrib/kubernetes_nginx/Dockerfile
+++ b/contrib/kubernetes_nginx/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:wheezy
+
+EXPOSE 443
+
+#Install Nginx and stop it from running
+RUN apt-get update && apt-get install openssl nginx apache2-utils -qq -y && rm -rf /var/lib/apt/lists/*
+RUN service nginx stop
+
+VOLUME ["/data"]
+
+# Add our Conf files and disable the default site
+ADD nginx.conf /etc/nginx/
+ADD kubernetes-site /etc/nginx/sites-enabled/
+RUN rm -f /etc/nginx/sites-enabled/default
+
+ENTRYPOINT nginx
+CMD []

--- a/contrib/kubernetes_nginx/README.md
+++ b/contrib/kubernetes_nginx/README.md
@@ -1,0 +1,26 @@
+kubernetes_nginx
+----------------
+
+This Dockerfile will build a docker image with nginx running (~130MB). It can be built with the following:
+
+    docker build -t kubernetes_nginx:latest .
+
+The running container makes some assumptions about items available to it. In particular:
+
+1. An SSL certificate and key in `/data` and named `server.cert`, `server.key`
+2. An `htpasswd` file at `/data/htpasswd`
+3. The kubernetes apiserver is on `127.0.0.1:8080`
+
+## Running the Container
+Running the container can be done with a similar command to the following but assumes you've placed with ssl cert and htpasswd files in the corresponding locations.
+
+    docker run --rm --net="host" -p "443:443" -t --name "kubernetes_nginx" -v "/opt/kubernetes_nginx:/data/:ro" kubernetes_nginx
+
+## Helper Scripts
+There are two helper scripts in this directory:
+
+1. `make-cert.sh` -  This will generate a self signed certificate and key in the directories specified by arguements $1 and $2
+2. `make-ca-cert.sh` - *currently GCE specific* - This script will build a CA certificate.
+
+## Notes
+-  `--net="host"` is being used since the kubernetes apiserver runs on the locally on the master node by default. This will vary by implementation.

--- a/contrib/kubernetes_nginx/kubernetes-site
+++ b/contrib/kubernetes_nginx/kubernetes-site
@@ -1,0 +1,41 @@
+# HTTPS server
+#
+
+server {
+	listen 443;
+	server_name localhost;
+
+	root html;
+	index index.html index.htm;
+
+	ssl on;
+	ssl_certificate /data/server.cert;
+	ssl_certificate_key /data/server.key;
+
+	ssl_session_timeout 5m;
+
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+	ssl_ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS;
+	ssl_prefer_server_ciphers on;
+
+	location / {
+		auth_basic            "Restricted";
+		auth_basic_user_file  /data/htpasswd;
+
+		# Proxy settings
+		# disable buffering so that watch works
+		proxy_buffering off;
+		proxy_pass http://127.0.0.1:8080/;
+		proxy_connect_timeout 159s;
+		proxy_send_timeout   600s;
+		proxy_read_timeout   600s;
+
+		# Disable retry
+		proxy_next_upstream off;
+
+		# Support web sockets
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection "upgrade";
+	}
+}

--- a/contrib/kubernetes_nginx/make-ca-cert.sh
+++ b/contrib/kubernetes_nginx/make-ca-cert.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cert_ip=$1
+
+# TODO: Add support for discovery on other providers?
+if [ "$cert_ip" == "_use_gce_external_ip_" ]; then
+  cert_ip=$(curl -s -H Metadata-Flavor:Google http://metadata.google.internal./computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
+fi  
+
+tmpdir=$(mktemp -d --tmpdir kubernetes_cacert.XXXXXX)
+trap 'rm -rf "${tmpdir}"' EXIT
+cd "${tmpdir}"
+
+# TODO: For now, this is a patched repo that makes subject-alt-name work, when the fix is upstream
+#  move back to the upstream easyrsa
+curl -L -J -O https://github.com/brendandburns/easy-rsa/archive/master.tar.gz > /dev/null 2>&1
+tar xzf easy-rsa-master.tar.gz > /dev/null 2>&1
+
+cd easy-rsa-master/easyrsa3
+./easyrsa init-pki > /dev/null 2>&1
+./easyrsa --batch build-ca nopass > /dev/null 2>&1
+./easyrsa --subject-alt-name=IP:$cert_ip build-server-full kubernetes-master nopass > /dev/null 2>&1
+./easyrsa build-client-full kubecfg nopass > /dev/null 2>&1
+cp -p pki/issued/kubernetes-master.crt /usr/share/nginx/server.cert > /dev/null 2>&1
+cp -p pki/private/kubernetes-master.key /usr/share/nginx/server.key > /dev/null 2>&1
+cp -p pki/ca.crt /usr/share/nginx/ca.crt
+cp -p pki/issued/kubecfg.crt /usr/share/nginx/kubecfg.crt
+cp -p pki/private/kubecfg.key /usr/share/nginx/kubecfg.key

--- a/contrib/kubernetes_nginx/make-cert.sh
+++ b/contrib/kubernetes_nginx/make-cert.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# $1 should be the key output location
+# $2 should be the cert output location
+
+if [[ $# -ne 2 ]]; then
+	echo "Incorrect number of Parameters"
+	echo '$1 should be the key out location'
+	echo '$2 should be the cert out location'
+	exit 1
+else
+	openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 \
+	    	    -subj "/CN=kubernetes.invalid/O=Kubernetes" \
+	            -keyout $1  -out $2
+fi

--- a/contrib/kubernetes_nginx/nginx.conf
+++ b/contrib/kubernetes_nginx/nginx.conf
@@ -1,0 +1,59 @@
+daemon off;
+user www-data;
+
+worker_processes 4;
+pid /var/run/nginx.pid;
+
+error_log /dev/stdout info;
+
+events {
+	worker_connections 768;
+	# multi_accept on;
+}
+
+http {
+
+	##
+	# Basic Settings
+	##
+
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+	# server_tokens off;
+
+	# server_names_hash_bucket_size 64;
+	# server_name_in_redirect off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# Logging Settings
+	##
+
+	access_log /dev/stdout;
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+	gzip_disable "msie6";
+
+	# gzip_vary on;
+	# gzip_proxied any;
+	# gzip_comp_level 6;
+	# gzip_buffers 16 8k;
+	# gzip_http_version 1.1;
+	# gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+	##
+	# Virtual Host Configs
+	##
+
+	include /etc/nginx/conf.d/*.conf;
+	include /etc/nginx/sites-enabled/*;
+}


### PR DESCRIPTION
Looking for comments on a path forward.

This is a small addition to contrib/ that will hold the standard k8s nginx service which proxies to the apiserver. This is a step towards dockerizing all the various services (https://github.com/GoogleCloudPlatform/kubernetes/issues/19).

Currently this image relies on a host volume which is requires to have the SSL certificates and htpasswd files in the correct locations. Leveraging host volumes has the following benefits:
1. Allows this image to be generic and hosted on hub.docker or a private registry
2. Allows each provider to determine how they want to generate certs and place them appropriately (salt, etc).
3. Allows users to easily place signed SSL certificates if needed.

The primary downside is the fact that we have to manage files on the host which must be in place prior to the container starting.

Thoughts?
