### PR TITLE
Adding static swagger spec and a script to update it

### DIFF
--- a/api/swagger-spec/api.json
+++ b/api/swagger-spec/api.json
@@ -1,0 +1,27 @@
+{
+  "swaggerVersion": "1.2",
+  "apiVersion": "",
+  "basePath": "127.0.0.1:8050",
+  "resourcePath": "/api",
+  "apis": [
+   {
+    "path": "/api",
+    "description": "get available api versions",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "get available api versions",
+      "nickname": "getApiVersions",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "application/json"
+      ]
+     }
+    ]
+   }
+  ]
+ }

--- a/api/swagger-spec/resourceListing.json
+++ b/api/swagger-spec/resourceListing.json
@@ -1,0 +1,30 @@
+{
+  "swaggerVersion": "1.2",
+  "apis": [
+   {
+    "path": "/api/v1beta1",
+    "description": "API at /api/v1beta1 version v1beta1"
+   },
+   {
+    "path": "/api/v1beta2",
+    "description": "API at /api/v1beta2 version v1beta2"
+   },
+   {
+    "path": "/api/v1beta3",
+    "description": "API at /api/v1beta3 version v1beta3"
+   },
+   {
+    "path": "/api",
+    "description": "get available api versions"
+   },
+   {
+    "path": "/version",
+    "description": "git code version from which this is built"
+   }
+  ],
+  "apiVersion": "",
+  "info": {
+   "title": "",
+   "description": ""
+  }
+ }

