### PR TITLE
Revert "Add --v=4 to e2e bash executions by default"

### DIFF
--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -531,9 +531,9 @@ func kubecfgArgs() string {
 // kubectl command (begining with a space).
 func kubectlArgs() string {
 	if *checkVersionSkew {
-		return " --match-server-version --v=4"
+		return " --match-server-version"
 	}
-	return " --v=4"
+	return ""
 }
 
 func bashWrap(cmd string) string {


### PR DESCRIPTION
This reverts commit abc621759ad72a42af7e113bb7623ee831fd9e60, which
interacts weirdly with Jenkins on the GKE provider. Tactical revert
until that can be figured out:

https://github.com/GoogleCloudPlatform/kubernetes/issues/3474
