### PR TITLE
Skip TestClusterDNS on GKE (since DNS is disabled there)

### DIFF
--- a/cmd/e2e/e2e.go
+++ b/cmd/e2e/e2e.go
@@ -447,6 +447,15 @@ func outputTAPSummary(infoList []TestInfo) {
 
 // TestClusterDNS checks that cluster DNS works.
 func TestClusterDNS(c *client.Client) bool {
+	// TODO:
+	// https://github.com/GoogleCloudPlatform/kubernetes/issues/3305
+	// (but even if it's fixed, this will need a version check for
+	// skewed version tests)
+	if os.Getenv("KUBERNETES_PROVIDER") == "gke" {
+		glog.Infof("skipping TestClusterDNS on gke")
+		return true
+	}
+
 	podClient := c.Pods(api.NamespaceDefault)
 
 	//TODO: Wait for skyDNS


### PR DESCRIPTION
We'll eventually want to do something fancier here. But the yak needs
to stop growing hair.
