### PR TITLE
Have Http Liveness Probe report "Unhealthy" on connection failure instead of "Unknown"

### DIFF
--- a/pkg/client/kubelet_test.go
+++ b/pkg/client/kubelet_test.go
@@ -131,10 +131,10 @@ func TestNewKubeletClient(t *testing.T) {
 
 	host := "127.0.0.1"
 	healthStatus, err := client.HealthCheck(host)
-	if healthStatus != health.Unknown {
-		t.Errorf("Expected %v and got %v.", health.Unknown, healthStatus)
+	if healthStatus != health.Unhealthy {
+		t.Errorf("Expected %v and got %v.", health.Unhealthy, healthStatus)
 	}
-	if err == nil {
-		t.Error("Expected a non nil error")
+	if err != nil {
+		t.Error("Expected a nil error")
 	}
 }

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -36,7 +36,7 @@ func TestHealthChecker(t *testing.T) {
 		health Status
 	}{
 		{http.StatusOK, Healthy},
-		{statusServerEarlyShutdown, Unknown},
+		{statusServerEarlyShutdown, Unhealthy},
 		{http.StatusBadRequest, Unhealthy},
 		{http.StatusBadGateway, Unhealthy},
 		{http.StatusInternalServerError, Unhealthy},
@@ -69,7 +69,7 @@ func TestHealthChecker(t *testing.T) {
 		}
 		hc := NewHealthChecker()
 		health, err := hc.HealthCheck("test", "", api.PodStatus{}, container)
-		if err != nil && tt.health != Unknown {
+		if err != nil && tt.health != Unhealthy {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if health != tt.health {

--- a/pkg/health/http.go
+++ b/pkg/health/http.go
@@ -88,13 +88,13 @@ func formatURL(host string, port int, path string) string {
 
 // DoHTTPCheck checks if a GET request to the url succeeds.
 // If the HTTP response code is successful (i.e. 400 > code >= 200), it returns Healthy.
-// If the HTTP response code is unsuccessful, it returns Unhealthy.
-// It returns Unknown and err if the HTTP communication itself fails.
+// If the HTTP response code is unsuccessful or HTTP communication fails, it returns Unhealthy.
 // This is exported because some other packages may want to do direct HTTP checks.
 func DoHTTPCheck(url string, client HTTPGetInterface) (Status, error) {
 	res, err := client.Get(url)
 	if err != nil {
-		return Unknown, err
+		glog.V(1).Infof("HTTP probe error: %v", err)
+		return Unhealthy, nil
 	}
 	defer res.Body.Close()
 	if res.StatusCode >= http.StatusOK && res.StatusCode < http.StatusBadRequest {


### PR DESCRIPTION
Based on #3041: modfiy HTTP liveness probe so when it fails due to connection issues, it will return an "Unhealthy" status instead of an "Unknown" status thus forcing kubelet to restart the container.
The reasoning behind this change is that if Kubelet can't establish a connection to the container service, considering they're on the same host,  it is fair to assume that the container is in an unhealthy state, and should be restarted.
