### PR TITLE
Store per-master-component command line flags in etcd, by creating a "MasterFlags" API directory (issue #1627).

### DIFF
--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -89,6 +89,20 @@ func main() {
 		glog.Fatalf("Invalid API configuration: %v", err)
 	}
 
+	// Fetch additional flags from the API server
+	flagsClient := kubeClient.MasterFlags(api.NamespaceDefault)
+	flags, err := flagsClient.Get("controller")
+	if err != nil {
+		glog.Fatalf("Could not read flags from api server: %v", err)
+	}
+	for k, v := range flags.Spec.CmdLineArg {
+		f := flag.Lookup(k)
+		if (f == nil) {
+			glog.Fatalf("Could not find flag %s", k)
+		}
+		f.Value.Set(v);
+	}
+
 	go http.ListenAndServe(net.JoinHostPort(address.String(), strconv.Itoa(*port)), nil)
 
 	endpoints := service.NewEndpointController(kubeClient)

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -45,6 +45,8 @@ func init() {
 		&ContainerManifestList{},
 		&BoundPod{},
 		&BoundPods{},
+		&MasterFlags{},
+		&MasterFlagsList{},
 	)
 }
 
@@ -68,3 +70,5 @@ func (*ContainerManifest) IsAnAPIObject()         {}
 func (*ContainerManifestList) IsAnAPIObject()     {}
 func (*BoundPod) IsAnAPIObject()                  {}
 func (*BoundPods) IsAnAPIObject()                 {}
+func (*MasterFlags) IsAnAPIObject()               {}
+func (*MasterFlagsList) IsAnAPIObject()           {}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -939,6 +939,28 @@ type EventList struct {
 	Items []Event `yaml:"items" json:"items"`
 }
 
+// MasterFlagsSpec specifies configuration of a kubernetes master component.
+type MasterFlagsSpec struct {
+	// The command line flags as key-value pairs.
+	CmdLineArg map[string]string `json:"cmdlinearg" yaml:"cmdlinearg"`
+}
+
+// MasterFlags represents the configuration of a kubernetes master component.
+type MasterFlags struct {
+	TypeMeta   `json:",inline" yaml:",inline"`
+	ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	Spec MasterFlagsSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
+}
+
+// MasterFlagsList is a list of MasterFlagss
+type MasterFlagsList struct {
+	TypeMeta `json:",inline" yaml:",inline"`
+	ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	Items []MasterFlags `json:"items" yaml:"items"`
+}
+
 // ContainerManifest corresponds to the Container Manifest format, documented at:
 // https://developers.google.com/compute/docs/containers/container_vms#container_manifest
 // This is used as the representation of Kubernetes workloads.

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -602,6 +602,24 @@ func init() {
 			return nil
 		},
 
+		func(in *newer.MasterFlags, out *MasterFlags, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			return s.Convert(&in.Spec, &out.Spec, 0)
+		},
+		func(in *MasterFlags, out *newer.MasterFlags, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
+				return err
+			}
+			return s.Convert(&in.Spec, &out.Spec, 0)
+		},
 		func(in *newer.Event, out *Event, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err
@@ -720,6 +738,25 @@ func init() {
 			return s.Convert(&in.Items, &out.Items, 0)
 		},
 		func(in *EventList, out *newer.EventList, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
+				return err
+			}
+			return s.Convert(&in.Items, &out.Items, 0)
+		},
+
+		func(in *newer.MasterFlagsList, out *MasterFlagsList, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			return s.Convert(&in.Items, &out.Items, 0)
+		},
+		func(in *MasterFlagsList, out *newer.MasterFlagsList, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err
 			}

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -46,6 +46,8 @@ func init() {
 		&ContainerManifestList{},
 		&BoundPod{},
 		&BoundPods{},
+		&MasterFlags{},
+		&MasterFlagsList{},
 	)
 }
 
@@ -69,3 +71,5 @@ func (*ContainerManifest) IsAnAPIObject()         {}
 func (*ContainerManifestList) IsAnAPIObject()     {}
 func (*BoundPod) IsAnAPIObject()                  {}
 func (*BoundPods) IsAnAPIObject()                 {}
+func (*MasterFlags) IsAnAPIObject()               {}
+func (*MasterFlagsList) IsAnAPIObject()           {}

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -780,3 +780,21 @@ type BoundPods struct {
 	// Items is the list of all pods bound to a given host.
 	Items []BoundPod `json:"items" yaml:"items" description:"list of all pods bound to a given host"`
 }
