### PR TITLE
Understand why cluster_dns e2e test fails

### DIFF
--- a/test/e2e/cluster_dns.go
+++ b/test/e2e/cluster_dns.go
@@ -131,6 +131,7 @@ func TestClusterDNS(c *client.Client) bool {
 				Do().Raw()
 			if err != nil {
 				failed = append(failed, name)
+				glog.V(4).Infof("Lookup for %s failed: %v", name, err)
 			}
 		}
 		if len(failed) == 0 {


### PR DESCRIPTION
I suspect this test fails due to a rate limit error but we can't tell from the existing output. This PR simply adds a log line to report why any specific lookup fails. @thockin 
