### PR TITLE
Use CAFile even if client certificate is not specified

### DIFF
--- a/pkg/client/kubelet.go
+++ b/pkg/client/kubelet.go
@@ -60,8 +60,14 @@ type HTTPKubeletClient struct {
 
 func NewKubeletClient(config *KubeletConfig) (KubeletClient, error) {
 	transport := http.DefaultTransport
-	if config.CAFile != "" {
+	if config.CertFile != "" {
 		t, err := NewClientCertTLSTransport(config.CertFile, config.KeyFile, config.CAFile)
+		if err != nil {
+			return nil, err
+		}
+		transport = t
+	} else if config.CAFile != "" {
+		t, err := NewTLSTransport(config.CAFile)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -80,6 +80,22 @@ func NewClientCertTLSTransport(certFile, keyFile, caFile string) (*http.Transpor
 	}, nil
 }
 
+func NewTLSTransport(caFile string) (*http.Transport, error) {
+	data, err := ioutil.ReadFile(caFile)
+	if err != nil {
+		return nil, err
+	}
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(data)
+	return &http.Transport{
+		TLSClientConfig: &tls.Config{
+			// Change default from SSLv3 to TLSv1.0 (because of POODLE vulnerability)
+			MinVersion: tls.VersionTLS10,
+			RootCAs:    certPool,
+		},
+	}, nil
+}
+
 func NewUnsafeTLSTransport() *http.Transport {
 	return &http.Transport{
 		TLSClientConfig: &tls.Config{


### PR DESCRIPTION
Even if client cert auth is not used, it is sometimes necessary to specify the trusted root ca's of the API server
