### PR TITLE
Support namespacing in cache.Store

### DIFF
--- a/pkg/client/cache/fifo.go
+++ b/pkg/client/cache/fifo.go
@@ -17,9 +17,8 @@ limitations under the License.
 package cache
 
 import (
+	"fmt"
 	"sync"
-
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 // FIFO receives adds and updates from a Reflector, and puts them in a queue for
@@ -33,11 +32,18 @@ type FIFO struct {
 	// We depend on the property that items in the set are in the queue and vice versa.
 	items map[string]interface{}
 	queue []string
+	// keyFunc is used to make the key used for queued item insertion and retrieval, and
+	// should be deterministic.
+	keyFunc KeyFunc
 }
 
 // Add inserts an item, and puts it in the queue. The item is only enqueued
 // if it doesn't already exist in the set.
-func (f *FIFO) Add(id string, obj interface{}) {
+func (f *FIFO) Add(obj interface{}) error {
+	id, err := f.keyFunc(obj)
+	if err != nil {
+		return fmt.Errorf("couldn't create key for object: %v", err)
+	}
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	if _, exists := f.items[id]; !exists {
@@ -45,20 +51,26 @@ func (f *FIFO) Add(id string, obj interface{}) {
 	}
 	f.items[id] = obj
 	f.cond.Broadcast()
+	return nil
 }
 
 // Update is the same as Add in this implementation.
-func (f *FIFO) Update(id string, obj interface{}) {
-	f.Add(id, obj)
+func (f *FIFO) Update(obj interface{}) error {
+	return f.Add(obj)
 }
 
 // Delete removes an item. It doesn't add it to the queue, because
 // this implementation assumes the consumer only cares about the objects,
 // not the order in which they were created/added.
-func (f *FIFO) Delete(id string) {
+func (f *FIFO) Delete(obj interface{}) error {
+	id, err := f.keyFunc(obj)
+	if err != nil {
+		return fmt.Errorf("couldn't create key for object: %v", err)
+	}
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	delete(f.items, id)
+	return err
 }
 
 // List returns a list of all the items.
@@ -72,25 +84,16 @@ func (f *FIFO) List() []interface{} {
 	return list
 }
 
-// ContainedIDs returns a util.StringSet containing all IDs of the stored items.
-// This is a snapshot of a moment in time, and one should keep in mind that
-// other go routines can add or remove items after you call this.
-func (c *FIFO) ContainedIDs() util.StringSet {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-	set := util.StringSet{}
-	for id := range c.items {
-		set.Insert(id)
-	}
-	return set
-}
-
 // Get returns the requested item, or sets exists=false.
-func (f *FIFO) Get(id string) (item interface{}, exists bool) {
+func (f *FIFO) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	id, err := f.keyFunc(obj)
+	if err != nil {
+		return nil, false, fmt.Errorf("couldn't create key for object: %v", err)
+	}
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 	item, exists = f.items[id]
-	return item, exists
+	return item, exists, nil
 }
 
 // Pop waits until an item is ready and returns it. If multiple items are
@@ -120,25 +123,36 @@ func (f *FIFO) Pop() interface{} {
 // 'f' takes ownersip of the map, you should not reference the map again
 // after calling this function. f's queue is reset, too; upon return, it
 // will contain the items in the map, in no particular order.
-func (f *FIFO) Replace(idToObj map[string]interface{}) {
+func (f *FIFO) Replace(list []interface{}) error {
+	items := map[string]interface{}{}
+	for _, item := range list {
+		key, err := f.keyFunc(item)
+		if err != nil {
+			return fmt.Errorf("couldn't create key for object: %v", err)
+		}
+		items[key] = item
+	}
+
 	f.lock.Lock()
 	defer f.lock.Unlock()
-	f.items = idToObj
+	f.items = items
 	f.queue = f.queue[:0]
-	for id := range idToObj {
+	for id := range items {
 		f.queue = append(f.queue, id)
 	}
 	if len(f.queue) > 0 {
 		f.cond.Broadcast()
 	}
+	return nil
 }
 
 // NewFIFO returns a Store which can be used to queue up items to
 // process.
-func NewFIFO() *FIFO {
+func NewFIFO(keyFunc KeyFunc) *FIFO {
 	f := &FIFO{
-		items: map[string]interface{}{},
-		queue: []string{},
+		items:   map[string]interface{}{},
+		queue:   []string{},
+		keyFunc: keyFunc,
 	}
 	f.cond.L = &f.lock
 	return f

--- a/pkg/client/cache/fifo_test.go
+++ b/pkg/client/cache/fifo_test.go
@@ -21,30 +21,43 @@ import (
 	"time"
 )
 
+func testFifoObjectKeyFunc(obj interface{}) (string, error) {
+	return obj.(testFifoObject).name, nil
+}
+
+type testFifoObject struct {
+	name string
+	val  interface{}
+}
+
 func TestFIFO_basic(t *testing.T) {
-	f := NewFIFO()
+	mkObj := func(name string, val interface{}) testFifoObject {
+		return testFifoObject{name: name, val: val}
+	}
+
+	f := NewFIFO(testFifoObjectKeyFunc)
 	const amount = 500
 	go func() {
 		for i := 0; i < amount; i++ {
-			f.Add(string([]rune{'a', rune(i)}), i+1)
+			f.Add(mkObj(string([]rune{'a', rune(i)}), i+1))
 		}
 	}()
 	go func() {
-		for u := uint(0); u < amount; u++ {
-			f.Add(string([]rune{'b', rune(u)}), u+1)
+		for u := uint64(0); u < amount; u++ {
+			f.Add(mkObj(string([]rune{'b', rune(u)}), u+1))
 		}
 	}()
 
 	lastInt := int(0)
-	lastUint := uint(0)
+	lastUint := uint64(0)
 	for i := 0; i < amount*2; i++ {
-		switch obj := f.Pop().(type) {
+		switch obj := f.Pop().(testFifoObject).val.(type) {
 		case int:
 			if obj <= lastInt {
 				t.Errorf("got %v (int) out of order, last was %v", obj, lastInt)
 			}
 			lastInt = obj
-		case uint:
+		case uint64:
 			if obj <= lastUint {
 				t.Errorf("got %v (uint) out of order, last was %v", obj, lastUint)
 			} else {
@@ -57,81 +70,93 @@ func TestFIFO_basic(t *testing.T) {
 }
 
 func TestFIFO_addUpdate(t *testing.T) {
-	f := NewFIFO()
-	f.Add("foo", 10)
-	f.Update("foo", 15)
-	got := make(chan int, 2)
+	mkObj := func(name string, val interface{}) testFifoObject {
+		return testFifoObject{name: name, val: val}
+	}
+
+	f := NewFIFO(testFifoObjectKeyFunc)
+	f.Add(mkObj("foo", 10))
+	f.Update(mkObj("foo", 15))
+	got := make(chan testFifoObject, 2)
 	go func() {
 		for {
-			got <- f.Pop().(int)
+			got <- f.Pop().(testFifoObject)
 		}
 	}()
 
 	first := <-got
-	if e, a := 15, first; e != a {
+	if e, a := 15, first.val; e != a {
 		t.Errorf("Didn't get updated value (%v), got %v", e, a)
 	}
 	select {
 	case unexpected := <-got:
-		t.Errorf("Got second value %v", unexpected)
+		t.Errorf("Got second value %v", unexpected.val)
 	case <-time.After(50 * time.Millisecond):
 	}
-	_, exists := f.Get("foo")
+	_, exists, _ := f.Get(mkObj("foo", ""))
 	if exists {
 		t.Errorf("item did not get removed")
 	}
 }
 
 func TestFIFO_addReplace(t *testing.T) {
-	f := NewFIFO()
-	f.Add("foo", 10)
-	f.Replace(map[string]interface{}{"foo": 15})
-	got := make(chan int, 2)
+	mkObj := func(name string, val interface{}) testFifoObject {
+		return testFifoObject{name: name, val: val}
+	}
+
+	f := NewFIFO(testFifoObjectKeyFunc)
+	f.Add(mkObj("foo", 10))
+	f.Replace([]interface{}{mkObj("foo", 15)})
+	got := make(chan testFifoObject, 2)
 	go func() {
 		for {
-			got <- f.Pop().(int)
+			got <- f.Pop().(testFifoObject)
 		}
 	}()
 
 	first := <-got
-	if e, a := 15, first; e != a {
+	if e, a := 15, first.val; e != a {
 		t.Errorf("Didn't get updated value (%v), got %v", e, a)
 	}
 	select {
 	case unexpected := <-got:
-		t.Errorf("Got second value %v", unexpected)
+		t.Errorf("Got second value %v", unexpected.val)
 	case <-time.After(50 * time.Millisecond):
 	}
-	_, exists := f.Get("foo")
+	_, exists, _ := f.Get(mkObj("foo", ""))
 	if exists {
 		t.Errorf("item did not get removed")
 	}
 }
 
 func TestFIFO_detectLineJumpers(t *testing.T) {
-	f := NewFIFO()
+	mkObj := func(name string, val interface{}) testFifoObject {
+		return testFifoObject{name: name, val: val}
+	}
 
-	f.Add("foo", 10)
-	f.Add("bar", 1)
-	f.Add("foo", 11)
-	f.Add("foo", 13)
-	f.Add("zab", 30)
+	f := NewFIFO(testFifoObjectKeyFunc)
 
-	if e, a := 13, f.Pop().(int); a != e {
+	f.Add(mkObj("foo", 10))
+	f.Add(mkObj("bar", 1))
+	f.Add(mkObj("foo", 11))
+	f.Add(mkObj("foo", 13))
+	f.Add(mkObj("zab", 30))
+
+	if e, a := 13, f.Pop().(testFifoObject).val; a != e {
 		t.Fatalf("expected %d, got %d", e, a)
 	}
 
-	f.Add("foo", 14) // ensure foo doesn't jump back in line
+	f.Add(mkObj("foo", 14)) // ensure foo doesn't jump back in line
 
-	if e, a := 1, f.Pop().(int); a != e {
+	if e, a := 1, f.Pop().(testFifoObject).val; a != e {
 		t.Fatalf("expected %d, got %d", e, a)
 	}
 
-	if e, a := 30, f.Pop().(int); a != e {
+	if e, a := 30, f.Pop().(testFifoObject).val; a != e {
 		t.Fatalf("expected %d, got %d", e, a)
 	}
 
-	if e, a := 14, f.Pop().(int); a != e {
+	if e, a := 14, f.Pop().(testFifoObject).val; a != e {
 		t.Fatalf("expected %d, got %d", e, a)
 	}
 }

--- a/pkg/client/cache/listers.go
+++ b/pkg/client/cache/listers.go
@@ -69,10 +69,17 @@ func (s *StoreToNodeLister) List() (machines api.NodeList, err error) {
 // rather than a method of StoreToNodeLister.
 // GetNodeInfo returns cached data for the minion 'id'.
 func (s *StoreToNodeLister) GetNodeInfo(id string) (*api.Node, error) {
-	if minion, ok := s.Get(id); ok {
-		return minion.(*api.Node), nil
+	minion, exists, err := s.Get(&api.Node{ObjectMeta: api.ObjectMeta{Name: id}})
+
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving minion '%v' from cache: %v", id, err)
 	}
-	return nil, fmt.Errorf("minion '%v' is not in cache", id)
+
+	if !exists {
+		return nil, fmt.Errorf("minion '%v' is not in cache", id)
+	}
+
+	return minion.(*api.Node), nil
 }
 
 // StoreToServiceLister makes a Store that has the List method of the client.ServiceInterface

--- a/pkg/client/cache/listers_test.go
+++ b/pkg/client/cache/listers_test.go
@@ -25,10 +25,10 @@ import (
 )
 
 func TestStoreToMinionLister(t *testing.T) {
-	store := NewStore()
+	store := NewStore(MetaNamespaceKeyFunc)
 	ids := util.NewStringSet("foo", "bar", "baz")
 	for id := range ids {
-		store.Add(id, &api.Node{ObjectMeta: api.ObjectMeta{Name: id}})
+		store.Add(&api.Node{ObjectMeta: api.ObjectMeta{Name: id}})
 	}
 	sml := StoreToNodeLister{store}
 
@@ -46,10 +46,10 @@ func TestStoreToMinionLister(t *testing.T) {
 }
 
 func TestStoreToPodLister(t *testing.T) {
-	store := NewStore()
+	store := NewStore(MetaNamespaceKeyFunc)
 	ids := []string{"foo", "bar", "baz"}
 	for _, id := range ids {
-		store.Add(id, &api.Pod{
+		store.Add(&api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name:   id,
 				Labels: map[string]string{"name": id},

--- a/pkg/client/cache/poller.go
+++ b/pkg/client/cache/poller.go
@@ -27,7 +27,7 @@ import (
 // one object at a time.
 type Enumerator interface {
 	Len() int
-	Get(index int) (ID string, object interface{})
+	Get(index int) (object interface{})
 }
 
 // GetFunc should return an enumerator that you wish the Poller to proccess.
@@ -76,14 +76,11 @@ func (p *Poller) run() {
 }
 
 func (p *Poller) sync(e Enumerator) {
-	current := p.store.ContainedIDs()
+	items := []interface{}{}
 	for i := 0; i < e.Len(); i++ {
-		id, object := e.Get(i)
-		p.store.Update(id, object)
-		current.Delete(id)
+		object := e.Get(i)
+		items = append(items, object)
 	}
-	// Delete all the objects not found.
-	for id := range current {
-		p.store.Delete(id)
-	}
+
+	p.store.Replace(items)
 }

--- a/pkg/client/cache/poller_test.go
+++ b/pkg/client/cache/poller_test.go
@@ -23,6 +23,10 @@ import (
 	"time"
 )
 
+func testPairKeyFunc(obj interface{}) (string, error) {
+	return obj.(testPair).id, nil
+}
+
 type testPair struct {
 	id  string
 	obj interface{}
@@ -30,8 +34,8 @@ type testPair struct {
 type testEnumerator []testPair
 
 func (t testEnumerator) Len() int { return len(t) }
-func (t testEnumerator) Get(i int) (string, interface{}) {
-	return t[i].id, t[i].obj
+func (t testEnumerator) Get(i int) interface{} {
+	return t[i]
 }
 
 func TestPoller_sync(t *testing.T) {
@@ -64,28 +68,35 @@ func TestPoller_sync(t *testing.T) {
 	}
 
 	for testCase, item := range table {
-		s := NewStore()
+		s := NewStore(testPairKeyFunc)
 		// This is a unit test for the sync function, hence the nil getFunc.
 		p := NewPoller(nil, 0, s)
 		for line, pairs := range item.steps {
 			p.sync(testEnumerator(pairs))
 
-			ids := s.ContainedIDs()
+			list := s.List()
 			for _, pair := range pairs {
-				if !ids.Has(pair.id) {
-					t.Errorf("%v, %v: expected to find entry for %v, but did not.", testCase, line, pair.id)
+				foundInList := false
+				for _, listItem := range list {
+					id, _ := testPairKeyFunc(listItem)
+					if pair.id == id {
+						foundInList = true
+					}
+				}
+				if !foundInList {
+					t.Errorf("%v, %v: expected to find list entry for %v, but did not.", testCase, line, pair.id)
 					continue
 				}
-				found, ok := s.Get(pair.id)
+				found, ok, _ := s.Get(pair)
 				if !ok {
 					t.Errorf("%v, %v: unexpected absent entry for %v", testCase, line, pair.id)
 					continue
 				}
-				if e, a := pair.obj, found; !reflect.DeepEqual(e, a) {
+				if e, a := pair.obj, found.(testPair).obj; !reflect.DeepEqual(e, a) {
 					t.Errorf("%v, %v: expected %v, got %v for %v", testCase, line, e, a, pair.id)
 				}
 			}
-			if e, a := len(pairs), len(ids); e != a {
+			if e, a := len(pairs), len(list); e != a {
 				t.Errorf("%v, %v: expected len %v, got %v", testCase, line, e, a)
 			}
 		}
@@ -93,7 +104,7 @@ func TestPoller_sync(t *testing.T) {
 }
 
 func TestPoller_Run(t *testing.T) {
-	s := NewStore()
+	s := NewStore(testPairKeyFunc)
 	const count = 10
 	var called = 0
 	done := make(chan struct{})
@@ -113,7 +124,7 @@ func TestPoller_Run(t *testing.T) {
 	<-done
 
 	// We never added anything, verify that.
-	if e, a := 0, len(s.ContainedIDs()); e != a {
+	if e, a := 0, len(s.List()); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 }

--- a/pkg/client/cache/store_test.go
+++ b/pkg/client/cache/store_test.go
@@ -24,63 +24,58 @@ import (
 
 // Test public interface
 func doTestStore(t *testing.T, store Store) {
-	store.Add("foo", "bar")
-	if item, ok := store.Get("foo"); !ok {
+	mkObj := func(id string, val string) testStoreObject {
+		return testStoreObject{id: id, val: val}
+	}
+
+	store.Add(mkObj("foo", "bar"))
+	if item, ok, _ := store.Get(mkObj("foo", "")); !ok {
 		t.Errorf("didn't find inserted item")
 	} else {
-		if e, a := "bar", item.(string); e != a {
+		if e, a := "bar", item.(testStoreObject).val; e != a {
 			t.Errorf("expected %v, got %v", e, a)
 		}
 	}
-	store.Update("foo", "baz")
-	if item, ok := store.Get("foo"); !ok {
+	store.Update(mkObj("foo", "baz"))
+	if item, ok, _ := store.Get(mkObj("foo", "")); !ok {
 		t.Errorf("didn't find inserted item")
 	} else {
-		if e, a := "baz", item.(string); e != a {
+		if e, a := "baz", item.(testStoreObject).val; e != a {
 			t.Errorf("expected %v, got %v", e, a)
 		}
 	}
-	store.Delete("foo")
-	if _, ok := store.Get("foo"); ok {
+	store.Delete(mkObj("foo", ""))
+	if _, ok, _ := store.Get(mkObj("foo", "")); ok {
 		t.Errorf("found deleted item??")
 	}
 
 	// Test List.
-	store.Add("a", "b")
-	store.Add("c", "d")
-	store.Add("e", "e")
+	store.Add(mkObj("a", "b"))
+	store.Add(mkObj("c", "d"))
+	store.Add(mkObj("e", "e"))
 	{
 		found := util.StringSet{}
 		for _, item := range store.List() {
-			found.Insert(item.(string))
+			found.Insert(item.(testStoreObject).val)
 		}
 		if !found.HasAll("b", "d", "e") {
-			t.Errorf("missing items")
+			t.Errorf("missing items, found: %v", found)
 		}
 		if len(found) != 3 {
-			t.Errorf("extra items")
-		}
-
-		// Check that ID list is correct.
-		ids := store.ContainedIDs()
-		if !ids.HasAll("a", "c", "e") {
-			t.Errorf("missing items")
-		}
-		if len(ids) != 3 {
 			t.Errorf("extra items")
 		}
 	}
 
 	// Test Replace.
-	store.Replace(map[string]interface{}{
-		"foo": "foo",
-		"bar": "bar",
+	store.Replace([]interface{}{
+		mkObj("foo", "foo"),
+		mkObj("bar", "bar"),
 	})
 
 	{
 		found := util.StringSet{}
 		for _, item := range store.List() {
-			found.Insert(item.(string))
+			found.Insert(item.(testStoreObject).val)
 		}
 		if !found.HasAll("foo", "bar") {
 			t.Errorf("missing items")
@@ -88,27 +83,27 @@ func doTestStore(t *testing.T, store Store) {
 		if len(found) != 2 {
 			t.Errorf("extra items")
 		}
-
-		// Check that ID list is correct.
-		ids := store.ContainedIDs()
-		if !ids.HasAll("foo", "bar") {
-			t.Errorf("missing items")
-		}
-		if len(ids) != 2 {
-			t.Errorf("extra items")
-		}
 	}
 }
 
+func testStoreKeyFunc(obj interface{}) (string, error) {
+	return obj.(testStoreObject).id, nil
+}
+
+type testStoreObject struct {
+	id  string
+	val string
+}
+
 func TestCache(t *testing.T) {
-	doTestStore(t, NewStore())
+	doTestStore(t, NewStore(testStoreKeyFunc))
 }
 
 func TestFIFOCache(t *testing.T) {
-	doTestStore(t, NewFIFO())
+	doTestStore(t, NewFIFO(testStoreKeyFunc))
 }
 
 func TestUndeltaStore(t *testing.T) {
 	nop := func([]interface{}) {}
-	doTestStore(t, NewUndeltaStore(nop))
+	doTestStore(t, NewUndeltaStore(nop, testStoreKeyFunc))
 }

--- a/pkg/client/cache/undelta_store.go
+++ b/pkg/client/cache/undelta_store.go
@@ -16,10 +16,6 @@ limitations under the License.
 
 package cache
 
-import (
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-)
-
 // UndeltaStore listens to incremental updates and sends complete state on every change.
 // It implements the Store interface so that it can receive a stream of mirrored objects
 // from Reflector.  Whenever it receives any complete (Store.Replace) or incremental change
@@ -46,36 +42,45 @@ var _ Store = &UndeltaStore{}
 // 4               Store.List() -> [a,b]
 // 5                                         Store.List() -> [a,b]
 
-func (u *UndeltaStore) Add(id string, obj interface{}) {
-	u.ActualStore.Add(id, obj)
+func (u *UndeltaStore) Add(obj interface{}) error {
+	if err := u.ActualStore.Add(obj); err != nil {
+		return err
+	}
 	u.PushFunc(u.ActualStore.List())
+	return nil
 }
-func (u *UndeltaStore) Update(id string, obj interface{}) {
-	u.ActualStore.Update(id, obj)
+func (u *UndeltaStore) Update(obj interface{}) error {
+	if err := u.ActualStore.Update(obj); err != nil {
+		return err
+	}
 	u.PushFunc(u.ActualStore.List())
+	return nil
 }
-func (u *UndeltaStore) Delete(id string) {
-	u.ActualStore.Delete(id)
+func (u *UndeltaStore) Delete(obj interface{}) error {
+	if err := u.ActualStore.Delete(obj); err != nil {
+		return err
+	}
 	u.PushFunc(u.ActualStore.List())
+	return nil
 }
 func (u *UndeltaStore) List() []interface{} {
 	return u.ActualStore.List()
 }
-func (u *UndeltaStore) ContainedIDs() util.StringSet {
-	return u.ActualStore.ContainedIDs()
+func (u *UndeltaStore) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	return u.ActualStore.Get(obj)
 }
-func (u *UndeltaStore) Get(id string) (item interface{}, exists bool) {
-	return u.ActualStore.Get(id)
-}
-func (u *UndeltaStore) Replace(idToObj map[string]interface{}) {
-	u.ActualStore.Replace(idToObj)
+func (u *UndeltaStore) Replace(list []interface{}) error {
+	if err := u.ActualStore.Replace(list); err != nil {
+		return err
+	}
 	u.PushFunc(u.ActualStore.List())
+	return nil
 }
 
 // NewUndeltaStore returns an UndeltaStore implemented with a Store.
-func NewUndeltaStore(pushFunc func([]interface{})) *UndeltaStore {
+func NewUndeltaStore(pushFunc func([]interface{}), keyFunc KeyFunc) *UndeltaStore {
 	return &UndeltaStore{
-		ActualStore: NewStore(),
+		ActualStore: NewStore(keyFunc),
 		PushFunc:    pushFunc,
 	}
 }

--- a/pkg/kubelet/config/apiserver.go
+++ b/pkg/kubelet/config/apiserver.go
@@ -53,5 +53,5 @@ func newSourceApiserverFromLW(lw cache.ListerWatcher, updates chan<- interface{}
 		}
 		updates <- kubelet.PodUpdate{bpods, kubelet.SET, kubelet.ApiserverSource}
 	}
-	cache.NewReflector(lw, &api.Pod{}, cache.NewUndeltaStore(send)).Run()
+	cache.NewReflector(lw, &api.Pod{}, cache.NewUndeltaStore(send, cache.MetaNamespaceKeyFunc)).Run()
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -93,7 +93,7 @@ func NewMainKubelet(
 		return nil, fmt.Errorf("invalid minimum GC age %d", minimumGCAge)
 	}
 
-	serviceStore := cache.NewStore()
+	serviceStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
 	if kubeClient != nil {
 		cache.NewReflector(&cache.ListWatch{kubeClient, labels.Everything(), "services", api.NamespaceAll}, &api.Service{}, serviceStore).Run()
 	}


### PR DESCRIPTION
Support namespacing in cache.Store by framing the interface functions
around interface{} and providing a key function to each Store implementation.

Implementation of a fix for #2294.
