### PR TITLE
Flag shorthand refactor1

### DIFF
--- a/pkg/client/clientcmd/overrides.go
+++ b/pkg/client/clientcmd/overrides.go
@@ -112,11 +112,10 @@ func RecommendedConfigOverrideFlags(prefix string) ConfigOverrideFlags {
 // BindAuthInfoFlags is a convenience method to bind the specified flags to their associated variables
 func BindAuthInfoFlags(authInfo *clientcmdapi.AuthInfo, flags *pflag.FlagSet, flagNames AuthOverrideFlags) {
 	// TODO short flag names are impossible to prefix.  code gets cleaner if we remove them
-	authPathUsage := "Path to the auth info file. If missing, prompt the user. Only used if using https."
 	if len(flagNames.AuthPathShort) > 0 {
-		flags.StringVarP(&authInfo.AuthPath, flagNames.AuthPath, flagNames.AuthPathShort, "", authPathUsage)
+		flags.StringVarP(&authInfo.AuthPath, flagNames.AuthPath, flagNames.AuthPathShort, "", "Path to the auth info file. If missing, prompt the user. Only used if using https.")
 	} else {
-		flags.StringVar(&authInfo.AuthPath, flagNames.AuthPath, "", authPathUsage)
+		flags.StringVar(&authInfo.AuthPath, flagNames.AuthPath, "", "Path to the auth info file. If missing, prompt the user. Only used if using https.")
 	}
 	flags.StringVar(&authInfo.ClientCertificate, flagNames.ClientCertificate, "", "Path to a client key file for TLS.")
 	flags.StringVar(&authInfo.ClientKey, flagNames.ClientKey, "", "Path to a client key file for TLS.")
@@ -126,11 +125,10 @@ func BindAuthInfoFlags(authInfo *clientcmdapi.AuthInfo, flags *pflag.FlagSet, fl
 // BindClusterFlags is a convenience method to bind the specified flags to their associated variables
 func BindClusterFlags(clusterInfo *clientcmdapi.Cluster, flags *pflag.FlagSet, flagNames ClusterOverrideFlags) {
 	// TODO short flag names are impossible to prefix.  code gets cleaner if we remove them
-	apiServerUsage := "The address of the Kubernetes API server"
 	if len(flagNames.APIServerShort) > 0 {
-		flags.StringVarP(&clusterInfo.Server, flagNames.APIServer, flagNames.APIServerShort, "", apiServerUsage)
+		flags.StringVarP(&clusterInfo.Server, flagNames.APIServer, flagNames.APIServerShort, "", "The address of the Kubernetes API server")
 	} else {
-		flags.StringVar(&clusterInfo.Server, flagNames.APIServer, "", apiServerUsage)
+		flags.StringVar(&clusterInfo.Server, flagNames.APIServer, "", "The address of the Kubernetes API server")
 	}
 	flags.StringVar(&clusterInfo.APIVersion, flagNames.APIVersion, "", "The API version to use when talking to the server")
 	flags.StringVar(&clusterInfo.CertificateAuthority, flagNames.CertificateAuthority, "", "Path to a cert. file for the certificate authority.")

--- a/pkg/client/clientcmd/overrides.go
+++ b/pkg/client/clientcmd/overrides.go
@@ -111,12 +111,7 @@ func RecommendedConfigOverrideFlags(prefix string) ConfigOverrideFlags {
 
 // BindAuthInfoFlags is a convenience method to bind the specified flags to their associated variables
 func BindAuthInfoFlags(authInfo *clientcmdapi.AuthInfo, flags *pflag.FlagSet, flagNames AuthOverrideFlags) {
-	// TODO short flag names are impossible to prefix.  code gets cleaner if we remove them
-	if len(flagNames.AuthPathShort) > 0 {
-		flags.StringVarP(&authInfo.AuthPath, flagNames.AuthPath, flagNames.AuthPathShort, "", "Path to the auth info file. If missing, prompt the user. Only used if using https.")
-	} else {
-		flags.StringVar(&authInfo.AuthPath, flagNames.AuthPath, "", "Path to the auth info file. If missing, prompt the user. Only used if using https.")
-	}
+	flags.StringVarP(&authInfo.AuthPath, flagNames.AuthPath, flagNames.AuthPathShort, "", "Path to the auth info file. If missing, prompt the user. Only used if using https.")
 	flags.StringVar(&authInfo.ClientCertificate, flagNames.ClientCertificate, "", "Path to a client key file for TLS.")
 	flags.StringVar(&authInfo.ClientKey, flagNames.ClientKey, "", "Path to a client key file for TLS.")
 	flags.StringVar(&authInfo.Token, flagNames.Token, "", "Bearer token for authentication to the API server.")
@@ -124,12 +119,7 @@ func BindAuthInfoFlags(authInfo *clientcmdapi.AuthInfo, flags *pflag.FlagSet, fl
 
 // BindClusterFlags is a convenience method to bind the specified flags to their associated variables
 func BindClusterFlags(clusterInfo *clientcmdapi.Cluster, flags *pflag.FlagSet, flagNames ClusterOverrideFlags) {
-	// TODO short flag names are impossible to prefix.  code gets cleaner if we remove them
-	if len(flagNames.APIServerShort) > 0 {
-		flags.StringVarP(&clusterInfo.Server, flagNames.APIServer, flagNames.APIServerShort, "", "The address of the Kubernetes API server")
-	} else {
-		flags.StringVar(&clusterInfo.Server, flagNames.APIServer, "", "The address of the Kubernetes API server")
-	}
+	flags.StringVarP(&clusterInfo.Server, flagNames.APIServer, flagNames.APIServerShort, "", "The address of the Kubernetes API server")
 	flags.StringVar(&clusterInfo.APIVersion, flagNames.APIVersion, "", "The API version to use when talking to the server")
 	flags.StringVar(&clusterInfo.CertificateAuthority, flagNames.CertificateAuthority, "", "Path to a cert. file for the certificate authority.")
 	flags.BoolVar(&clusterInfo.InsecureSkipTLSVerify, flagNames.InsecureSkipTLSVerify, false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.")


### PR DESCRIPTION
@deads2k @bgrant0607 

This addresses the refactor suggested in https://github.com/GoogleCloudPlatform/kubernetes/pull/3641#discussion_r23262172

I wanted to bring this in again in #3672 but unfortunately it was already merged when I saw it.

There's really no need to introduce this amount of complexity. I can see your claim that this is an undocumented feature but unfortunately you could argue that most of the "pflag" package is undocumented itself...

In any case, it's pretty clear from the code that that's meant to be that way, for instance, all implementations end up using `VarP`:
https://github.com/spf13/pflag/blob/master/string.go#L26

Using an empty string to represent "no shorthand" is quite a natural convention and there's no reason why we shouldn't rely on it on our code.
