### PR TITLE
Remove duplicate --master arg from kube-scheduler

### DIFF
--- a/cluster/saltbase/salt/kube-scheduler/initd
+++ b/cluster/saltbase/salt/kube-scheduler/initd
@@ -18,7 +18,7 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="The Kubernetes scheduler plugin"
 NAME=kube-scheduler
 DAEMON=/usr/local/bin/kube-scheduler
-DAEMON_ARGS=" --master=127.0.0.1:8080"
+DAEMON_ARGS=" "
 DAEMON_LOG_FILE=/var/log/$NAME.log
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME


### PR DESCRIPTION
On init.d systems, kube-scheduler's is launched like this:

```
/usr/local/bin/kube-scheduler --master=127.0.0.1:8080 --master=127.0.0.1:8080 --v=2
```

This patch removes the duplicate --master arg, harmonizing it with the systemd configuration
