### PR TITLE
Show help message in kubectl.sh if no args.

### DIFF
--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -128,5 +128,5 @@ if [[ -n "${KUBE_MASTER_IP-}" && -z "${KUBERNETES_MASTER-}" ]]; then
   export KUBERNETES_MASTER=https://${KUBE_MASTER_IP}
 fi
 
-echo "Running:" "${kubectl}" "${config[@]:+${config[@]}}" "${@}" >&2
-"${kubectl}" "${config[@]:+${config[@]}}" "${@}"
+echo "Running:" "${kubectl}" "${config[@]:+${config[@]}}" "${@+$@}" >&2
+"${kubectl}" "${config[@]:+${config[@]}}" "${@+$@}"


### PR DESCRIPTION
When no args are passed to a script, "$@" is unset,
which causes a shell error in "nounset" mode.

This change passes an empty string to kubectl in that case
so it can print help.

This also updates docs/kubectl.md because the hook told me to.
