### PR TITLE
Make RESTMapper scope aware, use it to inform kubectl and swagger behavior

### DIFF
--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -103,25 +103,6 @@ func init() {
 			return interfaces, true
 		},
 	)
-	// scopes that are used to qualify resources in the API
-	namespaceAsQueryParam := meta.RESTScope{
-		Name:             "namespace",
-		ParamName:        "namespace",
-		ParamPath:        false,
-		ParamDescription: "object name and auth scope, such as for teams and projects",
-	}
-	namespaceAsPathParam := meta.RESTScope{
-		Name:             "namespace",
-		ParamName:        "ns",
-		ParamPath:        true,
-		ParamDescription: "object name and auth scope, such as for teams and projects",
-	}
-	rootScope := meta.RESTScope{
-		Name:      "root",
-		ParamName: "",
-		ParamPath: true,
-	}
-
 	// list of versions we support on the server
 	versions := []string{"v1beta1", "v1beta2", "v1beta3"}
 
@@ -133,9 +114,9 @@ func init() {
 
 	// backwards compatibility, prior to v1beta3, we identified the namespace as a query parameter
 	versionToNamespaceScope := map[string]meta.RESTScope{
-		"v1beta1": namespaceAsQueryParam,
-		"v1beta2": namespaceAsQueryParam,
-		"v1beta3": namespaceAsPathParam,
+		"v1beta1": meta.RESTScopeNamespaceLegacy,
+		"v1beta2": meta.RESTScopeNamespaceLegacy,
+		"v1beta3": meta.RESTScopeNamespace,
 	}
 
 	// the list of kinds that are scoped at the root of the api hierarchy
@@ -155,7 +136,7 @@ func init() {
 			scope := versionToNamespaceScope[version]
 			_, found = kindToRootScope[kind]
 			if found {
-				scope = rootScope
+				scope = meta.RESTScopeRoot
 			}
 			mapper.Add(scope, kind, version, mixedCase)
 		}

--- a/pkg/api/meta/interfaces.go
+++ b/pkg/api/meta/interfaces.go
@@ -94,6 +94,21 @@ type MetadataAccessor interface {
 	runtime.ResourceVersioner
 }
 
+// RESTScope contains the information needed to deal with REST Resources that are in a resource hierarchy
+type RESTScope struct {
+	// Name of the scope (e.g. "cluster", "namespace", etc.)
+	Name string
+	// ParamName is the optional name of the parameter that should be inserted in the resource url
+	// If empty, no param will be inserted
+	ParamName string
+	// ParamPath is a boolean that controls how the parameter is manifested in resource paths
+	// If true, this parameter is encoded in path (i.e. /{paramName}/{paramValue})
+	// If false, this parameter is encoded in query (i.e. ?{paramName}={paramValue})
+	ParamPath bool
+	// ParamDescription is the optional description to use to document the parameter in api documentation
+	ParamDescription string
+}
+
 // RESTMapping contains the information needed to deal with objects of a specific
 // resource and kind in a RESTful manner.
 type RESTMapping struct {
@@ -103,6 +118,9 @@ type RESTMapping struct {
 	// for convenience for passing around a consistent mapping.
 	APIVersion string
 	Kind       string
+
+	// Scope contains the information needed to deal with REST Resources that are in a resource hierarchy
+	Scope RESTScope
 
 	runtime.Codec
 	runtime.ObjectConvertor

--- a/pkg/api/meta/interfaces.go
+++ b/pkg/api/meta/interfaces.go
@@ -94,19 +94,26 @@ type MetadataAccessor interface {
 	runtime.ResourceVersioner
 }
 
-// RESTScope contains the information needed to deal with REST Resources that are in a resource hierarchy
-type RESTScope struct {
-	// Name of the scope (e.g. "cluster", "namespace", etc.)
-	Name string
+type RESTScopeName string
+
+const (
+	RESTScopeNameNamespace RESTScopeName = "namespace"
+	RESTScopeNameRoot      RESTScopeName = "root"
+)
+
+// RESTScope contains the information needed to deal with REST resources that are in a resource hierarchy
+type RESTScope interface {
+	// Name of the scope
+	Name() RESTScopeName
 	// ParamName is the optional name of the parameter that should be inserted in the resource url
 	// If empty, no param will be inserted
-	ParamName string
+	ParamName() string
 	// ParamPath is a boolean that controls how the parameter is manifested in resource paths
 	// If true, this parameter is encoded in path (i.e. /{paramName}/{paramValue})
 	// If false, this parameter is encoded in query (i.e. ?{paramName}={paramValue})
-	ParamPath bool
+	ParamPath() bool
 	// ParamDescription is the optional description to use to document the parameter in api documentation
-	ParamDescription string
+	ParamDescription() string
 }
 
 // RESTMapping contains the information needed to deal with objects of a specific

--- a/pkg/api/meta/interfaces.go
+++ b/pkg/api/meta/interfaces.go
@@ -102,6 +102,8 @@ const (
 )
 
 // RESTScope contains the information needed to deal with REST resources that are in a resource hierarchy
+// TODO After we deprecate v1beta1 and v1beta2, we can look a supporting removing the flexibility of supporting
+// either a query or path param, and instead just support path param
 type RESTScope interface {
 	// Name of the scope
 	Name() RESTScopeName

--- a/pkg/api/meta/restmapper.go
+++ b/pkg/api/meta/restmapper.go
@@ -21,6 +21,45 @@ import (
 	"strings"
 )
 
+// Implements RESTScope interface
+type restScope struct {
+	name             RESTScopeName
+	paramName        string
+	paramPath        bool
+	paramDescription string
+}
+
+func (r *restScope) Name() RESTScopeName {
+	return r.name
+}
+func (r *restScope) ParamName() string {
+	return r.paramName
+}
+func (r *restScope) ParamPath() bool {
+	return r.paramPath
+}
+func (r *restScope) ParamDescription() string {
+	return r.paramDescription
+}
+
+var RESTScopeNamespaceLegacy = &restScope{
+	name:             RESTScopeNameNamespace,
+	paramName:        "namespace",
+	paramPath:        false,
+	paramDescription: "object name and auth scope, such as for teams and projects",
+}
+
+var RESTScopeNamespace = &restScope{
+	name:             RESTScopeNameNamespace,
+	paramName:        "namespace",
+	paramPath:        true,
+	paramDescription: "object name and auth scope, such as for teams and projects",
+}
+
+var RESTScopeRoot = &restScope{
+	name: RESTScopeNameRoot,
+}
+
 // typeMeta is used as a key for lookup in the mapping between REST path and
 // API object.
 type typeMeta struct {
@@ -89,6 +128,9 @@ func (m *DefaultRESTMapper) Add(scope RESTScope, kind string, version string, mi
 
 // kindToResource converts Kind to a resource name.
 func kindToResource(kind string, mixedCase bool) (plural, singular string) {
+	if len(kind) == 0 {
+		return
+	}
 	if mixedCase {
 		// Legacy support for mixed case names
 		singular = strings.ToLower(kind[:1]) + kind[1:]

--- a/pkg/api/meta/restmapper.go
+++ b/pkg/api/meta/restmapper.go
@@ -19,8 +19,6 @@ package meta
 import (
 	"fmt"
 	"strings"
-
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
 // typeMeta is used as a key for lookup in the mapping between REST path and
@@ -45,6 +43,7 @@ type typeMeta struct {
 type DefaultRESTMapper struct {
 	mapping        map[string]typeMeta
 	reverse        map[typeMeta]string
+	scopes         map[typeMeta]RESTScope
 	versions       []string
 	interfacesFunc VersionInterfacesFunc
 }
@@ -61,36 +60,31 @@ type VersionInterfacesFunc func(apiVersion string) (*VersionInterfaces, bool)
 func NewDefaultRESTMapper(versions []string, f VersionInterfacesFunc) *DefaultRESTMapper {
 	mapping := make(map[string]typeMeta)
 	reverse := make(map[typeMeta]string)
+	scopes := make(map[typeMeta]RESTScope)
 	// TODO: verify name mappings work correctly when versions differ
 
 	return &DefaultRESTMapper{
-		mapping: mapping,
-		reverse: reverse,
-
+		mapping:        mapping,
+		reverse:        reverse,
+		scopes:         scopes,
 		versions:       versions,
 		interfacesFunc: f,
 	}
 }
 
-// Add adds objects from a runtime.Scheme and its named versions to this map.
-// If mixedCase is true, the legacy v1beta1/v1beta2 Kubernetes resource naming convention
-// will be applied (camelCase vs lowercase).
-func (m *DefaultRESTMapper) Add(scheme *runtime.Scheme, mixedCase bool, versions ...string) {
-	for _, version := range versions {
-		for kind := range scheme.KnownTypes(version) {
-			plural, singular := kindToResource(kind, mixedCase)
-			meta := typeMeta{APIVersion: version, Kind: kind}
-			if _, ok := m.mapping[plural]; !ok {
-				m.mapping[plural] = meta
-				m.mapping[singular] = meta
-				if strings.ToLower(plural) != plural {
-					m.mapping[strings.ToLower(plural)] = meta
-					m.mapping[strings.ToLower(singular)] = meta
-				}
-			}
-			m.reverse[meta] = plural
+func (m *DefaultRESTMapper) Add(scope RESTScope, kind string, version string, mixedCase bool) {
+	plural, singular := kindToResource(kind, mixedCase)
+	meta := typeMeta{APIVersion: version, Kind: kind}
+	if _, ok := m.mapping[plural]; !ok {
+		m.mapping[plural] = meta
+		m.mapping[singular] = meta
+		if strings.ToLower(plural) != plural {
+			m.mapping[strings.ToLower(plural)] = meta
+			m.mapping[strings.ToLower(singular)] = meta
 		}
 	}
+	m.reverse[meta] = plural
+	m.scopes[meta] = scope
 }
 
 // kindToResource converts Kind to a resource name.
@@ -167,6 +161,12 @@ func (m *DefaultRESTMapper) RESTMapping(kind string, versions ...string) (*RESTM
 		return nil, fmt.Errorf("the provided version %q and kind %q cannot be mapped to a supported object", version, kind)
 	}
 
+	// Ensure we have a REST scope
+	scope, ok := m.scopes[typeMeta{APIVersion: version, Kind: kind}]
+	if !ok {
+		return nil, fmt.Errorf("the provided version %q and kind %q cannot be mapped to a supported scope", version, kind)
+	}
+
 	interfaces, ok := m.interfacesFunc(version)
 	if !ok {
 		return nil, fmt.Errorf("the provided version %q has no relevant versions", version)
@@ -176,6 +176,7 @@ func (m *DefaultRESTMapper) RESTMapping(kind string, versions ...string) (*RESTM
 		Resource:   resource,
 		APIVersion: version,
 		Kind:       kind,
+		Scope:      scope,
 
 		Codec:            interfaces.Codec,
 		ObjectConvertor:  interfaces.ObjectConvertor,

--- a/pkg/api/meta/restmapper.go
+++ b/pkg/api/meta/restmapper.go
@@ -51,7 +51,7 @@ var RESTScopeNamespaceLegacy = &restScope{
 
 var RESTScopeNamespace = &restScope{
 	name:             RESTScopeNameNamespace,
-	paramName:        "namespace",
+	paramName:        "ns",
 	paramPath:        true,
 	paramDescription: "object name and auth scope, such as for teams and projects",
 }

--- a/pkg/api/meta/restmapper_test.go
+++ b/pkg/api/meta/restmapper_test.go
@@ -75,10 +75,7 @@ func TestRESTMapperVersionAndKindForResource(t *testing.T) {
 	}
 	for i, testCase := range testCases {
 		mapper := NewDefaultRESTMapper([]string{"test"}, fakeInterfaces)
-		scheme := runtime.NewScheme()
-		scheme.AddKnownTypes("test", &InternalObject{})
-		mapper.Add(scheme, testCase.MixedCase, "test")
-
+		mapper.Add(RESTScopeNamespace, testCase.Kind, testCase.APIVersion, testCase.MixedCase)
 		v, k, err := mapper.VersionAndKindForResource(testCase.Resource)
 		hasErr := err != nil
 		if hasErr != testCase.Err {
@@ -150,10 +147,7 @@ func TestRESTMapperRESTMapping(t *testing.T) {
 	}
 	for i, testCase := range testCases {
 		mapper := NewDefaultRESTMapper(testCase.DefaultVersions, fakeInterfaces)
-		scheme := runtime.NewScheme()
-		scheme.AddKnownTypes("test", &InternalObject{})
-		mapper.Add(scheme, testCase.MixedCase, "test")
-
+		mapper.Add(RESTScopeNamespace, "InternalObject", "test", testCase.MixedCase)
 		mapping, err := mapper.RESTMapping(testCase.Kind, testCase.APIVersions...)
 		hasErr := err != nil
 		if hasErr != testCase.Err {
@@ -180,11 +174,8 @@ func TestRESTMapperRESTMapping(t *testing.T) {
 
 func TestRESTMapperRESTMappingSelectsVersion(t *testing.T) {
 	mapper := NewDefaultRESTMapper([]string{"test1", "test2"}, fakeInterfaces)
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes("test1", &InternalObject{})
-	scheme.AddKnownTypeWithName("test2", "OtherObject", &InternalObject{})
-	scheme.AddKnownTypeWithName("test3", "OtherObject", &InternalObject{})
-	mapper.Add(scheme, false, "test1", "test2")
+	mapper.Add(RESTScopeNamespace, "InternalObject", "test1", false)
+	mapper.Add(RESTScopeNamespace, "OtherObject", "test2", false)
 
 	// pick default matching object kind based on search order
 	mapping, err := mapper.RESTMapping("OtherObject")
@@ -236,10 +227,7 @@ func TestRESTMapperRESTMappingSelectsVersion(t *testing.T) {
 
 func TestRESTMapperReportsErrorOnBadVersion(t *testing.T) {
 	mapper := NewDefaultRESTMapper([]string{"test1", "test2"}, unmatchedVersionInterfaces)
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes("test1", &InternalObject{})
-	mapper.Add(scheme, false, "test1")
-
+	mapper.Add(RESTScopeNamespace, "InternalObject", "test1", false)
 	_, err := mapper.RESTMapping("InternalObject", "test1")
 	if err == nil {
 		t.Errorf("unexpected non-error")

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -116,40 +116,7 @@ func registerResourceHandlers(ws *restful.WebService, version string, path strin
 	}
 	versionedObject := indirectArbitraryPointer(versionedPtr)
 
-	mapping, err := mapper.RESTMapping(kind, version)
-	if err != nil {
-		glog.V(1).Infof("OH NOES kind %s version %s err: %v", kind, version, err)
-		return err
-	}
-
-	// See github.com/emicklei/go-restful/blob/master/jsr311.go for routing logic
-	// and status-code behavior
-	// check if this
-	scope := mapping.Scope
-	var scopeParam *restful.Parameter
-	if len(scope.ParamName()) > 0 && scope.ParamPath() {
-		path = scope.ParamName() + "/{" + scope.ParamName() + "}/" + path
-		scopeParam = ws.PathParameter(scope.ParamName(), scope.ParamDescription()).DataType("string")
-	}
-
-	glog.V(5).Infof("Installing version=/%s, kind=/%s, path=/%s", version, kind, path)
-
-	nameParam := ws.PathParameter("name", "name of the "+kind).DataType("string")
-
-	createRoute := ws.POST(path).To(h).
-		Doc("create a " + kind).
-		Operation("create" + kind)
-	addParamIf(createRoute, scopeParam, scopeParam != nil)
-	if _, ok := storage.(RESTCreater); ok {
-		ws.Route(createRoute.Reads(versionedObject)) // from the request
-	} else {
-		ws.Route(createRoute.Returns(http.StatusMethodNotAllowed, "creating objects is not supported", nil))
-	}
-
-	listRoute := ws.GET(path).To(h).
-		Doc("list objects of kind " + kind).
-		Operation("list" + kind)
-	addParamIf(listRoute, scopeParam, scopeParam != nil)
+	var versionedList interface{}
 	if lister, ok := storage.(RESTLister); ok {
 		list := lister.NewList()
 		_, listKind, err := api.Scheme.ObjectVersionAndKind(list)
@@ -157,56 +124,171 @@ func registerResourceHandlers(ws *restful.WebService, version string, path strin
 		if err != nil {
 			return err
 		}
-		versionedList := indirectArbitraryPointer(versionedListPtr)
-		glog.V(5).Infoln("type: ", reflect.TypeOf(versionedList))
-		ws.Route(listRoute.Returns(http.StatusOK, "OK", versionedList))
-	} else {
-		ws.Route(listRoute.Returns(http.StatusMethodNotAllowed, "listing objects is not supported", nil))
+		versionedList = indirectArbitraryPointer(versionedListPtr)
 	}
 
-	getRoute := ws.GET(path + "/{name}").To(h).
-		Doc("read the specified " + kind).
-		Operation("read" + kind).
-		Param(nameParam)
-	addParamIf(getRoute, scopeParam, scopeParam != nil)
+	mapping, err := mapper.RESTMapping(kind, version)
+	if err != nil {
+		glog.V(1).Infof("OH NOES kind %s version %s err: %v", kind, version, err)
+		return err
+	}
+
+	// names are always in path
+	nameParam := ws.PathParameter("name", "name of the "+kind).DataType("string")
+
+	// what verbs are supported by the storage, used to know what verbs we support per path
+	storageVerbs := map[string]bool{}
+	if _, ok := storage.(RESTCreater); ok {
+		storageVerbs["RESTCreater"] = true
+	}
+	if _, ok := storage.(RESTLister); ok {
+		storageVerbs["RESTLister"] = true
+	}
 	if _, ok := storage.(RESTGetter); ok {
-		ws.Route(getRoute.Writes(versionedObject)) // on the response
-	} else {
-		ws.Route(getRoute.Returns(http.StatusMethodNotAllowed, "reading individual objects is not supported", nil))
+		storageVerbs["RESTGetter"] = true
 	}
-
-	updateRoute := ws.PUT(path + "/{name}").To(h).
-		Doc("update the specified " + kind).
-		Operation("update" + kind).
-		Param(nameParam)
-	addParamIf(updateRoute, scopeParam, scopeParam != nil)
-	if _, ok := storage.(RESTUpdater); ok {
-		ws.Route(updateRoute.Reads(versionedObject)) // from the request
-	} else {
-		ws.Route(updateRoute.Returns(http.StatusMethodNotAllowed, "updating objects is not supported", nil))
-	}
-
-	// TODO: Support PATCH
-	deleteRoute := ws.DELETE(path + "/{name}").To(h).
-		Doc("delete the specified " + kind).
-		Operation("delete" + kind).
-		Param(nameParam)
-	addParamIf(deleteRoute, scopeParam, scopeParam != nil)
 	if _, ok := storage.(RESTDeleter); ok {
-		ws.Route(deleteRoute)
-	} else {
-		ws.Route(deleteRoute.Returns(http.StatusMethodNotAllowed, "deleting objects is not supported", nil))
+		storageVerbs["RESTDeleter"] = true
+	}
+	if _, ok := storage.(RESTUpdater); ok {
+		storageVerbs["RESTUpdater"] = true
 	}
 
+	// path to verbs takes a path, and set of http verbs we should claim to support on this path
+	// given current url formats, this is scope specific
+	// for example, in v1beta3 url styles we would support the following:
+	// /ns/{namespace}/{resource} = []{POST, GET}  // list resources in this namespace scope
+	// /ns/{namespace}/{resource}/{name} = []{GET, PUT, DELETE} // handle an individual resource
+	// /{resource} = []{GET} // list resources across all namespaces
+	pathToVerbs := map[string][]string{}
+	// similar to the above, it maps the ordered set of parameters that need to be documented
+	pathToParam := map[string][]*restful.Parameter{}
+	// pathToStorageVerb lets us distinguish between RESTLister and RESTGetter on verb=GET
+	pathToStorageVerb := map[string]string{}
+	scope := mapping.Scope
+	if scope.Name() != meta.RESTScopeNameNamespace {
+		// non-namespaced resources support a smaller set of resource paths
+		resourcesPath := path
+		resourcesPathVerbs := []string{}
+		resourcesPathVerbs = appendStringIf(resourcesPathVerbs, "POST", storageVerbs["RESTCreater"])
+		resourcesPathVerbs = appendStringIf(resourcesPathVerbs, "GET", storageVerbs["RESTLister"])
+		pathToVerbs[resourcesPath] = resourcesPathVerbs
+		pathToParam[resourcesPath] = []*restful.Parameter{}
+		pathToStorageVerb[resourcesPath] = "RESTLister"
+
+		itemPath := resourcesPath + "/{name}"
+		itemPathVerbs := []string{}
+		itemPathVerbs = appendStringIf(itemPathVerbs, "GET", storageVerbs["RESTGetter"])
+		itemPathVerbs = appendStringIf(itemPathVerbs, "PUT", storageVerbs["RESTUpdater"])
+		itemPathVerbs = appendStringIf(itemPathVerbs, "DELETE", storageVerbs["RESTDeleter"])
+		pathToVerbs[itemPath] = itemPathVerbs
+		pathToParam[itemPath] = []*restful.Parameter{nameParam}
+		pathToStorageVerb[itemPath] = "RESTGetter"
+
+	} else {
+		// v1beta3 format with namespace in path
+		if scope.ParamPath() {
+			namespaceParam := ws.PathParameter(scope.ParamName(), scope.ParamDescription()).DataType("string")
+
+			resourceByNamespace := scope.ParamName() + "/{" + scope.ParamName() + "}/" + path
+			resourceByNamespaceVerbs := []string{}
+			resourceByNamespaceVerbs = appendStringIf(resourceByNamespaceVerbs, "POST", storageVerbs["RESTCreater"])
+			resourceByNamespaceVerbs = appendStringIf(resourceByNamespaceVerbs, "GET", storageVerbs["RESTLister"])
+			pathToVerbs[resourceByNamespace] = resourceByNamespaceVerbs
+			pathToParam[resourceByNamespace] = []*restful.Parameter{namespaceParam}
+			pathToStorageVerb[resourceByNamespace] = "RESTLister"
+
+			itemPath := resourceByNamespace + "/{name}"
+			itemPathVerbs := []string{}
+			itemPathVerbs = appendStringIf(itemPathVerbs, "GET", storageVerbs["RESTGetter"])
+			itemPathVerbs = appendStringIf(itemPathVerbs, "PUT", storageVerbs["RESTUpdater"])
+			itemPathVerbs = appendStringIf(itemPathVerbs, "DELETE", storageVerbs["RESTDeleter"])
+			pathToVerbs[itemPath] = itemPathVerbs
+			pathToParam[itemPath] = []*restful.Parameter{namespaceParam, nameParam}
+			pathToStorageVerb[itemPath] = "RESTGetter"
+
+			listAcrossNamespace := path
+			listAcrossNamespaceVerbs := []string{}
+			listAcrossNamespaceVerbs = appendStringIf(listAcrossNamespaceVerbs, "GET", storageVerbs["RESTLister"])
+			pathToVerbs[listAcrossNamespace] = listAcrossNamespaceVerbs
+			pathToParam[listAcrossNamespace] = []*restful.Parameter{}
+			pathToStorageVerb[listAcrossNamespace] = "RESTLister"
+
+		} else {
+			// v1beta1/v1beta2 format where namespace was a query parameter
+			namespaceParam := ws.QueryParameter(scope.ParamName(), scope.ParamDescription()).DataType("string")
+
+			resourcesPath := path
+			resourcesPathVerbs := []string{}
+			resourcesPathVerbs = appendStringIf(resourcesPathVerbs, "POST", storageVerbs["RESTCreater"])
+			resourcesPathVerbs = appendStringIf(resourcesPathVerbs, "GET", storageVerbs["RESTLister"])
+			pathToVerbs[resourcesPath] = resourcesPathVerbs
+			pathToParam[resourcesPath] = []*restful.Parameter{namespaceParam}
+			pathToStorageVerb[resourcesPath] = "RESTLister"
+
+			itemPath := resourcesPath + "/{name}"
+			itemPathVerbs := []string{}
+			itemPathVerbs = appendStringIf(itemPathVerbs, "GET", storageVerbs["RESTGetter"])
+			itemPathVerbs = appendStringIf(itemPathVerbs, "PUT", storageVerbs["RESTUpdater"])
+			itemPathVerbs = appendStringIf(itemPathVerbs, "DELETE", storageVerbs["RESTDeleter"])
+			pathToVerbs[itemPath] = itemPathVerbs
+			pathToParam[itemPath] = []*restful.Parameter{namespaceParam, nameParam}
+			pathToStorageVerb[itemPath] = "RESTGetter"
+		}
+	}
+
+	// See github.com/emicklei/go-restful/blob/master/jsr311.go for routing logic
+	// and status-code behavior
+	for path, verbs := range pathToVerbs {
+		glog.V(5).Infof("Installing version=/%s, kind=/%s, path=/%s", version, kind, path)
+
+		params := pathToParam[path]
+		for _, verb := range verbs {
+			var route *restful.RouteBuilder
+			switch verb {
+			case "POST":
+				route = ws.POST(path).To(h).
+					Doc("create a " + kind).
+					Operation("create" + kind).Reads(versionedObject)
+			case "PUT":
+				route = ws.PUT(path).To(h).
+					Doc("update the specified " + kind).
+					Operation("update" + kind).Reads(versionedObject)
+			case "DELETE":
+				route = ws.DELETE(path).To(h).
+					Doc("delete the specified " + kind).
+					Operation("delete" + kind)
+			case "GET":
+				doc := "read the specified " + kind
+				op := "read" + kind
+				if pathToStorageVerb[path] == "RESTLister" {
+					doc = "list objects of kind " + kind
+					op = "list" + kind
+				}
+				route = ws.GET(path).To(h).
+					Doc(doc).
+					Operation(op)
+				if pathToStorageVerb[path] == "RESTLister" {
+					route = route.Returns(http.StatusOK, "OK", versionedList)
+				} else {
+					route = route.Writes(versionedObject)
+				}
+			}
+			for paramIndex := range params {
+				route.Param(params[paramIndex])
+			}
+			ws.Route(route)
+		}
+	}
 	return nil
 }
 
-// Adds the given param to the given route builder if shouldAdd is true. Does nothing if shouldAdd is false.
-func addParamIf(b *restful.RouteBuilder, parameter *restful.Parameter, shouldAdd bool) *restful.RouteBuilder {
-	if !shouldAdd {
-		return b
+// appendStringIf appends the value to the slice if shouldAdd is true
+func appendStringIf(slice []string, value string, shouldAdd bool) []string {
+	if shouldAdd {
+		return append(slice, value)
 	}
-	return b.Param(parameter)
+	return slice
 }
 
 // InstallREST registers the REST handlers (storage, watch, proxy and redirect) into a restful Container.

--- a/pkg/apiserver/proxy_test.go
+++ b/pkg/apiserver/proxy_test.go
@@ -230,7 +230,7 @@ func TestProxy(t *testing.T) {
 		}
 		handler := Handle(map[string]RESTStorage{
 			"foo": simpleStorage,
-		}, codec, "/prefix", "version", selfLinker, admissionControl)
+		}, codec, "/prefix", "version", selfLinker, admissionControl, mapper)
 		server := httptest.NewServer(handler)
 		defer server.Close()
 

--- a/pkg/apiserver/redirect_test.go
+++ b/pkg/apiserver/redirect_test.go
@@ -31,7 +31,7 @@ func TestRedirect(t *testing.T) {
 	}
 	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, codec, "/prefix", "version", selfLinker, admissionControl)
+	}, codec, "/prefix", "version", selfLinker, admissionControl, mapper)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -84,7 +84,7 @@ func TestRedirectWithNamespaces(t *testing.T) {
 	}
 	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, codec, "/prefix", "version", selfLinker, admissionControl)
+	}, codec, "/prefix", "version", selfLinker, admissionControl, mapper)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -50,7 +50,7 @@ func TestWatchWebsocket(t *testing.T) {
 	_ = ResourceWatcher(simpleStorage) // Give compile error if this doesn't work.
 	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, codec, "/api", "version", selfLinker, admissionControl)
+	}, codec, "/api", "version", selfLinker, admissionControl, mapper)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -104,7 +104,7 @@ func TestWatchHTTP(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
 	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, codec, "/api", "version", selfLinker, admissionControl)
+	}, codec, "/api", "version", selfLinker, admissionControl, mapper)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 	client := http.Client{}
@@ -167,7 +167,7 @@ func TestWatchParamParsing(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
 	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, codec, "/api", "version", selfLinker, admissionControl)
+	}, codec, "/api", "version", selfLinker, admissionControl, mapper)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -239,7 +239,7 @@ func TestWatchProtocolSelection(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
 	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, codec, "/api", "version", selfLinker, admissionControl)
+	}, codec, "/api", "version", selfLinker, admissionControl, mapper)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 	defer server.CloseClientConnections()

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -66,7 +66,13 @@ func newExternalScheme() (*runtime.Scheme, meta.RESTMapper, runtime.Codec) {
 			MetadataAccessor: meta.NewAccessor(),
 		}, (version == "unlikelyversion")
 	})
-	mapper.Add(scheme, false, "unlikelyversion")
+	for _, version := range []string{"unlikelyversion"} {
+		for kind := range scheme.KnownTypes(version) {
+			mixedCase := false
+			scope := meta.RESTScopeNamespace
+			mapper.Add(scope, kind, version, mixedCase)
+		}
+	}
 
 	return scheme, mapper, codec
 }

--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -402,6 +402,7 @@ func (b *Builder) Do() *Result {
 	if b.requireNamespace {
 		helpers = append(helpers, RequireNamespace(b.namespace))
 	}
+	helpers = append(helpers, FilterNamespace())
 	r.visitor = NewDecoratedVisitor(r.visitor, helpers...)
 	return r
 }

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -173,6 +173,37 @@ func TestPathBuilder(t *testing.T) {
 	}
 }
 
+func TestNodeBuilder(t *testing.T) {
+	node := &api.Node{
+		ObjectMeta: api.ObjectMeta{Name: "node1", Namespace: "should-not-have", ResourceVersion: "10"},
+		Spec: api.NodeSpec{
+			Capacity: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("1000m"),
+				api.ResourceMemory: resource.MustParse("1Mi"),
+			},
+		},
+	}
+	r, w := io.Pipe()
+	go func() {
+		defer w.Close()
+		w.Write([]byte(runtime.EncodeOrDie(latest.Codec, node)))
+	}()
+
+	b := NewBuilder(latest.RESTMapper, api.Scheme, fakeClient()).
+		NamespaceParam("test").Stream(r, "STDIN")
+
+	test := &testVisitor{}
+
+	err := b.Do().Visit(test.Handle)
+	if err != nil || len(test.Infos) != 1 {
+		t.Fatalf("unexpected response: %v %#v", err, test.Infos)
+	}
+	info := test.Infos[0]
+	if info.Name != "node1" || info.Namespace != "" || info.Object == nil {
+		t.Errorf("unexpected info: %#v", info)
+	}
+}
+
 func TestPathBuilderWithMultiple(t *testing.T) {
 	b := NewBuilder(latest.RESTMapper, api.Scheme, fakeClient()).
 		FilenameParam("../../../examples/guestbook/redis-master.json").

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"

--- a/pkg/kubectl/resource/mapper.go
+++ b/pkg/kubectl/resource/mapper.go
@@ -54,6 +54,9 @@ func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
 	}
 	name, _ := mapping.MetadataAccessor.Name(obj)
 	namespace, _ := mapping.MetadataAccessor.Namespace(obj)
+	if mapping.Scope.Name != "namespace" {
+		namespace = ""
+	}
 	resourceVersion, _ := mapping.MetadataAccessor.ResourceVersion(obj)
 	return &Info{
 		Mapping:   mapping,

--- a/pkg/kubectl/resource/mapper.go
+++ b/pkg/kubectl/resource/mapper.go
@@ -54,9 +54,6 @@ func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
 	}
 	name, _ := mapping.MetadataAccessor.Name(obj)
 	namespace, _ := mapping.MetadataAccessor.Namespace(obj)
-	if mapping.Scope.Name != "namespace" {
-		namespace = ""
-	}
 	resourceVersion, _ := mapping.MetadataAccessor.ResourceVersion(obj)
 	return &Info{
 		Mapping:   mapping,

--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -384,6 +384,17 @@ func UpdateObjectNamespace(info *Info) error {
 	return nil
 }
 
+// FilterNamespace omits the namespace if the object is not namespace scoped
+func FilterNamespace() VisitorFunc {
+	return func(info *Info) error {
+		if info.Mapping.Scope.Name() != meta.RESTScopeNameNamespace {
+			info.Namespace = ""
+			UpdateObjectNamespace(info)
+		}
+		return nil
+	}
+}
+
 // SetNamespace ensures that every Info object visited will have a namespace
 // set. If info.Object is set, it will be mutated as well.
 func SetNamespace(namespace string) VisitorFunc {

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta2"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"
@@ -491,25 +492,25 @@ func (m *Master) getServersToValidate(c *Config) map[string]apiserver.Server {
 }
 
 // api_v1beta1 returns the resources and codec for API version v1beta1.
-func (m *Master) api_v1beta1() (map[string]apiserver.RESTStorage, runtime.Codec, string, runtime.SelfLinker, admission.Interface) {
+func (m *Master) api_v1beta1() (map[string]apiserver.RESTStorage, runtime.Codec, string, runtime.SelfLinker, admission.Interface, meta.RESTMapper) {
 	storage := make(map[string]apiserver.RESTStorage)
 	for k, v := range m.storage {
 		storage[k] = v
 	}
-	return storage, v1beta1.Codec, "/api/v1beta1", latest.SelfLinker, m.admissionControl
+	return storage, v1beta1.Codec, "/api/v1beta1", latest.SelfLinker, m.admissionControl, latest.RESTMapper
 }
 
 // api_v1beta2 returns the resources and codec for API version v1beta2.
-func (m *Master) api_v1beta2() (map[string]apiserver.RESTStorage, runtime.Codec, string, runtime.SelfLinker, admission.Interface) {
+func (m *Master) api_v1beta2() (map[string]apiserver.RESTStorage, runtime.Codec, string, runtime.SelfLinker, admission.Interface, meta.RESTMapper) {
 	storage := make(map[string]apiserver.RESTStorage)
 	for k, v := range m.storage {
 		storage[k] = v
 	}
-	return storage, v1beta2.Codec, "/api/v1beta2", latest.SelfLinker, m.admissionControl
+	return storage, v1beta2.Codec, "/api/v1beta2", latest.SelfLinker, m.admissionControl, latest.RESTMapper
 }
 
 // api_v1beta3 returns the resources and codec for API version v1beta3.
-func (m *Master) api_v1beta3() (map[string]apiserver.RESTStorage, runtime.Codec, string, runtime.SelfLinker, admission.Interface) {
+func (m *Master) api_v1beta3() (map[string]apiserver.RESTStorage, runtime.Codec, string, runtime.SelfLinker, admission.Interface, meta.RESTMapper) {
 	storage := make(map[string]apiserver.RESTStorage)
 	for k, v := range m.storage {
 		if k == "minions" {
@@ -517,5 +518,5 @@ func (m *Master) api_v1beta3() (map[string]apiserver.RESTStorage, runtime.Codec,
 		}
 		storage[strings.ToLower(k)] = v
 	}
-	return storage, v1beta3.Codec, "/api/v1beta3", latest.SelfLinker, m.admissionControl
+	return storage, v1beta3.Codec, "/api/v1beta3", latest.SelfLinker, m.admissionControl, latest.RESTMapper
 }

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -245,10 +245,10 @@ func getTestRequests() []struct {
 		{"GET", "/api/v1beta1/bindings", "", code405},              // Bindings are write-only
 		{"POST", "/api/v1beta1/pods" + timeoutFlag, aPod, code200}, // Need a pod to bind or you get a 404
 		{"POST", "/api/v1beta1/bindings" + timeoutFlag, aBinding, code200},
-		{"PUT", "/api/v1beta1/bindings/a" + timeoutFlag, aBinding, code405},
+		{"PUT", "/api/v1beta1/bindings/a" + timeoutFlag, aBinding, code404},
 		{"GET", "/api/v1beta1/bindings", "", code405},
-		{"GET", "/api/v1beta1/bindings/a", "", code405}, // No bindings instances
-		{"DELETE", "/api/v1beta1/bindings/a" + timeoutFlag, "", code405},
+		{"GET", "/api/v1beta1/bindings/a", "", code404}, // No bindings instances
+		{"DELETE", "/api/v1beta1/bindings/a" + timeoutFlag, "", code404},
 
 		// Non-existent object type.
 		{"GET", "/api/v1beta1/foo", "", code404},


### PR DESCRIPTION
This is the more generic solution to #3901 

It basically sets us up to have the `kube-apiserver` intelligent enough to know if a resource should generate namespace relative paths, and it lets ``kubectl` know when a resource should have a namespace set on the client side.

Right now, this change will make `Node/Minion` always be non-namespaced.

I will use this pattern to support #3613 when I add a `Namespace` object.

fyi - @jlowdermilk @smarterclayton @erictune @brendanburns @bgrant0607 @pmorie
