### PR TITLE
validate-cluster is broken for vagrant

### DIFF
--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -79,7 +79,7 @@ for (( i=0; i<${#MINION_NAMES[@]}; i++)); do
     done
 
     name="${MINION_NAMES[$i]}"
-    if [ "$KUBERNETES_PROVIDER" != "vsphere" ]; then
+    if [ "$KUBERNETES_PROVIDER" != "vsphere" ] && [ "$KUBERNETES_PROVIDER" != "vagrant" ]; then
       # Grab fully qualified name
       name=$(grep "${MINION_NAMES[$i]}\." "${MINIONS_FILE}")
     fi


### PR DESCRIPTION
There's a bad attempt to lookup fully qualified names inside of a file with ip addresses.  I'm not certain that this works for any provider, but I know it's busted on vagrant.

@derekwaynecarr Vagrant e2e is broken without this (or something like this)
