### PR TITLE
explicitly declare gce_cloud package name

### DIFF
--- a/pkg/volume/gce_util.go
+++ b/pkg/volume/gce_util.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/gce"
+	gce_cloud "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/gce"
 )
 
 const partitionRegex = "[a-z][a-z]*(?P<partition>[0-9][0-9]*)?"


### PR DESCRIPTION
The folder name differs from the package name which is tricky for some static analysis tools to figure out. This was being marked and incorrectly removed by goimports as an unused import. This change will allow goimports to run on ./pkg/, ./cmd/, ./plugin/ without hiccups, which is nice.
