### PR TITLE
Fix conditional docker_opts in salt/docker/docker-defaults

### DIFF
--- a/cluster/saltbase/salt/docker/docker-defaults
+++ b/cluster/saltbase/salt/docker/docker-defaults
@@ -1,5 +1,5 @@
 DOCKER_OPTS=""
-{% if grains.docker_opts is defined %}
+{% if grains.docker_opts %}
 DOCKER_OPTS="${DOCKER_OPTS} {{grains.docker_opts}}"
 {% endif %}
 DOCKER_OPTS="${DOCKER_OPTS} --bridge cbr0 --iptables=false --ip-masq=false -r=false"


### PR DESCRIPTION
'is defined' apparently returns true if the variable exists but has empty/None value. In that case you get

`DOCKER_OPTS="${DOCKER_OPTS} None"`

in /etc/default/docker, which causes the docker command to fail. Fix is to use [plain if](http://jinja.pocoo.org/docs/dev/templates/#if) , which checks that variable is defined and 'nonempty'.
