### PR TITLE
pull more complete information from request

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -10,7 +10,7 @@ readonly port is not currently subject to authorization, but is planned to be
 removed soon.)
 
 The authorization check for any request compares attributes of the context of
-the request, (such as user, resource kind, and namespace) with access
+the request, (such as user, resource, and namespace) with access
 policies.  An API call must be allowed by some policy in order to proceed.
 
 The following implementations are available, and are selected by flag:
@@ -28,10 +28,10 @@ The following implementations are available, and are selected by flag:
 A request has 4 attributes that can be considered for authorization:
   - user (the user-string which a user was authenticated as).
   - whether the request is readonly (GETs are readonly)
-  - what kind of object is being accessed 
+  - what resource is being accessed 
     - applies only to the API endpoints, such as 
         `/api/v1beta1/pods`.  For miscelaneous endpoints, like `/version`, the
-        kind is the empty string.
+        resource is the empty string.
   - the namespace of the object being access, or the empty string if the
         endpoint does not support namespaced objects.
 
@@ -49,7 +49,7 @@ Each line is a "policy object".  A policy object is a map with the following pro
     - `user`, type string; the user-string from `--token_auth_file`
     - `readonly`, type boolean, when true, means that the policy only applies to GET
       operations.
-    - `kind`, type string; a kind of object, from an URL, such as `pods`.
+    - `resource`, type string; a resource from an URL, such as `pods`.
     - `namespace`, type string; a namespace string.
 
 An unset property is the same as a property set to the zero value for its type (e.g. empty string, 0, false).
@@ -76,9 +76,9 @@ To permit an action Policy with an unset namespace applies regardless of namespa
 
 ### Examples
  1. Alice can do anything: `{"user":"alice"}`
- 2. Kubelet can read any pods: `{"user":"kubelet", "kind": "pods", "readonly": true}`
- 3. Kubelet can read and write events: `{"user":"kubelet", "kind": "events"}`
- 4. Bob can just read pods in namespace "projectCaribou": `{"user":"bob", "kind": "pods", "readonly": true, "ns": "projectCaribou"}`
+ 2. Kubelet can read any pods: `{"user":"kubelet", "resource": "pods", "readonly": true}`
+ 3. Kubelet can read and write events: `{"user":"kubelet", "resource": "events"}`
+ 4. Bob can just read pods in namespace "projectCaribou": `{"user":"bob", "resource": "pods", "readonly": true, "ns": "projectCaribou"}`
 
 [Complete file example](../pkg/auth/authorizer/abac/example_policy_file.jsonl)
 

