### PR TITLE
Don't assume every AWS instances have tags

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -29,7 +29,7 @@ function json_val {
 # TODO (ayurchuk) Refactor the get_* functions to use filters
 # TODO (bburns) Parameterize this for multiple cluster per project
 function get_instance_ids {
-  python -c 'import json,sys; lst = [str(instance["InstanceId"]) for reservation in json.load(sys.stdin)["Reservations"] for instance in reservation["Instances"] for tag in instance["Tags"] if tag["Value"].startswith("kubernetes-minion") or tag["Value"].startswith("kubernetes-master")]; print " ".join(lst)'
+  python -c 'import json,sys; lst = [str(instance["InstanceId"]) for reservation in json.load(sys.stdin)["Reservations"] for instance in reservation["Instances"] for tag in instance.get("Tags", []) if tag["Value"].startswith("kubernetes-minion") or tag["Value"].startswith("kubernetes-master")]; print " ".join(lst)'
 }
 
 function get_vpc_id {


### PR DESCRIPTION
AWS EC2 instances may not have tags at all, including _Name_ tag. However on `get_instance_ids()` function in util.sh, it expects `Tags` key for every instances so it fails when there are instances with no tags.
