### PR TITLE
Make Docker container dirs writable for pos file

### DIFF
--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.manifest
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.manifest
@@ -6,7 +6,6 @@ containers:
     volumeMounts:
       - name: containers
         mountPath: /var/lib/docker/containers
-        readOnly: true
       - name: hosts
         mountPath: /outerhost
         readOnly: true

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.manifest
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.manifest
@@ -6,7 +6,6 @@ containers:
     volumeMounts:
       - name: containers
         mountPath: /var/lib/docker/containers
-        readOnly: true
 volumes:
   - name: containers
     source:


### PR DESCRIPTION
We now need to be able to write a POS file for tracking log rotations to the Docker container log file directory, so we need to remove the readOnly constraint.
