### PR TITLE
api: add container's id to ContainerStatus

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -404,7 +404,8 @@ type ContainerStatus struct {
 	// not just PodInfo. Now we need this to remove docker.Container from API
 	PodIP string `json:"podIP,omitempty"`
 	// TODO(dchen1107): Need to decide how to represent this in v1beta3
-	Image string `json:"image"`
+	Image       string `json:"image"`
+	ContainerID string `json:"containerID,omitempty" description:"container's ID in the format 'docker://<container_id>'"`
 }
 
 // PodInfo contains one entry for every container with available info.

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -363,7 +363,8 @@ type ContainerStatus struct {
 	// not just PodInfo. Now we need this to remove docker.Container from API
 	PodIP string `json:"podIP,omitempty" description:"pod's IP address"`
 	// TODO(dchen1107): Need to decide how to reprensent this in v1beta3
-	Image string `json:"image" description:"image of the container"`
+	Image       string `json:"image" description:"image of the container"`
+	ContainerID string `json:"containerID,omitempty" description:"container's ID in the format 'docker://<container_id>'"`
 }
 
 // PodInfo contains one entry for every container with available info.

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -328,7 +328,8 @@ type ContainerStatus struct {
 	// not just PodInfo. Now we need this to remove docker.Container from API
 	PodIP string `json:"podIP,omitempty" description:"pod's IP address"`
 	// TODO(dchen1107): Need to decide how to reprensent this in v1beta3
-	Image string `json:"image" description:"image of the container"`
+	Image       string `json:"image" description:"image of the container"`
+	ContainerID string `json:"containerID,omitempty" description:"container's ID in the format 'docker://<container_id>'"`
 }
 
 // PodInfo contains one entry for every container with available info.

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -422,6 +422,7 @@ type ContainerStatus struct {
 	RestartCount int `json:"restartCount"`
 	// TODO(dchen1107): Introduce our own NetworkSettings struct here?
 	// TODO(dchen1107): Which image the container is running with?
+	ContainerID string `json:"containerID,omitempty" description:"container's ID in the format 'docker://<container_id>'"`
 }
 
 // PodInfo contains one entry for every container with available info.

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -389,7 +389,8 @@ func inspectContainer(client DockerInterface, dockerID, containerName, tPath str
 
 	glog.V(3).Infof("Container inspect result: %+v", *inspectResult)
 	containerStatus := api.ContainerStatus{
-		Image: inspectResult.Config.Image,
+		Image:       inspectResult.Config.Image,
+		ContainerID: "docker://" + dockerID,
 	}
 
 	waiting := true


### PR DESCRIPTION
Sometimes for external applications it is useful to correlate the pod
containers to the real docker instances.

This patch adds a new entry in the container status (containerID) which
is used to identify the instance.

Signed-off-by: Federico Simoncelli fsimonce@redhat.com
