### PR TITLE
Fix podstatus issue caused by docker's resource temporarily unavailable issue

### DIFF
--- a/cluster/saltbase/salt/docker/docker-defaults
+++ b/cluster/saltbase/salt/docker/docker-defaults
@@ -3,3 +3,4 @@ DOCKER_OPTS=""
 DOCKER_OPTS="${DOCKER_OPTS} {{grains.docker_opts}}"
 {% endif %}
 DOCKER_OPTS="${DOCKER_OPTS} --bridge cbr0 --iptables=false --ip-masq=false -r=false"
+DOCKER_NOFILE=1000000


### PR DESCRIPTION
Fix #4188. I tested this PR by pushing it to a running cluster with heavy load (300 pods on 4 nodes)

$ ./cluster/kubectl.sh get pods -l app=hostnames | awk '{print $(NF-2)}' | sort | uniq -c 
Project: golden-system-455
Zone: us-central1-b
Running: ./cluster/../cluster/gce/../../_output/dockerized/bin/linux/amd64/kubectl get pods -l app=hostnames
      1 HOST
    110 kubernetes-minion-1.c.golden-system-455.internal/130.211.172.228
    113 kubernetes-minion-2.c.golden-system-455.internal/104.154.62.162
     62 kubernetes-minion-3.c.golden-system-455.internal/104.154.62.20
     15 kubernetes-minion-4.c.golden-system-455.internal/104.154.55.124

And periodically checking podstatus of all pods for a couple of hours, and there is no flaps among Running, Pending and Unknown anymore: 

```
$ while true; do ./cluster/kubectl.sh get pods -l app=hostnames | grep -v Running; date ; sleep 10; done 
Project: golden-system-455
Zone: us-central1-b
Running: ./cluster/../cluster/gce/../../_output/dockerized/bin/linux/amd64/kubectl get pods -l app=hostnames
POD                 IP                  CONTAINER(S)        IMAGE(S)                    HOST                                                               LABELS              STATUS
Wed Feb 11 21:57:10 PST 2015
...
Running: ./cluster/../cluster/gce/../../_output/dockerized/bin/linux/amd64/kubectl get pods -l app=hostnames
POD                 IP                  CONTAINER(S)        IMAGE(S)                    HOST                                                               LABELS              STATUS
Wed Feb 11 23:58:38 PST 2015
Project: golden-system-455
Zone: us-central1-b
Running: ./cluster/../cluster/gce/../../_output/dockerized/bin/linux/amd64/kubectl get pods -l app=hostnames
POD                 IP                  CONTAINER(S)        IMAGE(S)                    HOST                                                               LABELS              STATUS
Wed Feb 11 23:58:55 PST 2015

```
