### PR TITLE
WIP - Add trace header for all incoming requests

### DIFF
--- a/pkg/api/context.go
+++ b/pkg/api/context.go
@@ -32,10 +32,18 @@ type key int
 
 // namespaceKey is the context key for the request namespace.
 const namespaceKey key = 0
+const traceKey key = 1
 
 // NewContext instantiates a base context object for request flows.
 func NewContext() Context {
 	return context.TODO()
+}
+
+func NewTracedContext(trace string) Context {
+	if len(trace) == 0 {
+		panic("all trace contexts must have a value")
+	}
+	return withTrace(context.Background(), trace)
 }
 
 // NewDefaultContext instantiates a base context object for request flows in the default namespace
@@ -50,6 +58,12 @@ func WithValue(parent Context, key interface{}, val interface{}) Context {
 		panic(stderrs.New("Invalid context type"))
 	}
 	return context.WithValue(internalCtx, key, val)
+}
+
+// TraceFrom returns the value of the trace key on the ctx.
+func TraceFrom(ctx Context) (string, bool) {
+	namespace, ok := ctx.Value(traceKey).(string)
+	return namespace, ok
 }
 
 // WithNamespace returns a copy of parent in which the namespace value is set
@@ -85,4 +99,9 @@ func WithNamespaceDefaultIfNone(parent Context) Context {
 		return WithNamespace(parent, NamespaceDefault)
 	}
 	return parent
+}
+
+// withTrace returns a copy of the parent in which the trace value is set
+func withTrace(parent Context, trace string) Context {
+	return WithValue(parent, traceKey, trace)
 }

--- a/pkg/api/httpcontext/httpcontext.go
+++ b/pkg/api/httpcontext/httpcontext.go
@@ -1,0 +1,76 @@
+package httpcontext
+
+import (
+	"math/rand"
+	"net/http"
+	"strconv"
+	"sync"
+
+	"github.com/golang/glog"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+const header = "X-Trace"
+
+var (
+	lock     sync.RWMutex
+	requests map[*http.Request]api.Context
+)
+
+func init() {
+	requests = make(map[*http.Request]api.Context)
+}
+
+func For(req *http.Request) api.Context {
+	lock.RLock()
+	defer lock.RUnlock()
+	ctx, ok := requests[req]
+	if !ok {
+		// All requests should have a context
+		ctx = api.NewContext()
+	}
+	return ctx
+}
+
+func Wrap(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		trace := traceFrom(req)
+		context := api.NewTracedContext(trace)
+		set(req, context)
+		defer remove(req)
+
+		w.Header().Set(header, trace)
+		handler.ServeHTTP(w, req)
+	})
+}
+
+func AddToRequest(req *http.Request, ctx api.Context) {
+	trace, ok := api.TraceFrom(ctx)
+	if !ok {
+		// TODO: I'd like to panic here as programmer error, but can just log for now
+		glog.Errorf("programmer error, context without trace used: %v", ctx)
+		return
+	}
+	req.Header.Set(header, trace)
+}
+
+func traceFrom(req *http.Request) string {
+	trace := req.Header.Get(header)
+	if len(trace) == 0 {
+		trace = strconv.FormatInt(int64(rand.Int63()), 10)
+	}
+	return trace
+}
+
+func set(req *http.Request, context api.Context) {
+	lock.Lock()
+	defer lock.Unlock()
+	requests[req] = context
+}
+
+func remove(req *http.Request) {
+	lock.Lock()
+	defer lock.Unlock()
+	delete(requests, req)
+}

--- a/pkg/apiserver/proxy.go
+++ b/pkg/apiserver/proxy.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/httpcontext"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -86,7 +87,7 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		notFound(w, req)
 		return
 	}
-	ctx := api.WithNamespace(api.NewContext(), namespace)
+	ctx := api.WithNamespace(httpcontext.For(req), namespace)
 	if len(parts) < 2 {
 		notFound(w, req)
 		return
@@ -151,6 +152,7 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	newReq.Header = req.Header
+	httpcontext.AddToRequest(newReq, ctx)
 
 	proxy := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: "http", Host: destURL.Host})
 	proxy.Transport = &proxyTransport{

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/httpcontext"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
@@ -148,7 +149,7 @@ func curry(f func(runtime.Object, *http.Request) error, req *http.Request) func(
 //    timeout=<duration> Timeout for synchronous requests, only applies if sync=true
 //    labels=<label-selector> Used for filtering list operations
 func (h *RESTHandler) handleRESTStorage(parts []string, req *http.Request, w http.ResponseWriter, storage RESTStorage, namespace, kind string) {
-	ctx := api.WithNamespace(api.NewContext(), namespace)
+	ctx := api.WithNamespace(httpcontext.For(req), namespace)
 	sync := req.URL.Query().Get("sync") == "true"
 	timeout := parseTimeout(req.URL.Query().Get("timeout"))
 	switch req.Method {

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/httpcontext"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta2"
@@ -410,7 +411,7 @@ func (m *Master) init(c *Config) {
 		handler = apiserver.CORS(handler, allowedOriginRegexps, nil, nil, "true")
 	}
 
-	m.InsecureHandler = handler
+	m.InsecureHandler = httpcontext.Wrap(handler)
 
 	attributeGetter := apiserver.NewRequestAttributeGetter(userContexts)
 	handler = apiserver.WithAuthorizationCheck(handler, attributeGetter, m.authorizer)
@@ -424,7 +425,7 @@ func (m *Master) init(c *Config) {
 	m.handlerContainer.Add(m.rootWebService)
 
 	// TODO: Make this optional?  Consumers of master depend on this currently.
-	m.Handler = handler
+	m.Handler = httpcontext.Wrap(handler)
 
 	if m.enableSwaggerSupport {
 		m.InstallSwaggerAPI()


### PR DESCRIPTION
This is a very simple PoC for a trace header to attach to requests and
move them through the system. The end goal is to establish a unique
identifier for an incoming request and propogate it down through all
layers of the stack and out to other endpoints. I'm not aware of a
library in Go that does this automatically, so I've started with the
basic sketch:
- Use google.Context (our api.Context object) to use or set a trace from the 'X-Trace' header as a top level http wrapper
- Set a context map for api.Context for code that does not properly pass api.Context but has access to the request
  - TODO: pass api.Context down through all of the api server methods
- Reuse the latest context in rest handler rather than initializing a new one
- Pass 'X-Trace' from RESTClient
- TODO: others

Feedback?
