### PR TITLE
GKE: Fix unbound variable when pd.sh fails

### DIFF
--- a/cluster/gke/config-common.sh
+++ b/cluster/gke/config-common.sh
@@ -21,6 +21,7 @@
 MASTER_NAME="k8s-${CLUSTER_NAME}-master"
 ZONE="${ZONE:-us-central1-f}"
 NUM_MINIONS="${NUM_MINIONS:-2}"
+MINION_NAMES=($(eval echo "k8s-${CLUSTER_NAME}-node-{1..${NUM_MINIONS}}"))
 CLUSTER_API_VERSION="${CLUSTER_API_VERSION:-}"
 # TODO(mbforbes): Actually plumb this through; this currently only works
 #                 because we use the 'default' network by default.

--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -188,14 +188,9 @@ function detect-master() {
 #   NUM_MINIONS
 #   CLUSTER_NAME
 # Vars set:
-#   MINION_NAMES (array)
+#   (none)
 function detect-minions() {
   echo "... in detect-minions()" >&2
-  # Just get the minion names.
-  MINION_NAMES=()
-  for (( i=1; i<=${NUM_MINIONS}; i++)); do
-    MINION_NAMES+=("k8s-${CLUSTER_NAME}-node-${i}")
-  done
 }
 
 # SSH to a node by name ($1) and run a command ($2).


### PR DESCRIPTION
In the other providers, MINION_NAMES is bound early and detect_minions
is actually only used to detect the IPs of the minions, which is why I
didn't expect to need to call it. Move the initialization to
config-common.sh in GKE as well.

This follows the pattern of cluster/gce/config-{default,test}.sh
