### PR TITLE
Fix for issue 3797.

### DIFF
--- a/pkg/credentialprovider/keyring.go
+++ b/pkg/credentialprovider/keyring.go
@@ -66,9 +66,20 @@ func (dk *BasicDockerKeyring) Add(cfg DockerConfig) {
 			continue
 		}
 
-		registry := parsed.Host + parsed.Path
-		dk.creds[registry] = creds
-		dk.index = append(dk.index, registry)
+		// The docker client allows exact matches:
+		//    foo.bar.com/namespace
+		// Or hostname matches:
+		//    foo.bar.com
+		// See ResolveAuthConfig in docker/registry/auth.go.
+		if parsed.Host != "" {
+			// NOTE: foo.bar.com comes through as Path.
+			dk.creds[parsed.Host] = creds
+			dk.index = append(dk.index, parsed.Host)
+		}
+		if parsed.Path != "/" {
+			dk.creds[parsed.Host+parsed.Path] = creds
+			dk.index = append(dk.index, parsed.Host+parsed.Path)
+		}
 	}
 
 	// Update the index used to identify which credentials to use for a given


### PR DESCRIPTION
Docker's logic for resolving credentials from .dockercfg accepts two kinds of matches:
1. an exact match between the dockercfg entry and the image prefix
2. a hostname match between the dockercfg entry and the image prefix

This change implements the latter, which permits the docker client to take .dockercfg entries of the form:
   https://quay.io/v1/
and use them for images of the form:
   quay.io/foo/bar
even though they are not a prefix-match.
