### PR TITLE
Reduce boilerplate

### DIFF
--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -25,6 +25,15 @@ import (
 )
 
 func init() {
+	// Our TypeMeta was split into two different structs.
+	newer.Scheme.AddStructFieldConversion(TypeMeta{}, "TypeMeta", newer.TypeMeta{}, "TypeMeta")
+	newer.Scheme.AddStructFieldConversion(TypeMeta{}, "TypeMeta", newer.ObjectMeta{}, "ObjectMeta")
+	newer.Scheme.AddStructFieldConversion(TypeMeta{}, "TypeMeta", newer.ListMeta{}, "ListMeta")
+
+	newer.Scheme.AddStructFieldConversion(newer.TypeMeta{}, "TypeMeta", TypeMeta{}, "TypeMeta")
+	newer.Scheme.AddStructFieldConversion(newer.ObjectMeta{}, "ObjectMeta", TypeMeta{}, "TypeMeta")
+	newer.Scheme.AddStructFieldConversion(newer.ListMeta{}, "ListMeta", TypeMeta{}, "TypeMeta")
+
 	newer.Scheme.AddConversionFuncs(
 		// TypeMeta must be split into two objects
 		func(in *newer.TypeMeta, out *TypeMeta, s conversion.Scope) error {
@@ -231,6 +240,7 @@ func init() {
 			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
 				return err
 			}
+			// TODO: Change this to use in.ObjectMeta.Labels.
 			if err := s.Convert(&in.Labels, &out.Labels, 0); err != nil {
 				return err
 			}
@@ -388,7 +398,6 @@ func init() {
 		},
 
 		func(in *newer.Service, out *Service, s conversion.Scope) error {
-
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err
 			}
@@ -435,62 +444,6 @@ func init() {
 			return nil
 		},
 
-		func(in *newer.Binding, out *Binding, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-
-			out.PodID = in.PodID
-			out.Host = in.Host
-
-			return nil
-		},
-		func(in *Binding, out *newer.Binding, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
-				return err
-			}
-
-			out.PodID = in.PodID
-			out.Host = in.Host
-
-			return nil
-		},
-
-		func(in *newer.Status, out *Status, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-
-			out.Code = in.Code
-			out.Message = in.Message
-			out.Reason = StatusReason(in.Reason)
-			out.Status = in.Status
-			return s.Convert(&in.Details, &out.Details, 0)
-		},
-		func(in *Status, out *newer.Status, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
-				return err
-			}
-
-			out.Code = in.Code
-			out.Message = in.Message
-			out.Reason = newer.StatusReason(in.Reason)
-			out.Status = in.Status
-			return s.Convert(&in.Details, &out.Details, 0)
-		},
-
 		func(in *newer.Minion, out *Minion, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err
@@ -518,253 +471,6 @@ func init() {
 
 			out.Status.HostIP = in.HostIP
 			return s.Convert(&in.NodeResources.Capacity, &out.Spec.Capacity, 0)
-		},
-
-		func(in *newer.BoundPod, out *BoundPod, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-
-			return s.Convert(&in.Spec, &out.Spec, 0)
-		},
-		func(in *BoundPod, out *newer.BoundPod, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
-				return err
-			}
-
-			return s.Convert(&in.Spec, &out.Spec, 0)
-		},
-
-		func(in *newer.BoundPods, out *BoundPods, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			out.Host = in.Host
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *BoundPods, out *newer.BoundPods, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
-				return err
-			}
-			out.Host = in.Host
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-
-		func(in *newer.Endpoints, out *Endpoints, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-
-			return s.Convert(&in.Endpoints, &out.Endpoints, 0)
-		},
-		func(in *Endpoints, out *newer.Endpoints, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
-				return err
-			}
-
-			return s.Convert(&in.Endpoints, &out.Endpoints, 0)
-		},
-
-		func(in *newer.ServerOp, out *ServerOp, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return nil
-		},
-		func(in *ServerOp, out *newer.ServerOp, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
-				return err
-			}
-			return nil
-		},
-
-		func(in *newer.Event, out *Event, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-
-			out.Message = in.Message
-			out.Reason = in.Reason
-			out.Source = in.Source
-			out.Status = in.Status
-			out.Timestamp = in.Timestamp
-			return s.Convert(&in.InvolvedObject, &out.InvolvedObject, 0)
-		},
-		func(in *Event, out *newer.Event, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
-				return err
-			}
-
-			out.Message = in.Message
-			out.Reason = in.Reason
-			out.Source = in.Source
-			out.Status = in.Status
-			out.Timestamp = in.Timestamp
-			return s.Convert(&in.InvolvedObject, &out.InvolvedObject, 0)
-		},
-
-		// Convert all the standard lists
-		func(in *newer.PodList, out *PodList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *PodList, out *newer.PodList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-
-		func(in *newer.ReplicationControllerList, out *ReplicationControllerList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *ReplicationControllerList, out *newer.ReplicationControllerList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-
-		func(in *newer.ServiceList, out *ServiceList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *ServiceList, out *newer.ServiceList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-
-		func(in *newer.EndpointsList, out *EndpointsList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *EndpointsList, out *newer.EndpointsList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-
-		func(in *newer.EventList, out *EventList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *EventList, out *newer.EventList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-
-		func(in *newer.ServerOpList, out *ServerOpList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *ServerOpList, out *newer.ServerOpList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-
-		func(in *newer.ContainerManifestList, out *ContainerManifestList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *ContainerManifestList, out *newer.ContainerManifestList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
 		},
 
 		// Object ID <-> Name

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -25,6 +25,15 @@ import (
 )
 
 func init() {
+	// Our TypeMeta was split into two different structs.
+	newer.Scheme.AddStructFieldConversion(TypeMeta{}, "TypeMeta", newer.TypeMeta{}, "TypeMeta")
+	newer.Scheme.AddStructFieldConversion(TypeMeta{}, "TypeMeta", newer.ObjectMeta{}, "ObjectMeta")
+	newer.Scheme.AddStructFieldConversion(TypeMeta{}, "TypeMeta", newer.ListMeta{}, "ListMeta")
+
+	newer.Scheme.AddStructFieldConversion(newer.TypeMeta{}, "TypeMeta", TypeMeta{}, "TypeMeta")
+	newer.Scheme.AddStructFieldConversion(newer.ObjectMeta{}, "ObjectMeta", TypeMeta{}, "TypeMeta")
+	newer.Scheme.AddStructFieldConversion(newer.ListMeta{}, "ListMeta", TypeMeta{}, "TypeMeta")
+
 	newer.Scheme.AddConversionFuncs(
 		// TypeMeta must be split into two objects
 		func(in *newer.TypeMeta, out *TypeMeta, s conversion.Scope) error {
@@ -135,6 +144,7 @@ func init() {
 			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
 				return err
 			}
+			// TODO: Change this to use in.ObjectMeta.Labels.
 			if err := s.Convert(&in.Labels, &out.Labels, 0); err != nil {
 				return err
 			}
@@ -364,62 +374,6 @@ func init() {
 			return nil
 		},
 
-		func(in *newer.Binding, out *Binding, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-
-			out.PodID = in.PodID
-			out.Host = in.Host
-
-			return nil
-		},
-		func(in *Binding, out *newer.Binding, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
-				return err
-			}
-
-			out.PodID = in.PodID
-			out.Host = in.Host
-
-			return nil
-		},
-
-		func(in *newer.Status, out *Status, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-
-			out.Code = in.Code
-			out.Message = in.Message
-			out.Reason = StatusReason(in.Reason)
-			out.Status = in.Status
-			return s.Convert(&in.Details, &out.Details, 0)
-		},
-		func(in *Status, out *newer.Status, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
-				return err
-			}
-
-			out.Code = in.Code
-			out.Message = in.Message
-			out.Reason = newer.StatusReason(in.Reason)
-			out.Status = in.Status
-			return s.Convert(&in.Details, &out.Details, 0)
-		},
-
 		func(in *newer.Minion, out *Minion, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err
@@ -447,272 +401,6 @@ func init() {
 
 			out.Status.HostIP = in.HostIP
 			return s.Convert(&in.NodeResources.Capacity, &out.Spec.Capacity, 0)
-		},
-
-		func(in *newer.BoundPod, out *BoundPod, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-
-			return s.Convert(&in.Spec, &out.Spec, 0)
-		},
-		func(in *BoundPod, out *newer.BoundPod, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
-				return err
-			}
-
-			return s.Convert(&in.Spec, &out.Spec, 0)
-		},
-
-		func(in *newer.BoundPods, out *BoundPods, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			out.Host = in.Host
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *BoundPods, out *newer.BoundPods, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
-				return err
-			}
-			out.Host = in.Host
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-
-		func(in *newer.Endpoints, out *Endpoints, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-
-			return s.Convert(&in.Endpoints, &out.Endpoints, 0)
-		},
-		func(in *Endpoints, out *newer.Endpoints, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
-				return err
-			}
-
-			return s.Convert(&in.Endpoints, &out.Endpoints, 0)
-		},
-
-		func(in *newer.ServerOp, out *ServerOp, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return nil
-		},
-		func(in *ServerOp, out *newer.ServerOp, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
-				return err
-			}
-			return nil
-		},
-
-		func(in *newer.Event, out *Event, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-
-			out.Message = in.Message
-			out.Reason = in.Reason
-			out.Source = in.Source
-			out.Status = in.Status
-			out.Timestamp = in.Timestamp
-			return s.Convert(&in.InvolvedObject, &out.InvolvedObject, 0)
-		},
-		func(in *Event, out *newer.Event, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
-				return err
-			}
-
-			out.Message = in.Message
-			out.Reason = in.Reason
-			out.Source = in.Source
-			out.Status = in.Status
-			out.Timestamp = in.Timestamp
-			return s.Convert(&in.InvolvedObject, &out.InvolvedObject, 0)
-		},
-
-		// Convert all the standard lists
-		func(in *newer.PodList, out *PodList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *PodList, out *newer.PodList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-
-		func(in *newer.ReplicationControllerList, out *ReplicationControllerList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *ReplicationControllerList, out *newer.ReplicationControllerList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-
-		func(in *newer.ServiceList, out *ServiceList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *ServiceList, out *newer.ServiceList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-
-		func(in *newer.EndpointsList, out *EndpointsList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *EndpointsList, out *newer.EndpointsList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-
-		func(in *newer.EventList, out *EventList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *EventList, out *newer.EventList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-
-		func(in *newer.MinionList, out *MinionList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *MinionList, out *newer.MinionList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-
-		func(in *newer.ServerOpList, out *ServerOpList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *ServerOpList, out *newer.ServerOpList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-
-		func(in *newer.ContainerManifestList, out *ContainerManifestList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
-		},
-		func(in *ContainerManifestList, out *newer.ContainerManifestList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
-				return err
-			}
-			return s.Convert(&in.Items, &out.Items, 0)
 		},
 
 		// Object ID <-> Name

--- a/pkg/conversion/converter_test.go
+++ b/pkg/conversion/converter_test.go
@@ -290,3 +290,95 @@ func TestConverter_flags(t *testing.T) {
 		}
 	}
 }
+
+func TestConverter_FieldRename(t *testing.T) {
+	type WeirdMeta struct {
+		Name string
+		Type string
+	}
+	type NameMeta struct {
+		Name string
+	}
+	type TypeMeta struct {
+		Type string
+	}
+	type A struct {
+		WeirdMeta
+	}
+	type B struct {
+		TypeMeta
+		NameMeta
+	}
+
+	c := NewConverter()
+	err := c.SetStructFieldCopy(WeirdMeta{}, "WeirdMeta", TypeMeta{}, "TypeMeta")
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	err = c.SetStructFieldCopy(WeirdMeta{}, "WeirdMeta", NameMeta{}, "NameMeta")
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	err = c.SetStructFieldCopy(TypeMeta{}, "TypeMeta", WeirdMeta{}, "WeirdMeta")
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	err = c.SetStructFieldCopy(NameMeta{}, "NameMeta", WeirdMeta{}, "WeirdMeta")
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	c.Debug = t
+
+	aVal := &A{
+		WeirdMeta: WeirdMeta{
+			Name: "Foo",
+			Type: "Bar",
+		},
+	}
+
+	bVal := &B{
+		TypeMeta: TypeMeta{"Bar"},
+		NameMeta: NameMeta{"Foo"},
+	}
+
+	table := map[string]struct {
+		from, to, expect interface{}
+		flags            FieldMatchingFlags
+	}{
+		"to": {
+			aVal,
+			&B{},
+			bVal,
+			AllowDifferentFieldTypeNames | SourceToDest | IgnoreMissingFields,
+		},
+		"from": {
+			bVal,
+			&A{},
+			aVal,
+			AllowDifferentFieldTypeNames | SourceToDest,
+		},
+		"toDestFirst": {
+			aVal,
+			&B{},
+			bVal,
+			AllowDifferentFieldTypeNames,
+		},
+		"fromDestFirst": {
+			bVal,
+			&A{},
+			aVal,
+			AllowDifferentFieldTypeNames | IgnoreMissingFields,
+		},
+	}
+
+	for name, item := range table {
+		err := c.Convert(item.from, item.to, item.flags, nil)
+		if err != nil {
+			t.Errorf("%v: unexpected error: %v", name, err)
+			continue
+		}
+		if e, a := item.expect, item.to; !reflect.DeepEqual(e, a) {
+			t.Errorf("%v: unexpected diff: %v", name, objDiff(e, a))
+		}
+	}
+}

--- a/pkg/conversion/scheme.go
+++ b/pkg/conversion/scheme.go
@@ -193,6 +193,14 @@ func (s *Scheme) AddConversionFuncs(conversionFuncs ...interface{}) error {
 	return nil
 }
 
+// AddStructFieldConversion allows you to specify a mechanical copy for a moved
+// or renamed struct field without writing an entire conversion function. See
+// the comment in Converter.SetStructFieldCopy for parameter details.
+// Call as many times as needed, even on the same fields.
+func (s *Scheme) AddStructFieldConversion(srcFieldType interface{}, srcFieldName string, destFieldType interface{}, destFieldName string) error {
+	return s.converter.SetStructFieldCopy(srcFieldType, srcFieldName, destFieldType, destFieldName)
+}
+
 // Convert will attempt to convert in into out. Both must be pointers. For easy
 // testing of conversion functions. Returns an error if the conversion isn't
 // possible. You can call this with types that haven't been registered (for example,

--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -217,6 +217,14 @@ func (s *Scheme) AddConversionFuncs(conversionFuncs ...interface{}) error {
 	return s.raw.AddConversionFuncs(conversionFuncs...)
 }
 
+// AddStructFieldConversion allows you to specify a mechanical copy for a moved
+// or renamed struct field without writing an entire conversion function. See
+// the comment in conversion.Converter.SetStructFieldCopy for parameter details.
+// Call as many times as needed, even on the same fields.
+func (s *Scheme) AddStructFieldConversion(srcFieldType interface{}, srcFieldName string, destFieldType interface{}, destFieldName string) error {
+	return s.raw.AddStructFieldConversion(srcFieldType, srcFieldName, destFieldType, destFieldName)
+}
+
 // Convert will attempt to convert in into out. Both must be pointers.
 // For easy testing of conversion functions. Returns an error if the conversion isn't
 // possible.


### PR DESCRIPTION
I've been becoming increasingly worried about the boilerplate in our conversion functions -- it's so easy for errors to hide in there. This change lets you specify struct field/name -> other struct field/name copying, so we don't have to repeat the same copy so many times.

In the future I might extend this to let you dig in multiple levels (e.g., in.Labels -> out.ObjectMeta.Labels), which should get rid of the rest of the boilerplate functions here. When I made these I was expecting to see mostly functions of the sort that fixes up the EnvVar type, where a tiny bit of actual logic is needed, and I've been dismayed at the proliferation of boilerplate...

(Speaking of errors, did pod's label location really not change to be inside object meta?)
