### PR TITLE
Track the sources that the kubelet has seen

### DIFF
--- a/pkg/kubelet/config/etcd.go
+++ b/pkg/kubelet/config/etcd.go
@@ -79,7 +79,7 @@ func (s *sourceEtcd) run() {
 			}
 
 			glog.V(4).Infof("Received state from etcd watch: %+v", pods)
-			s.updates <- kubelet.PodUpdate{pods, kubelet.SET}
+			s.updates <- kubelet.PodUpdate{pods, kubelet.SET, kubelet.EtcdSource}
 		}
 	}
 }

--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -73,14 +73,14 @@ func (s *sourceFile) extractFromPath() error {
 		if err != nil {
 			return err
 		}
-		s.updates <- kubelet.PodUpdate{pods, kubelet.SET}
+		s.updates <- kubelet.PodUpdate{pods, kubelet.SET, kubelet.FileSource}
 
 	case statInfo.Mode().IsRegular():
 		pod, err := extractFromFile(path)
 		if err != nil {
 			return err
 		}
-		s.updates <- kubelet.PodUpdate{[]api.BoundPod{pod}, kubelet.SET}
+		s.updates <- kubelet.PodUpdate{[]api.BoundPod{pod}, kubelet.SET, kubelet.FileSource}
 
 	default:
 		return fmt.Errorf("path is not a directory or file")

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -119,7 +119,7 @@ func TestReadFromFile(t *testing.T) {
 	select {
 	case got := <-ch:
 		update := got.(kubelet.PodUpdate)
-		expected := CreatePodUpdate(kubelet.SET, api.BoundPod{
+		expected := CreatePodUpdate(kubelet.SET, kubelet.FileSource, api.BoundPod{
 			ObjectMeta: api.ObjectMeta{
 				Name:      simpleSubdomainSafeHash(file.Name()),
 				UID:       simpleSubdomainSafeHash(file.Name()),
@@ -170,7 +170,7 @@ func TestExtractFromValidDataFile(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	update := (<-ch).(kubelet.PodUpdate)
-	expected := CreatePodUpdate(kubelet.SET, expectedPod)
+	expected := CreatePodUpdate(kubelet.SET, kubelet.FileSource, expectedPod)
 	if !reflect.DeepEqual(expected, update) {
 		t.Errorf("Expected %#v, Got %#v", expected, update)
 	}
@@ -191,7 +191,7 @@ func TestExtractFromEmptyDir(t *testing.T) {
 	}
 
 	update := (<-ch).(kubelet.PodUpdate)
-	expected := CreatePodUpdate(kubelet.SET)
+	expected := CreatePodUpdate(kubelet.SET, kubelet.FileSource)
 	if !reflect.DeepEqual(expected, update) {
 		t.Errorf("Expected %#v, Got %#v", expected, update)
 	}
@@ -239,7 +239,7 @@ func TestExtractFromDir(t *testing.T) {
 	}
 
 	update := (<-ch).(kubelet.PodUpdate)
-	expected := CreatePodUpdate(kubelet.SET, pods...)
+	expected := CreatePodUpdate(kubelet.SET, kubelet.FileSource, pods...)
 	sort.Sort(sortedPods(update.Pods))
 	sort.Sort(sortedPods(expected.Pods))
 	if !reflect.DeepEqual(expected, update) {

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -97,7 +97,7 @@ func (s *sourceURL) extractFromURL() error {
 		if len(pod.Namespace) == 0 {
 			pod.Namespace = api.NamespaceDefault
 		}
-		s.updates <- kubelet.PodUpdate{[]api.BoundPod{pod}, kubelet.SET}
+		s.updates <- kubelet.PodUpdate{[]api.BoundPod{pod}, kubelet.SET, kubelet.HTTPSource}
 		return nil
 	}
 
@@ -138,7 +138,7 @@ func (s *sourceURL) extractFromURL() error {
 				pod.Namespace = api.NamespaceDefault
 			}
 		}
-		s.updates <- kubelet.PodUpdate{boundPods.Items, kubelet.SET}
+		s.updates <- kubelet.PodUpdate{boundPods.Items, kubelet.SET, kubelet.HTTPSource}
 		return nil
 	}
 

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -124,6 +124,7 @@ func TestExtractFromHTTP(t *testing.T) {
 			desc:      "Single manifest",
 			manifests: api.ContainerManifest{Version: "v1beta1", ID: "foo"},
 			expected: CreatePodUpdate(kubelet.SET,
+				kubelet.HTTPSource,
 				api.BoundPod{
 					ObjectMeta: api.ObjectMeta{
 						Name:      "foo",
@@ -141,6 +142,7 @@ func TestExtractFromHTTP(t *testing.T) {
 				{Version: "v1beta1", ID: "bar", Containers: []api.Container{{Name: "1", Image: "foo"}}},
 			},
 			expected: CreatePodUpdate(kubelet.SET,
+				kubelet.HTTPSource,
 				api.BoundPod{
 					ObjectMeta: api.ObjectMeta{
 						Name:      "1",
@@ -169,7 +171,7 @@ func TestExtractFromHTTP(t *testing.T) {
 		{
 			desc:      "Empty Array",
 			manifests: []api.ContainerManifest{},
-			expected:  CreatePodUpdate(kubelet.SET),
+			expected:  CreatePodUpdate(kubelet.SET, kubelet.HTTPSource),
 		},
 	}
 	for _, testCase := range testCases {

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -76,7 +76,7 @@ func TestGetContainerID(t *testing.T) {
 		t.Errorf("Failed to find container %#v", dockerContainer)
 	}
 
-	fakeDocker.clearCalls()
+	fakeDocker.ClearCalls()
 	dockerContainer, found, _ = dockerContainers.FindPodContainer("foobar", "", "foo")
 	verifyCalls(t, fakeDocker, []string{})
 	if dockerContainer != nil || found {

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -40,10 +40,14 @@ type FakeDockerClient struct {
 	VersionInfo   docker.Env
 }
 
-func (f *FakeDockerClient) clearCalls() {
+func (f *FakeDockerClient) ClearCalls() {
 	f.Lock()
 	defer f.Unlock()
 	f.called = []string{}
+	f.Stopped = []string{}
+	f.pulled = []string{}
+	f.Created = []string{}
+	f.Removed = []string{}
 }
 
 func (f *FakeDockerClient) AssertCalls(calls []string) (err error) {

--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -59,6 +59,7 @@ func ListenAndServeKubeletServer(host HostInterface, updates chan<- interface{},
 		WriteTimeout:   5 * time.Minute,
 		MaxHeaderBytes: 1 << 20,
 	}
+	updates <- PodUpdate{[]api.BoundPod{}, SET, ServerSource}
 	glog.Fatal(s.ListenAndServe())
 }
 
@@ -143,7 +144,7 @@ func (s *Server) handleContainer(w http.ResponseWriter, req *http.Request) {
 	if pod.UID == "" {
 		pod.UID = "1"
 	}
-	s.updates <- PodUpdate{[]api.BoundPod{pod}, SET}
+	s.updates <- PodUpdate{[]api.BoundPod{pod}, SET, ServerSource}
 
 }
 
@@ -166,8 +167,7 @@ func (s *Server) handleContainers(w http.ResponseWriter, req *http.Request) {
 		pods[i].Name = fmt.Sprintf("%d", i+1)
 		pods[i].Spec = specs[i]
 	}
-	s.updates <- PodUpdate{pods, SET}
-
+	s.updates <- PodUpdate{pods, SET, ServerSource}
 }
 
 // handleContainerLogs handles containerLogs request against the Kubelet

--- a/pkg/kubelet/types.go
+++ b/pkg/kubelet/types.go
@@ -36,6 +36,18 @@ const (
 	REMOVE
 	// Pods with the given ids have been updated in this source
 	UPDATE
+
+	// These constants identify the sources of pods
+	// Updates from a file
+	FileSource = "file"
+	// Updates from etcd
+	EtcdSource = "etcd"
+	// Updates from querying a web page
+	HTTPSource = "http"
+	// Updates received to the kubelet server
+	ServerSource = "server"
+	// Updates from all sources
+	AllSource = "*"
 )
 
 // PodUpdate defines an operation sent on the channel. You can add or remove single services by
@@ -48,8 +60,9 @@ const (
 // functionally similar, this helps our unit tests properly check that the correct PodUpdates
 // are generated.
 type PodUpdate struct {
-	Pods []api.BoundPod
-	Op   PodOperation
+	Pods   []api.BoundPod
+	Op     PodOperation
+	Source string
 }
 
 // GetPodFullName returns a name that uniquely identifies a pod across all config sources.


### PR DESCRIPTION
And only delete pods when every source has been seen at least once.

Addresses #1954 

Needs more unit test coverage, but here for an initial review of the design.
