### PR TITLE
Count only non-dead pods in replicationController current state replicas count

### DIFF
--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -140,7 +140,8 @@ func (rm *ReplicationManager) watchControllers(resourceVersion *string) {
 	}
 }
 
-func (rm *ReplicationManager) filterActivePods(pods []api.Pod) []api.Pod {
+// Helper function. Also used in pkg/registry/controller, for now.
+func FilterActivePods(pods []api.Pod) []api.Pod {
 	var result []api.Pod
 	for _, value := range pods {
 		if api.PodSucceeded != value.Status.Phase &&
@@ -157,7 +158,7 @@ func (rm *ReplicationManager) syncReplicationController(controller api.Replicati
 	if err != nil {
 		return err
 	}
-	filteredList := rm.filterActivePods(podList.Items)
+	filteredList := FilterActivePods(podList.Items)
 	diff := len(filteredList) - controller.Spec.Replicas
 	if diff < 0 {
 		diff *= -1

--- a/pkg/registry/controller/rest.go
+++ b/pkg/registry/controller/rest.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	rc "github.com/GoogleCloudPlatform/kubernetes/pkg/controller"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -149,6 +150,7 @@ func (rs *REST) Watch(ctx api.Context, label, field labels.Selector, resourceVer
 	return rs.registry.WatchControllers(ctx, label, field, resourceVersion)
 }
 
+// TODO #2726: The controller should populate the current state, not the apiserver
 func (rs *REST) fillCurrentState(ctx api.Context, controller *api.ReplicationController) error {
 	if rs.podLister == nil {
 		return nil
@@ -157,6 +159,6 @@ func (rs *REST) fillCurrentState(ctx api.Context, controller *api.ReplicationCon
 	if err != nil {
 		return err
 	}
-	controller.Status.Replicas = len(list.Items)
+	controller.Status.Replicas = len(rc.FilterActivePods(list.Items))
 	return nil
 }


### PR DESCRIPTION
The way it currently stands, resizing a replica pool downwards doesn't change the number of replicas reported, since the killed pods transition to the Failed phase. This should return the same count that the controller manager is using to determine whether to add or remove replicas.

Without this fix, contrib/rctools/stop.sh never terminates.
