### PR TITLE
Fix nil docker client (how did this ever work???)

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -207,8 +207,8 @@ func (d *dockerContainerCommandRunner) RunInContainer(containerID string, cmd []
 
 // NewDockerContainerCommandRunner creates a ContainerCommandRunner which uses nsinit to run a command
 // inside a container.
-func NewDockerContainerCommandRunner() ContainerCommandRunner {
-	return &dockerContainerCommandRunner{}
+func NewDockerContainerCommandRunner(client DockerInterface) ContainerCommandRunner {
+	return &dockerContainerCommandRunner{client: client}
 }
 
 func (p dockerPuller) Pull(image string) error {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -73,7 +73,7 @@ func NewMainKubelet(
 		resyncInterval:        ri,
 		networkContainerImage: ni,
 		podWorkers:            newPodWorkers(),
-		runner:                dockertools.NewDockerContainerCommandRunner(),
+		runner:                dockertools.NewDockerContainerCommandRunner(dc),
 		httpClient:            &http.Client{},
 		pullQPS:               pullQPS,
 		pullBurst:             pullBurst,


### PR DESCRIPTION
Addresses stacktrace from https://github.com/GoogleCloudPlatform/kubernetes/issues/1998#issuecomment-61741291

How the heck did this get in like this? We clearly need an integration test for RunInContainer.
