### PR TITLE
Return node unhealthy if http request fails

### DIFF
--- a/pkg/health/http.go
+++ b/pkg/health/http.go
@@ -94,6 +94,7 @@ func formatURL(host string, port int, path string) string {
 func DoHTTPCheck(url string, client HTTPGetInterface) (Status, error) {
 	res, err := client.Get(url)
 	if err != nil {
+		glog.V(1).Infof("Health check failed for %s, Error: %v", url, err)
 		return Unknown, err
 	}
 	defer res.Body.Close()

--- a/pkg/registry/minion/healthy_registry.go
+++ b/pkg/registry/minion/healthy_registry.go
@@ -45,11 +45,11 @@ func (r *HealthyRegistry) GetMinion(ctx api.Context, minionID string) (*api.Mini
 		return nil, err
 	}
 	status, err := r.client.HealthCheck(minionID)
+	if status == health.Unhealthy || status == health.Unknown {
+		return nil, ErrNotHealty
+	}
 	if err != nil {
 		return nil, err
-	}
-	if status == health.Unhealthy {
-		return nil, ErrNotHealty
 	}
 	return minion, nil
 }


### PR DESCRIPTION
If health check cannot talk to kubelet (http connection fail, instead of 500 code), it will return a connection fail instead of Unhealth status. Part of #2192

@lavalamp 
