### PR TITLE
Fix nil dereference in kubectl run-container

### DIFF
--- a/docs/kubectl.md
+++ b/docs/kubectl.md
@@ -825,7 +825,7 @@ Examples:
 
   $ kubectl run-container nginx --image=dockerfile/nginx --replicas=5
   <starts a replicated instance of nginx>
-  
+
   $ kubectl run-container nginx --image=dockerfile/nginx --dry-run
   <just print the corresponding API objects, don't actually send them to the apiserver>
 

--- a/pkg/kubectl/cmd/printing.go
+++ b/pkg/kubectl/cmd/printing.go
@@ -36,28 +36,23 @@ func AddPrinterFlags(cmd *cobra.Command) {
 }
 
 // PrintObject prints an api object given command line flags to modify the output format
-func PrintObject(cmd *cobra.Command, obj runtime.Object, f *Factory, out io.Writer) {
+func PrintObject(cmd *cobra.Command, obj runtime.Object, f *Factory, out io.Writer) error {
 	mapper, _ := f.Object(cmd)
 	_, kind, err := api.Scheme.ObjectVersionAndKind(obj)
-	checkErr(err)
+	if err != nil {
+		return err
+	}
 
 	mapping, err := mapper.RESTMapping(kind)
-	checkErr(err)
-
-	printer, ok, err := PrinterForCommand(cmd)
-	checkErr(err)
-
-	if ok {
-		version := outputVersion(cmd)
-		if len(version) == 0 {
-			version = mapping.APIVersion
-		}
-		if len(version) == 0 {
-			checkErr(fmt.Errorf("you must specify an output-version when using this output format"))
-		}
-		printer = kubectl.NewVersionedPrinter(printer, mapping.ObjectConvertor, version)
+	if err != nil {
+		return err
 	}
-	printer.PrintObj(obj, out)
+
+	printer, err := PrinterForMapping(f, cmd, mapping)
+	if err != nil {
+		return err
+	}
+	return printer.PrintObj(obj, out)
 }
 
 // outputVersion returns the preferred output version for generic content (JSON, YAML, or templates)

--- a/pkg/kubectl/cmd/printing_test.go
+++ b/pkg/kubectl/cmd/printing_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	. "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
+)
+
+func ExamplePrintReplicationController() {
+	f, tf, codec := NewAPIFactory()
+	tf.Printer = kubectl.NewHumanReadablePrinter(false)
+	tf.Client = &client.FakeRESTClient{
+		Codec:  codec,
+		Client: nil,
+	}
+	cmd := f.NewCmdRunContainer(os.Stdout)
+	ctrl := &api.ReplicationController{
+		ObjectMeta: api.ObjectMeta{
+			Name:   "foo",
+			Labels: map[string]string{"foo": "bar"},
+		},
+		Spec: api.ReplicationControllerSpec{
+			Replicas: 1,
+			Selector: map[string]string{"foo": "bar"},
+			Template: &api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{"foo": "bar"},
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Name:  "foo",
+							Image: "someimage",
+						},
+					},
+				},
+			},
+		},
+	}
+	err := PrintObject(cmd, ctrl, f, os.Stdout)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+	// Output:
+	// CONTROLLER          CONTAINER(S)        IMAGE(S)            SELECTOR            REPLICAS
+	// foo                 foo                 someimage           foo=bar             1
+}

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -38,7 +38,7 @@ Examples:
 
   $ kubectl run-container nginx --image=dockerfile/nginx --replicas=5
   <starts a replicated instance of nginx>
-  
+
   $ kubectl run-container nginx --image=dockerfile/nginx --dry-run
   <just print the corresponding API objects, don't actually send them to the apiserver>`,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -70,7 +70,9 @@ Examples:
 				controller, err = client.ReplicationControllers(namespace).Create(controller.(*api.ReplicationController))
 				checkErr(err)
 			}
-			PrintObject(cmd, controller, f, out)
+
+			err = PrintObject(cmd, controller, f, out)
+			checkErr(err)
 		},
 	}
 	AddPrinterFlags(cmd)


### PR DESCRIPTION
PrintObject was calling PrintObj on nil when PrinterForCommand(cmd) didn't find an existing printer. Fixed and added test with example.

cc @brendanburns 
