### PR TITLE
Change nginx bind port so it doesn't conflict

### DIFF
--- a/docs/getting-started-guides/locally.md
+++ b/docs/getting-started-guides/locally.md
@@ -45,7 +45,7 @@ You can now use any of the cluster/kubecfg.sh commands to interact with your loc
 cluster/kubecfg.sh list /pods
 cluster/kubecfg.sh list /services
 cluster/kubecfg.sh list /replicationControllers
-cluster/kubecfg.sh -p 8080:80 run dockerfile/nginx 1 myNginx
+cluster/kubecfg.sh -p 8081:80 run dockerfile/nginx 1 myNginx
 
 
 ## begin wait for provision to complete, you can monitor the docker pull by opening a new terminal


### PR DESCRIPTION
Currently if you follow this guide when it comes to starting nginx you get this error:

```
Error starting userland proxy: listen tcp 0.0.0.0:8080
```

Because Kubernetes is already listening on :8080, so you can't bind nginx to :8080, so I've changed it to :8081
