### PR TITLE
Update monitoring components to the latest released versions.

### DIFF
--- a/cluster/addons/cluster-monitoring/grafana-service.yaml
+++ b/cluster/addons/cluster-monitoring/grafana-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v1beta1"
 kind: "Service"
 id: "monitoring-grafana"
-port: 8087
+port: 80
 containerPort: 80
 selector: 
   name: "influxGrafana"

--- a/cluster/addons/cluster-monitoring/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/heapster-controller.yaml
@@ -12,7 +12,11 @@ desiredState:
         id: "monitoring-heapsterController"
         containers:
           - name: "heapster"
-            image: "kubernetes/heapster:v0.5"
+            image: "kubernetes/heapster:v0.6"
+            env: 
+              - name: "INFLUXDB_HOST"
+                value: "monitoring-influxdb"
+
     labels: 
       name: "heapster"
       uses: "monitoring-influxdb"

--- a/cluster/addons/cluster-monitoring/heapster-service.yaml
+++ b/cluster/addons/cluster-monitoring/heapster-service.yaml
@@ -1,0 +1,7 @@
+apiVersion: "v1beta1"
+kind: "Service"
+id: "monitoring-heapster"
+port: 80
+containerPort: 8082
+selector: 
+  name: "heapster"

--- a/cluster/addons/cluster-monitoring/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb-grafana-controller.yaml
@@ -14,14 +14,14 @@ desiredState:
         id: "monitoring-influxGrafanaController"
         containers: 
           - name: "influxdb"
-            image: "kubernetes/heapster_influxdb:v0.2"
+            image: "kubernetes/heapster_influxdb:v0.3"
             ports: 
               - containerPort: 8083
                 hostPort: 8083
               - containerPort: 8086
                 hostPort: 8086
           - name: "grafana"
-            image: "kubernetes/heapster_grafana:v0.2"
+            image: "kubernetes/heapster_grafana:v0.3"
             ports: 
               - containerPort: 80
                 hostPort: 80

--- a/cluster/addons/cluster-monitoring/influxdb-service.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v1beta1"
 kind: "Service"
 id: "monitoring-influxdb"
-port: 8085
+port: 80
 containerPort: 8086
 selector: 
   name: "influxGrafana"

--- a/hack/e2e-suite/monitoring.sh
+++ b/hack/e2e-suite/monitoring.sh
@@ -51,6 +51,10 @@ function setup {
 function cleanup {
   "${KUBECFG}" resize monitoring-influxGrafanaController 0 &> /dev/null || true
   "${KUBECFG}" resize monitoring-heapsterController 0 &> /dev/null || true
+  while kubectl.sh get pods -l "name=influxGrafana" -o template -t {{range.items}}{{.id}}:{{end}} | grep -c . &> /dev/null \
+    || kubectl.sh get pods -l "name=heapster" -o template -t {{range.items}}{{.id}}:{{end}} | grep -c . &> /dev/null; do
+    sleep 2
+  done
   "${KUBECTL}" delete -f "${MONITORING}/" &> /dev/null || true
 
   # This only has work to do on gce and gke
@@ -103,6 +107,9 @@ function wait-for-pods {
 }
 
 trap cleanup EXIT
+
+# Remove any pre-existing monitoring services.
+cleanup 
 
 # Start monitoring pods and services.
 setup


### PR DESCRIPTION
Heapster runs using DNS. This is required for reliable deployment of heapster. 
