### PR TITLE
Collect Kubelet logs with Fluentd->(Elasticsearch|Cloud Logging)

### DIFF
--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.manifest
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.manifest
@@ -9,11 +9,18 @@ containers:
       - name: hosts
         mountPath: /outerhost
         readOnly: true
+      - name: varlog
+        mountPath: /varlog
+volumes:
 volumes:
   - name: containers
     source:
       hostDir:
         path: /var/lib/docker/containers
+  - name: varlog
+    source:
+      hostDir:
+        path: /var/log
   - name: hosts
     source:
       hostDir:

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.manifest
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.manifest
@@ -6,8 +6,14 @@ containers:
     volumeMounts:
       - name: containers
         mountPath: /var/lib/docker/containers
+      - name: varlog
+        mountPath: /varlog
 volumes:
   - name: containers
     source:
       hostDir:
         path: /var/lib/docker/containers
+  - name: varlog
+    source:
+      hostDir:
+        path: /var/log

--- a/contrib/logging/fluentd-es-image/td-agent.conf
+++ b/contrib/logging/fluentd-es-image/td-agent.conf
@@ -52,3 +52,21 @@
    logstash_format true
    flush_interval 5s
 </match>
+
+<source>
+  type tail
+  format none
+  path /varlog/kubelet.log
+  pos_file /varlog/kubelet.log.pos
+  tag kubelet
+</source>
+
+<match kubelet>
+   type elasticsearch
+   log_level info
+   include_tag_key true
+   host %ES_HOST%
+   port 9200
+   logstash_format true
+   flush_interval 5s
+</match>

--- a/contrib/logging/fluentd-gcp-image/google-fluentd.conf
+++ b/contrib/logging/fluentd-gcp-image/google-fluentd.conf
@@ -30,3 +30,21 @@
   # Disable the limit on the number of retries (retry forever).
   disable_retry_limit
 </match>
+
+<source>
+  type tail
+  format none
+  time_key time
+  path /varlog/kubelet.log
+  pos_file /varlog/kubelet.log.pos
+  tag kubelet
+</source>
+
+<match kubelet>
+  type google_cloud
+  flush_interval 5s
+  # Never wait longer than 5 minutes between retries.
+  max_retry_wait 300
+  # Disable the limit on the number of retries (retry forever).
+  disable_retry_limit
+</match>


### PR DESCRIPTION
This PR allows us to collect Kubelet logs. This PR:
- Modifies the manifest files for the Fluentd -> Elasticsearch and Cloud Logging images to map /var/log to allow /var/log/kubelet.log to be collected
- Modifies the Docker images for Fluentd collector containers to collect /var/log/kubelet.log and send to Elasticsearch or Cloud Logging (depending on the container)
  @dchen1107 
