### PR TITLE
Sketch: a different take on defaulting values

### DIFF
--- a/pkg/api/v1beta1/defaults.go
+++ b/pkg/api/v1beta1/defaults.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+func init() {
+	api.Scheme.AddDefaultingFuncs(
+		func(in *Volume, out *api.Volume) {
+			if in.Source == nil || util.AllFieldsNil(in.Source) {
+				out.Source = &api.VolumeSource{
+					EmptyDir: &api.EmptyDir{},
+				}
+			}
+		},
+		func(in *Port, out *api.Port) {
+			if in.Protocol == "" {
+				out.Protocol = api.ProtocolTCP
+			}
+		},
+		func(in *Container, out *api.Container) {
+			// TODO: delete helper functions that touch this
+			if in.ImagePullPolicy == "" {
+				out.ImagePullPolicy = api.PullIfNotPresent
+			}
+			if in.TerminationMessagePath == "" {
+				// TODO: fix other code that sets this
+				out.TerminationMessagePath = api.TerminationMessagePathDefault
+			}
+		},
+		func(in *RestartPolicy, out *api.RestartPolicy) {
+			if util.AllFieldsNil(in) {
+				out.Always = &api.RestartPolicyAlways{}
+			}
+		},
+		func(in *Service, out *api.Service) {
+			if in.Protocol == "" {
+				out.Spec.Protocol = api.ProtocolTCP
+			}
+		},
+	)
+}
+
+// TODO: remove redundant code in validation and conversion

