### PR TITLE
Fixes malformed OBJECT_URL in rackspace setup script

### DIFF
--- a/cluster/rackspace/util.sh
+++ b/cluster/rackspace/util.sh
@@ -151,7 +151,7 @@ rax-boot-master() {
 
 # Copy cloud-config to KUBE_TEMP and work some sed magic
   sed -e "s|DISCOVERY_ID|${DISCOVERY_ID}|" \
-      -e "s|CLOUD_FILES_URL|${RELEASE_TMP_URL//&/\&}|" \
+      -e "s|CLOUD_FILES_URL|${RELEASE_TMP_URL//&/\\&}|" \
       -e "s|KUBE_USER|${KUBE_USER}|" \
       -e "s|KUBE_PASSWORD|${KUBE_PASSWORD}|" \
       -e "s|PORTAL_NET|${PORTAL_NET}|" \

--- a/cluster/rackspace/util.sh
+++ b/cluster/rackspace/util.sh
@@ -183,7 +183,7 @@ rax-boot-minions() {
 
     sed -e "s|DISCOVERY_ID|${DISCOVERY_ID}|" \
         -e "s|INDEX|$((i + 1))|g" \
-        -e "s|CLOUD_FILES_URL|${RELEASE_TMP_URL//&/\&}|" \
+        -e "s|CLOUD_FILES_URL|${RELEASE_TMP_URL//&/\\&}|" \
         -e "s|ENABLE_NODE_MONITORING|${ENABLE_NODE_MONITORING:-false}|" \
         -e "s|ENABLE_NODE_LOGGING|${ENABLE_NODE_LOGGING:-false}|" \
         -e "s|LOGGING_DESTINATION|${LOGGING_DESTINATION:-}|" \


### PR DESCRIPTION
download-release service was failing on kubernetes-master in rackspace because it was trying to download the tarball from a URL ending with

  ?temp_url_sig=4f47ae556255a448139df9eb7b5e38123002162eCLOUD_FILES_URLtemp_url_expires=1418328424

this is due to an improperly escaped backslash in the util.sh script, fixed here.
