### PR TITLE
Add *useful* DeepEqual

### DIFF
--- a/pkg/conversion/converter.go
+++ b/pkg/conversion/converter.go
@@ -359,7 +359,9 @@ func (c *Converter) convert(sv, dv reflect.Value, scope *scope) error {
 	}
 
 	if !scope.flags.IsSet(AllowDifferentFieldTypeNames) && c.NameFunc(dt) != c.NameFunc(st) {
-		return scope.error("type names don't match (%v, %v)", c.NameFunc(st), c.NameFunc(dt))
+		return scope.error(
+			"type names don't match (%v, %v), and no conversion 'func (%v, %v) error' registered.",
+			c.NameFunc(st), c.NameFunc(dt), st, dt)
 	}
 
 	// This should handle all simple types.

--- a/pkg/conversion/deep_equal_test.go
+++ b/pkg/conversion/deep_equal_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conversion
+
+import (
+	"testing"
+)
+
+func TestEqualities(t *testing.T) {
+	e := Equalities{}
+	err := e.AddFuncs(
+		func(a, b int) bool {
+			return a+1 == b
+		},
+	)
+	if err != nil {
+		t.Fatalf("Unexpected: %v", err)
+	}
+
+	table := []struct {
+		a, b  interface{}
+		equal bool
+	}{
+		{1, 2, true},
+		{2, 1, false},
+		{"foo", "foo", true},
+		{map[string]int{"foo": 1}, map[string]int{"foo": 2}, true},
+		{map[string]int{}, map[string]int(nil), true},
+		{[]int{}, []int(nil), true},
+	}
+
+	for _, item := range table {
+		if e, a := item.equal, e.DeepEqual(item.a, item.b); e != a {
+			t.Errorf("Expected (%+v == %+v) == %v, but got %v", item.a, item.b, e, a)
+		}
+	}
+}


### PR DESCRIPTION
It would be extremely useful to do deep _semantic_ comparisons for some tests (like the fuzz test). This adds a mechanism to allow that. This commit is moved from one of my other PRs on account of it being separate & generally useful.
