### PR TITLE
Remove logging on apiserver startup

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -129,7 +129,6 @@ func registerResourceHandlers(ws *restful.WebService, version string, path strin
 
 	mapping, err := mapper.RESTMapping(kind, version)
 	if err != nil {
-		glog.V(1).Infof("OH NOES kind %s version %s err: %v", kind, version, err)
 		return err
 	}
 
@@ -240,7 +239,6 @@ func registerResourceHandlers(ws *restful.WebService, version string, path strin
 	// See github.com/emicklei/go-restful/blob/master/jsr311.go for routing logic
 	// and status-code behavior
 	for path, verbs := range pathToVerbs {
-		glog.V(5).Infof("Installing version=/%s, kind=/%s, path=/%s", version, kind, path)
 
 		params := pathToParam[path]
 		for _, verb := range verbs {


### PR DESCRIPTION
Now that we return errors on startup there's not much value in the
startup log for anyone except a few developers.  Nuke
