### PR TITLE
Use EXIT pseudo-signal

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -150,6 +150,6 @@ cleanup()
     exit 0
 }
 
-trap cleanup EXIT SIGINT
+trap cleanup EXIT
 
 while true; do read x; done

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -33,7 +33,7 @@ cleanup() {
 "${KUBE_ROOT}/hack/build-go.sh" "$@" cmd/integration
 
 # Run cleanup to stop etcd on interrupt or other kill signal.
-trap cleanup HUP INT QUIT TERM
+trap cleanup EXIT
 
 kube::etcd::start
 


### PR DESCRIPTION
test-integration won't cleanup etcd when test fails, use EXIT which will always do cleanup.
local-up-cluster will do cleanup twice due to EXIT and SIGINT. 

POSIX spec doesn't say too much about EXIT condition, but most shell do trap EXIT on sigint, sigterm (bash, zsh, fish).  Looks like dash won't trap.
Not sure if this is the correct way, but it's annoying to kill etcd everytime integration test fails; and to see the ""no such process" message.
