### PR TITLE
Remove curl check from Kibana image

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/kibana-image/run_kibana_nginx.sh
+++ b/cluster/addons/fluentd-elasticsearch/kibana-image/run_kibana_nginx.sh
@@ -61,9 +61,6 @@ PROXY_HOST=${ELASTICSEARCH_LOGGING_SERVICE_HOST:-127.0.0.1}
 echo PROXY_HOST=${PROXY_HOST}
 PROXY_PORT=${ELASTICSEARCH_SERVICE_LOGGING_PORT:-9200}
 echo PROXY_PORT=${PROXY_PORT}
-# Test the connection to Elasticsearch
-echo "Running curl http://${PROXY_HOST}:${PROXY_PORT}"
-curl http://${PROXY_HOST}:${PROXY_PORT}
  
 # Create a config.hs that defines the Elasticsearch server to be
 # at http://${ES_HOST}:${ES_PORT}/elasticsearch from the perspective of


### PR DESCRIPTION
The curl check will fail if Elasticsearch service is not worked by a running instance of Elasticsearch which is now fairly likely since Elasticsearch and Kibana are launched at the same time during the cluster level logging setup. This PR removes this curl check which was mainly put in originally to help with debugging during development.

@thockin 
