### PR TITLE
More small refactors for v1beta3 -> internal

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -435,25 +435,6 @@ type RestartPolicy struct {
 	Never     *RestartPolicyNever     `json:"never,omitempty"`
 }
 
-// PodState is the state of a pod, used as either input (desired state) or output (current state).
-type PodState struct {
-	Manifest ContainerManifest `json:"manifest,omitempty"`
-	Status   PodPhase          `json:"status,omitempty"`
-	// A human readable message indicating details about why the pod is in this state.
-	Message string `json:"message,omitempty"`
-	Host    string `json:"host,omitempty"`
-	HostIP  string `json:"hostIP,omitempty"`
-	PodIP   string `json:"podIP,omitempty"`
-
-	// The key of this map is the *name* of the container within the manifest; it has one
-	// entry per container in the manifest. The value of this map is currently the output
-	// of `docker inspect`. This output format is *not* final and should not be relied
-	// upon.
-	// TODO: Make real decisions about what our info should look like. Re-enable fuzz test
-	// when we have done this.
-	Info PodInfo `json:"info,omitempty"`
-}
-
 // PodList is a list of Pods.
 type PodList struct {
 	TypeMeta `json:",inline"`

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -196,6 +196,18 @@ func init() {
 			out.PodIP = in.PodIP
 			return nil
 		},
+		func(in *newer.PodSpec, out *PodState, s conversion.Scope) error {
+			if err := s.Convert(&in, &out.Manifest, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(in *PodState, out *newer.PodSpec, s conversion.Scope) error {
+			if err := s.Convert(&in.Manifest, &out, 0); err != nil {
+				return err
+			}
+			return nil
+		},
 
 		// Convert all to the new PodPhase constants
 		func(in *newer.PodPhase, out *PodStatus, s conversion.Scope) error {

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -291,8 +291,6 @@ type ExecAction struct {
 // LivenessProbe describes how to probe a container for liveness.
 // TODO: pass structured data to the actions, and document that data here.
 type LivenessProbe struct {
-	// Type of liveness probe.  Current legal values "HTTP", "TCP", "Exec"
-	Type string `json:"type,omitempty"`
 	// HTTPGetProbe parameters, required if Type == 'HTTP'
 	HTTPGet *HTTPGetAction `json:"httpGet,omitempty"`
 	// TCPSocketProbe parameter, required if Type == 'TCP'

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -418,8 +418,13 @@ type ContainerStatus struct {
 	// garbage collection.  This value will get capped at 5 by GC.
 	RestartCount int `json:"restartCount"`
 	// TODO(dchen1107): Introduce our own NetworkSettings struct here?
-	// TODO(dchen1107): Which image the container is running with?
 	ContainerID string `json:"containerID,omitempty" description:"container's ID in the format 'docker://<container_id>'"`
+	// The IP of the Pod
+	// PodIP is deprecated and will be removed from v1beta3 once it becomes possible for the Kubelet to report PodStatus.
+	PodIP string `json:"podIP,omitempty"`
+	// TODO(dchen1107): Which image the container is running with?
+	// The image the container is running
+	Image string `json:"image"`
 }
 
 // PodInfo contains one entry for every container with available info.

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -348,11 +348,6 @@ func validateRestartPolicy(restartPolicy *api.RestartPolicy) errs.ValidationErro
 	return allErrors
 }
 
-func ValidatePodState(podState *api.PodState) errs.ValidationErrorList {
-	allErrs := errs.ValidationErrorList(ValidateManifest(&podState.Manifest)).Prefix("manifest")
-	return allErrs
-}
-
 // ValidatePod tests if required fields in the pod are set.
 func ValidatePod(pod *api.Pod) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}

--- a/pkg/health/exec.go
+++ b/pkg/health/exec.go
@@ -38,7 +38,7 @@ func NewExecHealthChecker(runner CommandRunner) HealthChecker {
 	return &ExecHealthChecker{runner}
 }
 
-func (e *ExecHealthChecker) HealthCheck(podFullName, podUUID string, currentState api.PodState, container api.Container) (Status, error) {
+func (e *ExecHealthChecker) HealthCheck(podFullName, podUUID string, status api.PodStatus, container api.Container) (Status, error) {
 	if container.LivenessProbe.Exec == nil {
 		return Unknown, fmt.Errorf("missing exec parameters")
 	}

--- a/pkg/health/exec_test.go
+++ b/pkg/health/exec_test.go
@@ -67,7 +67,7 @@ func TestExec(t *testing.T) {
 	for _, test := range tests {
 		fake.out = test.output
 		fake.err = test.err
-		status, err := checker.HealthCheck("test", "", api.PodState{}, api.Container{LivenessProbe: test.probe})
+		status, err := checker.HealthCheck("test", "", api.PodStatus{}, api.Container{LivenessProbe: test.probe})
 		if status != test.expectedStatus {
 			t.Errorf("expected %v, got %v", test.expectedStatus, status)
 		}

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -35,7 +35,7 @@ const (
 
 // HealthChecker defines an abstract interface for checking container health.
 type HealthChecker interface {
-	HealthCheck(podFullName, podUUID string, currentState api.PodState, container api.Container) (Status, error)
+	HealthCheck(podFullName, podUUID string, status api.PodStatus, container api.Container) (Status, error)
 	CanCheck(probe *api.LivenessProbe) bool
 }
 
@@ -78,13 +78,13 @@ func (m *muxHealthChecker) findCheckerFor(probe *api.LivenessProbe) HealthChecke
 
 // HealthCheck delegates the health-checking of the container to one of the bundled implementations.
 // If there is no health checker that can check container it returns Unknown, nil.
-func (m *muxHealthChecker) HealthCheck(podFullName, podUUID string, currentState api.PodState, container api.Container) (Status, error) {
+func (m *muxHealthChecker) HealthCheck(podFullName, podUUID string, status api.PodStatus, container api.Container) (Status, error) {
 	checker := m.findCheckerFor(container.LivenessProbe)
 	if checker == nil {
 		glog.Warningf("Failed to find health checker for %s %+v", container.Name, container.LivenessProbe)
 		return Unknown, nil
 	}
-	return checker.HealthCheck(podFullName, podUUID, currentState, container)
+	return checker.HealthCheck(podFullName, podUUID, status, container)
 }
 
 func (m *muxHealthChecker) CanCheck(probe *api.LivenessProbe) bool {

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -68,7 +68,7 @@ func TestHealthChecker(t *testing.T) {
 			},
 		}
 		hc := NewHealthChecker()
-		health, err := hc.HealthCheck("test", "", api.PodState{}, container)
+		health, err := hc.HealthCheck("test", "", api.PodStatus{}, container)
 		if err != nil && tt.health != Unknown {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -131,7 +131,7 @@ func TestMuxHealthChecker(t *testing.T) {
 		}
 		container.LivenessProbe.HTTPGet.Port = util.NewIntOrStringFromString(port)
 		container.LivenessProbe.HTTPGet.Host = host
-		health, err := mc.HealthCheck("test", "", api.PodState{}, container)
+		health, err := mc.HealthCheck("test", "", api.PodStatus{}, container)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}

--- a/pkg/health/http.go
+++ b/pkg/health/http.go
@@ -44,7 +44,7 @@ func NewHTTPHealthChecker(client *http.Client) HealthChecker {
 }
 
 // getURLParts parses the components of the target URL.  For testability.
-func getURLParts(currentState api.PodState, container api.Container) (string, int, string, error) {
+func getURLParts(status api.PodStatus, container api.Container) (string, int, string, error) {
 	params := container.LivenessProbe.HTTPGet
 	if params == nil {
 		return "", -1, "", fmt.Errorf("no HTTP parameters specified: %v", container)
@@ -70,7 +70,7 @@ func getURLParts(currentState api.PodState, container api.Container) (string, in
 	if len(params.Host) > 0 {
 		host = params.Host
 	} else {
-		host = currentState.PodIP
+		host = status.PodIP
 	}
 
 	return host, port, params.Path, nil
@@ -105,8 +105,8 @@ func DoHTTPCheck(url string, client HTTPGetInterface) (Status, error) {
 }
 
 // HealthCheck checks if the container is healthy by trying sending HTTP Get requests to the container.
-func (h *HTTPHealthChecker) HealthCheck(podFullName, podUUID string, currentState api.PodState, container api.Container) (Status, error) {
-	host, port, path, err := getURLParts(currentState, container)
+func (h *HTTPHealthChecker) HealthCheck(podFullName, podUUID string, status api.PodStatus, container api.Container) (Status, error) {
+	host, port, path, err := getURLParts(status, container)
 	if err != nil {
 		return Unknown, err
 	}

--- a/pkg/health/http_test.go
+++ b/pkg/health/http_test.go
@@ -46,7 +46,7 @@ func TestGetURLParts(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		state := api.PodState{PodIP: "127.0.0.1"}
+		state := api.PodStatus{PodIP: "127.0.0.1"}
 		container := api.Container{
 			Ports: []api.Port{{Name: "found", HostPort: 93}},
 			LivenessProbe: &api.LivenessProbe{
@@ -123,7 +123,7 @@ func TestHTTPHealthChecker(t *testing.T) {
 			params.Port = util.NewIntOrStringFromString(port)
 			params.Host = host
 		}
-		health, err := hc.HealthCheck("test", "", api.PodState{PodIP: host}, container)
+		health, err := hc.HealthCheck("test", "", api.PodStatus{PodIP: host}, container)
 		if test.health == Unknown && err == nil {
 			t.Errorf("Expected error")
 		}

--- a/pkg/health/tcp.go
+++ b/pkg/health/tcp.go
@@ -29,7 +29,7 @@ import (
 type TCPHealthChecker struct{}
 
 // getTCPAddrParts parses the components of a TCP connection address.  For testability.
-func getTCPAddrParts(currentState api.PodState, container api.Container) (string, int, error) {
+func getTCPAddrParts(status api.PodStatus, container api.Container) (string, int, error) {
 	params := container.LivenessProbe.TCPSocket
 	if params == nil {
 		return "", -1, fmt.Errorf("error, no TCP parameters specified: %v", container)
@@ -51,11 +51,11 @@ func getTCPAddrParts(currentState api.PodState, container api.Container) (string
 	if port == -1 {
 		return "", -1, fmt.Errorf("unknown port: %v", params.Port)
 	}
-	if len(currentState.PodIP) == 0 {
+	if len(status.PodIP) == 0 {
 		return "", -1, fmt.Errorf("no host specified.")
 	}
 
-	return currentState.PodIP, port, nil
+	return status.PodIP, port, nil
 }
 
 // DoTCPCheck checks that a TCP socket to the address can be opened.
@@ -74,8 +74,8 @@ func DoTCPCheck(addr string) (Status, error) {
 	return Healthy, nil
 }
 
-func (t *TCPHealthChecker) HealthCheck(podFullName, podUUID string, currentState api.PodState, container api.Container) (Status, error) {
-	host, port, err := getTCPAddrParts(currentState, container)
+func (t *TCPHealthChecker) HealthCheck(podFullName, podUUID string, status api.PodStatus, container api.Container) (Status, error) {
+	host, port, err := getTCPAddrParts(status, container)
 	if err != nil {
 		return Unknown, err
 	}

--- a/pkg/health/tcp_test.go
+++ b/pkg/health/tcp_test.go
@@ -44,7 +44,7 @@ func TestGetTCPAddrParts(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		state := api.PodState{PodIP: "1.2.3.4"}
+		state := api.PodStatus{PodIP: "1.2.3.4"}
 		container := api.Container{
 			Ports: []api.Port{{Name: "found", HostPort: 93}},
 			LivenessProbe: &api.LivenessProbe{
@@ -101,7 +101,7 @@ func TestTcpHealthChecker(t *testing.T) {
 		if params != nil && test.expectedStatus == Healthy {
 			params.Port = util.NewIntOrStringFromString(port)
 		}
-		status, err := checker.HealthCheck("test", "", api.PodState{PodIP: host}, container)
+		status, err := checker.HealthCheck("test", "", api.PodStatus{PodIP: host}, container)
 		if status != test.expectedStatus {
 			t.Errorf("expected: %v, got: %v", test.expectedStatus, status)
 		}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -601,7 +601,7 @@ func TestSyncPodDeletesDuplicate(t *testing.T) {
 
 type FalseHealthChecker struct{}
 
-func (f *FalseHealthChecker) HealthCheck(podFullName, podUUID string, state api.PodState, container api.Container) (health.Status, error) {
+func (f *FalseHealthChecker) HealthCheck(podFullName, podUUID string, status api.PodStatus, container api.Container) (health.Status, error) {
 	return health.Unhealthy, nil
 }
 


### PR DESCRIPTION
PodState is gone, PodIP/Image were missing in v1beta3, LivenessProbe.Type got pulled
from the original versions

Part of #1519
