### PR TITLE
Convert liveness e2e test to Go

### DIFF
--- a/test/e2e/driver.go
+++ b/test/e2e/driver.go
@@ -88,6 +88,8 @@ func RunE2ETests(authConfig, certDir, host, repoRoot, provider string, orderseed
 		{TestPodHasServiceEnvVars, "TestPodHasServiceEnvVars"},
 		{TestBasic, "TestBasic"},
 		{TestPrivate, "TestPrivate"},
+		{TestLivenessHttp, "TestLivenessHttp"},
+		{TestLivenessExec, "TestLivenessExec"},
 	}
 
 	// Check testList for non-existent tests and populate a StringSet with tests to run.

--- a/test/e2e/liveness.go
+++ b/test/e2e/liveness.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Tests for liveness probes, both with http and with docker exec.
+// These tests use the descriptions in examples/liveness to create test pods.
+
+package e2e
+
+import (
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/golang/glog"
+)
+
+func runLivenessTest(c *client.Client, yamlFileName string) bool {
+	// Read the pod description from the YAML file.
+	podDescr := loadPodOrDie(assetPath("examples", "liveness", yamlFileName))
+	// Randomize the pod name to prevent the test to fail due to problems in clean up from
+	// previous tests or parallel executions of this same test.
+	podName := podDescr.Name + "-" + string(util.NewUUID())
+	podDescr.Name = podName
+	// Create the pod.
+	glog.Infof("Creating pod %s", podName)
+	_, err := c.Pods(api.NamespaceDefault).Create(podDescr)
+	if err != nil {
+		glog.Infof("Failed to create pod %s: %v", podName, err)
+		return false
+	}
+	// At the end of the test, clean up by removing the pod.
+	defer c.Pods(api.NamespaceDefault).Delete(podName)
+	// Wait until the pod is not pending. (Here we need to check for something other than
+	// 'Pending' other than checking for 'Running', since when failures occur, we go to
+	// 'Terminated' which can cause indefinite blocking.)
+	if !waitForPodNotPending(c, podName) {
+		glog.Infof("Failed to start pod %s", podName)
+		return false
+	}
+	glog.Infof("Started pod %s", podName)
+
+	// Check the pod's current state and verify that restartCount is present.
+	pod, err := c.Pods(api.NamespaceDefault).Get(podName)
+	if err != nil {
+		glog.Errorf("Get pod %s failed: %v", podName, err)
+		return false
+	}
+	initialRestartCount := pod.Status.Info["liveness"].RestartCount
+	glog.Infof("Initial restart count of pod %s is %d", podName, initialRestartCount)
+
+	// Wait for at most 48 * 5 = 240s = 4 minutes until restartCount is incremented
+	for i := 0; i < 48; i++ {
+		// Wait until restartCount is incremented.
+		time.Sleep(5 * time.Second)
+		pod, err = c.Pods(api.NamespaceDefault).Get(podName)
+		if err != nil {
+			glog.Errorf("Get pod %s failed: %v", podName, err)
+			return false
+		}
+		restartCount := pod.Status.Info["liveness"].RestartCount
+		glog.Infof("Restart count of pod %s is now %d", podName, restartCount)
+		if restartCount > initialRestartCount {
+			glog.Infof("Restart count of pod %s increased from %d to %d during the test", podName, initialRestartCount, restartCount)
+			return true
+		}
+	}
+
+	glog.Errorf("Did not see the restart count of pod %s increase from %d during the test", podName, initialRestartCount)
+	return false
+}
+
+// TestLivenessHttp tests restarts with a /healthz http liveness probe.
+func TestLivenessHttp(c *client.Client) bool {
+	return runLivenessTest(c, "http-liveness.yaml")
+}
+
+// TestLivenessExec tests restarts with a docker exec "cat /tmp/health" liveness probe.
+func TestLivenessExec(c *client.Client) bool {
+	return runLivenessTest(c, "exec-liveness.yaml")
+}


### PR DESCRIPTION
This commit reimplements `hack/e2e-suite/liveness.sh` in Go as part of `cmd/e2e`, addressing #3696.

Full test output is here:

