### PR TITLE
Eliminate tar_options, to work around bugs in new salt version

### DIFF
--- a/cluster/saltbase/salt/etcd/init.sls
+++ b/cluster/saltbase/salt/etcd/init.sls
@@ -24,7 +24,9 @@ etcd-tar:
     - source_hash: {{ etcd_tar_hash }}
     - archive_format: tar
     - if_missing: /usr/local/src/etcd-{{ etcd_version }}-linux-amd64
+{% if grains['saltversioninfo'] <= (2014, 7, 0, 0) %}
     - tar_options: xz
+{% endif %}
   file.directory:
     - name: /usr/local/src/etcd-{{ etcd_version }}-linux-amd64
     - user: root


### PR DESCRIPTION
There appear to be two relevant bugs in the latest salt version (v2014.7.1):

https://github.com/saltstack/salt/issues/20195 means we cannot specify x any more

https://github.com/saltstack/salt/issues/20201 is more serious - it double quotes the filename, meaning the filename cannot be found.  By removing tar_options entirely we go through a different code path, using a Python tarfile extractor, which works.

Fixes issue #3932
