### PR TITLE
Updated etcd-pod-dir-fetch logging.

### DIFF
--- a/pkg/kubelet/config/etcd.go
+++ b/pkg/kubelet/config/etcd.go
@@ -61,7 +61,7 @@ func (s *sourceEtcd) run() {
 	boundPods := api.BoundPods{}
 	err := s.helper.ExtractObj(s.key, &boundPods, false)
 	if err != nil {
-		if (tools.IsEtcdNotFound(err)) {
+		if tools.IsEtcdNotFound(err) {
 			glog.V(4).Infof("etcd failed to retrieve the value for the key %q. Error: %v", s.key, err)
 			return
 		}

--- a/pkg/kubelet/config/etcd.go
+++ b/pkg/kubelet/config/etcd.go
@@ -61,6 +61,10 @@ func (s *sourceEtcd) run() {
 	boundPods := api.BoundPods{}
 	err := s.helper.ExtractObj(s.key, &boundPods, false)
 	if err != nil {
+		if (tools.IsEtcdNotFound(err)) {
+			glog.V(4).Infof("etcd failed to retrieve the value for the key %q. Error: %v", s.key, err)
+			return
+		}
 		glog.Errorf("etcd failed to retrieve the value for the key %q. Error: %v", s.key, err)
 		return
 	}


### PR DESCRIPTION
#4159

Updated logging. If etcd-pod-dir-fetch fails because dir was absent, an info message is logged. 2) For all other reasons, the regular error message is logged.

@dchen1107 
