### PR TITLE
cloudprovider: add instance id to NodeSpec

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -781,6 +781,8 @@ type NodeSpec struct {
 	// PodCIDR represents the pod IP range assigned to the node
 	// Note: assigning IP ranges to nodes might need to be revisited when we support migratable IPs.
 	PodCIDR string `json:"cidr,omitempty"`
+	// External ID of the node assigned by some machine database (e.g. a cloud provider)
+	ExternalID string `json:"externalID,omitempty"`
 }
 
 // NodeStatus is information about the current status of a node.

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -699,6 +699,7 @@ func init() {
 
 			out.HostIP = in.Status.HostIP
 			out.PodCIDR = in.Spec.PodCIDR
+			out.ExternalID = in.Spec.ExternalID
 			return s.Convert(&in.Spec.Capacity, &out.NodeResources.Capacity, 0)
 		},
 		func(in *Minion, out *newer.Node, s conversion.Scope) error {
@@ -720,6 +721,7 @@ func init() {
 
 			out.Status.HostIP = in.HostIP
 			out.Spec.PodCIDR = in.PodCIDR
+			out.Spec.ExternalID = in.ExternalID
 			return s.Convert(&in.NodeResources.Capacity, &out.Spec.Capacity, 0)
 		},
 		func(in *newer.LimitRange, out *LimitRange, s conversion.Scope) error {

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -690,6 +690,8 @@ type Minion struct {
 	Status NodeStatus `json:"status,omitempty" description:"current status of node"`
 	// Labels for the node
 	Labels map[string]string `json:"labels,omitempty" description:"map of string keys and values that can be used to organize and categorize minions; labels of a minion assigned by the scheduler must match the scheduled pod's nodeSelector"`
+	// External ID of the node
+	ExternalID string `json:"externalID,omitempty" description:"external id of the node assigned by some machine database (e.g. a cloud provider)"`
 }
 
 // MinionList is a list of minions.

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -619,6 +619,7 @@ func init() {
 
 			out.HostIP = in.Status.HostIP
 			out.PodCIDR = in.Spec.PodCIDR
+			out.ExternalID = in.Spec.ExternalID
 			return s.Convert(&in.Spec.Capacity, &out.NodeResources.Capacity, 0)
 		},
 		func(in *Minion, out *newer.Node, s conversion.Scope) error {
@@ -640,6 +641,7 @@ func init() {
 
 			out.Status.HostIP = in.HostIP
 			out.Spec.PodCIDR = in.PodCIDR
+			out.Spec.ExternalID = in.ExternalID
 			return s.Convert(&in.NodeResources.Capacity, &out.Spec.Capacity, 0)
 		},
 		func(in *newer.LimitRange, out *LimitRange, s conversion.Scope) error {

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -654,6 +654,8 @@ type Minion struct {
 	Status NodeStatus `json:"status,omitempty" description:"current status of node"`
 	// Labels for the node
 	Labels map[string]string `json:"labels,omitempty" description:"map of string keys and values that can be used to organize and categorize minions; labels of a minion assigned by the scheduler must match the scheduled pod's nodeSelector"`
+	// External ID of the node
+	ExternalID string `json:"externalID,omitempty" description:"external id of the node assigned by some machine database (e.g. a cloud provider)"`
 }
 
 // MinionList is a list of minions.

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -814,6 +814,8 @@ type NodeSpec struct {
 	Capacity ResourceList `json:"capacity,omitempty"`
 	// PodCIDR represents the pod IP range assigned to the node
 	PodCIDR string `json:"cidr,omitempty"`
+	// External ID of the node assigned by some machine database (e.g. a cloud provider)
+	ExternalID string `json:"externalID,omitempty"`
 }
 
 // NodeStatus is information about the current status of a node.

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -150,6 +150,11 @@ func (aws *AWSCloud) IPAddress(name string) (net.IP, error) {
 	return ip, nil
 }
 
+// ExternalID returns the cloud provider ID of the specified instance.
+func (aws *AWSCloud) ExternalID(name string) (string, error) {
+	return "", fmt.Errorf("unimplemented")
+}
+
 // Return a list of instances matching regex string.
 func (aws *AWSCloud) getInstancesByRegex(regex string) ([]string, error) {
 	resp, err := aws.ec2.Instances(nil, nil)

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -122,6 +122,28 @@ func (aws *AWSCloud) Zones() (cloudprovider.Zones, bool) {
 
 // IPAddress is an implementation of Instances.IPAddress.
 func (aws *AWSCloud) IPAddress(name string) (net.IP, error) {
+	inst, err := aws.getInstancesByDnsName(name)
+	if err != nil {
+		return nil, err
+	}
+	ip := net.ParseIP(inst.PrivateIpAddress)
+	if ip == nil {
+		return nil, fmt.Errorf("invalid network IP: %s", inst.PrivateIpAddress)
+	}
+	return ip, nil
+}
+
+// ExternalID returns the cloud provider ID of the specified instance.
+func (aws *AWSCloud) ExternalID(name string) (string, error) {
+	inst, err := aws.getInstancesByDnsName(name)
+	if err != nil {
+		return "", err
+	}
+	return inst.InstanceId, nil
+}
+
+// Return the instances matching the relevant private dns name.
+func (aws *AWSCloud) getInstancesByDnsName(name string) (*ec2.Instance, error) {
 	f := ec2.NewFilter()
 	f.Add("private-dns-name", name)
 
@@ -142,17 +164,7 @@ func (aws *AWSCloud) IPAddress(name string) (net.IP, error) {
 		return nil, fmt.Errorf("multiple instances found for host: %s", name)
 	}
 
-	ipAddress := resp.Reservations[0].Instances[0].PrivateIpAddress
-	ip := net.ParseIP(ipAddress)
-	if ip == nil {
-		return nil, fmt.Errorf("invalid network IP: %s", ipAddress)
-	}
-	return ip, nil
-}
-
-// ExternalID returns the cloud provider ID of the specified instance.
-func (aws *AWSCloud) ExternalID(name string) (string, error) {
-	return "", fmt.Errorf("unimplemented")
+	return &resp.Reservations[0].Instances[0], nil
 }
 
 // Return a list of instances matching regex string.

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -59,6 +59,8 @@ type TCPLoadBalancer interface {
 type Instances interface {
 	// IPAddress returns an IP address of the specified instance.
 	IPAddress(name string) (net.IP, error)
+	// ExternalID returns the cloud provider ID of the specified instance.
+	ExternalID(name string) (string, error)
 	// List lists instances that match 'filter' which is a regular expression which must match the entire instance name (fqdn)
 	List(filter string) ([]string, error)
 	// GetNodeResources gets the resources for a particular node

--- a/pkg/cloudprovider/controller/nodecontroller.go
+++ b/pkg/cloudprovider/controller/nodecontroller.go
@@ -231,6 +231,12 @@ func (s *NodeController) PopulateIPs(nodes *api.NodeList) (*api.NodeList, error)
 			} else {
 				node.Status.HostIP = hostIP.String()
 			}
+			instanceID, err := instances.ExternalID(node.Name)
+			if err != nil {
+				glog.Errorf("error getting instance id for %s: %v", node.Name, err)
+			} else {
+				node.Spec.ExternalID = instanceID
+			}
 		}
 	} else {
 		for i := range nodes.Items {

--- a/pkg/cloudprovider/fake/fake.go
+++ b/pkg/cloudprovider/fake/fake.go
@@ -30,6 +30,7 @@ type FakeCloud struct {
 	Err           error
 	Calls         []string
 	IP            net.IP
+	ExtID         string
 	Machines      []string
 	NodeResources *api.NodeResources
 	ClusterList   []string
@@ -108,6 +109,13 @@ func (f *FakeCloud) DeleteTCPLoadBalancer(name, region string) error {
 func (f *FakeCloud) IPAddress(instance string) (net.IP, error) {
 	f.addCall("ip-address")
 	return f.IP, f.Err
+}
+
+// ExternalID is a test-spy implementation of Instances.ExternalID.
+// It adds an entry "external-id" into the internal method call record.
+func (f *FakeCloud) ExternalID(instance string) (string, error) {
+	f.addCall("external-id")
+	return f.ExtID, f.Err
 }
 
 // List is a test-spy implementation of Instances.List.

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -294,6 +294,11 @@ func (gce *GCECloud) IPAddress(instance string) (net.IP, error) {
 	return ip, nil
 }
 
+// ExternalID returns the cloud provider ID of the specified instance.
+func (gce *GCECloud) ExternalID(instance string) (string, error) {
+	return "", fmt.Errorf("unimplemented")
+}
+
 // fqdnSuffix is hacky function to compute the delta between hostame and hostname -f.
 func fqdnSuffix() (string, error) {
 	fullHostname, err := exec.Command("hostname", "-f").Output()

--- a/pkg/cloudprovider/openstack/openstack.go
+++ b/pkg/cloudprovider/openstack/openstack.go
@@ -314,7 +314,11 @@ func (i *Instances) IPAddress(name string) (net.IP, error) {
 
 // ExternalID returns the cloud provider ID of the specified instance.
 func (i *Instances) ExternalID(name string) (string, error) {
-	return "", fmt.Errorf("unimplemented")
+	srv, err := getServerByName(i.compute, name)
+	if err != nil {
+		return "", err
+	}
+	return srv.ID, nil
 }
 
 func (i *Instances) GetNodeResources(name string) (*api.NodeResources, error) {

--- a/pkg/cloudprovider/openstack/openstack.go
+++ b/pkg/cloudprovider/openstack/openstack.go
@@ -312,6 +312,11 @@ func (i *Instances) IPAddress(name string) (net.IP, error) {
 	return net.ParseIP(ip), err
 }
 
+// ExternalID returns the cloud provider ID of the specified instance.
+func (i *Instances) ExternalID(name string) (string, error) {
+	return "", fmt.Errorf("unimplemented")
+}
+
 func (i *Instances) GetNodeResources(name string) (*api.NodeResources, error) {
 	glog.V(2).Infof("GetNodeResources(%v) called", name)
 

--- a/pkg/cloudprovider/ovirt/ovirt.go
+++ b/pkg/cloudprovider/ovirt/ovirt.go
@@ -34,6 +34,7 @@ import (
 )
 
 type OVirtInstance struct {
+	UUID      string
 	Name      string
 	IPAddress string
 }
@@ -61,6 +62,7 @@ type XmlVmAddress struct {
 }
 
 type XmlVmInfo struct {
+	UUID      string         `xml:"id,attr"`
 	Name      string         `xml:"name"`
 	Hostname  string         `xml:"guest_info>fqdn"`
 	Addresses []XmlVmAddress `xml:"guest_info>ips>ip"`
@@ -155,7 +157,11 @@ func (v *OVirtCloud) IPAddress(name string) (net.IP, error) {
 
 // ExternalID returns the cloud provider ID of the specified instance.
 func (v *OVirtCloud) ExternalID(name string) (string, error) {
-	return "", fmt.Errorf("unimplemented")
+	instance, err := v.fetchInstance(name)
+	if err != nil {
+		return "", err
+	}
+	return instance.UUID, nil
 }
 
 func getInstancesFromXml(body io.Reader) (OVirtInstanceMap, error) {
@@ -185,6 +191,7 @@ func getInstancesFromXml(body io.Reader) (OVirtInstanceMap, error) {
 			}
 
 			instances[vm.Hostname] = OVirtInstance{
+				UUID:      vm.UUID,
 				Name:      vm.Name,
 				IPAddress: address,
 			}

--- a/pkg/cloudprovider/ovirt/ovirt.go
+++ b/pkg/cloudprovider/ovirt/ovirt.go
@@ -153,6 +153,11 @@ func (v *OVirtCloud) IPAddress(name string) (net.IP, error) {
 	return address, nil
 }
 
+// ExternalID returns the cloud provider ID of the specified instance.
+func (v *OVirtCloud) ExternalID(name string) (string, error) {
+	return "", fmt.Errorf("unimplemented")
+}
+
 func getInstancesFromXml(body io.Reader) (OVirtInstanceMap, error) {
 	if body == nil {
 		return nil, fmt.Errorf("ovirt rest-api response body is missing")

--- a/pkg/cloudprovider/ovirt/ovirt_test.go
+++ b/pkg/cloudprovider/ovirt/ovirt_test.go
@@ -118,7 +118,9 @@ func TestOVirtCloudXmlParsing(t *testing.T) {
 	if len(instances4) != 2 {
 		t.Fatalf("Unexpected number of instance(s): %d", len(instances4))
 	}
-	if instances4[0] != "host1" || instances4[1] != "host3" {
+
+	names := instances4.ListSortedNames()
+	if names[0] != "host1" || names[1] != "host3" {
 		t.Fatalf("Unexpected instance(s): %s", instances4)
 	}
 }

--- a/pkg/cloudprovider/rackspace/rackspace.go
+++ b/pkg/cloudprovider/rackspace/rackspace.go
@@ -363,6 +363,11 @@ func (i *Instances) IPAddress(name string) (net.IP, error) {
 	return net.ParseIP(ip), err
 }
 
+// ExternalID returns the cloud provider ID of the specified instance.
+func (i *Instances) ExternalID(name string) (string, error) {
+	return "", fmt.Errorf("unimplemented")
+}
+
 func (i *Instances) GetNodeResources(name string) (*api.NodeResources, error) {
 	glog.V(2).Infof("GetNodeResources(%v) called", name)
 

--- a/pkg/cloudprovider/vagrant/vagrant.go
+++ b/pkg/cloudprovider/vagrant/vagrant.go
@@ -119,6 +119,11 @@ func (v *VagrantCloud) IPAddress(instance string) (net.IP, error) {
 	return nil, fmt.Errorf("unable to find IP address for instance: %s", instance)
 }
 
+// ExternalID returns the cloud provider ID of the specified instance.
+func (v *VagrantCloud) ExternalID(instance string) (string, error) {
+	return "", fmt.Errorf("unimplemented")
+}
+
 // saltMinionsByRole filters a list of minions that have a matching role.
 func (v *VagrantCloud) saltMinionsByRole(minions []SaltMinion, role string) []SaltMinion {
 	var filteredMinions []SaltMinion


### PR DESCRIPTION
Sometimes for external applications it is important to identify the cloud instance of the nodes. Until this patch there was no contract that the node name returned by List was also the unique identifier of the cloud instance. This new API ensures that an external application can reliably retrieve the relevant instance id of the nodes.
