### PR TITLE
Revert "Add a Retry-After header when rate limit is exceeded"

### DIFF
--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -72,7 +72,6 @@ func RateLimit(rl util.RateLimiter, handler http.Handler) http.Handler {
 			return
 		}
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Header().Set("Retry-After", "1")
 		fmt.Fprintf(w, "Rate limit exceeded.")
 	})
 }

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -35,7 +35,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	watchjson "github.com/GoogleCloudPlatform/kubernetes/pkg/watch/json"
-	"github.com/golang/glog"
 )
 
 // specialParams lists parameters that are handled specially and which users of Request
@@ -458,10 +457,6 @@ func (r *Request) Do() Result {
 		client = http.DefaultClient
 	}
 
-	// Right now we make about ten retry attempts if we get a Retry-After response.
-	// TODO: Change to a timeout based approach.
-	retries := 0
-
 	for {
 		if r.err != nil {
 			return Result{err: &RequestConstructionError{r.err}}
@@ -483,19 +478,6 @@ func (r *Request) Do() Result {
 			continue
 		}
 
-		if resp.StatusCode == http.StatusServiceUnavailable {
-			if retries < 10 {
-				retries++
-				if waitFor := resp.Header.Get("Retry-After"); waitFor != "" {
-					delay, err := strconv.Atoi(waitFor)
-					if err == nil {
-						glog.V(4).Infof("Got a Retry-After %s response for attempt %d to %v", waitFor, retries, r.finalURL())
-						time.Sleep(time.Duration(delay) * time.Second)
-						continue
-					}
-				}
-			}
-		}
 		return Result{respBody, created, err, r.codec}
 	}
 }


### PR DESCRIPTION
Reverts GoogleCloudPlatform/kubernetes#3704

Satnam forgot about the service JSON and the replication controller JSON, he is planning to re-write them using Go literals.
