### PR TITLE
Check other dirs for .dockercfg

### DIFF
--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/cmd/kubelet/app"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/credentialprovider"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master/ports"
@@ -126,6 +127,8 @@ func main() {
 	if err != nil && len(apiServerList) > 0 {
 		glog.Warningf("No API client: %v", err)
 	}
+
+	credentialprovider.SetPreferredDockercfgPath(*rootDirectory)
 
 	kcfg := standalone.KubeletConfig{
 		Address:                 address,

--- a/pkg/credentialprovider/provider.go
+++ b/pkg/credentialprovider/provider.go
@@ -68,7 +68,7 @@ func (d *defaultDockerConfigProvider) Provide() DockerConfig {
 	if cfg, err := ReadDockerConfigFile(); err == nil {
 		return cfg
 	} else if !os.IsNotExist(err) {
-		glog.V(1).Infof("Unable to parse Docker config file: %v", err)
+		glog.V(4).Infof("Unable to parse Docker config file: %v", err)
 	}
 	return DockerConfig{}
 }

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/clientauth"
 	nodeControllerPkg "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/controller"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/controller"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/credentialprovider"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/config"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools"
@@ -187,6 +188,8 @@ func RunKubelet(kcfg *KubeletConfig) {
 	}
 	kubelet.SetupLogging()
 	kubelet.SetupCapabilities(kcfg.AllowPrivileged)
+
+	credentialprovider.SetPreferredDockercfgPath(kcfg.RootDirectory)
 
 	cfg := makePodSourceConfig(kcfg)
 	k, err := createAndInitKubelet(kcfg, cfg)


### PR DESCRIPTION
As per @thockin's comment, I tried to pick sane locations/priorities for .dockercfg paths without a --dockercfg which can easily be added later. This also raised the log level. This was manually tested and worked. Fixes #1767.