--- a/api/swagger-spec/v1beta1.json
+++ b/api/swagger-spec/v1beta1.json
@@ -1,0 +1,4247 @@
+{
+  "swaggerVersion": "1.2",
+  "apiVersion": "v1beta1",
+  "basePath": "127.0.0.1:8050",
+  "resourcePath": "/api/v1beta1",
+  "apis": [
+   {
+    "path": "/api/v1beta1/services",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.Service",
+      "method": "GET",
+      "summary": "list objects of kind Service",
+      "nickname": "listService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Service",
+      "nickname": "createService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.Service",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/replicationControllers",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.ReplicationControllerList",
+      "method": "GET",
+      "summary": "list objects of kind ReplicationController",
+      "nickname": "listReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a ReplicationController",
+      "nickname": "createReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.ReplicationController",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/events",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.EventList",
+      "method": "GET",
+      "summary": "list objects of kind Event",
+      "nickname": "listEvent",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Event",
+      "nickname": "createEvent",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.Event",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/nodes/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.Minion",
+      "method": "GET",
+      "summary": "watch a particular Node",
+      "nickname": "watchNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/redirect/nodes/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "redirect GET request to Node",
+      "nickname": "redirectNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/proxy/nodes/{name}/{path:*}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "proxy GET requests to Node",
+      "nickname": "proxyGETNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "proxy PUT requests to Node",
+      "nickname": "proxyPUTNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "proxy POST requests to Node",
+      "nickname": "proxyPOSTNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "proxy DELETE requests to Node",
+      "nickname": "proxyDELETENode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/limitRanges",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.LimitRangeList",
+      "method": "GET",
+      "summary": "watch a list of LimitRange",
+      "nickname": "watchLimitRangelist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/pods",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.PodList",
+      "method": "GET",
+      "summary": "list objects of kind Pod",
+      "nickname": "listPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Pod",
+      "nickname": "createPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.Pod",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/endpoints",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.EndpointsList",
+      "method": "GET",
+      "summary": "list objects of kind Endpoints",
+      "nickname": "listEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Endpoints",
+      "nickname": "createEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.Endpoints",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/endpoints",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.EndpointsList",
+      "method": "GET",
+      "summary": "watch a list of Endpoints",
+      "nickname": "watchEndpointslist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/redirect/minions/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "redirect GET request to Node",
+      "nickname": "redirectNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/proxy/minions/{name}/{path:*}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "proxy GET requests to Node",
+      "nickname": "proxyGETNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "proxy PUT requests to Node",
+      "nickname": "proxyPUTNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "proxy POST requests to Node",
+      "nickname": "proxyPOSTNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "proxy DELETE requests to Node",
+      "nickname": "proxyDELETENode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/pods",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.PodList",
+      "method": "GET",
+      "summary": "watch a list of Pod",
+      "nickname": "watchPodlist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/minions/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.Minion",
+      "method": "GET",
+      "summary": "watch a particular Node",
+      "nickname": "watchNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/events/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.Event",
+      "method": "GET",
+      "summary": "watch a particular Event",
+      "nickname": "watchEvent",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Event",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/pods/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.Pod",
+      "method": "GET",
+      "summary": "read the specified Pod",
+      "nickname": "readPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified Pod",
+      "nickname": "updatePod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.Pod",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Pod",
+      "nickname": "deletePod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/replicationControllers/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.ReplicationController",
+      "method": "GET",
+      "summary": "watch a particular ReplicationController",
+      "nickname": "watchReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ReplicationController",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/endpoints/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.Endpoints",
+      "method": "GET",
+      "summary": "read the specified Endpoints",
+      "nickname": "readEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Endpoints",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified Endpoints",
+      "nickname": "updateEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Endpoints",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.Endpoints",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/resourceQuotas",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.ResourceQuotaList",
+      "method": "GET",
+      "summary": "list objects of kind ResourceQuota",
+      "nickname": "listResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a ResourceQuota",
+      "nickname": "createResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.ResourceQuota",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/proxy/pods/{name}/{path:*}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "proxy GET requests to Pod",
+      "nickname": "proxyGETPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "proxy PUT requests to Pod",
+      "nickname": "proxyPUTPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "proxy POST requests to Pod",
+      "nickname": "proxyPOSTPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "proxy DELETE requests to Pod",
+      "nickname": "proxyDELETEPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/nodes",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.MinionList",
+      "method": "GET",
+      "summary": "list objects of kind Node",
+      "nickname": "listNode",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Node",
+      "nickname": "createNode",
+      "parameters": [
+       {
+        "type": "v1beta1.Minion",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/limitRanges/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.LimitRange",
+      "method": "GET",
+      "summary": "watch a particular LimitRange",
+      "nickname": "watchLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the LimitRange",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/proxy/services/{name}/{path:*}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "proxy GET requests to Service",
+      "nickname": "proxyGETService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "proxy PUT requests to Service",
+      "nickname": "proxyPUTService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "proxy POST requests to Service",
+      "nickname": "proxyPOSTService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "proxy DELETE requests to Service",
+      "nickname": "proxyDELETEService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/redirect/pods/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "redirect GET request to Pod",
+      "nickname": "redirectPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/bindings",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Binding",
+      "nickname": "createBinding",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.Binding",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/events/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.Event",
+      "method": "GET",
+      "summary": "read the specified Event",
+      "nickname": "readEvent",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Event",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Event",
+      "nickname": "deleteEvent",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Event",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/services",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.Service",
+      "method": "GET",
+      "summary": "watch a list of Service",
+      "nickname": "watchServicelist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/services/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.Service",
+      "method": "GET",
+      "summary": "watch a particular Service",
+      "nickname": "watchService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/nodes/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.Minion",
+      "method": "GET",
+      "summary": "read the specified Node",
+      "nickname": "readNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified Node",
+      "nickname": "updateNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.Minion",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Node",
+      "nickname": "deleteNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/limitRanges",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.LimitRangeList",
+      "method": "GET",
+      "summary": "list objects of kind LimitRange",
+      "nickname": "listLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a LimitRange",
+      "nickname": "createLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.LimitRange",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/replicationControllers",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.ReplicationControllerList",
+      "method": "GET",
+      "summary": "watch a list of ReplicationController",
+      "nickname": "watchReplicationControllerlist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/minions",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.MinionList",
+      "method": "GET",
+      "summary": "list objects of kind Node",
+      "nickname": "listNode",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Node",
+      "nickname": "createNode",
+      "parameters": [
+       {
+        "type": "v1beta1.Minion",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/minions",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.MinionList",
+      "method": "GET",
+      "summary": "watch a list of Node",
+      "nickname": "watchNodelist",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/resourceQuotas/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.ResourceQuota",
+      "method": "GET",
+      "summary": "read the specified ResourceQuota",
+      "nickname": "readResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ResourceQuota",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified ResourceQuota",
+      "nickname": "updateResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ResourceQuota",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.ResourceQuota",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a ResourceQuota",
+      "nickname": "deleteResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ResourceQuota",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/services/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.Service",
+      "method": "GET",
+      "summary": "read the specified Service",
+      "nickname": "readService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified Service",
+      "nickname": "updateService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.Service",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Service",
+      "nickname": "deleteService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/minions/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.Minion",
+      "method": "GET",
+      "summary": "read the specified Node",
+      "nickname": "readNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified Node",
+      "nickname": "updateNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.Minion",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Node",
+      "nickname": "deleteNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/events",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.EventList",
+      "method": "GET",
+      "summary": "watch a list of Event",
+      "nickname": "watchEventlist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/redirect/services/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "redirect GET request to Service",
+      "nickname": "redirectService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/limitRanges/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.LimitRange",
+      "method": "GET",
+      "summary": "read the specified LimitRange",
+      "nickname": "readLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the LimitRange",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified LimitRange",
+      "nickname": "updateLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the LimitRange",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.LimitRange",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a LimitRange",
+      "nickname": "deleteLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the LimitRange",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/pods/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.Pod",
+      "method": "GET",
+      "summary": "watch a particular Pod",
+      "nickname": "watchPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/replicationControllers/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.ReplicationController",
+      "method": "GET",
+      "summary": "read the specified ReplicationController",
+      "nickname": "readReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ReplicationController",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified ReplicationController",
+      "nickname": "updateReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ReplicationController",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.ReplicationController",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a ReplicationController",
+      "nickname": "deleteReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ReplicationController",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/resourceQuotas",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.ResourceQuotaList",
+      "method": "GET",
+      "summary": "watch a list of ResourceQuota",
+      "nickname": "watchResourceQuotalist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/resourceQuotas/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.ResourceQuota",
+      "method": "GET",
+      "summary": "watch a particular ResourceQuota",
+      "nickname": "watchResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ResourceQuota",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/resourceQuotaUsages",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a ResourceQuotaUsage",
+      "nickname": "createResourceQuotaUsage",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.ResourceQuotaUsage",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/endpoints/{name}",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.Endpoints",
+      "method": "GET",
+      "summary": "watch a particular Endpoints",
+      "nickname": "watchEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Endpoints",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/watch/nodes",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.MinionList",
+      "method": "GET",
+      "summary": "watch a list of Node",
+      "nickname": "watchNodelist",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   }
+  ],
+  "models": {
+   "v1beta1.Binding": {
+    "id": "v1beta1.Binding",
+    "required": [
+     "podID",
+     "host"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "host": {
+      "type": "string",
+      "description": "host to which to bind the specified pod"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "podID": {
+      "type": "string",
+      "description": "name of the pod to bind"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.Capabilities": {
+    "id": "v1beta1.Capabilities",
+    "properties": {
+     "add": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.CapabilityType"
+       }
+      ],
+      "description": "added capabilities"
+     },
+     "drop": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.CapabilityType"
+       }
+      ],
+      "description": "droped capabilities"
+     }
+    }
+   },
+   "v1beta1.CapabilityType": {
+    "id": "v1beta1.CapabilityType",
+    "properties": {}
+   },
+   "v1beta1.Container": {
+    "id": "v1beta1.Container",
+    "required": [
+     "name",
+     "image",
+     "imagePullPolicy"
+    ],
+    "properties": {
+     "capabilities": {
+      "type": "v1beta1.Capabilities",
+      "description": "capabilities for container"
+     },
+     "command": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "string"
+       }
+      ],
+      "description": "command argv array; not executed within a shell; defaults to entrypoint or command in the image"
+     },
+     "cpu": {
+      "type": "integer",
+      "format": "int32",
+      "description": "CPU share in thousandths of a core"
+     },
+     "env": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.EnvVar"
+       }
+      ],
+      "description": "list of environment variables to set in the container"
+     },
+     "image": {
+      "type": "string",
+      "description": "Docker image name"
+     },
+     "imagePullPolicy": {
+      "type": "v1beta1.PullPolicy",
+      "description": "image pull policy; one of PullAlways, PullNever, PullIfNotPresent; defaults to PullAlways if :latest tag is specified, or PullIfNotPresent otherwise"
+     },
+     "lifecycle": {
+      "type": "v1beta1.Lifecycle",
+      "description": "actions that the management system should take in response to container lifecycle events"
+     },
+     "livenessProbe": {
+      "type": "v1beta1.LivenessProbe",
+      "description": "periodic probe of container liveness; container will be restarted if the probe fails"
+     },
+     "memory": {
+      "type": "integer",
+      "format": "int64",
+      "description": "memory limit in bytes; defaults to unlimited"
+     },
+     "name": {
+      "type": "string",
+      "description": "name of the container; must be a DNS_LABEL and unique within the pod"
+     },
+     "ports": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.Port"
+       }
+      ],
+      "description": "list of ports to expose from the container"
+     },
+     "privileged": {
+      "type": "boolean",
+      "description": "whether or not the container is granted privileged status; defaults to false"
+     },
+     "resources": {
+      "type": "v1beta1.ResourceRequirementSpec",
+      "description": "Compute Resources required by this container"
+     },
+     "terminationMessagePath": {
+      "type": "string",
+      "description": "path at which the file to which the container's termination message will be written is mounted into the container's filesystem; message written is intended to be brief final status, such as an assertion failure message; defaults to /dev/termination-log"
+     },
+     "volumeMounts": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.VolumeMount"
+       }
+      ],
+      "description": "pod volumes to mount into the container's filesystem"
+     },
+     "workingDir": {
+      "type": "string",
+      "description": "container's working directory; defaults to image's default"
+     }
+    }
+   },
+   "v1beta1.ContainerManifest": {
+    "id": "v1beta1.ContainerManifest",
+    "required": [
+     "version",
+     "id",
+     "volumes",
+     "containers"
+    ],
+    "properties": {
+     "containers": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.Container"
+       }
+      ],
+      "description": "list of containers belonging to the pod"
+     },
+     "dnsPolicy": {
+      "type": "v1beta1.DNSPolicy",
+      "description": "DNS policy for containers within the pod; one of 'ClusterFirst' or 'Default'"
+     },
+     "id": {
+      "type": "string",
+      "description": "manifest name; must be a DNS_SUBDOMAIN"
+     },
+     "restartPolicy": {
+      "type": "v1beta1.RestartPolicy",
+      "description": "restart policy for all containers within the pod; one of RestartPolicyAlways, RestartPolicyOnFailure, RestartPolicyNever"
+     },
+     "uuid": {
+      "type": "types.UID",
+      "description": "manifest UUID"
+     },
+     "version": {
+      "type": "string",
+      "description": "manifest version; must be v1beta1"
+     },
+     "volumes": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.Volume"
+       }
+      ],
+      "description": "list of volumes that can be mounted by containers belonging to the pod"
+     }
+    }
+   },
+   "v1beta1.EmptyDir": {
+    "id": "v1beta1.EmptyDir",
+    "properties": {}
+   },
+   "v1beta1.Endpoints": {
+    "id": "v1beta1.Endpoints",
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "endpoints": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "string"
+       }
+      ],
+      "description": "list of endpoints corresponding to a service, of the form address:port, such as 10.10.1.1:1909"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.EndpointsList": {
+    "id": "v1beta1.EndpointsList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.Endpoints"
+       }
+      ],
+      "description": "list of service endpoint lists"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.EnvVar": {
+    "id": "v1beta1.EnvVar",
+    "required": [
+     "name"
+    ],
+    "properties": {
+     "key": {
+      "type": "string",
+      "description": "name of the environment variable; must be a C_IDENTIFIER; deprecated - use name instead"
+     },
+     "name": {
+      "type": "string",
+      "description": "name of the environment variable; must be a C_IDENTIFIER"
+     },
+     "value": {
+      "type": "string",
+      "description": "value of the environment variable; defaults to empty string"
+     }
+    }
+   },
+   "v1beta1.Event": {
+    "id": "v1beta1.Event",
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "host": {
+      "type": "string",
+      "description": "host name on which this event was generated"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "involvedObject": {
+      "type": "v1beta1.ObjectReference",
+      "description": "object that this event is about"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "message": {
+      "type": "string",
+      "description": "human-readable description of the status of this operation"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "reason": {
+      "type": "string",
+      "description": "short, machine understandable string that gives the reason for the transition into the object's current status"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "source": {
+      "type": "string",
+      "description": "component reporting this event; short machine understandable string"
+     },
+     "status": {
+      "type": "string",
+      "description": "short, machine understandable string that describes the current status of the referred object"
+     },
+     "timestamp": {
+      "type": "string",
+      "description": "time at which the client recorded the event"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.EventList": {
+    "id": "v1beta1.EventList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.Event"
+       }
+      ],
+      "description": "list of events"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.ExecAction": {
+    "id": "v1beta1.ExecAction",
+    "properties": {
+     "command": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "string"
+       }
+      ],
+      "description": "command line to execute inside the container; working directory for the command is root ('/') in the container's file system; the command is exec'd, not run inside a shell; exit status of 0 is treated as live/healthy and non-zero is unhealthy"
+     }
+    }
+   },
+   "v1beta1.GCEPersistentDisk": {
+    "id": "v1beta1.GCEPersistentDisk",
+    "required": [
+     "pdName"
+    ],
+    "properties": {
+     "fsType": {
+      "type": "string",
+      "description": "file system type to mount, such as ext4, xfs, ntfs"
+     },
+     "partition": {
+      "type": "integer",
+      "format": "int32",
+      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted"
+     },
+     "pdName": {
+      "type": "string",
+      "description": "unique name of the PD resource in GCE"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "read-only if true, read-write otherwise (false or unspecified)"
+     }
+    }
+   },
+   "v1beta1.GitRepo": {
+    "id": "v1beta1.GitRepo",
+    "required": [
+     "repository",
+     "revision"
+    ],
+    "properties": {
+     "repository": {
+      "type": "string",
+      "description": "repository URL"
+     },
+     "revision": {
+      "type": "string",
+      "description": "commit hash for the specified revision"
+     }
+    }
+   },
+   "v1beta1.HTTPGetAction": {
+    "id": "v1beta1.HTTPGetAction",
+    "properties": {
+     "host": {
+      "type": "string",
+      "description": "hostname to connect to; defaults to pod IP"
+     },
+     "path": {
+      "type": "string",
+      "description": "path to access on the HTTP server"
+     },
+     "port": {
+      "type": "string",
+      "description": "number or name of the port to access on the container"
+     }
+    }
+   },
+   "v1beta1.Handler": {
+    "id": "v1beta1.Handler",
+    "properties": {
+     "exec": {
+      "type": "v1beta1.ExecAction",
+      "description": "exec-based handler"
+     },
+     "httpGet": {
+      "type": "v1beta1.HTTPGetAction",
+      "description": "HTTP-based handler"
+     },
+     "tcpSocket": {
+      "type": "v1beta1.TCPSocketAction",
+      "description": "TCP-based handler; TCP hooks not yet supported"
+     }
+    }
+   },
+   "v1beta1.HostPath": {
+    "id": "v1beta1.HostPath",
+    "required": [
+     "path"
+    ],
+    "properties": {
+     "path": {
+      "type": "string",
+      "description": "path of the directory on the host"
+     }
+    }
+   },
+   "v1beta1.Lifecycle": {
+    "id": "v1beta1.Lifecycle",
+    "properties": {
+     "postStart": {
+      "type": "v1beta1.Handler",
+      "description": "called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes"
+     },
+     "preStop": {
+      "type": "v1beta1.Handler",
+      "description": "called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes"
+     }
+    }
+   },
+   "v1beta1.LimitRange": {
+    "id": "v1beta1.LimitRange",
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "spec": {
+      "type": "v1beta1.LimitRangeSpec"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.LimitRangeItem": {
+    "id": "v1beta1.LimitRangeItem",
+    "properties": {
+     "max": {
+      "type": "v1beta1.ResourceList"
+     },
+     "min": {
+      "type": "v1beta1.ResourceList"
+     },
+     "type": {
+      "type": "v1beta1.LimitType"
+     }
+    }
+   },
+   "v1beta1.LimitRangeList": {
+    "id": "v1beta1.LimitRangeList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.LimitRange"
+       }
+      ]
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.LimitRangeSpec": {
+    "id": "v1beta1.LimitRangeSpec",
+    "required": [
+     "limits"
+    ],
+    "properties": {
+     "limits": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.LimitRangeItem"
+       }
+      ]
+     }
+    }
+   },
+   "v1beta1.LivenessProbe": {
+    "id": "v1beta1.LivenessProbe",
+    "properties": {
+     "exec": {
+      "type": "v1beta1.ExecAction",
+      "description": "parameters for exec-based liveness probe"
+     },
+     "httpGet": {
+      "type": "v1beta1.HTTPGetAction",
+      "description": "parameters for HTTP-based liveness probe"
+     },
+     "initialDelaySeconds": {
+      "type": "integer",
+      "format": "int64",
+      "description": "number of seconds after the container has started before liveness probes are initiated"
+     },
+     "tcpSocket": {
+      "type": "v1beta1.TCPSocketAction",
+      "description": "parameters for TCP-based liveness probe"
+     }
+    }
+   },
+   "v1beta1.Minion": {
+    "id": "v1beta1.Minion",
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "hostIP": {
+      "type": "string",
+      "description": "IP address of the node"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "labels": {
+      "type": "v1beta1.Minion.labels",
+      "description": "map of string keys and values that can be used to organize and categorize minions; labels of a minion assigned by the scheduler must match the scheduled pod's nodeSelector"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "resources": {
+      "type": "v1beta1.NodeResources",
+      "description": "characterization of node resources"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "status": {
+      "type": "v1beta1.NodeStatus",
+      "description": "current status of node"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.Minion.labels": {
+    "id": "v1beta1.Minion.labels",
+    "properties": {}
+   },
+   "v1beta1.MinionList": {
+    "id": "v1beta1.MinionList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.Minion"
+       }
+      ],
+      "description": "list of nodes"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "minions": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.Minion"
+       }
+      ],
+      "description": "list of nodes; deprecated"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.NodeCondition": {
+    "id": "v1beta1.NodeCondition",
+    "required": [
+     "kind",
+     "status"
+    ],
+    "properties": {
+     "kind": {
+      "type": "v1beta1.NodeConditionKind",
+      "description": "kind of the condition, one of reachable, ready"
+     },
+     "lastTransitionTime": {
+      "type": "string",
+      "description": "last time the condition transit from one status to another"
+     },
+     "message": {
+      "type": "string",
+      "description": "human readable message indicating details about last transition"
+     },
+     "reason": {
+      "type": "string",
+      "description": "(brief) reason for the condition's last transition"
+     },
+     "status": {
+      "type": "v1beta1.NodeConditionStatus",
+      "description": "status of the condition, one of full, none, unknown"
+     }
+    }
+   },
+   "v1beta1.NodeResources": {
+    "id": "v1beta1.NodeResources",
+    "properties": {
+     "capacity": {
+      "type": "v1beta1.ResourceList",
+      "description": "resource capacity of a node represented as a map of resource name to quantity of resource"
+     }
+    }
+   },
+   "v1beta1.NodeStatus": {
+    "id": "v1beta1.NodeStatus",
+    "properties": {
+     "conditions": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.NodeCondition"
+       }
+      ],
+      "description": "conditions is an array of current node conditions"
+     },
+     "phase": {
+      "type": "v1beta1.NodePhase",
+      "description": "node phase is the current lifecycle phase of the node"
+     }
+    }
+   },
+   "v1beta1.ObjectReference": {
+    "id": "v1beta1.ObjectReference",
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent"
+     },
+     "fieldPath": {
+      "type": "string",
+      "description": "if referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of the referent"
+     },
+     "name": {
+      "type": "string",
+      "description": "id of the referent"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace of the referent"
+     },
+     "resourceVersion": {
+      "type": "string",
+      "description": "specific resourceVersion to which this reference is made, if any"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "uid of the referent"
+     }
+    }
+   },
+   "v1beta1.Pod": {
+    "id": "v1beta1.Pod",
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "currentState": {
+      "type": "v1beta1.PodState",
+      "description": "current state of the pod"
+     },
+     "desiredState": {
+      "type": "v1beta1.PodState",
+      "description": "specification of the desired state of the pod"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "labels": {
+      "type": "v1beta1.Pod.labels",
+      "description": "map of string keys and values that can be used to organize and categorize pods; may match selectors of replication controllers and services"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "nodeSelector": {
+      "type": "v1beta1.Pod.nodeSelector",
+      "description": "selector which must match a node's labels for the pod to be scheduled on that node"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.Pod.labels": {
+    "id": "v1beta1.Pod.labels",
+    "properties": {}
+   },
+   "v1beta1.Pod.nodeSelector": {
+    "id": "v1beta1.Pod.nodeSelector",
+    "properties": {}
+   },
+   "v1beta1.PodList": {
+    "id": "v1beta1.PodList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.Pod"
+       }
+      ],
+      "description": "list of pods"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.PodState": {
+    "id": "v1beta1.PodState",
+    "properties": {
+     "host": {
+      "type": "string",
+      "description": "host to which the pod is assigned; empty if not yet scheduled"
+     },
+     "hostIP": {
+      "type": "string",
+      "description": "IP address of the host to which the pod is assigned; empty if not yet scheduled"
+     },
+     "info": {
+      "type": "v1beta1.PodInfo",
+      "description": "map of container name to container status"
+     },
+     "manifest": {
+      "type": "v1beta1.ContainerManifest",
+      "description": "manifest of containers and volumes comprising the pod"
+     },
+     "message": {
+      "type": "string",
+      "description": "human readable message indicating details about why the pod is in this condition"
+     },
+     "podIP": {
+      "type": "string",
+      "description": "IP address allocated to the pod; routable at least within the cluster; empty if not yet allocated"
+     },
+     "status": {
+      "type": "v1beta1.PodStatus",
+      "description": "current condition of the pod, Waiting, Running, or Terminated"
+     }
+    }
+   },
+   "v1beta1.PodTemplate": {
+    "id": "v1beta1.PodTemplate",
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.PodTemplate.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about pods created from the template"
+     },
+     "desiredState": {
+      "type": "v1beta1.PodState",
+      "description": "specification of the desired state of pods created from this template"
+     },
+     "labels": {
+      "type": "v1beta1.PodTemplate.labels",
+      "description": "map of string keys and values that can be used to organize and categorize the pods created from the template; must match the selector of the replication controller to which the template belongs; may match selectors of services"
+     },
+     "nodeSelector": {
+      "type": "v1beta1.PodTemplate.nodeSelector",
+      "description": "a selector which must be true for the pod to fit on a node"
+     }
+    }
+   },
+   "v1beta1.PodTemplate.annotations": {
+    "id": "v1beta1.PodTemplate.annotations",
+    "properties": {}
+   },
+   "v1beta1.PodTemplate.labels": {
+    "id": "v1beta1.PodTemplate.labels",
+    "properties": {}
+   },
+   "v1beta1.PodTemplate.nodeSelector": {
+    "id": "v1beta1.PodTemplate.nodeSelector",
+    "properties": {}
+   },
+   "v1beta1.Port": {
+    "id": "v1beta1.Port",
+    "required": [
+     "containerPort"
+    ],
+    "properties": {
+     "containerPort": {
+      "type": "integer",
+      "format": "int32",
+      "description": "number of port to expose on the pod's IP address"
+     },
+     "hostIP": {
+      "type": "string",
+      "description": "host IP to bind the port to"
+     },
+     "hostPort": {
+      "type": "integer",
+      "format": "int32",
+      "description": "number of port to expose on the host; most containers do not need this"
+     },
+     "name": {
+      "type": "string",
+      "description": "name for the port that can be referred to by services; must be a DNS_LABEL and unique without the pod"
+     },
+     "protocol": {
+      "type": "v1beta1.Protocol",
+      "description": "protocol for port; must be UDP or TCP; TCP if unspecified"
+     }
+    }
+   },
+   "v1beta1.ReplicationController": {
+    "id": "v1beta1.ReplicationController",
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "currentState": {
+      "type": "v1beta1.ReplicationControllerState",
+      "description": "current state of the replication controller"
+     },
+     "desiredState": {
+      "type": "v1beta1.ReplicationControllerState",
+      "description": "specification of the desired state of the replication controller"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "labels": {
+      "type": "v1beta1.ReplicationController.labels",
+      "description": "map of string keys and values that can be used to organize and categorize replication controllers"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.ReplicationController.labels": {
+    "id": "v1beta1.ReplicationController.labels",
+    "properties": {}
+   },
+   "v1beta1.ReplicationControllerList": {
+    "id": "v1beta1.ReplicationControllerList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.ReplicationController"
+       }
+      ],
+      "description": "list of replication controllers"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.ReplicationControllerState": {
+    "id": "v1beta1.ReplicationControllerState",
+    "required": [
+     "replicas"
+    ],
+    "properties": {
+     "podTemplate": {
+      "type": "v1beta1.PodTemplate",
+      "description": "template for pods to be created by this replication controller when the observed number of replicas is less than the desired number of replicas"
+     },
+     "replicaSelector": {
+      "type": "v1beta1.ReplicationControllerState.replicaSelector",
+      "description": "label keys and values that must match in order to be controlled by this replication controller"
+     },
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "number of replicas (desired or observed, as appropriate)"
+     }
+    }
+   },
+   "v1beta1.ReplicationControllerState.replicaSelector": {
+    "id": "v1beta1.ReplicationControllerState.replicaSelector",
+    "properties": {}
+   },
+   "v1beta1.ResourceQuota": {
+    "id": "v1beta1.ResourceQuota",
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "spec": {
+      "type": "v1beta1.ResourceQuotaSpec"
+     },
+     "status": {
+      "type": "v1beta1.ResourceQuotaStatus"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.ResourceQuotaList": {
+    "id": "v1beta1.ResourceQuotaList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta1.ResourceQuota"
+       }
+      ]
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.ResourceQuotaSpec": {
+    "id": "v1beta1.ResourceQuotaSpec",
+    "properties": {
+     "hard": {
+      "type": "v1beta1.ResourceList"
+     }
+    }
+   },
+   "v1beta1.ResourceQuotaStatus": {
+    "id": "v1beta1.ResourceQuotaStatus",
+    "properties": {
+     "hard": {
+      "type": "v1beta1.ResourceList"
+     },
+     "used": {
+      "type": "v1beta1.ResourceList"
+     }
+    }
+   },
+   "v1beta1.ResourceQuotaUsage": {
+    "id": "v1beta1.ResourceQuotaUsage",
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "status": {
+      "type": "v1beta1.ResourceQuotaStatus"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.ResourceRequirementSpec": {
+    "id": "v1beta1.ResourceRequirementSpec",
+    "properties": {
+     "limits": {
+      "type": "v1beta1.ResourceList",
+      "description": "Maximum amount of compute resources allowed"
+     }
+    }
+   },
+   "v1beta1.RestartPolicy": {
+    "id": "v1beta1.RestartPolicy",
+    "properties": {
+     "always": {
+      "type": "v1beta1.RestartPolicyAlways",
+      "description": "always restart the container after termination"
+     },
+     "never": {
+      "type": "v1beta1.RestartPolicyNever",
+      "description": "never restart the container"
+     },
+     "onFailure": {
+      "type": "v1beta1.RestartPolicyOnFailure",
+      "description": "restart the container if it fails for any reason, but not if it succeeds (exit 0)"
+     }
+    }
+   },
+   "v1beta1.RestartPolicyAlways": {
+    "id": "v1beta1.RestartPolicyAlways",
+    "properties": {}
+   },
+   "v1beta1.RestartPolicyNever": {
+    "id": "v1beta1.RestartPolicyNever",
+    "properties": {}
+   },
+   "v1beta1.RestartPolicyOnFailure": {
+    "id": "v1beta1.RestartPolicyOnFailure",
+    "properties": {}
+   },
+   "v1beta1.Service": {
+    "id": "v1beta1.Service",
+    "required": [
+     "port",
+     "selector"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta1.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "containerPort": {
+      "type": "string",
+      "description": "number or name of the port to access on the containers belonging to pods targeted by the service"
+     },
+     "createExternalLoadBalancer": {
+      "type": "boolean",
+      "description": "set up a cloud-provider-specific load balancer on an external IP"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "labels": {
+      "type": "v1beta1.Service.labels",
+      "description": "map of string keys and values that can be used to organize and categorize services"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "port": {
+      "type": "integer",
+      "format": "int32",
+      "description": "port exposed by the service"
+     },
+     "portalIP": {
+      "type": "string",
+      "description": "IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused, and creation of the service will fail otherwise; cannot be updated"
+     },
+     "protocol": {
+      "type": "v1beta1.Protocol",
+      "description": "protocol for port; must be UDP or TCP; TCP if unspecified"
+     },
+     "proxyPort": {
+      "type": "integer",
+      "format": "int32",
+      "description": "if non-zero, a pre-allocated host port used for this service by the proxy on each node; assigned by the master and ignored on input"
+     },
+     "publicIPs": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "string"
+       }
+      ],
+      "description": "externally visible IPs from which to select the address for the external load balancer"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selector": {
+      "type": "v1beta1.Service.selector",
+      "description": "label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "sessionAffinity": {
+      "type": "v1beta1.AffinityType",
+      "description": "enable client IP based session affinity; must be ClientIP or None; defaults to None"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta1.Service.labels": {
+    "id": "v1beta1.Service.labels",
+    "properties": {}
+   },
+   "v1beta1.Service.selector": {
+    "id": "v1beta1.Service.selector",
+    "properties": {}
+   },
+   "v1beta1.TCPSocketAction": {
+    "id": "v1beta1.TCPSocketAction",
+    "properties": {
+     "port": {
+      "type": "string",
+      "description": "number of name of the port to access on the container"
+     }
+    }
+   },
+   "v1beta1.Volume": {
+    "id": "v1beta1.Volume",
+    "required": [
+     "name"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "volume name; must be a DNS_LABEL and unique within the pod"
+     },
+     "source": {
+      "type": "v1beta1.VolumeSource",
+      "description": "location and type of volume to mount; at most one of HostDir, EmptyDir, GCEPersistentDisk, or GitRepo; default is EmptyDir"
+     }
+    }
+   },
+   "v1beta1.VolumeMount": {
+    "id": "v1beta1.VolumeMount",
+    "required": [
+     "name",
+     "mountPath"
+    ],
+    "properties": {
+     "mountPath": {
+      "type": "string",
+      "description": "path within the container at which the volume should be mounted; overrides path"
+     },
+     "mountType": {
+      "type": "string",
+      "description": "LOCAL or HOST; defaults to LOCAL; deprecated"
+     },
+     "name": {
+      "type": "string",
+      "description": "name of the volume to mount"
+     },
+     "path": {
+      "type": "string",
+      "description": "path within the container at which the volume should be mounted; deprecated"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "mounted read-only if true, read-write otherwise (false or unspecified)"
+     }
+    }
+   },
+   "v1beta1.VolumeSource": {
+    "id": "v1beta1.VolumeSource",
+    "required": [
+     "hostDir",
+     "emptyDir",
+     "persistentDisk",
+     "gitRepo"
+    ],
+    "properties": {
+     "emptyDir": {
+      "type": "v1beta1.EmptyDir",
+      "description": "temporary directory that shares a pod's lifetime"
+     },
+     "gitRepo": {
+      "type": "v1beta1.GitRepo",
+      "description": "git repository at a particular revision"
+     },
+     "hostDir": {
+      "type": "v1beta1.HostPath",
+      "description": "pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host"
+     },
+     "persistentDisk": {
+      "type": "v1beta1.GCEPersistentDisk",
+      "description": "GCE disk resource attached to the host machine on demand"
+     }
+    }
+   }
+  }
+ }

