### PR TITLE
Fixing broken swagger-ui

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -167,8 +167,7 @@ func registerResourceHandlers(ws *restful.WebService, version string, path strin
 	if _, ok := storage.(RESTGetter); ok {
 		ws.Route(getRoute.Writes(versionedObject)) // on the response
 	} else {
-		ws.Route(ws.GET(path+"/{name}").To(h).
-			Returns(http.StatusMethodNotAllowed, "reading individual objects is not supported", nil))
+		ws.Route(getRoute.Returns(http.StatusMethodNotAllowed, "reading individual objects is not supported", nil))
 	}
 
 	updateRoute := ws.PUT(path + "/{name}").To(h).


### PR DESCRIPTION
Fixing a bug in https://github.com/GoogleCloudPlatform/kubernetes/pull/3404 which broke swagger-ui.
Swagger-ui requires operation to be defined on all Routes.
