### PR TITLE
Remove pods from failed node

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -203,8 +203,8 @@ func startComponents(manifestURL string) (apiServerURL string) {
 
 	nodeResources := &api.NodeResources{}
 
-	nodeController := nodeControllerPkg.NewNodeController(nil, "", machineList, nodeResources, cl, fakeKubeletClient{}, 5*time.Minute)
-	nodeController.Run(5*time.Second, 10, true)
+	nodeController := nodeControllerPkg.NewNodeController(nil, "", machineList, nodeResources, cl, fakeKubeletClient{}, 10, 5*time.Minute)
+	nodeController.Run(5*time.Second, true)
 
 	// Kubelet (localhost)
 	testRootDir := makeTempDirOrDie("kubelet_integ_1.")

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -202,7 +202,8 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	controllerManager.Run(10 * time.Minute)
 
 	nodeResources := &api.NodeResources{}
-	nodeController := nodeControllerPkg.NewNodeController(nil, "", machineList, nodeResources, cl, fakeKubeletClient{})
+
+	nodeController := nodeControllerPkg.NewNodeController(nil, "", machineList, nodeResources, cl, fakeKubeletClient{}, 5*time.Minute)
 	nodeController.Run(5*time.Second, 10, true)
 
 	// Kubelet (localhost)

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -123,7 +123,8 @@ func runControllerManager(machineList []string, cl *client.Client, nodeMilliCPU,
 		},
 	}
 	kubeClient := &client.HTTPKubeletClient{Client: http.DefaultClient, Port: ports.KubeletPort}
-	nodeController := nodeControllerPkg.NewNodeController(nil, "", machineList, nodeResources, cl, kubeClient)
+
+	nodeController := nodeControllerPkg.NewNodeController(nil, "", machineList, nodeResources, cl, kubeClient, 5*time.Minute)
 	nodeController.Run(10*time.Second, 10, true)
 
 	endpoints := service.NewEndpointController(cl)

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -124,8 +124,8 @@ func runControllerManager(machineList []string, cl *client.Client, nodeMilliCPU,
 	}
 	kubeClient := &client.HTTPKubeletClient{Client: http.DefaultClient, Port: ports.KubeletPort}
 
