### PR TITLE
Turn on color, turn on EmitSpecProgress

### DIFF
--- a/test/e2e/driver.go
+++ b/test/e2e/driver.go
@@ -32,12 +32,11 @@ import (
 type testResult bool
 
 func init() {
-	// Turn off colors by default to make it easier to collect console output in Jenkins
-	// Override colors off with --ginkgo.noColor=false in the command-line
-	config.DefaultReporterConfig.NoColor = true
-
 	// Turn on verbose by default to get spec names
 	config.DefaultReporterConfig.Verbose = true
+
+	// Turn on EmitSpecProgress to get spec progress (especially on interrupt)
+	config.GinkgoConfig.EmitSpecProgress = true
 
 	// Randomize specs as well as suites
 	config.GinkgoConfig.RandomizeAllSpecs = true


### PR DESCRIPTION
Jenkins has awesome JUnit output, so the console having colors isn't a problem. 

This adds failure summaries, too. Which is awesome.

Here's sample output:

```
$ hack/ginkgo-e2e.sh --report_dir=. --ginkgo.focus=stupid.sh
Project: artful-fortress-786
Zone: us-central1-f   
Running Suite: Kubernetes e2e Suite
===================================
Random Seed: 1423265010 - Will randomize all specs
Will run 1 of 21 specs

SSSSS
------------------------------
Shell
  tests that stupid.sh passes
  /usr/local/google/home/zml/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/shell.go:47
[It] tests that stupid.sh passes
  /usr/local/google/home/zml/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/shell.go:47
STEP: Running /usr/local/google/home/zml/kubernetes/hack/e2e-suite/stupid.sh

• Failure [0.011 seconds]
Shell
/usr/local/google/home/zml/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/shell.go:49
  tests that stupid.sh passes [It]
  /usr/local/google/home/zml/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/shell.go:47

  Error running &{/usr/local/google/home/zml/kubernetes/hack/e2e-suite/stupid.sh [/usr/local/google/home/zml/kubernetes/hack/e2e-suite/stupid.sh] []  <nil> Nor
mal output
  more normal output
  SOME ERROR
   Normal output
  more normal output
  SOME ERROR
   [] <nil> 0x4c208112520 exit status 1 <nil> true [0x4c20803c2f0 0x4c20803c310 0x4c20803c310] [0x4c20803c2f0 0x4c20803c310] [0x4c20803c308] [0x5c38b0] 0x4c208
0b22a0}:
  Command output:
  Normal output
  more normal output
  SOME ERROR



  /usr/local/google/home/zml/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/shell.go:67
------------------------------
SSSSSSSSSSSSSSS

Summarizing 1 Failure:

[Fail] Shell [It] tests that stupid.sh passes 
/usr/local/google/home/zml/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/shell.go:67

Ran 1 of 21 Specs in 0.012 seconds
FAIL! -- 0 Passed | 1 Failed | 0 Pending | 20 Skipped F0206 15:23:30.169928   15018 driver.go:81] At least one test failed
```
