### PR TITLE
Support node label update

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -535,3 +535,15 @@ func ValidateMinion(minion *api.Minion) errs.ValidationErrorList {
 	allErrs = append(allErrs, validateLabels(minion.Labels)...)
 	return allErrs
 }
+
+// ValidateMinionUpdate tests to make sure a minion update can be applied.  Modifies oldMinion.
+func ValidateMinionUpdate(oldMinion *api.Minion, minion *api.Minion) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	// TODO: why we need two labels for minion.
+	oldMinion.Labels = minion.Labels
+	oldMinion.ObjectMeta.Labels = minion.ObjectMeta.Labels
+	if !reflect.DeepEqual(oldMinion, minion) {
+		allErrs = append(allErrs, fmt.Errorf("Update contains more than labels changes"))
+	}
+	return allErrs
+}

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -1065,3 +1065,62 @@ func TestValidateMinion(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateMinionUpdate(t *testing.T) {
+	tests := []struct {
+		oldMinion api.Minion
+		minion    api.Minion
+		valid     bool
+	}{
+		{api.Minion{}, api.Minion{}, true},
+		{api.Minion{
+			ObjectMeta: api.ObjectMeta{
+				Name: "foo"}},
+			api.Minion{
+				ObjectMeta: api.ObjectMeta{
+					Name: "bar"},
+			}, false},
+		{api.Minion{
+			ObjectMeta: api.ObjectMeta{
+				Name:   "foo",
+				Labels: map[string]string{"foo": "bar"},
+			},
+		}, api.Minion{
+			ObjectMeta: api.ObjectMeta{
+				Name:   "foo",
+				Labels: map[string]string{"foo": "baz"},
+			},
+		}, true},
+		{api.Minion{
+			ObjectMeta: api.ObjectMeta{
+				Name: "foo",
+			},
+		}, api.Minion{
+			ObjectMeta: api.ObjectMeta{
+				Name:   "foo",
+				Labels: map[string]string{"foo": "baz"},
+			},
+		}, true},
+		{api.Minion{
+			ObjectMeta: api.ObjectMeta{
+				Name:   "foo",
+				Labels: map[string]string{"bar": "foo"},
+			},
+		}, api.Minion{
+			ObjectMeta: api.ObjectMeta{
+				Name:   "foo",
+				Labels: map[string]string{"foo": "baz"},
+			},
+		}, true},
+	}
+	for _, test := range tests {
+		errs := ValidateMinionUpdate(&test.oldMinion, &test.minion)
+		if test.valid && len(errs) > 0 {
+			t.Errorf("Unexpected error: %v", errs)
+			t.Logf("%#v vs %#v", test.oldMinion.ObjectMeta, test.minion.ObjectMeta)
+		}
+		if !test.valid && len(errs) == 0 {
+			t.Errorf("Unexpected non-error")
+		}
+	}
+}

--- a/pkg/registry/etcd/etcd.go
+++ b/pkg/registry/etcd/etcd.go
@@ -581,6 +581,12 @@ func (r *Registry) CreateMinion(ctx api.Context, minion *api.Minion) error {
 	return etcderr.InterpretCreateError(err, "minion", minion.Name)
 }
 
+func (r *Registry) UpdateMinion(ctx api.Context, minion *api.Minion) error {
+	// TODO: Add some validations.
+	err := r.SetObj(makeMinionKey(minion.Name), minion)
+	return etcderr.InterpretUpdateError(err, "minion", minion.Name)
+}
+
 func (r *Registry) GetMinion(ctx api.Context, minionID string) (*api.Minion, error) {
 	var minion api.Minion
 	key := makeMinionKey(minionID)

--- a/pkg/registry/minion/healthy_registry.go
+++ b/pkg/registry/minion/healthy_registry.go
@@ -62,6 +62,10 @@ func (r *HealthyRegistry) CreateMinion(ctx api.Context, minion *api.Minion) erro
 	return r.delegate.CreateMinion(ctx, minion)
 }
 
+func (r *HealthyRegistry) UpdateMinion(ctx api.Context, minion *api.Minion) error {
+	return r.delegate.UpdateMinion(ctx, minion)
+}
+
 func (r *HealthyRegistry) ListMinions(ctx api.Context) (currentMinions *api.MinionList, err error) {
 	result := &api.MinionList{}
 	list, err := r.delegate.ListMinions(ctx)

--- a/pkg/registry/minion/registry.go
+++ b/pkg/registry/minion/registry.go
@@ -22,6 +22,7 @@ import "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 type Registry interface {
 	ListMinions(ctx api.Context) (*api.MinionList, error)
 	CreateMinion(ctx api.Context, minion *api.Minion) error
+	UpdateMinion(ctx api.Context, minion *api.Minion) error
 	GetMinion(ctx api.Context, minionID string) (*api.Minion, error)
 	DeleteMinion(ctx api.Context, minionID string) error
 }

--- a/pkg/registry/minion/rest.go
+++ b/pkg/registry/minion/rest.go
@@ -105,16 +105,22 @@ func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan apiserver.RE
 	if !ok {
 		return nil, fmt.Errorf("not a minion: %#v", obj)
 	}
-	if errs := validation.ValidateMinion(minion); len(errs) > 0 {
+
+	// TODO: GetMinion will health check the minion, but we shouldn't require the minion to be
+	// running for updating labels.
+	oldMinion, err := rs.registry.GetMinion(ctx, minion.Name)
+	if err != nil {
+		return nil, err
+	}
+	if errs := validation.ValidateMinionUpdate(oldMinion, minion); len(errs) > 0 {
 		return nil, kerrors.NewInvalid("minion", minion.Name, errs)
 	}
+
 	return apiserver.MakeAsync(func() (runtime.Object, error) {
 		err := rs.registry.UpdateMinion(ctx, minion)
 		if err != nil {
 			return nil, err
 		}
-		// TODO: GetMinion will health check the minion, but we shouldn't require the minion to be
-		// running for updating labels.
 		return rs.registry.GetMinion(ctx, minion.Name)
 	}), nil
 }

--- a/pkg/registry/registrytest/minion.go
+++ b/pkg/registry/registrytest/minion.go
@@ -60,6 +60,18 @@ func (r *MinionRegistry) CreateMinion(ctx api.Context, minion *api.Minion) error
 	return r.Err
 }
 
