### PR TITLE
Improve e2e tests

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 # TODO(jbeda): Provide a way to override project
+# gcloud multiplexing for shared GCE/GKE tests.
+GCLOUD=gcloud
 ZONE=us-central1-b
 MASTER_SIZE=n1-standard-1
 MINION_SIZE=n1-standard-1

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 # TODO(jbeda): Provide a way to override project
+# gcloud multiplexing for shared GCE/GKE tests.
+GCLOUD=gcloud
 ZONE=us-central1-b
 MASTER_SIZE=g1-small
 MINION_SIZE=g1-small

--- a/hack/e2e-suite/certs.sh
+++ b/hack/e2e-suite/certs.sh
@@ -25,14 +25,18 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${KUBE_ROOT}/cluster/kube-env.sh"
 source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
 
-if [[ "${KUBERNETES_PROVIDER}" != "gce" ]]; then
-  echo "Skipping certs test on non-gce provider."
+if [[ "${KUBERNETES_PROVIDER}" != "gce" ]] && [[ "${KUBERNETES_PROVIDER}" != "gke" ]]; then
+  echo "WARNING: Skipping certs.sh for cloud provider: ${KUBERNETES_PROVIDER}."
   exit 0
 fi
+
+# Set KUBE_MASTER
+detect-master
 
 # IMPORTANT: there are upstream things that rely on these files.
 # Do *not* fix this test by changing this path, unless you _really_ know
 # what you are doing.
 for file in kubecfg.key kubecfg.crt ca.crt; do
-  gcloud compute ssh --zone="${ZONE}" "${MASTER_NAME}" --command "ls /srv/kubernetes/${file}"
+  echo "Checking for ${file}"
+  "${GCLOUD}" compute ssh --zone="${ZONE}" "${KUBE_MASTER}" --command "ls /srv/kubernetes/${file}"
 done

--- a/hack/e2e-suite/pd.sh
+++ b/hack/e2e-suite/pd.sh
@@ -25,9 +25,9 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${KUBE_ROOT}/cluster/kube-env.sh"
 source "${KUBE_ROOT}/cluster/$KUBERNETES_PROVIDER/util.sh"
 
-if [[ "$KUBERNETES_PROVIDER" != "gce" ]]; then
-    echo "PD test is only run for GCE"
-    return 0
+if [[ "$KUBERNETES_PROVIDER" != "gce" ]] && [[ "$KUBERNETES_PROVIDER" != "gke" ]]; then
+  echo "WARNING: Skipping pd.sh for cloud provider: ${KUBERNETES_PROVIDER}."
+  exit 0
 fi
 
 disk_name="e2e-$(date +%H-%M-%s)"

--- a/hack/e2e-suite/private.sh
+++ b/hack/e2e-suite/private.sh
@@ -21,66 +21,16 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [[ "${KUBERNETES_PROVIDER:-gce}" != "gce" ]]; then
-  echo WARNING: Skipping private.sh for cloud provider: $KUBERNETES_PROVIDER.
-  exit 0
-fi
-
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${KUBE_ROOT}/cluster/kube-env.sh"
 source "${KUBE_ROOT}/cluster/$KUBERNETES_PROVIDER/util.sh"
 
-# Launch some pods.
-num_pods=2
-$KUBECFG -p 8080:9376 run container.cloud.google.com/_b_k8s_test/serve_hostname ${num_pods} my-hostname
-
-function teardown() {
-  echo "Cleaning up test artifacts"
-  $KUBECFG stop my-hostname
-  $KUBECFG rm my-hostname
-}
-
-trap "teardown" EXIT
-
-pod_id_list=$($KUBECFG '-template={{range.items}}{{.id}} {{end}}' -l replicationController=my-hostname list pods)
-# Pod turn up on a clean cluster can take a while for the docker image pull.
-all_running=0
-for i in $(seq 1 24); do
-  echo "Waiting for pods to come up."
-  sleep 5
-  all_running=1
-  for id in $pod_id_list; do
-    current_status=$($KUBECFG -template '{{.currentState.status}}' get pods/$id) || true
-    if [[ "$current_status" != "Running" ]]; then
-      all_running=0
-      break
-    fi
-  done
-  if [[ "${all_running}" == 1 ]]; then
-    break
-  fi
-done
-if [[ "${all_running}" == 0 ]]; then
-  echo "Pods did not come up in time"
-  exit 1
+# Private image works only on GCE and GKE.
+if [[ "${KUBERNETES_PROVIDER}" != "gce" ]] && [[ "${KUBERNETES_PROVIDER}" != "gke" ]]; then
+  echo "WARNING: Skipping private.sh for cloud provider: ${KUBERNETES_PROVIDER}."
+  exit 0
 fi
 
-# Get minion IP addresses
-detect-minions
-
-# let images stabilize
-echo "Letting images stabilize"
-sleep 5
-
-# Verify that something is listening.
-for id in ${pod_id_list}; do
-  ip=$($KUBECFG -template '{{.currentState.hostIP}}' get pods/$id)
-  echo "Trying to reach server that should be running at ${ip}:8080..."
-  ok=0
-  for i in $(seq 1 5); do
-    curl --connect-timeout 1 "http://${ip}:8080" >/dev/null 2>&1 && ok=1 && break
-    sleep 2
-  done
-done
-
-exit 0
+# Run the basic.sh test, but using this image.
+export POD_IMG_SRV="container.cloud.google.com/_b_k8s_test/serve_hostname"
+source "${KUBE_ROOT}/hack/e2e-suite/basic.sh"

--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -165,7 +165,7 @@ func Up() bool {
 
 // Is the e2e cluster up?
 func IsUp() bool {
-	return runBash("get status", `$KUBECFG -server_version`)
+	return runBash("get status", `$KUBECTL version`)
 }
 
 func tryUp() bool {


### PR DESCRIPTION
A few changes made while adding gke as a provider (coming soon):
- fix up a test that could pass while largely checking nothing (basic.sh)
- refactor a test that was almost entirely copy-paste (private.sh)
- make gcloud bin configurable in preparation for gke provider
- add additional gce/gke gating on tests that need it
- add additional logging where it is helpful for when the tests actually fail
