### PR TITLE
fix e2e for all providers except gce

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -21,13 +21,6 @@
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${KUBE_ROOT}/cluster/gce/${KUBE_CONFIG_FILE-"config-default.sh"}"
 
-# Some useful colors.
-declare -r color_start="\033["
-declare -r color_red="${color_start}0;31m"
-declare -r color_yellow="${color_start}0;33m"
-declare -r color_green="${color_start}0;32m"
-declare -r color_norm="${color_start}0m"
-
 # Verify prereqs
 function verify-prereqs {
   local cmd

--- a/cluster/kube-env.sh
+++ b/cluster/kube-env.sh
@@ -21,3 +21,11 @@
 # The valid values: 'gce', 'aws', 'azure', 'vagrant', 'local', 'vsphere'
 
 KUBERNETES_PROVIDER=${KUBERNETES_PROVIDER:-gce}
+
+# Some useful colors.
+declare -r color_start="\033["
+declare -r color_red="${color_start}0;31m"
+declare -r color_yellow="${color_start}0;33m"
+declare -r color_green="${color_start}0;32m"
+declare -r color_norm="${color_start}0m"
+


### PR DESCRIPTION
The colors aren't present for any provider other than GCE.  Move the color definition to kube-env.sh so that everyone has them.

@derekwaynecarr  vagrant environments are broken until the color definitions are present.
