### PR TITLE
MountPath in VolumeMount is a required field. Removing the omitempty.

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -233,7 +233,7 @@ type VolumeMount struct {
 	// Optional: Defaults to false (read-write).
 	ReadOnly bool `json:"readOnly,omitempty"`
 	// Required.
-	MountPath string `json:"mountPath,omitempty"`
+	MountPath string `json:"mountPath"`
 }
 
 // EnvVar represents an environment variable present in a Container.

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -170,7 +170,7 @@ type VolumeMount struct {
 	// Required.
 	// Exactly one of the following must be set.  If both are set, prefer MountPath.
 	// DEPRECATED: Path will be removed in a future version of the API.
-	MountPath string `json:"mountPath,omitempty" description:"path within the container at which the volume should be mounted; overrides path"`
+	MountPath string `json:"mountPath" description:"path within the container at which the volume should be mounted; overrides path"`
 	Path      string `json:"path,omitempty" description:"path within the container at which the volume should be mounted; deprecated"`
 	// One of: "LOCAL" (local volume) or "HOST" (external mount from the host). Default: LOCAL.
 	// DEPRECATED: MountType will be removed in a future version of the API.

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -144,7 +144,7 @@ type VolumeMount struct {
 	// Optional: Defaults to false (read-write).
 	ReadOnly bool `json:"readOnly,omitempty" description:"mounted read-only if true, read-write otherwise (false or unspecified)"`
 	// Required.
-	MountPath string `json:"mountPath,omitempty" description:"path within the container at which the volume should be mounted"`
+	MountPath string `json:"mountPath" description:"path within the container at which the volume should be mounted"`
 }
 
 // EnvVar represents an environment variable present in a Container.

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -253,7 +253,7 @@ type VolumeMount struct {
 	// Optional: Defaults to false (read-write).
 	ReadOnly bool `json:"readOnly,omitempty"`
 	// Required.
-	MountPath string `json:"mountPath,omitempty"`
+	MountPath string `json:"mountPath"`
 }
 
 // EnvVar represents an environment variable present in a Container.


### PR DESCRIPTION
Removing omitempty for MountPath in VolumeMount definition.
