### PR TITLE
Query hostIP for Nodes

### DIFF
--- a/pkg/cloudprovider/controller/minioncontroller.go
+++ b/pkg/cloudprovider/controller/minioncontroller.go
@@ -143,6 +143,12 @@ func (s *MinionController) cloudMinions() (*api.MinionList, error) {
 	}
 	for i := range matches {
 		result.Items[i].Name = matches[i]
+		hostIP, err := instances.IPAddress(matches[i])
+		if err != nil {
+			glog.Errorf("error getting instance ip address for %s: %v", matches[i], err)
+		} else {
+			result.Items[i].Status.HostIP = hostIP.String()
+		}
 		resources, err := instances.GetNodeResources(matches[i])
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Query cloud provider for host ip address.

The semantic of IPAddress() method is very clear; to make things less destructive, we just log errors instead of returning error.
