### PR TITLE
Make the Fluentd/Elasticsearch logging robust to log rotation

### DIFF
--- a/contrib/logging/fluentd-es-image/td-agent.conf
+++ b/contrib/logging/fluentd-es-image/td-agent.conf
@@ -38,7 +38,7 @@
   format json
   time_key time
   path /var/lib/docker/containers/*/*-json.log
-  pos /var/lib/docker/containers/*/*-json.log.pos
+  pos_file /var/lib/docker/containers/*/*-json.log.pos
   time_format %Y-%m-%dT%H:%M:%S
   tag docker.container.*
 </source>


### PR DESCRIPTION
This extra line helps Fluentd keep track of any log rotations. The PR corrects the syntax which i.e. replace "pos" with "pos_file".