+
+// MasterFlagsSpec specifies configuration of a kubernetes master component.
+type MasterFlagsSpec struct {
+	// The command line flags as key-value pairs.
+	CmdLineArg map[string]string `json:"cmdlinearg" yaml:"cmdlinearg"`
+}
+
+// MasterFlags represents the configuration of a kubernetes master component.
+type MasterFlags struct {
+	TypeMeta   `json:",inline" yaml:",inline"`
+	Spec MasterFlagsSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
+}
+
+// MasterFlagsList is a list of MasterFlagss
+type MasterFlagsList struct {
+	TypeMeta `json:",inline" yaml:",inline"`
+	Items []MasterFlags `json:"items" yaml:"items"`
+}

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -562,6 +562,25 @@ func init() {
 			return s.Convert(&in.InvolvedObject, &out.InvolvedObject, 0)
 		},
 
+		func(in *newer.MasterFlags, out *MasterFlags, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			return s.Convert(&in.Spec, &out.Spec, 0)
+		},
+		func(in *MasterFlags, out *newer.MasterFlags, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
+				return err
+			}
+			return s.Convert(&in.Spec, &out.Spec, 0)
+		},
+
 		// Convert all the standard lists
 		func(in *newer.PodList, out *PodList, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
@@ -658,6 +677,24 @@ func init() {
 			return s.Convert(&in.Items, &out.Items, 0)
 		},
 
+		func(in *newer.MasterFlagsList, out *MasterFlagsList, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			return s.Convert(&in.Items, &out.Items, 0)
+		},
+		func(in *MasterFlagsList, out *newer.MasterFlagsList, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.TypeMeta, &out.ListMeta, 0); err != nil {
+				return err
+			}
+			return s.Convert(&in.Items, &out.Items, 0)
+		},
 		func(in *newer.MinionList, out *MinionList, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err

--- a/pkg/api/v1beta2/register.go
+++ b/pkg/api/v1beta2/register.go
@@ -46,6 +46,8 @@ func init() {
 		&ContainerManifestList{},
 		&BoundPod{},
 		&BoundPods{},
+		&MasterFlags{},
+		&MasterFlagsList{},
 	)
 }
 
@@ -69,3 +71,5 @@ func (*ContainerManifest) IsAnAPIObject()         {}
 func (*ContainerManifestList) IsAnAPIObject()     {}
 func (*BoundPod) IsAnAPIObject()                  {}
 func (*BoundPods) IsAnAPIObject()                 {}
+func (*MasterFlags) IsAnAPIObject()               {}
+func (*MasterFlagsList) IsAnAPIObject()           {}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -781,3 +781,21 @@ type BoundPods struct {
 	// Items is the list of all pods bound to a given host.
 	Items []BoundPod `json:"items" yaml:"items" description:"list of all pods bound to a given host"`
 }
+
+// MasterFlagsSpec specifies configuration of a kubernetes master component.
+type MasterFlagsSpec struct {
+	// The command line flags as key-value pairs.
+	CmdLineArg map[string]string `json:"cmdlinearg" yaml:"cmdlinearg"`
+}
+
+// MasterFlags represents the configuration of a kubernetes master component.
+type MasterFlags struct {
+	TypeMeta `json:",inline" yaml:",inline"`
+	Spec MasterFlagsSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
+}
+
+// MasterFlagsList is a list of MasterFlagss
+type MasterFlagsList struct {
+	TypeMeta `json:",inline" yaml:",inline"`
+	Items []MasterFlags `json:"items" yaml:"items"`
+}

--- a/pkg/api/v1beta3/register.go
+++ b/pkg/api/v1beta3/register.go
@@ -46,6 +46,8 @@ func init() {
 		&OperationList{},
 		&Event{},
 		&EventList{},
+		&MasterFlags{},
+		&MasterFlagsList{},
 	)
 }
 
@@ -69,3 +71,5 @@ func (*Operation) IsAnAPIObject()                 {}
 func (*OperationList) IsAnAPIObject()             {}
 func (*Event) IsAnAPIObject()                     {}
 func (*EventList) IsAnAPIObject()                 {}
+func (*MasterFlags) IsAnAPIObject()               {}
+func (*MasterFlagsList) IsAnAPIObject()           {}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -944,3 +944,25 @@ type EventList struct {
 
 	Items []Event `json:"items" yaml:"items"`
 }
