### PR TITLE
Don't assume every AWS VPC has tags

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -33,7 +33,7 @@ function get_instance_ids {
 }
 
 function get_vpc_id {
-  python -c 'import json,sys; lst = [str(vpc["VpcId"]) for vpc in json.load(sys.stdin)["Vpcs"] for tag in vpc["Tags"] if tag["Value"] == "kubernetes-vpc"]; print "".join(lst)'
+  python -c 'import json,sys; lst = [str(vpc["VpcId"]) for vpc in json.load(sys.stdin)["Vpcs"] for tag in vpc.get("Tags", []) if tag["Value"] == "kubernetes-vpc"]; print "".join(lst)'
 }
 
 function get_subnet_id {


### PR DESCRIPTION
The default VPC has no tags (by default), so we should use get()

Fixes: #2634
