### PR TITLE
Allow RESTStorage objects to not implement methods

### DIFF
--- a/pkg/api/errors/errors.go
+++ b/pkg/api/errors/errors.go
@@ -159,6 +159,19 @@ func NewBadRequest(reason string) error {
 	}}
 }
 
+// NewMethodNotSupported returns an error indicating the requested action is not supported on this kind.
+func NewMethodNotSupported(kind, action string) error {
+	return &StatusError{api.Status{
+		Status: api.StatusFailure,
+		Code:   http.StatusMethodNotAllowed,
+		Reason: api.StatusReasonMethodNotAllowed,
+		Details: &api.StatusDetails{
+			Kind: kind,
+		},
+		Message: fmt.Sprintf("%s is not supported on resources of kind %q", action, kind),
+	}}
+}
+
 // NewInternalError returns an error indicating the item is invalid and cannot be processed.
 func NewInternalError(err error) error {
 	return &StatusError{api.Status{
@@ -190,6 +203,12 @@ func IsConflict(err error) bool {
 // IsInvalid determines if the err is an error which indicates the provided resource is not valid.
 func IsInvalid(err error) bool {
 	return reasonForError(err) == api.StatusReasonInvalid
+}
+
+// IsMethodNotSupported determines if the err is an error which indicates the provided action could not
+// be performed because it is not supported by the server.
+func IsMethodNotSupported(err error) bool {
+	return reasonForError(err) == api.StatusReasonMethodNotAllowed
 }
 
 // IsBadRequest determines if err is an error which indicates that the request is invalid.

--- a/pkg/api/errors/errors_test.go
+++ b/pkg/api/errors/errors_test.go
@@ -40,6 +40,12 @@ func TestErrorNew(t *testing.T) {
 	if IsInvalid(err) {
 		t.Errorf("expected to not be %s", api.StatusReasonInvalid)
 	}
+	if IsBadRequest(err) {
+		t.Errorf("expected to not be %s", api.StatusReasonBadRequest)
+	}
+	if IsMethodNotSupported(err) {
+		t.Errorf("expected to not be %s", api.StatusReasonMethodNotAllowed)
+	}
 
 	if !IsConflict(NewConflict("test", "2", errors.New("message"))) {
 		t.Errorf("expected to be conflict")
@@ -49,6 +55,12 @@ func TestErrorNew(t *testing.T) {
 	}
 	if !IsInvalid(NewInvalid("test", "2", nil)) {
 		t.Errorf("expected to be %s", api.StatusReasonInvalid)
+	}
+	if !IsBadRequest(NewBadRequest("reason")) {
+		t.Errorf("expected to be %s", api.StatusReasonBadRequest)
+	}
+	if !IsMethodNotSupported(NewMethodNotSupported("foo", "delete")) {
+		t.Errorf("expected to be %s", api.StatusReasonMethodNotAllowed)
 	}
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -931,6 +931,11 @@ const (
 	// data was invalid.  API calls that return BadRequest can never succeed.
 	StatusReasonBadRequest StatusReason = "BadRequest"
 
+	// StatusReasonMethodNotAllowed means that the action the client attempted to perform on the
+	// resource was not supported by the code - for instance, attempting to delete a resource that
+	// can only be created. API calls that return MethodNotAllowed can never succeed.
+	StatusReasonMethodNotAllowed StatusReason = "MethodNotAllowed"
+
 	// StatusReasonInternalError indicates that an internal error occurred, it is unexpected
 	// and the outcome of the call is unknown.
 	// Details (optional):

--- a/pkg/apiserver/interfaces.go
+++ b/pkg/apiserver/interfaces.go
@@ -24,28 +24,43 @@ import (
 )
 
 // RESTStorage is a generic interface for RESTful storage services.
-// Resources which are exported to the RESTful API of apiserver need to implement this interface.
+// Resources which are exported to the RESTful API of apiserver need to implement this interface. It is expected
+// that objects may implement any of the REST* interfaces.
+// TODO: implement dynamic introspection (so GenericREST objects can indicate what they implement)
 type RESTStorage interface {
 	// New returns an empty object that can be used with Create and Update after request data has been put into it.
 	// This object must be a pointer type for use with Codec.DecodeInto([]byte, runtime.Object)
 	New() runtime.Object
+}
 
+type RESTLister interface {
+	// NewList returns an empty object that can be used with the List call.
+	// This object must be a pointer type for use with Codec.DecodeInto([]byte, runtime.Object)
+	NewList() runtime.Object
 	// List selects resources in the storage which match to the selector.
 	List(ctx api.Context, label, field labels.Selector) (runtime.Object, error)
+}
 
+type RESTGetter interface {
 	// Get finds a resource in the storage by id and returns it.
 	// Although it can return an arbitrary error value, IsNotFound(err) is true for the
 	// returned error value err when the specified resource is not found.
 	Get(ctx api.Context, id string) (runtime.Object, error)
+}
 
+type RESTDeleter interface {
 	// Delete finds a resource in the storage and deletes it.
 	// Although it can return an arbitrary error value, IsNotFound(err) is true for the
 	// returned error value err when the specified resource is not found.
 	Delete(ctx api.Context, id string) (<-chan RESTResult, error)
+}
 
+type RESTCreater interface {
 	// Create creates a new version of a resource.
 	Create(ctx api.Context, obj runtime.Object) (<-chan RESTResult, error)
+}
 
+type RESTUpdater interface {
 	// Update finds a resource in the storage and updates it. Some implementations
 	// may allow updates creates the object - they should set the Created flag of
 	// the returned RESTResultto true. In the event of an asynchronous error returned

--- a/pkg/apiserver/proxy.go
+++ b/pkg/apiserver/proxy.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -106,7 +107,7 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	redirector, ok := storage.(Redirector)
 	if !ok {
 		httplog.LogOf(req, w).Addf("'%v' is not a redirector", kind)
-		notFound(w, req)
+		errorJSON(errors.NewMethodNotSupported(kind, "proxy"), r.codec, w)
 		return
 	}
 

--- a/pkg/apiserver/redirect.go
+++ b/pkg/apiserver/redirect.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
@@ -53,7 +54,7 @@ func (r *RedirectHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	redirector, ok := storage.(Redirector)
 	if !ok {
 		httplog.LogOf(req, w).Addf("'%v' is not a redirector", kind)
-		notFound(w, req)
+		errorJSON(errors.NewMethodNotSupported(kind, "redirect"), r.codec, w)
 		return
 	}
 

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
@@ -48,14 +48,13 @@ func (h *RESTHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		notFound(w, req)
 		return
 	}
-	storage := h.storage[kind]
-	if storage == nil {
-		httplog.LogOf(req, w).Addf("'%v' has no storage object", kind)
+	storage, ok := h.storage[kind]
+	if !ok {
 		notFound(w, req)
 		return
 	}
 
-	h.handleRESTStorage(parts, req, w, storage, namespace)
+	h.handleRESTStorage(parts, req, w, storage, namespace, kind)
 }
 
 // Sets the SelfLink field of the object.
@@ -148,7 +147,7 @@ func curry(f func(runtime.Object, *http.Request) error, req *http.Request) func(
 //    sync=[false|true] Synchronous request (only applies to create, update, delete operations)
 //    timeout=<duration> Timeout for synchronous requests, only applies if sync=true
 //    labels=<label-selector> Used for filtering list operations
-func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w http.ResponseWriter, storage RESTStorage, namespace string) {
+func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w http.ResponseWriter, storage RESTStorage, namespace, kind string) {
 	ctx := api.WithNamespace(api.NewContext(), namespace)
 	sync := req.URL.Query().Get("sync") == "true"
 	timeout := parseTimeout(req.URL.Query().Get("timeout"))
@@ -166,7 +165,12 @@ func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w htt
 				errorJSON(err, h.codec, w)
 				return
 			}
-			list, err := storage.List(ctx, label, field)
+			lister, ok := storage.(RESTLister)
+			if !ok {
+				errorJSON(errors.NewMethodNotSupported(kind, "list"), h.codec, w)
+				return
+			}
+			list, err := lister.List(ctx, label, field)
 			if err != nil {
 				errorJSON(err, h.codec, w)
 				return
@@ -177,7 +181,12 @@ func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w htt
 			}
 			writeJSON(http.StatusOK, h.codec, list, w)
 		case 2:
-			item, err := storage.Get(ctx, parts[1])
+			getter, ok := storage.(RESTGetter)
+			if !ok {
+				errorJSON(errors.NewMethodNotSupported(kind, "get"), h.codec, w)
+				return
+			}
+			item, err := getter.Get(ctx, parts[1])
 			if err != nil {
 				errorJSON(err, h.codec, w)
 				return
@@ -196,6 +205,12 @@ func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w htt
 			notFound(w, req)
 			return
 		}
+		creater, ok := storage.(RESTCreater)
+		if !ok {
+			errorJSON(errors.NewMethodNotSupported(kind, "create"), h.codec, w)
+			return
+		}
+
 		body, err := readBody(req)
 		if err != nil {
 			errorJSON(err, h.codec, w)
@@ -215,7 +230,7 @@ func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w htt
 			return
 		}
 
-		out, err := storage.Create(ctx, obj)
+		out, err := creater.Create(ctx, obj)
 		if err != nil {
 			errorJSON(err, h.codec, w)
 			return
@@ -228,6 +243,11 @@ func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w htt
 			notFound(w, req)
 			return
 		}
+		deleter, ok := storage.(RESTDeleter)
+		if !ok {
+			errorJSON(errors.NewMethodNotSupported(kind, "delete"), h.codec, w)
+			return
+		}
 
 		// invoke admission control
 		err := h.admissionControl.Admit(admission.NewAttributesRecord(nil, namespace, parts[0], "DELETE"))
@@ -236,7 +256,7 @@ func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w htt
 			return
 		}
 
-		out, err := storage.Delete(ctx, parts[1])
+		out, err := deleter.Delete(ctx, parts[1])
 		if err != nil {
 			errorJSON(err, h.codec, w)
 			return
@@ -249,6 +269,12 @@ func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w htt
 			notFound(w, req)
 			return
 		}
+		updater, ok := storage.(RESTUpdater)
+		if !ok {
+			errorJSON(errors.NewMethodNotSupported(kind, "create"), h.codec, w)
+			return
+		}
+
 		body, err := readBody(req)
 		if err != nil {
 			errorJSON(err, h.codec, w)
@@ -268,7 +294,7 @@ func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w htt
 			return
 		}
 
-		out, err := storage.Update(ctx, obj)
+		out, err := updater.Update(ctx, obj)
 		if err != nil {
 			errorJSON(err, h.codec, w)
 			return

--- a/pkg/master/publish.go
+++ b/pkg/master/publish.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 
 	"github.com/golang/glog"
 )
@@ -94,7 +95,7 @@ func (m *Master) createMasterServiceIfNeeded(serviceName string, port int) error
 	}
 	// Kids, don't do this at home: this is a hack. There's no good way to call the business
 	// logic which lives in the REST object from here.
-	c, err := m.storage["services"].Create(ctx, svc)
+	c, err := m.storage["services"].(apiserver.RESTCreater).Create(ctx, svc)
 	if err != nil {
 		return err
 	}

--- a/pkg/master/rest_to_nodes.go
+++ b/pkg/master/rest_to_nodes.go
@@ -33,6 +33,9 @@ import (
 // TODO: considering that the only difference between the various client types
 // and RESTStorage type is the type of the arguments, maybe use "go generate" to
 // write a specialized adaptor for every client type?
+//
+// TODO: this also means that pod and node API endpoints have to be colocated in the same
+// process
 func RESTStorageToNodes(storage apiserver.RESTStorage) client.NodesInterface {
 	return &nodeAdaptor{storage}
 }
@@ -61,7 +64,7 @@ func (n *nodeAdaptor) Create(minion *api.Node) (*api.Node, error) {
 // List lists all the nodes in the cluster.
 func (n *nodeAdaptor) List() (*api.NodeList, error) {
 	ctx := api.NewContext()
-	obj, err := n.storage.List(ctx, labels.Everything(), labels.Everything())
+	obj, err := n.storage.(apiserver.RESTLister).List(ctx, labels.Everything(), labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +74,7 @@ func (n *nodeAdaptor) List() (*api.NodeList, error) {
 // Get gets an existing minion
 func (n *nodeAdaptor) Get(name string) (*api.Node, error) {
 	ctx := api.NewContext()
-	obj, err := n.storage.Get(ctx, name)
+	obj, err := n.storage.(apiserver.RESTGetter).Get(ctx, name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/binding/rest.go
+++ b/pkg/registry/binding/rest.go
@@ -20,9 +20,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
@@ -38,21 +36,6 @@ func NewREST(bindingRegistry Registry) *REST {
 	return &REST{
 		registry: bindingRegistry,
 	}
-}
-
-// List returns an error because bindings are write-only objects.
-func (*REST) List(ctx api.Context, label, field labels.Selector) (runtime.Object, error) {
-	return nil, errors.NewNotFound("binding", "list")
-}
-
-// Get returns an error because bindings are write-only objects.
-func (*REST) Get(ctx api.Context, id string) (runtime.Object, error) {
-	return nil, errors.NewNotFound("binding", id)
-}
-
-// Delete returns an error because bindings are write-only objects.
-func (*REST) Delete(ctx api.Context, id string) (<-chan apiserver.RESTResult, error) {
-	return nil, errors.NewNotFound("binding", id)
 }
 
 // New returns a new binding object fit for having data unmarshalled into it.
@@ -72,9 +55,4 @@ func (b *REST) Create(ctx api.Context, obj runtime.Object) (<-chan apiserver.RES
 		}
 		return &api.Status{Status: api.StatusSuccess}, nil
 	}), nil
-}
-
-// Update returns an error-- this object may not be updated.
-func (b *REST) Update(ctx api.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
-	return nil, fmt.Errorf("bindings may not be changed.")
 }

--- a/pkg/registry/binding/rest_test.go
+++ b/pkg/registry/binding/rest_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 )
 
 func TestNewREST(t *testing.T) {
@@ -48,30 +47,6 @@ func TestNewREST(t *testing.T) {
 	}
 	if e, a := binding, obj; !reflect.DeepEqual(e, a) {
 		t.Errorf("Expected %#v, but got %#v", e, a)
-	}
-}
-
-func TestRESTUnsupported(t *testing.T) {
-	var ctx api.Context
-	mockRegistry := MockRegistry{
-		OnApplyBinding: func(b *api.Binding) error { return nil },
-	}
-	b := NewREST(mockRegistry)
-	if _, err := b.Delete(ctx, "binding id"); err == nil {
-		t.Errorf("unexpected non-error")
-	}
-	if _, err := b.Update(ctx, &api.Binding{PodID: "foo", Host: "new machine"}); err == nil {
-		t.Errorf("unexpected non-error")
-	}
-	if _, err := b.Get(ctx, "binding id"); err == nil {
-		t.Errorf("unexpected non-error")
-	}
-	if _, err := b.List(ctx, labels.Set{"name": "foo"}.AsSelector(), labels.Everything()); err == nil {
-		t.Errorf("unexpected non-error")
-	}
-	// Try sending wrong object just to get 100% coverage
-	if _, err := b.Create(ctx, &api.Pod{}); err == nil {
-		t.Errorf("unexpected non-error")
 	}
 }
 

--- a/pkg/registry/controller/rest.go
+++ b/pkg/registry/controller/rest.go
@@ -122,6 +122,10 @@ func (*REST) New() runtime.Object {
 	return &api.ReplicationController{}
 }
 
+func (*REST) NewList() runtime.Object {
+	return &api.ReplicationControllerList{}
+}
+
 // Update replaces a given ReplicationController instance with an existing
 // instance in storage.registry.
 func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {

--- a/pkg/registry/endpoint/rest.go
+++ b/pkg/registry/endpoint/rest.go
@@ -105,3 +105,7 @@ func (rs *REST) Delete(ctx api.Context, id string) (<-chan apiserver.RESTResult,
 func (rs REST) New() runtime.Object {
 	return &api.Endpoints{}
 }
+
+func (*REST) NewList() runtime.Object {
+	return &api.EndpointsList{}
+}

--- a/pkg/registry/endpoint/rest.go
+++ b/pkg/registry/endpoint/rest.go
@@ -96,11 +96,6 @@ func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan apiserver.RE
 	}), nil
 }
 
-// Delete satisfies the RESTStorage interface but is unimplemented.
-func (rs *REST) Delete(ctx api.Context, id string) (<-chan apiserver.RESTResult, error) {
-	return nil, errors.NewBadRequest("Endpoints are read-only")
-}
-
 // New implements the RESTStorage interface.
 func (rs REST) New() runtime.Object {
 	return &api.Endpoints{}

--- a/pkg/registry/endpoint/rest_test.go
+++ b/pkg/registry/endpoint/rest_test.go
@@ -96,14 +96,3 @@ func TestEndpointsRegistryList(t *testing.T) {
 		t.Errorf("Unexpected resource version: %#v", sl)
 	}
 }
-
-func TestEndpointsRegistryDelete(t *testing.T) {
-	registry := registrytest.NewServiceRegistry()
-	storage := NewREST(registry)
-	_, err := storage.Delete(api.NewContext(), "n/a")
-	if err == nil {
-		t.Error("unexpected non-error")
-	} else if !errors.IsBadRequest(err) {
-		t.Errorf("unexpected error: %v", err)
-	}
-}

--- a/pkg/registry/event/rest.go
+++ b/pkg/registry/event/rest.go
@@ -131,8 +131,3 @@ func (*REST) New() runtime.Object {
 func (*REST) NewList() runtime.Object {
 	return &api.EventList{}
 }
-
-// Update returns an error: Events are not mutable.
-func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
-	return nil, fmt.Errorf("not allowed: 'Event' objects are not mutable")
-}

--- a/pkg/registry/event/rest.go
+++ b/pkg/registry/event/rest.go
@@ -128,6 +128,10 @@ func (*REST) New() runtime.Object {
 	return &api.Event{}
 }
 
+func (*REST) NewList() runtime.Object {
+	return &api.EventList{}
+}
+
 // Update returns an error: Events are not mutable.
 func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
 	return nil, fmt.Errorf("not allowed: 'Event' objects are not mutable")

--- a/pkg/registry/event/rest_test.go
+++ b/pkg/registry/event/rest_test.go
@@ -172,20 +172,6 @@ func TestRESTgetAttrs(t *testing.T) {
 	}
 }
 
-func TestRESTUpdate(t *testing.T) {
-	_, rest := NewTestREST()
-	eventA := testEvent("foo")
-	c, err := rest.Create(api.NewDefaultContext(), eventA)
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-	<-c
-	_, err = rest.Update(api.NewDefaultContext(), eventA)
-	if err == nil {
-		t.Errorf("unexpected non-error")
-	}
-}
-
 func TestRESTList(t *testing.T) {
 	reg, rest := NewTestREST()
 	eventA := &api.Event{

--- a/pkg/registry/minion/rest.go
+++ b/pkg/registry/minion/rest.go
@@ -104,6 +104,10 @@ func (rs *REST) New() runtime.Object {
 	return &api.Node{}
 }
 
+func (*REST) NewList() runtime.Object {
+	return &api.NodeList{}
+}
+
 // Update satisfies the RESTStorage interface.
 func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
 	minion, ok := obj.(*api.Node)

--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -161,6 +161,10 @@ func (*REST) New() runtime.Object {
 	return &api.Pod{}
 }
 
+func (*REST) NewList() runtime.Object {
+	return &api.PodList{}
+}
+
 func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
 	pod := obj.(*api.Pod)
 	if !api.ValidNamespace(ctx, &pod.ObjectMeta) {

--- a/pkg/registry/service/rest.go
+++ b/pkg/registry/service/rest.go
@@ -217,6 +217,10 @@ func (*REST) New() runtime.Object {
 	return &api.Service{}
 }
 
+func (*REST) NewList() runtime.Object {
+	return &api.Service{}
+}
+
 func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
 	service := obj.(*api.Service)
 	if !api.ValidNamespace(ctx, &service.ObjectMeta) {

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -222,7 +222,7 @@ func getTestRequests() []struct {
 		{"PUT", "/api/v1beta1/endpoints/a" + syncFlags, aEndpoints, code200},
 		{"GET", "/api/v1beta1/endpoints", "", code200},
 		{"GET", "/api/v1beta1/endpoints/a", "", code200},
-		{"DELETE", "/api/v1beta1/endpoints/a" + syncFlags, "", code400},
+		{"DELETE", "/api/v1beta1/endpoints/a" + syncFlags, "", code405},
 
 		// Normal methods on minions
 		{"GET", "/api/v1beta1/minions", "", code200},
@@ -235,7 +235,7 @@ func getTestRequests() []struct {
 		// Normal methods on events
 		{"GET", "/api/v1beta1/events", "", code200},
 		{"POST", "/api/v1beta1/events" + syncFlags, aEvent, code200},
-		{"PUT", "/api/v1beta1/events/a" + syncFlags, aEvent, code500}, // See #2114 about why 500
+		{"PUT", "/api/v1beta1/events/a" + syncFlags, aEvent, code405},
 		{"GET", "/api/v1beta1/events", "", code200},
 		{"GET", "/api/v1beta1/events", "", code200},
 		{"GET", "/api/v1beta1/events/a", "", code200},
@@ -245,10 +245,10 @@ func getTestRequests() []struct {
 		{"GET", "/api/v1beta1/bindings", "", code405},            // Bindings are write-only
 		{"POST", "/api/v1beta1/pods" + syncFlags, aPod, code200}, // Need a pod to bind or you get a 404
 		{"POST", "/api/v1beta1/bindings" + syncFlags, aBinding, code200},
-		{"PUT", "/api/v1beta1/bindings/a" + syncFlags, aBinding, code500}, // See #2114 about why 500
+		{"PUT", "/api/v1beta1/bindings/a" + syncFlags, aBinding, code405},
 		{"GET", "/api/v1beta1/bindings", "", code405},
-		{"GET", "/api/v1beta1/bindings/a", "", code404}, // No bindings instances
-		{"DELETE", "/api/v1beta1/bindings/a" + syncFlags, "", code404},
+		{"GET", "/api/v1beta1/bindings/a", "", code405}, // No bindings instances
+		{"DELETE", "/api/v1beta1/bindings/a" + syncFlags, "", code405},
 
 		// Non-existent object type.
 		{"GET", "/api/v1beta1/foo", "", code404},


### PR DESCRIPTION
Instead of requiring all REST objects to implement all REST methods,
make the availability of of given method depend on what is implemented,
and return the appropriate error from the response as well as document the
operation is _not_ supported in Swagger.

This allows generic clients to more easily distinguish between "not implemented"
for a particular resource and the absence of a resource altogether.

In the future, to support generic REST implementations, a DynamicRESTStorage
interface could be defined which returns an object that implements only the supported
methods.

@lavalamp / @bgrant0607
