### PR TITLE
api: add image's id to ContainerStatus

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -440,6 +440,7 @@ type ContainerStatus struct {
 	PodIP string `json:"podIP,omitempty"`
 	// TODO(dchen1107): Need to decide how to represent this in v1beta3
 	Image       string `json:"image"`
+	ImageID     string `json:"imageID" description:"ID of the container's image"`
 	ContainerID string `json:"containerID,omitempty" description:"container's ID in the format 'docker://<container_id>'"`
 }
 

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -406,6 +406,7 @@ type ContainerStatus struct {
 	PodIP string `json:"podIP,omitempty" description:"pod's IP address"`
 	// TODO(dchen1107): Need to decide how to reprensent this in v1beta3
 	Image       string `json:"image" description:"image of the container"`
+	ImageID     string `json:"imageID" description:"ID of the container's image"`
 	ContainerID string `json:"containerID,omitempty" description:"container's ID in the format 'docker://<container_id>'"`
 }
 

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -370,6 +370,7 @@ type ContainerStatus struct {
 	PodIP string `json:"podIP,omitempty" description:"pod's IP address"`
 	// TODO(dchen1107): Need to decide how to reprensent this in v1beta3
 	Image       string `json:"image" description:"image of the container"`
+	ImageID     string `json:"imageID" description:"ID of the container's image"`
 	ContainerID string `json:"containerID,omitempty" description:"container's ID in the format 'docker://<container_id>'"`
 }
 

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -462,7 +462,8 @@ type ContainerStatus struct {
 	PodIP string `json:"podIP,omitempty"`
 	// TODO(dchen1107): Which image the container is running with?
 	// The image the container is running
-	Image string `json:"image"`
+	Image   string `json:"image"`
+	ImageID string `json:"imageID" description:"ID of the container's image"`
 }
 
 // PodInfo contains one entry for every container with available info.

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -41,6 +41,7 @@ import (
 
 const (
 	PodInfraContainerName = leaky.PodInfraContainerName
+	DockerPrefix          = "docker://"
 )
 
 // DockerInterface is an abstract interface for testability.  It abstracts the interface of docker.Client.
@@ -399,7 +400,8 @@ func inspectContainer(client DockerInterface, dockerID, containerName, tPath str
 	glog.V(3).Infof("Container inspect result: %+v", *inspectResult)
 	containerStatus := api.ContainerStatus{
 		Image:       inspectResult.Config.Image,
-		ContainerID: "docker://" + dockerID,
+		ImageID:     DockerPrefix + inspectResult.Image,
+		ContainerID: DockerPrefix + dockerID,
 	}
 
 	waiting := true


### PR DESCRIPTION
Sometimes for external applications it is important to identify
exactly what images are running. Since tags can be moved to point
to newer builds this information can be used to identify old images
running.

Signed-off-by: Federico Simoncelli fsimonce@redhat.com
