### PR TITLE
Service visibility w/in namespaces, master services, set env vars in kubelet

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -192,13 +192,13 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	// Kubelet (localhost)
 	testRootDir := makeTempDirOrDie("kubelet_integ_1.")
 	glog.Infof("Using %s as root dir for kubelet #1", testRootDir)
-	standalone.SimpleRunKubelet(cl, etcdClient, &fakeDocker1, machineList[0], testRootDir, manifestURL, "127.0.0.1", 10250)
+	standalone.SimpleRunKubelet(cl, etcdClient, &fakeDocker1, machineList[0], testRootDir, manifestURL, "127.0.0.1", 10250, api.NamespaceDefault)
 	// Kubelet (machine)
 	// Create a second kubelet so that the guestbook example's two redis slaves both
 	// have a place they can schedule.
 	testRootDir = makeTempDirOrDie("kubelet_integ_2.")
 	glog.Infof("Using %s as root dir for kubelet #2", testRootDir)
-	standalone.SimpleRunKubelet(cl, etcdClient, &fakeDocker2, machineList[1], testRootDir, "", "127.0.0.1", 10251)
+	standalone.SimpleRunKubelet(cl, etcdClient, &fakeDocker2, machineList[1], testRootDir, "", "127.0.0.1", 10251, api.NamespaceDefault)
 
 	return apiServer.URL
 }

--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/capabilities"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
@@ -87,6 +88,7 @@ var (
 		Port:        10250,
 		EnableHttps: false,
 	}
