### PR TITLE
Add kubernetes-test.tar.gz

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -503,6 +503,7 @@ function kube::release::package_tarballs() {
   kube::release::package_client_tarballs
   kube::release::package_server_tarballs
   kube::release::package_salt_tarball
+  kube::release::package_test_tarball
   kube::release::package_full_tarball
 }
 
@@ -579,6 +580,31 @@ function kube::release::package_salt_tarball() {
   cp -R "${KUBE_ROOT}/cluster/saltbase" "${release_stage}/"
 
   local package_name="${RELEASE_DIR}/kubernetes-salt.tar.gz"
+  kube::release::create_tarball "${package_name}" "${release_stage}/.."
+}
+
+# This is the stuff you need to run tests from the binary distribution.
+function kube::release::package_test_tarball() {
+  echo "+++ Building tarball: test"
+
+  local release_stage="${RELEASE_STAGE}/test/kubernetes"
+  rm -rf "${release_stage}"
+  mkdir -p "${release_stage}"
+
+  local platform
+  for platform in "${KUBE_CLIENT_PLATFORMS[@]}"; do
+    local test_bins=("${KUBE_TEST_BINARIES[@]}")
+    if [[ "${platform%/*}" == "windows" ]]; then
+      test_bins=("${KUBE_TEST_BINARIES_WIN[@]}")
+    fi
+    mkdir -p "${release_stage}/platforms/${platform}"
+    cp "${test_bins[@]/#/${LOCAL_OUTPUT_BINPATH}/${platform}/}" \
+      "${release_stage}/platforms/${platform}"
+  done
+
+  cp -R --parents ${KUBE_TEST_PORTABLE[@]} ${release_stage}
+
+  local package_name="${RELEASE_DIR}/kubernetes-test.tar.gz"
   kube::release::create_tarball "${package_name}" "${release_stage}/.."
 }
 

--- a/cmd/e2e/e2e.go
+++ b/cmd/e2e/e2e.go
@@ -56,7 +56,9 @@ func waitForPodRunning(c *client.Client, id string) {
 	}
 }
 
-// assetPath returns a path to the requested file; safe on all OSes.
+// assetPath returns a path to the requested file; safe on all
+// OSes. NOTE: If you use an asset in this test, you MUST add it to
+// the KUBE_TEST_PORTABLE array in hack/lib/golang.sh.
 func assetPath(pathElements ...string) string {
 	return filepath.Join(*repoRoot, filepath.Join(pathElements...))
 }

--- a/hack/e2e-suite/goe2e.sh
+++ b/hack/e2e-suite/goe2e.sh
@@ -60,6 +60,7 @@ esac
 locations=(
   "${KUBE_ROOT}/_output/dockerized/bin/${host_os}/${host_arch}/e2e"
   "${KUBE_ROOT}/_output/local/bin/${host_os}/${host_arch}/e2e"
+  "${KUBE_ROOT}/platforms/${host_os}/${host_arch}/e2e"
 )
 e2e=$( (ls -t "${locations[@]}" 2>/dev/null || true) | head -1 )
 

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -48,6 +48,15 @@ readonly KUBE_TEST_TARGETS=(
   cmd/integration
 )
 readonly KUBE_TEST_BINARIES=("${KUBE_TEST_TARGETS[@]##*/}")
+readonly KUBE_TEST_BINARIES_WIN=("${KUBE_TEST_BINARIES[@]/%/.exe}")
+readonly KUBE_TEST_PORTABLE=(
+  api/examples/pod.json
+  cmd/e2e/pod.json
+  contrib/for-tests/network-tester/rc.json
+  contrib/for-tests/network-tester/service.json
+  hack/e2e.go
+  hack/e2e-suite
+)
 
 # If we update this we need to also update the set of golang compilers we build
 # in 'build/build-image/Dockerfile'


### PR DESCRIPTION
Add test artifacts to the build. This lets you do:

tar -xzf kubernetes.tar.gz
tar -xzf kubernetes-test.tar.gz
cd kubernetes
go run ./hack/e2e.go -up -test -down

without having a git checkout.
