### PR TITLE
Updating handleIndex in master to list all valid paths.

### DIFF
--- a/pkg/api/unversioned.go
+++ b/pkg/api/unversioned.go
@@ -24,3 +24,9 @@ package api
 type APIVersions struct {
 	Versions []string `json:"versions"`
 }
+
+// RootPaths lists the paths available at root.
+// For example: "/healthz", "/api".
+type RootPaths struct {
+	Paths []string `json:"paths"`
+}

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -62,9 +62,9 @@ func Handle(storage map[string]RESTStorage, codec runtime.Codec, root string, ve
 	group := NewAPIGroupVersion(storage, codec, prefix, selfLinker, admissionControl)
 	container := restful.NewContainer()
 	mux := container.ServeMux
-	group.InstallREST(container, root, version)
+	group.InstallREST(container, mux, root, version)
 	ws := new(restful.WebService)
-	InstallSupport(container, ws)
+	InstallSupport(mux, ws)
 	container.Add(ws)
 	return &defaultAPIServer{mux, group}
 }
@@ -203,7 +203,7 @@ func addParamIf(b *restful.RouteBuilder, parameter *restful.Parameter, shouldAdd
 // InstallREST registers the REST handlers (storage, watch, and operations) into a restful Container.
 // It is expected that the provided path root prefix will serve all operations. Root MUST NOT end
 // in a slash. A restful WebService is created for the group and version.
-func (g *APIGroupVersion) InstallREST(container *restful.Container, root string, version string) error {
+func (g *APIGroupVersion) InstallREST(container *restful.Container, mux Mux, root string, version string) error {
 	prefix := path.Join(root, version)
 	restHandler := &g.handler
 	strippedHandler := http.StripPrefix(prefix, restHandler)
@@ -268,8 +268,6 @@ func (g *APIGroupVersion) InstallREST(container *restful.Container, root string,
 
 	// TODO: port the rest of these. Sadly, if we don't, we'll have inconsistent
 	// API behavior, as well as lack of documentation
-	mux := container.ServeMux
-
 	// Note: update GetAttribs() when adding a handler.
 	mux.Handle(prefix+"/watch/", http.StripPrefix(prefix+"/watch/", watchHandler))
 	mux.Handle(prefix+"/proxy/", http.StripPrefix(prefix+"/proxy/", proxyHandler))
@@ -296,9 +294,9 @@ func InstallValidator(mux Mux, servers func() map[string]Server) {
 
 // TODO: document all handlers
 // InstallSupport registers the APIServer support functions
-func InstallSupport(container *restful.Container, ws *restful.WebService) {
+func InstallSupport(mux Mux, ws *restful.WebService) {
 	// TODO: convert healthz to restful and remove container arg
-	healthz.InstallHandler(container.ServeMux)
+	healthz.InstallHandler(mux)
 
 	// Set up a service to return the git code version.
 	ws.Path("/version")

--- a/pkg/apiserver/index.go
+++ b/pkg/apiserver/index.go
@@ -17,11 +17,24 @@ limitations under the License.
 package apiserver
 
 import (
-	"io"
 	"net/http"
+	"sort"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+
+	"github.com/emicklei/go-restful"
 )
 
-// handleIndex is the root index page for Kubernetes.
-func HandleIndex(w http.ResponseWriter, r *http.Request) {
-	io.WriteString(w, "<html><body>Welcome to Kubernetes</body></html>")
+func IndexHandler(container *restful.Container, muxHelper *MuxHelper) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var handledPaths []string
+		// Extract the paths handled using restful.WebService
+		for _, ws := range container.RegisteredWebServices() {
+			handledPaths = append(handledPaths, ws.RootPath())
+		}
+		// Extract the paths handled using mux handler.
+		handledPaths = append(handledPaths, muxHelper.RegisteredPaths...)
+		sort.Strings(handledPaths)
+		writeRawJSON(http.StatusOK, api.RootPaths{Paths: handledPaths}, w)
+	}
 }

--- a/pkg/apiserver/mux_helper.go
+++ b/pkg/apiserver/mux_helper.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"net/http"
+)
+
+// Offers additional functionality over ServeMux, for ex: supports listing registered paths.
+type MuxHelper struct {
+	Mux             Mux
+	RegisteredPaths []string
+}
+
+func (m *MuxHelper) Handle(path string, handler http.Handler) {
+	m.RegisteredPaths = append(m.RegisteredPaths, path)
+	m.Mux.Handle(path, handler)
+}
+
+func (m *MuxHelper) HandleFunc(path string, handler func(http.ResponseWriter, *http.Request)) {
+	m.RegisteredPaths = append(m.RegisteredPaths, path)
+	m.Mux.HandleFunc(path, handler)
+}


### PR DESCRIPTION
The list of valid paths is computed from http.ServeMux and restful.WebService.
Adding a mux helper - wrapper over mux, that keeps track of the paths handled by mux.
