### PR TITLE
Set initial timeout upon UDP proxy connection creation

### DIFF
--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -226,6 +226,10 @@ func (udp *udpProxySocket) getBackendConn(activeClients *clientCache, cliAddr ne
 		if err != nil {
 			return nil, err
 		}
+		if err = svrConn.SetDeadline(time.Now().Add(timeout)); err != nil {
+			glog.Errorf("SetDeadline failed: %v", err)
+			return nil, err
+		}
 		activeClients.clients[cliAddr.String()] = svrConn
 		go func(cliAddr net.Addr, svrConn net.Conn, activeClients *clientCache, timeout time.Duration) {
 			defer util.HandleCrash()


### PR DESCRIPTION
This PR is an attempt to prevent [connections leaking forever](https://github.com/GoogleCloudPlatform/kubernetes/issues/1274). `ProxyLoop` and `proxyClient` both have `SetDeadline` calls just after they `Write` and `Read`, respectively. These deadlines set timeouts after the successful `Read` and `Write`. However, a leak may occur just after the connection is created as the write and/or read calls block(s) the first time they are called.
