### PR TITLE
Remove dependency of podex from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ install:
   - ./hack/verify-description.sh
   - ./hack/travis/install-std-race.sh
   - ./hack/build-go.sh
-  - go get ./contrib/podex
 
 script:
   - KUBE_TIMEOUT='-timeout 60s' ./hack/test-go.sh


### PR DESCRIPTION
Hopefully this one would fix travis build failures since this morning, but the root cause is not found though: 

go get ./contrib/podex
github.com/fsouza/go-dockerclient
../../fsouza/go-dockerclient/tar.go:30: unknown archive.TarOptions field 'Excludes' in struct literal
The command "go get ./contrib/podex" failed and exited with 2 during .

I didn't find any place depending on podex. 

@erictune 
