### PR TITLE
Set Retry-After header before calling WriteHeader

### DIFF
--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -73,8 +73,8 @@ func RateLimit(rl util.RateLimiter, handler http.Handler) http.Handler {
 			return
 		}
 		// Return a 429 status indicating "Too Many Requests"
-		w.WriteHeader(errors.StatusTooManyRequests)
 		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(errors.StatusTooManyRequests)
 		fmt.Fprintf(w, "Rate limit is 1 QPS or a burst of 20")
 	})
 }


### PR DESCRIPTION
I did some digging and saw that the Retry-After header value was not being returned because I incorrectly set it after the call to WriteHeader. Fixed. 
