### PR TITLE
Utility functions for Gingko By and Fail

### DIFF
--- a/test/e2e/rc.go
+++ b/test/e2e/rc.go
@@ -120,9 +120,8 @@ func ServeImageOrFail(c *client.Client, test string, image string) {
 			break
 		}
 		if time.Since(t) > listTimeout {
-			Fail(fmt.Sprintf(
-				"Controller %s: Gave up waiting for %d pods to come up after seeing only %d pods after %v seconds",
-				name, replicas, len(pods.Items), time.Since(t).Seconds()))
+			Failf("Controller %s: Gave up waiting for %d pods to come up after seeing only %d pods after %v seconds",
+				name, replicas, len(pods.Items), time.Since(t).Seconds())
 		}
 		time.Sleep(5 * time.Second)
 		pods, err = c.Pods(ns).List(label)
@@ -150,8 +149,8 @@ func ServeImageOrFail(c *client.Client, test string, image string) {
 				break
 			}
 			if time.Since(t) >= hostIPTimeout {
-				Fail(fmt.Sprintf("Controller %s: Gave up waiting for hostIP of replica %d after %v seconds",
-					name, i, time.Since(t).Seconds()))
+				Failf("Controller %s: Gave up waiting for hostIP of replica %d after %v seconds",
+					name, i, time.Since(t).Seconds())
 			}
 			Logf("Controller %s: Retrying to get the hostIP of replica %d", name, i+1)
 			time.Sleep(5 * time.Second)
@@ -168,20 +167,20 @@ func ServeImageOrFail(c *client.Client, test string, image string) {
 	for i, pod := range pods.Items {
 		resp, err := http.Get(fmt.Sprintf("http://%s:8080", pod.Status.HostIP))
 		if err != nil {
-			Fail(fmt.Sprintf("Controller %s: Failed to GET from replica %d: %v", name, i+1, err))
+			Failf("Controller %s: Failed to GET from replica %d: %v", name, i+1, err)
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			Fail(fmt.Sprintf("Controller %s: Expected OK status code for replica %d but got %d", name, i+1, resp.StatusCode))
+			Failf("Controller %s: Expected OK status code for replica %d but got %d", name, i+1, resp.StatusCode)
 		}
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			Fail(fmt.Sprintf("Controller %s: Failed to read the body of the GET response from replica %d: %v",
-				name, i+1, err))
+			Failf("Controller %s: Failed to read the body of the GET response from replica %d: %v",
+				name, i+1, err)
 		}
 		// The body should be the pod name.
 		if string(body) != pod.Name {
-			Fail(fmt.Sprintf("Controller %s: Replica %d expected response %s but got %s", name, i+1, pod.Name, string(body)))
+			Failf("Controller %s: Replica %d expected response %s but got %s", name, i+1, pod.Name, string(body))
 		}
 		Logf("Controller %s: Got expected result from replica %d: %s", name, i+1, string(body))
 	}

--- a/test/e2e/rc.go
+++ b/test/e2e/rc.go
@@ -99,12 +99,12 @@ func ServeImageOrFail(c *client.Client, test string, image string) {
 		// Resize the replication controller to zero to get rid of pods.
 		controller.Spec.Replicas = 0
 		if _, err = c.ReplicationControllers(ns).Update(controller); err != nil {
-			By(fmt.Sprintf("Failed to resize replication controller %s to zero: %v", name, err))
+			Logf("Failed to resize replication controller %s to zero: %v", name, err)
 		}
 
 		// Delete the replication controller.
 		if err = c.ReplicationControllers(ns).Delete(name); err != nil {
-			By(fmt.Sprintf("Failed to delete replication controller %s: %v", name, err))
+			Logf("Failed to delete replication controller %s: %v", name, err)
 		}
 	}()
 
