### PR TITLE
Keep boolean status of imported flags

### DIFF
--- a/pkg/util/pflag_import.go
+++ b/pkg/util/pflag_import.go
@@ -65,6 +65,18 @@ func (v *flagValueWrapper) Type() string {
 	return v.flagType
 }
 
+type boolFlag interface {
+	flag.Value
+	IsBoolFlag() bool
+}
+
+func (v *flagValueWrapper) IsBoolFlag() bool {
+	if bv, ok := v.inner.(boolFlag); ok {
+		return bv.IsBoolFlag()
+	}
+	return false
+}
+
 // Imports a 'flag.Flag' into a 'pflag.FlagSet'.  The "short" option is unset
 // and the type is inferred using reflection.
 func AddFlagToPFlagSet(f *flag.Flag, fs *pflag.FlagSet) {


### PR DESCRIPTION
This addresses @thockin's comment in https://github.com/GoogleCloudPlatform/kubernetes/pull/3740#issuecomment-71121632

The issue was introduced in #3480 which migrated from Go's flag module to pflag for flag parsing.

This patch handles the flags imported from native flag into pflag. It makes glog flags such as `--logtostderr` and `--alsologtostderr` keep working without requiring an explicit `=true`.

Tested by building kubelet and invoking it with `--logtostderr`. Also tested a few non-boolean flags to ensure they weren't affected.

Lightly tested... I'd appreciate it if you could take another look to make sure this won't break anything else...

@thockin @jbeda 
