### PR TITLE
Enable public IPs even in not createExternal...

### DIFF
--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -40,8 +40,7 @@ type serviceInfo struct {
 	timeout    time.Duration
 	mu         sync.Mutex // protects active
 	active     bool
-	// TODO: make this an net.IP address
-	publicIP []string
+	publicIP   []string // TODO: make this a []net.IP
 }
 
 func (si *serviceInfo) isActive() bool {
@@ -445,7 +444,7 @@ func (proxier *Proxier) OnUpdate(services []api.Service) {
 		if exists && info.isActive() && info.portalPort == service.Spec.Port && info.portalIP.Equal(serviceIP) {
 			continue
 		}
-		if exists && (info.portalPort != service.Spec.Port || !info.portalIP.Equal(serviceIP) || service.Spec.CreateExternalLoadBalancer != (len(info.publicIP) > 0)) {
+		if exists && (info.portalPort != service.Spec.Port || !info.portalIP.Equal(serviceIP) || !ipsEqual(service.Spec.PublicIPs, info.publicIP)) {
 			glog.V(4).Infof("Something changed for service %q: stopping it", service.Name)
 			err := proxier.closePortal(service.Name, info)
 			if err != nil {
@@ -464,9 +463,7 @@ func (proxier *Proxier) OnUpdate(services []api.Service) {
 		}
 		info.portalIP = serviceIP
 		info.portalPort = service.Spec.Port
-		if service.Spec.CreateExternalLoadBalancer {
-			info.publicIP = service.Spec.PublicIPs
-		}
+		info.publicIP = service.Spec.PublicIPs
 		err = proxier.openPortal(service.Name, info)
 		if err != nil {
 			glog.Errorf("Failed to open portal for %q: %v", service.Name, err)
@@ -487,6 +484,18 @@ func (proxier *Proxier) OnUpdate(services []api.Service) {
 			}
 		}
 	}
+}
+
+func ipsEqual(lhs, rhs []string) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+	for i := range lhs {
+		if lhs[i] != rhs[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (proxier *Proxier) openPortal(service string, info *serviceInfo) error {


### PR DESCRIPTION
This allows the proxier to portal Public IPs even if the
createExternalLoadBalancer flag is not set.

This also fixes what appears to be a bug in the createExternalLoadBalancer path
wherein multiple PublicIPs would get truncated.

Fixes #2627

@brendandburns 
