### PR TITLE
Create tool for resizing a replication controller via kubectl.

### DIFF
--- a/contrib/rctools/README.md
+++ b/contrib/rctools/README.md
@@ -1,0 +1,17 @@
+# Replication controller tools
+
+## resize.sh
+Resizes a replication controller to the specified number of pods.
+```
+$ resize.sh
+usage: resize.sh <replication controller name> <size>
+$ resize.sh redisslave 4
+```
+
+## stop.sh
+Resizes a replication controller to 0 pods and waits until the pods are deleted.
+```
+$ stop.sh
+usage: stop.sh <replication controller name>
+$ stop.sh redisslave
+```

--- a/contrib/rctools/resize.sh
+++ b/contrib/rctools/resize.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This command resizes a replication controller using kubectl.
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+KUBECTL="${KUBE_ROOT}/cluster/kubectl.sh"
+
+if [[ $# != 2 ]] ; then
+  echo "usage: $0 <replication controller name> <size>" >&2
+  exit 1
+fi
+
+rc="$1"
+size="$2"
+
+"${KUBECTL}" get -o json rc "$rc" | sed 's/"replicas": [0-9][0-9]*/"replicas": '"$size"'/' | "${KUBECTL}" update -f - rc "$rc"

--- a/contrib/rctools/stop.sh
+++ b/contrib/rctools/stop.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This command resizes a replication controller to 0.
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+KUBECTL="${KUBE_ROOT}/cluster/kubectl.sh"
+RESIZE="${KUBE_ROOT}/contrib/rctools/resize.sh"
+
+if [[ $# != 1 ]] ; then
+  echo "usage: $0 <replication controller name>" >&2
+  exit 1
+fi
+
+rc="$1"
+
+"${RESIZE}" "$rc" 0
+
+# kubectl describe output includes a line like:
+# Replicas:       2 current / 2 desired
+
+# Wait until it shows 0 pods
+while true; do
+  pods=$(${KUBECTL} describe rc "$rc" | awk '/^Replicas:/{print $2}')
+  if [[ "$pods" -eq 0 ]] ; then
+    exit 0
+  else
+    echo "$pods remaining..."
+  fi
+  sleep 1
+done
+
+exit 1

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -393,8 +393,7 @@ func (p *TemplatePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 
 func tabbedString(f func(io.Writer) error) (string, error) {
 	out := new(tabwriter.Writer)
-	b := make([]byte, 1024)
-	buf := bytes.NewBuffer(b)
+	buf := &bytes.Buffer{}
 	out.Init(buf, 0, 8, 1, '\t', 0)
 
 	err := f(out)


### PR DESCRIPTION
Demonstration about how kubecfg functionality can be implemented with the current kubectl functionality, until the capability is implemented in a more first-class way.

Also fixes #2496.
