### PR TITLE
Initial ipv6 / iptables work

### DIFF
--- a/cluster/saltbase/salt/docker/docker-defaults
+++ b/cluster/saltbase/salt/docker/docker-defaults
@@ -1,1 +1,6 @@
-DOCKER_OPTS="--bridge cbr0 --iptables=false --ip-masq=false -r=false"
+{% if grains.docker_opts is defined %}
+  {% set docker_opts = grains.docker_opts %}
+{% else %}
+  {% set docker_opts = "" %}
+{% endif %}
+DOCKER_OPTS="{{docker_opts}} --bridge cbr0 --iptables=false --ip-masq=false -r=false"

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -100,8 +100,12 @@ func main() {
 		}
 	}
 
+	protocol := iptables.ProtocolIpv4
+	if net.IP(bindAddress).To4() == nil {
+		protocol = iptables.ProtocolIpv6
+	}
 	loadBalancer := proxy.NewLoadBalancerRR()
-	proxier := proxy.NewProxier(loadBalancer, net.IP(bindAddress), iptables.New(exec.New()))
+	proxier := proxy.NewProxier(loadBalancer, net.IP(bindAddress), iptables.New(exec.New(), protocol))
 	// Wire proxier to handle changes to services
 	serviceConfig.RegisterHandler(proxier)
 	// And wire loadBalancer to handle changes to endpoints to services

--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -529,8 +529,11 @@ func iptablesFlush(ipt iptables.Interface) error {
 }
 
 // Used below.
