### PR TITLE
util.EncodeJSON proven harmful, remove it everywhere

### DIFF
--- a/pkg/cloudprovider/controller/minioncontroller_test.go
+++ b/pkg/cloudprovider/controller/minioncontroller_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
-func newMinionList(count int) api.MinionList {
+func newMinionList(count int) *api.MinionList {
 	minions := []api.Minion{}
 	for i := 0; i < count; i++ {
 		minions = append(minions, api.Minion{
@@ -39,7 +39,7 @@ func newMinionList(count int) api.MinionList {
 			},
 		})
 	}
-	return api.MinionList{
+	return &api.MinionList{
 		Items: minions,
 	}
 }
@@ -52,7 +52,7 @@ type serverResponse struct {
 func makeTestServer(t *testing.T, minionResponse serverResponse) (*httptest.Server, *util.FakeHandler) {
 	fakeMinionHandler := util.FakeHandler{
 		StatusCode:   minionResponse.statusCode,
-		ResponseBody: util.EncodeJSON(minionResponse.obj),
+		ResponseBody: runtime.EncodeOrDie(testapi.Codec(), minionResponse.obj.(runtime.Object)),
 	}
 	mux := http.NewServeMux()
 	mux.Handle("/api/"+testapi.Version()+"/minions", &fakeMinionHandler)

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -284,10 +284,10 @@ func TestSynchonize(t *testing.T) {
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
 					{
-						Value: util.EncodeJSON(controllerSpec1),
+						Value: runtime.EncodeOrDie(testapi.Codec(), &controllerSpec1),
 					},
 					{
-						Value: util.EncodeJSON(controllerSpec2),
+						Value: runtime.EncodeOrDie(testapi.Codec(), &controllerSpec2),
 					},
 				},
 			},

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -30,7 +30,6 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/google/cadvisor/info"
 )
 
@@ -97,6 +96,15 @@ func newServerTest() *serverTestFramework {
 	return fw
 }
 
+// encodeJSON returns obj marshalled as a JSON string, panicing on any errors
+func encodeJSON(obj interface{}) string {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}
+
 func readResp(resp *http.Response) (string, error) {
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
@@ -124,7 +132,7 @@ func TestContainer(t *testing.T) {
 			},
 		},
 	}
-	body := bytes.NewBuffer([]byte(util.EncodeJSON(expected[0]))) // Only send a single ContainerManifest
+	body := bytes.NewBuffer([]byte(encodeJSON(expected[0]))) // Only send a single ContainerManifest
 	resp, err := http.Post(fw.testHTTPServer.URL+"/container", "application/json", body)
 	if err != nil {
 		t.Errorf("Post returned: %v", err)
@@ -199,7 +207,7 @@ func TestContainers(t *testing.T) {
 			},
 		},
 	}
-	body := bytes.NewBuffer([]byte(util.EncodeJSON(expected)))
+	body := bytes.NewBuffer([]byte(encodeJSON(expected)))
 	resp, err := http.Post(fw.testHTTPServer.URL+"/containers", "application/json", body)
 	if err != nil {
 		t.Errorf("Post returned: %v", err)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -60,12 +60,6 @@ func Forever(f func(), period time.Duration) {
 	}
 }
 
-// EncodeJSON returns obj marshalled as a JSON string, ignoring any errors.
-func EncodeJSON(obj interface{}) string {
-	data, _ := json.Marshal(obj)
-	return string(data)
-}
-
 // IntOrString is a type that can hold an int or a string.  When used in
 // JSON or YAML marshalling and unmarshalling, it produces or consumes the
 // inner type.  This allows you to have, for example, a JSON field that can

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -24,39 +24,6 @@ import (
 	"gopkg.in/v1/yaml"
 )
 
-type FakeTypeMeta struct {
-	ID string
-}
-type FakePod struct {
-	FakeTypeMeta `json:",inline" yaml:",inline"`
-	Labels       map[string]string
-	Int          int
-	Str          string
-}
-
-func TestEncodeJSON(t *testing.T) {
-	pod := FakePod{
-		FakeTypeMeta: FakeTypeMeta{ID: "foo"},
-		Labels: map[string]string{
-			"foo": "bar",
-			"baz": "blah",
-		},
-		Int: -6,
-		Str: "a string",
-	}
-
-	body := EncodeJSON(pod)
-
-	expectedBody, err := json.Marshal(pod)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	if string(expectedBody) != body {
-		t.Errorf("JSON doesn't match.  Expected %s, saw %s", expectedBody, body)
-	}
-}
-
 func TestHandleCrash(t *testing.T) {
 	count := 0
 	expect := 10


### PR DESCRIPTION
People were misusing EncodeJSON in tests when they should be using `runtime.EncodeOrDie(testapi.Codec(), obj)`.  Removing the potential for cutting self on sharp objects.
