### PR TITLE
Update guestbook,walkthrough examples to use kubectl instead of kubecfg.

### DIFF
--- a/examples/walkthrough/k8s201.md
+++ b/examples/walkthrough/k8s201.md
@@ -9,7 +9,7 @@ scaling.
 Having already learned about Pods and how to create them, you may be struck by an urge to create many, many pods.  Please do!  But eventually you will need a system to organize these pods into groups.  The system for achieving this in Kubernetes is Labels.  Labels are key-value pairs that are attached to each API object in Kubernetes.  Label selectors can be passed along with a RESTful ```list``` request to the apiserver to retrieve a list of objects which match that label selector.  For example:
 
 ```sh
-cluster/kubecfg.sh -l name=nginx list pods
+cluster/kubectl.sh get pods -l name=nginx
 ```
 
 Lists all pods who name label matches 'nginx'.  Labels are discussed in detail [elsewhere](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/labels.md), but they are a core concept for two additional building blocks for Kubernetes, Replication Controllers and Services


### PR DESCRIPTION
Update the guestbook and walkthrough examples to use kubectl.

Part of #2575. Will do the same for update-demo in a separate PR, as it requires a
kubectl equivalent for `rollingupdate` (which does not exist), and also needs the update
e2e changed at the same time.
