### PR TITLE
Update walkthrough to support kubectl create

### DIFF
--- a/examples/walkthrough/pod1.yaml
+++ b/examples/walkthrough/pod1.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1beta1
+kind: Pod
 id: www
 desiredState:
   manifest:

--- a/examples/walkthrough/pod2.yaml
+++ b/examples/walkthrough/pod2.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1beta1
+kind: Pod
 id: storage
 desiredState:
   manifest:


### PR DESCRIPTION
kubectl create (as opposed to kubecfg) requires `kind` in the pod to work, so I add it here.
