### PR TITLE
Simplify ValidateClusterSize() to use cmd.Output() directly

### DIFF
--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -184,12 +184,16 @@ func Up() bool {
 // Ensure that the cluster is large engough to run the e2e tests.
 func ValidateClusterSize() {
 	// Check that there are at least 3 minions running
-	res, stdout, _ := finishRunningWithOutputs("validate cluster size", exec.Command(path.Join(*root, "hack/e2e-internal/e2e-cluster-size.sh")))
-	if !res {
-		log.Fatal("Could not get nodes to validate cluster size")
+	cmd := exec.Command(path.Join(*root, "hack/e2e-internal/e2e-cluster-size.sh"))
+	if *verbose {
+		cmd.Stderr = os.Stderr
+	}
+	stdout, err := cmd.Output()
+	if err != nil {
+		log.Fatal("Could not get nodes to validate cluster size (%s)", err)
 	}
 
-	numNodes, err := strconv.Atoi(strings.TrimSpace(stdout))
+	numNodes, err := strconv.Atoi(strings.TrimSpace(string(stdout)))
 	if err != nil {
 		log.Fatalf("Could not count number of nodes to validate cluster size (%s)", err)
 	}


### PR DESCRIPTION
This is a first step towards getting rid of `finishRunningWithOutputs` and using the native `os/exec` methods directly where possible.

Output is slightly modified because now even in verbose mode the output of `e2e-cluster-size.sh` is not printed.

Before this commit:

```
$ go run hack/e2e.go -test -v
2015/02/10 15:31:22 Running in background: watchEvents
2015/02/10 15:31:22 Running: get status
Project: filbranden-cloud
Zone: us-central1-b
Project: filbranden-cloud
Zone: us-central1-b
Running: /usr/local/google/home/filbranden/devel/kubernetes/cluster/../cluster/gce/../../_output/dockerized/bin/linux/amd64/kubectl --match-server-version version
Client Version: version.Info{Major:"0", Minor:"10+", GitVersion:"v0.10.0-325-g6b3bb763f08516", GitCommit:"6b3bb763f085165381d7cbf6de883b28bdb01863", GitTreeState:"clean"}
Server Version: version.Info{Major:"0", Minor:"10+", GitVersion:"v0.10.0-325-g6b3bb763f08516", GitCommit:"6b3bb763f085165381d7cbf6de883b28bdb01863", GitTreeState:"clean"}
2015/02/10 15:31:26 Running: validate cluster size
Project: filbranden-cloud
Zone: us-central1-b
Project: filbranden-cloud
Zone: us-central1-b
Running: /usr/local/google/home/filbranden/devel/kubernetes/cluster/../cluster/gce/../../_output/dockerized/bin/linux/amd64/kubectl --match-server-version get minions --no-headers
2
2015/02/10 15:31:29 Running: Ginkgo tests
Project: filbranden-cloud
Zone: us-central1-b
Running Suite: Kubernetes e2e Suite
===================================
...
```

After this commit:

```
$ go run hack/e2e.go -test -v
2015/02/10 15:47:29 Running in background: watchEvents
2015/02/10 15:47:29 Running: get status
Project: filbranden-cloud
Zone: us-central1-b
Project: filbranden-cloud
Zone: us-central1-b
Running: /usr/local/google/home/filbranden/devel/kubernetes/cluster/../cluster/gce/../../_output/dockerized/bin/linux/amd64/kubectl --match-server-version version
Client Version: version.Info{Major:"0", Minor:"10+", GitVersion:"v0.10.0-325-g6b3bb763f08516", GitCommit:"6b3bb763f085165381d7cbf6de883b28bdb01863", GitTreeState:"clean"}
Server Version: version.Info{Major:"0", Minor:"10+", GitVersion:"v0.10.0-325-g6b3bb763f08516", GitCommit:"6b3bb763f085165381d7cbf6de883b28bdb01863", GitTreeState:"clean"}
Project: filbranden-cloud
Zone: us-central1-b
Project: filbranden-cloud
Zone: us-central1-b
Running: /usr/local/google/home/filbranden/devel/kubernetes/cluster/../cluster/gce/../../_output/dockerized/bin/linux/amd64/kubectl --match-server-version get minions --no-headers
2015/02/10 15:47:36 Running: Ginkgo tests
Project: filbranden-cloud
Zone: us-central1-b
Running Suite: Kubernetes e2e Suite
===================================
...
```

Tested with a cluster too small:

```
$ go run hack/e2e.go -test -v
2015/02/10 15:48:42 Running in background: watchEvents
2015/02/10 15:48:42 Running: get status
Project: filbranden-cloud
Zone: us-central1-b
Project: filbranden-cloud
Zone: us-central1-b
Running: /usr/local/google/home/filbranden/devel/kubernetes/cluster/../cluster/gce/../../_output/dockerized/bin/linux/amd64/kubectl --match-server-version version
Client Version: version.Info{Major:"0", Minor:"10+", GitVersion:"v0.10.0-325-g6b3bb763f08516", GitCommit:"6b3bb763f085165381d7cbf6de883b28bdb01863", GitTreeState:"clean"}
Server Version: version.Info{Major:"0", Minor:"10+", GitVersion:"v0.10.0-325-g6b3bb763f08516", GitCommit:"6b3bb763f085165381d7cbf6de883b28bdb01863", GitTreeState:"clean"}
Project: filbranden-cloud
Zone: us-central1-b
Project: filbranden-cloud
Zone: us-central1-b
Running: /usr/local/google/home/filbranden/devel/kubernetes/cluster/../cluster/gce/../../_output/dockerized/bin/linux/amd64/kubectl --match-server-version get minions --no-headers
2015/02/10 15:48:49 Cluster size (1) is too small to run e2e tests.  2 Minions are required.
exit status 1
```

And same without extra verbosity:

```
$ go run hack/e2e.go -test
2015/02/10 15:50:15 Running in background: watchEvents
2015/02/10 15:50:15 Running: get status
2015/02/10 15:50:22 Cluster size (1) is too small to run e2e tests.  2 Minions are required.
exit status 1
```

@zmerlynn @satnam6502 @roberthbailey 
