### PR TITLE
Replace kubecfg with kubectl in e2e tests

### DIFF
--- a/hack/e2e-suite/guestbook.sh
+++ b/hack/e2e-suite/guestbook.sh
@@ -29,23 +29,21 @@ source "${KUBE_ROOT}/cluster/$KUBERNETES_PROVIDER/util.sh"
 GUESTBOOK="${KUBE_ROOT}/examples/guestbook"
 
 # Launch the guestbook example
-$KUBECFG -c "${GUESTBOOK}/redis-master.json" create /pods
-$KUBECFG -c "${GUESTBOOK}/redis-master-service.json" create /services
-$KUBECFG -c "${GUESTBOOK}/redis-slave-controller.json" create /replicationControllers
+${KUBECTL} create -f  "${GUESTBOOK}"
 
-sleep 5
+sleep 15
 
-POD_LIST_1=$($KUBECFG '-template={{range.items}}{{.id}} {{end}}' list pods)
+POD_LIST_1=$(${KUBECTL} get pods -o template '--template={{range.items}}{{.id}} {{end}}')
 echo "Pods running: ${POD_LIST_1}"
 
-$KUBECFG stop redis-slave-controller
-# Needed until issue #103 gets fixed
-sleep 25
-$KUBECFG rm redis-slave-controller
-$KUBECFG delete services/redis-master
-$KUBECFG delete pods/redis-master
+# TODO make this an actual test. Open up a firewall and use curl to post and
+# read a message via the frontend
 
-POD_LIST_2=$($KUBECFG '-template={{range.items}}{{.id}} {{end}}' list pods)
+${KUBECTL} stop rc redis-slave-controller
+${KUBECTL} delete services redis-master
+${KUBECTL} delete pods redis-master
+
+POD_LIST_2=$(${KUBECTL} get pods -o template '--template={{range.items}}{{.id}} {{end}}')
 echo "Pods running after shutdown: ${POD_LIST_2}"
 
 exit 0

--- a/hack/e2e-suite/services.sh
+++ b/hack/e2e-suite/services.sh
@@ -135,9 +135,8 @@ __EOF__
 #   $1: service name
 function stop_service() {
   echo "Stopping service '$1'"
-  ${KUBECFG} stop "$1" || true
-  ${KUBECFG} delete "/replicationControllers/$1" || true
-  ${KUBECFG} delete "/services/$1" || true
+  ${KUBECTL} stop rc "$1" || true
+  ${KUBECTL} delete services "$1" || true
 }
 
 # Args:
@@ -309,9 +308,9 @@ svc1_pods=$(query_pods "${svc1_name}" "${svc1_count}")
 svc2_pods=$(query_pods "${svc2_name}" "${svc2_count}")
 
 # Get the portal IPs.
-svc1_ip=$(${KUBECFG} -template '{{.portalIP}}' get "services/${svc1_name}")
+svc1_ip=$(${KUBECTL} get services -o template '--template={{.portalIP}}' "${svc1_name}")
 test -n "${svc1_ip}" || error "Service1 IP is blank"
-svc2_ip=$(${KUBECFG} -template '{{.portalIP}}' get "services/${svc2_name}")
+svc2_ip=$(${KUBECTL} get services -o template '--template={{.portalIP}}' "${svc2_name}")
 test -n "${svc2_ip}" || error "Service2 IP is blank"
 if [[ "${svc1_ip}" == "${svc2_ip}" ]]; then
   error "Portal IPs conflict: ${svc1_ip}"
@@ -381,7 +380,7 @@ wait_for_pods "${svc3_name}" "${svc3_count}"
 svc3_pods=$(query_pods "${svc3_name}" "${svc3_count}")
 
 # Get the portal IP.
-svc3_ip=$(${KUBECFG} -template '{{.portalIP}}' get "services/${svc3_name}")
+svc3_ip=$(${KUBECTL} get services -o template '--template={{.portalIP}}' "${svc3_name}")
 test -n "${svc3_ip}" || error "Service3 IP is blank"
 
 echo "Verifying the portals from the host"
@@ -437,7 +436,7 @@ wait_for_pods "${svc4_name}" "${svc4_count}"
 svc4_pods=$(query_pods "${svc4_name}" "${svc4_count}")
 
 # Get the portal IP.
-svc4_ip=$(${KUBECFG} -template '{{.portalIP}}' get "services/${svc4_name}")
+svc4_ip=$(${KUBECTL} get services -o template '--template={{.portalIP}}' "${svc4_name}")
 test -n "${svc4_ip}" || error "Service4 IP is blank"
 if [[ "${svc4_ip}" == "${svc2_ip}" || "${svc4_ip}" == "${svc3_ip}" ]]; then
   error "Portal IPs conflict: ${svc4_ip}"

--- a/hack/e2e-suite/update.sh
+++ b/hack/e2e-suite/update.sh
@@ -53,7 +53,7 @@ function validate() {
     for id in "${pod_id_list[@]+${pod_id_list[@]}}"; do
       local template_string current_status current_image host_ip
 
-      # NB: kubectl & kubecfg add the "exists" function to the standard template functions.
+      # NB: kubectl adds the "exists" function to the standard template functions.
       # This lets us check to see if the "running" entry exists for each of the containers
       # we care about. Exists will never return an error and it's safe to check a chain of
       # things, any one of which may not exist. In the below template, all of info,

--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -57,7 +57,6 @@ var (
 		"You can explicitly set to false if you're, e.g., testing client changes "+
 		"for which the server version doesn't make a difference.")
 
-	cfgCmd = flag.String("cfg", "", "If nonempty, pass this as an argument, and call kubecfg. Implies -v.")
 	ctlCmd = flag.String("ctl", "", "If nonempty, pass this as an argument, and call kubectl. Implies -v. (-test, -cfg, -ctl are mutually exclusive)")
 )
 
@@ -164,8 +163,6 @@ func main() {
 
 	failure := false
 	switch {
-	case *cfgCmd != "":
-		failure = !runBash("'kubecfg "+*cfgCmd+"'", "$KUBECFG "+*cfgCmd)
 	case *ctlCmd != "":
 		failure = !runBash("'kubectl "+*ctlCmd+"'", "$KUBECTL "+*ctlCmd)
 	case *tests != "":
@@ -537,15 +534,6 @@ func printPrefixedLines(prefix, s string) {
 }
 
 // returns either "", or a list of args intended for appending with the
-// kubecfg or kubectl commands (begining with a space).
-func kubecfgArgs() string {
-	if *checkVersionSkew {
-		return " -expect_version_match"
-	}
-	return ""
-}
-
-// returns either "", or a list of args intended for appending with the
 // kubectl command (begining with a space).
 func kubectlArgs() string {
 	if *checkVersionSkew {
@@ -564,7 +552,6 @@ export KUBE_CONFIG_FILE="config-test.sh"
 
 # TODO(jbeda): This will break on usage if there is a space in
 # ${KUBE_ROOT}.  Convert to an array?  Or an exported function?
-export KUBECFG="` + versionRoot + `/cluster/kubecfg.sh` + kubecfgArgs() + `"
 export KUBECTL="` + versionRoot + `/cluster/kubectl.sh` + kubectlArgs() + `"
 
 source "` + *root + `/cluster/kube-env.sh"


### PR DESCRIPTION
Closes #2576. `liveness.sh` and `pd.sh` were flaky for me, but appear to be the same at head.
