### PR TITLE
Migrate API defaulting to a centralized location

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -319,6 +319,8 @@ func runSelfLinkTest(c *client.Client) {
 				Selector: map[string]string{
 					"foo": "bar",
 				},
+				Protocol:        "TCP",
+				SessionAffinity: "None",
 			},
 		},
 	).Do().Into(&svc)
@@ -381,6 +383,8 @@ func runAtomicPutTest(c *client.Client) {
 				Selector: map[string]string{
 					"foo": "bar",
 				},
+				Protocol:        "TCP",
+				SessionAffinity: "None",
 			},
 		},
 	).Do().Into(&svc)
@@ -521,8 +525,11 @@ func runServiceTest(client *client.Client) {
 					Ports: []api.Port{
 						{ContainerPort: 1234},
 					},
+					ImagePullPolicy: "PullIfNotPresent",
 				},
 			},
+			RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+			DNSPolicy:     api.DNSClusterFirst,
 		},
 		Status: api.PodStatus{
 			PodIP: "1.2.3.4",
@@ -541,7 +548,9 @@ func runServiceTest(client *client.Client) {
 			Selector: map[string]string{
 				"name": "thisisalonglabel",
 			},
-			Port: 8080,
+			Port:            8080,
+			Protocol:        "TCP",
+			SessionAffinity: "None",
 		},
 	}
 	_, err = client.Services(api.NamespaceDefault).Create(&svc1)
@@ -558,7 +567,9 @@ func runServiceTest(client *client.Client) {
 			Selector: map[string]string{
 				"name": "thisisalonglabel",
 			},
-			Port: 8080,
+			Port:            8080,
+			Protocol:        "TCP",
+			SessionAffinity: "None",
 		},
 	}
 	_, err = client.Services(api.NamespaceDefault).Create(&svc2)

--- a/pkg/api/conversion.go
+++ b/pkg/api/conversion.go
@@ -47,14 +47,6 @@ func init() {
 			out.Spec.DNSPolicy = in.DNSPolicy
 			out.Name = in.ID
 			out.UID = in.UUID
-			// TODO(dchen1107): Move this conversion to pkg/api/v1beta[123]/conversion.go
-			// along with fixing #1502
-			for i := range out.Spec.Containers {
-				ctr := &out.Spec.Containers[i]
-				if len(ctr.TerminationMessagePath) == 0 {
-					ctr.TerminationMessagePath = TerminationMessagePathDefault
-				}
-			}
 			return nil
 		},
 		func(in *BoundPod, out *ContainerManifest, s conversion.Scope) error {
@@ -65,12 +57,6 @@ func init() {
 			out.Version = "v1beta2"
 			out.ID = in.Name
 			out.UUID = in.UID
-			for i := range out.Containers {
-				ctr := &out.Containers[i]
-				if len(ctr.TerminationMessagePath) == 0 {
-					ctr.TerminationMessagePath = TerminationMessagePathDefault
-				}
-			}
 			return nil
 		},
 

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -158,6 +158,10 @@ func TestEncode_Ptr(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{
 			Labels: map[string]string{"name": "foo"},
 		},
+		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+			DNSPolicy:     api.DNSClusterFirst,
+		},
 	}
 	obj := runtime.Object(pod)
 	data, err := latest.Codec.Encode(obj)
@@ -169,7 +173,7 @@ func TestEncode_Ptr(t *testing.T) {
 		t.Fatalf("Got wrong type")
 	}
 	if !api.Semantic.DeepEqual(obj2, pod) {
-		t.Errorf("Expected:\n %#v,\n Got:\n %#v", &pod, obj2)
+		t.Errorf("Expected:\n %#v,\n Got:\n %#v", pod, obj2)
 	}
 }
 

--- a/pkg/api/v1beta1/defaults.go
+++ b/pkg/api/v1beta1/defaults.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+func init() {
+	api.Scheme.AddDefaultingFuncs(
+		func(obj *Volume) {
+			if obj.Source == nil || util.AllPtrFieldsNil(obj.Source) {
+				obj.Source = &VolumeSource{
+					EmptyDir: &EmptyDir{},
+				}
+			}
+		},
+		func(obj *Port) {
+			if obj.Protocol == "" {
+				obj.Protocol = ProtocolTCP
+			}
+		},
+		func(obj *Container) {
+			// TODO: delete helper functions that touch this
+			if obj.ImagePullPolicy == "" {
+				obj.ImagePullPolicy = PullIfNotPresent
+			}
+			if obj.TerminationMessagePath == "" {
+				// TODO: fix other code that sets this
+				obj.TerminationMessagePath = api.TerminationMessagePathDefault
+			}
+		},
+		func(obj *RestartPolicy) {
+			if util.AllPtrFieldsNil(obj) {
+				obj.Always = &RestartPolicyAlways{}
+			}
+		},
+		func(obj *Service) {
+			if obj.Protocol == "" {
+				obj.Protocol = ProtocolTCP
+			}
+		},
+	)
+}
+
+// TODO: remove redundant code in validation and conversion

--- a/pkg/api/v1beta1/defaults_test.go
+++ b/pkg/api/v1beta1/defaults_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1_test
+
+import (
+	"reflect"
+	"testing"
+
+	current "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+)
+
+func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
+	data, err := current.Codec.Encode(obj)
+	if err != nil {
+		t.Errorf("%v\n %#v", err, obj)
+		return nil
+	}
+	obj2 := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(runtime.Object)
+	err = current.Codec.DecodeInto(data, obj2)
+	if err != nil {
+		t.Errorf("%v\nData: %s\nSource: %#v", err, string(data), obj)
+		return nil
+	}
+	return obj2
+}
+
+func TestSetDefaultService(t *testing.T) {
+	svc := &current.Service{}
+	obj2 := roundTrip(t, runtime.Object(svc))
+	svc2 := obj2.(*current.Service)
+	if svc2.Protocol != current.ProtocolTCP {
+		t.Errorf("Expected default protocol :%s, got: %s", current.ProtocolTCP, svc2.Protocol)
+	}
+	if svc2.SessionAffinity != current.AffinityTypeNone {
+		t.Errorf("Expected default sesseion affinity type:%s, got: %s", current.AffinityTypeNone, svc2.SessionAffinity)
+	}
+}
+
+func TestSetDefaulPodSpec(t *testing.T) {
+	bp := &current.BoundPod{}
+	obj2 := roundTrip(t, runtime.Object(bp))
+	bp2 := obj2.(*current.BoundPod)
+	if bp2.Spec.DNSPolicy != current.DNSClusterFirst {
+		t.Errorf("Expected default dns policy :%s, got: %s", current.DNSClusterFirst, bp2.Spec.DNSPolicy)
+	}
+	policy := bp2.Spec.RestartPolicy
+	if policy.Never != nil || policy.OnFailure != nil || policy.Always == nil {
+		t.Errorf("Expected only policy.Aways is set, got: %s", policy)
+	}
+}

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -71,6 +71,11 @@ type ContainerManifestList struct {
 	Items    []ContainerManifest `json:"items" description:"list of pod container manifests"`
 }
 
