### PR TITLE
Stop httptest server.

### DIFF
--- a/pkg/apiserver/handlers_test.go
+++ b/pkg/apiserver/handlers_test.go
@@ -37,6 +37,7 @@ func TestRateLimit(t *testing.T) {
 				}
 			},
 		)))
+		defer server.Close()
 		http.Get(server.URL)
 	}
 }
@@ -49,6 +50,7 @@ func TestReadOnly(t *testing.T) {
 			}
 		},
 	)))
+	defer server.Close()
 	for _, verb := range []string{"GET", "POST", "PUT", "DELETE", "CREATE"} {
 		req, err := http.NewRequest(verb, server.URL, nil)
 		if err != nil {

--- a/pkg/apiserver/operation_test.go
+++ b/pkg/apiserver/operation_test.go
@@ -116,6 +116,7 @@ func TestOperationsList(t *testing.T) {
 	}, codec, "/prefix/version", selfLinker)
 	handler.(*defaultAPIServer).group.handler.asyncOpWait = 0
 	server := httptest.NewServer(handler)
+	defer server.Close()
 	client := http.Client{}
 
 	simple := &Simple{
@@ -172,6 +173,7 @@ func TestOpGet(t *testing.T) {
 	}, codec, "/prefix/version", selfLinker)
 	handler.(*defaultAPIServer).group.handler.asyncOpWait = 0
 	server := httptest.NewServer(handler)
+	defer server.Close()
 	client := http.Client{}
 
 	simple := &Simple{

--- a/pkg/apiserver/proxy_test.go
+++ b/pkg/apiserver/proxy_test.go
@@ -156,6 +156,7 @@ func TestProxy(t *testing.T) {
 			}
 			fmt.Fprint(w, item.respBody)
 		}))
+		defer proxyServer.Close()
 
 		simpleStorage := &SimpleRESTStorage{
 			errors:                    map[string]error{},
@@ -166,6 +167,7 @@ func TestProxy(t *testing.T) {
 			"foo": simpleStorage,
 		}, codec, "/prefix/version", selfLinker)
 		server := httptest.NewServer(handler)
+		defer server.Close()
 
 		req, err := http.NewRequest(
 			item.method,

--- a/pkg/apiserver/redirect_test.go
+++ b/pkg/apiserver/redirect_test.go
@@ -33,6 +33,7 @@ func TestRedirect(t *testing.T) {
 		"foo": simpleStorage,
 	}, codec, "/prefix/version", selfLinker)
 	server := httptest.NewServer(handler)
+	defer server.Close()
 
 	dontFollow := errors.New("don't follow")
 	client := http.Client{

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -52,6 +52,7 @@ func TestWatchWebsocket(t *testing.T) {
 		"foo": simpleStorage,
 	}, codec, "/prefix/version", selfLinker)
 	server := httptest.NewServer(handler)
+	defer server.Close()
 
 	dest, _ := url.Parse(server.URL)
 	dest.Scheme = "ws" // Required by websocket, though the server never sees it.
@@ -98,6 +99,7 @@ func TestWatchHTTP(t *testing.T) {
 		"foo": simpleStorage,
 	}, codec, "/prefix/version", selfLinker)
 	server := httptest.NewServer(handler)
+	defer server.Close()
 	client := http.Client{}
 
 	dest, _ := url.Parse(server.URL)
@@ -151,6 +153,7 @@ func TestWatchParamParsing(t *testing.T) {
 		"foo": simpleStorage,
 	}, codec, "/prefix/version", selfLinker)
 	server := httptest.NewServer(handler)
+	defer server.Close()
 
 	dest, _ := url.Parse(server.URL)
 	dest.Path = "/prefix/version/watch/foo"
@@ -222,6 +225,8 @@ func TestWatchProtocolSelection(t *testing.T) {
 		"foo": simpleStorage,
 	}, codec, "/prefix/version", selfLinker)
 	server := httptest.NewServer(handler)
+	defer server.Close()
+	defer server.CloseClientConnections()
 	client := http.Client{}
 
 	dest, _ := url.Parse(server.URL)

--- a/pkg/client/containerinfo_test.go
+++ b/pkg/client/containerinfo_test.go
@@ -70,6 +70,7 @@ func testHTTPContainerInfoGetter(
 			t.Fatal(err)
 		}
 	}))
