### PR TITLE
Make the output of kubectl.sh narrower

### DIFF
--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -127,12 +127,16 @@ func formatLabels(labelMap map[string]string) string {
 	return l
 }
 
-func makeImageList(spec *api.PodSpec) string {
+func listOfImages(spec *api.PodSpec) []string {
 	var images []string
 	for _, container := range spec.Containers {
 		images = append(images, container.Image)
 	}
-	return strings.Join(images, ",")
+	return images
+}
+
+func makeImageList(spec *api.PodSpec) string {
+	return strings.Join(listOfImages(spec), ",")
 }
 
 // ExpandResourceShortcut will return the expanded version of resource


### PR DESCRIPTION
The output of `kubectl.sh get` now uses a separate line for each image which makes the output narrower but longer. Example:

```
$ kubectl.sh get pods
NAME                           IMAGE(S)                       HOST                                                           LABELS                      STATUS
influx-grafana                 kubernetes/heapster_influxdb   kubernetes-minion-3.c.kubernetes-elk.internal/146.148.76.82    name=influxdb               Running
                               kubernetes/heapster_grafana                                                                                               
                               dockerfile/elasticsearch                                                                                                  
heapster                       kubernetes/heapster            kubernetes-minion-1.c.kubernetes-elk.internal/130.211.126.68   name=heapster               Running
synthetic-logger-0.25lps-pod   ubuntu:14.04                   kubernetes-minion-1.c.kubernetes-elk.internal/130.211.126.68   name=synth-logging-source   Running
elasticsearch-pod              dockerfile/elasticsearch       kubernetes-minion-2.c.kubernetes-elk.internal/23.236.59.213    app=elasticsearch           Running
kibana-pod                     kubernetes/kibana:latest       kubernetes-minion-4.c.kubernetes-elk.internal/130.211.121.21   app=kibana-viewer           Running
synthetic-logger-10lps-pod     ubuntu:14.04                   kubernetes-minion-1.c.kubernetes-elk.internal/130.211.126.68   name=synth-logging-source   Running
```
