### PR TITLE
If an object has no namespace, do not add a leading slash

### DIFF
--- a/pkg/client/cache/store.go
+++ b/pkg/client/cache/store.go
@@ -57,7 +57,10 @@ func MetaNamespaceKeyFunc(obj interface{}) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("object has no meta: %v", err)
 	}
-	return meta.Namespace() + "/" + meta.Name(), nil
+	if len(meta.Namespace()) > 0 {
+		return meta.Namespace() + "/" + meta.Name(), nil
+	}
+	return meta.Name(), nil
 }
 
 type cache struct {


### PR DESCRIPTION
@smarterclayton - simple change, but useful now that we have resources that are not in a namespace that actually enforce that objectMeta.Namespace == "", will help avoid making one off funcs.
