### PR TITLE
Sticky Session Implementation

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -48,7 +48,7 @@ type TCPLoadBalancer interface {
 	// TODO: Break this up into different interfaces (LB, etc) when we have more than one type of service
 	TCPLoadBalancerExists(name, region string) (bool, error)
 	// CreateTCPLoadBalancer creates a new tcp load balancer. Returns the IP address of the balancer
-	CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string) (net.IP, error)
+	CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (net.IP, error)
 	// UpdateTCPLoadBalancer updates hosts under the specified load balancer.
 	UpdateTCPLoadBalancer(name, region string, hosts []string) error
 	// DeleteTCPLoadBalancer deletes a specified load balancer.

--- a/pkg/cloudprovider/fake/fake.go
+++ b/pkg/cloudprovider/fake/fake.go
@@ -84,7 +84,7 @@ func (f *FakeCloud) TCPLoadBalancerExists(name, region string) (bool, error) {
 
 // CreateTCPLoadBalancer is a test-spy implementation of TCPLoadBalancer.CreateTCPLoadBalancer.
 // It adds an entry "create" into the internal method call record.
-func (f *FakeCloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string) (net.IP, error) {
+func (f *FakeCloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (net.IP, error) {
 	f.addCall("create")
 	return f.ExternalIP, f.Err
 }

--- a/pkg/proxy/loadbalancer.go
+++ b/pkg/proxy/loadbalancer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package proxy
 
 import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"net"
 )
 
@@ -25,4 +26,6 @@ type LoadBalancer interface {
 	// NextEndpoint returns the endpoint to handle a request for the given
 	// service and source address.
 	NextEndpoint(service string, srcAddr net.Addr) (string, error)
+	NewService(service string, sessionAffinityType api.AffinityType, stickyMaxAgeMinutes int) error
+	CleanupStaleStickySessions(service string)
 }

--- a/pkg/proxy/roundrobin_test.go
+++ b/pkg/proxy/roundrobin_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package proxy
 
 import (
+	"net"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -68,8 +69,8 @@ func TestLoadBalanceFailsWithNoEndpoints(t *testing.T) {
 	}
 }
 
-func expectEndpoint(t *testing.T, loadBalancer *LoadBalancerRR, service string, expected string) {
-	endpoint, err := loadBalancer.NextEndpoint(service, nil)
+func expectEndpoint(t *testing.T, loadBalancer *LoadBalancerRR, service string, expected string, netaddr net.Addr) {
+	endpoint, err := loadBalancer.NextEndpoint(service, netaddr)
 	if err != nil {
 		t.Errorf("Didn't find a service for %s, expected %s, failed with: %v", service, expected, err)
 	}
@@ -90,10 +91,10 @@ func TestLoadBalanceWorksWithSingleEndpoint(t *testing.T) {
 		Endpoints:  []string{"endpoint1:40"},
 	}
 	loadBalancer.OnUpdate(endpoints)
-	expectEndpoint(t, loadBalancer, "foo", "endpoint1:40")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint1:40")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint1:40")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint1:40")
+	expectEndpoint(t, loadBalancer, "foo", "endpoint1:40", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint1:40", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint1:40", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint1:40", nil)
 }
 
 func TestLoadBalanceWorksWithMultipleEndpoints(t *testing.T) {
@@ -108,10 +109,10 @@ func TestLoadBalanceWorksWithMultipleEndpoints(t *testing.T) {
 		Endpoints:  []string{"endpoint:1", "endpoint:2", "endpoint:3"},
 	}
 	loadBalancer.OnUpdate(endpoints)
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:1")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:2")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:3")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:1")
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:3", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", nil)
 }
 
 func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
