### PR TITLE
Fix kube-controller-manager failing to start because "Jinja variable 'cloud_config' is undefined"

### DIFF
--- a/cluster/saltbase/salt/kube-controller-manager/default
+++ b/cluster/saltbase/salt/kube-controller-manager/default
@@ -1,3 +1,4 @@
+{% set cloud_config = "" -%}
 {% set daemon_args = "$DAEMON_ARGS" -%}
 {% if grains['os_family'] == 'RedHat' -%}
 	{% set daemon_args = "" -%}


### PR DESCRIPTION
Fixes the following issue with deployment (which looks like it was introduced by #3068):

```
----------
          ID: /etc/default/kube-controller-manager
    Function: file.managed
      Result: False
     Comment: Unable to manage file: Jinja variable 'cloud_config' is undefined; line 49

              ---
              [...]
                {% set machines = "-machines=$(echo ${MACHINE_IPS[@]} | xargs -n1 echo | paste -sd,)" -%}
                {% set minion_regexp = "" -%}
              {% endif -%}
              {% endif -%}

              DAEMON_ARGS="{{daemon_args}} {{master}} {{machines}} {{ minion_regexp }} {{ cloud_provider }} {{ cloud_config }} {{pillar['log_level']}}"    <======================
              ---
     Changes:   
```

```
     ----------
               ID: kube-controller-manager
         Function: service.running
           Result: False
          Comment: One or more requisite failed
          Changes:   
```
