### PR TITLE
Strip extra '-' from md5sum output when creating S3 bucket

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -162,7 +162,7 @@ function upload-server-tars() {
   if which md5 > /dev/null 2>&1; then
     project_hash=$(md5 -q -s "${USER} ${key}")
   else
-    project_hash=$(echo -n "${USER} ${key}" | md5sum)
+    project_hash=$(echo -n "${USER} ${key}" | md5sum | awk '{ print $1 }')
   fi
   local -r staging_bucket="kubernetes-staging-${project_hash}"
 

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -106,7 +106,7 @@ function upload-server-tars() {
   if which md5 > /dev/null 2>&1; then
     project_hash=$(md5 -q -s "$PROJECT")
   else
-    project_hash=$(echo -n "$PROJECT" | md5sum)
+    project_hash=$(echo -n "$PROJECT" | md5sum | awk '{ print $1 }')
   fi
   project_hash=${project_hash:0:5}
 


### PR DESCRIPTION
md5sum prints out the hash, followed by the filename. When piped in from
stdin, this equates to a '-' character.

cluster/aws/util.sh was incorrectly including this '-' character as part
of the S3 bucket name, causing the script to fail on Linux machines with
the md5sum binary. (In contrast to the md5 binary on MacOS, which works correctly). 

i.e. the generated URI is

"s3://kubernetes-staging-0ac68d8c77915cc1069a9e2f5e1f1d2d -"

instead of

"s3://kubernetes-staging-0ac68d8c77915cc1069a9e2f5e1f1d2d"

(Note the extra '-')

Fixed by using `awk` to return only the first column (up to the space)

This is my first PR for this project. I've followed the instructions and signed the `Contributor License Agreement`, but let me know if I've missed anything and I'll amend. 
