### PR TITLE
Allow proxying to a resource at /

### DIFF
--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -155,6 +155,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage RESTStorage
 		actions = appendIf(actions, action{"WATCH", "/watch/" + itemPath, nameParams}, storageVerbs["ResourceWatcher"])
 		actions = appendIf(actions, action{"REDIRECT", "/redirect/" + itemPath, nameParams}, storageVerbs["Redirector"])
 		actions = appendIf(actions, action{"PROXY", "/proxy/" + itemPath + "/{path:*}", nameParams}, storageVerbs["Redirector"])
+		actions = appendIf(actions, action{"PROXY", "/proxy/" + itemPath, nameParams}, storageVerbs["Redirector"])
 	} else {
 		// v1beta3 format with namespace in path
 		if scope.ParamPath() {
@@ -174,6 +175,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage RESTStorage
 			actions = appendIf(actions, action{"WATCH", "/watch/" + itemPath, nameParams}, storageVerbs["ResourceWatcher"])
 			actions = appendIf(actions, action{"REDIRECT", "/redirect/" + itemPath, nameParams}, storageVerbs["Redirector"])
 			actions = appendIf(actions, action{"PROXY", "/proxy/" + itemPath + "/{path:*}", nameParams}, storageVerbs["Redirector"])
+			actions = appendIf(actions, action{"PROXY", "/proxy/" + itemPath, nameParams}, storageVerbs["Redirector"])
 
 			// list across namespace.
 			actions = appendIf(actions, action{"LIST", path, params}, storageVerbs["RESTLister"])
@@ -195,6 +197,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage RESTStorage
 			actions = appendIf(actions, action{"WATCH", "/watch/" + itemPath, nameParams}, storageVerbs["ResourceWatcher"])
 			actions = appendIf(actions, action{"REDIRECT", "/redirect/" + itemPath, nameParams}, storageVerbs["Redirector"])
 			actions = appendIf(actions, action{"PROXY", "/proxy/" + itemPath + "/{path:*}", nameParams}, storageVerbs["Redirector"])
+			actions = appendIf(actions, action{"PROXY", "/proxy/" + itemPath, nameParams}, storageVerbs["Redirector"])
 		}
 	}
 

--- a/pkg/apiserver/proxy_test.go
+++ b/pkg/apiserver/proxy_test.go
@@ -244,6 +244,7 @@ func TestProxy(t *testing.T) {
 		{"DELETE", "/some/dir/id", "", "ok", "text/css", "default"},
 		{"GET", "/some/dir/id", "", "answer", "text/css", "other"},
 		{"GET", "/trailing/slash/", "", "answer", "text/css", "default"},
+		{"GET", "/", "", "answer", "text/css", "default"},
 	}
 
 	for _, item := range table {


### PR DESCRIPTION
Add a route for `/proxy/<kind>/<name>/` without requiring additional path
information. This allows for e.g. `/proxy/service/myservice/`, which will
proxy to the service at `/`, instead of always requiring something in the
path.
