### PR TITLE
Fix few vet errors.

### DIFF
--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -286,7 +286,7 @@ func Test() (results ResultsByTest) {
 			continue
 		}
 		if err != nil {
-			log.Fatal("Bad test pattern: %v", tests)
+			log.Fatalf("Bad test pattern: %v", *tests)
 		}
 		toRun = append(toRun, name)
 	}

--- a/pkg/client/clientcmd/provided_flags.go
+++ b/pkg/client/clientcmd/provided_flags.go
@@ -96,5 +96,5 @@ func (flag *BoolFlag) Provided() bool {
 }
 
 func (flag *BoolFlag) String() string {
-	return fmt.Sprintf("%s", flag.Value)
+	return fmt.Sprintf("%t", flag.Value)
 }

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -393,7 +393,7 @@ func TestRequestWatch(t *testing.T) {
 		if testCase.Empty {
 			_, ok := <-watch.ResultChan()
 			if ok {
-				t.Errorf("%d: expected the watch to be empty: %#v", watch)
+				t.Errorf("%d: expected the watch to be empty: %#v", i, watch)
 			}
 		}
 	}

--- a/pkg/cloudprovider/controller/minioncontroller.go
+++ b/pkg/cloudprovider/controller/minioncontroller.go
@@ -88,7 +88,6 @@ func (s *MinionController) SyncStatic(period time.Duration) error {
 		}
 		time.Sleep(period)
 	}
-	return nil
 }
 
 // SyncCloud syncs list of instances from cloudprovider to master etcd registry.

--- a/pkg/cloudprovider/openstack/openstack_test.go
+++ b/pkg/cloudprovider/openstack/openstack_test.go
@@ -49,7 +49,7 @@ monitor-max-retries = 3
 	}
 
 	if !cfg.LoadBalancer.CreateMonitor {
-		t.Errorf("incorrect lb.createmonitor: %s", cfg.LoadBalancer.CreateMonitor)
+		t.Errorf("incorrect lb.createmonitor: %t", cfg.LoadBalancer.CreateMonitor)
 	}
 	if cfg.LoadBalancer.MonitorDelay.Duration != 1*time.Minute {
 		t.Errorf("incorrect lb.monitordelay: %s", cfg.LoadBalancer.MonitorDelay)
@@ -58,7 +58,7 @@ monitor-max-retries = 3
 		t.Errorf("incorrect lb.monitortimeout: %s", cfg.LoadBalancer.MonitorTimeout)
 	}
 	if cfg.LoadBalancer.MonitorMaxRetries != 3 {
-		t.Errorf("incorrect lb.monitormaxretries: %s", cfg.LoadBalancer.MonitorMaxRetries)
+		t.Errorf("incorrect lb.monitormaxretries: %d", cfg.LoadBalancer.MonitorMaxRetries)
 	}
 }
 

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -92,7 +92,7 @@ func RunScheduler(cl *client.Client) {
 	schedulerConfigFactory := factory.NewConfigFactory(cl)
 	schedulerConfig, err := schedulerConfigFactory.Create()
 	if err != nil {
-		glog.Fatal("Couldn't create scheduler config: %v", err)
+		glog.Fatalf("Couldn't create scheduler config: %v", err)
 	}
 	scheduler.New(schedulerConfig).Run()
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -141,11 +141,11 @@ func CompileRegexps(regexpStrings []string) ([]*regexp.Regexp, error) {
 // Writes 'value' to /proc/self/oom_score_adj.
 func ApplyOomScoreAdj(value int) error {
 	if value < -1000 || value > 1000 {
-		return fmt.Errorf("invalid value(%d) specified for oom_score_adj. Values must be within the range [-1000, 1000]")
+		return fmt.Errorf("invalid value(%d) specified for oom_score_adj. Values must be within the range [-1000, 1000]", value)
 	}
 
 	if err := ioutil.WriteFile("/proc/self/oom_score_adj", []byte(strconv.Itoa(value)), 0700); err != nil {
-		fmt.Errorf("failed to set oom_score_adj to %s - %q", value, err)
+		fmt.Errorf("failed to set oom_score_adj to %d - %q", value, err)
 	}
 
 	return nil

--- a/plugin/pkg/auth/authenticator/request/x509/x509_test.go
+++ b/plugin/pkg/auth/authenticator/request/x509/x509_test.go
@@ -531,13 +531,13 @@ func TestX509(t *testing.T) {
 		}
 
 		if testCase.ExpectOK != ok {
-			t.Errorf("%s: Expected ok=%v, got %v", testCase.ExpectOK, ok)
+			t.Errorf("%s: Expected ok=%v, got %v", k, testCase.ExpectOK, ok)
 			continue
 		}
 
 		if testCase.ExpectOK {
 			if testCase.ExpectUserName != user.GetName() {
-				t.Errorf("%s: Expected user.name=%v, got %v", testCase.ExpectUserName, user.GetName())
+				t.Errorf("%s: Expected user.name=%v, got %v", k, testCase.ExpectUserName, user.GetName())
 				continue
 			}
 		}

--- a/plugin/pkg/scheduler/algorithmprovider/plugins_test.go
+++ b/plugin/pkg/scheduler/algorithmprovider/plugins_test.go
@@ -49,7 +49,7 @@ func TestAlgorithmProviders(t *testing.T) {
 			break
 		}
 		if len(p.PriorityFunctionKeys) == 0 {
-			t.Error("%s algorithm provider shouldn't have 0 priority functions", pn)
+			t.Errorf("%s algorithm provider shouldn't have 0 priority functions", pn)
 		}
 		for _, pf := range p.PriorityFunctionKeys.List() {
 			if !factory.IsPriorityFunctionRegistered(pf) {


### PR DESCRIPTION
There are quite a few 'composite literal uses unkeyed fields' errors that I have kept out of this patch.
And there's a couple where vet just seems confused. These are the easiest ones.
