### PR TITLE
Endpoint.Namespace is not being set when it has no resolved endpoints

### DIFF
--- a/pkg/registry/endpoint/rest.go
+++ b/pkg/registry/endpoint/rest.go
@@ -67,7 +67,9 @@ func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan apiserver.RE
 	if len(endpoints.Name) == 0 {
 		return nil, fmt.Errorf("id is required: %#v", obj)
 	}
-
+	if !api.ValidNamespace(ctx, &endpoints.ObjectMeta) {
+		return nil, errors.NewConflict("endpoints", endpoints.Namespace, fmt.Errorf("Endpoints.Namespace does not match the provided context"))
+	}
 	api.FillObjectMetaSystemFields(ctx, &endpoints.ObjectMeta)
 
 	return apiserver.MakeAsync(func() (runtime.Object, error) {


### PR DESCRIPTION
Create a service that has no resolved pods and therefore no Endpoints.endpoints, you get an entry in etcd that has an un-populated Endpoints.Namespace value.  

Note the object is created in the right part of the etcd hierarchy for the namespace, but it's just missing the Namespace value.

```
kubectl -n other create -f myservice.json
curl -u vagrant:vagrant -k https://10.245.1.2/api/v1beta1/endpoints?namespace=foo | python -mjson.tool
{
    "apiVersion": "v1beta1",
    "creationTimestamp": null,
    "items": [
        {
            "creationTimestamp": "2014-11-24T19:17:56Z",
            "id": "zk-mdi",
            "resourceVersion": 30,
            "selfLink": "/api/v1beta1/endpoints/zk-mdi",
            "uid": "9871ed6c-740e-11e4-b811-0800279696e1"
        }
    ],
    "kind": "EndpointsList",
    "resourceVersion": 30,
    "selfLink": "/api/v1beta1/endpoints"
}
```
