### PR TITLE
Fix broken flaky-tests.md documentation link

### DIFF
--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -194,7 +194,7 @@ go run e2e.go -ctl='delete pod foobar'
 ```
 
 ## Testing out flaky tests
-[Instructions here](docs/devel/flaky-tests.md)
+[Instructions here](flaky-tests.md)
 
 ## Add/Update dependencies
 


### PR DESCRIPTION
The link ended up pointing at ./docs/devel/docs/devel/flaky-tests.md instead of .docs/devel/flaky-tests.md
