### PR TITLE
kubectl: use underscore for all command line options not dash

### DIFF
--- a/contrib/completions/bash/kubectl
+++ b/contrib/completions/bash/kubectl
@@ -43,7 +43,7 @@ __has_resource()
 __kubectl_parse_get()
 {
     local kubectl_output out
-    if kubectl_output=$(kubectl get --no-headers "$1" 2>/dev/null); then
+    if kubectl_output=$(kubectl get --no_headers "$1" 2>/dev/null); then
         out=($(echo "${kubectl_output}" | awk '{print $1}'))
         COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
     fi
@@ -64,32 +64,32 @@ __kubectl_get_containers()
 __kubectl_pre_command()
 {
     local flags=(
-            --api-version=
+            --api_version=
             -a
-            --auth-path=
-            --certificate-authority=
-            --client-certificate=
-            --client-key=
-            --insecure-skip-tls-verify=
-            --match-server-version=
+            --auth_path=
+            --certificate_authority=
+            --client_certificate=
+            --client_key=
+            --insecure_skip_tls_verify=
+            --match_server_version=
             -n
             --namespace=
-            --ns-path=
+            --ns_path=
             -s
             --server=
     )
     local api_versions=(v1beta1 v1beta2 v1beta3)
 
     case $prev in
-        --api-version)
+        --api_version)
             COMPREPLY=( $(compgen -W "${api_versions[*]}" -- "$cur") )
             return 0
             ;;
-        -a | --auth-path | --certificate-authority | --client-certificate | --client-key | --ns-path)
+        -a | --auth_path | --certificate_authority | --client_certificate | --client_key | --ns_path)
             _filedir
             return 0
             ;;
-        --insecure-skip-tls-verify | --match-server-version)
+        --insecure_skip_tls_verify | --match_server_version)
             COMPREPLY=( $(compgen -W "true false" -- "$cur") )
             return 0
             ;;

--- a/pkg/client/clientcmd/client_builder.go
+++ b/pkg/client/clientcmd/client_builder.go
@@ -73,13 +73,13 @@ func NewBuilder(authLoader AuthLoader) Builder {
 
 const (
 	FlagApiServer       = "server"
-	FlagMatchApiVersion = "match-server-version"
-	FlagApiVersion      = "api-version"
-	FlagAuthPath        = "auth-path"
-	FlagInsecure        = "insecure-skip-tls-verify"
-	FlagCertFile        = "client-certificate"
-	FlagKeyFile         = "client-key"
-	FlagCAFile          = "certificate-authority"
+	FlagMatchApiVersion = "match_server_version"
+	FlagApiVersion      = "api_version"
+	FlagAuthPath        = "auth_path"
+	FlagInsecure        = "insecure_skip_tls_verify"
+	FlagCertFile        = "client_certificate"
+	FlagKeyFile         = "client_key"
+	FlagCAFile          = "certificate_authority"
 	FlagBearerToken     = "token"
 )
 

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -100,7 +100,7 @@ Find more information at https://github.com/GoogleCloudPlatform/kubernetes.`,
 	// TODO Change flag names to consts to allow safer lookup from subcommands.
 	// TODO Add a verbose flag that turns on glog logging. Probably need a way
 	// to do that automatically for every subcommand.
-	cmds.PersistentFlags().String("ns-path", os.Getenv("HOME")+"/.kubernetes_ns", "Path to the namespace info file that holds the namespace context to use for CLI requests.")
+	cmds.PersistentFlags().String("ns_path", os.Getenv("HOME")+"/.kubernetes_ns", "Path to the namespace info file that holds the namespace context to use for CLI requests.")
 	cmds.PersistentFlags().StringP("namespace", "n", "", "If present, the namespace scope for this CLI request.")
 	cmds.PersistentFlags().Bool("validate", false, "If true, use a schema to validate the input before sending it")
 
@@ -147,7 +147,7 @@ func GetKubeNamespace(cmd *cobra.Command) string {
 		result = ns
 		glog.V(2).Infof("Using namespace from -ns flag")
 	} else {
-		nsPath := GetFlagString(cmd, "ns-path")
+		nsPath := GetFlagString(cmd, "ns_path")
 		nsInfo, err := kubectl.LoadNamespaceInfo(nsPath)
 		if err != nil {
 			glog.Fatalf("Error loading current namespace: %v", err)
@@ -165,7 +165,7 @@ func GetExplicitKubeNamespace(cmd *cobra.Command) (string, bool) {
 	if ns := GetFlagString(cmd, "namespace"); len(ns) > 0 {
 		return ns, true
 	}
-	// TODO: determine when --ns-path is set but equal to the default
+	// TODO: determine when --ns_path is set but equal to the default
 	// value and return its value and true.
 	return "", false
 }

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -59,10 +59,10 @@ Examples:
 
 			outputFormat := GetFlagString(cmd, "output")
 			templateFile := GetFlagString(cmd, "template")
-			defaultPrinter, err := f.Printer(cmd, mapping, GetFlagBool(cmd, "no-headers"))
+			defaultPrinter, err := f.Printer(cmd, mapping, GetFlagBool(cmd, "no_headers"))
 			checkErr(err)
 
-			outputVersion := GetFlagString(cmd, "output-version")
+			outputVersion := GetFlagString(cmd, "output_version")
 			if len(outputVersion) == 0 {
 				outputVersion = mapping.APIVersion
 			}
@@ -74,7 +74,7 @@ Examples:
 			obj, err := restHelper.Get(namespace, name, labelSelector)
 			checkErr(err)
 
-			isWatch, isWatchOnly := GetFlagBool(cmd, "watch"), GetFlagBool(cmd, "watch-only")
+			isWatch, isWatchOnly := GetFlagBool(cmd, "watch"), GetFlagBool(cmd, "watch_only")
 
 			// print the current object
 			if !isWatchOnly {
@@ -96,11 +96,11 @@ Examples:
 		},
 	}
 	cmd.Flags().StringP("output", "o", "", "Output format: json|yaml|template|templatefile")
-	cmd.Flags().String("output-version", "", "Output the formatted object with the given version (default api-version)")
-	cmd.Flags().Bool("no-headers", false, "When using the default output, don't print headers")
+	cmd.Flags().String("output_version", "", "Output the formatted object with the given version (default api-version)")
+	cmd.Flags().Bool("no_headers", false, "When using the default output, don't print headers")
 	cmd.Flags().StringP("template", "t", "", "Template string or path to template file to use when --output=template or --output=templatefile")
 	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on")
 	cmd.Flags().BoolP("watch", "w", false, "After listing/getting the requested object, watch for changes.")
-	cmd.Flags().Bool("watch-only", false, "Watch for changes to the requseted object(s), without listing/getting first.")
+	cmd.Flags().Bool("watch_only", false, "Watch for changes to the requseted object(s), without listing/getting first.")
 	return cmd
 }


### PR DESCRIPTION
Every other utility
  --hello_string=
kubectl uses
  --hello-string=

I am happy to go the other way, and make everything else use dash, but
user consistency should be a goal.
