### PR TITLE
kubectl is double printing errors

### DIFF
--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -20,14 +20,11 @@ import (
 	"os"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
-
-	"github.com/golang/glog"
 )
 
 func main() {
 	cmd := cmd.NewFactory().NewKubectlCommand(os.Stdout)
 	if err := cmd.Execute(); err != nil {
-		glog.Errorf("error: %v", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
cobra/command prints errs that are returned by cmd.Execute(), so
printing it twice does not accomplish anything.
