### PR TITLE
Reduce number of minions to improve user experience

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ END
 end
 
 # The number of minions to provision
-$num_minion = (ENV['NUM_MINIONS'] || 3).to_i
+$num_minion = (ENV['NUM_MINIONS'] || 1).to_i
 
 # ip configuration
 $master_ip = ENV['MASTER_IP']

--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -17,7 +17,7 @@
 ## Contains configuration values for interacting with the Vagrant cluster
 
 # Number of minions in the cluster
-NUM_MINIONS=${NUM_MINIONS-"3"}
+NUM_MINIONS=${NUM_MINIONS-"1"}
 export NUM_MINIONS
 
 # The IP of the master

--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -8,7 +8,7 @@
 
 ### Setup
 
-By default, the Vagrant setup will create a single kubernetes-master and 3 kubernetes-minions. Each VM will take 512 MB, so make sure you have at least 2 GB of free memory. To start your local cluster, open a shell and run:
+By default, the Vagrant setup will create a single kubernetes-master and 1 kubernetes-minion. Each VM will take 512 MB, so make sure you have at least 2 GB of free memory. To start your local cluster, open a shell and run:
 
 ```
 cd kubernetes
@@ -28,6 +28,11 @@ To access the master or any minion:
 ```
 vagrant ssh master
 vagrant ssh minion-1
+```
+
+If you are running more than one minion, you can access the others by:
+
+```
 vagrant ssh minion-2
 vagrant ssh minion-3
 ```


### PR DESCRIPTION
This is a change to improve the initial user experience of trying Kubernetes on Vagrant.

Now that we have per pod IP, there is no reason why we cannot run with just a single minion for 99% of use cases.  If folks want to test cross minion communication, they can increase the NUM_MINION to 2.

But this should address the complaints of 'its slow to boostrap the environment' for initial users that don't read documentation all that often.
