### PR TITLE
kubectl doesn't fail silently with no k8s master

### DIFF
--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -123,7 +123,7 @@ elif [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
   )
 fi
 
-detect-master &> /dev/null
+detect-master > /dev/null
 if [[ -n "${KUBE_MASTER_IP-}" && -z "${KUBERNETES_MASTER-}" ]]; then
   export KUBERNETES_MASTER=https://${KUBE_MASTER_IP}
 fi


### PR DESCRIPTION
Before the change, running cluster/kubectl.sh when there is no underlying Kubernetes master was failing silently. After this change this will write sth like that:
Project: groovy-sentry-504
Zone: us-central1-b
ERROR: (gcloud.compute.instances.describe) Could not fetch resource:
- The resource 'projects/groovy-sentry-504/zones/us-central1-b/instances/kubernetes-master' was not found

Also, this is making it consistent with cluster/kubecfg.sh

This change is part of fixing #3300
