### PR TITLE
Change tag to latest and use correct pos file syntax for detection of log rotation

### DIFF
--- a/contrib/logging/fluentd-es-image/Makefile
+++ b/contrib/logging/fluentd-es-image/Makefile
@@ -1,6 +1,6 @@
 .PHONY:	build push
 
-TAG = 1.0
+TAG = latest
 
 build:	
 	sudo docker build -t kubernetes/fluentd-elasticsearch:$(TAG) .

--- a/contrib/logging/fluentd-es-image/td-agent.conf
+++ b/contrib/logging/fluentd-es-image/td-agent.conf
@@ -38,6 +38,7 @@
   format json
   time_key time
   path /var/lib/docker/containers/*/*-json.log
+  pos_file /var/lib/docker/containers/containers.log.pos
   time_format %Y-%m-%dT%H:%M:%S
   tag docker.container.*
 </source>


### PR DESCRIPTION
I got a response from the TreasureData folks who told me the correct syntax for pos files with wildcard paths i.e. use just one pos file.
