### PR TITLE
reset err value to SetDeadline return

### DIFF
--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -204,7 +204,7 @@ func (udp *udpProxySocket) ProxyLoop(service string, info *serviceInfo, proxier 
 			}
 			continue
 		}
-		svrConn.SetDeadline(time.Now().Add(info.timeout))
+		err = svrConn.SetDeadline(time.Now().Add(info.timeout))
 		if err != nil {
 			glog.Errorf("SetDeadline failed: %v", err)
 			continue
@@ -248,7 +248,7 @@ func (udp *udpProxySocket) proxyClient(cliAddr net.Addr, svrConn net.Conn, activ
 			}
 			break
 		}
-		svrConn.SetDeadline(time.Now().Add(timeout))
+		err = svrConn.SetDeadline(time.Now().Add(timeout))
 		if err != nil {
 			glog.Errorf("SetDeadline failed: %v", err)
 			break


### PR DESCRIPTION
As I attempt https://github.com/GoogleCloudPlatform/kubernetes/issues/1274, I notice that there could be a problem in the current code.

Regarding the fix on line 251:
If `err` is not modified between the previous `if err != nil {` and the `if err != nil {` right after the change then the if block right after the fix is dead code due to the `break` in the preceding if block. Because `err` is a local variable and it is not modified in those lines, I don't see how it could change.

Am I missing something here?

I made a PR here instead of an issue since the change is quite small.
