### PR TITLE
Do not log an error when file does not exist

### DIFF
--- a/pkg/credentialprovider/config.go
+++ b/pkg/credentialprovider/config.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -53,6 +54,9 @@ func ReadDockerConfigFile() (cfg DockerConfig, err error) {
 	absDockerConfigFileLocation, err = filepath.Abs(dockerConfigFileLocation)
 	glog.V(2).Infof("looking for .dockercfg at %s", absDockerConfigFileLocation)
 	contents, err := ioutil.ReadFile(absDockerConfigFileLocation)
+	if os.IsNotExist(err) {
+		return make(DockerConfig), nil
+	}
 	if err != nil {
 		glog.Errorf("while trying to read %s: %v", absDockerConfigFileLocation, err)
 		return nil, err


### PR DESCRIPTION
Docker credentials do not have to be present, so ignore path not found errors
when trying to load them.
