### PR TITLE
democratize restart-apiserver method across clouds

### DIFF
--- a/cluster/azure/util.sh
+++ b/cluster/azure/util.sh
@@ -555,6 +555,11 @@ function restart-kube-proxy {
     ssh-to-node "$1" "sudo /etc/init.d/kube-proxy restart"
 }
 
+# Restart the kube-proxy on the master ($1)
+function restart-apiserver {
+    ssh-to-node "$1" "sudo /etc/init.d/kube-apiserver restart"
+}
+
 # Setup monitoring using heapster and InfluxDB
 function setup-monitoring-firewall {
     echo "not implemented"  >/dev/null

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -748,6 +748,11 @@ function restart-kube-proxy {
   ssh-to-node "$1" "sudo /etc/init.d/kube-proxy restart"
 }
 
+# Restart the kube-proxy on a node ($1)
+function restart-apiserver {
+  ssh-to-node "$1" "sudo /etc/init.d/kube-apiserver restart"
+}
+
 # Setup monitoring firewalls using heapster and InfluxDB
 function setup-monitoring-firewall {
   if [[ "${ENABLE_CLUSTER_MONITORING}" != "true" ]]; then

--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -214,6 +214,12 @@ function restart-kube-proxy() {
   ssh-to-node "$1" "sudo /etc/init.d/kube-proxy restart"
 }
 
+# Restart the kube-proxy on master ($1)
+function restart-apiserver() {
+  echo "... in restart-kube-apiserver()"  >&2
+  ssh-to-node "$1" "sudo /etc/init.d/kube-apiserver restart"
+}
+
 # Execute after running tests to perform any required clean-up.  This is called
 # from hack/e2e-test.sh. This calls kube-down, so the cluster still exists when
 # this is called.

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -306,7 +306,7 @@ function restart-kube-proxy {
 
 # Restart the apiserver
 function restart-apiserver {
-  ssh-to-node "${master}" "sudo systemctl restart kube-apiserver"
+  ssh-to-node "$1" "sudo systemctl restart kube-apiserver"
 }
 
 function setup-monitoring-firewall {

--- a/hack/e2e-suite/services.sh
+++ b/hack/e2e-suite/services.sh
@@ -415,11 +415,7 @@ verify_from_container "${svc3_name}" "${svc3_ip}" "${svc3_port}" \
 #
 echo "Test 6: Restart the master, make sure portals come back."
 echo "Restarting the master"
-if [[ "$KUBERNETES_PROVIDER" == "vagrant" ]]; then
-    restart-apiserver "${master}"
-else
-    ssh-to-node "${master}" "sudo /etc/init.d/kube-apiserver restart"
-fi
+restart-apiserver "${master}"
 sleep 5
 echo "Verifying the portals from the host"
 wait_for_service_up "${svc3_name}" "${svc3_ip}" "${svc3_port}" \


### PR DESCRIPTION
Different cloud providers may have a different way of managing apiserver. e.g. vagrant fedora uses systemd and not /etc/init.d
