### PR TITLE
Moar authorization attributes

### DIFF
--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -145,6 +145,12 @@ func main() {
 	}
 
 	n := net.IPNet(portalNet)
+
+	authorizer, err := apiserver.NewAuthorizerFromAuthorizationConfig(*authorizationMode)
+	if err != nil {
+		glog.Fatalf("Invalid Authorization Config: %v", err)
+	}
+
 	config := &master.Config{
 		Client:                client,
 		Cloud:                 cloud,
@@ -161,7 +167,7 @@ func main() {
 		ReadOnlyPort:          *readOnlyPort,
 		ReadWritePort:         *port,
 		PublicAddress:         *publicAddressOverride,
-		AuthorizationMode:     *authorizationMode,
+		Authorizer:            authorizer,
 	}
 	m := master.New(config)
 

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -36,6 +36,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	minionControllerPkg "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/controller"
 	replicationControllerPkg "github.com/GoogleCloudPlatform/kubernetes/pkg/controller"
@@ -146,7 +147,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 		KubeletClient:     fakeKubeletClient{},
 		EnableLogsSupport: false,
 		APIPrefix:         "/api",
-		AuthorizationMode: "AlwaysAllow",
+		Authorizer:        apiserver.NewAlwaysAllowAuthorizer(),
 
 		ReadWritePort: portNumber,
 		ReadOnlyPort:  portNumber,

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -107,6 +107,7 @@ func (g *APIGroup) InstallREST(mux Mux, paths ...string) {
 		prefix = strings.TrimRight(prefix, "/")
 		proxyHandler := &ProxyHandler{prefix + "/proxy/", g.handler.storage, g.handler.codec}
 		mux.Handle(prefix+"/", http.StripPrefix(prefix, restHandler))
+		// Note: update GetAttribs() when adding a handler.
 		mux.Handle(prefix+"/watch/", http.StripPrefix(prefix+"/watch/", watchHandler))
 		mux.Handle(prefix+"/proxy/", http.StripPrefix(prefix+"/proxy/", proxyHandler))
 		mux.Handle(prefix+"/redirect/", http.StripPrefix(prefix+"/redirect/", redirectHandler))

--- a/pkg/apiserver/authz.go
+++ b/pkg/apiserver/authz.go
@@ -36,6 +36,10 @@ func (alwaysAllowAuthorizer) Authorize(a authorizer.Attributes) (err error) {
 	return nil
 }
 
+func NewAlwaysAllowAuthorizer() authorizer.Authorizer {
+	return new(alwaysAllowAuthorizer)
+}
+
 // alwaysDenyAuthorizer is an implementation of authorizer.Attributes
 // which always says no to an authorization request.
 // It is useful in unit tests to force an operation to be forbidden.
@@ -43,6 +47,10 @@ type alwaysDenyAuthorizer struct{}
 
 func (alwaysDenyAuthorizer) Authorize(a authorizer.Attributes) (err error) {
 	return errors.New("Everything is forbidden.")
+}
+
+func NewAlwaysDenyAuthorizer() authorizer.Authorizer {
+	return new(alwaysDenyAuthorizer)
 }
 
 const (
@@ -59,9 +67,9 @@ func NewAuthorizerFromAuthorizationConfig(authorizationMode string) (authorizer.
 	// Keep cases in sync with constant list above.
 	switch authorizationMode {
 	case ModeAlwaysAllow:
-		return new(alwaysAllowAuthorizer), nil
+		return NewAlwaysAllowAuthorizer(), nil
 	case ModeAlwaysDeny:
-		return new(alwaysDenyAuthorizer), nil
+		return NewAlwaysDenyAuthorizer(), nil
 	default:
 		return nil, errors.New("Unknown authorization mode")
 	}

--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -30,10 +30,49 @@ import (
 	"github.com/golang/glog"
 )
 
+// specialVerbs contains just strings which are used in REST paths for special actions that don't fall under the normal
+// CRUDdy GET/POST/PUT/DELETE actions on REST objects.
+// TODO: find a way to keep this up to date automatically.  Maybe dynamically populate list as handlers added to
+// master's Mux.
+var specialVerbs = map[string]bool{
+	"proxy":    true,
+	"redirect": true,
+	"watch":    true,
+}
+
+// KindFromRequest returns Kind if Kind can be extracted from the request.  Otherwise, the empty string.
+func KindFromRequest(req http.Request) string {
+	// TODO: find a way to keep this code's assumptions about paths up to date with changes in the code.  Maybe instead
+	// of directly adding handler's code to the master's Mux, have a function which forces the structure when adding
+	// them.
+	parts := splitPath(req.URL.Path)
+	if len(parts) > 2 && parts[0] == "api" {
+		if _, ok := specialVerbs[parts[2]]; ok {
+			if len(parts) > 3 {
+				return parts[3]
+			}
+		} else {
+			return parts[2]
+		}
+	}
+	return ""
+}
+
+// IsReadOnlyReq() is true for any (or at least many) request which has no observable
+// side effects on state of apiserver (though there may be internal side effects like
+// caching and logging).
+func IsReadOnlyReq(req http.Request) bool {
+	if req.Method == "GET" {
+		// TODO: add OPTIONS and HEAD if we ever support those.
+		return true
+	}
+	return false
+}
+
 // ReadOnly passes all GET requests on to handler, and returns an error on all other requests.
 func ReadOnly(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.Method == "GET" {
+		if IsReadOnlyReq(*req) {
 			handler.ServeHTTP(w, req)
 			return
 		}
@@ -142,6 +181,17 @@ func (r *requestAttributeGetter) GetAttribs(req *http.Request) authorizer.Attrib
 	if ok {
 		attribs.User = user
 	}
+
+	attribs.ReadOnly = IsReadOnlyReq(*req)
+
+	// If a path follows the conventions of the REST object store, then
+	// we can extract the object Kind.  Otherwise, not.
+	attribs.Kind = KindFromRequest(*req)
+
+	// If the request specifies a namespace, then the namespace is filled in.
+	// Assumes there is no empty string namespace.  Unspecified results
+	// in empty (does not understand defaulting rules.)
+	attribs.Namespace = req.URL.Query().Get("namespace")
 
 	return &attribs
 }

--- a/pkg/auth/authorizer/interfaces.go
+++ b/pkg/auth/authorizer/interfaces.go
@@ -23,7 +23,20 @@ import (
 // Attributes is an interface used by an Authorizer to get information about a request
 // that is used to make an authorization decision.
 type Attributes interface {
+	// The user string which the request was authenticated as, or empty if
+	// no authentication occured and the request was allowed to proceed.
 	GetUserName() string
+	// TODO: add groups, e.g. GetGroups() []string
+
+	// When IsReadOnly() == true, the request has no side effects, other than
+	// caching, logging, and other incidentals.
+	IsReadOnly() bool
+
+	// The namespace of the object, if a request is for a REST object.
+	GetNamespace() string
+
+	// The kind of object, if a request is for a REST object.
+	GetKind() string
 }
 
 // Authorizer makes an authorization decision based on information gained by making
@@ -35,9 +48,24 @@ type Authorizer interface {
 
 // AttributesRecord implements Attributes interface.
 type AttributesRecord struct {
-	User user.Info
+	User      user.Info
+	ReadOnly  bool
+	Namespace string
+	Kind      string
 }
 
 func (a *AttributesRecord) GetUserName() string {
 	return a.User.GetName()
+}
+
+func (a *AttributesRecord) IsReadOnly() bool {
+	return a.ReadOnly
+}
+
+func (a *AttributesRecord) GetNamespace() string {
+	return a.Namespace
+}
+
+func (a *AttributesRecord) GetKind() string {
+	return a.Kind
 }

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
@@ -45,7 +46,7 @@ func TestClient(t *testing.T) {
 		EnableLogsSupport: false,
 		EnableUISupport:   false,
 		APIPrefix:         "/api",
-		AuthorizationMode: "AlwaysAllow",
+		Authorizer:        apiserver.NewAlwaysAllowAuthorizer(),
 	})
 
 	s := httptest.NewServer(m.Handler)


### PR DESCRIPTION
Based on PR #2117.

Future PRs will
- refactor the growing code duplication in `test/integration/auth_test.go`.
- replace injected Authorizer with a new authorization mode and acl file.
- improve documentation.
