### PR TITLE
update cluster/gce to use container-vm image alias

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -23,11 +23,7 @@ MINION_SIZE=n1-standard-1
 NUM_MINIONS=${NUM_MINIONS:-4}
 MINION_DISK_TYPE=pd-standard
 MINION_DISK_SIZE=10GB
-# TODO(dchen1107): Filed an internal issue to create an alias
-# for containervm image, so that gcloud will expand this
-# to the latest supported image.
-IMAGE=container-vm-v20150112
-IMAGE_PROJECT=google-containers
+IMAGE=container-vm
 NETWORK=${KUBE_GCE_NETWORK:-default}
 INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX:-kubernetes}"
 MASTER_NAME="${INSTANCE_PREFIX}-master"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -23,11 +23,7 @@ MINION_SIZE=g1-small
 NUM_MINIONS=${NUM_MINIONS:-2}
 MINION_DISK_TYPE=pd-standard
 MINION_DISK_SIZE=10GB
-# TODO(dchen1107): Filed an internal issue to create an alias
-# for containervm image, so that gcloud will expand this
-# to the latest supported image.
-IMAGE=container-vm-v20150112
-IMAGE_PROJECT=google-containers
+IMAGE=container-vm
 NETWORK=${KUBE_GCE_NETWORK:-e2e}
 INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX:-e2e-test-${USER}}"
 MASTER_NAME="${INSTANCE_PREFIX}-master"

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -306,7 +306,6 @@ function create-minion {
       --machine-type "${MINION_SIZE}" \
       --boot-disk-type "${MINION_DISK_TYPE}" \
       --boot-disk-size "${MINION_DISK_SIZE}" \
-      --image-project="${IMAGE_PROJECT}" \
       --image "${IMAGE}" \
       --tags "${MINION_TAG}" \
       --network "${NETWORK}" \
@@ -421,7 +420,6 @@ function kube-up {
     --project "${PROJECT}" \
     --zone "${ZONE}" \
     --machine-type "${MASTER_SIZE}" \
-    --image-project="${IMAGE_PROJECT}" \
     --image "${IMAGE}" \
     --tags "${MASTER_TAG}" \
     --network "${NETWORK}" \


### PR DESCRIPTION
- Ensures the latest container-vm image
- remove IMAGE_PROJECT variable because container-vm alias
  does not currently work with the google-containers project.
  We may want to re-add an IMAGE_PROJECT variable later, but we'd
  want to make sure that util.sh works if it is unset or set to NULL

Submitted Oakleon CLA today
