### PR TITLE
Deleting OperationHandler for handling /operation endpoint on server

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -195,7 +195,7 @@ func addParamIf(b *restful.RouteBuilder, parameter *restful.Parameter, shouldAdd
 	return b.Param(parameter)
 }
 
-// InstallREST registers the REST handlers (storage, watch, and operations) into a restful Container.
+// InstallREST registers the REST handlers (storage, watch, proxy and redirect) into a restful Container.
 // It is expected that the provided path root prefix will serve all operations. Root MUST NOT end
 // in a slash. A restful WebService is created for the group and version.
 func (g *APIGroupVersion) InstallREST(container *restful.Container, mux Mux, root string, version string) error {
@@ -210,7 +210,6 @@ func (g *APIGroupVersion) InstallREST(container *restful.Container, mux Mux, roo
 	}
 	proxyHandler := &ProxyHandler{prefix + "/proxy/", g.handler.storage, g.handler.codec}
 	redirectHandler := &RedirectHandler{g.handler.storage, g.handler.codec}
-	opHandler := &OperationHandler{g.handler.ops, g.handler.codec}
 
 	// Create a new WebService for this APIGroupVersion at the specified path prefix
 	// TODO: Pass in more descriptive documentation
@@ -269,8 +268,6 @@ func (g *APIGroupVersion) InstallREST(container *restful.Container, mux Mux, roo
 	mux.Handle(prefix+"/watch/", http.StripPrefix(prefix+"/watch/", watchHandler))
 	mux.Handle(prefix+"/proxy/", http.StripPrefix(prefix+"/proxy/", proxyHandler))
 	mux.Handle(prefix+"/redirect/", http.StripPrefix(prefix+"/redirect/", redirectHandler))
-	mux.Handle(prefix+"/operations", http.StripPrefix(prefix+"/operations", opHandler))
-	mux.Handle(prefix+"/operations/", http.StripPrefix(prefix+"/operations/", opHandler))
 
 	container.Add(ws)
 

--- a/pkg/apiserver/operation.go
+++ b/pkg/apiserver/operation.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apiserver
 
 import (
-	"net/http"
 	"sort"
 	"strconv"
 	"sync"
@@ -25,42 +24,8 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
-
-type OperationHandler struct {
-	ops   *Operations
-	codec runtime.Codec
-}
-
-func (h *OperationHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	parts := splitPath(req.URL.Path)
-	if len(parts) > 1 || req.Method != "GET" {
-		notFound(w, req)
-		return
-	}
-	if len(parts) == 0 {
-		// List outstanding operations.
-		list := h.ops.List()
-		writeJSON(http.StatusOK, h.codec, list, w)
-		return
-	}
-
-	op := h.ops.Get(parts[0])
-	if op == nil {
-		notFound(w, req)
-		return
-	}
-
-	result, complete := op.StatusOrResult()
-	obj := result.Object
-	if complete {
-		writeJSON(http.StatusOK, h.codec, obj, w)
-	} else {
-		writeJSON(http.StatusAccepted, h.codec, obj, w)
-	}
-}
 
 // Operation represents an ongoing action which the server is performing.
 type Operation struct {

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -257,10 +257,6 @@ func getTestRequests() []struct {
 		{"GET", "/api/v1beta1/foo/a", "", code404},
 		{"DELETE", "/api/v1beta1/foo" + timeoutFlag, "", code404},
 
-		// Operations
-		{"GET", "/api/v1beta1/operations", "", code200},
-		{"GET", "/api/v1beta1/operations/1234567890", "", code404},
-
 		// Special verbs on nodes
 		// TODO: Will become 405 once these are converted to go-restful
 		{"GET", "/api/v1beta1/proxy/minions/a", "", code404},


### PR DESCRIPTION
Replaces https://github.com/GoogleCloudPlatform/kubernetes/pull/3697
For https://github.com/GoogleCloudPlatform/kubernetes/issues/3644
