### PR TITLE
make-cert.sh: Create directory before writing cert

### DIFF
--- a/cluster/saltbase/salt/generate-cert/make-cert.sh
+++ b/cluster/saltbase/salt/generate-cert/make-cert.sh
@@ -17,6 +17,8 @@
 cert_dir=/srv/kubernetes
 cert_file_owner=apiserver.apiserver
 
+mkdir -p "$cert_dir"
+
 openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 \
   -subj "/CN=kubernetes.invalid/O=Kubernetes" \
   -keyout "${cert_dir}/server.key" -out "${cert_dir}/server.cert"


### PR DESCRIPTION
Adds a "mkdir -p" to the make-cert.sh.  This fixes an issue where the
script could fail if /srv/kubernetes did not exist previously.  Fixes for https://github.com/GoogleCloudPlatform/kubernetes/issues/2363.