@@ -126,21 +127,21 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 		Endpoints:  []string{"endpoint:1", "endpoint:2", "endpoint:3"},
 	}
 	loadBalancer.OnUpdate(endpoints)
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:1")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:2")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:3")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:1")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:2")
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:3", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", nil)
 	// Then update the configuration with one fewer endpoints, make sure
 	// we start in the beginning again
 	endpoints[0] = api.Endpoints{ObjectMeta: api.ObjectMeta{Name: "foo"},
 		Endpoints: []string{"endpoint:8", "endpoint:9"},
 	}
 	loadBalancer.OnUpdate(endpoints)
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:8")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:9")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:8")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:9")
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:8", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:9", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:8", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:9", nil)
 	// Clear endpoints
 	endpoints[0] = api.Endpoints{ObjectMeta: api.ObjectMeta{Name: "foo"}, Endpoints: []string{}}
 	loadBalancer.OnUpdate(endpoints)
@@ -167,17 +168,17 @@ func TestLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 		Endpoints:  []string{"endpoint:4", "endpoint:5"},
 	}
 	loadBalancer.OnUpdate(endpoints)
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:1")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:2")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:3")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:1")
-	expectEndpoint(t, loadBalancer, "foo", "endpoint:2")
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:3", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", nil)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", nil)
 
-	expectEndpoint(t, loadBalancer, "bar", "endpoint:4")
-	expectEndpoint(t, loadBalancer, "bar", "endpoint:5")
-	expectEndpoint(t, loadBalancer, "bar", "endpoint:4")
-	expectEndpoint(t, loadBalancer, "bar", "endpoint:5")
-	expectEndpoint(t, loadBalancer, "bar", "endpoint:4")
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:4", nil)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:5", nil)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:4", nil)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:5", nil)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:4", nil)
 
 	// Then update the configuration by removing foo
 	loadBalancer.OnUpdate(endpoints[1:])
@@ -187,8 +188,228 @@ func TestLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	}
 
 	// but bar is still there, and we continue RR from where we left off.
