### PR TITLE
Remove trailing newline from served hostname in serve_hostname

### DIFF
--- a/contrib/for-demos/serve_hostname/serve_hostname.go
+++ b/contrib/for-demos/serve_hostname/serve_hostname.go
@@ -44,7 +44,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error from os.Hostname(): %s", err)
 	}
-	hostname += "\n"
 
 	if *doTcp {
 		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))


### PR DESCRIPTION
I'd like the trailing newline to be removed from the response which makes the code for checking the served hostname cleaner since it then does not need to strip out the newline. @thockin 
