### PR TITLE
Add a PodUnknown phase and make ListPods return even when there are errors

### DIFF
--- a/pkg/api/latest/latest_test.go
+++ b/pkg/api/latest/latest_test.go
@@ -65,7 +65,7 @@ var apiObjectFuzzer = fuzz.New().NilChance(.5).NumElements(1, 1).Funcs(
 		j.FieldPath = c.RandString()
 	},
 	func(j *internal.PodPhase, c fuzz.Continue) {
-		statuses := []internal.PodPhase{internal.PodPending, internal.PodRunning, internal.PodFailed}
+		statuses := []internal.PodPhase{internal.PodPending, internal.PodRunning, internal.PodFailed, internal.PodUnknown}
 		*j = statuses[c.Rand.Intn(len(statuses))]
 	},
 	func(j *internal.ReplicationControllerSpec, c fuzz.Continue) {

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -69,7 +69,7 @@ var apiObjectFuzzer = fuzz.New().NilChance(.5).NumElements(1, 1).Funcs(
 		j.SelfLink = c.RandString()
 	},
 	func(j *api.PodPhase, c fuzz.Continue) {
-		statuses := []api.PodPhase{api.PodPending, api.PodRunning, api.PodFailed}
+		statuses := []api.PodPhase{api.PodPending, api.PodRunning, api.PodFailed, api.PodUnknown}
 		*j = statuses[c.Rand.Intn(len(statuses))]
 	},
 	func(j *api.ReplicationControllerSpec, c fuzz.Continue) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -365,6 +365,9 @@ const (
 	// PodFailed means that all containers in the pod have terminated, and at least one container has
 	// terminated in a failure (exited with a non-zero exit code or was stopped by the system).
 	PodFailed PodPhase = "Failed"
+	// PodUnknown means that for some reason the state of the pod could not be obtained, typically due
+	// to an error in communicating with the host of the pod.
+	PodUnknown PodPhase = "Unknown"
 )
 
 type ContainerStateWaiting struct {

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -226,6 +226,8 @@ func init() {
 				*out = PodTerminated
 			case newer.PodFailed:
 				*out = PodTerminated
+			case newer.PodUnknown:
+				*out = PodUnknown
 			default:
 				return errors.New("The string provided is not a valid PodPhase constant value")
 			}
@@ -244,6 +246,8 @@ func init() {
 			case PodTerminated:
 				// Older API versions did not contain enough info to map to PodSucceeded
 				*out = newer.PodFailed
+			case PodUnknown:
+				*out = newer.PodUnknown
 			default:
 				return errors.New("The string provided is not a valid PodPhase constant value")
 			}

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -319,6 +319,8 @@ const (
 	PodRunning PodStatus = "Running"
 	// PodTerminated means that the pod has stopped.
 	PodTerminated PodStatus = "Terminated"
+	// PodUnknown means that we failed to obtain info about the pod.
+	PodUnknown PodStatus = "Unknown"
 )
 
 type ContainerStateWaiting struct {

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -116,6 +116,8 @@ func init() {
 				*out = PodTerminated
 			case newer.PodFailed:
 				*out = PodTerminated
+			case newer.PodUnknown:
+				*out = PodUnknown
 			default:
 				return errors.New("The string provided is not a valid PodPhase constant value")
 			}
@@ -134,6 +136,8 @@ func init() {
 			case PodTerminated:
 				// Older API versions did not contain enough info to map to PodSucceeded
 				*out = newer.PodFailed
+			case PodUnknown:
+				*out = newer.PodUnknown
 			default:
 				return errors.New("The string provided is not a valid PodPhase constant value")
 			}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -284,6 +284,8 @@ const (
 	PodRunning PodStatus = "Running"
 	// PodTerminated means that the pod has stopped.
 	PodTerminated PodStatus = "Terminated"
+	// PodUnknown means that we failed to obtain info about the pod.
+	PodUnknown PodStatus = "Unknown"
 )
 
 type ContainerStateWaiting struct {

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -381,6 +381,9 @@ const (
 	// PodFailed means that all containers in the pod have terminated, and at least one container has
 	// terminated in a failure (exited with a non-zero exit code or was stopped by the system).
 	PodFailed PodPhase = "Failed"
+	// PodUnknown means that for some reason the state of the pod could not be obtained, typically due
+	// to an error in communicating with the host of the pod.
+	PodUnknown PodPhase = "Unknown"
 )
 
 type ContainerStateWaiting struct {

--- a/pkg/api/validation/schema_test.go
+++ b/pkg/api/validation/schema_test.go
@@ -71,7 +71,7 @@ var apiObjectFuzzer = fuzz.New().NilChance(.5).NumElements(1, 1).Funcs(
 		j.SelfLink = c.RandString()
 	},
 	func(j *api.PodPhase, c fuzz.Continue) {
-		statuses := []api.PodPhase{api.PodPending, api.PodRunning, api.PodFailed}
+		statuses := []api.PodPhase{api.PodPending, api.PodRunning, api.PodFailed, api.PodUnknown}
 		*j = statuses[c.Rand.Intn(len(statuses))]
 	},
 	func(j *api.ReplicationControllerSpec, c fuzz.Continue) {

--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -171,7 +171,7 @@ func (rs *REST) List(ctx api.Context, label, field labels.Selector) (runtime.Obj
 			rs.fillPodInfo(pod)
 			status, err := getPodStatus(pod, rs.nodes)
 			if err != nil {
-				return pod, err
+				status = api.PodUnknown
 			}
 			pod.Status.Phase = status
 			if pod.Status.Host != "" {
@@ -285,8 +285,8 @@ func getPodStatus(pod *api.Pod, nodes client.NodeInterface) (api.PodPhase, error
 			if errors.IsNotFound(err) {
 				return api.PodFailed, nil
 			}
-			glog.Errorf("Error listing minions: %v", err)
-			return "", err
+			glog.Errorf("Error getting pod info: %v", err)
+			return api.PodUnknown, nil
 		}
 	} else {
 		glog.Errorf("Unexpected missing minion interface, status may be in-accurate")


### PR DESCRIPTION
When obtaining info for some pods.

Partially addresses issues raised in #2487 
