### PR TITLE
Fix the update e2e test to remove a race.

### DIFF
--- a/hack/e2e-suite/update.sh
+++ b/hack/e2e-suite/update.sh
@@ -44,6 +44,10 @@ function validate() {
 
     local id
     num_running=0
+    if [[ ${#pod_id_list[@]} -ne $num_replicas ]]; then
+      echo "Too few or too many replicas."
+      continue
+    fi
     for id in "${pod_id_list[@]+${pod_id_list[@]}}"; do
       local template_string current_status current_image host_ip
 
@@ -78,7 +82,7 @@ function validate() {
       fi
 
       template_string="{{(index .currentState.info \"${CONTROLLER_NAME}\").image}}"
-      current_image=$($KUBECFG -template="${template_string}" get "pods/$id")
+      current_image=$($KUBECFG -template="${template_string}" get "pods/$id") || true
       if [[ "$current_image" != "${DOCKER_HUB_USER}/update-demo:${container_image_version}" ]]; then
         echo "  ${id} is created but running wrong image"
         continue


### PR DESCRIPTION
See #2361 

The problem occurs when we scale down, and the pod doesn't get deleted quick enough, and then disappears underneath us while we're trying to introspect it.

Solved in two ways:
- Make a failed get not fail the test
- Explicitly look for a match to the expected number of replicas.
