### PR TITLE
Never set pod.Name in kubelet config code

### DIFF
--- a/pkg/kubelet/config/etcd.go
+++ b/pkg/kubelet/config/etcd.go
@@ -19,7 +19,6 @@ package config
 
 import (
 	"errors"
-	"fmt"
 	"path"
 	"strconv"
 	"time"
@@ -93,10 +92,7 @@ func eventToPods(ev watch.Event) ([]api.BoundPod, error) {
 		return pods, errors.New("unable to parse response as BoundPods")
 	}
 
-	for i, pod := range boundPods.Items {
-		if len(pod.Name) == 0 {
-			pod.Name = fmt.Sprintf("%d", i+1)
-		}
+	for _, pod := range boundPods.Items {
 		// TODO: generate random UID if not present
 		if pod.UID == "" && !pod.CreationTimestamp.IsZero() {
 			pod.UID = strconv.FormatInt(pod.CreationTimestamp.Unix(), 10)

--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -153,7 +153,6 @@ func extractFromFile(filename string) (api.BoundPod, error) {
 		return pod, fmt.Errorf("can't convert pod from file %q: %v", filename, err)
 	}
 
-	pod.Name = simpleSubdomainSafeHash(filename)
 	if len(pod.UID) == 0 {
 		pod.UID = simpleSubdomainSafeHash(filename)
 	}

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -121,7 +121,7 @@ func TestReadFromFile(t *testing.T) {
 		update := got.(kubelet.PodUpdate)
 		expected := CreatePodUpdate(kubelet.SET, kubelet.FileSource, api.BoundPod{
 			ObjectMeta: api.ObjectMeta{
-				Name:      simpleSubdomainSafeHash(file.Name()),
+				Name:      "test",
 				UID:       simpleSubdomainSafeHash(file.Name()),
 				Namespace: "default",
 			},
@@ -160,8 +160,6 @@ func TestExtractFromValidDataFile(t *testing.T) {
 	}
 	file := writeTestFile(t, os.TempDir(), "test_pod_config", string(text))
 	defer os.Remove(file.Name())
-
-	expectedPod.Name = simpleSubdomainSafeHash(file.Name())
 
 	ch := make(chan interface{}, 1)
 	c := sourceFile{file.Name(), ch}
@@ -228,7 +226,6 @@ func TestExtractFromDir(t *testing.T) {
 		}
 		ioutil.WriteFile(name, data, 0755)
 		files[i] = file
-		pods[i].Name = simpleSubdomainSafeHash(name)
 	}
 
 	ch := make(chan interface{}, 1)

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -91,9 +91,6 @@ func (s *sourceURL) extractFromURL() error {
 		if err := api.Scheme.Convert(&manifest, &pod); err != nil {
 			return err
 		}
-		if len(pod.Name) == 0 {
-			pod.Name = "1"
-		}
 		if len(pod.Namespace) == 0 {
 			pod.Namespace = api.NamespaceDefault
 		}


### PR DESCRIPTION
I think it is time to tighten up input requirements.  The validation code will
reject a pod that has an empty name field.
