### PR TITLE
Change TestNetwork to allow parallel execution

### DIFF
--- a/test/e2e/network.go
+++ b/test/e2e/network.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
 )
 
@@ -31,11 +32,27 @@ func TestNetwork(c *client.Client) bool {
 	}
 
 	ns := api.NamespaceDefault
-	svc, err := c.Services(ns).Create(loadObjectOrDie(assetPath(
-		"contrib", "for-tests", "network-tester", "service.json",
-	)).(*api.Service))
+	// TODO(satnam6502): Replace call of randomSuffix with call to NewUUID when service
+	//                   names have the same form as pod and replication controller names.
+	name := "nettest-" + randomSuffix()
+	svc, err := c.Services(ns).Create(&api.Service{
+		ObjectMeta: api.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"name": name,
+			},
+		},
+		Spec: api.ServiceSpec{
+			Port:          8080,
+			ContainerPort: util.NewIntOrStringFromInt(8080),
+			Selector: map[string]string{
+				"name": name,
+			},
+		},
+	})
+	glog.Infof("Creating service with name %s", svc.Name)
 	if err != nil {
-		glog.Errorf("unable to create test service: %v", err)
+		glog.Errorf("unable to create test service %s: %v", svc.Name, err)
 		return false
 	}
 	// Clean up service
@@ -44,10 +61,35 @@ func TestNetwork(c *client.Client) bool {
 			glog.Errorf("unable to delete svc %v: %v", svc.Name, err)
 		}
 	}()
-
-	rc, err := c.ReplicationControllers(ns).Create(loadObjectOrDie(assetPath(
-		"contrib", "for-tests", "network-tester", "rc.json",
-	)).(*api.ReplicationController))
+	rc, err := c.ReplicationControllers(ns).Create(&api.ReplicationController{
+		ObjectMeta: api.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"name": name,
+			},
+		},
+		Spec: api.ReplicationControllerSpec{
+			Replicas: 8,
+			Selector: map[string]string{
+				"name": name,
+			},
+			Template: &api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{"name": name},
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Name:    "webserver",
+							Image:   "kubernetes/nettest:latest",
+							Command: []string{"-service=" + name},
+							Ports:   []api.Port{{ContainerPort: 8080}},
+						},
+					},
+				},
+			},
+		},
+	})
 	if err != nil {
 		glog.Errorf("unable to create test rc: %v", err)
 		return false
@@ -66,7 +108,7 @@ func TestNetwork(c *client.Client) bool {
 	}()
 	const maxAttempts = 60
 	for i := 0; i < maxAttempts; i++ {
-		time.Sleep(time.Second)
+		time.Sleep(2 * time.Second)
 		body, err := c.Get().Prefix("proxy").Resource("services").Name(svc.Name).Suffix("status").Do().Raw()
 		if err != nil {
 			glog.Infof("Attempt %v/%v: service/pod still starting. (error: '%v')", i, maxAttempts, err)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -18,7 +18,9 @@ package e2e
 
 import (
 	"io/ioutil"
+	"math/rand"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -182,4 +184,13 @@ func parseServiceOrDie(json string) *api.Service {
 		glog.Fatalf("Failed to cast service: %v", obj)
 	}
 	return service
+}
+
+// TODO: Allow service names to have the same form as names
+//       for pods and replication controllers so we don't
+//       need to use such a function and can instead
+//       use the UUID utilty function.
+func randomSuffix() string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return strconv.Itoa(r.Int() % 10000)
 }


### PR DESCRIPTION
Change the TestNetwork end to end test to support parallel executions. Remove dependency on JSON files. 
@filbranden 
