### PR TITLE
simplify util.ErrorList by eliminating errorListInternal

### DIFF
--- a/pkg/api/errors/errors.go
+++ b/pkg/api/errors/errors.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 // StatusError is an error intended for consumption by a REST API server; it can also be
@@ -126,7 +127,7 @@ func NewInvalid(kind, name string, errs ValidationErrorList) error {
 			ID:     name,
 			Causes: causes,
 		},
-		Message: fmt.Sprintf("%s %q is invalid: %v", kind, name, errs.ToError()),
+		Message: fmt.Sprintf("%s %q is invalid: %v", kind, name, util.SliceToError(errs)),
 	}}
 }
 

--- a/pkg/api/errors/validation.go
+++ b/pkg/api/errors/validation.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
 )
 
@@ -121,18 +120,7 @@ func NewFieldNotFound(field string, value interface{}) *ValidationError {
 	return &ValidationError{ValidationErrorTypeNotFound, field, value, ""}
 }
 
-// ValidationErrorList is a collection of ValidationErrors.  This does not
-// implement the error interface to avoid confusion where an empty
-// ValidationErrorList would still be an error (non-nil).  To produce a single
-// error instance from a ValidationErrorList, use the ToError() method, which
-// will return nil for an empty ValidationErrorList.
-type ValidationErrorList util.ErrorList
-
-// ToError converts a ValidationErrorList into a "normal" error, or nil if the
-// list is empty.
-func (list ValidationErrorList) ToError() error {
-	return util.ErrorList(list).ToError()
-}
+type ValidationErrorList []error
 
 // Prefix adds a prefix to the Field of every ValidationError in the list.
 // Returns the list for convenience.

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -851,7 +851,7 @@ func TestValidateService(t *testing.T) {
 		registry.List = tc.existing
 		errs := ValidateService(&tc.svc, registry, api.NewDefaultContext())
 		if len(errs) != tc.numErrs {
-			t.Errorf("Unexpected error list for case %q: %v", tc.name, errs.ToError())
+			t.Errorf("Unexpected error list for case %q: %v", tc.name, util.SliceToError(errs))
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,7 +23,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 type RESTClientPoster interface {
@@ -37,8 +36,8 @@ type ClientPosterFunc func(mapping *meta.RESTMapping) (RESTClientPoster, error)
 // be valid API type. It requires ObjectTyper to parse the Version and Kind and
 // RESTMapper to get the resource URI and REST client that knows how to create
 // given type
-func CreateObjects(typer runtime.ObjectTyper, mapper meta.RESTMapper, clientFor ClientPosterFunc, objects []runtime.Object) util.ErrorList {
-	allErrors := util.ErrorList{}
+func CreateObjects(typer runtime.ObjectTyper, mapper meta.RESTMapper, clientFor ClientPosterFunc, objects []runtime.Object) []error {
+	var allErrors []error
 	for i, obj := range objects {
 		version, kind, err := typer.ObjectVersionAndKind(obj)
 		if err != nil {

--- a/pkg/kubectl/cmd/createall.go
+++ b/pkg/kubectl/cmd/createall.go
@@ -23,14 +23,13 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/config"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 )
 
 // DataToObjects converts the raw JSON data into API objects
-func DataToObjects(m meta.RESTMapper, t runtime.ObjectTyper, data []byte) (result []runtime.Object, errors util.ErrorList) {
+func DataToObjects(m meta.RESTMapper, t runtime.ObjectTyper, data []byte) (result []runtime.Object, errors []error) {
 	configObj := []runtime.RawExtension{}
 
 	if err := yaml.Unmarshal(data, &configObj); err != nil {

--- a/pkg/util/error_list.go
+++ b/pkg/util/error_list.go
@@ -20,18 +20,17 @@ import (
 	"fmt"
 )
 
-// ErrorList is a collection of errors.  This does not implement the error
-// interface to avoid confusion where an empty ErrorList would still be an
-// error (non-nil).  To produce a single error instance from an ErrorList, use
-// the ToError() method, which will return nil for an empty ErrorList.
-type ErrorList []error
+// []error is a collection of errors. This does not implement the error
+// interface to avoid confusion where an empty []error would still be an
+// error (non-nil).  To produce a single error instance from an []error, use
+// the SliceToError() method, which will return nil for an empty []error.
 
-// This helper implements the error interface for ErrorList, but prevents
-// accidental conversion of ErrorList to error.
-type errorListInternal ErrorList
+// This helper implements the error interface for []error, but prevents
+// accidental conversion of []error to error.
+type errorList []error
 
 // Error is part of the error interface.
-func (list errorListInternal) Error() string {
+func (list errorList) Error() string {
 	if len(list) == 0 {
 		return ""
 	}
@@ -46,10 +45,10 @@ func (list errorListInternal) Error() string {
 	return result
 }
 
-// ToError converts an ErrorList into a "normal" error, or nil if the list is empty.
-func (list ErrorList) ToError() error {
-	if len(list) == 0 {
+// SliceToError converts an []error into a "normal" error, or nil if the slice is empty.
+func SliceToError(errs []error) error {
+	if len(errs) == 0 {
 		return nil
 	}
-	return errorListInternal(list)
+	return errorList(errs)
 }

--- a/pkg/util/error_list_test.go
+++ b/pkg/util/error_list_test.go
@@ -22,24 +22,24 @@ import (
 )
 
 func TestErrorList(t *testing.T) {
-	errList := ErrorList{}
-	err := errList.ToError()
+	var errList []error
+	err := SliceToError(errList)
 	if err != nil {
 		t.Errorf("expected nil, got %v", err)
 	}
-	if a := errorListInternal(errList).Error(); a != "" {
+	if a := errorList(errList).Error(); a != "" {
 		t.Errorf("expected empty string, got %q", a)
 	}
 
 	testCases := []struct {
-		errs     ErrorList
+		errs     []error
 		expected string
 	}{
-		{ErrorList{fmt.Errorf("abc")}, "abc"},
-		{ErrorList{fmt.Errorf("abc"), fmt.Errorf("123")}, "[abc, 123]"},
+		{[]error{fmt.Errorf("abc")}, "abc"},
+		{[]error{fmt.Errorf("abc"), fmt.Errorf("123")}, "[abc, 123]"},
 	}
 	for _, testCase := range testCases {
-		err := testCase.errs.ToError()
+		err := SliceToError(testCase.errs)
 		if err == nil {
 			t.Errorf("expected an error, got nil: %v", testCase)
 			continue

--- a/plugin/pkg/auth/authenticator/request/union/union.go
+++ b/plugin/pkg/auth/authenticator/request/union/union.go
@@ -35,7 +35,7 @@ func New(authRequestHandlers ...authenticator.Request) authenticator.Request {
 // AuthenticateRequest authenticates the request using a chain of authenticator.Request objects.  The first
 // success returns that identity.  Errors are only returned if no matches are found.
 func (authHandler unionAuthRequestHandler) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
-	var errors util.ErrorList
+	var errors []error
 	for _, currAuthRequestHandler := range authHandler {
 		info, ok, err := currAuthRequestHandler.AuthenticateRequest(req)
 		if err != nil {
@@ -48,5 +48,5 @@ func (authHandler unionAuthRequestHandler) AuthenticateRequest(req *http.Request
 		}
 	}
 
-	return nil, false, errors.ToError()
+	return nil, false, util.SliceToError(errors)
 }

--- a/plugin/pkg/auth/authenticator/request/x509/x509.go
+++ b/plugin/pkg/auth/authenticator/request/x509/x509.go
@@ -55,7 +55,7 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool,
 		return nil, false, nil
 	}
 
-	var errors util.ErrorList
+	var errors []error
 	for _, cert := range req.TLS.PeerCertificates {
 		chains, err := cert.Verify(a.opts)
 		if err != nil {
@@ -75,7 +75,7 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool,
 			}
 		}
 	}
-	return nil, false, errors.ToError()
+	return nil, false, util.SliceToError(errors)
 }
 
 // DefaultVerifyOptions returns VerifyOptions that use the system root certificates, current time,


### PR DESCRIPTION
This refactor makes ErrorList introspectable as per Issue 1605 https://github.com/GoogleCloudPlatform/kubernetes/issues/1605. It passes make check. 
