### PR TITLE
Fix namespace error in kubectl update

### DIFF
--- a/pkg/kubectl/cmd/update.go
+++ b/pkg/kubectl/cmd/update.go
@@ -49,8 +49,12 @@ Examples:
 			client, err := f.Client(cmd, mapping)
 			checkErr(err)
 
-			err = CompareNamespaceFromFile(cmd, namespace)
-			checkErr(err)
+			// use the default namespace if not specified, or check for conflict with the file's namespace
+			if len(namespace) == 0 {
+				namespace = GetKubeNamespace(cmd)
+				err = CompareNamespaceFromFile(cmd, namespace)
+				checkErr(err)
+			}
 
 			err = kubectl.NewRESTHelper(client, mapping).Update(namespace, name, true, data)
 			checkErr(err)


### PR DESCRIPTION
```
$ kubectl update -f pod.json --namespace=mfojtik
F1202 15:14:17.157424 18538 cmd.go:113] The namespace from the provided file "" does not match the namespace "mfojtik". You must pass '--namespace=' to perform this operation.
```
