### PR TITLE
Using google/cadvisor:0.7.1 instead of :latest

### DIFF
--- a/cluster/saltbase/salt/cadvisor/cadvisor.manifest
+++ b/cluster/saltbase/salt/cadvisor/cadvisor.manifest
@@ -2,7 +2,7 @@ version: v1beta2
 id: cadvisor-agent
 containers:
   - name: cadvisor
-    image: google/cadvisor:latest
+    image: google/cadvisor:0.7.1
     ports:
       - name: http
         containerPort: 8080


### PR DESCRIPTION
@brendandburns @filbranden @thockin @vmarmol 

We talked about caching pause and cadvisor images to containervm image. But even the default policy is PullIfNotPresent, if a image with tag :latest, kubelet is going to treat it as PullAlways. On another hand, I think bundling cadvisor version with kuberenetes release is the right approach anyway. 
