### PR TITLE
Do not use {} in systemd environment variables

### DIFF
--- a/contrib/init/systemd/kube-apiserver.service
+++ b/contrib/init/systemd/kube-apiserver.service
@@ -7,15 +7,15 @@ EnvironmentFile=-/etc/kubernetes/config
 EnvironmentFile=-/etc/kubernetes/apiserver
 User=kube
 ExecStart=/usr/bin/kube-apiserver \
-	    ${KUBE_LOGTOSTDERR} \
-	    ${KUBE_LOG_LEVEL} \
-	    ${KUBE_ETCD_SERVERS} \
-	    ${KUBE_API_ADDRESS} \
-	    ${KUBE_API_PORT} \
-	    ${KUBELET_PORT} \
-	    ${KUBE_ALLOW_PRIV} \
-	    ${KUBE_SERVICE_ADDRESSES} \
-	    ${KUBE_API_ARGS}
+	    $KUBE_LOGTOSTDERR \
+	    $KUBE_LOG_LEVEL \
+	    $KUBE_ETCD_SERVERS \
+	    $KUBE_API_ADDRESS \
+	    $KUBE_API_PORT \
+	    $KUBELET_PORT \
+	    $KUBE_ALLOW_PRIV \
+	    $KUBE_SERVICE_ADDRESSES \
+	    $KUBE_API_ARGS
 Restart=on-failure
 
 [Install]

--- a/contrib/init/systemd/kube-controller-manager.service
+++ b/contrib/init/systemd/kube-controller-manager.service
@@ -8,11 +8,11 @@ EnvironmentFile=-/etc/kubernetes/apiserver
 EnvironmentFile=-/etc/kubernetes/controller-manager
 User=kube
 ExecStart=/usr/bin/kube-controller-manager \
-	    ${KUBE_LOGTOSTDERR} \
-	    ${KUBE_LOG_LEVEL} \
-	    ${KUBELET_ADDRESSES} \
-	    ${KUBE_MASTER} \
-	    ${KUBE_CONTROLLER_MANAGER_ARGS}
+	    $KUBE_LOGTOSTDERR \
+	    $KUBE_LOG_LEVEL \
+	    $KUBELET_ADDRESSES \
+	    $KUBE_MASTER \
+	    $KUBE_CONTROLLER_MANAGER_ARGS
 Restart=on-failure
 
 [Install]

--- a/contrib/init/systemd/kube-proxy.service
+++ b/contrib/init/systemd/kube-proxy.service
@@ -6,10 +6,10 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 EnvironmentFile=-/etc/kubernetes/config
 EnvironmentFile=-/etc/kubernetes/proxy
 ExecStart=/usr/bin/kube-proxy \
-	    ${KUBE_LOGTOSTDERR} \
-	    ${KUBE_LOG_LEVEL} \
-	    ${KUBE_ETCD_SERVERS} \
-	    ${KUBE_PROXY_ARGS}
+	    $KUBE_LOGTOSTDERR \
+	    $KUBE_LOG_LEVEL \
+	    $KUBE_ETCD_SERVERS \
+	    $KUBE_PROXY_ARGS
 Restart=on-failure
 
 [Install]

--- a/contrib/init/systemd/kube-scheduler.service
+++ b/contrib/init/systemd/kube-scheduler.service
@@ -8,10 +8,10 @@ EnvironmentFile=-/etc/kubernetes/apiserver
 EnvironmentFile=-/etc/kubernetes/scheduler
 User=kube
 ExecStart=/usr/bin/kube-scheduler \
-	    ${KUBE_LOGTOSTDERR} \
-	    ${KUBE_LOG_LEVEL} \
-	    ${KUBE_MASTER} \
-	    ${KUBE_SCHEDULER_ARGS}
+	    $KUBE_LOGTOSTDERR \
+	    $KUBE_LOG_LEVEL \
+	    $KUBE_MASTER \
+	    $KUBE_SCHEDULER_ARGS
 Restart=on-failure
 
 [Install]

--- a/contrib/init/systemd/kubelet.service
+++ b/contrib/init/systemd/kubelet.service
@@ -9,14 +9,14 @@ WorkingDirectory=/var/lib/kubelet
 EnvironmentFile=-/etc/kubernetes/config
 EnvironmentFile=-/etc/kubernetes/kubelet
 ExecStart=/usr/bin/kubelet \
-	    ${KUBE_LOGTOSTDERR} \
-	    ${KUBE_LOG_LEVEL} \
-	    ${KUBE_ETCD_SERVERS} \
-	    ${KUBELET_ADDRESS} \
-	    ${KUBELET_PORT} \
-	    ${KUBELET_HOSTNAME} \
-	    ${KUBE_ALLOW_PRIV} \
-	    ${KUBELET_ARGS}
+	    $KUBE_LOGTOSTDERR \
+	    $KUBE_LOG_LEVEL \
+	    $KUBE_ETCD_SERVERS \
+	    $KUBELET_ADDRESS \
+	    $KUBELET_PORT \
+	    $KUBELET_HOSTNAME \
+	    $KUBE_ALLOW_PRIV \
+	    $KUBELET_ARGS
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
From the systemd man page:
 Use "${FOO}" as part of a word, or as a word of its own, on the command
 line, in which case it will be
 replaced by the value of the environment variable including
 all whitespace it contains, resulting in a single argument.
 Use "$FOO" as a separate word on the
 command line, in which case it will be replaced
 by the value of the environment variable split at
 whitespace, resulting in zero or more arguments.

Since we want people to be able to use these for multiple arguments we
need to make sure we don't use {} around the env vars...
