### PR TITLE
Fix vagrant regression

### DIFF
--- a/cluster/saltbase/pillar/mine.sls
+++ b/cluster/saltbase/pillar/mine.sls
@@ -1,4 +1,8 @@
 # Allow everyone to see cached values of who sits at what IP
+{% set networkInterfaceName = "eth0" %}
+{% if grains.networkInterfaceName is defined %}
+  {% set networkInterfaceName = grains.networkInterfaceName %}
+{% endif %}
 mine_functions:
-  network.ip_addrs: [eth0]
+  network.ip_addrs: [{{networkInterfaceName}}]
   grains.items: []

--- a/cluster/saltbase/salt/kube-apiserver/default
+++ b/cluster/saltbase/salt/kube-apiserver/default
@@ -10,6 +10,12 @@
 
 {% set address = "-address=127.0.0.1" %}
 
+{% set publicAddressOverride = "" %}
+{% if grains.publicAddressOverride is defined %}
+  {% set publicAddressOverride = "-public_address_override=" + grains.publicAddressOverride %}
+{% endif %}
+
+
 {% if grains.etcd_servers is defined %}
   {% set etcd_servers = "-etcd_servers=http://" + grains.etcd_servers + ":4001" %}
 {% else %}
@@ -40,4 +46,4 @@
 {% endif %}
 {% endif %}
 
-DAEMON_ARGS="{{daemon_args}} {{address}} {{etcd_servers}} {{ cloud_provider }} --allow_privileged={{pillar['allow_privileged']}} {{portal_net}} {{cert_file}} {{key_file}} {{secure_port}} {{token_auth_file}}"
+DAEMON_ARGS="{{daemon_args}} {{address}} {{etcd_servers}} {{ cloud_provider }} --allow_privileged={{pillar['allow_privileged']}} {{portal_net}} {{cert_file}} {{key_file}} {{secure_port}} {{token_auth_file}} {{publicAddressOverride}}"

--- a/cluster/saltbase/salt/kubelet/init.sls
+++ b/cluster/saltbase/salt/kubelet/init.sls
@@ -38,6 +38,8 @@
 
 {% endif %}
 
+{% if grains.cloud is defined %}
+{% if grains.cloud == 'gce' %}
 # Kubelet will run without this file but will not be able to send events to the apiserver.
 /var/lib/kubelet/kubernetes_auth:
   file.managed:
@@ -45,6 +47,8 @@
     - user: root
     - group: root
     - mode: 400
+{% endif %}
+{% endif %}
 
 kubelet:
   group.present:
@@ -65,5 +69,9 @@ kubelet:
 {% if grains['os_family'] != 'RedHat' %}
       - file: /etc/init.d/kubelet
 {% endif %}
+{% if grains.cloud is defined %}
+{% if grains.cloud == 'gce' %}
       - file: /var/lib/kubelet/kubernetes_auth
+{% endif %}
+{% endif %}
 

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -68,7 +68,9 @@ cat <<EOF >/etc/salt/minion.d/grains.conf
 grains:
   node_ip: $MASTER_IP
   master_ip: $MASTER_IP
+  publicAddressOverride: $MASTER_IP
   network_mode: openvswitch
+  networkInterfaceName: eth1
   etcd_servers: $MASTER_IP
   cloud: vagrant
   cloud_provider: vagrant

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -48,6 +48,8 @@ grains:
   network_mode: openvswitch
   node_ip: $MINION_IP
   etcd_servers: $MASTER_IP
+  networkInterfaceName: eth1
+  apiservers: $MASTER_IP
   roles:
     - kubernetes-pool
     - kubernetes-pool-vagrant

--- a/docs/salt.md
+++ b/docs/salt.md
@@ -51,6 +51,7 @@ The following enumerates the set of defined key/value pairs that are supported t
 
 Key | Value
 ------------- | -------------
+`apiservers` | (Optional) The IP address / host name where a kubelet can get read-only access to kube-apiserver
 `cbr-cidr` | (Optional) The minion IP address range used for the docker container bridge.
 `cloud` | (Optional) Which IaaS platform is used to host kubernetes, *gce*, *azure*, *aws*, *vagrant*
 `cloud_provider` | (Optional) The cloud_provider used by apiserver: *gce*, *azure*, *vagrant*
@@ -60,6 +61,8 @@ Key | Value
 `node_ip` | (Optional) The IP address to use to address this node
 `minion_ip` | (Optional) Mapped to the kubelet hostname_override, K8S TODO - change this name
 `network_mode` | (Optional) Networking model to use among nodes: *openvswitch*
+`networkInterfaceName` | (Optional) Networking interface to use to bind addresses, default value *etho0*
+`publicAddressOverride` | (Optional) The IP address the kube-apiserver should use to bind against for external read-only access
 `roles` | (Required) 1. `kubernetes-master` means this machine is the master in the kubernetes cluster.  2. `kubernetes-pool` means this machine is a kubernetes-minion.  Depending on the role, the Salt scripts will provision different resources on the machine.
 
 These keys may be leveraged by the Salt sls files to branch behavior.


### PR DESCRIPTION
Fixes #2475 

There were a number of issues:
1. The kube-apiserver cannot pick the first interface it finds to set the address to listen to for public interaction, it must be the address that corresponds to eth1, which is $MASTER_IP, which is routable in the private cluster.
2. The kubelet would never previously start because a prereq to the service.running clause was the presence of the kubernetes_auth file which was not present outside of GCE.
3. The minion grains.conf needed a set entry for the address to use to contact the readonly API server against because ips[0][0] could not be used since according to the current mine.conf, it looks for eth0 which does not exist as an interface name on the vagrant setup.

We should do a future PR to make the network interface to use not hard-coded to eth0, but this gets around the issue using the other enumerated flags which are far more deterministic right now.