+
+// MasterFlagsSpec specifies configuration of a kubernetes master component.
+type MasterFlagsSpec struct {
+	// The command line flags as key-value pairs.
+	CmdLineArg map[string]string `json:"cmdlinearg" yaml:"cmdlinearg"`
+}
+
+// MasterFlags represents the configuration of a kubernetes master component.
+type MasterFlags struct {
+	TypeMeta   `json:",inline" yaml:",inline"`
+	ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	Spec MasterFlagsSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
+}
+
+// MasterFlagsList is a list of MasterFlagss
+type MasterFlagsList struct {
+	TypeMeta `json:",inline" yaml:",inline"`
+	ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	Items []MasterFlags `json:"items" yaml:"items"`
+}

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -541,6 +541,16 @@ func ValidateMinion(minion *api.Minion) errs.ValidationErrorList {
 	return allErrs
 }
 
+// ValidateMasterFlags tests if required fields in the MasterFlags are set.
+func ValidateMasterFlags(flags *api.MasterFlags) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	if len(flags.Name) == 0 {
+		allErrs = append(allErrs, errs.NewFieldRequired("name", flags.Name))
+	}
+	allErrs = append(allErrs, validateLabels(flags.Labels)...)
+	return allErrs
+}
+
 // ValidateMinionUpdate tests to make sure a minion update can be applied.  Modifies oldMinion.
 func ValidateMinionUpdate(oldMinion *api.Minion, minion *api.Minion) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -48,6 +48,10 @@ func (c *Client) Events(namespace string) EventInterface {
 	return newEvents(c, namespace)
 }
 
+func (c *Client) MasterFlags(namespace string) MasterFlagsInterface {
+	return newMasterFlags(c, namespace)
+}
+
 func (c *Client) Endpoints(namespace string) EndpointsInterface {
 	return newEndpoints(c, namespace)
 }

