### PR TITLE
added spreading by shared labels

### DIFF
--- a/pkg/scheduler/spreading.go
+++ b/pkg/scheduler/spreading.go
@@ -55,6 +55,7 @@ func NewSpreadingScheduler(podLister PodLister, minionLister MinionLister, predi
 
 // Returns a map of pod name to pod with an entry for all pods that have at least one label in the label set.
 // This could possibly be replaced with an orTerm selector but it doesn't exist yet.
+// TODO: look at replacing podSet key with pod.ObjectMeta.UID when it's populated
 func getMatchingPods(labelSet map[string]string, podLister PodLister) (map[string]api.Pod, error) {
 	podSet := map[string]api.Pod{}
 	for k, v := range labelSet {
@@ -64,7 +65,7 @@ func getMatchingPods(labelSet map[string]string, podLister PodLister) (map[strin
 		}
 
 		for _, pod := range pods {
-			podSet[pod.ObjectMeta.Name] = pod
+			podSet[pod.ObjectMeta.Namespace+pod.ObjectMeta.Name] = pod
 		}
 	}
 	return podSet, nil

--- a/pkg/scheduler/spreading_test.go
+++ b/pkg/scheduler/spreading_test.go
@@ -97,6 +97,16 @@ func TestSpreadPriority(t *testing.T) {
 			expectedList: []HostPriority{{"machine1", 3}, {"machine2", 4}},
 			test:         "three label matches",
 		},
+		{
+			pod: api.Pod{ObjectMeta: api.ObjectMeta{Labels: labels1}},
+			pods: []api.Pod{
+				{CurrentState: machine1State, ObjectMeta: api.ObjectMeta{Labels: labels1, Name: "a", Namespace: "a"}},
+				{CurrentState: machine2State, ObjectMeta: api.ObjectMeta{Labels: labels1, Name: "a", Namespace: "b"}},
+			},
+			nodes:        []string{"machine1", "machine2"},
+			expectedList: []HostPriority{{"machine1", 2}, {"machine2", 2}},
+			test:         "same name different namespace",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Spread pods that share labels rather than only spreading pods that have exactly equal label sets.

Referencing #1965, although maybe not a resolution, this may be an improvement over the current implementation
