### PR TITLE
Enable watch on node labels.

### DIFF
--- a/pkg/registry/minion/healthy_registry.go
+++ b/pkg/registry/minion/healthy_registry.go
@@ -20,6 +20,8 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/health"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
 	"github.com/golang/glog"
 )
@@ -85,4 +87,8 @@ func (r *HealthyRegistry) ListMinions(ctx api.Context) (currentMinions *api.Node
 		}
 	}
 	return result, nil
+}
+
+func (r *HealthyRegistry) WatchMinions(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	return r.delegate.WatchMinions(ctx, label, field, resourceVersion)
 }

--- a/pkg/registry/minion/registry.go
+++ b/pkg/registry/minion/registry.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package minion
 
-import "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
 
 // MinionRegistry is an interface for things that know how to store minions.
 type Registry interface {
@@ -25,4 +29,5 @@ type Registry interface {
 	UpdateMinion(ctx api.Context, minion *api.Node) error
 	GetMinion(ctx api.Context, minionID string) (*api.Node, error)
 	DeleteMinion(ctx api.Context, minionID string) error
+	WatchMinions(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error)
 }

--- a/pkg/registry/minion/rest_test.go
+++ b/pkg/registry/minion/rest_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
 )
 
-func TestMinionREST(t *testing.T) {
+func TestMinionRegistryREST(t *testing.T) {
 	ms := NewREST(registrytest.NewMinionRegistry([]string{"foo", "bar"}, api.NodeResources{}))
 	ctx := api.NewContext()
 	if obj, err := ms.Get(ctx, "foo"); err != nil || obj.(*api.Node).Name != "foo" {
@@ -87,7 +87,7 @@ func TestMinionREST(t *testing.T) {
 	}
 }
 
-func TestMinionStorageWithHealthCheck(t *testing.T) {
+func TestMinionRegistryHealthCheck(t *testing.T) {
 	minionRegistry := registrytest.NewMinionRegistry([]string{}, api.NodeResources{})
 	minionHealthRegistry := HealthyRegistry{
 		delegate: minionRegistry,
@@ -119,7 +119,7 @@ func contains(nodes *api.NodeList, nodeID string) bool {
 	return false
 }
 
-func TestMinionStorageInvalidUpdate(t *testing.T) {
+func TestMinionRegistryInvalidUpdate(t *testing.T) {
 	storage := NewREST(registrytest.NewMinionRegistry([]string{"foo", "bar"}, api.NodeResources{}))
 	ctx := api.NewContext()
 	obj, err := storage.Get(ctx, "foo")
@@ -136,7 +136,7 @@ func TestMinionStorageInvalidUpdate(t *testing.T) {
 	}
 }
 
-func TestMinionStorageValidUpdate(t *testing.T) {
+func TestMinionRegistryValidUpdate(t *testing.T) {
 	storage := NewREST(registrytest.NewMinionRegistry([]string{"foo", "bar"}, api.NodeResources{}))
 	ctx := api.NewContext()
 	obj, err := storage.Get(ctx, "foo")
@@ -156,7 +156,7 @@ func TestMinionStorageValidUpdate(t *testing.T) {
 	}
 }
 
-func TestMinionStorageValidatesCreate(t *testing.T) {
+func TestMinionRegistryValidatesCreate(t *testing.T) {
 	storage := NewREST(registrytest.NewMinionRegistry([]string{"foo", "bar"}, api.NodeResources{}))
 	ctx := api.NewContext()
 	validSelector := map[string]string{"a": "b"}

--- a/pkg/registry/registrytest/minion.go
+++ b/pkg/registry/registrytest/minion.go
@@ -20,15 +20,20 @@ import (
 	"sync"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
+// MinionRegistry implements minion.Registry interface.
 type MinionRegistry struct {
 	Err     error
 	Minion  string
 	Minions api.NodeList
+
 	sync.Mutex
 }
 
+// MakeMinionList constructs api.MinionList from list of minion names and a NodeResource.
 func MakeMinionList(minions []string, nodeResources api.NodeResources) *api.NodeList {
 	list := api.NodeList{
 		Items: make([]api.Node, len(minions)),
@@ -94,4 +99,8 @@ func (r *MinionRegistry) DeleteMinion(ctx api.Context, minionID string) error {
 	}
 	r.Minions.Items = newList
 	return r.Err
+}
+
+func (r *MinionRegistry) WatchMinions(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	return nil, r.Err
 }

--- a/pkg/registry/registrytest/pod.go
+++ b/pkg/registry/registrytest/pod.go
@@ -65,7 +65,6 @@ func (r *PodRegistry) ListPods(ctx api.Context, selector labels.Selector) (*api.
 
 func (r *PodRegistry) WatchPods(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return r.broadcaster.Watch(), nil
-
 }
 
 func (r *PodRegistry) GetPod(ctx api.Context, podId string) (*api.Pod, error) {


### PR DESCRIPTION
Add node watch.  I haven't updated scheduler or node controller to use the watch, since we can't support filtering based on field before NodeStatus is in place.

Our watch code is not tested (at least the filter function).  I added a rest-level watch test for the new minion watch code.  If it's ok, then I can update other object test also.
