### PR TITLE
Add lock files to suspend GC temporarily

### DIFF
--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -60,6 +60,8 @@ var (
 	runonce                 = flag.Bool("runonce", false, "If true, exit after spawning pods from local manifests or remote urls. Exclusive with --etcd_servers, --api_servers, and --enable-server")
 	enableDebuggingHandlers = flag.Bool("enable_debugging_handlers", true, "Enables server endpoints for log collection and local running of containers and commands")
 	minimumGCAge            = flag.Duration("minimum_container_ttl_duration", 1*time.Minute, "Minimum age for a finished container before it is garbage collected.  Examples: '300ms', '10s' or '2h45m'")
+	imageGCLockFile         = flag.String("image_gc_lock_file_path", "", "Path to a file to indicate suspend garbage collection for images while it exists")
+	containerGCLockFile     = flag.String("container_gc_lock_file_path", "", "Path to a file to indicate suspend garbage collection for containers while it exists")
 	maxContainerCount       = flag.Int("maximum_dead_containers_per_container", 5, "Maximum number of old instances of a container to retain per container.  Each container takes up some disk space.  Default: 5.")
 	authPath                = flag.String("auth_path", "", "Path to .kubernetes_auth file, specifying how to authenticate to API server.")
 	cAdvisorPort            = flag.Uint("cadvisor_port", 4194, "The port of the localhost cAdvisor endpoint")
@@ -140,6 +142,8 @@ func main() {
 		RegistryPullQPS:         *registryPullQPS,
 		RegistryBurst:           *registryBurst,
 		MinimumGCAge:            *minimumGCAge,
+		ImageGCLockFile:         *imageGCLockFile,
+		ContainerGCLockFile:     *containerGCLockFile,
 		MaxContainerCount:       *maxContainerCount,
 		ClusterDomain:           *clusterDomain,
 		ClusterDNS:              clusterDNS,

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -77,6 +77,8 @@ func NewMainKubelet(
 	pullQPS float32,
 	pullBurst int,
 	minimumGCAge time.Duration,
+	imageGCLockFile string,
+	containerGCLockFile string,
 	maxContainerCount int,
 	sourceReady SourceReadyFn,
 	clusterDomain string,
@@ -113,6 +115,8 @@ func NewMainKubelet(
 		pullQPS:                pullQPS,
 		pullBurst:              pullBurst,
 		minimumGCAge:           minimumGCAge,
+		imageGCLockFile:        imageGCLockFile,
+		containerGCLockFile:    containerGCLockFile,
 		maxContainerCount:      maxContainerCount,
 		sourceReady:            sourceReady,
 		clusterDomain:          clusterDomain,
@@ -180,8 +184,10 @@ type Kubelet struct {
 	cadvisorLock   sync.RWMutex
 
 	// Optional, minimum age required for garbage collection.  If zero, no limit.
-	minimumGCAge      time.Duration
-	maxContainerCount int
+	minimumGCAge        time.Duration
+	maxContainerCount   int
+	imageGCLockFile     string
+	containerGCLockFile string
 
 	// If non-empty, use this for container DNS search.
 	clusterDomain string
@@ -343,6 +349,10 @@ func (kl *Kubelet) getUnusedImages() ([]string, error) {
 }
 
 func (kl *Kubelet) GarbageCollectImages() error {
+	if _, err := os.Stat(kl.imageGCLockFile); err == nil {
+		return nil
+	}
+
 	images, err := kl.getUnusedImages()
 	if err != nil {
 		return err
@@ -358,6 +368,9 @@ func (kl *Kubelet) GarbageCollectImages() error {
 // TODO: Also enforce a maximum total number of containers.
 func (kl *Kubelet) GarbageCollectContainers() error {
 	if kl.maxContainerCount == 0 {
+		return nil
+	}
+	if _, err := os.Stat(kl.containerGCLockFile); err == nil {
 		return nil
 	}
 	containers, err := dockertools.GetKubeletDockerContainers(kl.dockerClient, true)

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -259,6 +259,8 @@ type KubeletConfig struct {
 	RegistryPullQPS         float64
 	RegistryBurst           int
 	MinimumGCAge            time.Duration
+	ImageGCLockFile         string
+	ContainerGCLockFile     string
 	MaxContainerCount       int
 	ClusterDomain           string
 	ClusterDNS              util.IP
@@ -284,6 +286,8 @@ func createAndInitKubelet(kc *KubeletConfig, pc *config.PodConfig) (*kubelet.Kub
 		float32(kc.RegistryPullQPS),
 		kc.RegistryBurst,
 		kc.MinimumGCAge,
+		kc.ImageGCLockFile,
+		kc.ContainerGCLockFile,
 		kc.MaxContainerCount,
 		pc.IsSourceSeen,
 		kc.ClusterDomain,


### PR DESCRIPTION
- Fix #3393.
- User can now specify path to file that can suspend kubelet's GC while
  it exist.
- kubelet's garbage collection may remove image or containers that
  created by administrator's maintenance operation.
- The root problem is image GC doesn't limit target to k8s related.
  - This is short-term fix.

@dchen1107 @thockin @brendandburns @goltermann could you review this patch for #3393?
