### PR TITLE
rename probe.Status to probe.Result

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -96,7 +96,7 @@ func (fakeKubeletClient) GetPodStatus(host, podNamespace, podID string) (api.Pod
 	return r, nil
 }
 
-func (fakeKubeletClient) HealthCheck(host string) (probe.Status, error) {
+func (fakeKubeletClient) HealthCheck(host string) (probe.Result, error) {
 	return probe.Success, nil
 }
 

--- a/pkg/apiserver/validator.go
+++ b/pkg/apiserver/validator.go
@@ -46,7 +46,7 @@ type validator struct {
 }
 
 // TODO: can this use pkg/probe/http
-func (s *Server) check(client httpGet) (probe.Status, string, error) {
+func (s *Server) check(client httpGet) (probe.Result, string, error) {
 	resp, err := client.Get("http://" + net.JoinHostPort(s.Addr, strconv.Itoa(s.Port)) + s.Path)
 	if err != nil {
 		return probe.Unknown, "", err
@@ -66,7 +66,7 @@ func (s *Server) check(client httpGet) (probe.Status, string, error) {
 type ServerStatus struct {
 	Component  string       `json:"component,omitempty"`
 	Health     string       `json:"health,omitempty"`
-	HealthCode probe.Status `json:"healthCode,omitempty"`
+	HealthCode probe.Result `json:"healthCode,omitempty"`
 	Msg        string       `json:"msg,omitempty"`
 	Err        string       `json:"err,omitempty"`
 }

--- a/pkg/apiserver/validator_test.go
+++ b/pkg/apiserver/validator_test.go
@@ -54,7 +54,7 @@ func TestValidate(t *testing.T) {
 	tests := []struct {
 		err            error
 		data           string
-		expectedStatus probe.Status
+		expectedStatus probe.Result
 		code           int
 		expectErr      bool
 	}{

--- a/pkg/client/kubelet.go
+++ b/pkg/client/kubelet.go
@@ -41,7 +41,7 @@ type KubeletClient interface {
 
 // KubeletHealthchecker is an interface for healthchecking kubelets
 type KubeletHealthChecker interface {
-	HealthCheck(host string) (probe.Status, error)
+	HealthCheck(host string) (probe.Result, error)
 }
 
 // PodInfoGetter is an interface for things that can get information about a pod's containers.
@@ -134,7 +134,7 @@ func (c *HTTPKubeletClient) GetPodStatus(host, podNamespace, podID string) (api.
 	return status, nil
 }
 
-func (c *HTTPKubeletClient) HealthCheck(host string) (probe.Status, error) {
+func (c *HTTPKubeletClient) HealthCheck(host string) (probe.Result, error) {
 	return httprobe.DoHTTPProbe(fmt.Sprintf("%s/healthz", c.url(host)), c.Client)
 }
 
@@ -148,6 +148,6 @@ func (c FakeKubeletClient) GetPodStatus(host, podNamespace string, podID string)
 	return api.PodStatusResult{}, errors.New("Not Implemented")
 }
 
-func (c FakeKubeletClient) HealthCheck(host string) (probe.Status, error) {
+func (c FakeKubeletClient) HealthCheck(host string) (probe.Result, error) {
 	return probe.Unknown, errors.New("Not Implemented")
 }

--- a/pkg/cloudprovider/controller/nodecontroller_test.go
+++ b/pkg/cloudprovider/controller/nodecontroller_test.go
@@ -102,7 +102,7 @@ func (m *FakeNodeHandler) Update(node *api.Node) (*api.Node, error) {
 
 // FakeKubeletClient is a fake implementation of KubeletClient.
 type FakeKubeletClient struct {
-	Status probe.Status
+	Status probe.Result
 	Err    error
 }
 
@@ -110,7 +110,7 @@ func (c *FakeKubeletClient) GetPodStatus(host, podNamespace, podID string) (api.
 	return api.PodStatusResult{}, errors.New("Not Implemented")
 }
 
-func (c *FakeKubeletClient) HealthCheck(host string) (probe.Status, error) {
+func (c *FakeKubeletClient) HealthCheck(host string) (probe.Result, error) {
 	return c.Status, c.Err
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1446,7 +1446,7 @@ func (kl *Kubelet) GetPodStatus(podFullName string, uid types.UID) (api.PodStatu
 	return podStatus, err
 }
 
-func (kl *Kubelet) probeLiveness(podFullName string, podUID types.UID, status api.PodStatus, container api.Container, dockerContainer *docker.APIContainers) (healthStatus probe.Status, err error) {
+func (kl *Kubelet) probeLiveness(podFullName string, podUID types.UID, status api.PodStatus, container api.Container, dockerContainer *docker.APIContainers) (healthStatus probe.Result, err error) {
 	// Give the container 60 seconds to start up.
 	if container.LivenessProbe == nil {
 		return probe.Success, nil

--- a/pkg/kubelet/probe.go
+++ b/pkg/kubelet/probe.go
@@ -39,7 +39,7 @@ var (
 	tcprober   = tcprobe.New()
 )
 
-func (kl *Kubelet) probeContainer(p *api.Probe, podFullName string, podUID types.UID, status api.PodStatus, container api.Container) (probe.Status, error) {
+func (kl *Kubelet) probeContainer(p *api.Probe, podFullName string, podUID types.UID, status api.PodStatus, container api.Container) (probe.Result, error) {
 	var timeout time.Duration
 	secs := container.LivenessProbe.TimeoutSeconds
 	if secs > 0 {
@@ -47,7 +47,6 @@ func (kl *Kubelet) probeContainer(p *api.Probe, podFullName string, podUID types
 	} else {
 		timeout = 1 * time.Second
 	}
-
 	if p.Exec != nil {
 		return execprober.Probe(kl.newExecInContainer(podFullName, podUID, container))
 	}

--- a/pkg/probe/exec/exec.go
+++ b/pkg/probe/exec/exec.go
@@ -33,7 +33,7 @@ func New() ExecProber {
 
 type ExecProber struct{}
 
-func (pr ExecProber) Probe(e uexec.Cmd) (probe.Status, error) {
+func (pr ExecProber) Probe(e uexec.Cmd) (probe.Result, error) {
 	data, err := e.CombinedOutput()
 	glog.V(4).Infof("health check response: %s", string(data))
 	if err != nil {

--- a/pkg/probe/exec/exec_test.go
+++ b/pkg/probe/exec/exec_test.go
@@ -35,7 +35,7 @@ func (f *FakeCmd) CombinedOutput() ([]byte, error) {
 func (f *FakeCmd) SetDir(dir string) {}
 
 type healthCheckTest struct {
-	expectedStatus probe.Status
+	expectedStatus probe.Result
 	expectError    bool
 	output         []byte
 	err            error

--- a/pkg/probe/http/http.go
+++ b/pkg/probe/http/http.go
@@ -38,7 +38,7 @@ type HTTPProber struct {
 }
 
 // Probe returns a ProbeRunner capable of running an http check.
-func (pr *HTTPProber) Probe(host string, port int, path string, timeout time.Duration) (probe.Status, error) {
+func (pr *HTTPProber) Probe(host string, port int, path string, timeout time.Duration) (probe.Result, error) {
 	return DoHTTPProbe(formatURL(host, port, path), &http.Client{Timeout: timeout, Transport: pr.transport})
 }
 
@@ -50,7 +50,7 @@ type HTTPGetInterface interface {
 // If the HTTP response code is successful (i.e. 400 > code >= 200), it returns Success.
 // If the HTTP response code is unsuccessful or HTTP communication fails, it returns Failure.
 // This is exported because some other packages may want to do direct HTTP probes.
-func DoHTTPProbe(url string, client HTTPGetInterface) (probe.Status, error) {
+func DoHTTPProbe(url string, client HTTPGetInterface) (probe.Result, error) {
 	res, err := client.Get(url)
 	if err != nil {
 		glog.V(1).Infof("HTTP probe error: %v", err)

--- a/pkg/probe/http/http_test.go
+++ b/pkg/probe/http/http_test.go
@@ -54,7 +54,7 @@ func TestHTTPProbeChecker(t *testing.T) {
 	prober := New()
 	testCases := []struct {
 		handler func(w http.ResponseWriter)
-		health  probe.Status
+		health  probe.Result
 	}{
 		// The probe will be filled in below.  This is primarily testing that an HTTP GET happens.
 		{handleReq(http.StatusOK), probe.Success},

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -16,16 +16,16 @@ limitations under the License.
 
 package probe
 
-type Status int
+type Result int
 
 // Status values must be one of these constants.
 const (
-	Success Status = iota
+	Success Result = iota
 	Failure
 	Unknown
 )
 
-func (s Status) String() string {
+func (s Result) String() string {
 	switch s {
 	case Success:
 		return "success"

--- a/pkg/probe/tcp/tcp.go
+++ b/pkg/probe/tcp/tcp.go
@@ -32,7 +32,7 @@ func New() TCPProber {
 
 type TCPProber struct{}
 
-func (pr TCPProber) Probe(host string, port int, timeout time.Duration) (probe.Status, error) {
+func (pr TCPProber) Probe(host string, port int, timeout time.Duration) (probe.Result, error) {
 	return DoTCPProbe(net.JoinHostPort(host, strconv.Itoa(port)), timeout)
 }
 
@@ -40,7 +40,7 @@ func (pr TCPProber) Probe(host string, port int, timeout time.Duration) (probe.S
 // If the socket can be opened, it returns Success
 // If the socket fails to open, it returns Failure.
 // This is exported because some other packages may want to do direct TCP probes.
-func DoTCPProbe(addr string, timeout time.Duration) (probe.Status, error) {
+func DoTCPProbe(addr string, timeout time.Duration) (probe.Result, error) {
 	conn, err := net.DialTimeout("tcp", addr, timeout)
 	if err != nil {
 		return probe.Failure, nil

--- a/pkg/probe/tcp/tcp_test.go
+++ b/pkg/probe/tcp/tcp_test.go
@@ -31,7 +31,7 @@ import (
 func TestTcpHealthChecker(t *testing.T) {
 	prober := New()
 	tests := []struct {
-		expectedStatus probe.Status
+		expectedStatus probe.Result
 		usePort        bool
 		expectError    bool
 	}{


### PR DESCRIPTION
Optional semantic change. The Result represents the outcome of a single probe of an object. A Status or HealthStatus could be derived from consecutive results of multiple different probes (e.g. a pod could have ReadinessProbes on two of it's containers and to become healthy each Probe must succeed 5 consecutive times for the pod to achieve a status of ready). The Status should probably be an pkg/api type (e.g. so the readiness Status of a pod can be a field of api.PodState and accessible from the endpoints controller). /cc @bgrant0607 
