### PR TITLE
Isolate pkg/kubectl/cmd tests from json files used in examples

### DIFF
--- a/pkg/kubectl/cmd/create_test.go
+++ b/pkg/kubectl/cmd/create_test.go
@@ -45,11 +45,11 @@ func TestCreateObject(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 
 	cmd := f.NewCmdCreate(buf)
-	cmd.Flags().Set("filename", "../../../examples/guestbook/redis-master.json")
+	cmd.Flags().Set("filename", "../../../test/api-resources/test-pod.json")
 	cmd.Run(cmd, []string{})
 
 	// uses the name from the file, not the response
-	if buf.String() != "redis-master\n" {
+	if buf.String() != "test-pod\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -77,11 +77,11 @@ func TestCreateMultipleObject(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 
 	cmd := f.NewCmdCreate(buf)
-	cmd.Flags().Set("filename", "../../../examples/guestbook/redis-master.json")
-	cmd.Flags().Set("filename", "../../../examples/guestbook/frontend-service.json")
+	cmd.Flags().Set("filename", "../../../test/api-resources/test-pod.json")
+	cmd.Flags().Set("filename", "../../../test/api-resources/test-service.json")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "redis-master\nfrontend\n" {
+	if buf.String() != "test-pod\ntest-service\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -111,10 +111,10 @@ func TestCreateDirectory(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 
 	cmd := f.NewCmdCreate(buf)
-	cmd.Flags().Set("filename", "../../../examples/guestbook")
+	cmd.Flags().Set("filename", "../../../test/api-resources")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "frontend-controller\nfrontend\nredis-master\nredis-master\nredis-slave-controller\nredisslave\n" {
+	if buf.String() != "test-controller\ntest-pod\ntest-service\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }

--- a/pkg/kubectl/cmd/delete_test.go
+++ b/pkg/kubectl/cmd/delete_test.go
@@ -35,7 +35,7 @@ func TestDeleteObject(t *testing.T) {
 		Codec: codec,
 		Client: client.HTTPClientFunc(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/ns/test/pods/redis-master" && m == "DELETE":
+			case p == "/ns/test/pods/test-pod" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Body: objBody(codec, &pods.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -47,11 +47,11 @@ func TestDeleteObject(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 
 	cmd := f.NewCmdDelete(buf)
-	cmd.Flags().Set("filename", "../../../examples/guestbook/redis-master.json")
+	cmd.Flags().Set("filename", "../../../test/api-resources/test-pod.json")
 	cmd.Run(cmd, []string{})
 
 	// uses the name from the file, not the response
-	if buf.String() != "redis-master\n" {
+	if buf.String() != "test-pod\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -63,7 +63,7 @@ func TestDeleteObjectIgnoreNotFound(t *testing.T) {
 		Codec: codec,
 		Client: client.HTTPClientFunc(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/ns/test/pods/redis-master" && m == "DELETE":
+			case p == "/ns/test/pods/test-pod" && m == "DELETE":
 				return &http.Response{StatusCode: 404, Body: stringBody("")}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -75,7 +75,7 @@ func TestDeleteObjectIgnoreNotFound(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 
 	cmd := f.NewCmdDelete(buf)
-	cmd.Flags().Set("filename", "../../../examples/guestbook/redis-master.json")
+	cmd.Flags().Set("filename", "../../../test/api-resources/test-pod.json")
 	cmd.Run(cmd, []string{})
 
 	if buf.String() != "" {
@@ -123,9 +123,9 @@ func TestDeleteMultipleObject(t *testing.T) {
 		Codec: codec,
 		Client: client.HTTPClientFunc(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/ns/test/pods/redis-master" && m == "DELETE":
+			case p == "/ns/test/pods/test-pod" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Body: objBody(codec, &pods.Items[0])}, nil
-			case p == "/ns/test/services/frontend" && m == "DELETE":
+			case p == "/ns/test/services/test-service" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Body: objBody(codec, &svc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -137,11 +137,11 @@ func TestDeleteMultipleObject(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 
 	cmd := f.NewCmdDelete(buf)
-	cmd.Flags().Set("filename", "../../../examples/guestbook/redis-master.json")
-	cmd.Flags().Set("filename", "../../../examples/guestbook/frontend-service.json")
+	cmd.Flags().Set("filename", "../../../test/api-resources/test-pod.json")
+	cmd.Flags().Set("filename", "../../../test/api-resources/test-service.json")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "redis-master\nfrontend\n" {
+	if buf.String() != "test-pod\ntest-service\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -155,9 +155,9 @@ func TestDeleteMultipleObjectIgnoreMissing(t *testing.T) {
 		Codec: codec,
 		Client: client.HTTPClientFunc(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/ns/test/pods/redis-master" && m == "DELETE":
+			case p == "/ns/test/pods/test-pod" && m == "DELETE":
 				return &http.Response{StatusCode: 404, Body: stringBody("")}, nil
-			case p == "/ns/test/services/frontend" && m == "DELETE":
+			case p == "/ns/test/services/test-service" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Body: objBody(codec, &svc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -169,11 +169,11 @@ func TestDeleteMultipleObjectIgnoreMissing(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 
 	cmd := f.NewCmdDelete(buf)
-	cmd.Flags().Set("filename", "../../../examples/guestbook/redis-master.json")
-	cmd.Flags().Set("filename", "../../../examples/guestbook/frontend-service.json")
+	cmd.Flags().Set("filename", "../../../test/api-resources/test-pod.json")
+	cmd.Flags().Set("filename", "../../../test/api-resources/test-service.json")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "frontend\n" {
+	if buf.String() != "test-service\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -203,10 +203,10 @@ func TestDeleteDirectory(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 
 	cmd := f.NewCmdDelete(buf)
-	cmd.Flags().Set("filename", "../../../examples/guestbook")
+	cmd.Flags().Set("filename", "../../../test/api-resources")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "frontend-controller\nfrontend\nredis-master\nredis-master\nredis-slave-controller\nredisslave\n" {
+	if buf.String() != "test-controller\ntest-pod\ntest-service\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }

--- a/pkg/kubectl/cmd/update_test.go
+++ b/pkg/kubectl/cmd/update_test.go
@@ -49,9 +49,9 @@ func TestUpdateObject(t *testing.T) {
 		Codec: codec,
 		Client: client.HTTPClientFunc(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/ns/test/pods/redis-master" && m == "GET":
+			case p == "/ns/test/pods/test-pod" && m == "GET":
 				return &http.Response{StatusCode: 200, Body: objBody(codec, &pods.Items[0])}, nil
-			case p == "/ns/test/pods/redis-master" && m == "PUT":
+			case p == "/ns/test/pods/test-pod" && m == "PUT":
 				return &http.Response{StatusCode: 200, Body: objBody(codec, &pods.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -63,11 +63,11 @@ func TestUpdateObject(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 
 	cmd := f.NewCmdUpdate(buf)
-	cmd.Flags().Set("filename", "../../../examples/guestbook/redis-master.json")
+	cmd.Flags().Set("filename", "../../../test/api-resources/test-pod.json")
 	cmd.Run(cmd, []string{})
 
 	// uses the name from the file, not the response
-	if buf.String() != "redis-master\n" {
+	if buf.String() != "test-pod\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -81,14 +81,14 @@ func TestUpdateMultipleObject(t *testing.T) {
 		Codec: codec,
 		Client: client.HTTPClientFunc(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/ns/test/pods/redis-master" && m == "GET":
+			case p == "/ns/test/pods/test-pod" && m == "GET":
 				return &http.Response{StatusCode: 200, Body: objBody(codec, &pods.Items[0])}, nil
-			case p == "/ns/test/pods/redis-master" && m == "PUT":
+			case p == "/ns/test/pods/test-pod" && m == "PUT":
 				return &http.Response{StatusCode: 200, Body: objBody(codec, &pods.Items[0])}, nil
 
-			case p == "/ns/test/services/frontend" && m == "GET":
+			case p == "/ns/test/services/test-service" && m == "GET":
 				return &http.Response{StatusCode: 200, Body: objBody(codec, &svc.Items[0])}, nil
-			case p == "/ns/test/services/frontend" && m == "PUT":
+			case p == "/ns/test/services/test-service" && m == "PUT":
 				return &http.Response{StatusCode: 200, Body: objBody(codec, &svc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -100,11 +100,11 @@ func TestUpdateMultipleObject(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 
 	cmd := f.NewCmdUpdate(buf)
-	cmd.Flags().Set("filename", "../../../examples/guestbook/redis-master.json")
-	cmd.Flags().Set("filename", "../../../examples/guestbook/frontend-service.json")
+	cmd.Flags().Set("filename", "../../../test/api-resources/test-pod.json")
+	cmd.Flags().Set("filename", "../../../test/api-resources/test-service.json")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "redis-master\nfrontend\n" {
+	if buf.String() != "test-pod\ntest-service\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -135,11 +135,11 @@ func TestUpdateDirectory(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 
 	cmd := f.NewCmdUpdate(buf)
-	cmd.Flags().Set("filename", "../../../examples/guestbook")
+	cmd.Flags().Set("filename", "../../../test/api-resources")
 	cmd.Flags().Set("namespace", "test")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "frontend-controller\nfrontend\nredis-master\nredis-master\nredis-slave-controller\nredisslave\n" {
+	if buf.String() != "test-controller\ntest-pod\ntest-service\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }

--- a/test/api-resources/test-controller.json
+++ b/test/api-resources/test-controller.json
@@ -1,0 +1,29 @@
+{
+  "id": "test-controller",
+  "kind": "ReplicationController",
+  "apiVersion": "v1beta1",
+  "desiredState": {
+    "replicas": 1,
+    "replicaSelector": {"name": "test-pod"},
+    "podTemplate": {
+      "desiredState": {
+        "manifest": {
+          "version": "v1beta1",
+          "id": "test-pod",
+          "containers": [{
+            "name": "redis-master",
+            "image": "dockerfile/redis",
+	          "cpu": 100,
+	          "ports": [{"containerPort": 6379}]
+          }]
+        }
+      },
+      "labels": {
+        "name": "test-pod",
+      }
+    }
+  },
+  "labels": {
+    "name": "test-controller"
+  }
+}

--- a/test/api-resources/test-pod.json
+++ b/test/api-resources/test-pod.json
@@ -1,0 +1,20 @@
+{
+  "id": "test-pod",
+  "kind": "Pod",
+  "apiVersion": "v1beta1",
+  "desiredState": {
+    "manifest": {
+      "version": "v1beta1",
+      "id": "test-pod",
+      "containers": [{
+        "name": "test-redis",
+        "image": "dockerfile/redis",
+        "cpu": 100,
+        "ports": [{"containerPort": 6379}]
+      }]
+    }
+  },
+  "labels": {
+    "name": "test-pod"
+  }
+}

--- a/test/api-resources/test-service.json
+++ b/test/api-resources/test-service.json
@@ -1,0 +1,13 @@
+{
+  "id": "test-service",
+  "kind": "Service",
+  "apiVersion": "v1beta1",
+  "port": 8000,
+  "containerPort": 7000,
+  "labels": {
+    "name": "test-service"
+  },
+  "selector": {
+    "name": "test-label"
+  }
+}


### PR DESCRIPTION
I've created new directory under test/api-resources for test API resources (pod, replication controller, service) and used them in pkg/kubectl/cmd.
