### PR TITLE
fix example usage of passing environment variables

### DIFF
--- a/examples/walkthrough/README.md
+++ b/examples/walkthrough/README.md
@@ -103,7 +103,7 @@ desiredState:
     containers:
       - name: git-monitor
         image: kubernetes/git-monitor
-        envVar:
+        env:
           - name: GIT_REPO
             value: http://github.com/some/repo.git
         volumeMounts:


### PR DESCRIPTION
The syntax is not envVar, that is the name of the internal struct.  The
list is just "env"
