### PR TITLE
Setting apiVersion in restful.WebService

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -189,6 +189,7 @@ func (g *APIGroupVersion) InstallREST(container *restful.Container, root string,
 	ws.Produces(restful.MIME_JSON)
 	// TODO: require json on input
 	//ws.Consumes(restful.MIME_JSON)
+	ws.ApiVersion(version)
 
 	// TODO: add scheme to APIGroupVersion rather than using api.Scheme
 


### PR DESCRIPTION
Setting apiVersion in restful.WebService so that the correct api version is returned by /swaggerapi/api/{apiVersion}