--- a/pkg/conversion/converter_test.go
+++ b/pkg/conversion/converter_test.go
@@ -36,14 +36,14 @@ func TestConverter_CallsRegisteredFunctions(t *testing.T) {
 	type C struct{}
 	c := NewConverter()
 	c.Debug = t
-	err := c.Register(func(in *A, out *B, s Scope) error {
+	err := c.RegisterConversionFunc(func(in *A, out *B, s Scope) error {
 		out.Bar = in.Foo
 		return s.Convert(&in.Baz, &out.Baz, 0)
 	})
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
-	err = c.Register(func(in *B, out *A, s Scope) error {
+	err = c.RegisterConversionFunc(func(in *B, out *A, s Scope) error {
 		out.Foo = in.Bar
 		return s.Convert(&in.Baz, &out.Baz, 0)
 	})
@@ -79,7 +79,7 @@ func TestConverter_CallsRegisteredFunctions(t *testing.T) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
-	err = c.Register(func(in *A, out *C, s Scope) error {
+	err = c.RegisterConversionFunc(func(in *A, out *C, s Scope) error {
 		return fmt.Errorf("C can't store an A, silly")
 	})
 	if err != nil {
@@ -103,7 +103,7 @@ func TestConverter_fuzz(t *testing.T) {
 
 	f := fuzz.New().NilChance(.5).NumElements(0, 100)
 	c := NewConverter()
-	c.NameFunc = func(t reflect.Type) string {
+	c.nameFunc = func(t reflect.Type) string {
 		// Hide the fact that we don't have separate packages for these things.
 		return map[reflect.Type]string{
 			reflect.TypeOf(TestType1{}):         "TestType1",
@@ -143,7 +143,7 @@ func TestConverter_tags(t *testing.T) {
 	}
 	c := NewConverter()
 	c.Debug = t
-	err := c.Register(
+	err := c.RegisterConversionFunc(
 		func(in *string, out *string, s Scope) error {
 			if e, a := "foo", s.SrcTag().Get("test"); e != a {
 				t.Errorf("expected %v, got %v", e, a)
@@ -166,7 +166,7 @@ func TestConverter_meta(t *testing.T) {
 	c := NewConverter()
 	c.Debug = t
 	checks := 0
-	err := c.Register(
+	err := c.RegisterConversionFunc(
 		func(in *Foo, out *Bar, s Scope) error {
 			if s.Meta() == nil || s.Meta().SrcVersion != "test" || s.Meta().DestVersion != "passes" {
 				t.Errorf("Meta did not get passed!")
@@ -179,7 +179,7 @@ func TestConverter_meta(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	err = c.Register(
+	err = c.RegisterConversionFunc(
 		func(in *string, out *string, s Scope) error {
 			if s.Meta() == nil || s.Meta().SrcVersion != "test" || s.Meta().DestVersion != "passes" {
 				t.Errorf("Meta did not get passed a second time!")

--- a/pkg/conversion/scheme.go
+++ b/pkg/conversion/scheme.go
@@ -63,7 +63,7 @@ func NewScheme() *Scheme {
 		InternalVersion: "",
 		MetaFactory:     DefaultMetaFactory,
 	}
-	s.converter.NameFunc = s.nameFunc
+	s.converter.nameFunc = s.nameFunc
 	return s
 }
 
@@ -185,7 +185,7 @@ func (s *Scheme) NewObject(versionName, typeName string) (interface{}, error) {
 // add conversion functions for things with changed/removed fields.
 func (s *Scheme) AddConversionFuncs(conversionFuncs ...interface{}) error {
 	for _, f := range conversionFuncs {
-		err := s.converter.Register(f)
+		err := s.converter.RegisterConversionFunc(f)
 		if err != nil {
 			return err
 		}

--- a/pkg/conversion/scheme.go
+++ b/pkg/conversion/scheme.go
@@ -193,6 +193,29 @@ func (s *Scheme) AddConversionFuncs(conversionFuncs ...interface{}) error {
 	return nil
 }
 
+// AddDefaultingFuncs adds functions to the list of default-value functions.
+// Each of the given functions is responsible for applying default values
+// when converting an instance of a versioned API object into an internal
+// API object.  These functions do not need to handle sub-objects. We deduce
+// how to call these functions from the types of their two parameters.
+//
+// s.AddDefaultingFuncs(
+//	func(in *v1beta1.Pod, out *api.Pod) {
+//		if obj.OptionalField == "" {
+//			obj.OptionalField = "DefaultValue"
+//		}
+//	},
+// )
+func (s *Scheme) AddDefaultingFuncs(defaultingFuncs ...interface{}) error {
+	for _, f := range defaultingFuncs {
+		err := s.converter.RegisterDefaultingFunc(f)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Convert will attempt to convert in into out. Both must be pointers. For easy
 // testing of conversion functions. Returns an error if the conversion isn't
 // possible. You can call this with types that haven't been registered (for example,

--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -203,7 +203,8 @@ func (s *Scheme) Log(l conversion.DebugLogger) {
 
 // AddConversionFuncs adds a function to the list of conversion functions. The given
 // function should know how to convert between two API objects. We deduce how to call
-// it from the types of its two parameters; see the comment for Converter.Register.
+// it from the types of its two parameters; see the comment for
+// Converter.RegisterConversionFunction.
 //
 // Note that, if you need to copy sub-objects that didn't change, it's safe to call
 // Convert() inside your conversionFuncs, as long as you don't start a conversion
@@ -215,6 +216,14 @@ func (s *Scheme) Log(l conversion.DebugLogger) {
 // function for things with changed/removed fields.
 func (s *Scheme) AddConversionFuncs(conversionFuncs ...interface{}) error {
 	return s.raw.AddConversionFuncs(conversionFuncs...)
+}
+
+// AddDefaultingFuncs adds a function to the list of value-defaulting functions. The given
+// function should apply defaults to an output object from an input object.
+// We deduce how to call it from the types of its two parameters; see the
+// comment for Converter.RegisterDefaultingFunction.
+func (s *Scheme) AddDefaultingFuncs(defaultingFuncs ...interface{}) error {
+	return s.raw.AddDefaultingFuncs(defaultingFuncs...)
 }
 
 // Convert will attempt to convert in into out. Both must be pointers.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -19,6 +19,7 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"regexp"
 	"runtime"
 	"time"
@@ -149,4 +150,18 @@ func CompileRegexps(regexpStrings []string) ([]*regexp.Regexp, error) {
 		regexps = append(regexps, r)
 	}
 	return regexps, nil
+}
+
+// Tests whether all pointer fields in a struct are nil.
+func AllFieldsNil(obj interface{}) bool {
+	v := reflect.ValueOf(obj)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	for i := 0; i < v.NumField(); i++ {
+		if v.Field(i).Kind() == reflect.Ptr && !v.Field(i).IsNil() {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -198,3 +198,47 @@ func TestCompileRegex(t *testing.T) {
 		t.Errorf("Wrong regex returned: '%v': %v", uncompiledRegexes[1], regexes[1])
 	}
 }
+
+func TestAllFieldsNil(t *testing.T) {
+	testCases := []struct {
+		obj      interface{}
+		expected bool
+	}{
+		{struct{}{}, true},
+		{struct{ Foo int }{12345}, true},
+		{&struct{ Foo int }{12345}, true},
+		{struct{ Foo *int }{nil}, true},
+		{&struct{ Foo *int }{nil}, true},
+		{struct {
+			Foo int
+			Bar *int
+		}{12345, nil}, true},
+		{&struct {
+			Foo int
+			Bar *int
+		}{12345, nil}, true},
+		{struct {
+			Foo *int
+			Bar *int
+		}{nil, nil}, true},
+		{&struct {
+			Foo *int
+			Bar *int
+		}{nil, nil}, true},
+		{struct{ Foo *int }{new(int)}, false},
+		{&struct{ Foo *int }{new(int)}, false},
+		{struct {
+			Foo *int
+			Bar *int
+		}{nil, new(int)}, false},
+		{&struct {
+			Foo *int
+			Bar *int
+		}{nil, new(int)}, false},
+	}
+	for i, tc := range testCases {
+		if AllFieldsNil(tc.obj) != tc.expected {
+			t.Errorf("case[%d]: expected %t, got %t", i, tc.expected, !tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
As compared to #2541 

One thing I don't like about this is the round-trip tests are all broken,
with no obvious fix.  We could hybrid the approaches and make conversion
call an ApplyDefaults method, and then make tests do that too, but it's
still manual for the tests.  Or we could make Convert() take a flag for "and apply defaults" and not do defaults in fuzzing tests.  Or we can limit what sorts of things are allowed to be defaults (so that there are never default values in fuzzing).  Or we could add struct tags that say "has a default" and treat those specially during fuzzing.
