### PR TITLE
Enable look-up by secondary index in cache

### DIFF
--- a/pkg/client/cache/index.go
+++ b/pkg/client/cache/index.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+// Indexer is a storage interface that lets you list objects using multiple indexing functions
+type Indexer interface {
+	Store
+	// Retrieve list of objects that match on the named indexing function
+	Index(indexName string, obj interface{}) ([]interface{}, error)
+}
+
+// IndexFunc knows how to provide an indexed value for an object.
+type IndexFunc func(obj interface{}) (string, error)
+
+// MetaNamespaceIndexFunc is a default index function that indexes based on an object's namespace
+func MetaNamespaceIndexFunc(obj interface{}) (string, error) {
+	meta, err := meta.Accessor(obj)
+	if err != nil {
+		return "", fmt.Errorf("object has no meta: %v", err)
+	}
+	return meta.Namespace(), nil
+}
+
+// Index maps the indexed value to a set of keys in the store that match on that value
+type Index map[string]util.StringSet
+
+// Indexers maps a name to a IndexFunc
+type Indexers map[string]IndexFunc
+
+// Indices maps a name to an Index
+type Indices map[string]Index

--- a/pkg/client/cache/store_test.go
+++ b/pkg/client/cache/store_test.go
@@ -87,7 +87,7 @@ func doTestStore(t *testing.T, store Store) {
 }
 
 // Test public interface
-func doTestIndex(t *testing.T, index Index) {
+func doTestIndex(t *testing.T, indexer Indexer) {
 	mkObj := func(id string, val string) testStoreObject {
 		return testStoreObject{id: id, val: val}
 	}
@@ -97,14 +97,14 @@ func doTestIndex(t *testing.T, index Index) {
 	expected["b"] = util.NewStringSet("a", "c")
 	expected["f"] = util.NewStringSet("e")
 	expected["h"] = util.NewStringSet("g")
-	index.Add(mkObj("a", "b"))
-	index.Add(mkObj("c", "b"))
-	index.Add(mkObj("e", "f"))
-	index.Add(mkObj("g", "h"))
+	indexer.Add(mkObj("a", "b"))
+	indexer.Add(mkObj("c", "b"))
+	indexer.Add(mkObj("e", "f"))
+	indexer.Add(mkObj("g", "h"))
 	{
 		for k, v := range expected {
 			found := util.StringSet{}
-			indexResults, err := index.Index(mkObj("", k))
+			indexResults, err := indexer.Index("by_val", mkObj("", k))
 			if err != nil {
 				t.Errorf("Unexpected error %v", err)
 			}
@@ -127,6 +127,12 @@ func testStoreIndexFunc(obj interface{}) (string, error) {
 	return obj.(testStoreObject).val, nil
 }
 
+func testStoreIndexers() Indexers {
+	indexers := Indexers{}
+	indexers["by_val"] = testStoreIndexFunc
+	return indexers
+}
+
 type testStoreObject struct {
 	id  string
 	val string
@@ -146,5 +152,5 @@ func TestUndeltaStore(t *testing.T) {
 }
 
 func TestIndex(t *testing.T) {
-	doTestIndex(t, NewIndex(testStoreKeyFunc, testStoreIndexFunc))
+	doTestIndex(t, NewIndexer(testStoreKeyFunc, testStoreIndexers()))
 }


### PR DESCRIPTION
This is an enhancement to our cache to let you optionally create a store that can build a secondary index on its data.  The main use case is I want to have a store that holds a bunch of resources across namespaces, and I want to be able to then interface with that store by asking to retrieve only the resources in namespace X.

If folks are good with this pattern, I will adopt it in the admission control handlers for resource quota and limit range.

@smarterclayton @ironcladlou @erictune 
