### PR TITLE
Integration test scaffolding fixes

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -19,6 +19,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -548,6 +549,7 @@ func runServiceTest(client *client.Client) {
 type testFunc func(*client.Client)
 
 func main() {
+	flag.Parse()
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	util.ReallyCrash = true
 	util.InitLogs()

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -173,7 +173,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	schedulerConfigFactory := factory.NewConfigFactory(cl)
 	schedulerConfig, err := schedulerConfigFactory.Create()
 	if err != nil {
-		glog.Fatal("Couldn't create scheduler config: %v", err)
+		glog.Fatalf("Couldn't create scheduler config: %v", err)
 	}
 	scheduler.New(schedulerConfig).Run()
 

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -157,6 +157,7 @@ func SimpleRunKubelet(etcdClient tools.EtcdClient, dockerClient dockertools.Dock
 		Address:                 util.IP(net.ParseIP(address)),
 		EnableServer:            true,
 		EnableDebuggingHandlers: true,
+		SyncFrequency:           3 * time.Second,
 	}
 	RunKubelet(&kcfg)
 }


### PR DESCRIPTION
A few things that are desperately broken in the integration test command.  This test is practically useless, IMO - impossible to comprehend and debug.
