### PR TITLE
Add a few extra test cases for API validation of labels

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -11,6 +11,15 @@ key/value labels set on it, with at most one label with a particular key.
 }
 ```
 
+While there are no restrictions on the format of label values, label keys must be of the form:
+```
+label-key ::= prefixed-name | name
+prefixed-name ::= prefix '/' name
+prefix ::= DNS_SUBDOMAIN
+name ::= DNS_LABEL
+```
+DNS_LABEL and DNS_SUBDOMAIN are defined in the [identifiers design doc](/docs/design/identifiers.md). The prefix is optional. If the prefix is not specified, the key is assumed to be private to the user. Other system components that wish to use labels must specify a prefix. The "kubernetes.io/" prefix is reserved for use by kubernetes components.
+
 Unlike [names and UIDs](identifiers.md), labels do not provide uniqueness. In general, we expect many objects to carry the same label(s). 
 
 Via a _label selector_, the client/user can identify a set of objects. The label selector is the core grouping primitive in Kubernetes. 

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -876,6 +876,26 @@ func TestValidatePodUpdate(t *testing.T) {
 			false,
 			"port change",
 		},
+		{
+			api.Pod{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+			api.Pod{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"Bar": "foo",
+					},
+				},
+			},
+			true,
+			"bad label change",
+		},
 	}
 
 	for _, test := range tests {
@@ -1640,6 +1660,17 @@ func TestValidateMinionUpdate(t *testing.T) {
 				Labels: map[string]string{"bar": "fooobaz"},
 			},
 		}, true},
+		{api.Node{
+			ObjectMeta: api.ObjectMeta{
+				Name:   "foo",
+				Labels: map[string]string{"foo": "baz"},
+			},
+		}, api.Node{
+			ObjectMeta: api.ObjectMeta{
+				Name:   "foo",
+				Labels: map[string]string{"Foo": "baz"},
+			},
+		}, false},
 	}
 	for i, test := range tests {
 		errs := ValidateMinionUpdate(&test.oldMinion, &test.minion)
@@ -1794,6 +1825,19 @@ func TestValidateServiceUpdate(t *testing.T) {
 				},
 				Spec: api.ServiceSpec{
 					PortalIP: "127.0.0.2",
+				},
+			}, false},
+		{ // 10
+			api.Service{
+				ObjectMeta: api.ObjectMeta{
+					Name:   "foo",
+					Labels: map[string]string{"foo": "baz"},
+				},
+			},
+			api.Service{
+				ObjectMeta: api.ObjectMeta{
+					Name:   "foo",
+					Labels: map[string]string{"Foo": "baz"},
 				},
 			}, false},
 	}


### PR DESCRIPTION
...that would have caught a bug that was in past versions. Also, copy the label key format requirements from the API types.go comments into the labels doc.

My way of feeling better about #4082 
