### PR TITLE
Fixed missing standalone.yaml fix to Docker overlay driver. Refs #3625.

### DIFF
--- a/docs/getting-started-guides/coreos/cloud-configs/standalone.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/standalone.yaml
@@ -62,7 +62,7 @@ coreos:
         [Service]
         EnvironmentFile=/run/flannel/subnet.env
         ExecStartPre=/bin/mount --make-rprivate /
-        ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=btrfs -H fd://
+        ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd://
 
         [Install]
         WantedBy=multi-user.target


### PR DESCRIPTION
@erictune @kelseyhightower you missed `standalone.yaml` in #3625.