-	nodeController := nodeControllerPkg.NewNodeController(nil, "", machineList, nodeResources, cl, kubeClient, 5*time.Minute)
-	nodeController.Run(10*time.Second, 10, true)
+	nodeController := nodeControllerPkg.NewNodeController(nil, "", machineList, nodeResources, cl, kubeClient, 10, 5*time.Minute)
+	nodeController.Run(10*time.Second, true)
 
 	endpoints := service.NewEndpointController(cl)
 	go util.Forever(func() { endpoints.SyncServiceEndpoints() }, time.Second*10)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -774,6 +774,7 @@ const (
 type NodeCondition struct {
 	Kind               NodeConditionKind   `json:"kind"`
 	Status             NodeConditionStatus `json:"status"`
+	LastProbeTime      util.Time           `json:"lastProbeTime,omitempty"`
 	LastTransitionTime util.Time           `json:"lastTransitionTime,omitempty"`
 	Reason             string              `json:"reason,omitempty"`
 	Message            string              `json:"message,omitempty"`

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -619,6 +619,7 @@ const (
 type NodeCondition struct {
 	Kind               NodeConditionKind   `json:"kind" description:"kind of the condition, one of reachable, ready"`
 	Status             NodeConditionStatus `json:"status" description:"status of the condition, one of full, none, unknown"`
+	LastProbeTime      util.Time           `json:"lastProbeTime,omitempty" description:"last time the condition was probed"`
 	LastTransitionTime util.Time           `json:"lastTransitionTime,omitempty" description:"last time the condition transit from one status to another"`
 	Reason             string              `json:"reason,omitempty" description:"(brief) reason for the condition's last transition"`
 	Message            string              `json:"message,omitempty" description:"human readable message indicating details about last transition"`

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -583,6 +583,7 @@ const (
 type NodeCondition struct {
 	Kind               NodeConditionKind   `json:"kind" description:"kind of the condition, one of reachable, ready"`
 	Status             NodeConditionStatus `json:"status" description:"status of the condition, one of full, none, unknown"`
+	LastProbeTime      util.Time           `json:"lastProbeTime,omitempty" description:"last time the condition was probed"`
 	LastTransitionTime util.Time           `json:"lastTransitionTime,omitempty" description:"last time the condition transit from one status to another"`
 	Reason             string              `json:"reason,omitempty" description:"(brief) reason for the condition's last transition"`
 	Message            string              `json:"message,omitempty" description:"human readable message indicating details about last transition"`

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -808,6 +808,7 @@ const (
 type NodeCondition struct {
 	Kind               NodeConditionKind   `json:"kind"`
 	Status             NodeConditionStatus `json:"status"`
+	LastProbeTime      util.Time           `json:"lastProbeTime,omitempty"`
 	LastTransitionTime util.Time           `json:"lastTransitionTime,omitempty"`
 	Reason             string              `json:"reason,omitempty"`
 	Message            string              `json:"message,omitempty"`

--- a/pkg/controllermanager/controllermanager.go
+++ b/pkg/controllermanager/controllermanager.go
@@ -54,11 +54,8 @@ type CMServer struct {
 	ResourceQuotaSyncPeriod time.Duration
 	RegisterRetryCount      int
 	MachineList             util.StringList
-<<<<<<< HEAD
 	SyncNodeList            bool
-=======
 	PodEvictionTimeout      time.Duration
->>>>>>> Remove pods from failed node
 
 	// TODO: Discover these by pinging the host machines, and rip out these params.
 	NodeMilliCPU int64
@@ -176,8 +173,9 @@ func (s *CMServer) Run(_ []string) error {
 		},
 	}
 
-	nodeController := nodeControllerPkg.NewNodeController(cloud, s.MinionRegexp, s.MachineList, nodeResources, kubeClient, kubeletClient, s.PodEvictionTimeout)
-	nodeController.Run(s.NodeSyncPeriod, s.RegisterRetryCount, s.SyncNodeList)
+	nodeController := nodeControllerPkg.NewNodeController(cloud, s.MinionRegexp, s.MachineList, nodeResources,
+		kubeClient, kubeletClient, s.RegisterRetryCount, s.PodEvictionTimeout)
+	nodeController.Run(s.NodeSyncPeriod, s.SyncNodeList)
 
 	resourceQuotaManager := resourcequota.NewResourceQuotaManager(kubeClient)
 	resourceQuotaManager.Run(s.ResourceQuotaSyncPeriod)

--- a/pkg/controllermanager/controllermanager.go
+++ b/pkg/controllermanager/controllermanager.go
@@ -54,7 +54,11 @@ type CMServer struct {
 	ResourceQuotaSyncPeriod time.Duration
 	RegisterRetryCount      int
 	MachineList             util.StringList
+<<<<<<< HEAD
 	SyncNodeList            bool
+=======
+	PodEvictionTimeout      time.Duration
+>>>>>>> Remove pods from failed node
 
 	// TODO: Discover these by pinging the host machines, and rip out these params.
 	NodeMilliCPU int64
@@ -63,7 +67,7 @@ type CMServer struct {
 	KubeletConfig client.KubeletConfig
 }
 
-// NewCMServer creates a new CMServer with default a default config.
+// NewCMServer creates a new CMServer with a default config.
 func NewCMServer() *CMServer {
 	s := CMServer{
 		Port:                    ports.ControllerManagerPort,
@@ -71,6 +75,7 @@ func NewCMServer() *CMServer {
 		NodeSyncPeriod:          10 * time.Second,
 		ResourceQuotaSyncPeriod: 10 * time.Second,
 		RegisterRetryCount:      10,
+		PodEvictionTimeout:      5 * time.Minute,
 		NodeMilliCPU:            1000,
 		NodeMemory:              resource.MustParse("3Gi"),
 		SyncNodeList:            true,
@@ -110,6 +115,7 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
 		"The period for syncing nodes from cloudprovider. Longer periods will result in "+
 		"fewer calls to cloud provider, but may delay addition of new nodes to cluster.")
 	fs.DurationVar(&s.ResourceQuotaSyncPeriod, "resource_quota_sync_period", s.ResourceQuotaSyncPeriod, "The period for syncing quota usage status in the system")
+	fs.DurationVar(&s.PodEvictionTimeout, "pod_eviction_timeout", s.PodEvictionTimeout, "The grace peroid for deleting pods on failed nodes.")
 	fs.IntVar(&s.RegisterRetryCount, "register_retry_count", s.RegisterRetryCount, ""+
 		"The number of retries for initial node registration.  Retry interval equals node_sync_period.")
 	fs.Var(&s.MachineList, "machines", "List of machines to schedule onto, comma separated.")
@@ -169,7 +175,8 @@ func (s *CMServer) Run(_ []string) error {
 			api.ResourceMemory: s.NodeMemory,
 		},
 	}
-	nodeController := nodeControllerPkg.NewNodeController(cloud, s.MinionRegexp, s.MachineList, nodeResources, kubeClient, kubeletClient)
+
+	nodeController := nodeControllerPkg.NewNodeController(cloud, s.MinionRegexp, s.MachineList, nodeResources, kubeClient, kubeletClient, s.PodEvictionTimeout)
 	nodeController.Run(s.NodeSyncPeriod, s.RegisterRetryCount, s.SyncNodeList)
 
 	resourceQuotaManager := resourcequota.NewResourceQuotaManager(kubeClient)


### PR DESCRIPTION
Need tests and fix current tests.  Reference issue #1366.

@bgrant0607 The problem here is whether we want to introduce the new 'LastProbTime' time.  If we don't, then we just use CurrentProbTime, which is time.Now().  The benefit of having a new field is that we get more conservative of when to delete pods; the benefit of not having the new field is that we do not need to push node status every tick.
