### PR TITLE
Add TODO comment for kubectl update patching

### DIFF
--- a/pkg/kubectl/cmd/update.go
+++ b/pkg/kubectl/cmd/update.go
@@ -85,6 +85,7 @@ Examples:
 				})
 				checkErr(err)
 			} else {
+				// TODO: Make patching work with -f, updating with patched JSON input files
 				name := updateWithPatch(cmd, args, f, patch)
 				fmt.Fprintf(out, "%s\n", name)
 			}


### PR DESCRIPTION
Add a TODO comment for a more versatile patching when doing kubectl update -f, as per https://github.com/GoogleCloudPlatform/kubernetes/pull/3805#discussion_r23944400

CC: @smarterclayton 