-	expectEndpoint(t, loadBalancer, "bar", "endpoint:5")
-	expectEndpoint(t, loadBalancer, "bar", "endpoint:4")
-	expectEndpoint(t, loadBalancer, "bar", "endpoint:5")
-	expectEndpoint(t, loadBalancer, "bar", "endpoint:4")
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:5", nil)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:4", nil)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:5", nil)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:4", nil)
+}
+
+func TestStickyLoadBalanceWorksWithSingleEndpoint(t *testing.T) {
+	client1 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+	client2 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 2), Port: 0}
+	loadBalancer := NewLoadBalancerRR()
+	endpoint, err := loadBalancer.NextEndpoint("foo", nil)
+	if err == nil || len(endpoint) != 0 {
+		t.Errorf("Didn't fail with non-existent service")
+	}
+	loadBalancer.NewService("foo", api.AffinityTypeClientIP, 0)
+	endpoints := make([]api.Endpoints, 1)
+	endpoints[0] = api.Endpoints{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		Endpoints:  []string{"endpoint:1"},
+	}
+	loadBalancer.OnUpdate(endpoints)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client2)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client2)
+}
+
+func TestStickyLoadBalanaceWorksWithMultipleEndpoints(t *testing.T) {
+	client1 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+	client2 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 2), Port: 0}
+	client3 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 3), Port: 0}
+	loadBalancer := NewLoadBalancerRR()
+	endpoint, err := loadBalancer.NextEndpoint("foo", nil)
+	if err == nil || len(endpoint) != 0 {
+		t.Errorf("Didn't fail with non-existent service")
+	}
+
+	loadBalancer.NewService("foo", api.AffinityTypeClientIP, 0)
+	endpoints := make([]api.Endpoints, 1)
+	endpoints[0] = api.Endpoints{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		Endpoints:  []string{"endpoint:1", "endpoint:2", "endpoint:3"},
+	}
+	loadBalancer.OnUpdate(endpoints)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", client2)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", client2)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:3", client3)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:3", client3)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+}
+
+func TestStickyLoadBalanaceWorksWithMultipleEndpointsStickyNone(t *testing.T) {
+	client1 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+	client2 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 2), Port: 0}
+	client3 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 3), Port: 0}
+	loadBalancer := NewLoadBalancerRR()
+	endpoint, err := loadBalancer.NextEndpoint("foo", nil)
+	if err == nil || len(endpoint) != 0 {
+		t.Errorf("Didn't fail with non-existent service")
+	}
+
+	loadBalancer.NewService("foo", api.AffinityTypeNone, 0)
+	endpoints := make([]api.Endpoints, 1)
+	endpoints[0] = api.Endpoints{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		Endpoints:  []string{"endpoint:1", "endpoint:2", "endpoint:3"},
+	}
+	loadBalancer.OnUpdate(endpoints)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:3", client2)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client2)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", client3)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:3", client3)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", client1)
+}
+
+func TestStickyLoadBalanaceWorksWithMultipleEndpointsRemoveOne(t *testing.T) {
+	client1 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+	client2 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 2), Port: 0}
+	client3 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 3), Port: 0}
+	client4 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 4), Port: 0}
+	client5 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 5), Port: 0}
+	client6 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 6), Port: 0}
+	loadBalancer := NewLoadBalancerRR()
+	endpoint, err := loadBalancer.NextEndpoint("foo", nil)
+	if err == nil || len(endpoint) != 0 {
+		t.Errorf("Didn't fail with non-existent service")
+	}
+
+	loadBalancer.NewService("foo", api.AffinityTypeClientIP, 0)
+	endpoints := make([]api.Endpoints, 1)
+	endpoints[0] = api.Endpoints{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		Endpoints:  []string{"endpoint:1", "endpoint:2", "endpoint:3"},
+	}
+	loadBalancer.OnUpdate(endpoints)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", client2)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", client2)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:3", client3)
+
+	endpoints[0] = api.Endpoints{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		Endpoints:  []string{"endpoint:1", "endpoint:2"},
+	}
+	loadBalancer.OnUpdate(endpoints)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", client2)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client3)
+
+	endpoints[0] = api.Endpoints{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		Endpoints:  []string{"endpoint:1", "endpoint:2", "endpoint:4"},
+	}
+	loadBalancer.OnUpdate(endpoints)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", client2)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client3)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client4)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", client5)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:4", client6)
+}
+
+func TestStickyLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
+	client1 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+	client2 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 2), Port: 0}
+	client3 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 3), Port: 0}
+	loadBalancer := NewLoadBalancerRR()
+	endpoint, err := loadBalancer.NextEndpoint("foo", nil)
+	if err == nil || len(endpoint) != 0 {
+		t.Errorf("Didn't fail with non-existent service")
+	}
+
+	loadBalancer.NewService("foo", api.AffinityTypeClientIP, 0)
+	endpoints := make([]api.Endpoints, 1)
+	endpoints[0] = api.Endpoints{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		Endpoints:  []string{"endpoint:1", "endpoint:2", "endpoint:3"},
+	}
+	loadBalancer.OnUpdate(endpoints)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", client2)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", client2)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:3", client3)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", client2)
+	// Then update the configuration with one fewer endpoints, make sure
+	// we start in the beginning again
+	endpoints[0] = api.Endpoints{ObjectMeta: api.ObjectMeta{Name: "foo"},
+		Endpoints: []string{"endpoint:4", "endpoint:5"},
+	}
+	loadBalancer.OnUpdate(endpoints)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:4", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:5", client2)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:4", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:5", client2)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:5", client2)
+
+	// Clear endpoints
+	endpoints[0] = api.Endpoints{ObjectMeta: api.ObjectMeta{Name: "foo"}, Endpoints: []string{}}
+	loadBalancer.OnUpdate(endpoints)
+
+	endpoint, err = loadBalancer.NextEndpoint("foo", nil)
+	if err == nil || len(endpoint) != 0 {
+		t.Errorf("Didn't fail with non-existent service")
+	}
+}
+
+func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
+	client1 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+	client2 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 2), Port: 0}
+	client3 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 3), Port: 0}
+	loadBalancer := NewLoadBalancerRR()
+	endpoint, err := loadBalancer.NextEndpoint("foo", nil)
+	if err == nil || len(endpoint) != 0 {
+		t.Errorf("Didn't fail with non-existent service")
+	}
+	loadBalancer.NewService("foo", api.AffinityTypeClientIP, 0)
+	endpoints := make([]api.Endpoints, 2)
+	endpoints[0] = api.Endpoints{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		Endpoints:  []string{"endpoint:1", "endpoint:2", "endpoint:3"},
+	}
+	loadBalancer.NewService("bar", api.AffinityTypeClientIP, 0)
+	endpoints[1] = api.Endpoints{
+		ObjectMeta: api.ObjectMeta{Name: "bar"},
+		Endpoints:  []string{"endpoint:4", "endpoint:5"},
+	}
+	loadBalancer.OnUpdate(endpoints)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", client2)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:3", client3)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:3", client3)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:1", client1)
+	expectEndpoint(t, loadBalancer, "foo", "endpoint:2", client2)
+
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:4", client1)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:5", client2)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:4", client1)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:5", client2)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:4", client1)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:4", client1)
+
+	// Then update the configuration by removing foo
+	loadBalancer.OnUpdate(endpoints[1:])
+	endpoint, err = loadBalancer.NextEndpoint("foo", nil)
+	if err == nil || len(endpoint) != 0 {
+		t.Errorf("Didn't fail with non-existent service")
+	}
+
+	// but bar is still there, and we continue RR from where we left off.
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:4", client1)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:5", client2)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:4", client1)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:5", client2)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:4", client1)
+	expectEndpoint(t, loadBalancer, "bar", "endpoint:4", client1)
 }

