### PR TITLE
WIP: Separate Namespace from ObjectMeta, not all objects are internal to a Namespace

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -296,10 +296,12 @@ func runSelfLinkTest(c *client.Client) {
 	var svc api.Service
 	err := c.Post().Resource("services").Body(
 		&api.Service{
-			ObjectMeta: api.ObjectMeta{
-				Name: "selflinktest",
-				Labels: map[string]string{
-					"name": "selflinktest",
+			NSObjectMeta: api.NSObjectMeta{
+				ObjectMeta: api.ObjectMeta{
+					Name: "selflinktest",
+					Labels: map[string]string{
+						"name": "selflinktest",
+					},
 				},
 			},
 			Spec: api.ServiceSpec{
@@ -358,10 +360,12 @@ func runAtomicPutTest(c *client.Client) {
 			TypeMeta: api.TypeMeta{
 				APIVersion: latest.Version,
 			},
-			ObjectMeta: api.ObjectMeta{
-				Name: "atomicservice",
-				Labels: map[string]string{
-					"name": "atomicService",
+			NSObjectMeta: api.NSObjectMeta{
+				ObjectMeta: api.ObjectMeta{
+					Name: "atomicservice",
+					Labels: map[string]string{
+						"name": "atomicService",
+					},
 				},
 			},
 			Spec: api.ServiceSpec{
@@ -496,10 +500,12 @@ func runMasterServiceTest(client *client.Client) {
 
 func runServiceTest(client *client.Client) {
 	pod := api.Pod{
-		ObjectMeta: api.ObjectMeta{
-			Name: "foo",
-			Labels: map[string]string{
-				"name": "thisisalonglabel",
+		NSObjectMeta: api.NSObjectMeta{
+			ObjectMeta: api.ObjectMeta{
+				Name: "foo",
+				Labels: map[string]string{
+					"name": "thisisalonglabel",
+				},
 			},
 		},
 		Spec: api.PodSpec{
@@ -525,7 +531,9 @@ func runServiceTest(client *client.Client) {
 		glog.Fatalf("FAILED: pod never started running %v", err)
 	}
 	svc1 := api.Service{
-		ObjectMeta: api.ObjectMeta{Name: "service1"},
+		NSObjectMeta: api.NSObjectMeta{
+			ObjectMeta: api.ObjectMeta{Name: "service1"},
+		},
 		Spec: api.ServiceSpec{
 			Selector: map[string]string{
 				"name": "thisisalonglabel",
@@ -542,7 +550,9 @@ func runServiceTest(client *client.Client) {
 	}
 	// A second service with the same port.
 	svc2 := api.Service{
-		ObjectMeta: api.ObjectMeta{Name: "service2"},
+		NSObjectMeta: api.NSObjectMeta{
+			ObjectMeta: api.ObjectMeta{Name: "service2"},
+		},
 		Spec: api.ServiceSpec{
 			Selector: map[string]string{
 				"name": "thisisalonglabel",

--- a/pkg/api/context.go
+++ b/pkg/api/context.go
@@ -70,7 +70,7 @@ func Namespace(ctx Context) string {
 }
 
 // ValidNamespace returns false if the namespace on the context differs from the resource.  If the resource has no namespace, it is set to the value in the context.
-func ValidNamespace(ctx Context, resource *ObjectMeta) bool {
+func ValidNamespace(ctx Context, resource *NSObjectMeta) bool {
 	ns, ok := NamespaceFrom(ctx)
 	if len(resource.Namespace) == 0 {
 		resource.Namespace = ns

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -74,19 +74,13 @@ type ListMeta struct {
 }
 
 // ObjectMeta is metadata that all persisted resources must have, which includes all objects
-// users must create. A resource may have only one of {ObjectMeta, ListMeta}.
+// users must create. A resource may have only one of {NSObjectMeta, ObjectMeta, ListMeta}.
 type ObjectMeta struct {
 	// Name is unique within a namespace.  Name is required when creating resources, although
 	// some resources may allow a client to request the generation of an appropriate name
 	// automatically. Name is primarily intended for creation idempotence and configuration
 	// definition.
 	Name string `json:"name,omitempty"`
-
-	// Namespace defines the space within which name must be unique. An empty namespace is
-	// equivalent to the "default" namespace, but "default" is the canonical representation.
-	// Not all objects are required to be scoped to a namespace - the value of this field for
-	// those objects will be empty.
-	Namespace string `json:"namespace,omitempty"`
 
 	// SelfLink is a URL representing this object.
 	SelfLink string `json:"selfLink,omitempty"`
@@ -124,6 +118,17 @@ type ObjectMeta struct {
 	// objects.  Annotation keys have the same formatting restrictions as Label keys. See the
 	// comments on Labels for details.
 	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// NSObjectMeta is metadata that all persisted namespace-scoped resources must have
+// A resource may have only one of {ObjectMeta, ListMeta, NSObjectMeta}.
+type NSObjectMeta struct {
+
+	// ObjectMeta is metadata that all persisted resources must have, which includes all objects
+	ObjectMeta
+
+	// Namespace defines the space within which ObjectMeta.Name must be unique.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 const (
@@ -422,7 +427,7 @@ type PodInfo map[string]ContainerStatus
 // DEPRECATED: Replaced with PodStatusResult
 type PodContainerInfo struct {
 	TypeMeta      `json:",inline"`
-	ObjectMeta    `json:"metadata,omitempty"`
+	NSObjectMeta  `json:"metadata,omitempty"`
 	ContainerInfo PodInfo `json:"containerInfo"`
 }
 
@@ -507,8 +512,8 @@ type PodStatus struct {
 
 // PodStatusResult is a wrapper for PodStatus returned by kubelet that can be encode/decoded
 type PodStatusResult struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	TypeMeta     `json:",inline"`
+	NSObjectMeta `json:"metadata,omitempty"`
 	// Status represents the current information about a pod. This data may not be up
 	// to date.
 	Status PodStatus `json:"status,omitempty"`
@@ -516,8 +521,8 @@ type PodStatusResult struct {
 
 // Pod is a collection of containers, used as either input (create, update) or as output (list, get).
 type Pod struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	TypeMeta     `json:",inline"`
+	NSObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the behavior of a pod.
 	Spec PodSpec `json:"spec,omitempty"`
@@ -530,7 +535,7 @@ type Pod struct {
 // PodTemplateSpec describes the data a pod should have when created from a template
 type PodTemplateSpec struct {
 	// Metadata of the pods created from this template.
-	ObjectMeta `json:"metadata,omitempty"`
+	NSObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the behavior of a pod.
 	Spec PodSpec `json:"spec,omitempty"`
@@ -538,8 +543,8 @@ type PodTemplateSpec struct {
 
 // PodTemplate describes a template for creating copies of a predefined pod.
 type PodTemplate struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	TypeMeta     `json:",inline"`
+	NSObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the pods that will be created from this template
 	Spec PodTemplateSpec `json:"spec,omitempty"`
@@ -584,8 +589,8 @@ type ReplicationControllerStatus struct {
 
 // ReplicationController represents the configuration of a replication controller.
 type ReplicationController struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	TypeMeta     `json:",inline"`
+	NSObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the desired behavior of this replication controller.
 	Spec ReplicationControllerSpec `json:"spec,omitempty"`
@@ -665,8 +670,8 @@ type ServiceSpec struct {
 // (for example 3306) that the proxy listens on, and the selector that determines which pods
 // will answer requests sent through the proxy.
 type Service struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	TypeMeta     `json:",inline"`
+	NSObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the behavior of a service.
 	Spec ServiceSpec `json:"spec,omitempty"`
@@ -678,8 +683,8 @@ type Service struct {
 // Endpoints is a collection of endpoints that implement the actual service, for example:
 // Name: "mysql", Endpoints: ["10.10.1.1:1909", "10.10.2.2:8834"]
 type Endpoints struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	TypeMeta     `json:",inline"`
+	NSObjectMeta `json:"metadata,omitempty"`
 
 	Endpoints []string `json:"endpoints,omitempty"`
 }
@@ -809,8 +814,8 @@ type NodeList struct {
 
 // Binding is written by a scheduler to cause a pod to be bound to a host.
 type Binding struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	TypeMeta     `json:",inline"`
+	NSObjectMeta `json:"metadata,omitempty"`
 
 	PodID string `json:"podID"`
 	Host  string `json:"host"`
@@ -1004,8 +1009,8 @@ const (
 
 // Operation is an operation delivered to API clients.
 type Operation struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	TypeMeta     `json:",inline"`
+	NSObjectMeta `json:"metadata,omitempty"`
 }
 
 // OperationList is a list of operations, as delivered to API clients.
@@ -1046,8 +1051,8 @@ type EventSource struct {
 // Event is a report of an event somewhere in the cluster.
 // TODO: Decide whether to store these separately or with the object they apply to.
 type Event struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	TypeMeta     `json:",inline"`
+	NSObjectMeta `json:"metadata,omitempty"`
 
 	// Required. The object that this event is about.
 	InvolvedObject ObjectReference `json:"involvedObject,omitempty"`
@@ -1111,8 +1116,8 @@ type ContainerManifestList struct {
 // defines how a Pod may change after a Binding is created. A Pod is a request to
 // execute a pod, whereas a BoundPod is the specification that would be run on a server.
 type BoundPod struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	TypeMeta     `json:",inline"`
+	NSObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the behavior of a pod.
 	Spec PodSpec `json:"spec,omitempty"`
@@ -1121,8 +1126,8 @@ type BoundPod struct {
 // BoundPods is a list of Pods bound to a common server. The resource version of
 // the pod list is guaranteed to only change when the list of bound pods changes.
 type BoundPods struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	TypeMeta     `json:",inline"`
+	NSObjectMeta `json:"metadata,omitempty"`
 
 	// Host is the name of a node that these pods were bound to.
 	Host string `json:"host"`
@@ -1167,8 +1172,8 @@ type LimitRangeSpec struct {
 
 // LimitRange sets resource usage limits for each kind of resource in a Namespace
 type LimitRange struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	TypeMeta     `json:",inline"`
+	NSObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the limits enforced
 	Spec LimitRangeSpec `json:"spec,omitempty"`

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -74,10 +74,22 @@ func init() {
 			}
 			return nil
 		},
-
+		func(in *TypeMeta, out *newer.NSObjectMeta, s conversion.Scope) error {
+			out.Namespace = in.Namespace
+			if err := s.Convert(in, &out.ObjectMeta, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(in *newer.NSObjectMeta, out *TypeMeta, s conversion.Scope) error {
+			out.Namespace = in.Namespace
+			if err := s.Convert(&in.ObjectMeta, out, 0); err != nil {
+				return err
+			}
+			return nil
+		},
 		// ObjectMeta must be converted to TypeMeta
 		func(in *newer.ObjectMeta, out *TypeMeta, s conversion.Scope) error {
-			out.Namespace = in.Namespace
 			out.ID = in.Name
 			out.UID = in.UID
 			out.CreationTimestamp = in.CreationTimestamp
@@ -92,7 +104,6 @@ func init() {
 			return s.Convert(&in.Annotations, &out.Annotations, 0)
 		},
 		func(in *TypeMeta, out *newer.ObjectMeta, s conversion.Scope) error {
-			out.Namespace = in.Namespace
 			out.Name = in.ID
 			out.UID = in.UID
 			out.CreationTimestamp = in.CreationTimestamp

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -74,10 +74,22 @@ func init() {
 			}
 			return nil
 		},
-
+		func(in *TypeMeta, out *newer.NSObjectMeta, s conversion.Scope) error {
+			out.Namespace = in.Namespace
+			if err := s.Convert(in, &out.ObjectMeta, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(in *newer.NSObjectMeta, out *TypeMeta, s conversion.Scope) error {
+			out.Namespace = in.Namespace
+			if err := s.Convert(&in.ObjectMeta, out, 0); err != nil {
+				return err
+			}
+			return nil
+		},
 		// ObjectMeta must be converted to TypeMeta
 		func(in *newer.ObjectMeta, out *TypeMeta, s conversion.Scope) error {
-			out.Namespace = in.Namespace
 			out.ID = in.Name
 			out.UID = in.UID
 			out.CreationTimestamp = in.CreationTimestamp
@@ -92,7 +104,6 @@ func init() {
 			return s.Convert(&in.Annotations, &out.Annotations, 0)
 		},
 		func(in *TypeMeta, out *newer.ObjectMeta, s conversion.Scope) error {
-			out.Namespace = in.Namespace
 			out.Name = in.ID
 			out.UID = in.UID
 			out.CreationTimestamp = in.CreationTimestamp

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -582,9 +582,6 @@ func ValidateBoundPod(pod *api.BoundPod) errs.ValidationErrorList {
 // ValidateMinion tests if required fields in the minion are set.
 func ValidateMinion(minion *api.Node) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
-	if len(minion.Namespace) != 0 {
-		allErrs = append(allErrs, errs.NewFieldInvalid("namespace", minion.Namespace, ""))
-	}
 	if len(minion.Name) == 0 {
 		allErrs = append(allErrs, errs.NewFieldRequired("name", minion.Name))
 	}

--- a/pkg/apiserver/operation.go
+++ b/pkg/apiserver/operation.go
@@ -126,7 +126,7 @@ func (ops *Operations) List() *api.OperationList {
 	sort.StringSlice(ids).Sort()
 	ol := &api.OperationList{}
 	for _, id := range ids {
-		ol.Items = append(ol.Items, api.Operation{ObjectMeta: api.ObjectMeta{Name: id}})
+		ol.Items = append(ol.Items, api.Operation{NSObjectMeta: api.NSObjectMeta{ObjectMeta: api.ObjectMeta{Name: id}}})
 	}
 	return ol
 }

--- a/pkg/client/fake_limit_ranges.go
+++ b/pkg/client/fake_limit_ranges.go
@@ -35,7 +35,7 @@ func (c *FakeLimitRanges) List(selector labels.Selector) (*api.LimitRangeList, e
 
 func (c *FakeLimitRanges) Get(name string) (*api.LimitRange, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-limitRange", Value: name})
-	return &api.LimitRange{ObjectMeta: api.ObjectMeta{Name: name, Namespace: c.Namespace}}, nil
+	return &api.LimitRange{NSObjectMeta: api.NSObjectMeta{ObjectMeta: api.ObjectMeta{Name: name}, Namespace: c.Namespace}}, nil
 }
 
 func (c *FakeLimitRanges) Delete(name string) error {

--- a/pkg/client/fake_pods.go
+++ b/pkg/client/fake_pods.go
@@ -35,7 +35,7 @@ func (c *FakePods) List(selector labels.Selector) (*api.PodList, error) {
 
 func (c *FakePods) Get(name string) (*api.Pod, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-pod", Value: name})
-	return &api.Pod{ObjectMeta: api.ObjectMeta{Name: name, Namespace: c.Namespace}}, nil
+	return &api.Pod{NSObjectMeta: api.NSObjectMeta{ObjectMeta: api.ObjectMeta{Name: name}, Namespace: c.Namespace}}, nil
 }
 
 func (c *FakePods) Delete(name string) error {

--- a/pkg/client/fake_services.go
+++ b/pkg/client/fake_services.go
@@ -36,7 +36,7 @@ func (c *FakeServices) List(selector labels.Selector) (*api.ServiceList, error) 
 
 func (c *FakeServices) Get(name string) (*api.Service, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-service", Value: name})
-	return &api.Service{ObjectMeta: api.ObjectMeta{Name: name, Namespace: c.Namespace}}, nil
+	return &api.Service{NSObjectMeta: api.NSObjectMeta{ObjectMeta: api.ObjectMeta{Name: name}, Namespace: c.Namespace}}, nil
 }
 
 func (c *FakeServices) Create(service *api.Service) (*api.Service, error) {

--- a/pkg/client/record/event.go
+++ b/pkg/client/record/event.go
@@ -163,8 +163,10 @@ func Event(object runtime.Object, reason, message string) {
 	t := util.Now()
 
 	e := &api.Event{
-		ObjectMeta: api.ObjectMeta{
-			Name:      fmt.Sprintf("%v.%x", ref.Name, t.UnixNano()),
+		NSObjectMeta: api.NSObjectMeta{
+			ObjectMeta: api.ObjectMeta{
+				Name: fmt.Sprintf("%v.%x", ref.Name, t.UnixNano()),
+			},
 			Namespace: ref.Namespace,
 		},
 		InvolvedObject: *ref,

--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -61,8 +61,10 @@ func (r RealPodControl) createReplica(namespace string, controller api.Replicati
 		desiredLabels[k] = v
 	}
 	pod := &api.Pod{
-		ObjectMeta: api.ObjectMeta{
-			Labels: desiredLabels,
+		NSObjectMeta: api.NSObjectMeta{
+			ObjectMeta: api.ObjectMeta{
+				Labels: desiredLabels,
+			},
 		},
 	}
 	if err := api.Scheme.Convert(&controller.Spec.Template.Spec, &pod.Spec); err != nil {

--- a/pkg/kubecfg/kubecfg.go
+++ b/pkg/kubecfg/kubecfg.go
@@ -243,8 +243,8 @@ func RunController(ctx api.Context, image, name string, replicas int, client cli
 		return err
 	}
 	controller := &api.ReplicationController{
-		ObjectMeta: api.ObjectMeta{
-			Name: name,
+		NSObjectMeta: api.NSObjectMeta{
+			ObjectMeta: api.ObjectMeta{Name: name},
 		},
 		Spec: api.ReplicationControllerSpec{
 			Replicas: replicas,
@@ -252,9 +252,11 @@ func RunController(ctx api.Context, image, name string, replicas int, client cli
 				"name": name,
 			},
 			Template: &api.PodTemplateSpec{
-				ObjectMeta: api.ObjectMeta{
-					Labels: map[string]string{
-						"name": name,
+				NSObjectMeta: api.NSObjectMeta{
+					ObjectMeta: api.ObjectMeta{
+						Labels: map[string]string{
+							"name": name,
+						},
 					},
 				},
 				Spec: api.PodSpec{
@@ -297,10 +299,12 @@ func RunController(ctx api.Context, image, name string, replicas int, client cli
 func createService(ctx api.Context, name string, port int, client client.Interface) (*api.Service, error) {
 	// TODO remove context in favor of just namespace string
 	svc := &api.Service{
-		ObjectMeta: api.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				"name": name,
+		NSObjectMeta: api.NSObjectMeta{
+			ObjectMeta: api.ObjectMeta{
+				Name: name,
+				Labels: map[string]string{
+					"name": name,
+				},
 			},
 		},
 		Spec: api.ServiceSpec{

--- a/pkg/kubectl/run.go
+++ b/pkg/kubectl/run.go
@@ -52,16 +52,20 @@ func (BasicReplicationController) Generate(params map[string]string) (runtime.Ob
 		return nil, err
 	}
 	controller := api.ReplicationController{
-		ObjectMeta: api.ObjectMeta{
-			Name:   params["name"],
-			Labels: labels,
+		NSObjectMeta: api.NSObjectMeta{
+			ObjectMeta: api.ObjectMeta{
+				Name:   params["name"],
+				Labels: labels,
+			},
 		},
 		Spec: api.ReplicationControllerSpec{
 			Replicas: count,
 			Selector: labels,
 			Template: &api.PodTemplateSpec{
-				ObjectMeta: api.ObjectMeta{
-					Labels: labels,
+				NSObjectMeta: api.NSObjectMeta{
+					ObjectMeta: api.ObjectMeta{
+						Labels: labels,
+					},
 				},
 				Spec: api.PodSpec{
 					Containers: []api.Container{

--- a/pkg/master/publish.go
+++ b/pkg/master/publish.go
@@ -82,10 +82,12 @@ func (m *Master) createMasterServiceIfNeeded(serviceName string, port int) error
 		return nil
 	}
 	svc := &api.Service{
-		ObjectMeta: api.ObjectMeta{
-			Name:      serviceName,
+		NSObjectMeta: api.NSObjectMeta{
 			Namespace: api.NamespaceDefault,
-			Labels:    map[string]string{"provider": "kubernetes", "component": "apiserver"},
+			ObjectMeta: api.ObjectMeta{
+				Name:   serviceName,
+				Labels: map[string]string{"provider": "kubernetes", "component": "apiserver"},
+			},
 		},
 		Spec: api.ServiceSpec{
 			Port: port,
@@ -116,9 +118,11 @@ func (m *Master) ensureEndpointsContain(serviceName string, endpoint string) err
 	e, err := m.endpointRegistry.GetEndpoints(ctx, serviceName)
 	if err != nil {
 		e = &api.Endpoints{
-			ObjectMeta: api.ObjectMeta{
-				Name:      serviceName,
+			NSObjectMeta: api.NSObjectMeta{
 				Namespace: api.NamespaceDefault,
+				ObjectMeta: api.ObjectMeta{
+					Name: serviceName,
+				},
 			},
 		}
 	}

--- a/pkg/proxy/config/etcd.go
+++ b/pkg/proxy/config/etcd.go
@@ -243,7 +243,7 @@ func (s ConfigSourceEtcd) ProcessChange(response *etcd.Response) {
 		parts := strings.Split(response.Node.Key[1:], "/")
 		if len(parts) == 4 {
 			glog.V(4).Infof("Deleting service: %s", parts[3])
-			serviceUpdate := ServiceUpdate{Op: REMOVE, Services: []api.Service{{ObjectMeta: api.ObjectMeta{Name: parts[3]}}}}
+			serviceUpdate := ServiceUpdate{Op: REMOVE, Services: []api.Service{{NSObjectMeta: api.NSObjectMeta{ObjectMeta: api.ObjectMeta{Name: parts[3]}}}}}
 			s.serviceChannel <- serviceUpdate
 			return
 		}

--- a/pkg/registry/controller/rest.go
+++ b/pkg/registry/controller/rest.go
@@ -58,7 +58,7 @@ func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan apiserver.RE
 	if !ok {
 		return nil, fmt.Errorf("not a replication controller: %#v", obj)
 	}
-	if !api.ValidNamespace(ctx, &controller.ObjectMeta) {
+	if !api.ValidNamespace(ctx, &controller.NSObjectMeta) {
 		return nil, errors.NewConflict("controller", controller.Namespace, fmt.Errorf("Controller.Namespace does not match the provided context"))
 	}
 
@@ -133,7 +133,7 @@ func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan apiserver.RE
 	if !ok {
 		return nil, fmt.Errorf("not a replication controller: %#v", obj)
 	}
-	if !api.ValidNamespace(ctx, &controller.ObjectMeta) {
+	if !api.ValidNamespace(ctx, &controller.NSObjectMeta) {
 		return nil, errors.NewConflict("controller", controller.Namespace, fmt.Errorf("Controller.Namespace does not match the provided context"))
 	}
 	if errs := validation.ValidateReplicationController(controller); len(errs) > 0 {

--- a/pkg/registry/endpoint/rest.go
+++ b/pkg/registry/endpoint/rest.go
@@ -67,7 +67,7 @@ func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan apiserver.RE
 	if len(endpoints.Name) == 0 {
 		return nil, fmt.Errorf("id is required: %#v", obj)
 	}
-	if !api.ValidNamespace(ctx, &endpoints.ObjectMeta) {
+	if !api.ValidNamespace(ctx, &endpoints.NSObjectMeta) {
 		return nil, errors.NewConflict("endpoints", endpoints.Namespace, fmt.Errorf("Endpoints.Namespace does not match the provided context"))
 	}
 	api.FillObjectMetaSystemFields(ctx, &endpoints.ObjectMeta)

--- a/pkg/registry/event/rest.go
+++ b/pkg/registry/event/rest.go
@@ -48,7 +48,7 @@ func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan apiserver.RE
 		return nil, fmt.Errorf("invalid object type")
 	}
 	if api.Namespace(ctx) != "" {
-		if !api.ValidNamespace(ctx, &event.ObjectMeta) {
+		if !api.ValidNamespace(ctx, &event.NSObjectMeta) {
 			return nil, errors.NewConflict("event", event.Namespace, fmt.Errorf("event.namespace does not match the provided context"))
 		}
 	}

--- a/pkg/registry/limitrange/rest.go
+++ b/pkg/registry/limitrange/rest.go
@@ -50,7 +50,7 @@ func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan apiserver.RE
 		return nil, fmt.Errorf("invalid object type")
 	}
 
-	if !api.ValidNamespace(ctx, &limitRange.ObjectMeta) {
+	if !api.ValidNamespace(ctx, &limitRange.NSObjectMeta) {
 		return nil, errors.NewConflict("limitRange", limitRange.Namespace, fmt.Errorf("LimitRange.Namespace does not match the provided context"))
 	}
 
@@ -79,7 +79,7 @@ func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan apiserver.RE
 		return nil, fmt.Errorf("invalid object type")
 	}
 
-	if !api.ValidNamespace(ctx, &limitRange.ObjectMeta) {
+	if !api.ValidNamespace(ctx, &limitRange.NSObjectMeta) {
 		return nil, errors.NewConflict("limitRange", limitRange.Namespace, fmt.Errorf("LimitRange.Namespace does not match the provided context"))
 	}
 

--- a/pkg/registry/minion/rest.go
+++ b/pkg/registry/minion/rest.go
@@ -114,11 +114,7 @@ func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan apiserver.RE
 	if !ok {
 		return nil, fmt.Errorf("not a minion: %#v", obj)
 	}
-	// This is hacky, but minions don't really have a namespace, but kubectl currently automatically
-	// stuffs one in there.  Fix it here temporarily until we fix kubectl
-	if minion.Namespace == api.NamespaceDefault {
-		minion.Namespace = api.NamespaceNone
-	}
+
 	// Clear out the self link, if specified, since it's not in the registry either.
 	minion.SelfLink = ""
 

--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -56,7 +56,7 @@ func NewREST(config *RESTConfig) *REST {
 
 func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
 	pod := obj.(*api.Pod)
-	if !api.ValidNamespace(ctx, &pod.ObjectMeta) {
+	if !api.ValidNamespace(ctx, &pod.NSObjectMeta) {
 		return nil, errors.NewConflict("pod", pod.Namespace, fmt.Errorf("Pod.Namespace does not match the provided context"))
 	}
 	api.FillObjectMetaSystemFields(ctx, &pod.ObjectMeta)
@@ -174,7 +174,7 @@ func (*REST) NewList() runtime.Object {
 
 func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
 	pod := obj.(*api.Pod)
-	if !api.ValidNamespace(ctx, &pod.ObjectMeta) {
+	if !api.ValidNamespace(ctx, &pod.NSObjectMeta) {
 		return nil, errors.NewConflict("pod", pod.Namespace, fmt.Errorf("Pod.Namespace does not match the provided context"))
 	}
 	if errs := validation.ValidatePod(pod); len(errs) > 0 {

--- a/pkg/registry/service/rest.go
+++ b/pkg/registry/service/rest.go
@@ -81,7 +81,7 @@ func reloadIPsFromStorage(ipa *ipAllocator, registry Registry) {
 
 func (rs *REST) Create(ctx api.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
 	service := obj.(*api.Service)
-	if !api.ValidNamespace(ctx, &service.ObjectMeta) {
+	if !api.ValidNamespace(ctx, &service.NSObjectMeta) {
 		return nil, errors.NewConflict("service", service.Namespace, fmt.Errorf("Service.Namespace does not match the provided context"))
 	}
 	if errs := validation.ValidateService(service, rs.registry, ctx); len(errs) > 0 {
@@ -223,7 +223,7 @@ func (*REST) NewList() runtime.Object {
 
 func (rs *REST) Update(ctx api.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
 	service := obj.(*api.Service)
-	if !api.ValidNamespace(ctx, &service.ObjectMeta) {
+	if !api.ValidNamespace(ctx, &service.NSObjectMeta) {
 		return nil, errors.NewConflict("service", service.Namespace, fmt.Errorf("Service.Namespace does not match the provided context"))
 	}
 	if errs := validation.ValidateService(service, rs.registry, ctx); len(errs) > 0 {

--- a/pkg/service/endpoints_controller.go
+++ b/pkg/service/endpoints_controller.go
@@ -81,8 +81,9 @@ func (e *EndpointController) SyncServiceEndpoints() error {
 		if err != nil {
 			if errors.IsNotFound(err) {
 				currentEndpoints = &api.Endpoints{
-					ObjectMeta: api.ObjectMeta{
-						Name: service.Name,
+					NSObjectMeta: api.NSObjectMeta{
+						ObjectMeta: api.ObjectMeta{
+							Name: service.Name},
 					},
 				}
 			} else {

--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -77,9 +77,9 @@ func (s *Scheduler) scheduleOne() {
 		return
 	}
 	b := &api.Binding{
-		ObjectMeta: api.ObjectMeta{Namespace: pod.Namespace},
-		PodID:      pod.Name,
-		Host:       dest,
+		NSObjectMeta: api.NSObjectMeta{Namespace: pod.Namespace},
+		PodID:        pod.Name,
+		Host:         dest,
 	}
 	if err := s.config.Binder.Bind(b); err != nil {
 		glog.V(1).Infof("Failed to bind pod: %v", err)

--- a/test/e2e/basic.go
+++ b/test/e2e/basic.go
@@ -44,8 +44,8 @@ func TestBasicImage(c *client.Client, test string, image string) bool {
 	// in contrib/for-demos/serve_hostname
 	glog.Infof("Creating replication controller %s", name)
 	controller, err := c.ReplicationControllers(ns).Create(&api.ReplicationController{
-		ObjectMeta: api.ObjectMeta{
-			Name: name,
+		NSObjectMeta: api.NSObjectMeta{
+			ObjectMeta: api.ObjectMeta{Name: name},
 		},
 		Spec: api.ReplicationControllerSpec{
 			Replicas: replicas,
@@ -53,8 +53,10 @@ func TestBasicImage(c *client.Client, test string, image string) bool {
 				"name": name,
 			},
 			Template: &api.PodTemplateSpec{
-				ObjectMeta: api.ObjectMeta{
-					Labels: map[string]string{"name": name},
+				NSObjectMeta: api.NSObjectMeta{
+					ObjectMeta: api.ObjectMeta{
+						Labels: map[string]string{"name": name},
+					},
 				},
 				Spec: api.PodSpec{
 					Containers: []api.Container{

--- a/test/e2e/cluster_dns.go
+++ b/test/e2e/cluster_dns.go
@@ -66,8 +66,8 @@ func TestClusterDNS(c *client.Client) bool {
 			Kind:       "Pod",
 			APIVersion: "v1beta1",
 		},
-		ObjectMeta: api.ObjectMeta{
-			Name: "dns-test-" + string(util.NewUUID()),
+		NSObjectMeta: api.NSObjectMeta{
+			ObjectMeta: api.ObjectMeta{Name: "dns-test-" + string(util.NewUUID())},
 		},
 		Spec: api.PodSpec{
 			Volumes: []api.Volume{

--- a/test/e2e/network.go
+++ b/test/e2e/network.go
@@ -36,10 +36,12 @@ func TestNetwork(c *client.Client) bool {
 	//                   names have the same form as pod and replication controller names.
 	name := "nettest-" + randomSuffix()
 	svc, err := c.Services(ns).Create(&api.Service{
-		ObjectMeta: api.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				"name": name,
+		NSObjectMeta: api.NSObjectMeta{
+			ObjectMeta: api.ObjectMeta{
+				Name: name,
+				Labels: map[string]string{
+					"name": name,
+				},
 			},
 		},
 		Spec: api.ServiceSpec{
@@ -62,10 +64,12 @@ func TestNetwork(c *client.Client) bool {
 		}
 	}()
 	rc, err := c.ReplicationControllers(ns).Create(&api.ReplicationController{
-		ObjectMeta: api.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				"name": name,
+		NSObjectMeta: api.NSObjectMeta{
+			ObjectMeta: api.ObjectMeta{
+				Name: name,
+				Labels: map[string]string{
+					"name": name,
+				},
 			},
 		},
 		Spec: api.ReplicationControllerSpec{
@@ -74,8 +78,10 @@ func TestNetwork(c *client.Client) bool {
 				"name": name,
 			},
 			Template: &api.PodTemplateSpec{
-				ObjectMeta: api.ObjectMeta{
-					Labels: map[string]string{"name": name},
+				NSObjectMeta: api.NSObjectMeta{
+					ObjectMeta: api.ObjectMeta{
+						Labels: map[string]string{"name": name},
+					},
 				},
 				Spec: api.PodSpec{
 					Containers: []api.Container{


### PR DESCRIPTION
Not all objects exist in a Namespace.  `Node` should not have a Namespace, and pending #3613, neither should `Namespace`.  In downstream OpenShift, we have objects that are external to a Namespace.  The list of things outside of a `Namespace` will probably grow over time as we cater to Kubernetes administrators over users.

This PR proposes the following:

```
// ObjectMeta is metadata that all persisted resources must have, which includes all objects
// users must create. A resource may have only one of {NSObjectMeta, ObjectMeta, ListMeta}.
type ObjectMeta struct {
    // Name is unique within a namespace.  Name is required when creating resources, although
    // some resources may allow a client to request the generation of an appropriate name
    // automatically. Name is primarily intended for creation idempotence and configuration
    // definition.
    Name string `json:"name,omitempty"`

    // SelfLink is a URL representing this object.
    SelfLink string `json:"selfLink,omitempty"`

    // UID is the unique in time and space value for this object. It is typically generated by
    // the server on successful creation of a resource and is not allowed to change on PUT
    // operations.
    UID types.UID `json:"uid,omitempty"`

    // An opaque value that represents the version of this resource. May be used for optimistic
    // concurrency, change detection, and the watch operation on a resource or set of resources.
    // Clients must treat these values as opaque and values may only be valid for a particular
    // resource or set of resources. Only servers will generate resource versions.
    ResourceVersion string `json:"resourceVersion,omitempty"`

    // CreationTimestamp is a timestamp representing the server time when this object was
    // created. It is not guaranteed to be set in happens-before order across separate operations.
    // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
    CreationTimestamp util.Time `json:"creationTimestamp,omitempty"`

    // Labels are key value pairs that may be used to scope and select individual resources.
    // Label keys are of the form:
    //     label-key ::= prefixed-name | name
    //     prefixed-name ::= prefix '/' name
    //     prefix ::= DNS_SUBDOMAIN
    //     name ::= DNS_LABEL
    // The prefix is optional.  If the prefix is not specified, the key is assumed to be private
    // to the user.  Other system components that wish to use labels must specify a prefix.  The
    // "kubernetes.io/" prefix is reserved for use by kubernetes components.
    // TODO: replace map[string]string with labels.LabelSet type
    Labels map[string]string `json:"labels,omitempty"`

    // Annotations are unstructured key value data stored with a resource that may be set by
    // external tooling. They are not queryable and should be preserved when modifying
    // objects.  Annotation keys have the same formatting restrictions as Label keys. See the
    // comments on Labels for details.
    Annotations map[string]string `json:"annotations,omitempty"`
}

// NSObjectMeta is metadata that all persisted namespace-scoped resources must have
// A resource may have only one of {ObjectMeta, ListMeta, NSObjectMeta}.
type NSObjectMeta struct {

    // ObjectMeta is metadata that all persisted resources must have, which includes all objects
    ObjectMeta

    // Namespace defines the space within which ObjectMeta.Name must be unique.
    Namespace string `json:"namespace,omitempty"`
}
```

Depending upon embedding `ObjectMeta` versus `NSObjectMeta` our client code in `kubectl` can do the right thing in `RESTMapper` to know if the URLs it builds should scope to a namespace or not.

Pending general agreement on this pattern, I will update unit tests, and make `Node` the first object that is properly externalized from a `Namespace`.

@erictune @thockin @bgrant0607 @smarterclayton 
