### PR TITLE
Reduce verbosity on integration tests

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -43,6 +43,6 @@ KUBE_GOFLAGS="-tags 'integration no-docker' " \
 
 kube::log::status "Running integration test scenario"
 
-"${KUBE_OUTPUT_HOSTBIN}/integration" --v=10
+"${KUBE_OUTPUT_HOSTBIN}/integration" --v=2
 
 cleanup


### PR DESCRIPTION
Now that we actually parse flags, -v=10 seems a bit heavy handed.
