### PR TITLE
If I access an individual namespace, the namespace context for request should match name

### DIFF
--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -292,8 +292,10 @@ func (r *APIRequestInfoResolver) GetAPIRequestInfo(req *http.Request) (APIReques
 	// URL forms: /namespaces/{namespace}/{kind}/*, where parts are adjusted to be relative to kind
 	if currentParts[0] == "namespaces" {
 		if len(currentParts) < 3 {
-			requestInfo.Namespace = ""
 			requestInfo.Resource = "namespaces"
+			if len(currentParts) > 1 {
+				requestInfo.Namespace = currentParts[1]
+			}
 		} else {
 			requestInfo.Resource = currentParts[2]
 			requestInfo.Namespace = currentParts[1]

--- a/pkg/apiserver/handlers_test.go
+++ b/pkg/apiserver/handlers_test.go
@@ -80,7 +80,7 @@ func TestGetAPIRequestInfo(t *testing.T) {
 
 		// resource paths
 		{"GET", "/namespaces", "list", "", "", "namespaces", "Namespace", "", []string{"namespaces"}},
-		{"GET", "/namespaces/other", "get", "", "", "namespaces", "Namespace", "other", []string{"namespaces", "other"}},
+		{"GET", "/namespaces/other", "get", "", "other", "namespaces", "Namespace", "other", []string{"namespaces", "other"}},
 
 		{"GET", "/namespaces/other/pods", "list", "", "other", "pods", "Pod", "", []string{"pods"}},
 		{"GET", "/namespaces/other/pods/foo", "get", "", "other", "pods", "Pod", "foo", []string{"pods", "foo"}},


### PR DESCRIPTION
This is a gap in the current namespace implementation.

If I call: /namespaces/foo, then the request namespace context MUST always be foo.

Important for policy.

@erictune @deads2k @smarterclayton 
