### PR TITLE
Node event

### DIFF
--- a/pkg/api/rest/types.go
+++ b/pkg/api/rest/types.go
@@ -128,7 +128,31 @@ func (nodeStrategy) Validate(obj runtime.Object) errors.ValidationErrorList {
 	return validation.ValidateMinion(node)
 }
 
-// namespaceStrategy implements behavior for nodes
+// eventStrategy implements behavior for events
+type eventStrategy struct {
+	runtime.ObjectTyper
+	api.NameGenerator
+}
+
+// Events is the default logic that applies when creating and updating event objects.
+var Events RESTCreateStrategy = eventStrategy{api.Scheme, api.SimpleNameGenerator}
+
+// NamespaceScoped is true for events.
+func (eventStrategy) NamespaceScoped() bool {
+	return true
+}
+
+func (eventStrategy) ResetBeforeCreate(obj runtime.Object) {
+	_ = obj.(*api.Event)
+}
+
+// Validate validates a new event.
+func (eventStrategy) Validate(obj runtime.Object) errors.ValidationErrorList {
+	event := obj.(*api.Event)
+	return validation.ValidateEvent(event)
+}
+
+// namespaceStrategy implements behavior for namespace
 type namespaceStrategy struct {
 	runtime.ObjectTyper
 	api.NameGenerator

--- a/pkg/cloudprovider/controller/nodecontroller.go
+++ b/pkg/cloudprovider/controller/nodecontroller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	apierrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/probe"
@@ -81,6 +82,9 @@ func (s *NodeController) Run(period time.Duration, syncNodeList, syncNodeStatus 
 	// Register intial set of nodes with their status set.
 	var nodes *api.NodeList
 	var err error
+
+	record.StartRecording(s.kubeClient.Events(""), api.EventSource{Component: "nodecontroller"})
+
 	if s.isRunningCloudProvider() {
 		if syncNodeList {
 			nodes, err = s.CloudNodes()
@@ -139,10 +143,14 @@ func (s *NodeController) RegisterNodes(nodes *api.NodeList, retryCount int, retr
 			if registered.Has(node.Name) {
 				continue
 			}
-			_, err := s.kubeClient.Nodes().Create(&node)
-			if err == nil || apierrors.IsAlreadyExists(err) {
+			createdNode, err := s.kubeClient.Nodes().Create(&node)
+			if err == nil {
 				registered.Insert(node.Name)
-				glog.Infof("Registered node in registry: %s", node.Name)
+				record.Eventf(createdNode, "created", "node %s created", createdNode.Name)
+				glog.Infof("Registered node %s in registry", node.Name)
+			} else if apierrors.IsAlreadyExists(err) {
+				registered.Insert(node.Name)
+				glog.Infof("Node %s already exists in registry", node.Name)
 			} else {
 				glog.Errorf("Error registering node %s, retrying: %s", node.Name, err)
 			}
@@ -179,9 +187,11 @@ func (s *NodeController) SyncCloud() error {
 	for _, node := range matches.Items {
 		if _, ok := nodeMap[node.Name]; !ok {
 			glog.Infof("Create node in registry: %s", node.Name)
-			_, err = s.kubeClient.Nodes().Create(&node)
+			createdNode, err := s.kubeClient.Nodes().Create(&node)
 			if err != nil {
 				glog.Errorf("Create node error: %s", node.Name)
+			} else {
+				record.Eventf(createdNode, "created", "node %s created", createdNode.Name)
 			}
 		}
 		delete(nodeMap, node.Name)
@@ -193,6 +203,8 @@ func (s *NodeController) SyncCloud() error {
 		err = s.kubeClient.Nodes().Delete(nodeID)
 		if err != nil {
 			glog.Errorf("Delete node error: %s", nodeID)
+		} else {
+			record.Eventf(nodeMap[nodeID], "deleted", "node %s deleted", nodeID)
 		}
 		s.deletePods(nodeID)
 	}
@@ -322,6 +334,11 @@ func (s *NodeController) DoCheck(node *api.Node) []api.NodeCondition {
 		// Set transition time to Now() if node status changes or `oldReadyCondition` is nil, which
 		// happens only when the node is checked for the first time.
 		newReadyCondition.LastTransitionTime = util.Now()
+		if newReadyCondition.Status == api.ConditionFull {
+			record.Eventf(node, "becomesReady", "node condition Ready changes to None")
+		} else {
+			record.Eventf(node, "becomesUnready", "node condition Ready changes to Full")
+		}
 	}
 
 	if newReadyCondition.Status != api.ConditionFull {

--- a/pkg/cloudprovider/controller/nodecontroller_test.go
+++ b/pkg/cloudprovider/controller/nodecontroller_test.go
@@ -27,7 +27,9 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	apierrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	fake_cloud "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/fake"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/probe"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -63,9 +65,11 @@ func (m *FakeNodeHandler) Create(node *api.Node) (*api.Node, error) {
 		}
 	}
 	if m.CreateHook == nil || m.CreateHook(m, node) {
-		nodeCopy := *node
-		m.CreatedNodes = append(m.CreatedNodes, &nodeCopy)
-		return node, nil
+		nodeWithSelfLink := *node
+		nodeWithSelfLink.SelfLink = testapi.SelfLink("nodes", node.Name)
+		m.CreatedNodes = append(m.CreatedNodes, &nodeWithSelfLink)
+		nodeCopy := nodeWithSelfLink
+		return &nodeCopy, nil
 	} else {
 		return nil, errors.New("Create error.")
 	}
@@ -135,17 +139,17 @@ func TestRegisterNodes(t *testing.T) {
 		expectedRequestCount int
 		expectedCreateCount  int
 		expectedFail         bool
+		expectedEventReason  []string
 	}{
 		{
 			// Register two nodes normally.
-			machines: []string{"node0", "node1"},
-			fakeNodeHandler: &FakeNodeHandler{
-				CreateHook: func(fake *FakeNodeHandler, node *api.Node) bool { return true },
-			},
+			machines:             []string{"node0", "node1"},
+			fakeNodeHandler:      &FakeNodeHandler{},
 			retryCount:           1,
 			expectedRequestCount: 2,
 			expectedCreateCount:  2,
 			expectedFail:         false,
+			expectedEventReason:  []string{"created", "created"},
 		},
 		{
 			// Canonicalize node names.
@@ -162,6 +166,7 @@ func TestRegisterNodes(t *testing.T) {
 			expectedRequestCount: 2,
 			expectedCreateCount:  2,
 			expectedFail:         false,
+			expectedEventReason:  []string{"created", "created"},
 		},
 		{
 			// No machine to register.
@@ -173,6 +178,7 @@ func TestRegisterNodes(t *testing.T) {
 			expectedRequestCount: 0,
 			expectedCreateCount:  0,
 			expectedFail:         false,
+			expectedEventReason:  []string{},
 		},
 		{
 			// Fail the first two requests.
@@ -189,6 +195,7 @@ func TestRegisterNodes(t *testing.T) {
 			expectedRequestCount: 4,
 			expectedCreateCount:  2,
 			expectedFail:         false,
+			expectedEventReason:  []string{"created", "created"},
 		},
 		{
 			// One node already exists
@@ -206,6 +213,7 @@ func TestRegisterNodes(t *testing.T) {
 			expectedRequestCount: 2,
 			expectedCreateCount:  1,
 			expectedFail:         false,
+			expectedEventReason:  []string{"created"},
 		},
 		{
 			// The first node always fails.
@@ -222,6 +230,7 @@ func TestRegisterNodes(t *testing.T) {
 			expectedRequestCount: 3, // 2 for node0, 1 for node1
 			expectedCreateCount:  1,
 			expectedFail:         true,
+			expectedEventReason:  []string{"created"},
 		},
 	}
 
@@ -231,6 +240,17 @@ func TestRegisterNodes(t *testing.T) {
 			nodes.Items = append(nodes.Items, *newNode(machine))
 		}
 		nodeController := NewNodeController(nil, "", item.machines, &api.NodeResources{}, item.fakeNodeHandler, nil, 10, time.Minute)
+		called := make(chan struct{})
+		calledCount := 0
+		events := record.GetEvents(func(e *api.Event) {
+			if e, a := item.expectedEventReason[calledCount], e.Reason; e != a {
+				t.Errorf("expected event reason %v, but got %v.", e, a)
+			}
+			calledCount += 1
+			if len(item.expectedEventReason) == calledCount {
+				close(called)
+			}
+		})
 		err := nodeController.RegisterNodes(&nodes, item.retryCount, time.Millisecond)
 		if !item.expectedFail && err != nil {
 			t.Errorf("unexpected error: %v", err)
@@ -244,6 +264,10 @@ func TestRegisterNodes(t *testing.T) {
 		if len(item.fakeNodeHandler.CreatedNodes) != item.expectedCreateCount {
 			t.Errorf("expected %v nodes, but got %v.", item.expectedCreateCount, item.fakeNodeHandler.CreatedNodes)
 		}
+		if len(item.expectedEventReason) != 0 {
+			<-called
+		}
+		events.Stop()
 	}
 }
 
@@ -368,6 +392,7 @@ func TestSyncCloud(t *testing.T) {
 		expectedRequestCount int
 		expectedCreated      []string
 		expectedDeleted      []string
+		expectedEventReason  []string
 	}{
 		{
 			// 1 existing node, 1 cloud nodes: do nothing.
@@ -381,6 +406,7 @@ func TestSyncCloud(t *testing.T) {
 			expectedRequestCount: 1, // List
 			expectedCreated:      []string{},
 			expectedDeleted:      []string{},
+			expectedEventReason:  []string{},
 		},
 		{
 			// 1 existing node, 2 cloud nodes: create 1.
@@ -394,11 +420,12 @@ func TestSyncCloud(t *testing.T) {
 			expectedRequestCount: 2, // List + Create
 			expectedCreated:      []string{"node1"},
 			expectedDeleted:      []string{},
+			expectedEventReason:  []string{"created"},
 		},
 		{
 			// 2 existing nodes, 1 cloud node: delete 1.
 			fakeNodeHandler: &FakeNodeHandler{
-				Existing: []*api.Node{newNode("node0"), newNode("node1")},
+				Existing: []*api.Node{newNodeWithSelfLink("node0"), newNodeWithSelfLink("node1")},
 			},
 			fakeCloud: &fake_cloud.FakeCloud{
 				Machines: []string{"node0"},
@@ -407,11 +434,12 @@ func TestSyncCloud(t *testing.T) {
 			expectedRequestCount: 2, // List + Delete
 			expectedCreated:      []string{},
 			expectedDeleted:      []string{"node1"},
+			expectedEventReason:  []string{"deleted"},
 		},
 		{
 			// 1 existing node, 3 cloud nodes but only 2 match regex: delete 1.
 			fakeNodeHandler: &FakeNodeHandler{
-				Existing: []*api.Node{newNode("node0")},
+				Existing: []*api.Node{newNodeWithSelfLink("node0")},
 			},
 			fakeCloud: &fake_cloud.FakeCloud{
 				Machines: []string{"node0", "node1", "fake"},
@@ -420,11 +448,23 @@ func TestSyncCloud(t *testing.T) {
 			expectedRequestCount: 2, // List + Create
 			expectedCreated:      []string{"node1"},
 			expectedDeleted:      []string{},
+			expectedEventReason:  []string{"created"},
 		},
 	}
 
 	for _, item := range table {
 		nodeController := NewNodeController(item.fakeCloud, item.matchRE, nil, &api.NodeResources{}, item.fakeNodeHandler, nil, 10, time.Minute)
+		called := make(chan struct{})
+		calledCount := 0
+		events := record.GetEvents(func(e *api.Event) {
+			if e, a := item.expectedEventReason[calledCount], e.Reason; e != a {
+				t.Errorf("expected event reason %v, but got %v.", e, a)
+			}
+			calledCount += 1
+			if len(item.expectedEventReason) == calledCount {
+				close(called)
+			}
+		})
 		if err := nodeController.SyncCloud(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -439,6 +479,10 @@ func TestSyncCloud(t *testing.T) {
 		if !reflect.DeepEqual(item.expectedDeleted, nodes) {
 			t.Errorf("expected node list %+v, got %+v", item.expectedDeleted, nodes)
 		}
+		if len(item.expectedEventReason) != 0 {
+			<-called
+		}
+		events.Stop()
 	}
 }
 
@@ -521,12 +565,28 @@ func TestSyncCloudDeletePods(t *testing.T) {
 
 func TestHealthCheckNode(t *testing.T) {
 	table := []struct {
-		node               *api.Node
-		fakeKubeletClient  *FakeKubeletClient
-		expectedConditions []api.NodeCondition
+		node                *api.Node
+		fakeKubeletClient   *FakeKubeletClient
+		expectedConditions  []api.NodeCondition
+		expectedSent        bool
+		expectedEventReason string
 	}{
 		{
-			node: newNode("node0"),
+			// Node is ready, and current probe is ready.
+			node: &api.Node{
+				ObjectMeta: api.ObjectMeta{Name: "node0"},
+				Status: api.NodeStatus{
+					Conditions: []api.NodeCondition{
+						{
+							Type:               api.NodeReady,
+							Status:             api.ConditionFull,
+							Reason:             "Node health check succeeded: kubelet /healthz endpoint returns ok",
+							LastProbeTime:      util.Now(),
+							LastTransitionTime: util.Now(),
+						},
+					},
+				},
+			},
 			fakeKubeletClient: &FakeKubeletClient{
 				Status: probe.Success,
 				Err:    nil,
@@ -538,9 +598,55 @@ func TestHealthCheckNode(t *testing.T) {
 					Reason: "Node health check succeeded: kubelet /healthz endpoint returns ok",
 				},
 			},
+			expectedSent:        false,
+			expectedEventReason: "",
 		},
 		{
-			node: newNode("node0"),
+			// Node is not ready, and current probe is ready.
+			node: &api.Node{
+				ObjectMeta: api.ObjectMeta{Name: "node0", SelfLink: testapi.SelfLink("nodes", "node0")},
+				Status: api.NodeStatus{
+					Conditions: []api.NodeCondition{
+						{
+							Type:               api.NodeReady,
+							Status:             api.ConditionNone,
+							Reason:             "Node health check failed: kubelet /healthz endpoint returns not ok",
+							LastProbeTime:      util.Now(),
+							LastTransitionTime: util.Now(),
+						},
+					},
+				},
+			},
+			fakeKubeletClient: &FakeKubeletClient{
+				Status: probe.Success,
+				Err:    nil,
+			},
+			expectedConditions: []api.NodeCondition{
+				{
+					Type:   api.NodeReady,
+					Status: api.ConditionFull,
+					Reason: "Node health check succeeded: kubelet /healthz endpoint returns ok",
+				},
+			},
+			expectedSent:        true,
+			expectedEventReason: "becomesReady",
+		},
+		{
+			// Node is ready, and current probe is not ready.
+			node: &api.Node{
+				ObjectMeta: api.ObjectMeta{Name: "node0", SelfLink: testapi.SelfLink("nodes", "node0")},
+				Status: api.NodeStatus{
+					Conditions: []api.NodeCondition{
+						{
+							Type:               api.NodeReady,
+							Status:             api.ConditionFull,
+							Reason:             "Node health check succeeded: kubelet /healthz endpoint returns ok",
+							LastProbeTime:      util.Now(),
+							LastTransitionTime: util.Now(),
+						},
+					},
+				},
+			},
 			fakeKubeletClient: &FakeKubeletClient{
 				Status: probe.Failure,
 				Err:    nil,
@@ -552,8 +658,41 @@ func TestHealthCheckNode(t *testing.T) {
 					Reason: "Node health check failed: kubelet /healthz endpoint returns not ok",
 				},
 			},
+			expectedSent:        true,
+			expectedEventReason: "becomesUnready",
 		},
 		{
+			// Node is not ready, and current probe is not ready.
+			node: &api.Node{
+				ObjectMeta: api.ObjectMeta{Name: "node0"},
+				Status: api.NodeStatus{
+					Conditions: []api.NodeCondition{
+						{
+							Type:               api.NodeReady,
+							Status:             api.ConditionNone,
+							Reason:             "Node health check failed: kubelet /healthz endpoint returns not ok",
+							LastProbeTime:      util.Now(),
+							LastTransitionTime: util.Now(),
+						},
+					},
+				},
+			},
+			fakeKubeletClient: &FakeKubeletClient{
+				Status: probe.Failure,
+				Err:    nil,
+			},
+			expectedConditions: []api.NodeCondition{
+				{
+					Type:   api.NodeReady,
+					Status: api.ConditionNone,
+					Reason: "Node health check failed: kubelet /healthz endpoint returns not ok",
+				},
+			},
+			expectedSent:        false,
+			expectedEventReason: "",
+		},
+		{
+			// Node is not ready, and current probe has error.
 			node: newNode("node0"),
 			fakeKubeletClient: &FakeKubeletClient{
 				Status: probe.Failure,
@@ -566,11 +705,20 @@ func TestHealthCheckNode(t *testing.T) {
 					Reason: "Node health check error: Error",
 				},
 			},
+			expectedSent:        false,
+			expectedEventReason: "",
 		},
 	}
 
 	for _, item := range table {
 		nodeController := NewNodeController(nil, "", nil, nil, nil, item.fakeKubeletClient, 10, time.Minute)
+		called := make(chan struct{})
+		events := record.GetEvents(func(e *api.Event) {
+			if e, a := item.expectedEventReason, e.Reason; e != a {
+				t.Errorf("expected event reason %v, but got %v.", e, a)
+			}
+			close(called)
+		})
 		conditions := nodeController.DoCheck(item.node)
 		for i := range conditions {
 			if conditions[i].LastTransitionTime.IsZero() {
@@ -585,6 +733,10 @@ func TestHealthCheckNode(t *testing.T) {
 		if !reflect.DeepEqual(item.expectedConditions, conditions) {
 			t.Errorf("expected conditions %+v, got %+v", item.expectedConditions, conditions)
 		}
+		if item.expectedSent {
+			<-called
+		}
+		events.Stop()
 	}
 }
 
@@ -1056,6 +1208,10 @@ func TestSyncNodeStatus(t *testing.T) {
 
 func newNode(name string) *api.Node {
 	return &api.Node{ObjectMeta: api.ObjectMeta{Name: name}}
+}
+
+func newNodeWithSelfLink(name string) *api.Node {
+	return &api.Node{ObjectMeta: api.ObjectMeta{Name: name, SelfLink: testapi.SelfLink("nodes", name)}}
 }
 
 func newPod(name, host string) *api.Pod {

--- a/pkg/registry/event/rest_test.go
+++ b/pkg/registry/event/rest_test.go
@@ -64,7 +64,7 @@ func TestRESTCreate(t *testing.T) {
 		}, {
 			ctx:   api.NewContext(),
 			event: testEvent("bar"),
-			valid: true,
+			valid: false,
 		}, {
 			ctx:   api.WithNamespace(api.NewContext(), "nondefault"),
 			event: testEvent("bazzzz"),

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -144,7 +144,6 @@ var aEvent string = `
   "involvedObject": {
     "kind": "Minion",
     "name": "a",
-    "namespace": "default",
     "apiVersion": "v1beta1",
   }%s
 }


### PR DESCRIPTION
Fix #4379 and publish node status change event.

The fix choses to not compare event namespace with node namespace, i.e. event namespace is default, and node namespace is None.  The alternative fix is to reset event namespace to none if involvedObject is a node.  I think the first fix is perferrable as event as a kind, is namespace scoped.

/cc @smarterclayton @dchen1107 @derekwaynecarr 
