### PR TITLE
Fix update-demo to work correctly with a web browser.

### DIFF
--- a/contrib/for-demos/test-webserver/test-webserver.go
+++ b/contrib/for-demos/test-webserver/test-webserver.go
@@ -39,7 +39,9 @@ func main() {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type")
+		w.Header().Set("Access-Control-Allow-Headers", "DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,Cache-Control,Content-Type")
+		// Disable If-Modified-Since so update-demo isn't broken by 304s
+		r.Header.Del("If-Modified-Since")
 		fs.ServeHTTP(w, r)
 	})
 

--- a/examples/update-demo/images/kitten/Dockerfile
+++ b/examples/update-demo/images/kitten/Dockerfile
@@ -13,4 +13,5 @@
 # limitations under the License.
 
 FROM kubernetes/test-webserver
-ADD html/data.json html/kitten.jpg /
+COPY html/kitten.jpg kitten.jpg
+COPY html/data.json data.json

--- a/examples/update-demo/images/nautilus/Dockerfile
+++ b/examples/update-demo/images/nautilus/Dockerfile
@@ -13,4 +13,5 @@
 # limitations under the License.
 
 FROM kubernetes/test-webserver
-ADD html/data.json html/nautilus.jpg /
+COPY html/nautilus.jpg nautilus.jpg
+COPY html/data.json data.json


### PR DESCRIPTION
The built in go http.Fileserver handles If-Modified-Since in the
header by comparing it with the last modified date on the
file/directory. Since the file is unaltered when we switch to a
new container, that results in 304s when trying to fetch data.json, so
the browser doesn't fetch the new picture after doing a rolling update.

Separately, the Dockerfile ADD command gets misinterpreted on older
clients as `copy html/data.json into a directory called 'html/kitten.jpg '`,
instead of the `copy these 2 files into root`. Changed to separate
commands using COPY, per [dockerfile best practices](https://docs.docker.com/articles/dockerfile_best-practices/#add-or-copy).
