### PR TITLE
NodeController should tolerate when nodes already exist

### DIFF
--- a/pkg/cloudprovider/controller/nodecontroller.go
+++ b/pkg/cloudprovider/controller/nodecontroller.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	apierrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/probe"
@@ -120,14 +121,14 @@ func (s *NodeController) RegisterNodes(nodes *api.NodeList, retryCount int, retr
 				continue
 			}
 			_, err := s.kubeClient.Nodes().Create(&node)
-			if err == nil {
+			if err == nil || apierrors.IsAlreadyExists(err) {
 				registered.Insert(node.Name)
 				glog.Infof("Registered node in registry: %s", node.Name)
 			} else {
-				glog.Errorf("Error registrying node %s, retrying: %s", node.Name, err)
+				glog.Errorf("Error registering node %s, retrying: %s", node.Name, err)
 			}
 			if registered.Len() == len(nodes.Items) {
-				glog.Infof("Successfully Registered all nodes")
+				glog.Infof("Successfully registered all nodes")
 				return nil
 			}
 		}


### PR DESCRIPTION
During startup, if nodes have already been defined the controller
does not need to create them, just needs to keep them up to date.
When defining a static list, the controller would loop and fail
repeatedly if the node existed.

I don't know if we need to update the node during registration,
as long as the sync loop checks it later.

@ddysher
