### PR TITLE
Ensure that kubectl get works with downstream resources

### DIFF
--- a/pkg/conversion/decode.go
+++ b/pkg/conversion/decode.go
@@ -36,6 +36,9 @@ func (s *Scheme) Decode(data []byte) (interface{}, error) {
 	if version == "" && s.InternalVersion != "" {
 		return nil, fmt.Errorf("version not set in '%s'", string(data))
 	}
+	if kind == "" {
+		return nil, fmt.Errorf("kind not set in '%s'", string(data))
+	}
 	obj, err := s.NewObject(version, kind)
 	if err != nil {
 		return nil, err

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	. "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+	"github.com/spf13/cobra"
+)
+
+type internalType struct {
+	Kind       string
+	APIVersion string
+
+	Name string
+}
+
+type externalType struct {
+	Kind       string `json:"kind"`
+	APIVersion string `json:"apiVersion"`
+
+	Name string `json:"name"`
+}
+
+func (*internalType) IsAnAPIObject() {}
+func (*externalType) IsAnAPIObject() {}
+
+func newExternalScheme() (*runtime.Scheme, meta.RESTMapper, runtime.Codec) {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName("", "Type", &internalType{})
+	scheme.AddKnownTypeWithName("unlikelyversion", "Type", &externalType{})
+
+	codec := runtime.CodecFor(scheme, "unlikelyversion")
+	mapper := meta.NewDefaultRESTMapper([]string{"unlikelyversion"}, func(version string) (*meta.VersionInterfaces, bool) {
+		return &meta.VersionInterfaces{
+			Codec:            codec,
+			ObjectConvertor:  scheme,
+			MetadataAccessor: meta.NewAccessor(),
+		}, (version == "unlikelyversion")
+	})
+	mapper.Add(scheme, false, "unlikelyversion")
+
+	return scheme, mapper, codec
+}
+
+type testPrinter struct {
+	Obj runtime.Object
+	Err error
+}
+
+func (t *testPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
+	t.Obj = obj
+	fmt.Fprintf(out, "%#v", obj)
+	return t.Err
+}
+
+type testDescriber struct {
+	Name, Namespace string
+	Output          string
+	Err             error
+}
+
+func (t *testDescriber) Describe(namespace, name string) (output string, err error) {
+	t.Namespace, t.Name = namespace, name
+	return t.Output, t.Err
+}
+
+type testFactory struct {
+	Client    kubectl.RESTClient
+	Describer kubectl.Describer
+	Printer   kubectl.ResourcePrinter
+	Err       error
+}
+
+func NewTestFactory() (*Factory, *testFactory, runtime.Codec) {
+	scheme, mapper, codec := newExternalScheme()
+	t := &testFactory{}
+	return &Factory{
+		Mapper: mapper,
+		Typer:  scheme,
+		Client: func(*cobra.Command, *meta.RESTMapping) (kubectl.RESTClient, error) {
+			return t.Client, t.Err
+		},
+		Describer: func(*cobra.Command, *meta.RESTMapping) (kubectl.Describer, error) {
+			return t.Describer, t.Err
+		},
+		Printer: func(cmd *cobra.Command, mapping *meta.RESTMapping, noHeaders bool) (kubectl.ResourcePrinter, error) {
+			return t.Printer, t.Err
+		},
+	}, t, codec
+}
+
+func objBody(codec runtime.Codec, obj runtime.Object) io.ReadCloser {
+	return ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(codec, obj))))
+}

