### PR TITLE
Explicitly send the error string to the Fatal log.

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -325,7 +325,7 @@ func DefaultClientConfig(flags *pflag.FlagSet) clientcmd.ClientConfig {
 
 func checkErr(err error) {
 	if err != nil {
-		glog.FatalDepth(1, err)
+		glog.FatalDepth(1, err.Error())
 	}
 }
 


### PR DESCRIPTION
@deads2k @smarterclayton @jlowdermilk 
