### PR TITLE
Understand OOMKilled reason from 'docker inspect'

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -403,10 +403,18 @@ func inspectContainer(client DockerInterface, dockerID, containerName, tPath str
 		}
 		waiting = false
 	} else if !inspectResult.State.FinishedAt.IsZero() {
-		// TODO(dchen1107): Integrate with event to provide a better reason
+		reason := ""
+		// Note: An application might handle OOMKilled gracefully.
+		// In that case, the container is oom killed, but the exit
+		// code could be 0.
+		if inspectResult.State.OOMKilled {
+			reason = "OOM Killed"
+		} else {
+			reason = inspectResult.State.Error
+		}
 		containerStatus.State.Termination = &api.ContainerStateTerminated{
 			ExitCode:   inspectResult.State.ExitCode,
-			Reason:     "",
+			Reason:     reason,
 			StartedAt:  util.NewTime(inspectResult.State.StartedAt),
 			FinishedAt: util.NewTime(inspectResult.State.FinishedAt),
 		}


### PR DESCRIPTION
All dependencies are resolved, and here are the code to pick up OOMKilled and Error information from docker 1.4. 

closed  #2834

cc/ @vishh 

I created a container for oom_test, here is the related status from kubelet:

```
        "oom-test": {
            "state": {
                "termination": {
                    "exitCode": 137,
                    "reason": "OOM Killed",
                    "startedAt": "2014-12-18T23:22:25Z",
                    "finishedAt": "2014-12-18T23:22:26Z"
                }
            },
```
