### PR TITLE
Add events to kubecfg's list of resource types

### DIFF
--- a/cmd/kubecfg/kubecfg.go
+++ b/cmd/kubecfg/kubecfg.go
@@ -80,6 +80,7 @@ var parser = kubecfg.NewParser(map[string]runtime.Object{
 	"services":               &api.Service{},
 	"replicationControllers": &api.ReplicationController{},
 	"minions":                &api.Minion{},
+	"events":                 &api.Event{},
 })
 
 func usage() {


### PR DESCRIPTION
kubectl appears to be correct already.
