### PR TITLE
Fix a flaky test by draining the worker pool after syncing.

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -182,8 +182,8 @@ func TestSyncPodsDoesNothing(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-
-	verifyCalls(t, fakeDocker, []string{"list"})
+	kubelet.drainWorkers()
+	verifyCalls(t, fakeDocker, []string{"list", "list", "inspect_container", "inspect_container"})
 }
 
 // drainWorkers waits until all workers are done.  Should only used for testing.


### PR DESCRIPTION
Closes #2048
