### PR TITLE
Update cadvisor manifest to bind mount "/sys" from global namespace.

### DIFF
--- a/cluster/saltbase/salt/cadvisor/cadvisor.manifest
+++ b/cluster/saltbase/salt/cadvisor/cadvisor.manifest
@@ -14,8 +14,8 @@ containers:
       - name: varlibdocker
         mountPath: /var/lib/docker
         readOnly: true
-      - name: cgroups
-        mountPath: /sys/fs/cgroup
+      - name: sysfs
+        mountPath: /sys
         readOnly: true
 volumes:
   - name: varrun


### PR DESCRIPTION
This is necessary for many of the new features that cadvisor supports.

cc: @rjnagal 
