### PR TITLE
remove empty namespace validation on minion

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -596,9 +596,6 @@ func ValidateBoundPod(pod *api.BoundPod) errs.ValidationErrorList {
 // ValidateMinion tests if required fields in the minion are set.
 func ValidateMinion(minion *api.Node) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
-	if len(minion.Namespace) != 0 {
-		allErrs = append(allErrs, errs.NewFieldInvalid("namespace", minion.Namespace, ""))
-	}
 	if len(minion.Name) == 0 {
 		allErrs = append(allErrs, errs.NewFieldRequired("name", minion.Name))
 	}


### PR DESCRIPTION
This is a PR to be merged into the release-0.9 branch to fix the minion creation issue documented in #3953. Node creation validation in this branch requires an empty namespace but kubectl is adding a namespace preventing minions from being created. This is fixed in master. Fixes #3953.
