### PR TITLE
When connections are broken on Watch, write fewer errors to logs

### DIFF
--- a/pkg/client/cache/reflector.go
+++ b/pkg/client/cache/reflector.go
@@ -172,7 +172,7 @@ func (r *Reflector) watchHandler(w watch.Interface, resourceVersion *string) err
 
 	watchDuration := time.Now().Sub(start)
 	if watchDuration < 1*time.Second && eventCount == 0 {
-		glog.Errorf("unexpected watch close - watch lasted less than a second and no items received")
+		glog.V(4).Infof("Unexpected watch close - watch lasted less than a second and no items received")
 		return errors.New("very short watch")
 	}
 	glog.V(4).Infof("Watch close - %v total %v items received", r.expectedType, eventCount)

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -298,6 +299,9 @@ func (r *Request) Watch() (watch.Interface, error) {
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		if isProbableEOF(err) {
+			return watch.NewEmptyWatch(), nil
+		}
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
@@ -308,6 +312,25 @@ func (r *Request) Watch() (watch.Interface, error) {
 		return nil, fmt.Errorf("for request '%v', got status: %v\nbody: %v", req.URL, resp.StatusCode, string(body))
 	}
 	return watch.NewStreamWatcher(watchjson.NewDecoder(resp.Body, r.codec)), nil
+}
+
+// isProbableEOF returns true if the given error resembles a connection termination
+// scenario that would justify assuming that the watch is empty. The watch stream
+// mechanism handles many common partial data errors, so closed connections can be
+// retried in many cases.
+func isProbableEOF(err error) bool {
+	if uerr, ok := err.(*url.Error); ok {
+		err = uerr.Err
+	}
+	switch {
+	case err == io.EOF:
+		return true
+	case err.Error() == "http: can't write HTTP request on broken connection":
+		return true
+	case strings.Contains(err.Error(), "connection reset by peer"):
+		return true
+	}
+	return false
 }
 
 // Stream formats and executes the request, and offers streaming of the response.

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -56,6 +56,26 @@ type Event struct {
 	Object runtime.Object
 }
 
+type emptyWatch chan Event
+
+// NewEmptyWatch returns a watch interface that returns no results and is closed.
+// May be used in certain error conditions where no information is available but
+// an error is not warranted.
+func NewEmptyWatch() Interface {
+	ch := make(chan Event)
+	close(ch)
+	return emptyWatch(ch)
+}
+
+// Stop implements Interface
+func (w emptyWatch) Stop() {
+}
+
+// ResultChan implements Interface
+func (w emptyWatch) ResultChan() <-chan Event {
+	return chan Event(w)
+}
+
 // FakeWatcher lets you test anything that consumes a watch.Interface; threadsafe.
 type FakeWatcher struct {
 	result  chan Event

--- a/pkg/watch/watch_test.go
+++ b/pkg/watch/watch_test.go
@@ -70,3 +70,16 @@ func TestFake(t *testing.T) {
 	go sender()
 	consumer(f)
 }
+
+func TestEmpty(t *testing.T) {
+	w := NewEmptyWatch()
+	_, ok := <-w.ResultChan()
+	if ok {
+		t.Errorf("unexpected result channel result")
+	}
+	w.Stop()
+	_, ok = <-w.ResultChan()
+	if ok {
+		t.Errorf("unexpected result channel result")
+	}
+}


### PR DESCRIPTION
Watch depends on long running connections, which intervening proxies may break without the control of the remote server. Specific errors handled are io.EOF, io.EOF wrapped by *url.Error, http connection
reset errors (caused by race conditions in golang http code), and connection reset by peer (simply tolerated).
