### PR TITLE
Revert "Make gce's kubeconfig context include the gce project"

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -508,7 +508,7 @@ function kube-up {
   local kube_auth="kubernetes_auth"
 
   local kubectl="${KUBE_ROOT}/cluster/kubectl.sh"
-  local context="${PROJECT}-${INSTANCE_PREFIX}"
+  local context="${INSTANCE_PREFIX}"
   local user="${INSTANCE_PREFIX}-admin"
   local config_dir="${HOME}/.kube/${context}"
 


### PR DESCRIPTION
This causes half the e2e tests to fail in Jenkins.

Reverts GoogleCloudPlatform/kubernetes#4337
