### PR TITLE
added algorithm name validation

### DIFF
--- a/plugin/pkg/scheduler/factory/plugins_test.go
+++ b/plugin/pkg/scheduler/factory/plugins_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package factory
+
+import "testing"
+
+func TestAlgorithmNameValidation(t *testing.T) {
+	algorithmNamesShouldValidate := []string{
+		"1SomeAlgo1rithm",
+		"someAlgor-ithm1",
+	}
+	algorithmNamesShouldNotValidate := []string{
+		"-SomeAlgorithm",
+		"SomeAlgorithm-",
+		"Some,Alg:orithm",
+	}
+	for _, name := range algorithmNamesShouldValidate {
+		if !validName.MatchString(name) {
+			t.Errorf("%v should be a valid algorithm name but is not valid.", name)
+		}
+	}
+	for _, name := range algorithmNamesShouldNotValidate {
+		if validName.MatchString(name) {
+			t.Errorf("%v should be an invalid algorithm name but is valid.", name)
+		}
+	}
+}


### PR DESCRIPTION
This adds some basic algorithm name validation to the scheduler's algorithm provider plugins. I though this would be useful in preparation for exploring runtime configuring of the scheduler algorithms. These names will be validated at build time by the test in [plugin/pkg/scheduler/algorithmprovider/plugins_test.go](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/plugin/pkg/scheduler/algorithmprovider/plugins_test.go).
