### PR TITLE
Clean up Kubernetes PullPolicy

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -18,7 +18,6 @@ package api
 
 import (
 	"reflect"
-	"strings"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
@@ -60,27 +59,4 @@ var Semantic = conversion.EqualitiesOrDie(
 		}
 		return a.Amount.Cmp(b.Amount) == 0
 	},
-	pullPoliciesEqual,
 )
-
-// TODO: Address these per #1502
-
-func IsPullAlways(p PullPolicy) bool {
-	return pullPoliciesEqual(p, PullAlways)
-}
-
-func IsPullNever(p PullPolicy) bool {
-	return pullPoliciesEqual(p, PullNever)
-}
-
-func IsPullIfNotPresent(p PullPolicy) bool {
-	// Default to pull if not present
-	if len(p) == 0 {
-		return true
-	}
-	return pullPoliciesEqual(p, PullIfNotPresent)
-}
-
-func pullPoliciesEqual(p1, p2 PullPolicy) bool {
-	return strings.ToLower(string(p1)) == strings.ToLower(string(p2))
-}

--- a/pkg/api/helpers_test.go
+++ b/pkg/api/helpers_test.go
@@ -59,8 +59,6 @@ func TestSemantic(t *testing.T) {
 			true,
 		},
 		{resource.MustParse("2m"), resource.MustParse("1m"), false},
-		{PullPolicy("NEVER"), PullPolicy("neveR"), true},
-		{PullPolicy("NEVER"), PullPolicy("neveRi"), false},
 	}
 
 	for index, item := range table {

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -156,7 +156,8 @@ func TestExtractFromHTTP(t *testing.T) {
 						Containers: []api.Container{{
 							Name:  "1",
 							Image: "foo",
-							TerminationMessagePath: "/dev/termination-log"}},
+							TerminationMessagePath: "/dev/termination-log",
+							ImagePullPolicy:        "PullIfNotPresent"}},
 					},
 				},
 				api.BoundPod{
@@ -169,7 +170,8 @@ func TestExtractFromHTTP(t *testing.T) {
 						Containers: []api.Container{{
 							Name:  "1",
 							Image: "foo",
-							TerminationMessagePath: "/dev/termination-log"}},
+							TerminationMessagePath: "/dev/termination-log",
+							ImagePullPolicy:        "PullIfNotPresent"}},
 					},
 				}),
 		},

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1089,9 +1089,8 @@ func (kl *Kubelet) syncPod(pod *api.BoundPod, dockerContainers dockertools.Docke
 		if err != nil {
 			glog.Errorf("Couldn't make a ref to pod %v, container %v: '%v'", pod.Name, container.Name, err)
 		}
-		if !api.IsPullNever(container.ImagePullPolicy) {
+		if container.ImagePullPolicy != api.PullNever {
 			present, err := kl.dockerPuller.IsImagePresent(container.Image)
-			latest := dockertools.RequireLatestImage(container.Image)
 			if err != nil {
 				if ref != nil {
 					record.Eventf(ref, "failed", "Failed to inspect image %q", container.Image)
@@ -1099,8 +1098,8 @@ func (kl *Kubelet) syncPod(pod *api.BoundPod, dockerContainers dockertools.Docke
 				glog.Errorf("Failed to inspect image %q: %v; skipping pod %q container %q", container.Image, err, podFullName, container.Name)
 				continue
 			}
-			if api.IsPullAlways(container.ImagePullPolicy) ||
-				(api.IsPullIfNotPresent(container.ImagePullPolicy) && (!present || latest)) {
+			if container.ImagePullPolicy == api.PullAlways ||
+				(container.ImagePullPolicy == api.PullIfNotPresent && (!present)) {
 				if err := kl.pullImage(container.Image, ref); err != nil {
 					continue
 				}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -448,7 +448,7 @@ func TestSyncPodsCreatesNetAndContainerPullsImage(t *testing.T) {
 			},
 			Spec: api.PodSpec{
 				Containers: []api.Container{
-					{Name: "bar"},
+					{Name: "bar", Image: "something", ImagePullPolicy: "PullIfNotPresent"},
 				},
 			},
 		},
@@ -463,7 +463,7 @@ func TestSyncPodsCreatesNetAndContainerPullsImage(t *testing.T) {
 
 	fakeDocker.Lock()
 
-	if !reflect.DeepEqual(puller.ImagesPulled, []string{"custom_image_name", ""}) {
+	if !reflect.DeepEqual(puller.ImagesPulled, []string{"custom_image_name", "something"}) {
 		t.Errorf("Unexpected pulled containers: %v", puller.ImagesPulled)
 	}
 
@@ -1836,7 +1836,7 @@ func TestSyncPodsWithPullPolicy(t *testing.T) {
 
 	fakeDocker.Lock()
 
-	if !reflect.DeepEqual(puller.ImagesPulled, []string{"custom_image_name", "pull_always_image", "pull_if_not_present_image", "want:latest"}) {
+	if !reflect.DeepEqual(puller.ImagesPulled, []string{"custom_image_name", "pull_always_image", "pull_if_not_present_image"}) {
 		t.Errorf("Unexpected pulled containers: %v", puller.ImagesPulled)
 	}
 


### PR DESCRIPTION
With this PR, kubernetes wounldn't change the user's setting. Also when PullPolicy is absent, the default is PullIfNotPresent except the case of image has :latest tag, and default is set to be PullAlways.

Also removed unused methods on determining PullPolicy at the run time from helper.go. 

cc @bgrant0607 
