### PR TITLE
fix interface conversion panic

### DIFF
--- a/pkg/proxy/config/config.go
+++ b/pkg/proxy/config/config.go
@@ -106,8 +106,8 @@ func (c *EndpointsConfig) Channel(source string) chan EndpointsUpdate {
 	return endpointsCh
 }
 
-func (c *EndpointsConfig) Config() map[string]map[string]api.Endpoints {
-	return c.store.MergedState().(map[string]map[string]api.Endpoints)
+func (c *EndpointsConfig) Config() []api.Endpoints {
+	return c.store.MergedState().([]api.Endpoints)
 }
 
 type endpointsStore struct {
@@ -201,8 +201,8 @@ func (c *ServiceConfig) Channel(source string) chan ServiceUpdate {
 	return serviceCh
 }
 
-func (c *ServiceConfig) Config() map[string]map[string]api.Service {
-	return c.store.MergedState().(map[string]map[string]api.Service)
+func (c *ServiceConfig) Config() []api.Service {
+	return c.store.MergedState().([]api.Service)
 }
 
 type serviceStore struct {


### PR DESCRIPTION
Methods currently throw interface conversion panics. See MergedState() return types.

```
panic: interface conversion: interface is []api.Endpoints, not map[string]map[string]api.Endpoints

goroutine 1 [running]:
github.com/GoogleCloudPlatform/kubernetes/pkg/proxy/config.(*EndpointsConfig).Config(0xc20800aee0, 0x0)
```
