### PR TITLE
Fix orphaned pod & volume cleanup order. Volumes need to be unmounted before pod cleanup.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1274,14 +1274,14 @@ func (kl *Kubelet) SyncPods(pods []api.BoundPod) error {
 		}
 	}
 
-	// Remove any orphaned pods.
-	err = kl.cleanupOrphanedPods(pods)
+	// Remove any orphaned volumes.
+	err = kl.cleanupOrphanedVolumes(pods)
 	if err != nil {
 		return err
 	}
 
-	// Remove any orphaned volumes.
-	err = kl.cleanupOrphanedVolumes(pods)
+	// Remove any orphaned pods.
+	err = kl.cleanupOrphanedPods(pods)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix orphaned pod & volume cleanup order. Volumes need to be unmounted before pod cleanup.
