### PR TITLE
Added Docker caching support for CoreOS-based cluster.

### DIFF
--- a/docs/getting-started-guides/aws/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/aws/cloud-configs/master.yaml
@@ -105,6 +105,40 @@ coreos:
         ExecStartPre=/usr/bin/chmod +x /opt/bin/flanneld
         ExecStartPre=/usr/bin/etcdctl mk /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "vxlan"}}'
         ExecStart=/opt/bin/flanneld
+    - name: docker.service
+      command: start
+      content: |
+        [Unit]
+        After=flannel.service
+        Wants=flannel.service
+        Description=Docker Application Container Engine
+        Documentation=http://docs.docker.io
+
+        [Service]
+        EnvironmentFile=/run/flannel/subnet.env
+        ExecStartPre=/bin/mount --make-rprivate /
+        ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd://
+
+        [Install]
+        WantedBy=multi-user.target
+    - name: docker-cache.service
+      command: start
+      content: |
+        [Unit]
+        Description=Docker cache proxy
+        Wants=network-online.target
+        Wants=docker.service
+        After=docker.service
+        After=docker-online.target
+
+        [Service]
+        ExecStart=/usr/bin/docker run --net host -d --name docker-registry \
+        -e STANDALONE=false \
+        -e MIRROR_SOURCE=https://registry-1.docker.io \
+        -e MIRROR_SOURCE_INDEX=https://index.docker.io \
+        registry
+        RemainAfterExit=true
+        Type=oneshot
     - name: kube-apiserver.service
       command: start
       content: |

--- a/docs/getting-started-guides/aws/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/aws/cloud-configs/node.yaml
@@ -44,7 +44,7 @@ coreos:
         [Service]
         EnvironmentFile=/run/flannel/subnet.env
         ExecStartPre=/bin/mount --make-rprivate /
-        ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd://
+        ExecStart=/usr/bin/docker --registry-mirror=http://<master-private-ip>:5000 -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd://
 
         [Install]
         WantedBy=multi-user.target

--- a/docs/getting-started-guides/coreos/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/master.yaml
@@ -105,6 +105,40 @@ coreos:
         ExecStartPre=/usr/bin/chmod +x /opt/bin/flanneld
         ExecStartPre=/usr/bin/etcdctl mk /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "vxlan"}}'
         ExecStart=/opt/bin/flanneld
+    - name: docker.service
+      command: start
+      content: |
+        [Unit]
+        After=flannel.service
+        Wants=flannel.service
+        Description=Docker Application Container Engine
+        Documentation=http://docs.docker.io
+
+        [Service]
+        EnvironmentFile=/run/flannel/subnet.env
+        ExecStartPre=/bin/mount --make-rprivate /
+        ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd://
+
+        [Install]
+        WantedBy=multi-user.target
+    - name: docker-cache.service
+      command: start
+      content: |
+        [Unit]
+        Description=Docker cache proxy
+        Wants=network-online.target
+        Wants=docker.service
+        After=docker.service
+        After=docker-online.target
+
+        [Service]
+        ExecStart=/usr/bin/docker run --net host -d --name docker-registry \
+        -e STANDALONE=false \
+        -e MIRROR_SOURCE=https://registry-1.docker.io \
+        -e MIRROR_SOURCE_INDEX=https://index.docker.io \
+        registry
+        RemainAfterExit=true
+        Type=oneshot
     - name: kube-apiserver.service
       command: start
       content: |

--- a/docs/getting-started-guides/coreos/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/node.yaml
@@ -44,7 +44,7 @@ coreos:
         [Service]
         EnvironmentFile=/run/flannel/subnet.env
         ExecStartPre=/bin/mount --make-rprivate /
-        ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd://
+        ExecStart=/usr/bin/docker --registry-mirror=http://<master-private-ip>:5000 -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd://
 
         [Install]
         WantedBy=multi-user.target


### PR DESCRIPTION
This is meant primarily to speed-up Docker images (re)download across a Kubernetes cluster that sits on top of CoreOS nodes.

In the future, this can trivially evolve to a combo of private registry and mirror of public registry.

`docker-registry` will run on master node with `mirroring` configured. Minions will run `docker` with mirror set to the registry running in the master.
