### PR TITLE
Provide a better error when Kubelet pod status is unexpected

### DIFF
--- a/pkg/client/kubelet.go
+++ b/pkg/client/kubelet.go
@@ -135,6 +135,9 @@ func (c *HTTPKubeletClient) GetPodStatus(host, podNamespace, podID string) (api.
 	if response.StatusCode == http.StatusNotFound {
 		return status, ErrPodInfoNotAvailable
 	}
+	if response.StatusCode >= 300 || response.StatusCode < 200 {
+		return status, fmt.Errorf("kubelet %q server responded with HTTP error code %d for pod %s/%s", host, response.StatusCode, podNamespace, podID)
+	}
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return status, err

--- a/pkg/client/kubelet_test.go
+++ b/pkg/client/kubelet_test.go
@@ -118,6 +118,46 @@ func TestHTTPKubeletClientNotFound(t *testing.T) {
 	}
 }
 
+func TestHTTPKubeletClientError(t *testing.T) {
+	expectObj := api.PodContainerInfo{
+		ContainerInfo: map[string]api.ContainerStatus{
+			"myID": {},
+		},
+	}
+	_, err := json.Marshal(expectObj)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	fakeHandler := util.FakeHandler{
+		StatusCode:   500,
+		ResponseBody: "Internal server error",
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+
+	hostURL, err := url.Parse(testServer.URL)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	parts := strings.Split(hostURL.Host, ":")
+
+	port, err := strconv.Atoi(parts[1])
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	podInfoGetter := &HTTPKubeletClient{
+		Client: http.DefaultClient,
+		Port:   uint(port),
+	}
+	_, err = podInfoGetter.GetPodStatus(parts[0], api.NamespaceDefault, "foo")
+	if err == nil || !strings.Contains(err.Error(), "HTTP error code 500") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestNewKubeletClient(t *testing.T) {
 	config := &KubeletConfig{
 		Port:        9000,


### PR DESCRIPTION
Treat HTTP errors with respect, provide a distinct error message
