### PR TITLE
Quote strings in bash populated YAML files.

### DIFF
--- a/cluster/gce/templates/create-dynamic-salt-files.sh
+++ b/cluster/gce/templates/create-dynamic-salt-files.sh
@@ -20,11 +20,11 @@
 
 mkdir -p /srv/salt-overlay/pillar
 cat <<EOF >/srv/salt-overlay/pillar/cluster-params.sls
-node_instance_prefix: $NODE_INSTANCE_PREFIX
-portal_net: $PORTAL_NET
-enable_node_monitoring: $ENABLE_NODE_MONITORING
-enable_node_logging: $ENABLE_NODE_LOGGING
-logging_destination: $LOGGING_DESTINATION
+node_instance_prefix: '$(echo "$NODE_INSTANCE_PREFIX" | sed -e "s/'/''/g")'
+portal_net: '$(echo "$PORTAL_NET" | sed -e "s/'/''/g")'
+enable_node_monitoring: '$(echo "$ENABLE_NODE_MONITORING" | sed -e "s/'/''/g")'
+enable_node_logging: '$(echo "$ENABLE_NODE_LOGGING" | sed -e "s/'/''/g")'
+logging_destination: '$(echo "$LOGGING_DESTINATION" | sed -e "s/'/''/g")'
 EOF
 
 mkdir -p /srv/salt-overlay/salt/nginx

--- a/cluster/gce/templates/salt-master.sh
+++ b/cluster/gce/templates/salt-master.sh
@@ -19,7 +19,9 @@ sed -i -e "\|^deb.*http://ftp.debian.org/debian| s/^/#/" /etc/apt/sources.list.d
 
 # Prepopulate the name of the Master
 mkdir -p /etc/salt/minion.d
-echo "master: $MASTER_NAME" > /etc/salt/minion.d/master.conf
+cat <<EOF >/etc/salt/minion.d/master.conf
+master: '$(echo "$MASTER_NAME" | sed -e "s/'/''/g")'
+EOF
 
 cat <<EOF >/etc/salt/minion.d/log-level-debug.conf
 log_level: debug

--- a/cluster/gce/templates/salt-minion.sh
+++ b/cluster/gce/templates/salt-minion.sh
@@ -20,7 +20,9 @@ sed -i -e "\|^deb.*http://ftp.debian.org/debian| s/^/#/" /etc/apt/sources.list.d
 
 # Prepopulate the name of the Master
 mkdir -p /etc/salt/minion.d
-echo "master: $MASTER_NAME" > /etc/salt/minion.d/master.conf
+cat <<EOF >/etc/salt/minion.d/master.conf
+master: '$(echo "$MASTER_NAME" | sed -e "s/'/''/g")'
+EOF
 
 cat <<EOF >/etc/salt/minion.d/log-level-debug.conf
 log_level: debug
@@ -32,7 +34,7 @@ cat <<EOF >/etc/salt/minion.d/grains.conf
 grains:
   roles:
     - kubernetes-pool
-  cbr-cidr: $MINION_IP_RANGE
+  cbr-cidr: '$(echo "$MINION_IP_RANGE" | sed -e "s/'/''/g")'
   cloud: gce
 EOF
 
@@ -51,7 +53,7 @@ fi
 
 if [[ -n "{DOCKER_OPTS}" ]]; then
 cat <<EOF >>/etc/salt/minion.d/grains.conf
-  docker_opts: $DOCKER_OPTS
+  docker_opts: '$(echo "$DOCKER_OPTS" | sed -e "s/'/''/g")'
 EOF
 fi
 

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -62,17 +62,19 @@ done
 
 # Update salt configuration
 mkdir -p /etc/salt/minion.d
-echo "master: $MASTER_NAME" > /etc/salt/minion.d/master.conf
+cat <<EOF >/etc/salt/minion.d/master.conf
+master: '$(echo "$MASTER_NAME" | sed -e "s/'/''/g")'
+EOF
 
 cat <<EOF >/etc/salt/minion.d/grains.conf
 grains:
-  node_ip: $MASTER_IP
-  master_ip: $MASTER_IP
-  publicAddressOverride: $MASTER_IP
+  node_ip: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
+  master_ip: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
+  publicAddressOverride: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
   network_mode: openvswitch
   networkInterfaceName: eth1
-  etcd_servers: $MASTER_IP
-  api_servers: $MASTER_IP
+  etcd_servers: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
+  api_servers: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
   cloud: vagrant
   cloud_provider: vagrant
   roles:
@@ -81,11 +83,11 @@ EOF
 
 mkdir -p /srv/salt-overlay/pillar
 cat <<EOF >/srv/salt-overlay/pillar/cluster-params.sls
-  portal_net: $PORTAL_NET
-  cert_ip: $MASTER_IP
-  enable_node_monitoring: $ENABLE_NODE_MONITORING
-  enable_node_logging: $ENABLE_NODE_LOGGING
-  logging_destination: $LOGGING_DESTINATION
+  portal_net: '$(echo "$PORTAL_NET" | sed -e "s/'/''/g")'
+  cert_ip: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
+  enable_node_monitoring: '$(echo "$ENABLE_NODE_MONITORING" | sed -e "s/'/''/g")'
+  enable_node_logging: '$(echo "$ENABLE_NODE_LOGGING" | sed -e "s/'/''/g")'
+  logging_destination: '$(echo "$LOGGING_DESTINATION" | sed -e "s/'/''/g")'
 EOF
 
 # Configure the salt-master
@@ -155,7 +157,6 @@ rest_cherrypy:
   webhook_disable_auth: True
 EOF
 
-
   # Install Salt Master
   #
   # -M installs the master
@@ -163,7 +164,7 @@ EOF
   curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -M -N
 
   # Install salt-api
-  #  
+  #
   # This is used to provide the network transport for salt-api
   yum install -y python-cherrypy
   # This is used to inform the cloud provider used in the vagrant cluster

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -40,22 +40,24 @@ done
 
 # Let the minion know who its master is
 mkdir -p /etc/salt/minion.d
-echo "master: $MASTER_NAME" > /etc/salt/minion.d/master.conf
+cat <<EOF >/etc/salt/minion.d/master.conf
+master: '$(echo "$MASTER_NAME" | sed -e "s/'/''/g")'
+EOF
 
 # Our minions will have a pool role to distinguish them from the master.
 cat <<EOF >/etc/salt/minion.d/grains.conf
 grains:
   network_mode: openvswitch
-  node_ip: $MINION_IP
-  etcd_servers: $MASTER_IP
-  api_servers: $MASTER_IP
+  node_ip: '$(echo "$MINION_IP" | sed -e "s/'/''/g")'
+  etcd_servers: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
+  api_servers: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
   networkInterfaceName: eth1
-  apiservers: $MASTER_IP
+  apiservers: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
   roles:
     - kubernetes-pool
     - kubernetes-pool-vagrant
-  cbr-cidr: $MINION_IP_RANGE
-  minion_ip: $MINION_IP
+  cbr-cidr: '$(echo "$MINION_IP_RANGE" | sed -e "s/'/''/g")'
+  minion_ip: '$(echo "$MINION_IP" | sed -e "s/'/''/g")'
 EOF
 
 # we will run provision to update code each time we test, so we do not want to do salt install each time


### PR DESCRIPTION
Quoting is hard.  When writing strings into YAML files, wrap them in single quotes.  Also escape any embedded single quotes in those strings via a double signle quote ('').
