### PR TITLE
Fix the service proxy to re-poll on watch closure no matter what.

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -19,6 +19,9 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
@@ -106,4 +109,26 @@ func (c *Client) ServerAPIVersions() (*api.APIVersions, error) {
 		return nil, fmt.Errorf("got '%s': %v", string(body), err)
 	}
 	return &v, nil
+}
+
+// IsTimeout tests if this is a timeout error in the underlying transport.
+// This is unbelievably ugly.
+// See: http://stackoverflow.com/questions/23494950/specifically-check-for-timeout-error for details
+func IsTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch err := err.(type) {
+	case *url.Error:
+		if err, ok := err.Err.(net.Error); ok {
+			return err.Timeout()
+		}
+	case net.Error:
+		return err.Timeout()
+	}
+
+	if strings.Contains(err.Error(), "use of closed network connection") {
+		return true
+	}
+	return false
 }

--- a/pkg/proxy/config/api.go
+++ b/pkg/proxy/config/api.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/wait"
@@ -93,6 +94,10 @@ func (s *SourceAPI) runServices(resourceVersion *string) {
 	watcher, err := s.servicesWatcher.Watch(labels.Everything(), labels.Everything(), *resourceVersion)
 	if err != nil {
 		glog.Errorf("Unable to watch for services changes: %v", err)
+		if !client.IsTimeout(err) {
+			// Reset so that we do a fresh get request
+			*resourceVersion = ""
+		}
 		time.Sleep(wait.Jitter(s.waitDuration, 0.0))
 		return
 	}
@@ -157,6 +162,11 @@ func (s *SourceAPI) runEndpoints(resourceVersion *string) {
 	watcher, err := s.endpointsWatcher.Watch(labels.Everything(), labels.Everything(), *resourceVersion)
 	if err != nil {
 		glog.Errorf("Unable to watch for endpoints changes: %v", err)
+		if !client.IsTimeout(err) {
+			// Reset so that we do a fresh get request
+			*resourceVersion = ""
+		}
+
 		time.Sleep(wait.Jitter(s.waitDuration, 0.0))
 		return
 	}


### PR DESCRIPTION
Should stop the bleeding on #3216 
