### PR TITLE
add health check to kube-proxy

### DIFF
--- a/pkg/master/ports/ports.go
+++ b/pkg/master/ports/ports.go
@@ -26,4 +26,7 @@ const (
 	// ControllerManagerPort is the default port for the controller manager status server.
 	// May be overridden by a flag at startup.
 	ControllerManagerPort = 10252
+	// ProxyPort is the default port for the proxy status server.
+	// May be overriden by a flag at startup.
+	ProxyPort = 10249
 )


### PR DESCRIPTION
A group of kube-proxies will often be used as a backend to a downstream proxy or load balancer. A health check will help downstreams verify network connectivity to the proxies.
