### PR TITLE
Turn on Elasticsearch logging by default for GCE platform

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -37,3 +37,10 @@ POLL_SLEEP_INTERVAL=3
 PORTAL_NET="10.0.0.0/16"
 # When set to true, heapster will be setup as part of the cluster bring up.
 MONITORING=true
+# Turn on Elasticsearch logging unless Google Cloud Logging has been selected or
+# if Elasticsearch logging has been specifically turned off.
+if [[ "${FLUENTD_GCP-}" != "true" ]]; then
+  if [[ "${FLUENTD_ELASTICSEARCH-}" != "false" ]]; then
+    FLUENTD_ELASTICSEARCH="true"
+  fi
+fi

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -299,6 +299,14 @@ function kube-up {
     grep -v "^#" "${KUBE_ROOT}/cluster/gce/templates/salt-master.sh"
   ) > "${KUBE_TEMP}/master-start.sh"
 
+  # Report logging choice (if any).
+  if [[ "${FLUENTD_ELASTICSEARCH-}" == "true" ]]; then
+    echo "+++ Logging using Fluentd to Elasticsearch"
+  fi
+  if [[ "${FLUENTD_GCP-}" == "true" ]]; then
+    echo "+++ Logging using Fluentd to Google Cloud Logging"
+  fi
+
   # For logging to GCP we need to enable some minion scopes.
   if [[ "${FLUENTD_GCP-}" == "true" ]]; then
      MINION_SCOPES="${MINION_SCOPES}, https://www.googleapis.com/auth/logging.write"


### PR DESCRIPTION
As requested by @brendandburns this PR turns on by default Fluentd logging to Elasticsearch on GCE.
If logging to Google Cloud platform is requested then this takes precedent and Elasticsearch logging is suppressed.
All logging can be turned off by ensuring FLUENTD_ELASTICSEARCH is set if "false" (or any value other than "true") and by not setting FLUENTD_GCP or making sure it has a value other than "true".
