### PR TITLE
Make credentialprovider less verbose about benign errors.

### DIFF
--- a/pkg/credentialprovider/gcp/metadata.go
+++ b/pkg/credentialprovider/gcp/metadata.go
@@ -105,7 +105,9 @@ func (g *metadataProvider) Enabled() bool {
 func (g *dockerConfigKeyProvider) Provide() credentialprovider.DockerConfig {
 	// Read the contents of the google-dockercfg metadata key and
 	// parse them as an alternate .dockercfg
-	if cfg, err := credentialprovider.ReadDockerConfigFileFromUrl(dockerConfigKey, g.Client, metadataHeader); err == nil {
+	if cfg, err := credentialprovider.ReadDockerConfigFileFromUrl(dockerConfigKey, g.Client, metadataHeader); err != nil {
+		glog.Errorf("while reading 'google-dockercfg' metadata: %v", err)
+	} else {
 		return cfg
 	}
 
@@ -115,9 +117,13 @@ func (g *dockerConfigKeyProvider) Provide() credentialprovider.DockerConfig {
 // Provide implements DockerConfigProvider
 func (g *dockerConfigUrlKeyProvider) Provide() credentialprovider.DockerConfig {
 	// Read the contents of the google-dockercfg-url key and load a .dockercfg from there
-	if url, err := credentialprovider.ReadUrl(dockerConfigUrlKey, g.Client, metadataHeader); err == nil {
+	if url, err := credentialprovider.ReadUrl(dockerConfigUrlKey, g.Client, metadataHeader); err != nil {
+		glog.Errorf("while reading 'google-dockercfg-url' metadata: %v", err)
+	} else {
 		if strings.HasPrefix(string(url), "http") {
-			if cfg, err := credentialprovider.ReadDockerConfigFileFromUrl(string(url), g.Client, nil); err == nil {
+			if cfg, err := credentialprovider.ReadDockerConfigFileFromUrl(string(url), g.Client, nil); err != nil {
+				glog.Errorf("while reading 'google-dockercfg-url'-specified url: %s, %v", string(url), err)
+			} else {
 				return cfg
 			}
 		} else {
@@ -162,11 +168,13 @@ func (g *containerRegistryProvider) Provide() credentialprovider.DockerConfig {
 
 	tokenJsonBlob, err := credentialprovider.ReadUrl(metadataToken, g.Client, metadataHeader)
 	if err != nil {
+		glog.Errorf("while reading access token endpoint: %v", err)
 		return cfg
 	}
 
 	email, err := credentialprovider.ReadUrl(metadataEmail, g.Client, metadataHeader)
 	if err != nil {
+		glog.Errorf("while reading email endpoint: %v", err)
 		return cfg
 	}
 


### PR DESCRIPTION
In particular, a few of the utilities used within the credentialprovider had the pattern:

```
    glog.Errorf("while blah %s: %v", s, err)
    return nil, err
```

This change composes the error message that is propagated and puts the burden of logging on the caller, which gives us the new pattern:

```
    return nil, fmt.Errorf("while blah %s: %v", s, err)
```

In particular, this allows us to squelch all output during kubelet startup when we are detecting whether certain credentialprovider plugins should even be enabled.

Fixes: https://github.com/GoogleCloudPlatform/kubernetes/issues/2673
