### PR TITLE
Generate pod.Name when pod.Name == "" for both HTTP and file sources.

### DIFF
--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -168,6 +168,12 @@ func extractFromFile(filename string) (api.BoundPod, error) {
 		pod.UID = types.UID(hex.EncodeToString(hasher.Sum(nil)[0:]))
 		glog.V(5).Infof("Generated UID %q for pod %q from file %s", pod.UID, pod.Name, filename)
 	}
+	// This is required for backward compatibility, and should be removed once we
+	// completely deprecate ContainerManifest.
+	if len(pod.Name) == 0 {
+		pod.Name = string(pod.UID)
+		glog.V(5).Infof("Generated Name %q for UID %q from file %s", pod.Name, pod.UID, filename)
+	}
 	if len(pod.Namespace) == 0 {
 		hasher := adler32.New()
 		fmt.Fprint(hasher, filename)

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -151,6 +151,12 @@ func applyDefaults(pod *api.BoundPod, url string) {
 		pod.UID = types.UID(hex.EncodeToString(hasher.Sum(nil)[0:]))
 		glog.V(5).Infof("Generated UID %q for pod %q from URL %s", pod.UID, pod.Name, url)
 	}
+	// This is required for backward compatibility, and should be removed once we
+	// completely deprecate ContainerManifest.
+	if len(pod.Name) == 0 {
+		pod.Name = string(pod.UID)
+		glog.V(5).Infof("Generate Name %q from UID %q from URL %s", pod.Name, pod.UID, url)
+	}
 	if len(pod.Namespace) == 0 {
 		hasher := adler32.New()
 		fmt.Fprint(hasher, url)

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -139,6 +139,23 @@ func TestExtractFromHTTP(t *testing.T) {
 				}),
 		},
 		{
+			desc:      "Single manifest without ID",
+			manifests: api.ContainerManifest{Version: "v1beta1", UUID: "111"},
+			expected: CreatePodUpdate(kubelet.SET,
+				kubelet.HTTPSource,
+				api.BoundPod{
+					ObjectMeta: api.ObjectMeta{
+						UID:       "111",
+						Name:      "111",
+						Namespace: "foobar",
+					},
+					Spec: api.PodSpec{
+						RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+						DNSPolicy:     api.DNSClusterFirst,
+					},
+				}),
+		},
+		{
 			desc: "Multiple manifests",
 			manifests: []api.ContainerManifest{
 				{Version: "v1beta1", ID: "foo", UUID: "111", Containers: []api.Container{{Name: "1", Image: "foo"}}},


### PR DESCRIPTION
Fix #3584 

cc @filbranden @thockin 
