### PR TITLE
hack/gofmt: allow go1.4

### DIFF
--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -24,7 +24,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.2|go1.3') ]]; then
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.2|go1.3|go1.4') ]]; then
   echo "Unknown go version '${GO_VERSION}', skipping gofmt."
   exit 0
 fi

--- a/pkg/kubecfg/resource_printer.go
+++ b/pkg/kubecfg/resource_printer.go
@@ -170,7 +170,7 @@ func (h *HumanReadablePrinter) printHeader(columnNames []string, w io.Writer) er
 		return err
 	}
 	var lines []string
-	for _ = range columnNames {
+	for range columnNames {
 		lines = append(lines, "----------")
 	}
 	_, err := fmt.Fprintf(w, "%s\n", strings.Join(lines, "\t"))

--- a/pkg/proxy/config/config.go
+++ b/pkg/proxy/config/config.go
@@ -262,7 +262,7 @@ func (s *serviceStore) MergedState() interface{} {
 // watchForUpdates invokes bcaster.Notify() with the latest version of an object
 // when changes occur.
 func watchForUpdates(bcaster *config.Broadcaster, accessor config.Accessor, updates <-chan struct{}) {
-	for _ = range updates {
+	for range updates {
 		bcaster.Notify(accessor.MergedState())
 	}
 }


### PR DESCRIPTION
Otherwise it is skipped with:

```
Unknown go version 'go', skipping gofmt.
```
