### PR TITLE
Basic initial instrumentation of the apiserver

### DIFF
--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -78,7 +78,6 @@ func (a *APIInstaller) newWebService() *restful.WebService {
 }
 
 func (a *APIInstaller) registerResourceHandlers(path string, storage RESTStorage, ws *restful.WebService, watchHandler http.Handler, redirectHandler http.Handler, proxyHandler http.Handler) error {
-
 	// Handler for standard REST verbs (GET, PUT, POST and DELETE).
 	restVerbHandler := restfulStripPrefix(a.prefix, a.restHandler)
 	object := storage.New()


### PR DESCRIPTION
This links in the prometheus library for monitoring, which exports some basic resource usage metrics by default, like number of goroutines, open file descriptors, resident and virtual memory, etc. I've also started adding in request counters and latency histograms, but have only done it to two of our HTTP handlers. If this looks reasonable, I'll add them to the rest of the handlers in a second PR.

Unfortunately, the prometheus client library seems to break the build for two of the client platforms (linux/386 and linux/arm). This shouldn't be merged until I can get that fixed (and remove it from the PR), but I'm sending this out now so that hopefully someone can explain why in the world we're requiring our apiserver package to be compilable on all client platforms. It seems really weird that we pull it in to tests that we require to run on all of them, when the server binary itself only has to run on linux/x86.

Issue #1625 
cc @vishh @vmarmol 