--- a/api/swagger-spec/v1beta2.json
+++ b/api/swagger-spec/v1beta2.json
@@ -1,0 +1,4226 @@
+{
+  "swaggerVersion": "1.2",
+  "apiVersion": "v1beta2",
+  "basePath": "127.0.0.1:8050",
+  "resourcePath": "/api/v1beta2",
+  "apis": [
+   {
+    "path": "/api/v1beta2/watch/endpoints",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.EndpointsList",
+      "method": "GET",
+      "summary": "watch a list of Endpoints",
+      "nickname": "watchEndpointslist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/pods/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.Pod",
+      "method": "GET",
+      "summary": "read the specified Pod",
+      "nickname": "readPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified Pod",
+      "nickname": "updatePod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.Pod",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Pod",
+      "nickname": "deletePod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/redirect/pods/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "redirect GET request to Pod",
+      "nickname": "redirectPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/minions/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.Minion",
+      "method": "GET",
+      "summary": "read the specified Node",
+      "nickname": "readNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified Node",
+      "nickname": "updateNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.Minion",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Node",
+      "nickname": "deleteNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/services/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.Service",
+      "method": "GET",
+      "summary": "watch a particular Service",
+      "nickname": "watchService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/limitRanges",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.LimitRangeList",
+      "method": "GET",
+      "summary": "list objects of kind LimitRange",
+      "nickname": "listLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a LimitRange",
+      "nickname": "createLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.LimitRange",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/limitRanges",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.LimitRangeList",
+      "method": "GET",
+      "summary": "watch a list of LimitRange",
+      "nickname": "watchLimitRangelist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/resourceQuotas",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.ResourceQuotaList",
+      "method": "GET",
+      "summary": "list objects of kind ResourceQuota",
+      "nickname": "listResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a ResourceQuota",
+      "nickname": "createResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.ResourceQuota",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/resourceQuotas/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.ResourceQuota",
+      "method": "GET",
+      "summary": "watch a particular ResourceQuota",
+      "nickname": "watchResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ResourceQuota",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/redirect/minions/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "redirect GET request to Node",
+      "nickname": "redirectNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/redirect/services/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "redirect GET request to Service",
+      "nickname": "redirectService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/redirect/nodes/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "redirect GET request to Node",
+      "nickname": "redirectNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/proxy/nodes/{name}/{path:*}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "proxy GET requests to Node",
+      "nickname": "proxyGETNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "proxy PUT requests to Node",
+      "nickname": "proxyPUTNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "proxy POST requests to Node",
+      "nickname": "proxyPOSTNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "proxy DELETE requests to Node",
+      "nickname": "proxyDELETENode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/replicationControllers",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.ReplicationControllerList",
+      "method": "GET",
+      "summary": "list objects of kind ReplicationController",
+      "nickname": "listReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a ReplicationController",
+      "nickname": "createReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.ReplicationController",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/limitRanges/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.LimitRange",
+      "method": "GET",
+      "summary": "read the specified LimitRange",
+      "nickname": "readLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the LimitRange",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified LimitRange",
+      "nickname": "updateLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the LimitRange",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.LimitRange",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a LimitRange",
+      "nickname": "deleteLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the LimitRange",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/bindings",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Binding",
+      "nickname": "createBinding",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.Binding",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/minions/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.Minion",
+      "method": "GET",
+      "summary": "watch a particular Node",
+      "nickname": "watchNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/events",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.EventList",
+      "method": "GET",
+      "summary": "watch a list of Event",
+      "nickname": "watchEventlist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/events/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.Event",
+      "method": "GET",
+      "summary": "read the specified Event",
+      "nickname": "readEvent",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Event",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Event",
+      "nickname": "deleteEvent",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Event",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/services",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.Service",
+      "method": "GET",
+      "summary": "list objects of kind Service",
+      "nickname": "listService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Service",
+      "nickname": "createService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.Service",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/replicationControllers/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.ReplicationController",
+      "method": "GET",
+      "summary": "read the specified ReplicationController",
+      "nickname": "readReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ReplicationController",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified ReplicationController",
+      "nickname": "updateReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ReplicationController",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.ReplicationController",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a ReplicationController",
+      "nickname": "deleteReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ReplicationController",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/resourceQuotas/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.ResourceQuota",
+      "method": "GET",
+      "summary": "read the specified ResourceQuota",
+      "nickname": "readResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ResourceQuota",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified ResourceQuota",
+      "nickname": "updateResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ResourceQuota",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.ResourceQuota",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a ResourceQuota",
+      "nickname": "deleteResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ResourceQuota",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/pods",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.PodList",
+      "method": "GET",
+      "summary": "list objects of kind Pod",
+      "nickname": "listPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Pod",
+      "nickname": "createPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.Pod",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/proxy/minions/{name}/{path:*}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "proxy GET requests to Node",
+      "nickname": "proxyGETNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "proxy PUT requests to Node",
+      "nickname": "proxyPUTNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "proxy POST requests to Node",
+      "nickname": "proxyPOSTNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "proxy DELETE requests to Node",
+      "nickname": "proxyDELETENode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/endpoints",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.EndpointsList",
+      "method": "GET",
+      "summary": "list objects of kind Endpoints",
+      "nickname": "listEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Endpoints",
+      "nickname": "createEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.Endpoints",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/nodes/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.Minion",
+      "method": "GET",
+      "summary": "watch a particular Node",
+      "nickname": "watchNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/replicationControllers",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.ReplicationControllerList",
+      "method": "GET",
+      "summary": "watch a list of ReplicationController",
+      "nickname": "watchReplicationControllerlist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/resourceQuotas",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.ResourceQuotaList",
+      "method": "GET",
+      "summary": "watch a list of ResourceQuota",
+      "nickname": "watchResourceQuotalist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/limitRanges/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.LimitRange",
+      "method": "GET",
+      "summary": "watch a particular LimitRange",
+      "nickname": "watchLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the LimitRange",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/minions",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.MinionList",
+      "method": "GET",
+      "summary": "list objects of kind Node",
+      "nickname": "listNode",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Node",
+      "nickname": "createNode",
+      "parameters": [
+       {
+        "type": "v1beta2.Minion",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/proxy/services/{name}/{path:*}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "proxy GET requests to Service",
+      "nickname": "proxyGETService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "proxy PUT requests to Service",
+      "nickname": "proxyPUTService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "proxy POST requests to Service",
+      "nickname": "proxyPOSTService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "proxy DELETE requests to Service",
+      "nickname": "proxyDELETEService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/nodes",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.MinionList",
+      "method": "GET",
+      "summary": "list objects of kind Node",
+      "nickname": "listNode",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Node",
+      "nickname": "createNode",
+      "parameters": [
+       {
+        "type": "v1beta2.Minion",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/nodes/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.Minion",
+      "method": "GET",
+      "summary": "read the specified Node",
+      "nickname": "readNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified Node",
+      "nickname": "updateNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.Minion",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Node",
+      "nickname": "deleteNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/nodes",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.MinionList",
+      "method": "GET",
+      "summary": "watch a list of Node",
+      "nickname": "watchNodelist",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/replicationControllers/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.ReplicationController",
+      "method": "GET",
+      "summary": "watch a particular ReplicationController",
+      "nickname": "watchReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ReplicationController",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/pods/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.Pod",
+      "method": "GET",
+      "summary": "watch a particular Pod",
+      "nickname": "watchPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/proxy/pods/{name}/{path:*}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "proxy GET requests to Pod",
+      "nickname": "proxyGETPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "proxy PUT requests to Pod",
+      "nickname": "proxyPUTPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "proxy POST requests to Pod",
+      "nickname": "proxyPOSTPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "proxy DELETE requests to Pod",
+      "nickname": "proxyDELETEPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/minions",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.MinionList",
+      "method": "GET",
+      "summary": "watch a list of Node",
+      "nickname": "watchNodelist",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/services",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.Service",
+      "method": "GET",
+      "summary": "watch a list of Service",
+      "nickname": "watchServicelist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/services/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.Service",
+      "method": "GET",
+      "summary": "read the specified Service",
+      "nickname": "readService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified Service",
+      "nickname": "updateService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.Service",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Service",
+      "nickname": "deleteService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/endpoints/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.Endpoints",
+      "method": "GET",
+      "summary": "read the specified Endpoints",
+      "nickname": "readEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Endpoints",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified Endpoints",
+      "nickname": "updateEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Endpoints",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.Endpoints",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/pods",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.PodList",
+      "method": "GET",
+      "summary": "watch a list of Pod",
+      "nickname": "watchPodlist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/events",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.EventList",
+      "method": "GET",
+      "summary": "list objects of kind Event",
+      "nickname": "listEvent",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Event",
+      "nickname": "createEvent",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.Event",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/events/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.Event",
+      "method": "GET",
+      "summary": "watch a particular Event",
+      "nickname": "watchEvent",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Event",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/resourceQuotaUsages",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a ResourceQuotaUsage",
+      "nickname": "createResourceQuotaUsage",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.ResourceQuotaUsage",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/watch/endpoints/{name}",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "v1beta2.Endpoints",
+      "method": "GET",
+      "summary": "watch a particular Endpoints",
+      "nickname": "watchEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Endpoints",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   }
+  ],
+  "models": {
+   "v1beta2.Binding": {
+    "id": "v1beta2.Binding",
+    "required": [
+     "podID",
+     "host"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "host": {
+      "type": "string",
+      "description": "host to which to bind the specified pod"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "podID": {
+      "type": "string",
+      "description": "name of the pod to bind"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.Capabilities": {
+    "id": "v1beta2.Capabilities",
+    "properties": {
+     "add": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta2.CapabilityType"
+       }
+      ],
+      "description": "added capabilities"
+     },
+     "drop": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta2.CapabilityType"
+       }
+      ],
+      "description": "droped capabilities"
+     }
+    }
+   },
+   "v1beta2.CapabilityType": {
+    "id": "v1beta2.CapabilityType",
+    "properties": {}
+   },
+   "v1beta2.Container": {
+    "id": "v1beta2.Container",
+    "required": [
+     "name",
+     "image",
+     "imagePullPolicy"
+    ],
+    "properties": {
+     "capabilities": {
+      "type": "v1beta2.Capabilities",
+      "description": "capabilities for container"
+     },
+     "command": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "string"
+       }
+      ],
+      "description": "command argv array; not executed within a shell; defaults to entrypoint or command in the image"
+     },
+     "cpu": {
+      "type": "integer",
+      "format": "int32",
+      "description": "CPU share in thousandths of a core"
+     },
+     "env": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta2.EnvVar"
+       }
+      ],
+      "description": "list of environment variables to set in the container"
+     },
+     "image": {
+      "type": "string",
+      "description": "Docker image name"
+     },
+     "imagePullPolicy": {
+      "type": "v1beta2.PullPolicy",
+      "description": "image pull policy; one of PullAlways, PullNever, PullIfNotPresent; defaults to PullAlways if :latest tag is specified, or PullIfNotPresent otherwise"
+     },
+     "lifecycle": {
+      "type": "v1beta2.Lifecycle",
+      "description": "actions that the management system should take in response to container lifecycle events"
+     },
+     "livenessProbe": {
+      "type": "v1beta2.LivenessProbe",
+      "description": "periodic probe of container liveness; container will be restarted if the probe fails"
+     },
+     "memory": {
+      "type": "integer",
+      "format": "int64",
+      "description": "memory limit in bytes; defaults to unlimited"
+     },
+     "name": {
+      "type": "string",
+      "description": "name of the container; must be a DNS_LABEL and unique within the pod"
+     },
+     "ports": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta2.Port"
+       }
+      ],
+      "description": "list of ports to expose from the container"
+     },
+     "privileged": {
+      "type": "boolean",
+      "description": "whether or not the container is granted privileged status; defaults to false"
+     },
+     "resources": {
+      "type": "v1beta2.ResourceRequirementSpec",
+      "description": "Compute Resources required by this container"
+     },
+     "terminationMessagePath": {
+      "type": "string",
+      "description": "path at which the file to which the container's termination message will be written is mounted into the container's filesystem; message written is intended to be brief final status, such as an assertion failure message; defaults to /dev/termination-log"
+     },
+     "volumeMounts": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta2.VolumeMount"
+       }
+      ],
+      "description": "pod volumes to mount into the container's filesystem"
+     },
+     "workingDir": {
+      "type": "string",
+      "description": "container's working directory; defaults to image's default"
+     }
+    }
+   },
+   "v1beta2.ContainerManifest": {
+    "id": "v1beta2.ContainerManifest",
+    "required": [
+     "version",
+     "id",
+     "volumes",
+     "containers"
+    ],
+    "properties": {
+     "containers": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta2.Container"
+       }
+      ],
+      "description": "list of containers belonging to the pod"
+     },
+     "dnsPolicy": {
+      "type": "v1beta2.DNSPolicy",
+      "description": "DNS policy for containers within the pod; one of 'ClusterFirst' or 'Default'"
+     },
+     "id": {
+      "type": "string",
+      "description": "manifest name; must be a DNS_SUBDOMAIN"
+     },
+     "restartPolicy": {
+      "type": "v1beta2.RestartPolicy",
+      "description": "restart policy for all containers within the pod; one of RestartPolicyAlways, RestartPolicyOnFailure, RestartPolicyNever"
+     },
+     "uuid": {
+      "type": "types.UID",
+      "description": "manifest UUID"
+     },
+     "version": {
+      "type": "string",
+      "description": "manifest version; must be v1beta1"
+     },
+     "volumes": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta2.Volume"
+       }
+      ],
+      "description": "list of volumes that can be mounted by containers belonging to the pod"
+     }
+    }
+   },
+   "v1beta2.EmptyDir": {
+    "id": "v1beta2.EmptyDir",
+    "properties": {}
+   },
+   "v1beta2.Endpoints": {
+    "id": "v1beta2.Endpoints",
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "endpoints": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "string"
+       }
+      ],
+      "description": "list of endpoints corresponding to a service, of the form address:port, such as 10.10.1.1:1909"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.EndpointsList": {
+    "id": "v1beta2.EndpointsList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta2.Endpoints"
+       }
+      ],
+      "description": "list of service endpoint lists"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.EnvVar": {
+    "id": "v1beta2.EnvVar",
+    "required": [
+     "name"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name of the environment variable; must be a C_IDENTIFIER"
+     },
+     "value": {
+      "type": "string",
+      "description": "value of the environment variable; defaults to empty string"
+     }
+    }
+   },
+   "v1beta2.Event": {
+    "id": "v1beta2.Event",
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "host": {
+      "type": "string",
+      "description": "host name on which this event was generated"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "involvedObject": {
+      "type": "v1beta2.ObjectReference",
+      "description": "object that this event is about"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "message": {
+      "type": "string",
+      "description": "human-readable description of the status of this operation"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "reason": {
+      "type": "string",
+      "description": "short, machine understandable string that gives the reason for the transition into the object's current status"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "source": {
+      "type": "string",
+      "description": "component reporting this event; short machine understandable string"
+     },
+     "status": {
+      "type": "string",
+      "description": "short, machine understandable string that describes the current status of the referred object"
+     },
+     "timestamp": {
+      "type": "string",
+      "description": "time at which the client recorded the event"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.EventList": {
+    "id": "v1beta2.EventList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta2.Event"
+       }
+      ],
+      "description": "list of events"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.ExecAction": {
+    "id": "v1beta2.ExecAction",
+    "properties": {
+     "command": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "string"
+       }
+      ],
+      "description": "command line to execute inside the container; working directory for the command is root ('/') in the container's file system; the command is exec'd, not run inside a shell; exit status of 0 is treated as live/healthy and non-zero is unhealthy"
+     }
+    }
+   },
+   "v1beta2.GCEPersistentDisk": {
+    "id": "v1beta2.GCEPersistentDisk",
+    "required": [
+     "pdName"
+    ],
+    "properties": {
+     "fsType": {
+      "type": "string",
+      "description": "file system type to mount, such as ext4, xfs, ntfs"
+     },
+     "partition": {
+      "type": "integer",
+      "format": "int32",
+      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted"
+     },
+     "pdName": {
+      "type": "string",
+      "description": "unique name of the PD resource in GCE"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "read-only if true, read-write otherwise (false or unspecified)"
+     }
+    }
+   },
+   "v1beta2.GitRepo": {
+    "id": "v1beta2.GitRepo",
+    "required": [
+     "repository",
+     "revision"
+    ],
+    "properties": {
+     "repository": {
+      "type": "string",
+      "description": "repository URL"
+     },
+     "revision": {
+      "type": "string",
+      "description": "commit hash for the specified revision"
+     }
+    }
+   },
+   "v1beta2.HTTPGetAction": {
+    "id": "v1beta2.HTTPGetAction",
+    "properties": {
+     "host": {
+      "type": "string",
+      "description": "hostname to connect to; defaults to pod IP"
+     },
+     "path": {
+      "type": "string",
+      "description": "path to access on the HTTP server"
+     },
+     "port": {
+      "type": "string",
+      "description": "number or name of the port to access on the container"
+     }
+    }
+   },
+   "v1beta2.Handler": {
+    "id": "v1beta2.Handler",
+    "properties": {
+     "exec": {
+      "type": "v1beta2.ExecAction",
+      "description": "exec-based handler"
+     },
+     "httpGet": {
+      "type": "v1beta2.HTTPGetAction",
+      "description": "HTTP-based handler"
+     },
+     "tcpSocket": {
+      "type": "v1beta2.TCPSocketAction",
+      "description": "TCP-based handler; TCP hooks not yet supported"
+     }
+    }
+   },
+   "v1beta2.HostPath": {
+    "id": "v1beta2.HostPath",
+    "required": [
+     "path"
+    ],
+    "properties": {
+     "path": {
+      "type": "string",
+      "description": "path of the directory on the host"
+     }
+    }
+   },
+   "v1beta2.Lifecycle": {
+    "id": "v1beta2.Lifecycle",
+    "properties": {
+     "postStart": {
+      "type": "v1beta2.Handler",
+      "description": "called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes"
+     },
+     "preStop": {
+      "type": "v1beta2.Handler",
+      "description": "called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes"
+     }
+    }
+   },
+   "v1beta2.LimitRange": {
+    "id": "v1beta2.LimitRange",
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "spec": {
+      "type": "v1beta2.LimitRangeSpec"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.LimitRangeItem": {
+    "id": "v1beta2.LimitRangeItem",
+    "properties": {
+     "max": {
+      "type": "v1beta2.ResourceList"
+     },
+     "min": {
+      "type": "v1beta2.ResourceList"
+     },
+     "type": {
+      "type": "v1beta2.LimitType"
+     }
+    }
+   },
+   "v1beta2.LimitRangeList": {
+    "id": "v1beta2.LimitRangeList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta2.LimitRange"
+       }
+      ]
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.LimitRangeSpec": {
+    "id": "v1beta2.LimitRangeSpec",
+    "required": [
+     "limits"
+    ],
+    "properties": {
+     "limits": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta2.LimitRangeItem"
+       }
+      ]
+     }
+    }
+   },
+   "v1beta2.LivenessProbe": {
+    "id": "v1beta2.LivenessProbe",
+    "properties": {
+     "exec": {
+      "type": "v1beta2.ExecAction",
+      "description": "parameters for exec-based liveness probe"
+     },
+     "httpGet": {
+      "type": "v1beta2.HTTPGetAction",
+      "description": "parameters for HTTP-based liveness probe"
+     },
+     "initialDelaySeconds": {
+      "type": "integer",
+      "format": "int64",
+      "description": "number of seconds after the container has started before liveness probes are initiated"
+     },
+     "tcpSocket": {
+      "type": "v1beta2.TCPSocketAction",
+      "description": "parameters for TCP-based liveness probe"
+     }
+    }
+   },
+   "v1beta2.Minion": {
+    "id": "v1beta2.Minion",
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "hostIP": {
+      "type": "string",
+      "description": "IP address of the node"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "labels": {
+      "type": "v1beta2.Minion.labels",
+      "description": "map of string keys and values that can be used to organize and categorize minions; labels of a minion assigned by the scheduler must match the scheduled pod's nodeSelector"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "resources": {
+      "type": "v1beta2.NodeResources",
+      "description": "characterization of node resources"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "status": {
+      "type": "v1beta2.NodeStatus",
+      "description": "current status of node"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.Minion.labels": {
+    "id": "v1beta2.Minion.labels",
+    "properties": {}
+   },
+   "v1beta2.MinionList": {
+    "id": "v1beta2.MinionList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta2.Minion"
+       }
+      ],
+      "description": "list of nodes"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.NodeCondition": {
+    "id": "v1beta2.NodeCondition",
+    "required": [
+     "kind",
+     "status"
+    ],
+    "properties": {
+     "kind": {
+      "type": "v1beta2.NodeConditionKind",
+      "description": "kind of the condition, one of reachable, ready"
+     },
+     "lastTransitionTime": {
+      "type": "string",
+      "description": "last time the condition transit from one status to another"
+     },
+     "message": {
+      "type": "string",
+      "description": "human readable message indicating details about last transition"
+     },
+     "reason": {
+      "type": "string",
+      "description": "(brief) reason for the condition's last transition"
+     },
+     "status": {
+      "type": "v1beta2.NodeConditionStatus",
+      "description": "status of the condition, one of full, none, unknown"
+     }
+    }
+   },
+   "v1beta2.NodeResources": {
+    "id": "v1beta2.NodeResources",
+    "properties": {
+     "capacity": {
+      "type": "v1beta2.ResourceList",
+      "description": "resource capacity of a node represented as a map of resource name to quantity of resource"
+     }
+    }
+   },
+   "v1beta2.NodeStatus": {
+    "id": "v1beta2.NodeStatus",
+    "properties": {
+     "conditions": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta2.NodeCondition"
+       }
+      ],
+      "description": "conditions is an array of current node conditions"
+     },
+     "phase": {
+      "type": "v1beta2.NodePhase",
+      "description": "node phase is the current lifecycle phase of the node"
+     }
+    }
+   },
+   "v1beta2.ObjectReference": {
+    "id": "v1beta2.ObjectReference",
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent"
+     },
+     "fieldPath": {
+      "type": "string",
+      "description": "if referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of the referent"
+     },
+     "name": {
+      "type": "string",
+      "description": "id of the referent"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace of the referent"
+     },
+     "resourceVersion": {
+      "type": "string",
+      "description": "specific resourceVersion to which this reference is made, if any"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "uid of the referent"
+     }
+    }
+   },
+   "v1beta2.Pod": {
+    "id": "v1beta2.Pod",
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "currentState": {
+      "type": "v1beta2.PodState",
+      "description": "current state of the pod"
+     },
+     "desiredState": {
+      "type": "v1beta2.PodState",
+      "description": "specification of the desired state of the pod"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "labels": {
+      "type": "v1beta2.Pod.labels",
+      "description": "map of string keys and values that can be used to organize and categorize pods; may match selectors of replication controllers and services"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "nodeSelector": {
+      "type": "v1beta2.Pod.nodeSelector",
+      "description": "selector which must match a node's labels for the pod to be scheduled on that node"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.Pod.labels": {
+    "id": "v1beta2.Pod.labels",
+    "properties": {}
+   },
+   "v1beta2.Pod.nodeSelector": {
+    "id": "v1beta2.Pod.nodeSelector",
+    "properties": {}
+   },
+   "v1beta2.PodList": {
+    "id": "v1beta2.PodList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta2.Pod"
+       }
+      ],
+      "description": "list of pods"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.PodState": {
+    "id": "v1beta2.PodState",
+    "properties": {
+     "host": {
+      "type": "string",
+      "description": "host to which the pod is assigned; empty if not yet scheduled"
+     },
+     "hostIP": {
+      "type": "string",
+      "description": "IP address of the host to which the pod is assigned; empty if not yet scheduled"
+     },
+     "info": {
+      "type": "v1beta2.PodInfo",
+      "description": "map of container name to container status"
+     },
+     "manifest": {
+      "type": "v1beta2.ContainerManifest",
+      "description": "manifest of containers and volumes comprising the pod"
+     },
+     "message": {
+      "type": "string",
+      "description": "human readable message indicating details about why the pod is in this condition"
+     },
+     "podIP": {
+      "type": "string",
+      "description": "IP address allocated to the pod; routable at least within the cluster; empty if not yet allocated"
+     },
+     "status": {
+      "type": "v1beta2.PodStatus",
+      "description": "current condition of the pod, Waiting, Running, or Terminated"
+     }
+    }
+   },
+   "v1beta2.PodTemplate": {
+    "id": "v1beta2.PodTemplate",
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.PodTemplate.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about pods created from the template"
+     },
+     "desiredState": {
+      "type": "v1beta2.PodState",
+      "description": "specification of the desired state of pods created from this template"
+     },
+     "labels": {
+      "type": "v1beta2.PodTemplate.labels",
+      "description": "map of string keys and values that can be used to organize and categorize the pods created from the template; must match the selector of the replication controller to which the template belongs; may match selectors of services"
+     },
+     "nodeSelector": {
+      "type": "v1beta2.PodTemplate.nodeSelector",
+      "description": "a selector which must be true for the pod to fit on a node"
+     }
+    }
+   },
+   "v1beta2.PodTemplate.annotations": {
+    "id": "v1beta2.PodTemplate.annotations",
+    "properties": {}
+   },
+   "v1beta2.PodTemplate.labels": {
+    "id": "v1beta2.PodTemplate.labels",
+    "properties": {}
+   },
+   "v1beta2.PodTemplate.nodeSelector": {
+    "id": "v1beta2.PodTemplate.nodeSelector",
+    "properties": {}
+   },
+   "v1beta2.Port": {
+    "id": "v1beta2.Port",
+    "required": [
+     "containerPort"
+    ],
+    "properties": {
+     "containerPort": {
+      "type": "integer",
+      "format": "int32",
+      "description": "number of port to expose on the pod's IP address"
+     },
+     "hostIP": {
+      "type": "string",
+      "description": "host IP to bind the port to"
+     },
+     "hostPort": {
+      "type": "integer",
+      "format": "int32",
+      "description": "number of port to expose on the host; most containers do not need this"
+     },
+     "name": {
+      "type": "string",
+      "description": "name for the port that can be referred to by services; must be a DNS_LABEL and unique without the pod"
+     },
+     "protocol": {
+      "type": "v1beta2.Protocol",
+      "description": "protocol for port; must be UDP or TCP; TCP if unspecified"
+     }
+    }
+   },
+   "v1beta2.ReplicationController": {
+    "id": "v1beta2.ReplicationController",
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "currentState": {
+      "type": "v1beta2.ReplicationControllerState",
+      "description": "current state of the replication controller"
+     },
+     "desiredState": {
+      "type": "v1beta2.ReplicationControllerState",
+      "description": "specification of the desired state of the replication controller"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "labels": {
+      "type": "v1beta2.ReplicationController.labels",
+      "description": "map of string keys and values that can be used to organize and categorize replication controllers"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.ReplicationController.labels": {
+    "id": "v1beta2.ReplicationController.labels",
+    "properties": {}
+   },
+   "v1beta2.ReplicationControllerList": {
+    "id": "v1beta2.ReplicationControllerList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta2.ReplicationController"
+       }
+      ],
+      "description": "list of replication controllers"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.ReplicationControllerState": {
+    "id": "v1beta2.ReplicationControllerState",
+    "required": [
+     "replicas"
+    ],
+    "properties": {
+     "podTemplate": {
+      "type": "v1beta2.PodTemplate",
+      "description": "template for pods to be created by this replication controller when the observed number of replicas is less than the desired number of replicas"
+     },
+     "replicaSelector": {
+      "type": "v1beta2.ReplicationControllerState.replicaSelector",
+      "description": "label keys and values that must match in order to be controlled by this replication controller"
+     },
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "number of replicas (desired or observed, as appropriate)"
+     }
+    }
+   },
+   "v1beta2.ReplicationControllerState.replicaSelector": {
+    "id": "v1beta2.ReplicationControllerState.replicaSelector",
+    "properties": {}
+   },
+   "v1beta2.ResourceQuota": {
+    "id": "v1beta2.ResourceQuota",
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "spec": {
+      "type": "v1beta2.ResourceQuotaSpec"
+     },
+     "status": {
+      "type": "v1beta2.ResourceQuotaStatus"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.ResourceQuotaList": {
+    "id": "v1beta2.ResourceQuotaList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta2.ResourceQuota"
+       }
+      ]
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.ResourceQuotaSpec": {
+    "id": "v1beta2.ResourceQuotaSpec",
+    "properties": {
+     "hard": {
+      "type": "v1beta2.ResourceList"
+     }
+    }
+   },
+   "v1beta2.ResourceQuotaStatus": {
+    "id": "v1beta2.ResourceQuotaStatus",
+    "properties": {
+     "hard": {
+      "type": "v1beta2.ResourceList"
+     },
+     "used": {
+      "type": "v1beta2.ResourceList"
+     }
+    }
+   },
+   "v1beta2.ResourceQuotaUsage": {
+    "id": "v1beta2.ResourceQuotaUsage",
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "status": {
+      "type": "v1beta2.ResourceQuotaStatus"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.ResourceRequirementSpec": {
+    "id": "v1beta2.ResourceRequirementSpec",
+    "properties": {
+     "limits": {
+      "type": "v1beta2.ResourceList",
+      "description": "Maximum amount of compute resources allowed"
+     }
+    }
+   },
+   "v1beta2.RestartPolicy": {
+    "id": "v1beta2.RestartPolicy",
+    "properties": {
+     "always": {
+      "type": "v1beta2.RestartPolicyAlways",
+      "description": "always restart the container after termination"
+     },
+     "never": {
+      "type": "v1beta2.RestartPolicyNever",
+      "description": "never restart the container"
+     },
+     "onFailure": {
+      "type": "v1beta2.RestartPolicyOnFailure",
+      "description": "restart the container if it fails for any reason, but not if it succeeds (exit 0)"
+     }
+    }
+   },
+   "v1beta2.RestartPolicyAlways": {
+    "id": "v1beta2.RestartPolicyAlways",
+    "properties": {}
+   },
+   "v1beta2.RestartPolicyNever": {
+    "id": "v1beta2.RestartPolicyNever",
+    "properties": {}
+   },
+   "v1beta2.RestartPolicyOnFailure": {
+    "id": "v1beta2.RestartPolicyOnFailure",
+    "properties": {}
+   },
+   "v1beta2.Service": {
+    "id": "v1beta2.Service",
+    "required": [
+     "port",
+     "selector"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta2.TypeMeta.annotations",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "containerPort": {
+      "type": "string",
+      "description": "number or name of the port to access on the containers belonging to pods targeted by the service"
+     },
+     "createExternalLoadBalancer": {
+      "type": "boolean",
+      "description": "set up a cloud-provider-specific load balancer on an external IP"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; recorded by the system; null for lists"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "id": {
+      "type": "string",
+      "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs"
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase"
+     },
+     "labels": {
+      "type": "v1beta2.Service.labels",
+      "description": "map of string keys and values that can be used to organize and categorize services"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default"
+     },
+     "port": {
+      "type": "integer",
+      "format": "int32",
+      "description": "port exposed by the service"
+     },
+     "portalIP": {
+      "type": "string",
+      "description": "IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused, and creation of the service will fail otherwise; cannot be updated"
+     },
+     "protocol": {
+      "type": "v1beta2.Protocol",
+      "description": "protocol for port; must be UDP or TCP; TCP if unspecified"
+     },
+     "proxyPort": {
+      "type": "integer",
+      "format": "int32",
+      "description": "if non-zero, a pre-allocated host port used for this service by the proxy on each node; assigned by the master and ignored on input"
+     },
+     "publicIPs": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "string"
+       }
+      ],
+      "description": "externally visible IPs from which to select the address for the external load balancer"
+     },
+     "resourceVersion": {
+      "type": "uint64",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; value must be treated as opaque by clients and passed unmodified back to the server"
+     },
+     "selector": {
+      "type": "v1beta2.Service.selector",
+      "description": "label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object"
+     },
+     "sessionAffinity": {
+      "type": "v1beta2.AffinityType",
+      "description": "enable client IP based session affinity; must be ClientIP or None; defaults to None"
+     },
+     "uid": {
+      "type": "types.UID",
+      "description": "UUID assigned by the system upon creation, unique across space and time"
+     }
+    }
+   },
+   "v1beta2.Service.labels": {
+    "id": "v1beta2.Service.labels",
+    "properties": {}
+   },
+   "v1beta2.Service.selector": {
+    "id": "v1beta2.Service.selector",
+    "properties": {}
+   },
+   "v1beta2.TCPSocketAction": {
+    "id": "v1beta2.TCPSocketAction",
+    "properties": {
+     "port": {
+      "type": "string",
+      "description": "number of name of the port to access on the container"
+     }
+    }
+   },
+   "v1beta2.Volume": {
+    "id": "v1beta2.Volume",
+    "required": [
+     "name"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "volume name; must be a DNS_LABEL and unique within the pod"
+     },
+     "source": {
+      "type": "v1beta2.VolumeSource",
+      "description": "location and type of volume to mount; at most one of HostDir, EmptyDir, GCEPersistentDisk, or GitRepo; default is EmptyDir"
+     }
+    }
+   },
+   "v1beta2.VolumeMount": {
+    "id": "v1beta2.VolumeMount",
+    "required": [
+     "name",
+     "mountPath"
+    ],
+    "properties": {
+     "mountPath": {
+      "type": "string",
+      "description": "path within the container at which the volume should be mounted"
+     },
+     "name": {
+      "type": "string",
+      "description": "name of the volume to mount"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "mounted read-only if true, read-write otherwise (false or unspecified)"
+     }
+    }
+   },
+   "v1beta2.VolumeSource": {
+    "id": "v1beta2.VolumeSource",
+    "required": [
+     "hostDir",
+     "emptyDir",
+     "persistentDisk",
+     "gitRepo"
+    ],
+    "properties": {
+     "emptyDir": {
+      "type": "v1beta2.EmptyDir",
+      "description": "temporary directory that shares a pod's lifetime"
+     },
+     "gitRepo": {
+      "type": "v1beta2.GitRepo",
+      "description": "git repository at a particular revision"
+     },
+     "hostDir": {
+      "type": "v1beta2.HostPath",
+      "description": "pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host"
+     },
+     "persistentDisk": {
+      "type": "v1beta2.GCEPersistentDisk",
+      "description": "GCE disk resource attached to the host machine on demand"
+     }
+    }
+   }
+  }
+ }

