### PR TITLE
Make Swagger API support optional, so that consumers can define their own

### DIFF
--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -171,6 +171,7 @@ func main() {
 		PortalNet:             &n,
 		EnableLogsSupport:     *enableLogsSupport,
 		EnableUISupport:       true,
+		EnableSwaggerSupport:  true,
 		APIPrefix:             *apiPrefix,
 		CorsAllowedOriginList: corsAllowedOriginList,
 		ReadOnlyPort:          *readOnlyPort,

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -87,15 +87,15 @@ func RunApiServer(cl *client.Client, etcdClient tools.EtcdClient, addr string, p
 			Client: http.DefaultClient,
 			Port:   10250,
 		},
-		EnableLogsSupport: false,
-		APIPrefix:         "/api",
-		Authorizer:        apiserver.NewAlwaysAllowAuthorizer(),
+		EnableLogsSupport:    false,
+		EnableSwaggerSupport: true,
+		APIPrefix:            "/api",
+		Authorizer:           apiserver.NewAlwaysAllowAuthorizer(),
 
 		ReadWritePort: port,
 		ReadOnlyPort:  port,
 		PublicAddress: addr,
 	})
-
 	handler.delegate = m.InsecureHandler
 
 	go http.ListenAndServe(fmt.Sprintf("%s:%d", addr, port), &handler)


### PR DESCRIPTION
OpenShift would like to also enable swagger, but we need to register our
services as swagger services prior to the SwaggerAPI being started. I've
added a bool (default false) to master.Config to enable swagger, and split
the method in master out so that a downstream consumer can call it.

No functional change for Kube, just more master flexibility.
