### PR TITLE
Start pulling external dependencies from GCS where possible

### DIFF
--- a/cluster/gce/templates/README.md
+++ b/cluster/gce/templates/README.md
@@ -1,0 +1,12 @@
+# Updating Salt debs
+
+We are caching all of the salt debs in GCS for speed and reliability.
+
+To update them, follow this simple N step process:
+
+1. Start up a new base image without salt installed.  SSH into this image.
+2. Install salt via their recommended method: `curl -L https://bootstrap.saltstack.com | sudo Csh -s -- -M -X`
+3. Find and download the debs that originated at the saltstack.com repo: `aptitude search --disable-columns -F "%p %V" "?installed?origin(saltstack.com)" | xargs aptitude download`
+4. Upload these to GCS: `gsutil cp *.deb gs://kubernetes-release/salt/`
+5. Make sure that everything is publicly readable: `gsutil acl ch -R -g all:R gs://kubernetes-release/salt/`
+6. Test things well :)

--- a/cluster/gce/templates/common.sh
+++ b/cluster/gce/templates/common.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Retry a download until we get it.
+#
+# $1 is the URL to download
+download-or-bust() {
+  until [[ -e "${1##*/}" ]]; do
+    echo "Downloading binary release tar ($SERVER_BINARY_TAR_URL)"
+    curl --ipv4 -LO --connect-timeout 20 --retry 6 --retry-delay 10 "$1"
+  done
+}
+
+# Install salt from GCS.  See README.md for instructions on how to update these
+# debs.
+#
+# $1 If set to --master, also install the master
+install-salt() {
+  apt-get update
+
+  mkdir -p /var/cache/salt-install
+  cd /var/cache/salt-install
+
+  TARS=(
+    libzmq3_3.2.3+dfsg-1~bpo70~dst+1_amd64.deb
+    python-zmq_13.1.0-1~bpo70~dst+1_amd64.deb
+    salt-common_2014.1.13+ds-1~bpo70+1_all.deb
+    salt-minion_2014.1.13+ds-1~bpo70+1_all.deb
+  )
+  if [[ ${1-} == '--master' ]]; then
+    TARS+=(salt-master_2014.1.13+ds-1~bpo70+1_all.deb)
+  fi
+  URL_BASE="https://storage.googleapis.com/kubernetes-release/salt"
+
+  for tar in "${TARS[@]}"; do
+    download-or-bust "${URL_BASE}/${tar}"
+    dpkg -i "${tar}"
+  done
+
+  # This will install any of the unmet dependencies from above.
+  apt-get install -f -y
+
+}

--- a/cluster/gce/templates/download-release.sh
+++ b/cluster/gce/templates/download-release.sh
@@ -22,10 +22,10 @@
 
 
 echo "Downloading binary release tar ($SERVER_BINARY_TAR_URL)"
-gsutil cp "$SERVER_BINARY_TAR_URL" .
+download-or-bust "$SERVER_BINARY_TAR_URL"
 
 echo "Downloading binary release tar ($SALT_TAR_URL)"
-gsutil cp "$SALT_TAR_URL" .
+download-or-bust "$SALT_TAR_URL"
 
 echo "Unpacking Salt tree"
 rm -rf kubernetes

--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -60,7 +60,7 @@ purge-old-docker:
 #    curl https://get.docker.com/ubuntu/dists/docker/main/binary-amd64/Packages
 # 2. Download based on that:
 #    curl -O https://get.docker.com/ubuntu/pool/main/<...>
-# 3. Upload to GCS (the cache control makes :
+# 3. Upload to GCS:
 #    gsutil cp <deb> gs://kubernetes-release/docker/<deb>
 # 4. Make it world readable:
 #    gsutil acl ch -R -g all:R gs://kubernetes-release/docker/<deb>

--- a/cluster/saltbase/salt/etcd/init.sls
+++ b/cluster/saltbase/salt/etcd/init.sls
@@ -1,7 +1,19 @@
+# We are caching the etcd tar file in GCS for reliability and speed.  To
+# update this to a new version, do the following:
+# 2. Download tar file:
+#    curl -LO https://github.com/coreos/etcd/releases/download/<ver>/etcd-<ver>-linux-amd64.tar.gz
+# 3. Upload to GCS (the cache control makes :
+#    gsutil cp <tar> gs://kubernetes-release/etcd/<tar>
+# 4. Make it world readable:
+#    gsutil -m acl ch -R -g all:R gs://kubernetes-release/etcd/
+# 5. Get a hash of the tar:
+#    shasum <tar>
+# 6. Update this file with new tar version and new hash
+
 {% set etcd_version="v0.4.6" %}
-{% set etcd_tar_url="https://github.com/coreos/etcd/releases/download/%s/etcd-%s-linux-amd64.tar.gz"
-  | format(etcd_version, etcd_version)  %}
-{% set etcd_tar_hash="md5=661d58424ff33dd837b8ee988dd79ae3" %}
+{% set etcd_tar_url="https://storage.googleapis.com/kubernetes-release/etcd/etcd-%s-linux-amd64.tar.gz"
+  | format(etcd_version)  %}
+{% set etcd_tar_hash="sha1=5db514e30b9f340eda00671230d5136855ae14d7" %}
 
 etcd-tar:
   archive:


### PR DESCRIPTION
This includes etcd and saltstack.

As a byproduct, this significantly improves deploy times on GCE.
