### PR TITLE
Don't include port in config when not specified.

### DIFF
--- a/pkg/kubectl/run.go
+++ b/pkg/kubectl/run.go
@@ -79,10 +79,14 @@ func (BasicReplicationController) Generate(params map[string]string) (runtime.Ob
 		if err != nil {
 			return nil, err
 		}
-		controller.Spec.Template.Spec.Containers[0].Ports = []api.Port{
-			{
-				ContainerPort: port,
-			},
+
+		// Don't include the port if it was not specified.
+		if port > 0 {
+			controller.Spec.Template.Spec.Containers[0].Ports = []api.Port{
+				{
+					ContainerPort: port,
+				},
+			}
 		}
 	}
 	return &controller, nil

--- a/pkg/kubectl/run_test.go
+++ b/pkg/kubectl/run_test.go
@@ -34,6 +34,7 @@ func TestGenerate(t *testing.T) {
 				"name":     "foo",
 				"image":    "someimage",
 				"replicas": "1",
+				"port":     "-1",
 			},
 			expected: &api.ReplicationController{
 				ObjectMeta: api.ObjectMeta{


### PR DESCRIPTION
When no port is specified the flag default of "-1" is taken.

Fixes #4305
