### PR TITLE
Preserve trailing slash in apiserver proxy.

### DIFF
--- a/pkg/apiserver/proxy.go
+++ b/pkg/apiserver/proxy.go
@@ -96,6 +96,12 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if len(parts) > 2 {
 		proxyParts := parts[2:]
 		rest = strings.Join(proxyParts, "/")
+		if strings.HasSuffix(req.URL.Path, "/") {
+			// The original path had a trailing slash, which has been stripped
+			// by KindAndNamespace(). We should add it back because some
+			// servers (like etcd) require it.
+			rest = rest + "/"
+		}
 	}
 	storage, ok := r.storage[kind]
 	if !ok {

--- a/pkg/apiserver/proxy_test.go
+++ b/pkg/apiserver/proxy_test.go
@@ -147,6 +147,7 @@ func TestProxy(t *testing.T) {
 		{"PUT", "/some/dir/id", "different question", "answer", "text/css", "default"},
 		{"DELETE", "/some/dir/id", "", "ok", "text/css", "default"},
 		{"GET", "/some/dir/id", "", "answer", "text/css", "other"},
+		{"GET", "/trailing/slash/", "", "answer", "text/css", "default"},
 	}
 
 	for _, item := range table {


### PR DESCRIPTION
Some servers are sensitive to the presence of a trailing slash.
For example, http://etcd/v2/keys returns 404 while
http://etcd/v2/keys/ returns the key named "/".
