### PR TITLE
Update README.md to include Godoc and Travis links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kubernetes
 
+[![GoDoc](https://godoc.org/github.com/GoogleCloudPlatform/kubernetes?status.png)](https://godoc.org/github.com/GoogleCloudPlatform/kubernetes) [![Travis](https://travis-ci.org/GoogleCloudPlatform/kubernetes.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/kubernetes)
+
 Kubernetes is an open source system for managing containerized applications across multiple hosts,
 providing basic mechanisms for deployment, maintenance, and scaling of applications.
 


### PR DESCRIPTION
I think these were (accidentally?) removed in #2507. I found them useful (especially as a quick-reference to Travis) so this PR adds them back.
