### PR TITLE
fix kubectl log completion

### DIFF
--- a/contrib/completions/bash/kubectl
+++ b/contrib/completions/bash/kubectl
@@ -53,7 +53,7 @@ __kubectl_parse_get()
 __kubectl_get_containers()
 {
     local template
-    template="{{ range .DesiredState.Manifest.Containers  }}{{ .Name }} {{ end }}"
+    template="{{ range .desiredState.manifest.containers  }}{{ .name }} {{ end }}"
 
     local kubectl_out
     if kubectl_out=$(kubectl get -o template --template="${template}" pods "$1" 2>/dev/null); then


### PR DESCRIPTION
When kubectl started returning the right object it changed the template
that needed to be used to get the name of the containers inside the pod.
