### PR TITLE
Fix removal of release-staging files while running hack/e2e-test.sh

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -473,9 +473,11 @@ function kube::release::package_tarballs() {
   mkdir -p "${RELEASE_DIR}"
   
   # Clean out cruft
-  find _output/release-stage/ -name '*~' -exec rm {} \;
-  find _output/release-stage/ -name '#*#' -exec rm {} \;
-  find _output/release-stage/ -name '.DS*' -exec rm {} \;
+  if [ -d "_output/release-stage/" ]; then
+    find _output/release-stage/ -name '*~' -exec rm {} \;
+    find _output/release-stage/ -name '#*#' -exec rm {} \;
+    find _output/release-stage/ -name '.DS*' -exec rm {} \;
+  fi
 
   kube::release::package_client_tarballs
   kube::release::package_server_tarballs


### PR DESCRIPTION
While running hack/e2e-test.sh from a fresh cloned client the _output/release-stage/ directory doesn't exist causing -exec rm to fail.
