### PR TITLE
If the image with :latest tag specified in Spec, kubelet should try

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -60,6 +60,7 @@ type DockerID string
 type DockerPuller interface {
 	Pull(image string) error
 	IsImagePresent(image string) (bool, error)
+	RequireLatestImage(name string) bool
 }
 
 // dockerPuller is the default implementation of DockerPuller.
@@ -247,8 +248,21 @@ func (p dockerPuller) IsImagePresent(name string) (bool, error) {
 	return false, err
 }
 
+func (p dockerPuller) RequireLatestImage(name string) bool {
+	_, tag := parseImageName(name)
+
+	if tag == "latest" {
+		return true
+	}
+	return false
+}
+
 func (p throttledDockerPuller) IsImagePresent(name string) (bool, error) {
 	return p.puller.IsImagePresent(name)
+}
+
+func (p throttledDockerPuller) RequireLatestImage(name string) bool {
+	return p.puller.RequireLatestImage(name)
 }
 
 // DockerContainers is a map of containers

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -210,3 +210,7 @@ func (f *FakeDockerPuller) IsImagePresent(name string) (bool, error) {
 	}
 	return false, nil
 }
+
+func (f *FakeDockerPuller) RequireLatestImage(name string) bool {
+	return true
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -714,11 +714,13 @@ func (kl *Kubelet) syncPod(pod *api.BoundPod, dockerContainers dockertools.Docke
 		glog.V(3).Infof("Container with name %s--%s--%s doesn't exist, creating %#v", podFullName, uuid, container.Name, container)
 		if !api.IsPullNever(container.ImagePullPolicy) {
 			present, err := kl.dockerPuller.IsImagePresent(container.Image)
+			latest := kl.dockerPuller.RequireLatestImage(container.Image)
 			if err != nil {
 				glog.Errorf("Failed to inspect image: %s: %#v skipping pod %s container %s", container.Image, err, podFullName, container.Name)
 				continue
 			}
-			if api.IsPullAlways(container.ImagePullPolicy) || !present {
+			if api.IsPullAlways(container.ImagePullPolicy) ||
+				(api.IsPullIfNotPresent(container.ImagePullPolicy) && (!present || latest)) {
 				if err := kl.dockerPuller.Pull(container.Image); err != nil {
 					glog.Errorf("Failed to pull image %s: %v skipping pod %s container %s.", container.Image, err, podFullName, container.Name)
 					continue


### PR DESCRIPTION
to pull the latest one even the policy is PullIfNotPresent.

My initial thought is that we should inspect ContainerSpec and set proper default based on image tag. But it looks like not very easy once we move all default setting to conversion. For now, I just put it to Kubelet, but I am open to other suggestion. 

@lavalamp @brendandburns 
