### PR TITLE
Remove use of KUBERNETES_PROVIDER env var from Go end to end tests

### DIFF
--- a/test/e2e/cluster_dns.go
+++ b/test/e2e/cluster_dns.go
@@ -18,7 +18,6 @@ package e2e
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -32,7 +31,7 @@ func TestClusterDNS(c *client.Client) bool {
 	// https://github.com/GoogleCloudPlatform/kubernetes/issues/3305
 	// (but even if it's fixed, this will need a version check for
 	// skewed version tests)
-	if os.Getenv("KUBERNETES_PROVIDER") == "gke" {
+	if testContext.provider == "gke" {
 		glog.Infof("skipping TestClusterDNS on gke")
 		return true
 	}

--- a/test/e2e/kubelet_sends_events.go
+++ b/test/e2e/kubelet_sends_events.go
@@ -17,7 +17,6 @@ limitations under the License.
 package e2e
 
 import (
-	"os"
 	"strconv"
 	"time"
 
@@ -29,13 +28,10 @@ import (
 
 // TestKubeletSendsEvent checks that kubelets and scheduler send events about pods scheduling and running.
 func TestKubeletSendsEvent(c *client.Client) bool {
-	provider := os.Getenv("KUBERNETES_PROVIDER")
+	provider := testContext.provider
 	if len(provider) > 0 && provider != "gce" && provider != "gke" {
 		glog.Infof("skipping TestKubeletSendsEvent on cloud provider %s", provider)
 		return true
-	}
-	if provider == "" {
-		glog.Info("KUBERNETES_PROVIDER is unset; assuming \"gce\"")
 	}
 
 	podClient := c.Pods(api.NamespaceDefault)


### PR DESCRIPTION
This PR removes the use of the `KUBERNETES_PROVIDER` env var from the Go end-to-end tests. This makes it easier to run the test since this env var does not need to be defined (the provider must be specified with the --provider flag). @filbranden @zmerlynn @roberthbailey 
