### PR TITLE
Print client version before evaluating server's.

### DIFF
--- a/pkg/kubectl/version.go
+++ b/pkg/kubectl/version.go
@@ -26,13 +26,14 @@ import (
 )
 
 func GetVersion(w io.Writer, kubeClient client.Interface) {
+	GetClientVersion(w)
+
 	serverVersion, err := kubeClient.ServerVersion()
 	if err != nil {
 		fmt.Printf("Couldn't read version from server: %v\n", err)
 		os.Exit(1)
 	}
 
-	GetClientVersion(w)
 	fmt.Fprintf(w, "Server Version: %#v\n", *serverVersion)
 }
 


### PR DESCRIPTION
This will allow the client version to be printed even if the server
version is not available.

Fixes #4098.
