### PR TITLE
proxy should fail fast if proxier is nil, rather than panic later

### DIFF
--- a/cmd/kube-proxy/proxy.go
+++ b/cmd/kube-proxy/proxy.go
@@ -66,6 +66,9 @@ func main() {
 	}
 	loadBalancer := proxy.NewLoadBalancerRR()
 	proxier := proxy.NewProxier(loadBalancer, net.IP(bindAddress), iptables.New(exec.New(), protocol))
+	if proxier == nil {
+		glog.Fatalf("failed to create proxier, aborting")
+	}
 	// Wire proxier to handle changes to services
 	serviceConfig.RegisterHandler(proxier)
 	// And wire loadBalancer to handle changes to endpoints to services


### PR DESCRIPTION
see https://github.com/mesosphere/kubernetes-mesos/issues/107 for details
