### PR TITLE
Changes to improve swagger ui

### DIFF
--- a/pkg/apiserver/index.go
+++ b/pkg/apiserver/index.go
@@ -17,21 +17,11 @@ limitations under the License.
 package apiserver
 
 import (
-	"fmt"
+	"io"
 	"net/http"
-
-	"github.com/emicklei/go-restful"
 )
 
 // handleIndex is the root index page for Kubernetes.
-func handleIndex(req *restful.Request, resp *restful.Response) {
-	// TODO: use restful's Request/Response methods
-	if req.Request.URL.Path != "/" && req.Request.URL.Path != "/index.html" {
-		notFound(resp.ResponseWriter, req.Request)
-		return
-	}
-	resp.ResponseWriter.WriteHeader(http.StatusOK)
-	// TODO: serve this out of a file
-	data := "<html><body>Welcome to Kubernetes</body></html>"
-	fmt.Fprint(resp.ResponseWriter, data)
+func HandleIndex(w http.ResponseWriter, r *http.Request) {
+	io.WriteString(w, "<html><body>Welcome to Kubernetes</body></html>")
 }

--- a/pkg/ui/installsupport.go
+++ b/pkg/ui/installsupport.go
@@ -26,14 +26,16 @@ type MuxInterface interface {
 	Handle(pattern string, handler http.Handler)
 }
 
-func InstallSupport(mux MuxInterface) {
+func InstallSupport(mux MuxInterface, enableSwaggerSupport bool) {
 	// Expose files in www/ on <host>/static/
 	fileServer := http.FileServer(&assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, Prefix: "www"})
 	prefix := "/static/"
 	mux.Handle(prefix, http.StripPrefix(prefix, fileServer))
 
-	// Expose files in third_party/swagger-ui/ on <host>/swagger-ui/
-	fileServer = http.FileServer(&assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, Prefix: "third_party/swagger-ui"})
-	prefix = "/swagger-ui/"
-	mux.Handle(prefix, http.StripPrefix(prefix, fileServer))
+	if enableSwaggerSupport {
+		// Expose files in third_party/swagger-ui/ on <host>/swagger-ui
+		fileServer = http.FileServer(&assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, Prefix: "third_party/swagger-ui"})
+		prefix = "/swagger-ui/"
+		mux.Handle(prefix, http.StripPrefix(prefix, fileServer))
+	}
 }


### PR DESCRIPTION
- Separating out version and api handlers into independent web
  services. Moved the version handler to /version and the api handler to /api.
- Registering index Handler on "/" using mux instead of restful WebService since we do not want to surface that in api docs.
- Updating the swagger code to surface swagger files only if config.EnableSwaggerSupport is true.
- Fixed a bug in registering namespace PathParameter, where it was being registered on the WebService instead of being registered on individual Routes.

This is how swagger ui looks now:
![y05dp3enbc](https://cloud.githubusercontent.com/assets/10199099/5674919/e798c05c-9767-11e4-8db1-203d18865e13.png)

![oyfda6rnvf](https://cloud.githubusercontent.com/assets/10199099/5674921/eebe0284-9767-11e4-83af-34ad1388d135.png)
