### PR TITLE
remove --ns-path option from .kubeconfig file

### DIFF
--- a/contrib/completions/bash/kubectl
+++ b/contrib/completions/bash/kubectl
@@ -72,9 +72,7 @@ __kubectl_pre_command()
             --client-key=
             --insecure-skip-tls-verify=
             --match-server-version=
-            -n
             --namespace=
-            --ns-path=
             -s
             --server=
     )
@@ -85,7 +83,7 @@ __kubectl_pre_command()
             COMPREPLY=( $(compgen -W "${api_versions[*]}" -- "$cur") )
             return 0
             ;;
-        -a | --auth-path | --certificate-authority | --client-certificate | --client-key | --ns-path)
+        -a | --auth-path | --certificate-authority | --client-certificate | --client-key)
             _filedir
             return 0
             ;;

--- a/docs/kubectl.md
+++ b/docs/kubectl.md
@@ -30,7 +30,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
       --token="": Bearer token for authentication to the API server.
@@ -66,7 +65,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -p, --port=8001: The port on which to run the proxy
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
@@ -124,7 +122,6 @@ Usage:
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
       --no-headers=false: When using the default output, don't print headers
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -o, --output="": Output format: json|yaml|template|templatefile
       --output-version="": Output the formatted object with the given version (default api-version)
   -l, --selector="": Selector (label query) to filter on
@@ -168,7 +165,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
       --token="": Bearer token for authentication to the API server.
@@ -214,7 +210,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
       --token="": Bearer token for authentication to the API server.
@@ -263,7 +258,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
       --patch="": A JSON document to override the existing resource.  The resource is downloaded, then patched with the JSON, the updated
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
@@ -323,7 +317,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -l, --selector="": Selector (label query) to filter on
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
@@ -371,7 +364,6 @@ Available Commands:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
       --token="": Bearer token for authentication to the API server.
@@ -389,7 +381,7 @@ Additional help topics:
   kubectl update        Update a resource by filename or stdin
   kubectl delete        Delete a resource by filename, stdin or resource and id
   kubectl config        config modifies .kubeconfig files
-  kubectl namespace     Set and view the current Kubernetes namespace
+  kubectl namespace     SUPERCEDED: Set and view the current Kubernetes namespace
   kubectl log           Print the logs for a container in a pod.
   kubectl rollingupdate Perform a rolling update of the given ReplicationController
   kubectl resize        Set a new size for a resizable resource (currently only Replication Controllers)
@@ -428,7 +420,6 @@ Usage:
       --match-server-version=false: Require server version to match client version
       --merge=false: merge together the full hierarchy of .kubeconfig files
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
       --token="": Bearer token for authentication to the API server.
@@ -471,7 +462,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
       --server=: server for the cluster entry in .kubeconfig
       --stderrthreshold=2: logs at or above this threshold go to stderr
       --token="": Bearer token for authentication to the API server.
@@ -514,7 +504,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
       --token=: token for the user entry in .kubeconfig
@@ -557,7 +546,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace=: namespace for the context entry in .kubeconfig
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
       --token="": Bearer token for authentication to the API server.
@@ -600,7 +588,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
       --token="": Bearer token for authentication to the API server.
@@ -641,7 +628,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
       --token="": Bearer token for authentication to the API server.
@@ -679,7 +665,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
       --token="": Bearer token for authentication to the API server.
@@ -691,16 +676,10 @@ Usage:
 ```
 
 #### namespace
-Set and view the current Kubernetes namespace scope for command line requests.
+SUPERCEDED:  Set and view the current Kubernetes namespace scope for command line requests.
 
-A Kubernetes namespace subdivides the cluster into groups of logically related pods, services, and replication controllers.
+namespace has been superceded by the context.namespace field of .kubeconfig files.  See 'kubectl config set-context --help' for more details.
 
-Examples:
-  $ kubectl namespace 
-  Using namespace default
-
-  $ kubectl namespace other
-  Set current namespace to other
 
 Usage:
 ```
@@ -723,7 +702,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
       --token="": Bearer token for authentication to the API server.
@@ -766,7 +744,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
       --token="": Bearer token for authentication to the API server.
@@ -814,7 +791,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
       --poll-interval="3s": Time delay between polling controller status after update. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
@@ -868,7 +844,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
       --replicas=-1: The new number desired number of replicas.  Required.
       --resource-version="": Precondition for resource version. Requires that the current resource version match this value in order to resize
   -s, --server="": The address of the Kubernetes API server
@@ -925,7 +900,6 @@ Usage:
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
       --no-headers=false: When using the default output, don't print headers
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -o, --output="": Output format: json|yaml|template|templatefile
       --output-version="": Output the formatted object with the given version (default api-version)
       --overrides="": An inline JSON override for the generated object.  If this is non-empty, it is parsed used to override the generated object.  Requires that the object supply a valid apiVersion field.
