### PR TITLE
Do not use nginx image in e2e test

### DIFF
--- a/cmd/e2e/e2e.go
+++ b/cmd/e2e/e2e.go
@@ -182,7 +182,7 @@ func TestKubeletSendsEvent(c *client.Client) bool {
 
 	podClient := c.Pods(api.NamespaceDefault)
 
-	pod := loadPodOrDie("./api/examples/pod.json")
+	pod := loadPodOrDie("./cmd/e2e/pod.json")
 	value := strconv.Itoa(time.Now().Nanosecond())
 	pod.Labels["time"] = value
 

--- a/cmd/e2e/pod.json
+++ b/cmd/e2e/pod.json
@@ -1,0 +1,23 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1beta1",
+  "id": "p",
+  "desiredState": {
+    "manifest": {
+      "version": "v1beta1",
+      "id": "p",
+      "containers": [{
+        "name": "p",
+        "image": "kubernetes/serve_hostname",
+        "ports": [{
+          "containerPort": 80,
+          "hostPort": 8080
+        }],
+      }]
+    }
+  },
+  "labels": {
+    "name": "foo"
+  }
+}
+


### PR DESCRIPTION
I inadvertently undid  #1803 when I added this test and used the example pod.  Fixing that now.
