### PR TITLE
Add some locking to prevent go data race logic from tripping.

### DIFF
--- a/pkg/registry/registrytest/controller.go
+++ b/pkg/registry/registrytest/controller.go
@@ -38,10 +38,14 @@ func (r *ControllerRegistry) SetError(err error) {
 }
 
 func (r *ControllerRegistry) ListControllers(ctx api.Context) (*api.ReplicationControllerList, error) {
+	r.Lock()
+	defer r.Unlock()
 	return r.Controllers, r.Err
 }
 
 func (r *ControllerRegistry) GetController(ctx api.Context, ID string) (*api.ReplicationController, error) {
+	r.Lock()
+	defer r.Unlock()
 	return &api.ReplicationController{}, r.Err
 }
 
@@ -52,13 +56,19 @@ func (r *ControllerRegistry) CreateController(ctx api.Context, controller *api.R
 }
 
 func (r *ControllerRegistry) UpdateController(ctx api.Context, controller *api.ReplicationController) error {
+	r.Lock()
+	defer r.Unlock()
 	return r.Err
 }
 
 func (r *ControllerRegistry) DeleteController(ctx api.Context, ID string) error {
+	r.Lock()
+	defer r.Unlock()
 	return r.Err
 }
 
 func (r *ControllerRegistry) WatchControllers(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	r.Lock()
+	defer r.Unlock()
 	return nil, r.Err
 }


### PR DESCRIPTION
Closes https://github.com/GoogleCloudPlatform/kubernetes/issues/4189 which has caused a couple of recent flakes on Shippable.
