### PR TITLE
Upgrade OSS k8s on GCE to latest containervm image: container-vm-v201501...

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -26,7 +26,7 @@ MINION_DISK_SIZE=10GB
 # TODO(dchen1107): Filed an internal issue to create an alias
 # for containervm image, so that gcloud will expand this
 # to the latest supported image.
-IMAGE=container-vm-v20141208
+IMAGE=container-vm-v20150112
 IMAGE_PROJECT=google-containers
 NETWORK=${KUBE_GCE_NETWORK:-default}
 INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX:-kubernetes}"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -26,7 +26,7 @@ MINION_DISK_SIZE=10GB
 # TODO(dchen1107): Filed an internal issue to create an alias
 # for containervm image, so that gcloud will expand this
 # to the latest supported image.
-IMAGE=container-vm-v20141208
+IMAGE=container-vm-v20150112
 IMAGE_PROJECT=google-containers
 NETWORK=${KUBE_GCE_NETWORK:-e2e}
 INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX:-e2e-test-${USER}}"


### PR DESCRIPTION
...12

e2e tests passed:

2015/01/14 15:10:53 Passed tests: basic.sh[1/1] certs.sh[1/1] goe2e.sh[1/1] guestbook.sh[1/1] liveness.sh[1/1] monitoring.sh[1/1] pd.sh[1/1] private.sh[1/1] services.sh[1/1] update.sh[1/1]
2015/01/14 15:10:53 Flaky tests:
2015/01/14 15:10:53 Failed tests:
2015/01/14 15:10:53 Success!