+	masterServiceNamespace = flag.String("master_service_namespace", api.NamespaceDefault, "The namespace from which the kubernetes master services should be injected into pods")
 )
 
 func init() {
@@ -177,25 +179,26 @@ func main() {
 	admissionController := admission.NewFromPlugins(client, admissionControlPluginNames, *admissionControlConfigFile)
 
 	config := &master.Config{
-		Client:                client,
-		Cloud:                 cloud,
-		EtcdHelper:            helper,
-		HealthCheckMinions:    *healthCheckMinions,
-		EventTTL:              *eventTTL,
-		KubeletClient:         kubeletClient,
-		PortalNet:             &n,
-		EnableLogsSupport:     *enableLogsSupport,
-		EnableUISupport:       true,
-		EnableSwaggerSupport:  true,
-		APIPrefix:             *apiPrefix,
-		CorsAllowedOriginList: corsAllowedOriginList,
-		ReadOnlyPort:          *readOnlyPort,
-		ReadWritePort:         *port,
-		PublicAddress:         *publicAddressOverride,
-		Authenticator:         authenticator,
-		Authorizer:            authorizer,
-		AdmissionControl:      admissionController,
-		EnableV1Beta3:         v1beta3,
+		Client:                 client,
+		Cloud:                  cloud,
+		EtcdHelper:             helper,
+		HealthCheckMinions:     *healthCheckMinions,
+		EventTTL:               *eventTTL,
+		KubeletClient:          kubeletClient,
+		PortalNet:              &n,
+		EnableLogsSupport:      *enableLogsSupport,
+		EnableUISupport:        true,
+		EnableSwaggerSupport:   true,
+		APIPrefix:              *apiPrefix,
+		CorsAllowedOriginList:  corsAllowedOriginList,
+		ReadOnlyPort:           *readOnlyPort,
+		ReadWritePort:          *port,
+		PublicAddress:          *publicAddressOverride,
+		Authenticator:          authenticator,
+		Authorizer:             authorizer,
+		AdmissionControl:       admissionController,
+		EnableV1Beta3:          v1beta3,
+		MasterServiceNamespace: *masterServiceNamespace,
 	}
 	m := master.New(config)
 

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master/ports"
@@ -64,6 +65,7 @@ var (
 	oomScoreAdj             = flag.Int("oom_score_adj", -900, "The oom_score_adj value for kubelet process. Values must be within the range [-1000, 1000]")
 	apiServerList           util.StringList
 	clusterDomain           = flag.String("cluster_domain", "", "Domain for this cluster.  If set, kubelet will configure all containers to search this domain in addition to the host's search domains")
+	masterServiceNamespace  = flag.String("master_service_namespace", api.NamespaceDefault, "The namespace from which the kubernetes master services should be injected into pods")
 	clusterDNS              = util.IP(nil)
 )
 
@@ -130,6 +132,7 @@ func main() {
 		DockerClient:            util.ConnectToDockerOrDie(*dockerEndpoint),
 		KubeClient:              client,
 		EtcdClient:              kubelet.EtcdClientOrDie(etcdServerList, *etcdConfigFile),
+		MasterServiceNamespace:  *masterServiceNamespace,
 	}
 
 	standalone.RunKubelet(&kcfg)

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -878,7 +878,10 @@ func TestValidateService(t *testing.T) {
 			},
 			existing: api.ServiceList{
 				Items: []api.Service{
-					{Spec: api.ServiceSpec{Port: 80, CreateExternalLoadBalancer: true}},
+					{
+						ObjectMeta: api.ObjectMeta{Name: "def123", Namespace: api.NamespaceDefault},
+						Spec:       api.ServiceSpec{Port: 80, CreateExternalLoadBalancer: true},
+					},
 				},
 			},
 			numErrs: 1,
@@ -895,7 +898,10 @@ func TestValidateService(t *testing.T) {
 			},
 			existing: api.ServiceList{
 				Items: []api.Service{
-					{Spec: api.ServiceSpec{Port: 80}},
+					{
+						ObjectMeta: api.ObjectMeta{Name: "def123", Namespace: api.NamespaceDefault},
+						Spec:       api.ServiceSpec{Port: 80},
+					},
 				},
 			},
 			numErrs: 0,
@@ -911,7 +917,10 @@ func TestValidateService(t *testing.T) {
 			},
 			existing: api.ServiceList{
 				Items: []api.Service{
-					{Spec: api.ServiceSpec{Port: 80, CreateExternalLoadBalancer: true}},
+					{
+						ObjectMeta: api.ObjectMeta{Name: "def123", Namespace: api.NamespaceDefault},
+						Spec:       api.ServiceSpec{Port: 80, CreateExternalLoadBalancer: true},
+					},
 				},
 			},
 			numErrs: 0,
@@ -927,7 +936,10 @@ func TestValidateService(t *testing.T) {
 			},
 			existing: api.ServiceList{
 				Items: []api.Service{
-					{Spec: api.ServiceSpec{Port: 80}},
+					{
+						ObjectMeta: api.ObjectMeta{Name: "def123", Namespace: api.NamespaceDefault},
+						Spec:       api.ServiceSpec{Port: 80},
+					},
 				},
 			},
 			numErrs: 0,

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -62,23 +62,24 @@ import (
 
 // Config is a structure used to configure a Master.
 type Config struct {
-	Client                *client.Client
-	Cloud                 cloudprovider.Interface
-	EtcdHelper            tools.EtcdHelper
-	HealthCheckMinions    bool
-	EventTTL              time.Duration
-	MinionRegexp          string
-	KubeletClient         client.KubeletClient
-	PortalNet             *net.IPNet
-	EnableLogsSupport     bool
-	EnableUISupport       bool
-	EnableSwaggerSupport  bool
-	EnableV1Beta3         bool
-	APIPrefix             string
-	CorsAllowedOriginList util.StringList
-	Authenticator         authenticator.Request
-	Authorizer            authorizer.Authorizer
-	AdmissionControl      admission.Interface
+	Client                 *client.Client
+	Cloud                  cloudprovider.Interface
+	EtcdHelper             tools.EtcdHelper
+	HealthCheckMinions     bool
+	EventTTL               time.Duration
+	MinionRegexp           string
+	KubeletClient          client.KubeletClient
+	PortalNet              *net.IPNet
+	EnableLogsSupport      bool
+	EnableUISupport        bool
+	EnableSwaggerSupport   bool
+	EnableV1Beta3          bool
+	APIPrefix              string
+	CorsAllowedOriginList  util.StringList
+	Authenticator          authenticator.Request
+	Authorizer             authorizer.Authorizer
+	AdmissionControl       admission.Interface
+	MasterServiceNamespace string
 
 	// If specified, all web services will be registered into this container
 	RestfulContainer *restful.Container
@@ -231,7 +232,8 @@ func New(c *Config) *Master {
 	minionRegistry := makeMinionRegistry(c)
 	serviceRegistry := etcd.NewRegistry(c.EtcdHelper, nil)
 	boundPodFactory := &pod.BasicBoundPodFactory{
-		ServiceRegistry: serviceRegistry,
+		ServiceRegistry:        serviceRegistry,
+		MasterServiceNamespace: c.MasterServiceNamespace,
 	}
 	if c.KubeletClient == nil {
 		glog.Fatalf("master.New() called with config.KubeletClient == nil")

--- a/pkg/registry/etcd/etcd_test.go
+++ b/pkg/registry/etcd/etcd_test.go
@@ -130,7 +130,8 @@ func TestEtcdCreatePod(t *testing.T) {
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreatePod(ctx, &api.Pod{
 		ObjectMeta: api.ObjectMeta{
-			Name: "foo",
+			Name:      "foo",
+			Namespace: api.NamespaceDefault,
 		},
 		Spec: api.PodSpec{
 			Containers: []api.Container{
@@ -240,7 +241,8 @@ func TestEtcdCreatePodWithContainersError(t *testing.T) {
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreatePod(ctx, &api.Pod{
 		ObjectMeta: api.ObjectMeta{
-			Name: "foo",
+			Name:      "foo",
+			Namespace: api.NamespaceDefault,
 		},
 	})
 	if err != nil {
@@ -282,7 +284,8 @@ func TestEtcdCreatePodWithContainersNotFound(t *testing.T) {
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreatePod(ctx, &api.Pod{
 		ObjectMeta: api.ObjectMeta{
-			Name: "foo",
+			Name:      "foo",
+			Namespace: api.NamespaceDefault,
 		},
 		Spec: api.PodSpec{
 			Containers: []api.Container{
@@ -346,7 +349,8 @@ func TestEtcdCreatePodWithExistingContainers(t *testing.T) {
 	registry := NewTestEtcdRegistry(fakeClient)
 	err := registry.CreatePod(ctx, &api.Pod{
 		ObjectMeta: api.ObjectMeta{
-			Name: "foo",
+			Name:      "foo",
+			Namespace: api.NamespaceDefault,
 		},
 		Spec: api.PodSpec{
 			Containers: []api.Container{

--- a/pkg/registry/service/rest_test.go
+++ b/pkg/registry/service/rest_test.go
@@ -347,13 +347,13 @@ func TestServiceRegistryList(t *testing.T) {
 	machines := []string{"foo", "bar", "baz"}
 	storage := NewREST(registry, fakeCloud, registrytest.NewMinionRegistry(machines, api.NodeResources{}), makeIPNet(t))
 	registry.CreateService(ctx, &api.Service{
-		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: api.NamespaceDefault},
 		Spec: api.ServiceSpec{
 			Selector: map[string]string{"bar": "baz"},
 		},
 	})
 	registry.CreateService(ctx, &api.Service{
-		ObjectMeta: api.ObjectMeta{Name: "foo2"},
+		ObjectMeta: api.ObjectMeta{Name: "foo2", Namespace: api.NamespaceDefault},
 		Spec: api.ServiceSpec{
 			Selector: map[string]string{"bar2": "baz2"},
 		},
@@ -585,7 +585,7 @@ func TestServiceRegistryIPReloadFromStorage(t *testing.T) {
 	rest1.portalMgr.randomAttempts = 0
 
 	svc := &api.Service{
-		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: api.NamespaceDefault},
 		Spec: api.ServiceSpec{
 			Selector: map[string]string{"bar": "baz"},
 			Port:     6502,
@@ -595,7 +595,7 @@ func TestServiceRegistryIPReloadFromStorage(t *testing.T) {
 	c, _ := rest1.Create(ctx, svc)
 	<-c
 	svc = &api.Service{
-		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: api.NamespaceDefault},
 		Spec: api.ServiceSpec{
 			Selector: map[string]string{"bar": "baz"},
 			Port:     6502,
@@ -609,7 +609,7 @@ func TestServiceRegistryIPReloadFromStorage(t *testing.T) {
 	rest2.portalMgr.randomAttempts = 0
 
 	svc = &api.Service{
-		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: api.NamespaceDefault},
 		Spec: api.ServiceSpec{
 			Selector: map[string]string{"bar": "baz"},
 			Port:     6502,


### PR DESCRIPTION
Fixes #3293.  This change:
1.  Handles setting environment variables from services correctly in `BoundPodFactory` and overlaying services in a pod's namespace on top the master services in a master service namespace
2.  Adds a service watch to the kubelet and adds setting environment variables for services directly in the kubelet (laying the groundwork for handling service environment var injection totally in the kubelet)
