### PR TITLE
make shorthand flags optional

### DIFF
--- a/pkg/client/clientcmd/overrides.go
+++ b/pkg/client/clientcmd/overrides.go
@@ -47,6 +47,7 @@ type ConfigOverrideFlags struct {
 // AuthOverrideFlags holds the flag names to be used for binding command line flags for AuthInfo objects
 type AuthOverrideFlags struct {
 	AuthPath          string
+	AuthPathShort     string
 	ClientCertificate string
 	ClientKey         string
 	Token             string
@@ -55,6 +56,7 @@ type AuthOverrideFlags struct {
 // ClusterOverride holds the flag names to be used for binding command line flags for Cluster objects
 type ClusterOverrideFlags struct {
 	APIServer             string
+	APIServerShort        string
 	APIVersion            string
 	CertificateAuthority  string
 	InsecureSkipTLSVerify string
@@ -109,8 +111,12 @@ func RecommendedConfigOverrideFlags(prefix string) ConfigOverrideFlags {
 
 // BindAuthInfoFlags is a convenience method to bind the specified flags to their associated variables
 func BindAuthInfoFlags(authInfo *clientcmdapi.AuthInfo, flags *pflag.FlagSet, flagNames AuthOverrideFlags) {
-	// TODO short flag names are impossible to prefix, decide whether to keep them or not
-	flags.StringVarP(&authInfo.AuthPath, flagNames.AuthPath, "a", "", "Path to the auth info file. If missing, prompt the user. Only used if using https.")
+	// TODO short flag names are impossible to prefix.  code gets cleaner if we remove them
+	if len(flagNames.AuthPathShort) > 0 {
+		flags.StringVarP(&authInfo.AuthPath, flagNames.AuthPath, flagNames.AuthPathShort, "", "Path to the auth info file. If missing, prompt the user. Only used if using https.")
+	} else {
+		flags.StringVar(&authInfo.AuthPath, flagNames.AuthPath, "", "Path to the auth info file. If missing, prompt the user. Only used if using https.")
+	}
 	flags.StringVar(&authInfo.ClientCertificate, flagNames.ClientCertificate, "", "Path to a client key file for TLS.")
 	flags.StringVar(&authInfo.ClientKey, flagNames.ClientKey, "", "Path to a client key file for TLS.")
 	flags.StringVar(&authInfo.Token, flagNames.Token, "", "Bearer token for authentication to the API server.")
@@ -118,8 +124,12 @@ func BindAuthInfoFlags(authInfo *clientcmdapi.AuthInfo, flags *pflag.FlagSet, fl
 
 // BindClusterFlags is a convenience method to bind the specified flags to their associated variables
 func BindClusterFlags(clusterInfo *clientcmdapi.Cluster, flags *pflag.FlagSet, flagNames ClusterOverrideFlags) {
-	// TODO short flag names are impossible to prefix, decide whether to keep them or not
-	flags.StringVarP(&clusterInfo.Server, flagNames.APIServer, "s", "", "The address of the Kubernetes API server")
+	// TODO short flag names are impossible to prefix.  code gets cleaner if we remove them
+	if len(flagNames.APIServerShort) > 0 {
+		flags.StringVarP(&clusterInfo.Server, flagNames.APIServer, flagNames.APIServerShort, "", "The address of the Kubernetes API server")
+	} else {
+		flags.StringVar(&clusterInfo.Server, flagNames.APIServer, "", "The address of the Kubernetes API server")
+	}
 	flags.StringVar(&clusterInfo.APIVersion, flagNames.APIVersion, "", "The API version to use when talking to the server")
 	flags.StringVar(&clusterInfo.CertificateAuthority, flagNames.CertificateAuthority, "", "Path to a cert. file for the certificate authority.")
 	flags.BoolVar(&clusterInfo.InsecureSkipTLSVerify, flagNames.InsecureSkipTLSVerify, false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.")

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -235,7 +235,12 @@ func DefaultClientConfig(flags *pflag.FlagSet) clientcmd.ClientConfig {
 	flags.StringVar(&loadingRules.CommandLinePath, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
 
 	overrides := &clientcmd.ConfigOverrides{}
-	clientcmd.BindOverrideFlags(overrides, flags, clientcmd.RecommendedConfigOverrideFlags(""))
+	flagNames := clientcmd.RecommendedConfigOverrideFlags("")
+	// short flagnames are disabled by default.  These are here for compatibility with existing scripts
+	flagNames.AuthOverrideFlags.AuthPathShort = "a"
+	flagNames.ClusterOverrideFlags.APIServerShort = "s"
+
+	clientcmd.BindOverrideFlags(overrides, flags, flagNames)
 	clientConfig := clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, overrides, os.Stdin)
 
 	return clientConfig


### PR DESCRIPTION
Having the shorthand flags fixed inside of the default bind methods makes re-using this code painful.  This simply adds an option to set shorthand flag names that doesn't bind them by default.
