### PR TITLE
Introduce PodStatusResult, and deprecate PodContainerInfo.

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -62,7 +62,7 @@ var (
 
 type fakeKubeletClient struct{}
 
-func (fakeKubeletClient) GetPodInfo(host, podNamespace, podID string) (api.PodContainerInfo, error) {
+func (fakeKubeletClient) GetPodStatus(host, podNamespace, podID string) (api.PodStatusResult, error) {
 	glog.V(3).Infof("Trying to get container info for %v/%v/%v", host, podNamespace, podID)
 	// This is a horrible hack to get around the fact that we can't provide
 	// different port numbers per kubelet...
@@ -81,7 +81,7 @@ func (fakeKubeletClient) GetPodInfo(host, podNamespace, podID string) (api.PodCo
 	default:
 		glog.Fatalf("Can't get info for: '%v', '%v - %v'", host, podNamespace, podID)
 	}
-	return c.GetPodInfo("localhost", podNamespace, podID)
+	return c.GetPodStatus("localhost", podNamespace, podID)
 }
 
 func (fakeKubeletClient) HealthCheck(host string) (health.Status, error) {
@@ -223,7 +223,7 @@ func podsOnMinions(c *client.Client, pods api.PodList) wait.ConditionFunc {
 			if len(host) == 0 {
 				return false, nil
 			}
-			if _, err := podInfo.GetPodInfo(host, namespace, id); err != nil {
+			if _, err := podInfo.GetPodStatus(host, namespace, id); err != nil {
 				return false, nil
 			}
 		}

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -25,9 +25,9 @@ var Scheme = runtime.NewScheme()
 
 func init() {
 	Scheme.AddKnownTypes("",
-		&PodContainerInfo{},
-		&PodList{},
 		&Pod{},
+		&PodList{},
+		&PodStatusResult{},
 		&ReplicationControllerList{},
 		&ReplicationController{},
 		&ServiceList{},
@@ -55,9 +55,9 @@ func init() {
 	Scheme.AddKnownTypeWithName("", "ServerOpList", &OperationList{})
 }
 
-func (*PodContainerInfo) IsAnAPIObject()          {}
 func (*Pod) IsAnAPIObject()                       {}
 func (*PodList) IsAnAPIObject()                   {}
+func (*PodStatusResult) IsAnAPIObject()           {}
 func (*ReplicationController) IsAnAPIObject()     {}
 func (*ReplicationControllerList) IsAnAPIObject() {}
 func (*Service) IsAnAPIObject()                   {}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -418,6 +418,7 @@ type ContainerStatus struct {
 type PodInfo map[string]ContainerStatus
 
 // PodContainerInfo is a wrapper for PodInfo that can be encode/decoded
+// DEPRECATED: Replaced with PodStatusResult
 type PodContainerInfo struct {
 	TypeMeta      `json:",inline"`
 	ObjectMeta    `json:"metadata,omitempty"`
@@ -501,6 +502,15 @@ type PodStatus struct {
 	// TODO: Make real decisions about what our info should look like. Re-enable fuzz test
 	// when we have done this.
 	Info PodInfo `json:"info,omitempty"`
+}
+
+// PodStatusResult is a wrapper for PodStatus returned by kubelet that can be encode/decoded
+type PodStatusResult struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+	// Status represents the current information about a pod. This data may not be up
+	// to date.
+	Status PodStatus `json:"status,omitempty"`
 }
 
 // Pod is a collection of containers, used as either input (create, update) or as output (list, get).

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -314,6 +314,30 @@ func init() {
 			}
 			return nil
 		},
+		func(in *newer.PodStatusResult, out *PodStatusResult, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Status, &out.State, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(in *PodStatusResult, out *newer.PodStatusResult, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.State, &out.Status, 0); err != nil {
+				return err
+			}
+			return nil
+		},
 
 		func(in *newer.ReplicationController, out *ReplicationController, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -27,7 +27,7 @@ var Codec = runtime.CodecFor(api.Scheme, "v1beta1")
 func init() {
 	api.Scheme.AddKnownTypes("v1beta1",
 		&Pod{},
-		&PodContainerInfo{},
+		&PodStatusResult{},
 		&PodList{},
 		&ReplicationController{},
 		&ReplicationControllerList{},
@@ -57,7 +57,7 @@ func init() {
 }
 
 func (*Pod) IsAnAPIObject()                       {}
-func (*PodContainerInfo) IsAnAPIObject()          {}
+func (*PodStatusResult) IsAnAPIObject()           {}
 func (*PodList) IsAnAPIObject()                   {}
 func (*ReplicationController) IsAnAPIObject()     {}
 func (*ReplicationControllerList) IsAnAPIObject() {}

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -412,6 +412,11 @@ type PodState struct {
 	Info PodInfo `json:"info,omitempty" description:"map of container name to container status"`
 }
 
+type PodStatusResult struct {
+	TypeMeta `json:",inline"`
+	State    PodState `json:"state,omitempty" description:"current state of the pod"`
+}
+
 // PodList is a list of Pods.
 type PodList struct {
 	TypeMeta `json:",inline"`

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -345,6 +345,31 @@ func init() {
 			return nil
 		},
 
+		func(in *newer.PodStatusResult, out *PodStatusResult, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Status, &out.State, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(in *PodStatusResult, out *newer.PodStatusResult, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.State, &out.Status, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+
 		func(in *newer.PodSpec, out *PodState, s conversion.Scope) error {
 			if err := s.Convert(&in, &out.Manifest, 0); err != nil {
 				return err

--- a/pkg/api/v1beta2/register.go
+++ b/pkg/api/v1beta2/register.go
@@ -27,7 +27,7 @@ var Codec = runtime.CodecFor(api.Scheme, "v1beta2")
 func init() {
 	api.Scheme.AddKnownTypes("v1beta2",
 		&Pod{},
-		&PodContainerInfo{},
+		&PodStatusResult{},
 		&PodList{},
 		&ReplicationController{},
 		&ReplicationControllerList{},
@@ -57,7 +57,7 @@ func init() {
 }
 
 func (*Pod) IsAnAPIObject()                       {}
-func (*PodContainerInfo) IsAnAPIObject()          {}
+func (*PodStatusResult) IsAnAPIObject()           {}
 func (*PodList) IsAnAPIObject()                   {}
 func (*ReplicationController) IsAnAPIObject()     {}
 func (*ReplicationControllerList) IsAnAPIObject() {}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -375,6 +375,11 @@ type PodState struct {
 	Info PodInfo `json:"info,omitempty" description:"map of container name to container status"`
 }
 
+type PodStatusResult struct {
+	TypeMeta `json:",inline"`
+	State    PodState `json:"state,omitempty" description:"current state of the pod"`
+}
+
 // PodList is a list of Pods.
 type PodList struct {
 	TypeMeta `json:",inline"`

--- a/pkg/api/v1beta3/register.go
+++ b/pkg/api/v1beta3/register.go
@@ -26,9 +26,9 @@ var Codec = runtime.CodecFor(api.Scheme, "v1beta3")
 
 func init() {
 	api.Scheme.AddKnownTypes("v1beta3",
-		&PodContainerInfo{},
 		&Pod{},
 		&PodList{},
+		&PodStatusResult{},
 		&PodTemplate{},
 		&PodTemplateList{},
 		&BoundPod{},
@@ -56,9 +56,9 @@ func init() {
 	api.Scheme.AddKnownTypeWithName("v1beta3", "ServerOpList", &OperationList{})
 }
 
-func (*PodContainerInfo) IsAnAPIObject()          {}
 func (*Pod) IsAnAPIObject()                       {}
 func (*PodList) IsAnAPIObject()                   {}
+func (*PodStatusResult) IsAnAPIObject()           {}
 func (*PodTemplate) IsAnAPIObject()               {}
 func (*PodTemplateList) IsAnAPIObject()           {}
 func (*BoundPod) IsAnAPIObject()                  {}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -435,13 +435,6 @@ type ContainerStatus struct {
 // PodInfo contains one entry for every container with available info.
 type PodInfo map[string]ContainerStatus
 
-// PodContainerInfo is a wrapper for PodInfo that can be encode/decoded
-type PodContainerInfo struct {
-	TypeMeta      `json:",inline"`
-	ObjectMeta    `json:"metadata,omitempty"`
-	ContainerInfo PodInfo `json:"containerInfo" description:"information about each container in this pod"`
-}
-
 type RestartPolicyAlways struct{}
 
 // TODO(dchen1107): Define what kinds of failures should restart.
@@ -509,6 +502,15 @@ type PodStatus struct {
 	// TODO: Make real decisions about what our info should look like. Re-enable fuzz test
 	// when we have done this.
 	Info PodInfo `json:"info,omitempty"`
+}
+
+// PodStatusResult is a wrapper for PodStatus returned by kubelet that can be encode/decoded
+type PodStatusResult struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+	// Status represents the current information about a pod. This data may not be up
+	// to date.
+	Status PodStatus `json:"status,omitempty"`
 }
 
 // Pod is a collection of containers that can run on a host. This resource is created

--- a/pkg/client/kubelet.go
+++ b/pkg/client/kubelet.go
@@ -46,9 +46,9 @@ type KubeletHealthChecker interface {
 // PodInfoGetter is an interface for things that can get information about a pod's containers.
 // Injectable for easy testing.
 type PodInfoGetter interface {
-	// GetPodInfo returns information about all containers which are part
-	// Returns an api.PodInfo, or an error if one occurs.
-	GetPodInfo(host, podNamespace, podID string) (api.PodContainerInfo, error)
+	// GetPodStatus returns information about all containers which are part
+	// Returns an api.PodStatus, or an error if one occurs.
+	GetPodStatus(host, podNamespace, podID string) (api.PodStatusResult, error)
 }
 
 // HTTPKubeletClient is the default implementation of PodInfoGetter and KubeletHealthchecker, accesses the kubelet over HTTP.
@@ -95,7 +95,7 @@ func (c *HTTPKubeletClient) url(host string) string {
 }
 
 // GetPodInfo gets information about the specified pod.
-func (c *HTTPKubeletClient) GetPodInfo(host, podNamespace, podID string) (api.PodContainerInfo, error) {
+func (c *HTTPKubeletClient) GetPodStatus(host, podNamespace, podID string) (api.PodStatusResult, error) {
 	request, err := http.NewRequest(
 		"GET",
 		fmt.Sprintf(
@@ -104,28 +104,28 @@ func (c *HTTPKubeletClient) GetPodInfo(host, podNamespace, podID string) (api.Po
 			podID,
 			podNamespace),
 		nil)
-	info := api.PodContainerInfo{}
+	status := api.PodStatusResult{}
 	if err != nil {
-		return info, err
+		return status, err
 	}
 	response, err := c.Client.Do(request)
 	if err != nil {
-		return info, err
+		return status, err
 	}
 	defer response.Body.Close()
 	if response.StatusCode == http.StatusNotFound {
-		return info, ErrPodInfoNotAvailable
+		return status, ErrPodInfoNotAvailable
 	}
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return info, err
+		return status, err
 	}
 	// Check that this data can be unmarshalled
-	err = latest.Codec.DecodeInto(body, &info)
+	err = latest.Codec.DecodeInto(body, &status)
 	if err != nil {
-		return info, err
+		return status, err
 	}
-	return info, nil
+	return status, nil
 }
 
 func (c *HTTPKubeletClient) HealthCheck(host string) (health.Status, error) {
@@ -138,8 +138,8 @@ func (c *HTTPKubeletClient) HealthCheck(host string) (health.Status, error) {
 type FakeKubeletClient struct{}
 
 // GetPodInfo is a fake implementation of PodInfoGetter.GetPodInfo.
-func (c FakeKubeletClient) GetPodInfo(host, podNamespace string, podID string) (api.PodContainerInfo, error) {
-	return api.PodContainerInfo{}, errors.New("Not Implemented")
+func (c FakeKubeletClient) GetPodStatus(host, podNamespace string, podID string) (api.PodStatusResult, error) {
+	return api.PodStatusResult{}, errors.New("Not Implemented")
 }
 
 func (c FakeKubeletClient) HealthCheck(host string) (health.Status, error) {

--- a/pkg/client/kubelet_test.go
+++ b/pkg/client/kubelet_test.go
@@ -31,9 +31,12 @@ import (
 )
 
 func TestHTTPKubeletClient(t *testing.T) {
-	expectObj := api.PodContainerInfo{
-		ContainerInfo: map[string]api.ContainerStatus{
-			"myID": {},
+	expectObj := api.PodStatusResult{
+		Status: api.PodStatus{
+			Info: map[string]api.ContainerStatus{
+				"myID1": {},
+				"myID2": {},
+			},
 		},
 	}
 	body, err := json.Marshal(expectObj)
@@ -64,13 +67,13 @@ func TestHTTPKubeletClient(t *testing.T) {
 		Client: http.DefaultClient,
 		Port:   uint(port),
 	}
-	gotObj, err := podInfoGetter.GetPodInfo(parts[0], api.NamespaceDefault, "foo")
+	gotObj, err := podInfoGetter.GetPodStatus(parts[0], api.NamespaceDefault, "foo")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
 	// reflect.DeepEqual(expectObj, gotObj) doesn't handle blank times well
-	if len(gotObj.ContainerInfo) != len(expectObj.ContainerInfo) {
+	if len(gotObj.Status.Info) != len(expectObj.Status.Info) {
 		t.Errorf("Unexpected response.  Expected: %#v, received %#v", expectObj, gotObj)
 	}
 }
@@ -109,7 +112,7 @@ func TestHTTPKubeletClientNotFound(t *testing.T) {
 		Client: http.DefaultClient,
 		Port:   uint(port),
 	}
-	_, err = podInfoGetter.GetPodInfo(parts[0], api.NamespaceDefault, "foo")
+	_, err = podInfoGetter.GetPodStatus(parts[0], api.NamespaceDefault, "foo")
 	if err != ErrPodInfoNotAvailable {
 		t.Errorf("Expected %#v, Got %#v", ErrPodInfoNotAvailable, err)
 	}

--- a/pkg/kubelet/handlers.go
+++ b/pkg/kubelet/handlers.go
@@ -71,17 +71,17 @@ func ResolvePort(portReference util.IntOrString, container *api.Container) (int,
 func (h *httpActionHandler) Run(podFullName string, uid types.UID, container *api.Container, handler *api.Handler) error {
 	host := handler.HTTPGet.Host
 	if len(host) == 0 {
-		var info api.PodInfo
-		info, err := h.kubelet.GetPodInfo(podFullName, uid)
+		var status api.PodStatus
+		status, err := h.kubelet.GetPodStatus(podFullName, uid)
 		if err != nil {
 			glog.Errorf("unable to get pod info, event handlers may be invalid.")
 			return err
 		}
-		netInfo, found := info[networkContainerName]
+		netInfo, found := status.Info[networkContainerName]
 		if found {
 			host = netInfo.PodIP
 		} else {
-			return fmt.Errorf("failed to find networking container: %v", info)
+			return fmt.Errorf("failed to find networking container: %v", status)
 		}
 	}
 	var port int

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1010,12 +1010,11 @@ func (kl *Kubelet) syncPod(pod *api.BoundPod, dockerContainers dockertools.Docke
 		return err
 	}
 
-	podStatus := api.PodStatus{}
-	info, err := kl.GetPodInfo(podFullName, uid)
+	podStatus, err := kl.GetPodStatus(podFullName, uid)
 	if err != nil {
 		glog.Errorf("Unable to get pod with name %q and uid %q info, health checks may be invalid", podFullName, uid)
 	}
-	netInfo, found := info[networkContainerName]
+	netInfo, found := podStatus.Info[networkContainerName]
 	if found {
 		podStatus.PodIP = netInfo.PodIP
 	}
@@ -1340,11 +1339,11 @@ func (kl *Kubelet) syncLoop(updates <-chan PodUpdate, handler SyncHandler) {
 }
 
 // GetKubeletContainerLogs returns logs from the container
-// The second parameter of GetPodInfo and FindPodContainer methods represents pod UUID, which is allowed to be blank
+// The second parameter of GetPodStatus and FindPodContainer methods represents pod UUID, which is allowed to be blank
 // TODO: this method is returning logs of random container attempts, when it should be returning the most recent attempt
 // or all of them.
 func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName, tail string, follow bool, stdout, stderr io.Writer) error {
-	_, err := kl.GetPodInfo(podFullName, "")
+	_, err := kl.GetPodStatus(podFullName, "")
 	if err == dockertools.ErrNoContainersInPod {
 		return fmt.Errorf("pod not found (%q)\n", podFullName)
 	}
@@ -1376,8 +1375,8 @@ func (kl *Kubelet) GetPodByName(namespace, name string) (*api.BoundPod, bool) {
 	return nil, false
 }
 
-// GetPodInfo returns information from Docker about the containers in a pod
-func (kl *Kubelet) GetPodInfo(podFullName string, uid types.UID) (api.PodInfo, error) {
+// GetPodStatus returns information from Docker about the containers in a pod
+func (kl *Kubelet) GetPodStatus(podFullName string, uid types.UID) (api.PodStatus, error) {
 	var manifest api.PodSpec
 	for _, pod := range kl.pods {
 		if GetPodFullName(&pod) == podFullName {
@@ -1385,7 +1384,14 @@ func (kl *Kubelet) GetPodInfo(podFullName string, uid types.UID) (api.PodInfo, e
 			break
 		}
 	}
-	return dockertools.GetDockerPodInfo(kl.dockerClient, manifest, podFullName, uid)
+
+	info, err := dockertools.GetDockerPodInfo(kl.dockerClient, manifest, podFullName, uid)
+
+	// TODO(dchen1107): Determine PodPhase here
+	var podStatus api.PodStatus
+	podStatus.Info = info
+
+	return podStatus, err
 }
 
 func (kl *Kubelet) healthy(podFullName string, podUID types.UID, status api.PodStatus, container api.Container, dockerContainer *docker.APIContainers) (health.Status, error) {

--- a/pkg/master/pod_cache.go
+++ b/pkg/master/pod_cache.go
@@ -144,13 +144,13 @@ func (p *PodCache) computePodStatus(pod *api.Pod) (api.PodStatus, error) {
 		return newStatus, nil
 	}
 
-	info, err := p.containerInfo.GetPodInfo(pod.Status.Host, pod.Namespace, pod.Name)
+	result, err := p.containerInfo.GetPodStatus(pod.Status.Host, pod.Namespace, pod.Name)
 	newStatus.HostIP = p.ipCache.GetInstanceIP(pod.Status.Host)
 
 	if err != nil {
 		newStatus.Phase = api.PodUnknown
 	} else {
-		newStatus.Info = info.ContainerInfo
+		newStatus.Info = result.Status.Info
 		newStatus.Phase = getPhase(&pod.Spec, newStatus.Info)
 		if netContainerInfo, ok := newStatus.Info["net"]; ok {
 			if netContainerInfo.PodIP != "" {


### PR DESCRIPTION
This is the first step of #3433. Now when apiserver asks for /podinfo, Kubelet returns PodStatusResult, not PodContaienerInfo which is a simple wrapper of the map of ContainerStatus. But all container's status still pass to apiserver for now. Next step is Kubelet make decision on PodPhase along with reasonable and well defined reasons, then we can hide net container completely. 

e2e tests are passed:

2015/01/15 17:01:42 Passed tests: basic.sh[1/1] certs.sh[1/1] goe2e.sh[1/1] guestbook.sh[1/1] liveness.sh[1/1] monitoring.sh[1/1] pd.sh[1/1] private.sh[1/1] services.sh[1/1] update.sh[1/1]
2015/01/15 17:01:42 Flaky tests:
2015/01/15 17:01:42 Failed tests:
2015/01/15 17:01:42 Success!
