### PR TITLE
kubectl proxy: make static prefix configurable

### DIFF
--- a/docs/kubectl.md
+++ b/docs/kubectl.md
@@ -75,7 +75,8 @@ Usage:
       --v=0: log level for V logs
       --validate=false: If true, use a schema to validate the input before sending it
       --vmodule=: comma-separated list of pattern=N settings for file-filtered logging
-  -w, --www="": Also serve static files from the given directory under the prefix /static
+  -w, --www="": Also serve static files from the given directory under the specified prefix
+  -P, --www-prefix="/static/": Prefix to serve static files under, if static file dir is specified
 
 ```
 

--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"io"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
 	"github.com/golang/glog"
@@ -36,12 +37,17 @@ func (f *Factory) NewCmdProxy(out io.Writer) *cobra.Command {
 			clientConfig, err := f.ClientConfig(cmd)
 			checkErr(err)
 
-			server, err := kubectl.NewProxyServer(GetFlagString(cmd, "www"), clientConfig)
+			staticPrefix := GetFlagString(cmd, "www-prefix")
+			if !strings.HasSuffix(staticPrefix, "/") {
+				staticPrefix += "/"
+			}
+			server, err := kubectl.NewProxyServer(GetFlagString(cmd, "www"), staticPrefix, clientConfig)
 			checkErr(err)
 			glog.Fatal(server.Serve(port))
 		},
 	}
-	cmd.Flags().StringP("www", "w", "", "Also serve static files from the given directory under the prefix /static")
+	cmd.Flags().StringP("www", "w", "", "Also serve static files from the given directory under the specified prefix")
+	cmd.Flags().StringP("www-prefix", "P", "/static/", "Prefix to serve static files under, if static file dir is specified")
 	cmd.Flags().IntP("port", "p", 8001, "The port on which to run the proxy")
 	return cmd
 }

--- a/pkg/kubectl/proxy_server.go
+++ b/pkg/kubectl/proxy_server.go
@@ -33,7 +33,7 @@ type ProxyServer struct {
 
 // NewProxyServer creates and installs a new ProxyServer.
 // It automatically registers the created ProxyServer to http.DefaultServeMux.
-func NewProxyServer(filebase string, cfg *client.Config) (*ProxyServer, error) {
+func NewProxyServer(filebase string, staticPrefix string, cfg *client.Config) (*ProxyServer, error) {
 	prefix := cfg.Prefix
 	if prefix == "" {
 		prefix = "/api"
@@ -47,7 +47,7 @@ func NewProxyServer(filebase string, cfg *client.Config) (*ProxyServer, error) {
 		return nil, err
 	}
 	http.Handle("/api/", http.StripPrefix("/api/", proxy))
-	http.Handle("/static/", newFileHandler("/static/", filebase))
+	http.Handle(staticPrefix, newFileHandler(staticPrefix, filebase))
 	return proxy, nil
 }
 


### PR DESCRIPTION
This makes it easier to use to serve front ends that rely on the proxying configuration to work around CORS or network restrictions. Enables static files to be served from / & still proxy /api/\* to appropriate API server.
