### PR TITLE
Increase API rate limit on read only port of apiserver

### DIFF
--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -60,8 +60,8 @@ var (
 		"The port from which to serve read-only resources. If 0, don't serve on a "+
 		"read-only address. It is assumed that firewall rules are set up such that "+
 		"this port is not reachable from outside of the cluster.")
-	apiRate     = flag.Float32("api_rate", 1.0, "API rate limit as QPS for the read only port")
-	apiBurst    = flag.Int("api_burst", 20, "API burst amount for the read only port")
+	apiRate     = flag.Float32("api_rate", 10.0, "API rate limit as QPS for the read only port")
+	apiBurst    = flag.Int("api_burst", 200, "API burst amount for the read only port")
 	securePort  = flag.Int("secure_port", 8443, "The port from which to serve HTTPS with authentication and authorization. If 0, don't serve HTTPS ")
 	tlsCertFile = flag.String("tls_cert_file", "", ""+
 		"File containing x509 Certificate for HTTPS.  (CA cert, if any, concatenated after server cert). "+
@@ -217,7 +217,7 @@ func main() {
 	// See the flag commentary to understand our assumptions when opening the read-only and read-write ports.
 
 	if roLocation != "" {
-		// Default settings allow 1 read-only request per second, allow up to 20 in a burst before enforcing.
+		// Default settings allow 10 read-only requests per second, allow up to 200 in a burst before enforcing.
 		rl := util.NewTokenBucketRateLimiter(*apiRate, *apiBurst)
 		readOnlyServer := &http.Server{
 			Addr:           roLocation,

--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -75,7 +75,7 @@ func RateLimit(rl util.RateLimiter, handler http.Handler) http.Handler {
 		// Return a 429 status indicating "Too Many Requests"
 		w.Header().Set("Retry-After", "1")
 		w.WriteHeader(errors.StatusTooManyRequests)
-		fmt.Fprintf(w, "Rate limit is 1 QPS or a burst of 20")
+		fmt.Fprintf(w, "Rate limit is 10 QPS or a burst of 200")
 	})
 }
 


### PR DESCRIPTION
It is very easy for the e2e tests to bust the rate limit of 1 QPS and 20 burst (even with 429s) e.g. I think that is what makes TestNetwork flaky because the webserver.go program it deploys as a Docker image can easily make too many apiserver requests.

I hope that increasing to 10QPS but a burst of 200 is acceptable in order to make our tests work.
Alternatively, we could change our test setup to run apiserver with flags to set 10QPS and burst 200 (I added flags for this recently).