--- a/pkg/registry/service/rest.go
+++ b/pkg/registry/service/rest.go
@@ -134,16 +134,20 @@ func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan apiserver.RE
 			if err != nil {
 				return nil, err
 			}
+			var affinityType api.AffinityType = api.AffinityTypeNone
+			if service.Spec.SessionAffinity != nil {
+				affinityType = *service.Spec.SessionAffinity
+			}
 			if len(service.Spec.PublicIPs) > 0 {
 				for _, publicIP := range service.Spec.PublicIPs {
-					_, err = balancer.CreateTCPLoadBalancer(service.Name, zone.Region, net.ParseIP(publicIP), service.Spec.Port, hostsFromMinionList(hosts))
+					_, err = balancer.CreateTCPLoadBalancer(service.Name, zone.Region, net.ParseIP(publicIP), service.Spec.Port, hostsFromMinionList(hosts), affinityType)
 					if err != nil {
 						// TODO: have to roll-back any successful calls.
 						return nil, err
 					}
 				}
 			} else {
-				ip, err := balancer.CreateTCPLoadBalancer(service.Name, zone.Region, nil, service.Spec.Port, hostsFromMinionList(hosts))
+				ip, err := balancer.CreateTCPLoadBalancer(service.Name, zone.Region, nil, service.Spec.Port, hostsFromMinionList(hosts), affinityType)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
Session Affinity implementation - see Issue #2867.  
pkg/proxy
- Added two new methods to loadbalancer interface.  1. NewService (service name, sessionAffinityType).  2. CleanupStaleStickySessions(service name, max sticky session age in minutes).  
- roundrobin.go - added implementation for the above two methods.  Also added a couple new structs to hold the hash map to maintain affinity between clients and endpoints.
- proxier.go - call LB.NewService with session affinity type when there are changes to the services (default affinity type is none).  Also call the LB.CleanupStaleStickySessions as part of the SyncLoop

pkg/cloudprovider & pkg/registry/service/rest.go
- If the service definition has CreateExternalLoadBalancer we need to tell the cloud provider to create the LB with session affinity if required.  These changes will automatically set cloud provided load balancer for sticky session if the service requires it - Note, this only works on GCE right now.
