### PR TITLE
Update verflag.go to work with pflag so that --version keeps working.

### DIFF
--- a/cmd/kubecfg/kubecfg.go
+++ b/cmd/kubecfg/kubecfg.go
@@ -43,28 +43,29 @@ import (
 )
 
 var (
-	serverVersion = verflag.Version("server_version", verflag.VersionFalse, "Print the server's version information and quit")
-	preventSkew   = flag.Bool("expect_version_match", false, "Fail if server's version doesn't match own version.")
-	config        = flag.String("c", "", "Path or URL to the config file, or '-' to read from STDIN")
-	selector      = flag.String("l", "", "Selector (label query) to use for listing")
-	fieldSelector = flag.String("fields", "", "Selector (field query) to use for listing")
-	updatePeriod  = flag.Duration("u", 60*time.Second, "Update interval period")
-	portSpec      = flag.String("p", "", "The port spec, comma-separated list of <external>:<internal>,...")
-	servicePort   = flag.Int("s", -1, "If positive, create and run a corresponding service on this port, only used with 'run'")
-	authConfig    = flag.String("auth", os.Getenv("HOME")+"/.kubernetes_auth", "Path to the auth info file.  If missing, prompt the user.  Only used if doing https.")
-	json          = flag.Bool("json", false, "If true, print raw JSON for responses")
-	yaml          = flag.Bool("yaml", false, "If true, print raw YAML for responses")
-	verbose       = flag.Bool("verbose", false, "If true, print extra information")
-	validate      = flag.Bool("validate", false, "If true, try to validate the passed in object using a swagger schema on the api server")
-	proxy         = flag.Bool("proxy", false, "If true, run a proxy to the api server")
-	www           = flag.String("www", "", "If -proxy is true, use this directory to serve static files")
-	templateFile  = flag.String("template_file", "", "If present, load this file as a golang template and use it for output printing")
-	templateStr   = flag.String("template", "", "If present, parse this string as a golang template and use it for output printing")
-	imageName     = flag.String("image", "", "Image used when updating a replicationController.  Will apply to the first container in the pod template.")
-	clientConfig  = &client.Config{}
-	openBrowser   = flag.Bool("open_browser", true, "If true, and -proxy is specified, open a browser pointed at the Kubernetes UX. Default true.")
-	ns            = flag.String("ns", "", "If present, the namespace scope for this request.")
-	nsFile        = flag.String("ns_file", os.Getenv("HOME")+"/.kubernetes_ns", "Path to the namespace file")
+	serverVersion    = flag.Bool("server_version", false, "Print the server's version information and quit")
+	rawServerVersion = flag.Bool("raw_server_version", false, "Print the server's raw version information and quit")
+	preventSkew      = flag.Bool("expect_version_match", false, "Fail if server's version doesn't match own version.")
+	config           = flag.String("c", "", "Path or URL to the config file, or '-' to read from STDIN")
+	selector         = flag.String("l", "", "Selector (label query) to use for listing")
+	fieldSelector    = flag.String("fields", "", "Selector (field query) to use for listing")
+	updatePeriod     = flag.Duration("u", 60*time.Second, "Update interval period")
+	portSpec         = flag.String("p", "", "The port spec, comma-separated list of <external>:<internal>,...")
+	servicePort      = flag.Int("s", -1, "If positive, create and run a corresponding service on this port, only used with 'run'")
+	authConfig       = flag.String("auth", os.Getenv("HOME")+"/.kubernetes_auth", "Path to the auth info file.  If missing, prompt the user.  Only used if doing https.")
+	json             = flag.Bool("json", false, "If true, print raw JSON for responses")
+	yaml             = flag.Bool("yaml", false, "If true, print raw YAML for responses")
+	verbose          = flag.Bool("verbose", false, "If true, print extra information")
+	validate         = flag.Bool("validate", false, "If true, try to validate the passed in object using a swagger schema on the api server")
+	proxy            = flag.Bool("proxy", false, "If true, run a proxy to the api server")
+	www              = flag.String("www", "", "If -proxy is true, use this directory to serve static files")
+	templateFile     = flag.String("template_file", "", "If present, load this file as a golang template and use it for output printing")
+	templateStr      = flag.String("template", "", "If present, parse this string as a golang template and use it for output printing")
+	imageName        = flag.String("image", "", "Image used when updating a replicationController.  Will apply to the first container in the pod template.")
+	clientConfig     = &client.Config{}
+	openBrowser      = flag.Bool("open_browser", true, "If true, and -proxy is specified, open a browser pointed at the Kubernetes UX. Default true.")
+	ns               = flag.String("ns", "", "If present, the namespace scope for this request.")
+	nsFile           = flag.String("ns_file", os.Getenv("HOME")+"/.kubernetes_ns", "Path to the namespace file")
 )
 
 func init() {
@@ -241,13 +242,13 @@ func main() {
 		glog.Fatalf("Can't configure client: %v", err)
 	}
 
-	if *serverVersion != verflag.VersionFalse {
+	if *serverVersion || *rawServerVersion {
 		got, err := kubeClient.ServerVersion()
 		if err != nil {
 			fmt.Printf("Couldn't read version from server: %v\n", err)
 			os.Exit(1)
 		}
-		if *serverVersion == verflag.VersionRaw {
+		if *rawServerVersion {
 			fmt.Printf("%#v\n", *got)
 			os.Exit(0)
 		} else {

--- a/pkg/version/verflag/verflag.go
+++ b/pkg/version/verflag/verflag.go
@@ -21,78 +21,23 @@ package verflag
 import (
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
 	flag "github.com/spf13/pflag"
 )
 
-type versionValue int
-
-const (
-	VersionFalse versionValue = 0
-	VersionTrue  versionValue = 1
-	VersionRaw   versionValue = 2
-)
-
-const strRawVersion string = "raw"
-
-func (v *versionValue) IsBoolFlag() bool {
-	return true
-}
-
-func (v *versionValue) Get() interface{} {
-	return versionValue(*v)
-}
-
-func (v *versionValue) Set(s string) error {
-	if s == strRawVersion {
-		*v = VersionRaw
-		return nil
-	}
-	boolVal, err := strconv.ParseBool(s)
-	if boolVal {
-		*v = VersionTrue
-	} else {
-		*v = VersionFalse
-	}
-	return err
-}
-
-func (v *versionValue) String() string {
-	if *v == VersionRaw {
-		return strRawVersion
-	}
-	return fmt.Sprintf("%v", bool(*v == VersionTrue))
-}
-
-// The type of the flag as requred by the pflag.Value interface
-func (v *versionValue) Type() string {
-	return "version"
-}
-
-func VersionVar(p *versionValue, name string, value versionValue, usage string) {
-	*p = value
-	flag.Var(p, name, usage)
-}
-
-func Version(name string, value versionValue, usage string) *versionValue {
-	p := new(versionValue)
-	VersionVar(p, name, value, usage)
-	return p
-}
-
 var (
-	versionFlag = Version("version", VersionFalse, "Print version information and quit")
+	versionFlag    = flag.Bool("version", false, "Print version information and quit")
+	rawVersionFlag = flag.Bool("raw_version", false, "Print raw version information and quit")
 )
 
 // PrintAndExitIfRequested will check if the -version flag was passed
 // and, if so, print the version and exit.
 func PrintAndExitIfRequested() {
-	if *versionFlag == VersionRaw {
+	if *rawVersionFlag {
 		fmt.Printf("%#v\n", version.Get())
 		os.Exit(0)
-	} else if *versionFlag == VersionTrue {
+	} else if *versionFlag {
 		fmt.Printf("Kubernetes %s\n", version.Get())
 		os.Exit(0)
 	}


### PR DESCRIPTION
This is a limitation of pflag that could be addressed by ogier/pflag#11, so once that is implemented we can look into reverting this one.

For now, this seems to be as good as we can do it, so let's proceed with it to make at least the expected --version calls work as one would expect.

@jbeda 