--- a/pkg/kubectl/cmd/describe_test.go
+++ b/pkg/kubectl/cmd/describe_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd_test
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+)
+
+// Verifies that schemas that are not in the master tree of Kubernetes can be retrieved via Get.
+func TestDescribeUnknownSchemaObject(t *testing.T) {
+	d := &testDescriber{Output: "test output"}
+	f, tf, codec := NewTestFactory()
+	tf.Describer = d
+	tf.Client = &client.FakeRESTClient{
+		Codec: codec,
+		Resp:  &http.Response{StatusCode: 200, Body: objBody(codec, &internalType{Name: "foo"})},
+	}
+	buf := bytes.NewBuffer([]byte{})
+
+	cmd := f.NewCmdDescribe(buf)
+	cmd.Flags().String("namespace", "test", "")
+	cmd.Run(cmd, []string{"type", "foo"})
+
+	if d.Name != "foo" || d.Namespace != "test" {
+		t.Errorf("unexpected describer: %#v", d)
+	}
+
+	if buf.String() != fmt.Sprintf("%s\n", d.Output) {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
+}

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd_test
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+)
+
+// Verifies that schemas that are not in the master tree of Kubernetes can be retrieved via Get.
+func TestGetUnknownSchemaObject(t *testing.T) {
+	f, tf, codec := NewTestFactory()
+	tf.Printer = &testPrinter{}
+	tf.Client = &client.FakeRESTClient{
+		Codec: codec,
+		Resp:  &http.Response{StatusCode: 200, Body: objBody(codec, &internalType{Name: "foo"})},
+	}
+	buf := bytes.NewBuffer([]byte{})
+
+	cmd := f.NewCmdGet(buf)
+	cmd.Flags().String("namespace", "test", "")
+	cmd.Run(cmd, []string{"type", "foo"})
+
+	expected := &internalType{Name: "foo"}
+	actual := tf.Printer.(*testPrinter).Obj
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("unexpected object: %#v", actual)
+	}
+	if buf.String() != fmt.Sprintf("%#v", expected) {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
+}

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -28,40 +28,40 @@ import (
 	"text/template"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/golang/glog"
 	"gopkg.in/v1/yaml"
 )
 
