### PR TITLE
Remove go 1.2 from travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 go:
   - 1.4
   - 1.3
-  - 1.2
 
 install:
   - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi


### PR DESCRIPTION
It is really flaky and has brought so many false alarms. 
