### PR TITLE
Use apiserver instead of etcd for kube-proxy.

### DIFF
--- a/cluster/saltbase/salt/kube-proxy/default
+++ b/cluster/saltbase/salt/kube-proxy/default
@@ -2,11 +2,11 @@
 {% if grains['os_family'] == 'RedHat' -%}
 	{% set daemon_args = "" -%}
 {% endif -%}
-{% if grains.etcd_servers is defined -%}
-  {% set etcd_servers = "-etcd_servers=http://" + grains.etcd_servers + ":4001" -%}
+{% if grains.api_servers is defined -%}
+  {% set api_servers = "-master=http://" + grains.api_servers + ":7080" -%}
 {% else -%}
   {% set ips = salt['mine.get']('roles:kubernetes-master', 'network.ip_addrs', 'grain').values() -%}
-  {% set etcd_servers = "-etcd_servers=http://" + ips[0][0] + ":4001" -%}
+  {% set api_servers = "-master=http://" + ips[0][0] + ":7080" -%}
 {% endif -%}
 
-DAEMON_ARGS="{{daemon_args}} {{etcd_servers}}"
+DAEMON_ARGS="{{daemon_args}} {{api_servers}}"

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -72,6 +72,7 @@ grains:
   network_mode: openvswitch
   networkInterfaceName: eth1
   etcd_servers: $MASTER_IP
+  api_servers: $MASTER_IP
   cloud: vagrant
   cloud_provider: vagrant
   roles:

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -48,6 +48,7 @@ grains:
   network_mode: openvswitch
   node_ip: $MINION_IP
   etcd_servers: $MASTER_IP
+  api_servers: $MASTER_IP
   networkInterfaceName: eth1
   apiservers: $MASTER_IP
   roles:


### PR DESCRIPTION
For cloud-providers that use salt, have kube-proxy use
apiserver instead of etcd as a config source.

Passes e2e test (with addition of #2733)
