### PR TITLE
Docker 1.4.1 on Fedora no longer provisions a docker group

### DIFF
--- a/cluster/saltbase/salt/kubelet/init.sls
+++ b/cluster/saltbase/salt/kubelet/init.sls
@@ -58,8 +58,10 @@ kubelet:
     - gid_from_name: True
     - shell: /sbin/nologin
     - home: /var/lib/kubelet
+{% if grains['os_family'] != 'RedHat' %}    
     - groups:
       - docker
+{% endif %}      
     - require:
       - group: kubelet
   service.running:

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -45,7 +45,3 @@ base:
   'roles:kubernetes-pool-vsphere':
     - match: grain
     - static-routes
-
-  'roles:kubernetes-pool-vagrant':
-    - match: grain
-    - vagrant

--- a/cluster/saltbase/salt/vagrant.sls
+++ b/cluster/saltbase/salt/vagrant.sls
@@ -1,7 +1,0 @@
-vagrant:
-  user.present:
-    - optional_groups:
-        - docker
-    - remove_groups: False
-    - require:
-      - pkg: docker-io

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -55,7 +55,6 @@ grains:
   apiservers: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
   roles:
     - kubernetes-pool
-    - kubernetes-pool-vagrant
   cbr-cidr: '$(echo "$CONTAINER_SUBNET" | sed -e "s/'/''/g")'
   minion_ip: '$(echo "$MINION_IP" | sed -e "s/'/''/g")'
 EOF


### PR DESCRIPTION
This changes the salt provisioning to no longer require the docker group when on a Red Hat os family.

For details on the docker 1.4.1 changes and how it no longer creates the docker group:
http://pkgs.fedoraproject.org/cgit/docker-io.git/commit/docker-io.spec?id=3407f4ee223a1a0dabef04bbd434aafa6b5bfa5c

It would be good if someone from GCE can validate this does not break their cluster formation.

@brendandburns 
