### PR TITLE
Start using GCE safe format and mount for mounting disks.

### DIFF
--- a/pkg/kubelet/volume/gce_pd/gce_pd.go
+++ b/pkg/kubelet/volume/gce_pd/gce_pd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/volume"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/exec"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/mount"
 	"github.com/golang/glog"
 )
@@ -71,7 +72,7 @@ func (plugin *gcePersistentDiskPlugin) CanSupport(spec *api.Volume) bool {
 
 func (plugin *gcePersistentDiskPlugin) NewBuilder(spec *api.Volume, podUID types.UID) (volume.Builder, error) {
 	// Inject real implementations here, test through the internal function.
-	return plugin.newBuilderInternal(spec, podUID, &GCEDiskUtil{}, mount.New())
+	return plugin.newBuilderInternal(spec, podUID, &GCEDiskUtil{}, &gceSafeFormatAndMount{mount.New(), exec.New()})
 }
 
 func (plugin *gcePersistentDiskPlugin) newBuilderInternal(spec *api.Volume, podUID types.UID, manager pdManager, mounter mount.Interface) (volume.Builder, error) {

--- a/pkg/kubelet/volume/gce_pd/gce_util.go
+++ b/pkg/kubelet/volume/gce_pd/gce_util.go
@@ -147,7 +147,7 @@ func (util *GCEDiskUtil) DetachDisk(pd *gcePersistentDisk, devicePath string) er
 // This eliminates the necesisty to format a PD before it is used with a Pod on GCE.
 // TODO: port this script into Go and use it for all Linux platforms
 type gceSafeFormatAndMount struct {
-	mount.Mounter
+	mount.Interface
 	runner exec.Interface
 }
 


### PR DESCRIPTION
This removes the need for disks to be formatted.
