### PR TITLE
inspect the full repo/image:tag name

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -222,8 +222,7 @@ func (p throttledDockerPuller) Pull(image string) error {
 	return fmt.Errorf("pull QPS exceeded.")
 }
 
-func (p dockerPuller) IsImagePresent(name string) (bool, error) {
-	image, _ := parseImageName(name)
+func (p dockerPuller) IsImagePresent(image string) (bool, error) {
 	_, err := p.client.InspectImage(image)
 	if err == nil {
 		return true, nil


### PR DESCRIPTION
Parsing the name won't pull a newly tagged image if a recent "latest" image has already been pulled.
See https://github.com/mesosphere/kubernetes-mesos/issues/104
