### PR TITLE
Implement apiserver communication for Vagrant

### DIFF
--- a/cluster/saltbase/salt/kube-apiserver/default
+++ b/cluster/saltbase/salt/kube-apiserver/default
@@ -40,7 +40,7 @@
 {% set token_auth_file = "-token_auth_file=/dev/null" -%}
 
 {% if grains.cloud is defined -%}
-{% if grains.cloud == 'gce' -%}
+{% if grains.cloud == 'gce' or grains.cloud == 'vagrant' -%}
     # TODO: generate and distribute tokens for other cloud providers.
     {% set token_auth_file = "-token_auth_file=/srv/kubernetes/known_tokens.csv" -%}
 {% endif -%}

--- a/cluster/saltbase/salt/kube-apiserver/init.sls
+++ b/cluster/saltbase/salt/kube-apiserver/init.sls
@@ -39,7 +39,7 @@
 {% endif %}
 
 {% if grains.cloud is defined %}
-{% if grains.cloud == 'gce' %}
+{% if grains.cloud == 'gce' or grains.cloud == 'vagrant' %}
 # TODO: generate and distribute tokens on other cloud providers.
 /srv/kubernetes/known_tokens.csv:
   file.managed:

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -108,6 +108,19 @@ state_verbose: False
 state_output: mixed
 EOF
 
+# Generate and distribute a shared secret (bearer token) to
+# apiserver and kubelet so that kubelet can authenticate to
+# apiserver to send events.
+kubelet_token=$(cat /dev/urandom | base64 | tr -d "=+/" | dd bs=32 count=1 2> /dev/null)
+
+mkdir -p /srv/salt-overlay/salt/kube-apiserver
+known_tokens_file="/srv/salt-overlay/salt/kube-apiserver/known_tokens.csv"
+(umask u=rw,go= ; echo "$kubelet_token,kubelet,kubelet" > $known_tokens_file)
+
+mkdir -p /srv/salt-overlay/salt/kubelet
+kubelet_auth_file="/srv/salt-overlay/salt/kubelet/kubernetes_auth"
+(umask u=rw,go= ; echo "{\"BearerToken\": \"$kubelet_token\", \"Insecure\": true }" > $kubelet_auth_file)
+
 # Configure nginx authorization
 mkdir -p "$KUBE_TEMP"
 mkdir -p /srv/salt-overlay/salt/nginx


### PR DESCRIPTION
This implementation is based on the GCE implementation from
618a367dbb48dbaa9c3b50e877858d854322fd0b.

I built this while trying to fix issue #2746.  It didn't work, but it did change some kubelet log messages from

```
Unable to write event [...]  failed (401) 401 Unauthorized: Unauthorized
```

to

```
Event(api.ObjectReference{Kind:"Minion", Namespace:"default", Name:"10.245.2.2", UID:"10.245.2.2", APIVersion:"", ResourceVersion:"", FieldPath:""}): status: '', reason: 'starting' Starting kubelet.
```

So I figured this might have some value. You're welcome to pull it if it's useful.
