### PR TITLE
Default to 0.0.0.0 for PublicAddress instead of first nic,which might be...

### DIFF
--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -54,7 +54,7 @@ var (
 	publicAddressOverride = flag.String("public_address_override", "", ""+
 		"Public serving address. Read only port will be opened on this address, "+
 		"and it is assumed that port 443 at this address will be proxied/redirected "+
-		"to '-address':'-port'. If blank, the address in the first listed interface "+
+		"to '-address':'-port'. If blank, Default value 0.0.0.0 "+
 		"will be used.")
 	readOnlyPort = flag.Int("read_only_port", 7080, ""+
 		"The port from which to serve read-only resources. If 0, don't serve on a "+

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -173,8 +173,8 @@ func setDefaults(c *Config) {
 		c.ReadWritePort = 443
 	}
 	for c.PublicAddress == "" {
-                defaultPublicAddress := "0.0.0.0"
-                glog.Infof("Public Address unspecified. Defaulting to %v.", defaultPublicAddress)
+		defaultPublicAddress := "0.0.0.0"
+		glog.Infof("Public Address unspecified. Defaulting to %v.", defaultPublicAddress)
 		c.PublicAddress = defaultPublicAddress
 	}
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -95,7 +95,7 @@ type Config struct {
 	// Defaults to 443 if not set.
 	ReadWritePort int
 
-	// If empty, the first result from net.InterfaceAddrs will be used.
+	// If empty, Defaults to 0.0.0.0.
 	PublicAddress string
 }
 

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -173,34 +173,9 @@ func setDefaults(c *Config) {
 		c.ReadWritePort = 443
 	}
 	for c.PublicAddress == "" {
-		// Find and use the first non-loopback address.
-		// TODO: potentially it'd be useful to skip the docker interface if it
-		// somehow is first in the list.
-		addrs, err := net.InterfaceAddrs()
-		if err != nil {
-			glog.Fatalf("Unable to get network interfaces: error='%v'", err)
-		}
-		found := false
-		for i := range addrs {
-			ip, _, err := net.ParseCIDR(addrs[i].String())
-			if err != nil {
-				glog.Errorf("Error parsing '%v': %v", addrs[i], err)
-				continue
-			}
-			if ip.IsLoopback() {
-				glog.Infof("'%v' (%v) is a loopback address, ignoring.", ip, addrs[i])
-				continue
-			}
-			found = true
-			c.PublicAddress = ip.String()
-			glog.Infof("Will report %v as public IP address.", ip)
-			break
-		}
-		if !found {
-			glog.Errorf("Unable to find suitable network address in list: '%v'\n"+
-				"Will try again in 5 seconds. Set the public address directly to avoid this wait.", addrs)
-			time.Sleep(5 * time.Second)
-		}
+                defaultPublicAddress := "0.0.0.0"
+                glog.Infof("Public Address unspecified. Defaulting to %v.", defaultPublicAddress)
+		c.PublicAddress = defaultPublicAddress
 	}
 }
 


### PR DESCRIPTION
Currently if PublicAddress is not given it picks the first nic's IP(it ignores loopback) This can be a  issue if the first nic belongs to docker/virtualbox/vmm etc.
This might work on some cloud environment where the first nic is the public IP of the node and the second nic might be the management IP but this is not universally applicable.
So , defaulting to 0.0.0.0 if no PublicAddress is given.
