### PR TITLE
Remove user agent logging (doesn't add significant value)

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -250,7 +250,6 @@ func (g *APIGroupVersion) InstallREST(container *restful.Container, root string,
 	// TODO: eliminate all the restful wrappers
 	// TODO: create a separate handler per verb
 	h := func(req *restful.Request, resp *restful.Response) {
-		glog.V(4).Infof("User-Agent: %s\n", req.HeaderParameter("User-Agent"))
 		strippedHandler.ServeHTTP(resp.ResponseWriter, req.Request)
 	}
 


### PR DESCRIPTION
We can reintroduce path/agent logging at a later point, this just clogs
verbose logs.
