### PR TITLE
Fix GCE scopes when using GCP Logging

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -297,7 +297,7 @@ function kube-up {
     echo "+++ Logging using Fluentd to ${LOGGING_DESTINATION:-unknown}"
     # For logging to GCP we need to enable some minion scopes.
     if [[ "${LOGGING_DESTINATION-}" == "gcp" ]]; then
-      MINION_SCOPES="${MINION_SCOPES}, https://www.googleapis.com/auth/logging.write"
+      MINION_SCOPES=(${MINION_SCOPES[@]} "https://www.googleapis.com/auth/logging.write")
     fi
   fi
 


### PR DESCRIPTION
v0.6.0 kube-up script fails to create minions when you enable logging and set LOGGING_DESTINATION=gcp.

This was caused by the change to MINION_SCOPES from a string to an array.
