### PR TITLE
Create client outside of Kubelet object.

### DIFF
--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -102,8 +102,6 @@ func main() {
 
 	kcfg := standalone.KubeletConfig{
 		Address:                 address,
-		AuthPath:                *authPath,
-		ApiServerList:           apiServerList,
 		AllowPrivileged:         *allowPrivileged,
 		HostnameOverride:        *hostnameOverride,
 		RootDirectory:           *rootDirectory,
@@ -125,6 +123,7 @@ func main() {
 		EnableServer:            *enableServer,
 		EnableDebuggingHandlers: *enableDebuggingHandlers,
 		DockerClient:            util.ConnectToDockerOrDie(*dockerEndpoint),
+		ApiClient:               kubelet.ApiClientMaybe(*authPath, apiServerList),
 		EtcdClient:              kubelet.EtcdClientOrDie(etcdServerList, *etcdConfigFile),
 	}
 

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -52,7 +52,7 @@ func startComponents(etcdClient tools.EtcdClient, cl *client.Client, addr string
 	standalone.RunControllerManager(machineList, cl, *nodeMilliCPU, *nodeMemory)
 
 	dockerClient := util.ConnectToDockerOrDie(*dockerEndpoint)
-	standalone.SimpleRunKubelet(etcdClient, dockerClient, machineList[0], "/tmp/kubernetes", "", "127.0.0.1", 10250)
+	standalone.SimpleRunKubelet(etcdClient, cl, dockerClient, machineList[0], "/tmp/kubernetes", "", "127.0.0.1", 10250)
 }
 
 func newApiClient(addr string, port int) *client.Client {

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -129,9 +129,10 @@ func RunControllerManager(machineList []string, cl *client.Client, nodeMilliCPU,
 
 // SimpleRunKubelet is a simple way to start a Kubelet talking to dockerEndpoint, using an etcdClient.
 // Under the hood it calls RunKubelet (below)
-func SimpleRunKubelet(etcdClient tools.EtcdClient, dockerClient dockertools.DockerInterface, hostname, rootDir, manifestURL, address string, port uint) {
+func SimpleRunKubelet(etcdClient tools.EtcdClient, apiClient *client.Client, dockerClient dockertools.DockerInterface, hostname, rootDir, manifestURL, address string, port uint) {
 	kcfg := KubeletConfig{
 		EtcdClient:            etcdClient,
+		ApiClient:             apiClient,
 		DockerClient:          dockerClient,
 		HostnameOverride:      hostname,
 		RootDirectory:         rootDir,
@@ -152,7 +153,7 @@ func SimpleRunKubelet(etcdClient tools.EtcdClient, dockerClient dockertools.Dock
 //   3 Standalone 'kubernetes' binary
 // Eventually, #2 will be replaced with instances of #3
 func RunKubelet(kcfg *KubeletConfig) {
-	kubelet.SetupEventSending(kcfg.AuthPath, kcfg.ApiServerList)
+	kubelet.SetupEventSending(kcfg.ApiClient)
 	kubelet.SetupLogging()
 	kubelet.SetupCapabilities(kcfg.AllowPrivileged)
 
@@ -210,11 +211,10 @@ func makePodSourceConfig(kc *KubeletConfig) *config.PodConfig {
 
 type KubeletConfig struct {
 	EtcdClient              tools.EtcdClient
+	ApiClient               *client.Client
 	DockerClient            dockertools.DockerInterface
 	CAdvisorPort            uint
 	Address                 util.IP
-	AuthPath                string
-	ApiServerList           util.StringList
 	AllowPrivileged         bool
 	HostnameOverride        string
 	RootDirectory           string


### PR DESCRIPTION
Add apiserver client to standalone.KubeletConfig.
Pass to SimpleRunKubelet and RunKubelet.
Move creation of client in integration.go to earlier so kubelet can get it.
Remove no-longer used vars from standalone.KubeletConfig.
