### PR TITLE
break api.Probe out of api.LivenessProbe

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -273,15 +273,10 @@ type ExecAction struct {
 	Command []string `json:"command,omitempty"`
 }
 
-// LivenessProbe describes a liveness probe to be examined to the container.
-// TODO: pass structured data to the actions, and document that data here.
-type LivenessProbe struct {
-	// HTTPGetProbe parameters, required if Type == 'http'
-	HTTPGet *HTTPGetAction `json:"httpGet,omitempty"`
-	// TCPSocketProbe parameter, required if Type == 'tcp'
-	TCPSocket *TCPSocketAction `json:"tcpSocket,omitempty"`
-	// ExecProbe parameter, required if Type == 'exec'
-	Exec *ExecAction `json:"exec,omitempty"`
+// Probe describes a liveness probe to be examined to the container.
+type Probe struct {
+	// The action taken to determine the health of a container
+	Handler `json:",inline"`
 	// Length of time before health checking is activated.  In seconds.
 	InitialDelaySeconds int64 `json:"initialDelaySeconds,omitempty"`
 }
@@ -316,7 +311,7 @@ type Container struct {
 	// Optional: Defaults to unlimited.
 	CPU           resource.Quantity `json:"cpu,omitempty"`
 	VolumeMounts  []VolumeMount     `json:"volumeMounts,omitempty"`
-	LivenessProbe *LivenessProbe    `json:"livenessProbe,omitempty"`
+	LivenessProbe *Probe            `json:"livenessProbe,omitempty"`
 	Lifecycle     *Lifecycle        `json:"lifecycle,omitempty"`
 	// Optional: Defaults to /dev/termination-log
 	TerminationMessagePath string `json:"terminationMessagePath,omitempty"`
@@ -334,6 +329,9 @@ type Handler struct {
 	Exec *ExecAction `json:"exec,omitempty"`
 	// HTTPGet specifies the http request to perform.
 	HTTPGet *HTTPGetAction `json:"httpGet,omitempty"`
+	// TCPSocket specifies an action involving a TCP port.
+	// TODO: implement a realistic TCP lifecycle hook
+	TCPSocket *TCPSocketAction `json:"tcpSocket,omitempty"`
 }
 
 // Lifecycle describes actions that the management system should take in response to container lifecycle

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -811,6 +811,33 @@ func init() {
 			}
 			return nil
 		},
+
+		func(in *newer.Probe, out *LivenessProbe, s conversion.Scope) error {
+			if err := s.Convert(&in.Exec, &out.Exec, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.HTTPGet, &out.HTTPGet, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.TCPSocket, &out.TCPSocket, 0); err != nil {
+				return err
+			}
+			out.InitialDelaySeconds = in.InitialDelaySeconds
+			return nil
+		},
+		func(in *LivenessProbe, out *newer.Probe, s conversion.Scope) error {
+			if err := s.Convert(&in.Exec, &out.Exec, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.HTTPGet, &out.HTTPGet, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.TCPSocket, &out.TCPSocket, 0); err != nil {
+				return err
+			}
+			out.InitialDelaySeconds = in.InitialDelaySeconds
+			return nil
+		},
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -270,14 +270,16 @@ type Container struct {
 }
 
 // Handler defines a specific action that should be taken
-// TODO: merge this with liveness probing?
 // TODO: pass structured data to these actions, and document that data here.
 type Handler struct {
 	// One and only one of the following should be specified.
 	// Exec specifies the action to take.
-	Exec *ExecAction `json:"exec,omitempty" description:"exec-based hook handler"`
+	Exec *ExecAction `json:"exec,omitempty" description:"exec-based handler"`
 	// HTTPGet specifies the http request to perform.
-	HTTPGet *HTTPGetAction `json:"httpGet,omitempty" description:"HTTP-based hook handler"`
+	HTTPGet *HTTPGetAction `json:"httpGet,omitempty" description:"HTTP-based handler"`
+	// TCPSocket specifies an action involving a TCP port.
+	// TODO: implement a realistic TCP lifecycle hook
+	TCPSocket *TCPSocketAction `json:"tcpSocket,omitempty"  description:"TCP-based handler; TCP hooks not yet supported"`
 }
 
 // Lifecycle describes actions that the management system should take in response to container lifecycle

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -724,6 +724,33 @@ func init() {
 			}
 			return nil
 		},
