### PR TITLE
test-cmd.sh can fail if public IP not available

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -69,6 +69,7 @@ wait_for_url "http://127.0.0.1:${KUBELET_PORT}/healthz" "kubelet: "
 # Start apiserver
 ${GO_OUT}/apiserver \
   --address="127.0.0.1" \
+  --public_address_override="127.0.0.1" \
   --port="${API_PORT}" \
   --etcd_servers="http://${ETCD_HOST}:${ETCD_PORT}" \
   --kubelet_port=${KUBELET_PORT} \


### PR DESCRIPTION
test-cmd runs a 127.0.0.1 version of the apiservers, but does not
set --public_address_override, which means it can fail on some systems
(like Macs) which don't expose a bindable external port by default.

Since reachability is not necessary for test-cmd.sh today, set
public_address_override to 127.0.0.1
