### PR TITLE
Reduce size of serve_hostname image

### DIFF
--- a/contrib/for-demos/serve_hostname/Dockerfile
+++ b/contrib/for-demos/serve_hostname/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM scratch
 MAINTAINER Tim Hockin <thockin@google.com>
 ADD serve_hostname /serve_hostname
 ADD serve_hostname.go /serve_hostname.go

--- a/contrib/for-demos/serve_hostname/Makefile
+++ b/contrib/for-demos/serve_hostname/Makefile
@@ -1,6 +1,6 @@
 all: serve_hostname
 
-TAG = 1.0
+TAG = 1.1
 
 serve_hostname: serve_hostname.go
 	CGO_ENABLED=0 go build -a -installsuffix cgo --ldflags '-w' ./serve_hostname.go

--- a/hack/e2e-suite/basic.sh
+++ b/hack/e2e-suite/basic.sh
@@ -34,7 +34,7 @@ function teardown() {
 trap "teardown" EXIT
 
 # Determine which pod image to launch (e.g. private.sh launches a different one).
-pod_img_srv="${POD_IMG_SRV:-kubernetes/serve_hostname}"
+pod_img_srv="${POD_IMG_SRV:-kubernetes/serve_hostname:1.1}"
 
 # Launch some pods.
 num_pods=2

--- a/hack/e2e-suite/private.sh
+++ b/hack/e2e-suite/private.sh
@@ -32,5 +32,5 @@ if [[ "${KUBERNETES_PROVIDER}" != "gce" ]] && [[ "${KUBERNETES_PROVIDER}" != "gk
 fi
 
 # Run the basic.sh test, but using this image.
-export POD_IMG_SRV="gcr.io/_b_k8s_test/serve_hostname:1.0"
+export POD_IMG_SRV="gcr.io/_b_k8s_test/serve_hostname:1.1"
 source "${KUBE_ROOT}/hack/e2e-suite/basic.sh"

--- a/test/e2e/basic.go
+++ b/test/e2e/basic.go
@@ -187,5 +187,5 @@ func TestBasicImage(c *client.Client, test string, image string) bool {
 // TestBasic performs the TestBasicImage check with the
 // image kubernetes/serve_hostname
 func TestBasic(c *client.Client) bool {
-	return TestBasicImage(c, "basic", "kubernetes/serve_hostname:1.0")
+	return TestBasicImage(c, "basic", "kubernetes/serve_hostname:1.1")
 }


### PR DESCRIPTION
Make `kubernets/serve_hostname` Docker image be based on scratch.
Modify `TestBasic` Go end-to-end test to use the smaller image.
@thockin 
