### PR TITLE
Make e2e shell tests work standalone

### DIFF
--- a/cluster/test-network.sh
+++ b/cluster/test-network.sh
@@ -19,7 +19,5 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${KUBE_ROOT}/cluster/kube-env.sh"
-source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
 
-${KUBE_ROOT}/hack/e2e-suite/goe2e.sh -tTestNetwork
+exec "${KUBE_ROOT}/hack/e2e-suite/goe2e.sh" -t TestNetwork

--- a/hack/e2e-suite/certs.sh
+++ b/hack/e2e-suite/certs.sh
@@ -22,8 +22,17 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+
+: ${KUBE_VERSION_ROOT:=${KUBE_ROOT}}
+: ${KUBECTL:="${KUBE_VERSION_ROOT}/cluster/kubectl.sh"}
+: ${KUBE_CONFIG_FILE:="config-test.sh"}
+
+export KUBECTL KUBE_CONFIG_FILE
+
 source "${KUBE_ROOT}/cluster/kube-env.sh"
-source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+source "${KUBE_VERSION_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+
+prepare-e2e
 
 if [[ "${KUBERNETES_PROVIDER}" != "gce" ]] && [[ "${KUBERNETES_PROVIDER}" != "gke" ]]; then
   echo "WARNING: Skipping certs.sh for cloud provider: ${KUBERNETES_PROVIDER}."

--- a/hack/e2e-suite/goe2e.sh
+++ b/hack/e2e-suite/goe2e.sh
@@ -14,11 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${KUBE_ROOT}/cluster/kube-env.sh"
-source "${KUBE_ROOT}/cluster/$KUBERNETES_PROVIDER/util.sh"
+set -o errexit
+set -o nounset
+set -o pipefail
 
-detect-master > /dev/null
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+
+: ${KUBE_VERSION_ROOT:=${KUBE_ROOT}}
+: ${KUBECTL:="${KUBE_VERSION_ROOT}/cluster/kubectl.sh"}
+: ${KUBE_CONFIG_FILE:="config-test.sh"}
+
+export KUBECTL KUBE_CONFIG_FILE
+
+source "${KUBE_ROOT}/cluster/kube-env.sh"
+source "${KUBE_VERSION_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+
+prepare-e2e
+
+detect-master >/dev/null
 
 # Detect the OS name/arch so that we can find our binary
 case "$(uname -s)" in

--- a/hack/e2e-suite/guestbook.sh
+++ b/hack/e2e-suite/guestbook.sh
@@ -23,8 +23,17 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+
+: ${KUBE_VERSION_ROOT:=${KUBE_ROOT}}
+: ${KUBECTL:="${KUBE_VERSION_ROOT}/cluster/kubectl.sh"}
+: ${KUBE_CONFIG_FILE:="config-test.sh"}
+
+export KUBECTL KUBE_CONFIG_FILE
+
 source "${KUBE_ROOT}/cluster/kube-env.sh"
-source "${KUBE_ROOT}/cluster/$KUBERNETES_PROVIDER/util.sh"
+source "${KUBE_VERSION_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+
+prepare-e2e
 
 GUESTBOOK="${KUBE_ROOT}/examples/guestbook"
 

--- a/hack/e2e-suite/liveness.sh
+++ b/hack/e2e-suite/liveness.sh
@@ -22,8 +22,17 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+
+: ${KUBE_VERSION_ROOT:=${KUBE_ROOT}}
+: ${KUBECTL:="${KUBE_VERSION_ROOT}/cluster/kubectl.sh"}
+: ${KUBE_CONFIG_FILE:="config-test.sh"}
+
+export KUBECTL KUBE_CONFIG_FILE
+
 source "${KUBE_ROOT}/cluster/kube-env.sh"
-source "${KUBE_ROOT}/cluster/$KUBERNETES_PROVIDER/util.sh"
+source "${KUBE_VERSION_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+
+prepare-e2e
 
 liveness_tests="http exec"
 if [[ ${KUBERNETES_PROVIDER} == "gke" ]]; then

--- a/hack/e2e-suite/monitoring.sh
+++ b/hack/e2e-suite/monitoring.sh
@@ -23,8 +23,17 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+
+: ${KUBE_VERSION_ROOT:=${KUBE_ROOT}}
+: ${KUBECTL:="${KUBE_VERSION_ROOT}/cluster/kubectl.sh"}
+: ${KUBE_CONFIG_FILE:="config-test.sh"}
+
+export KUBECTL KUBE_CONFIG_FILE
+
 source "${KUBE_ROOT}/cluster/kube-env.sh"
