### PR TITLE
Fix link to the dns addon readme

### DIFF
--- a/docs/dns.md
+++ b/docs/dns.md
@@ -35,4 +35,4 @@ time.
 
 ## For more information
 
-See [the docs for the cluster addon](cluster/addons/dns/README.md).
+See [the docs for the cluster addon](../cluster/addons/dns/README.md).


### PR DESCRIPTION
Hi!

I noticed that the link to the dns addon readme was broken. This PR fixes the route.