@@ -115,7 +115,7 @@ func ServeImageOrFail(c *client.Client, test string, image string) {
 	Expect(err).NotTo(HaveOccurred())
 	t := time.Now()
 	for {
-		By(fmt.Sprintf("Controller %s: Found %d pods out of %d", name, len(pods.Items), replicas))
+		Logf("Controller %s: Found %d pods out of %d", name, len(pods.Items), replicas)
 		if len(pods.Items) == replicas {
 			break
 		}
@@ -128,6 +128,8 @@ func ServeImageOrFail(c *client.Client, test string, image string) {
 		pods, err = c.Pods(ns).List(label)
 		Expect(err).NotTo(HaveOccurred())
 	}
+
+	By("Ensuring each pod is running and has a hostIP")
 
 	// Wait for the pods to enter the running state. Waiting loops until the pods
 	// are running so non-running pods cause a timeout for this test.
@@ -144,14 +146,14 @@ func ServeImageOrFail(c *client.Client, test string, image string) {
 			p, err := c.Pods(ns).Get(pod.Name)
 			Expect(err).NotTo(HaveOccurred())
 			if p.Status.HostIP != "" {
-				By(fmt.Sprintf("Controller %s: Replica %d has hostIP: %s", name, i+1, p.Status.HostIP))
+				Logf("Controller %s: Replica %d has hostIP: %s", name, i+1, p.Status.HostIP)
 				break
 			}
 			if time.Since(t) >= hostIPTimeout {
 				Fail(fmt.Sprintf("Controller %s: Gave up waiting for hostIP of replica %d after %v seconds",
 					name, i, time.Since(t).Seconds()))
 			}
-			By(fmt.Sprintf("Controller %s: Retrying to get the hostIP of replica %d", name, i+1))
+			Logf("Controller %s: Retrying to get the hostIP of replica %d", name, i+1)
 			time.Sleep(5 * time.Second)
 		}
 	}
@@ -161,6 +163,8 @@ func ServeImageOrFail(c *client.Client, test string, image string) {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Verify that something is listening.
+	By("Trying to dial each unique pod")
+
 	for i, pod := range pods.Items {
 		resp, err := http.Get(fmt.Sprintf("http://%s:8080", pod.Status.HostIP))
 		if err != nil {
@@ -179,6 +183,6 @@ func ServeImageOrFail(c *client.Client, test string, image string) {
 		if string(body) != pod.Name {
 			Fail(fmt.Sprintf("Controller %s: Replica %d expected response %s but got %s", name, i+1, pod.Name, string(body)))
 		}
-		By(fmt.Sprintf("Controller %s: Got expected result from replica %d: %s", name, i+1, string(body)))
+		Logf("Controller %s: Got expected result from replica %d: %s", name, i+1, string(body))
 	}
 }

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -44,6 +44,10 @@ func Logf(format string, a ...interface{}) {
 	fmt.Fprintf(GinkgoWriter, "INFO: "+format+"\n", a...)
 }
 
+func Failf(format string, a ...interface{}) {
+	Fail(fmt.Sprintf(format, a...))
+}
+
 func waitForPodRunning(c *client.Client, id string, tryFor time.Duration) error {
 	trySecs := int(tryFor.Seconds())
 	for i := 0; i <= trySecs; i += 5 {


### PR DESCRIPTION
Split from #4269, let's argue about it here.

I think this is a twofold issue:
- Bikeshed over name: Logf is a little misleading in that it might suggest it's logging, when it's going to `GinkgoWriter`. I don't find it that misleading, because it _has_ to be something within the gingko package or our own due to the way it's called, so it's clearly a test function. I almost called it `Byf` to stick to Go patterns, but `Byf` is horri-bad name. Also, as @rrati points out on IRC, `By()` actually has a semantic distinction - even though I really do want all output going to `GinkgoWriter` to get all the output in the same place, `By()` is meant for step delineation, and it's a bit a perversion. (Just not a horrible one.) A better longer term solution would be a PR sent to Gingko for an actual first class `Log()` function, which sort of exists in their `testing` compatibility mode already but not in their normal mode. That part was meant to be a bit of a side-bar to say: This function might _ought_ to be named `Logf()` anyways, and doing something else: (maybe it needs to add "INFO:") so that people think to separate steps and logs. Maybe.
- ... or should we even bother. Arguably this is just some extra typing and people can stop being so damn lazy.

@filbranden @rrati @roberthbailey @satnam6502 
