### PR TITLE
Update copyright year for files created today

### DIFF
--- a/pkg/util/hash.go
+++ b/pkg/util/hash.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Google Inc. All rights reserved.
+Copyright 2015 Google Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/util/hash_test.go
+++ b/pkg/util/hash_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Google Inc. All rights reserved.
+Copyright 2015 Google Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Now that pr #3225 fixes boilerplate issue of "Copyright 2015".