+func (r *MinionRegistry) UpdateMinion(ctx api.Context, minion *api.Minion) error {
+	r.Lock()
+	defer r.Unlock()
+	for i, node := range r.Minions.Items {
+		if node.Name == minion.Name {
+			r.Minions.Items[i] = *minion
+			return r.Err
+		}
+	}
+	return r.Err
+}
+
 func (r *MinionRegistry) GetMinion(ctx api.Context, minionID string) (*api.Minion, error) {
 	r.Lock()
 	defer r.Unlock()

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -306,7 +306,7 @@ func getTestRequests() []struct {
 		// Normal methods on minions
 		{"GET", "/api/v1beta1/minions", "", code200},
 		{"POST", "/api/v1beta1/minions" + syncFlags, aMinion, code200},
-		{"PUT", "/api/v1beta1/minions/a" + syncFlags, aMinion, code500}, // See #2114 about why 500
+		{"PUT", "/api/v1beta1/minions/a" + syncFlags, aMinion, code409}, // See #2115 about why 409
 		{"GET", "/api/v1beta1/minions", "", code200},
 		{"GET", "/api/v1beta1/minions/a", "", code200},
 		{"DELETE", "/api/v1beta1/minions/a" + syncFlags, "", code200},

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -306,7 +306,7 @@ func getTestRequests() []struct {
 		// Normal methods on minions
 		{"GET", "/api/v1beta1/minions", "", code200},
 		{"POST", "/api/v1beta1/minions" + syncFlags, aMinion, code200},
-		{"PUT", "/api/v1beta1/minions/a" + syncFlags, aMinion, code409}, // See #2115 about why 409
+		{"PUT", "/api/v1beta1/minions/a" + syncFlags, aMinion, code422}, // TODO: GET and put back server-provided fields to avoid a 422
 		{"GET", "/api/v1beta1/minions", "", code200},
 		{"GET", "/api/v1beta1/minions/a", "", code200},
 		{"DELETE", "/api/v1beta1/minions/a" + syncFlags, "", code200},


### PR DESCRIPTION
This PR is a basic support for node label update.  @brendanburns In case of label change, do we trigger a reschedule of current pods on updated node?  It's possible for the label change to break schedule predicate.  

@derekwaynecarr What is the status of node namespace.  Our api takes context obj, but I didn't see how it is used in k8s.  Are we going to only use default for node?   kubectl will check for namespace when updating, I'm not sure what namespace we'd use for node update.
