### PR TITLE
Calling 'vagrant up' directly is not supported.  Instead, please run the...

### DIFF
--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -71,7 +71,7 @@ vagrant provision
 To stop and then restart the cluster:
 ```
 vagrant halt
-vagrant up
+cluster/kube-up.sh
 ```
 
 To destroy the cluster:


### PR DESCRIPTION
... following:

  export KUBERNETES_PROVIDER=vagrant
  ./cluster/kube-up.sh
