### PR TITLE
Move verbosity flag into driver.go, randomize specs

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -102,6 +102,5 @@ fi
 "${e2e}" "${auth_config[@]:+${auth_config[@]}}" \
   --host="https://${KUBE_MASTER_IP-}" \
   --provider="${KUBERNETES_PROVIDER}" \
-  --ginkgo.v \
   ${E2E_REPORT_DIR+"--report_dir=${E2E_REPORT_DIR}"} \
   "${@}"

--- a/test/e2e/driver.go
+++ b/test/e2e/driver.go
@@ -35,6 +35,12 @@ func init() {
 	// Turn off colors by default to make it easier to collect console output in Jenkins
 	// Override colors off with --ginkgo.noColor=false in the command-line
 	config.DefaultReporterConfig.NoColor = true
+
+	// Turn on verbose by default to get spec names
+	config.DefaultReporterConfig.Verbose = true
+
+	// Randomize specs as well as suites
+	config.GinkgoConfig.RandomizeAllSpecs = true
 }
 
 func (t *testResult) Fail() { *t = false }


### PR DESCRIPTION
Before we get too many suites baked, I want to get spec randomization
in, just so no one accidentally thinks things flow from top to bottom.