--- a/pkg/admission/attributes.go
+++ b/pkg/admission/attributes.go
@@ -22,15 +22,15 @@ import (
 
 type attributesRecord struct {
 	namespace string
-	kind      string
+	resource  string
 	operation string
 	object    runtime.Object
 }
 
-func NewAttributesRecord(object runtime.Object, namespace, kind, operation string) Attributes {
+func NewAttributesRecord(object runtime.Object, namespace, resource, operation string) Attributes {
 	return &attributesRecord{
 		namespace: namespace,
-		kind:      kind,
+		resource:  resource,
 		operation: operation,
 		object:    object,
 	}
@@ -40,8 +40,8 @@ func (record *attributesRecord) GetNamespace() string {
 	return record.namespace
 }
 
-func (record *attributesRecord) GetKind() string {
-	return record.kind
+func (record *attributesRecord) GetResource() string {
+	return record.resource
 }
 
 func (record *attributesRecord) GetOperation() string {

--- a/pkg/admission/interfaces.go
+++ b/pkg/admission/interfaces.go
@@ -24,7 +24,7 @@ import (
 // that is used to make an admission decision.
 type Attributes interface {
 	GetNamespace() string
-	GetKind() string
+	GetResource() string
 	GetOperation() string
 	GetObject() runtime.Object
 }

--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -49,13 +49,14 @@ func (a *APIInstaller) Install() (ws *restful.WebService, errors []error) {
 
 	// Initialize the custom handlers.
 	watchHandler := (&WatchHandler{
-		storage:         a.restHandler.storage,
-		codec:           a.restHandler.codec,
-		canonicalPrefix: a.restHandler.canonicalPrefix,
-		selfLinker:      a.restHandler.selfLinker,
+		storage:                a.restHandler.storage,
+		codec:                  a.restHandler.codec,
+		canonicalPrefix:        a.restHandler.canonicalPrefix,
+		selfLinker:             a.restHandler.selfLinker,
+		apiRequestInfoResolver: a.restHandler.apiRequestInfoResolver,
 	})
-	redirectHandler := (&RedirectHandler{a.restHandler.storage, a.restHandler.codec})
-	proxyHandler := (&ProxyHandler{a.prefix + "/proxy/", a.restHandler.storage, a.restHandler.codec})
+	redirectHandler := (&RedirectHandler{a.restHandler.storage, a.restHandler.codec, a.restHandler.apiRequestInfoResolver})
+	proxyHandler := (&ProxyHandler{a.prefix + "/proxy/", a.restHandler.storage, a.restHandler.codec, a.restHandler.apiRequestInfoResolver})
 
 	for path, storage := range a.restHandler.storage {
 		if err := a.registerResourceHandlers(path, storage, ws, watchHandler, redirectHandler, proxyHandler); err != nil {

--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -176,8 +176,8 @@ func (r *requestAttributeGetter) GetAttribs(req *http.Request) authorizer.Attrib
 	apiRequestInfo, _ := r.apiRequestInfoResolver.GetAPIRequestInfo(req)
 
 	// If a path follows the conventions of the REST object store, then
-	// we can extract the object Kind.  Otherwise, not.
-	attribs.Kind = apiRequestInfo.Resource
+	// we can extract the resource.  Otherwise, not.
+	attribs.Resource = apiRequestInfo.Resource
 
 	// If the request specifies a namespace, then the namespace is filled in.
 	// Assumes there is no empty string namespace.  Unspecified results

--- a/pkg/apiserver/proxy.go
+++ b/pkg/apiserver/proxy.go
@@ -75,17 +75,20 @@ var tagsToAttrs = map[string]util.StringSet{
 // ProxyHandler provides a http.Handler which will proxy traffic to locations
 // specified by items implementing Redirector.
 type ProxyHandler struct {
-	prefix  string
-	storage map[string]RESTStorage
-	codec   runtime.Codec
+	prefix                 string
+	storage                map[string]RESTStorage
+	codec                  runtime.Codec
+	apiRequestInfoResolver *APIRequestInfoResolver
 }
 
 func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	namespace, kind, parts, err := KindAndNamespace(req)
+	requestInfo, err := r.apiRequestInfoResolver.GetAPIRequestInfo(req)
 	if err != nil {
 		notFound(w, req)
 		return
 	}
+	namespace, resource, parts := requestInfo.Namespace, requestInfo.Resource, requestInfo.Parts
+
 	ctx := api.WithNamespace(api.NewContext(), namespace)
 	if len(parts) < 2 {
 		notFound(w, req)
@@ -103,17 +106,17 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			rest = rest + "/"
 		}
 	}
-	storage, ok := r.storage[kind]
+	storage, ok := r.storage[resource]
 	if !ok {
-		httplog.LogOf(req, w).Addf("'%v' has no storage object", kind)
+		httplog.LogOf(req, w).Addf("'%v' has no storage object", resource)
 		notFound(w, req)
 		return
 	}
 
 	redirector, ok := storage.(Redirector)
 	if !ok {
-		httplog.LogOf(req, w).Addf("'%v' is not a redirector", kind)
-		errorJSON(errors.NewMethodNotSupported(kind, "proxy"), r.codec, w)
+		httplog.LogOf(req, w).Addf("'%v' is not a redirector", resource)
+		errorJSON(errors.NewMethodNotSupported(resource, "proxy"), r.codec, w)
 		return
 	}
 
@@ -156,7 +159,7 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	proxy.Transport = &proxyTransport{
 		proxyScheme:      req.URL.Scheme,
 		proxyHost:        req.URL.Host,
-		proxyPathPrepend: path.Join(r.prefix, "ns", namespace, kind, id),
+		proxyPathPrepend: path.Join(r.prefix, "ns", namespace, resource, id),
 	}
 	proxy.FlushInterval = 200 * time.Millisecond
 	proxy.ServeHTTP(w, newReq)

--- a/pkg/auth/authorizer/abac/abac.go
+++ b/pkg/auth/authorizer/abac/abac.go
@@ -52,7 +52,7 @@ type policy struct {
 
 	// TODO: make this a proper REST object with its own registry.
 	Readonly  bool   `json:"readonly,omitempty"`
-	Kind      string `json:"kind,omitempty"`
+	Resource  string `json:"resource,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
 
 	// TODO: "expires" string in RFC3339 format.
@@ -100,7 +100,7 @@ func NewFromFile(path string) (policyList, error) {
 func (p policy) matches(a authorizer.Attributes) bool {
 	if p.subjectMatches(a) {
 		if p.Readonly == false || (p.Readonly == a.IsReadOnly()) {
-			if p.Kind == "" || (p.Kind == a.GetKind()) {
+			if p.Resource == "" || (p.Resource == a.GetResource()) {
 				if p.Namespace == "" || (p.Namespace == a.GetNamespace()) {
 					return true
 				}

--- a/pkg/auth/authorizer/abac/abac_test.go
+++ b/pkg/auth/authorizer/abac/abac_test.go
@@ -76,49 +76,49 @@ func NotTestAuthorize(t *testing.T) {
 	testCases := []struct {
 		User        user.DefaultInfo
 		RO          bool
-		Kind        string
+		Resource    string
 		NS          string
 		ExpectAllow bool
 	}{
 		// Scheduler can read pods
-		{User: uScheduler, RO: true, Kind: "pods", NS: "ns1", ExpectAllow: true},
-		{User: uScheduler, RO: true, Kind: "pods", NS: "", ExpectAllow: true},
+		{User: uScheduler, RO: true, Resource: "pods", NS: "ns1", ExpectAllow: true},
+		{User: uScheduler, RO: true, Resource: "pods", NS: "", ExpectAllow: true},
 		// Scheduler cannot write pods
-		{User: uScheduler, RO: false, Kind: "pods", NS: "ns1", ExpectAllow: false},
-		{User: uScheduler, RO: false, Kind: "pods", NS: "", ExpectAllow: false},
+		{User: uScheduler, RO: false, Resource: "pods", NS: "ns1", ExpectAllow: false},
+		{User: uScheduler, RO: false, Resource: "pods", NS: "", ExpectAllow: false},
 		// Scheduler can write bindings
-		{User: uScheduler, RO: true, Kind: "bindings", NS: "ns1", ExpectAllow: true},
-		{User: uScheduler, RO: true, Kind: "bindings", NS: "", ExpectAllow: true},
+		{User: uScheduler, RO: true, Resource: "bindings", NS: "ns1", ExpectAllow: true},
+		{User: uScheduler, RO: true, Resource: "bindings", NS: "", ExpectAllow: true},
 
 		// Alice can read and write anything in the right namespace.
-		{User: uAlice, RO: true, Kind: "pods", NS: "projectCaribou", ExpectAllow: true},
-		{User: uAlice, RO: true, Kind: "widgets", NS: "projectCaribou", ExpectAllow: true},
-		{User: uAlice, RO: true, Kind: "", NS: "projectCaribou", ExpectAllow: true},
-		{User: uAlice, RO: false, Kind: "pods", NS: "projectCaribou", ExpectAllow: true},
-		{User: uAlice, RO: false, Kind: "widgets", NS: "projectCaribou", ExpectAllow: true},
-		{User: uAlice, RO: false, Kind: "", NS: "projectCaribou", ExpectAllow: true},
+		{User: uAlice, RO: true, Resource: "pods", NS: "projectCaribou", ExpectAllow: true},
+		{User: uAlice, RO: true, Resource: "widgets", NS: "projectCaribou", ExpectAllow: true},
+		{User: uAlice, RO: true, Resource: "", NS: "projectCaribou", ExpectAllow: true},
+		{User: uAlice, RO: false, Resource: "pods", NS: "projectCaribou", ExpectAllow: true},
+		{User: uAlice, RO: false, Resource: "widgets", NS: "projectCaribou", ExpectAllow: true},
+		{User: uAlice, RO: false, Resource: "", NS: "projectCaribou", ExpectAllow: true},
 		// .. but not the wrong namespace.
-		{User: uAlice, RO: true, Kind: "pods", NS: "ns1", ExpectAllow: false},
-		{User: uAlice, RO: true, Kind: "widgets", NS: "ns1", ExpectAllow: false},
-		{User: uAlice, RO: true, Kind: "", NS: "ns1", ExpectAllow: false},
+		{User: uAlice, RO: true, Resource: "pods", NS: "ns1", ExpectAllow: false},
+		{User: uAlice, RO: true, Resource: "widgets", NS: "ns1", ExpectAllow: false},
+		{User: uAlice, RO: true, Resource: "", NS: "ns1", ExpectAllow: false},
 
 		// Chuck can read events, since anyone can.
-		{User: uChuck, RO: true, Kind: "events", NS: "ns1", ExpectAllow: true},
-		{User: uChuck, RO: true, Kind: "events", NS: "", ExpectAllow: true},
+		{User: uChuck, RO: true, Resource: "events", NS: "ns1", ExpectAllow: true},
+		{User: uChuck, RO: true, Resource: "events", NS: "", ExpectAllow: true},
 		// Chuck can't do other things.
-		{User: uChuck, RO: false, Kind: "events", NS: "ns1", ExpectAllow: false},
-		{User: uChuck, RO: true, Kind: "pods", NS: "ns1", ExpectAllow: false},
-		{User: uChuck, RO: true, Kind: "floop", NS: "ns1", ExpectAllow: false},
+		{User: uChuck, RO: false, Resource: "events", NS: "ns1", ExpectAllow: false},
+		{User: uChuck, RO: true, Resource: "pods", NS: "ns1", ExpectAllow: false},
+		{User: uChuck, RO: true, Resource: "floop", NS: "ns1", ExpectAllow: false},
 		// Chunk can't access things with no kind or namespace
 		// TODO: find a way to give someone access to miscelaneous endpoints, such as
 		// /healthz, /version, etc.
-		{User: uChuck, RO: true, Kind: "", NS: "", ExpectAllow: false},
+		{User: uChuck, RO: true, Resource: "", NS: "", ExpectAllow: false},
 	}
 	for _, tc := range testCases {
 		attr := authorizer.AttributesRecord{
 			User:      &tc.User,
 			ReadOnly:  tc.RO,
-			Kind:      tc.Kind,
+			Resource:  tc.Resource,
 			Namespace: tc.NS,
 		}
 		t.Logf("tc: %v -> attr %v", tc, attr)

--- a/pkg/auth/authorizer/abac/example_policy_file.jsonl
+++ b/pkg/auth/authorizer/abac/example_policy_file.jsonl
@@ -1,9 +1,9 @@
 {"user":"admin"}
-{"user":"scheduler", "readonly": true, "kind": "pods"}
-{"user":"scheduler", "kind": "bindings"}
-{"user":"kubelet",  "readonly": true, "kind": "pods"}
-{"user":"kubelet",  "readonly": true, "kind": "services"}
-{"user":"kubelet",  "readonly": true, "kind": "endpoints"}
-{"user":"kubelet", "kind": "events"}
+{"user":"scheduler", "readonly": true, "resource": "pods"}
+{"user":"scheduler", "resource": "bindings"}
+{"user":"kubelet",  "readonly": true, "resource": "pods"}
+{"user":"kubelet",  "readonly": true, "resource": "services"}
+{"user":"kubelet",  "readonly": true, "resource": "endpoints"}
+{"user":"kubelet", "resource": "events"}
 {"user":"alice", "ns": "projectCaribou"}
 {"user":"bob", "readonly": true, "ns": "projectCaribou"}

--- a/pkg/auth/authorizer/interfaces.go
+++ b/pkg/auth/authorizer/interfaces.go
@@ -40,7 +40,7 @@ type Attributes interface {
 	GetNamespace() string
 
 	// The kind of object, if a request is for a REST object.
-	GetKind() string
+	GetResource() string
 }
 
 // Authorizer makes an authorization decision based on information gained by making
@@ -55,7 +55,7 @@ type AttributesRecord struct {
 	User      user.Info
 	ReadOnly  bool
 	Namespace string
-	Kind      string
+	Resource  string
 }
 
 func (a AttributesRecord) GetUserName() string {
@@ -74,6 +74,6 @@ func (a AttributesRecord) GetNamespace() string {
 	return a.Namespace
 }
 
-func (a AttributesRecord) GetKind() string {
-	return a.Kind
+func (a AttributesRecord) GetResource() string {
+	return a.Resource
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -454,7 +454,7 @@ func (m *Master) init(c *Config) {
 
 	m.InsecureHandler = handler
 
-	attributeGetter := apiserver.NewRequestAttributeGetter(userContexts)
+	attributeGetter := apiserver.NewRequestAttributeGetter(userContexts, latest.RESTMapper, "api")
 	handler = apiserver.WithAuthorizationCheck(handler, attributeGetter, m.authorizer)
 
 	// Install Authenticator
@@ -531,25 +531,25 @@ func (m *Master) getServersToValidate(c *Config) map[string]apiserver.Server {
 }
 
 // api_v1beta1 returns the resources and codec for API version v1beta1.
-func (m *Master) api_v1beta1() (map[string]apiserver.RESTStorage, runtime.Codec, string, runtime.SelfLinker, admission.Interface, meta.RESTMapper) {
+func (m *Master) api_v1beta1() (map[string]apiserver.RESTStorage, runtime.Codec, string, string, runtime.SelfLinker, admission.Interface, meta.RESTMapper) {
 	storage := make(map[string]apiserver.RESTStorage)
 	for k, v := range m.storage {
 		storage[k] = v
 	}
-	return storage, v1beta1.Codec, "/api/v1beta1", latest.SelfLinker, m.admissionControl, latest.RESTMapper
+	return storage, v1beta1.Codec, "api", "/api/v1beta1", latest.SelfLinker, m.admissionControl, latest.RESTMapper
 }
 
 // api_v1beta2 returns the resources and codec for API version v1beta2.
-func (m *Master) api_v1beta2() (map[string]apiserver.RESTStorage, runtime.Codec, string, runtime.SelfLinker, admission.Interface, meta.RESTMapper) {
+func (m *Master) api_v1beta2() (map[string]apiserver.RESTStorage, runtime.Codec, string, string, runtime.SelfLinker, admission.Interface, meta.RESTMapper) {
 	storage := make(map[string]apiserver.RESTStorage)
 	for k, v := range m.storage {
 		storage[k] = v
 	}
-	return storage, v1beta2.Codec, "/api/v1beta2", latest.SelfLinker, m.admissionControl, latest.RESTMapper
+	return storage, v1beta2.Codec, "api", "/api/v1beta2", latest.SelfLinker, m.admissionControl, latest.RESTMapper
 }
 
 // api_v1beta3 returns the resources and codec for API version v1beta3.
-func (m *Master) api_v1beta3() (map[string]apiserver.RESTStorage, runtime.Codec, string, runtime.SelfLinker, admission.Interface, meta.RESTMapper) {
+func (m *Master) api_v1beta3() (map[string]apiserver.RESTStorage, runtime.Codec, string, string, runtime.SelfLinker, admission.Interface, meta.RESTMapper) {
 	storage := make(map[string]apiserver.RESTStorage)
 	for k, v := range m.storage {
 		if k == "minions" {
@@ -557,5 +557,5 @@ func (m *Master) api_v1beta3() (map[string]apiserver.RESTStorage, runtime.Codec,
 		}
 		storage[strings.ToLower(k)] = v
 	}
-	return storage, v1beta3.Codec, "/api/v1beta3", latest.SelfLinker, m.admissionControl, latest.RESTMapper
+	return storage, v1beta3.Codec, "api", "/api/v1beta3", latest.SelfLinker, m.admissionControl, latest.RESTMapper
 }

--- a/plugin/pkg/admission/deny/admission.go
+++ b/plugin/pkg/admission/deny/admission.go
@@ -36,7 +36,7 @@ func init() {
 type alwaysDeny struct{}
 
 func (alwaysDeny) Admit(a admission.Attributes) (err error) {
-	return apierrors.NewForbidden(a.GetKind(), "", errors.New("Admission control is denying all modifications"))
+	return apierrors.NewForbidden(a.GetResource(), "", errors.New("Admission control is denying all modifications"))
 }
 
 func NewAlwaysDeny() admission.Interface {

--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -58,7 +58,7 @@ func (l *limitRanger) Admit(a admission.Attributes) (err error) {
 	// ensure it meets each prescribed min/max
 	for i := range items.Items {
 		limitRange := &items.Items[i]
-		err = l.limitFunc(limitRange, a.GetKind(), a.GetObject())
+		err = l.limitFunc(limitRange, a.GetResource(), a.GetObject())
 		if err != nil {
 			return err
 		}
@@ -86,8 +86,8 @@ func Max(a int64, b int64) int64 {
 }
 
 // PodLimitFunc enforces that a pod spec does not exceed any limits specified on the supplied limit range
-func PodLimitFunc(limitRange *api.LimitRange, kind string, obj runtime.Object) error {
-	if kind != "pods" {
+func PodLimitFunc(limitRange *api.LimitRange, resourceName string, obj runtime.Object) error {
+	if resourceName != "pods" {
 		return nil
 	}
 
@@ -161,11 +161,11 @@ func PodLimitFunc(limitRange *api.LimitRange, kind string, obj runtime.Object) e
 				switch minOrMax {
 				case "Min":
 					if observed < enforced {
-						return apierrors.NewForbidden(kind, pod.Name, err)
+						return apierrors.NewForbidden(resourceName, pod.Name, err)
 					}
 				case "Max":
 					if observed > enforced {
-						return apierrors.NewForbidden(kind, pod.Name, err)
+						return apierrors.NewForbidden(resourceName, pod.Name, err)
 					}
 				}
 			}

--- a/plugin/pkg/admission/resourcedefaults/admission.go
+++ b/plugin/pkg/admission/resourcedefaults/admission.go
@@ -47,7 +47,7 @@ func (resourceDefaults) Admit(a admission.Attributes) (err error) {
 	}
 
 	// we only care about pods
-	if a.GetKind() != "pods" {
+	if a.GetResource() != "pods" {
 		return nil
 	}
 

--- a/plugin/pkg/admission/resourcequota/admission.go
+++ b/plugin/pkg/admission/resourcequota/admission.go
@@ -44,7 +44,7 @@ func NewResourceQuota(client client.Interface) admission.Interface {
 	return &quota{client: client}
 }
 
-var kindToResourceName = map[string]api.ResourceName{
+var resourceToResourceName = map[string]api.ResourceName{
 	"pods":                   api.ResourcePods,
 	"services":               api.ResourceServices,
 	"replicationControllers": api.ResourceReplicationControllers,
@@ -57,7 +57,7 @@ func (q *quota) Admit(a admission.Attributes) (err error) {
 	}
 
 	obj := a.GetObject()
-	kind := a.GetKind()
+	resource := a.GetResource()
 	name := "Unknown"
 	if obj != nil {
 		name, _ = meta.NewAccessor().Name(obj)
@@ -65,7 +65,7 @@ func (q *quota) Admit(a admission.Attributes) (err error) {
 
 	list, err := q.client.ResourceQuotas(a.GetNamespace()).List(labels.Everything())
 	if err != nil {
-		return apierrors.NewForbidden(a.GetKind(), name, fmt.Errorf("Unable to %s %s at this time because there was an error enforcing quota", a.GetOperation(), kind))
+		return apierrors.NewForbidden(a.GetResource(), name, fmt.Errorf("Unable to %s %s at this time because there was an error enforcing quota", a.GetOperation(), resource))
 	}
 
 	if len(list.Items) == 0 {
@@ -90,7 +90,7 @@ func (q *quota) Admit(a admission.Attributes) (err error) {
 			usage.Status = quota.Status
 			err = q.client.ResourceQuotaUsages(usage.Namespace).Create(&usage)
 			if err != nil {
-				return apierrors.NewForbidden(a.GetKind(), name, fmt.Errorf("Unable to %s %s at this time because there was an error enforcing quota", a.GetOperation(), a.GetKind()))
+				return apierrors.NewForbidden(a.GetResource(), name, fmt.Errorf("Unable to %s %s at this time because there was an error enforcing quota", a.GetOperation(), a.GetResource()))
 			}
 		}
 	}
@@ -102,7 +102,7 @@ func (q *quota) Admit(a admission.Attributes) (err error) {
 // Return an error if the operation should not pass admission control
 func IncrementUsage(a admission.Attributes, status *api.ResourceQuotaStatus, client client.Interface) (bool, error) {
 	obj := a.GetObject()
-	kind := a.GetKind()
+	resourceName := a.GetResource()
 	name := "Unknown"
 	if obj != nil {
 		name, _ = meta.NewAccessor().Name(obj)
@@ -114,15 +114,15 @@ func IncrementUsage(a admission.Attributes, status *api.ResourceQuotaStatus, cli
 	}
 	// handle max counts for each kind of resource (pods, services, replicationControllers, etc.)
 	if a.GetOperation() == "CREATE" {
-		resourceName := kindToResourceName[a.GetKind()]
+		resourceName := resourceToResourceName[a.GetResource()]
 		hard, hardFound := status.Hard[resourceName]
 		if hardFound {
 			used, usedFound := status.Used[resourceName]
 			if !usedFound {
-				return false, apierrors.NewForbidden(kind, name, fmt.Errorf("Quota usage stats are not yet known, unable to admit resource until an accurate count is completed."))
+				return false, apierrors.NewForbidden(a.GetResource(), name, fmt.Errorf("Quota usage stats are not yet known, unable to admit resource until an accurate count is completed."))
 			}
 			if used.Value() >= hard.Value() {
-				return false, apierrors.NewForbidden(kind, name, fmt.Errorf("Limited to %s %s", hard.String(), kind))
+				return false, apierrors.NewForbidden(a.GetResource(), name, fmt.Errorf("Limited to %s %s", hard.String(), a.GetResource()))
 			} else {
 				status.Used[resourceName] = *resource.NewQuantity(used.Value()+int64(1), resource.DecimalSI)
 				dirty = true
@@ -130,7 +130,7 @@ func IncrementUsage(a admission.Attributes, status *api.ResourceQuotaStatus, cli
 		}
 	}
 	// handle memory/cpu constraints, and any diff of usage based on memory/cpu on updates
-	if a.GetKind() == "pods" && (set[api.ResourceMemory] || set[api.ResourceCPU]) {
+	if a.GetResource() == "pods" && (set[api.ResourceMemory] || set[api.ResourceCPU]) {
 		pod := obj.(*api.Pod)
 		deltaCPU := resourcequota.PodCPU(pod)
 		deltaMemory := resourcequota.PodMemory(pod)
@@ -138,7 +138,7 @@ func IncrementUsage(a admission.Attributes, status *api.ResourceQuotaStatus, cli
 		if a.GetOperation() == "UPDATE" {
 			oldPod, err := client.Pods(a.GetNamespace()).Get(pod.Name)
 			if err != nil {
-				return false, apierrors.NewForbidden(kind, name, err)
+				return false, apierrors.NewForbidden(resourceName, name, err)
 			}
 			oldCPU := resourcequota.PodCPU(oldPod)
 			oldMemory := resourcequota.PodMemory(oldPod)
@@ -150,10 +150,10 @@ func IncrementUsage(a admission.Attributes, status *api.ResourceQuotaStatus, cli
 		if hardMemFound {
 			used, usedFound := status.Used[api.ResourceMemory]
 			if !usedFound {
-				return false, apierrors.NewForbidden(kind, name, fmt.Errorf("Quota usage stats are not yet known, unable to admit resource until an accurate count is completed."))
+				return false, apierrors.NewForbidden(resourceName, name, fmt.Errorf("Quota usage stats are not yet known, unable to admit resource until an accurate count is completed."))
 			}
 			if used.Value()+deltaMemory.Value() > hardMem.Value() {
-				return false, apierrors.NewForbidden(kind, name, fmt.Errorf("Limited to %s memory", hardMem.String()))
+				return false, apierrors.NewForbidden(resourceName, name, fmt.Errorf("Limited to %s memory", hardMem.String()))
 			} else {
 				status.Used[api.ResourceMemory] = *resource.NewQuantity(used.Value()+deltaMemory.Value(), resource.DecimalSI)
 				dirty = true
@@ -163,10 +163,10 @@ func IncrementUsage(a admission.Attributes, status *api.ResourceQuotaStatus, cli
 		if hardCPUFound {
 			used, usedFound := status.Used[api.ResourceCPU]
 			if !usedFound {
-				return false, apierrors.NewForbidden(kind, name, fmt.Errorf("Quota usage stats are not yet known, unable to admit resource until an accurate count is completed."))
+				return false, apierrors.NewForbidden(resourceName, name, fmt.Errorf("Quota usage stats are not yet known, unable to admit resource until an accurate count is completed."))
 			}
 			if used.MilliValue()+deltaCPU.MilliValue() > hardCPU.MilliValue() {
-				return false, apierrors.NewForbidden(kind, name, fmt.Errorf("Limited to %s CPU", hardCPU.String()))
+				return false, apierrors.NewForbidden(resourceName, name, fmt.Errorf("Limited to %s CPU", hardCPU.String()))
 			} else {
 				status.Used[api.ResourceCPU] = *resource.NewMilliQuantity(used.MilliValue()+deltaCPU.MilliValue(), resource.DecimalSI)
 				dirty = true

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -691,7 +691,7 @@ func TestKindAuthorization(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	a := newAuthorizerWithContents(t, `{"kind": "services"}
+	a := newAuthorizerWithContents(t, `{"resource": "services"}
 `)
 
 	var m *master.Master


### PR DESCRIPTION
This change updates apiserver.KindAndNamespace call to return a more detailed set of information for an API request, it wraps the return in a struct to avoid a large number of returned arguments, and it updates the code to allow the configuration of multiple API roots.

@derekwaynecarr I know you were talking about updating the same method to make a different set of tweaks.

/cc @smarterclayton @liggitt
