### PR TITLE
Fix vagrant regression, add flag to easily enable v1beta3

### DIFF
--- a/cluster/saltbase/salt/kube-apiserver/default
+++ b/cluster/saltbase/salt/kube-apiserver/default
@@ -23,6 +23,7 @@
   {% set etcd_servers = "--etcd_servers=http://" + ips[0][0] + ":4001" -%}
 {% endif -%}
 
+{% set cloud_config = "" -%}
 {% if grains.cloud is defined -%}
 {% if grains.cloud == 'gce' -%}
   {% set cloud_provider = "--cloud_provider=gce" -%}
@@ -55,4 +56,9 @@
  {% set admission_control = "--admission_control=" + grains.admission_control -%}
 {% endif -%}
 
-DAEMON_ARGS="{{daemon_args}} {{address}} {{etcd_servers}} {{ cloud_provider }} {{ cloud_config }} {{admission_control}} --allow_privileged={{pillar['allow_privileged']}} {{portal_net}} {{cert_file}} {{key_file}} {{secure_port}} {{token_auth_file}} {{publicAddressOverride}} {{pillar['log_level']}}"
+{% set runtime_config = "" -%}
+{% if grains.runtime_config is defined -%}
+ {% set runtime_config = "--runtime_config=" + grains.runtime_config -%}
+{% endif -%}
+
+DAEMON_ARGS="{{daemon_args}} {{address}} {{etcd_servers}} {{ cloud_provider }} {{ cloud_config }} {{ runtime_config }} {{admission_control}} --allow_privileged={{pillar['allow_privileged']}} {{portal_net}} {{cert_file}} {{key_file}} {{secure_port}} {{token_auth_file}} {{publicAddressOverride}} {{pillar['log_level']}}"

--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -66,3 +66,7 @@ ENABLE_CLUSTER_DNS=true
 DNS_SERVER_IP="10.247.0.10"
 DNS_DOMAIN="kubernetes.local"
 DNS_REPLICAS=1
+
+# Optional: Enable setting flags for kube-apiserver to turn on behavior in active-dev
+RUNTIME_CONFIG=""
+#RUNTIME_CONFIG="api/v1beta3"

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -76,6 +76,7 @@ grains:
   roles:
     - kubernetes-master
   admission_control: AlwaysAdmit
+  runtime_config: '$(echo "$RUNTIME_CONFIG" | sed -e "s/'/''/g")'
 EOF
 
 mkdir -p /srv/salt-overlay/pillar

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -78,6 +78,7 @@ function create-provision-scripts {
     echo "ENABLE_CLUSTER_DNS='${ENABLE_CLUSTER_DNS:-false}'"
     echo "DNS_SERVER_IP='${DNS_SERVER_IP:-}'"
     echo "DNS_DOMAIN='${DNS_DOMAIN:-}'"
+    echo "RUNTIME_CONFIG='${RUNTIME_CONFIG:-}'"
     grep -v "^#" "${KUBE_ROOT}/cluster/vagrant/provision-master.sh"
   ) > "${KUBE_TEMP}/master-start.sh"
 


### PR DESCRIPTION
Fixes regression introduced in #3970 to make cloud_config a global variable so its always initialized.

Added a runtime_config to let you easily enable v1beta3 for further debugging.

@smarterclayton - this is blocking, so quick review would be good.
