### PR TITLE
Add script to push CI artifacts to gs://kubernetes-release/ci

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -41,7 +41,8 @@ readonly KUBE_GCS_MAKE_PUBLIC="${KUBE_GCS_MAKE_PUBLIC:-y}"
 # KUBE_GCS_RELEASE_BUCKET default: kubernetes-releases-${project_hash}
 readonly KUBE_GCS_RELEASE_PREFIX=${KUBE_GCS_RELEASE_PREFIX-devel}/
 readonly KUBE_GCS_DOCKER_REG_PREFIX=${KUBE_GCS_DOCKER_REG_PREFIX-docker-reg}/
-
+readonly KUBE_GCS_LATEST_FILE=${KUBE_GCS_LATEST_FILE:-}
+readonly KUBE_GCS_LATEST_CONTENTS=${KUBE_GCS_LATEST_CONTENTS:-}
 
 # Constants
 readonly KUBE_BUILD_IMAGE_REPO=kube-build
@@ -850,4 +851,21 @@ function kube::release::gcs::copy_release_artifacts() {
   fi
 
   gsutil ls -lhr "${gcs_destination}"
+}
+
+function kube::release::gcs::publish_latest() {
+  local latest_file_dst="gs://${KUBE_GCS_RELEASE_BUCKET}/${KUBE_GCS_LATEST_FILE}"
+
+  mkdir -p "${RELEASE_STAGE}/upload"
+  echo ${KUBE_GCS_LATEST_CONTENTS} > "${RELEASE_STAGE}/upload/latest"
+
+  gsutil -m "${gcs_options[@]+${gcs_options[@]}}" cp \
+    "${RELEASE_STAGE}/upload/latest" "${latest_file_dst}"
+
+  if [[ ${KUBE_GCS_MAKE_PUBLIC} =~ ^[yY]$ ]]; then
+    gsutil acl ch -R -g all:R "${latest_file_dst}" >/dev/null 2>&1
+  fi
+
+  echo "+++ gsutil cat ${latest_file_dst}:"
+  gsutil cat ${latest_file_dst}
 }

--- a/build/push-ci-build.sh
+++ b/build/push-ci-build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Pushes a continuous integration build to our official CI repository
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+LATEST=$(git describe)
+KUBE_GCS_NO_CACHING=n
+KUBE_GCS_MAKE_PUBLIC=y
+KUBE_GCS_UPLOAD_RELEASE=y
+KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+KUBE_GCS_PROJECT=google-containers
+KUBE_GCS_RELEASE_PREFIX="ci/${LATEST}"
+KUBE_GCS_LATEST_FILE="ci/latest.txt"
+KUBE_GCS_LATEST_CONTENTS=${LATEST}
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "$KUBE_ROOT/build/common.sh"
+
+kube::release::gcs::release
+kube::release::gcs::publish_latest


### PR DESCRIPTION
This pushes artifacts in a similar manner to the official release,
except that instead of release/vFOO, it goes to ci/$(git describe),
e.g.: gs://kubernetes-release/ci/v0.7.0-315-gcae5722

It also pushes a text file to gs://kubernetes-release/ci/latest.txt,
so anyone can do, for instance:

gsutil ls gs://kubernetes-release/ci/$(gsutil cat gs://kubernetes-release/ci/latest.txt)

(In a parallel change, I'm going to flip the jenkins scripts over to
use git describe, since it's shorter and a little more descriptive)
