### PR TITLE
Make an 'allow-ssh-on-all-nodes' firewall rule when on a non-default net...

### DIFF
--- a/cluster/gke/config-common.sh
+++ b/cluster/gke/config-common.sh
@@ -26,6 +26,7 @@ CLUSTER_API_VERSION="${CLUSTER_API_VERSION:-}"
 #                 because we use the 'default' network by default.
 NETWORK="${NETWORK:-default}"
 NETWORK_RANGE="${NETWORK_RANGE:-10.240.0.0/16}"
+FIREWALL_SSH="${FIREWALL_SSH:-${NETWORK}-allow-ssh}"
 GCLOUD="${GCLOUD:-gcloud}"
 GCLOUD_CONFIG_DIR="${GCLOUD_CONFIG_DIR:-${HOME}/.config/gcloud/kubernetes}"
 ENABLE_CLUSTER_DNS=false

--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -94,6 +94,17 @@ function kube-up() {
     gcloud compute networks create "${NETWORK}" --range "${NETWORK_RANGE}"
   fi
 
+  # Allow SSH on all nodes in the network. This doesn't actually check whether
+  # such a rule exists, only whether we've created this exact rule.
+  if ! gcloud compute firewall-rules describe "${FIREWALL_SSH}" &>/dev/null; then
+    echo "Creating new firewall for SSH: ${FIREWALL_SSH}" >&2
+    gcloud compute firewall-rules create "${FIREWALL_SSH}" \
+      --allow="tcp:22" \
+      --network="${NETWORK}" \
+      --project="${PROJECT}" \
+      --source-ranges="0.0.0.0/0"
+  fi
+
   # Bring up the cluster.
   "${GCLOUD}" preview container clusters create "${CLUSTER_NAME}" \
     --zone="${ZONE}" \


### PR DESCRIPTION
...work.

Otherwise, our 'gcloud preview container clusters create' call fails because it can't copy any of the cert/auth files from the master.
