### PR TITLE
In example unit file, run the scheduler as kube, not root

### DIFF
--- a/contrib/init/systemd/kube-scheduler.service
+++ b/contrib/init/systemd/kube-scheduler.service
@@ -6,6 +6,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 EnvironmentFile=-/etc/kubernetes/config
 EnvironmentFile=-/etc/kubernetes/apiserver
 EnvironmentFile=-/etc/kubernetes/scheduler
+User=kube
 ExecStart=/usr/bin/kube-scheduler \
 	    ${KUBE_LOGTOSTDERR} \
 	    ${KUBE_LOG_LEVEL} \


### PR DESCRIPTION
Only the kubelet and proxy do things which need root privs
