### PR TITLE
Compute IP addresses for big clusters for the GCE provider

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -34,8 +34,48 @@ MASTER_NAME="${INSTANCE_PREFIX}-master"
 MASTER_TAG="${INSTANCE_PREFIX}-master"
 MINION_TAG="${INSTANCE_PREFIX}-minion"
 MINION_NAMES=($(eval echo ${INSTANCE_PREFIX}-minion-{1..${NUM_MINIONS}}))
+
+function increment_ipv4 {
+  local ip_base=$1
+  local incr_amount=$2
+  local -a ip_components
+  local ip_regex="([0-9]+).([0-9]+).([0-9]+).([0-9]+)"
+  [[ $ip_base =~ $ip_regex ]]
+  ip_components=("${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}" "${BASH_REMATCH[4]}")
+  ip_dec=0
+  local comp
+  for comp in "${ip_components[@]}"; do
+    ip_dec=$((ip_dec<<8))
+    ip_dec=$((ip_dec + $comp))
+  done
+ 
+  ip_dec=$((ip_dec + $incr_amount))
+ 
+  ip_components=()
+  local i
+  for ((i=0; i < 4; i++)); do
+    comp=$((ip_dec & 0xFF))
+    ip_components+=($comp)
+    ip_dec=$((ip_dec>>8))
+  done
+  echo "${ip_components[3]}.${ip_components[2]}.${ip_components[1]}.${ip_components[0]}"
+}
+ 
+node_count="${NUM_MINIONS}"
+next_node="10.244.0.0"
+node_subnet_size=24
+node_subnet_count=$((2 ** (32-$node_subnet_size)))
+subnets=()
+ 
+for ((node_num=0; node_num<node_count; node_num++)); do
+  subnets+=("$next_node"/24)
+  next_node=$(increment_ipv4 $next_node $node_subnet_count)
+done
+echo "${subnets[@]}"
+
 CLUSTER_IP_RANGE="10.244.0.0/16"
-MINION_IP_RANGES=($(eval echo "10.244.{1..${NUM_MINIONS}}.0/24"))
+MINION_IP_RANGES=($(eval echo "${subnets[@]}"))
+
 MINION_SCOPES=("storage-ro" "compute-rw")
 # Increase the sleep interval value if concerned about API rate limits. 3, in seconds, is the default.
 POLL_SLEEP_INTERVAL=3


### PR DESCRIPTION
Allow large clusters to be created for the GCE provider. This change allows more than 255 IP addresses to be computed for the cluster. @jbeda 
