### PR TITLE
Make getKubeConfig public to allow it for external consumption

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -153,7 +153,9 @@ func getExplicitKubeNamespace(cmd *cobra.Command) (string, bool) {
 	return "", false
 }
 
-func getKubeConfig(cmd *cobra.Command) *client.Config {
+// GetKubeConfig returns a config used for the Kubernetes client with CLI
+// options parsed.
+func GetKubeConfig(cmd *cobra.Command) *client.Config {
 	config := &client.Config{}
 
 	var host string
@@ -203,7 +205,7 @@ func getKubeConfig(cmd *cobra.Command) *client.Config {
 }
 
 func getKubeClient(cmd *cobra.Command) *client.Client {
-	config := getKubeConfig(cmd)
+	config := GetKubeConfig(cmd)
 
 	// The binary version.
 	matchVersion := GetFlagBool(cmd, "match-server-version")

--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -32,7 +32,7 @@ func NewCmdProxy(out io.Writer) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			port := GetFlagInt(cmd, "port")
 			glog.Infof("Starting to serve on localhost:%d", port)
-			server, err := kubectl.NewProxyServer(GetFlagString(cmd, "www"), getKubeConfig(cmd), port)
+			server, err := kubectl.NewProxyServer(GetFlagString(cmd, "www"), GetKubeConfig(cmd), port)
 			checkErr(err)
 			glog.Fatal(server.Serve())
 		},


### PR DESCRIPTION
This helper is useful for parsing the default CLI options and it could be potentially used  in other projects, without causing them to re-implement the same helper.

For example, if I want to build my version of kubectl, that talks to different API, I can use this helper to parse the CLI options and then just override the `Prefix`.

@smarterclayton @fabianofranz
