### PR TITLE
Make RESTClient more generic to API version, simplify version handling

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -44,7 +44,7 @@ func (c *Client) ReplicationControllers(namespace string) ReplicationControllerI
 }
 
 func (c *Client) Nodes() NodeInterface {
-	return newNodes(c, c.preV1Beta3)
+	return newNodes(c)
 }
 
 func (c *Client) Events(namespace string) EventInterface {
@@ -78,9 +78,6 @@ type APIStatus interface {
 // Client is the implementation of a Kubernetes client.
 type Client struct {
 	*RESTClient
-
-	// preV1Beta3 is true for v1beta1 and v1beta2
-	preV1Beta3 bool
 }
 
 // ServerVersion retrieves and parses the server's version.
@@ -131,4 +128,9 @@ func IsTimeout(err error) bool {
 		return true
 	}
 	return false
+}
+
+// preV1Beta3 returns true if the provided API version is an API introduced before v1beta3.
+func preV1Beta3(version string) bool {
+	return version == "v1beta1" || version == "v1beta2"
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -165,7 +165,7 @@ func (c *testClient) ValidateCommon(t *testing.T, err error) {
 // buildResourcePath is a convenience function for knowing if a namespace should be in a path param or not
 func buildResourcePath(namespace, resource string) string {
 	if len(namespace) > 0 {
-		if NamespaceInPathFor(testapi.Version()) {
+		if !(testapi.Version() == "v1beta1" || testapi.Version() == "v1beta2") {
 			return path.Join("ns", namespace, resource)
 		}
 	}
@@ -183,7 +183,7 @@ func buildQueryValues(namespace string, query url.Values) url.Values {
 		}
 	}
 	if len(namespace) > 0 {
-		if !NamespaceInPathFor(testapi.Version()) {
+		if testapi.Version() == "v1beta1" || testapi.Version() == "v1beta2" {
 			v.Set("namespace", namespace)
 		}
 	}
@@ -765,7 +765,7 @@ func TestNewMinionPath(t *testing.T) {
 		Response: Response{StatusCode: 200},
 	}
 	cl := c.Setup()
-	cl.preV1Beta3 = false
+	cl.apiVersion = "v1beta3"
 	err := cl.Nodes().Delete("foo")
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -90,23 +90,28 @@ func (f HTTPClientFunc) Do(req *http.Request) (*http.Response, error) {
 type FakeRESTClient struct {
 	Client HTTPClient
 	Codec  runtime.Codec
+	Legacy bool
 	Req    *http.Request
 	Resp   *http.Response
 	Err    error
 }
 
 func (c *FakeRESTClient) Get() *Request {
-	return NewRequest(c, "GET", &url.URL{Host: "localhost"}, c.Codec, true)
+	return NewRequest(c, "GET", &url.URL{Host: "localhost"}, c.Codec, c.Legacy, c.Legacy)
 }
+
 func (c *FakeRESTClient) Put() *Request {
-	return NewRequest(c, "PUT", &url.URL{Host: "localhost"}, c.Codec, true)
+	return NewRequest(c, "PUT", &url.URL{Host: "localhost"}, c.Codec, c.Legacy, c.Legacy)
 }
+
 func (c *FakeRESTClient) Post() *Request {
-	return NewRequest(c, "POST", &url.URL{Host: "localhost"}, c.Codec, true)
+	return NewRequest(c, "POST", &url.URL{Host: "localhost"}, c.Codec, c.Legacy, c.Legacy)
 }
+
 func (c *FakeRESTClient) Delete() *Request {
-	return NewRequest(c, "DELETE", &url.URL{Host: "localhost"}, c.Codec, true)
+	return NewRequest(c, "DELETE", &url.URL{Host: "localhost"}, c.Codec, c.Legacy, c.Legacy)
 }
+
 func (c *FakeRESTClient) Do(req *http.Request) (*http.Response, error) {
 	c.Req = req
 	if c.Client != HTTPClient(nil) {

--- a/pkg/client/helper_test.go
+++ b/pkg/client/helper_test.go
@@ -85,6 +85,10 @@ func TestIsConfigTransportTLS(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
+		if err := SetKubernetesDefaults(testCase.Config); err != nil {
+			t.Errorf("setting defaults failed for %#v: %v", testCase.Config, err)
+			continue
+		}
 		useTLS := IsConfigTransportTLS(testCase.Config)
 		if testCase.TransportTLS != useTLS {
 			t.Errorf("expected %v for %#v", testCase.TransportTLS, testCase.Config)

--- a/pkg/client/minions.go
+++ b/pkg/client/minions.go
@@ -35,18 +35,17 @@ type NodeInterface interface {
 
 // nodes implements NodesInterface
 type nodes struct {
-	r          *Client
-	preV1Beta3 bool
+	r *Client
 }
 
 // newNodes returns a nodes object. Uses "minions" as the
 // URL resource name for v1beta1 and v1beta2.
-func newNodes(c *Client, isPreV1Beta3 bool) *nodes {
-	return &nodes{c, isPreV1Beta3}
+func newNodes(c *Client) *nodes {
+	return &nodes{c}
 }
 
 func (c *nodes) resourceName() string {
-	if c.preV1Beta3 {
+	if preV1Beta3(c.r.APIVersion()) {
 		return "minions"
 	}
 	return "nodes"

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -75,21 +75,21 @@ func TestRequestWithErrorWontChange(t *testing.T) {
 }
 
 func TestRequestPreservesBaseTrailingSlash(t *testing.T) {
-	r := &Request{baseURL: &url.URL{}, path: "/path/"}
+	r := &Request{baseURL: &url.URL{}, path: "/path/", namespaceInQuery: true}
 	if s := r.finalURL(); s != "/path/" {
 		t.Errorf("trailing slash should be preserved: %s", s)
 	}
 }
 
 func TestRequestAbsPathPreservesTrailingSlash(t *testing.T) {
-	r := (&Request{baseURL: &url.URL{}}).AbsPath("/foo/")
+	r := (&Request{baseURL: &url.URL{}, namespaceInQuery: true}).AbsPath("/foo/")
 	if s := r.finalURL(); s != "/foo/" {
 		t.Errorf("trailing slash should be preserved: %s", s)
 	}
 }
 
 func TestRequestAbsPathJoins(t *testing.T) {
-	r := (&Request{baseURL: &url.URL{}}).AbsPath("foo/bar", "baz")
+	r := (&Request{baseURL: &url.URL{}, namespaceInQuery: true}).AbsPath("foo/bar", "baz")
 	if s := r.finalURL(); s != "foo/bar/baz" {
 		t.Errorf("trailing slash should be preserved: %s", s)
 	}
@@ -100,6 +100,7 @@ func TestRequestSetsNamespace(t *testing.T) {
 		baseURL: &url.URL{
 			Path: "/",
 		},
+		namespaceInQuery: true,
 	}).Namespace("foo")
 	if r.namespace == "" {
 		t.Errorf("namespace should be set: %#v", r)
@@ -112,7 +113,6 @@ func TestRequestSetsNamespace(t *testing.T) {
 		baseURL: &url.URL{
 			Path: "/",
 		},
-		namespaceInPath: true,
 	}).Namespace("foo")
 	if s := r.finalURL(); s != "ns/foo" {
 		t.Errorf("namespace should be in path: %s", s)
@@ -121,9 +121,8 @@ func TestRequestSetsNamespace(t *testing.T) {
 
 func TestRequestOrdersNamespaceInPath(t *testing.T) {
 	r := (&Request{
-		baseURL:         &url.URL{},
-		path:            "/test/",
-		namespaceInPath: true,
+		baseURL: &url.URL{},
+		path:    "/test/",
 	}).Name("bar").Resource("baz").Namespace("foo")
 	if s := r.finalURL(); s != "/test/ns/foo/baz/bar" {
 		t.Errorf("namespace should be in order in path: %s", s)
@@ -212,7 +211,7 @@ func TestTransformResponse(t *testing.T) {
 		{Response: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewReader(invalid))}, Data: invalid},
 	}
 	for i, test := range testCases {
-		r := NewRequest(nil, "", uri, testapi.Codec(), true)
+		r := NewRequest(nil, "", uri, testapi.Codec(), true, true)
 		if test.Response.Body == nil {
 			test.Response.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -48,7 +48,7 @@ func getFakeClient(t *testing.T, validURLs []string) (ClientPosterFunc, *httptes
 	return func(mapping *meta.RESTMapping) (RESTClientPoster, error) {
 		fakeCodec := runtime.CodecFor(api.Scheme, "v1beta1")
 		fakeUri, _ := url.Parse(server.URL + "/api/v1beta1")
-		return client.NewRESTClient(fakeUri, fakeCodec, false), nil
+		return client.NewRESTClient(fakeUri, "v1beta1", fakeCodec, true), nil
 	}, server
 }
 

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 func makeNamespaceURL(namespace, suffix string) string {
-	if client.NamespaceInPathFor(testapi.Version()) {
+	if !(testapi.Version() == "v1beta1" || testapi.Version() == "v1beta2") {
 		return makeURL("/ns/" + namespace + suffix)
 	}
 	return makeURL(suffix + "?namespace=" + namespace)

--- a/plugin/pkg/scheduler/factory/factory_test.go
+++ b/plugin/pkg/scheduler/factory/factory_test.go
@@ -88,7 +88,7 @@ func TestPollMinions(t *testing.T) {
 }
 
 func makeNamespaceURL(namespace, suffix string, isClient bool) string {
-	if client.NamespaceInPathFor(testapi.Version()) {
+	if !(testapi.Version() == "v1beta1" || testapi.Version() == "v1beta2") {
 		return makeURL("/ns/" + namespace + suffix)
 	}
 	// if this is a url the client should call, encode the url


### PR DESCRIPTION
RESTClient is an abstraction on top of arbitrary HTTP endpoints that
follow the Kubernetes API conventions. Refactored RESTClientFor so that
assumptions that are Kube specific happen outside of that method (so
others can reuse the RESTClient). Added more validation to client.New
to ensure clients give good input. Exposed APIVersion on RESTClient
as a method so that wrapper code (code that adds typed / structured
methods over rest endpoints like client.Client) can more easily make
decisions about what APIVersion it is running under.

@lavalamp @derekwaynecarr fyi
