### PR TITLE
Reinstate cluster logging URLs to the end of kube-up.sh

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-service.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-service.yaml
@@ -3,6 +3,8 @@ kind: Service
 id: elasticsearch-logging
 containerPort: es-port
 port: 9200
+labels:
+  name: elasticsearch-logging
 selector:
   name: elasticsearch-logging
 createExternalLoadBalancer: true

--- a/cluster/addons/fluentd-elasticsearch/kibana-service.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-service.yaml
@@ -3,7 +3,8 @@ kind: Service
 id: kibana-logging
 containerPort: kibana-port
 port: 5601
+labels:
+  name: kibana-logging
 selector:
   name: kibana-logging
 createExternalLoadBalancer: true
- 


### PR DESCRIPTION
Adds labels to the services, waits for them to be created (which
should be instant, but just in case), query the forwarding rules like
as we did before.

Fixes #3893
