### PR TITLE
Kill the forced upload to GCS.

### DIFF
--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -49,6 +49,6 @@ git clean -fdx
 go run ./hack/e2e.go -v -build
 
 # Push to GCS
-yes | ./build/push-ci-build.sh
+./build/push-ci-build.sh
 
 sha256sum _output/release-tars/kubernetes*.tar.gz


### PR DESCRIPTION
This actually tickles the -opipefail, and is only necessary if you're
rebuilding (which isn't really safe, because it can slice downstream
builds.)
