### PR TITLE
Rename ListPods methods to List.

### DIFF
--- a/pkg/client/cache/listers.go
+++ b/pkg/client/cache/listers.go
@@ -31,7 +31,8 @@ import (
 //
 // Example:
 // s := cache.NewStore()
-// XXX NewReflector(... s ...)
+// lw := cache.ListWatch{Client: c, FieldSelector: sel, Resource: "pods"}
+// r := cache.NewReflector(lw, &api.Pod{}, s).Run()
 // l := StoreToPodLister{s}
 // l.List()
 type StoreToPodLister struct {
@@ -39,10 +40,10 @@ type StoreToPodLister struct {
 }
 
 // TODO Get rid of the selector because that is confusing because the user might not realize that there has already been
-// some selection at the caching stage.  Also, consistency will facilitate code generation.
-// TODO: Rename to List() instead of ListPods() for consistency with other resources and with pkg/client..
-func (s *StoreToPodLister) ListPods(selector labels.Selector) (pods []api.Pod, err error) {
-	for _, m := range s.List() {
+// some selection at the caching stage.  Also, consistency will facilitate code generation.  However, the pkg/client
+// is inconsistent too.
+func (s *StoreToPodLister) List(selector labels.Selector) (pods []api.Pod, err error) {
+	for _, m := range s.Store.List() {
 		pod := m.(*api.Pod)
 		if selector.Matches(labels.Set(pod.Labels)) {
 			pods = append(pods, *pod)

--- a/pkg/client/cache/listers_test.go
+++ b/pkg/client/cache/listers_test.go
@@ -59,7 +59,7 @@ func TestStoreToPodLister(t *testing.T) {
 	spl := StoreToPodLister{store}
 
 	for _, id := range ids {
-		got, err := spl.ListPods(labels.Set{"name": id}.AsSelector())
+		got, err := spl.List(labels.Set{"name": id}.AsSelector())
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 			continue

--- a/pkg/client/doc.go
+++ b/pkg/client/doc.go
@@ -30,7 +30,7 @@ Most consumers should use the Config object to create a Client:
     if err != nil {
       // handle error
     }
-    client.ListPods()
+    client.Pods(ns).List()
 
 More advanced consumers may wish to provide their own transport via a http.RoundTripper:
 

--- a/pkg/client/pods.go
+++ b/pkg/client/pods.go
@@ -52,7 +52,7 @@ func newPods(c *Client, namespace string) *pods {
 	}
 }
 
-// ListPods takes a selector, and returns the list of pods that match that selector.
+// List takes a selector, and returns the list of pods that match that selector.
 func (c *pods) List(selector labels.Selector) (result *api.PodList, err error) {
 	result = &api.PodList{}
 	err = c.r.Get().Namespace(c.ns).Resource("pods").SelectorParam("labels", selector).Do().Into(result)

--- a/pkg/clientauth/clientauth.go
+++ b/pkg/clientauth/clientauth.go
@@ -58,7 +58,7 @@ Example:
     clientConfig.Host = "example.com:4901"
     clientConfig = info.MergeWithConfig()
     client := client.New(clientConfig)
-    client.ListPods()
+    client.Pods(ns).List()
 */
 package clientauth
 

--- a/pkg/scheduler/listers.go
+++ b/pkg/scheduler/listers.go
@@ -36,15 +36,15 @@ func (f FakeMinionLister) List() (api.NodeList, error) {
 
 // PodLister interface represents anything that can list pods for a scheduler.
 type PodLister interface {
-	// TODO: make this exactly the same as client's ListPods() method...
-	ListPods(labels.Selector) ([]api.Pod, error)
+	// TODO: make this exactly the same as client's Pods(ns).List() method, by returning a api.PodList
+	List(labels.Selector) ([]api.Pod, error)
 }
 
 // FakePodLister implements PodLister on an []api.Pods for test purposes.
 type FakePodLister []api.Pod
 
-// ListPods returns []api.Pod matching a query.
-func (f FakePodLister) ListPods(s labels.Selector) (selected []api.Pod, err error) {
+// List returns []api.Pod matching a query.
+func (f FakePodLister) List(s labels.Selector) (selected []api.Pod, err error) {
 	for _, pod := range f {
 		if s.Matches(labels.Set(pod.Labels)) {
 			selected = append(selected, pod)

--- a/pkg/scheduler/predicates.go
+++ b/pkg/scheduler/predicates.go
@@ -198,7 +198,7 @@ func getUsedPorts(pods ...api.Pod) map[int]bool {
 func MapPodsToMachines(lister PodLister) (map[string][]api.Pod, error) {
 	machineToPods := map[string][]api.Pod{}
 	// TODO: perform more targeted query...
-	pods, err := lister.ListPods(labels.Everything())
+	pods, err := lister.List(labels.Everything())
 	if err != nil {
 		return map[string][]api.Pod{}, err
 	}

--- a/pkg/scheduler/spreading.go
+++ b/pkg/scheduler/spreading.go
@@ -28,7 +28,7 @@ import (
 // may not provide optimal spreading for the members of that Service.
 // TODO: consider if we want to include Service label sets in the scheduling priority.
 func CalculateSpreadPriority(pod api.Pod, podLister PodLister, minionLister MinionLister) (HostPriorityList, error) {
-	pods, err := podLister.ListPods(labels.SelectorFromSet(pod.Labels))
+	pods, err := podLister.List(labels.SelectorFromSet(pod.Labels))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For greater similarity to pkg/client.
Does not cover registry's ListPods.
Fix an example in a comment.
