### PR TITLE
Configurable API prefix for kubectl proxy

### DIFF
--- a/docs/kubectl.md
+++ b/docs/kubectl.md
@@ -49,6 +49,7 @@ Usage:
 
  Available Flags:
       --alsologtostderr=false: log to standard error as well as files
+      --api-prefix="/api/": Prefix to serve the proxied API under
       --api-version="": The API version to use when talking to the server
   -a, --auth-path="": Path to the auth info file. If missing, prompt the user. Only used if using https.
       --certificate-authority="": Path to a cert. file for the certificate authority.

--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -42,13 +42,20 @@ func (f *Factory) NewCmdProxy(out io.Writer) *cobra.Command {
 			if !strings.HasSuffix(staticPrefix, "/") {
 				staticPrefix += "/"
 			}
-			server, err := kubectl.NewProxyServer(util.GetFlagString(cmd, "www"), staticPrefix, clientConfig)
+
+			apiProxyPrefix := util.GetFlagString(cmd, "api-prefix")
+			if !strings.HasSuffix(apiProxyPrefix, "/") {
+				apiProxyPrefix += "/"
+			}
+			server, err := kubectl.NewProxyServer(util.GetFlagString(cmd, "www"), apiProxyPrefix, staticPrefix, clientConfig)
+
 			checkErr(err)
 			glog.Fatal(server.Serve(port))
 		},
 	}
 	cmd.Flags().StringP("www", "w", "", "Also serve static files from the given directory under the specified prefix")
 	cmd.Flags().StringP("www-prefix", "P", "/static/", "Prefix to serve static files under, if static file dir is specified")
+	cmd.Flags().StringP("api-prefix", "", "/api/", "Prefix to serve the proxied API under")
 	cmd.Flags().IntP("port", "p", 8001, "The port on which to run the proxy")
 	return cmd
 }

--- a/pkg/kubectl/proxy_server.go
+++ b/pkg/kubectl/proxy_server.go
@@ -33,7 +33,7 @@ type ProxyServer struct {
 
 // NewProxyServer creates and installs a new ProxyServer.
 // It automatically registers the created ProxyServer to http.DefaultServeMux.
-func NewProxyServer(filebase string, staticPrefix string, cfg *client.Config) (*ProxyServer, error) {
+func NewProxyServer(filebase string, apiProxyPrefix string, staticPrefix string, cfg *client.Config) (*ProxyServer, error) {
 	prefix := cfg.Prefix
 	if prefix == "" {
 		prefix = "/api"
@@ -46,7 +46,7 @@ func NewProxyServer(filebase string, staticPrefix string, cfg *client.Config) (*
 	if proxy.Transport, err = client.TransportFor(cfg); err != nil {
 		return nil, err
 	}
-	http.Handle("/api/", http.StripPrefix("/api/", proxy))
+	http.Handle(apiProxyPrefix, http.StripPrefix(apiProxyPrefix, proxy))
 	http.Handle(staticPrefix, newFileHandler(staticPrefix, filebase))
 	return proxy, nil
 }


### PR DESCRIPTION
Makes the API prefix in the proxy more customizable for apps that want to serve static content & serve the API under a different URL. Defaults to /api/ to retain existing functionality.
