### PR TITLE
Shared IPC namespace for containers in a pod

### DIFF
--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -50,7 +50,7 @@ var (
 	address                 = util.IP(net.ParseIP("127.0.0.1"))
 	port                    = flag.Uint("port", ports.KubeletPort, "The port for the info server to serve on")
 	hostnameOverride        = flag.String("hostname_override", "", "If non-empty, will use this string as identification instead of the actual hostname.")
-	networkContainerImage   = flag.String("network_container_image", kubelet.NetworkContainerImage, "The image that network containers in each pod will use.")
+	podInfraContainerImage  = flag.String("pod_infra_container_image", kubelet.PodInfraContainerImage, "The image whose network/ipc namespaces containers in each pod will use.")
 	dockerEndpoint          = flag.String("docker_endpoint", "", "If non-empty, use this for the docker endpoint to communicate with")
 	etcdServerList          util.StringList
 	etcdConfigFile          = flag.String("etcd_config", "", "The config file for the etcd client. Mutually exclusive with -etcd_servers")
@@ -136,7 +136,7 @@ func main() {
 		ManifestURL:             *manifestURL,
 		FileCheckFrequency:      *fileCheckFrequency,
 		HttpCheckFrequency:      *httpCheckFrequency,
-		NetworkContainerImage:   *networkContainerImage,
+		PodInfraContainerImage:  *podInfraContainerImage,
 		SyncFrequency:           *syncFrequency,
 		RegistryPullQPS:         *registryPullQPS,
 		RegistryBurst:           *registryBurst,

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -37,6 +37,10 @@ import (
 	"github.com/golang/glog"
 )
 
+const (
+	PodInfraContainerName = "POD" // This should match the constant defined in kubelet
+)
+
 // DockerInterface is an abstract interface for testability.  It abstracts the interface of docker.Client.
 type DockerInterface interface {
 	ListContainers(options docker.ListContainersOptions) ([]docker.APIContainers, error)
@@ -372,8 +376,8 @@ var (
 	// ErrNoContainersInPod is returned when there are no containers for a given pod
 	ErrNoContainersInPod = errors.New("no containers exist for this pod")
 
-	// ErrNoNetworkContainerInPod is returned when there is no network container for a given pod
-	ErrNoNetworkContainerInPod = errors.New("No network container exists for this pod")
+	// ErrNoPodInfraContainerInPod is returned when there is no pod infra container for a given pod
+	ErrNoPodInfraContainerInPod = errors.New("No pod infra container exists for this pod")
 
 	// ErrContainerCannotRun is returned when a container is created, but cannot run properly
 	ErrContainerCannotRun = errors.New("Container cannot run")
@@ -401,7 +405,7 @@ func inspectContainer(client DockerInterface, dockerID, containerName, tPath str
 		containerStatus.State.Running = &api.ContainerStateRunning{
 			StartedAt: util.NewTime(inspectResult.State.StartedAt),
 		}
-		if containerName == "net" && inspectResult.NetworkSettings != nil {
+		if containerName == PodInfraContainerName && inspectResult.NetworkSettings != nil {
 			containerStatus.PodIP = inspectResult.NetworkSettings.IPAddress
 		}
 		waiting = false
@@ -454,7 +458,7 @@ func GetDockerPodInfo(client DockerInterface, manifest api.PodSpec, podFullName 
 	for _, container := range manifest.Containers {
 		expectedContainers[container.Name] = container
 	}
-	expectedContainers["net"] = api.Container{}
+	expectedContainers[PodInfraContainerName] = api.Container{}
 
 	containers, err := client.ListContainers(docker.ListContainersOptions{All: true})
 	if err != nil {
@@ -498,9 +502,9 @@ func GetDockerPodInfo(client DockerInterface, manifest api.PodSpec, podFullName 
 		return nil, ErrNoContainersInPod
 	}
 
-	// First make sure we are not missing network container
-	if _, found := info["net"]; !found {
-		return nil, ErrNoNetworkContainerInPod
+	// First make sure we are not missing pod infra container
+	if _, found := info[PodInfraContainerName]; !found {
+		return nil, ErrNoPodInfraContainerInPod
 	}
 
 	if len(info) < (len(manifest.Containers) + 1) {

--- a/pkg/kubelet/handlers.go
+++ b/pkg/kubelet/handlers.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
@@ -77,7 +78,7 @@ func (h *httpActionHandler) Run(podFullName string, uid types.UID, container *ap
 			glog.Errorf("unable to get pod info, event handlers may be invalid.")
 			return err
 		}
-		netInfo, found := status.Info[networkContainerName]
+		netInfo, found := status.Info[dockertools.PodInfraContainerName]
 		if found {
 			host = netInfo.PodIP
 		} else {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -336,8 +336,8 @@ func TestSyncPodsDoesNothing(t *testing.T) {
 			ID:    "1234",
 		},
 		{
-			// network container
-			Names: []string{"/k8s_net_foo.new.test_12345678_0"},
+			// pod infra container
+			Names: []string{"/k8s_POD_foo.new.test_12345678_0"},
 			ID:    "9876",
 		},
 	}
@@ -426,7 +426,7 @@ func matchString(t *testing.T, pattern, str string) bool {
 
 func TestSyncPodsCreatesNetAndContainer(t *testing.T) {
 	kubelet, fakeDocker := newTestKubelet(t)
-	kubelet.networkContainerImage = "custom_image_name"
+	kubelet.podInfraContainerImage = "custom_image_name"
 	fakeDocker.ContainerList = []docker.APIContainers{}
 	err := kubelet.SyncPods([]api.BoundPod{
 		{
@@ -455,7 +455,7 @@ func TestSyncPodsCreatesNetAndContainer(t *testing.T) {
 
 	found := false
 	for _, c := range fakeDocker.ContainerList {
-		if c.Image == "custom_image_name" && strings.HasPrefix(c.Names[0], "/k8s_net") {
+		if c.Image == "custom_image_name" && strings.HasPrefix(c.Names[0], "/k8s_POD") {
 			found = true
 		}
 	}
@@ -464,7 +464,7 @@ func TestSyncPodsCreatesNetAndContainer(t *testing.T) {
 	}
 
 	if len(fakeDocker.Created) != 2 ||
-		!matchString(t, "k8s_net\\.[a-f0-9]+_foo.new.test_", fakeDocker.Created[0]) ||
+		!matchString(t, "k8s_POD\\.[a-f0-9]+_foo.new.test_", fakeDocker.Created[0]) ||
 		!matchString(t, "k8s_bar\\.[a-f0-9]+_foo.new.test_", fakeDocker.Created[1]) {
 		t.Errorf("Unexpected containers created %v", fakeDocker.Created)
 	}
@@ -475,7 +475,7 @@ func TestSyncPodsCreatesNetAndContainerPullsImage(t *testing.T) {
 	kubelet, fakeDocker := newTestKubelet(t)
 	puller := kubelet.dockerPuller.(*dockertools.FakeDockerPuller)
 	puller.HasImages = []string{}
-	kubelet.networkContainerImage = "custom_image_name"
+	kubelet.podInfraContainerImage = "custom_image_name"
 	fakeDocker.ContainerList = []docker.APIContainers{}
 	err := kubelet.SyncPods([]api.BoundPod{
 		{
@@ -507,7 +507,7 @@ func TestSyncPodsCreatesNetAndContainerPullsImage(t *testing.T) {
 	}
 
 	if len(fakeDocker.Created) != 2 ||
-		!matchString(t, "k8s_net\\.[a-f0-9]+_foo.new.test_", fakeDocker.Created[0]) ||
+		!matchString(t, "k8s_POD\\.[a-f0-9]+_foo.new.test_", fakeDocker.Created[0]) ||
 		!matchString(t, "k8s_bar\\.[a-f0-9]+_foo.new.test_", fakeDocker.Created[1]) {
 		t.Errorf("Unexpected containers created %v", fakeDocker.Created)
 	}
@@ -518,8 +518,8 @@ func TestSyncPodsWithNetCreatesContainer(t *testing.T) {
 	kubelet, fakeDocker := newTestKubelet(t)
 	fakeDocker.ContainerList = []docker.APIContainers{
 		{
-			// network container
-			Names: []string{"/k8s_net_foo.new.test_12345678_0"},
+			// pod infra container
+			Names: []string{"/k8s_POD_foo.new.test_12345678_0"},
 			ID:    "9876",
 		},
 	}
@@ -560,8 +560,8 @@ func TestSyncPodsWithNetCreatesContainerCallsHandler(t *testing.T) {
 	kubelet.httpClient = &fakeHttp
 	fakeDocker.ContainerList = []docker.APIContainers{
 		{
-			// network container
-			Names: []string{"/k8s_net_foo.new.test_12345678_0"},
+			// pod infra container
+			Names: []string{"/k8s_POD_foo.new.test_12345678_0"},
 			ID:    "9876",
 		},
 	}
@@ -666,8 +666,8 @@ func TestSyncPodsDeletesWhenSourcesAreReady(t *testing.T) {
 			ID:    "1234",
 		},
 		{
-			// network container
-			Names: []string{"/k8s_net_foo.new.test_12345678_42"},
+			// pod infra container
+			Names: []string{"/k8s_POD_foo.new.test_12345678_42"},
 			ID:    "9876",
 		},
 	}
@@ -714,8 +714,8 @@ func TestSyncPodsDeletesWhenContainerSourceReady(t *testing.T) {
 			ID:    "7492",
 		},
 		{
-			// network container
-			Names: []string{"/k8s_net_boo.default.testSource_12345678_42"},
+			// pod infra container
+			Names: []string{"/k8s_POD_boo.default.testSource_12345678_42"},
 			ID:    "3542",
 		},
 
@@ -725,8 +725,8 @@ func TestSyncPodsDeletesWhenContainerSourceReady(t *testing.T) {
 			ID:    "1234",
 		},
 		{
-			// network container
-			Names: []string{"/k8s_net_foo.new.otherSource_12345678_42"},
+			// pod infra container
+			Names: []string{"/k8s_POD_foo.new.otherSource_12345678_42"},
 			ID:    "9876",
 		},
 	}
@@ -767,8 +767,8 @@ func TestSyncPodsDeletes(t *testing.T) {
 			ID:    "1234",
 		},
 		{
-			// network container
-			Names: []string{"/k8s_net_foo.new.test_12345678_42"},
+			// pod infra container
+			Names: []string{"/k8s_POD_foo.new.test_12345678_42"},
 			ID:    "9876",
 		},
 		{
@@ -805,8 +805,8 @@ func TestSyncPodDeletesDuplicate(t *testing.T) {
 			ID:    "1234",
 		},
 		"9876": &docker.APIContainers{
-			// network container
-			Names: []string{"/k8s_net_bar.new.test_12345678_2222"},
+			// pod infra container
+			Names: []string{"/k8s_POD_bar.new.test_12345678_2222"},
 			ID:    "9876",
 		},
 		"4567": &docker.APIContainers{
@@ -865,8 +865,8 @@ func TestSyncPodBadHash(t *testing.T) {
 			ID:    "1234",
 		},
 		"9876": &docker.APIContainers{
-			// network container
-			Names: []string{"/k8s_net_foo.new.test_12345678_42"},
+			// pod infra container
+			Names: []string{"/k8s_POD_foo.new.test_12345678_42"},
 			ID:    "9876",
 		},
 	}
@@ -912,8 +912,8 @@ func TestSyncPodUnhealthy(t *testing.T) {
 			ID:    "1234",
 		},
 		"9876": &docker.APIContainers{
-			// network container
-			Names: []string{"/k8s_net_foo.new.test_12345678_42"},
+			// pod infra container
+			Names: []string{"/k8s_POD_foo.new.test_12345678_42"},
 			ID:    "9876",
 		},
 	}
@@ -1559,8 +1559,8 @@ func TestSyncPodEventHandlerFails(t *testing.T) {
 	}
 	dockerContainers := dockertools.DockerContainers{
 		"9876": &docker.APIContainers{
-			// network container
-			Names: []string{"/k8s_net_foo.new.test_12345678_42"},
+			// pod infra container
+			Names: []string{"/k8s_POD_foo.new.test_12345678_42"},
 			ID:    "9876",
 		},
 	}
@@ -1607,33 +1607,33 @@ func TestKubeletGarbageCollection(t *testing.T) {
 		{
 			containers: []docker.APIContainers{
 				{
-					// network container
-					Names: []string{"/k8s_net_foo.new.test_.deadbeef_42"},
+					// pod infra container
+					Names: []string{"/k8s_POD_foo.new.test_.deadbeef_42"},
 					ID:    "1876",
 				},
 				{
-					// network container
-					Names: []string{"/k8s_net_foo.new.test_.deadbeef_42"},
+					// pod infra container
+					Names: []string{"/k8s_POD_foo.new.test_.deadbeef_42"},
 					ID:    "2876",
 				},
 				{
-					// network container
-					Names: []string{"/k8s_net_foo.new.test_.deadbeef_42"},
+					// pod infra container
+					Names: []string{"/k8s_POD_foo.new.test_.deadbeef_42"},
 					ID:    "3876",
 				},
 				{
-					// network container
-					Names: []string{"/k8s_net_foo.new.test_.deadbeef_42"},
+					// pod infra container
+					Names: []string{"/k8s_POD_foo.new.test_.deadbeef_42"},
 					ID:    "4876",
 				},
 				{
-					// network container
-					Names: []string{"/k8s_net_foo.new.test_.deadbeef_42"},
+					// pod infra container
+					Names: []string{"/k8s_POD_foo.new.test_.deadbeef_42"},
 					ID:    "5876",
 				},
 				{
-					// network container
-					Names: []string{"/k8s_net_foo.new.test_.deadbeef_42"},
+					// pod infra container
+					Names: []string{"/k8s_POD_foo.new.test_.deadbeef_42"},
 					ID:    "6876",
 				},
 			},
@@ -1651,38 +1651,38 @@ func TestKubeletGarbageCollection(t *testing.T) {
 		{
 			containers: []docker.APIContainers{
 				{
-					// network container
-					Names: []string{"/k8s_net_foo.new.test_.deadbeef_42"},
+					// pod infra container
+					Names: []string{"/k8s_POD_foo.new.test_.deadbeef_42"},
 					ID:    "1876",
 				},
 				{
-					// network container
-					Names: []string{"/k8s_net_foo.new.test_.deadbeef_42"},
+					// pod infra container
+					Names: []string{"/k8s_POD_foo.new.test_.deadbeef_42"},
 					ID:    "2876",
 				},
 				{
-					// network container
-					Names: []string{"/k8s_net_foo.new.test_.deadbeef_42"},
+					// pod infra container
+					Names: []string{"/k8s_POD_foo.new.test_.deadbeef_42"},
 					ID:    "3876",
 				},
 				{
-					// network container
-					Names: []string{"/k8s_net_foo.new.test_.deadbeef_42"},
+					// pod infra container
+					Names: []string{"/k8s_POD_foo.new.test_.deadbeef_42"},
 					ID:    "4876",
 				},
 				{
-					// network container
-					Names: []string{"/k8s_net_foo.new.test_.deadbeef_42"},
+					// pod infra container
+					Names: []string{"/k8s_POD_foo.new.test_.deadbeef_42"},
 					ID:    "5876",
 				},
 				{
-					// network container
-					Names: []string{"/k8s_net_foo.new.test_.deadbeef_42"},
+					// pod infra container
+					Names: []string{"/k8s_POD_foo.new.test_.deadbeef_42"},
 					ID:    "6876",
 				},
 				{
-					// network container
-					Names: []string{"/k8s_net_foo.new.test_.deadbeef_42"},
+					// pod infra container
+					Names: []string{"/k8s_POD_foo.new.test_.deadbeef_42"},
 					ID:    "7876",
 				},
 			},
@@ -1707,8 +1707,8 @@ func TestKubeletGarbageCollection(t *testing.T) {
 		{
 			containers: []docker.APIContainers{
 				{
-					// network container
-					Names: []string{"/k8s_net_foo.new.test_.deadbeef_42"},
+					// pod infra container
+					Names: []string{"/k8s_POD_foo.new.test_.deadbeef_42"},
 					ID:    "1876",
 				},
 			},
@@ -1896,7 +1896,7 @@ func TestSyncPodsWithPullPolicy(t *testing.T) {
 	kubelet, fakeDocker := newTestKubelet(t)
 	puller := kubelet.dockerPuller.(*dockertools.FakeDockerPuller)
 	puller.HasImages = []string{"existing_one", "want:latest"}
-	kubelet.networkContainerImage = "custom_image_name"
+	kubelet.podInfraContainerImage = "custom_image_name"
 	fakeDocker.ContainerList = []docker.APIContainers{}
 	err := kubelet.SyncPods([]api.BoundPod{
 		{

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -153,13 +153,13 @@ func SimpleRunKubelet(client *client.Client,
 	masterServiceNamespace string,
 	volumePlugins []volume.Plugin) {
 	kcfg := KubeletConfig{
-		KubeClient:            client,
-		EtcdClient:            etcdClient,
-		DockerClient:          dockerClient,
-		HostnameOverride:      hostname,
-		RootDirectory:         rootDir,
-		ManifestURL:           manifestURL,
-		NetworkContainerImage: kubelet.NetworkContainerImage,
+		KubeClient:             client,
+		EtcdClient:             etcdClient,
+		DockerClient:           dockerClient,
+		HostnameOverride:       hostname,
+		RootDirectory:          rootDir,
+		ManifestURL:            manifestURL,
+		PodInfraContainerImage: kubelet.PodInfraContainerImage,
 		Port:                    port,
 		Address:                 util.IP(net.ParseIP(address)),
 		EnableServer:            true,
@@ -256,7 +256,7 @@ type KubeletConfig struct {
 	FileCheckFrequency      time.Duration
 	HttpCheckFrequency      time.Duration
 	Hostname                string
-	NetworkContainerImage   string
+	PodInfraContainerImage  string
 	SyncFrequency           time.Duration
 	RegistryPullQPS         float64
 	RegistryBurst           int
@@ -282,7 +282,7 @@ func createAndInitKubelet(kc *KubeletConfig, pc *config.PodConfig) (*kubelet.Kub
 		kc.EtcdClient,
 		kc.KubeClient,
 		kc.RootDirectory,
-		kc.NetworkContainerImage,
+		kc.PodInfraContainerImage,
 		kc.SyncFrequency,
 		float32(kc.RegistryPullQPS),
 		kc.RegistryBurst,


### PR DESCRIPTION
#1615

This PR makes the containers in a pod share ipc namespace in addition to network namespace. The "network container" is renamed to "pod infra container" as per @thockin suggestion.
Here is some output from testing:

```
[root@kubernetes-minion-1 ~]# docker ps
CONTAINER ID        IMAGE                                  COMMAND                CREATED              STATUS              PORTS                    NAMES
5db6f3cea91c        dockerfile/nginx:latest                "nginx"                About a minute ago   Up About a minute                            k8s_mynginx.6617bbd0_1a59f6e9-a5b9-11e4-a611-0800279696e1.default.api_1a59f6e9-a5b9-11e4-a611-0800279696e1_b7f0a81d               
d99d954d65bc        google/cadvisor:0.8.0                  "/usr/bin/cadvisor"    7 minutes ago        Up 7 minutes                                 k8s_cadvisor.4c14154f_cadvisor-agent.file-6bb810db-kubernetes-minion-1.file_3fd0c171b08ee83650fd343a6fdf9653_aa7ac19c             
05187563d087        kubernetes/fluentd-elasticsearch:1.0   "/bin/sh -c '/usr/sb   9 minutes ago        Up 9 minutes                                 k8s_fluentd-es.f0e4cc_fluentd-to-elasticsearch.file-8cd71177-kubernetes-minion-1.file_a6e8b87c41aade4c1d35ead1804d8fc4_39c7aec3   
c81cc8a37ce4        kubernetes/pause:go                    "/pause"               14 minutes ago       Up 14 minutes       0.0.0.0:9191->80/tcp     k8s_POD.a29db6ef_1a59f6e9-a5b9-11e4-a611-0800279696e1.default.api_1a59f6e9-a5b9-11e4-a611-0800279696e1_b963898c                   
39b274cc5f5c        kubernetes/pause:go                    "/pause"               19 minutes ago       Up 19 minutes                                k8s_POD.a812958f_fluentd-to-elasticsearch.file-8cd71177-kubernetes-minion-1.file_a6e8b87c41aade4c1d35ead1804d8fc4_385ae96c        
5d9bc25d14ad        kubernetes/pause:go                    "/pause"               19 minutes ago       Up 19 minutes       0.0.0.0:4194->8080/tcp   k8s_POD.117b915_cadvisor-agent.file-6bb810db-kubernetes-minion-1.file_3fd0c171b08ee83650fd343a6fdf9653_88393ead                   
[root@kubernetes-minion-1 ~]# docker inspect 5db6f3cea91c | grep Mode
        "IpcMode": "container:c81cc8a37ce411133f366abe4d45e6ea91e6071485e4f29ed12b74419a5fa86b",
        "NetworkMode": "container:c81cc8a37ce411133f366abe4d45e6ea91e6071485e4f29ed12b74419a5fa86b",
[root@kubernetes-minion-1 ~]# docker inspect c81cc8a37ce4 | grep Pid
        "Pid": 13521,
[root@kubernetes-minion-1 ~]# docker inspect 5db6f3cea91c | grep Pid
        "Pid": 18463,
[root@kubernetes-minion-1 ~]# ls -l /proc/13521/ns
total 0
lrwxrwxrwx 1 root root 0 Jan 27 00:25 ipc -> ipc:[4026532395]
lrwxrwxrwx 1 root root 0 Jan 27 00:27 mnt -> mnt:[4026532393]
lrwxrwxrwx 1 root root 0 Jan 27 00:25 net -> net:[4026532398]
lrwxrwxrwx 1 root root 0 Jan 27 00:27 pid -> pid:[4026532396]
lrwxrwxrwx 1 root root 0 Jan 27 00:27 uts -> uts:[4026532394]
[root@kubernetes-minion-1 ~]# ls -l /proc/18463/ns
total 0
lrwxrwxrwx 1 root root 0 Jan 27 00:27 ipc -> ipc:[4026532395]
lrwxrwxrwx 1 root root 0 Jan 27 00:27 mnt -> mnt:[4026532510]
lrwxrwxrwx 1 root root 0 Jan 27 00:27 net -> net:[4026532398]
lrwxrwxrwx 1 root root 0 Jan 27 00:27 pid -> pid:[4026532513]
lrwxrwxrwx 1 root root 0 Jan 27 00:27 uts -> uts:[4026532511]
```

@thockin @vishh PTAL
