### PR TITLE
Unpatch Jenkins now that #4177 is fixed

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -83,5 +83,7 @@ export E2E_REPORT_DIR=${WORKSPACE}
 go run ./hack/e2e.go ${E2E_OPT} -v --down
 go run ./hack/e2e.go ${E2E_OPT} -v --up
 go run ./hack/e2e.go -v --ctl="version --match-server-version=false"
-go run ./hack/e2e.go ${E2E_OPT} -v --test || echo "Ignored, Jenkins will pass/fail based on test failures"
+status=0
+go run ./hack/e2e.go ${E2E_OPT} -v --test || status=$?
 go run ./hack/e2e.go ${E2E_OPT} -v --down
+exit $status


### PR DESCRIPTION
And actually, make it more better: Go ahead and tear down the cluster
even when tests fail, but (hopefully) relay the test exit status
correctly. This fails if there's a double error (if -down _also_
fails, we'll fail due to errexit), but either way is a build failure,
and this means that the teardown of a test failure build isn't getting
charged to the next run.
