### PR TITLE
Allow network end-to-end test to be run in parallel

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -18,7 +18,9 @@ package e2e
 
 import (
 	"io/ioutil"
+	"math/rand"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -182,4 +184,13 @@ func parseServiceOrDie(json string) *api.Service {
 		glog.Fatalf("Failed to cast service: %v", obj)
 	}
 	return service
+}
+
+// TODO: Allow service names to have the same form as names
+//       for pods and replication controllers so we don't
+//       need to use such a function and can instead
+//       use the UUID utilty function.
+func randomSuffix() string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return strconv.Itoa(r.Int() % 10000)
 }


### PR DESCRIPTION
Generate resources with unique names for the end to end test `TestNetwork`.
Services can't have long names so I've generated a random number to use as a suffix.
@thockin has ideas about making service names conform to the same form as used for pod names and replication controllers.
@filbranden @zmerlynn 
