### PR TITLE
Use curl exclusively in vSphere deployment

### DIFF
--- a/cluster/vsphere/templates/salt-master.sh
+++ b/cluster/vsphere/templates/salt-master.sh
@@ -50,7 +50,5 @@ EOF
 #
 # -M installs the master
 set +x
-wget -q -O - https://bootstrap.saltstack.com | sh -s -- -M -X
+curl -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -M -X
 set -x
-
-echo $MASTER_HTPASSWD > /srv/salt/nginx/htpasswd

--- a/cluster/vsphere/templates/salt-minion.sh
+++ b/cluster/vsphere/templates/salt-minion.sh
@@ -48,4 +48,4 @@ EOF
 #
 # We specify -X to avoid a race condition that can cause minion failure to
 # install.  See https://github.com/saltstack/salt-bootstrap/issues/270
-wget -q -O - https://bootstrap.saltstack.com | sh -s -- -X
+curl -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -X

--- a/docs/getting-started-guides/vsphere.md
+++ b/docs/getting-started-guides/vsphere.md
@@ -27,15 +27,15 @@ convenient).
 
 ### Setup
 
-Download a prebuilt Debian VMDK to be used as base image:
+Download a prebuilt Debian 7.7 VMDK that we'll use as a base image:
 
 ```sh
-wget https://storage.googleapis.com/govmomi/vmdk/kube.vmdk.gz{,.md5}
+curl --remote-name-all https://storage.googleapis.com/govmomi/vmdk/2014-11-11/kube.vmdk.gz{,.md5}
 md5sum -c kube.vmdk.gz.md5
 gzip -d kube.vmdk.gz
 ```
 
-Upload this VMDK to your vSphere instance:
+Import this VMDK into your vSphere datastore:
 
 ```sh
 export GOVC_URL='user:pass@hostname'
@@ -46,7 +46,7 @@ export GOVC_RESOURCE_POOL='resource pool or cluster with access to datastore'
 govc import.vmdk kube.vmdk ./kube/
 ```
 
-Verify that the VMDK was correctly uploaded and expanded to 10GiB:
+Verify that the VMDK was correctly uploaded and expanded to ~3GiB:
 
 ```sh
 govc datastore.ls ./kube/


### PR DESCRIPTION
This fixes #2295.

I also removed the superfluous `MASTER_HTPASSWD` line in the salt master template, since that is now generated in the salt overlay tree.
