### PR TITLE
make cadvisor port configurable on the kubelet

### DIFF
--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -60,6 +60,7 @@ var (
 	minimumGCAge            = flag.Duration("minimum_container_ttl_duration", 0, "Minimum age for a finished container before it is garbage collected.  Examples: '300ms', '10s' or '2h45m'")
 	maxContainerCount       = flag.Int("maximum_dead_containers_per_container", 5, "Maximum number of old instances of a container to retain per container.  Each container takes up some disk space.  Default: 5.")
 	authPath                = flag.String("auth_path", "", "Path to .kubernetes_auth file, specifying how to authenticate to API server.")
+	cAdvisorPort            = flag.Uint("cadvisor_port", 4194, "The port of the localhost cAdvisor endpoint")
 	apiServerList           util.StringList
 )
 
@@ -110,6 +111,7 @@ func main() {
 		MaxContainerCount:       *maxContainerCount,
 		Runonce:                 *runonce,
 		Port:                    *port,
+		CAdvisorPort:            *cAdvisorPort,
 		EnableServer:            *enableServer,
 		EnableDebuggingHandlers: *enableDebuggingHandlers,
 		DockerClient:            kubelet.ConnectToDockerOrDie(*dockerEndpoint),

--- a/examples/monitoring/README.md
+++ b/examples/monitoring/README.md
@@ -1,3 +1,3 @@
 # Heapster
 
-Heapster enables monitoring of Kubernetes Clusters using [cAdvisor](https://github.com/google/cadvisor). Detailed information about heapster can be found [here](https://github.com/GoogleCloudPlatform/heapster).
+Heapster enables monitoring of Kubernetes Clusters using [cAdvisor](https://github.com/google/cadvisor). The kubelet will communicate with an instance of cAdvisor running on localhost and proxy container stats to Heapster. Kubelet will attempt to connect to cAdvisor on port 4194 by default but this port can be configured with kubelet's `-cadvisor_port` run flag. Detailed information about heapster can be found [here](https://github.com/GoogleCloudPlatform/heapster).

--- a/pkg/kubelet/util.go
+++ b/pkg/kubelet/util.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -88,11 +89,11 @@ func GarbageCollectLoop(k *Kubelet) {
 }
 
 // TODO: move this into the kubelet itself
-func MonitorCAdvisor(k *Kubelet) {
+func MonitorCAdvisor(k *Kubelet, cp uint) {
 	defer util.HandleCrash()
 	// TODO: Monitor this connection, reconnect if needed?
 	glog.V(1).Infof("Trying to create cadvisor client.")
-	cadvisorClient, err := cadvisor.NewClient("http://127.0.0.1:4194")
+	cadvisorClient, err := cadvisor.NewClient("http://127.0.0.1:" + strconv.Itoa(int(cp)))
 	if err != nil {
 		glog.Errorf("Error on creating cadvisor client: %v", err)
 		return

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -220,6 +220,7 @@ func makePodSourceConfig(kc *KubeletConfig) *config.PodConfig {
 type KubeletConfig struct {
 	EtcdClient              tools.EtcdClient
 	DockerClient            dockertools.DockerInterface
+	CAdvisorPort            uint
 	Address                 util.IP
 	AuthPath                string
 	ApiServerList           util.StringList
@@ -262,7 +263,7 @@ func createAndInitKubelet(kc *KubeletConfig) *kubelet.Kubelet {
 	k.BirthCry()
 
 	go kubelet.GarbageCollectLoop(k)
-	go kubelet.MonitorCAdvisor(k)
+	go kubelet.MonitorCAdvisor(k, kc.CAdvisorPort)
 	kubelet.InitHealthChecking(k)
 
 	return k


### PR DESCRIPTION
The [cadvisor quickstart guide](https://github.com/google/cadvisor#quick-start-running-cadvisor-in-a-docker-container) recommends port 8080 but the kubelet looks for cadvisor on the hardcoded port 4194. This decision is also not documented anywhere and could lead to confusion. See GoogleCloudPlatform/heapster#15. It would be nice to have the option to configure the port kubelet looks for cadvisor on.

Resolve #2758 
