### PR TITLE
Generate pod.Name when pod.Name == "" for both HTTP and file sources.

### DIFF
--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -156,6 +156,12 @@ func extractFromFile(filename string) (api.BoundPod, error) {
 	if len(pod.UID) == 0 {
 		pod.UID = simpleSubdomainSafeHash(filename)
 	}
+	// This is required for backward compatibility, and should be removed once we
+	// completely deprecate ContainerManifest.
+	if len(pod.Name) == 0 {
+		pod.Name = string(pod.UID)
+		glog.V(5).Infof("Generated Name %q for UID %q from file %s", pod.Name, pod.UID, filename)
+	}
 	if len(pod.Namespace) == 0 {
 		pod.Namespace = api.NamespaceDefault
 	}

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -91,6 +91,11 @@ func (s *sourceURL) extractFromURL() error {
 		if err := api.Scheme.Convert(&manifest, &pod); err != nil {
 			return err
 		}
+		// This is required for backward compatibility, and should be removed once we
+		// completely deprecate ContainerManifest.
+		if len(pod.Name) == 0 {
+			pod.Name = "1"
+		}
 		if len(pod.Namespace) == 0 {
 			pod.Namespace = api.NamespaceDefault
 		}

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -137,6 +137,23 @@ func TestExtractFromHTTP(t *testing.T) {
 				}),
 		},
 		{
+			desc:      "Single manifest without ID",
+			manifests: api.ContainerManifest{Version: "v1beta1", UUID: "111"},
+			expected: CreatePodUpdate(kubelet.SET,
+				kubelet.HTTPSource,
+				api.BoundPod{
+					ObjectMeta: api.ObjectMeta{
+						UID:       "111",
+						Name:      "1",
+						Namespace: "default",
+					},
+					Spec: api.PodSpec{
+						RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+						DNSPolicy:     api.DNSClusterFirst,
+					},
+				}),
+		},
+		{
 			desc: "Multiple manifests",
 			manifests: []api.ContainerManifest{
 				{Version: "v1beta1", ID: "", Containers: []api.Container{{Name: "1", Image: "foo"}}},


### PR DESCRIPTION
Fix #3584 

cc/ @thockin 

I patched release-0.8 branch with PR #3725 with some modification in both http.go and http_test.go. 
