### PR TITLE
Reenable coverage and race detection on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - ./hack/build-go.sh
 
 script:
-  - KUBE_TIMEOUT='-timeout 60s' ./hack/test-go.sh
+  - KUBE_RACE="-race" KUBE_COVER="-cover -covermode=atomic" KUBE_TIMEOUT='-timeout 60s' ./hack/test-go.sh
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/test-cmd.sh
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/test-integration.sh
 

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -44,9 +44,9 @@ kube::test::find_pkgs() {
 }
 
 # -covermode=atomic becomes default with -race in Go >=1.3
-KUBE_COVER="" #${KUBE_COVER:--cover -covermode=atomic}
 KUBE_TIMEOUT=${KUBE_TIMEOUT:--timeout 120s}
-KUBE_RACE="" #${KUBE_RACE:--race}
+KUBE_COVER=${KUBE_COVER:-} # use KUBE_COVER="-cover -covermode=atomic" for full coverage
+KUBE_RACE=${KUBE_RACE:-}   # use KUBE_RACE="-race" to enable race testing
 
 kube::test::usage() {
   kube::log::usage_from_stdin <<EOF

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -39,6 +39,7 @@ kube::etcd::start
 
 kube::log::status "Running integration test cases"
 KUBE_GOFLAGS="-tags 'integration no-docker' " \
+  KUBE_RACE="-race" \
   "${KUBE_ROOT}/hack/test-go.sh" test/integration
 
 kube::log::status "Running integration test scenario"

--- a/pkg/client/record/event.go
+++ b/pkg/client/record/event.go
@@ -30,6 +30,9 @@ import (
 	"github.com/golang/glog"
 )
 
+// retryEventSleep is the time between record failures to retry.  Available for test alteration.
+var retryEventSleep = 1 * time.Second
+
 // EventRecorder knows how to store events (client.Client implements it.)
 // EventRecorder must respect the namespace that will be embedded in 'event'.
 // It is assumed that EventRecorder will return the same sorts of errors as
@@ -41,6 +44,7 @@ type EventRecorder interface {
 // StartRecording starts sending events to recorder. Call once while initializing
 // your binary. Subsequent calls will be ignored. The return value can be ignored
 // or used to stop recording, if desired.
+// TODO: make me an object with parameterizable queue length and retry interval
 func StartRecording(recorder EventRecorder, source api.EventSource) watch.Interface {
 	return GetEvents(func(event *api.Event) {
 		// Make a copy before modification, because there could be multiple listeners.
@@ -80,7 +84,7 @@ func StartRecording(recorder EventRecorder, source api.EventSource) watch.Interf
 				break
 			}
 			glog.Errorf("Unable to write event: '%v' (will retry in 1 second)", err)
-			time.Sleep(1 * time.Second)
+			time.Sleep(retryEventSleep)
 		}
 	})
 }

--- a/pkg/kubecfg/kubecfg.go
+++ b/pkg/kubecfg/kubecfg.go
@@ -107,6 +107,12 @@ func SaveNamespaceInfo(path string, ns *NamespaceInfo) error {
 	return err
 }
 
+// extracted for test speed
+var (
+	updatePollInterval = 5 * time.Second
+	updatePollTimeout  = 300 * time.Second
+)
+
 // Update performs a rolling update of a collection of pods.
 // 'name' points to a replication controller.
 // 'client' is used for updating pods.
@@ -149,7 +155,7 @@ func Update(ctx api.Context, name string, client client.Interface, updatePeriod 
 		}
 		time.Sleep(updatePeriod)
 	}
-	return wait.Poll(time.Second*5, time.Second*300, func() (bool, error) {
+	return wait.Poll(updatePollInterval, updatePollTimeout, func() (bool, error) {
 		podList, err := client.Pods(api.Namespace(ctx)).List(s)
 		if err != nil {
 			return false, err

--- a/pkg/kubecfg/kubecfg_test.go
+++ b/pkg/kubecfg/kubecfg_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
@@ -33,6 +34,10 @@ func validateAction(expectedAction, actualAction client.FakeAction, t *testing.T
 	if !reflect.DeepEqual(expectedAction, actualAction) {
 		t.Errorf("Unexpected Action: %#v, expected: %#v", actualAction, expectedAction)
 	}
+}
+
+func init() {
+	updatePollInterval = 1 * time.Millisecond
 }
 
 func TestUpdateWithPods(t *testing.T) {

--- a/plugin/pkg/scheduler/factory/factory_test.go
+++ b/plugin/pkg/scheduler/factory/factory_test.go
@@ -118,8 +118,10 @@ func TestDefaultErrorFunc(t *testing.T) {
 	factory := NewConfigFactory(client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()}))
 	queue := cache.NewFIFO()
 	podBackoff := podBackoff{
-		perPodBackoff: map[string]*backoffEntry{},
-		clock:         &fakeClock{},
+		perPodBackoff:   map[string]*backoffEntry{},
+		clock:           &fakeClock{},
+		defaultDuration: 1 * time.Millisecond,
+		maxDuration:     1 * time.Second,
 	}
 	errFunc := factory.makeDefaultErrorFunc(&podBackoff, queue)
 
@@ -203,8 +205,10 @@ func TestBind(t *testing.T) {
 func TestBackoff(t *testing.T) {
 	clock := fakeClock{}
 	backoff := podBackoff{
-		perPodBackoff: map[string]*backoffEntry{},
-		clock:         &clock,
+		perPodBackoff:   map[string]*backoffEntry{},
+		clock:           &clock,
+		defaultDuration: 1 * time.Second,
+		maxDuration:     60 * time.Second,
 	}
 
 	tests := []struct {


### PR DESCRIPTION
7d5ac856c506896ca95527d41cb80df3fdcba02c accidentally disabled coverage and race (understandably, because they're soooo slow), and @lavalamp and I discussed leaving it disabled in hack/test-go.sh usage.  This reenables it for travis.  The difference now between race and non race is ~33% of total time, and coverage is non-trivial.

Fixed 3 other slow tests to take ~10s off test time.
