### PR TITLE
Add kuber box location env to make it faster.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,11 +19,14 @@ $minion_ips_str = $minion_ips.join(",")
 # Determine the OS platform to use
 $kube_os = ENV['KUBERNETES_OS'] || "fedora"
 
+# Check if we already have kube box
+$kube_box_url = ENV['KUBERNETES_BOX_URL'] || "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-20_chef-provisionerless.box"
+
 # OS platform to box information
 $kube_box = {
   "fedora" => {
     "name" => "fedora20",
-    "box_url" => "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-20_chef-provisionerless.box"
+    "box_url" => $kube_box_url 
   }
 }
 

--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -12,7 +12,9 @@ By default, the Vagrant setup will create a single kubernetes-master and 3 kuber
 
 ```
 cd kubernetes
-vagrant up
+
+# kubernetes will download box from s3 by default (see details in Vagrantfile), unless a box url env is provided.
+KUBERNETES_BOX_URL=path_of_your_kuber_box vagrant up
 ```
 
 Vagrant will provision each machine in the cluster with all the necessary components to run Kubernetes.  The initial setup can take a few minutes to complete on each machine.


### PR DESCRIPTION
KUBERNETES_BOX is big and host in S3, downloading it again and again waste a lot of time. So we can use a ENV to tell kuber that I already have that box.
