### PR TITLE
Ansible playbook for cloudstack

### DIFF
--- a/docs/getting-started-guides/README.md
+++ b/docs/getting-started-guides/README.md
@@ -7,7 +7,8 @@ Vagrant        | Ansible      | Fedora | [docs](../../docs/getting-started-guide
 GKE            |              |        | [docs](https://cloud.google.com/container-engine)      | Commercial                   | Uses K8s version 0.9.2
 AWS            | CoreOS       | CoreOS | [docs](../../docs/getting-started-guides/coreos.md)    | Community                    | Uses K8s version 0.9.1
 GCE            | CoreOS       | CoreOS | [docs](../../docs/getting-started-guides/coreos.md)    | Community (@kelseyhightower) | Uses K8s version 0.9.1
-Vagrant        | CoreOS       | CoreOS | [docs](../../docs/getting-started-guides/coreos.md)    | Community (@pires)           | Uses K8s version 0.9.1 
+Vagrant        | CoreOS       | CoreOS | [docs](../../docs/getting-started-guides/coreos.md)    | Community (@pires)           | Uses K8s version 0.9.1
+CloudStack     | Ansible      | CoreOS | [docs](../../docs/getting-started-guides/cloudstack.md)| Community (@sebgoa)          | Uses K8s version 0.9.1
 Vmware         |              | Debian | [docs](../../docs/getting-started-guides/vsphere.md)   | Community (@pietern)         | Uses K8s version 0.9.1
 AWS            | Saltstack    | Ubuntu | [docs](../../docs/getting-started-guides/aws.md)       | Community (@justinsb)        | Uses K8s version 0.5.0 
 Vmware         | CoreOS       | CoreOS | [docs](../../docs/getting-started-guides/coreos.md)    | Community (@kelseyhightower) |

--- a/docs/getting-started-guides/cloudstack.md
+++ b/docs/getting-started-guides/cloudstack.md
@@ -1,8 +1,90 @@
 ## Deploying Kubernetes on [CloudStack](http://cloudstack.apache.org)
 
-CloudStack is software to build public and private clouds based on hardware virtualization principles (traditional IaaS). To deploy Kubernetes on CloudStack there are several possibilities depending on the Cloud being used and what images are made available. [Exoscale](http://exoscale.ch) for instance makes a [CoreOS](http://coreos.com) template available, therefore instructions to deploy Kubernetes on coreOS can be used. CloudStack also has a vagrant plugin available, hence Vagrant could be used to deploy Kubernetes either using the existing shell provisioner or using new Salt based recipes.
+CloudStack is a software to build public and private clouds based on hardware virtualization principles (traditional IaaS). To deploy Kubernetes on CloudStack there are several possibilities depending on the Cloud being used and what images are made available. [Exoscale](http://exoscale.ch) for instance makes a [CoreOS](http://coreos.com) template available, therefore instructions to deploy Kubernetes on coreOS can be used. CloudStack also has a vagrant plugin available, hence Vagrant could be used to deploy Kubernetes either using the existing shell provisioner or using new Salt based recipes.
 
-Here we introduce the existing documentation.
+[CoreOS](http://coreos.com) templates for CloudStack are built [nightly](http://stable.release.core-os.net/amd64-usr/current/). CloudStack operators need to [register](http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/latest/templates.html) this template in their cloud before proceeding with these Kubernetes deployment instructions.
 
-* [Kubernetes on Exoscale](https://github.com/runseb/kubernetes-exoscale)
+There are currently two deployment techniques.
+
+* [Kubernetes on Exoscale](https://github.com/runseb/kubernetes-exoscale).
+   This uses [libcloud](http://libcloud.apache.org) to launch CoreOS instances and pass the appropriate cloud-config setup using userdata. Several manual steps are required. This is obsoleted by the Ansible playbook detailed below.
+
+* [Ansible playbook](https://github.com/runseb/ansible-kubernetes).
+  This is completely automated, a single playbook deploys Kubernetes based on the coreOS [instructions](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/getting-started-guides/coreos/coreos_multinode_cluster.md).
+
+#Ansible playbook
+
+This [Ansible](http://ansibleworks.com) playbook deploys Kubernetes on a CloudStack based Cloud using CoreOS images. The playbook, creates an ssh key pair, creates a security group and associated rules and finally starts coreOS instances configured via cloud-init.
+
+Prerequisites
+-------------
+
+    $ sudo apt-get install -y python-pip
+    $ sudo pip install ansible
+    $ sudo pip install cs
+
+[_cs_](http://github.com/exoscale/cs) is a python module for the CloudStack API.
+
+Set your CloudStack endpoint, API keys and HTTP method used.
+
+You can define them as environment variables: `CLOUDSTACK_ENDPOINT`, `CLOUDSTACK_KEY`, `CLOUDSTACK_SECRET` and `CLOUDSTACK_METHOD`.
+
+Or create a `~/.cloudstack.ini` file:
+
+    [cloudstack]
+    endpoint = <your cloudstack api endpoint>
+    key = <your api access key> 
+    secret = <your api secret key> 
+    method = post
+
+We need to use the http POST method to pass the _large_ userdata to the coreOS instances.
+
+Clone the playbook
+------------------
+
+    $ git clone --recursive https://github.com/runseb/ansible-kubernetes.git
+    $ cd ansible-kubernetes
+
+The [ansible-cloudstack](https://github.com/resmo/ansible-cloudstack) module is setup in this repository as a submodule, hence the `--recursive`.
+
+Create a Kubernetes cluster
+---------------------------
+
+You simply need to run the playbook.
+
+    $ ansible-playbook k8s.yml
+
+Some variables can be edited in the `k8s.yml` file.
+
+    vars:
+      ssh_key: k8s
+      k8s_num_nodes: 2
+      k8s_security_group_name: k8s
+      k8s_node_prefix: k8s2
+      k8s_template: Linux CoreOS alpha 435 64-bit 10GB Disk
+      k8s_instance_type: Tiny
+
+This will start a Kubernetes master node and a number of compute nodes (by default 2).
+The `instance_type` and `template` by default are specific to [exoscale](http://exoscale.ch), edit them to specify your CloudStack cloud specific template and instance type (i.e service offering).
+
+Check the tasks and templates in `roles/k8s` if you want to modify anything.
+
+Once the playbook as finished, it will print out the IP of the Kubernetes master:
+
+    TASK: [k8s | debug msg='k8s master IP is {{ k8s_master.default_ip }}'] ******** 
+
+SSH to it using the key that was created and using the _core_ user and you can list the machines in your cluster:
+
+    $ ssh -i ~/.ssh/id_rsa_k8s core@<maste IP>
+    $ fleetctl list-machines
+    MACHINE		IP		       METADATA
+    a017c422...	<node #1 IP>   role=node
+    ad13bf84...	<master IP>	   role=master
+    e9af8293...	<node #2 IP>   role=node
+
+
+
+
+
+
 


### PR DESCRIPTION
Some new instructions to deploy Kubernetes on CloudStack.
This shows the steps to use an ansible playbook to automatically deploy k8s.
It creates ssh key, security groups and starts coreOS instances.
The coreOS instances are configured based on the same cloud-config description used for ec2 etc...
