### PR TITLE
Fix error in Fluenetd->ES colo pod definition

### DIFF
--- a/contrib/logging/fluentd-ek-colo/Makefile
+++ b/contrib/logging/fluentd-ek-colo/Makefile
@@ -9,14 +9,14 @@ down:	logger-down es-kibana-down
 
 
 es-kibana-up:	
-	-${KUBECTL} create -f es-kibana-pod.yml
 	-${KUBECTL} create -f es-service.yml
+	-${KUBECTL} create -f es-kibana-pod.yml
 	-${KUBECTL} create -f kibana-service.yml
 
 es-kibana-down:
 	-${KUBECTL} delete pods elasticsearch-kibana-pod
 	-${KUBECTL} delete service kibana-colo
-	-${KUBECTL} delete service elasticsearch-colo
+	-${KUBECTL} delete service elasticsearch
 
 update:	
 	-${KUBECTL} delete pods elasticsearch-kibana-pod
@@ -33,7 +33,7 @@ get:
 	${KUBECTL} get services
 
 net:	
-	gcutil getforwardingrule elasticsearch-colo
+	gcutil getforwardingrule elasticsearch
 	gcutil getforwardingrule kibana-colo
 
 firewall:	

--- a/contrib/logging/fluentd-ek-colo/es-kibana-pod.yml
+++ b/contrib/logging/fluentd-ek-colo/es-kibana-pod.yml
@@ -16,14 +16,14 @@ desiredState:
         volumeMounts:
           - name: es-persistent-storage
             mountPath: /data
-    volumes:
-      - name: es-persistent-storage
-        source:
-          emptyDir: {}
       - name: kibana-image
         image: kubernetes/kibana
         ports:
           - name: kibana-port
             containerPort: 80
+    volumes:
+      - name: es-persistent-storage
+        source:
+          emptyDir: {}
 labels:
   app: elasticsearch-kibana

--- a/contrib/logging/fluentd-ek-colo/es-service.yml
+++ b/contrib/logging/fluentd-ek-colo/es-service.yml
@@ -1,6 +1,6 @@
 apiVersion: v1beta1
 kind: Service
-id: elasticsearch-colo
+id: elasticsearch
 containerPort: es-port
 port: 9200
 selector:


### PR DESCRIPTION
The volumes section for this service definition was in the wrong place.
