### PR TITLE
GKE: Fix services.sh for server versions < 0.8.0

### DIFF
--- a/hack/e2e-suite/services.sh
+++ b/hack/e2e-suite/services.sh
@@ -388,8 +388,10 @@ verify_from_container "${svc3_name}" "${svc3_ip}" "${svc3_port}" \
 #
 echo "Test 5: Remove the iptables rules, make sure they come back."
 echo "Manually removing iptables rules"
-ssh-to-node "${test_node}" "sudo iptables -t nat -F KUBE-PORTALS-HOST"
-ssh-to-node "${test_node}" "sudo iptables -t nat -F KUBE-PORTALS-CONTAINER"
+# Remove both the new and old style chains, in case we're testing on an old kubelet
+ssh-to-node "${test_node}" "sudo iptables -t nat -F KUBE-PORTALS-HOST || true"
+ssh-to-node "${test_node}" "sudo iptables -t nat -F KUBE-PORTALS-CONTAINER || true"
+ssh-to-node "${test_node}" "sudo iptables -t nat -F KUBE-PROXY || true"
 echo "Verifying the portals from the host"
 wait_for_service_up "${svc3_name}" "${svc3_ip}" "${svc3_port}" \
     "${svc3_count}" "${svc3_pods}"


### PR DESCRIPTION
Commit e045c6ce broke this test against all server versions <0.8.0,
which immediately broke the GKE Jenkins runs.
