### PR TITLE
Increase timeout for TestEtcdSourceExistingBoundPods test

### DIFF
--- a/pkg/kubelet/config/etcd_test.go
+++ b/pkg/kubelet/config/etcd_test.go
@@ -71,8 +71,8 @@ func TestEtcdSourceExistingBoundPods(t *testing.T) {
 			update.Pods[1].ObjectMeta.Name != "bar" {
 			t.Errorf("Unexpected update response: %#v", update)
 		}
-	case <-time.After(2 * time.Millisecond):
-		t.Errorf("Expected update, timeout insteam")
+	case <-time.After(200 * time.Millisecond):
+		t.Errorf("Expected update, timeout instead")
 	}
 }
 


### PR DESCRIPTION
Fixes #3495 
I can't get it to fail, even at 1 nanosecond on my machine locally, but I'm guessing when running on the Travis machines it's much more likely to get preempted. So I'm increasing the timeout 10x. Reopen #3495 if the test is still falky after this
