### PR TITLE
Check namespace on create of objects like update

### DIFF
--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -47,6 +47,14 @@ Examples:
 			client, err := f.Client(cmd, mapping)
 			checkErr(err)
 
+			// use the default namespace if not specified, or check for conflict with the file's namespace
+			if len(namespace) == 0 {
+				namespace = getKubeNamespace(cmd)
+			} else {
+				err = CompareNamespaceFromFile(cmd, namespace)
+				checkErr(err)
+			}
+
 			err = kubectl.NewRESTHelper(client, mapping).Create(namespace, true, data)
 			checkErr(err)
 			fmt.Fprintf(out, "%s\n", name)


### PR DESCRIPTION
A user should be allowed to create an object in a non-default namespace
if non is specified in the passed file.

@derekwaynecarr review please
