### PR TITLE
WIP: Creating a mechanism for external IP access

### DIFF
--- a/cmd/onramp/onramp.go
+++ b/cmd/onramp/onramp.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2014 Neil Horman <nhorman@tuxdriver.com>. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"net"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/version/verflag"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/onramp"
+	"github.com/coreos/go-etcd/etcd"
+	"github.com/golang/glog"
+)
+
+var (
+	etcdServerList util.StringList
+	bindAddress    = util.IP(net.ParseIP("0.0.0.0"))
+)
+
+func init() {
+	flag.Var(&etcdServerList, "etcd_servers", "List of etcd servers to watch (http://ip:port), comma separated (optional). Mutually exclusive with -etcd_config")
+}
+
+func main() {
+	flag.Parse()
+	util.InitLogs()
+	defer util.FlushLogs()
+
+	verflag.PrintAndExitIfRequested()
+
+	var etcdClient *etcd.Client
+
+	// Set up etcd client
+	if len(etcdServerList) > 0 {
+		// Set up logger for etcd client
+		etcd.SetLogger(util.NewLogger("etcd "))
+		etcdClient = etcd.NewClient(etcdServerList)
+	}
+
+	if etcdClient != nil {
+		glog.Infof("Watching for etcd configs at %v", etcdClient.GetCluster())
+        }
+
+	Onrmp := onramp.NewOnramp(etcdClient)
+	// Start watching for work to do
+	go util.Forever(func() { Onrmp.Run() }, 0)
+
+	select { }
+}

