### PR TITLE
add --use_go_build option when building binaries

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# any command line arguments will be passed to hack/build_go.sh to build the
+# cmd/integration binary.  --use_go_build is a legitimate argument, as are
+# any other build time arguments.
+
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -26,9 +30,7 @@ cleanup() {
   kube::log::status "Integration test cleanup complete"
 }
 
-if [[ -z ${KUBE_NO_BUILD_INTEGRATION-} ]]; then
-    "${KUBE_ROOT}/hack/build-go.sh" cmd/integration
-fi
+"${KUBE_ROOT}/hack/build-go.sh" "$@" cmd/integration
 
 # Run cleanup to stop etcd on interrupt or other kill signal.
 trap cleanup HUP INT QUIT TERM


### PR DESCRIPTION
This needs to be rebased once #2092 is committed as only the top commit is relevant.

Biggest question is how to handle passing --use_go_build from test-integration.sh to hack/build-go.sh

Do people like "$@" or should I use a shell variable?
