### PR TITLE
Return logs for failed and succeeded pods too.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1423,8 +1423,11 @@ func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName, tail stri
 			return fmt.Errorf("failed to get status for pod %q - %v", podFullName, err)
 		}
 	}
-	if podStatus.Phase != api.PodRunning {
-		return fmt.Errorf("pod %q is not in 'Running' state - State: %q", podFullName, podStatus.Phase)
+	switch podStatus.Phase {
+	case api.PodRunning, api.PodSucceeded, api.PodFailed:
+		break
+	default:
+		return fmt.Errorf("pod %q is not in 'Running', 'Succeeded' or 'Failed' state - State: %q", podFullName, podStatus.Phase)
 	}
 	exists := false
 	dockerContainerID := ""


### PR DESCRIPTION
This fixes flakes in the client-envvars e2e test, for example:

```
[90m/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/pods.go:364[0m

  [91m"FOOSERVICE_SERVICE_HOST=" in client env vars
  Expected
      <string>: Internal Error: pod "client-envvars-a3cf9fee-b310-11e4-b7bb-42010af067aa.default.api" is not in 'Running' state - State: "Succeeded"

  to contain substring
      <string>: FOOSERVICE_SERVICE_HOST=[0m
```