-var zeroIP = net.ParseIP("0.0.0.0")
-var localhostIP = net.ParseIP("127.0.0.1")
+var zeroIPv4 = net.ParseIP("0.0.0.0")
+var localhostIPv4 = net.ParseIP("127.0.0.1")
+
+var zeroIPv6 = net.ParseIP("::0")
+var localhostIPv6 = net.ParseIP("::1")
 
 // Build a slice of iptables args for a portal rule.
 func iptablesPortalArgs(destIP net.IP, destPort int, proxyIP net.IP, proxyPort int, service string) []string {
@@ -558,10 +561,13 @@ func iptablesPortalArgs(destIP net.IP, destPort int, proxyIP net.IP, proxyPort i
 	// Unfortunately, I don't know of any way to listen on some (N > 1)
 	// interfaces but not ALL interfaces, short of doing it manually, and
 	// this is simpler than that.
-	if proxyIP.Equal(zeroIP) || proxyIP.Equal(localhostIP) {
+	if proxyIP.Equal(zeroIPv4) || proxyIP.Equal(zeroIPv6) ||
+		proxyIP.Equal(localhostIPv4) || proxyIP.Equal(localhostIPv6) {
+		// TODO: Can we REDIRECT with IPv6?
 		args = append(args, "-j", "REDIRECT", "--to-ports", fmt.Sprintf("%d", proxyPort))
 	} else {
-		args = append(args, "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", proxyIP.String(), proxyPort))
+		// TODO: Can we DNAT with IPv6?
+		args = append(args, "-j", "DNAT", "--to-destination", net.JoinHostPort(proxyIP.String(), strconv.Itoa(proxyPort)))
 	}
 	return args
 }

--- a/pkg/proxy/proxier_test.go
+++ b/pkg/proxy/proxier_test.go
@@ -93,6 +93,10 @@ func (fake *fakeIptables) DeleteRule(table iptables.Table, chain iptables.Chain,
 	return nil
 }
 
+func (fake *fakeIptables) IsIpv6() bool {
+	return false
+}
+
 var tcpServerPort string
 var udpServerPort string
 

--- a/pkg/registry/service/ip_allocator.go
+++ b/pkg/registry/service/ip_allocator.go
@@ -18,17 +18,67 @@ package service
 
 import (
 	"fmt"
+	math_rand "math/rand"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/golang/glog"
 )
 
 type ipAllocator struct {
-	subnet *net.IPNet
-	// TODO: This could be smarter, but for now a bitmap will suffice.
 	lock sync.Mutex // protects 'used'
-	used []byte     // a bitmap of allocated IPs
+
+	subnet         net.IPNet
+	ipSpaceSize    int64 // Size of subnet, or -1 if it does not fit in an int64
+	used           ipAddrSet
+	randomAttempts int
+
+	random *math_rand.Rand
+}
+
+type ipAddrSet struct {
+	// We are pretty severely restricted in the types of things we can use as a key
+	ips map[string]bool
+}
+
+func (s *ipAddrSet) Init() {
+	s.ips = map[string]bool{}
+}
+
+// Adds to the ipAddrSet; returns true iff it was added (was not already in set)
+func (s *ipAddrSet) Size() int {
+	return len(s.ips)
+}
+
+func (s *ipAddrSet) Contains(ip net.IP) bool {
+	key := ip.String()
+	exists := s.ips[key]
+	return exists
+}
+
+// Adds to the ipAddrSet; returns true iff it was added (was not already in set)
+func (s *ipAddrSet) Add(ip net.IP) bool {
+	key := ip.String()
+	exists := s.ips[key]
+	if exists {
+		return false
+	}
+	s.ips[key] = true
+	return true
+}
+
+// Removes from the ipAddrSet; returns true iff it was removed (was already in set)
+func (s *ipAddrSet) Remove(ip net.IP) bool {
+	key := ip.String()
+	exists := s.ips[key]
+	if !exists {
+		return false
+	}
+	delete(s.ips, key)
+	// TODO: We probably should add this IP to an 'embargo' list for a limited amount of time
+
+	return true
 }
 
 // The smallest number of IPs we accept.
@@ -40,20 +90,42 @@ func newIPAllocator(subnet *net.IPNet) *ipAllocator {
 		return nil
 	}
 
+	seed := time.Now().UTC().UnixNano()
+	r := math_rand.New(math_rand.NewSource(seed))
+
+	ipSpaceSize := int64(-1)
 	ones, bits := subnet.Mask.Size()
-	// TODO: some settings with IPv6 address could cause this to take
-	// an excessive amount of memory.
-	numIps := 1 << uint(bits-ones)
-	if numIps < minIPSpace {
-		glog.Errorf("IPAllocator requires at least %d IPs", minIPSpace)
-		return nil
+	if (bits-ones) < 63 {
+		ipSpaceSize = int64(1)<<uint(bits - ones)
+
+		if ipSpaceSize < minIPSpace {
+			glog.Errorf("IPAllocator requires at least %d IPs", minIPSpace)
+			return nil
+		}
 	}
+
 	ipa := &ipAllocator{
-		subnet: subnet,
-		used:   make([]byte, numIps/8),
+		subnet:      *subnet,
+		ipSpaceSize: ipSpaceSize,
+		random:      r,
+		randomAttempts: 1000,
 	}
-	ipa.used[0] = 0x01            // block the network addr
-	ipa.used[(numIps/8)-1] = 0x80 // block the broadcast addr
+	ipa.used.Init()
+
+	zero := make(net.IP, len(subnet.IP), len(subnet.IP))
+	for i := 0; i < len(subnet.IP); i++ {
+		zero[i] = subnet.IP[i]&subnet.Mask[i]
+	}
+	ipa.used.Add(zero) // block the zero addr
+
+	ipa.used.Add(subnet.IP) // block the network addr
+
+	broadcast := make(net.IP, len(subnet.IP), len(subnet.IP))
+	for i := 0; i < len(subnet.IP); i++ {
+		broadcast[i] = subnet.IP[i]|^subnet.Mask[i]
+	}
+	ipa.used.Add(broadcast) // block the broadcast addr
+
 	return ipa
 }
 
@@ -65,13 +137,11 @@ func (ipa *ipAllocator) Allocate(ip net.IP) error {
 	if !ipa.subnet.Contains(ip) {
 		return fmt.Errorf("IP %s does not fall within subnet %s", ip, ipa.subnet)
 	}
-	offset := ipSub(ip, ipa.subnet.IP)
-	i := offset / 8
-	m := byte(1 << byte(offset%8))
-	if ipa.used[i]&m != 0 {
+
+	if !ipa.used.Add(ip) {
 		return fmt.Errorf("IP %s is already allocated", ip)
 	}
-	ipa.used[i] |= m
+
 	return nil
 }
 
@@ -80,33 +150,48 @@ func (ipa *ipAllocator) AllocateNext() (net.IP, error) {
 	ipa.lock.Lock()
 	defer ipa.lock.Unlock()
 
-	for i := range ipa.used {
-		if ipa.used[i] != 0xff {
-			freeMask := ^ipa.used[i]
-			nextBit, err := ffs(freeMask)
-			if err != nil {
-				// If this happens, something really weird is going on.
-				glog.Errorf("ffs(%#x) had an unexpected error: %s", freeMask, err)
-				return nil, err
-			}
-			ipa.used[i] |= 1 << nextBit
-			offset := (i * 8) + int(nextBit)
-			ip := ipAdd(ipa.subnet.IP, offset)
+	if int64(ipa.used.Size()) == ipa.ipSpaceSize {
+		return nil, fmt.Errorf("can't find a free IP in %s", ipa.subnet)
+	}
+
+	// Try randomly first
+	for i := 0; i < ipa.randomAttempts; i++ {
+		ip := ipa.createRandomIp()
+
+		if ipa.used.Add(ip) {
 			return ip, nil
 		}
 	}
+
+	// If that doesn't work, try a linear search
+	ip := copyIP(ipa.subnet.IP)
+	for ipa.subnet.Contains(ip) {
+		ip = ipAdd(ip, 1)
+		if ipa.used.Add(ip) {
+			return ip, nil
+		}
+	}
+
 	return nil, fmt.Errorf("can't find a free IP in %s", ipa.subnet)
 }
 
-// This is a really dumb implementation of find-first-set-bit.
-func ffs(val byte) (uint, error) {
-	if val == 0 {
-		return 0, fmt.Errorf("Can't find-first-set on 0")
+func (ipa *ipAllocator) createRandomIp() net.IP {
+	ip := ipa.subnet.IP
+	mask := ipa.subnet.Mask
+	n := len(ip)
+
+	randomIp := make(net.IP, n, n)
+
+	for i := 0; i < n; i++ {
+		if mask[i] == 0xff {
+			randomIp[i] = ipa.subnet.IP[i]
+		} else {
+			b := byte(ipa.random.Intn(256))
+			randomIp[i] = (ipa.subnet.IP[i]&mask[i])|(b&^mask[i])
+		}
 	}
-	i := uint(0)
-	for ; i < 8 && (val&(1<<i) == 0); i++ {
-	}
-	return i, nil
+
+	return randomIp
 }
 
 // Add an offset to an IP address - used for joining network addr and host addr parts.
@@ -118,36 +203,9 @@ func ipAdd(ip net.IP, offset int) net.IP {
 		result := int(out[i]) + add
 		out[i] = byte(result % 256)
 		offset >>= 8
-		offset += result / 256 // carry
+		offset += result/256 // carry
 	}
 	return out
-}
-
-// Subtract two IPs, returning the difference as an offset - used or splitting an IP into
-// network addr and host addr parts.
-func ipSub(lhs, rhs net.IP) int {
-	// If they are not the same length, normalize them.  Make copies because net.IP is
-	// a slice underneath. Sneaky sneaky.
-	lhs = simplifyIP(lhs)
-	rhs = simplifyIP(rhs)
-	if len(lhs) != len(rhs) {
-		lhs = copyIP(lhs).To16()
-		rhs = copyIP(rhs).To16()
-	}
-	offset := 0
-	borrow := 0
-	// Loop from most-significant to least.
-	for i := range lhs {
-		offset <<= 8
-		result := (int(lhs[i]) - borrow) - int(rhs[i])
-		if result < 0 {
-			borrow = 1
-		} else {
-			borrow = 0
-		}
-		offset += result
-	}
-	return offset
 }
 
 // Get the optimal slice for an IP. IPv4 addresses will come back in a 4 byte slice. IPv6
@@ -176,9 +234,6 @@ func (ipa *ipAllocator) Release(ip net.IP) error {
 	if !ipa.subnet.Contains(ip) {
 		return fmt.Errorf("IP %s does not fall within subnet %s", ip, ipa.subnet)
 	}
-	offset := ipSub(ip, ipa.subnet.IP)
-	i := offset / 8
-	m := byte(1 << byte(offset%8))
-	ipa.used[i] &^= m
+	ipa.used.Remove(ip)
 	return nil
 }

--- a/pkg/registry/service/ip_allocator.go
+++ b/pkg/registry/service/ip_allocator.go
@@ -95,8 +95,8 @@ func newIPAllocator(subnet *net.IPNet) *ipAllocator {
 
 	ipSpaceSize := int64(-1)
 	ones, bits := subnet.Mask.Size()
-	if (bits-ones) < 63 {
-		ipSpaceSize = int64(1)<<uint(bits - ones)
+	if (bits - ones) < 63 {
+		ipSpaceSize = int64(1) << uint(bits-ones)
 
 		if ipSpaceSize < minIPSpace {
 			glog.Errorf("IPAllocator requires at least %d IPs", minIPSpace)
@@ -105,16 +105,16 @@ func newIPAllocator(subnet *net.IPNet) *ipAllocator {
 	}
 
 	ipa := &ipAllocator{
-		subnet:      *subnet,
-		ipSpaceSize: ipSpaceSize,
-		random:      r,
+		subnet:         *subnet,
+		ipSpaceSize:    ipSpaceSize,
+		random:         r,
 		randomAttempts: 1000,
 	}
 	ipa.used.Init()
 
 	zero := make(net.IP, len(subnet.IP), len(subnet.IP))
 	for i := 0; i < len(subnet.IP); i++ {
-		zero[i] = subnet.IP[i]&subnet.Mask[i]
+		zero[i] = subnet.IP[i] & subnet.Mask[i]
 	}
 	ipa.used.Add(zero) // block the zero addr
 
@@ -122,7 +122,7 @@ func newIPAllocator(subnet *net.IPNet) *ipAllocator {
 
 	broadcast := make(net.IP, len(subnet.IP), len(subnet.IP))
 	for i := 0; i < len(subnet.IP); i++ {
-		broadcast[i] = subnet.IP[i]|^subnet.Mask[i]
+		broadcast[i] = subnet.IP[i] | ^subnet.Mask[i]
 	}
 	ipa.used.Add(broadcast) // block the broadcast addr
 
@@ -187,7 +187,7 @@ func (ipa *ipAllocator) createRandomIp() net.IP {
 			randomIp[i] = ipa.subnet.IP[i]
 		} else {
 			b := byte(ipa.random.Intn(256))
-			randomIp[i] = (ipa.subnet.IP[i]&mask[i])|(b&^mask[i])
+			randomIp[i] = (ipa.subnet.IP[i] & mask[i]) | (b &^ mask[i])
 		}
 	}
 
@@ -203,7 +203,7 @@ func ipAdd(ip net.IP, offset int) net.IP {
 		result := int(out[i]) + add
 		out[i] = byte(result % 256)
 		offset >>= 8
-		offset += result/256 // carry
+		offset += result / 256 // carry
 	}
 	return out
 }

--- a/pkg/registry/service/rest_test.go
+++ b/pkg/registry/service/rest_test.go
@@ -44,6 +44,8 @@ func TestServiceRegistryCreate(t *testing.T) {
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
 	storage := NewREST(registry, fakeCloud, registrytest.NewMinionRegistry(machines, api.NodeResources{}), makeIPNet(t))
+	storage.portalMgr.randomAttempts = 0
+
 	svc := &api.Service{
 		Port:       6502,
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
@@ -414,6 +416,7 @@ func TestServiceRegistryIPAllocation(t *testing.T) {
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
 	rest := NewREST(registry, fakeCloud, registrytest.NewMinionRegistry(machines, api.NodeResources{}), makeIPNet(t))
+	rest.portalMgr.randomAttempts = 0
 
 	svc1 := &api.Service{
 		Port:       6502,
@@ -467,6 +470,7 @@ func TestServiceRegistryIPReallocation(t *testing.T) {
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
 	rest := NewREST(registry, fakeCloud, registrytest.NewMinionRegistry(machines, api.NodeResources{}), makeIPNet(t))
+	rest.portalMgr.randomAttempts = 0
 
 	svc1 := &api.Service{
 		Port:       6502,
@@ -509,6 +513,7 @@ func TestServiceRegistryIPUpdate(t *testing.T) {
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
 	rest := NewREST(registry, fakeCloud, registrytest.NewMinionRegistry(machines, api.NodeResources{}), makeIPNet(t))
+	rest.portalMgr.randomAttempts = 0
 
 	svc := &api.Service{
 		Port:       6502,
@@ -561,6 +566,7 @@ func TestServiceRegistryIPExternalLoadBalancer(t *testing.T) {
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
 	rest := NewREST(registry, fakeCloud, registrytest.NewMinionRegistry(machines, api.NodeResources{}), makeIPNet(t))
+	rest.portalMgr.randomAttempts = 0
 
 	svc := &api.Service{
 		Port:                       6502,
@@ -588,6 +594,7 @@ func TestServiceRegistryIPReloadFromStorage(t *testing.T) {
 	fakeCloud := &cloud.FakeCloud{}
 	machines := []string{"foo", "bar", "baz"}
 	rest1 := NewREST(registry, fakeCloud, registrytest.NewMinionRegistry(machines, api.NodeResources{}), makeIPNet(t))
+	rest1.portalMgr.randomAttempts = 0
 
 	svc := &api.Service{
 		Port:       6502,
@@ -607,6 +614,7 @@ func TestServiceRegistryIPReloadFromStorage(t *testing.T) {
 
 	// This will reload from storage, finding the previous 2
 	rest2 := NewREST(registry, fakeCloud, registrytest.NewMinionRegistry(machines, api.NodeResources{}), makeIPNet(t))
+	rest2.portalMgr.randomAttempts = 0
 
 	svc = &api.Service{
 		Port:       6502,


### PR DESCRIPTION
More for discussion than for actual merging (for now).

I think IPv6 could solve the address allocation problem that seems to be holding k8s back on EC2.  EC2 "tolerates" IPv6 for internal networking by using protocol 41 encapsulation.

I'm currently working on getting cluster/kube-up.sh to work, but in the meantime feedback on this idea would be helpful!
