### PR TITLE
Compare containers by name, not by pointer equality.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -425,7 +425,7 @@ func (kl *Kubelet) runHandler(podFullName, uuid string, container *api.Container
 func fieldPath(pod *api.BoundPod, container *api.Container) (string, error) {
 	for i := range pod.Spec.Containers {
 		here := &pod.Spec.Containers[i]
-		if here == container {
+		if here.Name == container.Name {
 			return fmt.Sprintf("spec.containers[%d]", i), nil
 		}
 	}


### PR DESCRIPTION
I guess the pointers that are passed around are not necessarily to the objects in the pod's container array.

This makes the events that kublet produces have the expected fieldPath (it used to call all containers "implicitly required", which is only true of the network namespace container). Unfortunately, it makes them less human-readable. It would be really nice if we could make containers a map of string to container, then it would still be easily human readable.
