### PR TITLE
Fix for issue #2400 : GCE kube-up.sh script fails to start monitoring 

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -606,8 +606,8 @@ function setup-monitoring {
 
 	# Re-use master auth for Grafana
 	get-password
-	sed -i "s/HTTP_USER, \"value\": \"[^\"]*\"/HTTP_USER, \"value\": \"$KUBE_USER\"/g" "${KUBE_ROOT}/examples/monitoring/influx-grafana-pod.json"
-	sed -i "s/HTTP_PASS, \"value\": \"[^\"]*\"/HTTP_PASS, \"value\": \"$KUBE_PASSWORD\"/g" "${KUBE_ROOT}/examples/monitoring/influx-grafana-pod.json"
+	sed -i '' "s/HTTP_USER, \"value\": \"[^\"]*\"/HTTP_USER, \"value\": \"$KUBE_USER\"/g" "${KUBE_ROOT}/examples/monitoring/influx-grafana-pod.json"
+	sed -i '' "s/HTTP_PASS, \"value\": \"[^\"]*\"/HTTP_PASS, \"value\": \"$KUBE_PASSWORD\"/g" "${KUBE_ROOT}/examples/monitoring/influx-grafana-pod.json"
         local kubectl=${KUBE_ROOT}/cluster/kubectl.sh
 	if "${kubectl}" create -f "${KUBE_ROOT}/examples/monitoring/influx-grafana-pod.json" &> /dev/null \
 	    && "${kubectl}" create -f "${KUBE_ROOT}/examples/monitoring/influx-grafana-service.json" &> /dev/null \


### PR DESCRIPTION
Fix a little typo so 'sed' command works.  Using empty backup extension since the intention seems to be that it isn't needed.
