### PR TITLE
Update master.go's UpdateAllContainers to every 5 seconds instead of 30.

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -351,7 +351,7 @@ func (m *Master) init(c *Config) {
 		RESTStorageToNodes(nodeRESTStorage).Nodes(),
 		m.podRegistry,
 	)
-	go util.Forever(func() { podCache.UpdateAllContainers() }, time.Second*30)
+	go util.Forever(func() { podCache.UpdateAllContainers() }, time.Second*5)
 	go util.Forever(func() { podCache.GarbageCollectPodStatus() }, time.Minute*30)
 
 	// TODO: Factor out the core API registration


### PR DESCRIPTION
Make pod status update every 5 seconds instead of every 30 to mask the issue #3952.  I suspect (but haven't confirmed) that #3927 doesn't completely address the issue since it will still happily cache a Pending status for up to 30 seconds even though the pod may have transitioned to Running already.
