### PR TITLE
Add a timeout to waitForPodRunning

### DIFF
--- a/test/e2e/basic.go
+++ b/test/e2e/basic.go
@@ -123,7 +123,11 @@ func TestBasicImage(c *client.Client, test string, image string) bool {
 	// Wait for the pods to enter the running state. Waiting loops until the pods
 	// are running so non-running pods cause a timeout for this test.
 	for _, pod := range pods.Items {
-		waitForPodRunning(c, pod.Name)
+		err = waitForPodRunning(c, pod.Name, 300*time.Second)
+		if err != nil {
+			glog.Errorf("waitForPodRunningFailed: %v", err.Error())
+			return false
+		}
 	}
 
 	// Try to make sure we get a hostIP for each pod.

--- a/test/e2e/events.go
+++ b/test/e2e/events.go
@@ -80,7 +80,8 @@ var _ = Describe("Events", func() {
 		}()
 
 		By("waiting for the pod to start running")
-		waitForPodRunning(c, pod.Name)
+		err = waitForPodRunning(c, pod.Name, 300*time.Second)
+		Expect(err).NotTo(HaveOccurred())
 
 		By("verifying the pod is in kubernetes")
 		pods, err := podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})))

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -145,7 +145,8 @@ var _ = Describe("Pods", func() {
 		}()
 
 		By("waiting for the pod to start running")
-		waitForPodRunning(c, pod.Name)
+		err = waitForPodRunning(c, pod.Name, 300*time.Second)
+		Expect(err).NotTo(HaveOccurred())
 
 		By("verifying the pod is in kubernetes")
 		pods, err := podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})))
@@ -168,7 +169,8 @@ var _ = Describe("Pods", func() {
 		}
 
 		By("waiting for the updated pod to start running")
-		waitForPodRunning(c, pod.Name)
+		err = waitForPodRunning(c, pod.Name, 300*time.Second)
+		Expect(err).NotTo(HaveOccurred())
 
 		By("verifying the updated pod is in kubernetes")
 		pods, err = podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})))
@@ -203,7 +205,8 @@ var _ = Describe("Pods", func() {
 			defer GinkgoRecover()
 			c.Pods(api.NamespaceDefault).Delete(serverPod.Name)
 		}()
-		waitForPodRunning(c, serverPod.Name)
+		err = waitForPodRunning(c, serverPod.Name, 300*time.Second)
+		Expect(err).NotTo(HaveOccurred())
 
 		// This service exposes port 8080 of the test pod as a service on port 8765
 		// TODO(filbranden): We would like to use a unique service name such as:

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -116,7 +116,8 @@ var _ = Describe("Services", func() {
 		}()
 
 		By("waiting for the pod to start running")
-		waitForPodRunning(c, pod.Name)
+		err = waitForPodRunning(c, pod.Name, 300*time.Second)
+		Expect(err).NotTo(HaveOccurred())
 
 		By("retrieving the pod")
 		pod, err = podClient.Get(pod.Name)


### PR DESCRIPTION
- Add a timeout, convert the function to return an error (which gives
  a reasonable status message for callers).
- Start converting glog to By.
