### PR TITLE
fixed bug in tools.NewEtcdClientStartServerIfNecessary

### DIFF
--- a/pkg/tools/etcd_tools.go
+++ b/pkg/tools/etcd_tools.go
@@ -377,7 +377,7 @@ func checkEtcd(host string) error {
 	if err != nil {
 		return err
 	}
-	if !strings.HasPrefix("etcd", string(body)) {
+	if !strings.HasPrefix(string(body), "etcd") {
 		return fmt.Errorf("unknown server: %s", string(body))
 	}
 	return nil


### PR DESCRIPTION
kubernetes executable always tries to start an etcd service even if one is running, e.g. because "etcd 0.4.6" is not a prefix of  "etcd"

see http://golang.org/pkg/strings/#HasPrefix