+	defer ts.Close()
 	hostURL, err := url.Parse(ts.URL)
 	if err != nil {
 		t.Fatal(err)
@@ -170,6 +171,7 @@ func TestHTTPGetMachineInfo(t *testing.T) {
 			t.Fatal(err)
 		}
 	}))
+	defer ts.Close()
 	hostURL, err := url.Parse(ts.URL)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/client/kubelet_test.go
+++ b/pkg/client/kubelet_test.go
@@ -43,6 +43,7 @@ func TestHTTPKubeletClient(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
 
 	hostURL, err := url.Parse(testServer.URL)
 	if err != nil {
@@ -85,6 +86,7 @@ func TestHTTPKubeletClientNotFound(t *testing.T) {
 		ResponseBody: "Pod not found",
 	}
 	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
 
 	hostURL, err := url.Parse(testServer.URL)
 	if err != nil {

--- a/pkg/client/restclient_test.go
+++ b/pkg/client/restclient_test.go
@@ -108,6 +108,7 @@ func TestDoRequestBearer(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
 	request, _ := http.NewRequest("GET", testServer.URL, nil)
 	c, err := RESTClientFor(&Config{Host: testServer.URL, BearerToken: "test"})
 	if err != nil {
@@ -131,6 +132,7 @@ func TestDoRequestAccepted(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
 	c, err := RESTClientFor(&Config{Host: testServer.URL, Username: "test", Version: testapi.Version()})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -164,6 +166,7 @@ func TestDoRequestAcceptedSuccess(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
 	c, err := RESTClientFor(&Config{Host: testServer.URL, Username: "user", Password: "pass", Version: testapi.Version()})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -194,6 +197,7 @@ func TestDoRequestFailed(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
 	c, err := RESTClientFor(&Config{Host: testServer.URL})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -221,6 +225,7 @@ func TestDoRequestCreated(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
 	c, err := RESTClientFor(&Config{Host: testServer.URL, Username: "user", Password: "pass", Version: testapi.Version()})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -113,6 +113,7 @@ func TestSyncReplicationControllerDoesNothing(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, Version: testapi.Version()})
 
 	fakePodControl := FakePodControl{}
@@ -133,6 +134,7 @@ func TestSyncReplicationControllerDeletes(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, Version: testapi.Version()})
 
 	fakePodControl := FakePodControl{}
@@ -153,6 +155,7 @@ func TestSyncReplicationControllerCreates(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, Version: testapi.Version()})
 
 	fakePodControl := FakePodControl{}
@@ -174,6 +177,7 @@ func TestCreateReplica(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, Version: testapi.Version()})
 
 	podControl := RealPodControl{
@@ -306,6 +310,7 @@ func TestSynchonize(t *testing.T) {
 		t.Errorf("Unexpected request for %v", req.RequestURI)
 	})
 	testServer := httptest.NewServer(mux)
+	defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, Version: testapi.Version()})
 	manager := NewReplicationManager(client)
 	fakePodControl := FakePodControl{}

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -46,6 +46,7 @@ func TestHealthChecker(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(tt.status)
 		}))
+		defer ts.Close()
 		u, err := url.Parse(ts.URL)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
@@ -114,6 +115,7 @@ func TestMuxHealthChecker(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
+		defer ts.Close()
 		u, err := url.Parse(ts.URL)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)

--- a/pkg/health/tcp_test.go
+++ b/pkg/health/tcp_test.go
@@ -82,6 +82,7 @@ func TestTcpHealthChecker(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
+	defer server.Close()
 	u, err := url.Parse(server.URL)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -105,6 +105,7 @@ func TestExtractInvalidManifest(t *testing.T) {
 			ResponseBody: string(data),
 		}
 		testServer := httptest.NewServer(&fakeHandler)
+		defer testServer.Close()
 		ch := make(chan interface{}, 1)
 		c := SourceURL{testServer.URL, ch, nil}
 		if err := c.extractFromURL(); err == nil {
@@ -171,6 +172,7 @@ func TestExtractFromHTTP(t *testing.T) {
 			ResponseBody: string(data),
 		}
 		testServer := httptest.NewServer(&fakeHandler)
+		defer testServer.Close()
 		ch := make(chan interface{}, 1)
 		c := SourceURL{testServer.URL, ch, nil}
 		if err := c.extractFromURL(); err != nil {

--- a/pkg/util/fake_handler_test.go
+++ b/pkg/util/fake_handler_test.go
@@ -26,6 +26,7 @@ import (
 func TestFakeHandlerPath(t *testing.T) {
 	handler := FakeHandler{}
 	server := httptest.NewServer(&handler)
+	defer server.Close()
 	method := "GET"
 	path := "/foo/bar"
 	body := "somebody"
@@ -47,6 +48,7 @@ func TestFakeHandlerPath(t *testing.T) {
 func TestFakeHandlerPathNoBody(t *testing.T) {
 	handler := FakeHandler{}
 	server := httptest.NewServer(&handler)
+	defer server.Close()
 	method := "GET"
 	path := "/foo/bar"
 
@@ -77,6 +79,7 @@ func (f *fakeError) Logf(format string, args ...interface{}) {}
 func TestFakeHandlerWrongPath(t *testing.T) {
 	handler := FakeHandler{}
 	server := httptest.NewServer(&handler)
+	defer server.Close()
 	method := "GET"
 	path := "/foo/bar"
 	fakeT := fakeError{}
@@ -101,6 +104,7 @@ func TestFakeHandlerWrongPath(t *testing.T) {
 func TestFakeHandlerWrongMethod(t *testing.T) {
 	handler := FakeHandler{}
 	server := httptest.NewServer(&handler)
+	defer server.Close()
 	method := "GET"
 	path := "/foo/bar"
 	fakeT := fakeError{}
@@ -125,6 +129,7 @@ func TestFakeHandlerWrongMethod(t *testing.T) {
 func TestFakeHandlerWrongBody(t *testing.T) {
 	handler := FakeHandler{}
 	server := httptest.NewServer(&handler)
+	defer server.Close()
 	method := "GET"
 	path := "/foo/bar"
 	body := "somebody"
@@ -151,6 +156,7 @@ func TestFakeHandlerWrongBody(t *testing.T) {
 func TestFakeHandlerNilBody(t *testing.T) {
 	handler := FakeHandler{}
 	server := httptest.NewServer(&handler)
+	defer server.Close()
 	method := "GET"
 	path := "/foo/bar"
 	body := "somebody"

--- a/plugin/pkg/scheduler/factory/factory_test.go
+++ b/plugin/pkg/scheduler/factory/factory_test.go
@@ -40,6 +40,7 @@ func TestCreate(t *testing.T) {
 		T:            t,
 	}
 	server := httptest.NewServer(&handler)
+	defer server.Close()
 	client := client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()})
 	factory := ConfigFactory{client}
 	factory.Create()
@@ -75,6 +76,7 @@ func TestCreateLists(t *testing.T) {
 			T:            t,
 		}
 		server := httptest.NewServer(&handler)
+		defer server.Close()
 		factory.Client = client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()})
 		// This test merely tests that the correct request is made.
 		item.factory().List()
@@ -132,6 +134,7 @@ func TestCreateWatches(t *testing.T) {
 			T:            t,
 		}
 		server := httptest.NewServer(&handler)
+		defer server.Close()
 		factory.Client = client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()})
 		// This test merely tests that the correct request is made.
 		item.factory().Watch(item.rv)
@@ -162,6 +165,7 @@ func TestPollMinions(t *testing.T) {
 		// FakeHandler musn't be sent requests other than the one you want to test.
 		mux.Handle("/api/"+testapi.Version()+"/minions", &handler)
 		server := httptest.NewServer(mux)
+		defer server.Close()
 		client := client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()})
 		cf := ConfigFactory{client}
 
@@ -189,6 +193,7 @@ func TestDefaultErrorFunc(t *testing.T) {
 	// FakeHandler musn't be sent requests other than the one you want to test.
 	mux.Handle("/api/"+testapi.Version()+"/pods/foo", &handler)
 	server := httptest.NewServer(mux)
+	defer server.Close()
 	factory := ConfigFactory{client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()})}
 	queue := cache.NewFIFO()
 	podBackoff := podBackoff{
@@ -312,6 +317,7 @@ func TestBind(t *testing.T) {
 			T:            t,
 		}
 		server := httptest.NewServer(&handler)
+		defer server.Close()
 		client := client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()})
 		b := binder{client}
 

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -47,6 +47,7 @@ func TestClient(t *testing.T) {
 	})
 
 	s := httptest.NewServer(m.Handler)
+	defer s.Close()
 
 	testCases := []string{
 		"v1beta1",


### PR DESCRIPTION
Close #2018  With a special case of pkg/apiserver/watch_test.go, where CloseClientConnection is used to close client connections (keep alive is used).
