### PR TITLE
Bumping kubelet write/read timeout

### DIFF
--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -54,8 +54,8 @@ func ListenAndServeKubeletServer(host HostInterface, updates chan<- interface{},
 	s := &http.Server{
 		Addr:           net.JoinHostPort(address.String(), strconv.FormatUint(uint64(port), 10)),
 		Handler:        &handler,
-		ReadTimeout:    10 * time.Second,
-		WriteTimeout:   10 * time.Second,
+		ReadTimeout:    5 * time.Minute,
+		WriteTimeout:   5 * time.Minute,
 		MaxHeaderBytes: 1 << 20,
 	}
 	glog.Fatal(s.ListenAndServe())


### PR DESCRIPTION
Increasing the kubelet write/read timeout.
Problem is that when the `containerLogs` are streamed, kubelet will close the connection after 10 seconds. Question is, if 5 minute timeout is reasonable? Spoke to @smarterclayton and he suggested to bump the timeout to 5 minutes.  
