### PR TITLE
changed the id of walkthrough example replication-controller to nginx

### DIFF
--- a/examples/walkthrough/replication-controller.yaml
+++ b/examples/walkthrough/replication-controller.yaml
@@ -13,7 +13,7 @@ desiredState:
     desiredState:
       manifest:
         version: v1beta1
-        id: ngix
+        id: nginx
         containers:
           - name: nginx
             image: dockerfile/nginx


### PR DESCRIPTION
changed the id of the desiredState manifest to become more identifiable with regard to its container name. 
