### PR TITLE
Rename HostDir to HostPath in v1beta3

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -151,12 +151,13 @@ type Volume struct {
 // VolumeSource represents the source location of a valume to mount.
 // Only one of its members may be specified.
 type VolumeSource struct {
-	// HostDir represents a pre-existing directory on the host machine that is directly
-	// exposed to the container. This is generally used for system agents or other privileged
-	// things that are allowed to see the host machine. Most containers will NOT need this.
+	// HostPath represents file or directory on the host machine that is
+	// directly exposed to the container. This is generally used for system
+	// agents or other privileged things that are allowed to see the host
+	// machine. Most containers will NOT need this.
 	// TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
 	// mount host directories as read/write.
-	HostDir *HostDir `json:"hostDir"`
+	HostPath *HostPath `json:"hostPath"`
 	// EmptyDir represents a temporary directory that shares a pod's lifetime.
 	EmptyDir *EmptyDir `json:"emptyDir"`
 	// GCEPersistentDisk represents a GCE Disk resource that is attached to a
@@ -166,8 +167,8 @@ type VolumeSource struct {
 	GitRepo *GitRepo `json:"gitRepo"`
 }
 
-// HostDir represents bare host directory volume.
-type HostDir struct {
+// HostPath represents bare host directory volume.
+type HostPath struct {
 	Path string `json:"path"`
 }
 

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -672,6 +672,41 @@ func init() {
 			}
 			return nil
 		},
+
+		// VolumeSource's HostDir is deprecated in favor of HostPath.
+		// TODO: It would be great if I could just map field names to
+		// convert or else maybe say "convert all members of this
+		// struct" and then fix up only the stuff that changed.
+		func(in *newer.VolumeSource, out *VolumeSource, s conversion.Scope) error {
+			if err := s.Convert(&in.EmptyDir, &out.EmptyDir, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.GitRepo, &out.GitRepo, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.GCEPersistentDisk, &out.GCEPersistentDisk, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.HostPath, &out.HostDir, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(in *VolumeSource, out *newer.VolumeSource, s conversion.Scope) error {
+			if err := s.Convert(&in.EmptyDir, &out.EmptyDir, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.GitRepo, &out.GitRepo, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.GCEPersistentDisk, &out.GCEPersistentDisk, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.HostDir, &out.HostPath, 0); err != nil {
+				return err
+			}
+			return nil
+		},
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -90,7 +90,7 @@ type VolumeSource struct {
 	// things that are allowed to see the host machine. Most containers will NOT need this.
 	// TODO(jonesdl) We need to restrict who can use host directory mounts and
 	// who can/can not mount host directories as read/write.
-	HostDir *HostDir `json:"hostDir" description:"pre-existing host directory; generally for privileged system daemons or other agents tied to the host"`
+	HostDir *HostPath `json:"hostDir" description:"pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host"`
 	// EmptyDir represents a temporary directory that shares a pod's lifetime.
 	EmptyDir *EmptyDir `json:"emptyDir" description:"temporary directory that shares a pod's lifetime"`
 	// GCEPersistentDisk represents a GCE Disk resource that is attached to a
@@ -100,8 +100,8 @@ type VolumeSource struct {
 	GitRepo *GitRepo `json:"gitRepo" description:"git repository at a particular revision"`
 }
 
-// HostDir represents bare host directory volume.
-type HostDir struct {
+// HostPath represents bare host directory volume.
+type HostPath struct {
 	Path string `json:"path" description:"path of the directory on the host"`
 }
 

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -590,6 +590,36 @@ func init() {
 			}
 			return nil
 		},
+		func(in *newer.VolumeSource, out *VolumeSource, s conversion.Scope) error {
+			if err := s.Convert(&in.EmptyDir, &out.EmptyDir, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.GitRepo, &out.GitRepo, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.GCEPersistentDisk, &out.GCEPersistentDisk, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.HostPath, &out.HostDir, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(in *VolumeSource, out *newer.VolumeSource, s conversion.Scope) error {
+			if err := s.Convert(&in.EmptyDir, &out.EmptyDir, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.GitRepo, &out.GitRepo, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.GCEPersistentDisk, &out.GCEPersistentDisk, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.HostDir, &out.HostPath, 0); err != nil {
+				return err
+			}
+			return nil
+		},
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -64,7 +64,7 @@ type VolumeSource struct {
 	// things that are allowed to see the host machine. Most containers will NOT need this.
 	// TODO(jonesdl) We need to restrict who can use host directory mounts and
 	// who can/can not mount host directories as read/write.
-	HostDir *HostDir `json:"hostDir" description:"pre-existing host directory; generally for privileged system daemons or other agents tied to the host"`
+	HostDir *HostPath `json:"hostDir" description:"pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host"`
 	// EmptyDir represents a temporary directory that shares a pod's lifetime.
 	EmptyDir *EmptyDir `json:"emptyDir" description:"temporary directory that shares a pod's lifetime"`
 	// A persistent disk that is mounted to the
@@ -74,8 +74,8 @@ type VolumeSource struct {
 	GitRepo *GitRepo `json:"gitRepo" description:"git repository at a particular revision"`
 }
 
-// HostDir represents bare host directory volume.
-type HostDir struct {
+// HostPath represents bare host directory volume.
+type HostPath struct {
 	Path string `json:"path" description:"path of the directory on the host"`
 }
 

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -170,12 +170,13 @@ type Volume struct {
 // VolumeSource represents the source location of a valume to mount.
 // Only one of its members may be specified.
 type VolumeSource struct {
-	// HostDir represents a pre-existing directory on the host machine that is directly
-	// exposed to the container. This is generally used for system agents or other privileged
-	// things that are allowed to see the host machine. Most containers will NOT need this.
+	// HostPath represents a pre-existing file or directory on the host
+	// machine that is directly exposed to the container. This is generally
+	// used for system agents or other privileged things that are allowed
+	// to see the host machine. Most containers will NOT need this.
 	// TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
 	// mount host directories as read/write.
-	HostDir *HostDir `json:"hostDir"`
+	HostPath *HostPath `json:"hostPath"`
 	// EmptyDir represents a temporary directory that shares a pod's lifetime.
 	EmptyDir *EmptyDir `json:"emptyDir"`
 	// GCEPersistentDisk represents a GCE Disk resource that is attached to a
@@ -185,8 +186,8 @@ type VolumeSource struct {
 	GitRepo *GitRepo `json:"gitRepo"`
 }
 
-// HostDir represents bare host directory volume.
-type HostDir struct {
+// HostPath represents bare host directory volume.
+type HostPath struct {
 	Path string `json:"path"`
 }
 

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -67,9 +67,9 @@ func validateVolumes(volumes []api.Volume) (util.StringSet, errs.ValidationError
 func validateSource(source *api.VolumeSource) errs.ValidationErrorList {
 	numVolumes := 0
 	allErrs := errs.ValidationErrorList{}
-	if source.HostDir != nil {
+	if source.HostPath != nil {
 		numVolumes++
-		allErrs = append(allErrs, validateHostDir(source.HostDir).Prefix("hostDirectory")...)
+		allErrs = append(allErrs, validateHostPath(source.HostPath).Prefix("hostPath")...)
 	}
 	if source.EmptyDir != nil {
 		numVolumes++
@@ -77,11 +77,11 @@ func validateSource(source *api.VolumeSource) errs.ValidationErrorList {
 	}
 	if source.GitRepo != nil {
 		numVolumes++
-		allErrs = append(allErrs, validateGitRepo(source.GitRepo)...)
+		allErrs = append(allErrs, validateGitRepo(source.GitRepo).Prefix("gitRepo")...)
 	}
 	if source.GCEPersistentDisk != nil {
 		numVolumes++
-		allErrs = append(allErrs, validateGCEPersistentDisk(source.GCEPersistentDisk)...)
+		allErrs = append(allErrs, validateGCEPersistentDisk(source.GCEPersistentDisk).Prefix("persistentDisk")...)
 	}
 	if numVolumes != 1 {
 		allErrs = append(allErrs, errs.NewFieldInvalid("", source, "exactly 1 volume type is required"))
@@ -89,10 +89,10 @@ func validateSource(source *api.VolumeSource) errs.ValidationErrorList {
 	return allErrs
 }
 
-func validateHostDir(hostDir *api.HostDir) errs.ValidationErrorList {
+func validateHostPath(hostDir *api.HostPath) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
 	if hostDir.Path == "" {
-		allErrs = append(allErrs, errs.NewNotFound("path", hostDir.Path))
+		allErrs = append(allErrs, errs.NewFieldRequired("path", hostDir.Path))
 	}
 	return allErrs
 }
@@ -100,7 +100,7 @@ func validateHostDir(hostDir *api.HostDir) errs.ValidationErrorList {
 func validateGitRepo(gitRepo *api.GitRepo) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
 	if gitRepo.Repository == "" {
-		allErrs = append(allErrs, errs.NewFieldRequired("gitRepo.Repository", gitRepo.Repository))
+		allErrs = append(allErrs, errs.NewFieldRequired("repository", gitRepo.Repository))
 	}
 	return allErrs
 }
@@ -108,13 +108,13 @@ func validateGitRepo(gitRepo *api.GitRepo) errs.ValidationErrorList {
 func validateGCEPersistentDisk(PD *api.GCEPersistentDisk) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
 	if PD.PDName == "" {
-		allErrs = append(allErrs, errs.NewFieldRequired("PD.PDName", PD.PDName))
+		allErrs = append(allErrs, errs.NewFieldRequired("pdName", PD.PDName))
 	}
 	if PD.FSType == "" {
-		allErrs = append(allErrs, errs.NewFieldRequired("PD.FSType", PD.FSType))
+		allErrs = append(allErrs, errs.NewFieldRequired("fsType", PD.FSType))
 	}
 	if PD.Partition < 0 || PD.Partition > 255 {
-		allErrs = append(allErrs, errs.NewFieldInvalid("PD.Partition", PD.Partition, ""))
+		allErrs = append(allErrs, errs.NewFieldInvalid("partition", PD.Partition, ""))
 	}
 	return allErrs
 }

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -77,8 +77,8 @@ func TestValidateLabels(t *testing.T) {
 func TestValidateVolumes(t *testing.T) {
 	successCase := []api.Volume{
 		{Name: "abc"},
-		{Name: "123", Source: &api.VolumeSource{HostDir: &api.HostDir{"/mnt/path2"}}},
-		{Name: "abc-123", Source: &api.VolumeSource{HostDir: &api.HostDir{"/mnt/path3"}}},
+		{Name: "123", Source: &api.VolumeSource{HostPath: &api.HostPath{"/mnt/path2"}}},
+		{Name: "abc-123", Source: &api.VolumeSource{HostPath: &api.HostPath{"/mnt/path3"}}},
 		{Name: "empty", Source: &api.VolumeSource{EmptyDir: &api.EmptyDir{}}},
 		{Name: "gcepd", Source: &api.VolumeSource{GCEPersistentDisk: &api.GCEPersistentDisk{"my-PD", "ext4", 1, false}}},
 		{Name: "gitrepo", Source: &api.VolumeSource{GitRepo: &api.GitRepo{"my-repo", "hashstring"}}},
@@ -366,8 +366,8 @@ func TestValidateManifest(t *testing.T) {
 		{
 			Version: "v1beta1",
 			ID:      "abc",
-			Volumes: []api.Volume{{Name: "vol1", Source: &api.VolumeSource{HostDir: &api.HostDir{"/mnt/vol1"}}},
-				{Name: "vol2", Source: &api.VolumeSource{HostDir: &api.HostDir{"/mnt/vol2"}}}},
+			Volumes: []api.Volume{{Name: "vol1", Source: &api.VolumeSource{HostPath: &api.HostPath{"/mnt/vol1"}}},
+				{Name: "vol2", Source: &api.VolumeSource{HostPath: &api.HostPath{"/mnt/vol2"}}}},
 			Containers: []api.Container{
 				{
 					Name:       "abc",

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -46,7 +46,7 @@ func ExampleManifestAndPod(id string) (api.ContainerManifest, api.BoundPod) {
 			{
 				Name: "host-dir",
 				Source: &api.VolumeSource{
-					HostDir: &api.HostDir{"/dir/path"},
+					HostPath: &api.HostPath{"/dir/path"},
 				},
 			},
 		},
@@ -68,7 +68,7 @@ func ExampleManifestAndPod(id string) (api.ContainerManifest, api.BoundPod) {
 				{
 					Name: "host-dir",
 					Source: &api.VolumeSource{
-						HostDir: &api.HostDir{"/dir/path"},
+						HostPath: &api.HostPath{"/dir/path"},
 					},
 				},
 			},

--- a/pkg/kubelet/volume/host_path/host_path.go
+++ b/pkg/kubelet/volume/host_path/host_path.go
@@ -46,14 +46,14 @@ func (plugin *hostPathPlugin) Name() string {
 }
 
 func (plugin *hostPathPlugin) CanSupport(spec *api.Volume) bool {
-	if spec.Source != nil && spec.Source.HostDir != nil {
+	if spec.Source != nil && spec.Source.HostPath != nil {
 		return true
 	}
 	return false
 }
 
 func (plugin *hostPathPlugin) NewBuilder(spec *api.Volume, podUID types.UID) (volume.Builder, error) {
-	return &hostPath{spec.Source.HostDir.Path}, nil
+	return &hostPath{spec.Source.HostPath.Path}, nil
 }
 
 func (plugin *hostPathPlugin) NewCleaner(volName string, podUID types.UID) (volume.Cleaner, error) {

--- a/pkg/kubelet/volume/host_path/host_path_test.go
+++ b/pkg/kubelet/volume/host_path/host_path_test.go
@@ -35,7 +35,7 @@ func TestCanSupport(t *testing.T) {
 	if plug.Name() != "kubernetes.io/host-path" {
 		t.Errorf("Wrong name: %s", plug.Name())
 	}
-	if !plug.CanSupport(&api.Volume{Source: &api.VolumeSource{HostDir: &api.HostDir{}}}) {
+	if !plug.CanSupport(&api.Volume{Source: &api.VolumeSource{HostPath: &api.HostPath{}}}) {
 		t.Errorf("Expected true")
 	}
 	if plug.CanSupport(&api.Volume{Source: nil}) {
@@ -53,7 +53,7 @@ func TestPlugin(t *testing.T) {
 	}
 	spec := &api.Volume{
 		Name:   "vol1",
-		Source: &api.VolumeSource{HostDir: &api.HostDir{"/vol1"}},
+		Source: &api.VolumeSource{HostPath: &api.HostPath{"/vol1"}},
 	}
 	builder, err := plug.NewBuilder(spec, types.UID("poduid"))
 	if err != nil {


### PR DESCRIPTION
I started with HostMount (as can still be seen in the volumes PR), but I like this better.  It's a minor point, but it irks me.  This could also be done in a compatible way, and accept both HostDir and HostPath, if anyone thinks that is worthwhile.  I think it might be.
