### PR TITLE
DNS Server IP outside of PORTAL_NET range for vagrant

### DIFF
--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -59,6 +59,6 @@ DOCKER_OPTS=""
 
 # Optional: Install cluster DNS.
 ENABLE_CLUSTER_DNS=true
-DNS_SERVER_IP="10.0.0.10"
+DNS_SERVER_IP="10.247.0.10"
 DNS_DOMAIN="kubernetes.local"
 DNS_REPLICAS=1


### PR DESCRIPTION
This fixes an error on vagrant provision where the assigned IP was outside the range in vagrant cluster.

This issue was unique to vagrant, as GCE PORTAL_NET is different than Vagrant PORTAL_NET
