### PR TITLE
Fix newlines in TAP stdout/stderr output

### DIFF
--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -499,10 +499,12 @@ func printBashOutputs(headerprefix, lineprefix, stdout, stderr string, escape bo
 func escapeOutput(s string) (out string) {
 	for _, r := range s {
 		switch {
+		case r == '\n':
+			out += string(r)
 		case !strconv.IsPrint(r):
 			out += " "
 		case r == ':':
-			out += "\u02D0" // "ː", MODIFIER LETTER TRIANGULAR COLON
+			out += "\ua789" // "꞉", modifier letter colon
 		default:
 			out += string(r)
 		}


### PR DESCRIPTION
It turns out, newlines are not "printable", causing the TAP
stderr/stdout output to be smushed. Also address etune's comment on
pr3208.