--- a/cmd/onramp/onramp.go
+++ b/cmd/onramp/onramp.go
@@ -59,6 +59,12 @@ func main() {
 	if len(kubeApiServer) > 0 {
 		kubeClient = client.NewOrDie(&client.Config{Host: kubeApiServer[0], Version: "v1beta1"})
 	}
+	if kubeClient != nil {
+		glog.Infof("Established api client to %s\n", kubeApiServer[0])
+	} else {
+		glog.Infof("Error in establishing api client\n")
+		return
+	}
 
 	if etcdClient != nil {
 		glog.Infof("Watching for etcd configs at %v", etcdClient.GetCluster())

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -24,6 +24,7 @@ readonly KUBE_SERVER_TARGETS=(
   cmd/apiserver
   cmd/controller-manager
   cmd/kubelet
+  cmd/onramp
   plugin/cmd/scheduler
 )
 readonly KUBE_SERVER_BINARIES=("${KUBE_SERVER_TARGETS[@]##*/}")

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -311,7 +311,6 @@ type Container struct {
 	Privileged bool `json:"privileged,omitempty" yaml:"privileged,omitempty"`
 	// Optional: Policy for pulling images for this container
 	ImagePullPolicy PullPolicy `json:"imagePullPolicy" yaml:"imagePullPolicy"`
-	ExternalName	string	`json:"externalName,omitempty" yaml:"externalName,omitempty"`
 }
 
 // Handler defines a specific action that should be taken
@@ -429,6 +428,7 @@ type PodState struct {
 	Host    string `json:"host,omitempty" yaml:"host,omitempty"`
 	HostIP  string `json:"hostIP,omitempty" yaml:"hostIP,omitempty"`
 	PodIP   string `json:"podIP,omitempty" yaml:"podIP,omitempty"`
+	ExternalName	string	`json:"externalName,omitempty" yaml:"externalName,omitempty"`
 
 	// The key of this map is the *name* of the container within the manifest; it has one
 	// entry per container in the manifest. The value of this map is currently the output

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -311,6 +311,7 @@ type Container struct {
 	Privileged bool `json:"privileged,omitempty" yaml:"privileged,omitempty"`
 	// Optional: Policy for pulling images for this container
 	ImagePullPolicy PullPolicy `json:"imagePullPolicy" yaml:"imagePullPolicy"`
+	ExternalName	string	`json:"externalName,omitempty" yaml:"externalName,omitempty"`
 }
 
 // Handler defines a specific action that should be taken

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -264,7 +264,6 @@ type Container struct {
 	Privileged bool `json:"privileged,omitempty" yaml:"privileged,omitempty"`
 	// Optional: Policy for pulling images for this container
 	ImagePullPolicy PullPolicy `json:"imagePullPolicy" yaml:"imagePullPolicy"`
-	ExternalName    string  `json:"externalName,omitempty" yaml:"externalName,omitempty"`
 }
 
 // Handler defines a specific action that should be taken
@@ -392,6 +391,7 @@ type PodState struct {
 	Host    string `json:"host,omitempty" yaml:"host,omitempty"`
 	HostIP  string `json:"hostIP,omitempty" yaml:"hostIP,omitempty"`
 	PodIP   string `json:"podIP,omitempty" yaml:"podIP,omitempty"`
+	ExternalName    string  `json:"externalName,omitempty" yaml:"externalName,omitempty"`
 
 	// The key of this map is the *name* of the container within the manifest; it has one
 	// entry per container in the manifest. The value of this map is currently the output

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -264,6 +264,7 @@ type Container struct {
 	Privileged bool `json:"privileged,omitempty" yaml:"privileged,omitempty"`
 	// Optional: Policy for pulling images for this container
 	ImagePullPolicy PullPolicy `json:"imagePullPolicy" yaml:"imagePullPolicy"`
+	ExternalName    string  `json:"externalName,omitempty" yaml:"externalName,omitempty"`
 }
 
 // Handler defines a specific action that should be taken

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -230,6 +230,7 @@ type Container struct {
 	Privileged bool `json:"privileged,omitempty" yaml:"privileged,omitempty"`
 	// Optional: Policy for pulling images for this container
 	ImagePullPolicy PullPolicy `json:"imagePullPolicy" yaml:"imagePullPolicy"`
+	ExternalName    string  `json:"externalName,omitempty" yaml:"externalName,omitempty"`
 }
 
 // Handler defines a specific action that should be taken

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -342,6 +342,7 @@ type Container struct {
 	Privileged bool `json:"privileged,omitempty" yaml:"privileged,omitempty"`
 	// Optional: Policy for pulling images for this container
 	ImagePullPolicy PullPolicy `json:"imagePullPolicy" yaml:"imagePullPolicy"`
+	ExternalName    string  `json:"externalName,omitempty" yaml:"externalName,omitempty"`
 }
 
 // Handler defines a specific action that should be taken

--- a/pkg/onramp/onramp.go
+++ b/pkg/onramp/onramp.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/exec"
 	"github.com/golang/glog"
 )
@@ -37,6 +38,8 @@ type podNameIP struct {
 type Onramp struct {
 	etcdClient tools.EtcdClient
 	kubeClient *client.Client
+	extInterface string
+	extAddrs util.StringList
 	podNameList []podNameIP
 	podNameLock *sync.Mutex
 	podMonitor	int
@@ -54,10 +57,12 @@ type OnrampRouterClaim struct {
 // Helper structs to allow use of foreign types
 type Container api.Container
 
-func NewOnramp(ec tools.EtcdClient, ac *client.Client) *Onramp {
+func NewOnramp(ec tools.EtcdClient, ac *client.Client, intf string, addrs util.StringList) *Onramp {
 	return &Onramp{
 		etcdClient: ec,
 		kubeClient: ac,
+		extInterface: intf,
+		extAddrs: addrs,
 		podNameLock: &sync.Mutex{},
 		podMonitor: 0,
 	}

--- a/pkg/onramp/onramp.go
+++ b/pkg/onramp/onramp.go
@@ -136,15 +136,13 @@ func (onrmp *Onramp) monitorPods() {
 	for {
 		glog.Infof("Sleeping\n")
 		time.Sleep(10 * time.Second)
-		glog.Infof("Checking podMonitor\n")
-		// Note: This is racy, fix it
-		if (onrmp.podMonitor == 0) {
-			glog.Infof("podmonitor already running\n");
-			return
-		}	
 		glog.Infof("Continuing monitor\n")
 		onrmp.podNameLock.Lock()
-
+		if (len(onrmp.podNameList) == 0) {
+			onrmp.podMonitor = 0
+			onrmp.podNameLock.Unlock()
+			return
+		}
 		for m := range onrmp.podNameList {
 			pod, err := pdi.Get(onrmp.podNameList[m].PodName)
 			if (err != nil) {

--- a/pkg/onramp/onramp.go
+++ b/pkg/onramp/onramp.go
@@ -200,7 +200,7 @@ func (onrmp *Onramp) Run() {
 
 	// Before we do anything else, the internal and external interfaces need to be set to
 	// forward
-	file, err := os.Open("/proc/sys/net/ipv4/conf/" + onrmp.extInterface + "/forwarding")
+	file, err := os.OpenFile("/proc/sys/net/ipv4/conf/" + onrmp.extInterface + "/forwarding", os.O_RDWR, 0666)
 	if (err != nil) {
 		glog.Infof("Could not find interface %s: \n", onrmp.extInterface, err)
 		return
@@ -208,7 +208,7 @@ func (onrmp *Onramp) Run() {
 	file.WriteString("1")
 	file.Close()
 
-	file, err = os.Open("/proc/sys/net/ipv4/conf/flannel.1/forwarding")
+	file, err = os.OpenFile("/proc/sys/net/ipv4/conf/flannel.1/forwarding", os.O_RDWR, 0666)
 
 	if (err != nil) {
 		glog.Infof("Could not find interface flannel.1: \n", err)

--- a/pkg/onramp/onramp.go
+++ b/pkg/onramp/onramp.go
@@ -225,6 +225,9 @@ func (onrmp *Onramp) Run() {
 	file.WriteString("1")
 	file.Close()
 
+	// Put our iptables nat table in a known, empty state
+	onrmp.mapAction("RESET", "X", "X", "X", "X", "X")
+
 	response, err := onrmp.etcdClient.Watch("/registry/pods/default/", 0, true, nil, nil)
 	if err != nil {
 		glog.Infof("Error on etcd watch: %s\n", err)

--- a/pkg/onramp/onramp.go
+++ b/pkg/onramp/onramp.go
@@ -130,6 +130,17 @@ func (onrmp *Onramp) allocateExtAddr() (extAddr *string) {
 	return newIP 
 }
 
+func (onrmp *Onramp) freeExtAddr(extAddr string) {
+	//remove the extAddr from the usedExtAddrs list and add it to the extAddrs list
+	for m := range onrmp.usedExtAddrs {
+		if (onrmp.usedExtAddrs[m] == extAddr) {
+			onrmp.usedExtAddrs = append(onrmp.usedExtAddrs[0:m], onrmp.usedExtAddrs[m+1:]...)
+			onrmp.extAddrs = append(onrmp.extAddrs, extAddr)
+			return
+		}
+	}
+}
+
 func (onrmp *Onramp) mapAction(action string, eintf string, iintf string, name string, extip string, podip string) (error) {
 
 	ex := exec.New()
@@ -164,7 +175,7 @@ func (onrmp *Onramp) monitorPods() {
 					glog.Infof("Error Executing Delete for pod %s: %s\n", onrmp.podNameList[m].PodName, err)
 					continue
 				}
-		
+				onrmp.freeExtAddr(onrmp.podNameList[m].ExtIP)
 				onrmp.podNameList = append(onrmp.podNameList[0:m], onrmp.podNameList[m+1:]...)
 				break; //Need to break here to restart the for loop with a new range computation		
 			}

--- a/pkg/onramp/onramp.go
+++ b/pkg/onramp/onramp.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package onramp 
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/golang/glog"
+)
+
+// New creates a new Kubelet for use in main
+func NewOnramp(ec tools.EtcdClient) *Onramp {
+	return &Onramp{
+		etcdClient:            ec,
+	}
+}
+
+// Kubelet is the main kubelet implementation.
+type Onramp struct {
+	etcdClient tools.EtcdClient
+}
+
+
+// Run starts the kubelet reacting to config updates
+func (onrmp *Onramp) Run() {
+
+	glog.Infof("In Onramp RUN!\n")
+	_, err := onrmp.etcdClient.Watch("/v2/keys/registry/pods/default/", 1, false, nil, nil)
+
+	if (err == nil) {
+		glog.Infof("Error on etcd watch: %s\n", err)
+		return
+	}
+
+}

--- a/pkg/onramp/onramp.go
+++ b/pkg/onramp/onramp.go
@@ -17,6 +17,7 @@ limitations under the License.
 package onramp
 
 import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
@@ -36,7 +37,11 @@ type Onramp struct {
 }
 
 func scanPod(onrmp *Onramp) {
-	pdi := onrmp.kubeClient.Pods("")
+	ns := api.NamespaceAll
+	pdi := onrmp.kubeClient.Pods(ns)
+	if pdi == nil {
+		return
+	}
 	pods, err := pdi.List(labels.Everything())
 	if err != nil {
 		return

--- a/pkg/onramp/onramp_iptables_setup.sh
+++ b/pkg/onramp/onramp_iptables_setup.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
 ACTION=$1
-PODNAME=$2
-EXTIP=$3
-PODIP=$4
+INTERFACE=$2
+PODNAME=$3
+EXTIP=$4
+PODIP=$5
 
 LOGFILE=`mktemp --tmpdir=/tmp $PODNAME.XXXXXX`
 
@@ -22,7 +23,7 @@ create_mapping()
 
 	# Start by creating the  DNAT rule on the private chain
 	echo "ADDING PRIVATE CHAIN $DNATCHAIN" >> $LOGFILE
-	iptables -t nat -A $DNATCHAIN -i em1 --destination $EXTIP/32 -j DNAT --to $PODIP >> $LOGFILE
+	iptables -t nat -A $DNATCHAIN -i $INTERFACE  -j DNAT --to $PODIP >> $LOGFILE
 
 	# Then setup the MASQ rule to do the SNAT
 	echo "ADDING PRIVATE CHAIN $SNATCHAIN" >> $LOGFILE
@@ -31,7 +32,7 @@ create_mapping()
 
 	# Then bind them in by jumping to them from the master chains
 	echo "ATTACHING NEW PRIVATE CHAINS" >> $LOGFILE
-	iptables -t nat -A PREROUTING -j $DNATCHAIN >> $LOGFILE
+	iptables -t nat -A PREROUTING --destination $EXTIP/32 -j $DNATCHAIN >> $LOGFILE
 	iptables -t nat -A POSTROUTING -j $SNATCHAIN >> $LOGFILE
 }
 

--- a/pkg/onramp/onramp_iptables_setup.sh
+++ b/pkg/onramp/onramp_iptables_setup.sh
@@ -97,6 +97,18 @@ delete_mapping()
 	iptables -t nat -X $SNATCHAIN >> $LOGFILE
 }
 
+reset_nat_table()
+{
+	echo "FLUSHING NAT TABLE" >> $LOGFILE
+	iptables --t nat --flush >> $LOGFILE 2>&1
+
+	for i in `iptables --list -t nat | grep Chain | grep "\-[D|S]NAT" | awk '{print $2}'`
+	do
+		echo "DELETEING $i" >> $LOGFILE
+		iptables -t nat -X $i >> $LOGFILE 2>&1
+	done
+}
+
 
 #START
 
@@ -113,6 +125,9 @@ MODIFY)
 	;;
 DELETE)
 	delete_mapping $PODNAME
+	;;
+RESET)
+	reset_nat_table
 	;;
 esac
 

--- a/pkg/onramp/onramp_iptables_setup.sh
+++ b/pkg/onramp/onramp_iptables_setup.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 
 ACTION=$1
-INTERFACE=$2
-PODNAME=$3
-EXTIP=$4
-PODIP=$5
+EINTERFACE=$2
+IINTERFACE=$3
+PODNAME=$4
+EXTIP=$5
+PODIP=$6
 
 LOGFILE=`mktemp --tmpdir=/tmp $PODNAME.XXXXXX`
 
@@ -23,11 +24,11 @@ create_mapping()
 
 	# Start by creating the  DNAT rule on the private chain
 	echo "ADDING PRIVATE CHAIN $DNATCHAIN" >> $LOGFILE
-	iptables -t nat -A $DNATCHAIN -i $INTERFACE  -j DNAT --to $PODIP >> $LOGFILE
+	iptables -t nat -A $DNATCHAIN -i $EINTERFACE  -j DNAT --to $PODIP >> $LOGFILE
 
 	# Then setup the MASQ rule to do the SNAT
 	echo "ADDING PRIVATE CHAIN $SNATCHAIN" >> $LOGFILE
-	iptables -t nat -A $SNATCHAIN -o flannel.1 -j MASQUERADE >> $LOGFILE
+	iptables -t nat -A $SNATCHAIN -o $IINTERFACE -j MASQUERADE >> $LOGFILE
 
 
 	# Then bind them in by jumping to them from the master chains

--- a/pkg/onramp/onramp_iptables_setup.sh
+++ b/pkg/onramp/onramp_iptables_setup.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+
+ACTION=$1
+PODNAME=$2
+EXTIP=$3
+PODIP=$4
+
+LOGFILE=/tmp/$PODNAME.log
+
+rm -f $LOGFILE
+
+create_mapping()
+{
+	local CHAINBASE=$1
+	local EXTIP=$2
+	local PODIP=$3
+
+	local DNATCHAIN=$CHAINBASE-DNAT
+	local SNATCHAIN=$CHAINBASE-SNAT
+
+	# Create the private chains
+	iptables -t nat -N $DNATCHAIN >> $LOGFILE
+	iptables -t nat -N $SNATCHAIN >> $LOGFILE
+
+	# Start by creating the  DNAT rule on the private chain
+	echo "ADDING PRIVATE CHAIN $DNATCHAIN" >> $LOGFILE
+	iptables -t nat -A $DNATCHAIN -i em1 --destination $EXTIP/32 -j DNAT --to $PODIP >> $LOGFILE
+
+	# Then setup the MASQ rule to do the SNAT
+	echo "ADDING PRIVATE CHAIN $SNATCHAIN" >> $LOGFILE
+	iptables -t nat -A $SNATCHAIN -o flannel.1 -j MASQUERADE >> $LOGFILE
+
+
+	# Then bind them in by jumping to them from the master chains
+	echo "ATTACHING NEW PRIVATE CHAINS" >> $LOGFILE
+	iptables -t nat -A PREROUTING -j $DNATCHAIN >> $LOGFILE
+	iptables -t nat -A POSTROUTING -j $SNATCHAIN >> $LOGFILE
+}
+
+find_rulenum()
+{
+	local CHAINBASE=$1
+	local MAINCHAIN=$2
+	local rulenum
+	local found
+
+	echo "LOOKING FOR RULES MATCHING $CHAINBASE in $MAINCHAIN" >> $LOGFILE
+	rulenum=1
+        iptables -t nat -L $MAINCHAIN | while read a
+        do
+		echo "CHECKING RULE $rulenum" >> $LOGFILE
+                echo $a | grep -q $CHAINBASE
+                if [ $? -eq 0 ]
+                then
+			found="yes"
+                else
+                        rulenum=$(($rulenum+1))
+                fi
+
+		if [ -n "$found" ]
+		then
+			rulenum=$(($rulenum-2))
+			echo "$rulenum"
+			break
+		fi
+        done
+
+
+}
+
+delete_mapping()
+{
+	local CHAINBASE=$1
+	local rulenum
+	local DNATCHAIN=$CHAINBASE-DNAT
+	local SNATCHAIN=$CHAINBASE-SNAT
+
+	echo "DELETING $CHAINBASE FROM MAIN CHAINS" >> $LOGFILE
+	rulenum=$(find_rulenum $CHAINBASE PREROUTING)
+
+	echo "DELETING FOUND PREROUTING RULE $rulenum" >> $LOGFILE
+
+	iptables -t nat -D PREROUTING $rulenum >> $LOGFILE
+
+	rulenum=$(find_rulenum $CHAINBASE POSTROUTING)
+
+	echo "DELETING FOUND POSTROUTING RULE $rulenum" >> $LOGFILE
+
+	iptables -t nat -D POSTROUTING $rulenum >> $LOGFILE
+
+	#now flush the private chains
+	iptables -t nat --flush $DNATCHAIN >> $LOGFILE
+	iptables -t nat --flush $SNATCHAIN >> $LOGFILE
+
+	# And delete the chains
+	iptables -t nat -X $DNATCHAIN >> $LOGFILE
+	iptables -t nat -X $SNATCHAIN >> $LOGFILE
+}
+
+
+#START
+
+echo "WORKING ON $ACTION $PODNAME FROM $EXTIP to $PODIP" >> $LOGFILE
+
+case $ACTION in
+
+ADD)
+	create_mapping $PODNAME $EXTIP $PODIP
+	;;
+MODIFY)
+	delete_mapping $PODNAME
+	create_mapping $POSNAME $EXTIP $PODIP
+	;;
+DELETE)
+	delete_mapping $PODNAME
+	;;
+esac
+
+exit 0
+

--- a/pkg/onramp/onramp_iptables_setup.sh
+++ b/pkg/onramp/onramp_iptables_setup.sh
@@ -5,9 +5,7 @@ PODNAME=$2
 EXTIP=$3
 PODIP=$4
 
-LOGFILE=/tmp/$PODNAME.log
-
-rm -f $LOGFILE
+LOGFILE=`mktemp --tmpdir=/tmp $PODNAME.XXXXXX`
 
 create_mapping()
 {
@@ -109,7 +107,7 @@ ADD)
 	;;
 MODIFY)
 	delete_mapping $PODNAME
-	create_mapping $POSNAME $EXTIP $PODIP
+	create_mapping $PODNAME $EXTIP $PODIP
 	;;
 DELETE)
 	delete_mapping $PODNAME

--- a/pkg/onramp/onramp_iptables_setup.sh
+++ b/pkg/onramp/onramp_iptables_setup.sh
@@ -33,7 +33,7 @@ create_mapping()
 	# Then bind them in by jumping to them from the master chains
 	echo "ATTACHING NEW PRIVATE CHAINS" >> $LOGFILE
 	iptables -t nat -A PREROUTING --destination $EXTIP/32 -j $DNATCHAIN >> $LOGFILE
-	iptables -t nat -A POSTROUTING -j $SNATCHAIN >> $LOGFILE
+	iptables -t nat -A POSTROUTING --destination $PODIP/32 -j $SNATCHAIN >> $LOGFILE
 }
 
 find_rulenum()


### PR DESCRIPTION
# Overview

One of the features thats missing in Kubernetes is the ability to assign external ip addresses to pods in a kube cloud.  This patch series is the start of my work to enable that access.  It allows this access via the following:
- The addition of a new json tag called **ExternalName** which identifies the fact that a pod at creation time is requesting external ip access.  The ExternalName field is currently a string that is meant to be interpreted as an FQDN that can be dynamically mapped to an external ip address.
- The addition of a server called an onramp router, who's purpose is to 
  - Monitor the api server for the addition of or removal of pods
  - Identification of pods which require external ip access
  - Claiming _ownership_ of pods, in the sense that only one onramp router in a cluser will serve a given pods external access needs
  - Managing the forwarding of packets bound for the external ip address to the pod address, and vice versa
# Operation

The onramp router monitors the apiserver for the addition of or removal of pods.  When a pod requiring external access is noted, the onramp router creates a key in etcd based on the pod name, creating a mutual exclusion point so that only one onramp router in a cluster manages external access for that pod.  An external address available to the router is selected, and iptables mappings are created so that traffic bound for that external address is DNAT-ed to the pod address, and SNAT-ed back to the onramp router (so that reverse traffic isn't split on the network).  Removal of pods needing external addresses, or updates to the pod internal address are likewise reflected in the onramp routers iptables setup.
# Limitations & Known issues

Too many to count at the moment, but some of the highlights are
- **Method of obtaining an  external ip address** - currently available external addresses are simply passed to the onramp router as a string list, and managed internally. It is assumed the external addresses are already assigned to the system running the onramp router.  We should enhance this so that multiple address allocation methods can be used for better address management
- **Internal network creation** - Currently onramp requires flannel to allocate and manage an overlay network interface on the system where onramp is running, and the interface name is simply passed to onramp via the command line.  It would be great to make internal network interface creation something internal to onramp based on a standardized etcd key format, so that multiple internal network mechanisms can be used.
- **etcd use cleanup** - Currently we monitor etcd directly for pod creation.  Need to clean that up to interface to the API server properly
- **iptables management** - Currently handled as a shell script that we exec out to, which is workable, and even somewhat convenient, but it would be nice to interface it to a go library
- **dynamic dns update** - Need to add code to optionally update a dynamic dns to map the ExternalName tag to the allocated external ip address.

Thoughts and comments appreciated.
