### PR TITLE
Allow, when testing, SelfLinks to be unset.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -96,7 +96,6 @@ func NewIntegrationTestKubelet(hn string, rd string, dc dockertools.DockerInterf
 		networkContainerImage: NetworkContainerImage,
 		resyncInterval:        3 * time.Second,
 		podWorkers:            newPodWorkers(),
-		dockerIDToRef:         map[dockertools.DockerID]*api.ObjectReference{},
 	}
 }
 
@@ -456,6 +455,9 @@ func containerRef(pod *api.BoundPod, container *api.Container) (*api.ObjectRefer
 func (kl *Kubelet) setRef(id dockertools.DockerID, ref *api.ObjectReference) {
 	kl.refLock.Lock()
 	defer kl.refLock.Unlock()
+	if kl.dockerIDToRef == nil {
+		kl.dockerIDToRef = map[dockertools.DockerID]*api.ObjectReference{}
+	}
 	kl.dockerIDToRef[id] = ref
 }
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -40,6 +40,11 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+func init() {
+	api.ForTesting_ReferencesAllowBlankSelfLinks = true
+	util.ReallyCrash = true
+}
+
 func newTestKubelet(t *testing.T) (*Kubelet, *tools.FakeEtcdClient, *dockertools.FakeDockerClient) {
 	fakeEtcdClient := tools.NewFakeEtcdClient(t)
 	fakeDocker := &dockertools.FakeDockerClient{}


### PR DESCRIPTION
Kubelet now makes events in tests.
