### PR TITLE
Stop running benchmarks for every travis run.  They're flaky.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ script:
   - KUBE_TIMEOUT='-timeout 60s' ./hack/test-go.sh
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/test-cmd.sh
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/test-integration.sh
-  - ./hack/benchmark-go.sh
 
 notifications:
   irc: "chat.freenode.net#google-containers"


### PR DESCRIPTION
@smarterclayton please take a look.  I would say at least 50% of the travis flakes that I see are the benchmarks getting killed.

I think we should def. run them somewhere, but with this on, travis is just too flaky.

Let me know if you have a better solution.

Thanks!
--brendan
