### PR TITLE
Fix OS X testtar build break

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -602,7 +602,7 @@ function kube::release::package_test_tarball() {
       "${release_stage}/platforms/${platform}"
   done
 
-  cp -R --parents ${KUBE_TEST_PORTABLE[@]} ${release_stage}
+  tar c ${KUBE_TEST_PORTABLE[@]} | tar x -C ${release_stage}
 
   local package_name="${RELEASE_DIR}/kubernetes-test.tar.gz"
   kube::release::create_tarball "${package_name}" "${release_stage}/.."


### PR DESCRIPTION
#3007 broke the build on OS X. Instead of using cp, handle copy in super portable way. Every tar on the planet should accept this.

Oblig XKCD: http://xkcd.com/1168/
