### PR TITLE
Don't set --etcd_servers argument for kubelet.

### DIFF
--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -2,12 +2,6 @@
 {% if grains['os_family'] == 'RedHat' -%}
   {% set daemon_args = "" -%}
 {% endif -%}
-{% if grains.etcd_servers is defined -%}
-  {% set etcd_servers = "--etcd_servers=http://" + grains.etcd_servers + ":4001" -%}
-{% else -%}
-  {% set ips = salt['mine.get']('roles:kubernetes-master', 'network.ip_addrs', 'grain').values() -%}
-  {% set etcd_servers = "--etcd_servers=http://" + ips[0][0] + ":4001" -%}
-{% endif -%}
 
 {% if grains.apiservers is defined -%}
   {% set apiservers = "--api_servers=https://" + grains.apiservers + ":6443" -%}
@@ -34,4 +28,4 @@
   {% set cluster_domain = "--cluster_domain=" + pillar['dns_domain'] %}
 {% endif %}
 
-DAEMON_ARGS="{{daemon_args}} {{etcd_servers}} {{apiservers}} {{auth_path}} {{hostname_override}} {{address}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}}"
+DAEMON_ARGS="{{daemon_args}} {{apiservers}} {{auth_path}} {{hostname_override}} {{address}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}}"


### PR DESCRIPTION
This is ignored by all recent kubelet versions when api_servers is
set.  And it is set in this salt file.

Passed e2e, except for pd.sh failure, which I can't see being related.
