### PR TITLE
Support readiness checks

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -89,6 +89,7 @@ func (fakeKubeletClient) GetPodStatus(host, podNamespace, podID string) (api.Pod
 	r.Status.PodIP = "1.2.3.4"
 	m := make(api.PodInfo)
 	for k, v := range r.Status.Info {
+		v.Ready = true
 		v.PodIP = "1.2.3.4"
 		m[k] = v
 	}

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -181,6 +181,9 @@ func init() {
 			if err := s.Convert(&in.Phase, &out.Status, 0); err != nil {
 				return err
 			}
+			if err := s.Convert(&in.Conditions, &out.Conditions, 0); err != nil {
+				return err
+			}
 			if err := s.Convert(&in.Info, &out.Info, 0); err != nil {
 				return err
 			}
@@ -192,6 +195,9 @@ func init() {
 		},
 		func(in *PodState, out *newer.PodStatus, s conversion.Scope) error {
 			if err := s.Convert(&in.Status, &out.Phase, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Conditions, &out.Conditions, 0); err != nil {
 				return err
 			}
 			if err := s.Convert(&in.Info, &out.Info, 0); err != nil {
@@ -489,6 +495,9 @@ func init() {
 			if err := s.Convert(&in.LivenessProbe, &out.LivenessProbe, 0); err != nil {
 				return err
 			}
+			if err := s.Convert(&in.ReadinessProbe, &out.ReadinessProbe, 0); err != nil {
+				return err
+			}
 			if err := s.Convert(&in.Lifecycle, &out.Lifecycle, 0); err != nil {
 				return err
 			}
@@ -567,6 +576,9 @@ func init() {
 				return err
 			}
 			if err := s.Convert(&in.LivenessProbe, &out.LivenessProbe, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ReadinessProbe, &out.ReadinessProbe, 0); err != nil {
 				return err
 			}
 			if err := s.Convert(&in.Lifecycle, &out.Lifecycle, 0); err != nil {

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -281,10 +281,11 @@ type Container struct {
 	// Optional: Defaults to unlimited.
 	CPU int `json:"cpu,omitempty" description:"CPU share in thousandths of a core"`
 	// Optional: Defaults to unlimited.
-	Memory        int64          `json:"memory,omitempty" description:"memory limit in bytes; defaults to unlimited"`
-	VolumeMounts  []VolumeMount  `json:"volumeMounts,omitempty" description:"pod volumes to mount into the container's filesystem"`
-	LivenessProbe *LivenessProbe `json:"livenessProbe,omitempty" description:"periodic probe of container liveness; container will be restarted if the probe fails"`
-	Lifecycle     *Lifecycle     `json:"lifecycle,omitempty" description:"actions that the management system should take in response to container lifecycle events"`
+	Memory         int64          `json:"memory,omitempty" description:"memory limit in bytes; defaults to unlimited"`
+	VolumeMounts   []VolumeMount  `json:"volumeMounts,omitempty" description:"pod volumes to mount into the container's filesystem"`
+	LivenessProbe  *LivenessProbe `json:"livenessProbe,omitempty" description:"periodic probe of container liveness; container will be restarted if the probe fails"`
+	ReadinessProbe *LivenessProbe `json:"readinessProbe,omitempty" description:"periodic probe of container service readiness; container will be removed from service endpoints if the probe fails"`
+	Lifecycle      *Lifecycle     `json:"lifecycle,omitempty" description:"actions that the management system should take in response to container lifecycle events"`
 	// Optional: Defaults to /dev/termination-log
 	TerminationMessagePath string `json:"terminationMessagePath,omitempty" description:"path at which the file to which the container's termination message will be written is mounted into the container's filesystem; message written is intended to be brief final status, such as an assertion failure message; defaults to /dev/termination-log"`
 	// Optional: Default to false.
@@ -352,6 +353,18 @@ type TypeMeta struct {
 	Annotations map[string]string `json:"annotations,omitempty" description:"map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"`
 }
 
+type ConditionStatus string
+
+// These are valid condition statuses. "ConditionFull" means a resource is in the condition;
+// "ConditionNone" means a resource is not in the condition; "ConditionUnknown" means kubernetes
+// can't decide if a resource is in the condition or not. In the future, we could add other
+// intermediate conditions, e.g. ConditionDegraded.
+const (
+	ConditionFull    ConditionStatus = "Full"
+	ConditionNone    ConditionStatus = "None"
+	ConditionUnknown ConditionStatus = "Unknown"
+)
+
 // PodStatus represents a status of a pod.
 type PodStatus string
 
@@ -400,6 +413,7 @@ type ContainerStatus struct {
 	// TODO(dchen1107): Should we rename PodStatus to a more generic name or have a separate states
 	// defined for container?
 	State ContainerState `json:"state,omitempty" description:"details about the container's current condition"`
+	Ready bool           `json:"ready" description:"specifies whether the container has passed its readiness probe"`
 	// Note that this is calculated from dead containers.  But those containers are subject to
 	// garbage collection.  This value will get capped at 5 by GC.
 	RestartCount int `json:"restartCount" description:"the number of times the container has been restarted, currently based on the number of dead containers that have not yet been removed"`
@@ -410,6 +424,21 @@ type ContainerStatus struct {
 	Image       string `json:"image" description:"image of the container"`
 	ImageID     string `json:"imageID" description:"ID of the container's image"`
 	ContainerID string `json:"containerID,omitempty" description:"container's ID in the format 'docker://<container_id>'"`
+}
+
+type PodConditionKind string
+
+// These are valid conditions of pod.
+const (
+	// PodReady means the pod is able to service requests and should be added to the
+	// load balancing pools of all matching services.
+	PodReady PodConditionKind = "Ready"
+)
+
+// TODO: add LastTransitionTime, Reason, Message to match NodeCondition api.
+type PodCondition struct {
+	Kind   PodConditionKind `json:"kind"`
+	Status ConditionStatus  `json:"status"`
 }
 
 // PodInfo contains one entry for every container with available info.
@@ -440,8 +469,9 @@ type RestartPolicy struct {
 
 // PodState is the state of a pod, used as either input (desired state) or output (current state).
 type PodState struct {
-	Manifest ContainerManifest `json:"manifest,omitempty" description:"manifest of containers and volumes comprising the pod"`
-	Status   PodStatus         `json:"status,omitempty" description:"current condition of the pod, Waiting, Running, or Terminated"`
+	Manifest   ContainerManifest `json:"manifest,omitempty" description:"manifest of containers and volumes comprising the pod"`
+	Status     PodStatus         `json:"status,omitempty" description:"current condition of the pod, Waiting, Running, or Terminated"`
+	Conditions []PodCondition    `json:"Condition,omitempty" description:"current service state of pod"`
 	// A human readable message indicating details about why the pod is in this state.
 	Message string `json:"message,omitempty" description:"human readable message indicating details about why the pod is in this condition"`
 	Host    string `json:"host,omitempty" description:"host to which the pod is assigned; empty if not yet scheduled"`
@@ -604,25 +634,13 @@ const (
 	NodeReady NodeConditionKind = "Ready"
 )
 
-type NodeConditionStatus string
-
-// These are valid condition status. "ConditionFull" means node is in the condition;
-// "ConditionNone" means node is not in the condition; "ConditionUnknown" means kubernetes
-// can't decide if node is in the condition or not. In the future, we could add other
-// intermediate conditions, e.g. ConditionDegraded.
-const (
-	ConditionFull    NodeConditionStatus = "Full"
-	ConditionNone    NodeConditionStatus = "None"
-	ConditionUnknown NodeConditionStatus = "Unknown"
-)
-
 type NodeCondition struct {
-	Kind               NodeConditionKind   `json:"kind" description:"kind of the condition, one of reachable, ready"`
-	Status             NodeConditionStatus `json:"status" description:"status of the condition, one of full, none, unknown"`
-	LastProbeTime      util.Time           `json:"lastProbeTime,omitempty" description:"last time the condition was probed"`
-	LastTransitionTime util.Time           `json:"lastTransitionTime,omitempty" description:"last time the condition transit from one status to another"`
-	Reason             string              `json:"reason,omitempty" description:"(brief) reason for the condition's last transition"`
-	Message            string              `json:"message,omitempty" description:"human readable message indicating details about last transition"`
+	Kind               NodeConditionKind `json:"kind" description:"kind of the condition, one of reachable, ready"`
+	Status             ConditionStatus   `json:"status" description:"status of the condition, one of full, none, unknown"`
+	LastProbeTime      util.Time         `json:"lastProbeTime,omitempty" description:"last time the condition was probed"`
+	LastTransitionTime util.Time         `json:"lastTransitionTime,omitempty" description:"last time the condition transit from one status to another"`
+	Reason             string            `json:"reason,omitempty" description:"(brief) reason for the condition's last transition"`
+	Message            string            `json:"message,omitempty" description:"human readable message indicating details about last transition"`
 }
 
 // NodeResources represents resources on a Kubernetes system node

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -341,6 +341,9 @@ func init() {
 			if err := s.Convert(&in.LivenessProbe, &out.LivenessProbe, 0); err != nil {
 				return err
 			}
+			if err := s.Convert(&in.ReadinessProbe, &out.ReadinessProbe, 0); err != nil {
+				return err
+			}
 			if err := s.Convert(&in.Lifecycle, &out.Lifecycle, 0); err != nil {
 				return err
 			}
@@ -423,6 +426,9 @@ func init() {
 			if err := s.Convert(&in.LivenessProbe, &out.LivenessProbe, 0); err != nil {
 				return err
 			}
+			if err := s.Convert(&in.ReadinessProbe, &out.ReadinessProbe, 0); err != nil {
+				return err
+			}
 			if err := s.Convert(&in.Lifecycle, &out.Lifecycle, 0); err != nil {
 				return err
 			}
@@ -475,6 +481,9 @@ func init() {
 			if err := s.Convert(&in.Info, &out.Info, 0); err != nil {
 				return err
 			}
+			if err := s.Convert(&in.Conditions, &out.Conditions, 0); err != nil {
+				return err
+			}
 			out.Message = in.Message
 			out.Host = in.Host
 			out.HostIP = in.HostIP
@@ -486,6 +495,9 @@ func init() {
 				return err
 			}
 			if err := s.Convert(&in.Info, &out.Info, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Conditions, &out.Conditions, 0); err != nil {
 				return err
 			}
 			out.Message = in.Message

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -358,13 +358,14 @@ type Container struct {
 	// Optional: Defaults to whatever is defined in the image.
 	Command []string `json:"command,omitempty"`
 	// Optional: Defaults to Docker's default.
-	WorkingDir    string               `json:"workingDir,omitempty"`
-	Ports         []Port               `json:"ports,omitempty"`
-	Env           []EnvVar             `json:"env,omitempty"`
-	Resources     ResourceRequirements `json:"resources,omitempty" description:"Compute Resources required by this container"`
-	VolumeMounts  []VolumeMount        `json:"volumeMounts,omitempty"`
-	LivenessProbe *Probe               `json:"livenessProbe,omitempty"`
-	Lifecycle     *Lifecycle           `json:"lifecycle,omitempty"`
+	WorkingDir     string               `json:"workingDir,omitempty"`
+	Ports          []Port               `json:"ports,omitempty"`
+	Env            []EnvVar             `json:"env,omitempty"`
+	Resources      ResourceRequirements `json:"resources,omitempty" description:"Compute Resources required by this container"`
+	VolumeMounts   []VolumeMount        `json:"volumeMounts,omitempty"`
+	LivenessProbe  *Probe               `json:"livenessProbe,omitempty"`
+	ReadinessProbe *Probe               `json:"readinessProbe,omitempty"`
+	Lifecycle      *Lifecycle           `json:"lifecycle,omitempty"`
 	// Optional: Defaults to /dev/termination-log
 	TerminationMessagePath string `json:"terminationMessagePath,omitempty"`
 	// Optional: Default to false.
@@ -400,27 +401,16 @@ type Lifecycle struct {
 	PreStop *Handler `json:"preStop,omitempty"`
 }
 
-// PodPhase is a label for the condition of a pod at the current time.
-type PodPhase string
+type ConditionStatus string
 
-// These are the valid states of pods.
+// These are valid condition statuses. "ConditionFull" means a resource is in the condition;
+// "ConditionNone" means a resource is not in the condition; "ConditionUnknown" means kubernetes
+// can't decide if a resource is in the condition or not. In the future, we could add other
+// intermediate conditions, e.g. ConditionDegraded.
 const (
-	// PodPending means the pod has been accepted by the system, but one or more of the containers
-	// has not been started. This includes time before being bound to a node, as well as time spent
-	// pulling images onto the host.
-	PodPending PodPhase = "Pending"
-	// PodRunning means the pod has been bound to a node and all of the containers have been started.
-	// At least one container is still running or is in the process of being restarted.
-	PodRunning PodPhase = "Running"
-	// PodSucceeded means that all containers in the pod have voluntarily terminated
-	// with a container exit code of 0, and the system is not going to restart any of these containers.
-	PodSucceeded PodPhase = "Succeeded"
-	// PodFailed means that all containers in the pod have terminated, and at least one container has
-	// terminated in a failure (exited with a non-zero exit code or was stopped by the system).
-	PodFailed PodPhase = "Failed"
-	// PodUnknown means that for some reason the state of the pod could not be obtained, typically due
-	// to an error in communicating with the host of the pod.
-	PodUnknown PodPhase = "Unknown"
+	ConditionFull    ConditionStatus = "Full"
+	ConditionNone    ConditionStatus = "None"
+	ConditionUnknown ConditionStatus = "Unknown"
 )
 
 type ContainerStateWaiting struct {
@@ -454,6 +444,7 @@ type ContainerStatus struct {
 	// TODO(dchen1107): Should we rename PodStatus to a more generic name or have a separate states
 	// defined for container?
 	State ContainerState `json:"state,omitempty"`
+	Ready bool           `json:"ready"`
 	// Note that this is calculated from dead containers.  But those containers are subject to
 	// garbage collection.  This value will get capped at 5 by GC.
 	RestartCount int `json:"restartCount"`
@@ -466,6 +457,44 @@ type ContainerStatus struct {
 	// The image the container is running
 	Image   string `json:"image"`
 	ImageID string `json:"imageID" description:"ID of the container's image"`
+}
+
+// PodPhase is a label for the condition of a pod at the current time.
+type PodPhase string
+
+// These are the valid statuses of pods.
+const (
+	// PodPending means the pod has been accepted by the system, but one or more of the containers
+	// has not been started. This includes time before being bound to a node, as well as time spent
+	// pulling images onto the host.
+	PodPending PodPhase = "Pending"
+	// PodRunning means the pod has been bound to a node and all of the containers have been started.
+	// At least one container is still running or is in the process of being restarted.
+	PodRunning PodPhase = "Running"
+	// PodSucceeded means that all containers in the pod have voluntarily terminated
+	// with a container exit code of 0, and the system is not going to restart any of these containers.
+	PodSucceeded PodPhase = "Succeeded"
+	// PodFailed means that all containers in the pod have terminated, and at least one container has
+	// terminated in a failure (exited with a non-zero exit code or was stopped by the system).
+	PodFailed PodPhase = "Failed"
+	// PodUnknown means that for some reason the state of the pod could not be obtained, typically due
+	// to an error in communicating with the host of the pod.
+	PodUnknown PodPhase = "Unknown"
+)
+
+type PodConditionKind string
+
+// These are valid conditions of pod.
+const (
+	// PodReady means the pod is able to service requests and should be added to the
+	// load balancing pools of all matching services.
+	PodReady PodConditionKind = "Ready"
+)
+
+// TODO: add LastTransitionTime, Reason, Message to match NodeCondition api.
+type PodCondition struct {
+	Kind   PodConditionKind `json:"kind"`
+	Status ConditionStatus  `json:"status"`
 }
 
 // PodInfo contains one entry for every container with available info.
@@ -521,7 +550,8 @@ type PodSpec struct {
 // PodStatus represents information about the status of a pod. Status may trail the actual
 // state of a system.
 type PodStatus struct {
-	Phase PodPhase `json:"phase,omitempty"`
+	Phase      PodPhase       `json:"phase,omitempty"`
+	Conditions []PodCondition `json:"Condition,omitempty"`
 	// A human readable message indicating details about why the pod is in this state.
 	Message string `json:"message,omitempty"`
 
@@ -793,25 +823,13 @@ const (
 	NodeReady NodeConditionKind = "Ready"
 )
 
-type NodeConditionStatus string
-
-// These are valid condition status. "ConditionFull" means node is in the condition;
-// "ConditionNone" means node is not in the condition; "ConditionUnknown" means kubernetes
-// can't decide if node is in the condition or not. In the future, we could add other
-// intermediate conditions, e.g. ConditionDegraded.
-const (
-	ConditionFull    NodeConditionStatus = "Full"
-	ConditionNone    NodeConditionStatus = "None"
-	ConditionUnknown NodeConditionStatus = "Unknown"
-)
-
 type NodeCondition struct {
-	Kind               NodeConditionKind   `json:"kind"`
-	Status             NodeConditionStatus `json:"status"`
-	LastProbeTime      util.Time           `json:"lastProbeTime,omitempty"`
-	LastTransitionTime util.Time           `json:"lastTransitionTime,omitempty"`
-	Reason             string              `json:"reason,omitempty"`
-	Message            string              `json:"message,omitempty"`
+	Kind               NodeConditionKind `json:"kind"`
+	Status             ConditionStatus   `json:"status"`
+	LastProbeTime      util.Time         `json:"lastProbeTime,omitempty"`
+	LastTransitionTime util.Time         `json:"lastTransitionTime,omitempty"`
+	Reason             string            `json:"reason,omitempty"`
+	Message            string            `json:"message,omitempty"`
 }
 
 // ResourceName is the name identifying various resources in a ResourceList.

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -120,6 +120,7 @@ func (f *FakeDockerClient) StartContainer(id string, hostConfig *docker.HostConf
 		ID:         id,
 		Config:     &docker.Config{Image: "testimage"},
 		HostConfig: hostConfig,
+		State:      docker.State{Running: true},
 	}
 	return f.Err
 }

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -66,6 +66,7 @@ func newTestKubelet(t *testing.T) (*Kubelet, *dockertools.FakeDockerClient) {
 	kubelet.sourceReady = func(source string) bool { return true }
 	kubelet.masterServiceNamespace = api.NamespaceDefault
 	kubelet.serviceLister = testServiceLister{}
+	kubelet.readiness = newReadinessStates()
 	if err := kubelet.setupDataDirs(); err != nil {
 		t.Fatalf("can't initialize kubelet data dirs: %v", err)
 	}

--- a/pkg/kubelet/probe_test.go
+++ b/pkg/kubelet/probe_test.go
@@ -17,10 +17,17 @@ limitations under the License.
 package kubelet
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/probe"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/exec"
+
+	"github.com/fsouza/go-dockerclient"
 )
 
 func TestFindPortByName(t *testing.T) {
@@ -125,6 +132,113 @@ func TestGetTCPAddrParts(t *testing.T) {
 			if host != test.host || port != test.port {
 				t.Errorf("Expected %s:%d, got %s:%d", test.host, test.port, host, port)
 			}
+		}
+	}
+}
+
+type fakeExecProber struct {
+	result probe.Result
+	err    error
+}
+
+func (p fakeExecProber) Probe(_ exec.Cmd) (probe.Result, error) {
+	return p.result, p.err
+}
+
+func makeTestKubelet(result probe.Result, err error) *Kubelet {
+	return &Kubelet{
+		prober: probeHolder{
+			exec: fakeExecProber{
+				result: result,
+				err:    err,
+			},
+		},
+	}
+}
+
+func TestProbeContainer(t *testing.T) {
+	dc := &docker.APIContainers{Created: time.Now().Unix()}
+	tests := []struct {
+		p              *api.Probe
+		defaultResult  probe.Result
+		expectError    bool
+		expectedResult probe.Result
+	}{
+		{
+			defaultResult:  probe.Success,
+			expectedResult: probe.Success,
+		},
+		{
+			defaultResult:  probe.Failure,
+			expectedResult: probe.Success,
+		},
+		{
+			p:              &api.Probe{InitialDelaySeconds: 100},
+			defaultResult:  probe.Failure,
+			expectError:    false,
+			expectedResult: probe.Failure,
+		},
+		{
+			p: &api.Probe{
+				InitialDelaySeconds: -100,
+			},
+			defaultResult:  probe.Failure,
+			expectError:    false,
+			expectedResult: probe.Unknown,
+		},
+		{
+			p: &api.Probe{
+				InitialDelaySeconds: -100,
+				Handler: api.Handler{
+					Exec: &api.ExecAction{},
+				},
+			},
+			defaultResult:  probe.Failure,
+			expectError:    false,
+			expectedResult: probe.Success,
+		},
+		{
+			p: &api.Probe{
+				InitialDelaySeconds: -100,
+				Handler: api.Handler{
+					Exec: &api.ExecAction{},
+				},
+			},
+			defaultResult:  probe.Failure,
+			expectError:    true,
+			expectedResult: probe.Unknown,
+		},
+		{
+			p: &api.Probe{
+				InitialDelaySeconds: -100,
+				Handler: api.Handler{
+					Exec: &api.ExecAction{},
+				},
+			},
+			defaultResult:  probe.Success,
+			expectError:    false,
+			expectedResult: probe.Failure,
+		},
+	}
+
+	for _, test := range tests {
+		var kl *Kubelet
+
+		if test.expectError {
+			kl = makeTestKubelet(test.expectedResult, errors.New("error"))
+		} else {
+			kl = makeTestKubelet(test.expectedResult, nil)
+		}
+
+		result, err := kl.probeContainer(test.p, "", types.UID(""), api.PodStatus{}, api.Container{}, dc, test.defaultResult)
+		if test.expectError && err == nil {
+			t.Error("Expected error but did no error was returned.")
+		}
+		if !test.expectError && err != nil {
+			t.Errorf("Expected error but got: %v", err)
+		}
+		if test.expectedResult != result {
+			t.Errorf("Expected result was %v but probeContainer() returned %v", test.expectedResult, result)
 		}
 	}
 }

--- a/pkg/master/pod_cache.go
+++ b/pkg/master/pod_cache.go
@@ -162,6 +162,7 @@ func (p *PodCache) computePodStatus(pod *api.Pod) (api.PodStatus, error) {
 	if pod.Status.Host == "" {
 		// Not assigned.
 		newStatus.Phase = api.PodPending
+		newStatus.Conditions = append(newStatus.Conditions, pod.Status.Conditions...)
 		return newStatus, nil
 	}
 
@@ -171,6 +172,7 @@ func (p *PodCache) computePodStatus(pod *api.Pod) (api.PodStatus, error) {
 	if err != nil || len(nodeStatus.Conditions) == 0 {
 		glog.V(5).Infof("node doesn't exist: %v %v, setting pod status to unknown", err, nodeStatus)
 		newStatus.Phase = api.PodUnknown
+		newStatus.Conditions = append(newStatus.Conditions, pod.Status.Conditions...)
 		return newStatus, nil
 	}
 
@@ -179,6 +181,7 @@ func (p *PodCache) computePodStatus(pod *api.Pod) (api.PodStatus, error) {
 		if (condition.Kind == api.NodeReady || condition.Kind == api.NodeReachable) && condition.Status == api.ConditionNone {
 			glog.V(5).Infof("node status: %v, setting pod status to unknown", condition)
 			newStatus.Phase = api.PodUnknown
+			newStatus.Conditions = append(newStatus.Conditions, pod.Status.Conditions...)
 			return newStatus, nil
 		}
 	}
@@ -189,6 +192,7 @@ func (p *PodCache) computePodStatus(pod *api.Pod) (api.PodStatus, error) {
 	if err != nil {
 		glog.Errorf("error getting pod status: %v, setting status to unknown", err)
 		newStatus.Phase = api.PodUnknown
+		newStatus.Conditions = append(newStatus.Conditions, pod.Status.Conditions...)
 	} else {
 		newStatus.Info = result.Status.Info
 		newStatus.PodIP = result.Status.PodIP
@@ -197,8 +201,10 @@ func (p *PodCache) computePodStatus(pod *api.Pod) (api.PodStatus, error) {
 			// propulated the status yet. This should go away once
 			// we removed boundPods
 			newStatus.Phase = api.PodPending
+			newStatus.Conditions = append(newStatus.Conditions, pod.Status.Conditions...)
 		} else {
 			newStatus.Phase = result.Status.Phase
+			newStatus.Conditions = result.Status.Conditions
 		}
 	}
 	return newStatus, err

--- a/pkg/probe/exec/exec.go
+++ b/pkg/probe/exec/exec.go
@@ -28,12 +28,16 @@ import (
 const defaultHealthyOutput = "ok"
 
 func New() ExecProber {
-	return ExecProber{}
+	return execProber{}
 }
 
-type ExecProber struct{}
+type ExecProber interface {
+	Probe(e uexec.Cmd) (probe.Result, error)
+}
 
-func (pr ExecProber) Probe(e uexec.Cmd) (probe.Result, error) {
+type execProber struct{}
+
+func (pr execProber) Probe(e uexec.Cmd) (probe.Result, error) {
 	data, err := e.CombinedOutput()
 	glog.V(4).Infof("health check response: %s", string(data))
 	if err != nil {

--- a/pkg/probe/http/http.go
+++ b/pkg/probe/http/http.go
@@ -30,15 +30,19 @@ import (
 
 func New() HTTPProber {
 	transport := &http.Transport{}
-	return HTTPProber{transport}
+	return httpProber{transport}
 }
 
-type HTTPProber struct {
+type HTTPProber interface {
+	Probe(host string, port int, path string, timeout time.Duration) (probe.Result, error)
+}
+
+type httpProber struct {
 	transport *http.Transport
 }
 
 // Probe returns a ProbeRunner capable of running an http check.
-func (pr *HTTPProber) Probe(host string, port int, path string, timeout time.Duration) (probe.Result, error) {
+func (pr httpProber) Probe(host string, port int, path string, timeout time.Duration) (probe.Result, error) {
 	return DoHTTPProbe(formatURL(host, port, path), &http.Client{Timeout: timeout, Transport: pr.transport})
 }
 

--- a/pkg/probe/tcp/tcp.go
+++ b/pkg/probe/tcp/tcp.go
@@ -27,12 +27,16 @@ import (
 )
 
 func New() TCPProber {
-	return TCPProber{}
+	return tcpProber{}
 }
 
-type TCPProber struct{}
+type TCPProber interface {
+	Probe(host string, port int, timeout time.Duration) (probe.Result, error)
+}
 
-func (pr TCPProber) Probe(host string, port int, timeout time.Duration) (probe.Result, error) {
+type tcpProber struct{}
+
+func (pr tcpProber) Probe(host string, port int, timeout time.Duration) (probe.Result, error) {
 	return DoTCPProbe(net.JoinHostPort(host, strconv.Itoa(port)), timeout)
 }
 

--- a/pkg/service/endpoints_controller.go
+++ b/pkg/service/endpoints_controller.go
@@ -76,6 +76,19 @@ func (e *EndpointController) SyncServiceEndpoints() error {
 				glog.Errorf("Failed to find an IP for pod %s/%s", pod.Namespace, pod.Name)
 				continue
 			}
+
+			inService := false
+			for _, c := range pod.Status.Conditions {
+				if c.Kind == api.PodReady && c.Status == api.ConditionFull {
+					inService = true
+					break
+				}
+			}
+			if !inService {
+				glog.V(5).Infof("Pod is out of service: %v/%v", pod.Namespace, pod.Name)
+				continue
+			}
+
 			endpoints = append(endpoints, net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(port)))
 		}
 		currentEndpoints, err := e.client.Endpoints(service.Namespace).Get(service.Name)

--- a/pkg/service/endpoints_controller_test.go
+++ b/pkg/service/endpoints_controller_test.go
@@ -49,6 +49,12 @@ func newPodList(count int) *api.PodList {
 			},
 			Status: api.PodStatus{
 				PodIP: "1.2.3.4",
+				Conditions: []api.PodCondition{
+					{
+						Kind:   api.PodReady,
+						Status: api.ConditionFull,
+					},
+				},
 			},
 		})
 	}


### PR DESCRIPTION
This is a pass at addressing #620, to support readiness checks of pods before being added to the endpoint pool of services. What's left is to do is write unit/integration tests and improve documentation. I'm opening this as a WIP to start discussion around the api and anything else.
