### PR TITLE
Make master take authenticator.Request interface instead of tokenfile

### DIFF
--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -150,6 +150,11 @@ func main() {
 
 	n := net.IPNet(portalNet)
 
+	authenticator, err := apiserver.NewAuthenticatorFromTokenFile(*tokenAuthFile)
+	if err != nil {
+		glog.Fatalf("Invalid Authentication Config: %v", err)
+	}
+
 	authorizer, err := apiserver.NewAuthorizerFromAuthorizationConfig(*authorizationMode, *authorizationPolicyFile)
 	if err != nil {
 		glog.Fatalf("Invalid Authorization Config: %v", err)
@@ -167,10 +172,10 @@ func main() {
 		EnableUISupport:       true,
 		APIPrefix:             *apiPrefix,
 		CorsAllowedOriginList: corsAllowedOriginList,
-		TokenAuthFile:         *tokenAuthFile,
 		ReadOnlyPort:          *readOnlyPort,
 		ReadWritePort:         *port,
 		PublicAddress:         *publicAddressOverride,
+		Authenticator:         authenticator,
 		Authorizer:            authorizer,
 	}
 	m := master.New(config)

--- a/pkg/apiserver/authn.go
+++ b/pkg/apiserver/authn.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/authenticator"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/authenticator/bearertoken"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/auth/authenticator/token/tokenfile"
+)
+
+// NewAuthenticatorFromTokenFile returns an authenticator.Request or an error
+func NewAuthenticatorFromTokenFile(tokenAuthFile string) (authenticator.Request, error) {
+	var authenticator authenticator.Request
+	if len(tokenAuthFile) != 0 {
+		tokenAuthenticator, err := tokenfile.NewCSV(tokenAuthFile)
+		if err != nil {
+			return nil, err
+		}
+		authenticator = bearertoken.New(tokenAuthenticator)
+	}
+	return authenticator, nil
+}

--- a/plugin/pkg/auth/authenticator/token/tokenfile/tokenfile.go
+++ b/plugin/pkg/auth/authenticator/token/tokenfile/tokenfile.go
@@ -29,7 +29,9 @@ type TokenAuthenticator struct {
 	tokens map[string]*user.DefaultInfo
 }
 
-func New(path string) (*TokenAuthenticator, error) {
+// NewCSV returns a TokenAuthenticator, populated from a CSV file.
+// The CSV file must contain records in the format "token,username,useruid"
+func NewCSV(path string) (*TokenAuthenticator, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err

--- a/plugin/pkg/auth/authenticator/token/tokenfile/tokenfile_test.go
+++ b/plugin/pkg/auth/authenticator/token/tokenfile/tokenfile_test.go
@@ -109,5 +109,5 @@ func newWithContents(t *testing.T, contents string) (auth *TokenAuthenticator, e
 		t.Fatalf("unexpected error writing tokenfile: %v", err)
 	}
 
-	return New(f.Name())
+	return NewCSV(f.Name())
 }

--- a/plugin/pkg/auth/authenticator/token/tokentest/tokentest.go
+++ b/plugin/pkg/auth/authenticator/token/tokentest/tokentest.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokentest
+
+import "github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
+
+type TokenAuthenticator struct {
+	Tokens map[string]*user.DefaultInfo
+}
+
+func New() *TokenAuthenticator {
+	return &TokenAuthenticator{
+		Tokens: make(map[string]*user.DefaultInfo),
+	}
+}
+func (a *TokenAuthenticator) AuthenticateToken(value string) (user.Info, bool, error) {
+	user, ok := a.Tokens[value]
+	if !ok {
+		return nil, false, nil
+	}
+	return user, true, nil
+}


### PR DESCRIPTION
This is a simpler first step to pluggable auth (token or otherwise). Moved the tokenfile implementation to plugins/pkg/auth/authenticator/token
