### PR TITLE
handle omitted rawExtension

### DIFF
--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -95,7 +95,7 @@ func (self *Scheme) embeddedObjectToRawExtension(in *EmbeddedObject, out *RawExt
 // given in conversion.Scope. It's placed in all schemes as a ConversionFunc to enable plugins;
 // see the comment for RawExtension.
 func (self *Scheme) rawExtensionToEmbeddedObject(in *RawExtension, out *EmbeddedObject, s conversion.Scope) error {
-	if len(in.RawJSON) == 4 && string(in.RawJSON) == "null" {
+	if len(in.RawJSON) == 0 || (len(in.RawJSON) == 4 && string(in.RawJSON) == "null") {
 		out.Object = nil
 		return nil
 	}


### PR DESCRIPTION
If rawExtensions are omitted, you get a weird error during the conversion.  This just catches the empty case and handles it as "null"

/cc @smarterclayton 
