### PR TITLE
Update replicationControllers get the namespace from the provided file "" does not match the namespace "default"

### DIFF
--- a/pkg/kubectl/cmd/resource.go
+++ b/pkg/kubectl/cmd/resource.go
@@ -155,8 +155,10 @@ func ResourceFromFile(filename string, typer runtime.ObjectTyper, mapper meta.RE
 // prevents a user from unintentionally updating the wrong namespace.
 func CompareNamespaceFromFile(cmd *cobra.Command, namespace string) error {
 	defaultNamespace := getKubeNamespace(cmd)
-	if defaultNamespace != namespace {
-		return fmt.Errorf("the namespace from the provided file %q does not match the namespace %q. You must pass '--namespace=%s' to perform this operation.", namespace, defaultNamespace, namespace)
+	if len(namespace) > 0 {
+		if defaultNamespace != namespace {
+			return fmt.Errorf("the namespace from the provided file %q does not match the namespace %q. You must pass '--namespace=%s' to perform this operation.", namespace, defaultNamespace, namespace)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Steps to Reproduce:
1. create a replicationController

`kubectl create -f apache-slave-controller.json apacheSlaveController`

```
kubectl get replicationControllers 
NAME                    IMAGE(S)                         SELECTOR            REPLICAS
apacheSlaveController   10.66.10.152:5000/gouyang/http   name=apacheslave    4
```
1. update the json file, change the repilcas to 2

```
head -n 10 apache-slave-controller.json 
{
  "id": "apacheSlaveController",
  "kind": "ReplicationController",
  "apiVersion": "v1beta1",
  "desiredState": {
    "replicas": 2,
    "replicaSelector": {"name": "apacheslave"},
    "podTemplate": {
      "desiredState": {
         "manifest": {
```
1. update replicationControllers as below:

```
kubectl update -f apache-slave-controller.json 
F1125 14:30:35.855052   18936 update.go:51] the namespace from the provided file "" does not match the namespace "default". You must pass '--namespace=' to perform this operation.
```

Actual results:
it get error as step 3 show3

Expected results:
update successfully, the REPLICAS become to 2.

Fix:
Only do the namespace comparision check if it was actually populated in the supplied input file.  If omitted, we should not error and just pick up the current kubectl namespace.
