### PR TITLE
Use docker.service not docker.socket in unit files

### DIFF
--- a/contrib/init/systemd/kubelet.service
+++ b/contrib/init/systemd/kubelet.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Kubernetes Kubelet Server
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-After=docker.socket cadvisor.service
-Requires=docker.socket
+After=docker.service cadvisor.service
+Requires=docker.service
 
 [Service]
 EnvironmentFile=-/etc/kubernetes/config


### PR DESCRIPTION
Some distros, include RHEL and Fedora, are doing away with the docker
socket by default in systemd units, for security reasons.  Instead rely
on the docker.service being started instead of socket activation.
