### PR TITLE
Convert load of api/examples/pod.json into native Go definition of the api.Pod

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -51,7 +51,6 @@ readonly KUBE_TEST_TARGETS=(
 readonly KUBE_TEST_BINARIES=("${KUBE_TEST_TARGETS[@]##*/}")
 readonly KUBE_TEST_BINARIES_WIN=("${KUBE_TEST_BINARIES[@]/%/.exe}")
 readonly KUBE_TEST_PORTABLE=(
-  api/examples/pod.json
   contrib/for-tests/network-tester/rc.json
   contrib/for-tests/network-tester/service.json
   hack/e2e.go


### PR DESCRIPTION
This is another step in removing external dependencies of the Go e2e tests.

Remove references to this file on list of files required to run e2e tests.

Also use an unique name for the pod, so that failure in cleanup of a
previous run should not break a new run with a name conflict.

Tested by running cmd/e2e -t TestPodUpdate against an API server in GCE.

@satnam6502 
