### PR TITLE
Deleting the API objects related to /operations

### DIFF
--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -35,8 +35,6 @@ func init() {
 		&NodeList{},
 		&Node{},
 		&Status{},
-		&OperationList{},
-		&Operation{},
 		&Endpoints{},
 		&EndpointsList{},
 		&Binding{},
@@ -56,8 +54,6 @@ func init() {
 	// Legacy names are supported
 	Scheme.AddKnownTypeWithName("", "Minion", &Node{})
 	Scheme.AddKnownTypeWithName("", "MinionList", &NodeList{})
-	Scheme.AddKnownTypeWithName("", "ServerOp", &Operation{})
-	Scheme.AddKnownTypeWithName("", "ServerOpList", &OperationList{})
 }
 
 func (*Pod) IsAnAPIObject()                       {}
@@ -73,8 +69,6 @@ func (*Node) IsAnAPIObject()                      {}
 func (*NodeList) IsAnAPIObject()                  {}
 func (*Binding) IsAnAPIObject()                   {}
 func (*Status) IsAnAPIObject()                    {}
-func (*Operation) IsAnAPIObject()                 {}
-func (*OperationList) IsAnAPIObject()             {}
 func (*Event) IsAnAPIObject()                     {}
 func (*EventList) IsAnAPIObject()                 {}
 func (*ContainerManifest) IsAnAPIObject()         {}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1028,20 +1028,6 @@ const (
 	CauseTypeFieldValueNotSupported CauseType = "FieldValueNotSupported"
 )
 
-// Operation is an operation delivered to API clients.
-type Operation struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
-}
-
-// OperationList is a list of operations, as delivered to API clients.
-type OperationList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
-
-	Items []Operation `json:"items"`
-}
-
 // ObjectReference contains enough information to let you inspect or modify the referred object.
 type ObjectReference struct {
 	Kind            string    `json:"kind,omitempty"`

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -39,8 +39,6 @@ func init() {
 		&MinionList{},
 		&Binding{},
 		&Status{},
-		&ServerOp{},
-		&ServerOpList{},
 		&Event{},
 		&EventList{},
 		&ContainerManifest{},
@@ -57,8 +55,6 @@ func init() {
 	// Future names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta1", "Node", &Minion{})
 	api.Scheme.AddKnownTypeWithName("v1beta1", "NodeList", &MinionList{})
-	api.Scheme.AddKnownTypeWithName("v1beta1", "Operation", &ServerOp{})
-	api.Scheme.AddKnownTypeWithName("v1beta1", "OperationList", &ServerOpList{})
 }
 
 func (*Pod) IsAnAPIObject()                       {}
@@ -74,8 +70,6 @@ func (*Minion) IsAnAPIObject()                    {}
 func (*MinionList) IsAnAPIObject()                {}
 func (*Binding) IsAnAPIObject()                   {}
 func (*Status) IsAnAPIObject()                    {}
-func (*ServerOp) IsAnAPIObject()                  {}
-func (*ServerOpList) IsAnAPIObject()              {}
 func (*Event) IsAnAPIObject()                     {}
 func (*EventList) IsAnAPIObject()                 {}
 func (*ContainerManifest) IsAnAPIObject()         {}

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -808,17 +808,6 @@ const (
 	CauseTypeFieldValueNotSupported CauseType = "FieldValueNotSupported"
 )
 
-// ServerOp is an operation delivered to API clients.
-type ServerOp struct {
-	TypeMeta `json:",inline"`
-}
-
-// ServerOpList is a list of operations, as delivered to API clients.
-type ServerOpList struct {
-	TypeMeta `json:",inline"`
-	Items    []ServerOp `json:"items" description:"list of operations"`
-}
-
 // ObjectReference contains enough information to let you inspect or modify the referred object.
 type ObjectReference struct {
 	Kind            string    `json:"kind,omitempty" description:"kind of the referent"`

--- a/pkg/api/v1beta2/register.go
+++ b/pkg/api/v1beta2/register.go
@@ -39,8 +39,6 @@ func init() {
 		&MinionList{},
 		&Binding{},
 		&Status{},
-		&ServerOp{},
-		&ServerOpList{},
 		&Event{},
 		&EventList{},
 		&ContainerManifest{},
@@ -57,8 +55,6 @@ func init() {
 	// Future names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta2", "Node", &Minion{})
 	api.Scheme.AddKnownTypeWithName("v1beta2", "NodeList", &MinionList{})
-	api.Scheme.AddKnownTypeWithName("v1beta2", "Operation", &ServerOp{})
-	api.Scheme.AddKnownTypeWithName("v1beta2", "OperationList", &ServerOpList{})
 }
 
 func (*Pod) IsAnAPIObject()                       {}
@@ -74,8 +70,6 @@ func (*Minion) IsAnAPIObject()                    {}
 func (*MinionList) IsAnAPIObject()                {}
 func (*Binding) IsAnAPIObject()                   {}
 func (*Status) IsAnAPIObject()                    {}
-func (*ServerOp) IsAnAPIObject()                  {}
-func (*ServerOpList) IsAnAPIObject()              {}
 func (*Event) IsAnAPIObject()                     {}
 func (*EventList) IsAnAPIObject()                 {}
 func (*ContainerManifest) IsAnAPIObject()         {}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -782,17 +782,6 @@ const (
 	CauseTypeFieldValueNotSupported CauseType = "FieldValueNotSupported"
 )
 
-// ServerOp is an operation delivered to API clients.
-type ServerOp struct {
-	TypeMeta `json:",inline"`
-}
-
-// ServerOpList is a list of operations, as delivered to API clients.
-type ServerOpList struct {
-	TypeMeta `json:",inline"`
-	Items    []ServerOp `json:"items" description:"list of operations"`
-}
-
 // ObjectReference contains enough information to let you inspect or modify the referred object.
 type ObjectReference struct {
 	Kind            string    `json:"kind,omitempty" description:"kind of the referent"`

--- a/pkg/api/v1beta3/register.go
+++ b/pkg/api/v1beta3/register.go
@@ -43,8 +43,6 @@ func init() {
 		&NodeList{},
 		&Binding{},
 		&Status{},
-		&Operation{},
-		&OperationList{},
 		&Event{},
 		&EventList{},
 		&List{},
@@ -57,8 +55,6 @@ func init() {
 	// Legacy names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta3", "Minion", &Node{})
 	api.Scheme.AddKnownTypeWithName("v1beta3", "MinionList", &NodeList{})
-	api.Scheme.AddKnownTypeWithName("v1beta3", "ServerOp", &Operation{})
-	api.Scheme.AddKnownTypeWithName("v1beta3", "ServerOpList", &OperationList{})
 }
 
 func (*Pod) IsAnAPIObject()                       {}
@@ -78,8 +74,6 @@ func (*Node) IsAnAPIObject()                      {}
 func (*NodeList) IsAnAPIObject()                  {}
 func (*Binding) IsAnAPIObject()                   {}
 func (*Status) IsAnAPIObject()                    {}
-func (*Operation) IsAnAPIObject()                 {}
-func (*OperationList) IsAnAPIObject()             {}
 func (*Event) IsAnAPIObject()                     {}
 func (*EventList) IsAnAPIObject()                 {}
 func (*List) IsAnAPIObject()                      {}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -1008,22 +1008,6 @@ const (
 	CauseTypeFieldValueNotSupported CauseType = "FieldValueNotSupported"
 )
 
-// Operation is a request from a client that has not yet been satisfied. The name of an
-// Operation is assigned by the server when an operation is started, and can be used by
-// clients to retrieve the final result of the operation at a later time.
-type Operation struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata"`
-}
-
-// OperationList is a list of operations, as delivered to API clients.
-type OperationList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
-
-	Items []Operation `json:"items"`
-}
-
 // ObjectReference contains enough information to let you inspect or modify the referred object.
 type ObjectReference struct {
 	Kind            string    `json:"kind,omitempty"`

--- a/pkg/apiserver/operation.go
+++ b/pkg/apiserver/operation.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apiserver
 
 import (
-	"sort"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -77,23 +76,6 @@ func (ops *Operations) insert(op *Operation) {
 	ops.lock.Lock()
 	defer ops.lock.Unlock()
 	ops.ops[op.ID] = op
-}
-
-// List lists operations for an API client.
-func (ops *Operations) List() *api.OperationList {
-	ops.lock.Lock()
-	defer ops.lock.Unlock()
-
-	ids := []string{}
-	for id := range ops.ops {
-		ids = append(ids, id)
-	}
-	sort.StringSlice(ids).Sort()
-	ol := &api.OperationList{}
-	for _, id := range ids {
-		ol.Items = append(ol.Items, api.Operation{ObjectMeta: api.ObjectMeta{Name: id}})
-	}
-	return ol
 }
 
 // Get returns the operation with the given ID, or nil.


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/3644
Now that we deleted the /operations endpoint, we do not need these API objects.
