### PR TITLE
Configure scheduler algorithm provider with cli option

### DIFF
--- a/plugin/pkg/scheduler/factory/plugins.go
+++ b/plugin/pkg/scheduler/factory/plugins.go
@@ -36,7 +36,7 @@ var (
 )
 
 const (
-	DefaultProvider = "default"
+	DefaultProvider = "DefaultProvider"
 )
 
 type AlgorithmProviderConfig struct {


### PR DESCRIPTION
Adds an algorithm_provider cli option to the kube-scheduler command and renames default provider to follow naming convention. This may be useful until #1627 is resolved.
