### PR TITLE
Cleanup to client initialization in Kubelet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Session.vim
 
 # Go test binaries
 *.test
+/hack/.test-cmd-auth
 
 # Mercurial files
 **/.hg

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -191,11 +191,11 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	minionController.Run(10 * time.Second)
 
 	// Kubelet (localhost)
-	standalone.SimpleRunKubelet(etcdClient, &fakeDocker1, machineList[0], testRootDir, manifestURL, "127.0.0.1", 10250)
+	standalone.SimpleRunKubelet(cl, etcdClient, &fakeDocker1, machineList[0], testRootDir, manifestURL, "127.0.0.1", 10250)
 	// Kubelet (machine)
 	// Create a second kubelet so that the guestbook example's two redis slaves both
 	// have a place they can schedule.
-	standalone.SimpleRunKubelet(etcdClient, &fakeDocker2, machineList[1], testRootDir2, "", "127.0.0.1", 10251)
+	standalone.SimpleRunKubelet(cl, etcdClient, &fakeDocker2, machineList[1], testRootDir2, "", "127.0.0.1", 10251)
 
 	return apiServer.URL
 }

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -100,10 +100,13 @@ func main() {
 		glog.Info(err)
 	}
 
+	client, err := standalone.GetAPIServerClient(*authPath, apiServerList)
+	if err != nil && len(apiServerList) > 0 {
+		glog.Warningf("No API client: %v", err)
+	}
+
 	kcfg := standalone.KubeletConfig{
 		Address:                 address,
-		AuthPath:                *authPath,
-		ApiServerList:           apiServerList,
 		AllowPrivileged:         *allowPrivileged,
 		HostnameOverride:        *hostnameOverride,
 		RootDirectory:           *rootDirectory,
@@ -125,6 +128,7 @@ func main() {
 		EnableServer:            *enableServer,
 		EnableDebuggingHandlers: *enableDebuggingHandlers,
 		DockerClient:            util.ConnectToDockerOrDie(*dockerEndpoint),
+		KubeClient:              client,
 		EtcdClient:              kubelet.EtcdClientOrDie(etcdServerList, *etcdConfigFile),
 	}
 

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -52,7 +52,7 @@ func startComponents(etcdClient tools.EtcdClient, cl *client.Client, addr string
 	standalone.RunControllerManager(machineList, cl, *nodeMilliCPU, *nodeMemory)
 
 	dockerClient := util.ConnectToDockerOrDie(*dockerEndpoint)
-	standalone.SimpleRunKubelet(etcdClient, dockerClient, machineList[0], "/tmp/kubernetes", "", "127.0.0.1", 10250)
+	standalone.SimpleRunKubelet(cl, etcdClient, dockerClient, machineList[0], "/tmp/kubernetes", "", "127.0.0.1", 10250)
 }
 
 func newApiClient(addr string, port int) *client.Client {

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -113,6 +113,8 @@ sudo "${GO_OUT}/kubelet" \
   --etcd_servers="http://127.0.0.1:4001" \
   --hostname_override="127.0.0.1" \
   --address="127.0.0.1" \
+  --api_servers="${API_HOST}:${API_PORT}" \
+  --auth_path="${KUBE_ROOT}/hack/.test-cmd-auth" \
   --port="$KUBELET_PORT" >"${KUBELET_LOG}" 2>&1 &
 KUBELET_PID=$!
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -58,6 +58,8 @@ kube::log::status "Starting kubelet"
   --etcd_servers="http://${ETCD_HOST}:${ETCD_PORT}" \
   --hostname_override="127.0.0.1" \
   --address="127.0.0.1" \
+  --api_servers="${API_HOST}:${API_PORT}" \
+  --auth_path="${KUBE_ROOT}/hack/.test-cmd-auth" \
   --port="$KUBELET_PORT" 1>&2 &
 KUBELET_PID=$!
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1132,6 +1132,8 @@ func (kl *Kubelet) syncLoop(updates <-chan PodUpdate, handler SyncHandler) {
 
 // GetKubeletContainerLogs returns logs from the container
 // The second parameter of GetPodInfo and FindPodContainer methods represents pod UUID, which is allowed to be blank
+// TODO: this method is returning logs of random container attempts, when it should be returning the most recent attempt
+// or all of them.
 func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName, tail string, follow bool, stdout, stderr io.Writer) error {
 	_, err := kl.GetPodInfo(podFullName, "")
 	if err == dockertools.ErrNoContainersInPod {
@@ -1151,6 +1153,18 @@ func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName, tail stri
 // GetBoundPods returns all pods bound to the kubelet and their spec
 func (kl *Kubelet) GetBoundPods() ([]api.BoundPod, error) {
 	return kl.pods, nil
+}
+
+// GetPodFullName provides the first pod that matches namespace and name, or false
+// if no such pod can be found.
+func (kl *Kubelet) GetPodByName(namespace, name string) (*api.BoundPod, bool) {
+	for i := range kl.pods {
+		pod := &kl.pods[i]
+		if pod.Namespace == namespace && pod.Name == name {
+			return pod, true
+		}
+	}
+	return nil, false
 }
 
 // GetPodInfo returns information from Docker about the containers in a pod

--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -33,7 +33,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/golang/glog"
 	"github.com/google/cadvisor/info"
@@ -66,6 +65,7 @@ type HostInterface interface {
 	GetRootInfo(req *info.ContainerInfoRequest) (*info.ContainerInfo, error)
 	GetMachineInfo() (*info.MachineInfo, error)
 	GetBoundPods() ([]api.BoundPod, error)
+	GetPodByName(namespace, name string) (*api.BoundPod, bool)
 	GetPodInfo(name, uuid string) (api.PodInfo, error)
 	RunInContainer(name, uuid, container string, cmd []string) ([]byte, error)
 	GetKubeletContainerLogs(podFullName, containerName, tail string, follow bool, stdout, stderr io.Writer) error
@@ -146,13 +146,11 @@ func (s *Server) handleContainerLogs(w http.ResponseWriter, req *http.Request) {
 	follow, _ := strconv.ParseBool(uriValues.Get("follow"))
 	tail := uriValues.Get("tail")
 
-	podFullName := GetPodFullName(&api.BoundPod{
-		ObjectMeta: api.ObjectMeta{
-			Name:        podID,
-			Namespace:   podNamespace,
-			Annotations: map[string]string{ConfigSourceAnnotationKey: "etcd"},
-		},
-	})
+	pod, ok := s.host.GetPodByName(podNamespace, podID)
+	if !ok {
+		http.Error(w, "Pod does not exist", http.StatusNotFound)
+		return
+	}
 
 	fw := FlushWriter{writer: w}
 	if flusher, ok := fw.writer.(http.Flusher); ok {
@@ -162,7 +160,7 @@ func (s *Server) handleContainerLogs(w http.ResponseWriter, req *http.Request) {
 	}
 	w.Header().Set("Transfer-Encoding", "chunked")
 	w.WriteHeader(http.StatusOK)
-	err = s.host.GetKubeletContainerLogs(podFullName, containerName, tail, follow, &fw, &fw)
+	err = s.host.GetKubeletContainerLogs(GetPodFullName(pod), containerName, tail, follow, &fw, &fw)
 	if err != nil {
 		s.error(w, err)
 		return
@@ -217,19 +215,12 @@ func (s *Server) handlePodInfo(w http.ResponseWriter, req *http.Request, version
 		http.Error(w, "Missing 'podNamespace=' query entry.", http.StatusBadRequest)
 		return
 	}
-	// TODO: backwards compatibility with existing API, needs API change
-	podFullName := GetPodFullName(&api.BoundPod{
-		ObjectMeta: api.ObjectMeta{
-			Name:        podID,
-			Namespace:   podNamespace,
-			Annotations: map[string]string{ConfigSourceAnnotationKey: "etcd"},
-		},
-	})
-	info, err := s.host.GetPodInfo(podFullName, podUUID)
-	if err == dockertools.ErrNoContainersInPod {
-		http.Error(w, "api.BoundPod does not exist", http.StatusNotFound)
+	pod, ok := s.host.GetPodByName(podNamespace, podID)
+	if !ok {
+		http.Error(w, "Pod does not exist", http.StatusNotFound)
 		return
 	}
+	info, err := s.host.GetPodInfo(GetPodFullName(pod), podUUID)
 	if err != nil {
 		s.error(w, err)
 		return
@@ -293,15 +284,13 @@ func (s *Server) handleRun(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "Unexpected path for command running", http.StatusBadRequest)
 		return
 	}
-	podFullName := GetPodFullName(&api.BoundPod{
-		ObjectMeta: api.ObjectMeta{
-			Name:        podID,
-			Namespace:   podNamespace,
-			Annotations: map[string]string{ConfigSourceAnnotationKey: "etcd"},
-		},
-	})
+	pod, ok := s.host.GetPodByName(podNamespace, podID)
+	if !ok {
+		http.Error(w, "Pod does not exist", http.StatusNotFound)
+		return
+	}
 	command := strings.Split(u.Query().Get("cmd"), " ")
-	data, err := s.host.RunInContainer(podFullName, uuid, container, command)
+	data, err := s.host.RunInContainer(GetPodFullName(pod), uuid, container, command)
 	if err != nil {
 		s.error(w, err)
 		return
@@ -344,24 +333,20 @@ func (s *Server) serveStats(w http.ResponseWriter, req *http.Request) {
 		// TODO(monnand) Implement this
 		errors.New("pod level status currently unimplemented")
 	case 3:
-		// Backward compatibility without uuid information
-		podFullName := GetPodFullName(&api.BoundPod{
-			ObjectMeta: api.ObjectMeta{
-				Name:        components[1],
-				Namespace:   api.NamespaceDefault,
-				Annotations: map[string]string{ConfigSourceAnnotationKey: "etcd"},
-			},
-		})
-		stats, err = s.host.GetContainerInfo(podFullName, "", components[2], &query)
+		// Backward compatibility without uuid information, does not support namespace
+		pod, ok := s.host.GetPodByName(api.NamespaceDefault, components[1])
+		if !ok {
+			http.Error(w, "Pod does not exist", http.StatusNotFound)
+			return
+		}
+		stats, err = s.host.GetContainerInfo(GetPodFullName(pod), "", components[2], &query)
 	case 5:
-		podFullName := GetPodFullName(&api.BoundPod{
-			ObjectMeta: api.ObjectMeta{
-				Name:        components[2],
-				Namespace:   components[1],
-				Annotations: map[string]string{ConfigSourceAnnotationKey: "etcd"},
-			},
-		})
-		stats, err = s.host.GetContainerInfo(podFullName, components[3], components[4], &query)
+		pod, ok := s.host.GetPodByName(components[1], components[2])
+		if !ok {
+			http.Error(w, "Pod does not exist", http.StatusNotFound)
+			return
+		}
+		stats, err = s.host.GetContainerInfo(GetPodFullName(pod), components[3], components[4], &query)
 	default:
 		http.Error(w, "unknown resource.", http.StatusNotFound)
 		return

--- a/pkg/tools/fake_etcd_client.go
+++ b/pkg/tools/fake_etcd_client.go
@@ -131,7 +131,7 @@ func (f *FakeEtcdClient) Get(key string, sort, recursive bool) (*etcd.Response, 
 		}
 		return &etcd.Response{}, EtcdErrorNotFound
 	}
-	f.t.Logf("returning %v: %v %#v", key, result.R, result.E)
+	f.t.Logf("returning %v: %#v %#v", key, result.R, result.E)
 	return result.R, result.E
 }
 
@@ -262,6 +262,7 @@ func (f *FakeEtcdClient) WaitForWatchCompletion() {
 }
 
 func (f *FakeEtcdClient) Watch(prefix string, waitIndex uint64, recursive bool, receiver chan *etcd.Response, stop chan bool) (*etcd.Response, error) {
+	f.Mutex.Lock()
 	if f.WatchImmediateError != nil {
 		return nil, f.WatchImmediateError
 	}
@@ -273,6 +274,7 @@ func (f *FakeEtcdClient) Watch(prefix string, waitIndex uint64, recursive bool, 
 	defer close(injectedError)
 	f.WatchInjectError = injectedError
 
+	f.Mutex.Unlock()
 	if receiver == nil {
 		return f.Get(prefix, false, recursive)
 	} else {


### PR DESCRIPTION
- Watching invalid label/field selectors should error
- Watch locks restrict ability to test certain things
- Kubelet does not properly distinguish between sources, prepare for API change

Extracted from #846, @erictune this is all stuff you'll hit

@lavalamp review please
