### PR TITLE
Setting WebServicesUrl in swagger config 

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -429,7 +429,8 @@ func (m *Master) init(c *Config) {
 func (m *Master) InstallSwaggerAPI() {
 	// Enable swagger UI and discovery API
 	swaggerConfig := swagger.Config{
-		WebServices: m.handlerContainer.RegisteredWebServices(),
+		WebServicesUrl: m.readWriteServer,
+		WebServices:    m.handlerContainer.RegisteredWebServices(),
 		// TODO: Parameterize the path?
 		ApiPath:         "/swaggerapi/",
 		SwaggerPath:     "/swaggerui/",


### PR DESCRIPTION
This is required so that the api docs contain correct basepath.

Before:
![image](https://cloud.githubusercontent.com/assets/10199099/5711771/e44c0100-9a61-11e4-9013-d9eef34c259d.png)

After:
![image](https://cloud.githubusercontent.com/assets/10199099/5711772/eb11c7ea-9a61-11e4-9880-d8e9254e26de.png)

Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/3411