@@ -974,7 +948,6 @@ Usage:
       --logtostderr=true: log to standard error instead of files
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -s, --server="": The address of the Kubernetes API server
       --stderrthreshold=2: logs at or above this threshold go to stderr
       --token="": Bearer token for authentication to the API server.
@@ -1026,7 +999,6 @@ Usage:
       --match-server-version=false: Require server version to match client version
       --namespace="": If present, the namespace scope for this CLI request.
       --no-headers=false: When using the default output, don't print headers
-      --ns-path="": Path to the namespace info file that holds the namespace context to use for CLI requests.
   -o, --output="": Output format: json|yaml|template|templatefile
       --output-version="": Output the formatted object with the given version (default api-version)
       --overrides="": An inline JSON override for the generated object.  If this is non-empty, it is parsed used to override the generated object.  Requires that the object supply a valid apiVersion field.

--- a/pkg/client/clientcmd/api/types.go
+++ b/pkg/client/clientcmd/api/types.go
@@ -83,8 +83,6 @@ type Context struct {
 	AuthInfo string `json:"user"`
 	// Namespace is the default namespace to use on unspecified requests
 	Namespace string `json:"namespace,omitempty"`
-	// NamespacePath is the path to a kubernetes ns file (~/.kubernetes_ns)
-	NamespacePath string `json:"namespace-path,omitempty"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
 	Extensions map[string]runtime.EmbeddedObject `json:"extensions,omitempty"`
 }

--- a/pkg/client/clientcmd/api/v1/types.go
+++ b/pkg/client/clientcmd/api/v1/types.go
@@ -83,8 +83,6 @@ type Context struct {
 	AuthInfo string `json:"user"`
 	// Namespace is the default namespace to use on unspecified requests
 	Namespace string `json:"namespace,omitempty"`
-	// NamespacePath is the path to a kubernetes ns file (~/.kubernetes_ns)
-	NamespacePath string `json:"namespace-path,omitempty"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
 	Extensions []NamedExtension `json:"extensions,omitempty"`
 }

--- a/pkg/client/clientcmd/client_config.go
+++ b/pkg/client/clientcmd/client_config.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/imdario/mergo"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/clientauth"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
 )
 
