### PR TITLE
Split up kubelet "source seen" logic

### DIFF
--- a/pkg/kubelet/types.go
+++ b/pkg/kubelet/types.go
@@ -18,8 +18,10 @@ package kubelet
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/golang/glog"
 )
 
 const ConfigSourceAnnotationKey = "kubernetes.io/config.source"
@@ -70,4 +72,21 @@ type PodUpdate struct {
 // GetPodFullName returns a name that uniquely identifies a pod across all config sources.
 func GetPodFullName(pod *api.BoundPod) string {
 	return fmt.Sprintf("%s.%s.%s", pod.Name, pod.Namespace, pod.Annotations[ConfigSourceAnnotationKey])
+}
+
+// ParsePodFullName unpacks a pod full name and returns the pod name, namespace, and annotations.
+// If the pod full name is invalid, empty strings are returend.
+func ParsePodFullName(podFullName string) (podName, podNamespace string, podAnnotations map[string]string) {
+	parts := strings.Split(podFullName, ".")
+	expectedNumFields := 3
+	actualNumFields := len(parts)
+	if actualNumFields != expectedNumFields {
+		glog.Warningf("found a podFullName (%q) with too few fields: expected %d, actual %d.", podFullName, expectedNumFields, actualNumFields)
+		return
+	}
+	podName = parts[0]
+	podNamespace = parts[1]
+	podAnnotations = make(map[string]string)
+	podAnnotations[ConfigSourceAnnotationKey] = parts[2]
+	return
 }

--- a/pkg/kubelet/types_test.go
+++ b/pkg/kubelet/types_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"testing"
+)
+
+func TestParsePodFullName(t *testing.T) {
+	// Arrange
+	podFullName := "ca4e7148-9ab9-11e4-924c-f0921cde18c1.default.etcd"
+
+	// Act
+	podName, podNamespace, podAnnotations := ParsePodFullName(podFullName)
+
+	// Assert
+	expectedPodName := "ca4e7148-9ab9-11e4-924c-f0921cde18c1"
+	expectedPodNamespace := "default"
+	expectedSource := "etcd"
+	if podName != expectedPodName {
+		t.Errorf("Unexpected PodName. Expected: %q Actual: %q", expectedPodName, podName)
+	}
+	if podNamespace != expectedPodNamespace {
+		t.Errorf("Unexpected PodNamespace. Expected: %q Actual: %q", expectedPodNamespace, podNamespace)
+	}
+	if podAnnotations[ConfigSourceAnnotationKey] != expectedSource {
+		t.Errorf("Unexpected PodSource. Expected: %q Actual: %q", expectedPodNamespace, podNamespace)
+	}
+
+}

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -277,7 +277,7 @@ func createAndInitKubelet(kc *KubeletConfig, pc *config.PodConfig) (*kubelet.Kub
 		kc.RegistryBurst,
 		kc.MinimumGCAge,
 		kc.MaxContainerCount,
-		pc.SeenAllSources,
+		pc.SourceSeen,
 		kc.ClusterDomain,
 		net.IP(kc.ClusterDNS))
 


### PR DESCRIPTION
Closes #3371 

Currently kubelet will refuse to kill any containers unless all sources have been marked as "seen".

To be more robust, this change enables a container to be killed as long as the source that created it has been "seen", regardless of the state of other sources.
