### PR TITLE
Fix health_test.go

### DIFF
--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -49,11 +49,11 @@ func TestHealthChecker(t *testing.T) {
 		defer ts.Close()
 		u, err := url.Parse(ts.URL)
 		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
+			t.Fatalf("Unexpected error: %v", err)
 		}
 		host, port, err := net.SplitHostPort(u.Host)
 		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
+			t.Fatalf("Unexpected error: %v", err)
 		}
 		if tt.status == statusServerEarlyShutdown {
 			ts.Close()
@@ -118,11 +118,11 @@ func TestMuxHealthChecker(t *testing.T) {
 		defer ts.Close()
 		u, err := url.Parse(ts.URL)
 		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
+			t.Fatalf("Unexpected error: %v", err)
 		}
 		host, port, err := net.SplitHostPort(u.Host)
 		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
+			t.Fatalf("Unexpected error: %v", err)
 		}
 		container := api.Container{
 			LivenessProbe: &api.LivenessProbe{


### PR DESCRIPTION
If there is any error happened in the preparation for the test, we should terminate the test rather than keep it going.
