### PR TITLE
Remove todos about adding usage to Pods.

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -393,8 +393,6 @@ type ContainerStatus struct {
 	PodIP string `json:"podIP,omitempty" yaml:"podIP,omitempty"`
 	// TODO(dchen1107): Need to decide how to represent this in v1beta3
 	Image string `yaml:"image" json:"image"`
-	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
-	// usage should be included.
 }
 
 // PodInfo contains one entry for every container with available info.

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -357,8 +357,6 @@ type ContainerStatus struct {
 	PodIP string `json:"podIP,omitempty" yaml:"podIP,omitempty"`
 	// TODO(dchen1107): Need to decide how to reprensent this in v1beta3
 	Image string `yaml:"image" json:"image"`
-	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
-	// usage should be included.
 }
 
 // PodInfo contains one entry for every container with available info.

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -322,8 +322,6 @@ type ContainerStatus struct {
 	PodIP string `json:"podIP,omitempty" yaml:"podIP,omitempty"`
 	// TODO(dchen1107): Need to decide how to reprensent this in v1beta3
 	Image string `yaml:"image" json:"image"`
-	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
-	// usage should be included.
 }
 
 // PodInfo contains one entry for every container with available info.

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -419,8 +419,6 @@ type ContainerStatus struct {
 	RestartCount int `json:"restartCount" yaml:"restartCount"`
 	// TODO(dchen1107): Introduce our own NetworkSettings struct here?
 	// TODO(dchen1107): Which image the container is running with?
-	// TODO(dchen1107): Once we have done with integration with cadvisor, resource
-	// usage should be included.
 }
 
 // PodInfo contains one entry for every container with available info.


### PR DESCRIPTION
Usage in Pods would be quite noisy when watching pods.
People should get usage from heapster, or from
some other object TBD.
