### PR TITLE
fix issue #2542:  'Building Docker image kube-build:build-53055 fails'

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -18,15 +18,15 @@ There is also early support for building Docker "run" containers
 
 ## Key scripts
 
-* `run.sh`: Run a command in a build docker container.  Common invocations:
-  *  `run.sh hack/build-go.sh`: Build just linux binaries in the container.  Pass options and packages as necessary.
-  *  `run.sh hack/build-cross.sh`: Build all binaries for all platforms
-  *  `run.sh hack/test-go.sh`: Run all unit tests
-  *  `run.sh hack/test-integration.sh`: Run integration test
-* `copy-output.sh`: This will copy the contents of `_output/dockerized/bin` from any remote Docker container to the local `_output/dockerized/bin`.  Right now this is only necessary on Mac OS X with `boot2docker` when your git repo isn't under `/Users`.
-* `make-clean.sh`: Clean out the contents of `_output/dockerized` and remove any local built container images.
-* `shell.sh`: Drop into a `bash` shell in a build container with a snapshot of the current repo code.
-* `release.sh`: Build everything, test it, and (optionally) upload the results to a GCS bucket.
+* `sudo ./run.sh`: Run a command in a build docker container.  Common invocations:
+  *  `sudo ./run.sh hack/build-go.sh`: Build just linux binaries in the container.  Pass options and packages as necessary.
+  *  `sudo ./run.sh hack/build-cross.sh`: Build all binaries for all platforms
+  *  `sudo ./run.sh hack/test-go.sh`: Run all unit tests
+  *  `sudo ./run.sh hack/test-integration.sh`: Run integration test
+* `sudo ./copy-output.sh`: This will copy the contents of `_output/dockerized/bin` from any remote Docker container to the local `_output/dockerized/bin`.  Right now this is only necessary on Mac OS X with `boot2docker` when your git repo isn't under `/Users`.
+* `sudo ./make-clean.sh`: Clean out the contents of `_output/dockerized` and remove any local built container images.
+* `sudo ./shell.sh`: Drop into a `bash` shell in a build container with a snapshot of the current repo code.
+* `sudo ./release.sh`: Build everything, test it, and (optionally) upload the results to a GCS bucket.
 
 ## Releasing
 


### PR DESCRIPTION
Clarify documentation on how to run compiling scripts.
(see  [Building Docker image kube-build:build-53055 fails #2542](https://github.com/GoogleCloudPlatform/kubernetes/issues/2542))
