### PR TITLE
Fix kubectl version to match client and server version output

### DIFF
--- a/pkg/kubectl/version.go
+++ b/pkg/kubectl/version.go
@@ -33,7 +33,7 @@ func GetVersion(w io.Writer, kubeClient client.Interface) {
 	}
 
 	GetClientVersion(w)
-	fmt.Fprintf(w, "Server Version: %#v\n", serverVersion)
+	fmt.Fprintf(w, "Server Version: %#v\n", *serverVersion)
 }
 
 func GetClientVersion(w io.Writer) {


### PR DESCRIPTION
Before this fix, the server version was printed from a pointer, making
the Go formatter prefix it with a &.

Before this patch:

```
$ kubectl version
Client Version: version.Info{Major:"0", Minor:"8+", GitVersion:"v0.8.0-509-g8537a73264b836", GitCommit:"8537a73264b836226cfca745ed37d65916e3b16f", GitTreeState:"clean"}
Server Version: &version.Info{Major:"0", Minor:"8+", GitVersion:"v0.8.0-509-g8537a73264b836", GitCommit:"8537a73264b836226cfca745ed37d65916e3b16f", GitTreeState:"clean"}
```

After this patch:

```
$ kubectl version
Client Version: version.Info{Major:"0", Minor:"8+", GitVersion:"v0.8.0-509-g8537a73264b836-dirty", GitCommit:"8537a73264b836226cfca745ed37d65916e3b16f", GitTreeState:"dirty"}
Server Version: version.Info{Major:"0", Minor:"8+", GitVersion:"v0.8.0-509-g8537a73264b836", GitCommit:"8537a73264b836226cfca745ed37d65916e3b16f", GitTreeState:"clean"}
```
