### PR TITLE
Namespace scope events in storage

### DIFF
--- a/pkg/registry/event/registry.go
+++ b/pkg/registry/event/registry.go
@@ -17,8 +17,6 @@ limitations under the License.
 package event
 
 import (
-	"path"
-
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	etcderr "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors/etcd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
@@ -52,11 +50,10 @@ func NewEtcdRegistry(h tools.EtcdHelper, ttl uint64) generic.Registry {
 			NewListFunc:  func() runtime.Object { return &api.EventList{} },
 			EndpointName: "events",
 			KeyRootFunc: func(ctx api.Context) string {
-				return "/registry/events"
+				return etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/events")
 			},
 			KeyFunc: func(ctx api.Context, id string) (string, error) {
-				// TODO - we need to store this in a namespace relative path
-				return path.Join("/registry/events", id), nil
+				return etcdgeneric.NamespaceKeyFunc(ctx, "/registry/events", id)
 			},
 			Helper: h,
 		},


### PR DESCRIPTION
Due to a bug, all events in etcd were going into the same etcd directory.

This change will scope events properly to a namespace like all other objects.

If you update a Kubernetes cluster that had populated events, this change will make the events no longer appear to the end-user.  Given that events had a TTL of 2 days by default, I am not sure how big of a deal that is to preserve the data versus state on the upgrade that cluster users will expire existing events.

@lavalamp - this is the fix per our previous discussion
