### PR TITLE
Modify "kubectl get events" to print FieldPath so BoundPod events for the same pod but different containers can be differentiated

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -975,10 +975,11 @@ type ObjectReference struct {
 	ResourceVersion string `json:"resourceVersion,omitempty"`
 
 	// Optional. If referring to a piece of an object instead of an entire object, this string
-	// should contain a valid field access statement. For example,
-	// if the object reference is to a container within a pod, this would take on a value like:
-	// "desiredState.manifest.containers[2]". Such statements are valid language constructs in
-	// both go and JavaScript. This is syntax is chosen only to have some well-defined way of
+	// should contain information to identify the sub-object. For example, if the object
+	// reference is to a container within a pod, this would take on a value like:
+	// "spec.containers{name}" (where "name" refers to the name of the container that triggered
+	// the event) or if no container name is specified "spec.containers[2]" (container with
+	// index 2 in this pod). This syntax is chosen only to have some well-defined way of
 	// referencing a part of an object.
 	// TODO: this design is not final and this field is subject to change in the future.
 	FieldPath string `json:"fieldPath,omitempty"`

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -777,10 +777,11 @@ type ObjectReference struct {
 	ResourceVersion string `json:"resourceVersion,omitempty" description:"specific resourceVersion to which this reference is made, if any"`
 
 	// Optional. If referring to a piece of an object instead of an entire object, this string
-	// should contain a valid field access statement. For example,
-	// if the object reference is to a container within a pod, this would take on a value like:
-	// "desiredState.manifest.containers[2]". Such statements are valid language constructs in
-	// both go and JavaScript. This is syntax is chosen only to have some well-defined way of
+	// should contain information to identify the sub-object. For example, if the object
+	// reference is to a container within a pod, this would take on a value like:
+	// "spec.containers{name}" (where "name" refers to the name of the container that triggered
+	// the event) or if no container name is specified "spec.containers[2]" (container with
+	// index 2 in this pod). This syntax is chosen only to have some well-defined way of
 	// referencing a part of an object.
 	// TODO: this design is not final and this field is subject to change in the future.
 	FieldPath string `json:"fieldPath,omitempty" description:"if referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]"`

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -750,10 +750,11 @@ type ObjectReference struct {
 	ResourceVersion string `json:"resourceVersion,omitempty" description:"specific resourceVersion to which this reference is made, if any"`
 
 	// Optional. If referring to a piece of an object instead of an entire object, this string
-	// should contain a valid field access statement. For example,
-	// if the object reference is to a container within a pod, this would take on a value like:
-	// "desiredState.manifest.containers[2]". Such statements are valid language constructs in
-	// both go and JavaScript. This is syntax is chosen only to have some well-defined way of
+	// should contain information to identify the sub-object. For example, if the object
+	// reference is to a container within a pod, this would take on a value like:
+	// "spec.containers{name}" (where "name" refers to the name of the container that triggered
+	// the event) or if no container name is specified "spec.containers[2]" (container with
+	// index 2 in this pod). This syntax is chosen only to have some well-defined way of
 	// referencing a part of an object.
 	// TODO: this design is not final and this field is subject to change in the future.
 	FieldPath string `json:"fieldPath,omitempty" description:"if referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]"`

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -993,10 +993,11 @@ type ObjectReference struct {
 	ResourceVersion string `json:"resourceVersion,omitempty"`
 
 	// Optional. If referring to a piece of an object instead of an entire object, this string
-	// should contain a valid field access statement. For example,
-	// if the object reference is to a container within a pod, this would take on a value like:
-	// "spec.containers[2]". Such statements are valid language constructs in
-	// both go and JavaScript. This is syntax is chosen only to have some well-defined way of
+	// should contain information to identify the sub-object. For example, if the object
+	// reference is to a container within a pod, this would take on a value like:
+	// "spec.containers{name}" (where "name" refers to the name of the container that triggered
+	// the event) or if no container name is specified "spec.containers[2]" (container with
+	// index 2 in this pod). This syntax is chosen only to have some well-defined way of
 	// referencing a part of an object.
 	// TODO: this design is not final and this field is subject to change in the future.
 	FieldPath string `json:"fieldPath,omitempty"`

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -193,7 +193,7 @@ var replicationControllerColumns = []string{"CONTROLLER", "CONTAINER(S)", "IMAGE
 var serviceColumns = []string{"NAME", "LABELS", "SELECTOR", "IP", "PORT"}
 var minionColumns = []string{"NAME", "LABELS"}
 var statusColumns = []string{"STATUS"}
-var eventColumns = []string{"TIME", "NAME", "KIND", "CONDITION", "REASON", "MESSAGE"}
+var eventColumns = []string{"TIME", "NAME", "KIND", "SUBOBJECT", "CONDITION", "REASON", "MESSAGE"}
 
 // addDefaultHandlers adds print handlers for default Kubernetes types.
 func (h *HumanReadablePrinter) addDefaultHandlers() {
@@ -339,10 +339,11 @@ func printStatus(status *api.Status, w io.Writer) error {
 
 func printEvent(event *api.Event, w io.Writer) error {
 	_, err := fmt.Fprintf(
-		w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+		w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 		event.Timestamp.Time.Format(time.RFC1123Z),
 		event.InvolvedObject.Name,
 		event.InvolvedObject.Kind,
+		event.InvolvedObject.FieldPath,
 		event.Condition,
 		event.Reason,
 		event.Message,

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -463,7 +463,11 @@ func fieldPath(pod *api.BoundPod, container *api.Container) (string, error) {
 	for i := range pod.Spec.Containers {
 		here := &pod.Spec.Containers[i]
 		if here.Name == container.Name {
-			return fmt.Sprintf("spec.containers[%d]", i), nil
+			if here.Name == "" {
+				return fmt.Sprintf("spec.containers[%d]", i), nil
+			} else {
+				return fmt.Sprintf("spec.containers{%s}", here.Name), nil
+			}
 		}
 	}
 	return "", fmt.Errorf("container %#v not found in pod %#v", container, pod)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -956,6 +956,7 @@ func TestFieldPath(t *testing.T) {
 	pod := &api.BoundPod{Spec: api.PodSpec{Containers: []api.Container{
 		{Name: "foo"},
 		{Name: "bar"},
+		{Name: ""},
 		{Name: "baz"},
 	}}}
 	table := map[string]struct {
@@ -964,9 +965,10 @@ func TestFieldPath(t *testing.T) {
 		path      string
 		success   bool
 	}{
-		"basic":            {pod, &api.Container{Name: "foo"}, "spec.containers[0]", true},
-		"basic2":           {pod, &api.Container{Name: "baz"}, "spec.containers[2]", true},
-		"basicSamePointer": {pod, &pod.Spec.Containers[0], "spec.containers[0]", true},
+		"basic":            {pod, &api.Container{Name: "foo"}, "spec.containers{foo}", true},
+		"basic2":           {pod, &api.Container{Name: "baz"}, "spec.containers{baz}", true},
+		"emptyName":        {pod, &api.Container{Name: ""}, "spec.containers[2]", true},
+		"basicSamePointer": {pod, &pod.Spec.Containers[0], "spec.containers{foo}", true},
 		"missing":          {pod, &api.Container{Name: "qux"}, "", false},
 	}
 


### PR DESCRIPTION
Fixes #3164 

Before change:

```
cluster/kubectl.sh get events | grep influx
TIME                              NAME                                          KIND                CONDITION           REASON              MESSAGE
Mon, 29 Dec 2014 21:56:59 +0000   influx-grafana                                BoundPod            waiting             pulled              Successfully pulled image kubernetes/pause:latest
Mon, 29 Dec 2014 21:56:59 +0000   influx-grafana                                BoundPod            waiting             created             Created with docker id 0536c9d30742adf4a6a956660ec99b2b71dcc68a478a35aa193fdea807951762
Mon, 29 Dec 2014 21:56:59 +0000   influx-grafana                                Pod                 Pending             scheduled           Successfully assigned influx-grafana to kubernetes-minion-1.c.saad-dev-vms.internal
Mon, 29 Dec 2014 21:57:00 +0000   influx-grafana                                BoundPod            running             started             Started with docker id 0536c9d30742adf4a6a956660ec99b2b71dcc68a478a35aa193fdea807951762
Mon, 29 Dec 2014 21:58:06 +0000   influx-grafana                                BoundPod            failed              failed              Failed to pull image kubernetes/heapster_influxdb
Mon, 29 Dec 2014 21:59:10 +0000   influx-grafana                                BoundPod            failed              failed              Failed to pull image kubernetes/heapster_grafana
Mon, 29 Dec 2014 21:59:59 +0000   influx-grafana                                BoundPod            waiting             created             Created with docker id 7a1f296a6b1602f18bd5911d73b40a2b356b7a871167539f2da941254a9cc7ae
Mon, 29 Dec 2014 21:59:59 +0000   influx-grafana                                BoundPod            waiting             pulled              Successfully pulled image dockerfile/elasticsearch
Mon, 29 Dec 2014 21:59:59 +0000   influx-grafana                                BoundPod            running             started             Started with docker id 7a1f296a6b1602f18bd5911d73b40a2b356b7a871167539f2da941254a9cc7ae
Mon, 29 Dec 2014 22:00:50 +0000   influx-grafana                                BoundPod            running             started             Started with docker id 49a3b1b6918af2233db7049d70362af4db9a1a3ae2dea930d79ad921781dc690
Mon, 29 Dec 2014 22:00:50 +0000   influx-grafana                                BoundPod            waiting             created             Created with docker id 49a3b1b6918af2233db7049d70362af4db9a1a3ae2dea930d79ad921781dc690
Mon, 29 Dec 2014 22:00:50 +0000   influx-grafana                                BoundPod            waiting             pulled              Successfully pulled image kubernetes/heapster_influxdb
```

`influx-grafana` `started` and `failed`. Not clear what's happening.

After change:

```
cluster/kubectl.sh get events | grep influx
TIME                              NAME                                          KIND                SUBOBJECT                           CONDITION           REASON              MESSAGE
Tue, 30 Dec 2014 00:54:48 +0000   influx-grafana                                BoundPod            implicitly required container net   waiting             pulled              Successfully pulled image kubernetes/pause:latest
Tue, 30 Dec 2014 00:54:49 +0000   influx-grafana                                BoundPod            implicitly required container net   waiting             created             Created with docker id d0cb37b498aaa6ce9408e243a6107e429335a31356d8d39823160fa8be19d98e
Tue, 30 Dec 2014 00:54:50 +0000   influx-grafana                                BoundPod            implicitly required container net   running             started             Started with docker id d0cb37b498aaa6ce9408e243a6107e429335a31356d8d39823160fa8be19d98e
Tue, 30 Dec 2014 00:54:50 +0000   influx-grafana                                Pod                                                     Pending             scheduled           Successfully assigned influx-grafana to kubernetes-minion-1.c.saad-dev-vms.internal
Tue, 30 Dec 2014 00:55:13 +0000   influx-grafana                                BoundPod            spec.containers{influxdb}           failed              failed              Failed to pull image kubernetes/heapster_influxdb
Tue, 30 Dec 2014 00:56:11 +0000   influx-grafana                                BoundPod            spec.containers{grafana}            failed              failed              Failed to pull image kubernetes/heapster_grafana
Tue, 30 Dec 2014 00:57:11 +0000   influx-grafana                                BoundPod            spec.containers{elasticsearch}      failed              failed              Failed to pull image dockerfile/elasticsearch
Tue, 30 Dec 2014 00:57:35 +0000   influx-grafana                                BoundPod            spec.containers{influxdb}           running             started             Started with docker id 32d74cdde587c699b387c4c185b53e61a66b8ba3ccd947bd165b32be4f734464
Tue, 30 Dec 2014 00:57:35 +0000   influx-grafana                                BoundPod            spec.containers{influxdb}           waiting             pulled              Successfully pulled image kubernetes/heapster_influxdb
```

`influx-grafana` containers `net` and `influxdb` `started` but containers `grafana` and `elasticsearch` `failed`. Easier to parse what's going on in the pod.

"kubectl get events" output is still pretty messy/hard to follow. I'll follow up with proposal(s) on how we can clean it up.