--- a/pkg/client/master_flags.go
+++ b/pkg/client/master_flags.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// MasterFlagsNamespacer can return a MasterFlagsInterface for the given namespace.
+type MasterFlagsNamespacer interface {
+	MasterFlags(namespace string) MasterFlagsInterface
+}
+
+// MasterFlagsInterface has methods to work with MasterFlags resources
+type MasterFlagsInterface interface {
+	Create(masterFlags *api.MasterFlags) (*api.MasterFlags, error)
+	List(label, field labels.Selector) (*api.MasterFlagsList, error)
+	Get(id string) (*api.MasterFlags, error)
+	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// masterFlags implements MasterFlags interface
+type masterFlags struct {
+	client    *Client
+	namespace string
+}
+
+// newMasterFlags returns a new masterFlags object.
+func newMasterFlags(c *Client, ns string) *masterFlags {
+	return &masterFlags{
+		client:    c,
+		namespace: ns,
+	}
+}
+
+// Create makes a new masterFlags. Returns the copy of the masterFlags the server returns,
+// or an error. The namespace to create the masterFlags within is deduced from the
+// masterFlags; it must either match this masterFlags client's namespace, or this masterFlags
+// client must have been created with the "" namespace.
+func (f *masterFlags) Create(masterFlags *api.MasterFlags) (*api.MasterFlags, error) {
+	if f.namespace != "" && masterFlags.Namespace != f.namespace {
+		return nil, fmt.Errorf("can't create a masterFlags with namespace '%v' in namespace '%v'", masterFlags.Namespace, f.namespace)
+	}
+	result := &api.MasterFlags{}
+	err := f.client.Post().
+		Path("masterFlags").
+		Namespace(masterFlags.Namespace).
+		Body(masterFlags).
+		Do().
+		Into(result)
+	return result, err
+}
+
+// List returns a list of masterFlags matching the selectors.
+func (f *masterFlags) List(label, field labels.Selector) (*api.MasterFlagsList, error) {
+	result := &api.MasterFlagsList{}
+	err := f.client.Get().
+		Path("masterFlags").
+		Namespace(f.namespace).
+		SelectorParam("labels", label).
+		SelectorParam("fields", field).
+		Do().
+		Into(result)
+	return result, err
+}
+
+// Get returns the given masterFlags, or an error.
+func (f *masterFlags) Get(id string) (*api.MasterFlags, error) {
+	result := &api.MasterFlags{}
+	err := f.client.Get().
+		Path("masterFlags").
+		Path(id).
+		Namespace(f.namespace).
+		Do().
+		Into(result)
+	return result, err
+}
+
+// Watch starts watching for masterFlags matching the given selectors.
+func (f *masterFlags) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	return f.client.Get().
+		Path("watch").
+		Path("masterFlags").
+		Param("resourceVersion", resourceVersion).
+		Namespace(f.namespace).
+		SelectorParam("labels", label).
+		SelectorParam("fields", field).
+		Watch()
+}

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -39,6 +39,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/binding"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/masterflags"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/controller"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/endpoint"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/etcd"
@@ -99,6 +100,7 @@ type Master struct {
 	minionRegistry        minion.Registry
 	bindingRegistry       binding.Registry
 	eventRegistry         generic.Registry
+	masterFlagsRegistry   generic.Registry
 	storage               map[string]apiserver.RESTStorage
 	client                *client.Client
 	portalNet             *net.IPNet
@@ -230,6 +232,7 @@ func New(c *Config) *Master {
 		endpointRegistry:      etcd.NewRegistry(c.EtcdHelper, nil),
 		bindingRegistry:       etcd.NewRegistry(c.EtcdHelper, boundPodFactory),
 		eventRegistry:         event.NewEtcdRegistry(c.EtcdHelper, uint64(c.EventTTL.Seconds())),
+		masterFlagsRegistry:   masterflags.NewEtcdRegistry(c.EtcdHelper),
 		minionRegistry:        minionRegistry,
 		client:                c.Client,
 		portalNet:             c.PortalNet,
@@ -323,6 +326,7 @@ func (m *Master) init(c *Config) {
 		"endpoints":              endpoint.NewREST(m.endpointRegistry),
 		"minions":                minion.NewREST(m.minionRegistry),
 		"events":                 event.NewREST(m.eventRegistry),
+		"masterFlags":            masterflags.NewREST(m.masterFlagsRegistry),
 
 		// TODO: should appear only in scheduler API group.
 		"bindings": binding.NewREST(m.bindingRegistry),

--- a/pkg/registry/etcd/etcd.go
+++ b/pkg/registry/etcd/etcd.go
@@ -42,6 +42,8 @@ const (
 	ServicePath string = "/registry/services/specs"
 	// ServiceEndpointPath is the path to service endpoints resources in etcd
 	ServiceEndpointPath string = "/registry/services/endpoints"
+	// MasterFlagsPath is the path to master component flags in etcd
+	ConfigPath string = "/registry/masterFlags"
 )
 
 // TODO: Need to add a reconciler loop that makes sure that things in pods are reflected into
@@ -390,7 +392,7 @@ func (r *Registry) DeleteController(ctx api.Context, controllerID string) error 
 	return etcderr.InterpretDeleteError(err, "replicationController", controllerID)
 }
 
-// makePodListKey constructs etcd paths to service directories enforcing namespace rules.
+// makeServiceListKey constructs etcd paths to service directories enforcing namespace rules.
 func makeServiceListKey(ctx api.Context) string {
 	return MakeEtcdListKey(ctx, ServicePath)
 }

--- a/pkg/registry/masterflags/doc.go
+++ b/pkg/registry/masterflags/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package event provides Registry interface and it's REST
+// implementation for storing Event api objects.
+package masterflags
+

--- a/pkg/registry/masterflags/registry.go
+++ b/pkg/registry/masterflags/registry.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package masterflags
+
+import (
+	"path"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	etcderr "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
+	etcdgeneric "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+)
+
+// registry implements custom changes to generic.Etcd.
+type registry struct {
+	*etcdgeneric.Etcd
+}
+
+func (r registry) Create(ctx api.Context, id string, obj runtime.Object) error {
+	err := r.Etcd.Helper.CreateObj(r.Etcd.KeyFunc(id), obj, 0)
+	return etcderr.InterpretCreateError(err, r.Etcd.EndpointName, id)
+}
+
+// NewEtcdRegistry returns a registry which will store MasterFlags in the given
+// EtcdHelper.
+func NewEtcdRegistry(h tools.EtcdHelper) generic.Registry {
+	return registry{
+		Etcd: &etcdgeneric.Etcd{
+			NewFunc:      func() runtime.Object { return &api.MasterFlags{} },
+			NewListFunc:  func() runtime.Object { return &api.MasterFlagsList{} },
+			EndpointName: "masterFlags",
+			KeyRoot:      "/registry/masterFlags",
+			KeyFunc: func(id string) string {
+				return path.Join("/registry/masterFlags", id)
+			},
+			Helper: h,
+		},
+	}
+}

--- a/pkg/registry/masterflags/registry_test.go
+++ b/pkg/registry/masterflags/registry_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package masterflags
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	"github.com/coreos/go-etcd/etcd"
+)
+
+func NewTestMasterFlagsEtcdRegistry(t *testing.T) (*tools.FakeEtcdClient, generic.Registry) {
+	f := tools.NewFakeEtcdClient(t)
+	f.TestIndex = true
+	h := tools.EtcdHelper{f, testapi.Codec(), tools.RuntimeVersionAdapter{testapi.MetadataAccessor()}}
+	return f, NewEtcdRegistry(h)
+}
+
+func TestMasterFlagsCreate(t *testing.T) {
+	masterFlagsA := &api.MasterFlags{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		Spec: api.MasterFlagsSpec{
+			CmdLineArg: map[string]string {"foo": "a"},
+		},
+	}
+	masterFlagsB := &api.MasterFlags{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		Spec: api.MasterFlagsSpec{
+			CmdLineArg: map[string]string {"foo": "b"},
+		},
+	}
+
+	nodeWithMasterFlagsA := tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Value:         runtime.EncodeOrDie(testapi.Codec(), masterFlagsA),
+				ModifiedIndex: 1,
+				CreatedIndex:  1,
+			},
+		},
+		E: nil,
+	}
+
+	emptyNode := tools.EtcdResponseWithError{
+		R: &etcd.Response{},
+		E: tools.EtcdErrorNotFound,
+	}
+
+	path := "/registry/masterFlags/foo"
+	key := "foo"
+
+	table := map[string]struct {
+		existing tools.EtcdResponseWithError
+		expect   tools.EtcdResponseWithError
+		toCreate runtime.Object
+		errOK    func(error) bool
+	}{
+		"normal": {
+			existing: emptyNode,
+			expect:   nodeWithMasterFlagsA,
+			toCreate: masterFlagsA,
+			errOK:    func(err error) bool { return err == nil },
+		},
+		"preExisting": {
+			existing: nodeWithMasterFlagsA,
+			expect:   nodeWithMasterFlagsA,
+			toCreate: masterFlagsB,
+			errOK:    errors.IsAlreadyExists,
+		},
+	}
+
+	for name, item := range table {
+		fakeClient, registry := NewTestMasterFlagsEtcdRegistry(t)
+		fakeClient.Data[path] = item.existing
+		err := registry.Create(api.NewContext(), key, item.toCreate)
+		if !item.errOK(err) {
+			t.Errorf("%v: unexpected error: %v", name, err)
+		}
+
+		if e, a := item.expect, fakeClient.Data[path]; !reflect.DeepEqual(e, a) {
+			t.Errorf("%v:\n%s", name, util.ObjectDiff(e, a))
+		}
+	}
+}

