### PR TITLE
Allow client.Config to be used for HTTP2 and WebSocket connections

### DIFF
--- a/pkg/client/helper_test.go
+++ b/pkg/client/helper_test.go
@@ -104,54 +104,68 @@ func TestTransportFor(t *testing.T) {
 		"ca transport": {
 			TLS: true,
 			Config: &Config{
-				CAData: []byte(rootCACert),
+				TLSClientConfig: TLSClientConfig{
+					CAData: []byte(rootCACert),
+				},
 			},
 		},
 		"bad ca file transport": {
 			Err: true,
 			Config: &Config{
-				CAFile: "invalid file",
+				TLSClientConfig: TLSClientConfig{
+					CAFile: "invalid file",
+				},
 			},
 		},
 		"ca data overriding bad ca file transport": {
 			TLS: true,
 			Config: &Config{
-				CAData: []byte(rootCACert),
-				CAFile: "invalid file",
+				TLSClientConfig: TLSClientConfig{
+					CAData: []byte(rootCACert),
+					CAFile: "invalid file",
+				},
 			},
 		},
 
 		"cert transport": {
 			TLS: true,
 			Config: &Config{
-				CertData: []byte(certData),
-				KeyData:  []byte(keyData),
-				CAData:   []byte(rootCACert),
+				TLSClientConfig: TLSClientConfig{
+					CertData: []byte(certData),
+					KeyData:  []byte(keyData),
+					CAData:   []byte(rootCACert),
+				},
 			},
 		},
 		"bad cert data transport": {
 			Err: true,
 			Config: &Config{
-				CertData: []byte(certData),
-				KeyData:  []byte("bad key data"),
-				CAData:   []byte(rootCACert),
+				TLSClientConfig: TLSClientConfig{
+					CertData: []byte(certData),
+					KeyData:  []byte("bad key data"),
+					CAData:   []byte(rootCACert),
+				},
 			},
 		},
 		"bad file cert transport": {
 			Err: true,
 			Config: &Config{
-				CertData: []byte(certData),
-				KeyFile:  "invalid file",
-				CAData:   []byte(rootCACert),
+				TLSClientConfig: TLSClientConfig{
+					CertData: []byte(certData),
+					KeyFile:  "invalid file",
+					CAData:   []byte(rootCACert),
+				},
 			},
 		},
 		"key data overriding bad file cert transport": {
 			TLS: true,
 			Config: &Config{
-				CertData: []byte(certData),
-				KeyData:  []byte(keyData),
-				KeyFile:  "invalid file",
-				CAData:   []byte(rootCACert),
+				TLSClientConfig: TLSClientConfig{
+					CertData: []byte(certData),
+					KeyData:  []byte(keyData),
+					KeyFile:  "invalid file",
+					CAData:   []byte(rootCACert),
+				},
 			},
 		},
 	}
@@ -206,15 +220,19 @@ func TestIsConfigTransportTLS(t *testing.T) {
 		},
 		{
 			Config: &Config{
-				Host:     "localhost",
-				CertFile: "foo",
+				Host: "localhost",
+				TLSClientConfig: TLSClientConfig{
+					CertFile: "foo",
+				},
 			},
 			TransportTLS: true,
 		},
 		{
 			Config: &Config{
-				Host:     "///:://localhost",
-				CertFile: "foo",
+				Host: "///:://localhost",
+				TLSClientConfig: TLSClientConfig{
+					CertFile: "foo",
+				},
 			},
 			TransportTLS: false,
 		},

--- a/pkg/client/kubelet_test.go
+++ b/pkg/client/kubelet_test.go
@@ -147,9 +147,11 @@ func TestNewKubeletClientTLSInvalid(t *testing.T) {
 		Port:        9000,
 		EnableHttps: true,
 		//Invalid certificate and key path
-		CertFile: "./testdata/mycertinvalid.cer",
-		KeyFile:  "./testdata/mycertinvalid.key",
-		CAFile:   "./testdata/myCA.cer",
+		TLSClientConfig: TLSClientConfig{
+			CertFile: "./testdata/mycertinvalid.cer",
+			KeyFile:  "./testdata/mycertinvalid.key",
+			CAFile:   "./testdata/myCA.cer",
+		},
 	}
 
 	client, err := NewKubeletClient(config)
@@ -165,11 +167,13 @@ func TestNewKubeletClientTLSValid(t *testing.T) {
 	config := &KubeletConfig{
 		Port:        9000,
 		EnableHttps: true,
-		CertFile:    "./testdata/mycertvalid.cer",
-		// TLS Configuration, only applies if EnableHttps is true.
-		KeyFile: "./testdata/mycertvalid.key",
-		// TLS Configuration, only applies if EnableHttps is true.
-		CAFile: "./testdata/myCA.cer",
+		TLSClientConfig: TLSClientConfig{
+			CertFile: "./testdata/mycertvalid.cer",
+			// TLS Configuration, only applies if EnableHttps is true.
+			KeyFile: "./testdata/mycertvalid.key",
+			// TLS Configuration, only applies if EnableHttps is true.
+			CAFile: "./testdata/myCA.cer",
+		},
 	}
 
 	client, err := NewKubeletClient(config)

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -23,9 +23,9 @@ import (
 )
 
 func TestUnsecuredTLSTransport(t *testing.T) {
-	transport := NewUnsafeTLSTransport()
-	if !transport.TLSClientConfig.InsecureSkipVerify {
-		t.Errorf("expected transport to be insecure")
+	cfg := NewUnsafeTLSConfig()
+	if !cfg.InsecureSkipVerify {
+		t.Errorf("expected config to be insecure")
 	}
 }
 


### PR DESCRIPTION
client.Config describes how to make a client connection to a server
for HTTP traffic, but for connection upgrade scenarios cannot be
used because the underlying http.Transport object can't allow the
connection to be hijacked. Reorganize the TLS and connection wrapper
methods so that a sophisticated client can do:

```
cfg := &client.Config{...} // from somewhere
tlsConfig, _ := client.TLSConfigFor(cfg)
_ := conn.Dial(...)
rt := MyRoundTripper() // some func that implements grabbing requests
wrapper, _ := client.HTTPWrappersFor(cfg)
req := &http.Request{}
req.Header.Set("Connection-Upgrade", ...)
_, := wrapper.RoundTrip(req)
// rt has been invoked with a fully formed Req with auth
rt.Req.Write(conn)
// read response for upgrade
```

It would be good to have utility function that does more of this,
but mostly enabling the HTTP2/SPDY client exec function right now.

@ncdc does this fit your needs?
