### PR TITLE
Make gce's kubeconfig context include the gce project

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -507,7 +507,7 @@ function kube-up {
   local kube_auth="kubernetes_auth"
 
   local kubectl="${KUBE_ROOT}/cluster/kubectl.sh"
-  local context="${INSTANCE_PREFIX}"
+  local context="${PROJECT}-${INSTANCE_PREFIX}"
   local user="${INSTANCE_PREFIX}-admin"
   local config_dir="${HOME}/.kube/${context}"
 


### PR DESCRIPTION
Change the .kubeconfig context that gce kube-up creates to project + instance prefix, so you can spin up clusters with the same name in different compute projects without overwriting .kubeconfig.
