### PR TITLE
Make multivalued requirement parser more whitespace tolerant

### DIFF
--- a/pkg/labels/selector_test.go
+++ b/pkg/labels/selector_test.go
@@ -309,16 +309,16 @@ func TestSetSelectorParser(t *testing.T) {
 		Valid bool
 	}{
 		{"", &LabelSelector{Requirements: nil}, true, true},
-		{"x", &LabelSelector{Requirements: []Requirement{
+		{"\rx", &LabelSelector{Requirements: []Requirement{
 			getRequirement("x", Exists, nil, t),
 		}}, true, true},
-		{"foo in (abc)", &LabelSelector{Requirements: []Requirement{
+		{"foo  in	 (abc)", &LabelSelector{Requirements: []Requirement{
 			getRequirement("foo", In, util.NewStringSet("abc"), t),
 		}}, true, true},
-		{"x not in (abc)", &LabelSelector{Requirements: []Requirement{
+		{"x not\n\tin (abc)", &LabelSelector{Requirements: []Requirement{
 			getRequirement("x", NotIn, util.NewStringSet("abc"), t),
 		}}, true, true},
-		{"x not in (abc,def)", &LabelSelector{Requirements: []Requirement{
+		{"x  not in	\t	(abc,def)", &LabelSelector{Requirements: []Requirement{
 			getRequirement("x", NotIn, util.NewStringSet("abc", "def"), t),
 		}}, true, true},
 		{"x in (abc,def)", &LabelSelector{Requirements: []Requirement{
@@ -342,7 +342,6 @@ func TestSetSelectorParser(t *testing.T) {
 		}}, false, true},
 		{"x,,y", nil, true, false},
 		{",x,y", nil, true, false},
-		{"x, y", nil, true, false},
 		{"x nott in (y)", nil, true, false},
 		{"x not in ( )", nil, true, false},
 		{"x not in (, a)", nil, true, false},


### PR DESCRIPTION
This adds a few areas to the syntax where more whitespace is allowed:
a. before key - i.e. " x"
b. after key for in/not in  cases - i.e. "x HERE in (foo)"
c. between "not" and "in" for not in case - i.e. "x not HERE in (foo)"
b. between "in" and value set for in/not in  cases - i.e. "x in HERE (foo)" "x not in HERE (foo)"

There are still some areas left so this PR is a start:
a. in the values set - i.e. "x in ( a , b )"
b. after key for exists case - i.e. "x "
c. after end of values set - i.e.  "x in (c) "
