### PR TITLE
Revert "GKE: Add ENABLE_CLUSTER_DNS, compute appropriate DNS_SERVER_IP"

### DIFF
--- a/cluster/gke/config-common.sh
+++ b/cluster/gke/config-common.sh
@@ -27,15 +27,7 @@ CLUSTER_API_VERSION="${CLUSTER_API_VERSION:-}"
 NETWORK="${NETWORK:-default}"
 GCLOUD="${GCLOUD:-gcloud}"
 GCLOUD_CONFIG_DIR="${GCLOUD_CONFIG_DIR:-${HOME}/.config/gcloud/kubernetes}"
-
-# Optional: Install cluster DNS.
-# TODO: enable this when DNS_SERVER_IP can be easily bound.
-ENABLE_CLUSTER_DNS=true
-# DNS_SERVER_IP bound during kube-up using servicesIpv4Cidr
-# and DNS_SERVER_OCTET.
-DNS_SERVER_OCTET="10"
-DNS_DOMAIN="kubernetes.local"
-DNS_REPLICAS=1
+ENABLE_CLUSTER_DNS=false
 
 # This is a hack, but I keep setting this when I run commands manually, and
 # then things grossly fail during normal runs because cluster/kubecfg.sh and

--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -85,8 +85,6 @@ function verify-prereqs() {
 #   CLUSTER_API_VERSION (optional)
 #   NUM_MINIONS
 function kube-up() {
-  local service_prefix
-
   echo "... in kube-up()" >&2
   detect-project >&2
   "${GCLOUD}" preview container clusters create "${CLUSTER_NAME}" \
@@ -95,19 +93,6 @@ function kube-up() {
     --cluster-api-version="${CLUSTER_API_VERSION:-}" \
     --num-nodes="${NUM_MINIONS}" \
     --network="${NETWORK}"
-
-  # Compute DNS_SERVER_IP: This is looking for something like
-  # "servicesIpv4Cidr: 10.27.240.0/20" and returning "10.27.240"
-  # (which is presumptious of at least a /24 network mask, but easier
-  # to use in bash than the /20). We then tack on the DNS_SERVER_OCTET
-  # to mutate the global DNS_SERVER_IP.
-  if [[ "${ENABLE_CLUSTER_DNS}" == "true" ]]; then
-    service_prefix=$("${GCLOUD}" preview container clusters describe \
-      --project="${PROJECT}" --zone="${ZONE}" "${CLUSTER_NAME}" |
-      egrep "^servicesIpv4Cidr:" | cut -f2 -d\ | cut -f1-3 -d.)
-
-    DNS_SERVER_IP="${service_prefix}.${DNS_SERVER_OCTET}"
-  fi
 }
 
 # Called during cluster/kube-up.sh


### PR DESCRIPTION
We actually can't yet support cluster DNS inside GKE yet; it conflicts
with how we handle startup internally.

This reverts commit fdccfe970db2ff5526fd6cbff10692c6cf6a3b20.
