### PR TITLE
Vagrant fixup for etcd 2.0 regression, and other issues

### DIFF
--- a/cluster/saltbase/salt/etcd/default
+++ b/cluster/saltbase/salt/etcd/default
@@ -1,2 +1,6 @@
-{% set hostname = grains.host %}
-DAEMON_ARGS="-peer-addr {{hostname}}:7001 -name {{hostname}}"
+{% set etcd_servers = "127.0.0.1" -%}
+{% if grains.etcd_servers is defined -%}
+  {% set etcd_servers = grains.etcd_servers -%}
+{% endif -%}
+
+DAEMON_ARGS="-addr {{etcd_servers}}:4001 -bind-addr {{etcd_servers}}:4001 -data-dir /var/etcd"

--- a/cluster/saltbase/salt/etcd/etcd.service
+++ b/cluster/saltbase/salt/etcd/etcd.service
@@ -6,6 +6,8 @@ Documentation=https://github.com/coreos/etcd
 Type=simple
 EnvironmentFile=/etc/default/etcd
 ExecStart=/usr/local/bin/etcd $DAEMON_ARGS
+Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/cluster/saltbase/salt/kube-addons/init.sls
+++ b/cluster/saltbase/salt/kube-addons/init.sls
@@ -56,9 +56,9 @@
     - user: root
     - group: root
 
-/usr/lib/systemd/scripts/kube-addons:
+/etc/kubernetes/kube-addons.sh:
   file.managed:
-    - source: salt://kube-addons/initd
+    - source: salt://kube-addons/kube-addons.sh
     - user: root
     - group: root
     - mode: 755

--- a/cluster/saltbase/salt/kube-addons/kube-addons.service
+++ b/cluster/saltbase/salt/kube-addons/kube-addons.service
@@ -3,7 +3,7 @@ Description=Kubernetes Addon Object Manager
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 
 [Service]
-ExecStart=/usr/lib/systemd/scripts/kube-addons start
+ExecStart=/etc/kubernetes/kube-addons.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/cluster/saltbase/salt/kube-addons/kube-addons.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addons.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
+
+# Copyright 2014 Google Inc. All rights reserved.
 #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # The business logic for whether a given object should be created
 # was already enforced by salt, and /etc/kubernetes/addons is the
 # managed result is of that. Start everything below that directory.

--- a/cluster/saltbase/salt/kube-addons/kube-addons.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addons.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# The business logic for whether a given object should be created
+# was already enforced by salt, and /etc/kubernetes/addons is the
+# managed result is of that. Start everything below that directory.
+echo "== Kubernetes addon manager started at $(date -Is) =="
+KUBECTL=/usr/local/bin/kubectl
+for obj in $(find /etc/kubernetes/addons -name \*.yaml); do
+  ${KUBECTL} --server="127.0.0.1:8080" create -f ${obj} &
+  echo "++ addon ${obj} started in pid $! ++"
+done
+noerrors="true"
+for pid in $(jobs -p); do
+  wait ${pid} || noerrors="false"
+  echo "++ pid ${pid} complete ++"
+done
+if [ ${noerrors} == "true" ]; then
+  echo "== Kubernetes addon manager completed successfully at $(date -Is) =="
+else
+  echo "== Kubernetes addon manager completed with errors at $(date -Is) =="
+fi
+
+# We stay around so that status checks by salt make it look like
+# the service is good. (We could do this is other ways, but this
+# is simple.)
+sleep infinity

--- a/cluster/saltbase/salt/monit/init.sls
+++ b/cluster/saltbase/salt/monit/init.sls
@@ -1,3 +1,5 @@
+{% if grains['os_family'] != 'RedHat' %}
+
 monit:
   pkg:
     - installed
@@ -17,3 +19,5 @@ monit-service:
     - watch:
       - pkg: monit 
       - file: /etc/monit/conf.d/etcd
+
+{% endif %}


### PR DESCRIPTION
This fixes the following:
1. Fix etcd DAEMON_ARGS for 2.0 with systemd
2. Do not use monit on RedHat os family in favor of just systemd restart
3. Fix kube-addons.service to actually work on a systemd based environment

@brendanburns @smarterclayton @satnam6502 - if one of you are around, please merge ASAP