+
+		func(in *newer.Probe, out *LivenessProbe, s conversion.Scope) error {
+			if err := s.Convert(&in.Exec, &out.Exec, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.HTTPGet, &out.HTTPGet, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.TCPSocket, &out.TCPSocket, 0); err != nil {
+				return err
+			}
+			out.InitialDelaySeconds = in.InitialDelaySeconds
+			return nil
+		},
+		func(in *LivenessProbe, out *newer.Probe, s conversion.Scope) error {
+			if err := s.Convert(&in.Exec, &out.Exec, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.HTTPGet, &out.HTTPGet, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.TCPSocket, &out.TCPSocket, 0); err != nil {
+				return err
+			}
+			out.InitialDelaySeconds = in.InitialDelaySeconds
+			return nil
+		},
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -238,9 +238,12 @@ type Container struct {
 type Handler struct {
 	// One and only one of the following should be specified.
 	// Exec specifies the action to take.
-	Exec *ExecAction `json:"exec,omitempty" description:"exec-based hook handler"`
+	Exec *ExecAction `json:"exec,omitempty" description:"exec-based handler"`
 	// HTTPGet specifies the http request to perform.
-	HTTPGet *HTTPGetAction `json:"httpGet,omitempty" description:"HTTP-based hook handler"`
+	HTTPGet *HTTPGetAction `json:"httpGet,omitempty" description:"HTTP-based handler"`
+	// TCPSocket specifies an action involving a TCP port.
+	// TODO: implement a realistic TCP lifecycle hook
+	TCPSocket *TCPSocketAction `json:"tcpSocket,omitempty"  description:"TCP-based handler; TCP hooks not yet supported"`
 }
 
 // Lifecycle describes actions that the management system should take in response to container lifecycle

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -291,15 +291,10 @@ type ExecAction struct {
 	Command []string `json:"command,omitempty"`
 }
 
-// LivenessProbe describes how to probe a container for liveness.
-// TODO: pass structured data to the actions, and document that data here.
-type LivenessProbe struct {
-	// HTTPGetProbe parameters, required if Type == 'HTTP'
-	HTTPGet *HTTPGetAction `json:"httpGet,omitempty"`
-	// TCPSocketProbe parameter, required if Type == 'TCP'
-	TCPSocket *TCPSocketAction `json:"tcpSocket,omitempty"`
-	// ExecProbe parameter, required if Type == 'Exec'
-	Exec *ExecAction `json:"exec,omitempty"`
+// Probe describes a liveness probe to be examined to the container.
+type Probe struct {
+	// The action taken to determine the health of a container
+	Handler `json:",inline"`
 	// Length of time before health checking is activated.  In seconds.
 	InitialDelaySeconds int64 `json:"initialDelaySeconds,omitempty"`
 }
@@ -334,7 +329,7 @@ type Container struct {
 	// Optional: Defaults to unlimited. Units: Cores. (500m == 1/2 core)
 	CPU           resource.Quantity `json:"cpu,omitempty"`
 	VolumeMounts  []VolumeMount     `json:"volumeMounts,omitempty"`
-	LivenessProbe *LivenessProbe    `json:"livenessProbe,omitempty"`
+	LivenessProbe *Probe            `json:"livenessProbe,omitempty"`
 	Lifecycle     *Lifecycle        `json:"lifecycle,omitempty"`
 	// Optional: Defaults to /dev/termination-log
 	TerminationMessagePath string `json:"terminationMessagePath,omitempty"`
@@ -352,6 +347,9 @@ type Handler struct {
 	Exec *ExecAction `json:"exec,omitempty"`
 	// HTTPGet specifies the http request to perform.
 	HTTPGet *HTTPGetAction `json:"httpGet,omitempty"`
+	// TCPSocket specifies an action involving a TCP port.
+	// TODO: implement a realistic TCP lifecycle hook
+	TCPSocket *TCPSocketAction `json:"tcpSocket,omitempty"`
 }
 
 // Lifecycle describes actions that the management system should take in response to container lifecycle

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -914,7 +914,7 @@ func TestSyncPodUnhealthy(t *testing.T) {
 		Spec: api.PodSpec{
 			Containers: []api.Container{
 				{Name: "bar",
-					LivenessProbe: &api.LivenessProbe{
+					LivenessProbe: &api.Probe{
 					// Always returns healthy == false
 					},
 				},

--- a/pkg/kubelet/probe.go
+++ b/pkg/kubelet/probe.go
@@ -38,7 +38,7 @@ var (
 	tcprober   = tcprobe.New()
 )
 
-func (kl *Kubelet) probeContainer(p *api.LivenessProbe, podFullName string, podUID types.UID, status api.PodStatus, container api.Container) (probe.Status, error) {
+func (kl *Kubelet) probeContainer(p *api.Probe, podFullName string, podUID types.UID, status api.PodStatus, container api.Container) (probe.Status, error) {
 	if p.Exec != nil {
 		return execprober.Probe(kl.newExecInContainer(podFullName, podUID, container))
 	}

--- a/pkg/kubelet/probe_test.go
+++ b/pkg/kubelet/probe_test.go
@@ -65,8 +65,10 @@ func TestGetURLParts(t *testing.T) {
 		state := api.PodStatus{PodIP: "127.0.0.1"}
 		container := api.Container{
 			Ports: []api.Port{{Name: "found", HostPort: 93}},
-			LivenessProbe: &api.LivenessProbe{
-				HTTPGet: test.probe,
+			LivenessProbe: &api.Probe{
+				Handler: api.Handler{
+					HTTPGet: test.probe,
+				},
 			},
 		}
 		p, err := extractPort(test.probe.Port, container)
@@ -106,8 +108,10 @@ func TestGetTCPAddrParts(t *testing.T) {
 		host := "1.2.3.4"
 		container := api.Container{
 			Ports: []api.Port{{Name: "found", HostPort: 93}},
-			LivenessProbe: &api.LivenessProbe{
-				TCPSocket: test.probe,
+			LivenessProbe: &api.Probe{
+				Handler: api.Handler{
+					TCPSocket: test.probe,
+				},
 			},
 		}
 		port, err := extractPort(test.probe.Port, container)


### PR DESCRIPTION
This PR breaks an api.Probe out of api.LivenessProbe so that it can be used in api types to be added. The breakout was chosen rather than renaming LivenessProbe so that future Probes need not share all configuration fields. For instance InitialDelaySeconds may not be relevant in a ReadinessProbe. This will cause conflicts with #3695 but it would make sense for this to be merged first.

/cc @bgrant0607 
