### PR TITLE
Get vagrant $vm_mem value from environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,11 +50,11 @@ else # sorry Windows folks, I can't help you
   $vm_cpus = 2
 end
 
-# Give VM 1024MB of RAM
+# Give VM 1024MB of RAM by default
 # In Fedora VM, tmpfs device is mapped to /tmp.  tmpfs is given 50% of RAM allocation.
 # When doing Salt provisioning, we copy approximately 200MB of content in /tmp before anything else happens.
 # This causes problems if anything else was in /tmp or the other directories that are bound to tmpfs device (i.e /run, etc.)
-$vm_mem = 1024
+$vm_mem = (ENV['KUBERNETES_MEMORY'] || 1024).to_i
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   def customize_vm(config)

--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -307,5 +307,14 @@ You can control the number of minions that are instantiated via the environment 
 export NUM_MINIONS=1
 ```
 
+#### I want my VMs to have more memory !
+
+You can control the memory allotted to virtual machines with the `KUBERNETES_MEMORY` environment variable.
+Just set it to the number of megabytes you would like the machines to have. For example:
+
+```
+export KUBERNETES_MEMORY=2048
+```
+
 #### I ran vagrant suspend and nothing works!
 ```vagrant suspend``` seems to mess up the network.  It's not supported at this time.


### PR DESCRIPTION
I'd like to put something in my environment similar to NUM_MINIONS to control the amount of memory Vagrant VMs get. I'm happy to submit a pull request, but would like feedback on the environment variable names to expedite things.

Some options would be: KUBERNETES_MEMORY, KUBERNETES_RAM, KUBE_MEMORY, KUBE_RAM.

Or, Master and Minion could be split up, lending variable names such as KUBERNETES_MASTER_MEMORY, KUBERNETES_MINION_MEMORY. If we're doing that, it's probably safe to drop the KUBERNETES_ on the thought MASTER_MEMORY is specific enough to Kubernetes. 
