### PR TITLE
The API server setup logging is debug specific, bump above V(4)

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -362,10 +362,16 @@ func (m *Master) init(c *Config) {
 	}
 
 	apiVersions := []string{"v1beta1", "v1beta2"}
-	apiserver.NewAPIGroupVersion(m.API_v1beta1()).InstallREST(m.handlerContainer, c.APIPrefix, "v1beta1")
-	apiserver.NewAPIGroupVersion(m.API_v1beta2()).InstallREST(m.handlerContainer, c.APIPrefix, "v1beta2")
+	if err := apiserver.NewAPIGroupVersion(m.API_v1beta1()).InstallREST(m.handlerContainer, c.APIPrefix, "v1beta1"); err != nil {
+		glog.Fatalf("Unable to setup API v1beta1: %v", err)
+	}
+	if err := apiserver.NewAPIGroupVersion(m.API_v1beta2()).InstallREST(m.handlerContainer, c.APIPrefix, "v1beta2"); err != nil {
+		glog.Fatalf("Unable to setup API v1beta2: %v", err)
+	}
 	if c.EnableV1Beta3 {
-		apiserver.NewAPIGroupVersion(m.API_v1beta3()).InstallREST(m.handlerContainer, c.APIPrefix, "v1beta3")
+		if err := apiserver.NewAPIGroupVersion(m.API_v1beta3()).InstallREST(m.handlerContainer, c.APIPrefix, "v1beta3"); err != nil {
+			glog.Fatalf("Unable to setup API v1beta3: %v", err)
+		}
 		apiVersions = []string{"v1beta1", "v1beta2", "v1beta3"}
 	}
 


### PR DESCRIPTION
Reduces some chatter in test suites where we are confident this code
already works.  Also removed any logging which is obvious from swagger.

Finally, rolls up InstallREST related errors all the way back to master,
which will glog.Fatalf (coding errors).
