### PR TITLE
WIP - a Per-Node controller

### DIFF
--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -30,6 +30,8 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
+	//FIXME: move minion to pkg.controller
+	//FIXME: rename these imports
 	minionControllerPkg "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/controller"
 	replicationControllerPkg "github.com/GoogleCloudPlatform/kubernetes/pkg/controller"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
@@ -96,6 +98,9 @@ func main() {
 
 	controllerManager := replicationControllerPkg.NewReplicationManager(kubeClient)
 	controllerManager.Run(10 * time.Second)
+
+	perNoderManager := replicationControllerPkg.NewPerNodeManager(kubeClient)
+	perNoderManager.Run(10 * time.Second)
 
 	cloud := cloudprovider.InitCloudProvider(*cloudProvider, *cloudConfigFile)
 	nodeResources := &api.NodeResources{

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -32,7 +32,8 @@ kube::etcd::start() {
 
   # Start etcd
   ETCD_DIR=$(mktemp -d -t test-etcd.XXXXXX)
-  etcd -name test -data-dir ${ETCD_DIR} -addr ${host}:${port} >/dev/null 2>/dev/null &
+  #etcd -name test -data-dir ${ETCD_DIR} -addr ${host}:${port} >/dev/null 2>/dev/null &
+  etcd >/dev/null 2>/dev/null &
   ETCD_PID=$!
 
   kube::util::wait_for_url "http://${host}:${port}/v2/keys/" "etcd: "

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -27,7 +27,7 @@ kube::util::wait_for_url() {
   local i
   for i in $(seq 1 $times); do
     local out
-    if out=$(curl -fs $url 2>/dev/null); then
+    if out=$(curl -s $url 2>/dev/null); then
       kube::log::status ${prefix}${out}
       return 0
     fi

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -29,6 +29,8 @@ func init() {
 		&Pod{},
 		&ReplicationControllerList{},
 		&ReplicationController{},
+		&PerNodeControllerList{},
+		&PerNodeController{},
 		&ServiceList{},
 		&Service{},
 		&MinionList{},
@@ -52,6 +54,8 @@ func (*Pod) IsAnAPIObject()                       {}
 func (*PodList) IsAnAPIObject()                   {}
 func (*ReplicationController) IsAnAPIObject()     {}
 func (*ReplicationControllerList) IsAnAPIObject() {}
+func (*PerNodeController) IsAnAPIObject()         {}
+func (*PerNodeControllerList) IsAnAPIObject()     {}
 func (*Service) IsAnAPIObject()                   {}
 func (*ServiceList) IsAnAPIObject()               {}
 func (*Endpoints) IsAnAPIObject()                 {}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -542,6 +542,59 @@ type ReplicationControllerList struct {
 	Items []ReplicationController `json:"items" yaml:"items"`
 }
 
+// PerNodeControllerSpec is the specification of a per-node pod controller.
+// As the internal representation of a per-node controller, it may have either
+// a TemplateRef or a Template set.
+type PerNodeControllerSpec struct {
+	//FIXME: how does it know whether it has already done a node or not?
+	//Maybe an automatic kubernetes.io/per-node-controller=uuid label?
+	// Selector is a label query over pods on each node that match this
+	// controller.
+	Selector map[string]string `json:"selector" yaml:"selector"`
+	//FIXME: need a node selector, too?
+
+	// TemplateRef is a reference to an object that describes the pod
+	// that will be created on each node. This reference is ignored if a
+	// Template is set.  Must be set before converting to a v1beta3 API
+	// object
+	TemplateRef *ObjectReference `json:"templateRef,omitempty" yaml:"templateRef,omitempty"`
+
+	// Template is the object that describes the pod that will be
+	// created on each node.  Internally, this takes precedence over a
+	// TemplateRef.  Must be set before converting to a v1beta1 or
+	// v1beta2 API object.
+	Template *PodTemplateSpec `json:"template,omitempty" yaml:"template,omitempty"`
+}
+
+// PerNodeControllerStatus represents the current status of a per-node
+// controller.
+type PerNodeControllerStatus struct {
+	// Replicas is the number of actual replicas.
+	//FIXME: not implemented properly?  Not meaningful?
+	Replicas int `json:"replicas" yaml:"replicas"`
+}
+
+// PerNodeController represents the configuration of a per-node controller.
+type PerNodeController struct {
+	TypeMeta   `json:",inline" yaml:",inline"`
+	ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	// Spec defines the desired behavior of this per-node controller.
+	Spec PerNodeControllerSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
+
+	// Status is the current status of this per-node controller. This data may be
+	// out of date by some window of time.
+	Status PerNodeControllerStatus `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+// PerNodeControllerList is a collection of replication controllers.
+type PerNodeControllerList struct {
+	TypeMeta `json:",inline" yaml:",inline"`
+	ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	Items []PerNodeController `json:"items" yaml:"items"`
+}
+
 // ServiceList holds a list of services.
 type ServiceList struct {
 	TypeMeta `json:",inline" yaml:",inline"`

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -307,6 +307,66 @@ func init() {
 			return nil
 		},
 
+		func(in *newer.PerNodeController, out *PerNodeController, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Labels, &out.Labels, 0); err != nil {
+				return err
+			}
+
+			if err := s.Convert(&in.Spec, &out.Spec, 0); err != nil {
+				return err
+			}
+			out.Status.Replicas = in.Status.Replicas
+			return nil
+		},
+		func(in *PerNodeController, out *newer.PerNodeController, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Labels, &out.Labels, 0); err != nil {
+				return err
+			}
+
+			if err := s.Convert(&in.Spec, &out.Spec, 0); err != nil {
+				return err
+			}
+			out.Status.Replicas = in.Status.Replicas
+			return nil
+		},
+
+		func(in *newer.PerNodeControllerSpec, out *PerNodeControllerSpec, s conversion.Scope) error {
+			if err := s.Convert(&in.Selector, &out.Selector, 0); err != nil {
+				return err
+			}
+			if in.TemplateRef != nil && in.Template == nil {
+				return errors.New("objects with a template ref cannot be converted to older objects, must populate template")
+			}
+			if in.Template != nil {
+				if err := s.Convert(in.Template, &out.Template, 0); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		func(in *PerNodeControllerSpec, out *newer.PerNodeControllerSpec, s conversion.Scope) error {
+			if err := s.Convert(&in.Selector, &out.Selector, 0); err != nil {
+				return err
+			}
+			out.Template = &newer.PodTemplateSpec{}
+			if err := s.Convert(&in.Template, out.Template, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+
 		func(in *newer.PodTemplateSpec, out *PodTemplate, s conversion.Scope) error {
 			if err := s.Convert(&in.Spec, &out.DesiredState.Manifest, 0); err != nil {
 				return err
@@ -628,6 +688,25 @@ func init() {
 			return s.Convert(&in.Items, &out.Items, 0)
 		},
 		func(in *ReplicationControllerList, out *newer.ReplicationControllerList, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
+				return err
+			}
+			return s.Convert(&in.Items, &out.Items, 0)
+		},
+
+		func(in *newer.PerNodeControllerList, out *PerNodeControllerList, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			return s.Convert(&in.Items, &out.Items, 0)
+		},
+		func(in *PerNodeControllerList, out *newer.PerNodeControllerList, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err
 			}

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -30,6 +30,8 @@ func init() {
 		&PodList{},
 		&ReplicationController{},
 		&ReplicationControllerList{},
+		&PerNodeController{},
+		&PerNodeControllerList{},
 		&Service{},
 		&ServiceList{},
 		&Endpoints{},
@@ -53,6 +55,8 @@ func (*Pod) IsAnAPIObject()                       {}
 func (*PodList) IsAnAPIObject()                   {}
 func (*ReplicationController) IsAnAPIObject()     {}
 func (*ReplicationControllerList) IsAnAPIObject() {}
+func (*PerNodeController) IsAnAPIObject()         {}
+func (*PerNodeControllerList) IsAnAPIObject()     {}
 func (*Service) IsAnAPIObject()                   {}
 func (*ServiceList) IsAnAPIObject()               {}
 func (*Endpoints) IsAnAPIObject()                 {}

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -438,6 +438,53 @@ type ReplicationController struct {
 	Labels       map[string]string          `json:"labels,omitempty" yaml:"labels,omitempty"`
 }
 
+// PerNodeControllerSpec is the specification of a per-node pod controller.
+// As the internal representation of a per-node controller, it may have either
+// a TemplateRef or a Template set.
+type PerNodeControllerSpec struct {
+	//FIXME: how does it know whether it has already done a node or not?
+	//Maybe an automatic kubernetes.io/per-node-controller=uuid label?
+	// Selector is a label query over pods on each node that match this
+	// controller.
+	Selector map[string]string `json:"selector" yaml:"selector"`
+	//FIXME: need a node selector, too?
+
+	// TemplateRef is a reference to an object that describes the pod
+	// that will be created on each node. This reference is ignored if a
+	// Template is set.  Must be set before converting to a v1beta3 API
+	// object
+	Template PodTemplate `json:"template,omitempty" yaml:"template,omitempty"`
+}
+
+// PerNodeControllerStatus represents the current status of a per-node
+// controller.
+type PerNodeControllerStatus struct {
+	// Replicas is the number of actual replicas.
+	//FIXME: not implemented properly?  Not meaningful?
+	Replicas int `json:"replicas" yaml:"replicas"`
+}
+
+// PerNodeController represents the configuration of a per-node controller.
+type PerNodeController struct {
+	TypeMeta `json:",inline" yaml:",inline"`
+
+	// Spec defines the desired behavior of this per-node controller.
+	Spec PerNodeControllerSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
+
+	// Status is the current status of this per-node controller. This data may be
+	// out of date by some window of time.
+	Status PerNodeControllerStatus `json:"status,omitempty" yaml:"status,omitempty"`
+
+	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+}
+
+// PerNodeControllerList is a collection of replication controllers.
+type PerNodeControllerList struct {
+	TypeMeta `json:",inline" yaml:",inline"`
+
+	Items []PerNodeController `json:"items" yaml:"items"`
+}
+
 // PodTemplate holds the information used for creating pods.
 type PodTemplate struct {
 	DesiredState PodState          `json:"desiredState,omitempty" yaml:"desiredState,omitempty"`

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -29,6 +29,7 @@ import (
 type Interface interface {
 	PodsNamespacer
 	ReplicationControllersNamespacer
+	PerNodeControllersNamespacer
 	ServicesNamespacer
 	EndpointsNamespacer
 	VersionInterface
@@ -38,6 +39,10 @@ type Interface interface {
 
 func (c *Client) ReplicationControllers(namespace string) ReplicationControllerInterface {
 	return newReplicationControllers(c, namespace)
+}
+
+func (c *Client) PerNodeControllers(namespace string) PerNodeControllerInterface {
+	return newPerNodeControllers(c, namespace)
 }
 
 func (c *Client) Minions() MinionInterface {

--- a/pkg/client/per_node_controllers.go
+++ b/pkg/client/per_node_controllers.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// PerNodeControllersNamespacer has methods to work with PerNodeController resources in a namespace
+type PerNodeControllersNamespacer interface {
+	PerNodeControllers(namespace string) PerNodeControllerInterface
+}
+
+// PerNodeControllerInterface has methods to work with PerNodeController resources.
+type PerNodeControllerInterface interface {
+	List(selector labels.Selector) (*api.PerNodeControllerList, error)
+	Get(name string) (*api.PerNodeController, error)
+	Create(ctrl *api.PerNodeController) (*api.PerNodeController, error)
+	Update(ctrl *api.PerNodeController) (*api.PerNodeController, error)
+	Delete(name string) error
+	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// perNodeControllers implements PerNodeControllersNamespacer interface
+type perNodeControllers struct {
+	r  *Client
+	ns string
+}
+
+// newPerNodeControllers returns a PodsClient
+func newPerNodeControllers(c *Client, namespace string) *perNodeControllers {
+	return &perNodeControllers{c, namespace}
+}
+
+// List takes a selector, and returns the list of per-node controllers that match that selector.
+func (c *perNodeControllers) List(selector labels.Selector) (result *api.PerNodeControllerList, err error) {
+	result = &api.PerNodeControllerList{}
+	err = c.r.Get().Namespace(c.ns).Path("perNodeControllers").SelectorParam("labels", selector).Do().Into(result)
+	return
+}
+
+// Get returns information about a particular per-node controller.
+func (c *perNodeControllers) Get(name string) (result *api.PerNodeController, err error) {
+	result = &api.PerNodeController{}
+	err = c.r.Get().Namespace(c.ns).Path("perNodeControllers").Path(name).Do().Into(result)
+	return
+}
+
+// Create creates a new per-node controller.
+func (c *perNodeControllers) Create(controller *api.PerNodeController) (result *api.PerNodeController, err error) {
+	result = &api.PerNodeController{}
+	err = c.r.Post().Namespace(c.ns).Path("perNodeControllers").Body(controller).Do().Into(result)
+	return
+}
+
+// Update updates an existing per-node controller.
+func (c *perNodeControllers) Update(controller *api.PerNodeController) (result *api.PerNodeController, err error) {
+	result = &api.PerNodeController{}
+	if len(controller.ResourceVersion) == 0 {
+		err = fmt.Errorf("invalid update object, missing resource version: %v", controller)
+		return
+	}
+	err = c.r.Put().Namespace(c.ns).Path("perNodeControllers").Path(controller.Name).Body(controller).Do().Into(result)
+	return
+}
+
+// Delete deletes an existing per-node controller.
+func (c *perNodeControllers) Delete(name string) error {
+	return c.r.Delete().Namespace(c.ns).Path("perNodeControllers").Path(name).Do().Error()
+}
+
+// Watch returns a watch.Interface that watches the requested controllers.
+func (c *perNodeControllers) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Namespace(c.ns).
+		Path("watch").
+		Path("perNodeControllers").
+		Param("resourceVersion", resourceVersion).
+		SelectorParam("labels", label).
+		SelectorParam("fields", field).
+		Watch()
+}

--- a/pkg/controller/common.go
+++ b/pkg/controller/common.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/golang/glog"
+)
+
+// PodController is an interface that knows how to add or delete pods
+// created as an interface to allow testing.
+type PodController interface {
+	// createPod creates new replicated pods according to the spec.
+	createPod(namespace string, template *api.PodTemplateSpec)
+	// deletePod deletes the pod identified by podID.
+	deletePod(namespace string, podID string) error
+}
+
+// RealPodControl is the default implementation of PodController.
+type RealPodControl struct {
+	kubeClient client.Interface
+}
+
+func (r RealPodControl) createPod(namespace string, template *api.PodTemplateSpec) {
+	desiredLabels := make(labels.Set)
+	for k, v := range template.Labels {
+		desiredLabels[k] = v
+	}
+	pod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Labels: desiredLabels,
+		},
+	}
+	if err := api.Scheme.Convert(&template.Spec, &pod.DesiredState.Manifest); err != nil {
+		glog.Errorf("Unable to convert pod template: %v", err)
+		return
+	}
+	if labels.Set(pod.Labels).AsSelector().Empty() {
+		glog.Errorf("Unable to create pod: no labels")
+		return
+	}
+	if _, err := r.kubeClient.Pods(namespace).Create(pod); err != nil {
+		glog.Errorf("Unable to create pod: %v", err)
+	}
+}
+
+func (r RealPodControl) deletePod(namespace, podID string) error {
+	return r.kubeClient.Pods(namespace).Delete(podID)
+}

--- a/pkg/controller/per_node_controller.go
+++ b/pkg/controller/per_node_controller.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/golang/glog"
+)
+
+// PerNodeManager is responsible for synchronizing PerNodeController objects stored
+// in the system with actual running pods.
+type PerNodeManager struct {
+	kubeClient client.Interface
+	podControl PodController
+	syncTime   <-chan time.Time
+
+	// To allow injection of syncPerNodeController for testing.
+	syncHandler func(controller api.PerNodeController) error
+}
+
+// NewPerNodeManager creates a new PerNodeManager.
+func NewPerNodeManager(kubeClient client.Interface) *PerNodeManager {
+	pnm := &PerNodeManager{
+		kubeClient: kubeClient,
+		podControl: RealPodControl{
+			kubeClient: kubeClient,
+		},
+	}
+	pnm.syncHandler = pnm.syncPerNodeController
+	return pnm
+}
+
+// Run begins watching and syncing.
+func (pnm *PerNodeManager) Run(period time.Duration) {
+	pnm.syncTime = time.Tick(period)
+	resourceVersion := ""
+	go util.Forever(func() { pnm.watchControllers(&resourceVersion) }, period)
+}
+
+// resourceVersion is a pointer to the resource version to use/update.
+func (pnm *PerNodeManager) watchControllers(resourceVersion *string) {
+	watching, err := pnm.kubeClient.PerNodeControllers(api.NamespaceAll).Watch(
+		labels.Everything(),
+		labels.Everything(),
+		*resourceVersion,
+	)
+	if err != nil {
+		glog.Errorf("Unexpected failure to watch: %v", err)
+		time.Sleep(5 * time.Second)
+		return
+	}
+	// TODO: We could watch minions too, and react when a new one joins.
+
+	for {
+		select {
+		case <-pnm.syncTime:
+			pnm.synchronize()
+		case event, open := <-watching.ResultChan():
+			if !open {
+				// watchChannel has been closed, or something else went
+				// wrong with our etcd watch call. Let the util.Forever()
+				// that called us call us again.
+				return
+			}
+			glog.V(4).Infof("Got watch: %#v", event)
+			rc, ok := event.Object.(*api.PerNodeController)
+			if !ok {
+				glog.Errorf("unexpected object: %#v", event.Object)
+				continue
+			}
+			// If we get disconnected, start where we left off.
+			*resourceVersion = rc.ResourceVersion
+			// Sync even if this is a deletion event, to ensure that we leave
+			// it in the desired state.
+			glog.V(4).Infof("About to sync from watch: %v", rc.Name)
+			if err := pnm.syncHandler(*rc); err != nil {
+				glog.Errorf("unexpected sync. error: %v", err)
+			}
+		}
+	}
+}
+
+func (pnm *PerNodeManager) syncPerNodeController(controller api.PerNodeController) error {
+	// Get the list of matching pods.
+	s := labels.Set(controller.Spec.Selector).AsSelector()
+	allPods, err := pnm.kubeClient.Pods(controller.Namespace).List(s)
+	if err != nil {
+		return err
+	}
+	pods := pnm.filterActivePods(allPods.Items)
+
+	// Get the list of minions.
+	nodes, err := pnm.kubeClient.Minions().List()
+	if err != nil {
+		return err
+	}
+
+	nodeMap := map[string][]*api.Pod{}
+	for i := range pods {
+		pod := &pods[i]
+		if nodeMap[pod.CurrentState.Host] == nil {
+			nodeMap[pod.CurrentState.Host] = []*api.Pod{}
+		}
+		nodeMap[pod.CurrentState.Host] = append(nodeMap[pod.CurrentState.Host], pod)
+	}
+	if len(nodes.Items) == len(pods) && len(nodeMap) == len(nodes.Items) {
+		// We have one pod per node - return early.
+		return nil
+	}
+
+	wait := sync.WaitGroup{}
+	for i := range nodes.Items {
+		node := &nodes.Items[i]
+		if nodeMap[node.Name] == nil {
+			// No pod on this node - start it.
+			glog.V(2).Infof("Node %s not running per-node pod %s.%s, creating it\n", node.Name, controller.Namespace, controller.Name)
+			wait.Add(1)
+			go func() {
+				defer wait.Done()
+				pnm.podControl.createPod(controller.Namespace, controller.Spec.Template)
+			}()
+		} else if len(nodeMap[node.Name]) != 1 {
+			// Too many pods on this node - kill some.
+			n := len(nodeMap[node.Name])
+			glog.V(2).Infof("Node %s has %d instances of per-node pod %s.%s, deleting %d\n", node.Name, n, controller.Namespace, controller.Name, n-1)
+			for i := range nodeMap[node.Name][1:] {
+				go func() {
+					defer wait.Done()
+					pnm.podControl.deletePod(controller.Namespace, nodeMap[node.Name][i].Name)
+				}()
+			}
+		}
+	}
+	wait.Wait()
+	return nil
+}
+
+func (pnm *PerNodeManager) filterActivePods(pods []api.Pod) []api.Pod {
+	var result []api.Pod
+	for _, value := range pods {
+		status := value.CurrentState.Status
+		if status != api.PodSucceeded && status != api.PodFailed {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func (pnm *PerNodeManager) synchronize() {
+	// TODO: remove this method completely and rely on the watch.
+	// Add resource version tracking to watch to make this work.
+	var controllers []api.PerNodeController
+	list, err := pnm.kubeClient.PerNodeControllers(api.NamespaceAll).List(labels.Everything())
+	if err != nil {
+		glog.Errorf("Synchronization error: %v (%#v)", err, err)
+		return
+	}
+	controllers = list.Items
+	wg := sync.WaitGroup{}
+	wg.Add(len(controllers))
+	for ix := range controllers {
+		go func(ix int) {
+			defer wg.Done()
+			glog.V(4).Infof("periodic sync of %v", controllers[ix].Name)
+			err := pnm.syncHandler(controllers[ix])
+			if err != nil {
+				glog.Errorf("Error synchronizing: %#v", err)
+			}
+		}(ix)
+	}
+	wg.Wait()
+}

--- a/pkg/controller/per_node_controller_test.go
+++ b/pkg/controller/per_node_controller_test.go
@@ -1,0 +1,365 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+/* FIXME: test
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+	"github.com/coreos/go-etcd/etcd"
+)
+
+func makeURL(suffix string) string {
+	return path.Join("/api", testapi.Version(), suffix)
+}
+
+type FakePodControl struct {
+	controllerSpec []api.ReplicationController
+	deletePodName  []string
+	lock           sync.Mutex
+}
+
+func (f *FakePodControl) createReplica(namespace string, spec api.ReplicationController) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.controllerSpec = append(f.controllerSpec, spec)
+}
+
+func (f *FakePodControl) deletePod(namespace string, podName string) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.deletePodName = append(f.deletePodName, podName)
+	return nil
+}
+
+func newReplicationController(replicas int) api.ReplicationController {
+	return api.ReplicationController{
+		Spec: api.ReplicationControllerSpec{
+			Replicas: replicas,
+			Template: &api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{
+						"name": "foo",
+						"type": "production",
+					},
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Image: "foo/bar",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newPodList(count int) *api.PodList {
+	pods := []api.Pod{}
+	for i := 0; i < count; i++ {
+		pods = append(pods, api.Pod{
+			ObjectMeta: api.ObjectMeta{
+				Name: fmt.Sprintf("pod%d", i),
+			},
+		})
+	}
+	return &api.PodList{
+		Items: pods,
+	}
+}
+
+func validateSyncReplication(t *testing.T, fakePodControl *FakePodControl, expectedCreates, expectedDeletes int) {
+	if len(fakePodControl.controllerSpec) != expectedCreates {
+		t.Errorf("Unexpected number of creates.  Expected %d, saw %d\n", expectedCreates, len(fakePodControl.controllerSpec))
+	}
+	if len(fakePodControl.deletePodName) != expectedDeletes {
+		t.Errorf("Unexpected number of deletes.  Expected %d, saw %d\n", expectedDeletes, len(fakePodControl.deletePodName))
+	}
+}
+
+func TestSyncReplicationControllerDoesNothing(t *testing.T) {
+	body, _ := latest.Codec.Encode(newPodList(2))
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(body),
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	client := client.NewOrDie(&client.Config{Host: testServer.URL, Version: testapi.Version()})
+
+	fakePodControl := FakePodControl{}
+
+	manager := NewReplicationManager(client)
+	manager.podControl = &fakePodControl
+
+	controllerSpec := newReplicationController(2)
+
+	manager.syncReplicationController(controllerSpec)
+	validateSyncReplication(t, &fakePodControl, 0, 0)
+}
+
+func TestSyncReplicationControllerDeletes(t *testing.T) {
+	body, _ := latest.Codec.Encode(newPodList(2))
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(body),
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	client := client.NewOrDie(&client.Config{Host: testServer.URL, Version: testapi.Version()})
+
+	fakePodControl := FakePodControl{}
+
+	manager := NewReplicationManager(client)
+	manager.podControl = &fakePodControl
+
+	controllerSpec := newReplicationController(1)
+
+	manager.syncReplicationController(controllerSpec)
+	validateSyncReplication(t, &fakePodControl, 0, 1)
+}
+
+func TestSyncReplicationControllerCreates(t *testing.T) {
+	body := runtime.EncodeOrDie(testapi.Codec(), newPodList(0))
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(body),
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	client := client.NewOrDie(&client.Config{Host: testServer.URL, Version: testapi.Version()})
+
+	fakePodControl := FakePodControl{}
+
+	manager := NewReplicationManager(client)
+	manager.podControl = &fakePodControl
+
+	controllerSpec := newReplicationController(2)
+
+	manager.syncReplicationController(controllerSpec)
+	validateSyncReplication(t, &fakePodControl, 2, 0)
+}
+
+func TestCreateReplica(t *testing.T) {
+	ns := api.NamespaceDefault
+	body := runtime.EncodeOrDie(testapi.Codec(), &api.Pod{})
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(body),
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	client := client.NewOrDie(&client.Config{Host: testServer.URL, Version: testapi.Version()})
+
+	podControl := RealPodControl{
+		kubeClient: client,
+	}
+
+	controllerSpec := api.ReplicationController{
+		ObjectMeta: api.ObjectMeta{
+			Name: "test",
+		},
+		Spec: api.ReplicationControllerSpec{
+			Template: &api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{
+						"name":                  "foo",
+						"type":                  "production",
+						"replicationController": "test",
+					},
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Image: "foo/bar",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	podControl.createReplica(ns, controllerSpec)
+
+	manifest := api.ContainerManifest{}
+	if err := api.Scheme.Convert(&controllerSpec.Spec.Template.Spec, &manifest); err != nil {
+		t.Fatalf("unexpected error", err)
+	}
+
+	expectedPod := api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Labels: controllerSpec.Spec.Template.Labels,
+		},
+		DesiredState: api.PodState{
+			Manifest: manifest,
+		},
+	}
+	fakeHandler.ValidateRequest(t, makeURL("/pods?namespace=default"), "POST", nil)
+	actualPod, err := client.Codec.Decode([]byte(fakeHandler.RequestBody))
+	if err != nil {
+		t.Errorf("Unexpected error: %#v", err)
+	}
+	if !reflect.DeepEqual(&expectedPod, actualPod) {
+		t.Logf("Body: %s", fakeHandler.RequestBody)
+		t.Errorf("Unexpected mismatch.  Expected\n %#v,\n Got:\n %#v", &expectedPod, actualPod)
+	}
+}
+
+func TestSynchonize(t *testing.T) {
+	controllerSpec1 := api.ReplicationController{
+		TypeMeta: api.TypeMeta{APIVersion: testapi.Version()},
+		Spec: api.ReplicationControllerSpec{
+			Replicas: 4,
+			Template: &api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{
+						"name": "foo",
+						"type": "production",
+					},
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Image: "foo/bar",
+						},
+					},
+				},
+			},
+		},
+	}
+	controllerSpec2 := api.ReplicationController{
+		TypeMeta: api.TypeMeta{APIVersion: testapi.Version()},
+		Spec: api.ReplicationControllerSpec{
+			Replicas: 3,
+			Template: &api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{
+						"name": "bar",
+						"type": "production",
+					},
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Image: "bar/baz",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeEtcd := tools.NewFakeEtcdClient(t)
+	fakeEtcd.Data["/registry/controllers"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{
+					{
+						Value: runtime.EncodeOrDie(testapi.Codec(), &controllerSpec1),
+					},
+					{
+						Value: runtime.EncodeOrDie(testapi.Codec(), &controllerSpec2),
+					},
+				},
+			},
+		},
+	}
+
+	fakePodHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: "{\"apiVersion\": \"" + testapi.Version() + "\", \"kind\": \"PodList\"}",
+		T:            t,
+	}
+	fakeControllerHandler := util.FakeHandler{
+		StatusCode: 200,
+		ResponseBody: runtime.EncodeOrDie(latest.Codec, &api.ReplicationControllerList{
+			Items: []api.ReplicationController{
+				controllerSpec1,
+				controllerSpec2,
+			},
+		}),
+		T: t,
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/api/"+testapi.Version()+"/pods/", &fakePodHandler)
+	mux.Handle("/api/"+testapi.Version()+"/replicationControllers/", &fakeControllerHandler)
+	mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		t.Errorf("Unexpected request for %v", req.RequestURI)
+	})
+	testServer := httptest.NewServer(mux)
+	defer testServer.Close()
+	client := client.NewOrDie(&client.Config{Host: testServer.URL, Version: testapi.Version()})
+	manager := NewReplicationManager(client)
+	fakePodControl := FakePodControl{}
+	manager.podControl = &fakePodControl
+
+	manager.synchronize()
+
+	validateSyncReplication(t, &fakePodControl, 7, 0)
+}
+
+type FakeWatcher struct {
+	w *watch.FakeWatcher
+	*client.Fake
+}
+
+func TestWatchControllers(t *testing.T) {
+	fakeWatch := watch.NewFake()
+	client := &client.Fake{Watch: fakeWatch}
+	manager := NewReplicationManager(client)
+	var testControllerSpec api.ReplicationController
+	received := make(chan struct{})
+	manager.syncHandler = func(controllerSpec api.ReplicationController) error {
+		if !reflect.DeepEqual(controllerSpec, testControllerSpec) {
+			t.Errorf("Expected %#v, but got %#v", testControllerSpec, controllerSpec)
+		}
+		close(received)
+		return nil
+	}
+
+	resourceVersion := ""
+	go manager.watchControllers(&resourceVersion)
+
+	// Test normal case
+	testControllerSpec.Name = "foo"
+
+	fakeWatch.Add(&testControllerSpec)
+
+	select {
+	case <-received:
+	case <-time.After(10 * time.Millisecond):
+		t.Errorf("Expected 1 call but got 0")
+	}
+}
+*/

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -32,8 +32,8 @@ func (f *Factory) NewCmdGet(out io.Writer) *cobra.Command {
 		Short: "Display one or many resources",
 		Long: `Display one or many resources.
 
-Possible resources include pods (po), replication controllers (rc), services
-(se), minions (mi), or events (ev).
+Possible resources include pods (po), replication controllers (rc), per-node
+controllers (pc), services (se), minions (mi), or events (ev).
 
 If you specify a Go template, you can use any fields defined for the API version
 you are connecting to the server with.

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -148,6 +148,7 @@ func ExpandResourceShortcut(resource string) string {
 	shortForms := map[string]string{
 		"po": "pods",
 		"rc": "replicationcontrollers",
+		"pc": "pernodecontrollers",
 		"se": "services",
 		"mi": "minions",
 		"ev": "events",

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -215,6 +215,7 @@ func (h *HumanReadablePrinter) validatePrintHandlerFunc(printFunc reflect.Value)
 
 var podColumns = []string{"NAME", "IMAGE(S)", "HOST", "LABELS", "STATUS"}
 var replicationControllerColumns = []string{"NAME", "IMAGE(S)", "SELECTOR", "REPLICAS"}
+var perNodeControllerColumns = []string{"NAME", "IMAGE(S)", "SELECTOR"}
 var serviceColumns = []string{"NAME", "LABELS", "SELECTOR", "IP", "PORT"}
 var minionColumns = []string{"NAME"}
 var statusColumns = []string{"STATUS"}
@@ -226,6 +227,8 @@ func (h *HumanReadablePrinter) addDefaultHandlers() {
 	h.Handler(podColumns, printPodList)
 	h.Handler(replicationControllerColumns, printReplicationController)
 	h.Handler(replicationControllerColumns, printReplicationControllerList)
+	h.Handler(perNodeControllerColumns, printPerNodeController)
+	h.Handler(perNodeControllerColumns, printPerNodeControllerList)
 	h.Handler(serviceColumns, printService)
 	h.Handler(serviceColumns, printServiceList)
 	h.Handler(minionColumns, printMinion)
@@ -302,6 +305,22 @@ func printReplicationController(controller *api.ReplicationController, w io.Writ
 func printReplicationControllerList(list *api.ReplicationControllerList, w io.Writer) error {
 	for _, controller := range list.Items {
 		if err := printReplicationController(&controller, w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printPerNodeController(controller *api.PerNodeController, w io.Writer) error {
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\n",
+		controller.Name, makeImageList(&controller.Spec.Template.Spec),
+		labels.Set(controller.Spec.Selector))
+	return err
+}
+
+func printPerNodeControllerList(list *api.PerNodeControllerList, w io.Writer) error {
+	for _, controller := range list.Items {
+		if err := printPerNodeController(&controller, w); err != nil {
 			return err
 		}
 	}

--- a/pkg/registry/etcd/etcd.go
+++ b/pkg/registry/etcd/etcd.go
@@ -36,8 +36,10 @@ import (
 const (
 	// PodPath is the path to pod resources in etcd
 	PodPath string = "/registry/pods"
-	// ControllerPath is the path to controller resources in etcd
-	ControllerPath string = "/registry/controllers"
+	// ReplicationControllerPath is the path to replication controller resources in etcd
+	ReplicationControllerPath string = "/registry/controllers" //FIXME: move to replication_controllers?
+	// PerNodeControllerPath is the path to per-node controller resources in etcd
+	PerNodeControllerPath string = "/registry/per_node_controllers"
 	// ServicePath is the path to service resources in etcd
 	ServicePath string = "/registry/services/specs"
 	// ServiceEndpointPath is the path to service endpoints resources in etcd
@@ -328,38 +330,38 @@ func (r *Registry) DeletePod(ctx api.Context, podID string) error {
 	})
 }
 
-// ListControllers obtains a list of ReplicationControllers.
-func (r *Registry) ListControllers(ctx api.Context) (*api.ReplicationControllerList, error) {
+// ListReplicationControllers obtains a list of ReplicationControllers.
+func (r *Registry) ListReplicationControllers(ctx api.Context) (*api.ReplicationControllerList, error) {
 	controllers := &api.ReplicationControllerList{}
-	key := makeControllerListKey(ctx)
+	key := makeReplicationControllerListKey(ctx)
 	err := r.ExtractToList(key, controllers)
 	return controllers, err
 }
 
-// WatchControllers begins watching for new, changed, or deleted controllers.
-func (r *Registry) WatchControllers(ctx api.Context, resourceVersion string) (watch.Interface, error) {
+// WatchReplicationControllers begins watching for new, changed, or deleted controllers.
+func (r *Registry) WatchReplicationControllers(ctx api.Context, resourceVersion string) (watch.Interface, error) {
 	version, err := tools.ParseWatchResourceVersion(resourceVersion, "replicationControllers")
 	if err != nil {
 		return nil, err
 	}
-	key := makeControllerListKey(ctx)
+	key := makeReplicationControllerListKey(ctx)
 	return r.WatchList(key, version, tools.Everything)
 }
 
-// makeControllerListKey constructs etcd paths to controller directories enforcing namespace rules.
-func makeControllerListKey(ctx api.Context) string {
-	return MakeEtcdListKey(ctx, ControllerPath)
+// makeReplicationControllerListKey constructs etcd paths to controller directories enforcing namespace rules.
+func makeReplicationControllerListKey(ctx api.Context) string {
+	return MakeEtcdListKey(ctx, ReplicationControllerPath)
 }
 
-// makeControllerKey constructs etcd paths to controller items enforcing namespace rules.
-func makeControllerKey(ctx api.Context, id string) (string, error) {
-	return MakeEtcdItemKey(ctx, ControllerPath, id)
+// makeReplicationControllerKey constructs etcd paths to controller items enforcing namespace rules.
+func makeReplicationControllerKey(ctx api.Context, id string) (string, error) {
+	return MakeEtcdItemKey(ctx, ReplicationControllerPath, id)
 }
 
-// GetController gets a specific ReplicationController specified by its ID.
-func (r *Registry) GetController(ctx api.Context, controllerID string) (*api.ReplicationController, error) {
+// GetReplicationController gets a specific ReplicationController specified by its ID.
+func (r *Registry) GetReplicationController(ctx api.Context, controllerID string) (*api.ReplicationController, error) {
 	var controller api.ReplicationController
-	key, err := makeControllerKey(ctx, controllerID)
+	key, err := makeReplicationControllerKey(ctx, controllerID)
 	if err != nil {
 		return nil, err
 	}
@@ -370,9 +372,9 @@ func (r *Registry) GetController(ctx api.Context, controllerID string) (*api.Rep
 	return &controller, nil
 }
 
-// CreateController creates a new ReplicationController.
-func (r *Registry) CreateController(ctx api.Context, controller *api.ReplicationController) error {
-	key, err := makeControllerKey(ctx, controller.Name)
+// CreateReplicationController creates a new ReplicationController.
+func (r *Registry) CreateReplicationController(ctx api.Context, controller *api.ReplicationController) error {
+	key, err := makeReplicationControllerKey(ctx, controller.Name)
 	if err != nil {
 		return err
 	}
@@ -380,9 +382,9 @@ func (r *Registry) CreateController(ctx api.Context, controller *api.Replication
 	return etcderr.InterpretCreateError(err, "replicationController", controller.Name)
 }
 
-// UpdateController replaces an existing ReplicationController.
-func (r *Registry) UpdateController(ctx api.Context, controller *api.ReplicationController) error {
-	key, err := makeControllerKey(ctx, controller.Name)
+// UpdateReplicationController replaces an existing ReplicationController.
+func (r *Registry) UpdateReplicationController(ctx api.Context, controller *api.ReplicationController) error {
+	key, err := makeReplicationControllerKey(ctx, controller.Name)
 	if err != nil {
 		return err
 	}
@@ -390,9 +392,81 @@ func (r *Registry) UpdateController(ctx api.Context, controller *api.Replication
 	return etcderr.InterpretUpdateError(err, "replicationController", controller.Name)
 }
 
-// DeleteController deletes a ReplicationController specified by its ID.
-func (r *Registry) DeleteController(ctx api.Context, controllerID string) error {
-	key, err := makeControllerKey(ctx, controllerID)
+// DeleteReplicationController deletes a ReplicationController specified by its ID.
+func (r *Registry) DeleteReplicationController(ctx api.Context, controllerID string) error {
+	key, err := makeReplicationControllerKey(ctx, controllerID)
+	if err != nil {
+		return err
+	}
+	err = r.Delete(key, false)
+	return etcderr.InterpretDeleteError(err, "replicationController", controllerID)
+}
+
+// ListPerNodeControllers obtains a list of PerNodeControllers.
+func (r *Registry) ListPerNodeControllers(ctx api.Context) (*api.PerNodeControllerList, error) {
+	controllers := &api.PerNodeControllerList{}
+	key := makePerNodeControllerListKey(ctx)
+	err := r.ExtractToList(key, controllers)
+	return controllers, err
+}
+
+// WatchPerNodeControllers begins watching for new, changed, or deleted controllers.
+func (r *Registry) WatchPerNodeControllers(ctx api.Context, resourceVersion string) (watch.Interface, error) {
+	version, err := tools.ParseWatchResourceVersion(resourceVersion, "replicationControllers")
+	if err != nil {
+		return nil, err
+	}
+	key := makePerNodeControllerListKey(ctx)
+	return r.WatchList(key, version, tools.Everything)
+}
+
+// makePerNodeControllerListKey constructs etcd paths to controller directories enforcing namespace rules.
+func makePerNodeControllerListKey(ctx api.Context) string {
+	return MakeEtcdListKey(ctx, PerNodeControllerPath)
+}
+
+// makePerNodeControllerKey constructs etcd paths to controller items enforcing namespace rules.
+func makePerNodeControllerKey(ctx api.Context, id string) (string, error) {
+	return MakeEtcdItemKey(ctx, PerNodeControllerPath, id)
+}
+
+// GetPerNodeController gets a specific PerNodeController specified by its ID.
+func (r *Registry) GetPerNodeController(ctx api.Context, controllerID string) (*api.PerNodeController, error) {
+	var controller api.PerNodeController
+	key, err := makePerNodeControllerKey(ctx, controllerID)
+	if err != nil {
+		return nil, err
+	}
+	err = r.ExtractObj(key, &controller, false)
+	if err != nil {
+		return nil, etcderr.InterpretGetError(err, "replicationController", controllerID)
+	}
+	return &controller, nil
+}
+
+// CreatePerNodeController creates a new PerNodeController.
+func (r *Registry) CreatePerNodeController(ctx api.Context, controller *api.PerNodeController) error {
+	key, err := makePerNodeControllerKey(ctx, controller.Name)
+	if err != nil {
+		return err
+	}
+	err = r.CreateObj(key, controller, 0)
+	return etcderr.InterpretCreateError(err, "replicationController", controller.Name)
+}
+
+// UpdatePerNodeController replaces an existing PerNodeController.
+func (r *Registry) UpdatePerNodeController(ctx api.Context, controller *api.PerNodeController) error {
+	key, err := makePerNodeControllerKey(ctx, controller.Name)
+	if err != nil {
+		return err
+	}
+	err = r.SetObj(key, controller)
+	return etcderr.InterpretUpdateError(err, "replicationController", controller.Name)
+}
+
+// DeletePerNodeController deletes a PerNodeController specified by its ID.
+func (r *Registry) DeletePerNodeController(ctx api.Context, controllerID string) error {
+	key, err := makePerNodeControllerKey(ctx, controllerID)
 	if err != nil {
 		return err
 	}

--- a/pkg/registry/per_node_controller/doc.go
+++ b/pkg/registry/per_node_controller/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package controller provides Registry interface and it's RESTStorage
-// implementation for storing ReplicationController api objects.
-package controller
+// Package per_node_controller provides Registry interface and its
+// RESTStorage implementation for storing PerNodeController api objects.
+package per_node_controller

--- a/pkg/registry/per_node_controller/registry.go
+++ b/pkg/registry/per_node_controller/registry.go
@@ -14,19 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package per_node_controller
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
-// Registry is an interface for things that know how to store ReplicationControllers.
+// Registry is an interface for things that know how to store PerNodeControllers.
 type Registry interface {
-	ListControllers(ctx api.Context) (*api.ReplicationControllerList, error)
-	WatchControllers(ctx api.Context, resourceVersion string) (watch.Interface, error)
-	GetController(ctx api.Context, controllerID string) (*api.ReplicationController, error)
-	CreateController(ctx api.Context, controller *api.ReplicationController) error
-	UpdateController(ctx api.Context, controller *api.ReplicationController) error
-	DeleteController(ctx api.Context, controllerID string) error
+	ListPerNodeControllers(ctx api.Context) (*api.PerNodeControllerList, error)
+	WatchPerNodeControllers(ctx api.Context, resourceVersion string) (watch.Interface, error)
+	GetPerNodeController(ctx api.Context, controllerID string) (*api.PerNodeController, error)
+	CreatePerNodeController(ctx api.Context, controller *api.PerNodeController) error
+	UpdatePerNodeController(ctx api.Context, controller *api.PerNodeController) error
+	DeletePerNodeController(ctx api.Context, controllerID string) error
 }

--- a/pkg/registry/per_node_controller/rest.go
+++ b/pkg/registry/per_node_controller/rest.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package per_node_controller
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// PodLister is anything that knows how to list pods.
+type PodLister interface {
+	ListPods(ctx api.Context, labels labels.Selector) (*api.PodList, error)
+}
+
+// REST implements apiserver.RESTStorage for the per-node controller service.
+type REST struct {
+	registry   Registry
+	podLister  PodLister
+	pollPeriod time.Duration
+}
+
+// NewREST returns a new apiserver.RESTStorage for the given registry and PodLister.
+func NewREST(registry Registry, podLister PodLister) *REST {
+	return &REST{
+		registry:   registry,
+		podLister:  podLister,
+		pollPeriod: time.Second * 10,
+	}
+}
+
+// Create registers the given PerNodeController.
+func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
+	controller, ok := obj.(*api.PerNodeController)
+	if !ok {
+		return nil, fmt.Errorf("not a per-node controller: %#v", obj)
+	}
+	if !api.ValidNamespace(ctx, &controller.ObjectMeta) {
+		return nil, errors.NewConflict("controller", controller.Namespace, fmt.Errorf("PerNodeController.Namespace does not match the provided context"))
+	}
+
+	if len(controller.Name) == 0 {
+		controller.Name = util.NewUUID().String()
+	}
+	if errs := validation.ValidatePerNodeController(controller); len(errs) > 0 {
+		return nil, errors.NewInvalid("perNodeController", controller.Name, errs)
+	}
+
+	api.FillObjectMetaSystemFields(ctx, &controller.ObjectMeta)
+
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		err := rs.registry.CreatePerNodeController(ctx, controller)
+		if err != nil {
+			return nil, err
+		}
+		return rs.registry.GetPerNodeController(ctx, controller.Name)
+	}), nil
+}
+
+// Delete asynchronously deletes the PerNodeController specified by its id.
+func (rs *REST) Delete(ctx api.Context, id string) (<-chan apiserver.RESTResult, error) {
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		return &api.Status{Status: api.StatusSuccess}, rs.registry.DeletePerNodeController(ctx, id)
+	}), nil
+}
+
+// Get obtains the PerNodeController specified by its id.
+func (rs *REST) Get(ctx api.Context, id string) (runtime.Object, error) {
+	controller, err := rs.registry.GetPerNodeController(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	rs.fillCurrentState(ctx, controller)
+	return controller, err
+}
+
+// List obtains a list of PerNodeControllers that match selector.
+func (rs *REST) List(ctx api.Context, label, field labels.Selector) (runtime.Object, error) {
+	if !field.Empty() {
+		return nil, fmt.Errorf("field selector not supported yet")
+	}
+	controllers, err := rs.registry.ListPerNodeControllers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	filtered := []api.PerNodeController{}
+	for _, controller := range controllers.Items {
+		if label.Matches(labels.Set(controller.Labels)) {
+			rs.fillCurrentState(ctx, &controller)
+			filtered = append(filtered, controller)
+		}
+	}
+	controllers.Items = filtered
+	return controllers, err
+}
+
+// New creates a new PerNodeController for use with Create and Update.
+func (*REST) New() runtime.Object {
+	return &api.PerNodeController{}
+}
+
+// Update replaces a given PerNodeController instance with an existing
+// instance in storage.registry.
+func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
+	controller, ok := obj.(*api.PerNodeController)
+	if !ok {
+		return nil, fmt.Errorf("not a per-node controller: %#v", obj)
+	}
+	if !api.ValidNamespace(ctx, &controller.ObjectMeta) {
+		return nil, errors.NewConflict("controller", controller.Namespace, fmt.Errorf("PerNodeController.Namespace does not match the provided context"))
+	}
+	if errs := validation.ValidatePerNodeController(controller); len(errs) > 0 {
+		return nil, errors.NewInvalid("perNodeController", controller.Name, errs)
+	}
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		err := rs.registry.UpdatePerNodeController(ctx, controller)
+		if err != nil {
+			return nil, err
+		}
+		return rs.registry.GetPerNodeController(ctx, controller.Name)
+	}), nil
+}
+
+// Watch returns PerNodeController events via a watch.Interface.
+// It implements apiserver.ResourceWatcher.
+func (rs *REST) Watch(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	if !field.Empty() {
+		return nil, fmt.Errorf("no field selector implemented for controllers")
+	}
+	incoming, err := rs.registry.WatchPerNodeControllers(ctx, resourceVersion)
+	if err != nil {
+		return nil, err
+	}
+	// TODO(lavalamp): remove watch.Filter, which is broken. Implement consistent way of filtering.
+	// TODO(lavalamp): this watch method needs a test.
+	return watch.Filter(incoming, func(e watch.Event) (watch.Event, bool) {
+		controller, ok := e.Object.(*api.PerNodeController)
+		if !ok {
+			// must be an error event-- pass it on
+			return e, true
+		}
+		match := label.Matches(labels.Set(controller.Labels))
+		if match {
+			rs.fillCurrentState(ctx, controller)
+		}
+		return e, match
+	}), nil
+}
+
+func (rs *REST) fillCurrentState(ctx api.Context, controller *api.PerNodeController) error {
+	if rs.podLister == nil {
+		return nil
+	}
+	list, err := rs.podLister.ListPods(ctx, labels.Set(controller.Spec.Selector).AsSelector())
+	if err != nil {
+		return err
+	}
+	controller.Status.Replicas = len(list.Items)
+	return nil
+}

--- a/pkg/registry/per_node_controller/rest_test.go
+++ b/pkg/registry/per_node_controller/rest_test.go
@@ -1,0 +1,419 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package per_node_controller
+
+/* FIXME: test
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
+)
+
+func TestListControllersError(t *testing.T) {
+	mockRegistry := registrytest.ControllerRegistry{
+		Err: fmt.Errorf("test error"),
+	}
+	storage := REST{
+		registry: &mockRegistry,
+	}
+	ctx := api.NewContext()
+	controllers, err := storage.List(ctx, labels.Everything(), labels.Everything())
+	if err != mockRegistry.Err {
+		t.Errorf("Expected %#v, Got %#v", mockRegistry.Err, err)
+	}
+	if controllers != nil {
+		t.Errorf("Unexpected non-nil ctrl list: %#v", controllers)
+	}
+}
+
+func TestListEmptyControllerList(t *testing.T) {
+	mockRegistry := registrytest.ControllerRegistry{nil, &api.PerNodeControllerList{ListMeta: api.ListMeta{ResourceVersion: "1"}}}
+	storage := REST{
+		registry: &mockRegistry,
+	}
+	ctx := api.NewContext()
+	controllers, err := storage.List(ctx, labels.Everything(), labels.Everything())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(controllers.(*api.PerNodeControllerList).Items) != 0 {
+		t.Errorf("Unexpected non-zero ctrl list: %#v", controllers)
+	}
+	if controllers.(*api.PerNodeControllerList).ResourceVersion != "1" {
+		t.Errorf("Unexpected resource version: %#v", controllers)
+	}
+}
+
+func TestListControllerList(t *testing.T) {
+	mockRegistry := registrytest.ControllerRegistry{
+		Controllers: &api.PerNodeControllerList{
+			Items: []api.PerNodeController{
+				{
+					ObjectMeta: api.ObjectMeta{
+						Name: "foo",
+					},
+				},
+				{
+					ObjectMeta: api.ObjectMeta{
+						Name: "bar",
+					},
+				},
+			},
+		},
+	}
+	storage := REST{
+		registry: &mockRegistry,
+	}
+	ctx := api.NewContext()
+	controllersObj, err := storage.List(ctx, labels.Everything(), labels.Everything())
+	controllers := controllersObj.(*api.PerNodeControllerList)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(controllers.Items) != 2 {
+		t.Errorf("Unexpected controller list: %#v", controllers)
+	}
+	if controllers.Items[0].Name != "foo" {
+		t.Errorf("Unexpected controller: %#v", controllers.Items[0])
+	}
+	if controllers.Items[1].Name != "bar" {
+		t.Errorf("Unexpected controller: %#v", controllers.Items[1])
+	}
+}
+
+func TestControllerDecode(t *testing.T) {
+	mockRegistry := registrytest.ControllerRegistry{}
+	storage := REST{
+		registry: &mockRegistry,
+	}
+	controller := &api.PerNodeController{
+		ObjectMeta: api.ObjectMeta{
+			Name: "foo",
+		},
+		Spec: api.PerNodeControllerSpec{
+			Template: &api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{
+						"name": "nginx",
+					},
+				},
+			},
+		},
+	}
+	body, err := latest.Codec.Encode(controller)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	controllerOut := storage.New()
+	if err := latest.Codec.DecodeInto(body, controllerOut); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if !reflect.DeepEqual(controller, controllerOut) {
+		t.Errorf("Expected %#v, found %#v", controller, controllerOut)
+	}
+}
+
+func TestControllerParsing(t *testing.T) {
+	expectedController := api.PerNodeController{
+		ObjectMeta: api.ObjectMeta{
+			Name: "nginxController",
+			Labels: map[string]string{
+				"name": "nginx",
+			},
+		},
+		Spec: api.PerNodeControllerSpec{
+			Replicas: 2,
+			Selector: map[string]string{
+				"name": "nginx",
+			},
+			Template: &api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{
+						"name": "nginx",
+					},
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Image: "dockerfile/nginx",
+							Ports: []api.Port{
+								{
+									ContainerPort: 80,
+									HostPort:      8080,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	file, err := ioutil.TempFile("", "controller")
+	fileName := file.Name()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	data, err := json.Marshal(expectedController)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	_, err = file.Write(data)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	err = file.Close()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	data, err = ioutil.ReadFile(fileName)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	var controller api.PerNodeController
+	err = json.Unmarshal(data, &controller)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if !reflect.DeepEqual(controller, expectedController) {
+		t.Errorf("Parsing failed: %s %#v %#v", string(data), controller, expectedController)
+	}
+}
+
+var validPodTemplate = api.PodTemplate{
+	Spec: api.PodTemplateSpec{
+		ObjectMeta: api.ObjectMeta{
+			Labels: map[string]string{"a": "b"},
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name:  "test",
+					Image: "test_image",
+				},
+			},
+		},
+	},
+}
+
+func TestCreateController(t *testing.T) {
+	mockRegistry := registrytest.ControllerRegistry{}
+	mockPodRegistry := registrytest.PodRegistry{
+		Pods: &api.PodList{
+			Items: []api.Pod{
+				{
+					ObjectMeta: api.ObjectMeta{
+						Name:   "foo",
+						Labels: map[string]string{"a": "b"},
+					},
+				},
+			},
+		},
+	}
+	storage := REST{
+		registry:   &mockRegistry,
+		podLister:  &mockPodRegistry,
+		pollPeriod: time.Millisecond * 1,
+	}
+	controller := &api.PerNodeController{
+		ObjectMeta: api.ObjectMeta{Name: "test"},
+		Spec: api.PerNodeControllerSpec{
+			Replicas: 2,
+			Selector: map[string]string{"a": "b"},
+			Template: &validPodTemplate.Spec,
+		},
+	}
+	ctx := api.NewDefaultContext()
+	channel, err := storage.Create(ctx, controller)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !api.HasObjectMetaSystemFieldValues(&controller.ObjectMeta) {
+		t.Errorf("storage did not populate object meta field values")
+	}
+
+	select {
+	case <-channel:
+		// expected case
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+}
+
+func TestControllerStorageValidatesCreate(t *testing.T) {
+	mockRegistry := registrytest.ControllerRegistry{}
+	storage := REST{
+		registry:   &mockRegistry,
+		podLister:  nil,
+		pollPeriod: time.Millisecond * 1,
+	}
+	failureCases := map[string]api.PerNodeController{
+		"empty ID": {
+			ObjectMeta: api.ObjectMeta{Name: ""},
+			Spec: api.PerNodeControllerSpec{
+				Selector: map[string]string{"bar": "baz"},
+			},
+		},
+		"empty selector": {
+			ObjectMeta: api.ObjectMeta{Name: "abc"},
+			Spec:       api.PerNodeControllerSpec{},
+		},
+	}
+	ctx := api.NewDefaultContext()
+	for _, failureCase := range failureCases {
+		c, err := storage.Create(ctx, &failureCase)
+		if c != nil {
+			t.Errorf("Expected nil channel")
+		}
+		if !errors.IsInvalid(err) {
+			t.Errorf("Expected to get an invalid resource error, got %v", err)
+		}
+	}
+}
+
+func TestControllerStorageValidatesUpdate(t *testing.T) {
+	mockRegistry := registrytest.ControllerRegistry{}
+	storage := REST{
+		registry:   &mockRegistry,
+		podLister:  nil,
+		pollPeriod: time.Millisecond * 1,
+	}
+	failureCases := map[string]api.PerNodeController{
+		"empty ID": {
+			ObjectMeta: api.ObjectMeta{Name: ""},
+			Spec: api.PerNodeControllerSpec{
+				Selector: map[string]string{"bar": "baz"},
+			},
+		},
+		"empty selector": {
+			ObjectMeta: api.ObjectMeta{Name: "abc"},
+			Spec:       api.PerNodeControllerSpec{},
+		},
+	}
+	ctx := api.NewDefaultContext()
+	for _, failureCase := range failureCases {
+		c, err := storage.Update(ctx, &failureCase)
+		if c != nil {
+			t.Errorf("Expected nil channel")
+		}
+		if !errors.IsInvalid(err) {
+			t.Errorf("Expected to get an invalid resource error, got %v", err)
+		}
+	}
+}
+
+type fakePodLister struct {
+	e error
+	l api.PodList
+	s labels.Selector
+}
+
+func (f *fakePodLister) ListPods(ctx api.Context, s labels.Selector) (*api.PodList, error) {
+	f.s = s
+	return &f.l, f.e
+}
+
+func TestFillCurrentState(t *testing.T) {
+	fakeLister := fakePodLister{
+		l: api.PodList{
+			Items: []api.Pod{
+				{ObjectMeta: api.ObjectMeta{Name: "foo"}},
+				{ObjectMeta: api.ObjectMeta{Name: "bar"}},
+			},
+		},
+	}
+	mockRegistry := registrytest.ControllerRegistry{}
+	storage := REST{
+		registry:  &mockRegistry,
+		podLister: &fakeLister,
+	}
+	controller := api.PerNodeController{
+		Spec: api.PerNodeControllerSpec{
+			Selector: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+	ctx := api.NewContext()
+	storage.fillCurrentState(ctx, &controller)
+	if controller.Status.Replicas != 2 {
+		t.Errorf("expected 2, got: %d", controller.Status.Replicas)
+	}
+	if !reflect.DeepEqual(fakeLister.s, labels.Set(controller.Spec.Selector).AsSelector()) {
+		t.Errorf("unexpected output: %#v %#v", labels.Set(controller.Spec.Selector).AsSelector(), fakeLister.s)
+	}
+}
+
+func TestCreateControllerWithConflictingNamespace(t *testing.T) {
+	storage := REST{}
+	controller := &api.PerNodeController{
+		ObjectMeta: api.ObjectMeta{Name: "test", Namespace: "not-default"},
+	}
+
+	ctx := api.NewDefaultContext()
+	channel, err := storage.Create(ctx, controller)
+	if channel != nil {
+		t.Error("Expected a nil channel, but we got a value")
+	}
+	if err == nil {
+		t.Errorf("Expected an error, but we didn't get one")
+	} else if strings.Index(err.Error(), "Controller.Namespace does not match the provided context") == -1 {
+		t.Errorf("Expected 'Controller.Namespace does not match the provided context' error, got '%v'", err.Error())
+	}
+}
+
+func TestUpdateControllerWithConflictingNamespace(t *testing.T) {
+	storage := REST{}
+	controller := &api.PerNodeController{
+		ObjectMeta: api.ObjectMeta{Name: "test", Namespace: "not-default"},
+	}
+
+	ctx := api.NewDefaultContext()
+	channel, err := storage.Update(ctx, controller)
+	if channel != nil {
+		t.Error("Expected a nil channel, but we got a value")
+	}
+	if err == nil {
+		t.Errorf("Expected an error, but we didn't get one")
+	} else if strings.Index(err.Error(), "Controller.Namespace does not match the provided context") == -1 {
+		t.Errorf("Expected 'Controller.Namespace does not match the provided context' error, got '%v'", err.Error())
+	}
+}
+*/

--- a/pkg/registry/registrytest/replication_controller.go
+++ b/pkg/registry/registrytest/replication_controller.go
@@ -27,26 +27,26 @@ type ControllerRegistry struct {
 	Controllers *api.ReplicationControllerList
 }
 
-func (r *ControllerRegistry) ListControllers(ctx api.Context) (*api.ReplicationControllerList, error) {
+func (r *ControllerRegistry) ListReplicationControllers(ctx api.Context) (*api.ReplicationControllerList, error) {
 	return r.Controllers, r.Err
 }
 
-func (r *ControllerRegistry) GetController(ctx api.Context, ID string) (*api.ReplicationController, error) {
+func (r *ControllerRegistry) GetReplicationController(ctx api.Context, ID string) (*api.ReplicationController, error) {
 	return &api.ReplicationController{}, r.Err
 }
 
-func (r *ControllerRegistry) CreateController(ctx api.Context, controller *api.ReplicationController) error {
+func (r *ControllerRegistry) CreateReplicationController(ctx api.Context, controller *api.ReplicationController) error {
 	return r.Err
 }
 
-func (r *ControllerRegistry) UpdateController(ctx api.Context, controller *api.ReplicationController) error {
+func (r *ControllerRegistry) UpdateReplicationController(ctx api.Context, controller *api.ReplicationController) error {
 	return r.Err
 }
 
-func (r *ControllerRegistry) DeleteController(ctx api.Context, ID string) error {
+func (r *ControllerRegistry) DeleteReplicationController(ctx api.Context, ID string) error {
 	return r.Err
 }
 
-func (r *ControllerRegistry) WatchControllers(ctx api.Context, resourceVersion string) (watch.Interface, error) {
+func (r *ControllerRegistry) WatchReplicationControllers(ctx api.Context, resourceVersion string) (watch.Interface, error) {
 	return nil, r.Err
 }

--- a/pkg/registry/replication_controller/doc.go
+++ b/pkg/registry/replication_controller/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package replication_controller provides Registry interface and its
+// RESTStorage implementation for storing ReplicationController api objects.
+package replication_controller

--- a/pkg/registry/replication_controller/registry.go
+++ b/pkg/registry/replication_controller/registry.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replication_controller
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// Registry is an interface for things that know how to store ReplicationControllers.
+type Registry interface {
+	ListReplicationControllers(ctx api.Context) (*api.ReplicationControllerList, error)
+	WatchReplicationControllers(ctx api.Context, resourceVersion string) (watch.Interface, error)
+	GetReplicationController(ctx api.Context, controllerID string) (*api.ReplicationController, error)
+	CreateReplicationController(ctx api.Context, controller *api.ReplicationController) error
+	UpdateReplicationController(ctx api.Context, controller *api.ReplicationController) error
+	DeleteReplicationController(ctx api.Context, controllerID string) error
+}

--- a/pkg/registry/replication_controller/rest_test.go
+++ b/pkg/registry/replication_controller/rest_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package replication_controller
 
 import (
 	"encoding/json"


### PR DESCRIPTION
```
This is a sketch of a controller that runs a pod on every node.

Issues:

Adding a new REST resource is incredibly tedious.  We should make REST
plugin-able and make them all completely self-contained plugins.

This being the first controller that isn't replication, lots of words are
wrong all over.  We've taken a lot of shortcuts and called
ReplicationControllers "controllers" all over.  E.g. the etcd path.

Do we want this to be a "sub-kind" of replication controller?  Or do we want
a new top-level REST object?

Kubectl should be able to load some form of plugin that allows for
descriptions and formatting without rebuilding.
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/kubernetes/2491)

<!-- Reviewable:end -->
