### PR TITLE
Fix pluralization in RESTMapper when kind ends with 'y'

### DIFF
--- a/pkg/api/meta/restmapper.go
+++ b/pkg/api/meta/restmapper.go
@@ -101,10 +101,13 @@ func kindToResource(kind string, mixedCase bool) (plural, singular string) {
 	} else {
 		singular = strings.ToLower(kind)
 	}
-	if !strings.HasSuffix(singular, "s") {
-		plural = singular + "s"
-	} else {
+	switch string(singular[len(singular)-1]) {
+	case "s":
 		plural = singular
+	case "y":
+		plural = strings.TrimSuffix(singular, "y") + "ies"
+	default:
+		plural = singular + "s"
 	}
 	return
 }

--- a/pkg/api/meta/restmapper_test.go
+++ b/pkg/api/meta/restmapper_test.go
@@ -106,6 +106,8 @@ func TestKindToResource(t *testing.T) {
 		// API convention changed with regard to capitalization for v1beta3
 		{Kind: "ReplicationController", MixedCase: false, Plural: "replicationcontrollers", Singular: "replicationcontroller"},
 
+		{Kind: "ImageRepository", MixedCase: true, Plural: "imageRepositories", Singular: "imageRepository"},
+
 		{Kind: "lowercase", MixedCase: false, Plural: "lowercases", Singular: "lowercase"},
 		// Don't add extra s if the original object is already plural
 		{Kind: "lowercases", MixedCase: false, Plural: "lowercases", Singular: "lowercases"},


### PR DESCRIPTION
@smarterclayton fyi
