### PR TITLE
Improve kubectl "get" error message

### DIFF
--- a/pkg/kubectl/cmd/resource.go
+++ b/pkg/kubectl/cmd/resource.go
@@ -44,7 +44,10 @@ func ResourceFromArgsOrFile(cmd *cobra.Command, args []string, filename string, 
 		}
 
 		version, kind, err := mapper.VersionAndKindForResource(resource)
-		checkErr(err)
+		if err != nil {
+			// The error returned by mapper is "no resource defined", which is a usage error
+			usageError(cmd, err.Error())
+		}
 
 		mapping, err = mapper.RESTMapping(version, kind)
 		checkErr(err)


### PR DESCRIPTION
Previous behavior:
$ kubectl get hosts
F1119 11:47:44.787154   29017 resource.go:111] no resource "hosts" has been defined
