### PR TITLE
Using ExtractObj instead of ExtractToList since BoundPods is not a List ...

### DIFF
--- a/pkg/kubelet/config/etcd.go
+++ b/pkg/kubelet/config/etcd.go
@@ -59,7 +59,7 @@ func NewSourceEtcd(key string, client tools.EtcdClient, updates chan<- interface
 
 func (s *sourceEtcd) run() {
 	boundPods := api.BoundPods{}
-	err := s.helper.ExtractToList(s.key, &boundPods)
+	err := s.helper.ExtractObj(s.key, &boundPods, false)
 	if err != nil {
 		glog.Errorf("etcd failed to retrieve the value for the key %q. Error: %v", s.key, err)
 		return


### PR DESCRIPTION
...type

After I push this fix to my testing cluster, all Unknown and killed pods are running now. We should add a soaking test for such failure, but now let's first fix the issue. 

Fix #3467
