### PR TITLE
Default ENABLE_CLUSTER_MONITORING to false

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -106,14 +106,14 @@ function ensure-temp-dir {
 }
 
 function setup-monitoring {
-  if [[ "${ENABLE_CLUSTER_MONITORING}" == "true" ]]; then
+  if [[ "${ENABLE_CLUSTER_MONITORING:-false}" == "true" ]]; then
     # TODO: Implement this.
     echo "Monitoring not currently supported on AWS"
   fi
 }
 
 function teardown-monitoring {
-  if [[ "${ENABLE_CLUSTER_MONITORING}" == "true" ]]; then
+  if [[ "${ENABLE_CLUSTER_MONITORING:-false}" == "true" ]]; then
     # TODO: Implement this.
     echo "Monitoring not currently supported on AWS"
   fi


### PR DESCRIPTION
Otherwise kube-down fails because the variable is not defined
