### PR TITLE
Update prometheus instrumentation library to include fix for building for linux/arm and linux/386 platforms

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -164,28 +164,28 @@
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/_vendor/goautoneg",
-			"Comment": "0.1.0-9-g52186fc",
-			"Rev": "52186fc518809dc9a56502348751e353866b2059"
+			"Comment": "0.1.0-11-gc70db11",
+			"Rev": "c70db11f1ee77a34066aa41345dca4b105c2ed06"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/_vendor/perks/quantile",
-			"Comment": "0.1.0-9-g52186fc",
-			"Rev": "52186fc518809dc9a56502348751e353866b2059"
+			"Comment": "0.1.0-11-gc70db11",
+			"Rev": "c70db11f1ee77a34066aa41345dca4b105c2ed06"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/model",
-			"Comment": "0.1.0-9-g52186fc",
-			"Rev": "52186fc518809dc9a56502348751e353866b2059"
+			"Comment": "0.1.0-11-gc70db11",
+			"Rev": "c70db11f1ee77a34066aa41345dca4b105c2ed06"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/prometheus",
-			"Comment": "0.1.0-9-g52186fc",
-			"Rev": "52186fc518809dc9a56502348751e353866b2059"
+			"Comment": "0.1.0-11-gc70db11",
+			"Rev": "c70db11f1ee77a34066aa41345dca4b105c2ed06"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/text",
-			"Comment": "0.1.0-9-g52186fc",
-			"Rev": "52186fc518809dc9a56502348751e353866b2059"
+			"Comment": "0.1.0-11-gc70db11",
+			"Rev": "c70db11f1ee77a34066aa41345dca4b105c2ed06"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_model/go",

--- a/Godeps/_workspace/src/github.com/prometheus/client_golang/prometheus/process_collector_procfs.go
+++ b/Godeps/_workspace/src/github.com/prometheus/client_golang/prometheus/process_collector_procfs.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build linux plan9 solaris
+// +build linux,cgo plan9,cgo solaris,cgo
 
 package prometheus
 

--- a/Godeps/_workspace/src/github.com/prometheus/client_golang/prometheus/process_collector_rest.go
+++ b/Godeps/_workspace/src/github.com/prometheus/client_golang/prometheus/process_collector_rest.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !linux,!plan9,!solaris
+// +build !linux,!plan9,!solaris !cgo
 
 package prometheus
 


### PR DESCRIPTION
Resolves the major issue with #4272.
