### PR TITLE
Do not use namespace in url paths pre v1beta3 from client

### DIFF
--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -96,16 +96,16 @@ type FakeRESTClient struct {
 }
 
 func (c *FakeRESTClient) Get() *Request {
-	return NewRequest(c, "GET", &url.URL{Host: "localhost"}, c.Codec)
+	return NewRequest(c, "GET", &url.URL{Host: "localhost"}, c.Codec, true)
 }
 func (c *FakeRESTClient) Put() *Request {
-	return NewRequest(c, "PUT", &url.URL{Host: "localhost"}, c.Codec)
+	return NewRequest(c, "PUT", &url.URL{Host: "localhost"}, c.Codec, true)
 }
 func (c *FakeRESTClient) Post() *Request {
-	return NewRequest(c, "POST", &url.URL{Host: "localhost"}, c.Codec)
+	return NewRequest(c, "POST", &url.URL{Host: "localhost"}, c.Codec, true)
 }
 func (c *FakeRESTClient) Delete() *Request {
-	return NewRequest(c, "DELETE", &url.URL{Host: "localhost"}, c.Codec)
+	return NewRequest(c, "DELETE", &url.URL{Host: "localhost"}, c.Codec, true)
 }
 func (c *FakeRESTClient) Do(req *http.Request) (*http.Response, error) {
 	c.Req = req

--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -117,7 +117,7 @@ func RESTClientFor(config *Config) (*RESTClient, error) {
 		return nil, err
 	}
 
-	client := NewRESTClient(baseURL, versionInterfaces.Codec)
+	client := NewRESTClient(baseURL, versionInterfaces.Codec, NamespaceInPathFor(version))
 
 	transport, err := TransportFor(config)
 	if err != nil {
@@ -251,4 +251,10 @@ func defaultVersionFor(config *Config) string {
 		version = latest.Version
 	}
 	return version
+}
+
+// namespaceInPathFor is used to control what api version should use namespace in url paths
+func NamespaceInPathFor(version string) bool {
+	// we use query param for v1beta1/v1beta2, v1beta3+ will use path param
+	return (version != "v1beta1" && version != "v1beta2")
 }

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -96,20 +96,23 @@ type Request struct {
 	sync     bool
 	timeout  time.Duration
 
+	// flag to control how to use namespace in urls
+	namespaceAsPath bool
+
 	// output
 	err  error
 	body io.Reader
 }
 
 // NewRequest creates a new request with the core attributes.
-func NewRequest(client HTTPClient, verb string, baseURL *url.URL, codec runtime.Codec) *Request {
+func NewRequest(client HTTPClient, verb string, baseURL *url.URL, codec runtime.Codec, namespaceAsPath bool) *Request {
 	return &Request{
-		client:  client,
-		verb:    verb,
-		baseURL: baseURL,
-		codec:   codec,
-
-		path: baseURL.Path,
+		client:          client,
+		verb:            verb,
+		baseURL:         baseURL,
+		codec:           codec,
+		namespaceAsPath: namespaceAsPath,
+		path:            baseURL.Path,
 	}
 }
 
@@ -136,8 +139,14 @@ func (r *Request) Namespace(namespace string) *Request {
 	if r.err != nil {
 		return r
 	}
+
 	if len(namespace) > 0 {
-		return r.Path("ns").Path(namespace)
+		if r.namespaceAsPath {
+			return r.Path("ns").Path(namespace)
+		} else {
+			return r.setParam("namespace", namespace)
+		}
+
 	}
 	return r
 }

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -137,7 +137,7 @@ func TestTransformResponse(t *testing.T) {
 		{Response: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewReader(invalid))}, Data: invalid},
 	}
 	for i, test := range testCases {
-		r := NewRequest(nil, "", uri, testapi.Codec())
+		r := NewRequest(nil, "", uri, testapi.Codec(), true)
 		if test.Response.Body == nil {
 			test.Response.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
 		}

--- a/pkg/client/restclient.go
+++ b/pkg/client/restclient.go
@@ -36,6 +36,10 @@ import (
 type RESTClient struct {
 	baseURL *url.URL
 
+	// namespaceInPath controls if URLs should encode the namespace as path param instead of query param
+	// needed for backward compatibility
+	namespaceInPath bool
+
 	// Codec is the encoding and decoding scheme that applies to a particular set of
 	// REST resources.
 	Codec runtime.Codec
@@ -56,7 +60,7 @@ type RESTClient struct {
 // NewRESTClient creates a new RESTClient. This client performs generic REST functions
 // such as Get, Put, Post, and Delete on specified paths.  Codec controls encoding and
 // decoding of responses from the server.
-func NewRESTClient(baseURL *url.URL, c runtime.Codec) *RESTClient {
+func NewRESTClient(baseURL *url.URL, c runtime.Codec, namespaceInPath bool) *RESTClient {
 	base := *baseURL
 	if !strings.HasSuffix(base.Path, "/") {
 		base.Path += "/"
@@ -67,6 +71,8 @@ func NewRESTClient(baseURL *url.URL, c runtime.Codec) *RESTClient {
 	return &RESTClient{
 		baseURL: &base,
 		Codec:   c,
+
+		namespaceInPath: namespaceInPath,
 
 		// Make asynchronous requests by default
 		Sync: false,
@@ -98,7 +104,7 @@ func (c *RESTClient) Verb(verb string) *Request {
 	if poller == nil {
 		poller = c.DefaultPoll
 	}
-	return NewRequest(c.Client, verb, c.baseURL, c.Codec).Poller(poller).Sync(c.Sync).Timeout(c.Timeout)
+	return NewRequest(c.Client, verb, c.baseURL, c.Codec, c.namespaceInPath).Poller(poller).Sync(c.Sync).Timeout(c.Timeout)
 }
 
 // Post begins a POST request. Short for c.Verb("POST").

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -48,7 +48,7 @@ func getFakeClient(t *testing.T, validURLs []string) (ClientPosterFunc, *httptes
 	return func(mapping *meta.RESTMapping) (RESTClientPoster, error) {
 		fakeCodec := runtime.CodecFor(api.Scheme, "v1beta1")
 		fakeUri, _ := url.Parse(server.URL + "/api/v1beta1")
-		return client.NewRESTClient(fakeUri, fakeCodec), nil
+		return client.NewRESTClient(fakeUri, fakeCodec, false), nil
 	}, server
 }
 

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -37,6 +37,13 @@ import (
 	"github.com/coreos/go-etcd/etcd"
 )
 
+func makeNamespaceURL(namespace, suffix string) string {
+	if client.NamespaceInPathFor(testapi.Version()) {
+		return makeURL("/ns/" + namespace + suffix)
+	}
+	return makeURL(suffix + "?namespace=" + namespace)
+}
+
 func makeURL(suffix string) string {
 	return path.Join("/api", testapi.Version(), suffix)
 }
@@ -221,7 +228,7 @@ func TestCreateReplica(t *testing.T) {
 		},
 		Spec: controllerSpec.Spec.Template.Spec,
 	}
-	fakeHandler.ValidateRequest(t, makeURL("/ns/default/pods"), "POST", nil)
+	fakeHandler.ValidateRequest(t, makeNamespaceURL("default", "/pods"), "POST", nil)
 	actualPod, err := client.Codec.Decode([]byte(fakeHandler.RequestBody))
 	if err != nil {
 		t.Errorf("Unexpected error: %#v", err)

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -204,7 +204,7 @@ func (factory *ConfigFactory) pollMinions() (cache.Enumerator, error) {
 
 func (factory *ConfigFactory) makeDefaultErrorFunc(backoff *podBackoff, podQueue *cache.FIFO) func(pod *api.Pod, err error) {
 	return func(pod *api.Pod, err error) {
-		glog.Errorf("Error scheduling %v: %v; retrying", pod.Name, err)
+		glog.Errorf("Error scheduling %v %v: %v; retrying", pod.Namespace, pod.Name, err)
 		backoff.gc()
 		// Retry asynchronously.
 		// Note that this is extremely rudimentary and we need a more real error handling path.


### PR DESCRIPTION
Fixes #3062 

The major change here is to just get the test cases now smart enough to know what type of url to look for based on the testapi.Version() so things will work when we run testapi.Version == v1beta3 like they used to.

FYI @lavalamp @smarterclayton 
