### PR TITLE
fixes godep save failure

### DIFF
--- a/contrib/podex/podex.go
+++ b/contrib/podex/podex.go
@@ -40,7 +40,7 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	goyaml "gopkg.in/v2/yaml"
+	goyaml "gopkg.in/yaml.v2"
 )
 
 const usage = "podex [-format=yaml|json] [-type=pod|container] [-id NAME] IMAGES..."


### PR DESCRIPTION
godep save ./... fails not finding package gopkg.in/v2/yaml as
the same package is availble as gopkg.in/yaml.v2 through Godeps.json
