### PR TITLE
Print the returned object in the event of a publish error

### DIFF
--- a/pkg/master/publish.go
+++ b/pkg/master/publish.go
@@ -104,7 +104,7 @@ func (m *Master) createMasterServiceIfNeeded(serviceName string, port int) error
 		// If all worked, we get back an *api.Service object.
 		return nil
 	}
-	return fmt.Errorf("unexpected response: %#v", resp)
+	return fmt.Errorf("unexpected response: %#v", resp.Object)
 }
 
 // ensureEndpointsContain sets the endpoints for the given service. Also removes


### PR DESCRIPTION
resp.Object is a pointer, so printing resp doesn't show what the
server returned.
