### PR TITLE
Make requesting user available in context

### DIFF
--- a/pkg/api/context.go
+++ b/pkg/api/context.go
@@ -19,6 +19,7 @@ package api
 import (
 	stderrs "errors"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
 	"golang.org/x/net/context"
 )
 
@@ -32,6 +33,9 @@ type key int
 
 // namespaceKey is the context key for the request namespace.
 const namespaceKey key = 0
+
+// userKey is the context key for the request user.
+const userKey key = 1
 
 // NewContext instantiates a base context object for request flows.
 func NewContext() Context {
@@ -85,4 +89,15 @@ func WithNamespaceDefaultIfNone(parent Context) Context {
 		return WithNamespace(parent, NamespaceDefault)
 	}
 	return parent
+}
+
+// WithUser returns a copy of parent in which the user value is set
+func WithUser(parent Context, user user.Info) Context {
+	return WithValue(parent, userKey, user)
+}
+
+// UserFrom returns the value of the user key on the ctx
+func UserFrom(ctx Context) (user.Info, bool) {
+	user, ok := ctx.Value(userKey).(user.Info)
+	return user, ok
 }

--- a/pkg/api/requestcontext.go
+++ b/pkg/api/requestcontext.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"errors"
+	"net/http"
+	"sync"
+)
+
+// RequestContextMapper keeps track of the context associated with a particular request
+type RequestContextMapper interface {
+	// Get returns the context associated with the given request (if any), and true if the request has an associated context, and false if it does not.
+	Get(req *http.Request) (Context, bool)
+	// Update maps the request to the given context. If no context was previously associated with the request, an error is returned.
+	// Update should only be called with a descendant context of the previously associated context.
+	// Updating to an unrelated context may return an error in the future.
+	// The context associated with a request should only be updated by a limited set of callers.
+	// Valid examples include the authentication layer, or an audit/tracing layer.
+	Update(req *http.Request, context Context) error
+}
+
+type requestContextMap struct {
+	contexts map[*http.Request]Context
+	lock     sync.Mutex
+}
+
+// NewRequestContextMapper returns a new RequestContextMapper.
+// The returned mapper must be added as a request filter using NewRequestContextFilter.
+func NewRequestContextMapper() RequestContextMapper {
+	return &requestContextMap{
+		contexts: make(map[*http.Request]Context),
+	}
+}
+
+// Get returns the context associated with the given request (if any), and true if the request has an associated context, and false if it does not.
+// Get will only return a valid context when called from inside the filter chain set up by NewRequestContextFilter()
+func (c *requestContextMap) Get(req *http.Request) (Context, bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	context, ok := c.contexts[req]
+	return context, ok
+}
+
+// Update maps the request to the given context.
+// If no context was previously associated with the request, an error is returned and the context is ignored.
+func (c *requestContextMap) Update(req *http.Request, context Context) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if _, ok := c.contexts[req]; !ok {
+		return errors.New("No context associated")
+	}
+	// TODO: ensure the new context is a descendant of the existing one
+	c.contexts[req] = context
+	return nil
+}
+
+// init maps the request to the given context and returns true if there was no context associated with the request already.
+// if a context was already associated with the request, it ignores the given context and returns false.
+// init is intentionally unexported to ensure that all init calls are paired with a remove after a request is handled
+func (c *requestContextMap) init(req *http.Request, context Context) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if _, exists := c.contexts[req]; exists {
+		return false
+	}
+	c.contexts[req] = context
+	return true
+}
+
+// remove is intentionally unexported to ensure that the context is not removed until a request is handled
+func (c *requestContextMap) remove(req *http.Request) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	delete(c.contexts, req)
+}
+
+// NewRequestContextFilter ensures there is a Context object associated with the request before calling the passed handler.
+// After the passed handler runs, the context is cleaned up.
+func NewRequestContextFilter(mapper RequestContextMapper, handler http.Handler) (http.Handler, error) {
+	if mapper, ok := mapper.(*requestContextMap); ok {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if mapper.init(req, NewContext()) {
+				// If we were the ones to successfully initialize, pair with a remove
+				defer mapper.remove(req)
+			}
+			handler.ServeHTTP(w, req)
+		}), nil
+	} else {
+		return handler, errors.New("Unknown RequestContextMapper implementation.")
+	}
+
+}
+
+// IsEmpty returns true if there are no contexts registered, or an error if it could not be determined. Intended for use by tests.
+func IsEmpty(requestsToContexts RequestContextMapper) (bool, error) {
+	if requestsToContexts, ok := requestsToContexts.(*requestContextMap); ok {
+		return len(requestsToContexts.contexts) == 0, nil
+	}
+	return true, errors.New("Unknown RequestContextMapper implementation")
+}

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -98,9 +98,9 @@ type defaultAPIServer struct {
 // as RESTful resources at prefix, serialized by codec, and also includes the support
 // http resources.
 // Note: This method is used only in tests.
-func Handle(storage map[string]RESTStorage, codec runtime.Codec, root string, version string, linker runtime.SelfLinker, admissionControl admission.Interface, mapper meta.RESTMapper) http.Handler {
+func Handle(storage map[string]RESTStorage, codec runtime.Codec, root string, version string, linker runtime.SelfLinker, admissionControl admission.Interface, contextMapper api.RequestContextMapper, mapper meta.RESTMapper) http.Handler {
 	prefix := path.Join(root, version)
-	group := NewAPIGroupVersion(storage, codec, root, prefix, linker, admissionControl, mapper)
+	group := NewAPIGroupVersion(storage, codec, root, prefix, linker, admissionControl, contextMapper, mapper)
 	container := restful.NewContainer()
 	container.Router(restful.CurlyRouter{})
 	mux := container.ServeMux
@@ -121,6 +121,7 @@ type APIGroupVersion struct {
 	prefix  string
 	linker  runtime.SelfLinker
 	admit   admission.Interface
+	context api.RequestContextMapper
 	mapper  meta.RESTMapper
 	// TODO: put me into a cleaner interface
 	info *APIRequestInfoResolver
@@ -131,13 +132,14 @@ type APIGroupVersion struct {
 // This is a helper method for registering multiple sets of REST handlers under different
 // prefixes onto a server.
 // TODO: add multitype codec serialization
-func NewAPIGroupVersion(storage map[string]RESTStorage, codec runtime.Codec, root, prefix string, linker runtime.SelfLinker, admissionControl admission.Interface, mapper meta.RESTMapper) *APIGroupVersion {
+func NewAPIGroupVersion(storage map[string]RESTStorage, codec runtime.Codec, root, prefix string, linker runtime.SelfLinker, admissionControl admission.Interface, contextMapper api.RequestContextMapper, mapper meta.RESTMapper) *APIGroupVersion {
 	return &APIGroupVersion{
 		storage: storage,
 		codec:   codec,
 		prefix:  prefix,
 		linker:  linker,
 		admit:   admissionControl,
+		context: contextMapper,
 		mapper:  mapper,
 		info:    &APIRequestInfoResolver{util.NewStringSet(root), latest.RESTMapper},
 	}

--- a/pkg/apiserver/proxy.go
+++ b/pkg/apiserver/proxy.go
@@ -78,6 +78,7 @@ type ProxyHandler struct {
 	prefix                 string
 	storage                map[string]RESTStorage
 	codec                  runtime.Codec
+	context                api.RequestContextMapper
 	apiRequestInfoResolver *APIRequestInfoResolver
 }
 
@@ -97,7 +98,11 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	verb = requestInfo.Verb
 	namespace, resource, parts := requestInfo.Namespace, requestInfo.Resource, requestInfo.Parts
 
-	ctx := api.WithNamespace(api.NewContext(), namespace)
+	ctx, ok := r.context.Get(req)
+	if !ok {
+		ctx = api.NewContext()
+	}
+	ctx = api.WithNamespace(ctx, namespace)
 	if len(parts) < 2 {
 		notFound(w, req)
 		httpCode = http.StatusNotFound

--- a/pkg/apiserver/proxy_test.go
+++ b/pkg/apiserver/proxy_test.go
@@ -281,12 +281,12 @@ func TestProxy(t *testing.T) {
 
 		namespaceHandler := Handle(map[string]RESTStorage{
 			"foo": simpleStorage,
-		}, codec, "/prefix", "version", selfLinker, admissionControl, namespaceMapper)
+		}, codec, "/prefix", "version", selfLinker, admissionControl, requestContextMapper, namespaceMapper)
 		namespaceServer := httptest.NewServer(namespaceHandler)
 		defer namespaceServer.Close()
 		legacyNamespaceHandler := Handle(map[string]RESTStorage{
 			"foo": simpleStorage,
-		}, codec, "/prefix", "version", selfLinker, admissionControl, legacyNamespaceMapper)
+		}, codec, "/prefix", "version", selfLinker, admissionControl, requestContextMapper, legacyNamespaceMapper)
 		legacyNamespaceServer := httptest.NewServer(legacyNamespaceHandler)
 		defer legacyNamespaceServer.Close()
 

--- a/pkg/apiserver/redirect.go
+++ b/pkg/apiserver/redirect.go
@@ -29,6 +29,7 @@ import (
 type RedirectHandler struct {
 	storage                map[string]RESTStorage
 	codec                  runtime.Codec
+	context                api.RequestContextMapper
 	apiRequestInfoResolver *APIRequestInfoResolver
 }
 
@@ -47,7 +48,11 @@ func (r *RedirectHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	verb = requestInfo.Verb
 	resource, parts := requestInfo.Resource, requestInfo.Parts
-	ctx := api.WithNamespace(api.NewContext(), requestInfo.Namespace)
+	ctx, ok := r.context.Get(req)
+	if !ok {
+		ctx = api.NewContext()
+	}
+	ctx = api.WithNamespace(ctx, requestInfo.Namespace)
 
 	// redirection requires /resource/resourceName path parts
 	if len(parts) != 2 || req.Method != "GET" {

--- a/pkg/apiserver/redirect_test.go
+++ b/pkg/apiserver/redirect_test.go
@@ -31,7 +31,7 @@ func TestRedirect(t *testing.T) {
 	}
 	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, codec, "/prefix", "version", selfLinker, admissionControl, mapper)
+	}, codec, "/prefix", "version", selfLinker, admissionControl, requestContextMapper, mapper)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -84,7 +84,7 @@ func TestRedirectWithNamespaces(t *testing.T) {
 	}
 	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, codec, "/prefix", "version", selfLinker, admissionControl, namespaceMapper)
+	}, codec, "/prefix", "version", selfLinker, admissionControl, requestContextMapper, namespaceMapper)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -29,6 +29,9 @@ import (
 	"github.com/emicklei/go-restful"
 )
 
+// ContextFunc returns a Context given a request - a context must be returned
+type ContextFunc func(req *restful.Request) api.Context
+
 // ResourceNameFunc returns a name (and optional namespace) given a request - if no name is present
 // an error must be returned.
 type ResourceNameFunc func(req *restful.Request) (namespace, name string, err error)
@@ -45,7 +48,7 @@ type ResourceNamespaceFunc func(req *restful.Request) (namespace string, err err
 type LinkResourceFunc func(req *restful.Request, obj runtime.Object) error
 
 // GetResource returns a function that handles retrieving a single resource from a RESTStorage object.
-func GetResource(r RESTGetter, nameFn ResourceNameFunc, linkFn LinkResourceFunc, codec runtime.Codec) restful.RouteFunction {
+func GetResource(r RESTGetter, ctxFn ContextFunc, nameFn ResourceNameFunc, linkFn LinkResourceFunc, codec runtime.Codec) restful.RouteFunction {
 	return func(req *restful.Request, res *restful.Response) {
 		w := res.ResponseWriter
 		namespace, name, err := nameFn(req)
@@ -53,7 +56,7 @@ func GetResource(r RESTGetter, nameFn ResourceNameFunc, linkFn LinkResourceFunc,
 			notFound(w, req.Request)
 			return
 		}
-		ctx := api.NewContext()
+		ctx := ctxFn(req)
 		if len(namespace) > 0 {
 			ctx = api.WithNamespace(ctx, namespace)
 		}
@@ -71,7 +74,7 @@ func GetResource(r RESTGetter, nameFn ResourceNameFunc, linkFn LinkResourceFunc,
 }
 
 // ListResource returns a function that handles retrieving a list of resources from a RESTStorage object.
-func ListResource(r RESTLister, namespaceFn ResourceNamespaceFunc, linkFn LinkResourceFunc, codec runtime.Codec) restful.RouteFunction {
+func ListResource(r RESTLister, ctxFn ContextFunc, namespaceFn ResourceNamespaceFunc, linkFn LinkResourceFunc, codec runtime.Codec) restful.RouteFunction {
 	return func(req *restful.Request, res *restful.Response) {
 		w := res.ResponseWriter
 
@@ -80,7 +83,7 @@ func ListResource(r RESTLister, namespaceFn ResourceNamespaceFunc, linkFn LinkRe
 			notFound(w, req.Request)
 			return
 		}
-		ctx := api.NewContext()
+		ctx := ctxFn(req)
 		if len(namespace) > 0 {
 			ctx = api.WithNamespace(ctx, namespace)
 		}
@@ -109,7 +112,7 @@ func ListResource(r RESTLister, namespaceFn ResourceNamespaceFunc, linkFn LinkRe
 }
 
 // CreateResource returns a function that will handle a resource creation.
-func CreateResource(r RESTCreater, namespaceFn ResourceNamespaceFunc, linkFn LinkResourceFunc, codec runtime.Codec, resource string, admit admission.Interface) restful.RouteFunction {
+func CreateResource(r RESTCreater, ctxFn ContextFunc, namespaceFn ResourceNamespaceFunc, linkFn LinkResourceFunc, codec runtime.Codec, resource string, admit admission.Interface) restful.RouteFunction {
 	return func(req *restful.Request, res *restful.Response) {
 		w := res.ResponseWriter
 
@@ -121,7 +124,7 @@ func CreateResource(r RESTCreater, namespaceFn ResourceNamespaceFunc, linkFn Lin
 			notFound(w, req.Request)
 			return
 		}
-		ctx := api.NewContext()
+		ctx := ctxFn(req)
 		if len(namespace) > 0 {
 			ctx = api.WithNamespace(ctx, namespace)
 		}
@@ -162,7 +165,7 @@ func CreateResource(r RESTCreater, namespaceFn ResourceNamespaceFunc, linkFn Lin
 }
 
 // UpdateResource returns a function that will handle a resource update
-func UpdateResource(r RESTUpdater, nameFn ResourceNameFunc, objNameFunc ObjectNameFunc, linkFn LinkResourceFunc, codec runtime.Codec, resource string, admit admission.Interface) restful.RouteFunction {
+func UpdateResource(r RESTUpdater, ctxFn ContextFunc, nameFn ResourceNameFunc, objNameFunc ObjectNameFunc, linkFn LinkResourceFunc, codec runtime.Codec, resource string, admit admission.Interface) restful.RouteFunction {
 	return func(req *restful.Request, res *restful.Response) {
 		w := res.ResponseWriter
 
@@ -174,7 +177,7 @@ func UpdateResource(r RESTUpdater, nameFn ResourceNameFunc, objNameFunc ObjectNa
 			notFound(w, req.Request)
 			return
 		}
-		ctx := api.NewContext()
+		ctx := ctxFn(req)
 		if len(namespace) > 0 {
 			ctx = api.WithNamespace(ctx, namespace)
 		}
@@ -238,7 +241,7 @@ func UpdateResource(r RESTUpdater, nameFn ResourceNameFunc, objNameFunc ObjectNa
 }
 
 // DeleteResource returns a function that will handle a resource deletion
-func DeleteResource(r RESTDeleter, nameFn ResourceNameFunc, linkFn LinkResourceFunc, codec runtime.Codec, resource, kind string, admit admission.Interface) restful.RouteFunction {
+func DeleteResource(r RESTDeleter, ctxFn ContextFunc, nameFn ResourceNameFunc, linkFn LinkResourceFunc, codec runtime.Codec, resource, kind string, admit admission.Interface) restful.RouteFunction {
 	return func(req *restful.Request, res *restful.Response) {
 		w := res.ResponseWriter
 
@@ -250,7 +253,7 @@ func DeleteResource(r RESTDeleter, nameFn ResourceNameFunc, linkFn LinkResourceF
 			notFound(w, req.Request)
 			return
 		}
-		ctx := api.NewContext()
+		ctx := ctxFn(req)
 		if len(namespace) > 0 {
 			ctx = api.WithNamespace(ctx, namespace)
 		}

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -50,7 +50,7 @@ func TestWatchWebsocket(t *testing.T) {
 	_ = ResourceWatcher(simpleStorage) // Give compile error if this doesn't work.
 	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, codec, "/api", "version", selfLinker, admissionControl, mapper)
+	}, codec, "/api", "version", selfLinker, admissionControl, requestContextMapper, mapper)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -104,7 +104,7 @@ func TestWatchHTTP(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
 	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, codec, "/api", "version", selfLinker, admissionControl, mapper)
+	}, codec, "/api", "version", selfLinker, admissionControl, requestContextMapper, mapper)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 	client := http.Client{}
@@ -167,7 +167,7 @@ func TestWatchParamParsing(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
 	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, codec, "/api", "version", selfLinker, admissionControl, mapper)
+	}, codec, "/api", "version", selfLinker, admissionControl, requestContextMapper, mapper)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -239,7 +239,7 @@ func TestWatchProtocolSelection(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
 	handler := Handle(map[string]RESTStorage{
 		"foo": simpleStorage,
-	}, codec, "/api", "version", selfLinker, admissionControl, mapper)
+	}, codec, "/api", "version", selfLinker, admissionControl, requestContextMapper, mapper)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 	defer server.CloseClientConnections()

--- a/pkg/auth/handlers/handlers.go
+++ b/pkg/auth/handlers/handlers.go
@@ -18,39 +18,35 @@ package handlers
 
 import (
 	"net/http"
-	"sync"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/authenticator"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
 	"github.com/golang/glog"
 )
-
-// RequestContext is the interface used to associate a user with an http Request.
-type RequestContext interface {
-	Set(*http.Request, user.Info)
-	Get(req *http.Request) (user.Info, bool)
-	Remove(*http.Request)
-}
 
 // NewRequestAuthenticator creates an http handler that tries to authenticate the given request as a user, and then
 // stores any such user found onto the provided context for the request. If authentication fails or returns an error
 // the failed handler is used. On success, handler is invoked to serve the request.
-func NewRequestAuthenticator(context RequestContext, auth authenticator.Request, failed http.Handler, handler http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		user, ok, err := auth.AuthenticateRequest(req)
-		if err != nil || !ok {
-			if err != nil {
-				glog.Errorf("Unable to authenticate the request due to an error: %v", err)
+func NewRequestAuthenticator(mapper api.RequestContextMapper, auth authenticator.Request, failed http.Handler, handler http.Handler) (http.Handler, error) {
+	return api.NewRequestContextFilter(
+		mapper,
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			user, ok, err := auth.AuthenticateRequest(req)
+			if err != nil || !ok {
+				if err != nil {
+					glog.Errorf("Unable to authenticate the request due to an error: %v", err)
+				}
+				failed.ServeHTTP(w, req)
+				return
 			}
-			failed.ServeHTTP(w, req)
-			return
-		}
 
-		context.Set(req, user)
-		defer context.Remove(req)
+			if ctx, ok := mapper.Get(req); ok {
+				mapper.Update(req, api.WithUser(ctx, user))
+			}
 
-		handler.ServeHTTP(w, req)
-	})
+			handler.ServeHTTP(w, req)
+		}),
+	)
 }
 
 var Unauthorized http.HandlerFunc = unauthorized
@@ -58,39 +54,4 @@ var Unauthorized http.HandlerFunc = unauthorized
 // unauthorized serves an unauthorized message to clients.
 func unauthorized(w http.ResponseWriter, req *http.Request) {
 	http.Error(w, "Unauthorized", http.StatusUnauthorized)
-}
-
-// UserRequestContext allows different levels of a call stack to store/retrieve info about the
-// current user associated with an http.Request.
-type UserRequestContext struct {
-	requests map[*http.Request]user.Info
-	lock     sync.Mutex
-}
-
-// NewUserRequestContext provides a map for storing and retrieving users associated with requests.
-// Be sure to pair each `context.Set(req, user)` call with a `defer context.Remove(req)` call or
-// you will leak requests. It implements the RequestContext interface.
-func NewUserRequestContext() *UserRequestContext {
-	return &UserRequestContext{
-		requests: make(map[*http.Request]user.Info),
-	}
-}
-
-func (c *UserRequestContext) Get(req *http.Request) (user.Info, bool) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	user, ok := c.requests[req]
-	return user, ok
-}
-
-func (c *UserRequestContext) Set(req *http.Request, user user.Info) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	c.requests[req] = user
-}
-
-func (c *UserRequestContext) Remove(req *http.Request) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	delete(c.requests, req)
 }


### PR DESCRIPTION
This PR does the following:
- Remove the map of requests to users
- Add a map of requests to contexts
- Initializes a context containing the user as the first step of an authenticated request
- Pass the requestToContext map into resthandler
- Modify resthandler to use the context already associated with the request if one exists

This feels gorpy, but I can't think of a better way to let resthandler have requesting user info without a global request-to-context (or user) map. Open to suggestions for cleaner ways to accomplish this.

@smarterclayton @erictune 
