### PR TITLE
Use util.Time consistently in types.go

### DIFF
--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -23,7 +23,6 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
@@ -136,14 +135,6 @@ var apiObjectFuzzer = fuzz.New().NilChance(.5).NumElements(1, 1).Funcs(
 		pm[c.RandString()] = docker.PortMapping{
 			c.RandString(): c.RandString(),
 		}
-	},
-	func(t *time.Time, c fuzz.Continue) {
-		// This is necessary because the standard fuzzed time.Time object is
-		// completely nil, but when JSON unmarshals dates it fills in the
-		// unexported loc field with the time.UTC object, resulting in
-		// reflect.DeepEqual returning false in the round trip tests. We solve it
-		// by using a date that will be identical to the one JSON unmarshals.
-		*t = time.Date(2000, 1, 1, 1, 1, 1, 0, time.UTC)
 	},
 )
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package api
 
 import (
-	"time"
-
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
@@ -373,7 +371,7 @@ type ContainerStateWaiting struct {
 }
 
 type ContainerStateRunning struct {
-	StartedAt time.Time `json:"startedAt,omitempty"`
+	StartedAt util.Time `json:"startedAt,omitempty"`
 }
 
 type ContainerStateTerminated struct {
@@ -381,8 +379,8 @@ type ContainerStateTerminated struct {
 	Signal     int       `json:"signal,omitempty"`
 	Reason     string    `json:"reason,omitempty"`
 	Message    string    `json:"message,omitempty"`
-	StartedAt  time.Time `json:"startedAt,omitempty"`
-	FinishedAt time.Time `json:"finishedAt,omitempty"`
+	StartedAt  util.Time `json:"startedAt,omitempty"`
+	FinishedAt util.Time `json:"finishedAt,omitempty"`
 }
 
 // ContainerState holds a possible state of container.

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"time"
-
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
@@ -329,19 +327,16 @@ type ContainerStateWaiting struct {
 }
 
 type ContainerStateRunning struct {
-	// TODO: change to util.Time
-	StartedAt time.Time `json:"startedAt,omitempty" description:"time at which the container was last (re-)started"`
+	StartedAt util.Time `json:"startedAt,omitempty" description:"time at which the container was last (re-)started"`
 }
 
 type ContainerStateTerminated struct {
-	ExitCode int    `json:"exitCode" description:"exit status from the last termination of the container"`
-	Signal   int    `json:"signal,omitempty" description:"signal from the last termination of the container"`
-	Reason   string `json:"reason,omitempty" description:"(brief) reason from the last termination of the container"`
-	Message  string `json:"message,omitempty" description:"message regarding the last termination of the container"`
-	// TODO: change to util.Time
-	StartedAt time.Time `json:"startedAt,omitempty" description:"time at which previous execution of the container started"`
-	// TODO: change to util.Time
-	FinishedAt time.Time `json:"finishedAt,omitempty" description:"time at which the container last terminated"`
+	ExitCode   int       `json:"exitCode" description:"exit status from the last termination of the container"`
+	Signal     int       `json:"signal,omitempty" description:"signal from the last termination of the container"`
+	Reason     string    `json:"reason,omitempty" description:"(brief) reason from the last termination of the container"`
+	Message    string    `json:"message,omitempty" description:"message regarding the last termination of the container"`
+	StartedAt  util.Time `json:"startedAt,omitempty" description:"time at which previous execution of the container started"`
+	FinishedAt util.Time `json:"finishedAt,omitempty" description:"time at which the container last terminated"`
 }
 
 // ContainerState holds a possible state of container.

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1beta2
 
 import (
-	"time"
-
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
@@ -294,19 +292,16 @@ type ContainerStateWaiting struct {
 }
 
 type ContainerStateRunning struct {
-	// TODO: change to util.Time
-	StartedAt time.Time `json:"startedAt,omitempty" description:"time at which the container was last (re-)started"`
+	StartedAt util.Time `json:"startedAt,omitempty" description:"time at which the container was last (re-)started"`
 }
 
 type ContainerStateTerminated struct {
-	ExitCode int    `json:"exitCode" description:"exit status from the last termination of the container"`
-	Signal   int    `json:"signal,omitempty" description:"signal from the last termination of the container"`
-	Reason   string `json:"reason,omitempty" description:"(brief) reason from the last termination of the container"`
-	Message  string `json:"message,omitempty" description:"message regarding the last termination of the container"`
-	// TODO: change to util.Time
-	StartedAt time.Time `json:"startedAt,omitempty" description:"time at which previous execution of the container started"`
-	// TODO: change to util.Time
-	FinishedAt time.Time `json:"finishedAt,omitempty" description:"time at which the container last terminated"`
+	ExitCode   int       `json:"exitCode" description:"exit status from the last termination of the container"`
+	Signal     int       `json:"signal,omitempty" description:"signal from the last termination of the container"`
+	Reason     string    `json:"reason,omitempty" description:"(brief) reason from the last termination of the container"`
+	Message    string    `json:"message,omitempty" description:"message regarding the last termination of the container"`
+	StartedAt  util.Time `json:"startedAt,omitempty" description:"time at which previous execution of the container started"`
+	FinishedAt util.Time `json:"finishedAt,omitempty" description:"time at which the container last terminated"`
 }
 
 // ContainerState holds a possible state of container.

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1beta3
 
 import (
-	"time"
-
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
@@ -393,7 +391,7 @@ type ContainerStateWaiting struct {
 }
 
 type ContainerStateRunning struct {
-	StartedAt time.Time `json:"startedAt,omitempty"`
+	StartedAt util.Time `json:"startedAt,omitempty"`
 }
 
 type ContainerStateTerminated struct {
@@ -401,8 +399,8 @@ type ContainerStateTerminated struct {
 	Signal     int       `json:"signal,omitempty"`
 	Reason     string    `json:"reason,omitempty"`
 	Message    string    `json:"message,omitempty"`
-	StartedAt  time.Time `json:"startedAt,omitempty"`
-	FinishedAt time.Time `json:"finishedAt,omitempty"`
+	StartedAt  util.Time `json:"startedAt,omitempty"`
+	FinishedAt util.Time `json:"finishedAt,omitempty"`
 }
 
 // ContainerState holds a possible state of container.

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -396,7 +396,7 @@ func inspectContainer(client DockerInterface, dockerID, containerName, tPath str
 	waiting := true
 	if inspectResult.State.Running {
 		containerStatus.State.Running = &api.ContainerStateRunning{
-			StartedAt: inspectResult.State.StartedAt,
+			StartedAt: util.NewTime(inspectResult.State.StartedAt),
 		}
 		if containerName == "net" && inspectResult.NetworkSettings != nil {
 			containerStatus.PodIP = inspectResult.NetworkSettings.IPAddress
@@ -407,8 +407,8 @@ func inspectContainer(client DockerInterface, dockerID, containerName, tPath str
 		containerStatus.State.Termination = &api.ContainerStateTerminated{
 			ExitCode:   inspectResult.State.ExitCode,
 			Reason:     "",
-			StartedAt:  inspectResult.State.StartedAt,
-			FinishedAt: inspectResult.State.FinishedAt,
+			StartedAt:  util.NewTime(inspectResult.State.StartedAt),
+			FinishedAt: util.NewTime(inspectResult.State.FinishedAt),
 		}
 		if tPath != "" {
 			path, found := inspectResult.Volumes[tPath]

--- a/pkg/registry/pod/rest_test.go
+++ b/pkg/registry/pod/rest_test.go
@@ -578,7 +578,7 @@ func TestFillPodInfo(t *testing.T) {
 			"net": {
 				State: api.ContainerState{
 					Running: &api.ContainerStateRunning{
-						StartedAt: expectedTime,
+						StartedAt: util.NewTime(expectedTime),
 					},
 				},
 				RestartCount: 1,

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -28,6 +28,11 @@ type Time struct {
 	time.Time
 }
 
+// NewTime returns a wrapped instance of the provided time
+func NewTime(time time.Time) Time {
+	return Time{time}
+}
+
 // Date returns the Time corresponding to the supplied parameters
 // by wrapping time.Date.
 func Date(year int, month time.Month, day, hour, min, sec, nsec int, loc *time.Location) Time {


### PR DESCRIPTION
@brendandburns moved the last instances of time.Time in types.go to util.Time to fix marshalling issues with zero times

/cc @ghodss as far as I can tell, this removed the need for the custom fuzzing
