### PR TITLE
contrib/git-sync: fix demo and doc

### DIFF
--- a/contrib/git-sync/README.md
+++ b/contrib/git-sync/README.md
@@ -10,7 +10,7 @@ It can be used to source a container volume with the content of a git repo.
 # build the container
 docker build -t git-sync .
 # run the git-sync container
-docker run -d GIT_SYNC_REPO=https://github.com/GoogleCloudPlatform/kubernetes -e GIT_SYNC_BRANCH=gh-pages -r HEAD -v /git-data:/git git-sync
+docker run -d GIT_SYNC_REPO=https://github.com/GoogleCloudPlatform/kubernetes GIT_SYNC_DEST=/git -e GIT_SYNC_BRANCH=gh-pages -r HEAD GIT_SYNC_DEST=/git -v /git-data:/git git-sync
 # run a nginx container to serve sync'ed content
 docker run -d -p 8080:80 -v /git-data:/usr/share/nginx/html nginx 
 ```

--- a/contrib/git-sync/demo/config/pod.yaml
+++ b/contrib/git-sync/demo/config/pod.yaml
@@ -8,11 +8,11 @@ desiredState:
     - name: git-sync
       image: proppy/git-sync
       imagePullPolicy: PullAlways
-      env::
-        - name: GIT_SYNC_REPO
-          value: https://github.com/proppy/blog.git
-        - name: GIT_SYNC_DEST
-          value: /git
+      env:
+      - name: GIT_SYNC_REPO
+        value: https://github.com/GoogleCloudPlatform/kubernetes.git
+      - name: GIT_SYNC_DEST
+        value: /git
       volumeMounts:
       - name: markdown
         mountPath: /git
@@ -20,12 +20,12 @@ desiredState:
       image: proppy/hugo
       imagePullPolicy: PullAlways
       env:
-      - name: SRC
-        value: /src
-      - name: BUILD_DRAFT
+      - name: HUGO_SRC
+        value: /src/contrib/git-sync/demo/blog
+      - name: HUGO_BUILD_DRAFT
         value: 'true'
-      - name: BASE_URL
-        value: kube.proppy.sh
+      - name: HUGO_BASE_URL
+        value: example.com
       volumeMounts:
       - name: markdown
         mountPath: /src

--- a/contrib/git-sync/demo/hugo/Dockerfile
+++ b/contrib/git-sync/demo/hugo/Dockerfile
@@ -1,13 +1,26 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 FROM golang
 RUN go get -v github.com/spf13/hugo
 RUN git clone --recursive https://github.com/spf13/hugoThemes.git /themes
 VOLUME ["/src", "/dest"]
 EXPOSE 1313
-ENV SRC /src
-ENV DEST /dest
-ENV THEME hyde
-ENV BUILD_DRAFT false
-ENV BASE_URL ""
+ENV HUGO_SRC /src
+ENV HUGO_DEST /dest
+ENV HUGO_THEME hyde
+ENV HUGO_BUILD_DRAFT false
+ENV HUGO_BASE_URL ""
 ADD run-hugo /run-hugo
 ENTRYPOINT ["/run-hugo"]
-CMD ["server", "--source=${SRC}", "--theme=${THEME}", "--buildDrafts=${BUILD_DRAFT}", "--baseUrl=${BASE_URL}", "--watch", "--destination=${DEST}", "--appendPort=false"]
+CMD ["server", "--source=${HUGO_SRC}", "--theme=${HUGO_THEME}", "--buildDrafts=${HUGO_BUILD_DRAFT}", "--baseUrl=${HUGO_BASE_URL}", "--watch", "--destination=${HUGO_DEST}", "--appendPort=false"]

--- a/contrib/git-sync/demo/hugo/README.md
+++ b/contrib/git-sync/demo/hugo/README.md
@@ -1,0 +1,12 @@
+# hugo
+
+`hugo` is a container that convert markdown into html using [hugo static site generator](http://gohugo.io/).
+
+## Usage
+
+```
+# build the container
+docker build -t hugo .
+# run the hugo container
+docker run -e HUGO_BASE_URL=example.com -v /path/to/md:/src -v /path/to/html:/dest hugo
+``

--- a/contrib/git-sync/demo/hugo/run-hugo
+++ b/contrib/git-sync/demo/hugo/run-hugo
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 set -ex
-if [ ! -d ${SRC}/themes ]; then
-    ln -s /themes ${SRC}/themes
+if [ ! -d ${HUGO_SRC}/themes ]; then
+    ln -s /themes ${HUGO_SRC}/themes
 fi
 hugo $(eval echo $*) # force default CMD env expansion


### PR DESCRIPTION
Fixing some typo and inconsistencies in the demo and the docs.

Tested that the demo is working here:
http://107.178.221.46/ (css is failing because I don't have any public domain name for it).
