### PR TITLE
Bindings were not correctly removed across namespaces on pod update and delete

### DIFF
--- a/pkg/registry/etcd/etcd.go
+++ b/pkg/registry/etcd/etcd.go
@@ -264,8 +264,9 @@ func (r *Registry) UpdatePod(ctx api.Context, pod *api.Pod) error {
 	return r.AtomicUpdate(containerKey, &api.BoundPods{}, func(in runtime.Object) (runtime.Object, error) {
 		boundPods := in.(*api.BoundPods)
 		for ix := range boundPods.Items {
-			if boundPods.Items[ix].Name == pod.Name {
-				boundPods.Items[ix].Spec = pod.Spec
+			item := &boundPods.Items[ix]
+			if item.Name == pod.Name && item.Namespace == pod.Namespace {
+				item.Spec = pod.Spec
 				return boundPods, nil
 			}
 		}
@@ -303,9 +304,9 @@ func (r *Registry) DeletePod(ctx api.Context, podID string) error {
 		pods := in.(*api.BoundPods)
 		newPods := make([]api.BoundPod, 0, len(pods.Items))
 		found := false
-		for _, pod := range pods.Items {
-			if pod.Name != podID {
-				newPods = append(newPods, pod)
+		for _, item := range pods.Items {
+			if item.Name != pod.Name || item.Namespace != pod.Namespace {
+				newPods = append(newPods, item)
 			} else {
 				found = true
 			}


### PR DESCRIPTION
When pods are deleted (or updated) and there is another pod bound to that host with the same pod name in a different namespace, the wrong binding can get removed.  It's likely people out there using multiple namespaces today have corrupted bindings - we really need to be able to regenerate / check the bindings.
