### PR TITLE
Fixed API server portal_net flag that could break service networking on CoreOS

### DIFF
--- a/docs/getting-started-guides/aws/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/aws/cloud-configs/master.yaml
@@ -121,7 +121,7 @@ coreos:
         ExecStart=/opt/bin/kube-apiserver \
         --address=0.0.0.0 \
         --port=8080 \
-        --portal_net=10.244.0.0/16 \
+        --portal_net=10.100.0.0/16 \
         --etcd_servers=http://127.0.0.1:4001 \
         --public_address_override=$private_ipv4 \
         --logtostderr=true

--- a/docs/getting-started-guides/aws/cloudformation-template.json
+++ b/docs/getting-started-guides/aws/cloudformation-template.json
@@ -247,7 +247,7 @@
           "        ExecStart=/opt/bin/kube-apiserver \\\n",
           "        --address=0.0.0.0 \\\n",
           "        --port=8080 \\\n",
-          "        --portal_net=10.244.0.0/16 \\\n",
+          "        --portal_net=10.100.0.0/16 \\\n",
           "        --etcd_servers=http://127.0.0.1:4001 \\\n",
           "        --public_address_override=$private_ipv4 \\\n",
           "        --logtostderr=true\n",

--- a/docs/getting-started-guides/coreos/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/master.yaml
@@ -121,7 +121,7 @@ coreos:
         ExecStart=/opt/bin/kube-apiserver \
         --address=0.0.0.0 \
         --port=8080 \
-        --portal_net=10.244.0.0/16 \
+        --portal_net=10.100.0.0/16 \
         --etcd_servers=http://127.0.0.1:4001 \
         --public_address_override=$private_ipv4 \
         --logtostderr=true

--- a/docs/getting-started-guides/coreos/cloud-configs/standalone.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/standalone.yaml
@@ -81,7 +81,7 @@ coreos:
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-apiserver
         ExecStart=/opt/bin/kube-apiserver \
         --address=0.0.0.0 \
-        --portal_net=10.244.0.0/16 \
+        --portal_net=10.100.0.0/16 \
         --port=8080 \
         --etcd_servers=http://127.0.0.1:4001 \
         --public_address_override=127.0.0.1 \


### PR DESCRIPTION
Fixed API server portal_net flag that could break service networking by assigning an IP address from a subnet already allocated to a node to a service.
