### PR TITLE
allow for unset $@ in kubectl.sh

### DIFF
--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -128,5 +128,5 @@ if [[ -n "${KUBE_MASTER_IP-}" && -z "${KUBERNETES_MASTER-}" ]]; then
   export KUBERNETES_MASTER=https://${KUBE_MASTER_IP}
 fi
 
-echo "Running:" "${kubectl}" "${config[@]:+${config[@]}}" "${@}" >&2
-"${kubectl}" "${config[@]:+${config[@]}}" "${@}"
+echo "Running:" "${kubectl}" "${config[@]:+${config[@]}}" "${@-}" >&2
+"${kubectl}" "${config[@]:+${config[@]}}" "${@-}"


### PR DESCRIPTION
Running cluster/kubectl.sh with no arguments resulted in the following
error.

```
cluster/kubectl.sh: line 131: @: unbound variable
```

With this change, the kubectl binary is called without a command
which results in a printout of the the usage text.