+const (
+	// TerminationMessagePathDefault means the default path to capture the application termination message running in a container
+	TerminationMessagePathDefault string = "/dev/termination-log"
+)
+
 // Volume represents a named volume in a pod that may be accessed by any containers in the pod.
 type Volume struct {
 	// Required: This must be a DNS_LABEL.  Each volume in a pod must have

--- a/pkg/api/v1beta2/defaults.go
+++ b/pkg/api/v1beta2/defaults.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package v1beta2
 
 import (
 	"strings"

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -252,6 +252,11 @@ type Container struct {
 	Capabilities Capabilities `json:"capabilities,omitempty" description:"capabilities for container"`
 }
 
+const (
+	// TerminationMessagePathDefault means the default path to capture the application termination message running in a container
+	TerminationMessagePathDefault string = "/dev/termination-log"
+)
+
 // Handler defines a specific action that should be taken
 // TODO: pass structured data to these actions, and document that data here.
 type Handler struct {

--- a/pkg/api/v1beta3/defaults.go
+++ b/pkg/api/v1beta3/defaults.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package v1beta3
 
 import (
 	"strings"
@@ -58,19 +58,14 @@ func init() {
 			}
 		},
 		func(obj *Service) {
-			if obj.Protocol == "" {
-				obj.Protocol = ProtocolTCP
+			if obj.Spec.Protocol == "" {
+				obj.Spec.Protocol = ProtocolTCP
 			}
-			if obj.SessionAffinity == "" {
-				obj.SessionAffinity = AffinityTypeNone
+			if obj.Spec.SessionAffinity == "" {
+				obj.Spec.SessionAffinity = AffinityTypeNone
 			}
 		},
 		func(obj *PodSpec) {
-			if obj.DNSPolicy == "" {
-				obj.DNSPolicy = DNSClusterFirst
-			}
-		},
-		func(obj *ContainerManifest) {
 			if obj.DNSPolicy == "" {
 				obj.DNSPolicy = DNSClusterFirst
 			}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -341,6 +341,11 @@ type ResourceRequirementSpec struct {
 	Limits ResourceList `json:"limits,omitempty" description:"Maximum amount of compute resources allowed"`
 }
 
+const (
+	// TerminationMessagePathDefault means the default path to capture the application termination message running in a container
+	TerminationMessagePathDefault string = "/dev/termination-log"
+)
+
 // Container represents a single container that is expected to be run on the host.
 type Container struct {
 	// Required: This must be a DNS_LABEL.  Each container in a pod must

--- a/pkg/api/validation/schema_test.go
+++ b/pkg/api/validation/schema_test.go
@@ -103,18 +103,17 @@ var invalidPod2 = `{
     "manifest": {
       "version": "v1beta1",
       "id": "apache-php",
-      "containers": [
-             {
-           "name": "apache-php",
-           "image": "php:5.6.2-apache",
-           "ports": [{ "name": "apache", "containerPort": 80, "hostPort":"13380", "protocol":"TCP" }],
-           "volumeMounts": [{"name": "shared-disk","mountPath": "/var/www/html", "readOnly": false}]
-        }
-           ]
+      "containers": [{
+         "name": "apache-php",
+         "image": "php:5.6.2-apache",
+         "ports": [{ "name": "apache", "containerPort": 80, "hostPort":"13380", "protocol":"TCP" }],
+         "volumeMounts": [{"name": "shared-disk","mountPath": "/var/www/html", "readOnly": false}]
+      }]
     }
   },
   "labels": { "name": "apache-php" },
   "restartPolicy": {"always": {}},
+  "dnsPolicy": "ClusterFirst",
   "volumes": [
     "name": "shared-disk",
     "source": {
@@ -134,18 +133,17 @@ var invalidPod3 = `{
     "manifest": {
       "version": "v1beta1",
       "id": "apache-php",
-      "containers": [
-             {
-           "name": "apache-php",
-           "image": "php:5.6.2-apache",
-           "ports": [{ "name": "apache", "containerPort": 80, "hostPort":"13380", "protocol":"TCP" }],
-           "volumeMounts": [{"name": "shared-disk","mountPath": "/var/www/html", "readOnly": false}]
-        }
-           ]
+      "containers": [{
+         "name": "apache-php",
+         "image": "php:5.6.2-apache",
+         "ports": [{ "name": "apache", "containerPort": 80, "hostPort":"13380", "protocol":"TCP" }],
+         "volumeMounts": [{"name": "shared-disk","mountPath": "/var/www/html", "readOnly": false}]
+      }]
     }
   },
   "labels": { "name": "apache-php" },
   "restartPolicy": {"always": {}},
+  "dnsPolicy": "ClusterFirst",
   "volumes": [
     {
       "name": "shared-disk",

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -96,7 +96,7 @@ func (c *testClient) Setup() *testClient {
 func (c *testClient) Validate(t *testing.T, received runtime.Object, err error) {
 	c.ValidateCommon(t, err)
 
-	if c.Response.Body != nil && !api.Semantic.DeepEqual(c.Response.Body, received) {
+	if c.Response.Body != nil && !api.Semantic.DeepDerivative(c.Response.Body, received) {
 		t.Errorf("bad response for request %#v: expected %#v, got %#v", c.Request, c.Response.Body, received)
 	}
 }

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -26,7 +26,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"reflect"
+	// "reflect"
 	"strings"
 	"testing"
 	"time"
@@ -62,7 +62,7 @@ func TestRequestWithErrorWontChange(t *testing.T) {
 	if changed != &r {
 		t.Errorf("returned request should point to the same object")
 	}
-	if !reflect.DeepEqual(&original, changed) {
+	if !api.Semantic.DeepDerivative(changed, &original) {
 		t.Errorf("expected %#v, got %#v", &original, changed)
 	}
 }
@@ -148,7 +148,7 @@ func TestRequestParseSelectorParam(t *testing.T) {
 
 func TestRequestParam(t *testing.T) {
 	r := (&Request{}).Param("foo", "a")
-	if !reflect.DeepEqual(map[string]string{"foo": "a"}, r.params) {
+	if !api.Semantic.DeepDerivative(r.params, map[string]string{"foo": "a"}) {
 		t.Errorf("should have set a param: %#v", r)
 	}
 }
@@ -218,7 +218,7 @@ func TestTransformResponse(t *testing.T) {
 		if hasErr != test.Error {
 			t.Errorf("%d: unexpected error: %t %v", i, test.Error, err)
 		}
-		if !(test.Data == nil && response == nil) && !reflect.DeepEqual(test.Data, response) {
+		if !(test.Data == nil && response == nil) && !api.Semantic.DeepDerivative(test.Data, response) {
 			t.Errorf("%d: unexpected response: %#v %#v", i, test.Data, response)
 		}
 		if test.Created != created {
@@ -491,7 +491,7 @@ func TestDoRequestNewWay(t *testing.T) {
 	}
 	if obj == nil {
 		t.Error("nil obj")
-	} else if !reflect.DeepEqual(obj, expectedObj) {
+	} else if !api.Semantic.DeepDerivative(expectedObj, obj) {
 		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
 	}
 	fakeHandler.ValidateRequest(t, "/api/v1beta2/foo/bar/baz?labels=name%3Dfoo&timeout=1s", "POST", &reqBody)
@@ -526,7 +526,7 @@ func TestDoRequestNewWayReader(t *testing.T) {
 	}
 	if obj == nil {
 		t.Error("nil obj")
-	} else if !reflect.DeepEqual(obj, expectedObj) {
+	} else if !api.Semantic.DeepDerivative(expectedObj, obj) {
 		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
 	}
 	tmpStr := string(reqBodyExpected)
@@ -562,7 +562,7 @@ func TestDoRequestNewWayObj(t *testing.T) {
 	}
 	if obj == nil {
 		t.Error("nil obj")
-	} else if !reflect.DeepEqual(obj, expectedObj) {
+	} else if !api.Semantic.DeepDerivative(expectedObj, obj) {
 		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
 	}
 	tmpStr := string(reqBodyExpected)
@@ -611,7 +611,7 @@ func TestDoRequestNewWayFile(t *testing.T) {
 	}
 	if obj == nil {
 		t.Error("nil obj")
-	} else if !reflect.DeepEqual(obj, expectedObj) {
+	} else if !api.Semantic.DeepDerivative(expectedObj, obj) {
 		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
 	}
 	if wasCreated {
@@ -653,7 +653,7 @@ func TestWasCreated(t *testing.T) {
 	}
 	if obj == nil {
 		t.Error("nil obj")
-	} else if !reflect.DeepEqual(obj, expectedObj) {
+	} else if !api.Semantic.DeepDerivative(expectedObj, obj) {
 		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
 	}
 	if !wasCreated {
@@ -790,7 +790,7 @@ func checkAuth(t *testing.T, expect *Config, r *http.Request) {
 	foundAuth, found := authFromReq(r)
 	if !found {
 		t.Errorf("no auth found")
-	} else if e, a := expect, foundAuth; !reflect.DeepEqual(e, a) {
+	} else if e, a := expect, foundAuth; !api.Semantic.DeepDerivative(e, a) {
 		t.Fatalf("Wrong basic auth: wanted %#v, got %#v", e, a)
 	}
 }
@@ -849,7 +849,7 @@ func TestWatch(t *testing.T) {
 		if e, a := item.t, got.Type; e != a {
 			t.Errorf("Expected %v, got %v", e, a)
 		}
-		if e, a := item.obj, got.Object; !reflect.DeepEqual(e, a) {
+		if e, a := item.obj, got.Object; !api.Semantic.DeepDerivative(e, a) {
 			t.Errorf("Expected %v, got %v", e, a)
 		}
 	}

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -239,7 +239,7 @@ func TestCreateReplica(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %#v", err)
 	}
-	if !api.Semantic.DeepEqual(&expectedPod, actualPod) {
+	if !api.Semantic.DeepDerivative(&expectedPod, actualPod) {
 		t.Logf("Body: %s", fakeHandler.RequestBody)
 		t.Errorf("Unexpected mismatch.  Expected\n %#v,\n Got:\n %#v", &expectedPod, actualPod)
 	}
@@ -351,7 +351,7 @@ func TestWatchControllers(t *testing.T) {
 	var testControllerSpec api.ReplicationController
 	received := make(chan struct{})
 	manager.syncHandler = func(controllerSpec api.ReplicationController) error {
-		if !api.Semantic.DeepEqual(controllerSpec, testControllerSpec) {
+		if !api.Semantic.DeepDerivative(controllerSpec, testControllerSpec) {
 			t.Errorf("Expected %#v, but got %#v", testControllerSpec, controllerSpec)
 		}
 		close(received)

--- a/pkg/conversion/converter.go
+++ b/pkg/conversion/converter.go
@@ -68,7 +68,6 @@ func NewConverter() *Converter {
 	return &Converter{
 		conversionFuncs:    map[typePair]reflect.Value{},
 		defaultingFuncs:    map[reflect.Type]reflect.Value{},
-		funcs:              map[typePair]reflect.Value{},
 		nameFunc:           func(t reflect.Type) string { return t.Name() },
 		structFieldDests:   map[typeNamePair][]typeNamePair{},
 		structFieldSources: map[typeNamePair][]typeNamePair{},
@@ -221,7 +220,7 @@ func (s *scope) error(message string, args ...interface{}) error {
 // used if recursive conversion calls are desired).  It must return an error.
 //
 // Example:
-// c.RegisteConversionFuncr(
+// c.RegisteConversionFunc(
 //         func(in *Pod, out *v1beta1.Pod, s Scope) error {
 //                 // conversion logic...
 //                 return nil
@@ -279,7 +278,7 @@ func (c *Converter) SetStructFieldCopy(srcFieldType interface{}, srcFieldName st
 // defaultingFunc must take one parameters: a pointer to the input type.
 //
 // Example:
-// c.RegisteDefaultingFuncr(
+// c.RegisteDefaultingFunc(
 //         func(in *v1beta1.Pod) {
 //                 // defaulting logic...
 //          })
@@ -415,7 +414,6 @@ func (c *Converter) callCustom(sv, dv, custom reflect.Value, scope *scope) error
 // one is registered.
 func (c *Converter) convert(sv, dv reflect.Value, scope *scope) error {
 	dt, st := dv.Type(), sv.Type()
-
 	// Apply default values.
 	if fv, ok := c.defaultingFuncs[st]; ok {
 		if c.Debug != nil {

--- a/pkg/conversion/converter_test.go
+++ b/pkg/conversion/converter_test.go
@@ -118,14 +118,14 @@ func TestConverter_CallsRegisteredFunctions(t *testing.T) {
 	type C struct{}
 	c := NewConverter()
 	c.Debug = t
-	err := c.Register(func(in *A, out *B, s Scope) error {
+	err := c.RegisterConversionFunc(func(in *A, out *B, s Scope) error {
 		out.Bar = in.Foo
 		return s.Convert(&in.Baz, &out.Baz, 0)
 	})
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
-	err = c.Register(func(in *B, out *A, s Scope) error {
+	err = c.RegisterConversionFunc(func(in *B, out *A, s Scope) error {
 		out.Foo = in.Bar
 		return s.Convert(&in.Baz, &out.Baz, 0)
 	})
@@ -161,7 +161,7 @@ func TestConverter_CallsRegisteredFunctions(t *testing.T) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
-	err = c.Register(func(in *A, out *C, s Scope) error {
+	err = c.RegisterConversionFunc(func(in *A, out *C, s Scope) error {
 		return fmt.Errorf("C can't store an A, silly")
 	})
 	if err != nil {
@@ -184,7 +184,7 @@ func TestConverter_fuzz(t *testing.T) {
 
 	f := fuzz.New().NilChance(.5).NumElements(0, 100)
 	c := NewConverter()
-	c.NameFunc = func(t reflect.Type) string {
+	c.nameFunc = func(t reflect.Type) string {
 		// Hide the fact that we don't have separate packages for these things.
 		return map[reflect.Type]string{
 			reflect.TypeOf(TestType1{}):         "TestType1",
@@ -270,7 +270,7 @@ func TestConverter_tags(t *testing.T) {
 	}
 	c := NewConverter()
 	c.Debug = t
-	err := c.Register(
+	err := c.RegisterConversionFunc(
 		func(in *string, out *string, s Scope) error {
 			if e, a := "foo", s.SrcTag().Get("test"); e != a {
 				t.Errorf("expected %v, got %v", e, a)
@@ -296,7 +296,7 @@ func TestConverter_meta(t *testing.T) {
 	c := NewConverter()
 	c.Debug = t
 	checks := 0
-	err := c.Register(
+	err := c.RegisterConversionFunc(
 		func(in *Foo, out *Bar, s Scope) error {
 			if s.Meta() == nil || s.Meta().SrcVersion != "test" || s.Meta().DestVersion != "passes" {
 				t.Errorf("Meta did not get passed!")
@@ -309,7 +309,7 @@ func TestConverter_meta(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	err = c.Register(
+	err = c.RegisterConversionFunc(
 		func(in *string, out *string, s Scope) error {
 			if s.Meta() == nil || s.Meta().SrcVersion != "test" || s.Meta().DestVersion != "passes" {
 				t.Errorf("Meta did not get passed a second time!")

--- a/pkg/conversion/converter_test.go
+++ b/pkg/conversion/converter_test.go
@@ -36,11 +36,11 @@ func TestConverter_DefaultConvert(t *testing.T) {
 	}
 	c := NewConverter()
 	c.Debug = t
-	c.NameFunc = func(t reflect.Type) string { return "MyType" }
+	c.nameFunc = func(t reflect.Type) string { return "MyType" }
 
 	// Ensure conversion funcs can call DefaultConvert to get default behavior,
 	// then fixup remaining fields manually
-	err := c.Register(func(in *A, out *B, s Scope) error {
+	err := c.RegisterConversionFunc(func(in *A, out *B, s Scope) error {
 		if err := s.DefaultConvert(in, out, IgnoreMissingFields); err != nil {
 			return err
 		}
@@ -224,7 +224,7 @@ func TestConverter_MapElemAddr(t *testing.T) {
 	}
 	c := NewConverter()
 	c.Debug = t
-	err := c.Register(
+	err := c.RegisterConversionFunc(
 		func(in *int, out *string, s Scope) error {
 			*out = fmt.Sprintf("%v", *in)
 			return nil
@@ -233,7 +233,7 @@ func TestConverter_MapElemAddr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	err = c.Register(
+	err = c.RegisterConversionFunc(
 		func(in *string, out *int, s Scope) error {
 			if str, err := strconv.Atoi(*in); err != nil {
 				return err

--- a/pkg/conversion/decode.go
+++ b/pkg/conversion/decode.go
@@ -103,27 +103,19 @@ func (s *Scheme) DecodeInto(data []byte, obj interface{}) error {
 		dataVersion = objVersion
 	}
 
-	if objVersion == dataVersion {
-		// Easy case!
-		err = yaml.Unmarshal(data, obj)
-		if err != nil {
-			return err
-		}
-	} else {
-		external, err := s.NewObject(dataVersion, dataKind)
-		if err != nil {
-			return err
-		}
-		// yaml is a superset of json, so we use it to decode here. That way,
-		// we understand both.
-		err = yaml.Unmarshal(data, external)
-		if err != nil {
-			return err
-		}
-		err = s.converter.Convert(external, obj, 0, s.generateConvertMeta(dataVersion, objVersion))
-		if err != nil {
-			return err
-		}
+	external, err := s.NewObject(dataVersion, dataKind)
+	if err != nil {
+		return err
+	}
+	// yaml is a superset of json, so we use it to decode here. That way,
+	// we understand both.
+	err = yaml.Unmarshal(data, external)
+	if err != nil {
+		return err
+	}
+	err = s.converter.Convert(external, obj, 0, s.generateConvertMeta(dataVersion, objVersion))
+	if err != nil {
+		return err
 	}
 
 	// Version and Kind should be blank in memory.

--- a/pkg/conversion/deep_equal.go
+++ b/pkg/conversion/deep_equal.go
@@ -233,3 +233,140 @@ func (e Equalities) DeepEqual(a1, a2 interface{}) bool {
 	}
 	return e.deepValueEqual(v1, v2, make(map[visit]bool), 0)
 }
+
+func (e Equalities) deepValueDerive(v1, v2 reflect.Value, visited map[visit]bool, depth int) bool {
+	if !v1.IsValid() || !v2.IsValid() {
+		return v1.IsValid() == v2.IsValid()
+	}
+	if v1.Type() != v2.Type() {
+		return false
+	}
+	if fv, ok := e[v1.Type()]; ok {
+		return fv.Call([]reflect.Value{v1, v2})[0].Bool()
+	}
+
+	hard := func(k reflect.Kind) bool {
+		switch k {
+		case reflect.Array, reflect.Map, reflect.Slice, reflect.Struct:
+			return true
+		}
+		return false
+	}
+
+	if v1.CanAddr() && v2.CanAddr() && hard(v1.Kind()) {
+		addr1 := v1.UnsafeAddr()
+		addr2 := v2.UnsafeAddr()
+		if addr1 > addr2 {
+			// Canonicalize order to reduce number of entries in visited.
+			addr1, addr2 = addr2, addr1
+		}
+
+		// Short circuit if references are identical ...
+		if addr1 == addr2 {
+			return true
+		}
+
+		// ... or already seen
+		typ := v1.Type()
+		v := visit{addr1, addr2, typ}
+		if visited[v] {
+			return true
+		}
+
+		// Remember for later.
+		visited[v] = true
+	}
+
+	switch v1.Kind() {
+	case reflect.Array:
+		for i := 0; i < v1.Len(); i++ {
+			if !e.deepValueDerive(v1.Index(i), v2.Index(i), visited, depth+1) {
+				return false
+			}
+		}
+		return true
+	case reflect.Slice:
+		if (v1.IsNil() || v1.Len() == 0) != (v2.IsNil() || v2.Len() == 0) {
+			return false
+		}
+		if v1.IsNil() || v1.Len() == 0 {
+			return true
+		}
+		if v1.Pointer() == v2.Pointer() {
+			return true
+		}
+		for i := 0; i < v1.Len(); i++ {
+			if !e.deepValueDerive(v1.Index(i), v2.Index(i), visited, depth+1) {
+				return false
+			}
+		}
+		return true
+	case reflect.String:
+		if v1.Len() == 0 {
+			return true
+		}
+		return v1.String() == v2.String()
+	case reflect.Interface:
+		if v1.IsNil() {
+			return true
+		}
+		return e.deepValueDerive(v1.Elem(), v2.Elem(), visited, depth+1)
+	case reflect.Ptr:
+		if v1.IsNil() {
+			return true
+		}
+		return e.deepValueDerive(v1.Elem(), v2.Elem(), visited, depth+1)
+	case reflect.Struct:
+		for i, n := 0, v1.NumField(); i < n; i++ {
+			if !e.deepValueDerive(v1.Field(i), v2.Field(i), visited, depth+1) {
+				return false
+			}
+		}
+		return true
+	case reflect.Map:
+		if (v1.IsNil() || v1.Len() == 0) != (v2.IsNil() || v2.Len() == 0) {
+			return false
+		}
+		if v1.IsNil() || v1.Len() == 0 {
+			return true
+		}
+		if v1.Pointer() == v2.Pointer() {
+			return true
+		}
+		for _, k := range v1.MapKeys() {
+			if !e.deepValueDerive(v1.MapIndex(k), v2.MapIndex(k), visited, depth+1) {
+				return false
+			}
+		}
+		return true
+	case reflect.Func:
+		if v1.IsNil() && v2.IsNil() {
+			return true
+		}
+		// Can't do better than this:
+		return false
+	default:
+		// Normal equality suffices
+		if v1.CanInterface() && v2.CanInterface() {
+			return v1.Interface() == v2.Interface()
+		}
+		return v1.CanInterface() == v2.CanInterface()
+	}
+}
+
+// DeepDerivative is similar to DeepEqual except that unset fields in a1 are
+// ignored (not compared). This allows we to focus on the fields that matter to
+// the semantic comparison.
+//
+// The unset fields include a nil pointer and an empty string.
+func (e Equalities) DeepDerivative(a1, a2 interface{}) bool {
+	if a1 == nil {
+		return true
+	}
+	v1 := reflect.ValueOf(a1)
+	v2 := reflect.ValueOf(a2)
+	if v1.Type() != v2.Type() {
+		return false
+	}
+	return e.deepValueDerive(v1, v2, make(map[visit]bool), 0)
+}

--- a/pkg/kubecfg/parse_test.go
+++ b/pkg/kubecfg/parse_test.go
@@ -73,11 +73,17 @@ func TestParsePod(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "test pod"},
 		Spec: api.PodSpec{
 			Containers: []api.Container{
-				{Name: "my container"},
+				{
+					Name:                   "my container",
+					ImagePullPolicy:        api.PullIfNotPresent,
+					TerminationMessagePath: api.TerminationMessagePathDefault,
+				},
 			},
 			Volumes: []api.Volume{
-				{Name: "volume"},
+				{Name: "volume", Source: api.VolumeSource{EmptyDir: &api.EmptyDir{}}},
 			},
+			RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+			DNSPolicy:     api.DNSClusterFirst,
 		},
 	}, v1beta1.Codec, testParser)
 }
@@ -96,6 +102,8 @@ func TestParseService(t *testing.T) {
 			Selector: map[string]string{
 				"area": "staging",
 			},
+			Protocol:        "TCP",
+			SessionAffinity: "None",
 		},
 	}, v1beta1.Codec, testParser)
 }
@@ -109,11 +117,17 @@ func TestParseController(t *testing.T) {
 			Template: &api.PodTemplateSpec{
 				Spec: api.PodSpec{
 					Containers: []api.Container{
-						{Name: "my container"},
+						{
+							Name:                   "my container",
+							ImagePullPolicy:        api.PullIfNotPresent,
+							TerminationMessagePath: api.TerminationMessagePathDefault,
+						},
 					},
 					Volumes: []api.Volume{
-						{Name: "volume"},
+						{Name: "volume", Source: api.VolumeSource{EmptyDir: &api.EmptyDir{}}},
 					},
+					RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+					DNSPolicy:     api.DNSClusterFirst,
 				},
 			},
 		},

--- a/pkg/kubecfg/resource_printer_test.go
+++ b/pkg/kubecfg/resource_printer_test.go
@@ -71,6 +71,10 @@ func TestYAMLPrinterPrint(t *testing.T) {
 
 	obj := &api.Pod{
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+			DNSPolicy:     api.DNSClusterFirst,
+		},
 	}
 	buf.Reset()
 	printer.PrintObj(obj, buf)
@@ -95,6 +99,10 @@ func TestIdentityPrinter(t *testing.T) {
 
 	obj := &api.Pod{
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+			DNSPolicy:     api.DNSClusterFirst,
+		},
 	}
 	buff.Reset()
 	printer.PrintObj(obj, buff)

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -42,9 +42,17 @@ func testData() (*api.PodList, *api.ServiceList) {
 		Items: []api.Pod{
 			{
 				ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "test", ResourceVersion: "10"},
+				Spec: api.PodSpec{
+					RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+					DNSPolicy:     api.DNSClusterFirst,
+				},
 			},
 			{
 				ObjectMeta: api.ObjectMeta{Name: "bar", Namespace: "test", ResourceVersion: "11"},
+				Spec: api.PodSpec{
+					RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+					DNSPolicy:     api.DNSClusterFirst,
+				},
 			},
 		},
 	}
@@ -55,6 +63,10 @@ func testData() (*api.PodList, *api.ServiceList) {
 		Items: []api.Service{
 			{
 				ObjectMeta: api.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
+				Spec: api.ServiceSpec{
+					Protocol:        "TCP",
+					SessionAffinity: "None",
+				},
 			},
 		},
 	}
@@ -296,6 +308,10 @@ func watchTestData() ([]api.Pod, []watch.Event) {
 				Namespace:       "test",
 				ResourceVersion: "10",
 			},
+			Spec: api.PodSpec{
+				RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+				DNSPolicy:     api.DNSClusterFirst,
+			},
 		},
 	}
 	events := []watch.Event{
@@ -307,6 +323,10 @@ func watchTestData() ([]api.Pod, []watch.Event) {
 					Namespace:       "test",
 					ResourceVersion: "11",
 				},
+				Spec: api.PodSpec{
+					RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+					DNSPolicy:     api.DNSClusterFirst,
+				},
 			},
 		},
 		{
@@ -316,6 +336,10 @@ func watchTestData() ([]api.Pod, []watch.Event) {
 					Name:            "foo",
 					Namespace:       "test",
 					ResourceVersion: "12",
+				},
+				Spec: api.PodSpec{
+					RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+					DNSPolicy:     api.DNSClusterFirst,
 				},
 			},
 		},

--- a/pkg/kubectl/cmd/helpers_test.go
+++ b/pkg/kubectl/cmd/helpers_test.go
@@ -42,6 +42,12 @@ func TestMerge(t *testing.T) {
 				ObjectMeta: api.ObjectMeta{
 					Name: "foo",
 				},
+				Spec: api.PodSpec{
+					RestartPolicy: api.RestartPolicy{
+						Always: &api.RestartPolicyAlways{},
+					},
+					DNSPolicy: api.DNSClusterFirst,
+				},
 			},
 		},
 		{
@@ -57,6 +63,10 @@ func TestMerge(t *testing.T) {
 				},
 				Spec: api.PodSpec{
 					Host: "bar",
+					RestartPolicy: api.RestartPolicy{
+						Always: &api.RestartPolicyAlways{},
+					},
+					DNSPolicy: api.DNSClusterFirst,
 				},
 			},
 		},
@@ -74,12 +84,18 @@ func TestMerge(t *testing.T) {
 				Spec: api.PodSpec{
 					Volumes: []api.Volume{
 						{
-							Name: "v1",
+							Name:   "v1",
+							Source: api.VolumeSource{EmptyDir: &api.EmptyDir{}},
 						},
 						{
-							Name: "v2",
+							Name:   "v2",
+							Source: api.VolumeSource{EmptyDir: &api.EmptyDir{}},
 						},
 					},
+					RestartPolicy: api.RestartPolicy{
+						Always: &api.RestartPolicyAlways{},
+					},
+					DNSPolicy: api.DNSClusterFirst,
 				},
 			},
 		},
@@ -91,13 +107,13 @@ func TestMerge(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
+	for i, test := range tests {
 		err := Merge(test.obj, test.fragment, "Pod")
 		if !test.expectErr {
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			} else if !reflect.DeepEqual(test.obj, test.expected) {
-				t.Errorf("\nexpected:\n%v\nsaw:\n%v", test.expected, test.obj)
+				t.Errorf("\n\ntestcase[%d]\nexpected:\n%v\nsaw:\n%v", i, test.expected, test.obj)
 			}
 		}
 		if test.expectErr && err == nil {

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -88,9 +88,17 @@ func testData() (*api.PodList, *api.ServiceList) {
 		Items: []api.Pod{
 			{
 				ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "test", ResourceVersion: "10"},
+				Spec: api.PodSpec{
+					RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+					DNSPolicy:     api.DNSClusterFirst,
+				},
 			},
 			{
 				ObjectMeta: api.ObjectMeta{Name: "bar", Namespace: "test", ResourceVersion: "11"},
+				Spec: api.PodSpec{
+					RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+					DNSPolicy:     api.DNSClusterFirst,
+				},
 			},
 		},
 	}
@@ -376,7 +384,7 @@ func TestSelector(t *testing.T) {
 	if err != nil || singular || len(test.Infos) != 3 {
 		t.Fatalf("unexpected response: %v %f %#v", err, singular, test.Infos)
 	}
-	if !reflect.DeepEqual([]runtime.Object{&pods.Items[0], &pods.Items[1], &svc.Items[0]}, test.Objects()) {
+	if !api.Semantic.DeepDerivative([]runtime.Object{&pods.Items[0], &pods.Items[1], &svc.Items[0]}, test.Objects()) {
 		t.Errorf("unexpected visited objects: %#v", test.Objects())
 	}
 
@@ -419,7 +427,7 @@ func TestStream(t *testing.T) {
 	if err != nil || singular || len(test.Infos) != 3 {
 		t.Fatalf("unexpected response: %v %f %#v", err, singular, test.Infos)
 	}
-	if !reflect.DeepEqual([]runtime.Object{&pods.Items[0], &pods.Items[1], &rc.Items[0]}, test.Objects()) {
+	if !api.Semantic.DeepDerivative([]runtime.Object{&pods.Items[0], &pods.Items[1], &rc.Items[0]}, test.Objects()) {
 		t.Errorf("unexpected visited objects: %#v", test.Objects())
 	}
 }
@@ -436,7 +444,7 @@ func TestYAMLStream(t *testing.T) {
 	if err != nil || singular || len(test.Infos) != 3 {
 		t.Fatalf("unexpected response: %v %f %#v", err, singular, test.Infos)
 	}
-	if !reflect.DeepEqual([]runtime.Object{&pods.Items[0], &pods.Items[1], &rc.Items[0]}, test.Objects()) {
+	if !api.Semantic.DeepDerivative([]runtime.Object{&pods.Items[0], &pods.Items[1], &rc.Items[0]}, test.Objects()) {
 		t.Errorf("unexpected visited objects: %#v", test.Objects())
 	}
 }
@@ -458,7 +466,7 @@ func TestMultipleObject(t *testing.T) {
 			&svc.Items[0],
 		},
 	}
-	if !reflect.DeepEqual(expected, obj) {
+	if !api.Semantic.DeepDerivative(expected, obj) {
 		t.Errorf("unexpected visited objects: %#v", obj)
 	}
 }
@@ -612,7 +620,7 @@ func TestLatest(t *testing.T) {
 	if err != nil || singular || len(test.Infos) != 3 {
 		t.Fatalf("unexpected response: %v %f %#v", err, singular, test.Infos)
 	}
-	if !reflect.DeepEqual([]runtime.Object{newPod, newPod2, newSvc}, test.Objects()) {
+	if !api.Semantic.DeepDerivative([]runtime.Object{newPod, newPod2, newSvc}, test.Objects()) {
 		t.Errorf("unexpected visited objects: %#v", test.Objects())
 	}
 }
@@ -646,7 +654,7 @@ func TestIgnoreStreamErrors(t *testing.T) {
 		t.Fatalf("unexpected response: %v %f %#v", err, singular, test.Infos)
 	}
 
-	if !reflect.DeepEqual([]runtime.Object{&pods.Items[0], &svc.Items[0]}, test.Objects()) {
+	if !api.Semantic.DeepDerivative([]runtime.Object{&pods.Items[0], &svc.Items[0]}, test.Objects()) {
 		t.Errorf("unexpected visited objects: %#v", test.Objects())
 	}
 }

--- a/pkg/kubectl/resource/helper_test.go
+++ b/pkg/kubectl/resource/helper_test.go
@@ -162,11 +162,17 @@ func TestHelperCreate(t *testing.T) {
 			Req:          expectPost,
 		},
 		{
-			Modify:       true,
-			Object:       &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"}},
-			ExpectObject: &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}},
-			Resp:         &http.Response{StatusCode: http.StatusOK, Body: objBody(&api.Status{Status: api.StatusSuccess})},
-			Req:          expectPost,
+			Modify: true,
+			Object: &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"}},
+			ExpectObject: &api.Pod{
+				ObjectMeta: api.ObjectMeta{Name: "foo"},
+				Spec: api.PodSpec{
+					RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+					DNSPolicy:     api.DNSClusterFirst,
+				},
+			},
+			Resp: &http.Response{StatusCode: http.StatusOK, Body: objBody(&api.Status{Status: api.StatusSuccess})},
+			Req:  expectPost,
 		},
 	}
 	for i, test := range tests {
@@ -400,9 +406,14 @@ func TestHelperUpdate(t *testing.T) {
 			Req: expectPut,
 		},
 		{
-			Object:       &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}},
-			ExpectObject: &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"}},
-
+			Object: &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}},
+			ExpectObject: &api.Pod{
+				ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"},
+				Spec: api.PodSpec{
+					RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+					DNSPolicy:     api.DNSClusterFirst,
+				},
+			},
 			Overwrite: true,
 			RespFunc: func(req *http.Request) (*http.Response, error) {
 				if req.Method == "PUT" {

--- a/pkg/kubelet/config/config_test.go
+++ b/pkg/kubelet/config/config_test.go
@@ -177,7 +177,7 @@ func TestNewPodAddedSnapshotAndUpdates(t *testing.T) {
 
 	// container updates are separated as UPDATE
 	pod := podUpdate.Pods[0]
-	pod.Spec.Containers = []api.Container{{Name: "bar", Image: "test"}}
+	pod.Spec.Containers = []api.Container{{Name: "bar", Image: "test", ImagePullPolicy: api.PullIfNotPresent}}
 	channel <- CreatePodUpdate(kubelet.ADD, NoneSource, pod)
 	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.UPDATE, NoneSource, pod))
 }
@@ -195,7 +195,7 @@ func TestNewPodAddedSnapshot(t *testing.T) {
 
 	// container updates are separated as UPDATE
 	pod := podUpdate.Pods[0]
-	pod.Spec.Containers = []api.Container{{Name: "bar", Image: "test"}}
+	pod.Spec.Containers = []api.Container{{Name: "bar", Image: "test", ImagePullPolicy: api.PullIfNotPresent}}
 	channel <- CreatePodUpdate(kubelet.ADD, NoneSource, pod)
 	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.SET, TestSource, pod))
 }
@@ -213,7 +213,7 @@ func TestNewPodAddedUpdatedRemoved(t *testing.T) {
 
 	// an kubelet.ADD should be converted to kubelet.UPDATE
 	pod := CreateValidPod("foo", "new", "test")
-	pod.Spec.Containers = []api.Container{{Name: "bar", Image: "test"}}
+	pod.Spec.Containers = []api.Container{{Name: "bar", Image: "test", ImagePullPolicy: api.PullIfNotPresent}}
 	podUpdate = CreatePodUpdate(kubelet.ADD, NoneSource, pod)
 	channel <- podUpdate
 	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.UPDATE, NoneSource, pod))
@@ -236,7 +236,7 @@ func TestNewPodAddedUpdatedSet(t *testing.T) {
 
 	// should be converted to an kubelet.ADD, kubelet.REMOVE, and kubelet.UPDATE
 	pod := CreateValidPod("foo2", "new", "test")
-	pod.Spec.Containers = []api.Container{{Name: "bar", Image: "test"}}
+	pod.Spec.Containers = []api.Container{{Name: "bar", Image: "test", ImagePullPolicy: api.PullIfNotPresent}}
 	podUpdate = CreatePodUpdate(kubelet.SET, NoneSource, pod, CreateValidPod("foo3", "new", ""), CreateValidPod("foo4", "new", "test"))
 	channel <- podUpdate
 	expectPodUpdate(t, ch,

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -62,7 +62,6 @@ func ExampleManifestAndPod(id string) (v1beta1.ContainerManifest, api.BoundPod) 
 				{
 					Name:  "c" + id,
 					Image: "foo",
-					TerminationMessagePath: "/somepath",
 				},
 			},
 			Volumes: []api.Volume{
@@ -94,7 +93,7 @@ func TestUpdateOnNonExistentFile(t *testing.T) {
 	case got := <-ch:
 		update := got.(kubelet.PodUpdate)
 		expected := CreatePodUpdate(kubelet.SET, kubelet.FileSource)
-		if !api.Semantic.DeepEqual(expected, update) {
+		if !api.Semantic.DeepDerivative(expected, update) {
 			t.Fatalf("Expected %#v, Got %#v", expected, update)
 		}
 
@@ -137,15 +136,7 @@ func TestReadFromFile(t *testing.T) {
 				Namespace: "",
 				SelfLink:  "",
 			},
-			Spec: api.PodSpec{
-				Containers: []api.Container{
-					{
-						Image: "test/image",
-						TerminationMessagePath: "/dev/termination-log",
-						ImagePullPolicy:        api.PullAlways,
-					},
-				},
-			},
+			Spec: api.PodSpec{Containers: []api.Container{{Image: "test/image"}}},
 		})
 
 		// There's no way to provide namespace in ContainerManifest, so
@@ -161,7 +152,7 @@ func TestReadFromFile(t *testing.T) {
 		}
 		update.Pods[0].ObjectMeta.SelfLink = ""
 
-		if !api.Semantic.DeepEqual(expected, update) {
+		if !api.Semantic.DeepDerivative(expected, update) {
 			t.Fatalf("Expected %#v, Got %#v", expected, update)
 		}
 
@@ -191,15 +182,7 @@ func TestReadFromFileWithoutID(t *testing.T) {
 				Namespace: "",
 				SelfLink:  "",
 			},
-			Spec: api.PodSpec{
-				Containers: []api.Container{
-					{
-						Image: "test/image",
-						TerminationMessagePath: "/dev/termination-log",
-						ImagePullPolicy:        api.PullAlways,
-					},
-				},
-			},
+			Spec: api.PodSpec{Containers: []api.Container{{Image: "test/image"}}},
 		})
 
 		if len(update.Pods[0].ObjectMeta.Name) == 0 {
@@ -209,7 +192,7 @@ func TestReadFromFileWithoutID(t *testing.T) {
 		update.Pods[0].ObjectMeta.Namespace = ""
 		update.Pods[0].ObjectMeta.SelfLink = ""
 
-		if !api.Semantic.DeepEqual(expected, update) {
+		if !api.Semantic.DeepDerivative(expected, update) {
 			t.Fatalf("Expected %#v, Got %#v", expected, update)
 		}
 
@@ -240,21 +223,13 @@ func TestReadV1Beta2FromFile(t *testing.T) {
 				Namespace: "",
 				SelfLink:  "",
 			},
-			Spec: api.PodSpec{
-				Containers: []api.Container{
-					{
-						Image: "test/image",
-						TerminationMessagePath: "/dev/termination-log",
-						ImagePullPolicy:        api.PullAlways,
-					},
-				},
-			},
+			Spec: api.PodSpec{Containers: []api.Container{{Image: "test/image"}}},
 		})
 
 		update.Pods[0].ObjectMeta.Namespace = ""
 		update.Pods[0].ObjectMeta.SelfLink = ""
 
-		if !api.Semantic.DeepEqual(expected, update) {
+		if !api.Semantic.DeepDerivative(expected, update) {
 			t.Fatalf("Expected %#v, Got %#v", expected, update)
 		}
 
@@ -315,7 +290,7 @@ func TestExtractFromEmptyDir(t *testing.T) {
 
 	update := (<-ch).(kubelet.PodUpdate)
 	expected := CreatePodUpdate(kubelet.SET, kubelet.FileSource)
-	if !api.Semantic.DeepEqual(expected, update) {
+	if !api.Semantic.DeepDerivative(expected, update) {
 		t.Errorf("Expected %#v, Got %#v", expected, update)
 	}
 }
@@ -371,7 +346,7 @@ func TestExtractFromDir(t *testing.T) {
 	}
 	sort.Sort(sortedPods(update.Pods))
 	sort.Sort(sortedPods(expected.Pods))
-	if !api.Semantic.DeepEqual(expected, update) {
+	if !api.Semantic.DeepDerivative(expected, update) {
 		t.Fatalf("Expected %#v, Got %#v", expected, update)
 	}
 	for i := range update.Pods {

--- a/pkg/master/publish.go
+++ b/pkg/master/publish.go
@@ -90,8 +90,10 @@ func (m *Master) createMasterServiceIfNeeded(serviceName string, serviceIP net.I
 		Spec: api.ServiceSpec{
 			Port: servicePort,
 			// maintained by this code, not by the pod selector
-			Selector: nil,
-			PortalIP: serviceIP.String(),
+			Selector:        nil,
+			PortalIP:        serviceIP.String(),
+			Protocol:        api.ProtocolTCP,
+			SessionAffinity: api.AffinityTypeNone,
 		},
 	}
 	// Kids, don't do this at home: this is a hack. There's no good way to call the business

--- a/pkg/registry/controller/rest_test.go
+++ b/pkg/registry/controller/rest_test.go
@@ -126,6 +126,10 @@ func TestControllerDecode(t *testing.T) {
 						"name": "nginx",
 					},
 				},
+				Spec: api.PodSpec{
+					RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+					DNSPolicy:     api.DNSClusterFirst,
+				},
 			},
 		},
 	}
@@ -225,10 +229,13 @@ var validPodTemplate = api.PodTemplate{
 		Spec: api.PodSpec{
 			Containers: []api.Container{
 				{
-					Name:  "test",
-					Image: "test_image",
+					Name:            "test",
+					Image:           "test_image",
+					ImagePullPolicy: api.PullIfNotPresent,
 				},
 			},
+			RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+			DNSPolicy:     api.DNSClusterFirst,
 		},
 	},
 }

--- a/pkg/registry/generic/etcd/etcd_test.go
+++ b/pkg/registry/generic/etcd/etcd_test.go
@@ -19,7 +19,6 @@ package etcd
 import (
 	"fmt"
 	"path"
-	"reflect"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -146,7 +145,7 @@ func TestEtcdList(t *testing.T) {
 			continue
 		}
 
-		if e, a := item.out, list; !reflect.DeepEqual(e, a) {
+		if e, a := item.out, list; !api.Semantic.DeepDerivative(e, a) {
 			t.Errorf("%v: Expected %#v, got %#v", name, e, a)
 		}
 	}
@@ -209,7 +208,7 @@ func TestEtcdCreate(t *testing.T) {
 			t.Errorf("%v: unexpected error: %v", name, err)
 		}
 
-		if e, a := item.expect, fakeClient.Data[path]; !reflect.DeepEqual(e, a) {
+		if e, a := item.expect, fakeClient.Data[path]; !api.Semantic.DeepDerivative(e, a) {
 			t.Errorf("%v:\n%s", name, util.ObjectDiff(e, a))
 		}
 	}
@@ -284,7 +283,7 @@ func TestEtcdUpdate(t *testing.T) {
 			t.Errorf("%v: unexpected error: %v", name, err)
 		}
 
-		if e, a := item.expect, fakeClient.Data[path]; !reflect.DeepEqual(e, a) {
+		if e, a := item.expect, fakeClient.Data[path]; !api.Semantic.DeepDerivative(e, a) {
 			t.Errorf("%v:\n%s", name, util.ObjectDiff(e, a))
 		}
 	}
@@ -340,7 +339,7 @@ func TestEtcdGet(t *testing.T) {
 			t.Errorf("%v: unexpected error: %v", name, err)
 		}
 
-		if e, a := item.expect, got; !reflect.DeepEqual(e, a) {
+		if e, a := item.expect, got; !api.Semantic.DeepDerivative(e, a) {
 			t.Errorf("%v:\n%s", name, util.ObjectDiff(e, a))
 		}
 	}
@@ -396,7 +395,7 @@ func TestEtcdDelete(t *testing.T) {
 			t.Errorf("%v: unexpected error: %v", name, err)
 		}
 
-		if e, a := item.expect, fakeClient.Data[path]; !reflect.DeepEqual(e, a) {
+		if e, a := item.expect, fakeClient.Data[path]; !api.Semantic.DeepDerivative(e, a) {
 			t.Errorf("%v:\n%s", name, util.ObjectDiff(e, a))
 		}
 	}
@@ -432,7 +431,7 @@ func TestEtcdWatch(t *testing.T) {
 		t.Fatalf("unexpected channel close")
 	}
 
-	if e, a := podA, got.Object; !reflect.DeepEqual(e, a) {
+	if e, a := podA, got.Object; !api.Semantic.DeepDerivative(e, a) {
 		t.Errorf("difference: %s", util.ObjectDiff(e, a))
 	}
 }

--- a/pkg/registry/pod/rest_test.go
+++ b/pkg/registry/pod/rest_test.go
@@ -88,6 +88,10 @@ func TestCreatePodRegistryError(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{
 			Name: "foo",
 		},
+		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+			DNSPolicy:     api.DNSClusterFirst,
+		},
 	}
 	ctx := api.NewDefaultContext()
 	ch, err := storage.Create(ctx, pod)
@@ -107,6 +111,10 @@ func TestCreatePodSetsIds(t *testing.T) {
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name: "foo",
+		},
+		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+			DNSPolicy:     api.DNSClusterFirst,
 		},
 	}
 	ctx := api.NewDefaultContext()
@@ -134,6 +142,10 @@ func TestCreatePodSetsUID(t *testing.T) {
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name: "foo",
+		},
+		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+			DNSPolicy:     api.DNSClusterFirst,
 		},
 	}
 	ctx := api.NewDefaultContext()
@@ -346,6 +358,10 @@ func TestPodDecode(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{
 			Name: "foo",
 		},
+		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+			DNSPolicy:     api.DNSClusterFirst,
+		},
 	}
 	body, err := latest.Codec.Encode(expected)
 	if err != nil {
@@ -447,7 +463,12 @@ func TestCreatePod(t *testing.T) {
 		registry: podRegistry,
 		podCache: &fakeCache{statusToReturn: &api.PodStatus{}},
 	}
-	pod := &api.Pod{}
+	pod := &api.Pod{
+		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+			DNSPolicy:     api.DNSClusterFirst,
+		},
+	}
 	pod.Name = "foo"
 	ctx := api.NewDefaultContext()
 	channel, err := storage.Create(ctx, pod)
@@ -470,6 +491,10 @@ func TestCreatePodWithConflictingNamespace(t *testing.T) {
 	storage := REST{}
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{Name: "test", Namespace: "not-default"},
+		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+			DNSPolicy:     api.DNSClusterFirst,
+		},
 	}
 
 	ctx := api.NewDefaultContext()
@@ -488,6 +513,10 @@ func TestUpdatePodWithConflictingNamespace(t *testing.T) {
 	storage := REST{}
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{Name: "test", Namespace: "not-default"},
+		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+			DNSPolicy:     api.DNSClusterFirst,
+		},
 	}
 
 	ctx := api.NewDefaultContext()
@@ -647,10 +676,13 @@ func TestCreate(t *testing.T) {
 			Spec: api.PodSpec{
 				Containers: []api.Container{
 					{
-						Name:  "test1",
-						Image: "foo",
+						Name:            "test1",
+						Image:           "foo",
+						ImagePullPolicy: api.PullIfNotPresent,
 					},
 				},
+				RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+				DNSPolicy:     api.DNSClusterFirst,
 			},
 		},
 		// invalid

--- a/pkg/registry/service/rest_test.go
+++ b/pkg/registry/service/rest_test.go
@@ -49,8 +49,10 @@ func TestServiceRegistryCreate(t *testing.T) {
 	svc := &api.Service{
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 		Spec: api.ServiceSpec{
-			Port:     6502,
-			Selector: map[string]string{"bar": "baz"},
+			Port:            6502,
+			Selector:        map[string]string{"bar": "baz"},
+			Protocol:        api.ProtocolTCP,
+			SessionAffinity: api.AffinityTypeNone,
 		},
 	}
 	ctx := api.NewDefaultContext()
@@ -91,14 +93,18 @@ func TestServiceStorageValidatesCreate(t *testing.T) {
 		"empty ID": {
 			ObjectMeta: api.ObjectMeta{Name: ""},
 			Spec: api.ServiceSpec{
-				Port:     6502,
-				Selector: map[string]string{"bar": "baz"},
+				Port:            6502,
+				Selector:        map[string]string{"bar": "baz"},
+				Protocol:        api.ProtocolTCP,
+				SessionAffinity: api.AffinityTypeNone,
 			},
 		},
 		"empty selector": {
 			ObjectMeta: api.ObjectMeta{Name: "foo"},
 			Spec: api.ServiceSpec{
-				Selector: map[string]string{"bar": "baz"},
+				Selector:        map[string]string{"bar": "baz"},
+				Protocol:        api.ProtocolTCP,
+				SessionAffinity: api.AffinityTypeNone,
 			},
 		},
 	}
@@ -129,8 +135,10 @@ func TestServiceRegistryUpdate(t *testing.T) {
 	c, err := storage.Update(ctx, &api.Service{
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 		Spec: api.ServiceSpec{
-			Port:     6502,
-			Selector: map[string]string{"bar": "baz2"},
+			Port:            6502,
+			Selector:        map[string]string{"bar": "baz2"},
+			Protocol:        api.ProtocolTCP,
+			SessionAffinity: api.AffinityTypeNone,
 		},
 	})
 	if err != nil {
@@ -164,15 +172,19 @@ func TestServiceStorageValidatesUpdate(t *testing.T) {
 		"empty ID": {
 			ObjectMeta: api.ObjectMeta{Name: ""},
 			Spec: api.ServiceSpec{
-				Port:     6502,
-				Selector: map[string]string{"bar": "baz"},
+				Port:            6502,
+				Selector:        map[string]string{"bar": "baz"},
+				Protocol:        api.ProtocolTCP,
+				SessionAffinity: api.AffinityTypeNone,
 			},
 		},
 		"invalid selector": {
 			ObjectMeta: api.ObjectMeta{Name: "foo"},
 			Spec: api.ServiceSpec{
-				Port:     6502,
-				Selector: map[string]string{"ThisSelectorFailsValidation": "ok"},
+				Port:            6502,
+				Selector:        map[string]string{"ThisSelectorFailsValidation": "ok"},
+				Protocol:        api.ProtocolTCP,
+				SessionAffinity: api.AffinityTypeNone,
 			},
 		},
 	}
@@ -199,6 +211,8 @@ func TestServiceRegistryExternalService(t *testing.T) {
 			Port:                       6502,
 			Selector:                   map[string]string{"bar": "baz"},
 			CreateExternalLoadBalancer: true,
+			Protocol:                   api.ProtocolTCP,
+			SessionAffinity:            api.AffinityTypeNone,
 		},
 	}
 	c, _ := storage.Create(ctx, svc)
@@ -228,6 +242,8 @@ func TestServiceRegistryExternalServiceError(t *testing.T) {
 			Port:                       6502,
 			Selector:                   map[string]string{"bar": "baz"},
 			CreateExternalLoadBalancer: true,
+			Protocol:                   api.ProtocolTCP,
+			SessionAffinity:            api.AffinityTypeNone,
 		},
 	}
 	ctx := api.NewDefaultContext()
@@ -250,7 +266,9 @@ func TestServiceRegistryDelete(t *testing.T) {
 	svc := &api.Service{
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 		Spec: api.ServiceSpec{
-			Selector: map[string]string{"bar": "baz"},
+			Selector:        map[string]string{"bar": "baz"},
+			Protocol:        api.ProtocolTCP,
+			SessionAffinity: api.AffinityTypeNone,
 		},
 	}
 	registry.CreateService(ctx, svc)
@@ -275,6 +293,8 @@ func TestServiceRegistryDeleteExternal(t *testing.T) {
 		Spec: api.ServiceSpec{
 			Selector:                   map[string]string{"bar": "baz"},
 			CreateExternalLoadBalancer: true,
+			Protocol:                   api.ProtocolTCP,
+			SessionAffinity:            api.AffinityTypeNone,
 		},
 	}
 	registry.CreateService(ctx, svc)
@@ -389,8 +409,10 @@ func TestServiceRegistryIPAllocation(t *testing.T) {
 	svc1 := &api.Service{
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 		Spec: api.ServiceSpec{
-			Selector: map[string]string{"bar": "baz"},
-			Port:     6502,
+			Selector:        map[string]string{"bar": "baz"},
+			Port:            6502,
+			Protocol:        api.ProtocolTCP,
+			SessionAffinity: api.AffinityTypeNone,
 		},
 	}
 	ctx := api.NewDefaultContext()
@@ -407,8 +429,10 @@ func TestServiceRegistryIPAllocation(t *testing.T) {
 	svc2 := &api.Service{
 		ObjectMeta: api.ObjectMeta{Name: "bar"},
 		Spec: api.ServiceSpec{
-			Selector: map[string]string{"bar": "baz"},
-			Port:     6502,
+			Selector:        map[string]string{"bar": "baz"},
+			Port:            6502,
+			Protocol:        api.ProtocolTCP,
+			SessionAffinity: api.AffinityTypeNone,
 		}}
 	ctx = api.NewDefaultContext()
 	c2, _ := rest.Create(ctx, svc2)
@@ -424,9 +448,11 @@ func TestServiceRegistryIPAllocation(t *testing.T) {
 	svc3 := &api.Service{
 		ObjectMeta: api.ObjectMeta{Name: "quux"},
 		Spec: api.ServiceSpec{
-			Selector: map[string]string{"bar": "baz"},
-			PortalIP: "1.2.3.93",
-			Port:     6502,
+			Selector:        map[string]string{"bar": "baz"},
+			PortalIP:        "1.2.3.93",
+			Port:            6502,
+			Protocol:        api.ProtocolTCP,
+			SessionAffinity: api.AffinityTypeNone,
 		},
 	}
 	ctx = api.NewDefaultContext()
@@ -448,8 +474,10 @@ func TestServiceRegistryIPReallocation(t *testing.T) {
 	svc1 := &api.Service{
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 		Spec: api.ServiceSpec{
-			Selector: map[string]string{"bar": "baz"},
-			Port:     6502,
+			Selector:        map[string]string{"bar": "baz"},
+			Port:            6502,
+			Protocol:        api.ProtocolTCP,
+			SessionAffinity: api.AffinityTypeNone,
 		},
 	}
 	ctx := api.NewDefaultContext()
@@ -469,8 +497,10 @@ func TestServiceRegistryIPReallocation(t *testing.T) {
 	svc2 := &api.Service{
 		ObjectMeta: api.ObjectMeta{Name: "bar"},
 		Spec: api.ServiceSpec{
-			Selector: map[string]string{"bar": "baz"},
-			Port:     6502,
+			Selector:        map[string]string{"bar": "baz"},
+			Port:            6502,
+			Protocol:        api.ProtocolTCP,
+			SessionAffinity: api.AffinityTypeNone,
 		},
 	}
 	ctx = api.NewDefaultContext()
@@ -495,8 +525,10 @@ func TestServiceRegistryIPUpdate(t *testing.T) {
 	svc := &api.Service{
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 		Spec: api.ServiceSpec{
-			Selector: map[string]string{"bar": "baz"},
-			Port:     6502,
+			Selector:        map[string]string{"bar": "baz"},
+			Port:            6502,
+			Protocol:        api.ProtocolTCP,
+			SessionAffinity: api.AffinityTypeNone,
 		},
 	}
 	ctx := api.NewDefaultContext()
@@ -551,6 +583,8 @@ func TestServiceRegistryIPExternalLoadBalancer(t *testing.T) {
 			Selector: map[string]string{"bar": "baz"},
 			Port:     6502,
 			CreateExternalLoadBalancer: true,
+			Protocol:                   api.ProtocolTCP,
+			SessionAffinity:            api.AffinityTypeNone,
 		},
 	}
 	ctx := api.NewDefaultContext()
@@ -586,8 +620,10 @@ func TestServiceRegistryIPReloadFromStorage(t *testing.T) {
 	svc := &api.Service{
 		ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: api.NamespaceDefault},
 		Spec: api.ServiceSpec{
-			Selector: map[string]string{"bar": "baz"},
-			Port:     6502,
+			Selector:        map[string]string{"bar": "baz"},
+			Port:            6502,
+			Protocol:        api.ProtocolTCP,
+			SessionAffinity: api.AffinityTypeNone,
 		},
 	}
 	ctx := api.NewDefaultContext()
@@ -596,8 +632,10 @@ func TestServiceRegistryIPReloadFromStorage(t *testing.T) {
 	svc = &api.Service{
 		ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: api.NamespaceDefault},
 		Spec: api.ServiceSpec{
-			Selector: map[string]string{"bar": "baz"},
-			Port:     6502,
+			Selector:        map[string]string{"bar": "baz"},
+			Port:            6502,
+			Protocol:        api.ProtocolTCP,
+			SessionAffinity: api.AffinityTypeNone,
 		},
 	}
 	c, _ = rest1.Create(ctx, svc)
@@ -610,8 +648,10 @@ func TestServiceRegistryIPReloadFromStorage(t *testing.T) {
 	svc = &api.Service{
 		ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: api.NamespaceDefault},
 		Spec: api.ServiceSpec{
-			Selector: map[string]string{"bar": "baz"},
-			Port:     6502,
+			Selector:        map[string]string{"bar": "baz"},
+			Port:            6502,
+			Protocol:        api.ProtocolTCP,
+			SessionAffinity: api.AffinityTypeNone,
 		},
 	}
 	c, _ = rest2.Create(ctx, svc)
@@ -671,8 +711,10 @@ func TestCreate(t *testing.T) {
 		// valid
 		&api.Service{
 			Spec: api.ServiceSpec{
-				Selector: map[string]string{"bar": "baz"},
-				Port:     6502,
+				Selector:        map[string]string{"bar": "baz"},
+				Port:            6502,
+				Protocol:        "TCP",
+				SessionAffinity: "None",
 			},
 		},
 		// invalid

--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -265,7 +265,8 @@ func (s *Scheme) Log(l conversion.DebugLogger) {
 
 // AddConversionFuncs adds a function to the list of conversion functions. The given
 // function should know how to convert between two API objects. We deduce how to call
-// it from the types of its two parameters; see the comment for Converter.Register.
+// it from the types of its two parameters; see the comment for
+// Converter.RegisterConversionFunction.
 //
 // Note that, if you need to copy sub-objects that didn't change, it's safe to call
 // Convert() inside your conversionFuncs, as long as you don't start a conversion
@@ -285,6 +286,13 @@ func (s *Scheme) AddConversionFuncs(conversionFuncs ...interface{}) error {
 // Call as many times as needed, even on the same fields.
 func (s *Scheme) AddStructFieldConversion(srcFieldType interface{}, srcFieldName string, destFieldType interface{}, destFieldName string) error {
 	return s.raw.AddStructFieldConversion(srcFieldType, srcFieldName, destFieldType, destFieldName)
+}
+
+// AddDefaultingFuncs adds a function to the list of value-defaulting functions.
+// We deduce how to call it from the types of its two parameters; see the
+// comment for Converter.RegisterDefaultingFunction.
+func (s *Scheme) AddDefaultingFuncs(defaultingFuncs ...interface{}) error {
+	return s.raw.AddDefaultingFuncs(defaultingFuncs...)
 }
 
 // Convert will attempt to convert in into out. Both must be pointers.

--- a/pkg/tools/etcd_tools_watch_test.go
+++ b/pkg/tools/etcd_tools_watch_test.go
@@ -18,7 +18,6 @@ package tools
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -123,7 +122,7 @@ func TestWatchInterpretations(t *testing.T) {
 				if e, a := item.expectType, event.Type; e != a {
 					t.Errorf("'%v - %v': expected %v, got %v", name, action, e, a)
 				}
-				if e, a := item.expectObject, event.Object; !reflect.DeepEqual(e, a) {
+				if e, a := item.expectObject, event.Object; !api.Semantic.DeepDerivative(e, a) {
 					t.Errorf("'%v - %v': expected %v, got %v", name, action, e, a)
 				}
 			}
@@ -250,7 +249,7 @@ func TestWatch(t *testing.T) {
 	if e, a := watch.Added, event.Type; e != a {
 		t.Errorf("Expected %v, got %v", e, a)
 	}
-	if e, a := pod, event.Object; !reflect.DeepEqual(e, a) {
+	if e, a := pod, event.Object; !api.Semantic.DeepDerivative(e, a) {
 		t.Errorf("Expected %v, got %v", e, a)
 	}
 
@@ -381,7 +380,7 @@ func TestWatchEtcdState(t *testing.T) {
 				t.Errorf("%s: expected type %v, got %v", k, e, a)
 				break
 			}
-			if e, a := testCase.Expected[i].Endpoints, event.Object.(*api.Endpoints).Endpoints; !reflect.DeepEqual(e, a) {
+			if e, a := testCase.Expected[i].Endpoints, event.Object.(*api.Endpoints).Endpoints; !api.Semantic.DeepDerivative(e, a) {
 				t.Errorf("%s: expected type %v, got %v", k, e, a)
 				break
 			}
@@ -456,7 +455,7 @@ func TestWatchFromZeroIndex(t *testing.T) {
 			t.Errorf("%s: expected pod with resource version %v, Got %#v", k, testCase.ExpectedVersion, actualPod)
 		}
 		pod.ResourceVersion = testCase.ExpectedVersion
-		if e, a := pod, event.Object; !reflect.DeepEqual(e, a) {
+		if e, a := pod, event.Object; !api.Semantic.DeepDerivative(e, a) {
 			t.Errorf("%s: expected %v, got %v", k, e, a)
 		}
 		watching.Stop()
@@ -515,7 +514,7 @@ func TestWatchListFromZeroIndex(t *testing.T) {
 			t.Errorf("Expected pod with resource version %d, Got %#v", 1, actualPod)
 		}
 		pod.ResourceVersion = "1"
-		if e, a := pod, event.Object; !reflect.DeepEqual(e, a) {
+		if e, a := pod, event.Object; !api.Semantic.DeepDerivative(e, a) {
 			t.Errorf("Expected %v, got %v", e, a)
 		}
 	}

--- a/pkg/watch/json/decoder_test.go
+++ b/pkg/watch/json/decoder_test.go
@@ -19,7 +19,6 @@ package json
 import (
 	"encoding/json"
 	"io"
-	"reflect"
 	"testing"
 	"time"
 
@@ -58,7 +57,7 @@ func TestDecoder(t *testing.T) {
 			if e, a := eventType, action; e != a {
 				t.Errorf("Expected %v, got %v", e, a)
 			}
-			if e, a := expect, got; !reflect.DeepEqual(e, a) {
+			if e, a := expect, got; !api.Semantic.DeepDerivative(e, a) {
 				t.Errorf("Expected %v, got %v", e, a)
 			}
 			t.Logf("Exited read")

--- a/pkg/watch/json/encoder_test.go
+++ b/pkg/watch/json/encoder_test.go
@@ -19,7 +19,6 @@ package json
 import (
 	"bytes"
 	"io/ioutil"
-	"reflect"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -66,7 +65,7 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 			t.Errorf("%d: unexpected error: %v", i, err)
 			continue
 		}
-		if !reflect.DeepEqual(testCase.Object, obj) {
+		if !api.Semantic.DeepDerivative(testCase.Object, obj) {
 			t.Errorf("%d: expected %#v, got %#v", i, testCase.Object, obj)
 		}
 		if event != testCase.Type {

--- a/plugin/pkg/scheduler/factory/factory_test.go
+++ b/plugin/pkg/scheduler/factory/factory_test.go
@@ -195,7 +195,13 @@ func makeURL(suffix string) string {
 }
 
 func TestDefaultErrorFunc(t *testing.T) {
-	testPod := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "bar"}}
+	testPod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "bar"},
+		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
+			DNSPolicy:     api.DNSClusterFirst,
+		},
+	}
 	handler := util.FakeHandler{
 		StatusCode:   200,
 		ResponseBody: runtime.EncodeOrDie(latest.Codec, testPod),


### PR DESCRIPTION
This PR is based on #2587 to fix issue #1502. Most API defaulting in validation.go and conversion.go have been migrated to defaults.go, where the defaulting functions are added to the decoder. The defaulting functions are tied to the specific API version, and will be called during decoding.
