### PR TITLE
Remove extra format in kubectl describe

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -202,7 +202,7 @@ func describeEvents(el *api.EventList, w io.Writer) {
 	sort.Sort(SortableEvents(el.Items))
 	fmt.Fprint(w, "Events:\nTime\tFrom\tSubobjectPath\tReason\tMessage\n")
 	for _, e := range el.Items {
-		fmt.Fprintf(w, "%s\t%v\t%v\t%v\t%v\t%v\n",
+		fmt.Fprintf(w, "%s\t%v\t%v\t%v\t%v\n",
 			e.Timestamp.Time.Format(time.RFC1123Z),
 			e.Source,
 			e.InvolvedObject.FieldPath,


### PR DESCRIPTION
e.g 

```
Mon, 26 Jan 2015 19:20:20 +0000 {kubelet kubernetes-minion-2.c.lucid-walker-725.internal}   spec.containers{lsj-pod}        started     Started with docker id ba8927d7305c0e9f8ff4977a65896facae3727738ca0c84a6161dfb21b95cd62 %!v(MISSING)
```

Wondering why go just silently accepts it...
