### PR TITLE
Export kubectl/cmd methods

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -123,7 +123,10 @@ func runHelp(cmd *cobra.Command, args []string) {
 	cmd.Help()
 }
 
-func getKubeNamespace(cmd *cobra.Command) string {
+// GetKubeNamespace returns the value of the namespace a
+// user provided on the command line or use the default
+// namespace.
+func GetKubeNamespace(cmd *cobra.Command) string {
 	result := api.NamespaceDefault
 	if ns := GetFlagString(cmd, "namespace"); len(ns) > 0 {
 		result = ns
@@ -140,10 +143,10 @@ func getKubeNamespace(cmd *cobra.Command) string {
 	return result
 }
 
-// getExplicitKubeNamespace returns the value of the namespace a
+// GetExplicitKubeNamespace returns the value of the namespace a
 // user explicitly provided on the command line, or false if no
 // such namespace was specified.
-func getExplicitKubeNamespace(cmd *cobra.Command) (string, bool) {
+func GetExplicitKubeNamespace(cmd *cobra.Command) (string, bool) {
 	if ns := GetFlagString(cmd, "namespace"); len(ns) > 0 {
 		return ns, true
 	}

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -49,7 +49,7 @@ Examples:
 
 			// use the default namespace if not specified, or check for conflict with the file's namespace
 			if len(namespace) == 0 {
-				namespace = getKubeNamespace(cmd)
+				namespace = GetKubeNamespace(cmd)
 			} else {
 				err = CompareNamespaceFromFile(cmd, namespace)
 				checkErr(err)

--- a/pkg/kubectl/cmd/log.go
+++ b/pkg/kubectl/cmd/log.go
@@ -17,8 +17,9 @@ limitations under the License.
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"io"
+
+	"github.com/spf13/cobra"
 )
 
 func (f *Factory) NewCmdLog(out io.Writer) *cobra.Command {
@@ -30,7 +31,7 @@ func (f *Factory) NewCmdLog(out io.Writer) *cobra.Command {
 				usageError(cmd, "<pod> and <container> are required for log")
 			}
 
-			namespace := getKubeNamespace(cmd)
+			namespace := GetKubeNamespace(cmd)
 
 			client, err := f.ClientBuilder.Client()
 			checkErr(err)

--- a/pkg/kubectl/cmd/resource.go
+++ b/pkg/kubectl/cmd/resource.go
@@ -37,7 +37,7 @@ func ResourceFromArgsOrFile(cmd *cobra.Command, args []string, filename string, 
 
 	if len(args) == 2 {
 		resource := kubectl.ExpandResourceShortcut(args[0])
-		namespace = getKubeNamespace(cmd)
+		namespace = GetKubeNamespace(cmd)
 		name = args[1]
 		if len(name) == 0 || len(resource) == 0 {
 			usageError(cmd, "Must specify filename or command line params")
@@ -75,7 +75,7 @@ func ResourceFromArgs(cmd *cobra.Command, args []string, mapper meta.RESTMapper)
 	}
 
 	resource := kubectl.ExpandResourceShortcut(args[0])
-	namespace = getKubeNamespace(cmd)
+	namespace = GetKubeNamespace(cmd)
 	name = args[1]
 	if len(name) == 0 || len(resource) == 0 {
 		usageError(cmd, "Must provide resource and name command line params")
@@ -102,7 +102,7 @@ func ResourceOrTypeFromArgs(cmd *cobra.Command, args []string, mapper meta.RESTM
 		usageError(cmd, "Must provide resource or a resource and name as command line params")
 	}
 
-	namespace = getKubeNamespace(cmd)
+	namespace = GetKubeNamespace(cmd)
 	if len(args) == 2 {
 		name = args[1]
 		if len(name) == 0 {
@@ -154,7 +154,7 @@ func ResourceFromFile(filename string, typer runtime.ObjectTyper, mapper meta.RE
 // or via the default namespace file does not match the namespace of an input file. This
 // prevents a user from unintentionally updating the wrong namespace.
 func CompareNamespaceFromFile(cmd *cobra.Command, namespace string) error {
-	defaultNamespace := getKubeNamespace(cmd)
+	defaultNamespace := GetKubeNamespace(cmd)
 	if len(namespace) > 0 {
 		if defaultNamespace != namespace {
 			return fmt.Errorf("the namespace from the provided file %q does not match the namespace %q. You must pass '--namespace=%s' to perform this operation.", namespace, defaultNamespace, namespace)


### PR DESCRIPTION
These commands are useful when build a CLI client based on kubectl to avoid code duplication and be consistent with eg. error reporting from upstream.

@smarterclayton fyi.
