### PR TITLE
Change kubelet working dir to /var/lib/kubelet

### DIFF
--- a/contrib/init/systemd/kubelet.service
+++ b/contrib/init/systemd/kubelet.service
@@ -5,6 +5,7 @@ After=docker.service cadvisor.service
 Requires=docker.service
 
 [Service]
+WorkingDirectory=/var/lib/kubelet
 EnvironmentFile=-/etc/kubernetes/config
 EnvironmentFile=-/etc/kubernetes/kubelet
 ExecStart=/usr/bin/kubelet \


### PR DESCRIPTION
Some image based OS do not allow writing to /. Since the kubelet looks
for .dockercfg files in the working dir and uses / as the working dir,
this means one can never set a .dockercfg on those distros. This moves
the kubelet working dir to /var/lib/kubelet, where the kubelet naturally
does its work.
