### PR TITLE
Stop both replication controllers in update-demo

### DIFF
--- a/examples/update-demo/5-down.sh
+++ b/examples/update-demo/5-down.sh
@@ -24,5 +24,9 @@ export KUBECTL=${KUBE_ROOT}/cluster/kubectl.sh
 set -x
 
 rc="update-demo-kitten"
+echo "Stopping replicationController ${rc}"
+$KUBECTL stop rc ${rc} || true
 
-$KUBECTL stop rc ${rc}
+rc="update-demo-nautilus"
+echo "Stopping replicationController ${rc}"
+$KUBECTL stop rc ${rc} || true


### PR DESCRIPTION
The update test may have failed, and if we leave an RC around it
causes subsequent tests to fail
