### PR TITLE
Remove CONDITION from event object completely

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1038,18 +1038,9 @@ type Event struct {
 	// Required. The object that this event is about.
 	InvolvedObject ObjectReference `json:"involvedObject,omitempty"`
 
-	// Should be a short, machine understandable string that describes the current condition
-	// of the referred object. This should not give the reason for being in this state.
-	// Examples: "Running", "CantStart", "CantSchedule", "Deleted".
-	// It's OK for components to make up conditions to report here, but the same string should
-	// always be used for the same conditions.
-	// TODO: define a way of making sure these are consistent and don't collide.
-	// TODO: provide exact specification for format.
-	Condition string `json:"condition,omitempty"`
-
 	// Optional; this should be a short, machine understandable string that gives the reason
-	// for the transition into the object's current condition. For example, if ObjectCondition is
-	// "CantStart", StatusReason might be "ImageNotFound".
+	// for this event being generated. For example, if the event is reporting that a container
+	// can't start, the Reason might be "ImageNotFound".
 	// TODO: provide exact specification for format.
 	Reason string `json:"reason,omitempty"`
 

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -562,7 +562,6 @@ func init() {
 			return nil
 		},
 
-		// Event Status <-> Condition
 		// Event Source <-> Source.Component
 		// Event Host <-> Source.Host
 		// TODO: remove this when it becomes possible to specify a field name conversion on a specific type
@@ -573,7 +572,6 @@ func init() {
 			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
 				return err
 			}
-			out.Status = in.Condition
 			out.Reason = in.Reason
 			out.Message = in.Message
 			out.Source = in.Source.Component
@@ -588,7 +586,6 @@ func init() {
 			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
 				return err
 			}
-			out.Condition = in.Status
 			out.Reason = in.Reason
 			out.Message = in.Message
 			out.Source.Component = in.Source

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -809,6 +809,7 @@ type Event struct {
 	// always be used for the same status.
 	// TODO: define a way of making sure these are consistent and don't collide.
 	// TODO: provide exact specification for format.
+	// DEPRECATED: Status (a.k.a Condition) value will be ignored.
 	Status string `json:"status,omitempty" description:"short, machine understandable string that describes the current status of the referred object"`
 
 	// Optional; this should be a short, machine understandable string that gives the reason

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -489,7 +489,6 @@ func init() {
 			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
 				return err
 			}
-			out.Status = in.Condition
 			out.Reason = in.Reason
 			out.Message = in.Message
 			out.Source = in.Source.Component
@@ -504,7 +503,6 @@ func init() {
 			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
 				return err
 			}
-			out.Condition = in.Status
 			out.Reason = in.Reason
 			out.Message = in.Message
 			out.Source.Component = in.Source

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -782,6 +782,7 @@ type Event struct {
 	// always be used for the same status.
 	// TODO: define a way of making sure these are consistent and don't collide.
 	// TODO: provide exact specification for format.
+	// DEPRECATED: Status (a.k.a Condition) value will be ignored.
 	Status string `json:"status,omitempty" description:"short, machine understandable string that describes the current status of the referred object"`
 
 	// Optional; this should be a short, machine understandable string that gives the reason

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -1029,18 +1029,8 @@ type Event struct {
 	// Required. The object that this event is about.
 	InvolvedObject ObjectReference `json:"involvedObject,omitempty"`
 
-	// Should be a short, machine understandable string that describes the current condition
-	// of the referred object. This should not give the reason for being in this state.
-	// Examples: "Running", "CantStart", "CantSchedule", "Deleted".
-	// It's OK for components to make up conditions to report here, but the same string should
-	// always be used for the same conditions.
-	// TODO: define a way of making sure these are consistent and don't collide.
-	// TODO: provide exact specification for format.
-	Condition string `json:"condition,omitempty"`
-
 	// Optional; this should be a short, machine understandable string that gives the reason
-	// for the transition into the object's current condition. For example, if ObjectCondition is
-	// "CantStart", StatusReason might be "ImageNotFound".
+	// for this event being generated.
 	// TODO: provide exact specification for format.
 	Reason string `json:"reason,omitempty"`
 

--- a/pkg/client/events_test.go
+++ b/pkg/client/events_test.go
@@ -63,7 +63,6 @@ func TestEventCreate(t *testing.T) {
 	timeStamp := util.Now()
 	event := &api.Event{
 		//namespace: namespace{"default"},
-		Condition:      "Running",
 		InvolvedObject: *objReference,
 		Timestamp:      timeStamp,
 	}
@@ -98,7 +97,6 @@ func TestEventGet(t *testing.T) {
 	}
 	timeStamp := util.Now()
 	event := &api.Event{
-		Condition:      "Running",
 		InvolvedObject: *objReference,
 		Timestamp:      timeStamp,
 	}
@@ -136,7 +134,6 @@ func TestEventList(t *testing.T) {
 	eventList := &api.EventList{
 		Items: []api.Event{
 			{
-				Condition:      "Running",
 				InvolvedObject: *objReference,
 				Timestamp:      timeStamp,
 			},

--- a/pkg/client/record/event.go
+++ b/pkg/client/record/event.go
@@ -93,7 +93,7 @@ func StartRecording(recorder EventRecorder, source api.EventSource) watch.Interf
 // return value can be ignored or used to stop logging, if desired.
 func StartLogging(logf func(format string, args ...interface{})) watch.Interface {
 	return GetEvents(func(e *api.Event) {
-		logf("Event(%#v): status: '%v', reason: '%v' %v", e.InvolvedObject, e.Condition, e.Reason, e.Message)
+		logf("Event(%#v): reason: '%v' %v", e.InvolvedObject, e.Reason, e.Message)
 	})
 }
 
@@ -127,17 +127,16 @@ var events = watch.NewBroadcaster(queueLen)
 // Event constructs an event from the given information and puts it in the queue for sending.
 // 'object' is the object this event is about. Event will make a reference-- or you may also
 // pass a reference to the object directly.
-// 'condition' is the new condition of the object. 'reason' is the reason it now has this status.
-// Both 'condition' and 'reason' should be short and unique; they will be used to automate
-// handling of events, so imagine people writing switch statements to handle them. You want to
-// make that easy.
+// 'reason' is the reason this event is generated. 'reason' should be short and unique; it will
+// be used to automate handling of events, so imagine people writing switch statements to
+// handle them. You want to make that easy.
 // 'message' is intended to be human readable.
 //
 // The resulting event will be created in the same namespace as the reference object.
-func Event(object runtime.Object, condition, reason, message string) {
+func Event(object runtime.Object, reason, message string) {
 	ref, err := api.GetReference(object)
 	if err != nil {
-		glog.Errorf("Could not construct reference to: '%#v' due to: '%v'. Will not report event: '%v' '%v' '%v'", object, err, condition, reason, message)
+		glog.Errorf("Could not construct reference to: '%#v' due to: '%v'. Will not report event: '%v' '%v'", object, err, reason, message)
 		return
 	}
 	t := util.Now()
@@ -148,7 +147,6 @@ func Event(object runtime.Object, condition, reason, message string) {
 			Namespace: ref.Namespace,
 		},
 		InvolvedObject: *ref,
-		Condition:      condition,
 		Reason:         reason,
 		Message:        message,
 		Timestamp:      t,
@@ -158,6 +156,6 @@ func Event(object runtime.Object, condition, reason, message string) {
 }
 
 // Eventf is just like Event, but with Sprintf for the message field.
-func Eventf(object runtime.Object, status, reason, messageFmt string, args ...interface{}) {
-	Event(object, status, reason, fmt.Sprintf(messageFmt, args...))
+func Eventf(object runtime.Object, reason, messageFmt string, args ...interface{}) {
+	Event(object, reason, fmt.Sprintf(messageFmt, args...))
 }

--- a/pkg/client/record/event_test.go
+++ b/pkg/client/record/event_test.go
@@ -64,16 +64,15 @@ func TestEventf(t *testing.T) {
 		t.Fatal(err)
 	}
 	table := []struct {
-		obj            runtime.Object
-		status, reason string
-		messageFmt     string
-		elements       []interface{}
-		expect         *api.Event
-		expectLog      string
+		obj        runtime.Object
+		reason     string
+		messageFmt string
+		elements   []interface{}
+		expect     *api.Event
+		expectLog  string
 	}{
 		{
 			obj:        testRef,
-			status:     "Running",
 			reason:     "Started",
 			messageFmt: "some verbose message: %v",
 			elements:   []interface{}{1},
@@ -90,16 +89,14 @@ func TestEventf(t *testing.T) {
 					APIVersion: "v1beta1",
 					FieldPath:  "desiredState.manifest.containers[2]",
 				},
-				Condition: "Running",
-				Reason:    "Started",
-				Message:   "some verbose message: 1",
-				Source:    api.EventSource{Component: "eventTest"},
+				Reason:  "Started",
+				Message: "some verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
 			},
-			expectLog: `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"v1beta1", ResourceVersion:"", FieldPath:"desiredState.manifest.containers[2]"}): status: 'Running', reason: 'Started' some verbose message: 1`,
+			expectLog: `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"v1beta1", ResourceVersion:"", FieldPath:"desiredState.manifest.containers[2]"}): reason: 'Started' some verbose message: 1`,
 		},
 		{
 			obj:        testPod,
-			status:     "Running",
 			reason:     "Started",
 			messageFmt: "some verbose message: %v",
 			elements:   []interface{}{1},
@@ -115,12 +112,11 @@ func TestEventf(t *testing.T) {
 					UID:        "bar",
 					APIVersion: "v1beta1",
 				},
-				Condition: "Running",
-				Reason:    "Started",
-				Message:   "some verbose message: 1",
-				Source:    api.EventSource{Component: "eventTest"},
+				Reason:  "Started",
+				Message: "some verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
 			},
-			expectLog: `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"v1beta1", ResourceVersion:"", FieldPath:""}): status: 'Running', reason: 'Started' some verbose message: 1`,
+			expectLog: `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"v1beta1", ResourceVersion:"", FieldPath:""}): reason: 'Started' some verbose message: 1`,
 		},
 	}
 
@@ -155,7 +151,7 @@ func TestEventf(t *testing.T) {
 			called <- struct{}{}
 		})
 
-		Eventf(item.obj, item.status, item.reason, item.messageFmt, item.elements...)
+		Eventf(item.obj, item.reason, item.messageFmt, item.elements...)
 
 		<-called
 		<-called
@@ -231,9 +227,9 @@ func TestWriteEventError(t *testing.T) {
 	).Stop()
 
 	for caseName := range table {
-		Event(ref, "Status", "Reason", caseName)
+		Event(ref, "Reason", caseName)
 	}
-	Event(ref, "Status", "Reason", "finished")
+	Event(ref, "Reason", "finished")
 	<-done
 
 	for caseName, item := range table {

--- a/pkg/kubecfg/resource_printer.go
+++ b/pkg/kubecfg/resource_printer.go
@@ -143,7 +143,7 @@ var replicationControllerColumns = []string{"Name", "Image(s)", "Selector", "Rep
 var serviceColumns = []string{"Name", "Labels", "Selector", "IP", "Port"}
 var minionColumns = []string{"Minion identifier", "Labels"}
 var statusColumns = []string{"Status"}
-var eventColumns = []string{"Name", "Kind", "Condition", "Reason", "Message"}
+var eventColumns = []string{"Name", "Kind", "Reason", "Message"}
 
 // addDefaultHandlers adds print handlers for default Kubernetes types.
 func (h *HumanReadablePrinter) addDefaultHandlers() {
@@ -269,10 +269,9 @@ func printStatus(status *api.Status, w io.Writer) error {
 
 func printEvent(event *api.Event, w io.Writer) error {
 	_, err := fmt.Fprintf(
-		w, "%s\t%s\t%s\t%s\t%s\n",
+		w, "%s\t%s\t%s\t%s\n",
 		event.InvolvedObject.Name,
 		event.InvolvedObject.Kind,
-		event.Condition,
 		event.Reason,
 		event.Message,
 	)

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -200,13 +200,12 @@ func describeEvents(el *api.EventList, w io.Writer) {
 		return
 	}
 	sort.Sort(SortableEvents(el.Items))
-	fmt.Fprint(w, "Events:\nTime\tFrom\tSubobjectPath\tCondition\tReason\tMessage\n")
+	fmt.Fprint(w, "Events:\nTime\tFrom\tSubobjectPath\tReason\tMessage\n")
 	for _, e := range el.Items {
 		fmt.Fprintf(w, "%s\t%v\t%v\t%v\t%v\t%v\n",
 			e.Timestamp.Time.Format(time.RFC1123Z),
 			e.Source,
 			e.InvolvedObject.FieldPath,
-			e.Condition,
 			e.Reason,
 			e.Message)
 	}

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -220,7 +220,7 @@ var replicationControllerColumns = []string{"CONTROLLER", "CONTAINER(S)", "IMAGE
 var serviceColumns = []string{"NAME", "LABELS", "SELECTOR", "IP", "PORT"}
 var minionColumns = []string{"NAME", "LABELS"}
 var statusColumns = []string{"STATUS"}
-var eventColumns = []string{"TIME", "NAME", "KIND", "SUBOBJECT", "CONDITION", "REASON", "SOURCE", "MESSAGE"}
+var eventColumns = []string{"TIME", "NAME", "KIND", "SUBOBJECT", "REASON", "SOURCE", "MESSAGE"}
 
 // addDefaultHandlers adds print handlers for default Kubernetes types.
 func (h *HumanReadablePrinter) addDefaultHandlers() {
@@ -367,12 +367,11 @@ func printStatus(status *api.Status, w io.Writer) error {
 
 func printEvent(event *api.Event, w io.Writer) error {
 	_, err := fmt.Fprintf(
-		w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 		event.Timestamp.Time.Format(time.RFC1123Z),
 		event.InvolvedObject.Name,
 		event.InvolvedObject.Kind,
 		event.InvolvedObject.FieldPath,
-		event.Condition,
 		event.Reason,
 		event.Source,
 		event.Message,

--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -305,7 +305,7 @@ func filterInvalidPods(pods []api.BoundPod, source string) (filtered []*api.Boun
 			name := bestPodIdentString(pod)
 			err := utilerrors.NewAggregate(errlist)
 			glog.Warningf("Pod[%d] (%s) from %s failed validation, ignoring: %v", i+1, name, source, err)
-			record.Eventf(pod, "", "failedValidation", "Error validating pod %s from %s, ignoring: %v", name, source, err)
+			record.Eventf(pod, "failedValidation", "Error validating pod %s from %s, ignoring: %v", name, source, err)
 			continue
 		}
 		filtered = append(filtered, pod)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -627,7 +627,7 @@ func (kl *Kubelet) runContainer(pod *api.BoundPod, container *api.Container, pod
 	dockerContainer, err := kl.dockerClient.CreateContainer(opts)
 	if err != nil {
 		if ref != nil {
-			record.Eventf(ref, "failed", "failed",
+			record.Eventf(ref, "failed",
 				"Failed to create docker container with error: %v", err)
 		}
 		return "", err
@@ -635,7 +635,7 @@ func (kl *Kubelet) runContainer(pod *api.BoundPod, container *api.Container, pod
 	// Remember this reference so we can report events about this container
 	if ref != nil {
 		kl.setRef(dockertools.DockerID(dockerContainer.ID), ref)
-		record.Eventf(ref, "waiting", "created", "Created with docker id %v", dockerContainer.ID)
+		record.Eventf(ref, "created", "Created with docker id %v", dockerContainer.ID)
 	}
 
 	if len(container.TerminationMessagePath) != 0 {
@@ -673,13 +673,13 @@ func (kl *Kubelet) runContainer(pod *api.BoundPod, container *api.Container, pod
 	err = kl.dockerClient.StartContainer(dockerContainer.ID, hc)
 	if err != nil {
 		if ref != nil {
-			record.Eventf(ref, "failed", "failed",
+			record.Eventf(ref, "failed",
 				"Failed to start with docker id %v with error: %v", dockerContainer.ID, err)
 		}
 		return "", err
 	}
 	if ref != nil {
-		record.Eventf(ref, "running", "started", "Started with docker id %v", dockerContainer.ID)
+		record.Eventf(ref, "started", "Started with docker id %v", dockerContainer.ID)
 	}
 
 	if container.Lifecycle != nil && container.Lifecycle.PostStart != nil {
@@ -765,7 +765,7 @@ func (kl *Kubelet) killContainerByID(ID, name string) error {
 		glog.Warningf("No ref for pod '%v' - '%v'", ID, name)
 	} else {
 		// TODO: pass reason down here, and state, or move this call up the stack.
-		record.Eventf(ref, "terminated", "killing", "Killing %v - %v", ID, name)
+		record.Eventf(ref, "killing", "Killing %v - %v", ID, name)
 	}
 
 	return err
@@ -797,7 +797,7 @@ func (kl *Kubelet) createNetworkContainer(pod *api.BoundPod) (dockertools.Docker
 	ok, err := kl.dockerPuller.IsImagePresent(container.Image)
 	if err != nil {
 		if ref != nil {
-			record.Eventf(ref, "failed", "failed", "Failed to inspect image %q", container.Image)
+			record.Eventf(ref, "failed", "Failed to inspect image %q", container.Image)
 		}
 		return "", err
 	}
@@ -807,7 +807,7 @@ func (kl *Kubelet) createNetworkContainer(pod *api.BoundPod) (dockertools.Docker
 		}
 	}
 	if ref != nil {
-		record.Eventf(ref, "waiting", "pulled", "Successfully pulled image %q", container.Image)
+		record.Eventf(ref, "pulled", "Successfully pulled image %q", container.Image)
 	}
 	return kl.runContainer(pod, container, nil, "")
 }
@@ -817,12 +817,12 @@ func (kl *Kubelet) pullImage(img string, ref *api.ObjectReference) error {
 	defer kl.pullLock.RUnlock()
 	if err := kl.dockerPuller.Pull(img); err != nil {
 		if ref != nil {
-			record.Eventf(ref, "failed", "failed", "Failed to pull image %q", img)
+			record.Eventf(ref, "failed", "Failed to pull image %q", img)
 		}
 		return err
 	}
 	if ref != nil {
-		record.Eventf(ref, "waiting", "pulled", "Successfully pulled image %q", img)
+		record.Eventf(ref, "pulled", "Successfully pulled image %q", img)
 	}
 	return nil
 }
@@ -991,7 +991,7 @@ func (kl *Kubelet) syncPod(pod *api.BoundPod, dockerContainers dockertools.Docke
 			latest := dockertools.RequireLatestImage(container.Image)
 			if err != nil {
 				if ref != nil {
-					record.Eventf(ref, "failed", "failed", "Failed to inspect image %q", container.Image)
+					record.Eventf(ref, "failed", "Failed to inspect image %q", container.Image)
 				}
 				glog.Errorf("Failed to inspect image %q: %v; skipping pod %q container %q", container.Image, err, podFullName, container.Name)
 				continue
@@ -1123,7 +1123,7 @@ func (kl *Kubelet) SyncPods(pods []api.BoundPod) error {
 		kl.podWorkers.Run(podFullName, func() {
 			if err := kl.syncPod(pod, dockerContainers); err != nil {
 				glog.Errorf("Error syncing pod, skipping: %v", err)
-				record.Eventf(pod, "", "failedSync", "Error syncing pod, skipping: %v", err)
+				record.Eventf(pod, "failedSync", "Error syncing pod, skipping: %v", err)
 			}
 		})
 	}
@@ -1335,5 +1335,5 @@ func (kl *Kubelet) BirthCry() {
 		UID:       kl.hostname,
 		Namespace: api.NamespaceDefault,
 	}
-	record.Eventf(ref, "", "starting", "Starting kubelet.")
+	record.Eventf(ref, "starting", "Starting kubelet.")
 }

--- a/pkg/registry/event/rest.go
+++ b/pkg/registry/event/rest.go
@@ -106,8 +106,6 @@ func (rs *REST) getAttrs(obj runtime.Object) (objLabels, objFields labels.Set, e
 		"involvedObject.apiVersion":      event.InvolvedObject.APIVersion,
 		"involvedObject.resourceVersion": fmt.Sprintf("%s", event.InvolvedObject.ResourceVersion),
 		"involvedObject.fieldPath":       event.InvolvedObject.FieldPath,
-		"condition":                      event.Condition,
-		"status":                         event.Condition, // TODO: remove me when we version fields
 		"reason":                         event.Reason,
 		"source":                         event.Source.Component,
 	}, nil

--- a/pkg/registry/event/rest_test.go
+++ b/pkg/registry/event/rest_test.go
@@ -143,9 +143,8 @@ func TestRESTgetAttrs(t *testing.T) {
 			ResourceVersion: "0",
 			FieldPath:       "",
 		},
-		Condition: "Tested",
-		Reason:    "ForTesting",
-		Source:    api.EventSource{Component: "test"},
+		Reason: "ForTesting",
+		Source: api.EventSource{Component: "test"},
 	}
 	label, field, err := rest.getAttrs(eventA)
 	if err != nil {
@@ -162,8 +161,6 @@ func TestRESTgetAttrs(t *testing.T) {
 		"involvedObject.apiVersion":      testapi.Version(),
 		"involvedObject.resourceVersion": "0",
 		"involvedObject.fieldPath":       "",
-		"condition":                      "Tested",
-		"status":                         "Tested",
 		"reason":                         "ForTesting",
 		"source":                         "test",
 	}
@@ -183,8 +180,8 @@ func TestRESTList(t *testing.T) {
 			ResourceVersion: "0",
 			FieldPath:       "",
 		},
-		Condition: "Tested",
-		Reason:    "ForTesting",
+		Reason: "ForTesting",
+		Source: api.EventSource{Component: "GoodSource"},
 	}
 	eventB := &api.Event{
 		InvolvedObject: api.ObjectReference{
@@ -195,8 +192,8 @@ func TestRESTList(t *testing.T) {
 			ResourceVersion: "0",
 			FieldPath:       "",
 		},
-		Condition: "Tested",
-		Reason:    "ForTesting",
+		Reason: "ForTesting",
+		Source: api.EventSource{Component: "GoodSource"},
 	}
 	eventC := &api.Event{
 		InvolvedObject: api.ObjectReference{
@@ -207,13 +204,13 @@ func TestRESTList(t *testing.T) {
 			ResourceVersion: "0",
 			FieldPath:       "",
 		},
-		Condition: "Untested",
-		Reason:    "ForTesting",
+		Reason: "ForTesting",
+		Source: api.EventSource{Component: "OtherSource"},
 	}
 	reg.ObjectList = &api.EventList{
 		Items: []api.Event{*eventA, *eventB, *eventC},
 	}
-	got, err := rest.List(api.NewContext(), labels.Everything(), labels.Set{"status": "Tested"}.AsSelector())
+	got, err := rest.List(api.NewContext(), labels.Everything(), labels.Set{"source": "GoodSource"}.AsSelector())
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
@@ -235,8 +232,7 @@ func TestRESTWatch(t *testing.T) {
 			ResourceVersion: "0",
 			FieldPath:       "",
 		},
-		Condition: "Tested",
-		Reason:    "ForTesting",
+		Reason: "ForTesting",
 	}
 	reg, rest := NewTestREST()
 	wi, err := rest.Watch(api.NewContext(), labels.Everything(), labels.Everything(), "0")

--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -72,7 +72,7 @@ func (s *Scheduler) scheduleOne() {
 	dest, err := s.config.Algorithm.Schedule(*pod, s.config.MinionLister)
 	if err != nil {
 		glog.V(1).Infof("Failed to schedule: %v", pod)
-		record.Eventf(pod, string(api.PodPending), "failedScheduling", "Error scheduling: %v", err)
+		record.Eventf(pod, "failedScheduling", "Error scheduling: %v", err)
 		s.config.Error(pod, err)
 		return
 	}
@@ -83,9 +83,9 @@ func (s *Scheduler) scheduleOne() {
 	}
 	if err := s.config.Binder.Bind(b); err != nil {
 		glog.V(1).Infof("Failed to bind pod: %v", err)
-		record.Eventf(pod, string(api.PodPending), "failedScheduling", "Binding rejected: %v", err)
+		record.Eventf(pod, "failedScheduling", "Binding rejected: %v", err)
 		s.config.Error(pod, err)
 		return
 	}
-	record.Eventf(pod, string(api.PodPending), "scheduled", "Successfully assigned %v to %v", pod.Name, dest)
+	record.Eventf(pod, "scheduled", "Successfully assigned %v to %v", pod.Name, dest)
 }


### PR DESCRIPTION
Closes #3172 

Removes the `CONDITION` column from "kubectl get events" output and from the `Event` object
See #3172 for rational