-source "${KUBE_ROOT}/cluster/$KUBERNETES_PROVIDER/util.sh"
+source "${KUBE_VERSION_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+
+prepare-e2e
 
 MONITORING="${KUBE_ROOT}/cluster/addons/cluster-monitoring"
 KUBECTL="${KUBE_ROOT}/cluster/kubectl.sh"

--- a/hack/e2e-suite/pd.sh
+++ b/hack/e2e-suite/pd.sh
@@ -22,8 +22,17 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+
+: ${KUBE_VERSION_ROOT:=${KUBE_ROOT}}
+: ${KUBECTL:="${KUBE_VERSION_ROOT}/cluster/kubectl.sh"}
+: ${KUBE_CONFIG_FILE:="config-test.sh"}
+
+export KUBECTL KUBE_CONFIG_FILE
+
 source "${KUBE_ROOT}/cluster/kube-env.sh"
-source "${KUBE_ROOT}/cluster/$KUBERNETES_PROVIDER/util.sh"
+source "${KUBE_VERSION_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+
+prepare-e2e
 
 if [[ "$KUBERNETES_PROVIDER" != "gce" ]] && [[ "$KUBERNETES_PROVIDER" != "gke" ]]; then
   echo "WARNING: Skipping pd.sh for cloud provider: ${KUBERNETES_PROVIDER}."

--- a/hack/e2e-suite/services.sh
+++ b/hack/e2e-suite/services.sh
@@ -21,8 +21,17 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+
+: ${KUBE_VERSION_ROOT:=${KUBE_ROOT}}
+: ${KUBECTL:="${KUBE_VERSION_ROOT}/cluster/kubectl.sh"}
+: ${KUBE_CONFIG_FILE:="config-test.sh"}
+
+export KUBECTL KUBE_CONFIG_FILE
+
 source "${KUBE_ROOT}/cluster/kube-env.sh"
-source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+source "${KUBE_VERSION_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+
+prepare-e2e
 
 if [[ "$KUBERNETES_PROVIDER" == "vagrant" ]]; then
   echo "WARNING: Skipping services.sh for ${KUBERNETES_PROVIDER}.  See https://github.com/GoogleCloudPlatform/kubernetes/issues/3655"

--- a/hack/e2e-suite/update.sh
+++ b/hack/e2e-suite/update.sh
@@ -21,9 +21,17 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${KUBE_ROOT}/cluster/kube-env.sh"
-source "${KUBE_ROOT}/cluster/$KUBERNETES_PROVIDER/util.sh"
 
+: ${KUBE_VERSION_ROOT:=${KUBE_ROOT}}
+: ${KUBECTL:="${KUBE_VERSION_ROOT}/cluster/kubectl.sh"}
+: ${KUBE_CONFIG_FILE:="config-test.sh"}
+
+export KUBECTL KUBE_CONFIG_FILE
+
+source "${KUBE_ROOT}/cluster/kube-env.sh"
+source "${KUBE_VERSION_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+
+prepare-e2e
 
 CONTROLLER_NAME=update-demo
 

--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -137,8 +137,11 @@ func main() {
 			log.Fatalf("Error preparing a binary of version %s: %s. Aborting.", *version, err)
 		} else {
 			versionRoot = newVersionRoot
+			os.Setenv("KUBE_VERSION_ROOT", newVersionRoot)
 		}
 	}
+
+	os.Setenv("KUBECTL", versionRoot+`/cluster/kubectl.sh`+kubectlArgs())
 
 	if *pushup {
 		if IsUp() {


### PR DESCRIPTION
Simply incorporate some of the boilerplate from hack/e2e.go into the scripts in hack/e2e-suite.

Use environment variables with default values to allow overrides in kubectl command line and to use a versioned package root.

Tested:
- Ran `go run hack/e2e.go -test` on a test cluster.
- Ran the test cases individually.
- Ran hack/e2e-suite/goe2e.sh -t Pods to confirm it takes arguments.
- Also fixed cluster/test-network.sh (which should be more and more irrelevant.)

Next step is to refactor `hack/e2e.go` replacing `runBash` and friends with a straight `exec.Command` run. The other commands (`-up`, `-build`, `-down` etc.) will also become standalone internal scripts.

As I expected, cluster/test-network.sh was a mistake and is now starting to become a maintenance burden.

@satnam6502 @zmerlynn 