--- a/pkg/registry/masterflags/rest.go
+++ b/pkg/registry/masterflags/rest.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package masterflags
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// REST adapts a masterFlags registry into apiserver's RESTStorage model.
+type REST struct {
+	registry generic.Registry
+}
+
+// NewREST returns a new REST. You must use a registry created by
+// NewEtcdRegistry unless you're testing.
+func NewREST(registry generic.Registry) *REST {
+	return &REST{
+		registry: registry,
+	}
+}
+
+func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
+	masterFlags, ok := obj.(*api.MasterFlags)
+	if !ok {
+		return nil, fmt.Errorf("invalid object type")
+	}
+	if api.Namespace(ctx) != "" {
+		if !api.ValidNamespace(ctx, &masterFlags.ObjectMeta) {
+			return nil, errors.NewConflict("masterFlags", masterFlags.Namespace, fmt.Errorf("masterFlags.namespace does not match the provided context"))
+		}
+	}
+	if errs := validation.ValidateMasterFlags(masterFlags); len(errs) > 0 {
+		return nil, errors.NewInvalid("masterFlags", masterFlags.Name, errs)
+	}
+	api.FillObjectMetaSystemFields(ctx, &masterFlags.ObjectMeta)
+
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		err := rs.registry.Create(ctx, masterFlags.Name, masterFlags)
+		if err != nil {
+			return nil, err
+		}
+		return rs.registry.Get(ctx, masterFlags.Name)
+	}), nil
+}
+
+func (rs *REST) Delete(ctx api.Context, id string) (<-chan apiserver.RESTResult, error) {
+	obj, err := rs.registry.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	_, ok := obj.(*api.MasterFlags)
+	if !ok {
+		return nil, fmt.Errorf("invalid object type")
+	}
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		return &api.Status{Status: api.StatusSuccess}, rs.registry.Delete(ctx, id)
+	}), nil
+}
+
+func (rs *REST) Get(ctx api.Context, id string) (runtime.Object, error) {
+	obj, err := rs.registry.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	masterFlags, ok := obj.(*api.MasterFlags)
+	if !ok {
+		return nil, fmt.Errorf("invalid object type")
+	}
+	return masterFlags, err
+}
+
+func (rs *REST) getAttrs(obj runtime.Object) (objLabels, objFields labels.Set, err error) {
+	_, ok := obj.(*api.MasterFlags)
+	if !ok {
+		return nil, nil, fmt.Errorf("invalid object type")
+	}
+	return labels.Set{}, labels.Set{}, nil
+}
+
+func (rs *REST) List(ctx api.Context, label, field labels.Selector) (runtime.Object, error) {
+	return rs.registry.List(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs})
+}
+
+// Watch returns MasterFlagss masterFlagss via a watch.Interface.
+// It implements apiserver.ResourceWatcher.
+func (rs *REST) Watch(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	return rs.registry.Watch(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs}, resourceVersion)
+}
+
+// New returns a new api.MasterFlags
+func (*REST) New() runtime.Object {
+	return &api.MasterFlags{}
+}
+
+func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
+	masterFlags, ok := obj.(*api.MasterFlags)
+	if !ok {
+		return nil, fmt.Errorf("invalid object type")
+	}
+	if api.Namespace(ctx) != "" {
+		if !api.ValidNamespace(ctx, &masterFlags.ObjectMeta) {
+			return nil, errors.NewConflict("masterFlags", masterFlags.Namespace, fmt.Errorf("masterFlags.namespace does not match the provided context"))
+		}
+	}
+	if errs := validation.ValidateMasterFlags(masterFlags); len(errs) > 0 {
+		return nil, errors.NewInvalid("masterFlags", masterFlags.Name, errs)
+	}
+	api.FillObjectMetaSystemFields(ctx, &masterFlags.ObjectMeta)
+
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		err := rs.registry.Update(ctx, masterFlags.Name, masterFlags)
+		if err != nil {
+			return nil, err
+		}
+		return rs.registry.Get(ctx, masterFlags.Name)
+	}), nil
+}

