### PR TITLE
Fixes #1612 kubelet should fail to start if it cannot create rootDir

### DIFF
--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -141,7 +141,7 @@ func main() {
 	}
 	*rootDirectory = path.Clean(*rootDirectory)
 	if err := os.MkdirAll(*rootDirectory, 0750); err != nil {
-		glog.Warningf("Error creating root directory: %v", err)
+		glog.Fatalf("Error creating root directory: %v", err)
 	}
 
 	// source of all configuration

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -54,6 +54,7 @@ kube::log::status "Running kubectl with no options"
 # Start kubelet
 kube::log::status "Starting kubelet"
 "${KUBE_OUTPUT_HOSTBIN}/kubelet" \
+  --root_dir=/tmp/kubelet.$$ \
   --etcd_servers="http://${ETCD_HOST}:${ETCD_PORT}" \
   --hostname_override="127.0.0.1" \
   --address="127.0.0.1" \


### PR DESCRIPTION
As mentioned in the ticket, kubelet will fail to start if it cannot create the rootDir.

I have a golang CLA if that will work for k8s as well.
