### PR TITLE
Updated docker version that supports exec to '1.3.0'.

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -92,8 +92,8 @@ type dockerContainerCommandRunner struct {
 	client DockerInterface
 }
 
-// The first version of docker that supports exec natively is 1.1.3
-var dockerVersionWithExec = []uint{1, 1, 3}
+// The first version of docker that supports exec natively is 1.3.0
+var dockerVersionWithExec = []uint{1, 3, 0}
 
 // Returns the major and minor version numbers of docker server.
 func (d *dockerContainerCommandRunner) getDockerServerVersion() ([]uint, error) {

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -143,7 +143,7 @@ func TestGetDockerServerVersion(t *testing.T) {
 }
 
 func TestExecSupportExists(t *testing.T) {
-	fakeDocker := &FakeDockerClient{VersionInfo: docker.Env{"Client version=1.2", "Server version=1.1.3", "Server API version=1.15"}}
+	fakeDocker := &FakeDockerClient{VersionInfo: docker.Env{"Client version=1.2", "Server version=1.3.0", "Server API version=1.15"}}
 	runner := dockerContainerCommandRunner{fakeDocker}
 	useNativeExec, err := runner.nativeExecSupportExists()
 	if err != nil {


### PR DESCRIPTION
#1684
