### PR TITLE
"kind" is needed to start the pod

### DIFF
--- a/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -128,6 +128,8 @@ done
 
 ```
 kubectl get minions
+NAME                LABELS
+fed-minion          <none>
 ```
 
 **The cluster should be running! Launch a test pod.**

--- a/examples/walkthrough/README.md
+++ b/examples/walkthrough/README.md
@@ -11,6 +11,7 @@ Trivially, a single container might be a pod.  For example, you can express a si
 
 ```yaml
 apiVersion: v1beta1
+kind: Pod
 id: www
 desiredState:
   manifest:
@@ -31,6 +32,7 @@ Now that's great for a static web server, but what about persistent storage?  We
 
 ```yaml
 apiVersion: v1beta1
+kind: Pod
 id: storage
 desiredState:
   manifest:
@@ -88,6 +90,7 @@ However, often you want to have two different containers that work together.  An
 
 ```yaml
 apiVersion: v1beta1
+kind: Pod
 id: www
 desiredState:
   manifest:


### PR DESCRIPTION
fix for the following error:
the provided version "v1beta1" and kind "" cannot be mapped to a supported object
