### PR TITLE
Extend timeout for proxy Webscoket calls to one day

### DIFF
--- a/contrib/logging/kibana-image/run_kibana_nginx.sh
+++ b/contrib/logging/kibana-image/run_kibana_nginx.sh
@@ -167,6 +167,7 @@ server {
         location ~ /elasticsearch/?(.*)$ {
         proxy_http_version 1.1;
                 proxy_set_header Upgrade \$http_upgrade;
+                proxy_read_timeout 1d;
                 proxy_set_header Connection "upgrade";
                 proxy_pass http://${PROXY_HOST}:${PROXY_PORT}/\$1;
         }


### PR DESCRIPTION
This help to address the issue of connection timeouts that occur after a while. Extending the read timeout to make Websocket calls from Kibana to Elasticsearch more robust.
