### PR TITLE
contrib/podex: fix ordering and manifest generation

### DIFF
--- a/contrib/podex/podex.go
+++ b/contrib/podex/podex.go
@@ -28,11 +28,9 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -215,11 +213,8 @@ func getImageMetadata(host, namespace, repo, tag string) (*imageMetadata, error)
 	if err != nil {
 		return nil, fmt.Errorf("error getting json for image %q: %v", imageID, err)
 	}
-	data, _ := ioutil.ReadAll(resp.Body)
-	buf := bytes.NewBuffer(data)
-	log.Print(string(data))
 	var image imageMetadata
-	if err := json.NewDecoder(buf).Decode(&image); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&image); err != nil {
 		return nil, fmt.Errorf("error decoding image %q metadata: %v", imageID, err)
 	}
 	return &image, nil

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -34,6 +34,7 @@ kube::test::find_dirs() {
           -o -wholename './target' \
           -o -wholename '*/third_party/*' \
           -o -wholename '*/Godeps/*' \
+	  -o -wholename '*/contrib/podex/*' \
         \) -prune \
       \) -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./||' | sort -u
   )


### PR DESCRIPTION
This PR fix the podex to make it works at all and moreuser friendly.
- it uses go-yaml Map\* types instead of v1beta1 types to:
  - maintain a friendly ordering or the properties
  -  filter fields that are currently supported and ignore others (that might have buggy omit empty clause)
- it adds support for pod manifest
- it makes default to yaml and pod manifest output
- it loses the prettyprinting of the JSON

You can try it with:

```
$ go get github.com/proppy/kubernetes/contrib/podex
$ podex nginx
id: nginx
kind: Pod
apiVersion: v1beta1
desiredState:
  manifest:
    version: v1beta1
    containers:
    - name: nginx
      image: nginx
      ports:
      - name: nginx-tcp-443
        containerPort: 443
      - name: nginx-tcp-80
        containerPort: 80
```
