### PR TITLE
Some more operations code cleanup

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -135,7 +135,6 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	}
 
 	cl := client.NewOrDie(&client.Config{Host: apiServer.URL, Version: testapi.Version()})
-	cl.PollPeriod = time.Millisecond * 100
 
 	helper, err := master.NewEtcdHelper(etcdClient, "")
 	if err != nil {

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -22,7 +22,6 @@ package main
 
 import (
 	"fmt"
-	"time"
 
 	kubeletapp "github.com/GoogleCloudPlatform/kubernetes/cmd/kubelet/app"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -61,7 +60,6 @@ func startComponents(etcdClient tools.EtcdClient, cl *client.Client, addr string
 func newApiClient(addr string, port int) *client.Client {
 	apiServerURL := fmt.Sprintf("http://%s:%d", addr, port)
 	cl := client.NewOrDie(&client.Config{Host: apiServerURL, Version: testapi.Version()})
-	cl.PollPeriod = time.Second * 1
 	return cl
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -821,12 +821,12 @@ type Status struct {
 	TypeMeta `json:",inline"`
 	ListMeta `json:"metadata,omitempty"`
 
-	// One of: "Success", "Failure", "Working" (for operations not yet completed)
+	// One of: "Success" or "Failure"
 	Status string `json:"status,omitempty"`
 	// A human-readable description of the status of this operation.
 	Message string `json:"message,omitempty"`
 	// A machine-readable description of why this operation is in the
-	// "Failure" or "Working" status. If this value is empty there
+	// "Failure" status. If this value is empty there
 	// is no information available. A Reason clarifies an HTTP status
 	// code but does not override it.
 	Reason StatusReason `json:"reason,omitempty"`
@@ -862,7 +862,6 @@ type StatusDetails struct {
 const (
 	StatusSuccess = "Success"
 	StatusFailure = "Failure"
-	StatusWorking = "Working"
 )
 
 // StatusReason is an enumeration of possible failure causes.  Each StatusReason
@@ -973,7 +972,7 @@ type StatusCause struct {
 
 // CauseType is a machine readable value providing more detail about what
 // occured in a status response. An operation may have multiple causes for a
-// status (whether Failure, Success, or Working).
+// status (whether Failure or Success).
 type CauseType string
 
 const (

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -636,15 +636,15 @@ type Binding struct {
 // import both.
 type Status struct {
 	TypeMeta `json:",inline"`
-	// One of: "Success", "Failure", "Working" (for operations not yet completed)
-	Status string `json:"status,omitempty" description:"status of the operation; either Working (not yet completed), Success, or Failure"`
+	// One of: "Success" or "Failure".
+	Status string `json:"status,omitempty" description:"status of the operation; either Success, or Failure"`
 	// A human-readable description of the status of this operation.
 	Message string `json:"message,omitempty" description:"human-readable description of the status of this operation"`
 	// A machine-readable description of why this operation is in the
-	// "Failure" or "Working" status. If this value is empty there
+	// "Failure" status. If this value is empty there
 	// is no information available. A Reason clarifies an HTTP status
 	// code but does not override it.
-	Reason StatusReason `json:"reason,omitempty" description:"machine-readable description of why this operation is in the 'Failure' or 'Working' status; if this value is empty there is no information available; a reason clarifies an HTTP status code but does not override it"`
+	Reason StatusReason `json:"reason,omitempty" description:"machine-readable description of why this operation is in the 'Failure' status; if this value is empty there is no information available; a reason clarifies an HTTP status code but does not override it"`
 	// Extended data associated with the reason.  Each reason may define its
 	// own extended details. This field is optional and the data returned
 	// is not guaranteed to conform to any schema except that defined by
@@ -676,7 +676,6 @@ type StatusDetails struct {
 const (
 	StatusSuccess = "Success"
 	StatusFailure = "Failure"
-	StatusWorking = "Working"
 )
 
 // StatusReason is an enumeration of possible failure causes.  Each StatusReason
@@ -739,7 +738,7 @@ type StatusCause struct {
 
 // CauseType is a machine readable value providing more detail about what
 // occured in a status response. An operation may have multiple causes for a
-// status (whether Failure, Success, or Working).
+// status (whether Failure or Success).
 type CauseType string
 
 const (

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -597,15 +597,15 @@ type Binding struct {
 // import both.
 type Status struct {
 	TypeMeta `json:",inline"`
-	// One of: "Success", "Failure", "Working" (for operations not yet completed)
-	Status string `json:"status,omitempty" description:"status of the operation; either Working (not yet completed), Success, or Failure"`
+	// One of: "Success" or "Failure"
+	Status string `json:"status,omitempty" description:"status of the operation; either Success or Failure"`
 	// A human-readable description of the status of this operation.
 	Message string `json:"message,omitempty" description:"human-readable description of the status of this operation"`
 	// A machine-readable description of why this operation is in the
-	// "Failure" or "Working" status. If this value is empty there
+	// "Failure" status. If this value is empty there
 	// is no information available. A Reason clarifies an HTTP status
 	// code but does not override it.
-	Reason StatusReason `json:"reason,omitempty" description:"machine-readable description of why this operation is in the 'Failure' or 'Working' status; if this value is empty there is no information available; a reason clarifies an HTTP status code but does not override it"`
+	Reason StatusReason `json:"reason,omitempty" description:"machine-readable description of why this operation is in the 'Failure' status; if this value is empty there is no information available; a reason clarifies an HTTP status code but does not override it"`
 	// Extended data associated with the reason.  Each reason may define its
 	// own extended details. This field is optional and the data returned
 	// is not guaranteed to conform to any schema except that defined by
@@ -637,7 +637,6 @@ type StatusDetails struct {
 const (
 	StatusSuccess = "Success"
 	StatusFailure = "Failure"
-	StatusWorking = "Working"
 )
 
 // StatusReason is an enumeration of possible failure causes.  Each StatusReason
@@ -713,7 +712,7 @@ type StatusCause struct {
 
 // CauseType is a machine readable value providing more detail about what
 // occured in a status response. An operation may have multiple causes for a
-// status (whether Failure, Success, or Working).
+// status (whether Failure or Success).
 type CauseType string
 
 const (

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -832,12 +832,12 @@ type Status struct {
 	TypeMeta `json:",inline"`
 	ListMeta `json:"metadata,omitempty"`
 
-	// One of: "Success", "Failure", "Working" (for operations not yet completed)
+	// One of: "Success" or "Failure"
 	Status string `json:"status,omitempty"`
 	// A human-readable description of the status of this operation.
 	Message string `json:"message,omitempty"`
 	// A machine-readable description of why this operation is in the
-	// "Failure" or "Working" status. If this value is empty there
+	// "Failure" status. If this value is empty there
 	// is no information available. A Reason clarifies an HTTP status
 	// code but does not override it.
 	Reason StatusReason `json:"reason,omitempty"`
@@ -872,7 +872,6 @@ type StatusDetails struct {
 const (
 	StatusSuccess = "Success"
 	StatusFailure = "Failure"
-	StatusWorking = "Working"
 )
 
 // StatusReason is an enumeration of possible failure causes.  Each StatusReason
@@ -948,7 +947,7 @@ type StatusCause struct {
 
 // CauseType is a machine readable value providing more detail about what
 // occured in a status response. An operation may have multiple causes for a
-// status (whether Failure, Success, or Working).
+// status (whether Failure or Success).
 type CauseType string
 
 const (

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -74,15 +74,14 @@ func interfacesFor(version string) (*meta.VersionInterfaces, error) {
 func init() {
 	// Certain API objects are returned regardless of the contents of storage:
 	// api.Status is returned in errors
-	// api.Operation/api.OperationList are returned by /operations
 
 	// "internal" version
 	api.Scheme.AddKnownTypes("", &Simple{}, &SimpleList{},
-		&api.Status{}, &api.Operation{}, &api.OperationList{})
+		&api.Status{})
 	// "version" version
 	// TODO: Use versioned api objects?
 	api.Scheme.AddKnownTypes(testVersion, &Simple{}, &SimpleList{},
-		&api.Status{}, &api.Operation{}, &api.OperationList{})
+		&api.Status{})
 
 	defMapper := meta.NewDefaultRESTMapper(
 		versions,

--- a/pkg/client/restclient.go
+++ b/pkg/client/restclient.go
@@ -22,8 +22,6 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-
-	"github.com/golang/glog"
 )
 
 // RESTClient imposes common Kubernetes API conventions on a set of resource paths.
@@ -51,12 +49,7 @@ type RESTClient struct {
 	// used.
 	Client HTTPClient
 
-	// Set the poll behavior of this client. If not set the DefaultPoll method will
-	// be called.
-	Poller PollFunc
-
-	PollPeriod time.Duration
-	Timeout    time.Duration
+	Timeout time.Duration
 }
 
 // NewRESTClient creates a new RESTClient. This client performs generic REST functions
@@ -78,9 +71,6 @@ func NewRESTClient(baseURL *url.URL, apiVersion string, c runtime.Codec, legacyB
 		Codec: c,
 
 		LegacyBehavior: legacyBehavior,
-
-		// Poll frequently
-		PollPeriod: time.Second * 2,
 	}
 }
 
@@ -102,11 +92,7 @@ func (c *RESTClient) Verb(verb string) *Request {
 	// if c.Client != nil {
 	// 	timeout = c.Client.Timeout
 	// }
-	poller := c.Poller
-	if poller == nil {
-		poller = c.DefaultPoll
-	}
-	return NewRequest(c.Client, verb, c.baseURL, c.Codec, c.LegacyBehavior, c.LegacyBehavior).Poller(poller).Timeout(c.Timeout)
+	return NewRequest(c.Client, verb, c.baseURL, c.Codec, c.LegacyBehavior, c.LegacyBehavior).Timeout(c.Timeout)
 }
 
 // Post begins a POST request. Short for c.Verb("POST").
@@ -127,22 +113,6 @@ func (c *RESTClient) Get() *Request {
 // Delete begins a DELETE request. Short for c.Verb("DELETE").
 func (c *RESTClient) Delete() *Request {
 	return c.Verb("DELETE")
-}
-
-// PollFor makes a request to do a single poll of the completion of the given operation.
-func (c *RESTClient) Operation(name string) *Request {
-	return c.Get().Resource("operations").Name(name).NoPoll()
-}
-
-// DefaultPoll performs a polling action based on the PollPeriod set on the Client.
-func (c *RESTClient) DefaultPoll(name string) (*Request, bool) {
-	if c.PollPeriod == 0 {
-		return nil, false
-	}
-	glog.Infof("Waiting for completion of operation %s", name)
-	time.Sleep(c.PollPeriod)
-	// Make a poll request
-	return c.Operation(name).Poller(c.DefaultPoll), true
 }
 
 // APIVersion returns the APIVersion this RESTClient is expected to use.

--- a/pkg/client/restclient_test.go
+++ b/pkg/client/restclient_test.go
@@ -157,10 +157,10 @@ func TestValidatesHostParameter(t *testing.T) {
 }
 
 func TestDoRequestBearer(t *testing.T) {
-	status := &api.Status{Status: api.StatusWorking}
+	status := &api.Status{Status: api.StatusFailure}
 	expectedBody, _ := latest.Codec.Encode(status)
 	fakeHandler := util.FakeHandler{
-		StatusCode:   202,
+		StatusCode:   400,
 		ResponseBody: string(expectedBody),
 		T:            t,
 	}
@@ -187,11 +187,11 @@ func TestDoRequestBearer(t *testing.T) {
 	}
 }
 
-func TestDoRequestAccepted(t *testing.T) {
-	status := &api.Status{Status: api.StatusWorking}
+func TestDoRequestWithoutPassword(t *testing.T) {
+	status := &api.Status{Status: api.StatusFailure}
 	expectedBody, _ := latest.Codec.Encode(status)
 	fakeHandler := util.FakeHandler{
-		StatusCode:   202,
+		StatusCode:   400,
 		ResponseBody: string(expectedBody),
 		T:            t,
 	}
@@ -228,11 +228,11 @@ func TestDoRequestAccepted(t *testing.T) {
 	fakeHandler.ValidateRequest(t, "/"+testapi.Version()+"/test", "GET", nil)
 }
 
-func TestDoRequestAcceptedSuccess(t *testing.T) {
+func TestDoRequestSuccess(t *testing.T) {
 	status := &api.Status{Status: api.StatusSuccess}
 	expectedBody, _ := latest.Codec.Encode(status)
 	fakeHandler := util.FakeHandler{
-		StatusCode:   202,
+		StatusCode:   200,
 		ResponseBody: string(expectedBody),
 		T:            t,
 	}
@@ -338,11 +338,4 @@ func TestDoRequestCreated(t *testing.T) {
 		t.Errorf("Unexpected mis-match. Expected %#v.  Saw %#v", status, statusOut)
 	}
 	fakeHandler.ValidateRequest(t, "/"+testapi.Version()+"/test", "GET", nil)
-}
-
-func TestDefaultPoll(t *testing.T) {
-	c := &RESTClient{PollPeriod: 0}
-	if req, ok := c.DefaultPoll("test"); req != nil || ok {
-		t.Errorf("expected nil request and not poll")
-	}
 }

--- a/pkg/registry/controller/rest.go
+++ b/pkg/registry/controller/rest.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
@@ -38,17 +37,15 @@ type PodLister interface {
 
 // REST implements apiserver.RESTStorage for the replication controller service.
 type REST struct {
-	registry   Registry
-	podLister  PodLister
-	pollPeriod time.Duration
+	registry  Registry
+	podLister PodLister
 }
 
 // NewREST returns a new apiserver.RESTStorage for the given registry and PodLister.
 func NewREST(registry Registry, podLister PodLister) *REST {
 	return &REST{
-		registry:   registry,
-		podLister:  podLister,
-		pollPeriod: time.Second * 10,
+		registry:  registry,
+		podLister: podLister,
 	}
 }
 

--- a/pkg/registry/controller/rest_test.go
+++ b/pkg/registry/controller/rest_test.go
@@ -243,9 +243,8 @@ func TestCreateController(t *testing.T) {
 		},
 	}
 	storage := REST{
-		registry:   &mockRegistry,
-		podLister:  &mockPodRegistry,
-		pollPeriod: time.Millisecond * 1,
+		registry:  &mockRegistry,
+		podLister: &mockPodRegistry,
 	}
 	controller := &api.ReplicationController{
 		ObjectMeta: api.ObjectMeta{Name: "test"},
@@ -278,9 +277,8 @@ func TestCreateController(t *testing.T) {
 func TestControllerStorageValidatesCreate(t *testing.T) {
 	mockRegistry := registrytest.ControllerRegistry{}
 	storage := REST{
-		registry:   &mockRegistry,
-		podLister:  nil,
-		pollPeriod: time.Millisecond * 1,
+		registry:  &mockRegistry,
+		podLister: nil,
 	}
 	failureCases := map[string]api.ReplicationController{
 		"empty ID": {
@@ -309,9 +307,8 @@ func TestControllerStorageValidatesCreate(t *testing.T) {
 func TestControllerStorageValidatesUpdate(t *testing.T) {
 	mockRegistry := registrytest.ControllerRegistry{}
 	storage := REST{
-		registry:   &mockRegistry,
-		podLister:  nil,
-		pollPeriod: time.Millisecond * 1,
+		registry:  &mockRegistry,
+		podLister: nil,
 	}
 	failureCases := map[string]api.ReplicationController{
 		"empty ID": {


### PR DESCRIPTION
Follow up to https://github.com/GoogleCloudPlatform/kubernetes/pull/3707 and https://github.com/GoogleCloudPlatform/kubernetes/pull/3891
For https://github.com/GoogleCloudPlatform/kubernetes/issues/3644

Deletes all operations related client code and removes Working as a valid apiserver operation Status
