### PR TITLE
Support for AWS ELB

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,8 +1,8 @@
 {
 	"ImportPath": "github.com/GoogleCloudPlatform/kubernetes",
-	"GoVersion": "go1.3",
+	"GoVersion": "go1.3.3",
 	"Packages": [
-		"./..."
+		"github.com/GoogleCloudPlatform/kubernetes/..."
 	],
 	"Deps": [
 		{
@@ -82,11 +82,15 @@
 		},
 		{
 			"ImportPath": "github.com/mitchellh/goamz/aws",
-			"Rev": "9cad7da945e699385c1a3e115aa255211921c9bb"
+			"Rev": "60c9ebf94137ed87197518512a5c7bc298c45059"
 		},
 		{
 			"ImportPath": "github.com/mitchellh/goamz/ec2",
-			"Rev": "9cad7da945e699385c1a3e115aa255211921c9bb"
+			"Rev": "60c9ebf94137ed87197518512a5c7bc298c45059"
+		},
+		{
+			"ImportPath": "github.com/mitchellh/goamz/elb",
+			"Rev": "60c9ebf94137ed87197518512a5c7bc298c45059"
 		},
 		{
 			"ImportPath": "github.com/mitchellh/mapstructure",

--- a/Godeps/_workspace/src/github.com/mitchellh/goamz/aws/aws.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/goamz/aws/aws.go
@@ -13,9 +13,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/vaughan0/go-ini"
 	"io/ioutil"
 	"os"
+
+	"github.com/vaughan0/go-ini"
 )
 
 // Region defines the URLs where AWS services may be accessed.
@@ -123,6 +124,23 @@ var EUWest = Region{
 	"https://route53.amazonaws.com",
 }
 
+var EUCentral = Region{
+	"eu-central-1",
+	"https://ec2.eu-central-1.amazonaws.com",
+	"https://s3-eu-central-1.amazonaws.com",
+	"",
+	true,
+	true,
+	"",
+	"https://sns.eu-central-1.amazonaws.com",
+	"https://sqs.eu-central-1.amazonaws.com",
+	"https://iam.amazonaws.com",
+	"https://elasticloadbalancing.eu-central-1.amazonaws.com",
+	"https://autoscaling.eu-central-1.amazonaws.com",
+	"https://rds.eu-central-1.amazonaws.com",
+	"https://route53.amazonaws.com",
+}
+
 var APSoutheast = Region{
 	"ap-southeast-1",
 	"https://ec2.ap-southeast-1.amazonaws.com",
@@ -213,6 +231,7 @@ var Regions = map[string]Region{
 	APSoutheast.Name:  APSoutheast,
 	APSoutheast2.Name: APSoutheast2,
 	EUWest.Name:       EUWest,
+	EUCentral.Name:    EUCentral,
 	USEast.Name:       USEast,
 	USWest.Name:       USWest,
 	USWest2.Name:      USWest2,
@@ -334,13 +353,16 @@ func SharedAuth() (auth Auth, err error) {
 		profileName = "default"
 	}
 
-	var homeDir = os.Getenv("HOME")
-	if homeDir == "" {
-		err = errors.New("Could not get HOME")
-		return
+	var credentialsFile = os.Getenv("AWS_CREDENTIAL_FILE")
+	if credentialsFile == "" {
+		var homeDir = os.Getenv("HOME")
+		if homeDir == "" {
+			err = errors.New("Could not get HOME")
+			return
+		}
+		credentialsFile = homeDir + "/.aws/credentials"
 	}
 
-	var credentialsFile = homeDir + "/.aws/credentials"
 	file, err := ini.LoadFile(credentialsFile)
 	if err != nil {
 		err = errors.New("Couldn't parse AWS credentials file")

--- a/Godeps/_workspace/src/github.com/mitchellh/goamz/ec2/ec2_test.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/goamz/ec2/ec2_test.go
@@ -95,13 +95,13 @@ func (s *S) TestRunInstancesErrorWithoutXML(c *C) {
 	testServer.WaitRequest()
 
 	c.Assert(resp, IsNil)
-	c.Assert(err, ErrorMatches, "500 Internal Server Error")
+	c.Assert(err, ErrorMatches, "")
 
 	ec2err, ok := err.(*ec2.Error)
 	c.Assert(ok, Equals, true)
 	c.Assert(ec2err.StatusCode, Equals, 500)
 	c.Assert(ec2err.Code, Equals, "")
-	c.Assert(ec2err.Message, Equals, "500 Internal Server Error")
+	c.Assert(ec2err.Message, Equals, "")
 	c.Assert(ec2err.RequestId, Equals, "")
 }
 
@@ -114,13 +114,13 @@ func (s *S) TestRequestSpotInstancesErrorWithoutXML(c *C) {
 	testServer.WaitRequest()
 
 	c.Assert(resp, IsNil)
-	c.Assert(err, ErrorMatches, "500 Internal Server Error")
+	c.Assert(err, ErrorMatches, "")
 
 	ec2err, ok := err.(*ec2.Error)
 	c.Assert(ok, Equals, true)
 	c.Assert(ec2err.StatusCode, Equals, 500)
 	c.Assert(ec2err.Code, Equals, "")
-	c.Assert(ec2err.Message, Equals, "500 Internal Server Error")
+	c.Assert(ec2err.Message, Equals, "")
 	c.Assert(ec2err.RequestId, Equals, "")
 }
 
@@ -136,10 +136,12 @@ func (s *S) TestRunInstancesExample(c *C) {
 		KernelId:              "kernel-id",
 		RamdiskId:             "ramdisk-id",
 		AvailZone:             "zone",
+		Tenancy:               "dedicated",
 		PlacementGroupName:    "group",
 		Monitoring:            true,
 		SubnetId:              "subnet-id",
 		DisableAPITermination: true,
+		EbsOptimized:          true,
 		ShutdownBehavior:      "terminate",
 		PrivateIPAddress:      "10.0.0.25",
 		BlockDevices: []ec2.BlockDeviceMapping{
@@ -168,6 +170,7 @@ func (s *S) TestRunInstancesExample(c *C) {
 	c.Assert(req.Form["Monitoring.Enabled"], DeepEquals, []string{"true"})
 	c.Assert(req.Form["SubnetId"], DeepEquals, []string{"subnet-id"})
 	c.Assert(req.Form["DisableApiTermination"], DeepEquals, []string{"true"})
+	c.Assert(req.Form["EbsOptimized"], DeepEquals, []string{"true"})
 	c.Assert(req.Form["InstanceInitiatedShutdownBehavior"], DeepEquals, []string{"terminate"})
 	c.Assert(req.Form["PrivateIpAddress"], DeepEquals, []string{"10.0.0.25"})
 	c.Assert(req.Form["BlockDeviceMapping.1.DeviceName"], DeepEquals, []string{"/dev/sdb"})
@@ -304,6 +307,7 @@ func (s *S) TestTerminateInstancesExample(c *C) {
 	c.Assert(req.Form["Monitoring.Enabled"], IsNil)
 	c.Assert(req.Form["SubnetId"], IsNil)
 	c.Assert(req.Form["DisableApiTermination"], IsNil)
+	c.Assert(req.Form["EbsOptimized"], IsNil)
 	c.Assert(req.Form["InstanceInitiatedShutdownBehavior"], IsNil)
 	c.Assert(req.Form["PrivateIpAddress"], IsNil)
 
@@ -372,6 +376,13 @@ func (s *S) TestDescribeInstancesExample1(c *C) {
 	c.Assert(r0i.PrivateDNSName, Equals, "domU-12-31-39-10-56-34.compute-1.internal")
 	c.Assert(r0i.DNSName, Equals, "ec2-174-129-165-232.compute-1.amazonaws.com")
 	c.Assert(r0i.AvailZone, Equals, "us-east-1b")
+
+	b0 := r0i.BlockDevices[0]
+	c.Assert(b0.DeviceName, Equals, "/dev/sda1")
+	c.Assert(b0.VolumeId, Equals, "vol-a082c1c9")
+	c.Assert(b0.Status, Equals, "attached")
+	c.Assert(b0.AttachTime, Equals, "2010-08-17T01:15:21.000Z")
+	c.Assert(b0.DeleteOnTermination, Equals, false)
 }
 
 func (s *S) TestDescribeInstancesExample2(c *C) {
@@ -1044,7 +1055,32 @@ func (s *S) TestSignatureWithEndpointPath(c *C) {
 	c.Assert(err, IsNil)
 
 	req := testServer.WaitRequest()
-	c.Assert(req.Form["Signature"], DeepEquals, []string{"QmvgkYGn19WirCuCz/jRp3RmRgFwWR5WRkKZ5AZnyXQ="})
+	c.Assert(req.Form["Signature"], DeepEquals, []string{"tyOTQ0c0T5ujskCPTWa5ATMtv7UyErgT339cU8O2+Q8="})
+}
+
+func (s *S) TestDescribeInstanceStatusExample(c *C) {
+	testServer.Response(200, nil, DescribeInstanceStatusExample)
+	options := &ec2.DescribeInstanceStatus{}
+	resp, err := s.ec2.DescribeInstanceStatus(options, nil)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeInstanceStatus"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "3be1508e-c444-4fef-89cc-0b1223c4f02fEXAMPLE")
+	c.Assert(resp.InstanceStatus[0].InstanceId, Equals, "i-1a2b3c4d")
+	c.Assert(resp.InstanceStatus[0].InstanceState.Code, Equals, 16)
+	c.Assert(resp.InstanceStatus[0].SystemStatus.Status, Equals, "impaired")
+	c.Assert(resp.InstanceStatus[0].SystemStatus.Details[0].Name, Equals, "reachability")
+	c.Assert(resp.InstanceStatus[0].SystemStatus.Details[0].Status, Equals, "failed")
+	c.Assert(resp.InstanceStatus[0].SystemStatus.Details[0].ImpairedSince, Equals, "YYYY-MM-DDTHH:MM:SS.000Z")
+	c.Assert(resp.InstanceStatus[0].InstanceStatus.Details[0].Name, Equals, "reachability")
+	c.Assert(resp.InstanceStatus[0].InstanceStatus.Details[0].Status, Equals, "failed")
+	c.Assert(resp.InstanceStatus[0].InstanceStatus.Details[0].ImpairedSince, Equals, "YYYY-MM-DDTHH:MM:SS.000Z")
+	c.Assert(resp.InstanceStatus[0].Events[0].Code, Equals, "instance-retirement")
+	c.Assert(resp.InstanceStatus[0].Events[0].Description, Equals, "The instance is running on degraded hardware")
+	c.Assert(resp.InstanceStatus[0].Events[0].NotBefore, Equals, "YYYY-MM-DDTHH:MM:SS+0000")
+	c.Assert(resp.InstanceStatus[0].Events[0].NotAfter, Equals, "YYYY-MM-DDTHH:MM:SS+0000")
 }
 
 func (s *S) TestAllocateAddressExample(c *C) {
@@ -1229,6 +1265,24 @@ func (s *S) TestCreateSubnet(c *C) {
 	c.Assert(resp.Subnet.AvailableIpAddressCount, Equals, 251)
 }
 
+func (s *S) TestModifySubnetAttribute(c *C) {
+	testServer.Response(200, nil, ModifySubnetAttributeExample)
+
+	options := &ec2.ModifySubnetAttribute{
+		SubnetId:            "foo",
+		MapPublicIpOnLaunch: true,
+	}
+
+	resp, err := s.ec2.ModifySubnetAttribute(options)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["SubnetId"], DeepEquals, []string{"foo"})
+	c.Assert(req.Form["MapPublicIpOnLaunch.Value"], DeepEquals, []string{"true"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+}
+
 func (s *S) TestResetImageAttribute(c *C) {
 	testServer.Response(200, nil, ResetImageAttributeExample)
 
@@ -1240,4 +1294,66 @@ func (s *S) TestResetImageAttribute(c *C) {
 
 	c.Assert(err, IsNil)
 	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+}
+
+func (s *S) TestDescribeAvailabilityZonesExample1(c *C) {
+	testServer.Response(200, nil, DescribeAvailabilityZonesExample1)
+
+	resp, err := s.ec2.DescribeAvailabilityZones(nil)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeAvailabilityZones"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+	c.Assert(resp.Zones, HasLen, 4)
+
+	z0 := resp.Zones[0]
+	c.Assert(z0.Name, Equals, "us-east-1a")
+	c.Assert(z0.Region, Equals, "us-east-1")
+	c.Assert(z0.State, Equals, "available")
+	c.Assert(z0.MessageSet, HasLen, 0)
+
+	z1 := resp.Zones[1]
+	c.Assert(z1.Name, Equals, "us-east-1b")
+	c.Assert(z1.Region, Equals, "us-east-1")
+	c.Assert(z1.State, Equals, "available")
+	c.Assert(z1.MessageSet, HasLen, 0)
+
+	z2 := resp.Zones[2]
+	c.Assert(z2.Name, Equals, "us-east-1c")
+	c.Assert(z2.Region, Equals, "us-east-1")
+	c.Assert(z2.State, Equals, "available")
+	c.Assert(z2.MessageSet, HasLen, 0)
+
+	z3 := resp.Zones[3]
+	c.Assert(z3.Name, Equals, "us-east-1d")
+	c.Assert(z3.Region, Equals, "us-east-1")
+	c.Assert(z3.State, Equals, "available")
+	c.Assert(z3.MessageSet, HasLen, 0)
+}
+
+func (s *S) TestDescribeAvailabilityZonesExample2(c *C) {
+	testServer.Response(200, nil, DescribeAvailabilityZonesExample2)
+
+	resp, err := s.ec2.DescribeAvailabilityZones(nil)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeAvailabilityZones"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+	c.Assert(resp.Zones, HasLen, 2)
+
+	z0 := resp.Zones[0]
+	c.Assert(z0.Name, Equals, "us-east-1a")
+	c.Assert(z0.Region, Equals, "us-east-1")
+	c.Assert(z0.State, Equals, "impaired")
+	c.Assert(z0.MessageSet, HasLen, 0)
+
+	z1 := resp.Zones[1]
+	c.Assert(z1.Name, Equals, "us-east-1b")
+	c.Assert(z1.Region, Equals, "us-east-1")
+	c.Assert(z1.State, Equals, "unavailable")
+	c.Assert(z1.MessageSet, DeepEquals, []string{"us-east-1b is currently down for maintenance."})
 }

--- a/Godeps/_workspace/src/github.com/mitchellh/goamz/ec2/ec2i_test.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/goamz/ec2/ec2i_test.go
@@ -166,6 +166,7 @@ var allRegions = []aws.Region{
 	aws.USEast,
 	aws.USWest,
 	aws.EUWest,
+	aws.EUCentral,
 	aws.APSoutheast,
 	aws.APNortheast,
 }

--- a/Godeps/_workspace/src/github.com/mitchellh/goamz/ec2/responses_test.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/goamz/ec2/responses_test.go
@@ -766,6 +766,137 @@ var AllocateAddressExample = `
 </AllocateAddressResponse>
 `
 
+// http://goo.gl/DFySJY
+var DescribeInstanceStatusExample = `
+<DescribeInstanceStatusResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+    <requestId>3be1508e-c444-4fef-89cc-0b1223c4f02fEXAMPLE</requestId>
+    <instanceStatusSet>
+        <item>
+            <instanceId>i-1a2b3c4d</instanceId>
+            <availabilityZone>us-east-1d</availabilityZone>
+            <instanceState>
+                <code>16</code>
+                <name>running</name>
+            </instanceState>
+            <systemStatus>
+                <status>impaired</status>
+                <details>
+                    <item>
+                        <name>reachability</name>
+                        <status>failed</status>
+                        <impairedSince>YYYY-MM-DDTHH:MM:SS.000Z</impairedSince>
+                    </item>
+                </details>
+            </systemStatus>
+            <instanceStatus>
+                <status>impaired</status>
+                <details>
+                    <item>
+                        <name>reachability</name>
+                        <status>failed</status>
+                        <impairedSince>YYYY-MM-DDTHH:MM:SS.000Z</impairedSince>
+                    </item>
+                </details>
+            </instanceStatus>
+            <eventsSet>
+              <item>
+                <code>instance-retirement</code>
+                <description>The instance is running on degraded hardware</description>
+                <notBefore>YYYY-MM-DDTHH:MM:SS+0000</notBefore>
+                <notAfter>YYYY-MM-DDTHH:MM:SS+0000</notAfter>
+              </item>
+            </eventsSet>
+        </item>
+        <item>
+            <instanceId>i-2a2b3c4d</instanceId>
+            <availabilityZone>us-east-1d</availabilityZone>
+            <instanceState>
+                <code>16</code>
+                <name>running</name>
+            </instanceState>
+            <systemStatus>
+                <status>ok</status>
+                <details>
+                    <item>
+                        <name>reachability</name>
+                        <status>passed</status>
+                    </item>
+                </details>
+            </systemStatus>
+            <instanceStatus>
+                <status>ok</status>
+                <details>
+                    <item>
+                        <name>reachability</name>
+                        <status>passed</status>
+                    </item>
+                </details>
+            </instanceStatus>
+            <eventsSet>
+              <item>
+                <code>instance-reboot</code>
+                <description>The instance is scheduled for a reboot</description>
+                <notBefore>YYYY-MM-DDTHH:MM:SS+0000</notBefore>
+                <notAfter>YYYY-MM-DDTHH:MM:SS+0000</notAfter>
+              </item>
+            </eventsSet>
+        </item>
+        <item>
+            <instanceId>i-3a2b3c4d</instanceId>
+            <availabilityZone>us-east-1c</availabilityZone>
+            <instanceState>
+                <code>16</code>
+                <name>running</name>
+            </instanceState>
+            <systemStatus>
+                <status>ok</status>
+                <details>
+                    <item>
+                        <name>reachability</name>
+                        <status>passed</status>
+                    </item>
+                </details>
+            </systemStatus>
+            <instanceStatus>
+                <status>ok</status>
+                <details>
+                    <item>
+                        <name>reachability</name>
+                        <status>passed</status>
+                    </item>
+                </details>
+            </instanceStatus>
+        </item>
+        <item>
+            <instanceId>i-4a2b3c4d</instanceId>
+            <availabilityZone>us-east-1c</availabilityZone>
+            <instanceState>
+                <code>16</code>
+                <name>running</name>
+            </instanceState>
+            <systemStatus>
+                <status>ok</status>
+                <details>
+                    <item>
+                        <name>reachability</name>
+                        <status>passed</status>
+                    </item>
+                </details>
+            </systemStatus>
+            <instanceStatus>
+                <status>insufficient-data</status>
+                <details>
+                    <item>
+                        <name>reachability</name>
+                        <status>insufficient-data</status>
+                    </item>
+                </details>
+            </instanceStatus>
+         </item>
+    </instanceStatusSet>
+</DescribeInstanceStatusResponse>
+`
+
 // http://goo.gl/3Q0oCc
 var ReleaseAddressExample = `
 <ReleaseAddressResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
@@ -845,10 +976,74 @@ var CreateSubnetExample = `
 </CreateSubnetResponse>
 `
 
+// http://goo.gl/tu2Kxm
+var ModifySubnetAttributeExample = `
+<ModifySubnetAttributeResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+   <return>true</return>
+</ModifySubnetAttributeResponse>
+`
+
 // http://goo.gl/r6ZCPm
 var ResetImageAttributeExample = `
 <ResetImageAttributeResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <return>true</return>
 </ResetImageAttributeResponse>
+`
+
+// http://goo.gl/ylxT4R
+var DescribeAvailabilityZonesExample1 = `
+<DescribeAvailabilityZonesResponse xmlns="http://ec2.amazonaws.com/doc/2014-05-01/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+   <availabilityZoneInfo>
+   <item>
+      <zoneName>us-east-1a</zoneName>
+      <zoneState>available</zoneState>
+      <regionName>us-east-1</regionName>
+      <messageSet/>
+   </item>
+   <item>
+      <zoneName>us-east-1b</zoneName>
+      <zoneState>available</zoneState>
+      <regionName>us-east-1</regionName>
+      <messageSet/>
+   </item>
+   <item>
+      <zoneName>us-east-1c</zoneName>
+      <zoneState>available</zoneState>
+      <regionName>us-east-1</regionName>
+      <messageSet/>
+   </item>
+   <item>
+      <zoneName>us-east-1d</zoneName>
+      <zoneState>available</zoneState>
+      <regionName>us-east-1</regionName>
+      <messageSet/>
+   </item>
+   </availabilityZoneInfo>
+</DescribeAvailabilityZonesResponse>
+`
+
+// http://goo.gl/ylxT4R
+var DescribeAvailabilityZonesExample2 = `
+<DescribeAvailabilityZonesResponse xmlns="http://ec2.amazonaws.com/doc/2014-05-01/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+   <availabilityZoneInfo>
+   <item>
+      <zoneName>us-east-1a</zoneName>
+      <zoneState>impaired</zoneState>
+      <regionName>us-east-1</regionName>
+      <messageSet/>
+   </item>
+   <item>
+      <zoneName>us-east-1b</zoneName>
+      <zoneState>unavailable</zoneState>
+      <regionName>us-east-1</regionName>
+      <messageSet>
+         <item>us-east-1b is currently down for maintenance.</item>
+      </messageSet>
+   </item>
+   </availabilityZoneInfo>
+</DescribeAvailabilityZonesResponse>
 `

--- a/Godeps/_workspace/src/github.com/mitchellh/goamz/elb/elb.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/goamz/elb/elb.go
@@ -1,0 +1,578 @@
+// The elb package provides types and functions for interaction with the AWS
+// Elastic Load Balancing service (ELB)
+package elb
+
+import (
+	"encoding/xml"
+	"github.com/mitchellh/goamz/aws"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// The ELB type encapsulates operations operations with the elb endpoint.
+type ELB struct {
+	aws.Auth
+	aws.Region
+	httpClient *http.Client
+}
+
+const APIVersion = "2012-06-01"
+
+// New creates a new ELB instance.
+func New(auth aws.Auth, region aws.Region) *ELB {
+	return NewWithClient(auth, region, aws.RetryingClient)
+}
+
+func NewWithClient(auth aws.Auth, region aws.Region, httpClient *http.Client) *ELB {
+	return &ELB{auth, region, httpClient}
+}
+
+func (elb *ELB) query(params map[string]string, resp interface{}) error {
+	params["Version"] = APIVersion
+	params["Timestamp"] = time.Now().In(time.UTC).Format(time.RFC3339)
+
+	endpoint, err := url.Parse(elb.Region.ELBEndpoint)
+	if err != nil {
+		return err
+	}
+
+	sign(elb.Auth, "GET", "/", params, endpoint.Host)
+	endpoint.RawQuery = multimap(params).Encode()
+	r, err := elb.httpClient.Get(endpoint.String())
+
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+	if r.StatusCode > 200 {
+		return buildError(r)
+	}
+
+	decoder := xml.NewDecoder(r.Body)
+	decodedBody := decoder.Decode(resp)
+
+	return decodedBody
+}
+
+func buildError(r *http.Response) error {
+	var (
+		err    Error
+		errors xmlErrors
+	)
+	xml.NewDecoder(r.Body).Decode(&errors)
+	if len(errors.Errors) > 0 {
+		err = errors.Errors[0]
+	}
+	err.StatusCode = r.StatusCode
+	if err.Message == "" {
+		err.Message = r.Status
+	}
+	return &err
+}
+
+func multimap(p map[string]string) url.Values {
+	q := make(url.Values, len(p))
+	for k, v := range p {
+		q[k] = []string{v}
+	}
+	return q
+}
+
+func makeParams(action string) map[string]string {
+	params := make(map[string]string)
+	params["Action"] = action
+	return params
+}
+
+// ----------------------------------------------------------------------------
+// ELB objects
+
+// A listener attaches to an elb
+type Listener struct {
+	InstancePort     int64  `xml:"Listener>InstancePort"`
+	InstanceProtocol string `xml:"Listener>InstanceProtocol"`
+	SSLCertificateId string `xml:"Listener>SSLCertificateId"`
+	LoadBalancerPort int64  `xml:"Listener>LoadBalancerPort"`
+	Protocol         string `xml:"Listener>Protocol"`
+}
+
+// An Instance attaches to an elb
+type Instance struct {
+	InstanceId string `xml:"InstanceId"`
+}
+
+// A tag attached to an elb
+type Tag struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
+}
+
+// An InstanceState from an elb health query
+type InstanceState struct {
+	InstanceId  string `xml:"InstanceId"`
+	Description string `xml:"Description"`
+	State       string `xml:"State"`
+	ReasonCode  string `xml:"ReasonCode"`
+}
+
+// An Instance attaches to an elb
+type AvailabilityZone struct {
+	AvailabilityZone string `xml:"member"`
+}
+
+// ----------------------------------------------------------------------------
+// AddTags
+
+type AddTags struct {
+	LoadBalancerNames []string
+	Tags              []Tag
+}
+
+type AddTagsResp struct {
+	RequestId string `xml:"ResponseMetadata>RequestId"`
+}
+
+func (elb *ELB) AddTags(options *AddTags) (resp *AddTagsResp, err error) {
+	params := makeParams("AddTags")
+
+	for i, v := range options.LoadBalancerNames {
+		params["LoadBalancerNames.member."+strconv.Itoa(i+1)] = v
+	}
+
+	for i, v := range options.Tags {
+		params["Tags.member."+strconv.Itoa(i+1)+".Key"] = v.Key
+		params["Tags.member."+strconv.Itoa(i+1)+".Value"] = v.Value
+	}
+
+	resp = &AddTagsResp{}
+
+	err = elb.query(params, resp)
+
+	return resp, err
+}
+
+// ----------------------------------------------------------------------------
+// RemoveTags
+
+type RemoveTags struct {
+	LoadBalancerNames []string
+	TagKeys           []string
+}
+
+type RemoveTagsResp struct {
+	RequestId string `xml:"ResponseMetadata>RequestId"`
+}
+
+func (elb *ELB) RemoveTags(options *RemoveTags) (resp *RemoveTagsResp, err error) {
+	params := makeParams("RemoveTags")
+
+	for i, v := range options.LoadBalancerNames {
+		params["LoadBalancerNames.member."+strconv.Itoa(i+1)] = v
+	}
+
+	for i, v := range options.TagKeys {
+		params["Tags.member."+strconv.Itoa(i+1)+".Key"] = v
+	}
+
+	resp = &RemoveTagsResp{}
+
+	err = elb.query(params, resp)
+
+	return resp, err
+}
+
+// ----------------------------------------------------------------------------
+// Create
+
+// The CreateLoadBalancer request parameters
+type CreateLoadBalancer struct {
+	AvailZone        []string
+	Listeners        []Listener
+	LoadBalancerName string
+	Internal         bool // true for vpc elbs
+	SecurityGroups   []string
+	Subnets          []string
+	Tags             []Tag
+}
+
+type CreateLoadBalancerResp struct {
+	DNSName   string `xml:"CreateLoadBalancerResult>DNSName"`
+	RequestId string `xml:"ResponseMetadata>RequestId"`
+}
+
+func (elb *ELB) CreateLoadBalancer(options *CreateLoadBalancer) (resp *CreateLoadBalancerResp, err error) {
+	params := makeParams("CreateLoadBalancer")
+
+	params["LoadBalancerName"] = options.LoadBalancerName
+
+	for i, v := range options.AvailZone {
+		params["AvailabilityZones.member."+strconv.Itoa(i+1)] = v
+	}
+
+	for i, v := range options.SecurityGroups {
+		params["SecurityGroups.member."+strconv.Itoa(i+1)] = v
+	}
+
+	for i, v := range options.Subnets {
+		params["Subnets.member."+strconv.Itoa(i+1)] = v
+	}
+
+	for i, v := range options.Listeners {
+		params["Listeners.member."+strconv.Itoa(i+1)+".LoadBalancerPort"] = strconv.FormatInt(v.LoadBalancerPort, 10)
+		params["Listeners.member."+strconv.Itoa(i+1)+".InstancePort"] = strconv.FormatInt(v.InstancePort, 10)
+		params["Listeners.member."+strconv.Itoa(i+1)+".Protocol"] = v.Protocol
+		params["Listeners.member."+strconv.Itoa(i+1)+".InstanceProtocol"] = v.InstanceProtocol
+		params["Listeners.member."+strconv.Itoa(i+1)+".SSLCertificateId"] = v.SSLCertificateId
+	}
+
+	for i, v := range options.Tags {
+		params["Tags.member."+strconv.Itoa(i+1)+".Key"] = v.Key
+		params["Tags.member."+strconv.Itoa(i+1)+".Value"] = v.Value
+	}
+
+	if options.Internal {
+		params["Scheme"] = "internal"
+	}
+
+	resp = &CreateLoadBalancerResp{}
+
+	err = elb.query(params, resp)
+
+	if err != nil {
+		resp = nil
+	}
+
+	return
+}
+
+// ----------------------------------------------------------------------------
+// Destroy
+
+// The DestroyLoadBalancer request parameters
+type DeleteLoadBalancer struct {
+	LoadBalancerName string
+}
+
+func (elb *ELB) DeleteLoadBalancer(options *DeleteLoadBalancer) (resp *SimpleResp, err error) {
+	params := makeParams("DeleteLoadBalancer")
+
+	params["LoadBalancerName"] = options.LoadBalancerName
+
+	resp = &SimpleResp{}
+
+	err = elb.query(params, resp)
+
+	if err != nil {
+		resp = nil
+	}
+
+	return
+}
+
+// ----------------------------------------------------------------------------
+// Describe
+
+// An individual load balancer
+type LoadBalancer struct {
+	LoadBalancerName  string             `xml:"LoadBalancerName"`
+	Listeners         []Listener         `xml:"ListenerDescriptions>member"`
+	Instances         []Instance         `xml:"Instances>member"`
+	HealthCheck       HealthCheck        `xml:"HealthCheck"`
+	AvailabilityZones []AvailabilityZone `xml:"AvailabilityZones"`
+	DNSName           string             `xml:"DNSName"`
+	SecurityGroups    []string           `xml:"SecurityGroups>member"`
+	Scheme            string             `xml:"Scheme"`
+	Subnets           []string           `xml:"Subnets>member"`
+}
+
+// DescribeLoadBalancer request params
+type DescribeLoadBalancer struct {
+	Names []string
+}
+
+type DescribeLoadBalancersResp struct {
+	RequestId     string         `xml:"ResponseMetadata>RequestId"`
+	LoadBalancers []LoadBalancer `xml:"DescribeLoadBalancersResult>LoadBalancerDescriptions>member"`
+}
+
+func (elb *ELB) DescribeLoadBalancers(options *DescribeLoadBalancer) (resp *DescribeLoadBalancersResp, err error) {
+	params := makeParams("DescribeLoadBalancers")
+
+	for i, v := range options.Names {
+		params["LoadBalancerNames.member."+strconv.Itoa(i+1)] = v
+	}
+
+	resp = &DescribeLoadBalancersResp{}
+
+	err = elb.query(params, resp)
+
+	if err != nil {
+		resp = nil
+	}
+
+	return
+}
+
+// ----------------------------------------------------------------------------
+// Attributes
+
+type AccessLog struct {
+	EmitInterval   int64
+	Enabled        bool
+	S3BucketName   string
+	S3BucketPrefix string
+}
+
+type ConnectionDraining struct {
+	Enabled bool
+	Timeout int64
+}
+
+type LoadBalancerAttributes struct {
+	CrossZoneLoadBalancingEnabled bool
+	ConnectionSettingsIdleTimeout int64
+	ConnectionDraining            ConnectionDraining
+	AccessLog                     AccessLog
+}
+
+type ModifyLoadBalancerAttributes struct {
+	LoadBalancerName       string
+	LoadBalancerAttributes LoadBalancerAttributes
+}
+
+func (elb *ELB) ModifyLoadBalancerAttributes(options *ModifyLoadBalancerAttributes) (resp *SimpleResp, err error) {
+	params := makeParams("ModifyLoadBalancerAttributes")
+
+	params["LoadBalancerName"] = options.LoadBalancerName
+	params["LoadBalancerAttributes.CrossZoneLoadBalancing.Enabled"] = strconv.FormatBool(options.LoadBalancerAttributes.CrossZoneLoadBalancingEnabled)
+	if options.LoadBalancerAttributes.ConnectionSettingsIdleTimeout > 0 {
+		params["LoadBalancerAttributes.ConnectionSettings.IdleTimeout"] = strconv.Itoa(int(options.LoadBalancerAttributes.ConnectionSettingsIdleTimeout))
+	}
+	if options.LoadBalancerAttributes.ConnectionDraining.Timeout > 0 {
+		params["LoadBalancerAttributes.ConnectionDraining.Timeout"] = strconv.Itoa(int(options.LoadBalancerAttributes.ConnectionDraining.Timeout))
+	}
+	params["LoadBalancerAttributes.ConnectionDraining.Enabled"] = strconv.FormatBool(options.LoadBalancerAttributes.ConnectionDraining.Enabled)
+	params["LoadBalancerAttributes.AccessLog.Enabled"] = strconv.FormatBool(options.LoadBalancerAttributes.AccessLog.Enabled)
+	if options.LoadBalancerAttributes.AccessLog.Enabled {
+		params["LoadBalancerAttributes.AccessLog.EmitInterval"] = strconv.Itoa(int(options.LoadBalancerAttributes.AccessLog.EmitInterval))
+		params["LoadBalancerAttributes.AccessLog.S3BucketName"] = options.LoadBalancerAttributes.AccessLog.S3BucketName
+		params["LoadBalancerAttributes.AccessLog.S3BucketPrefix"] = options.LoadBalancerAttributes.AccessLog.S3BucketPrefix
+	}
+
+	resp = &SimpleResp{}
+
+	err = elb.query(params, resp)
+
+	if err != nil {
+		resp = nil
+	}
+
+	return
+}
+
+// ----------------------------------------------------------------------------
+// Instance Registration / deregistration
+
+// The RegisterInstancesWithLoadBalancer request parameters
+type RegisterInstancesWithLoadBalancer struct {
+	LoadBalancerName string
+	Instances        []string
+}
+
+type RegisterInstancesWithLoadBalancerResp struct {
+	Instances []Instance `xml:"RegisterInstancesWithLoadBalancerResult>Instances>member"`
+	RequestId string     `xml:"ResponseMetadata>RequestId"`
+}
+
+func (elb *ELB) RegisterInstancesWithLoadBalancer(options *RegisterInstancesWithLoadBalancer) (resp *RegisterInstancesWithLoadBalancerResp, err error) {
+	params := makeParams("RegisterInstancesWithLoadBalancer")
+
+	params["LoadBalancerName"] = options.LoadBalancerName
+
+	for i, v := range options.Instances {
+		params["Instances.member."+strconv.Itoa(i+1)+".InstanceId"] = v
+	}
+
+	resp = &RegisterInstancesWithLoadBalancerResp{}
+
+	err = elb.query(params, resp)
+
+	if err != nil {
+		resp = nil
+	}
+
+	return
+}
+
+// The DeregisterInstancesFromLoadBalancer request parameters
+type DeregisterInstancesFromLoadBalancer struct {
+	LoadBalancerName string
+	Instances        []string
+}
+
+type DeregisterInstancesFromLoadBalancerResp struct {
+	Instances []Instance `xml:"DeregisterInstancesFromLoadBalancerResult>Instances>member"`
+	RequestId string     `xml:"ResponseMetadata>RequestId"`
+}
+
+func (elb *ELB) DeregisterInstancesFromLoadBalancer(options *DeregisterInstancesFromLoadBalancer) (resp *DeregisterInstancesFromLoadBalancerResp, err error) {
+	params := makeParams("DeregisterInstancesFromLoadBalancer")
+
+	params["LoadBalancerName"] = options.LoadBalancerName
+
+	for i, v := range options.Instances {
+		params["Instances.member."+strconv.Itoa(i+1)+".InstanceId"] = v
+	}
+
+	resp = &DeregisterInstancesFromLoadBalancerResp{}
+
+	err = elb.query(params, resp)
+
+	if err != nil {
+		resp = nil
+	}
+
+	return
+}
+
+// ----------------------------------------------------------------------------
+// DescribeTags
+
+type DescribeTags struct {
+	LoadBalancerNames []string
+}
+
+type LoadBalancerTag struct {
+	Tags             []Tag  `xml:"Tags>member"`
+	LoadBalancerName string `xml:"LoadBalancerName"`
+}
+
+type DescribeTagsResp struct {
+	LoadBalancerTags []LoadBalancerTag `xml:"DescribeTagsResult>TagDescriptions>member"`
+	NextToken        string            `xml:"DescribeTagsResult>NextToken"`
+	RequestId        string            `xml:"ResponseMetadata>RequestId"`
+}
+
+func (elb *ELB) DescribeTags(options *DescribeTags) (resp *DescribeTagsResp, err error) {
+	params := makeParams("DescribeTags")
+
+	for i, v := range options.LoadBalancerNames {
+		params["LoadBalancerNames.member."+strconv.Itoa(i+1)] = v
+	}
+
+	resp = &DescribeTagsResp{}
+
+	err = elb.query(params, resp)
+
+	if err != nil {
+		resp = nil
+	}
+
+	return
+}
+
+// ----------------------------------------------------------------------------
+// Health Checks
+
+type HealthCheck struct {
+	HealthyThreshold   int64  `xml:"HealthyThreshold"`
+	UnhealthyThreshold int64  `xml:"UnhealthyThreshold"`
+	Interval           int64  `xml:"Interval"`
+	Target             string `xml:"Target"`
+	Timeout            int64  `xml:"Timeout"`
+}
+
+type ConfigureHealthCheck struct {
+	LoadBalancerName string
+	Check            HealthCheck
+}
+
+type ConfigureHealthCheckResp struct {
+	Check     HealthCheck `xml:"ConfigureHealthCheckResult>HealthCheck"`
+	RequestId string      `xml:"ResponseMetadata>RequestId"`
+}
+
+func (elb *ELB) ConfigureHealthCheck(options *ConfigureHealthCheck) (resp *ConfigureHealthCheckResp, err error) {
+	params := makeParams("ConfigureHealthCheck")
+
+	params["LoadBalancerName"] = options.LoadBalancerName
+	params["HealthCheck.HealthyThreshold"] = strconv.Itoa(int(options.Check.HealthyThreshold))
+	params["HealthCheck.UnhealthyThreshold"] = strconv.Itoa(int(options.Check.UnhealthyThreshold))
+	params["HealthCheck.Interval"] = strconv.Itoa(int(options.Check.Interval))
+	params["HealthCheck.Target"] = options.Check.Target
+	params["HealthCheck.Timeout"] = strconv.Itoa(int(options.Check.Timeout))
+
+	resp = &ConfigureHealthCheckResp{}
+
+	err = elb.query(params, resp)
+
+	if err != nil {
+		resp = nil
+	}
+
+	return
+}
+
+// ----------------------------------------------------------------------------
+// Instance Health
+
+// The DescribeInstanceHealth request parameters
+type DescribeInstanceHealth struct {
+	LoadBalancerName string
+}
+
+type DescribeInstanceHealthResp struct {
+	InstanceStates []InstanceState `xml:"DescribeInstanceHealthResult>InstanceStates>member"`
+	RequestId      string          `xml:"ResponseMetadata>RequestId"`
+}
+
+func (elb *ELB) DescribeInstanceHealth(options *DescribeInstanceHealth) (resp *DescribeInstanceHealthResp, err error) {
+	params := makeParams("DescribeInstanceHealth")
+
+	params["LoadBalancerName"] = options.LoadBalancerName
+
+	resp = &DescribeInstanceHealthResp{}
+
+	err = elb.query(params, resp)
+
+	if err != nil {
+		resp = nil
+	}
+
+	return
+}
+
+// Responses
+
+type SimpleResp struct {
+	RequestId string `xml:"ResponseMetadata>RequestId"`
+}
+
+type xmlErrors struct {
+	Errors []Error `xml:"Error"`
+}
+
+// Error encapsulates an elb error.
+type Error struct {
+	// HTTP status code of the error.
+	StatusCode int
+
+	// AWS code of the error.
+	Code string
+
+	// Message explaining the error.
+	Message string
+}
+
+func (e *Error) Error() string {
+	var prefix string
+	if e.Code != "" {
+		prefix = e.Code + ": "
+	}
+	if prefix == "" && e.StatusCode > 0 {
+		prefix = strconv.Itoa(e.StatusCode) + ": "
+	}
+	return prefix + e.Message
+}

--- a/Godeps/_workspace/src/github.com/mitchellh/goamz/elb/elb_test.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/goamz/elb/elb_test.go
@@ -1,0 +1,235 @@
+package elb_test
+
+import (
+	"github.com/mitchellh/goamz/aws"
+	"github.com/mitchellh/goamz/elb"
+	"github.com/mitchellh/goamz/testutil"
+	. "github.com/motain/gocheck"
+	"testing"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type S struct {
+	elb *elb.ELB
+}
+
+var _ = Suite(&S{})
+
+var testServer = testutil.NewHTTPServer()
+
+func (s *S) SetUpSuite(c *C) {
+	testServer.Start()
+	auth := aws.Auth{"abc", "123", ""}
+	s.elb = elb.NewWithClient(auth, aws.Region{ELBEndpoint: testServer.URL}, testutil.DefaultClient)
+}
+
+func (s *S) TearDownTest(c *C) {
+	testServer.Flush()
+}
+
+func (s *S) TestAddTags(c *C) {
+	testServer.Response(200, nil, AddTagsExample)
+
+	options := elb.AddTags{
+		LoadBalancerNames: []string{"foobar"},
+		Tags: []elb.Tag{
+			{
+				Key:   "hello",
+				Value: "world",
+			},
+		},
+	}
+
+	resp, err := s.elb.AddTags(&options)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"AddTags"})
+	c.Assert(req.Form["LoadBalancerNames.member.1"], DeepEquals, []string{"foobar"})
+	c.Assert(req.Form["Tags.member.1.Key"], DeepEquals, []string{"hello"})
+	c.Assert(req.Form["Tags.member.1.Value"], DeepEquals, []string{"world"})
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "360e81f7-1100-11e4-b6ed-0f30EXAMPLE")
+}
+
+func (s *S) TestRemoveTags(c *C) {
+	testServer.Response(200, nil, RemoveTagsExample)
+
+	options := elb.RemoveTags{
+		LoadBalancerNames: []string{"foobar"},
+		TagKeys:           []string{"hello"},
+	}
+
+	resp, err := s.elb.RemoveTags(&options)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"RemoveTags"})
+	c.Assert(req.Form["LoadBalancerNames.member.1"], DeepEquals, []string{"foobar"})
+	c.Assert(req.Form["Tags.member.1.Key"], DeepEquals, []string{"hello"})
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "83c88b9d-12b7-11e3-8b82-87b12EXAMPLE")
+}
+
+func (s *S) TestCreateLoadBalancer(c *C) {
+	testServer.Response(200, nil, CreateLoadBalancerExample)
+
+	options := elb.CreateLoadBalancer{
+		AvailZone: []string{"us-east-1a"},
+		Listeners: []elb.Listener{elb.Listener{
+			InstancePort:     80,
+			InstanceProtocol: "http",
+			SSLCertificateId: "needToAddASSLCertToYourAWSAccount",
+			LoadBalancerPort: 80,
+			Protocol:         "http",
+		},
+		},
+		LoadBalancerName: "foobar",
+		Internal:         false,
+		SecurityGroups:   []string{"sg1"},
+		Subnets:          []string{"sn1"},
+	}
+
+	resp, err := s.elb.CreateLoadBalancer(&options)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"CreateLoadBalancer"})
+	c.Assert(req.Form["LoadBalancerName"], DeepEquals, []string{"foobar"})
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "1549581b-12b7-11e3-895e-1334aEXAMPLE")
+}
+
+func (s *S) TestDeleteLoadBalancer(c *C) {
+	testServer.Response(200, nil, DeleteLoadBalancerExample)
+
+	options := elb.DeleteLoadBalancer{
+		LoadBalancerName: "foobar",
+	}
+
+	resp, err := s.elb.DeleteLoadBalancer(&options)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DeleteLoadBalancer"})
+	c.Assert(req.Form["LoadBalancerName"], DeepEquals, []string{"foobar"})
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "1549581b-12b7-11e3-895e-1334aEXAMPLE")
+}
+
+func (s *S) TestDescribeLoadBalancers(c *C) {
+	testServer.Response(200, nil, DescribeLoadBalancersExample)
+
+	options := elb.DescribeLoadBalancer{
+		Names: []string{"foobar"},
+	}
+
+	resp, err := s.elb.DescribeLoadBalancers(&options)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeLoadBalancers"})
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "83c88b9d-12b7-11e3-8b82-87b12EXAMPLE")
+	c.Assert(resp.LoadBalancers[0].LoadBalancerName, Equals, "MyLoadBalancer")
+	c.Assert(resp.LoadBalancers[0].Listeners[0].Protocol, Equals, "HTTP")
+	c.Assert(resp.LoadBalancers[0].Instances[0].InstanceId, Equals, "i-e4cbe38d")
+	c.Assert(resp.LoadBalancers[0].AvailabilityZones[0].AvailabilityZone, Equals, "us-east-1a")
+	c.Assert(resp.LoadBalancers[0].Scheme, Equals, "internet-facing")
+	c.Assert(resp.LoadBalancers[0].DNSName, Equals, "MyLoadBalancer-123456789.us-east-1.elb.amazonaws.com")
+	c.Assert(resp.LoadBalancers[0].HealthCheck.HealthyThreshold, Equals, int64(2))
+	c.Assert(resp.LoadBalancers[0].HealthCheck.UnhealthyThreshold, Equals, int64(10))
+	c.Assert(resp.LoadBalancers[0].HealthCheck.Interval, Equals, int64(90))
+	c.Assert(resp.LoadBalancers[0].HealthCheck.Target, Equals, "HTTP:80/")
+	c.Assert(resp.LoadBalancers[0].HealthCheck.Timeout, Equals, int64(60))
+}
+
+func (s *S) TestRegisterInstancesWithLoadBalancer(c *C) {
+	testServer.Response(200, nil, RegisterInstancesWithLoadBalancerExample)
+
+	options := elb.RegisterInstancesWithLoadBalancer{
+		LoadBalancerName: "foobar",
+		Instances:        []string{"instance-1", "instance-2"},
+	}
+
+	resp, err := s.elb.RegisterInstancesWithLoadBalancer(&options)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"RegisterInstancesWithLoadBalancer"})
+	c.Assert(req.Form["LoadBalancerName"], DeepEquals, []string{"foobar"})
+	c.Assert(req.Form["Instances.member.1.InstanceId"], DeepEquals, []string{"instance-1"})
+	c.Assert(req.Form["Instances.member.2.InstanceId"], DeepEquals, []string{"instance-2"})
+	c.Assert(err, IsNil)
+
+	c.Assert(resp.Instances[0].InstanceId, Equals, "i-315b7e51")
+	c.Assert(resp.RequestId, Equals, "83c88b9d-12b7-11e3-8b82-87b12EXAMPLE")
+}
+
+func (s *S) TestDeregisterInstancesFromLoadBalancer(c *C) {
+	testServer.Response(200, nil, DeregisterInstancesFromLoadBalancerExample)
+
+	options := elb.DeregisterInstancesFromLoadBalancer{
+		LoadBalancerName: "foobar",
+		Instances:        []string{"instance-1", "instance-2"},
+	}
+
+	resp, err := s.elb.DeregisterInstancesFromLoadBalancer(&options)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DeregisterInstancesFromLoadBalancer"})
+	c.Assert(req.Form["LoadBalancerName"], DeepEquals, []string{"foobar"})
+	c.Assert(req.Form["Instances.member.1.InstanceId"], DeepEquals, []string{"instance-1"})
+	c.Assert(req.Form["Instances.member.2.InstanceId"], DeepEquals, []string{"instance-2"})
+	c.Assert(err, IsNil)
+
+	c.Assert(resp.Instances[0].InstanceId, Equals, "i-6ec63d59")
+	c.Assert(resp.RequestId, Equals, "83c88b9d-12b7-11e3-8b82-87b12EXAMPLE")
+}
+
+func (s *S) TestConfigureHealthCheck(c *C) {
+	testServer.Response(200, nil, ConfigureHealthCheckExample)
+
+	options := elb.ConfigureHealthCheck{
+		LoadBalancerName: "foobar",
+		Check: elb.HealthCheck{
+			HealthyThreshold:   2,
+			UnhealthyThreshold: 2,
+			Interval:           30,
+			Target:             "HTTP:80/ping",
+			Timeout:            3,
+		},
+	}
+
+	resp, err := s.elb.ConfigureHealthCheck(&options)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"ConfigureHealthCheck"})
+	c.Assert(req.Form["LoadBalancerName"], DeepEquals, []string{"foobar"})
+	c.Assert(err, IsNil)
+
+	c.Assert(resp.Check.HealthyThreshold, Equals, int64(2))
+	c.Assert(resp.Check.UnhealthyThreshold, Equals, int64(2))
+	c.Assert(resp.Check.Interval, Equals, int64(30))
+	c.Assert(resp.Check.Target, Equals, "HTTP:80/ping")
+	c.Assert(resp.Check.Timeout, Equals, int64(3))
+	c.Assert(resp.RequestId, Equals, "83c88b9d-12b7-11e3-8b82-87b12EXAMPLE")
+}
+
+func (s *S) TestDescribeInstanceHealth(c *C) {
+	testServer.Response(200, nil, DescribeInstanceHealthExample)
+
+	options := elb.DescribeInstanceHealth{
+		LoadBalancerName: "foobar",
+	}
+
+	resp, err := s.elb.DescribeInstanceHealth(&options)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeInstanceHealth"})
+	c.Assert(req.Form["LoadBalancerName"], DeepEquals, []string{"foobar"})
+	c.Assert(err, IsNil)
+
+	c.Assert(resp.InstanceStates[0].InstanceId, Equals, "i-90d8c2a5")
+	c.Assert(resp.InstanceStates[0].State, Equals, "InService")
+	c.Assert(resp.InstanceStates[1].InstanceId, Equals, "i-06ea3e60")
+	c.Assert(resp.InstanceStates[1].State, Equals, "OutOfService")
+	c.Assert(resp.RequestId, Equals, "1549581b-12b7-11e3-895e-1334aEXAMPLE")
+}

--- a/Godeps/_workspace/src/github.com/mitchellh/goamz/elb/responses_test.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/goamz/elb/responses_test.go
@@ -1,0 +1,182 @@
+package elb_test
+
+var ErrorDump = `
+<?xml version="1.0" encoding="UTF-8"?>
+<Response><Errors><Error><Code>UnsupportedOperation</Code>
+<Message></Message>
+</Error></Errors><RequestID>0503f4e9-bbd6-483c-b54f-c4ae9f3b30f4</RequestID></Response>
+`
+
+// http://goo.gl/OkMdtJ
+var AddTagsExample = `
+<AddTagsResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
+  <AddTagsResult/>
+  <ResponseMetadata>
+    <RequestId>360e81f7-1100-11e4-b6ed-0f30EXAMPLE</RequestId>
+  </ResponseMetadata>
+</AddTagsResponse>
+`
+
+// http://goo.gl/nT2E89
+var RemoveTagsExample = `
+<RemoveTagsResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
+  <RemoveTagsResult/>
+  <ResponseMetadata>
+    <RequestId>83c88b9d-12b7-11e3-8b82-87b12EXAMPLE</RequestId>
+  </ResponseMetadata>
+</RemoveTagsResponse>
+`
+
+// http://goo.gl/gQRD2H
+var CreateLoadBalancerExample = `
+<CreateLoadBalancerResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
+  <CreateLoadBalancerResult>
+    <DNSName>MyLoadBalancer-1234567890.us-east-1.elb.amazonaws.com</DNSName>
+  </CreateLoadBalancerResult>
+  <ResponseMetadata>
+    <RequestId>1549581b-12b7-11e3-895e-1334aEXAMPLE</RequestId>
+  </ResponseMetadata>
+</CreateLoadBalancerResponse>
+`
+
+// http://goo.gl/GLZeBN
+var DeleteLoadBalancerExample = `
+<DeleteLoadBalancerResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
+  <ResponseMetadata>
+    <RequestId>1549581b-12b7-11e3-895e-1334aEXAMPLE</RequestId>
+  </ResponseMetadata>
+</DeleteLoadBalancerResponse>
+`
+
+// http://goo.gl/8UgpQ8
+var DescribeLoadBalancersExample = `
+<DescribeLoadBalancersResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
+  <DescribeLoadBalancersResult>
+      <LoadBalancerDescriptions>
+        <member>
+          <SecurityGroups/>
+          <LoadBalancerName>MyLoadBalancer</LoadBalancerName>
+          <CreatedTime>2013-05-24T21:15:31.280Z</CreatedTime>
+          <HealthCheck>
+            <Interval>90</Interval>
+            <Target>HTTP:80/</Target>
+            <HealthyThreshold>2</HealthyThreshold>
+            <Timeout>60</Timeout>
+            <UnhealthyThreshold>10</UnhealthyThreshold>
+          </HealthCheck>
+          <ListenerDescriptions>
+            <member>
+              <PolicyNames/>
+              <Listener>
+                <Protocol>HTTP</Protocol>
+                <LoadBalancerPort>80</LoadBalancerPort>
+                <InstanceProtocol>HTTP</InstanceProtocol>
+                <SSLCertificateId>needToAddASSLCertToYourAWSAccount</SSLCertificateId>
+                <InstancePort>80</InstancePort>
+              </Listener>
+            </member>
+          </ListenerDescriptions>
+          <Instances>
+            <member>
+              <InstanceId>i-e4cbe38d</InstanceId>
+            </member>
+          </Instances>
+          <Policies>
+            <AppCookieStickinessPolicies/>
+            <OtherPolicies/>
+            <LBCookieStickinessPolicies/>
+          </Policies>
+          <AvailabilityZones>
+            <member>us-east-1a</member>
+          </AvailabilityZones>
+          <CanonicalHostedZoneNameID>ZZZZZZZZZZZ123X</CanonicalHostedZoneNameID>
+          <CanonicalHostedZoneName>MyLoadBalancer-123456789.us-east-1.elb.amazonaws.com</CanonicalHostedZoneName>
+          <Scheme>internet-facing</Scheme>
+          <SourceSecurityGroup>
+            <OwnerAlias>amazon-elb</OwnerAlias>
+            <GroupName>amazon-elb-sg</GroupName>
+          </SourceSecurityGroup>
+          <DNSName>MyLoadBalancer-123456789.us-east-1.elb.amazonaws.com</DNSName>
+          <BackendServerDescriptions/>
+          <Subnets/>
+        </member>
+      </LoadBalancerDescriptions>
+    </DescribeLoadBalancersResult>
+  <ResponseMetadata>
+      <RequestId>83c88b9d-12b7-11e3-8b82-87b12EXAMPLE</RequestId>
+  </ResponseMetadata>
+</DescribeLoadBalancersResponse>
+`
+
+// http://goo.gl/Uz1N66
+var RegisterInstancesWithLoadBalancerExample = `
+<RegisterInstancesWithLoadBalancerResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
+  <RegisterInstancesWithLoadBalancerResult>
+    <Instances>
+      <member>
+        <InstanceId>i-315b7e51</InstanceId>
+      </member>
+    </Instances>
+  </RegisterInstancesWithLoadBalancerResult>
+<ResponseMetadata>
+    <RequestId>83c88b9d-12b7-11e3-8b82-87b12EXAMPLE</RequestId>
+</ResponseMetadata>
+</RegisterInstancesWithLoadBalancerResponse>
+ `
+
+// http://goo.gl/5OMv62
+var DeregisterInstancesFromLoadBalancerExample = `
+<DeregisterInstancesFromLoadBalancerResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
+  <DeregisterInstancesFromLoadBalancerResult>
+    <Instances>
+      <member>
+        <InstanceId>i-6ec63d59</InstanceId>
+      </member>
+    </Instances>
+  </DeregisterInstancesFromLoadBalancerResult>
+<ResponseMetadata>
+    <RequestId>83c88b9d-12b7-11e3-8b82-87b12EXAMPLE</RequestId>
+</ResponseMetadata>
+</DeregisterInstancesFromLoadBalancerResponse>
+`
+
+// http://docs.aws.amazon.com/ElasticLoadBalancing/latest/APIReference/API_ConfigureHealthCheck.html
+var ConfigureHealthCheckExample = `
+<ConfigureHealthCheckResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
+<ConfigureHealthCheckResult>
+    <HealthCheck>
+      <Interval>30</Interval>
+      <Target>HTTP:80/ping</Target>
+      <HealthyThreshold>2</HealthyThreshold>
+      <Timeout>3</Timeout>
+      <UnhealthyThreshold>2</UnhealthyThreshold>
+    </HealthCheck>
+</ConfigureHealthCheckResult>
+<ResponseMetadata>
+    <RequestId>83c88b9d-12b7-11e3-8b82-87b12EXAMPLE</RequestId>
+</ResponseMetadata>
+</ConfigureHealthCheckResponse>`
+
+// http://goo.gl/cGNxfj
+var DescribeInstanceHealthExample = `
+<DescribeInstanceHealthResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
+  <DescribeInstanceHealthResult>
+    <InstanceStates>
+      <member>
+        <Description>N/A</Description>
+        <InstanceId>i-90d8c2a5</InstanceId>
+        <State>InService</State>
+        <ReasonCode>N/A</ReasonCode>
+      </member>
+      <member>
+        <Description>N/A</Description>
+        <InstanceId>i-06ea3e60</InstanceId>
+        <State>OutOfService</State>
+        <ReasonCode>N/A</ReasonCode>
+      </member>
+    </InstanceStates>
+  </DescribeInstanceHealthResult>
+  <ResponseMetadata>
+    <RequestId>1549581b-12b7-11e3-895e-1334aEXAMPLE</RequestId>
+  </ResponseMetadata>
+</DescribeInstanceHealthResponse>`

--- a/Godeps/_workspace/src/github.com/mitchellh/goamz/elb/sign.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/goamz/elb/sign.go
@@ -1,0 +1,38 @@
+package elb
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"github.com/mitchellh/goamz/aws"
+	"sort"
+	"strings"
+)
+
+// ----------------------------------------------------------------------------
+// Version 2 signing (http://goo.gl/RSRp5)
+
+var b64 = base64.StdEncoding
+
+func sign(auth aws.Auth, method, path string, params map[string]string, host string) {
+	params["AWSAccessKeyId"] = auth.AccessKey
+	params["SignatureVersion"] = "2"
+	params["SignatureMethod"] = "HmacSHA256"
+	if auth.Token != "" {
+		params["SecurityToken"] = auth.Token
+	}
+
+	var sarray []string
+	for k, v := range params {
+		sarray = append(sarray, aws.Encode(k)+"="+aws.Encode(v))
+	}
+	sort.StringSlice(sarray).Sort()
+	joined := strings.Join(sarray, "&")
+	payload := method + "\n" + host + "\n" + path + "\n" + joined
+	hash := hmac.New(sha256.New, []byte(auth.SecretKey))
+	hash.Write([]byte(payload))
+	signature := make([]byte, b64.EncodedLen(hash.Size()))
+	b64.Encode(signature, hash.Sum(nil))
+
+	params["Signature"] = string(signature)
+}

--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -448,6 +448,11 @@ function kube-down {
   $AWS_CMD detach-internet-gateway --internet-gateway-id $igw_id --vpc-id $vpc_id > /dev/null
   $AWS_CMD delete-internet-gateway --internet-gateway-id $igw_id > /dev/null
   $AWS_CMD delete-security-group --group-id $sec_group_id > /dev/null
-  $AWS_CMD delete-route --route-table-id $route_table_id --destination-cidr-block 0.0.0.0/0 > /dev/null
+
+  has_zero_route=$($AWS_CMD describe-route-tables --route-table-id $route_table_id --filter Name=route.destination-cidr-block,Values=0.0.0.0/0 | get_route_table_id $vpc_id)
+  if [[ ! -z ${has_zero_route} ]]; then
+    $AWS_CMD delete-route --route-table-id $route_table_id --destination-cidr-block 0.0.0.0/0 > /dev/null
+  fi
+
   $AWS_CMD delete-vpc --vpc-id $vpc_id > /dev/null
 }

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -76,24 +76,24 @@ func (self*Filter) Where(name string, value string) (*Filter) {
 	return self
 }
 
-func removeDuplicates(in []string) ([]string) {
-	out := []string{}
-	done := map[string]string{}
-	for _, s := range in {
-		if done[s] != "" {
-			continue
-		}
-		out = append(out, s)
-		done[s] = s
-	}
-	return out
-}
+//func removeDuplicates(in []string) ([]string) {
+//	out := []string{}
+//	done := map[string]string{}
+//	for _, s := range in {
+//		if done[s] != "" {
+//			continue
+//		}
+//		out = append(out, s)
+//		done[s] = s
+//	}
+//	return out
+//}
 
 // AWSCloud is an implementation of Interface and Instances for Amazon Web Services.
 type AWSCloud struct {
-	auth aws.Auth
-	ec2  EC2
-	metadata AwsMetadata
+	auth             aws.Auth
+	ec2              EC2
+	metadata         AwsMetadata
 	elbClients map[string]*elb.ELB
 	cfg *AWSCloudConfig
 	availabilityZone string
@@ -423,14 +423,14 @@ func (self *awsCloudLoadBalancer) CreateTCPLoadBalancer(name, region string, ext
 	}
 
 	subnetIds := []string{}
-	zones := []string{}
+	//	zones := []string{}
 	for _, subnet := range subnets.Subnets {
 		subnetIds = append(subnetIds, subnet.SubnetId)
 		if !strings.HasPrefix(subnet.AvailabilityZone, region) {
 			glog.Error("found AZ that did not match region", subnet.AvailabilityZone, " vs ", region)
 			return "", fmt.Errorf("invalid AZ for region")
 		}
-		zones = append(zones, subnet.AvailabilityZone)
+		//		zones = append(zones, subnet.AvailabilityZone)
 	}
 
 	createRequest := &elb.CreateLoadBalancer{}
@@ -446,8 +446,10 @@ func (self *awsCloudLoadBalancer) CreateTCPLoadBalancer(name, region string, ext
 	//	createRequest.Tags = []Tag { nameTag }
 
 	//	zones := []string{"us-east-1a"}
-	createRequest.AvailZone = removeDuplicates(zones)
+	//	createRequest.AvailZone = removeDuplicates(zones)
 
+	// We are supposed to specify one subnet per AZ.
+	// TODO: What happens if we have more than one subnet per AZ?
 	createRequest.Subnets = subnetIds
 
 	sgName := "k8s-elb-" + name

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -21,10 +21,13 @@ import (
 	"io"
 	"net"
 	"regexp"
+	"sync"
 
 	"code.google.com/p/gcfg"
 	"github.com/mitchellh/goamz/aws"
 	"github.com/mitchellh/goamz/ec2"
+	"github.com/mitchellh/goamz/elb"
+	"github.com/golang/glog"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
@@ -32,12 +35,69 @@ import (
 
 type EC2 interface {
 	Instances(instIds []string, filter *ec2.Filter) (resp *ec2.InstancesResp, err error)
+	CreateSecurityGroup(group ec2.SecurityGroup) (resp *ec2.CreateSecurityGroupResp, err error)
+	CreateTags(resourceIds []string, tags []ec2.Tag) (resp *ec2.SimpleResp, err error)
+
+	DescribeVpcs(vpcIds []string, filter *ec2.Filter) (resp *ec2.VpcsResp, err error)
+
+	DescribeSubnets(subnetIds []string, filter *ec2.Filter) (resp *ec2.SubnetsResp, err error)
 }
 
-// AWSCloud is an implementation of Interface, TCPLoadBalancer and Instances for Amazon Web Services.
+
+type Filter struct {
+	predicates []*FilterPredicate
+}
+
+type FilterPredicate struct {
+	Name   string
+	Values []string
+}
+
+func NewFilter() (*Filter) {
+	return &Filter{}
+}
+
+func (self*Filter) toAws() (filter *ec2.Filter) {
+	awsFilter := ec2.NewFilter()
+	for _, predicate := range self.predicates {
+		awsFilter.Add(predicate.Name, predicate.Values...)
+	}
+	return awsFilter
+}
+
+func (self*Filter) Where(name string, value string) (*Filter) {
+	values := []string{value}
+	predicate := &FilterPredicate{Name: name, Values: values}
+	self.predicates = append(self.predicates, predicate)
+	return self
+}
+
+func removeDuplicates(in []string) ([]string) {
+	out := []string{}
+	done := map[string]string{}
+	for _, s := range in {
+		if done[s] != "" {
+			continue
+		}
+		out = append(out, s)
+		done[s] = s
+	}
+	return out
+}
+
+// AWSCloud is an implementation of Interface and Instances for Amazon Web Services.
 type AWSCloud struct {
-	ec2 EC2
+	auth aws.Auth
+	ec2  EC2
+	elbClients map[string]*elb.ELB
 	cfg *AWSCloudConfig
+
+	mutex sync.Mutex
+}
+
+// awsCloudLoadBalancer is an implementation of TCPLoadBalancer for Amazon Web Services.
+type awsCloudLoadBalancer struct {
+	awsCloud *AWSCloud
 }
 
 type AWSCloudConfig struct {
@@ -50,8 +110,8 @@ type AuthFunc func() (auth aws.Auth, err error)
 
 func init() {
 	cloudprovider.RegisterCloudProvider("aws", func(config io.Reader) (cloudprovider.Interface, error) {
-		return newAWSCloud(config, getAuth)
-	})
+			return newAWSCloud(config, getAuth)
+		})
 }
 
 func getAuth() (auth aws.Auth, err error) {
@@ -96,6 +156,7 @@ func newAWSCloud(config io.Reader, authFunc AuthFunc) (*AWSCloud, error) {
 
 	ec2 := ec2.New(auth, region)
 	return &AWSCloud{
+		auth: auth,
 		ec2: ec2,
 		cfg: cfg,
 	}, nil
@@ -107,7 +168,9 @@ func (aws *AWSCloud) Clusters() (cloudprovider.Clusters, bool) {
 
 // TCPLoadBalancer returns an implementation of TCPLoadBalancer for Amazon Web Services.
 func (aws *AWSCloud) TCPLoadBalancer() (cloudprovider.TCPLoadBalancer, bool) {
-	return nil, false
+	lb := &awsCloudLoadBalancer{}
+	lb.awsCloud = aws
+	return lb, true
 }
 
 // Instances returns an implementation of Instances for Amazon Web Services.
@@ -187,4 +250,289 @@ func (aws *AWSCloud) List(filter string) ([]string, error) {
 
 func (v *AWSCloud) GetNodeResources(name string) (*api.NodeResources, error) {
 	return nil, nil
+}
+
+// Builds an ELB client
+func (self *AWSCloud) getElbClient(regionName string) (*elb.ELB, error) {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	region, ok := aws.Regions[regionName]
+	if !ok {
+		return nil, fmt.Errorf("not a valid AWS region: %s", regionName)
+	}
+	elbClient, found := self.elbClients[region.Name]
+	if !found {
+		elbClient = elb.New(self.auth, region)
+		self.elbClients[region.Name] = elbClient
+	}
+	return elbClient, nil
+}
+
+// Find the kubernetes vpc
+func (self *AWSCloud) findVpc() (*ec2.VPC, error) {
+	client := self.ec2
+
+	// TODO: How do we want to identify our VPC?
+	filter := NewFilter().Where("tag:Name", "kubernetes-vpc")
+
+	ids := []string{}
+	response, err := client.DescribeVpcs(ids, filter.toAws())
+	if err != nil {
+		glog.Error("error listing VPCs", err)
+		return nil, err
+	}
+
+	vpcs := response.VPCs
+	if len(vpcs) == 0 {
+		return nil, nil
+	}
+	if len(vpcs) == 1 {
+		return &vpcs[0], nil
+	}
+
+	glog.Warning("Found multiple VPCs; picking arbitrarily", vpcs)
+	return &vpcs[0], nil
+}
+
+func (self *AWSCloud) describeSubnets(subnetIds []string, filter *Filter) (*ec2.SubnetsResp, error) {
+	client := self.ec2
+
+	subnets, err := client.DescribeSubnets(subnetIds, filter.toAws())
+	if err != nil {
+		glog.Error("error listing subnets", err)
+		return nil, err
+	}
+
+	return subnets, nil
+}
+
+// Builds an ELB client
+func (self *awsCloudLoadBalancer) getElbClient(region string) (*elb.ELB, error) {
+	return self.awsCloud.getElbClient(region)
+}
+
+// Gets the current load balancer state
+func (self *awsCloudLoadBalancer) describeLoadBalancer(client *elb.ELB, name string) (*elb.LoadBalancer, error) {
+	request := &elb.DescribeLoadBalancer{}
+	request.Names = []string { name }
+	response, err := client.DescribeLoadBalancers(request)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, loadBalancer := range response.LoadBalancers {
+		return &loadBalancer, nil
+	}
+	return nil, nil
+}
+
+// TCPLoadBalancerExists is an implementation of TCPLoadBalancer.TCPLoadBalancerExists.
+func (self *awsCloudLoadBalancer) TCPLoadBalancerExists(name, region string) (bool, error) {
+	client, err := self.getElbClient(region)
+	if err != nil {
+		return false, err
+	}
+
+	lb, err := self.describeLoadBalancer(client, name)
+	if err != nil {
+		return false, err
+	}
+
+	if lb != nil {
+		return true, nil
+	}
+	return false, nil
+}
+
+// Create a security group that will be used with the load balancer
+func (self *AWSCloud) createSecurityGroup(vpcId, name, description string) (string, error) {
+	client := self.ec2
+
+	request := ec2.SecurityGroup{}
+	request.VpcId = vpcId
+	request.Name = name
+	request.Description = description
+	response, err := client.CreateSecurityGroup(request)
+	if err != nil {
+		return "", err
+	}
+
+	return response.Id, nil
+}
+
+func (self *AWSCloud) createTags(resourceId string, tags []ec2.Tag) (error) {
+	client := self.ec2
+
+	resourceIds := []string { resourceId }
+
+	_, err := client.CreateTags(resourceIds, tags)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateTCPLoadBalancer is an implementation of TCPLoadBalancer.CreateTCPLoadBalancer.
+func (self *awsCloudLoadBalancer) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string) (string, error) {
+	client, err := self.getElbClient(region)
+	if err != nil {
+		return "", err
+	}
+
+	vpc, err := self.awsCloud.findVpc()
+	if err != nil {
+		glog.Error("error finding vpc", err)
+		return "", err
+	}
+
+	if vpc == nil {
+		return "", fmt.Errorf("Unable to find vpc")
+	}
+
+	subnets, err := self.awsCloud.describeSubnets(nil, NewFilter().Where("vpc-id", vpc.VpcId))
+	if err != nil {
+		glog.Error("error listing subnets", err)
+		return "", err
+	}
+
+	subnetIds := []string{}
+	zones := []string{}
+	for _, subnet := range subnets.Subnets {
+		subnetIds = append(subnetIds, subnet.SubnetId)
+		zones = append(zones, subnet.AvailabilityZone)
+	}
+
+	createRequest := &elb.CreateLoadBalancer{}
+	createRequest.LoadBalancerName = name
+
+	listener := elb.Listener{}
+	listener.InstancePort = int64(port)
+	listener.LoadBalancerPort = int64(port)
+	listener.Protocol = "tcp"
+	listener.InstanceProtocol = "tcp"
+	createRequest.Listeners = []elb.Listener{ listener }
+	//	nameTag := &elb.Tag{ Key: "Name", Value: name}
+	//	createRequest.Tags = []Tag { nameTag }
+
+	//	zones := []string{"us-east-1a"}
+	createRequest.AvailZone = removeDuplicates(zones)
+
+	createRequest.Subnets = subnetIds
+
+	sgName := "sg-elb-" + name
+	sgDescription := "Security group for ELB " + name
+	securityGroupId, err := self.awsCloud.createSecurityGroup(vpc.VpcId, sgName, sgDescription)
+	if err != nil {
+		return "", err
+	}
+	createRequest.SecurityGroups = []string { securityGroupId }
+
+	if len(externalIP) > 0 {
+		return "", fmt.Errorf("External IP cannot be specified for AWS ELB")
+	}
+
+	createResponse, err := client.CreateLoadBalancer(createRequest)
+	if err != nil {
+		return "", err
+	}
+
+	dnsName := createResponse.DNSName
+
+	registerRequest := &elb.RegisterInstancesWithLoadBalancer{}
+	registerRequest.LoadBalancerName = name
+	registerRequest.Instances = hosts
+
+	registerResponse, err := client.RegisterInstancesWithLoadBalancer(registerRequest)
+	if err != nil {
+		return "", err
+	}
+
+	glog.V(1).Info("Updated instances registered with load-balancer", name, registerResponse.Instances)
+
+	// TODO: Wait for creation?
+
+	return dnsName, nil
+}
+
+// UpdateTCPLoadBalancer is an implementation of TCPLoadBalancer.UpdateTCPLoadBalancer.
+func (self *awsCloudLoadBalancer) UpdateTCPLoadBalancer(name, region string, hosts []string) error {
+	client, err := self.getElbClient(region)
+	if err != nil {
+		return err
+	}
+
+	lb, err := self.describeLoadBalancer(client, name)
+	if err != nil {
+		return err
+	}
+
+	if lb == nil {
+		return fmt.Errorf("Load balancer not found")
+	}
+
+	existingInstances := map[string]*elb.Instance{}
+	for _, instance := range lb.Instances {
+		existingInstances[instance.InstanceId] = &instance
+	}
+
+	wantInstances := map[string]string{}
+	for _, host := range hosts {
+		wantInstances[host] = host
+	}
+
+	addInstances := []string{}
+	for key, _ := range wantInstances {
+		_, found := existingInstances[key]
+		if !found {
+			addInstances = append(addInstances, key)
+		}
+	}
+
+	removeInstances := []string{}
+	for key, _ := range existingInstances {
+		_, found := wantInstances[key]
+		if !found {
+			removeInstances = append(removeInstances, key)
+		}
+	}
+
+	if len(addInstances) > 0 {
+		registerRequest := &elb.RegisterInstancesWithLoadBalancer{}
+		registerRequest.Instances = addInstances
+		registerRequest.LoadBalancerName = lb.LoadBalancerName
+		_, err = client.RegisterInstancesWithLoadBalancer(registerRequest)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(removeInstances) > 0 {
+		deregisterRequest := &elb.DeregisterInstancesFromLoadBalancer{}
+		deregisterRequest.Instances = removeInstances
+		deregisterRequest.LoadBalancerName = lb.LoadBalancerName
+		_, err = client.DeregisterInstancesFromLoadBalancer(deregisterRequest)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// DeleteTCPLoadBalancer is an implementation of TCPLoadBalancer.DeleteTCPLoadBalancer.
+func (self *awsCloudLoadBalancer) DeleteTCPLoadBalancer(name, region string) error {
+	client, err := self.getElbClient(region)
+	if err != nil {
+		return err
+	}
+
+	request := &elb.DeleteLoadBalancer{}
+	request.LoadBalancerName = name
+	_, err = client.DeleteLoadBalancer(request)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -364,7 +364,12 @@ func (self *awsCloudLoadBalancer) describeLoadBalancer(client *elb.ELB, name str
 	request.Names = []string { name }
 	response, err := client.DescribeLoadBalancers(request)
 	if err != nil {
-		glog.Error("error describing load balancer", err)
+		elbError, ok := err.(*elb.Error)
+		if ok && elbError.Code == "LoadBalancerNotFound" {
+			// Not found
+			return nil, nil
+		}
+		glog.Error("error describing load balancer: ", err)
 		return nil, err
 	}
 

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -181,6 +181,7 @@ func newAWSCloud(config io.Reader, metadata AwsMetadata, authFunc AuthFunc) (*AW
 		region: &region,
 		ec2: ec2,
 		cfg: cfg,
+		elbClients: map[string]*elb.ELB{},
 	}, nil
 }
 

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -622,7 +622,7 @@ func (self *awsCloudLoadBalancer) UpdateTCPLoadBalancer(name, region string, hos
 	}
 
 	addInstances := []string{}
-	for key, _ := range wantInstances {
+	for key := range wantInstances {
 		_, found := existingInstances[key]
 		if !found {
 			addInstances = append(addInstances, key)
@@ -630,7 +630,7 @@ func (self *awsCloudLoadBalancer) UpdateTCPLoadBalancer(name, region string, hos
 	}
 
 	removeInstances := []string{}
-	for key, _ := range existingInstances {
+	for key := range existingInstances {
 		_, found := wantInstances[key]
 		if !found {
 			removeInstances = append(removeInstances, key)

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -131,6 +131,8 @@ func readAWSCloudConfig(config io.Reader) (*AWSCloudConfig, error) {
 	}
 
 	if cfg.Global.Region == "" {
+		// TODO: We can get this from curl http://169.254.169.254/latest/meta-data/placement/availability-zone
+		// (that is the AZ; but we can strip the last character/prefix match to get the region)
 		return nil, fmt.Errorf("no region specified in configuration file")
 	}
 

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -450,8 +450,8 @@ func (self *awsCloudLoadBalancer) CreateTCPLoadBalancer(name, region string, ext
 
 	createRequest.Subnets = subnetIds
 
-	sgName := "sg-elb-" + name
-	sgDescription := "Security group for ELB " + name
+	sgName := "k8s-elb-" + name
+	sgDescription := "Security group for Kubernetes ELB " + name
 	securityGroupId, err := self.awsCloud.createSecurityGroup(vpc.VpcId, sgName, sgDescription)
 	if err != nil {
 		return "", err

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -122,8 +122,8 @@ type AuthFunc func() (auth aws.Auth, err error)
 
 func init() {
 	cloudprovider.RegisterCloudProvider("aws", func(config io.Reader) (cloudprovider.Interface, error) {
-			return newAWSCloud(config, &instanceMetadata{}, getAuth)
-		})
+		return newAWSCloud(config, &instanceMetadata{}, getAuth)
+	})
 }
 
 func getAuth() (auth aws.Auth, err error) {
@@ -394,7 +394,6 @@ func (self *AWSCloud) ensureSecurityGroupIngess(securityGroupId string, sourceIp
 	return true, nil
 }
 
-
 func (self *AWSCloud) describeSubnets(subnetIds []string, filter *Filter) (*ec2.SubnetsResp, error) {
 	client := self.ec2
 
@@ -501,7 +500,7 @@ func (self *awsCloudLoadBalancer) hostsToInstances(hosts []string) ([]*ec2.Insta
 			return nil, err
 		}
 		if instance == nil {
-			return nil, fmt.Errorf("unable to find instance "+host)
+			return nil, fmt.Errorf("unable to find instance " + host)
 		}
 		instances = append(instances, instance)
 	}

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -727,6 +727,8 @@ func (self *awsCloudLoadBalancer) DeleteTCPLoadBalancer(name, region string) err
 		return err
 	}
 
+	// TODO: Delete security group
+
 	request := &elb.DeleteLoadBalancer{}
 	request.LoadBalancerName = name
 	_, err = client.DeleteLoadBalancer(request)

--- a/pkg/cloudprovider/aws/aws_test.go
+++ b/pkg/cloudprovider/aws/aws_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws_cloud
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -83,15 +84,30 @@ func (ec2 *FakeEC2) Instances(instanceIds []string, filter *ec2.Filter) (resp *e
 	return ec2.instances(instanceIds, filter)
 }
 
+func (ec2 *FakeEC2) CreateSecurityGroup(group ec2.SecurityGroup) (resp *ec2.CreateSecurityGroupResp, err error) {
+	return nil, fmt.Errorf("Not implemented by FakeEC2")
+}
+func (ec2 *FakeEC2) CreateTags(resourceIds []string, tags []ec2.Tag) (resp *ec2.SimpleResp, err error) {
+	return nil, fmt.Errorf("Not implemented by FakeEC2")
+}
+
+func (ec2 *FakeEC2) DescribeVpcs(vpcIds []string, filter *ec2.Filter) (resp *ec2.VpcsResp, err error) {
+	return nil, fmt.Errorf("Not implemented by FakeEC2")
+}
+
+func (ec2 *FakeEC2) DescribeSubnets(subnetIds []string, filter *ec2.Filter) (resp *ec2.SubnetsResp, err error) {
+	return nil, fmt.Errorf("Not implemented by FakeEC2")
+}
+
 func mockInstancesResp(instances []ec2.Instance) (aws *AWSCloud) {
 	return &AWSCloud{
-		&FakeEC2{
-			func(instanceIds []string, filter *ec2.Filter) (resp *ec2.InstancesResp, err error) {
+		ec2: &FakeEC2{
+			instances: func(instanceIds []string, filter *ec2.Filter) (resp *ec2.InstancesResp, err error) {
 				return &ec2.InstancesResp{"",
 					[]ec2.Reservation{
 						{"", "", "", nil, instances}}}, nil
 			}},
-		nil}
+		}
 }
 
 func TestList(t *testing.T) {

--- a/pkg/cloudprovider/aws/aws_test.go
+++ b/pkg/cloudprovider/aws/aws_test.go
@@ -117,6 +117,10 @@ func (ec2 *FakeEC2) SecurityGroups(groups []ec2.SecurityGroup, filter *ec2.Filte
 	return nil, fmt.Errorf("Not implemented by FakeEC2")
 }
 
+func (ec2 *FakeEC2) AuthorizeSecurityGroup(group ec2.SecurityGroup, perms []ec2.IPPerm) (resp *ec2.SimpleResp, err error) {
+	return nil, fmt.Errorf("Not implemented by FakeEC2")
+}
+
 func mockInstancesResp(instances []ec2.Instance) (aws *AWSCloud) {
 	return &AWSCloud{
 		ec2: &FakeEC2{

--- a/pkg/cloudprovider/aws/aws_test.go
+++ b/pkg/cloudprovider/aws/aws_test.go
@@ -113,6 +113,10 @@ func (ec2 *FakeEC2) DescribeSubnets(subnetIds []string, filter *ec2.Filter) (res
 	return nil, fmt.Errorf("Not implemented by FakeEC2")
 }
 
+func (ec2 *FakeEC2) SecurityGroups(groups []ec2.SecurityGroup, filter *ec2.Filter) (resp *ec2.SecurityGroupsResp, err error) {
+	return nil, fmt.Errorf("Not implemented by FakeEC2")
+}
+
 func mockInstancesResp(instances []ec2.Instance) (aws *AWSCloud) {
 	return &AWSCloud{
 		ec2: &FakeEC2{
@@ -121,7 +125,7 @@ func mockInstancesResp(instances []ec2.Instance) (aws *AWSCloud) {
 					[]ec2.Reservation{
 						{"", "", "", nil, instances}}}, nil
 			}},
-		}
+	}
 }
 
 func TestList(t *testing.T) {

--- a/pkg/cloudprovider/aws/aws_test.go
+++ b/pkg/cloudprovider/aws/aws_test.go
@@ -30,7 +30,7 @@ type mockAwsMetadata struct {
 	az string
 }
 
-func (self*mockAwsMetadata) GetInstanceAz() (az string, err error) {
+func (self *mockAwsMetadata) GetInstanceAz() (az string, err error) {
 	return az, nil
 }
 

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -45,7 +45,7 @@ type Clusters interface {
 // LoadBalancerInfo describes a load balancer, in particular how inbound traffic is presented
 type LoadBalancerInfo struct {
 	// If DestIP is not specified, traffic is assumed to reach the instance primary IP
-	DestIP              net.IP
+	DestIP net.IP
 
 	// Populated by AWS, not currently used
 	ExternalDnsName string

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -47,8 +47,8 @@ type TCPLoadBalancer interface {
 	// TCPLoadBalancerExists returns whether the specified load balancer exists.
 	// TODO: Break this up into different interfaces (LB, etc) when we have more than one type of service
 	TCPLoadBalancerExists(name, region string) (bool, error)
-	// CreateTCPLoadBalancer creates a new tcp load balancer. Returns the IP address of the balancer
-	CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string) (net.IP, error)
+	// CreateTCPLoadBalancer creates a new tcp load balancer. Returns the DNS name or IP address of the balancer
+	CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string) (string, error)
 	// UpdateTCPLoadBalancer updates hosts under the specified load balancer.
 	UpdateTCPLoadBalancer(name, region string, hosts []string) error
 	// DeleteTCPLoadBalancer deletes a specified load balancer.

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -42,13 +42,22 @@ type Clusters interface {
 	Master(clusterName string) (string, error)
 }
 
+// LoadBalancerInfo describes a load balancer, in particular how inbound traffic is presented
+type LoadBalancerInfo struct {
+	// If DestIP is not specified, traffic is assumed to reach the instance primary IP
+	DestIP              net.IP
+
+	// Populated by AWS, not currently used
+	ExternalDnsName string
+}
+
 // TCPLoadBalancer is an abstract, pluggable interface for TCP load balancers.
 type TCPLoadBalancer interface {
 	// TCPLoadBalancerExists returns whether the specified load balancer exists.
 	// TODO: Break this up into different interfaces (LB, etc) when we have more than one type of service
 	TCPLoadBalancerExists(name, region string) (bool, error)
 	// CreateTCPLoadBalancer creates a new tcp load balancer. Returns the DNS name or IP address of the balancer
-	CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string) (string, error)
+	CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string) (*LoadBalancerInfo, error)
 	// UpdateTCPLoadBalancer updates hosts under the specified load balancer.
 	UpdateTCPLoadBalancer(name, region string, hosts []string) error
 	// DeleteTCPLoadBalancer deletes a specified load balancer.

--- a/pkg/cloudprovider/fake/fake.go
+++ b/pkg/cloudprovider/fake/fake.go
@@ -84,9 +84,11 @@ func (f *FakeCloud) TCPLoadBalancerExists(name, region string) (bool, error) {
 
 // CreateTCPLoadBalancer is a test-spy implementation of TCPLoadBalancer.CreateTCPLoadBalancer.
 // It adds an entry "create" into the internal method call record.
-func (f *FakeCloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string) (string, error) {
+func (f *FakeCloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string) (*cloudprovider.LoadBalancerInfo, error) {
 	f.addCall("create")
-	return f.ExternalIP.String(), f.Err
+	loadBalancerInfo := &cloudprovider.LoadBalancerInfo{}
+	loadBalancerInfo.DestIP = f.ExternalIP
+	return loadBalancerInfo, f.Err
 }
 
 // UpdateTCPLoadBalancer is a test-spy implementation of TCPLoadBalancer.UpdateTCPLoadBalancer.

--- a/pkg/cloudprovider/fake/fake.go
+++ b/pkg/cloudprovider/fake/fake.go
@@ -84,9 +84,9 @@ func (f *FakeCloud) TCPLoadBalancerExists(name, region string) (bool, error) {
 
 // CreateTCPLoadBalancer is a test-spy implementation of TCPLoadBalancer.CreateTCPLoadBalancer.
 // It adds an entry "create" into the internal method call record.
-func (f *FakeCloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string) (net.IP, error) {
+func (f *FakeCloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string) (string, error) {
 	f.addCall("create")
-	return f.ExternalIP, f.Err
+	return f.ExternalIP.String(), f.Err
 }
 
 // UpdateTCPLoadBalancer is a test-spy implementation of TCPLoadBalancer.UpdateTCPLoadBalancer.

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -192,10 +192,10 @@ func (gce *GCECloud) TCPLoadBalancerExists(name, region string) (bool, error) {
 }
 
 // CreateTCPLoadBalancer is an implementation of TCPLoadBalancer.CreateTCPLoadBalancer.
-func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string) (net.IP, error) {
+func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string) (string, error) {
 	pool, err := gce.makeTargetPool(name, region, hosts)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	req := &compute.ForwardingRule{
 		Name:       name,
@@ -208,17 +208,17 @@ func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.I
 	}
 	op, err := gce.service.ForwardingRules.Insert(gce.projectID, region, req).Do()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	err = gce.waitForRegionOp(op, region)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	fwd, err := gce.service.ForwardingRules.Get(gce.projectID, region, name).Do()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return net.ParseIP(fwd.IPAddress), nil
+	return net.ParseIP(fwd.IPAddress).String(), nil
 }
 
 // UpdateTCPLoadBalancer is an implementation of TCPLoadBalancer.UpdateTCPLoadBalancer.

--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -467,8 +467,8 @@ func (proxier *Proxier) OnUpdate(services []api.Service) {
 		if service.Spec.CreateExternalLoadBalancer {
 			publicIPs := service.Spec.PublicIPs
 			if len(publicIPs) == 0 {
-				glog.Info("Using instance IP for load balancer: ", proxier.listenAddress);
-				publicIPs = []string{ proxier.listenAddress.String() }
+				glog.Info("Using instance IP for load balancer: ", proxier.listenAddress)
+				publicIPs = []string{proxier.listenAddress.String()}
 			}
 			glog.Info("Load balancer public ips: ", publicIPs)
 			info.publicIP = publicIPs

--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -669,7 +669,7 @@ func iptablesPortalArgs(destNet iptableNetworkSpec, destPort int, protocol api.P
 		args = append(args, "-j", "DNAT", "--to-destination", net.JoinHostPort(proxyIP.String(), strconv.Itoa(proxyPort)))
 	}
 
-	glog.Info("Built iptables args", args, "for dest", dest)
-	
+	glog.Info("Built iptables args", args, "for dest", destNet)
+
 	return args
 }

--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -609,7 +609,7 @@ func iptablesIpToNetmask(ip net.IP) iptableNetworkSpec {
 		ipLength = 32
 	}
 
-	self.network = net.IPNet{IP: ip, Mask: net.CIDRMask(ipLength, 0)}
+	self.network = net.IPNet{IP: ip, Mask: net.CIDRMask(ipLength, ipLength)}
 	return self
 }
 

--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -465,7 +465,11 @@ func (proxier *Proxier) OnUpdate(services []api.Service) {
 		info.portalIP = serviceIP
 		info.portalPort = service.Spec.Port
 		if service.Spec.CreateExternalLoadBalancer {
-			info.publicIP = service.Spec.PublicIPs
+			publicIPs := service.Spec.PublicIPs
+			if len(publicIPs) == 0 {
+				publicIPs = []string{ proxier.listenAddress.String() }
+			}
+			info.publicIP = publicIPs
 		}
 		err = proxier.openPortal(service.Name, info)
 		if err != nil {

--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -467,8 +467,10 @@ func (proxier *Proxier) OnUpdate(services []api.Service) {
 		if service.Spec.CreateExternalLoadBalancer {
 			publicIPs := service.Spec.PublicIPs
 			if len(publicIPs) == 0 {
+				glog.Info("Using instance IP for load balancer: ", proxier.listenAddress);
 				publicIPs = []string{ proxier.listenAddress.String() }
 			}
+			glog.Info("Load balancer public ips: ", publicIPs)
 			info.publicIP = publicIPs
 		}
 		err = proxier.openPortal(service.Name, info)

--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -613,6 +613,14 @@ func iptablesIpToNetmask(ip net.IP) iptableNetworkSpec {
 	return self
 }
 
+func (self iptableNetworkSpec) String() string {
+	invertString := ""
+	if self.invert {
+		invertString = "!"
+	}
+	return fmt.Sprintf("iptableNetworkSpec: %v %v", invertString, self.network)
+}
+
 // Build a slice of iptables args for a portal rule.
 func iptablesPortalArgs(destNet iptableNetworkSpec, destPort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, service string) []string {
 	// This list needs to include all fields as they are eventually spit out
@@ -660,5 +668,8 @@ func iptablesPortalArgs(destNet iptableNetworkSpec, destPort int, protocol api.P
 		// TODO: Can we DNAT with IPv6?
 		args = append(args, "-j", "DNAT", "--to-destination", net.JoinHostPort(proxyIP.String(), strconv.Itoa(proxyPort)))
 	}
+
+	glog.Info("Built iptables args", args, "for dest", dest)
+	
 	return args
 }

--- a/pkg/proxy/proxier_test.go
+++ b/pkg/proxy/proxier_test.go
@@ -100,10 +100,19 @@ func (fake *fakeIptables) IsIpv6() bool {
 
 var tcpServerPort string
 var udpServerPort string
+var defaultServiceNet *net.IPNet
 
 func init() {
+	var err error
+
 	// Don't handle panics
 	util.ReallyCrash = true
+
+	// populate defaultServiceNet
+	_, defaultServiceNet, err = net.ParseCIDR("10.0.0.0/8")
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse: %v", err))
+	}
 
 	// TCP setup.
 	tcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -176,7 +185,7 @@ func TestTCPProxy(t *testing.T) {
 		},
 	})
 
-	p := NewProxier(lb, net.ParseIP("127.0.0.1"), &fakeIptables{})
+	p := NewProxier(lb, net.ParseIP("127.0.0.1"), defaultServiceNet, &fakeIptables{})
 
 	svcInfo, err := p.addServiceOnPort("echo", "TCP", 0, time.Second)
 	if err != nil {
@@ -194,7 +203,7 @@ func TestUDPProxy(t *testing.T) {
 		},
 	})
 
-	p := NewProxier(lb, net.ParseIP("127.0.0.1"), &fakeIptables{})
+	p := NewProxier(lb, net.ParseIP("127.0.0.1"), defaultServiceNet, &fakeIptables{})
 
 	svcInfo, err := p.addServiceOnPort("echo", "UDP", 0, time.Second)
 	if err != nil {
@@ -221,7 +230,7 @@ func TestTCPProxyStop(t *testing.T) {
 		},
 	})
 
-	p := NewProxier(lb, net.ParseIP("127.0.0.1"), &fakeIptables{})
+	p := NewProxier(lb, net.ParseIP("127.0.0.1"), defaultServiceNet, &fakeIptables{})
 
 	svcInfo, err := p.addServiceOnPort("echo", "TCP", 0, time.Second)
 	if err != nil {
@@ -249,7 +258,7 @@ func TestUDPProxyStop(t *testing.T) {
 		},
 	})
 
-	p := NewProxier(lb, net.ParseIP("127.0.0.1"), &fakeIptables{})
+	p := NewProxier(lb, net.ParseIP("127.0.0.1"), defaultServiceNet, &fakeIptables{})
 
 	svcInfo, err := p.addServiceOnPort("echo", "UDP", 0, time.Second)
 	if err != nil {
@@ -277,7 +286,7 @@ func TestTCPProxyUpdateDelete(t *testing.T) {
 		},
 	})
 
-	p := NewProxier(lb, net.ParseIP("127.0.0.1"), &fakeIptables{})
+	p := NewProxier(lb, net.ParseIP("127.0.0.1"), defaultServiceNet, &fakeIptables{})
 
 	svcInfo, err := p.addServiceOnPort("echo", "TCP", 0, time.Second)
 	if err != nil {
@@ -304,7 +313,7 @@ func TestUDPProxyUpdateDelete(t *testing.T) {
 		},
 	})
 
-	p := NewProxier(lb, net.ParseIP("127.0.0.1"), &fakeIptables{})
+	p := NewProxier(lb, net.ParseIP("127.0.0.1"), defaultServiceNet, &fakeIptables{})
 
 	svcInfo, err := p.addServiceOnPort("echo", "UDP", 0, time.Second)
 	if err != nil {
@@ -331,7 +340,7 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 		},
 	})
 
-	p := NewProxier(lb, net.ParseIP("127.0.0.1"), &fakeIptables{})
+	p := NewProxier(lb, net.ParseIP("127.0.0.1"), defaultServiceNet, &fakeIptables{})
 
 	svcInfo, err := p.addServiceOnPort("echo", "TCP", 0, time.Second)
 	if err != nil {
@@ -362,7 +371,7 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 		},
 	})
 
-	p := NewProxier(lb, net.ParseIP("127.0.0.1"), &fakeIptables{})
+	p := NewProxier(lb, net.ParseIP("127.0.0.1"), defaultServiceNet, &fakeIptables{})
 
 	svcInfo, err := p.addServiceOnPort("echo", "UDP", 0, time.Second)
 	if err != nil {
@@ -393,7 +402,7 @@ func TestTCPProxyUpdatePort(t *testing.T) {
 		},
 	})
 
-	p := NewProxier(lb, net.ParseIP("127.0.0.1"), &fakeIptables{})
+	p := NewProxier(lb, net.ParseIP("127.0.0.1"), defaultServiceNet, &fakeIptables{})
 
 	svcInfo, err := p.addServiceOnPort("echo", "TCP", 0, time.Second)
 	if err != nil {
@@ -438,7 +447,7 @@ func TestUDPProxyUpdatePort(t *testing.T) {
 		},
 	})
 
-	p := NewProxier(lb, net.ParseIP("127.0.0.1"), &fakeIptables{})
+	p := NewProxier(lb, net.ParseIP("127.0.0.1"), defaultServiceNet, &fakeIptables{})
 
 	svcInfo, err := p.addServiceOnPort("echo", "UDP", 0, time.Second)
 	if err != nil {

--- a/pkg/registry/service/rest.go
+++ b/pkg/registry/service/rest.go
@@ -130,21 +130,21 @@ func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan apiserver.RE
 			if err != nil {
 				return nil, err
 			}
-			var ip net.IP
+			var endpoint string
 			if len(service.Spec.PublicIPs) > 0 {
 				for _, publicIP := range service.Spec.PublicIPs {
-					ip, err = balancer.CreateTCPLoadBalancer(service.Name, zone.Region, net.ParseIP(publicIP), service.Spec.Port, hostsFromMinionList(hosts))
+					endpoint, err = balancer.CreateTCPLoadBalancer(service.Name, zone.Region, net.ParseIP(publicIP), service.Spec.Port, hostsFromMinionList(hosts))
 					if err != nil {
 						break
 					}
 				}
 			} else {
-				ip, err = balancer.CreateTCPLoadBalancer(service.Name, zone.Region, nil, service.Spec.Port, hostsFromMinionList(hosts))
+				endpoint, err = balancer.CreateTCPLoadBalancer(service.Name, zone.Region, nil, service.Spec.Port, hostsFromMinionList(hosts))
 			}
 			if err != nil {
 				return nil, err
 			}
-			service.Spec.PublicIPs = []string{ip.String()}
+			service.Spec.PublicIPs = []string{endpoint}
 		}
 		err := rs.registry.CreateService(ctx, service)
 		if err != nil {


### PR DESCRIPTION
Mostly for review/discussion.  I think that there are several patches here which I will need to split out.

Most trickily, AWS ELB inbound traffic has a destination of the instance IP; I think that GCE has a destination of the load balancer's public IP.  This requires some tweaks to proxying, and in order to avoid a loop the proxy needs to know the private subnet (10.0.0.0/8).  I think it could also use the AWS instance IP instead.

Other than that, no huge surprises.  I needed the Zones functionality, and so I get the current AZ from the EC2 metadata service.  I guess we should get the (default?) region from here as well.

I propose a good first step would be to add the Godeps dependency for ELB, so the patch becomes more manageable!
