### PR TITLE
Check in default blank file for kubelet/kubernetes_auth

### DIFF
--- a/cluster/saltbase/salt/kubelet/init.sls
+++ b/cluster/saltbase/salt/kubelet/init.sls
@@ -38,17 +38,17 @@
 
 {% endif %}
 
-{% if grains.cloud is defined %}
-{% if grains.cloud == 'gce' %}
-# Kubelet will run without this file but will not be able to send events to the apiserver.
+# The default here is that this file is blank.  If this is the case, the kubelet
+# won't be able to parse it as JSON and it'll not be able to publish events to
+# the apiserver.  You'll see a single error line in the kubelet start up file
+# about this.
 /var/lib/kubelet/kubernetes_auth:
   file.managed:
     - source: salt://kubelet/kubernetes_auth
     - user: root
     - group: root
     - mode: 400
-{% endif %}
-{% endif %}
+    - makedirs: true
 
 kubelet:
   group.present:
@@ -69,9 +69,5 @@ kubelet:
 {% if grains['os_family'] != 'RedHat' %}
       - file: /etc/init.d/kubelet
 {% endif %}
-{% if grains.cloud is defined %}
-{% if grains.cloud == 'gce' %}
       - file: /var/lib/kubelet/kubernetes_auth
-{% endif %}
-{% endif %}
 


### PR DESCRIPTION
This lets us eliminate some per-cloud stuff in our salt.  This is an alternate fix for #2475.
