### PR TITLE
Add Labels and Annotations to MetadataAccessor

### DIFF
--- a/pkg/api/meta/interfaces.go
+++ b/pkg/api/meta/interfaces.go
@@ -46,6 +46,10 @@ type Interface interface {
 	SetResourceVersion(version string)
 	SelfLink() string
 	SetSelfLink(selfLink string)
+	Labels() map[string]string
+	SetLabels(labels map[string]string)
+	Annotations() map[string]string
+	SetAnnotations(annotations map[string]string)
 }
 
 // MetadataAccessor lets you work with object and list metadata from any of the versioned or
@@ -72,6 +76,12 @@ type MetadataAccessor interface {
 
 	SelfLink(obj runtime.Object) (string, error)
 	SetSelfLink(obj runtime.Object, selfLink string) error
+
+	Labels(obj runtime.Object) (map[string]string, error)
+	SetLabels(obj runtime.Object, labels map[string]string) error
+
+	Annotations(obj runtime.Object) (map[string]string, error)
+	SetAnnotations(obj runtime.Object, annotations map[string]string) error
 
 	runtime.ResourceVersioner
 }

--- a/pkg/api/meta/meta.go
+++ b/pkg/api/meta/meta.go
@@ -185,6 +185,40 @@ func (resourceAccessor) SetSelfLink(obj runtime.Object, selfLink string) error {
 	return nil
 }
 
