### PR TITLE
Use path.Join in proxy_server in pkg kubectl

### DIFF
--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -70,7 +70,8 @@ type NamespaceInfo struct {
 	Namespace string
 }
 
-// LoadNamespaceInfo parses a NamespaceInfo object from a file path. It creates a file at the specified path if it doesn't exist with the default namespace.
+// LoadNamespaceInfo parses a NamespaceInfo object from a file path.
+// It creates a file at the specified path if it doesn't exist with the default namespace.
 func LoadNamespaceInfo(path string) (*NamespaceInfo, error) {
 	var ns NamespaceInfo
 	if _, err := os.Stat(path); os.IsNotExist(err) {


### PR DESCRIPTION
There is a `singleJoiningSlash` func that used to handle join("http://host:port", "/hello"). 
But we could parse the url first, then join the url.Path with "/hello". 
So we can get rid of `singleJoiningSlash` and use path.Join.
