### PR TITLE
Allow kubectl get to fetch multiple resource types by label

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
@@ -42,6 +43,7 @@ const (
 
 // Factory provides abstractions that allow the Kubectl command to be extended across multiple types
 // of resources and different API sets.
+// TODO: make the functions interfaces
 type Factory struct {
 	clients *clientCache
 	flags   *pflag.FlagSet
@@ -216,6 +218,13 @@ func DefaultClientConfig(flags *pflag.FlagSet) clientcmd.ClientConfig {
 	clientConfig := clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, overrides, os.Stdin)
 
 	return clientConfig
+}
+
+// ClientMapperForCommand returns a ClientMapper for the given command and factory.
+func ClientMapperForCommand(cmd *cobra.Command, f *Factory) resource.ClientMapper {
+	return resource.ClientMapperFunc(func(mapping *meta.RESTMapping) (resource.RESTClient, error) {
+		return f.RESTClient(cmd, mapping)
+	})
 }
 
 func checkErr(err error) {

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -59,7 +59,7 @@ Examples:
 			checkErr(err)
 			selector := GetFlagString(cmd, "selector")
 			found := 0
-			ResourcesFromArgsOrFile(cmd, args, filename, selector, f.Typer, f.Mapper, f.RESTClient, schema).Visit(func(r *resource.Info) error {
+			ResourcesFromArgsOrFile(cmd, args, filename, selector, f.Typer, f.Mapper, f.RESTClient, schema, true).Visit(func(r *resource.Info) error {
 				found++
 				if err := resource.NewHelper(r.Client, r.Mapping).Delete(r.Namespace, r.Name); err != nil {
 					return err

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -20,14 +20,17 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
 	"github.com/spf13/cobra"
 )
 
+// NewCmdGet creates a command object for the generic "get" action, which
+// retrieves one or more resources from a server.
 func (f *Factory) NewCmdGet(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get [(-o|--output=)json|yaml|...] <resource> [<id>]",
@@ -48,66 +51,134 @@ Examples:
   <list single replication controller in ps output format>
 
   $ kubectl get -o json pod 1234-56-7890-234234-456456
-  <list single pod in json output format>`,
+  <list single pod in json output format>
+
+  $ kubectl get rc,services
+  <list replication controllers and services together in ps output format>`,
 		Run: func(cmd *cobra.Command, args []string) {
-			mapping, namespace, name := ResourceOrTypeFromArgs(cmd, args, f.Mapper)
-
-			selector := GetFlagString(cmd, "selector")
-			labelSelector, err := labels.ParseSelector(selector)
-			checkErr(err)
-
-			client, err := f.RESTClient(cmd, mapping)
-			checkErr(err)
-
-			outputFormat := GetFlagString(cmd, "output")
-			templateFile := GetFlagString(cmd, "template")
-			defaultPrinter, err := f.Printer(cmd, mapping, GetFlagBool(cmd, "no-headers"))
-			checkErr(err)
-
-			outputVersion := GetFlagString(cmd, "output-version")
-			if len(outputVersion) == 0 {
-				outputVersion = mapping.APIVersion
-			}
-
-			printer, err := kubectl.GetPrinter(outputFormat, templateFile, outputVersion, mapping.ObjectConvertor, defaultPrinter)
-			checkErr(err)
-
-			restHelper := resource.NewHelper(client, mapping)
-			var obj runtime.Object
-			if len(name) == 0 {
-				obj, err = restHelper.List(namespace, labelSelector)
-			} else {
-				obj, err = restHelper.Get(namespace, name)
-			}
-			checkErr(err)
-
-			isWatch, isWatchOnly := GetFlagBool(cmd, "watch"), GetFlagBool(cmd, "watch-only")
-
-			// print the current object
-			if !isWatchOnly {
-				if err := printer.PrintObj(obj, out); err != nil {
-					checkErr(fmt.Errorf("unable to output the provided object: %v", err))
-				}
-			}
-
-			// print watched changes
-			if isWatch || isWatchOnly {
-				rv, err := mapping.MetadataAccessor.ResourceVersion(obj)
-				checkErr(err)
-
-				w, err := restHelper.Watch(namespace, rv, labelSelector, labels.Everything())
-				checkErr(err)
-
-				kubectl.WatchLoop(w, printer, out)
-			}
+			RunGet(f, out, cmd, args)
 		},
 	}
 	cmd.Flags().StringP("output", "o", "", "Output format: json|yaml|template|templatefile")
 	cmd.Flags().String("output-version", "", "Output the formatted object with the given version (default api-version)")
 	cmd.Flags().Bool("no-headers", false, "When using the default output, don't print headers")
-	cmd.Flags().StringP("template", "t", "", "Template string or path to template file to use when --output=template or --output=templatefile")
+	cmd.Flags().StringP("template", "t", "", "Template string or path to template file to use when -o=template or -o=templatefile.")
 	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on")
 	cmd.Flags().BoolP("watch", "w", false, "After listing/getting the requested object, watch for changes.")
 	cmd.Flags().Bool("watch-only", false, "Watch for changes to the requseted object(s), without listing/getting first.")
 	return cmd
+}
+
+// RunGet implements the generic Get command
+// TODO: convert all direct flag accessors to a struct and pass that instead of cmd
+// TODO: return an error instead of using glog.Fatal and checkErr
+func RunGet(f *Factory, out io.Writer, cmd *cobra.Command, args []string) {
+	selector := GetFlagString(cmd, "selector")
+
+	// handle watch separately since we cannot watch multiple resource types
+	isWatch, isWatchOnly := GetFlagBool(cmd, "watch"), GetFlagBool(cmd, "watch-only")
+	if isWatch || isWatchOnly {
+		r := resource.NewBuilder(f.Mapper, f.Typer, ClientMapperForCommand(cmd, f)).
+			NamespaceParam(GetKubeNamespace(cmd)).DefaultNamespace().
+			SelectorParam(selector).
+			ResourceTypeOrNameArgs(args...).
+			SingleResourceType().
+			Do()
+
+		mapping, err := r.ResourceMapping()
+		checkErr(err)
+
+		printer, err := printerForMapping(f, cmd, mapping)
+		checkErr(err)
+
+		obj, err := r.Object()
+		checkErr(err)
+
+		rv, err := mapping.MetadataAccessor.ResourceVersion(obj)
+		checkErr(err)
+
+		// print the current object
+		if !isWatchOnly {
+			if err := printer.PrintObj(obj, out); err != nil {
+				checkErr(fmt.Errorf("unable to output the provided object: %v", err))
+			}
+		}
+
+		// print watched changes
+		w, err := r.Watch(rv)
+		checkErr(err)
+
+		kubectl.WatchLoop(w, func(e watch.Event) error {
+			return printer.PrintObj(e.Object, out)
+		})
+		return
+	}
+
+	printer, generic, err := printerForCommand(cmd)
+	checkErr(err)
+
+	b := resource.NewBuilder(f.Mapper, f.Typer, ClientMapperForCommand(cmd, f)).
+		NamespaceParam(GetKubeNamespace(cmd)).DefaultNamespace().
+		SelectorParam(selector).
+		ResourceTypeOrNameArgs(args...).
+		Latest()
+
+	if generic {
+		// the outermost object will be converted to the output-version
+		printer = kubectl.NewVersionedPrinter(printer, api.Scheme, outputVersion(cmd))
+
+		obj, err := b.Flatten().Do().Object()
+		checkErr(err)
+
+		err = printer.PrintObj(obj, out)
+		checkErr(err)
+		return
+	}
+
+	// use the default printer for each object
+	err = b.Do().Visit(func(r *resource.Info) error {
+		printer, err := printerForMapping(f, cmd, r.Mapping)
+		if err != nil {
+			return err
+		}
+		return printer.PrintObj(r.Object, out)
+	})
+	checkErr(err)
+}
+
+// outputVersion returns the preferred output version for generic content (JSON, YAML, or templates)
+func outputVersion(cmd *cobra.Command) string {
+	outputVersion := GetFlagString(cmd, "output-version")
+	if len(outputVersion) == 0 {
+		outputVersion = GetFlagString(cmd, "api-version")
+	}
+	return outputVersion
+}
+
+// printerForCommand returns the default printer for this command.
+func printerForCommand(cmd *cobra.Command) (kubectl.ResourcePrinter, bool, error) {
+	outputFormat := GetFlagString(cmd, "output")
+	templateFile := GetFlagString(cmd, "template")
+	if len(outputFormat) == 0 && len(templateFile) != 0 {
+		outputFormat = "template"
+	}
+
+	return kubectl.GetPrinter(outputFormat, templateFile)
+}
+
+// printerForMapping returns a printer suitable for displaying the provided resource type.
+func printerForMapping(f *Factory, cmd *cobra.Command, mapping *meta.RESTMapping) (kubectl.ResourcePrinter, error) {
+	printer, ok, err := printerForCommand(cmd)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		printer = kubectl.NewVersionedPrinter(printer, mapping.ObjectConvertor, outputVersion(cmd))
+	} else {
+		printer, err = f.Printer(cmd, mapping, GetFlagBool(cmd, "no-headers"))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return printer, nil
 }


### PR DESCRIPTION
Like Delete, which can now run over multiple types:

```
kubectl delete pods,services -l name=foo
```

Get should be able to span items for label selection

```
kubectl get pods,services -l name=foo
```

Not yet complete, want feedback from @bgrant0607.

Follow up to #2751
