### PR TITLE
Revert "Allow network end-to-end test to be run in parallel"

### DIFF
--- a/test/e2e/network.go
+++ b/test/e2e/network.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
 )
 
@@ -32,12 +31,9 @@ func TestNetwork(c *client.Client) bool {
 	}
 
 	ns := api.NamespaceDefault
-	s := loadObjectOrDie(assetPath("contrib", "for-tests", "network-tester", "service.json")).(*api.Service)
-	// TODO(satnam6502): Replace call of randomSuffix with call to NewUUID when service
-	//                   names have the same form as pod and replication controller names.
-	s.Name += "-" + randomSuffix()
-	glog.Infof("Creating service with name %s", s.Name)
-	svc, err := c.Services(ns).Create(s)
+	svc, err := c.Services(ns).Create(loadObjectOrDie(assetPath(
+		"contrib", "for-tests", "network-tester", "service.json",
+	)).(*api.Service))
 	if err != nil {
 		glog.Errorf("unable to create test service: %v", err)
 		return false
@@ -49,9 +45,9 @@ func TestNetwork(c *client.Client) bool {
 		}
 	}()
 
-	r := loadObjectOrDie(assetPath("contrib", "for-tests", "network-tester", "rc.json")).(*api.ReplicationController)
-	r.Name += "-" + string(util.NewUUID())
-	rc, err := c.ReplicationControllers(ns).Create(r)
+	rc, err := c.ReplicationControllers(ns).Create(loadObjectOrDie(assetPath(
+		"contrib", "for-tests", "network-tester", "rc.json",
+	)).(*api.ReplicationController))
 	if err != nil {
 		glog.Errorf("unable to create test rc: %v", err)
 		return false
@@ -70,7 +66,7 @@ func TestNetwork(c *client.Client) bool {
 	}()
 	const maxAttempts = 60
 	for i := 0; i < maxAttempts; i++ {
-		time.Sleep(2 * time.Second)
+		time.Sleep(time.Second)
 		body, err := c.Get().Prefix("proxy").Resource("services").Name(svc.Name).Suffix("status").Do().Raw()
 		if err != nil {
 			glog.Infof("Attempt %v/%v: service/pod still starting. (error: '%v')", i, maxAttempts, err)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -18,9 +18,7 @@ package e2e
 
 import (
 	"io/ioutil"
-	"math/rand"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -184,13 +182,4 @@ func parseServiceOrDie(json string) *api.Service {
 		glog.Fatalf("Failed to cast service: %v", obj)
 	}
 	return service
-}
-
-// TODO: Allow service names to have the same form as names
-//       for pods and replication controllers so we don't
-//       need to use such a function and can instead
-//       use the UUID utilty function.
-func randomSuffix() string {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	return strconv.Itoa(r.Int() % 10000)
 }


### PR DESCRIPTION
Reverts GoogleCloudPlatform/kubernetes#3749

Satnam forgot about the service JSON and the replication controller JSON, he is planning to re-write them using Go literals.