--- a/api/swagger-spec/v1beta3.json
+++ b/api/swagger-spec/v1beta3.json
@@ -1,0 +1,3812 @@
+{
+  "swaggerVersion": "1.2",
+  "apiVersion": "v1beta3",
+  "basePath": "127.0.0.1:8050",
+  "resourcePath": "/api/v1beta3",
+  "apis": [
+   {
+    "path": "/api/v1beta3/resourcequotas",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.ResourceQuotaList",
+      "method": "GET",
+      "summary": "list objects of kind ResourceQuota",
+      "nickname": "listResourceQuota",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/ns/{ns}/pods",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.PodList",
+      "method": "GET",
+      "summary": "list objects of kind Pod",
+      "nickname": "listPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Pod",
+      "nickname": "createPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.Pod",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/services",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.Service",
+      "method": "GET",
+      "summary": "list objects of kind Service",
+      "nickname": "listService",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/proxy/nodes/{name}/{path:*}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "proxy GET requests to Node",
+      "nickname": "proxyGETNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "proxy PUT requests to Node",
+      "nickname": "proxyPUTNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "proxy POST requests to Node",
+      "nickname": "proxyPOSTNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "proxy DELETE requests to Node",
+      "nickname": "proxyDELETENode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/ns/{ns}/replicationcontrollers",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.ReplicationControllerList",
+      "method": "GET",
+      "summary": "watch a list of ReplicationController",
+      "nickname": "watchReplicationControllerlist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/ns/{ns}/services",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.Service",
+      "method": "GET",
+      "summary": "list objects of kind Service",
+      "nickname": "listService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Service",
+      "nickname": "createService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.Service",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/ns/{ns}/limitranges",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.LimitRangeList",
+      "method": "GET",
+      "summary": "list objects of kind LimitRange",
+      "nickname": "listLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a LimitRange",
+      "nickname": "createLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.LimitRange",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/ns/{ns}/events",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.EventList",
+      "method": "GET",
+      "summary": "list objects of kind Event",
+      "nickname": "listEvent",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Event",
+      "nickname": "createEvent",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.Event",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/ns/{ns}/events/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.Event",
+      "method": "GET",
+      "summary": "watch a particular Event",
+      "nickname": "watchEvent",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Event",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/ns/{ns}/resourcequotas",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.ResourceQuotaList",
+      "method": "GET",
+      "summary": "watch a list of ResourceQuota",
+      "nickname": "watchResourceQuotalist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/ns/{ns}/resourcequotausages",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a ResourceQuotaUsage",
+      "nickname": "createResourceQuotaUsage",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.ResourceQuotaUsage",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/endpoints",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.EndpointsList",
+      "method": "GET",
+      "summary": "watch a list of Endpoints",
+      "nickname": "watchEndpointslist",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/ns/{ns}/pods",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.PodList",
+      "method": "GET",
+      "summary": "watch a list of Pod",
+      "nickname": "watchPodlist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/replicationcontrollers",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.ReplicationControllerList",
+      "method": "GET",
+      "summary": "list objects of kind ReplicationController",
+      "nickname": "listReplicationController",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/replicationcontrollers",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.ReplicationControllerList",
+      "method": "GET",
+      "summary": "watch a list of ReplicationController",
+      "nickname": "watchReplicationControllerlist",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/ns/{ns}/limitranges/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.LimitRange",
+      "method": "GET",
+      "summary": "watch a particular LimitRange",
+      "nickname": "watchLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the LimitRange",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/limitranges",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.LimitRangeList",
+      "method": "GET",
+      "summary": "list objects of kind LimitRange",
+      "nickname": "listLimitRange",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/nodes/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.Node",
+      "method": "GET",
+      "summary": "read the specified Node",
+      "nickname": "readNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified Node",
+      "nickname": "updateNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.Node",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Node",
+      "nickname": "deleteNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/nodes/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.Node",
+      "method": "GET",
+      "summary": "watch a particular Node",
+      "nickname": "watchNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/ns/{ns}/events",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.EventList",
+      "method": "GET",
+      "summary": "watch a list of Event",
+      "nickname": "watchEventlist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/ns/{ns}/events/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.Event",
+      "method": "GET",
+      "summary": "read the specified Event",
+      "nickname": "readEvent",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Event",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Event",
+      "nickname": "deleteEvent",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Event",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/ns/{ns}/endpoints/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.Endpoints",
+      "method": "GET",
+      "summary": "read the specified Endpoints",
+      "nickname": "readEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Endpoints",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified Endpoints",
+      "nickname": "updateEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Endpoints",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.Endpoints",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/pods",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.PodList",
+      "method": "GET",
+      "summary": "list objects of kind Pod",
+      "nickname": "listPod",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/ns/{ns}/services/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.Service",
+      "method": "GET",
+      "summary": "read the specified Service",
+      "nickname": "readService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified Service",
+      "nickname": "updateService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.Service",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Service",
+      "nickname": "deleteService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/events",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.EventList",
+      "method": "GET",
+      "summary": "list objects of kind Event",
+      "nickname": "listEvent",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/ns/{ns}/endpoints",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.EndpointsList",
+      "method": "GET",
+      "summary": "watch a list of Endpoints",
+      "nickname": "watchEndpointslist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/nodes",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.NodeList",
+      "method": "GET",
+      "summary": "watch a list of Node",
+      "nickname": "watchNodelist",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/ns/{ns}/resourcequotas",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.ResourceQuotaList",
+      "method": "GET",
+      "summary": "list objects of kind ResourceQuota",
+      "nickname": "listResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a ResourceQuota",
+      "nickname": "createResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.ResourceQuota",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/ns/{ns}/bindings",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Binding",
+      "nickname": "createBinding",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.Binding",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/services",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.Service",
+      "method": "GET",
+      "summary": "watch a list of Service",
+      "nickname": "watchServicelist",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/ns/{ns}/limitranges",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.LimitRangeList",
+      "method": "GET",
+      "summary": "watch a list of LimitRange",
+      "nickname": "watchLimitRangelist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/ns/{ns}/limitranges/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.LimitRange",
+      "method": "GET",
+      "summary": "read the specified LimitRange",
+      "nickname": "readLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the LimitRange",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified LimitRange",
+      "nickname": "updateLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the LimitRange",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.LimitRange",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a LimitRange",
+      "nickname": "deleteLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the LimitRange",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/ns/{ns}/resourcequotas/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.ResourceQuota",
+      "method": "GET",
+      "summary": "read the specified ResourceQuota",
+      "nickname": "readResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ResourceQuota",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified ResourceQuota",
+      "nickname": "updateResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ResourceQuota",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.ResourceQuota",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a ResourceQuota",
+      "nickname": "deleteResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ResourceQuota",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/ns/{ns}/pods/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.Pod",
+      "method": "GET",
+      "summary": "read the specified Pod",
+      "nickname": "readPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified Pod",
+      "nickname": "updatePod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.Pod",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Pod",
+      "nickname": "deletePod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/ns/{ns}/pods/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.Pod",
+      "method": "GET",
+      "summary": "watch a particular Pod",
+      "nickname": "watchPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/proxy/ns/{ns}/pods/{name}/{path:*}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "proxy GET requests to Pod",
+      "nickname": "proxyGETPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "proxy PUT requests to Pod",
+      "nickname": "proxyPUTPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "proxy POST requests to Pod",
+      "nickname": "proxyPOSTPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "proxy DELETE requests to Pod",
+      "nickname": "proxyDELETEPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/endpoints",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.EndpointsList",
+      "method": "GET",
+      "summary": "list objects of kind Endpoints",
+      "nickname": "listEndpoints",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/resourcequotas",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.ResourceQuotaList",
+      "method": "GET",
+      "summary": "watch a list of ResourceQuota",
+      "nickname": "watchResourceQuotalist",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/ns/{ns}/replicationcontrollers",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.ReplicationControllerList",
+      "method": "GET",
+      "summary": "list objects of kind ReplicationController",
+      "nickname": "listReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a ReplicationController",
+      "nickname": "createReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.ReplicationController",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/ns/{ns}/replicationcontrollers/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.ReplicationController",
+      "method": "GET",
+      "summary": "watch a particular ReplicationController",
+      "nickname": "watchReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ReplicationController",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/ns/{ns}/services",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.Service",
+      "method": "GET",
+      "summary": "watch a list of Service",
+      "nickname": "watchServicelist",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/ns/{ns}/resourcequotas/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.ResourceQuota",
+      "method": "GET",
+      "summary": "watch a particular ResourceQuota",
+      "nickname": "watchResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ResourceQuota",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/ns/{ns}/services/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.Service",
+      "method": "GET",
+      "summary": "watch a particular Service",
+      "nickname": "watchService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/events",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.EventList",
+      "method": "GET",
+      "summary": "watch a list of Event",
+      "nickname": "watchEventlist",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/nodes",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.NodeList",
+      "method": "GET",
+      "summary": "list objects of kind Node",
+      "nickname": "listNode",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Node",
+      "nickname": "createNode",
+      "parameters": [
+       {
+        "type": "v1beta3.Node",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/proxy/ns/{ns}/services/{name}/{path:*}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "proxy GET requests to Service",
+      "nickname": "proxyGETService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "proxy PUT requests to Service",
+      "nickname": "proxyPUTService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "proxy POST requests to Service",
+      "nickname": "proxyPOSTService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "proxy DELETE requests to Service",
+      "nickname": "proxyDELETEService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/ns/{ns}/endpoints",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.EndpointsList",
+      "method": "GET",
+      "summary": "list objects of kind Endpoints",
+      "nickname": "listEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "POST",
+      "summary": "create a Endpoints",
+      "nickname": "createEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.Endpoints",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/ns/{ns}/endpoints/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.Endpoints",
+      "method": "GET",
+      "summary": "watch a particular Endpoints",
+      "nickname": "watchEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Endpoints",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/redirect/nodes/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "redirect GET request to Node",
+      "nickname": "redirectNode",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/pods",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.PodList",
+      "method": "GET",
+      "summary": "watch a list of Pod",
+      "nickname": "watchPodlist",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/ns/{ns}/replicationcontrollers/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.ReplicationController",
+      "method": "GET",
+      "summary": "read the specified ReplicationController",
+      "nickname": "readReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ReplicationController",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "update the specified ReplicationController",
+      "nickname": "updateReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ReplicationController",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.ReplicationController",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a ReplicationController",
+      "nickname": "deleteReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ReplicationController",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/redirect/ns/{ns}/services/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "redirect GET request to Service",
+      "nickname": "redirectService",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/limitranges",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.LimitRangeList",
+      "method": "GET",
+      "summary": "watch a list of LimitRange",
+      "nickname": "watchLimitRangelist",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/redirect/ns/{ns}/pods/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "redirect GET request to Pod",
+      "nickname": "redirectPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "ns",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   }
+  ],
+  "models": {
+   "v1beta3.Binding": {
+    "id": "v1beta3.Binding",
+    "required": [
+     "podID",
+     "host"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta3.ObjectMeta.annotations"
+     },
+     "apiVersion": {
+      "type": "string"
+     },
+     "creationTimestamp": {
+      "type": "string"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "host": {
+      "type": "string"
+     },
+     "kind": {
+      "type": "string"
+     },
+     "labels": {
+      "type": "v1beta3.ObjectMeta.labels"
+     },
+     "name": {
+      "type": "string"
+     },
+     "namespace": {
+      "type": "string"
+     },
+     "podID": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     },
+     "uid": {
+      "type": "types.UID"
+     }
+    }
+   },
+   "v1beta3.Capabilities": {
+    "id": "v1beta3.Capabilities",
+    "properties": {
+     "add": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta3.CapabilityType"
+       }
+      ]
+     },
+     "drop": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta3.CapabilityType"
+       }
+      ]
+     }
+    }
+   },
+   "v1beta3.CapabilityType": {
+    "id": "v1beta3.CapabilityType",
+    "properties": {}
+   },
+   "v1beta3.Container": {
+    "id": "v1beta3.Container",
+    "required": [
+     "name",
+     "image",
+     "imagePullPolicy"
+    ],
+    "properties": {
+     "capabilities": {
+      "type": "v1beta3.Capabilities"
+     },
+     "command": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "string"
+       }
+      ]
+     },
+     "env": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta3.EnvVar"
+       }
+      ]
+     },
+     "image": {
+      "type": "string"
+     },
+     "imagePullPolicy": {
+      "type": "v1beta3.PullPolicy"
+     },
+     "lifecycle": {
+      "type": "v1beta3.Lifecycle"
+     },
+     "livenessProbe": {
+      "type": "v1beta3.Probe"
+     },
+     "name": {
+      "type": "string"
+     },
+     "ports": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta3.Port"
+       }
+      ]
+     },
+     "privileged": {
+      "type": "boolean"
+     },
+     "resources": {
+      "type": "v1beta3.ResourceRequirementSpec",
+      "description": "Compute Resources required by this container"
+     },
+     "terminationMessagePath": {
+      "type": "string"
+     },
+     "volumeMounts": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta3.VolumeMount"
+       }
+      ]
+     },
+     "workingDir": {
+      "type": "string"
+     }
+    }
+   },
+   "v1beta3.EmptyDir": {
+    "id": "v1beta3.EmptyDir",
+    "properties": {}
+   },
+   "v1beta3.Endpoints": {
+    "id": "v1beta3.Endpoints",
+    "required": [
+     "endpoints"
+    ],
+    "properties": {
+     "annotations": {
+      "type": "v1beta3.ObjectMeta.annotations"
+     },
+     "apiVersion": {
+      "type": "string"
+     },
+     "creationTimestamp": {
+      "type": "string"
+     },
+     "endpoints": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "string"
+       }
+      ]
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "kind": {
+      "type": "string"
+     },
+     "labels": {
+      "type": "v1beta3.ObjectMeta.labels"
+     },
+     "name": {
+      "type": "string"
+     },
+     "namespace": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     },
+     "uid": {
+      "type": "types.UID"
+     }
+    }
+   },
+   "v1beta3.EndpointsList": {
+    "id": "v1beta3.EndpointsList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta3.Endpoints"
+       }
+      ]
+     },
+     "kind": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     }
+    }
+   },
+   "v1beta3.EnvVar": {
+    "id": "v1beta3.EnvVar",
+    "required": [
+     "name"
+    ],
+    "properties": {
+     "name": {
+      "type": "string"
+     },
+     "value": {
+      "type": "string"
+     }
+    }
+   },
+   "v1beta3.Event": {
+    "id": "v1beta3.Event",
+    "properties": {
+     "annotations": {
+      "type": "v1beta3.ObjectMeta.annotations"
+     },
+     "apiVersion": {
+      "type": "string"
+     },
+     "creationTimestamp": {
+      "type": "string"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "involvedObject": {
+      "type": "v1beta3.ObjectReference"
+     },
+     "kind": {
+      "type": "string"
+     },
+     "labels": {
+      "type": "v1beta3.ObjectMeta.labels"
+     },
+     "message": {
+      "type": "string"
+     },
+     "name": {
+      "type": "string"
+     },
+     "namespace": {
+      "type": "string"
+     },
+     "reason": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     },
+     "source": {
+      "type": "v1beta3.EventSource"
+     },
+     "timestamp": {
+      "type": "string"
+     },
+     "uid": {
+      "type": "types.UID"
+     }
+    }
+   },
+   "v1beta3.EventList": {
+    "id": "v1beta3.EventList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta3.Event"
+       }
+      ]
+     },
+     "kind": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     }
+    }
+   },
+   "v1beta3.EventSource": {
+    "id": "v1beta3.EventSource",
+    "properties": {
+     "component": {
+      "type": "string"
+     },
+     "host": {
+      "type": "string"
+     }
+    }
+   },
+   "v1beta3.ExecAction": {
+    "id": "v1beta3.ExecAction",
+    "properties": {
+     "command": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "string"
+       }
+      ]
+     }
+    }
+   },
+   "v1beta3.GCEPersistentDisk": {
+    "id": "v1beta3.GCEPersistentDisk",
+    "required": [
+     "pdName"
+    ],
+    "properties": {
+     "fsType": {
+      "type": "string"
+     },
+     "partition": {
+      "type": "integer",
+      "format": "int32"
+     },
+     "pdName": {
+      "type": "string"
+     },
+     "readOnly": {
+      "type": "boolean"
+     }
+    }
+   },
+   "v1beta3.GitRepo": {
+    "id": "v1beta3.GitRepo",
+    "required": [
+     "repository",
+     "revision"
+    ],
+    "properties": {
+     "repository": {
+      "type": "string"
+     },
+     "revision": {
+      "type": "string"
+     }
+    }
+   },
+   "v1beta3.HTTPGetAction": {
+    "id": "v1beta3.HTTPGetAction",
+    "properties": {
+     "host": {
+      "type": "string"
+     },
+     "path": {
+      "type": "string"
+     },
+     "port": {
+      "type": "string"
+     }
+    }
+   },
+   "v1beta3.Handler": {
+    "id": "v1beta3.Handler",
+    "properties": {
+     "exec": {
+      "type": "v1beta3.ExecAction"
+     },
+     "httpGet": {
+      "type": "v1beta3.HTTPGetAction"
+     },
+     "tcpSocket": {
+      "type": "v1beta3.TCPSocketAction"
+     }
+    }
+   },
+   "v1beta3.HostPath": {
+    "id": "v1beta3.HostPath",
+    "required": [
+     "path"
+    ],
+    "properties": {
+     "path": {
+      "type": "string"
+     }
+    }
+   },
+   "v1beta3.Lifecycle": {
+    "id": "v1beta3.Lifecycle",
+    "properties": {
+     "postStart": {
+      "type": "v1beta3.Handler"
+     },
+     "preStop": {
+      "type": "v1beta3.Handler"
+     }
+    }
+   },
+   "v1beta3.LimitRange": {
+    "id": "v1beta3.LimitRange",
+    "properties": {
+     "annotations": {
+      "type": "v1beta3.ObjectMeta.annotations"
+     },
+     "apiVersion": {
+      "type": "string"
+     },
+     "creationTimestamp": {
+      "type": "string"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "kind": {
+      "type": "string"
+     },
+     "labels": {
+      "type": "v1beta3.ObjectMeta.labels"
+     },
+     "name": {
+      "type": "string"
+     },
+     "namespace": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     },
+     "spec": {
+      "type": "v1beta3.LimitRangeSpec"
+     },
+     "uid": {
+      "type": "types.UID"
+     }
+    }
+   },
+   "v1beta3.LimitRangeItem": {
+    "id": "v1beta3.LimitRangeItem",
+    "properties": {
+     "max": {
+      "type": "v1beta3.ResourceList"
+     },
+     "min": {
+      "type": "v1beta3.ResourceList"
+     },
+     "type": {
+      "type": "v1beta3.LimitType"
+     }
+    }
+   },
+   "v1beta3.LimitRangeList": {
+    "id": "v1beta3.LimitRangeList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta3.LimitRange"
+       }
+      ]
+     },
+     "kind": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     }
+    }
+   },
+   "v1beta3.LimitRangeSpec": {
+    "id": "v1beta3.LimitRangeSpec",
+    "required": [
+     "limits"
+    ],
+    "properties": {
+     "limits": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta3.LimitRangeItem"
+       }
+      ]
+     }
+    }
+   },
+   "v1beta3.Node": {
+    "id": "v1beta3.Node",
+    "properties": {
+     "annotations": {
+      "type": "v1beta3.ObjectMeta.annotations"
+     },
+     "apiVersion": {
+      "type": "string"
+     },
+     "creationTimestamp": {
+      "type": "string"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "kind": {
+      "type": "string"
+     },
+     "labels": {
+      "type": "v1beta3.ObjectMeta.labels"
+     },
+     "name": {
+      "type": "string"
+     },
+     "namespace": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     },
+     "spec": {
+      "type": "v1beta3.NodeSpec"
+     },
+     "status": {
+      "type": "v1beta3.NodeStatus"
+     },
+     "uid": {
+      "type": "types.UID"
+     }
+    }
+   },
+   "v1beta3.NodeCondition": {
+    "id": "v1beta3.NodeCondition",
+    "required": [
+     "kind",
+     "status"
+    ],
+    "properties": {
+     "kind": {
+      "type": "v1beta3.NodeConditionKind"
+     },
+     "lastTransitionTime": {
+      "type": "string"
+     },
+     "message": {
+      "type": "string"
+     },
+     "reason": {
+      "type": "string"
+     },
+     "status": {
+      "type": "v1beta3.NodeConditionStatus"
+     }
+    }
+   },
+   "v1beta3.NodeList": {
+    "id": "v1beta3.NodeList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta3.Node"
+       }
+      ]
+     },
+     "kind": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     }
+    }
+   },
+   "v1beta3.NodeSpec": {
+    "id": "v1beta3.NodeSpec",
+    "properties": {
+     "capacity": {
+      "type": "v1beta3.ResourceList"
+     }
+    }
+   },
+   "v1beta3.NodeStatus": {
+    "id": "v1beta3.NodeStatus",
+    "properties": {
+     "conditions": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta3.NodeCondition"
+       }
+      ]
+     },
+     "hostIP": {
+      "type": "string"
+     },
+     "phase": {
+      "type": "v1beta3.NodePhase"
+     }
+    }
+   },
+   "v1beta3.ObjectReference": {
+    "id": "v1beta3.ObjectReference",
+    "properties": {
+     "apiVersion": {
+      "type": "string"
+     },
+     "fieldPath": {
+      "type": "string"
+     },
+     "kind": {
+      "type": "string"
+     },
+     "name": {
+      "type": "string"
+     },
+     "namespace": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "uid": {
+      "type": "types.UID"
+     }
+    }
+   },
+   "v1beta3.Pod": {
+    "id": "v1beta3.Pod",
+    "properties": {
+     "annotations": {
+      "type": "v1beta3.ObjectMeta.annotations"
+     },
+     "apiVersion": {
+      "type": "string"
+     },
+     "creationTimestamp": {
+      "type": "string"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "kind": {
+      "type": "string"
+     },
+     "labels": {
+      "type": "v1beta3.ObjectMeta.labels"
+     },
+     "name": {
+      "type": "string"
+     },
+     "namespace": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     },
+     "spec": {
+      "type": "v1beta3.PodSpec"
+     },
+     "status": {
+      "type": "v1beta3.PodStatus"
+     },
+     "uid": {
+      "type": "types.UID"
+     }
+    }
+   },
+   "v1beta3.PodList": {
+    "id": "v1beta3.PodList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta3.Pod"
+       }
+      ]
+     },
+     "kind": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     }
+    }
+   },
+   "v1beta3.PodSpec": {
+    "id": "v1beta3.PodSpec",
+    "required": [
+     "volumes",
+     "containers"
+    ],
+    "properties": {
+     "containers": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta3.Container"
+       }
+      ]
+     },
+     "dnsPolicy": {
+      "type": "v1beta3.DNSPolicy"
+     },
+     "host": {
+      "type": "string",
+      "description": "host requested for this pod"
+     },
+     "nodeSelector": {
+      "type": "v1beta3.PodSpec.nodeSelector"
+     },
+     "restartPolicy": {
+      "type": "v1beta3.RestartPolicy"
+     },
+     "volumes": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta3.Volume"
+       }
+      ]
+     }
+    }
+   },
+   "v1beta3.PodSpec.nodeSelector": {
+    "id": "v1beta3.PodSpec.nodeSelector",
+    "properties": {}
+   },
+   "v1beta3.PodStatus": {
+    "id": "v1beta3.PodStatus",
+    "properties": {
+     "host": {
+      "type": "string"
+     },
+     "hostIP": {
+      "type": "string"
+     },
+     "info": {
+      "type": "v1beta3.PodInfo"
+     },
+     "message": {
+      "type": "string"
+     },
+     "phase": {
+      "type": "v1beta3.PodPhase"
+     },
+     "podIP": {
+      "type": "string"
+     }
+    }
+   },
+   "v1beta3.PodTemplateSpec": {
+    "id": "v1beta3.PodTemplateSpec",
+    "properties": {
+     "annotations": {
+      "type": "v1beta3.ObjectMeta.annotations"
+     },
+     "creationTimestamp": {
+      "type": "string"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "labels": {
+      "type": "v1beta3.ObjectMeta.labels"
+     },
+     "name": {
+      "type": "string"
+     },
+     "namespace": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     },
+     "spec": {
+      "type": "v1beta3.PodSpec"
+     },
+     "uid": {
+      "type": "types.UID"
+     }
+    }
+   },
+   "v1beta3.Port": {
+    "id": "v1beta3.Port",
+    "required": [
+     "containerPort"
+    ],
+    "properties": {
+     "containerPort": {
+      "type": "integer",
+      "format": "int32"
+     },
+     "hostIP": {
+      "type": "string"
+     },
+     "hostPort": {
+      "type": "integer",
+      "format": "int32"
+     },
+     "name": {
+      "type": "string"
+     },
+     "protocol": {
+      "type": "v1beta3.Protocol"
+     }
+    }
+   },
+   "v1beta3.Probe": {
+    "id": "v1beta3.Probe",
+    "properties": {
+     "exec": {
+      "type": "v1beta3.ExecAction"
+     },
+     "httpGet": {
+      "type": "v1beta3.HTTPGetAction"
+     },
+     "initialDelaySeconds": {
+      "type": "integer",
+      "format": "int64"
+     },
+     "tcpSocket": {
+      "type": "v1beta3.TCPSocketAction"
+     }
+    }
+   },
+   "v1beta3.ReplicationController": {
+    "id": "v1beta3.ReplicationController",
+    "properties": {
+     "annotations": {
+      "type": "v1beta3.ObjectMeta.annotations"
+     },
+     "apiVersion": {
+      "type": "string"
+     },
+     "creationTimestamp": {
+      "type": "string"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "kind": {
+      "type": "string"
+     },
+     "labels": {
+      "type": "v1beta3.ObjectMeta.labels"
+     },
+     "name": {
+      "type": "string"
+     },
+     "namespace": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     },
+     "spec": {
+      "type": "v1beta3.ReplicationControllerSpec"
+     },
+     "status": {
+      "type": "v1beta3.ReplicationControllerStatus"
+     },
+     "uid": {
+      "type": "types.UID"
+     }
+    }
+   },
+   "v1beta3.ReplicationControllerList": {
+    "id": "v1beta3.ReplicationControllerList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta3.ReplicationController"
+       }
+      ]
+     },
+     "kind": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     }
+    }
+   },
+   "v1beta3.ReplicationControllerSpec": {
+    "id": "v1beta3.ReplicationControllerSpec",
+    "required": [
+     "replicas"
+    ],
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32"
+     },
+     "selector": {
+      "type": "v1beta3.ReplicationControllerSpec.selector"
+     },
+     "template": {
+      "type": "v1beta3.PodTemplateSpec"
+     },
+     "templateRef": {
+      "type": "v1beta3.ObjectReference"
+     }
+    }
+   },
+   "v1beta3.ReplicationControllerSpec.selector": {
+    "id": "v1beta3.ReplicationControllerSpec.selector",
+    "properties": {}
+   },
+   "v1beta3.ReplicationControllerStatus": {
+    "id": "v1beta3.ReplicationControllerStatus",
+    "required": [
+     "replicas"
+    ],
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "v1beta3.ResourceQuota": {
+    "id": "v1beta3.ResourceQuota",
+    "properties": {
+     "annotations": {
+      "type": "v1beta3.ObjectMeta.annotations"
+     },
+     "apiVersion": {
+      "type": "string"
+     },
+     "creationTimestamp": {
+      "type": "string"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "kind": {
+      "type": "string"
+     },
+     "labels": {
+      "type": "v1beta3.ObjectMeta.labels"
+     },
+     "name": {
+      "type": "string"
+     },
+     "namespace": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     },
+     "spec": {
+      "type": "v1beta3.ResourceQuotaSpec"
+     },
+     "status": {
+      "type": "v1beta3.ResourceQuotaStatus"
+     },
+     "uid": {
+      "type": "types.UID"
+     }
+    }
+   },
+   "v1beta3.ResourceQuotaList": {
+    "id": "v1beta3.ResourceQuotaList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string"
+     },
+     "items": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "v1beta3.ResourceQuota"
+       }
+      ]
+     },
+     "kind": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     }
+    }
+   },
+   "v1beta3.ResourceQuotaSpec": {
+    "id": "v1beta3.ResourceQuotaSpec",
+    "properties": {
+     "hard": {
+      "type": "v1beta3.ResourceList"
+     }
+    }
+   },
+   "v1beta3.ResourceQuotaStatus": {
+    "id": "v1beta3.ResourceQuotaStatus",
+    "properties": {
+     "hard": {
+      "type": "v1beta3.ResourceList"
+     },
+     "used": {
+      "type": "v1beta3.ResourceList"
+     }
+    }
+   },
+   "v1beta3.ResourceQuotaUsage": {
+    "id": "v1beta3.ResourceQuotaUsage",
+    "properties": {
+     "annotations": {
+      "type": "v1beta3.ObjectMeta.annotations"
+     },
+     "apiVersion": {
+      "type": "string"
+     },
+     "creationTimestamp": {
+      "type": "string"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "kind": {
+      "type": "string"
+     },
+     "labels": {
+      "type": "v1beta3.ObjectMeta.labels"
+     },
+     "name": {
+      "type": "string"
+     },
+     "namespace": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     },
+     "status": {
+      "type": "v1beta3.ResourceQuotaStatus"
+     },
+     "uid": {
+      "type": "types.UID"
+     }
+    }
+   },
+   "v1beta3.ResourceRequirementSpec": {
+    "id": "v1beta3.ResourceRequirementSpec",
+    "properties": {
+     "limits": {
+      "type": "v1beta3.ResourceList",
+      "description": "Maximum amount of compute resources allowed"
+     }
+    }
+   },
+   "v1beta3.RestartPolicy": {
+    "id": "v1beta3.RestartPolicy",
+    "properties": {
+     "always": {
+      "type": "v1beta3.RestartPolicyAlways"
+     },
+     "never": {
+      "type": "v1beta3.RestartPolicyNever"
+     },
+     "onFailure": {
+      "type": "v1beta3.RestartPolicyOnFailure"
+     }
+    }
+   },
+   "v1beta3.RestartPolicyAlways": {
+    "id": "v1beta3.RestartPolicyAlways",
+    "properties": {}
+   },
+   "v1beta3.RestartPolicyNever": {
+    "id": "v1beta3.RestartPolicyNever",
+    "properties": {}
+   },
+   "v1beta3.RestartPolicyOnFailure": {
+    "id": "v1beta3.RestartPolicyOnFailure",
+    "properties": {}
+   },
+   "v1beta3.Service": {
+    "id": "v1beta3.Service",
+    "properties": {
+     "annotations": {
+      "type": "v1beta3.ObjectMeta.annotations"
+     },
+     "apiVersion": {
+      "type": "string"
+     },
+     "creationTimestamp": {
+      "type": "string"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "kind": {
+      "type": "string"
+     },
+     "labels": {
+      "type": "v1beta3.ObjectMeta.labels"
+     },
+     "name": {
+      "type": "string"
+     },
+     "namespace": {
+      "type": "string"
+     },
+     "resourceVersion": {
+      "type": "string"
+     },
+     "selfLink": {
+      "type": "string"
+     },
+     "spec": {
+      "type": "v1beta3.ServiceSpec"
+     },
+     "status": {
+      "type": "v1beta3.ServiceStatus"
+     },
+     "uid": {
+      "type": "types.UID"
+     }
+    }
+   },
+   "v1beta3.ServiceSpec": {
+    "id": "v1beta3.ServiceSpec",
+    "required": [
+     "port",
+     "selector"
+    ],
+    "properties": {
+     "containerPort": {
+      "type": "string"
+     },
+     "createExternalLoadBalancer": {
+      "type": "boolean"
+     },
+     "port": {
+      "type": "integer",
+      "format": "int32"
+     },
+     "portalIP": {
+      "type": "string"
+     },
+     "protocol": {
+      "type": "v1beta3.Protocol"
+     },
+     "publicIPs": {
+      "type": "array",
+      "items": [
+       {
+        "$ref": "string"
+       }
+      ]
+     },
+     "selector": {
+      "type": "v1beta3.ServiceSpec.selector"
+     },
+     "sessionAffinity": {
+      "type": "v1beta3.AffinityType"
+     }
+    }
+   },
+   "v1beta3.ServiceSpec.selector": {
+    "id": "v1beta3.ServiceSpec.selector",
+    "properties": {}
+   },
+   "v1beta3.ServiceStatus": {
+    "id": "v1beta3.ServiceStatus",
+    "properties": {}
+   },
+   "v1beta3.TCPSocketAction": {
+    "id": "v1beta3.TCPSocketAction",
+    "properties": {
+     "port": {
+      "type": "string"
+     }
+    }
+   },
+   "v1beta3.Volume": {
+    "id": "v1beta3.Volume",
+    "required": [
+     "name"
+    ],
+    "properties": {
+     "name": {
+      "type": "string"
+     },
+     "source": {
+      "type": "v1beta3.VolumeSource"
+     }
+    }
+   },
+   "v1beta3.VolumeMount": {
+    "id": "v1beta3.VolumeMount",
+    "required": [
+     "name",
+     "mountPath"
+    ],
+    "properties": {
+     "mountPath": {
+      "type": "string"
+     },
+     "name": {
+      "type": "string"
+     },
+     "readOnly": {
+      "type": "boolean"
+     }
+    }
+   },
+   "v1beta3.VolumeSource": {
+    "id": "v1beta3.VolumeSource",
+    "required": [
+     "hostPath",
+     "emptyDir",
+     "gcePersistentDisk",
+     "gitRepo"
+    ],
+    "properties": {
+     "emptyDir": {
+      "type": "v1beta3.EmptyDir"
+     },
+     "gcePersistentDisk": {
+      "type": "v1beta3.GCEPersistentDisk"
+     },
+     "gitRepo": {
+      "type": "v1beta3.GitRepo"
+     },
+     "hostPath": {
+      "type": "v1beta3.HostPath"
+     }
+    }
+   }
+  }
+ }

