### PR TITLE
Boilerplate checks on 2014, but commit included a 2015 (breaks travis)

### DIFF
--- a/hack/e2e-from-release.sh
+++ b/hack/e2e-from-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Revert boilerplate to 2014 until hack/verify-boilerplate.sh is fixed
