### PR TITLE
Use a constant for the pod infra container name

### DIFF
--- a/pkg/kubecfg/resource_printer_test.go
+++ b/pkg/kubecfg/resource_printer_test.go
@@ -181,7 +181,7 @@ func TestTemplateEmitsVersionedObjects(t *testing.T) {
 }
 
 func TestTemplatePanic(t *testing.T) {
-	tmpl := `{{and ((index .currentState.info "update-demo").state.running.startedAt) .currentState.info.net.state.running.startedAt}}`
+	tmpl := `{{and ((index .currentState.info "foo").state.running.startedAt) .currentState.info.net.state.running.startedAt}}`
 	printer, err := NewTemplatePrinter([]byte(tmpl))
 	if err != nil {
 		t.Fatalf("tmpl fail: %v", err)
@@ -204,18 +204,18 @@ func TestTemplateStrings(t *testing.T) {
 	}{
 		"nilInfo":   {api.Pod{}, "false"},
 		"emptyInfo": {api.Pod{Status: api.PodStatus{Info: api.PodInfo{}}}, "false"},
-		"containerExists": {
+		"fooExists": {
 			api.Pod{
 				Status: api.PodStatus{
-					Info: api.PodInfo{"update-demo": api.ContainerStatus{}},
+					Info: api.PodInfo{"foo": api.ContainerStatus{}},
 				},
 			},
 			"false",
 		},
-		"podExists": {
+		"barExists": {
 			api.Pod{
 				Status: api.PodStatus{
-					Info: api.PodInfo{"POD": api.ContainerStatus{}},
+					Info: api.PodInfo{"bar": api.ContainerStatus{}},
 				},
 			},
 			"false",
@@ -224,8 +224,8 @@ func TestTemplateStrings(t *testing.T) {
 			api.Pod{
 				Status: api.PodStatus{
 					Info: api.PodInfo{
-						"update-demo": api.ContainerStatus{},
-						"POD":         api.ContainerStatus{},
+						"foo": api.ContainerStatus{},
+						"bar": api.ContainerStatus{},
 					},
 				},
 			},
@@ -235,8 +235,8 @@ func TestTemplateStrings(t *testing.T) {
 			api.Pod{
 				Status: api.PodStatus{
 					Info: api.PodInfo{
-						"update-demo": api.ContainerStatus{},
-						"POD": api.ContainerStatus{
+						"foo": api.ContainerStatus{},
+						"bar": api.ContainerStatus{
 							State: api.ContainerState{
 								Running: &api.ContainerStateRunning{
 									StartedAt: util.Time{},
@@ -252,14 +252,14 @@ func TestTemplateStrings(t *testing.T) {
 			api.Pod{
 				Status: api.PodStatus{
 					Info: api.PodInfo{
-						"update-demo": api.ContainerStatus{
+						"foo": api.ContainerStatus{
 							State: api.ContainerState{
 								Running: &api.ContainerStateRunning{
 									StartedAt: util.Time{},
 								},
 							},
 						},
-						"POD": api.ContainerStatus{
+						"bar": api.ContainerStatus{
 							State: api.ContainerState{
 								Running: &api.ContainerStateRunning{
 									StartedAt: util.Time{},
@@ -276,14 +276,14 @@ func TestTemplateStrings(t *testing.T) {
 	// The point of this test is to verify that the below template works. If you change this
 	// template, you need to update hack/e2e-suite/update.sh.
 	tmpl :=
-		`{{and (exists . "currentState" "info" "update-demo" "state" "running") (exists . "currentState" "info" "POD" "state" "running")}}`
+		`{{and (exists . "currentState" "info" "foo" "state" "running") (exists . "currentState" "info" "bar" "state" "running")}}`
 	useThisToDebug := `
 a: {{exists . "currentState"}}
 b: {{exists . "currentState" "info"}}
-c: {{exists . "currentState" "info" "update-demo"}}
-d: {{exists . "currentState" "info" "update-demo" "state"}}
-e: {{exists . "currentState" "info" "update-demo" "state" "running"}}
-f: {{exists . "currentState" "info" "update-demo" "state" "running" "startedAt"}}`
+c: {{exists . "currentState" "info" "foo"}}
+d: {{exists . "currentState" "info" "foo" "state"}}
+e: {{exists . "currentState" "info" "foo" "state" "running"}}
+f: {{exists . "currentState" "info" "foo" "state" "running" "startedAt"}}`
 	_ = useThisToDebug // don't complain about unused var
 
 	printer, err := NewTemplatePrinter([]byte(tmpl))

--- a/pkg/kubectl/resource_printer_test.go
+++ b/pkg/kubectl/resource_printer_test.go
@@ -305,7 +305,7 @@ func TestTemplateEmitsVersionedObjects(t *testing.T) {
 }
 
 func TestTemplatePanic(t *testing.T) {
-	tmpl := `{{and ((index .currentState.info "update-demo").state.running.startedAt) .currentState.info.net.state.running.startedAt}}`
+	tmpl := `{{and ((index .currentState.info "foo").state.running.startedAt) .currentState.info.net.state.running.startedAt}}`
 	printer, err := NewTemplatePrinter([]byte(tmpl))
 	if err != nil {
 		t.Fatalf("tmpl fail: %v", err)
@@ -328,18 +328,18 @@ func TestTemplateStrings(t *testing.T) {
 	}{
 		"nilInfo":   {api.Pod{}, "false"},
 		"emptyInfo": {api.Pod{Status: api.PodStatus{Info: api.PodInfo{}}}, "false"},
-		"containerExists": {
+		"fooExists": {
 			api.Pod{
 				Status: api.PodStatus{
-					Info: api.PodInfo{"update-demo": api.ContainerStatus{}},
+					Info: api.PodInfo{"foo": api.ContainerStatus{}},
 				},
 			},
 			"false",
 		},
-		"netExists": {
+		"barExists": {
 			api.Pod{
 				Status: api.PodStatus{
-					Info: api.PodInfo{"POD": api.ContainerStatus{}},
+					Info: api.PodInfo{"bar": api.ContainerStatus{}},
 				},
 			},
 			"false",
@@ -348,8 +348,8 @@ func TestTemplateStrings(t *testing.T) {
 			api.Pod{
 				Status: api.PodStatus{
 					Info: api.PodInfo{
-						"update-demo": api.ContainerStatus{},
-						"POD":         api.ContainerStatus{},
+						"foo": api.ContainerStatus{},
+						"bar": api.ContainerStatus{},
 					},
 				},
 			},
@@ -359,8 +359,8 @@ func TestTemplateStrings(t *testing.T) {
 			api.Pod{
 				Status: api.PodStatus{
 					Info: api.PodInfo{
-						"update-demo": api.ContainerStatus{},
-						"POD": api.ContainerStatus{
+						"foo": api.ContainerStatus{},
+						"bar": api.ContainerStatus{
 							State: api.ContainerState{
 								Running: &api.ContainerStateRunning{
 									StartedAt: util.Time{},
@@ -376,14 +376,14 @@ func TestTemplateStrings(t *testing.T) {
 			api.Pod{
 				Status: api.PodStatus{
 					Info: api.PodInfo{
-						"update-demo": api.ContainerStatus{
+						"foo": api.ContainerStatus{
 							State: api.ContainerState{
 								Running: &api.ContainerStateRunning{
 									StartedAt: util.Time{},
 								},
 							},
 						},
-						"POD": api.ContainerStatus{
+						"bar": api.ContainerStatus{
 							State: api.ContainerState{
 								Running: &api.ContainerStateRunning{
 									StartedAt: util.Time{},
@@ -400,14 +400,14 @@ func TestTemplateStrings(t *testing.T) {
 	// The point of this test is to verify that the below template works. If you change this
 	// template, you need to update hack/e2e-suite/update.sh.
 	tmpl :=
-		`{{and (exists . "currentState" "info" "update-demo" "state" "running") (exists . "currentState" "info" "POD" "state" "running")}}`
+		`{{and (exists . "currentState" "info" "foo" "state" "running") (exists . "currentState" "info" "bar" "state" "running")}}`
 	useThisToDebug := `
 a: {{exists . "currentState"}}
 b: {{exists . "currentState" "info"}}
-c: {{exists . "currentState" "info" "update-demo"}}
-d: {{exists . "currentState" "info" "update-demo" "state"}}
-e: {{exists . "currentState" "info" "update-demo" "state" "running"}}
-f: {{exists . "currentState" "info" "update-demo" "state" "running" "startedAt"}}`
+c: {{exists . "currentState" "info" "foo"}}
+d: {{exists . "currentState" "info" "foo" "state"}}
+e: {{exists . "currentState" "info" "foo" "state" "running"}}
+f: {{exists . "currentState" "info" "foo" "state" "running" "startedAt"}}`
 	_ = useThisToDebug // don't complain about unused var
 
 	p, err := NewTemplatePrinter([]byte(tmpl))

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/credentialprovider"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/leaky"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	docker "github.com/fsouza/go-dockerclient"
@@ -38,7 +39,7 @@ import (
 )
 
 const (
-	PodInfraContainerName = "POD" // This should match the constant defined in kubelet
+	PodInfraContainerName = leaky.PodInfraContainerName
 )
 
 // DockerInterface is an abstract interface for testability.  It abstracts the interface of docker.Client.

--- a/pkg/kubelet/leaky/leaky.go
+++ b/pkg/kubelet/leaky/leaky.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package leaky holds bits of kubelet that should be internal but have leaked
+// out through bad abstractions.  TODO: delete all of this.
+package leaky
+
+const (
+	// This is used in a few places outside of Kubelet, such as indexing
+	// into the container info.
+	PodInfraContainerName = "POD"
+)

--- a/pkg/master/pod_cache.go
+++ b/pkg/master/pod_cache.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/leaky"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/pod"
 
@@ -169,7 +170,7 @@ func (p *PodCache) computePodStatus(pod *api.Pod) (api.PodStatus, error) {
 	} else {
 		newStatus.Info = result.Status.Info
 		newStatus.Phase = getPhase(&pod.Spec, newStatus.Info)
-		if netContainerInfo, ok := newStatus.Info["POD"]; ok {
+		if netContainerInfo, ok := newStatus.Info[leaky.PodInfraContainerName]; ok {
 			if netContainerInfo.PodIP != "" {
 				newStatus.PodIP = netContainerInfo.PodIP
 			}

--- a/pkg/master/pod_cache_test.go
+++ b/pkg/master/pod_cache_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/leaky"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
@@ -339,7 +340,7 @@ func TestFillPodStatus(t *testing.T) {
 			HostIP: "ip of machine",
 			PodIP:  expectedIP,
 			Info: api.PodInfo{
-				"POD": {
+				leaky.PodInfraContainerName: {
 					State: api.ContainerState{
 						Running: &api.ContainerStateRunning{
 							StartedAt: util.NewTime(expectedTime),
@@ -374,7 +375,7 @@ func TestFillPodInfoNoData(t *testing.T) {
 			Host:   "machine",
 			HostIP: "ip of machine",
 			Info: api.PodInfo{
-				"POD": {},
+				leaky.PodInfraContainerName: {},
 			},
 		},
 		nodes: []api.Node{*makeHealthyNode("machine")},


### PR DESCRIPTION
This is an implementation detail that has leaked out of kubelet.  Use a
constant to prevent divergence, for now.  Plan to get rid of it.

Also changed places that were using that same name, but did not really need it to be the same.

@dchen1107
