### PR TITLE
Update generic etcd to enable namespace scoped resources

### DIFF
--- a/pkg/registry/event/registry.go
+++ b/pkg/registry/event/registry.go
@@ -51,7 +51,7 @@ func NewEtcdRegistry(h tools.EtcdHelper, ttl uint64) generic.Registry {
 			NewFunc:      func() runtime.Object { return &api.Event{} },
 			NewListFunc:  func() runtime.Object { return &api.EventList{} },
 			EndpointName: "events",
-			KeyRoot: func(ctx api.Context) string {
+			KeyRootFunc: func(ctx api.Context) string {
 				return "/registry/events"
 			},
 			KeyFunc: func(ctx api.Context, id string) (string, error) {

--- a/pkg/registry/generic/etcd/etcd_test.go
+++ b/pkg/registry/generic/etcd/etcd_test.go
@@ -41,9 +41,9 @@ func NewTestGenericEtcdRegistry(t *testing.T) (*tools.FakeEtcdClient, *Etcd) {
 		NewFunc:      func() runtime.Object { return &api.Pod{} },
 		NewListFunc:  func() runtime.Object { return &api.PodList{} },
 		EndpointName: "pods",
-		KeyRoot:      "/registry/pods",
-		KeyFunc: func(id string) string {
-			return path.Join("/registry/pods", id)
+		KeyRoot:      func(ctx api.Context) string { return "/registry/pods" },
+		KeyFunc: func(ctx api.Context, id string) (string, error) {
+			return path.Join("/registry/pods", id), nil
 		},
 		Helper: h,
 	}
@@ -139,7 +139,7 @@ func TestEtcdList(t *testing.T) {
 
 	for name, item := range table {
 		fakeClient, registry := NewTestGenericEtcdRegistry(t)
-		fakeClient.Data[registry.KeyRoot] = item.in
+		fakeClient.Data[registry.KeyRoot(api.NewContext())] = item.in
 		list, err := registry.List(api.NewContext(), item.m)
 		if e, a := item.succeed, err == nil; e != a {
 			t.Errorf("%v: expected %v, got %v", name, e, a)

--- a/pkg/registry/generic/etcd/etcd_test.go
+++ b/pkg/registry/generic/etcd/etcd_test.go
@@ -41,7 +41,7 @@ func NewTestGenericEtcdRegistry(t *testing.T) (*tools.FakeEtcdClient, *Etcd) {
 		NewFunc:      func() runtime.Object { return &api.Pod{} },
 		NewListFunc:  func() runtime.Object { return &api.PodList{} },
 		EndpointName: "pods",
-		KeyRoot:      func(ctx api.Context) string { return "/registry/pods" },
+		KeyRootFunc:  func(ctx api.Context) string { return "/registry/pods" },
 		KeyFunc: func(ctx api.Context, id string) (string, error) {
 			return path.Join("/registry/pods", id), nil
 		},
@@ -139,7 +139,7 @@ func TestEtcdList(t *testing.T) {
 
 	for name, item := range table {
 		fakeClient, registry := NewTestGenericEtcdRegistry(t)
-		fakeClient.Data[registry.KeyRoot(api.NewContext())] = item.in
+		fakeClient.Data[registry.KeyRootFunc(api.NewContext())] = item.in
 		list, err := registry.List(api.NewContext(), item.m)
 		if e, a := item.succeed, err == nil; e != a {
 			t.Errorf("%v: expected %v, got %v", name, e, a)


### PR DESCRIPTION
Modified the KeyFunc and KeyRoot functions to support accessing the context object so we can use this registry for namespace scoped resources.
