### PR TITLE
Update etcd-http-read-timeout to match with coreos validator

### DIFF
--- a/docs/getting-started-guides/aws/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/aws/cloud-configs/master.yaml
@@ -10,7 +10,7 @@ coreos:
     bind-addr: 0.0.0.0
     peer-addr: $private_ipv4:7001
     cluster-active-size: 1
-    http-read-timeout: 86400
+    http-read-timeout: 86400.0
     snapshot: true
   units:
     - name: etcd.service

--- a/docs/getting-started-guides/aws/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/aws/cloud-configs/master.yaml
@@ -10,7 +10,7 @@ coreos:
     bind-addr: 0.0.0.0
     peer-addr: $private_ipv4:7001
     cluster-active-size: 1
-    etcd-http-read-timeout: 86400
+    http-read-timeout: 86400
     snapshot: true
   units:
     - name: etcd.service


### PR DESCRIPTION
Refering to https://github.com/coreos/coreos-cloudinit-validator/blob/master/third_party/github.com/coreos/coreos-cloudinit/config/etcd.go#L31
http-read-timeout must be used to fit in coreos validator
