### PR TITLE
v1beta1 should return Minion as kind, rather than Node

### DIFF
--- a/pkg/api/v1beta1/conversion_test.go
+++ b/pkg/api/v1beta1/conversion_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -27,6 +28,15 @@ import (
 var Convert = newer.Scheme.Convert
 
 func TestNodeConversion(t *testing.T) {
+	version, kind, err := newer.Scheme.ObjectVersionAndKind(&current.Minion{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if version != "v1beta1" || kind != "Minion" {
+		t.Errorf("unexpected version and kind: %s %s", version, kind)
+	}
+
+	newer.Scheme.Log(t)
 	obj, err := current.Codec.Decode([]byte(`{"kind":"Node","apiVersion":"v1beta1"}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -46,6 +56,19 @@ func TestNodeConversion(t *testing.T) {
 	obj = &newer.Node{}
 	if err := current.Codec.DecodeInto([]byte(`{"kind":"Node","apiVersion":"v1beta1"}`), obj); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obj = &newer.Node{}
+	data, err := current.Codec.Encode(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m := map[string]interface{}{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["kind"] != "Minion" {
+		t.Errorf("unexpected encoding: %s - %#v", m["kind"], string(data))
 	}
 }
 

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -25,12 +25,6 @@ import (
 var Codec = runtime.CodecFor(api.Scheme, "v1beta1")
 
 func init() {
-	// Future names are supported, and declared first so they take precedence
-	api.Scheme.AddKnownTypeWithName("v1beta1", "Node", &Minion{})
-	api.Scheme.AddKnownTypeWithName("v1beta1", "NodeList", &MinionList{})
-	api.Scheme.AddKnownTypeWithName("v1beta1", "Operation", &ServerOp{})
-	api.Scheme.AddKnownTypeWithName("v1beta1", "OperationList", &ServerOpList{})
-
 	api.Scheme.AddKnownTypes("v1beta1",
 		&Pod{},
 		&PodContainerInfo{},
@@ -58,6 +52,8 @@ func init() {
 	// Future names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta1", "Node", &Minion{})
 	api.Scheme.AddKnownTypeWithName("v1beta1", "NodeList", &MinionList{})
+	api.Scheme.AddKnownTypeWithName("v1beta1", "Operation", &ServerOp{})
+	api.Scheme.AddKnownTypeWithName("v1beta1", "OperationList", &ServerOpList{})
 }
 
 func (*Pod) IsAnAPIObject()                       {}

--- a/pkg/api/v1beta2/conversion_test.go
+++ b/pkg/api/v1beta2/conversion_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package v1beta2_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	newer "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	current "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
+	current "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta2"
 )
 
 func TestServiceEmptySelector(t *testing.T) {
@@ -56,6 +57,15 @@ func TestServiceEmptySelector(t *testing.T) {
 }
 
 func TestNodeConversion(t *testing.T) {
+	version, kind, err := newer.Scheme.ObjectVersionAndKind(&current.Minion{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if version != "v1beta2" || kind != "Minion" {
+		t.Errorf("unexpected version and kind: %s %s", version, kind)
+	}
+
+	newer.Scheme.Log(t)
 	obj, err := current.Codec.Decode([]byte(`{"kind":"Node","apiVersion":"v1beta2"}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -75,5 +85,18 @@ func TestNodeConversion(t *testing.T) {
 	obj = &newer.Node{}
 	if err := current.Codec.DecodeInto([]byte(`{"kind":"Node","apiVersion":"v1beta2"}`), obj); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obj = &newer.Node{}
+	data, err := current.Codec.Encode(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m := map[string]interface{}{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["kind"] != "Minion" {
+		t.Errorf("unexpected encoding: %s - %#v", m["kind"], string(data))
 	}
 }

--- a/pkg/api/v1beta2/register.go
+++ b/pkg/api/v1beta2/register.go
@@ -25,12 +25,6 @@ import (
 var Codec = runtime.CodecFor(api.Scheme, "v1beta2")
 
 func init() {
-	// Future names are supported, and declared first so they take precedence
-	api.Scheme.AddKnownTypeWithName("v1beta2", "Node", &Minion{})
-	api.Scheme.AddKnownTypeWithName("v1beta2", "NodeList", &MinionList{})
-	api.Scheme.AddKnownTypeWithName("v1beta2", "Operation", &ServerOp{})
-	api.Scheme.AddKnownTypeWithName("v1beta2", "OperationList", &ServerOpList{})
-
 	api.Scheme.AddKnownTypes("v1beta2",
 		&Pod{},
 		&PodContainerInfo{},
@@ -58,6 +52,8 @@ func init() {
 	// Future names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta2", "Node", &Minion{})
 	api.Scheme.AddKnownTypeWithName("v1beta2", "NodeList", &MinionList{})
+	api.Scheme.AddKnownTypeWithName("v1beta2", "Operation", &ServerOp{})
+	api.Scheme.AddKnownTypeWithName("v1beta2", "OperationList", &ServerOpList{})
 }
 
 func (*Pod) IsAnAPIObject()                       {}

--- a/pkg/conversion/encode.go
+++ b/pkg/conversion/encode.go
@@ -74,6 +74,12 @@ func (s *Scheme) EncodeToVersion(obj interface{}, destVersion string) (data []by
 		obj = objOut
 	}
 
+	// ensure the output object name comes from the destination type
+	_, objKind, err = s.ObjectVersionAndKind(obj)
+	if err != nil {
+		return nil, err
+	}
+
 	// Version and Kind should be set on the wire.
 	err = s.SetVersionAndKind(destVersion, objKind, obj)
 	if err != nil {

--- a/pkg/conversion/scheme.go
+++ b/pkg/conversion/scheme.go
@@ -72,13 +72,20 @@ func (s *Scheme) Log(l DebugLogger) {
 	s.converter.Debug = l
 }
 
-// nameFunc returns the name of the type that we wish to use for encoding. Defaults to
-// the go name of the type if the type is not registered.
+// nameFunc returns the name of the type that we wish to use to determine when two types attempt
+// a conversion. Defaults to the go name of the type if the type is not registered.
 func (s *Scheme) nameFunc(t reflect.Type) string {
 	// find the preferred names for this type
 	names, ok := s.typeToKind[t]
 	if !ok {
 		return t.Name()
+	}
+	if internal, ok := s.versionMap[""]; ok {
+		for _, name := range names {
+			if t, ok := internal[name]; ok {
+				return s.typeToKind[t][0]
+			}
+		}
 	}
 	return names[0]
 }


### PR DESCRIPTION
This changes the internal name logic (for conversion) to prefer the
internal registered preferred name for a resource, and then makes
v1beta1 and v1beta2 prefer Minion.

Fixes #3010
