### PR TITLE
Require a KubeletClient in master.New()

### DIFF
--- a/pkg/client/kubelet.go
+++ b/pkg/client/kubelet.go
@@ -126,13 +126,16 @@ func (c *HTTPKubeletClient) HealthCheck(host string) (health.Status, error) {
 	return health.DoHTTPCheck(fmt.Sprintf("%s/healthz", c.url(host)), c.Client)
 }
 
-// FakeKubeletClient is a fake implementation of PodInfoGetter. It is useful for testing.
-type FakePodInfoGetter struct {
-	data api.PodInfo
-	err  error
-}
+// FakeKubeletClient is a fake implementation of KubeletClient which returns an error
+// when called.  It is useful to pass to the master in a test configuration with
+// no kubelets.
+type FakeKubeletClient struct{}
 
 // GetPodInfo is a fake implementation of PodInfoGetter.GetPodInfo.
-func (c *FakePodInfoGetter) GetPodInfo(host, podNamespace string, podID string) (api.PodInfo, error) {
-	return c.data, c.err
+func (c FakeKubeletClient) GetPodInfo(host, podNamespace string, podID string) (api.PodInfo, error) {
+	return api.PodInfo{}, errors.New("Not Implemented")
+}
+
+func (c FakeKubeletClient) HealthCheck(host string) (health.Status, error) {
+	return health.Unknown, errors.New("Not Implemented")
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -206,6 +206,9 @@ func New(c *Config) *Master {
 	boundPodFactory := &pod.BasicBoundPodFactory{
 		ServiceRegistry: serviceRegistry,
 	}
+	if c.KubeletClient == nil {
+		glog.Fatalf("master.New() called with config.KubeletClient == nil")
+	}
 	m := &Master{
 		podRegistry:           etcd.NewRegistry(c.EtcdHelper, boundPodFactory),
 		controllerRegistry:    etcd.NewRegistry(c.EtcdHelper, nil),

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
 
 	"github.com/golang/glog"
@@ -80,6 +81,7 @@ func TestWhoAmI(t *testing.T) {
 	defer os.Remove(tokenFilename)
 	m := master.New(&master.Config{
 		EtcdHelper:        helper,
+		KubeletClient:     client.FakeKubeletClient{},
 		EnableLogsSupport: false,
 		EnableUISupport:   false,
 		APIPrefix:         "/api",
@@ -364,6 +366,7 @@ func TestAuthModeAlwaysAllow(t *testing.T) {
 
 	m := master.New(&master.Config{
 		EtcdHelper:        helper,
+		KubeletClient:     client.FakeKubeletClient{},
 		EnableLogsSupport: false,
 		EnableUISupport:   false,
 		APIPrefix:         "/api",
@@ -408,6 +411,7 @@ func TestAuthModeAlwaysDeny(t *testing.T) {
 
 	m := master.New(&master.Config{
 		EtcdHelper:        helper,
+		KubeletClient:     client.FakeKubeletClient{},
 		EnableLogsSupport: false,
 		EnableUISupport:   false,
 		APIPrefix:         "/api",

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -41,6 +41,7 @@ func TestClient(t *testing.T) {
 	}
 	m := master.New(&master.Config{
 		EtcdHelper:        helper,
+		KubeletClient:     client.FakeKubeletClient{},
 		EnableLogsSupport: false,
 		EnableUISupport:   false,
 		APIPrefix:         "/api",


### PR DESCRIPTION
Several tests which create a master don't pass in a podCache.
If the test takes more than 30s (as can happen on Travis, but not so much on your local box), the test will get a nil pointer panic.
