### PR TITLE
Fix a crash for kubelet when without EtcdClient.

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"reflect"
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -225,8 +226,7 @@ func makePodSourceConfig(kc *KubeletConfig) *config.PodConfig {
 		glog.Infof("Adding manifest url: %v", kc.ManifestURL)
 		config.NewSourceURL(kc.ManifestURL, kc.HttpCheckFrequency, cfg.Channel(kubelet.HTTPSource))
 	}
-
-	if kc.EtcdClient != nil {
+	if !reflect.ValueOf(kc.EtcdClient).IsNil() {
 		glog.Infof("Watching for etcd configs at %v", kc.EtcdClient.GetCluster())
 		config.NewSourceEtcd(config.EtcdKeyForHost(kc.Hostname), kc.EtcdClient, cfg.Channel(kubelet.EtcdSource))
 	}


### PR DESCRIPTION
The crash is found when we build containervm-image in both release-7.3 and release-8.0. The root cause is trying to comparing the interface EtcdClient which contains a nil value to nil. @brendandburns @filbranden 

I0109 00:01:24.542892    2377 util.go:65] Connecting to docker on
unix:///var/run/docker.sock
I0109 00:01:24.542951    2377 util.go:178] No api servers specified.
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x50 pc=0x59b415]

goroutine 16 [running]:
runtime.panic(0x9bbd40, 0xdd5d73)
        /usr/local/go/src/pkg/runtime/panic.c:279 +0xf5
github.com/coreos/go-etcd/etcd.(*Client).GetCluster(0x0, 0x65,
0x4a817c800, 0xc208004600)
        /tmp/builderOIYgM8/bootstrap-vz/assets/vendor/src/github.com/GoogleCloudPlatform/kubernetes/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/client.go:284
+0x5
github.com/GoogleCloudPlatform/kubernetes/pkg/standalone.makePodSourceConfig(0xc2080857a0,
0x10)
        /tmp/builderOIYgM8/bootstrap-vz/assets/vendor/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/standalone/standalone.go:217
+0x15a
github.com/GoogleCloudPlatform/kubernetes/pkg/standalone.RunKubelet(0xc2080857a0)
        /tmp/builderOIYgM8/bootstrap-vz/assets/vendor/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/standalone/standalone.go:178
+0xf3
main.main()
        /tmp/builderOIYgM8/bootstrap-vz/assets/vendor/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/cmd/kubelet/kubelet.go:121
+0x41c
