### PR TITLE
Reinstate ROService test now that rate limit issue has been addressed

### DIFF
--- a/test/e2e/driver.go
+++ b/test/e2e/driver.go
@@ -74,10 +74,7 @@ func RunE2ETests(authConfig, certDir, host, repoRoot, provider string, orderseed
 	}()
 
 	tests := []testSpec{
-		/*  Disable TestKubernetesROService due to rate limiter issues.
-		    TODO: Add this test back when rate limiting is working properly.
-				{TestKubernetesROService, "TestKubernetesROService"},
-		*/
+		{TestKubernetesROService, "TestKubernetesROService"},
 		{TestKubeletSendsEvent, "TestKubeletSendsEvent"},
 		{TestImportantURLs, "TestImportantURLs"},
 		{TestPodUpdate, "TestPodUpdate"},


### PR DESCRIPTION
This was disabled because of rate limit issues which have now been addressed. The test itself just makes one API call. @filbranden 