-// GetPrinter returns a resource printer and a bool indicating whether the object must be
-// versioned for the given format.
-func GetPrinter(version, format, templateFile string, defaultPrinter ResourcePrinter) (ResourcePrinter, error) {
+// GetPrinter takes a format type, an optional format argument, a version and a convertor
+// to be used if the underlying printer requires the object to be in a specific schema (
+// any of the generic formatters), and the default printer to use for this object.
+func GetPrinter(format, formatArgument, version string, convertor runtime.ObjectConvertor, defaultPrinter ResourcePrinter) (ResourcePrinter, error) {
 	var printer ResourcePrinter
 	switch format {
 	case "json":
-		printer = &JSONPrinter{version}
+		printer = &JSONPrinter{version, convertor}
 	case "yaml":
-		printer = &YAMLPrinter{version}
+		printer = &YAMLPrinter{version, convertor}
 	case "template":
-		if len(templateFile) == 0 {
+		if len(formatArgument) == 0 {
 			return nil, fmt.Errorf("template format specified but no template given")
 		}
 		var err error
-		printer, err = NewTemplatePrinter(version, []byte(templateFile))
+		printer, err = NewTemplatePrinter([]byte(formatArgument), version, convertor)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing template %s, %v\n", templateFile, err)
+			return nil, fmt.Errorf("error parsing template %s, %v\n", formatArgument, err)
 		}
 	case "templatefile":
-		if len(templateFile) == 0 {
+		if len(formatArgument) == 0 {
 			return nil, fmt.Errorf("templatefile format specified but no template file given")
 		}
-		data, err := ioutil.ReadFile(templateFile)
+		data, err := ioutil.ReadFile(formatArgument)
 		if err != nil {
-			return nil, fmt.Errorf("error reading template %s, %v\n", templateFile, err)
+			return nil, fmt.Errorf("error reading template %s, %v\n", formatArgument, err)
 		}
-		printer, err = NewTemplatePrinter(version, data)
+		printer, err = NewTemplatePrinter(data, version, convertor)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing template %s, %v\n", string(data), err)
 		}
@@ -73,28 +73,27 @@ func GetPrinter(version, format, templateFile string, defaultPrinter ResourcePri
 	return printer, nil
 }
 
-// ResourcePrinter is an interface that knows how to print API resources.
+// ResourcePrinter is an interface that knows how to print runtime objects.
 type ResourcePrinter interface {
 	// Print receives an arbitrary object, formats it and prints it to a writer.
 	PrintObj(runtime.Object, io.Writer) error
-
-	// Returns true if this printer emits properly versioned output.
-	IsVersioned() bool
 }
 
-// JSONPrinter is an implementation of ResourcePrinter which prints as JSON.
+// JSONPrinter is an implementation of ResourcePrinter which outputs an object as JSON.
+// The input object is assumed to be in the internal version of an API and is converted
+// to the given version first.
 type JSONPrinter struct {
-	version string
+	version   string
+	convertor runtime.ObjectConvertor
 }
 
 // PrintObj is an implementation of ResourcePrinter.PrintObj which simply writes the object to the Writer.
-func (j *JSONPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
-	vi, err := latest.InterfacesFor(j.version)
+func (p *JSONPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	outObj, err := p.convertor.ConvertToVersion(obj, p.version)
 	if err != nil {
 		return err
 	}
-
-	data, err := vi.Codec.Encode(obj)
+	data, err := json.Marshal(outObj)
 	if err != nil {
 		return err
 	}
@@ -105,39 +104,20 @@ func (j *JSONPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	return err
 }
 
-// IsVersioned returns true.
-func (*JSONPrinter) IsVersioned() bool { return true }
-
-func toVersionedMap(version string, obj runtime.Object) (map[string]interface{}, error) {
-	vi, err := latest.InterfacesFor(version)
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := vi.Codec.Encode(obj)
-	if err != nil {
-		return nil, err
-	}
-	outObj := map[string]interface{}{}
-	err = json.Unmarshal(data, &outObj)
-	if err != nil {
-		return nil, err
-	}
-	return outObj, nil
-}
-
-// YAMLPrinter is an implementation of ResourcePrinter which prints as YAML.
+// YAMLPrinter is an implementation of ResourcePrinter which outputs an object as YAML.
+// The input object is assumed to be in the internal version of an API and is converted
+// to the given version first.
 type YAMLPrinter struct {
-	version string
+	version   string
+	convertor runtime.ObjectConvertor
 }
 
 // PrintObj prints the data as YAML.
-func (y *YAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
-	outObj, err := toVersionedMap(y.version, obj)
+func (p *YAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	outObj, err := p.convertor.ConvertToVersion(obj, p.version)
 	if err != nil {
 		return err
 	}
-
 	output, err := yaml.Marshal(outObj)
 	if err != nil {
 		return err
@@ -145,9 +125,6 @@ func (y *YAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	_, err = fmt.Fprint(w, string(output))
 	return err
 }
-
-// IsVersioned returns true.
-func (*YAMLPrinter) IsVersioned() bool { return true }
 
 type handlerEntry struct {
 	columns   []string
@@ -163,9 +140,6 @@ type HumanReadablePrinter struct {
 	noHeaders  bool
 	lastType   reflect.Type
 }
-
-// IsVersioned returns false-- human readable printers do not make versioned output.
-func (*HumanReadablePrinter) IsVersioned() bool { return false }
 
 // NewHumanReadablePrinter creates a HumanReadablePrinter.
 func NewHumanReadablePrinter(noHeaders bool) *HumanReadablePrinter {
@@ -387,28 +361,34 @@ func (h *HumanReadablePrinter) PrintObj(obj runtime.Object, output io.Writer) er
 
 // TemplatePrinter is an implementation of ResourcePrinter which formats data with a Go Template.
 type TemplatePrinter struct {
-	version  string
-	template *template.Template
+	template  *template.Template
+	version   string
+	convertor runtime.ObjectConvertor
 }
 
-func NewTemplatePrinter(version string, tmpl []byte) (*TemplatePrinter, error) {
+func NewTemplatePrinter(tmpl []byte, asVersion string, convertor runtime.ObjectConvertor) (*TemplatePrinter, error) {
 	t, err := template.New("output").Parse(string(tmpl))
 	if err != nil {
 		return nil, err
 	}
-	return &TemplatePrinter{version, t}, nil
+	return &TemplatePrinter{t, asVersion, convertor}, nil
 }
 
-// IsVersioned returns true.
-func (*TemplatePrinter) IsVersioned() bool { return true }
-
 // PrintObj formats the obj with the Go Template.
-func (t *TemplatePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
-	outObj, err := toVersionedMap(t.version, obj)
+func (p *TemplatePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	outObj, err := p.convertor.ConvertToVersion(obj, p.version)
 	if err != nil {
 		return err
 	}
-	return t.template.Execute(w, outObj)
+	data, err := json.Marshal(outObj)
+	if err != nil {
+		return err
+	}
+	out := map[string]interface{}{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	return p.template.Execute(w, out)
 }
 
 func tabbedString(f func(io.Writer) error) (string, error) {

--- a/pkg/kubectl/resthelper_test.go
+++ b/pkg/kubectl/resthelper_test.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -33,39 +32,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
-
-type httpClientFunc func(*http.Request) (*http.Response, error)
-
-func (f httpClientFunc) Do(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
-
-type FakeRESTClient struct {
-	Client client.HTTPClient
-	Req    *http.Request
-	Resp   *http.Response
-	Err    error
-}
-
-func (c *FakeRESTClient) Get() *client.Request {
-	return client.NewRequest(c, "GET", &url.URL{Host: "localhost"}, testapi.Codec())
-}
-func (c *FakeRESTClient) Put() *client.Request {
-	return client.NewRequest(c, "PUT", &url.URL{Host: "localhost"}, testapi.Codec())
-}
-func (c *FakeRESTClient) Post() *client.Request {
-	return client.NewRequest(c, "POST", &url.URL{Host: "localhost"}, testapi.Codec())
-}
-func (c *FakeRESTClient) Delete() *client.Request {
-	return client.NewRequest(c, "DELETE", &url.URL{Host: "localhost"}, testapi.Codec())
-}
-func (c *FakeRESTClient) Do(req *http.Request) (*http.Response, error) {
-	c.Req = req
-	if c.Client != client.HTTPClient(nil) {
-		return c.Client.Do(req)
-	}
-	return c.Resp, c.Err
-}
 
 func objBody(obj runtime.Object) io.ReadCloser {
 	return ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(testapi.Codec(), obj))))
@@ -112,9 +78,10 @@ func TestRESTHelperDelete(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		client := &FakeRESTClient{
-			Resp: test.Resp,
-			Err:  test.HttpErr,
+		client := &client.FakeRESTClient{
+			Codec: testapi.Codec(),
+			Resp:  test.Resp,
+			Err:   test.HttpErr,
 		}
 		modifier := &RESTHelper{
 			RESTClient: client,
@@ -147,7 +114,7 @@ func TestRESTHelperCreate(t *testing.T) {
 
 	tests := []struct {
 		Resp     *http.Response
-		RespFunc httpClientFunc
+		RespFunc client.HttpClientFunc
 		HttpErr  error
 		Modify   bool
 		Object   runtime.Object
@@ -192,9 +159,10 @@ func TestRESTHelperCreate(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		client := &FakeRESTClient{
-			Resp: test.Resp,
-			Err:  test.HttpErr,
+		client := &client.FakeRESTClient{
+			Codec: testapi.Codec(),
+			Resp:  test.Resp,
+			Err:   test.HttpErr,
 		}
 		if test.RespFunc != nil {
 			client.Client = test.RespFunc
@@ -275,9 +243,10 @@ func TestRESTHelperGet(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		client := &FakeRESTClient{
-			Resp: test.Resp,
-			Err:  test.HttpErr,
+		client := &client.FakeRESTClient{
+			Codec: testapi.Codec(),
+			Resp:  test.Resp,
+			Err:   test.HttpErr,
 		}
 		modifier := &RESTHelper{
 			RESTClient: client,
@@ -317,7 +286,7 @@ func TestRESTHelperUpdate(t *testing.T) {
 
 	tests := []struct {
 		Resp      *http.Response
-		RespFunc  httpClientFunc
+		RespFunc  client.HttpClientFunc
 		HttpErr   error
 		Overwrite bool
 		Object    runtime.Object
@@ -368,9 +337,10 @@ func TestRESTHelperUpdate(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		client := &FakeRESTClient{
-			Resp: test.Resp,
-			Err:  test.HttpErr,
+		client := &client.FakeRESTClient{
+			Codec: testapi.Codec(),
+			Resp:  test.Resp,
+			Err:   test.HttpErr,
 		}
 		if test.RespFunc != nil {
 			client.Client = test.RespFunc


### PR DESCRIPTION
Commit a198a62 introduced a dependency linking the Kube API versions to the implementation
of watching resources used in kubectl.  This removes that dependency and allows conversion
to be handled by the ObjectConvertor defined in the kubectl factory.

@lavalamp review please
