### PR TITLE
Backport annotations to PodTemplateSpec

### DIFF
--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -418,6 +418,9 @@ func init() {
 			if err := s.Convert(&in.ObjectMeta.Labels, &out.Labels, 0); err != nil {
 				return err
 			}
+			if err := s.Convert(&in.ObjectMeta.Annotations, &out.Annotations, 0); err != nil {
+				return err
+			}
 			return nil
 		},
 		func(in *PodTemplate, out *newer.PodTemplateSpec, s conversion.Scope) error {
@@ -429,6 +432,9 @@ func init() {
 				return err
 			}
 			if err := s.Convert(&in.Labels, &out.ObjectMeta.Labels, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Annotations, &out.ObjectMeta.Annotations, 0); err != nil {
 				return err
 			}
 			return nil

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -493,6 +493,7 @@ type PodTemplate struct {
 	DesiredState PodState          `json:"desiredState,omitempty" description:"specification of the desired state of pods created from this template"`
 	NodeSelector map[string]string `json:"nodeSelector,omitempty" description:"a selector which must be true for the pod to fit on a node"`
 	Labels       map[string]string `json:"labels,omitempty" description:"map of string keys and values that can be used to organize and categorize the pods created from the template; must match the selector of the replication controller to which the template belongs; may match selectors of services"`
+	Annotations  map[string]string `json:"annotations,omitempty" description:"map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about pods created from the template"`
 }
 
 // Session Affinity Type string

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -282,6 +282,9 @@ func init() {
 			if err := s.Convert(&in.ObjectMeta.Labels, &out.Labels, 0); err != nil {
 				return err
 			}
+			if err := s.Convert(&in.ObjectMeta.Annotations, &out.Annotations, 0); err != nil {
+				return err
+			}
 			return nil
 		},
 		func(in *PodTemplate, out *newer.PodTemplateSpec, s conversion.Scope) error {
@@ -293,6 +296,9 @@ func init() {
 				return err
 			}
 			if err := s.Convert(&in.Labels, &out.ObjectMeta.Labels, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Annotations, &out.ObjectMeta.Annotations, 0); err != nil {
 				return err
 			}
 			return nil

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -457,6 +457,7 @@ type PodTemplate struct {
 	DesiredState PodState          `json:"desiredState,omitempty" description:"specification of the desired state of pods created from this template"`
 	NodeSelector map[string]string `json:"nodeSelector,omitempty" description:"a selector which must be true for the pod to fit on a node"`
 	Labels       map[string]string `json:"labels,omitempty" description:"map of string keys and values that can be used to organize and categorize the pods created from the template; must match the selector of the replication controller to which the template belongs; may match selectors of services"`
+	Annotations  map[string]string `json:"annotations,omitempty" description:"map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about pods created from the template"`
 }
 
 // Session Affinity Type string

--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -61,6 +61,10 @@ func (r RealPodControl) createReplica(namespace string, controller api.Replicati
 	for k, v := range controller.Spec.Template.Labels {
 		desiredLabels[k] = v
 	}
+	desiredAnnotations := make(labels.Set)
+	for k, v := range controller.Spec.Template.Annotations {
+		desiredAnnotations[k] = v
+	}
 
 	// use the dash (if the name isn't too long) to make the pod name a bit prettier
 	prefix := fmt.Sprintf("%s-", controller.Name)
@@ -71,6 +75,7 @@ func (r RealPodControl) createReplica(namespace string, controller api.Replicati
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Labels:       desiredLabels,
+			Annotations:  desiredAnnotations,
 			GenerateName: prefix,
 		},
 	}


### PR DESCRIPTION
Backport annotation support to v1beta1 and v1beta2 PodTemplateSpec. This
allows ReplicationController users to specify annotations for Pods in
addition to labels.
