### PR TITLE
Reconcile kubelet and kube-proxy watching code, initial steps. 

### DIFF
--- a/pkg/proxy/config/api.go
+++ b/pkg/proxy/config/api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/glog"
 )
 
+// TODO: to use Reflector, need to change the ServicesWatcher to a generic ListerWatcher.
 // ServicesWatcher is capable of listing and watching for changes to services across ALL namespaces
 type ServicesWatcher interface {
 	List(label labels.Selector) (*api.ServiceList, error)
@@ -43,12 +44,22 @@ type EndpointsWatcher interface {
 // SourceAPI implements a configuration source for services and endpoints that
 // uses the client watch API to efficiently detect changes.
 type SourceAPI struct {
-	servicesWatcher  ServicesWatcher
-	endpointsWatcher EndpointsWatcher
+	s servicesReflector
+	e endpointsReflector
+}
 
-	services  chan<- ServiceUpdate
-	endpoints chan<- EndpointsUpdate
+type servicesReflector struct {
+	watcher           ServicesWatcher
+	services          chan<- ServiceUpdate
+	resourceVersion   string
+	waitDuration      time.Duration
+	reconnectDuration time.Duration
+}
 
+type endpointsReflector struct {
+	watcher           EndpointsWatcher
+	endpoints         chan<- EndpointsUpdate
+	resourceVersion   string
 	waitDuration      time.Duration
 	reconnectDuration time.Duration
 }
@@ -56,42 +67,54 @@ type SourceAPI struct {
 // NewSourceAPI creates a config source that watches for changes to the services and endpoints.
 func NewSourceAPI(servicesWatcher ServicesWatcher, endpointsWatcher EndpointsWatcher, period time.Duration, services chan<- ServiceUpdate, endpoints chan<- EndpointsUpdate) *SourceAPI {
 	config := &SourceAPI{
-		servicesWatcher:  servicesWatcher,
-		endpointsWatcher: endpointsWatcher,
-		services:         services,
-		endpoints:        endpoints,
-
-		waitDuration: period,
-		// prevent hot loops if the server starts to misbehave
-		reconnectDuration: time.Second * 1,
+		s: servicesReflector{
+			watcher:         servicesWatcher,
+			services:        services,
+			resourceVersion: "",
+			waitDuration:    period,
+			// prevent hot loops if the server starts to misbehave
+			reconnectDuration: time.Second * 1,
+		},
+		e: endpointsReflector{
+			watcher:         endpointsWatcher,
+			endpoints:       endpoints,
+			resourceVersion: "",
+			waitDuration:    period,
+			// prevent hot loops if the server starts to misbehave
+			reconnectDuration: time.Second * 1,
+		},
 	}
-	serviceVersion := ""
-	go util.Forever(func() {
-		config.runServices(&serviceVersion)
-		time.Sleep(wait.Jitter(config.reconnectDuration, 0.0))
-	}, period)
-	endpointVersion := ""
-	go util.Forever(func() {
-		config.runEndpoints(&endpointVersion)
-		time.Sleep(wait.Jitter(config.reconnectDuration, 0.0))
-	}, period)
+	go util.Forever(func() { config.s.listAndWatch() }, period)
+	go util.Forever(func() { config.e.listAndWatch() }, period)
 	return config
 }
 
-// runServices loops forever looking for changes to services.
-func (s *SourceAPI) runServices(resourceVersion *string) {
+func (r *servicesReflector) listAndWatch() {
+	r.run(&r.resourceVersion)
+	time.Sleep(wait.Jitter(r.reconnectDuration, 0.0))
+}
+
+func (r *endpointsReflector) listAndWatch() {
+	r.run(&r.resourceVersion)
+	time.Sleep(wait.Jitter(r.reconnectDuration, 0.0))
+}
+
+// run loops forever looking for changes to services.
+func (s *servicesReflector) run(resourceVersion *string) {
 	if len(*resourceVersion) == 0 {
-		services, err := s.servicesWatcher.List(labels.Everything())
+		services, err := s.watcher.List(labels.Everything())
 		if err != nil {
 			glog.Errorf("Unable to load services: %v", err)
+			// TODO: reconcile with pkg/client/cache which doesn't use reflector.
 			time.Sleep(wait.Jitter(s.waitDuration, 0.0))
 			return
 		}
 		*resourceVersion = services.ResourceVersion
+		// TODO: replace with code to update the
 		s.services <- ServiceUpdate{Op: SET, Services: services.Items}
 	}
 
-	watcher, err := s.servicesWatcher.Watch(labels.Everything(), labels.Everything(), *resourceVersion)
+	watcher, err := s.watcher.Watch(labels.Everything(), labels.Everything(), *resourceVersion)
 	if err != nil {
 		glog.Errorf("Unable to watch for services changes: %v", err)
 		if !client.IsTimeout(err) {
@@ -104,11 +127,11 @@ func (s *SourceAPI) runServices(resourceVersion *string) {
 	defer watcher.Stop()
 
 	ch := watcher.ResultChan()
-	handleServicesWatch(resourceVersion, ch, s.services)
+	s.watchHandler(resourceVersion, ch, s.services)
 }
 
-// handleServicesWatch loops over an event channel and delivers config changes to an update channel.
-func handleServicesWatch(resourceVersion *string, ch <-chan watch.Event, updates chan<- ServiceUpdate) {
+// watchHandler loops over an event channel and delivers config changes to an update channel.
+func (s *servicesReflector) watchHandler(resourceVersion *string, ch <-chan watch.Event, updates chan<- ServiceUpdate) {
 	for {
 		select {
 		case event, ok := <-ch:
@@ -146,10 +169,10 @@ func handleServicesWatch(resourceVersion *string, ch <-chan watch.Event, updates
 	}
 }
 
-// runEndpoints loops forever looking for changes to endpoints.
-func (s *SourceAPI) runEndpoints(resourceVersion *string) {
+// run loops forever looking for changes to endpoints.
+func (s *endpointsReflector) run(resourceVersion *string) {
 	if len(*resourceVersion) == 0 {
-		endpoints, err := s.endpointsWatcher.List(labels.Everything())
+		endpoints, err := s.watcher.List(labels.Everything())
 		if err != nil {
 			glog.Errorf("Unable to load endpoints: %v", err)
 			time.Sleep(wait.Jitter(s.waitDuration, 0.0))
@@ -159,7 +182,7 @@ func (s *SourceAPI) runEndpoints(resourceVersion *string) {
 		s.endpoints <- EndpointsUpdate{Op: SET, Endpoints: endpoints.Items}
 	}
 
-	watcher, err := s.endpointsWatcher.Watch(labels.Everything(), labels.Everything(), *resourceVersion)
+	watcher, err := s.watcher.Watch(labels.Everything(), labels.Everything(), *resourceVersion)
 	if err != nil {
 		glog.Errorf("Unable to watch for endpoints changes: %v", err)
 		if !client.IsTimeout(err) {
@@ -173,11 +196,11 @@ func (s *SourceAPI) runEndpoints(resourceVersion *string) {
 	defer watcher.Stop()
 
 	ch := watcher.ResultChan()
-	handleEndpointsWatch(resourceVersion, ch, s.endpoints)
+	s.watchHandler(resourceVersion, ch, s.endpoints)
 }
 
-// handleEndpointsWatch loops over an event channel and delivers config changes to an update channel.
-func handleEndpointsWatch(resourceVersion *string, ch <-chan watch.Event, updates chan<- EndpointsUpdate) {
+// watchHandler loops over an event channel and delivers config changes to an update channel.
+func (s *endpointsReflector) watchHandler(resourceVersion *string, ch <-chan watch.Event, updates chan<- EndpointsUpdate) {
 	for {
 		select {
 		case event, ok := <-ch:


### PR DESCRIPTION
kubelet and kube-proxy have functionally similar, but different resource watching code.
I have a long term mission to have them share most of the same code (along with scheduler and controller manager).  These simple refactors are baby steps towards that goal.  I'll squash after review and the separate commits make it easier to review (and easier to rebase, so I don't really get what is so hot about squashing, but that is another discussion.)
