### PR TITLE
Set oom_score_adj for kubelet and kube-proxy to a low value

### DIFF
--- a/cmd/kube-proxy/proxy.go
+++ b/cmd/kube-proxy/proxy.go
@@ -42,6 +42,7 @@ var (
 	bindAddress    = util.IP(net.ParseIP("0.0.0.0"))
 	clientConfig   = &client.Config{}
 	healthz_port   = flag.Int("healthz_port", 10249, "The port to bind the health check server. Use 0 to disable.")
+	oomScoreAdj    = flag.Int("oom_score_adj", -899, "The oom_score_adj value for kube-proxy process. Values must be within the range [-1000, 1000]")
 )
 
 func init() {
@@ -54,6 +55,10 @@ func main() {
 	flag.Parse()
 	util.InitLogs()
 	defer util.FlushLogs()
+
+	if err := util.ApplyOomScoreAdj(*oomScoreAdj); err != nil {
+		glog.Info(err)
+	}
 
 	verflag.PrintAndExitIfRequested()
 

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -61,6 +61,7 @@ var (
 	maxContainerCount       = flag.Int("maximum_dead_containers_per_container", 5, "Maximum number of old instances of a container to retain per container.  Each container takes up some disk space.  Default: 5.")
 	authPath                = flag.String("auth_path", "", "Path to .kubernetes_auth file, specifying how to authenticate to API server.")
 	cAdvisorPort            = flag.Uint("cadvisor_port", 4194, "The port of the localhost cAdvisor endpoint")
+	oomScoreAdj             = flag.Int("oom_score_adj", -900, "The oom_score_adj value for kubelet process. Values must be within the range [-1000, 1000]")
 	apiServerList           util.StringList
 )
 
@@ -91,6 +92,10 @@ func main() {
 	verflag.PrintAndExitIfRequested()
 
 	setupRunOnce()
+
+	if err := util.ApplyOomScoreAdj(*oomScoreAdj); err != nil {
+		glog.Info(err)
+	}
 
 	kcfg := standalone.KubeletConfig{
 		Address:                 address,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -19,8 +19,10 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"regexp"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/golang/glog"
@@ -133,4 +135,17 @@ func CompileRegexps(regexpStrings []string) ([]*regexp.Regexp, error) {
 		regexps = append(regexps, r)
 	}
 	return regexps, nil
+}
+
+// Writes 'value' to /proc/self/oom_score_adj.
+func ApplyOomScoreAdj(value int) error {
+	if value < -1000 || value > 1000 {
+		return fmt.Errorf("invalid value(%d) specified for oom_score_adj. Values must be within the range [-1000, 1000]")
+	}
+
+	if err := ioutil.WriteFile("/proc/self/oom_score_adj", []byte(strconv.Itoa(value)), 0700); err != nil {
+		fmt.Errorf("failed to set oom_score_adj to %s - %q", value, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This helps kubelet and kube-proxy survive OOM kills.

First stage of fixing #2852 
