### PR TITLE
kubectl label command crashes when a resource has no labels

### DIFF
--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -156,6 +156,10 @@ func labelFunc(obj runtime.Object, overwrite bool, resourceVersion string, label
 		}
 	}
 
+	if meta.Labels == nil {
+		meta.Labels = make(map[string]string)
+	}
+
 	for key, value := range labels {
 		meta.Labels[key] = value
 	}

--- a/pkg/kubectl/cmd/label_test.go
+++ b/pkg/kubectl/cmd/label_test.go
@@ -230,6 +230,17 @@ func TestLabelFunc(t *testing.T) {
 				},
 			},
 		},
+		{
+			obj: &api.Pod{
+				ObjectMeta: api.ObjectMeta{},
+			},
+			labels: map[string]string{"a": "b"},
+			expected: &api.Pod{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{"a": "b"},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		out, err := labelFunc(test.obj, test.overwrite, test.version, test.labels, test.remove)


### PR DESCRIPTION
```
$ cat redis-master.json
{
  "id": "redis-master",
  "kind": "Pod",
  "apiVersion": "v1beta1",
  "desiredState": {
    "manifest": {
      "version": "v1beta1",
      "id": "redis-master",
      "containers": [{
        "name": "master",
        "image": "dockerfile/redis",
        "cpu": 100,
        "ports": [{
          "containerPort": 6379,
          "hostPort": 6379
        }]
      }]
    }
  }
}
$ kubectl create -f redis-master.json
$ kubectl get po
POD                 IP                  CONTAINER(S)        IMAGE(S)            HOST                        LABELS              STATUS
redis-master       10.244.23.2         master              dockerfile/redis    172.17.8.103/172.17.8.103   <none>              Running

$ kubectl label po redis-master name=bar 
# crash
```
