### PR TITLE
WIP: Modify kube-push for GCE to bring down the existing master VM and completely replace it with a new one

### DIFF
--- a/cluster/gce/templates/mount-pd.sh
+++ b/cluster/gce/templates/mount-pd.sh
@@ -14,20 +14,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Formats and mounts a persistent disk to store the persistent data on the
-# master -- etcd's data and the security certs/keys.
+# Mounts a persistent disk (formatting if needed) to store the persistent data
+# on the master -- etcd's data, a few settings, and security certs/keys/tokens.
+#
+# This script can be reused to mount an existing PD because all of its
+# operations modifying the disk are idempotent -- safe_format_and_mount only
+# formats an unformatted disk, and mkdir -p will leave a directory be if it
+# already exists.
 
 device_info=$(ls -l /dev/disk/by-id/google-master-pd)
 relative_path=${device_info##* }
 device_path="/dev/disk/by-id/${relative_path}"
 
-# Format and mount the disk to the directory used by etcd.
+# Format and mount the disk, create directories on it for all of the master's
+# persistent data, and link them to where they're used.
 mkdir -p /mnt/master-pd
 /usr/share/google/safe_format_and_mount -m "mkfs.ext4 -F" "${device_path}" /mnt/master-pd
 mkdir -m 700 -p /mnt/master-pd/var/etcd
 mkdir -p /mnt/master-pd/srv/kubernetes
+mkdir -p /mnt/master-pd/srv/salt-overlay
 ln -s /mnt/master-pd/var/etcd /var/etcd
 ln -s /mnt/master-pd/srv/kubernetes /srv/kubernetes
+ln -s /mnt/master-pd/srv/salt-overlay /srv/salt-overlay
 
 # This is a bit of a hack to get around the fact that salt has to run after the
 # PD and mounted directory are already set up. We can't give ownership of the

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -376,6 +376,13 @@ function kube-up {
     --target-tags "${MASTER_TAG}" \
     --allow tcp:443 &
 
+  # We have to make sure the disk is created before creating the master VM, so
+  # run this in the foreground.
+  gcloud compute disks create "${MASTER_NAME}-pd" \
+    --project "${PROJECT}" \
+    --zone "${ZONE}" \
+    --size "10GB"
+
   (
     echo "#! /bin/bash"
     echo "mkdir -p /var/cache/kubernetes-install"
@@ -393,27 +400,11 @@ function kube-up {
     echo "readonly DNS_SERVER_IP='${DNS_SERVER_IP:-}'"
     echo "readonly DNS_DOMAIN='${DNS_DOMAIN:-}'"
     grep -v "^#" "${KUBE_ROOT}/cluster/gce/templates/common.sh"
-    grep -v "^#" "${KUBE_ROOT}/cluster/gce/templates/format-and-mount-pd.sh"
+    grep -v "^#" "${KUBE_ROOT}/cluster/gce/templates/mount-pd.sh"
     grep -v "^#" "${KUBE_ROOT}/cluster/gce/templates/create-dynamic-salt-files.sh"
     grep -v "^#" "${KUBE_ROOT}/cluster/gce/templates/download-release.sh"
     grep -v "^#" "${KUBE_ROOT}/cluster/gce/templates/salt-master.sh"
   ) > "${KUBE_TEMP}/master-start.sh"
-
-  # Report logging choice (if any).
-  if [[ "${ENABLE_NODE_LOGGING-}" == "true" ]]; then
-    echo "+++ Logging using Fluentd to ${LOGGING_DESTINATION:-unknown}"
-    # For logging to GCP we need to enable some minion scopes.
-    if [[ "${LOGGING_DESTINATION-}" == "gcp" ]]; then
-      MINION_SCOPES+=('https://www.googleapis.com/auth/logging.write')
-    fi
-  fi
-
-  # We have to make sure the disk is created before creating the master VM, so
-  # run this in the foreground.
-  gcloud compute disks create "${MASTER_NAME}-pd" \
-    --project "${PROJECT}" \
-    --zone "${ZONE}" \
-    --size "10GB"
 
   gcloud compute instances create "${MASTER_NAME}" \
     --project "${PROJECT}" \
@@ -429,6 +420,15 @@ function kube-up {
 
   # Create a single firewall rule for all minions.
   create-firewall-rule "${MINION_TAG}-all" "${CLUSTER_IP_RANGE}" "${MINION_TAG}" &
+
+  # Report logging choice (if any).
+  if [[ "${ENABLE_NODE_LOGGING-}" == "true" ]]; then
+    echo "+++ Logging using Fluentd to ${LOGGING_DESTINATION:-unknown}"
+    # For logging to GCP we need to enable some minion scopes.
+    if [[ "${LOGGING_DESTINATION-}" == "gcp" ]]; then
+      MINION_SCOPES+=('https://www.googleapis.com/auth/logging.write')
+    fi
+  fi
 
   # Wait for last batch of jobs.
   wait-for-jobs
@@ -478,6 +478,16 @@ function kube-up {
   wait-for-jobs
 
   detect-master
+
+  # Reserve the master's IP so that it can later be transferred to another VM
+  # without disrupting the kubelets. IPs are associated with regions, not zones,
+  # so extract the region name, which is the same as the zone but with the final
+  # dash and characters trailing the dash removed.
+  local REGION=${ZONE%-*}
+  gcloud compute addresses create "${MASTER_NAME}-ip" \
+    --project "${PROJECT}" \
+    --addresses "${KUBE_MASTER_IP}" \
+    --region "${REGION}"
 
   echo "Waiting for cluster initialization."
   echo
@@ -634,6 +644,14 @@ function kube-down {
     routes=( "${routes[@]:10}" )
   done
 
+  # Delete the master's reserved IP
+  local REGION=${ZONE%-*}
+  gcloud compute addresses delete \
+    --project "${PROJECT}" \
+    --region "${REGION}" \
+    --quiet \
+    "${MASTER_NAME}-ip" || true
+
 }
 
 # Update a kubernetes cluster with latest source
@@ -644,29 +662,76 @@ function kube-push {
   # Make sure we have the tar files staged on Google Storage
   find-release-tars
   upload-server-tars
+  ensure-temp-dir
 
+  # We want to save the IP and data disk from the existing master, kill the
+  # master, then bring up a new master with the same IP and data disk. The IP
+  # should already be saved as a static IP from when we created, so we just need
+  # to safely unmount and detach the disk.
+  gcloud compute ssh \
+    --project "${PROJECT}" \
+    --zone "$ZONE" \
+    "${KUBE_MASTER}" \
+    --command "sudo service etcd stop; sudo umount /dev/disk/by-id/google-master-pd"
+
+  gcloud compute instances detach-disk "${MASTER_NAME}" \
+    --project "${PROJECT}" \
+    --zone "${ZONE}" \
+    --disk "${MASTER_NAME}-pd"
+
+  gcloud compute instances delete \
+    --project "${PROJECT}" \
+    --quiet \
+    --delete-disks boot \
+    --zone "${ZONE}" \
+    "${MASTER_NAME}" || true
+
+  # Create a new master with mostly the same startup script as for the kube-up
+  # case, but without the dynamically created salt files and its paramters.
   (
     echo "#! /bin/bash"
     echo "mkdir -p /var/cache/kubernetes-install"
     echo "cd /var/cache/kubernetes-install"
+    echo "readonly MASTER_NAME='${MASTER_NAME}'"
     echo "readonly SERVER_BINARY_TAR_URL='${SERVER_BINARY_TAR_URL}'"
     echo "readonly SALT_TAR_URL='${SALT_TAR_URL}'"
     grep -v "^#" "${KUBE_ROOT}/cluster/gce/templates/common.sh"
+    grep -v "^#" "${KUBE_ROOT}/cluster/gce/templates/mount-pd.sh"
     grep -v "^#" "${KUBE_ROOT}/cluster/gce/templates/download-release.sh"
-    echo "echo Executing configuration"
-    echo "sudo salt '*' mine.update"
-    echo "sudo salt --force-color '*' state.highstate"
-  ) | gcloud compute ssh --project "${PROJECT}" --zone "$ZONE" "$KUBE_MASTER" --command "sudo bash"
+    grep -v "^#" "${KUBE_ROOT}/cluster/gce/templates/salt-master.sh"
+  ) > "${KUBE_TEMP}/master-start.sh"
 
+  gcloud compute instances create "${MASTER_NAME}" \
+    --project "${PROJECT}" \
+    --zone "${ZONE}" \
+    --machine-type "${MASTER_SIZE}" \
+    --image-project="${IMAGE_PROJECT}" \
+    --image "${IMAGE}" \
+    --tags "${MASTER_TAG}" \
+    --network "${NETWORK}" \
+    --address "${MASTER_NAME}-ip" \
+    --scopes "storage-ro" "compute-rw" \
+    --metadata-from-file "startup-script=${KUBE_TEMP}/master-start.sh" \
+    --disk name="${MASTER_NAME}-pd" device-name=master-pd mode=rw boot=no auto-delete=no &
+  wait-for-jobs
+
+  detect-master
   get-password
 
+  echo "Waiting for master initialization."
   echo
-  echo "Kubernetes cluster is running.  The master is running at:"
+  echo "  This will continually check to see if the API for kubernetes is reachable."
+  echo "  This might loop forever if there was some uncaught error during start"
+  echo "  up."
   echo
-  echo "  https://${KUBE_MASTER_IP}"
-  echo
-  echo "The user name and password to use is located in ~/.kubernetes_auth."
-  echo
+
+  until curl --insecure --user "${KUBE_USER}:${KUBE_PASSWORD}" --max-time 5 \
+          --fail --output /dev/null --silent "https://${KUBE_MASTER_IP}/api/v1beta1/pods"; do
+      printf "."
+      sleep 2
+  done
+
+  echo "Kubernetes cluster updated."
 
 }
 


### PR DESCRIPTION
This makes upgrades less likely to break in weird ways and adds support for easily upgrading underlying components on the master like the guest OS or etcd.

To do this, we reserve the IP address of the master after it's created and store all dynamically created files on a persistent disk (PD). Then, kube-push consists of swapping the PD and reserved IP address over to a new VM with the desired components on it.

This has been tested to pass the /validate endpoint after upgrading between a few different recent commit versions.
