### PR TITLE
RFC: Kubectl use api servers

### DIFF
--- a/cmd/e2e/e2e.go
+++ b/cmd/e2e/e2e.go
@@ -84,7 +84,7 @@ func loadPodOrDie(filePath string) *api.Pod {
 
 func loadClientOrDie() *client.Client {
 	config := client.Config{
-		Host: *host,
+		ApiServerList: util.StringList{ *host },
 	}
 	auth, err := clientauth.LoadFromFile(*authConfig)
 	if err != nil {

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -133,7 +133,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 		glog.Fatalf("Failed to connect to etcd")
 	}
 
-	cl := client.NewOrDie(&client.Config{Host: apiServer.URL, Version: testapi.Version()})
+	cl := client.NewOrDie(&client.Config{ApiServerList: util.StringList{ apiServer.URL }, Version: testapi.Version()})
 	cl.PollPeriod = time.Millisecond * 100
 	cl.Sync = true
 
@@ -567,7 +567,7 @@ func main() {
 	// Wait for the synchronization threads to come up.
 	time.Sleep(time.Second * 10)
 
-	kubeClient := client.NewOrDie(&client.Config{Host: apiServerURL, Version: testapi.Version()})
+	kubeClient := client.NewOrDie(&client.Config{ApiServerList: util.StringList{ apiServerURL }, Version: testapi.Version()})
 
 	// Run tests in parallel
 	testFuncs := []testFunc{

--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -136,7 +136,7 @@ func main() {
 
 	// TODO: expose same flags as client.BindClientConfigFlags but for a server
 	clientConfig := &client.Config{
-		Host:    net.JoinHostPort(address.String(), strconv.Itoa(int(*port))),
+		ApiServerList:    util.StringList{ net.JoinHostPort(address.String(), strconv.Itoa(int(*port))) },
 		Version: *storageVersion,
 	}
 	client, err := client.New(clientConfig)

--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -81,13 +81,17 @@ func main() {
 	verflag.PrintAndExitIfRequested()
 	verifyMinionFlags()
 
-	if len(clientConfig.Host) == 0 {
-		glog.Fatal("usage: controller-manager -master <master>")
-	}
-
 	kubeClient, err := client.New(clientConfig)
 	if err != nil {
 		glog.Fatalf("Invalid API configuration: %v", err)
+	}
+
+	// TODO: adapt controller-manager to support LB over several servers
+	if len(clientConfig.ApiServerList) == 0 {
+		glog.Fatal("usage: controller-manager -api_servers=<ip:port>")
+	}
+	if len(clientConfig.ApiServerList) > 1 {
+		glog.Infof("Mulitple api servers specified.  Picking first one")
 	}
 
 	if int64(int(*nodeMilliCPU)) != *nodeMilliCPU {

--- a/cmd/kube-proxy/proxy.go
+++ b/cmd/kube-proxy/proxy.go
@@ -76,8 +76,8 @@ func main() {
 	// are registered yet.
 
 	// define api config source
-	if clientConfig.Host != "" {
-		glog.Infof("Using api calls to get config %v", clientConfig.Host)
+	if len(clientConfig.ApiServerList) != 0 {
+		glog.Infof("Using api calls to get config %v", clientConfig.ApiServerList[0])
 		client, err := client.New(clientConfig)
 		if err != nil {
 			glog.Fatalf("Invalid API configuration: %v", err)

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -58,7 +58,7 @@ func startComponents(etcdClient tools.EtcdClient, cl *client.Client, addr string
 
 func newApiClient(addr string, port int) *client.Client {
 	apiServerURL := fmt.Sprintf("http://%s:%d", addr, port)
-	cl := client.NewOrDie(&client.Config{Host: apiServerURL, Version: testapi.Version()})
+	cl := client.NewOrDie(&client.Config{ApiServerList: util.StringList{ apiServerURL }, Version: testapi.Version()})
 	cl.PollPeriod = time.Second * 1
 	cl.Sync = true
 	return cl

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -84,7 +84,7 @@ func (c *testClient) Setup() *testClient {
 			version = testapi.Version()
 		}
 		c.Client = NewOrDie(&Config{
-			Host:    c.server.URL,
+			ApiServerList:    util.StringList{ c.server.URL },
 			Version: version,
 		})
 	}
@@ -573,7 +573,7 @@ func TestGetServerVersion(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}))
-	client := NewOrDie(&Config{Host: server.URL})
+	client := NewOrDie(&Config{ApiServerList: util.StringList{server.URL}})
 
 	got, err := client.ServerVersion()
 	if err != nil {
@@ -597,7 +597,7 @@ func TestGetServerAPIVersions(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}))
-	client := NewOrDie(&Config{Host: server.URL})
+	client := NewOrDie(&Config{ApiServerList: util.StringList{server.URL}})
 	got, err := client.ServerAPIVersions()
 	if err != nil {
 		t.Fatalf("unexpected encoding error: %v", err)

--- a/pkg/client/clientcmd/client_builder.go
+++ b/pkg/client/clientcmd/client_builder.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/clientauth"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
 )
 
@@ -126,12 +127,12 @@ func (builder *builder) Client() (*client.Client, error) {
 func (builder *builder) Config() (*client.Config, error) {
 	clientConfig := client.Config{}
 	if len(builder.apiserver) > 0 {
-		clientConfig.Host = builder.apiserver
+		clientConfig.ApiServerList = util.StringList{ builder.apiserver }
 	} else if len(os.Getenv("KUBERNETES_MASTER")) > 0 {
-		clientConfig.Host = os.Getenv("KUBERNETES_MASTER")
+		clientConfig.ApiServerList = util.StringList{ os.Getenv("KUBERNETES_MASTER") }
 	} else {
 		// TODO: eventually apiserver should start on 443 and be secure by default
-		clientConfig.Host = "http://localhost:8080"
+		clientConfig.ApiServerList = util.StringList{ "http://localhost:8080" }
 	}
 	clientConfig.Version = builder.apiVersion
 

--- a/pkg/client/clientcmd/client_builder_test.go
+++ b/pkg/client/clientcmd/client_builder_test.go
@@ -60,7 +60,7 @@ func TestSetAllArgumentsOnly(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	matchStringArg(args.server, clientConfig.Host, t)
+	matchStringArg(args.server, clientConfig.ApiServerList[0], t)
 	matchStringArg(args.apiVersion, clientConfig.Version, t)
 	matchStringArg(args.certFile, clientConfig.CertFile, t)
 	matchStringArg(args.keyFile, clientConfig.KeyFile, t)
@@ -82,7 +82,7 @@ func TestSetInsecureArgumentsOnly(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	matchStringArg(args.server, clientConfig.Host, t)
+	matchStringArg(args.server, clientConfig.ApiServerList[0], t)
 	matchStringArg(args.apiVersion, clientConfig.Version, t)
 
 	// all security related params should be empty in the resulting config even though we set them because we're using http transport
@@ -123,7 +123,7 @@ func TestReadAuthFile(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	matchStringArg(args.server, clientConfig.Host, t)
+	matchStringArg(args.server, clientConfig.ApiServerList[0], t)
 	matchStringArg(args.apiVersion, clientConfig.Version, t)
 	matchStringArg("delta", clientConfig.CertFile, t)
 	matchStringArg("echo", clientConfig.KeyFile, t)
@@ -164,7 +164,7 @@ func TestAuthFileOverridden(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	matchStringArg(args.server, clientConfig.Host, t)
+	matchStringArg(args.server, clientConfig.ApiServerList[0], t)
 	matchStringArg(args.apiVersion, clientConfig.Version, t)
 	matchStringArg(args.certFile, clientConfig.CertFile, t)
 	matchStringArg(args.keyFile, clientConfig.KeyFile, t)

--- a/pkg/client/clientcmd/provided_flags.go
+++ b/pkg/client/clientcmd/provided_flags.go
@@ -19,7 +19,9 @@ package clientcmd
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/spf13/pflag"
 )
 
@@ -60,6 +62,34 @@ func (flag *StringFlag) Provided() bool {
 
 func (flag *StringFlag) String() string {
 	return flag.Value
+}
+
+type StringListFlag struct {
+	Default		util.StringList
+	Value		util.StringList
+	WasProvided	bool
+}
+
+func (flag *StringListFlag) SetDefault(value string) {
+	flag.Value = nil
+	flag.WasProvided = false
+}
+
+func (flag *StringListFlag) Set(value string) error {
+	flag.WasProvided = true
+	return flag.Value.Set(value)
+}
+
+func (flag *StringListFlag) Type() string {
+	return "stringlist"
+}
+
+func (flag *StringListFlag) Provided() bool {
+	return flag.WasProvided
+}
+
+func (flag *StringListFlag) String() string {
+	return strings.Join(flag.Value, ",")
 }
 
 // BoolFlag implements FlagProvider

--- a/pkg/client/flags.go
+++ b/pkg/client/flags.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package client
 
+import (
+	"flag"
+
+)
+
 // FlagSet abstracts the flag interface for compatibility with both Golang "flag"
 // and cobra pflags (Posix style).
 type FlagSet interface {
@@ -27,7 +32,7 @@ type FlagSet interface {
 // BindClientConfigFlags registers a standard set of CLI flags for connecting to a Kubernetes API server.
 // TODO this method is superceded by pkg/client/clientcmd/client_builder.go
 func BindClientConfigFlags(flags FlagSet, config *Config) {
-	flags.StringVar(&config.Host, "master", config.Host, "The address of the Kubernetes API server")
+	flag.Var(&config.ApiServerList, "api_servers", "Comma seperated list of API servers, <ip:port>, or urls.")
 	flags.StringVar(&config.Version, "api_version", config.Version, "The API version to use when talking to the server")
 	flags.BoolVar(&config.Insecure, "insecure_skip_tls_verify", config.Insecure, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.")
 	flags.StringVar(&config.CertFile, "client_certificate", config.CertFile, "Path to a client key file for TLS.")

--- a/pkg/client/flags_test.go
+++ b/pkg/client/flags_test.go
@@ -61,7 +61,7 @@ func TestBindClientConfigFlags(t *testing.T) {
 	flags := &fakeFlagSet{t, util.StringSet{}}
 	config := &Config{}
 	BindClientConfigFlags(flags, config)
-	if len(flags.set) != 6 {
+	if len(flags.set) != 5 {
 		t.Errorf("unexpected flag set: %#v", flags)
 	}
 }

--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -24,13 +24,14 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 // Config holds the common attributes that can be passed to a Kubernetes client on
 // initialization.
 type Config struct {
-	// Host must be a host string, a host:port pair, or a URL to the base of the API.
-	Host string
+	// List of addresses to the API server in <ip:port> or url format
+	ApiServerList util.StringList
 	// Prefix is the sub path of the server. If not specified, the client will set
 	// a default value.  Use "/" to indicate the server root should be used
 	Prefix string
@@ -235,9 +236,9 @@ func defaultServerUrlFor(config *Config) (*url.URL, error) {
 	// TODO: move the default to secure when the apiserver supports TLS by default
 	// config.Insecure is taken to mean "I want HTTPS but don't bother checking the certs against a CA."
 	defaultTLS := config.CertFile != "" || config.Insecure
-	host := config.Host
-	if host == "" {
-		host = "localhost"
+	host := "localhost"
+	if len(config.ApiServerList) > 0 {
+		host = config.ApiServerList[0]
 	}
 	return DefaultServerURL(host, config.Prefix, version, defaultTLS)
 }

--- a/pkg/client/helper_test.go
+++ b/pkg/client/helper_test.go
@@ -19,6 +19,8 @@ package client
 import (
 	"net/http"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 func TestTransportFor(t *testing.T) {
@@ -58,27 +60,27 @@ func TestIsConfigTransportTLS(t *testing.T) {
 		},
 		{
 			Config: &Config{
-				Host: "https://localhost",
+				ApiServerList: util.StringList{"https://localhost"},
 			},
 			TransportTLS: true,
 		},
 		{
 			Config: &Config{
-				Host:     "localhost",
+				ApiServerList: util.StringList{"localhost"},
 				CertFile: "foo",
 			},
 			TransportTLS: true,
 		},
 		{
 			Config: &Config{
-				Host:     "///:://localhost",
+				ApiServerList: util.StringList{"///:://localhost"},
 				CertFile: "foo",
 			},
 			TransportTLS: false,
 		},
 		{
 			Config: &Config{
-				Host:     "1.2.3.4:567",
+				ApiServerList: util.StringList{"1.2.3.4:567"},
 				Insecure: true,
 			},
 			TransportTLS: true,

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -285,7 +285,7 @@ func TestDoRequestNewWay(t *testing.T) {
 	}
 	testServer := httptest.NewServer(&fakeHandler)
 	defer testServer.Close()
-	c := NewOrDie(&Config{Host: testServer.URL, Version: "v1beta2", Username: "user", Password: "pass"})
+	c := NewOrDie(&Config{ApiServerList: util.StringList{testServer.URL}, Version: "v1beta2", Username: "user", Password: "pass"})
 	obj, err := c.Verb("POST").
 		Path("foo/bar").
 		Path("baz").
@@ -319,7 +319,7 @@ func TestDoRequestNewWayReader(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	c := NewOrDie(&Config{Host: testServer.URL, Version: "v1beta1", Username: "user", Password: "pass"})
+	c := NewOrDie(&Config{ApiServerList: util.StringList{testServer.URL}, Version: "v1beta1", Username: "user", Password: "pass"})
 	obj, err := c.Verb("POST").
 		Path("foo/bar").
 		Path("baz").
@@ -355,7 +355,7 @@ func TestDoRequestNewWayObj(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	c := NewOrDie(&Config{Host: testServer.URL, Version: "v1beta2", Username: "user", Password: "pass"})
+	c := NewOrDie(&Config{ApiServerList: util.StringList{testServer.URL}, Version: "v1beta2", Username: "user", Password: "pass"})
 	obj, err := c.Verb("POST").
 		Path("foo/bar").
 		Path("baz").
@@ -404,7 +404,7 @@ func TestDoRequestNewWayFile(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	c := NewOrDie(&Config{Host: testServer.URL, Version: "v1beta1", Username: "user", Password: "pass"})
+	c := NewOrDie(&Config{ApiServerList: util.StringList{testServer.URL}, Version: "v1beta1", Username: "user", Password: "pass"})
 	wasCreated := true
 	obj, err := c.Verb("POST").
 		Path("foo/bar").
@@ -447,7 +447,7 @@ func TestWasCreated(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	c := NewOrDie(&Config{Host: testServer.URL, Version: "v1beta1", Username: "user", Password: "pass"})
+	c := NewOrDie(&Config{ApiServerList: util.StringList{testServer.URL}, Version: "v1beta1", Username: "user", Password: "pass"})
 	wasCreated := false
 	obj, err := c.Verb("PUT").
 		Path("foo/bar").
@@ -632,7 +632,7 @@ func TestPolling(t *testing.T) {
 		w.Write(data)
 	}))
 
-	c := NewOrDie(&Config{Host: testServer.URL, Version: "v1beta1", Username: "user", Password: "pass"})
+	c := NewOrDie(&Config{ApiServerList: util.StringList{testServer.URL}, Version: "v1beta1", Username: "user", Password: "pass"})
 	c.PollPeriod = 1 * time.Millisecond
 	trials := []func(){
 		func() {
@@ -737,7 +737,7 @@ func TestWatch(t *testing.T) {
 	}))
 
 	s, err := New(&Config{
-		Host:     testServer.URL,
+		ApiServerList: util.StringList{testServer.URL},
 		Version:  "v1beta1",
 		Username: "user",
 		Password: "pass",
@@ -787,7 +787,7 @@ func TestStream(t *testing.T) {
 	}))
 
 	s, err := New(&Config{
-		Host:     testServer.URL,
+		ApiServerList: util.StringList{testServer.URL},
 		Version:  "v1beta1",
 		Username: "user",
 		Password: "pass",

--- a/pkg/client/restclient_test.go
+++ b/pkg/client/restclient_test.go
@@ -43,7 +43,7 @@ func TestChecksCodec(t *testing.T) {
 		"v1beta3": {true, "", nil},
 	}
 	for version, expected := range testCases {
-		client, err := RESTClientFor(&Config{Host: "127.0.0.1", Version: version})
+		client, err := RESTClientFor(&Config{ApiServerList: util.StringList{"127.0.0.1"}, Version: version})
 		switch {
 		case err == nil && expected.Err:
 			t.Errorf("expected error but was nil")
@@ -81,7 +81,7 @@ func TestValidatesHostParameter(t *testing.T) {
 		{"host/server", "", "", true},
 	}
 	for i, testCase := range testCases {
-		c, err := RESTClientFor(&Config{Host: testCase.Host, Prefix: testCase.Prefix, Version: "v1beta1"})
+		c, err := RESTClientFor(&Config{ApiServerList: util.StringList{testCase.Host}, Prefix: testCase.Prefix, Version: "v1beta1"})
 		switch {
 		case err == nil && testCase.Err:
 			t.Errorf("expected error but was nil")
@@ -110,7 +110,7 @@ func TestDoRequestBearer(t *testing.T) {
 	testServer := httptest.NewServer(&fakeHandler)
 	defer testServer.Close()
 	request, _ := http.NewRequest("GET", testServer.URL, nil)
-	c, err := RESTClientFor(&Config{Host: testServer.URL, BearerToken: "test"})
+	c, err := RESTClientFor(&Config{ApiServerList: util.StringList{testServer.URL}, BearerToken: "test"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestDoRequestAccepted(t *testing.T) {
 	}
 	testServer := httptest.NewServer(&fakeHandler)
 	defer testServer.Close()
-	c, err := RESTClientFor(&Config{Host: testServer.URL, Username: "test", Version: testapi.Version()})
+	c, err := RESTClientFor(&Config{ApiServerList: util.StringList{testServer.URL}, Username: "test", Version: testapi.Version()})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestDoRequestAcceptedSuccess(t *testing.T) {
 	}
 	testServer := httptest.NewServer(&fakeHandler)
 	defer testServer.Close()
-	c, err := RESTClientFor(&Config{Host: testServer.URL, Username: "user", Password: "pass", Version: testapi.Version()})
+	c, err := RESTClientFor(&Config{ApiServerList: util.StringList{testServer.URL}, Username: "user", Password: "pass", Version: testapi.Version()})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestDoRequestFailed(t *testing.T) {
 	}
 	testServer := httptest.NewServer(&fakeHandler)
 	defer testServer.Close()
-	c, err := RESTClientFor(&Config{Host: testServer.URL})
+	c, err := RESTClientFor(&Config{ApiServerList: util.StringList{testServer.URL}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -226,7 +226,7 @@ func TestDoRequestCreated(t *testing.T) {
 	}
 	testServer := httptest.NewServer(&fakeHandler)
 	defer testServer.Close()
-	c, err := RESTClientFor(&Config{Host: testServer.URL, Username: "user", Password: "pass", Version: testapi.Version()})
+	c, err := RESTClientFor(&Config{ApiServerList: util.StringList{testServer.URL}, Username: "user", Password: "pass", Version: testapi.Version()})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -114,7 +114,7 @@ func TestSyncReplicationControllerDoesNothing(t *testing.T) {
 	}
 	testServer := httptest.NewServer(&fakeHandler)
 	defer testServer.Close()
-	client := client.NewOrDie(&client.Config{Host: testServer.URL, Version: testapi.Version()})
+	client := client.NewOrDie(&client.Config{ApiServerList: util.StringList{testServer.URL}, Version: testapi.Version()})
 
 	fakePodControl := FakePodControl{}
 
@@ -135,7 +135,7 @@ func TestSyncReplicationControllerDeletes(t *testing.T) {
 	}
 	testServer := httptest.NewServer(&fakeHandler)
 	defer testServer.Close()
-	client := client.NewOrDie(&client.Config{Host: testServer.URL, Version: testapi.Version()})
+	client := client.NewOrDie(&client.Config{ApiServerList: util.StringList{testServer.URL}, Version: testapi.Version()})
 
 	fakePodControl := FakePodControl{}
 
@@ -156,7 +156,7 @@ func TestSyncReplicationControllerCreates(t *testing.T) {
 	}
 	testServer := httptest.NewServer(&fakeHandler)
 	defer testServer.Close()
-	client := client.NewOrDie(&client.Config{Host: testServer.URL, Version: testapi.Version()})
+	client := client.NewOrDie(&client.Config{ApiServerList: util.StringList{testServer.URL}, Version: testapi.Version()})
 
 	fakePodControl := FakePodControl{}
 
@@ -178,7 +178,7 @@ func TestCreateReplica(t *testing.T) {
 	}
 	testServer := httptest.NewServer(&fakeHandler)
 	defer testServer.Close()
-	client := client.NewOrDie(&client.Config{Host: testServer.URL, Version: testapi.Version()})
+	client := client.NewOrDie(&client.Config{ApiServerList: util.StringList{testServer.URL}, Version: testapi.Version()})
 
 	podControl := RealPodControl{
 		kubeClient: client,
@@ -316,7 +316,7 @@ func TestSynchonize(t *testing.T) {
 	})
 	testServer := httptest.NewServer(mux)
 	defer testServer.Close()
-	client := client.NewOrDie(&client.Config{Host: testServer.URL, Version: testapi.Version()})
+	client := client.NewOrDie(&client.Config{ApiServerList: util.StringList{testServer.URL}, Version: testapi.Version()})
 	manager := NewReplicationManager(client)
 	fakePodControl := FakePodControl{}
 	manager.podControl = &fakePodControl

--- a/pkg/kubecfg/proxy_server.go
+++ b/pkg/kubecfg/proxy_server.go
@@ -37,7 +37,7 @@ func NewProxyServer(filebase string, cfg *client.Config) (*ProxyServer, error) {
 	if prefix == "" {
 		prefix = "/api"
 	}
-	target, err := url.Parse(singleJoiningSlash(cfg.Host, prefix))
+	target, err := url.Parse(singleJoiningSlash(cfg.ApiServerList[0], prefix))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubectl/proxy_server.go
+++ b/pkg/kubectl/proxy_server.go
@@ -39,7 +39,7 @@ func NewProxyServer(filebase string, cfg *client.Config, port int) (*ProxyServer
 	if prefix == "" {
 		prefix = "/api"
 	}
-	target, err := url.Parse(singleJoiningSlash(cfg.Host, prefix))
+	target, err := url.Parse(singleJoiningSlash(cfg.ApiServerList[0], prefix))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/util.go
+++ b/pkg/kubelet/util.go
@@ -164,7 +164,7 @@ func getApiserverClient(authPath string, apiServerList util.StringList) (*client
 	if len(apiServerList) > 1 {
 		glog.Infof("Mulitple api servers specified.  Picking first one")
 	}
-	clientConfig.Host = apiServerList[0]
+	clientConfig.ApiServerList = apiServerList
 	if c, err := client.New(&clientConfig); err != nil {
 		return nil, err
 	} else {


### PR DESCRIPTION
If we agree that we want to switch everything to use -api_servers (which might be wrong for anything other than kubelet) do we want to switch kubectl to use -api_servers, instead of its own -server=?
