### PR TITLE
Revert "Fix inflight merge conflict by adapting rollingupdate to #2861"

### DIFF
--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -21,7 +21,6 @@ import (
 	"io"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
 	"github.com/spf13/cobra"
 )
@@ -69,9 +68,7 @@ $ cat frontend-v2.json | kubectl rollingupdate frontend-v1 -f -
 			err = CompareNamespaceFromFile(cmd, namespace)
 			checkErr(err)
 
-			config, err := f.ClientConfig.ClientConfig()
-			checkErr(err)
-			client, err := client.New(config)
+			client, err := f.ClientBuilder.Client()
 			checkErr(err)
 			obj, err := mapping.Codec.Decode(data)
 			checkErr(err)


### PR DESCRIPTION
Reverts GoogleCloudPlatform/kubernetes#3273 dependent PR needs reverting.
