### PR TITLE
Add a lock around the other docker pull.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -905,14 +905,17 @@ func (kl *Kubelet) syncPod(pod *api.BoundPod, dockerContainers dockertools.Docke
 			}
 			if api.IsPullAlways(container.ImagePullPolicy) ||
 				(api.IsPullIfNotPresent(container.ImagePullPolicy) && (!present || latest)) {
+				kl.pullLock.RLock()
 				if err := kl.dockerPuller.Pull(container.Image); err != nil {
 					if ref != nil {
 
 						record.Eventf(ref, "failed", "failed", "Failed to pull image %q", container.Image)
 					}
 					glog.Errorf("Failed to pull image %q: %v; skipping pod %q container %q.", container.Image, err, podFullName, container.Name)
+					kl.pullLock.RUnlock()
 					continue
 				}
+				kl.pullLock.RUnlock()
 				if ref != nil {
 					record.Eventf(ref, "waiting", "pulled", "Successfully pulled image %q", container.Image)
 				}


### PR DESCRIPTION
Fixes e2e (I hope), certainly passes e2e in my client.
