### PR TITLE
Using container-vm-v20141208 as the default image on GCE.

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -22,7 +22,7 @@ NUM_MINIONS=4
 # TODO(dchen1107): Filed an internal issue to create an alias
 # for containervm image, so that gcloud will expand this
 # to the latest supported image.
-IMAGE=container-vm-v20141016
+IMAGE=container-vm-v20141208
 IMAGE_PROJECT=google-containers
 NETWORK=default
 INSTANCE_PREFIX=kubernetes

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -22,7 +22,7 @@ NUM_MINIONS=2
 # TODO(dchen1107): Filed an internal issue to create an alias
 # for containervm image, so that gcloud will expand this
 # to the latest supported image.
-IMAGE=container-vm-v20141016
+IMAGE=container-vm-v20141208
 IMAGE_PROJECT=google-containers
 NETWORK=e2e
 INSTANCE_PREFIX="e2e-test-${USER}"


### PR DESCRIPTION
I published container-vm-v20141208 as the new image for external users 2 hours ago. Also tested it with entire e2e test-suite. Also did manual tests on creating pod / service. Now it is the time to make it the default for OSS kubernetes. 
