### PR TITLE
Make periodic sync nodes from -cloud_provider/-machines optional.

### DIFF
--- a/cluster/saltbase/salt/kube-controller-manager/default
+++ b/cluster/saltbase/salt/kube-controller-manager/default
@@ -9,6 +9,7 @@
 {% set machines = ""-%}
 {% set cloud_provider = "" -%}
 {% set minion_regexp = "--minion_regexp=.*" -%}
+{% set sync_nodes = "--sync_nodes=true" -%}
 {% if grains.cloud_provider is defined -%}
   {% set cloud_provider = "--cloud_provider=" + grains.cloud_provider -%}
 {% endif -%}
@@ -47,4 +48,4 @@
 {% endif -%}
 {% endif -%}
 
-DAEMON_ARGS="{{daemon_args}} {{master}} {{machines}} {{ minion_regexp }} {{ cloud_provider }} {{ cloud_config }} {{pillar['log_level']}}"
+DAEMON_ARGS="{{daemon_args}} {{master}} {{machines}} {{ minion_regexp }} {{ cloud_provider }} {{ sync_nodes }} {{ cloud_config }} {{pillar['log_level']}}"

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -198,7 +198,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 
 	nodeResources := &api.NodeResources{}
 	nodeController := nodeControllerPkg.NewNodeController(nil, "", machineList, nodeResources, cl, fakeKubeletClient{})
-	nodeController.Run(5*time.Second, 10)
+	nodeController.Run(5*time.Second, 10, true)
 
 	// Kubelet (localhost)
 	testRootDir := makeTempDirOrDie("kubelet_integ_1.")

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -124,7 +124,7 @@ func runControllerManager(machineList []string, cl *client.Client, nodeMilliCPU,
 	}
 	kubeClient := &client.HTTPKubeletClient{Client: http.DefaultClient, Port: ports.KubeletPort}
 	nodeController := nodeControllerPkg.NewNodeController(nil, "", machineList, nodeResources, cl, kubeClient)
-	nodeController.Run(10*time.Second, 10)
+	nodeController.Run(10*time.Second, 10, true)
 
 	endpoints := service.NewEndpointController(cl)
 	go util.Forever(func() { endpoints.SyncServiceEndpoints() }, time.Second*10)

--- a/docs/man/kube-controller-manager.1.md
+++ b/docs/man/kube-controller-manager.1.md
@@ -36,7 +36,7 @@ The kube-controller-manager has several options.
 	The provider for cloud services. Empty string for no provider.
 
 **--minion_regexp**=""
-	If non empty, and -cloud_provider is specified, a regular expression for matching minion VMs.
+	If non empty, and --cloud_provider is specified, a regular expression for matching minion VMs.
 
 **--insecure_skip_tls_verify**=false
 	If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
@@ -55,6 +55,9 @@ The kube-controller-manager has several options.
 
 **--machines**=[]
     List of machines to schedule onto, comma separated.
+
+**--sync_nodes**=true
+        If true, and --cloud_provider is specified, sync nodes from the cloud provider. Default true.
 
 **--master**=""
 	The address of the Kubernetes API server.

--- a/docs/node.md
+++ b/docs/node.md
@@ -110,9 +110,11 @@ any binary; therefore, to
 join Kubernetes cluster, you as an admin need to make sure proper services are
 running in the node. In the future, we plan to automatically provision some node
 services. In case of no cloud provider, Node Controller simply registers all
-machines from `-machines` flag, any futher interactions need to be done manually
-by using `kubectl`. If you are paranoid, leave `-machines` empty and create all
+machines from `--machines` flag, any futher interactions need to be done manually
+by using `kubectl`. If you are paranoid, leave `--machines` empty and create all
 machines from `kubectl` one by one - the two approaches are equivalent.
+Optionally you can skip cluster-wide node synchronization with
+'--sync_nodes=false' and can use REST api/kubectl cli to add/remove nodes.
 
 Node life-cycle management in the Node Controller is still under development, it
 is supposed to manage the Node Status Specification defined above.


### PR DESCRIPTION
-sync_nodes=false gives user flexibility to add/remove nodes in the
cluster using REST api/kubectl cli and at the same time can use
cloud provider for other resources like persistent disks, etc.
