### PR TITLE
Add missing Salt requisites

### DIFF
--- a/cluster/saltbase/salt/etcd/init.sls
+++ b/cluster/saltbase/salt/etcd/init.sls
@@ -78,6 +78,9 @@ etcd:
     - user: etcd
     - group: etcd
     - dir_mode: 700
+    - require:
+      - user: etcd
+      - group: etcd
 
 {% if grains['os_family'] == 'RedHat' %}
 
@@ -118,4 +121,8 @@ etcd-service:
       {% endif %}
       - file: etcd-tar
       - file: etcd-symlink
+    - require:
+      - file: /var/etcd
+      - user: etcd
+      - group: etcd
 


### PR DESCRIPTION
Some requisite declarations in etcd Salt deployment SLS are missing, which may cause the etcd service to fail to start because the user and group have not yet been created. This PR adds the missing requisites.