@@ -241,25 +241,10 @@ func (config DirectClientConfig) Namespace() (string, error) {
 
 	configContext := config.getContext()
 
-	if len(configContext.Namespace) != 0 {
-		return configContext.Namespace, nil
+	if len(configContext.Namespace) == 0 {
+		return api.NamespaceDefault, nil
 	}
-
-	if len(configContext.NamespacePath) != 0 {
-		nsInfo, err := kubectl.LoadNamespaceInfo(configContext.NamespacePath)
-		if err != nil {
-			return "", err
-		}
-
-		return nsInfo.Namespace, nil
-	}
-
-	// if nothing was specified, try the default file
-	nsInfo, err := kubectl.LoadNamespaceInfo(os.Getenv("HOME") + "/.kubernetes_ns")
-	if err != nil {
-		return "", err
-	}
-	return nsInfo.Namespace, nil
+	return configContext.Namespace, nil
 }
 
 // ConfirmUsable looks a particular context and determines if that particular part of the config is useable.  There might still be errors in the config,

--- a/pkg/client/clientcmd/overrides.go
+++ b/pkg/client/clientcmd/overrides.go
@@ -56,7 +56,6 @@ type ContextOverrideFlags struct {
 	Namespace    string
 	// allow the potential for shorter namespace flags for commands that tend to work across namespaces
 	NamespaceShort string
-	NamespacePath  string
 }
 
 // ClusterOverride holds the flag names to be used for binding command line flags for Cluster objects
@@ -69,19 +68,18 @@ type ClusterOverrideFlags struct {
 }
 
 const (
-	FlagClusterName   = "cluster"
-	FlagAuthInfoName  = "user"
-	FlagContext       = "context"
-	FlagNamespace     = "namespace"
-	FlagNamespacePath = "ns-path"
-	FlagAPIServer     = "server"
-	FlagAPIVersion    = "api-version"
-	FlagAuthPath      = "auth-path"
-	FlagInsecure      = "insecure-skip-tls-verify"
-	FlagCertFile      = "client-certificate"
-	FlagKeyFile       = "client-key"
-	FlagCAFile        = "certificate-authority"
-	FlagBearerToken   = "token"
+	FlagClusterName  = "cluster"
+	FlagAuthInfoName = "user"
+	FlagContext      = "context"
+	FlagNamespace    = "namespace"
+	FlagAPIServer    = "server"
+	FlagAPIVersion   = "api-version"
+	FlagAuthPath     = "auth-path"
+	FlagInsecure     = "insecure-skip-tls-verify"
+	FlagCertFile     = "client-certificate"
+	FlagKeyFile      = "client-key"
+	FlagCAFile       = "certificate-authority"
+	FlagBearerToken  = "token"
 )
 
 // RecommendedAuthOverrideFlags is a convenience method to return recommended flag names prefixed with a string of your choosing
@@ -117,10 +115,9 @@ func RecommendedConfigOverrideFlags(prefix string) ConfigOverrideFlags {
 // RecommendedContextOverrideFlags is a convenience method to return recommended flag names prefixed with a string of your choosing
 func RecommendedContextOverrideFlags(prefix string) ContextOverrideFlags {
 	return ContextOverrideFlags{
-		ClusterName:   prefix + FlagClusterName,
-		AuthInfoName:  prefix + FlagAuthInfoName,
-		Namespace:     prefix + FlagNamespace,
-		NamespacePath: prefix + FlagNamespacePath,
+		ClusterName:  prefix + FlagClusterName,
+		AuthInfoName: prefix + FlagAuthInfoName,
+		Namespace:    prefix + FlagNamespace,
 	}
 }
 
@@ -153,5 +150,4 @@ func BindContextFlags(contextInfo *clientcmdapi.Context, flags *pflag.FlagSet, f
 	flags.StringVar(&contextInfo.Cluster, flagNames.ClusterName, "", "The name of the kubeconfig cluster to use")
 	flags.StringVar(&contextInfo.AuthInfo, flagNames.AuthInfoName, "", "The name of the kubeconfig user to use")
 	flags.StringVarP(&contextInfo.Namespace, flagNames.Namespace, flagNames.NamespaceShort, "", "If present, the namespace scope for this CLI request.")
-	flags.StringVar(&contextInfo.NamespacePath, flagNames.NamespacePath, "", "Path to the namespace info file that holds the namespace context to use for CLI requests.")
 }

--- a/pkg/kubectl/cmd/namespace.go
+++ b/pkg/kubectl/cmd/namespace.go
@@ -18,43 +18,24 @@ package cmd
 
 import (
 	"io"
+	"os"
 
-	"fmt"
-
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 )
 
+// TODO remove once people have been given enough time to notice
 func NewCmdNamespace(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "namespace [<namespace>]",
-		Short: "Set and view the current Kubernetes namespace",
-		Long: `Set and view the current Kubernetes namespace scope for command line requests.
+		Short: "SUPERCEDED: Set and view the current Kubernetes namespace",
+		Long: `SUPERCEDED:  Set and view the current Kubernetes namespace scope for command line requests.
 
-A Kubernetes namespace subdivides the cluster into groups of logically related pods, services, and replication controllers.
-
-Examples:
-  $ kubectl namespace 
-  Using namespace default
-
-  $ kubectl namespace other
-  Set current namespace to other`,
+namespace has been superceded by the context.namespace field of .kubeconfig files.  See 'kubectl config set-context --help' for more details.
+`,
 		Run: func(cmd *cobra.Command, args []string) {
-			nsPath := GetFlagString(cmd, "ns-path")
-			var err error
-			var ns *kubectl.NamespaceInfo
-			switch len(args) {
-			case 0:
-				ns, err = kubectl.LoadNamespaceInfo(nsPath)
-				fmt.Printf("Using namespace %s\n", ns.Namespace)
-			case 1:
-				ns = &kubectl.NamespaceInfo{Namespace: args[0]}
-				err = kubectl.SaveNamespaceInfo(nsPath, ns)
-				fmt.Printf("Set current namespace to %s\n", ns.Namespace)
-			default:
-				usageError(cmd, "kubectl namespace [<namespace>]")
-			}
-			checkErr(err)
+			glog.Errorln("namespace has been superceded by the context.namespace field of .kubeconfig files.  See 'kubectl config set-context --help' for more details.")
+			os.Exit(1)
 		},
 	}
 	return cmd


### PR DESCRIPTION
This removes the --ns-path option from the .kubeconfig file and from the command line options.  Since kubectl would no longer make use of the file, I also remove the namspace command.

This is a breaking change.  Scripts that used --ns-path will stop working, ~/.kubernetes_ns will no longer provide a default. \

Fulfills comments in https://github.com/GoogleCloudPlatform/kubernetes/pull/3470#discussion_r23255043.

@derekwaynecarr I did not remove --ns_file from kubecfg.  Does that satisfy your concern expressed here: https://github.com/GoogleCloudPlatform/kubernetes/pull/3470#discussion_r23278884?  kubecfg and kubectl already make use of separate config files, so this doesn't seem too severe.
