### PR TITLE
Replace "net" by "pod infra" in docs, comments and format strings.

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -621,9 +621,9 @@ func main() {
 			createdPods.Insert(p[:n-8])
 		}
 	}
-	// We expect 9: 2 net containers + 2 pods from the replication controller +
-	//              1 net container + 2 pods from the URL +
-	//              1 net container + 1 pod from the service test.
+	// We expect 9: 2 pod infra containers + 2 pods from the replication controller +
+	//              1 pod infra container + 2 pods from the URL +
+	//              1 pod infra container + 1 pod from the service test.
 	if len(createdPods) != 9 {
 		glog.Fatalf("Unexpected list of created pods:\n\n%#v\n\n%#v\n\n%#v\n\n", createdPods.List(), fakeDocker1.Created, fakeDocker2.Created)
 	}

--- a/docs/container-environment.md
+++ b/docs/container-environment.md
@@ -59,7 +59,7 @@ This hook is called immediately before a container is terminated.  This event h
 A single parameter named reason is passed to the handler which contains the reason for termination.  Currently the valid values for reason are:
 * ●	```Delete``` - indicating an API call to delete the pod containing this container.
 * ●	```Health``` - indicating that a health check of the container failed.
-* ●	```Dependency``` - indicating that a dependency for the container or the pod is missing, and thus, the container needs to be restarted.  Examples include, the network container crashing, or persistent disk failing for a container that mounts PD.
+* ●	```Dependency``` - indicating that a dependency for the container or the pod is missing, and thus, the container needs to be restarted.  Examples include, the pod infra container crashing, or persistent disk failing for a container that mounts PD.
 
 Eventually, user specified reasons may be [added to the API](https://github.com/GoogleCloudPlatform/kubernetes/issues/137).
 

--- a/docs/design/networking.md
+++ b/docs/design/networking.md
@@ -62,7 +62,7 @@ Docker allocates IP addresses from a bridge we create on each node, using its �
   - creates a new pair of veth devices and binds them to the netns
   - auto-assigns an IP from docker’s IP range
 
-2. Create the user containers and specify the name of the network container as their “net” argument. Docker finds the PID of the command running in the network container and attaches to the netns of that PID.
+2. Create the user containers and specify the name of the pod infra container as their “POD” argument. Docker finds the PID of the command running in the pod infra container and attaches to the netns and ipcns of that PID.
 
 ### Other networking implementation examples
 With the primary aim of providing IP-per-pod-model, other implementations exist to serve the purpose outside of GCE.
@@ -77,7 +77,7 @@ Right now, docker inspect doesn't show the networking configuration of the conta
 
 ### External IP assignment
 
-We want to be able to assign IP addresses externally from Docker ([Docker issue #6743](https://github.com/dotcloud/docker/issues/6743)) so that we don't need to statically allocate fixed-size IP ranges to each node, so that IP addresses can be made stable across network container restarts ([Docker issue #2801](https://github.com/dotcloud/docker/issues/2801)), and to facilitate pod migration. Right now, if the network container dies, all the user containers must be stopped and restarted because the netns of the network container will change on restart, and any subsequent user container restart will join that new netns, thereby not being able to see its peers. Additionally, a change in IP address would encounter DNS caching/TTL problems. External IP assignment would also simplify DNS support (see below).
+We want to be able to assign IP addresses externally from Docker ([Docker issue #6743](https://github.com/dotcloud/docker/issues/6743)) so that we don't need to statically allocate fixed-size IP ranges to each node, so that IP addresses can be made stable across pod infra container restarts ([Docker issue #2801](https://github.com/dotcloud/docker/issues/2801)), and to facilitate pod migration. Right now, if the pod infra container dies, all the user containers must be stopped and restarted because the netns of the pod infra container will change on restart, and any subsequent user container restart will join that new netns, thereby not being able to see its peers. Additionally, a change in IP address would encounter DNS caching/TTL problems. External IP assignment would also simplify DNS support (see below).
 
 ### Naming, discovery, and load balancing
 

--- a/docs/man/kubelet.1.md
+++ b/docs/man/kubelet.1.md
@@ -65,8 +65,8 @@ There are 4 ways that a container manifest can be provided to the Kubelet:
 **--manifest_url**=""
 	URL for accessing the container manifest.
 
-**--network_container_image**="kubernetes/pause:latest"
-	The image that network containers in each pod will use.
+**--pod_infra_container_image**="kubernetes/pause:latest"
+	The image that pod infra containers in each pod will use.
 
 **--port**=10250
 	The port for the info server to serve on.

--- a/docs/man/man1/kubelet.1
+++ b/docs/man/man1/kubelet.1
@@ -89,8 +89,8 @@ HTTP server The kubelet can also listen for HTTP and respond to a simple API (un
     URL for accessing the container manifest.
 
 .PP
-\fB\-\-network\_container\_image\fP="kubernetes/pause:latest"
-    The image that network containers in each pod will use.
+\fB\-\-pod\_infra\_container\_image\fP="kubernetes/pause:latest"
+    The image that pod infra containers in each pod will use.
 
 .PP
 \fB\-\-port\fP=10250

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -987,7 +987,7 @@ func (kl *Kubelet) syncPod(pod *api.BoundPod, dockerContainers dockertools.Docke
 	if podInfraDockerContainer, found, _ := dockerContainers.FindPodContainer(podFullName, uid, dockertools.PodInfraContainerName); found {
 		podInfraContainerID = dockertools.DockerID(podInfraDockerContainer.ID)
 	} else {
-		glog.V(2).Infof("Network container doesn't exist for pod %q, killing and re-creating the pod", podFullName)
+		glog.V(2).Infof("Pod infra container doesn't exist for pod %q, killing and re-creating the pod", podFullName)
 		count, err := kl.killContainersInPod(pod, dockerContainers)
 		if err != nil {
 			return err

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -459,7 +459,7 @@ func TestSyncPodsCreatesNetAndContainer(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Errorf("Custom net container not found: %v", fakeDocker.ContainerList)
+		t.Errorf("Custom pod infra container not found: %v", fakeDocker.ContainerList)
 	}
 
 	if len(fakeDocker.Created) != 2 ||


### PR DESCRIPTION
Cleanup references to net container (See #3817).
