### PR TITLE
Give the API server access to TLS certs.

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -227,7 +227,7 @@ function kube-up {
   if [ ! -f $AWS_SSH_KEY ]; then
     ssh-keygen -f $AWS_SSH_KEY -N ''
   fi
-    
+
   $AWS_CMD import-key-pair --key-name kubernetes --public-key-material file://$AWS_SSH_KEY.pub > /dev/null 2>&1 || true
   VPC_ID=$($AWS_CMD create-vpc --cidr-block 172.20.0.0/16 | json_val '["Vpc"]["VpcId"]')
   $AWS_CMD modify-vpc-attribute --vpc-id $VPC_ID --enable-dns-support '{"Value": true}' > /dev/null
@@ -294,14 +294,14 @@ function kube-up {
       --security-group-ids $SEC_GROUP_ID \
       --associate-public-ip-address \
       --user-data file://${KUBE_TEMP}/minion-start-${i}.sh | json_val '["Instances"][0]["InstanceId"]')
-    sleep 3        
+    sleep 3
     n=0
     until [ $n -ge 5 ]; do
       $AWS_CMD create-tags --resources $minion_id --tags Key=Name,Value=${MINION_NAMES[$i]} > /dev/null && break
       n=$[$n+1]
       sleep 15
     done
-        
+
     sleep 3
     n=0
     until [ $n -ge 5 ]; do
@@ -309,7 +309,7 @@ function kube-up {
       n=$[$n+1]
       sleep 15
     done
-    
+
     sleep 3
     $AWS_CMD modify-instance-attribute --instance-id $minion_id --source-dest-check '{"Value": false}' > /dev/null
 
@@ -343,7 +343,7 @@ function kube-up {
   detect-master > /dev/null
   detect-minions > /dev/null
 
-  # Wait 3 minutes for cluster to come up.  We hit it with a "highstate" after that to 
+  # Wait 3 minutes for cluster to come up.  We hit it with a "highstate" after that to
   # make sure that everything is well configured.
   echo "Waiting for cluster to settle"
   local i
@@ -353,7 +353,7 @@ function kube-up {
   done
   echo "Re-running salt highstate"
   ssh -oStrictHostKeyChecking=no -i ~/.ssh/kube_aws_rsa ubuntu@${KUBE_MASTER_IP} sudo salt '*' state.highstate > /dev/null
-    
+
   echo "Waiting for cluster initialization."
   echo
   echo "  This will continually check to see if the API for kubernetes is reachable."
@@ -400,9 +400,9 @@ function kube-up {
   # config file.  Distribute the same way the htpasswd is done.
   (
     umask 077
-    ssh -oStrictHostKeyChecking=no -i ~/.ssh/kube_aws_rsa ubuntu@${KUBE_MASTER_IP} sudo cat /usr/share/nginx/kubecfg.crt >"${HOME}/${kube_cert}" 2>/dev/null
-    ssh -oStrictHostKeyChecking=no -i ~/.ssh/kube_aws_rsa ubuntu@${KUBE_MASTER_IP} sudo cat /usr/share/nginx/kubecfg.key >"${HOME}/${kube_key}" 2>/dev/null
-    ssh -oStrictHostKeyChecking=no -i ~/.ssh/kube_aws_rsa ubuntu@${KUBE_MASTER_IP} sudo cat /usr/share/nginx/ca.crt >"${HOME}/${ca_cert}" 2>/dev/null
+    ssh -oStrictHostKeyChecking=no -i ~/.ssh/kube_aws_rsa ubuntu@${KUBE_MASTER_IP} sudo cat /srv/kubernetes/kubecfg.crt >"${HOME}/${kube_cert}" 2>/dev/null
+    ssh -oStrictHostKeyChecking=no -i ~/.ssh/kube_aws_rsa ubuntu@${KUBE_MASTER_IP} sudo cat /srv/kubernetes/kubecfg.key >"${HOME}/${kube_key}" 2>/dev/null
+    ssh -oStrictHostKeyChecking=no -i ~/.ssh/kube_aws_rsa ubuntu@${KUBE_MASTER_IP} sudo cat /srv/kubernetes/ca.crt >"${HOME}/${ca_cert}" 2>/dev/null
 
     cat << EOF > ~/.kubernetes_auth
 {

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -422,9 +422,9 @@ function kube-up {
   # TODO: generate ADMIN (and KUBELET) tokens and put those in the master's
   # config file.  Distribute the same way the htpasswd is done.
   (umask 077
-   gcutil ssh "${MASTER_NAME}" sudo cat /usr/share/nginx/kubecfg.crt >"${HOME}/${kube_cert}" 2>/dev/null
-   gcutil ssh "${MASTER_NAME}" sudo cat /usr/share/nginx/kubecfg.key >"${HOME}/${kube_key}" 2>/dev/null
-   gcutil ssh "${MASTER_NAME}" sudo cat /usr/share/nginx/ca.crt >"${HOME}/${ca_cert}" 2>/dev/null
+   gcutil ssh "${MASTER_NAME}" sudo cat /srv/kubernetes/kubecfg.crt >"${HOME}/${kube_cert}" 2>/dev/null
+   gcutil ssh "${MASTER_NAME}" sudo cat /srv/kubernetes/kubecfg.key >"${HOME}/${kube_key}" 2>/dev/null
+   gcutil ssh "${MASTER_NAME}" sudo cat /srv/kubernetes/ca.crt >"${HOME}/${ca_cert}" 2>/dev/null
 
    cat << EOF > ~/.kubernetes_auth
 {

--- a/cluster/saltbase/salt/apiserver/default
+++ b/cluster/saltbase/salt/apiserver/default
@@ -27,4 +27,7 @@
   {% set portal_net = "-portal_net=" + pillar['portal_net'] %}
 {% endif %}
 
-DAEMON_ARGS="{{daemon_args}} {{address}} {{etcd_servers}} {{ cloud_provider }} --allow_privileged={{pillar['allow_privileged']}} {{portal_net}}"
+{% set cert_file = "-tls_cert_file=/srv/kubernetes/server.cert" %}
+{% set key_file = "-tls_private_key_file=/srv/kubernetes/server.key" %}
+
+DAEMON_ARGS="{{daemon_args}} {{address}} {{etcd_servers}} {{ cloud_provider }} --allow_privileged={{pillar['allow_privileged']}} {{portal_net}} {{cert_file}} {{key_file}}"

--- a/cluster/saltbase/salt/generate-cert/init.sls
+++ b/cluster/saltbase/salt/generate-cert/init.sls
@@ -1,0 +1,38 @@
+{% if grains.cloud is defined %}
+  {% if grains.cloud == 'gce' %}
+    {% set cert_ip='_use_gce_external_ip_' %}
+  {% endif %}
+  {% if grains.cloud == 'aws' %}
+    {% set cert_ip='_use_aws_external_ip_' %}
+  {% endif %}
+  {% if grains.cloud == 'vagrant' %}
+    {% set cert_ip=grains.fqdn_ip4 %}
+  {% endif %}
+  {% if grains.cloud == 'vsphere' %}
+    {% set cert_ip=grains.ip_interfaces.eth0[0] %}
+  {% endif %}
+{% endif %}
+
+# If there is a pillar defined, override any defaults.
+{% if pillar['cert_ip'] is defined %}
+  {% set cert_ip=pillar['cert_ip'] %}
+{% endif %}
+
+{% set certgen="make-cert.sh" %}
+{% if cert_ip is defined %}
+  {% set certgen="make-ca-cert.sh" %}
+{% endif %}
+
+kubernetes-cert:
+  cmd.script:
+    - unless: test -f /srv/kubernetes/server.cert
+    - source: salt://generate-cert/{{certgen}}
+{% if cert_ip is defined %}
+    - args: {{cert_ip}}
+    - require:
+      - pkg: curl
+{% endif %}
+    - cwd: /
+    - user: root
+    - group: root
+    - shell: /bin/bash

--- a/cluster/saltbase/salt/generate-cert/make-cert.sh
+++ b/cluster/saltbase/salt/generate-cert/make-cert.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+cert_dir=/srv/kubernetes
+
 openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 \
   -subj "/CN=kubernetes.invalid/O=Kubernetes" \
-  -keyout /usr/share/nginx/server.key  -out /usr/share/nginx/server.cert
+  -keyout "${cert_dir}/server.key" -out "${cert_dir}/server.cert"

--- a/cluster/saltbase/salt/nginx/init.sls
+++ b/cluster/saltbase/salt/nginx/init.sls
@@ -8,45 +8,7 @@ nginx:
       - file: /etc/nginx/nginx.conf
       - file: /etc/nginx/sites-enabled/default
       - file: /usr/share/nginx/htpasswd
-      - cmd: /usr/share/nginx/server.cert
-
-{% if grains.cloud is defined %}
-  {% if grains.cloud == 'gce' %}
-    {% set cert_ip='_use_gce_external_ip_' %}
-  {% endif %}
-  {% if grains.cloud == 'aws' %}
-    {% set cert_ip='_use_aws_external_ip_' %}
-  {% endif %}
-  {% if grains.cloud == 'vagrant' %}
-    {% set cert_ip=grains.fqdn_ip4 %}
-  {% endif %}
-  {% if grains.cloud == 'vsphere' %}
-    {% set cert_ip=grains.ip_interfaces.eth0[0] %}
-  {% endif %}
-{% endif %}
-# If there is a pillar defined, override any defaults.
-{% if pillar['cert_ip'] is defined %}
-  {% set cert_ip=pillar['cert_ip'] %}
-{% endif %}
-
-{% set certgen="make-cert.sh" %}
-{% if cert_ip is defined %}
-  {% set certgen="make-ca-cert.sh" %}
-{% endif %}
-
-/usr/share/nginx/server.cert:
-  cmd.script:
-    - unless: test -f /usr/share/nginx/server.cert
-    - source: salt://nginx/{{certgen}} 
-{% if cert_ip is defined %}
-    - args: {{cert_ip}}
-    - require:
-      - pkg: curl
-{% endif %}
-    - cwd: /
-    - user: root
-    - group: root
-    - shell: /bin/bash
+      - cmd: kubernetes-cert
 
 /etc/nginx/nginx.conf:
   file:

--- a/cluster/saltbase/salt/nginx/kubernetes-site
+++ b/cluster/saltbase/salt/nginx/kubernetes-site
@@ -33,8 +33,8 @@ server {
         index index.html index.htm;
 
         ssl on;
-        ssl_certificate /usr/share/nginx/server.cert;
-        ssl_certificate_key /usr/share/nginx/server.key;
+        ssl_certificate /srv/kubernetes/server.cert;
+        ssl_certificate_key /srv/kubernetes/server.key;
 
         ssl_session_timeout 5m;
 
@@ -53,7 +53,7 @@ server {
           proxy_connect_timeout 159s;
           proxy_send_timeout   600s;
           proxy_read_timeout   600s;
-          
+
           # Disable retry
           proxy_next_upstream off;
 

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -26,6 +26,7 @@ base:
 
   'roles:kubernetes-master':
     - match: grain
+    - generate-cert
     - etcd
     - apiserver
     - controller-manager

--- a/cluster/vsphere/util.sh
+++ b/cluster/vsphere/util.sh
@@ -397,9 +397,9 @@ function kube-up {
   (
     umask 077
 
-    kube-ssh "${KUBE_MASTER_IP}" sudo cat /usr/share/nginx/kubecfg.crt >"${HOME}/${kube_cert}" 2>/dev/null
-    kube-ssh "${KUBE_MASTER_IP}" sudo cat /usr/share/nginx/kubecfg.key >"${HOME}/${kube_key}" 2>/dev/null
-    kube-ssh "${KUBE_MASTER_IP}" sudo cat /usr/share/nginx/ca.crt >"${HOME}/${ca_cert}" 2>/dev/null
+    kube-ssh "${KUBE_MASTER_IP}" sudo cat /srv/kubernetes/kubecfg.crt >"${HOME}/${kube_cert}" 2>/dev/null
+    kube-ssh "${KUBE_MASTER_IP}" sudo cat /srv/kubernetes/kubecfg.key >"${HOME}/${kube_key}" 2>/dev/null
+    kube-ssh "${KUBE_MASTER_IP}" sudo cat /srv/kubernetes/ca.crt >"${HOME}/${ca_cert}" 2>/dev/null
 
     cat << EOF > ~/.kubernetes_auth
     {


### PR DESCRIPTION
Moved the cert generation to a separate salt state and put it in a more appropriate sharable location (`/srv/kubernetes/`).
