### PR TITLE
Etcd data dir must be empty

### DIFF
--- a/cluster/saltbase/salt/etcd/default
+++ b/cluster/saltbase/salt/etcd/default
@@ -3,4 +3,4 @@
   {% set etcd_servers = grains.etcd_servers -%}
 {% endif -%}
 
-DAEMON_ARGS="-addr {{etcd_servers}}:4001 -bind-addr {{etcd_servers}}:4001 -data-dir /var/etcd"
+DAEMON_ARGS="-addr {{etcd_servers}}:4001 -bind-addr {{etcd_servers}}:4001 -data-dir /var/etcd/data"

--- a/cluster/saltbase/salt/etcd/etcd.conf
+++ b/cluster/saltbase/salt/etcd/etcd.conf
@@ -1,4 +1,4 @@
 bind_addr = "0.0.0.0"
 peer_bind_addr = "0.0.0.0"
-data_dir = "/var/etcd"
+data_dir = "/var/etcd/data"
 max_retry_attempts = 60

--- a/cluster/saltbase/salt/etcd/init.sls
+++ b/cluster/saltbase/salt/etcd/init.sls
@@ -84,6 +84,15 @@ etcd:
       - user: etcd
       - group: etcd
 
+/var/etcd/data:
+  file.directory:
+    - user: etcd
+    - group: etcd
+    - dir_mode: 700
+    - require:
+      - user: etcd
+      - group: etcd
+
 {% if grains['os_family'] == 'RedHat' %}
 
 /etc/default/etcd:
@@ -125,6 +134,7 @@ etcd-service:
       - file: etcd-symlink
     - require:
       - file: /var/etcd
+      - file: /var/etcd/data
       - user: etcd
       - group: etcd
 

--- a/cluster/saltbase/salt/etcd/initd
+++ b/cluster/saltbase/salt/etcd/initd
@@ -18,7 +18,7 @@ NAME=etcd
 DAEMON=/usr/local/bin/$NAME
 # DAEMON_ARGS="-peer-addr $HOSTNAME:7001 -name $HOSTNAME"
 host_ip=$(hostname -i)
-DAEMON_ARGS="-addr ${host_ip}:4001 -bind-addr ${host_ip}:4001 -data-dir /var/etcd -initial-advertise-peer-urls http://${HOSTNAME}:2380 -name ${HOSTNAME} -initial-cluster ${HOSTNAME}=http://${HOSTNAME}:2380"
+DAEMON_ARGS="-addr ${host_ip}:4001 -bind-addr ${host_ip}:4001 -data-dir /var/etcd/data -initial-advertise-peer-urls http://${HOSTNAME}:2380 -name ${HOSTNAME} -initial-cluster ${HOSTNAME}=http://${HOSTNAME}:2380"
 DAEMON_LOG_FILE=/var/log/$NAME.log
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME


### PR DESCRIPTION
With the version-bump to the latest version of etcd, etcd gets confused if there are any non-etcd files in its datadir.  It gives the error "unknown wal version in data dir /var/etcd" and fails to start.

When datadir == the homedir for the etcd user, we get e.g. bash profile files in there.

I don't think this affects GCE, because GCE uses the persistent disk "switcheroo" for /var/etcd

I'm not entirely sure whether this is compatible with GCE / other platforms... But this error took me by surprise this morning, so I wanted to at least get the error message "unknown wal version in data dir /var/etcd" into the GitHub issue search :-)
