### PR TITLE
Put a version tag on kubernetes/serve_hostname

### DIFF
--- a/contrib/for-demos/serve_hostname/Makefile
+++ b/contrib/for-demos/serve_hostname/Makefile
@@ -1,13 +1,15 @@
 all: serve_hostname
 
+TAG = 1.0
+
 serve_hostname: serve_hostname.go
 	CGO_ENABLED=0 go build -a --ldflags '-w' ./serve_hostname.go
 
 container: serve_hostname
-	sudo docker build -t kubernetes/serve_hostname .
+	sudo docker build -t kubernetes/serve_hostname:$(TAG) .
 
 push:
-	sudo docker push kubernetes/serve_hostname
+	sudo docker push kubernetes/serve_hostname:$(TAG)
 
 clean:
 	rm -f serve_hostname


### PR DESCRIPTION
Out of paranoia reverting kubernetes/serve_hostname:latest to what it was before and pushing the new image with a 1.0 tag. @thockin 
