### PR TITLE
Allow commands to specify a short namespace

### DIFF
--- a/pkg/client/clientcmd/overrides.go
+++ b/pkg/client/clientcmd/overrides.go
@@ -51,10 +51,12 @@ type AuthOverrideFlags struct {
 
 // ContextOverrideFlags holds the flag names to be used for binding command line flags for Cluster objects
 type ContextOverrideFlags struct {
-	ClusterName   string
-	AuthInfoName  string
-	Namespace     string
-	NamespacePath string
+	ClusterName  string
+	AuthInfoName string
+	Namespace    string
+	// allow the potential for shorter namespace flags for commands that tend to work across namespaces
+	NamespaceShort string
+	NamespacePath  string
 }
 
 // ClusterOverride holds the flag names to be used for binding command line flags for Cluster objects
@@ -150,6 +152,6 @@ func BindOverrideFlags(overrides *ConfigOverrides, flags *pflag.FlagSet, flagNam
 func BindContextFlags(contextInfo *clientcmdapi.Context, flags *pflag.FlagSet, flagNames ContextOverrideFlags) {
 	flags.StringVar(&contextInfo.Cluster, flagNames.ClusterName, "", "The name of the kubeconfig cluster to use")
 	flags.StringVar(&contextInfo.AuthInfo, flagNames.AuthInfoName, "", "The name of the kubeconfig user to use")
-	flags.StringVar(&contextInfo.Namespace, flagNames.Namespace, "", "If present, the namespace scope for this CLI request.")
+	flags.StringVarP(&contextInfo.Namespace, flagNames.Namespace, flagNames.NamespaceShort, "", "If present, the namespace scope for this CLI request.")
 	flags.StringVar(&contextInfo.NamespacePath, flagNames.NamespacePath, "", "Path to the namespace info file that holds the namespace context to use for CLI requests.")
 }


### PR DESCRIPTION
OpenShift currently uses '-n', so this allows downstream CLIs
to set a short namespace.  However, this should only be used in general for
commands that want to work across namespaces frequently - such as admin
level operations on entire namespaces like quota or cleanup behavior where
you have permissions and need to rapidly switch.
