### PR TITLE
Fix hack/e2e-test.sh broken due to removed flag from hack/e2e.go

### DIFF
--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -15,6 +15,6 @@
 # limitations under the License.
 
 # Provided for backwards compatibility
-go run "$(dirname $0)/e2e.go" -v -build -up -tests="*" -down
+go run "$(dirname $0)/e2e.go" -v -build -up -test -down
 
 exit $?


### PR DESCRIPTION
Seems to got broken by https://github.com/GoogleCloudPlatform/kubernetes/commit/688f96cd3314664de0653665699dab5672e57cb7
