### PR TITLE
Fix inline comment about label examples.

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -24,6 +24,7 @@ dimensions, such as:
    - `tier=frontend`, `tier=backend`, ...
    - `partition=customerA`, `partition=customerB`, ...
    - `track=daily`, `track=weekly`
+
 These are just examples; you are free to develop your own conventions.
 
 Label selectors permit very simple filtering by label keys and values.   Currently, label selectors only support these forms:


### PR DESCRIPTION
Hi!

I was reading the documentation and I noticed that there was a new line missing in the labels doc. I've fixed the problem.

I've signed the CLA with my email david.calavera@gmail.com
