### PR TITLE
Enable docker registry cache. By default it is off

### DIFF
--- a/cluster/gce/templates/salt-minion.sh
+++ b/cluster/gce/templates/salt-minion.sh
@@ -36,6 +36,17 @@ grains:
   cloud: gce
 EOF
 
+# Decide if enable the cache
+if [[ "${ENABLE_DOCKER_REGISTRY_CACHE}" == "true" ]]; then 
+    REGION=$(echo "${ZONE}" | cut -f 1,2 -d -)
+    echo "Enable docker registry cache at region: " $REGION
+    DOCKER_OPTS="--registry-mirror=\"https://${REGION}.docker-cache.clustermaster.net\""
+
+    cat <<EOF >>/etc/salt/minion.d/grains.conf
+  docker_opts: $DOCKER_OPTS
+EOF
+fi
+
 install-salt
 
 # Wait a few minutes and trigger another Salt run to better recover from

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -328,8 +328,10 @@ function kube-up {
   for (( i=0; i<${#MINION_NAMES[@]}; i++)); do
     (
       echo "#! /bin/bash"
+      echo "ZONE='${ZONE}'"
       echo "MASTER_NAME='${MASTER_NAME}'"
       echo "MINION_IP_RANGE='${MINION_IP_RANGES[$i]}'"
+      echo "ENABLE_DOCKER_REGISTRY_CACHE='${ENABLE_DOCKER_REGISTRY_CACHE:-false}'"
       grep -v "^#" "${KUBE_ROOT}/cluster/gce/templates/common.sh"
       grep -v "^#" "${KUBE_ROOT}/cluster/gce/templates/salt-minion.sh"
     ) > "${KUBE_TEMP}/minion-start-${i}.sh"


### PR DESCRIPTION
I tested it in my cluster, and saw overall performance improvement over time. 

@timbot @brendandburns @thockin 
