### PR TITLE
Allow cluster DNS e2e test to be run in parallel

### DIFF
--- a/test/e2e/driver.go
+++ b/test/e2e/driver.go
@@ -69,7 +69,11 @@ func RunE2ETests(authConfig, certDir, host, repoRoot, provider string, orderseed
 	// TODO: Associate a timeout with each test individually.
 	go func() {
 		defer util.FlushLogs()
-		time.Sleep(10 * time.Minute)
+		// TODO: We should modify testSpec to include an estimated running time
+		//       for each test and use that information to estimate a timeout
+		//       value. Until then, as we add more tests (and before we move to
+		//       parallel testing) we need to adjust this value as we add more tests.
+		time.Sleep(15 * time.Minute)
 		glog.Fatalf("This test has timed out. Cleanup not guaranteed.")
 	}()
 


### PR DESCRIPTION
As part of the push to get to a point where we can run the e2e tests back to back reliably and in parallel this changes the cluster DNS test to generate a pod with a unique name. It also increases the timeout for the Go e2e tests to accommodate more tests that have been recently added. @thockin @filbranden 
