### PR TITLE
Add a Retry-After header when rate limit is exceeded

### DIFF
--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -72,6 +72,7 @@ func RateLimit(rl util.RateLimiter, handler http.Handler) http.Handler {
 			return
 		}
 		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Header().Set("Retry-After", "1")
 		fmt.Fprintf(w, "Rate limit exceeded.")
 	})
 }


### PR DESCRIPTION
This PR is a first attempt to address issue #3702.
Ideally we would use a timeout based approach, but for now this PR adds a `Retry-After` response header from the throttling code and the `Do` method in `request.go` observes this and waits for the retry period and makes about 10 retries before giving up. @bgrant0607 
Still working out how to test this.
