### PR TITLE
Chmod the right file in cluster/vagrant/util.sh

### DIFF
--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -62,7 +62,7 @@ function kube-up {
 }
 EOF
 
-   chmod 0600 ~/.kubernetes_auth "${HOME}/${kube_cert}" \
+   chmod 0600 ~/.kubernetes_vagrant_auth "${HOME}/${kube_cert}" \
      "${HOME}/${kube_key}" "${HOME}/${ca_cert}"
   )
 


### PR DESCRIPTION
Most of platforms use ~/.kubernetes_auth, but Vagrant is different.
This commit fixes one instance where a setup script did not take this
difference into account.

One might argue that this file name should be specified as a variable.
I decided it against making that change in this CL in order to keep it
very simple.