--- a/api/swagger-spec/version.json
+++ b/api/swagger-spec/version.json
@@ -1,0 +1,27 @@
+{
+  "swaggerVersion": "1.2",
+  "apiVersion": "",
+  "basePath": "127.0.0.1:8050",
+  "resourcePath": "/version",
+  "apis": [
+   {
+    "path": "/version",
+    "description": "git code version from which this is built",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "get the code version",
+      "nickname": "getCodeVersion",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "application/json"
+      ]
+     }
+    ]
+   }
+  ]
+ }

--- a/hack/update-swagger-spec.sh
+++ b/hack/update-swagger-spec.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script to fetch latest swagger spec.
+# Puts the updated spec at swagger-spec/
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+SWAGGER_ROOT_DIR="${KUBE_ROOT}/api/swagger-spec"
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+function cleanup()
+{
+    [[ -n ${APISERVER_PID-} ]] && kill ${APISERVER_PID} 1>&2 2>/dev/null
+
+    kube::etcd::cleanup
+
+    kube::log::status "Clean up complete"
+}
+
+trap cleanup EXIT SIGINT
+
+kube::etcd::start
+
+ETCD_HOST=${ETCD_HOST:-127.0.0.1}
+ETCD_PORT=${ETCD_PORT:-4001}
+API_PORT=${API_PORT:-8050}
+API_HOST=${API_HOST:-127.0.0.1}
+KUBELET_PORT=${KUBELET_PORT:-10250}
+
+# Start kube-apiserver
+kube::log::status "Starting kube-apiserver"
+"${KUBE_OUTPUT_HOSTBIN}/kube-apiserver" \
+  --address="127.0.0.1" \
+  --public_address_override="127.0.0.1" \
+  --port="${API_PORT}" \
+  --etcd_servers="http://${ETCD_HOST}:${ETCD_PORT}" \
+  --public_address_override="127.0.0.1" \
+  --kubelet_port=${KUBELET_PORT} \
+  --runtime_config=api/v1beta3 \
+  --portal_net="10.0.0.0/24" 1>&2 &
+APISERVER_PID=$!
+
+kube::util::wait_for_url "http://127.0.0.1:${API_PORT}/healthz" "apiserver: "
+
+SWAGGER_API_PATH="http://127.0.0.1:${API_PORT}/swaggerapi/"
+kube::log::status "Updating " ${SWAGGER_ROOT_DIR}
+curl ${SWAGGER_API_PATH} > ${SWAGGER_ROOT_DIR}/resourceListing.json
+curl ${SWAGGER_API_PATH}version > ${SWAGGER_ROOT_DIR}/version.json
+curl ${SWAGGER_API_PATH}api > ${SWAGGER_ROOT_DIR}/api.json
+curl ${SWAGGER_API_PATH}api/v1beta1 > ${SWAGGER_ROOT_DIR}/v1beta1.json
+curl ${SWAGGER_API_PATH}api/v1beta2 > ${SWAGGER_ROOT_DIR}/v1beta2.json
+curl ${SWAGGER_API_PATH}api/v1beta3 > ${SWAGGER_ROOT_DIR}/v1beta3.json
+
+kube::log::status "SUCCESS"


### PR DESCRIPTION
The static swagger spec will be used by Swagger UI to generate static documentation hosted on kubernetes.io.

update-swagger-spec.sh starts the apiserver and then curls the swagger spec.
