### PR TITLE
Add RunUntil to the Reflector and Poller to allow early termination

### DIFF
--- a/pkg/client/cache/poller.go
+++ b/pkg/client/cache/poller.go
@@ -57,14 +57,22 @@ func NewPoller(getFunc GetFunc, period time.Duration, store Store) *Poller {
 
 // Run begins polling. It starts a goroutine and returns immediately.
 func (p *Poller) Run() {
-	go util.Forever(func() {
-		e, err := p.getFunc()
-		if err != nil {
-			glog.Errorf("failed to list: %v", err)
-			return
-		}
-		p.sync(e)
-	}, p.period)
+	go util.Forever(p.run, p.period)
+}
+
+// RunUntil begins polling. It starts a goroutine and returns immediately.
+// It will stop when the stopCh is closed.
+func (p *Poller) RunUntil(stopCh <-chan struct{}) {
+	go util.Until(p.run, p.period, stopCh)
+}
+
+func (p *Poller) run() {
+	e, err := p.getFunc()
+	if err != nil {
+		glog.Errorf("failed to list: %v", err)
+		return
+	}
+	p.sync(e)
 }
 
 func (p *Poller) sync(e Enumerator) {

--- a/pkg/client/cache/reflector.go
+++ b/pkg/client/cache/reflector.go
@@ -72,6 +72,12 @@ func (r *Reflector) Run() {
 	go util.Forever(func() { r.listAndWatch() }, r.period)
 }
 
+// RunUntil starts a watch and handles watch events. Will restart the watch if it is closed.
+// RunUntil starts a goroutine and returns immediately. It will exit when stopCh is closed.
+func (r *Reflector) RunUntil(stopCh <-chan struct{}) {
+	go util.Until(func() { r.listAndWatch() }, r.period, stopCh)
+}
+
 func (r *Reflector) listAndWatch() {
 	var resourceVersion string
 


### PR DESCRIPTION
This is useful for test suites where you want to kill your workers
without having to run one test env per execution.
