### PR TITLE
Fix healthz test error handling

### DIFF
--- a/pkg/healthz/healthz_test.go
+++ b/pkg/healthz/healthz_test.go
@@ -27,7 +27,7 @@ func TestInstallHandler(t *testing.T) {
 	InstallHandler(mux)
 	req, err := http.NewRequest("GET", "http://example.com/healthz", nil)
 	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
+		t.Fatalf("Unexpected error: %v", err)
 	}
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)


### PR DESCRIPTION
If we fail to new the request for testing, we should terminate the test instead of calling T.Error and continuing. 
