### PR TITLE
Fix "Kubelet doesn't kill old pods when BoundPods is empty" issue

### DIFF
--- a/pkg/kubelet/config/etcd_test.go
+++ b/pkg/kubelet/config/etcd_test.go
@@ -33,7 +33,7 @@ func TestEventToPods(t *testing.T) {
 		{
 			input: watch.Event{Object: nil},
 			pods:  []api.BoundPod{},
-			fail:  true,
+			fail:  false,
 		},
 		{
 			input: watch.Event{Object: &api.BoundPods{}},

--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -64,6 +64,8 @@ func (s *sourceFile) extractFromPath() error {
 		if !os.IsNotExist(err) {
 			return err
 		}
+		// Emit an update with an empty PodList to allow FileSource to be marked as seen
+		s.updates <- kubelet.PodUpdate{[]api.BoundPod{}, kubelet.SET, kubelet.FileSource}
 		return fmt.Errorf("path does not exist, ignoring")
 	}
 

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -92,8 +92,14 @@ func TestUpdateOnNonExistentFile(t *testing.T) {
 	NewSourceFile("random_non_existent_path", time.Millisecond, ch)
 	select {
 	case got := <-ch:
-		t.Errorf("Expected no update, Got %#v", got)
+		update := got.(kubelet.PodUpdate)
+		expected := CreatePodUpdate(kubelet.SET, kubelet.FileSource)
+		if !api.Semantic.DeepEqual(expected, update) {
+			t.Fatalf("Expected %#v, Got %#v", expected, update)
+		}
+
 	case <-time.After(2 * time.Millisecond):
+		t.Errorf("Expected update, timeout instead")
 	}
 }
 

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -69,6 +69,8 @@ func (s *sourceURL) extractFromURL() error {
 		return fmt.Errorf("%v: %v", s.url, resp.Status)
 	}
 	if len(data) == 0 {
+		// Emit an update with an empty PodList to allow HTTPSource to be marked as seen
+		s.updates <- kubelet.PodUpdate{[]api.BoundPod{}, kubelet.SET, kubelet.HTTPSource}
 		return fmt.Errorf("zero-length data received from %v", s.url)
 	}
 	// Short circuit if the manifest has not changed since the last time it was read.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1118,9 +1118,6 @@ func (kl *Kubelet) syncLoop(updates <-chan PodUpdate, handler SyncHandler) {
 			}
 		case <-time.After(kl.resyncInterval):
 			glog.V(4).Infof("Periodic sync")
-			if kl.pods == nil {
-				continue
-			}
 		}
 
 		err := handler.SyncPods(kl.pods)


### PR DESCRIPTION
Fixes #2495: **Kubelet doesn't kill old pods when BoundPods is empty**

The first time kubelet starts, while there are no updates, `kl.pods` is `nil` ([pkg/kubelet/kubelet.go#L1118](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/kubelet/kubelet.go#L1118)):

``` GO
case <-time.After(kl.resyncInterval):
    glog.V(4).Infof("Periodic sync")
    if kl.pods == nil {
        continue
    }
```

which guarantees that [`syncPods(...)`](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/kubelet/kubelet.go#L992), which contains the container killing logic is never called.

So the first part of the fix is to remove this check and allow `syncPods(...)` to be called even when nil, so that the first periodic sync can clean up old containers.

However, this isn't enough because inside `syncPods(...)` there is a check to make sure that all sources have been "seen" before it will kill old containers ([pkg/kubelet/kubelet.go#L1026](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/kubelet/kubelet.go#L1026)):

``` GO
if !kl.sourcesReady() {
    // If the sources aren't ready, skip deletion, as we may accidentally delete pods
    // for sources that haven't reported yet.
    glog.V(4).Infof("Skipping deletes, sources aren't ready yet.")
    return nil
}
```

This check is performed in the [`SeenAllSources()`](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/kubelet/config/config.go#L87) function, and is `true` only if a `SET` update has been seen for all registered kubelet sources.

However, no `SET` update is emitted by any of the sources until they successfully read a value, which means the original problem still exists.

So the second part of the fix is to have the kubelet boundpod sources (etcd, file, and http) all emit a `SET` update with an empty pod list when the source is first read but no value exists; the empty update will not make it back to the kubelet sync loop because it will be filtered out by the [update merge logic](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/kubelet/config/config.go#L140); but it will cause the source to be [marked as seen](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/kubelet/config/config.go#L238) so the periodic sync (enabled by the first fix) will clean up the old containers (since all sources will now be marked as seen after the first read attempt).
