### PR TITLE
fix Godeps.json; upgrade context, html, and websocket packages

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -145,18 +145,15 @@
 		},
 		{
 			"ImportPath": "golang.org/x/net/context",
-			"Comment": "null-214",
-			"Rev": "c043f0dc72e4cdd23ae039470ea9d63e6680a1b2"
+			"Rev": "cbcac7bb8415db9b6cb4d1ebab1dc9afbd688b97"
 		},
 		{
 			"ImportPath": "golang.org/x/net/html",
-			"Comment": "null-214",
-			"Rev": "c043f0dc72e4cdd23ae039470ea9d63e6680a1b2"
+			"Rev": "cbcac7bb8415db9b6cb4d1ebab1dc9afbd688b97"
 		},
 		{
 			"ImportPath": "golang.org/x/net/websocket",
-			"Comment": "null-214",
-			"Rev": "c043f0dc72e4cdd23ae039470ea9d63e6680a1b2"
+			"Rev": "cbcac7bb8415db9b6cb4d1ebab1dc9afbd688b97"
 		},
 		{
 			"ImportPath": "gopkg.in/v2/yaml",

--- a/Godeps/_workspace/src/golang.org/x/net/context/context.go
+++ b/Godeps/_workspace/src/golang.org/x/net/context/context.go
@@ -34,7 +34,7 @@
 //
 // See http://blog.golang.org/context for example code for a server that uses
 // Contexts.
-package context
+package context // import "golang.org/x/net/context"
 
 import (
 	"errors"

--- a/Godeps/_workspace/src/golang.org/x/net/html/atom/atom.go
+++ b/Godeps/_workspace/src/golang.org/x/net/html/atom/atom.go
@@ -15,7 +15,7 @@
 // whether atom.H1 < atom.H2 may also change. The codes are not guaranteed to
 // be dense. The only guarantees are that e.g. looking up "div" will yield
 // atom.Div, calling atom.Div.String will return "div", and atom.Div != 0.
-package atom
+package atom // import "golang.org/x/net/html/atom"
 
 // Atom is an integer code for a string. The zero value maps to "".
 type Atom uint32

--- a/Godeps/_workspace/src/golang.org/x/net/html/charset/charset.go
+++ b/Godeps/_workspace/src/golang.org/x/net/html/charset/charset.go
@@ -6,7 +6,7 @@
 //
 // The mapping from encoding labels to encodings is defined at
 // http://encoding.spec.whatwg.org.
-package charset
+package charset // import "golang.org/x/net/html/charset"
 
 import (
 	"bytes"

--- a/Godeps/_workspace/src/golang.org/x/net/html/doc.go
+++ b/Godeps/_workspace/src/golang.org/x/net/html/doc.go
@@ -93,7 +93,7 @@ The relevant specifications include:
 http://www.whatwg.org/specs/web-apps/current-work/multipage/syntax.html and
 http://www.whatwg.org/specs/web-apps/current-work/multipage/tokenization.html
 */
-package html
+package html // import "golang.org/x/net/html"
 
 // The tokenization algorithm implemented by this package is not a line-by-line
 // transliteration of the relatively verbose state-machine in the WHATWG

--- a/Godeps/_workspace/src/golang.org/x/net/websocket/websocket.go
+++ b/Godeps/_workspace/src/golang.org/x/net/websocket/websocket.go
@@ -4,7 +4,7 @@
 
 // Package websocket implements a client and server for the WebSocket protocol
 // as specified in RFC 6455.
-package websocket
+package websocket // import "golang.org/x/net/websocket"
 
 import (
 	"bufio"


### PR DESCRIPTION
I think the revisions got messed up with the package rename? At least now I can run godep restore.
