### PR TITLE
Disable TestKubernetesROService e2e test

### DIFF
--- a/test/e2e/driver.go
+++ b/test/e2e/driver.go
@@ -76,7 +76,10 @@ func RunE2ETests(authConfig, certDir, host, repoRoot, provider string, orderseed
 	c := loadClientOrDie()
 
 	tests := []testSpec{
-		{TestKubernetesROService, "TestKubernetesROService"},
+		/*  Disable TestKubernetesROService due to rate limiter issues.
+		    TODO: Add this test back when rate limiting is working properly.
+				{TestKubernetesROService, "TestKubernetesROService"},
+		*/
 		{TestKubeletSendsEvent, "TestKubeletSendsEvent"},
 		{TestImportantURLs, "TestImportantURLs"},
 		{TestPodUpdate, "TestPodUpdate"},


### PR DESCRIPTION
This test is failing probably due to an error with rate limiting. Let's remove this test until we can get to the bottom of this issue.
