### PR TITLE
Don't hold up the entire event queue for a single bad event.

### DIFF
--- a/pkg/api/errors/errors.go
+++ b/pkg/api/errors/errors.go
@@ -24,34 +24,46 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
-// statusError is an error intended for consumption by a REST API server.
-type statusError struct {
-	status api.Status
+// StatusError is an error intended for consumption by a REST API server; it can also be
+// reconstructed by clients from a REST response. Public to allow easy type switches.
+type StatusError struct {
+	ErrStatus api.Status
 }
 
 // Error implements the Error interface.
-func (e *statusError) Error() string {
-	return e.status.Message
+func (e *StatusError) Error() string {
+	return e.ErrStatus.Message
 }
 
-// Status converts this error into an api.Status object.
-func (e *statusError) Status() api.Status {
-	return e.status
+// Status allows access to e's status without having to know the detailed workings
+// of StatusError. Used by pkg/apiserver.
+func (e *StatusError) Status() api.Status {
+	return e.ErrStatus
 }
 
-// FromObject generates an statusError from an api.Status, if that is the type of obj; otherwise,
-// returns an error created by fmt.Errorf.
+// UnexpectedObjectError can be returned by FromObject if it's passed a non-status object.
+type UnexpectedObjectError struct {
+	Object runtime.Object
+}
+
+// Error returns an error message describing 'u'.
+func (u *UnexpectedObjectError) Error() string {
+	return fmt.Sprintf("unexpected object: %v", u.Object)
+}
+
+// FromObject generates an StatusError from an api.Status, if that is the type of obj; otherwise,
+// returns an UnexpecteObjectError.
 func FromObject(obj runtime.Object) error {
 	switch t := obj.(type) {
 	case *api.Status:
-		return &statusError{*t}
+		return &StatusError{*t}
 	}
-	return fmt.Errorf("unexpected object: %v", obj)
+	return &UnexpectedObjectError{obj}
 }
 
 // NewNotFound returns a new error which indicates that the resource of the kind and the name was not found.
 func NewNotFound(kind, name string) error {
-	return &statusError{api.Status{
+	return &StatusError{api.Status{
 		Status: api.StatusFailure,
 		Code:   http.StatusNotFound,
 		Reason: api.StatusReasonNotFound,
@@ -65,7 +77,7 @@ func NewNotFound(kind, name string) error {
 
 // NewAlreadyExists returns an error indicating the item requested exists by that identifier.
 func NewAlreadyExists(kind, name string) error {
-	return &statusError{api.Status{
+	return &StatusError{api.Status{
 		Status: api.StatusFailure,
 		Code:   http.StatusConflict,
 		Reason: api.StatusReasonAlreadyExists,
@@ -79,7 +91,7 @@ func NewAlreadyExists(kind, name string) error {
 
 // NewConflict returns an error indicating the item can't be updated as provided.
 func NewConflict(kind, name string, err error) error {
-	return &statusError{api.Status{
+	return &StatusError{api.Status{
 		Status: api.StatusFailure,
 		Code:   http.StatusConflict,
 		Reason: api.StatusReasonConflict,
@@ -103,7 +115,7 @@ func NewInvalid(kind, name string, errs ValidationErrorList) error {
 			})
 		}
 	}
-	return &statusError{api.Status{
+	return &StatusError{api.Status{
 		Status: api.StatusFailure,
 		Code:   422, // RFC 4918: StatusUnprocessableEntity
 		Reason: api.StatusReasonInvalid,
@@ -118,7 +130,7 @@ func NewInvalid(kind, name string, errs ValidationErrorList) error {
 
 // NewBadRequest creates an error that indicates that the request is invalid and can not be processed.
 func NewBadRequest(reason string) error {
-	return &statusError{
+	return &StatusError{
 		api.Status{
 			Status: api.StatusFailure,
 			Code:   http.StatusBadRequest,
@@ -134,7 +146,7 @@ func NewBadRequest(reason string) error {
 
 // NewInternalError returns an error indicating the item is invalid and cannot be processed.
 func NewInternalError(err error) error {
-	return &statusError{api.Status{
+	return &StatusError{api.Status{
 		Status: api.StatusFailure,
 		Code:   http.StatusInternalServerError,
 		Reason: api.StatusReasonInternalError,
@@ -172,8 +184,8 @@ func IsBadRequest(err error) bool {
 
 func reasonForError(err error) api.StatusReason {
 	switch t := err.(type) {
-	case *statusError:
-		return t.status.Reason
+	case *StatusError:
+		return t.ErrStatus.Reason
 	}
 	return api.StatusReasonUnknown
 }

--- a/pkg/api/errors/errors_test.go
+++ b/pkg/api/errors/errors_test.go
@@ -117,7 +117,7 @@ func TestNewInvalid(t *testing.T) {
 		vErr, expected := testCase.Err, testCase.Details
 		expected.Causes[0].Message = vErr.Error()
 		err := NewInvalid("kind", "name", ValidationErrorList{vErr})
-		status := err.(*statusError).Status()
+		status := err.(*StatusError).ErrStatus
 		if status.Code != 422 || status.Reason != api.StatusReasonInvalid {
 			t.Errorf("%d: unexpected status: %#v", i, status)
 		}

--- a/pkg/client/record/event.go
+++ b/pkg/client/record/event.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -30,6 +32,8 @@ import (
 
 // EventRecorder knows how to store events (client.Client implements it.)
 // EventRecorder must respect the namespace that will be embedded in 'event'.
+// It is assumed that EventRecorder will return the same sorts of errors as
+// pkg/client's REST client.
 type EventRecorder interface {
 	Create(event *api.Event) (*api.Event, error)
 }
@@ -44,13 +48,39 @@ func StartRecording(recorder EventRecorder, sourceName string) watch.Interface {
 		eventCopy := *event
 		event = &eventCopy
 		event.Source = sourceName
+		try := 0
 		for {
+			try++
 			_, err := recorder.Create(event)
 			if err == nil {
 				break
 			}
-			glog.Errorf("Sleeping: Unable to write event: %v", err)
-			time.Sleep(10 * time.Second)
+			// If we can't contact the server, then hold everything while we keep trying.
+			// Otherwise, something about the event is malformed and we should abandon it.
+			giveUp := false
+			switch err.(type) {
+			case *client.RequestConstructionError:
+				// We will construct the request the same next time, so don't keep trying.
+				giveUp = true
+			case *errors.StatusError:
+				// This indicates that the server understood and rejected our request.
+				giveUp = true
+			case *errors.UnexpectedObjectError:
+				// We don't expect this; it implies the server's response didn't match a
+				// known pattern. Go ahead and retry.
+			default:
+				// This case includes actual http transport errors. Go ahead and retry.
+			}
+			if giveUp {
+				glog.Errorf("Unable to write event '%#v': '%v' (will not retry!)", event, err)
+				break
+			}
+			if try >= 3 {
+				glog.Errorf("Unable to write event '%#v': '%v' (retry limit exceeded!)", event, err)
+				break
+			}
+			glog.Errorf("Unable to write event: '%v' (will retry in 1 second)", err)
+			time.Sleep(1 * time.Second)
 		}
 	})
 }


### PR DESCRIPTION
Also, don't retry forever.

Make error types easier to introspect on.

Closes #2428.
