### PR TITLE
Do not consider an empty string to be an error in list.go

### DIFF
--- a/pkg/util/list.go
+++ b/pkg/util/list.go
@@ -29,9 +29,6 @@ func (sl *StringList) String() string {
 
 func (sl *StringList) Set(value string) error {
 	for _, s := range strings.Split(value, ",") {
-		if len(s) == 0 {
-			return fmt.Errorf("value should not be an empty string")
-		}
 		*sl = append(*sl, s)
 	}
 	return nil

--- a/pkg/util/list_test.go
+++ b/pkg/util/list_test.go
@@ -30,13 +30,3 @@ func TestStringListSet(t *testing.T) {
 		t.Errorf("expected: %v, got: %v:", expected, sl)
 	}
 }
-
-func TestStringListSetErr(t *testing.T) {
-	var sl StringList
-	if err := sl.Set(""); err == nil {
-		t.Errorf("expected error for empty string")
-	}
-	if err := sl.Set(","); err == nil {
-		t.Errorf("expected error for list of empty strings")
-	}
-}


### PR DESCRIPTION
Due to changes in the kube cluster up/down commands one of the flags need to be able to take an empty string and this should be considered valid.
