### PR TITLE
Add events to kubectl describe

### DIFF
--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -396,7 +396,7 @@ func (t *TemplatePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	return t.template.Execute(w, outObj)
 }
 
-func tabbedString(f func(*tabwriter.Writer) error) (string, error) {
+func tabbedString(f func(io.Writer) error) (string, error) {
 	out := new(tabwriter.Writer)
 	b := make([]byte, 1024)
 	buf := bytes.NewBuffer(b)


### PR DESCRIPTION
@bgrant0607 this demonstrates event reporting even for pods that have been deleted...

We don't really have a good way of testing kubectl describe, we will need to add tests as tools start relying on it.
