### PR TITLE
Kubectl should be able to display endpoints directly and for service

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -249,6 +249,11 @@ func (d *ServiceDescriber) Describe(namespace, name string) (string, error) {
 		return "", err
 	}
 
+	endpoints, err := d.Endpoints(namespace).Get(name)
+	if err != nil {
+		endpoints = &api.Endpoints{}
+	}
+
 	events, _ := d.Events(namespace).Search(service)
 
 	return tabbedString(func(out io.Writer) error {
@@ -256,6 +261,7 @@ func (d *ServiceDescriber) Describe(namespace, name string) (string, error) {
 		fmt.Fprintf(out, "Labels:\t%s\n", formatLabels(service.Labels))
 		fmt.Fprintf(out, "Selector:\t%s\n", formatLabels(service.Spec.Selector))
 		fmt.Fprintf(out, "Port:\t%d\n", service.Spec.Port)
+		fmt.Fprintf(out, "Endpoints:\t%s\n", stringList(endpoints.Endpoints))
 		if events != nil {
 			describeEvents(events, out)
 		}

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -218,6 +218,7 @@ func (h *HumanReadablePrinter) validatePrintHandlerFunc(printFunc reflect.Value)
 var podColumns = []string{"POD", "IP", "CONTAINER(S)", "IMAGE(S)", "HOST", "LABELS", "STATUS"}
 var replicationControllerColumns = []string{"CONTROLLER", "CONTAINER(S)", "IMAGE(S)", "SELECTOR", "REPLICAS"}
 var serviceColumns = []string{"NAME", "LABELS", "SELECTOR", "IP", "PORT"}
+var endpointColumns = []string{"NAME", "ENDPOINTS"}
 var minionColumns = []string{"NAME", "LABELS", "STATUS"}
 var statusColumns = []string{"STATUS"}
 var eventColumns = []string{"TIME", "NAME", "KIND", "SUBOBJECT", "REASON", "SOURCE", "MESSAGE"}
@@ -232,6 +233,7 @@ func (h *HumanReadablePrinter) addDefaultHandlers() {
 	h.Handler(replicationControllerColumns, printReplicationControllerList)
 	h.Handler(serviceColumns, printService)
 	h.Handler(serviceColumns, printServiceList)
+	h.Handler(endpointColumns, printEndpoints)
 	h.Handler(minionColumns, printMinion)
 	h.Handler(minionColumns, printMinionList)
 	h.Handler(statusColumns, printStatus)
@@ -253,6 +255,13 @@ func (h *HumanReadablePrinter) printHeader(columnNames []string, w io.Writer) er
 		return err
 	}
 	return nil
+}
+
+func stringList(list []string) string {
+	if len(list) == 0 {
+		return "<empty>"
+	}
+	return strings.Join(list, ",")
 }
 
 func podHostString(host, ip string) string {
@@ -350,6 +359,11 @@ func printServiceList(list *api.ServiceList, w io.Writer) error {
 		}
 	}
 	return nil
+}
+
+func printEndpoints(endpoint *api.Endpoints, w io.Writer) error {
+	_, err := fmt.Fprintf(w, "%s\t%s\n", endpoint.Name, stringList(endpoint.Endpoints))
+	return err
 }
 
 func printMinion(minion *api.Node, w io.Writer) error {

--- a/pkg/kubectl/resource_printer_test.go
+++ b/pkg/kubectl/resource_printer_test.go
@@ -452,10 +452,11 @@ func TestPrinters(t *testing.T) {
 		"pod":             &api.Pod{ObjectMeta: om("pod")},
 		"emptyPodList":    &api.PodList{},
 		"nonEmptyPodList": &api.PodList{Items: []api.Pod{{}}},
+		"endpoints":       &api.Endpoints{Endpoints: []string{"127.0.0.1", "localhost:8080"}},
 	}
 	// map of printer name to set of objects it should fail on.
 	expectedErrors := map[string]util.StringSet{
-		"template2": util.NewStringSet("pod", "emptyPodList"),
+		"template2": util.NewStringSet("pod", "emptyPodList", "endpoints"),
 	}
 
 	for pName, p := range printers {


### PR DESCRIPTION
kubectl get endpoints <servicename>
    kubectl describe service <servicename>

should have printers for endpoints