--- a/pkg/registry/masterflags/rest_test.go
+++ b/pkg/registry/masterflags/rest_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package masterflags
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+type testRegistry struct {
+	*registrytest.GenericRegistry
+}
+
+func NewTestREST() (testRegistry, *REST) {
+	reg := testRegistry{registrytest.NewGeneric(nil)}
+	return reg, NewREST(reg)
+}
+
+func testMasterFlags(name string) *api.MasterFlags {
+	return &api.MasterFlags{
+		ObjectMeta: api.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: api.MasterFlagsSpec{
+			CmdLineArg: map[string]string {"a": "b"},
+		},
+	}
+}
+
+func TestRESTCreate(t *testing.T) {
+	table := []struct {
+		ctx   api.Context
+		masterFlags *api.MasterFlags
+		valid bool
+	}{
+		{
+			ctx:   api.NewDefaultContext(),
+			masterFlags: testMasterFlags("foo"),
+			valid: true,
+		}, {
+			ctx:   api.NewContext(),
+			masterFlags: testMasterFlags("bar"),
+			valid: true,
+		}, {
+			ctx:   api.WithNamespace(api.NewContext(), "nondefault"),
+			masterFlags: testMasterFlags("bazzzz"),
+			valid: false,
+		},
+	}
+
+	for _, item := range table {
+		_, rest := NewTestREST()
+		c, err := rest.Create(item.ctx, item.masterFlags)
+		if !item.valid {
+			if err == nil {
+				ctxNS := api.Namespace(item.ctx)
+				t.Errorf("unexpected non-error for %v (%v, %v)", item.masterFlags.Name, ctxNS, item.masterFlags.Namespace)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%v: Unexpected error %v", item.masterFlags.Name, err)
+			continue
+		}
+		if !api.HasObjectMetaSystemFieldValues(&item.masterFlags.ObjectMeta) {
+			t.Errorf("storage did not populate object meta field values")
+		}
+		if e, a := item.masterFlags, (<-c).Object; !reflect.DeepEqual(e, a) {
+			t.Errorf("diff: %s", util.ObjectDiff(e, a))
+		}
+		// Ensure we implement the interface
+		_ = apiserver.ResourceWatcher(rest)
+	}
+}
+
+func TestRESTUpdate(t *testing.T) {
+	_, rest := NewTestREST()
+	masterFlagsA := testMasterFlags("foo")
+	ctx := api.NewDefaultContext()
+	c, err := rest.Create(ctx, masterFlagsA)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	<-c
+	masterFlagsB := testMasterFlags("bar")
+	c2, err2 := rest.Update(ctx, masterFlagsB)
+	if err2 != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	if e, b := masterFlagsB, (<-c2).Object; !reflect.DeepEqual(e, b) {
+		t.Errorf("diff: %s", util.ObjectDiff(e, b))
+	}
+}
+
+func TestRESTDelete(t *testing.T) {
+	_, rest := NewTestREST()
+	masterFlagsA := testMasterFlags("foo")
+	c, err := rest.Create(api.NewDefaultContext(), masterFlagsA)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	<-c
+	c, err = rest.Delete(api.NewDefaultContext(), masterFlagsA.Name)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	if stat := (<-c).Object.(*api.Status); stat.Status != api.StatusSuccess {
+		t.Errorf("unexpected status: %v", stat)
+	}
+}
+
+func TestRESTGet(t *testing.T) {
+	_, rest := NewTestREST()
+	masterFlagsA := testMasterFlags("foo")
+	c, err := rest.Create(api.NewDefaultContext(), masterFlagsA)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	<-c
+	got, err := rest.Get(api.NewDefaultContext(), masterFlagsA.Name)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	if e, a := masterFlagsA, got; !reflect.DeepEqual(e, a) {
+		t.Errorf("diff: %s", util.ObjectDiff(e, a))
+	}
+}
+
+func TestRESTList(t *testing.T) {
+	reg, rest := NewTestREST()
+
+	masterFlagsA := &api.MasterFlags{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Spec: api.MasterFlagsSpec{
+			CmdLineArg: map[string]string {"a": "b"},
+		},
+	}
+	masterFlagsB := &api.MasterFlags{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "bar",
+			Namespace: "default",
+		},
+		Spec: api.MasterFlagsSpec{
+			CmdLineArg: map[string]string {"c": "d"},
+		},
+	}
+	masterFlagsC := &api.MasterFlags{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "baz",
+			Namespace: "default",
+		},
+		Spec: api.MasterFlagsSpec{
+			CmdLineArg: map[string]string {"e": "f"},
+		},
+	}
+	
+	reg.ObjectList = &api.MasterFlagsList{
+		Items: []api.MasterFlags{*masterFlagsA, *masterFlagsB, *masterFlagsC},
+	}
+	got, err := rest.List(api.NewContext(), labels.Everything(), labels.Everything())
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	expect := &api.MasterFlagsList{
+		Items: []api.MasterFlags{*masterFlagsA, *masterFlagsB, *masterFlagsC},
+	}
+	if e, a := expect, got; !reflect.DeepEqual(e, a) {
+		t.Errorf("diff: %s", util.ObjectDiff(e, a))
+	}
+}
+
+func TestRESTWatch(t *testing.T) {
+	masterFlagsA := &api.MasterFlags{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Spec: api.MasterFlagsSpec{
+			CmdLineArg: map[string]string {"a": "b"},
+		},
+	}
+	reg, rest := NewTestREST()
+	wi, err := rest.Watch(api.NewContext(), labels.Everything(), labels.Everything(), "0")
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	go func() {
+		reg.Mux.Action(watch.Added, masterFlagsA)
+	}()
+	got := <-wi.ResultChan()
+	if e, a := masterFlagsA, got.Object; !reflect.DeepEqual(e, a) {
+		t.Errorf("diff: %s", util.ObjectDiff(e, a))
+	}
+}


### PR DESCRIPTION
command line flags (issue #1627).