```
$ _output/local/bin/linux/amd64/e2e --host=https://w.x.y.z --provider=gce -t TestLivenessHttp -t TestLivenessExec
I0122 08:12:17.580023    6502 driver.go:113] Skipping test 1 TestKubernetesROService
I0122 08:12:17.580107    6502 driver.go:113] Skipping test 2 TestKubeletSendsEvent
I0122 08:12:17.580118    6502 driver.go:113] Skipping test 3 TestImportantURLs
I0122 08:12:17.580127    6502 driver.go:113] Skipping test 4 TestPodUpdate
I0122 08:12:17.580135    6502 driver.go:113] Skipping test 5 TestNetwork
I0122 08:12:17.580144    6502 driver.go:113] Skipping test 6 TestClusterDNS
I0122 08:12:17.580152    6502 driver.go:113] Skipping test 7 TestPodHasServiceEnvVars
I0122 08:12:17.580160    6502 driver.go:113] Skipping test 8 TestBasic
I0122 08:12:17.580169    6502 driver.go:113] Skipping test 9 TestPrivate
I0122 08:12:17.580195    6502 driver.go:134] Tests shuffled with orderseed 0xf645583b
I0122 08:12:17.580206    6502 driver.go:139] Running test 1 TestLivenessExec
I0122 08:12:17.581459    6502 liveness.go:36] Creating pod liveness-exec-6f917474-a251-11e4-8cc2-d4ae52bb3eea
I0122 08:12:22.811556    6502 liveness.go:49] Started pod liveness-exec-6f917474-a251-11e4-8cc2-d4ae52bb3eea
I0122 08:12:22.855581    6502 liveness.go:58] Initial restart count of pod liveness-exec-6f917474-a251-11e4-8cc2-d4ae52bb3eea is 0
I0122 08:12:27.899504    6502 liveness.go:70] Restart count of pod liveness-exec-6f917474-a251-11e4-8cc2-d4ae52bb3eea is now 0
I0122 08:12:32.951877    6502 liveness.go:70] Restart count of pod liveness-exec-6f917474-a251-11e4-8cc2-d4ae52bb3eea is now 0
I0122 08:12:38.045968    6502 liveness.go:70] Restart count of pod liveness-exec-6f917474-a251-11e4-8cc2-d4ae52bb3eea is now 0
I0122 08:12:43.090849    6502 liveness.go:70] Restart count of pod liveness-exec-6f917474-a251-11e4-8cc2-d4ae52bb3eea is now 0
I0122 08:12:48.136043    6502 liveness.go:70] Restart count of pod liveness-exec-6f917474-a251-11e4-8cc2-d4ae52bb3eea is now 0
I0122 08:12:53.183254    6502 liveness.go:70] Restart count of pod liveness-exec-6f917474-a251-11e4-8cc2-d4ae52bb3eea is now 1
I0122 08:12:53.183298    6502 liveness.go:72] Restart count of pod liveness-exec-6f917474-a251-11e4-8cc2-d4ae52bb3eea increased from 0 to 1 during the test
I0122 08:12:53.238692    6502 driver.go:145]         test 1 passed
I0122 08:12:53.238750    6502 driver.go:139] Running test 2 TestLivenessHttp
I0122 08:12:53.239768    6502 liveness.go:36] Creating pod liveness-http-84d28569-a251-11e4-8cc2-d4ae52bb3eea
I0122 08:12:58.338253    6502 liveness.go:49] Started pod liveness-http-84d28569-a251-11e4-8cc2-d4ae52bb3eea
I0122 08:12:58.382713    6502 liveness.go:58] Initial restart count of pod liveness-http-84d28569-a251-11e4-8cc2-d4ae52bb3eea is 0
I0122 08:13:03.426951    6502 liveness.go:70] Restart count of pod liveness-http-84d28569-a251-11e4-8cc2-d4ae52bb3eea is now 0
I0122 08:13:08.472785    6502 liveness.go:70] Restart count of pod liveness-http-84d28569-a251-11e4-8cc2-d4ae52bb3eea is now 0
I0122 08:13:13.517579    6502 liveness.go:70] Restart count of pod liveness-http-84d28569-a251-11e4-8cc2-d4ae52bb3eea is now 0
I0122 08:13:18.561653    6502 liveness.go:70] Restart count of pod liveness-http-84d28569-a251-11e4-8cc2-d4ae52bb3eea is now 0
I0122 08:13:23.605442    6502 liveness.go:70] Restart count of pod liveness-http-84d28569-a251-11e4-8cc2-d4ae52bb3eea is now 1
I0122 08:13:23.605471    6502 liveness.go:72] Restart count of pod liveness-http-84d28569-a251-11e4-8cc2-d4ae52bb3eea increased from 0 to 1 during the test
I0122 08:13:23.659282    6502 driver.go:145]         test 2 passed
I0122 08:13:23.659316    6502 driver.go:43] 1..2
I0122 08:13:23.659325    6502 driver.go:46] ok 1 - TestLivenessExec
I0122 08:13:23.659335    6502 driver.go:46] ok 2 - TestLivenessHttp
I0122 08:13:23.659344    6502 driver.go:155] All tests pass
```

I'm currently running the full e2e to confirm it works together with the others.

@satnam6502 @zmerlynn @rrati 
