### PR TITLE
Add a GetByKey method to Store

### DIFF
--- a/pkg/client/cache/fifo.go
+++ b/pkg/client/cache/fifo.go
@@ -86,13 +86,18 @@ func (f *FIFO) List() []interface{} {
 
 // Get returns the requested item, or sets exists=false.
 func (f *FIFO) Get(obj interface{}) (item interface{}, exists bool, err error) {
-	id, err := f.keyFunc(obj)
+	key, err := f.keyFunc(obj)
 	if err != nil {
 		return nil, false, fmt.Errorf("couldn't create key for object: %v", err)
 	}
+	return f.GetByKey(key)
+}
+
+// GetByKey returns the requested item, or sets exists=false.
+func (f *FIFO) GetByKey(key string) (item interface{}, exists bool, err error) {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
-	item, exists = f.items[id]
+	item, exists = f.items[key]
 	return item, exists, nil
 }
 

--- a/pkg/client/cache/undelta_store.go
+++ b/pkg/client/cache/undelta_store.go
@@ -69,6 +69,9 @@ func (u *UndeltaStore) List() []interface{} {
 func (u *UndeltaStore) Get(obj interface{}) (item interface{}, exists bool, err error) {
 	return u.ActualStore.Get(obj)
 }
+func (u *UndeltaStore) GetByKey(key string) (item interface{}, exists bool, err error) {
+	return u.ActualStore.GetByKey(key)
+}
 func (u *UndeltaStore) Replace(list []interface{}) error {
 	if err := u.ActualStore.Replace(list); err != nil {
 		return err


### PR DESCRIPTION
Without the ability to retrieve underlying items by key (instead of
the object passed to KeyFunc) it is impossible to build wrappers
around cache.Store that want to make decisions about keys, because
they would need to reconstruct the object passed to Get.

This allows retrieval by key, and makes sure Get(obj) uses it.
