### PR TITLE
make kubectl factory flag binding optional

### DIFF
--- a/cmd/gendocs/gen_kubectl_docs.go
+++ b/cmd/gendocs/gen_kubectl_docs.go
@@ -30,7 +30,7 @@ func main() {
 	// Set environment variables used by kubectl so the output is consistent,
 	// regardless of where we run.
 	os.Setenv("HOME", "/home/username")
-	kubectl := cmd.NewFactory().NewKubectlCommand(out)
+	kubectl := cmd.NewFactory(nil).NewKubectlCommand(out)
 	fmt.Fprintf(out, "## %s\n\n", kubectl.Name())
 	fmt.Fprintf(out, "%s\n\n", kubectl.Short)
 	fmt.Fprintln(out, "### Commands\n")

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -23,7 +23,7 @@ import (
 )
 
 func main() {
-	cmd := cmd.NewFactory().NewKubectlCommand(os.Stdout)
+	cmd := cmd.NewFactory(nil).NewKubectlCommand(os.Stdout)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -69,11 +69,18 @@ type Factory struct {
 }
 
 // NewFactory creates a factory with the default Kubernetes resources defined
-func NewFactory() *Factory {
+// if optionalClientConfig is nil, then flags will be bound to a new clientcmd.ClientConfig.
+// if optionalClientConfig is not nil, then this factory will make use of it.
+func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 	mapper := kubectl.ShortcutExpander{latest.RESTMapper}
 
 	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
-	clientConfig := DefaultClientConfig(flags)
+
+	clientConfig := optionalClientConfig
+	if optionalClientConfig == nil {
+		clientConfig = DefaultClientConfig(flags)
+	}
+
 	clients := &clientCache{
 		clients: make(map[string]*client.Client),
 		loader:  clientConfig,

--- a/pkg/kubectl/cmd/factory_test.go
+++ b/pkg/kubectl/cmd/factory_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
+	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
+)
+
+func TestNewFactoryDefaultFlagBindings(t *testing.T) {
+	factory := NewFactory(nil)
+
+	if !factory.flags.HasFlags() {
+		t.Errorf("Expected flags, but didn't get any")
+	}
+}
+
+func TestNewFactoryNoFlagBindings(t *testing.T) {
+	clientConfig := clientcmd.NewDefaultClientConfig(*clientcmdapi.NewConfig(), &clientcmd.ConfigOverrides{})
+	factory := NewFactory(clientConfig)
+
+	if factory.flags.HasFlags() {
+		t.Errorf("Expected zero flags, but got %v", factory.flags)
+	}
+}


### PR DESCRIPTION
kubectlcmd.NewFactory() binds flags for the clientcmd.ClientConfig it contains.  That is nice for callers who don't want to customize any flag behavior, but those who do can't use NewFactory() as it is today.

This change allows a caller to specify a ClientConfig for the Factory to use.  Passing nil results in the same behavior we have today.  The argument is named "optional" to try to make that obvious.
