### PR TITLE
Fix the conversion routine for PodStatus to PodPhase 

### DIFF
--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -225,7 +225,7 @@ func init() {
 			case newer.PodRunning:
 				*out = PodRunning
 			case newer.PodSucceeded:
-				*out = PodTerminated
+				*out = PodSucceeded
 			case newer.PodFailed:
 				*out = PodTerminated
 			case newer.PodUnknown:
@@ -248,6 +248,8 @@ func init() {
 			case PodTerminated:
 				// Older API versions did not contain enough info to map to PodSucceeded
 				*out = newer.PodFailed
+			case PodSucceeded:
+				*out = newer.PodSucceeded
 			case PodUnknown:
 				*out = newer.PodUnknown
 			default:

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -317,10 +317,12 @@ const (
 	PodWaiting PodStatus = "Waiting"
 	// PodRunning means that the pod is up and running.
 	PodRunning PodStatus = "Running"
-	// PodTerminated means that the pod has stopped.
+	// PodTerminated means that the pod has stopped with error(s)
 	PodTerminated PodStatus = "Terminated"
 	// PodUnknown means that we failed to obtain info about the pod.
 	PodUnknown PodStatus = "Unknown"
+	// PodSucceeded means that the pod has stopped without error(s)
+	PodSucceeded PodStatus = "Succeeded"
 )
 
 type ContainerStateWaiting struct {

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -113,7 +113,7 @@ func init() {
 			case newer.PodRunning:
 				*out = PodRunning
 			case newer.PodSucceeded:
-				*out = PodTerminated
+				*out = PodSucceeded
 			case newer.PodFailed:
 				*out = PodTerminated
 			case newer.PodUnknown:
@@ -136,6 +136,8 @@ func init() {
 			case PodTerminated:
 				// Older API versions did not contain enough info to map to PodSucceeded
 				*out = newer.PodFailed
+			case PodSucceeded:
+				*out = newer.PodSucceeded
 			case PodUnknown:
 				*out = newer.PodUnknown
 			default:

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -286,6 +286,8 @@ const (
 	PodTerminated PodStatus = "Terminated"
 	// PodUnknown means that we failed to obtain info about the pod.
 	PodUnknown PodStatus = "Unknown"
+	// PodSucceeded means that the pod has stopped without error(s)
+	PodSucceeded PodStatus = "Succeeded"
 )
 
 type ContainerStateWaiting struct {


### PR DESCRIPTION
Fixed #2632

I verified this through a running cluster. Without this PR:

$ cluster/kubectl.sh  get  pods
POD                                    CONTAINER(S)        IMAGE(S)                                 HOST                                                               LABELS                                       STATUS
php1                                   nginx1              dockerfile/nginx                         kubernetes-minion-2.c.golden-system-455.internal/130.211.154.13    name=nginx1                                  Failed
...

With this PR:

$ cluster/kubectl.sh  get  pods
POD                                    CONTAINER(S)        IMAGE(S)                                 HOST                                                               LABELS                                       STATUS
php1                                   nginx1              dockerfile/nginx                         kubernetes-minion-2.c.golden-system-455.internal/130.211.154.13    name=nginx1                                  Succeeded

Pod php1 has RestartNever as its policy. 
