### PR TITLE
Vagrant fix - Add python-cherrypy as explicit install for salt-api 

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -149,7 +149,9 @@ EOF
   curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -M -N
 
   # Install salt-api
-  #
+  #  
+  # This is used to provide the network transport for salt-api
+  yum install -y python-cherrypy
   # This is used to inform the cloud provider used in the vagrant cluster
   yum install -y salt-api
   # Set log level to a level higher than "info" to prevent the message about


### PR DESCRIPTION
Fixes #2746 

There appears to have been a packaging change in Salt, and the prerequisite module for serving salt-api was not getting laid down.  The salt-api was halting when it attempted to load the module, and as a result, the vagrant cloud_provider could not discover any minions.
