### PR TITLE
Fix download link in aws/kubecfg documentation

### DIFF
--- a/docs/getting-started-guides/aws/kubecfg.md
+++ b/docs/getting-started-guides/aws/kubecfg.md
@@ -11,7 +11,7 @@ wget http://storage.googleapis.com/k8s/darwin/kubecfg
 ### Linux
 
 ```
-wget http://storage.googleapis.com/k8s/darwin/kubecfg
+wget http://storage.googleapis.com/k8s/linux/kubecfg
 ```
 
 ### Copy kubecfg to your path


### PR DESCRIPTION
Kubecfg's download link on Darwin and Linux are points to http://storage.googleapis.com/k8s/darwin/kubecfg .
Later one should be changed to http://storage.googleapis.com/k8s/linux/kubecfg .
