### PR TITLE
Eliminate use of glog in test/e2e/util.go, convert functions to return errors

### DIFF
--- a/test/e2e/basic.go
+++ b/test/e2e/basic.go
@@ -199,8 +199,8 @@ func TestBasic(c *client.Client) bool {
 
 var _ = Describe("TestBasic", func() {
 	It("should pass", func() {
-		// TODO: Instead of OrDie, client should Fail the test if there's a problem.
-		// In general tests should Fail() instead of glog.Fatalf().
-		Expect(TestBasic(loadClientOrDie())).To(BeTrue())
+		c, err := loadClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(TestBasic(c)).To(BeTrue())
 	})
 })

--- a/test/e2e/endpoints.go
+++ b/test/e2e/endpoints.go
@@ -189,8 +189,8 @@ func TestEndpoints(c *client.Client) bool {
 
 var _ = Describe("TestEndpoints", func() {
 	It("should pass", func() {
-		// TODO: Instead of OrDie, client should Fail the test if there's a problem.
-		// In general tests should Fail() instead of glog.Fatalf().
-		Expect(TestEndpoints(loadClientOrDie())).To(BeTrue())
+		c, err := loadClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(TestEndpoints(c)).To(BeTrue())
 	})
 })

--- a/test/e2e/events.go
+++ b/test/e2e/events.go
@@ -34,7 +34,9 @@ var _ = Describe("Events", func() {
 	var c *client.Client
 
 	BeforeEach(func() {
-		c = loadClientOrDie()
+		var err error
+		c, err = loadClient()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should be sent by kubelets and the scheduler about pods scheduling and running", func() {

--- a/test/e2e/liveness.go
+++ b/test/e2e/liveness.go
@@ -137,16 +137,16 @@ func TestLivenessExec(c *client.Client) bool {
 
 var _ = Describe("TestLivenessHttp", func() {
 	It("should pass", func() {
-		// TODO: Instead of OrDie, client should Fail the test if there's a problem.
-		// In general tests should Fail() instead of glog.Fatalf().
-		Expect(TestLivenessHttp(loadClientOrDie())).To(BeTrue())
+		c, err := loadClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(TestLivenessHttp(c)).To(BeTrue())
 	})
 })
 
 var _ = Describe("TestLivenessExec", func() {
 	It("should pass", func() {
-		// TODO: Instead of OrDie, client should Fail the test if there's a problem.
-		// In general tests should Fail() instead of glog.Fatalf().
-		Expect(TestLivenessExec(loadClientOrDie())).To(BeTrue())
+		c, err := loadClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(TestLivenessExec(c)).To(BeTrue())
 	})
 })

--- a/test/e2e/liveness.go
+++ b/test/e2e/liveness.go
@@ -44,8 +44,9 @@ func runLivenessTest(c *client.Client, podDescr *api.Pod) bool {
 	// Wait until the pod is not pending. (Here we need to check for something other than
 	// 'Pending' other than checking for 'Running', since when failures occur, we go to
 	// 'Terminated' which can cause indefinite blocking.)
-	if !waitForPodNotPending(c, ns, podDescr.Name) {
-		glog.Infof("Failed to start pod %s in namespace %s", podDescr.Name, ns)
+	err = waitForPodNotPending(c, ns, podDescr.Name, 60*time.Second)
+	if err != nil {
+		glog.Infof("Failed to start pod %s in namespace %s: %v", podDescr.Name, ns, err)
 		return false
 	}
 	glog.Infof("Started pod %s in namespace %s", podDescr.Name, ns)

--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -33,7 +33,9 @@ var _ = Describe("Networking", func() {
 	var c *client.Client
 
 	BeforeEach(func() {
-		c = loadClientOrDie()
+		var err error
+		c, err = loadClient()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should function for pods", func() {

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -36,7 +36,9 @@ var _ = Describe("Pods", func() {
 	)
 
 	BeforeEach(func() {
-		c = loadClientOrDie()
+		var err error
+		c, err = loadClient()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should be submitted and removed", func() {

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -275,10 +275,8 @@ var _ = Describe("Pods", func() {
 		}()
 
 		// Wait for client pod to complete.
-		success := waitForPodSuccess(c, clientPod.Name, clientPod.Spec.Containers[0].Name)
-		if !success {
-			Fail(fmt.Sprintf("Failed to run client pod to detect service env vars."))
-		}
+		err = waitForPodSuccess(c, clientPod.Name, clientPod.Spec.Containers[0].Name, 60*time.Second)
+		Expect(err).NotTo(HaveOccurred())
 
 		// Grab its logs.  Get host first.
 		clientPodStatus, err := c.Pods(api.NamespaceDefault).Get(clientPod.Name)

--- a/test/e2e/private.go
+++ b/test/e2e/private.go
@@ -39,8 +39,8 @@ func TestPrivate(c *client.Client) bool {
 
 var _ = Describe("TestPrivate", func() {
 	It("should pass", func() {
-		// TODO: Instead of OrDie, client should Fail the test if there's a problem.
-		// In general tests should Fail() instead of glog.Fatalf().
-		Expect(TestPrivate(loadClientOrDie())).To(BeTrue())
+		c, err := loadClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(TestPrivate(c)).To(BeTrue())
 	})
 })

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -32,7 +32,9 @@ var _ = Describe("Services", func() {
 	var c *client.Client
 
 	BeforeEach(func() {
-		c = loadClientOrDie()
+		var err error
+		c, err = loadClient()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should provide DNS for the cluster", func() {


### PR DESCRIPTION
We've had a lot of complaints about the e2e test output, and one of the issues is the mixed output formats. Now that we've embraced a framework, let's actually use its output. This also shifts several functions to percolate errors back to tests, which seems vaguely more appropriate for a library. (Though I'm happy to just shift these all to "OrFail" now that we're in Gingko. Really I could go either way.)

(Note that some tests still log using glog.)

@filbranden @rrati @satnam6502 
