### PR TITLE
Fix broken hack/cluster-validate.sh because output-versions were not locked

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -325,17 +325,9 @@ func (c *clientCache) ClientConfigForVersion(version string) (*client.Config, er
 		}
 	}
 
-	// TODO: remove when SetKubernetesDefaults gets added
-	if len(version) == 0 {
-		version = c.defaultConfig.Version
-	}
-
 	// TODO: have a better config copy method
 	config := *c.defaultConfig
-
-	// TODO: call new client.SetKubernetesDefaults method
-	// instead of doing this
-	config.Version = version
+	client.SetKubernetesDefaults(&config)
 	return &config, nil
 }
 

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -109,6 +109,9 @@ func NewVersionedPrinter(printer ResourcePrinter, convertor runtime.ObjectConver
 
 // PrintObj implements ResourcePrinter
 func (p *VersionedPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	if len(p.version) == 0 {
+		return fmt.Errorf("no version specified, object cannot be converted")
+	}
 	converted, err := p.convertor.ConvertToVersion(obj, p.version)
 	if err != nil {
 		return err


### PR DESCRIPTION
Combination of changes to kubectl get and clientcmd resulted in no api-version
value being set, which resulted in converting to internal.  Make that unpossible.

@lavalamp
