### PR TITLE
Modify nginx port to avoid collision with api server

### DIFF
--- a/api/examples/pod.json
+++ b/api/examples/pod.json
@@ -11,7 +11,7 @@
         "image": "dockerfile/nginx",
         "ports": [{
           "containerPort": 80,
-          "hostPort": 8080
+          "hostPort": 8081
         }],
         "livenessProbe": {
           "enabled": true,
@@ -19,7 +19,7 @@
           "initialDelaySeconds": 30,
           "httpGet": {
             "path": "/index.html",
-            "port": "8080"
+            "port": "8081"
           }
         }
       }]

--- a/docs/getting-started-guides/gce.md
+++ b/docs/getting-started-guides/gce.md
@@ -96,7 +96,7 @@ Where pod.json contains something like:
         "image": "dockerfile/nginx",
         "ports": [{
           "containerPort": 80,
-          "hostPort": 8080
+          "hostPort": 8081
         }],
         "livenessProbe": {
           "enabled": true,
@@ -104,7 +104,7 @@ Where pod.json contains something like:
           "initialDelaySeconds": 30,
           "httpGet": {
             "path": "/index.html",
-            "port": "8080"
+            "port": "8081"
           }
         }
       }]
@@ -127,6 +127,9 @@ and delete the pod you just created:
 ```bash
 cluster/kubectl.sh delete pods php
 ```
+
+Since this pod is scheduled on a minion running in GCE, you will have to enable incoming tcp traffic via the port specified in the
+pod manifest before you see the nginx welcome page. After doing so, it should be visible at http://<external ip of minion running nginx>:<port from manifest>.
 
 Look in `examples/` for more examples
 


### PR DESCRIPTION
Spinning up a local cluster with the basic pod manifest in examples/pod.json causes a port collision, since the api server also runs on 8080. This PR changes the port to 8081, and updates the documentation appropriately.
