### PR TITLE
Make Fluentd/Elasticsearch logging support be robust to log rotation

### DIFF
--- a/contrib/logging/fluentd-es-image/td-agent.conf
+++ b/contrib/logging/fluentd-es-image/td-agent.conf
@@ -38,6 +38,7 @@
   format json
   time_key time
   path /var/lib/docker/containers/*/*-json.log
+  pos /var/lib/docker/containers/*/*-json.log.pos
   time_format %Y-%m-%dT%H:%M:%S
   tag docker.container.*
 </source>


### PR DESCRIPTION
This one additional line makes Fluentd create an extra file to track any rotation of the Docker container logs and deal appropriately with where to continue reading.