+func (resourceAccessor) Labels(obj runtime.Object) (map[string]string, error) {
+	accessor, err := Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	return accessor.Labels(), nil
+}
+
+func (resourceAccessor) SetLabels(obj runtime.Object, labels map[string]string) error {
+	accessor, err := Accessor(obj)
+	if err != nil {
+		return err
+	}
+	accessor.SetLabels(labels)
+	return nil
+}
+
+func (resourceAccessor) Annotations(obj runtime.Object) (map[string]string, error) {
+	accessor, err := Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	return accessor.Annotations(), nil
+}
+
+func (resourceAccessor) SetAnnotations(obj runtime.Object, annotations map[string]string) error {
+	accessor, err := Accessor(obj)
+	if err != nil {
+		return err
+	}
+	accessor.SetAnnotations(annotations)
+	return nil
+}
+
 func (resourceAccessor) ResourceVersion(obj runtime.Object) (string, error) {
 	accessor, err := Accessor(obj)
 	if err != nil {
@@ -212,6 +246,8 @@ type genericAccessor struct {
 	kind            *string
 	resourceVersion *string
 	selfLink        *string
+	labels          *map[string]string
+	annotations     *map[string]string
 }
 
 func (a genericAccessor) Namespace() string {
@@ -288,6 +324,28 @@ func (a genericAccessor) SetSelfLink(selfLink string) {
 	*a.selfLink = selfLink
 }
 
+func (a genericAccessor) Labels() map[string]string {
+	if a.labels == nil {
+		return nil
+	}
+	return *a.labels
+}
+
+func (a genericAccessor) SetLabels(labels map[string]string) {
+	*a.labels = labels
+}
+
+func (a genericAccessor) Annotations() map[string]string {
+	if a.annotations == nil {
+		return nil
+	}
+	return *a.annotations
+}
+
+func (a genericAccessor) SetAnnotations(annotations map[string]string) {
+	*a.annotations = annotations
+}
+
 // fieldPtr puts the address of fieldName, which must be a member of v,
 // into dest, which must be an address of a variable to which this field's
 // address can be assigned.
@@ -338,6 +396,12 @@ func extractFromObjectMeta(v reflect.Value, a *genericAccessor) error {
 		return err
 	}
 	if err := fieldPtr(v, "SelfLink", &a.selfLink); err != nil {
+		return err
+	}
+	if err := fieldPtr(v, "Labels", &a.labels); err != nil {
+		return err
+	}
+	if err := fieldPtr(v, "Annotations", &a.annotations); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/api/meta/meta_test.go
+++ b/pkg/api/meta/meta_test.go
@@ -388,7 +388,7 @@ func TestGenericListMeta(t *testing.T) {
 }
 
 type MyAPIObject struct {
-	runtime.TypeMeta `yaml:",inline" json:",inline"`
+	TypeMeta InternalTypeMeta `json:",inline" yaml:",inline"`
 }
 
 func (*MyAPIObject) IsAnAPIObject() {}
@@ -405,8 +405,8 @@ func TestResourceVersionerOfAPI(t *testing.T) {
 	}
 	testCases := map[string]T{
 		"empty api object":                   {&MyAPIObject{}, ""},
-		"api object with version":            {&MyAPIObject{TypeMeta: runtime.TypeMeta{ResourceVersion: "1"}}, "1"},
-		"pointer to api object with version": {&MyAPIObject{TypeMeta: runtime.TypeMeta{ResourceVersion: "1"}}, "1"},
+		"api object with version":            {&MyAPIObject{TypeMeta: InternalTypeMeta{ResourceVersion: "1"}}, "1"},
+		"pointer to api object with version": {&MyAPIObject{TypeMeta: InternalTypeMeta{ResourceVersion: "1"}}, "1"},
 	}
 	versioning := NewAccessor()
 	for key, testCase := range testCases {
@@ -436,7 +436,7 @@ func TestResourceVersionerOfAPI(t *testing.T) {
 		runtime.Object
 		Expected string
 	}{
-		"pointer to api object with version": {&MyAPIObject{TypeMeta: runtime.TypeMeta{ResourceVersion: "1"}}, "1"},
+		"pointer to api object with version": {&MyAPIObject{TypeMeta: InternalTypeMeta{ResourceVersion: "1"}}, "1"},
 	}
 	for key, testCase := range setCases {
 		if err := versioning.SetResourceVersion(testCase.Object, "5"); err != nil {
@@ -460,7 +460,7 @@ func TestTypeMetaSelfLinker(t *testing.T) {
 		succeed bool
 	}{
 		"normal": {
-			obj:     &MyAPIObject{TypeMeta: runtime.TypeMeta{SelfLink: "foobar"}},
+			obj:     &MyAPIObject{TypeMeta: InternalTypeMeta{SelfLink: "foobar"}},
 			expect:  "foobar",
 			try:     "newbar",
 			succeed: true,

--- a/pkg/api/meta/meta_test.go
+++ b/pkg/api/meta/meta_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package meta
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
@@ -25,14 +26,16 @@ import (
 
 func TestGenericTypeMeta(t *testing.T) {
 	type TypeMeta struct {
-		Kind              string    `json:"kind,omitempty" yaml:"kind,omitempty"`
-		Namespace         string    `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-		Name              string    `json:"name,omitempty" yaml:"name,omitempty"`
-		UID               string    `json:"uid,omitempty" yaml:"uid,omitempty"`
-		CreationTimestamp util.Time `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
-		SelfLink          string    `json:"selfLink,omitempty" yaml:"selfLink,omitempty"`
-		ResourceVersion   string    `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
-		APIVersion        string    `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+		Kind              string            `json:"kind,omitempty" yaml:"kind,omitempty"`
+		Namespace         string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+		Name              string            `json:"name,omitempty" yaml:"name,omitempty"`
+		UID               string            `json:"uid,omitempty" yaml:"uid,omitempty"`
+		CreationTimestamp util.Time         `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
+		SelfLink          string            `json:"selfLink,omitempty" yaml:"selfLink,omitempty"`
+		ResourceVersion   string            `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
+		APIVersion        string            `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+		Labels            map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+		Annotations       map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	}
 	type Object struct {
 		TypeMeta `json:",inline" yaml:",inline"`
@@ -46,11 +49,13 @@ func TestGenericTypeMeta(t *testing.T) {
 			Kind:            "b",
 			ResourceVersion: "1",
 			SelfLink:        "some/place/only/we/know",
+			Labels:          map[string]string{"foo": "bar"},
+			Annotations:     map[string]string{"x": "y"},
 		},
 	}
 	accessor, err := Accessor(&j)
 	if err != nil {
-		t.Fatalf("new err: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if e, a := "bar", accessor.Namespace(); e != a {
 		t.Errorf("expected %v, got %v", e, a)
@@ -107,14 +112,16 @@ func TestGenericTypeMeta(t *testing.T) {
 }
 
 type InternalTypeMeta struct {
-	Kind              string    `json:"kind,omitempty" yaml:"kind,omitempty"`
-	Namespace         string    `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	Name              string    `json:"name,omitempty" yaml:"name,omitempty"`
-	UID               string    `json:"uid,omitempty" yaml:"uid,omitempty"`
-	CreationTimestamp util.Time `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
-	SelfLink          string    `json:"selfLink,omitempty" yaml:"selfLink,omitempty"`
-	ResourceVersion   string    `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
-	APIVersion        string    `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	Kind              string            `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Namespace         string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Name              string            `json:"name,omitempty" yaml:"name,omitempty"`
+	UID               string            `json:"uid,omitempty" yaml:"uid,omitempty"`
+	CreationTimestamp util.Time         `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
+	SelfLink          string            `json:"selfLink,omitempty" yaml:"selfLink,omitempty"`
+	ResourceVersion   string            `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
+	APIVersion        string            `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations       map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }
 type InternalObject struct {
 	TypeMeta InternalTypeMeta `json:",inline" yaml:",inline"`
@@ -132,6 +139,8 @@ func TestGenericTypeMetaAccessor(t *testing.T) {
 			Kind:            "b",
 			ResourceVersion: "1",
 			SelfLink:        "some/place/only/we/know",
+			Labels:          map[string]string{"foo": "bar"},
+			Annotations:     map[string]string{"x": "y"},
 		},
 	}
 	accessor := NewAccessor()
@@ -184,6 +193,20 @@ func TestGenericTypeMetaAccessor(t *testing.T) {
 	if e, a := "some/place/only/we/know", selfLink; e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
+	labels, err := accessor.Labels(j)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if e, a := 1, len(labels); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	annotations, err := accessor.Annotations(j)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if e, a := 1, len(annotations); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
 
 	if err := accessor.SetNamespace(j, "baz"); err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -204,6 +227,13 @@ func TestGenericTypeMetaAccessor(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if err := accessor.SetSelfLink(j, "google.com"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := accessor.SetLabels(j, map[string]string{}); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	var nilMap map[string]string
+	if err := accessor.SetAnnotations(j, nilMap); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
@@ -229,6 +259,12 @@ func TestGenericTypeMetaAccessor(t *testing.T) {
 	if e, a := "google.com", j.TypeMeta.SelfLink; e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
+	if e, a := map[string]string{}, j.TypeMeta.Labels; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %#v, got %#v", e, a)
+	}
+	if e, a := nilMap, j.TypeMeta.Annotations; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %#v, got %#v", e, a)
+	}
 }
 
 func TestGenericObjectMeta(t *testing.T) {
@@ -237,12 +273,14 @@ func TestGenericObjectMeta(t *testing.T) {
 		APIVersion string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
 	}
 	type ObjectMeta struct {
-		Namespace         string    `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-		Name              string    `json:"name,omitempty" yaml:"name,omitempty"`
-		UID               string    `json:"uid,omitempty" yaml:"uid,omitempty"`
-		CreationTimestamp util.Time `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
-		SelfLink          string    `json:"selfLink,omitempty" yaml:"selfLink,omitempty"`
-		ResourceVersion   string    `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
+		Namespace         string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+		Name              string            `json:"name,omitempty" yaml:"name,omitempty"`
+		UID               string            `json:"uid,omitempty" yaml:"uid,omitempty"`
+		CreationTimestamp util.Time         `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
+		SelfLink          string            `json:"selfLink,omitempty" yaml:"selfLink,omitempty"`
+		ResourceVersion   string            `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
+		Labels            map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+		Annotations       map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	}
 	type Object struct {
 		TypeMeta   `json:",inline" yaml:",inline"`
@@ -259,11 +297,13 @@ func TestGenericObjectMeta(t *testing.T) {
 			UID:             "uid",
 			ResourceVersion: "1",
 			SelfLink:        "some/place/only/we/know",
+			Labels:          map[string]string{"foo": "bar"},
+			Annotations:     map[string]string{"a": "b"},
 		},
 	}
 	accessor, err := Accessor(&j)
 	if err != nil {
-		t.Fatalf("new err: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if e, a := "bar", accessor.Namespace(); e != a {
 		t.Errorf("expected %v, got %v", e, a)
@@ -286,6 +326,12 @@ func TestGenericObjectMeta(t *testing.T) {
 	if e, a := "some/place/only/we/know", accessor.SelfLink(); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
+	if e, a := 1, len(accessor.Labels()); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := 1, len(accessor.Annotations()); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
 
 	accessor.SetNamespace("baz")
 	accessor.SetName("bar")
@@ -294,6 +340,8 @@ func TestGenericObjectMeta(t *testing.T) {
 	accessor.SetKind("d")
 	accessor.SetResourceVersion("2")
 	accessor.SetSelfLink("google.com")
+	accessor.SetLabels(map[string]string{"other": "label"})
+	accessor.SetAnnotations(map[string]string{"c": "d"})
 
 	// Prove that accessor changes the original object.
 	if e, a := "baz", j.Namespace; e != a {
@@ -316,6 +364,12 @@ func TestGenericObjectMeta(t *testing.T) {
 	}
 	if e, a := "google.com", j.SelfLink; e != a {
 		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := map[string]string{"other": "label"}, j.Labels; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %#v, got %#v", e, a)
+	}
+	if e, a := map[string]string{"c": "d"}, j.Annotations; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %#v, got %#v", e, a)
 	}
 }
 
@@ -344,7 +398,7 @@ func TestGenericListMeta(t *testing.T) {
 	}
 	accessor, err := Accessor(&j)
 	if err != nil {
-		t.Fatalf("new err: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if e, a := "", accessor.Name(); e != a {
 		t.Errorf("expected %v, got %v", e, a)


### PR DESCRIPTION
Justification of this PR:
I need MetadataAccessor to be able to read & write Labels from runtime.Object. Then I could get rid of type-switches, as in https://github.com/openshift/origin/blob/master/pkg/config/config.go#L104.
