### PR TITLE
Handle missing auth file gracefully in kubelet

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -62,7 +62,11 @@ func (h *delegateHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func GetAPIServerClient(authPath string, apiServerList util.StringList) (*client.Client, error) {
 	authInfo, err := clientauth.LoadFromFile(authPath)
 	if err != nil {
-		return nil, err
+		glog.Warningf("Could not load kubernetes auth path: %v. Continuing with defaults.", err)
+	}
+	if authInfo == nil {
+		// authInfo didn't load correctly - continue with defaults.
+		authInfo = &clientauth.Info{}
 	}
 	clientConfig, err := authInfo.MergeWithConfig(client.Config{})
 	if err != nil {


### PR DESCRIPTION
Currently, in hack/local-up-cluster.sh, the kubelet command line parameter includes `--auth_path=/home/vagrant/gopath/src/github.com/GoogleCloudPlatform/kubernetes/hack/.test-cmd-auth`. If this path is missing (which it is by default, since it is (and should be) under .gitignore), kubelet starts up normally but refuses to talk to the apiserver at all. However, nothing in this file is required. As such I made the auth file optional, logging a warning if loading it does not work, and continuing with the default config (which works, especially in hack/local-up-cluster.sh).

It's possible that I am affecting more than kubelet here - if I am I can update the commit message for clarity.

@erictune @brendanburns 
