### PR TITLE
Make httplog more useful by using glog.*Depth.

### DIFF
--- a/pkg/httplog/log.go
+++ b/pkg/httplog/log.go
@@ -63,7 +63,7 @@ type passthroughLogger struct{}
 
 // Addf logs info immediately.
 func (passthroughLogger) Addf(format string, data ...interface{}) {
-	glog.Infof(format, data...)
+	glog.InfoDepth(1, fmt.Sprintf(format, data...))
 }
 
 // DefaultStacktracePred is the default implementation of StacktracePred.
@@ -148,7 +148,9 @@ func (rl *respLogger) Addf(format string, data ...interface{}) {
 // Log is intended to be called once at the end of your request handler, via defer
 func (rl *respLogger) Log() {
 	latency := time.Since(rl.startTime)
-	glog.V(2).Infof("%s %s: (%v) %v%v%v", rl.req.Method, rl.req.RequestURI, latency, rl.status, rl.statusStack, rl.addedInfo)
+	if glog.V(2) {
+		glog.InfoDepth(1, fmt.Sprintf("%s %s: (%v) %v%v%v", rl.req.Method, rl.req.RequestURI, latency, rl.status, rl.statusStack, rl.addedInfo))
+	}
 }
 
 // Header implements http.ResponseWriter.


### PR DESCRIPTION
Close #2100 

With this change, the initial log line: 

I1213 00:05:02.919080    8245 log.go:151] GET /api/v1beta1/minions: (10.922746ms) 200

Convert to the following:

I1213 00:07:41.092850    9845 handlers.go:121] GET /api/v1beta1/minions: (15.214229ms) 200

cc/ @lavalamp 
