### PR TITLE
Make master service IP static (no longer randomly assigned)

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -162,7 +162,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 		AdmissionControl:  admit.NewAlwaysAdmit(),
 		ReadWritePort:     portNumber,
 		ReadOnlyPort:      portNumber,
-		PublicAddress:     host,
+		PublicAddress:     net.ParseIP(host),
 	})
 	handler.delegate = m.Handler
 

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -97,8 +97,8 @@ type Config struct {
 	// Defaults to 443 if not set.
 	ReadWritePort int
 
-	// If empty, the first result from net.InterfaceAddrs will be used.
-	PublicAddress string
+	// If nil, the first result from net.InterfaceAddrs will be used.
+	PublicAddress net.IP
 }
 
 // Master contains state for a Kubernetes cluster master/api server.
@@ -133,9 +133,14 @@ type Master struct {
 	v1beta3               bool
 	nodeIPCache           IPGetter
 
-	readOnlyServer  string
-	readWriteServer string
-	masterServices  *util.Runner
+	publicIP             net.IP
+	publicReadOnlyPort   int
+	publicReadWritePort  int
+	serviceReadOnlyIP    net.IP
+	serviceReadOnlyPort  int
+	serviceReadWriteIP   net.IP
+	serviceReadWritePort int
+	masterServices       *util.Runner
 
 	// "Outputs"
 	Handler         http.Handler
@@ -176,7 +181,7 @@ func setDefaults(c *Config) {
 	if c.ReadWritePort == 0 {
 		c.ReadWritePort = 443
 	}
-	for c.PublicAddress == "" {
+	for c.PublicAddress == nil {
 		// Find and use the first non-loopback address.
 		// TODO: potentially it'd be useful to skip the docker interface if it
 		// somehow is first in the list.
@@ -196,7 +201,7 @@ func setDefaults(c *Config) {
 				continue
 			}
 			found = true
-			c.PublicAddress = ip.String()
+			c.PublicAddress = ip
 			glog.Infof("Will report %v as public IP address.", ip)
 			break
 		}
@@ -244,6 +249,17 @@ func New(c *Config) *Master {
 		glog.Fatalf("master.New() called with config.KubeletClient == nil")
 	}
 
+	// Select the first two valid IPs from portalNet to use as the master service portalIPs
+	serviceReadOnlyIP, err := service.GetIndexedIP(c.PortalNet, 1)
+	if err != nil {
+		glog.Fatalf("Failed to generate service read-only IP for master service: %v", err)
+	}
+	serviceReadWriteIP, err := service.GetIndexedIP(c.PortalNet, 2)
+	if err != nil {
+		glog.Fatalf("Failed to generate service read-write IP for master service: %v", err)
+	}
+	glog.Infof("Setting master service IPs based on PortalNet subnet to %q (read-only) and %q (read-write).", serviceReadOnlyIP, serviceReadWriteIP)
+
 	m := &Master{
 		podRegistry:           etcd.NewRegistry(c.EtcdHelper, boundPodFactory),
 		controllerRegistry:    etcd.NewRegistry(c.EtcdHelper, nil),
@@ -268,9 +284,16 @@ func New(c *Config) *Master {
 		v1beta3:               c.EnableV1Beta3,
 		nodeIPCache:           NewIPCache(c.Cloud, util.RealClock{}, 30*time.Second),
 
-		masterCount:     c.MasterCount,
-		readOnlyServer:  net.JoinHostPort(c.PublicAddress, strconv.Itoa(int(c.ReadOnlyPort))),
-		readWriteServer: net.JoinHostPort(c.PublicAddress, strconv.Itoa(int(c.ReadWritePort))),
+		masterCount:         c.MasterCount,
+		publicIP:            c.PublicAddress,
+		publicReadOnlyPort:  c.ReadOnlyPort,
+		publicReadWritePort: c.ReadWritePort,
+		serviceReadOnlyIP:   serviceReadOnlyIP,
+		// TODO: serviceReadOnlyPort should be passed in as an argument, it may not always be 80
+		serviceReadOnlyPort: 80,
+		serviceReadWriteIP:  serviceReadWriteIP,
+		// TODO: serviceReadWritePort should be passed in as an argument, it may not always be 443
+		serviceReadWritePort: 443,
 	}
 
 	if c.RestfulContainer != nil {
@@ -443,7 +466,7 @@ func (m *Master) init(c *Config) {
 func (m *Master) InstallSwaggerAPI() {
 	// Enable swagger UI and discovery API
 	swaggerConfig := swagger.Config{
-		WebServicesUrl: m.readWriteServer,
+		WebServicesUrl: net.JoinHostPort(m.publicIP.String(), strconv.Itoa(int(m.publicReadWritePort))),
 		WebServices:    m.handlerContainer.RegisteredWebServices(),
 		// TODO: Parameterize the path?
 		ApiPath:         "/swaggerapi/",

--- a/pkg/registry/service/ip_allocator.go
+++ b/pkg/registry/service/ip_allocator.go
@@ -174,6 +174,18 @@ func (ipa *ipAllocator) AllocateNext() (net.IP, error) {
 	return nil, fmt.Errorf("can't find a free IP in %s", ipa.subnet)
 }
 
+// Returns the index-th IP from the specified subnet range.
+// For example, subnet "10.0.0.0/24" with index "2" will return the IP "10.0.0.2".
+// TODO(saad-ali): Move this (and any other functions that are independent of ipAllocator) to some
+// place more generic.
+func GetIndexedIP(subnet *net.IPNet, index int) (net.IP, error) {
+	ip := ipAdd(subnet.IP, index /* offset */)
+	if !subnet.Contains(ip) {
+		return nil, fmt.Errorf("can't generate IP with index %d from subnet. subnet too small. subnet: %q", index, subnet)
+	}
+	return ip, nil
+}
+
 func (ipa *ipAllocator) createRandomIp() net.IP {
 	ip := ipa.subnet.IP
 	mask := ipa.subnet.Mask

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -85,7 +85,7 @@ func GetAPIServerClient(authPath string, apiServerList util.StringList) (*client
 }
 
 // RunApiServer starts an API server in a go routine.
-func RunApiServer(cl *client.Client, etcdClient tools.EtcdClient, addr string, port int, masterServiceNamespace string) {
+func RunApiServer(cl *client.Client, etcdClient tools.EtcdClient, addr net.IP, port int, masterServiceNamespace string) {
 	handler := delegateHandler{}
 
 	helper, err := master.NewEtcdHelper(etcdClient, "")

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -106,7 +106,7 @@ var aService string = `
   "apiVersion": "v1beta1",
   "id": "a",
   "port": 8000,
-  "portalIP": "10.0.0.1",
+  "portalIP": "10.0.0.100",
   "labels": { "name": "a" },
   "selector": { "name": "a" }
 }


### PR DESCRIPTION
Closes #2410 

The master service currently does not select it's own internal service IP address. When the master service is created, it does not specify a `PortalIP` (see [pkg/master/publish.go#L90](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/pkg/master/publish.go#L90)), which causes `ipAllocator` to automatically select an internal IP address for the master service (see [pkg/registry/service/rest.go#L94](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/registry/service/rest.go#L94)).

The SkyDNS service, which is started after the master, does select it's own internal service IP address, because it specifies the `PortalIp` in the service definition (see [cluster/addons/dns/skydns-svc.yaml.in](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/cluster/addons/dns/skydns-svc.yaml.in)).

If the randomly assigned master service IP address happens to be the same as the statically assigned DNS IP address, the DNS service will fail to start.

To prevent this potential collision we modify the master service to specify a static IP address for itself (different from the DNS service's address).
