### PR TITLE
Replace kubecfg with kubectl in setup scripts

### DIFF
--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -140,7 +140,7 @@ function verify-cluster {
     local count="0"
     until [[ "$count" == "1" ]]; do
       local minions
-      minions=$("${KUBE_ROOT}/cluster/kubecfg.sh" -template '{{range.items}}{{.id}}:{{end}}' list minions)
+      minions=$("${KUBE_ROOT}/cluster/kubectl.sh" get minions -o template -t '{{range.items}}{{.id}}:{{end}}')
       count=$(echo $minions | grep -c "${MINION_IPS[i]}") || {
         printf "."
         sleep 2

--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -35,7 +35,7 @@ detect-minions > /dev/null
 MINIONS_FILE=/tmp/minions
 attempt=0
 while true; do
-  "${KUBE_ROOT}/cluster/kubecfg.sh" -template $'{{range.items}}{{.id}}\n{{end}}' list minions > "${MINIONS_FILE}"
+  "${KUBE_ROOT}/cluster/kubectl.sh" get minions -o template -t $'{{range.items}}{{.id}}\n{{end}}' > "${MINIONS_FILE}"
   found=$(grep -c . "${MINIONS_FILE}")
   if [[ ${found} == "${NUM_MINIONS}" ]]; then
     break


### PR DESCRIPTION
Replaces two instances of kubecfg with kubectl in cluster startup and
validation scripts.

This is one small step on the road to #2144.
