### PR TITLE
Issue 2948: fix "kubectl get events" result not sorted

### DIFF
--- a/pkg/kubectl/sorted_event_list.go
+++ b/pkg/kubectl/sorted_event_list.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+// SortableEvents implements sort.Interface for []api.Event based on the Timestamp field
+type SortableEvents []api.Event
+
+func (list SortableEvents) Len() int {
+	return len(list)
+}
+
+func (list SortableEvents) Swap(i, j int) {
+	list[i], list[j] = list[j], list[i]
+}
+
+func (list SortableEvents) Less(i, j int) bool {
+	return list[i].Timestamp.Time.Before(list[j].Timestamp.Time)
+}

--- a/pkg/kubectl/sorted_event_list_test.go
+++ b/pkg/kubectl/sorted_event_list_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// VerifyDatesInOrder checks the start of each line for a RFC1123Z date
+// and posts error if all subsequent dates are not equal or increasing
+func VerifyDatesInOrder(
+	resultToTest, rowDelimiter, columnDelimiter string, t *testing.T) {
+	lines := strings.Split(resultToTest, rowDelimiter)
+	var previousTime time.Time
+	for _, str := range lines {
+		columns := strings.Split(str, columnDelimiter)
+		if len(columns) > 0 {
+			currentTime, err := time.Parse(time.RFC1123Z, columns[0])
+			if err == nil {
+				if previousTime.After(currentTime) {
+					t.Errorf(
+						"Output is not sorted by time. %s should be listed after %s. Complete output: %s",
+						previousTime.Format(time.RFC1123Z),
+						currentTime.Format(time.RFC1123Z),
+						resultToTest)
+				}
+				previousTime = currentTime
+			}
+		}
+	}
+
+}
+
+func TestSortableEvents(t *testing.T) {
+	// Arrange
+	list := SortableEvents([]api.Event{
+		{
+			Source:    "kubelet",
+			Message:   "Item 1",
+			Timestamp: util.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
+		},
+		{
+			Source:    "scheduler",
+			Message:   "Item 2",
+			Timestamp: util.NewTime(time.Date(1987, time.June, 17, 0, 0, 0, 0, time.UTC)),
+		},
+		{
+			Source:    "kubelet",
+			Message:   "Item 3",
+			Timestamp: util.NewTime(time.Date(2002, time.December, 25, 0, 0, 0, 0, time.UTC)),
+		},
+	})
+
+	// Act
+	sort.Sort(list)
+
+	// Assert
+	if list[0].Message != "Item 2" ||
+		list[1].Message != "Item 3" ||
+		list[2].Message != "Item 1" {
+		t.Fatal("List is not sorted by time. List: ", list)
+	}
+}


### PR DESCRIPTION
Fixes #2948
- Added a "TIME" column to results from both "kubectl get events" and "kubectl describe pod x"
- Added code to sort the result from "kubectl get events" by event timestamp
  - Verified that sorting has negligible impact on runtime while sorting 8000 events
- Confirmed that "kubectl describe pod x" is already sorting results by time
- Added unit tests to verify both "kubectl get events" and "kubectl describe pod x" results are sorted by time.
