### PR TITLE
Add ContainerRuntimeInterface.

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -32,7 +32,6 @@ import (
 	"sync"
 	"time"
 
-	kubeletapp "github.com/GoogleCloudPlatform/kubernetes/cmd/kubelet/app"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
@@ -211,13 +210,15 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	// Kubelet (localhost)
 	testRootDir := makeTempDirOrDie("kubelet_integ_1.")
 	glog.Infof("Using %s as root dir for kubelet #1", testRootDir)
-	kubeletapp.SimpleRunKubelet(cl, nil, &fakeDocker1, machineList[0], testRootDir, manifestURL, "127.0.0.1", 10250, api.NamespaceDefault, empty_dir.ProbeVolumePlugins())
+	fakeDockerRuntime1 := dockertools.NewDockerRuntime(&fakeDocker1)
+	kubeletServer.SimpleRunKubelet(cl, nil, fakeDockerRuntime1, machineList[0], testRootDir, manifestURL, "127.0.0.1", 10250, api.NamespaceDefault, empty_dir.ProbeVolumePlugins())
 	// Kubelet (machine)
 	// Create a second kubelet so that the guestbook example's two redis slaves both
 	// have a place they can schedule.
 	testRootDir = makeTempDirOrDie("kubelet_integ_2.")
 	glog.Infof("Using %s as root dir for kubelet #2", testRootDir)
-	kubeletapp.SimpleRunKubelet(cl, nil, &fakeDocker2, machineList[1], testRootDir, "", "127.0.0.1", 10251, api.NamespaceDefault, empty_dir.ProbeVolumePlugins())
+	fakeDockerRuntime2 := dockertools.NewDockerRuntime(&fakeDocker2)
+	kubeletServer.SimpleRunKubelet(cl, nil, fakeDockerRuntime2, machineList[1], testRootDir, "", "127.0.0.1", 10251, api.NamespaceDefault, empty_dir.ProbeVolumePlugins())
 
 	return apiServer.URL
 }

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -32,6 +32,7 @@ import (
 	"sync"
 	"time"
 
+	kubeletapp "github.com/GoogleCloudPlatform/kubernetes/cmd/kubelet/app"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
@@ -211,14 +212,14 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	testRootDir := makeTempDirOrDie("kubelet_integ_1.")
 	glog.Infof("Using %s as root dir for kubelet #1", testRootDir)
 	fakeDockerRuntime1 := dockertools.NewDockerRuntime(&fakeDocker1)
-	kubeletServer.SimpleRunKubelet(cl, nil, fakeDockerRuntime1, machineList[0], testRootDir, manifestURL, "127.0.0.1", 10250, api.NamespaceDefault, empty_dir.ProbeVolumePlugins())
+	kubeletapp.SimpleRunKubelet(cl, nil, fakeDockerRuntime1, machineList[0], testRootDir, manifestURL, "127.0.0.1", 10250, api.NamespaceDefault, empty_dir.ProbeVolumePlugins())
 	// Kubelet (machine)
 	// Create a second kubelet so that the guestbook example's two redis slaves both
 	// have a place they can schedule.
 	testRootDir = makeTempDirOrDie("kubelet_integ_2.")
 	glog.Infof("Using %s as root dir for kubelet #2", testRootDir)
 	fakeDockerRuntime2 := dockertools.NewDockerRuntime(&fakeDocker2)
-	kubeletServer.SimpleRunKubelet(cl, nil, fakeDockerRuntime2, machineList[1], testRootDir, "", "127.0.0.1", 10251, api.NamespaceDefault, empty_dir.ProbeVolumePlugins())
+	kubeletapp.SimpleRunKubelet(cl, nil, fakeDockerRuntime2, machineList[1], testRootDir, "", "127.0.0.1", 10251, api.NamespaceDefault, empty_dir.ProbeVolumePlugins())
 
 	return apiServer.URL
 }

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -251,7 +251,7 @@ func (s *KubeletServer) createAPIServerClient() (*client.Client, error) {
 // Under the hood it calls RunKubelet (below)
 func SimpleRunKubelet(client *client.Client,
 	etcdClient tools.EtcdClient,
-	containerRuntime container.ContainerRuntimeInterface,
+	containerRuntime container.Runtime,
 	hostname, rootDir, manifestURL, address string,
 	port uint,
 	masterServiceNamespace string,
@@ -353,7 +353,7 @@ func makePodSourceConfig(kc *KubeletConfig) *config.PodConfig {
 type KubeletConfig struct {
 	EtcdClient                     tools.EtcdClient
 	KubeClient                     *client.Client
-	ContainerRuntime               container.ContainerRuntimeInterface
+	ContainerRuntime               container.Runtime
 	CAdvisorPort                   uint
 	Address                        util.IP
 	AllowPrivileged                bool

--- a/pkg/kubelet/cadvisor.go
+++ b/pkg/kubelet/cadvisor.go
@@ -71,7 +71,7 @@ func (kl *Kubelet) GetContainerInfo(podFullName string, uid types.UID, container
 	if cc == nil {
 		return nil, fmt.Errorf("no cadvisor connection")
 	}
-	dockerContainers, err := dockertools.GetKubeletDockerContainers(kl.dockerClient, false)
+	dockerContainers, err := dockertools.GetKubeletDockerContainers(kl.containerRuntime, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -21,7 +21,7 @@ import "github.com/fsouza/go-dockerclient"
 // ContainerRuntimeInterface is the abstract interface for container runtime.
 type ContainerRuntimeInterface interface {
 	ListContainers(options ListContainersOptions) ([]Container, error)
-	InspectContainer(id string) (*docker.Container, error)
+	InspectContainer(id string) (*Container, error)
 	CreateContainer(docker.CreateContainerOptions) (*docker.Container, error)
 	StartContainer(id string, hostConfig *docker.HostConfig) error
 	StopContainer(id string, timeout uint) error

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -30,7 +30,7 @@ type Runtime interface {
 	ListImages(opts ListImagesOptions) ([]*Image, error)
 	PullImage(opts PullImageOptions) error
 	RemoveImage(image string) error
-	Logs(opts docker.LogsOptions) error
+	Logs(opts LogsOptions) error
 	Version() (*docker.Env, error)
 	CreateExec(docker.CreateExecOptions) (*docker.Exec, error)
 	StartExec(string, docker.StartExecOptions) error

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -25,7 +25,7 @@ type ContainerRuntimeInterface interface {
 	CreateContainer(options CreateContainerOptions) (*Container, error)
 	StartContainer(id string, hostConfig *HostConfig) error
 	StopContainer(id string, timeout uint) error
-	RemoveContainer(opts docker.RemoveContainerOptions) error
+	RemoveContainer(opts RemoveContainerOptions) error
 	InspectImage(image string) (*docker.Image, error)
 	ListImages(opts docker.ListImagesOptions) ([]docker.APIImages, error)
 	PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -18,8 +18,8 @@ package container
 
 import "github.com/fsouza/go-dockerclient"
 
-// ContainerRuntimeInterface is the abstract interface for container runtime.
-type ContainerRuntimeInterface interface {
+// Runtime is the abstract interface for container runtime.
+type Runtime interface {
 	ListContainers(options ListContainersOptions) ([]*Container, error)
 	InspectContainer(id string) (*Container, error)
 	CreateContainer(options CreateContainerOptions) (*Container, error)

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -27,7 +27,7 @@ type ContainerRuntimeInterface interface {
 	StopContainer(id string, timeout uint) error
 	RemoveContainer(opts RemoveContainerOptions) error
 	InspectImage(image string) (*Image, error)
-	ListImages(opts docker.ListImagesOptions) ([]docker.APIImages, error)
+	ListImages(opts ListImagesOptions) ([]*Image, error)
 	PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error
 	RemoveImage(image string) error
 	Logs(opts docker.LogsOptions) error

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -28,7 +28,7 @@ type Runtime interface {
 	RemoveContainer(opts RemoveContainerOptions) error
 	InspectImage(image string) (*Image, error)
 	ListImages(opts ListImagesOptions) ([]*Image, error)
-	PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error
+	PullImage(opts PullImageOptions) error
 	RemoveImage(image string) error
 	Logs(opts docker.LogsOptions) error
 	Version() (*docker.Env, error)

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -31,5 +31,5 @@ type Runtime interface {
 	Logs(opts LogsOptions) error
 	Version() ([]string, error)
 	CreateExec(opts CreateExecOptions) (*Exec, error)
-	StartExec(string, StartExecOptions) error
+	StartExec(id string, opts StartExecOptions) error
 }

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -26,7 +26,7 @@ type ContainerRuntimeInterface interface {
 	StartContainer(id string, hostConfig *HostConfig) error
 	StopContainer(id string, timeout uint) error
 	RemoveContainer(opts RemoveContainerOptions) error
-	InspectImage(image string) (*docker.Image, error)
+	InspectImage(image string) (*Image, error)
 	ListImages(opts docker.ListImagesOptions) ([]docker.APIImages, error)
 	PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error
 	RemoveImage(image string) error

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -16,13 +16,11 @@ limitations under the License.
 
 package container
 
-import (
-	"github.com/fsouza/go-dockerclient"
-)
+import "github.com/fsouza/go-dockerclient"
 
 // ContainerRuntimeInterface is the abstract interface for container runtime.
 type ContainerRuntimeInterface interface {
-	ListContainers(options docker.ListContainersOptions) ([]docker.APIContainers, error)
+	ListContainers(options ListContainersOptions) ([]Container, error)
 	InspectContainer(id string) (*docker.Container, error)
 	CreateContainer(docker.CreateContainerOptions) (*docker.Container, error)
 	StartContainer(id string, hostConfig *docker.HostConfig) error

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -22,7 +22,7 @@ import "github.com/fsouza/go-dockerclient"
 type ContainerRuntimeInterface interface {
 	ListContainers(options ListContainersOptions) ([]*Container, error)
 	InspectContainer(id string) (*Container, error)
-	CreateContainer(docker.CreateContainerOptions) (*docker.Container, error)
+	CreateContainer(options CreateContainerOptions) (*Container, error)
 	StartContainer(id string, hostConfig *docker.HostConfig) error
 	StopContainer(id string, timeout uint) error
 	RemoveContainer(opts docker.RemoveContainerOptions) error

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -23,7 +23,7 @@ type ContainerRuntimeInterface interface {
 	ListContainers(options ListContainersOptions) ([]*Container, error)
 	InspectContainer(id string) (*Container, error)
 	CreateContainer(options CreateContainerOptions) (*Container, error)
-	StartContainer(id string, hostConfig *docker.HostConfig) error
+	StartContainer(id string, hostConfig *HostConfig) error
 	StopContainer(id string, timeout uint) error
 	RemoveContainer(opts docker.RemoveContainerOptions) error
 	InspectImage(image string) (*docker.Image, error)

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -20,7 +20,7 @@ import "github.com/fsouza/go-dockerclient"
 
 // ContainerRuntimeInterface is the abstract interface for container runtime.
 type ContainerRuntimeInterface interface {
-	ListContainers(options ListContainersOptions) ([]Container, error)
+	ListContainers(options ListContainersOptions) ([]*Container, error)
 	InspectContainer(id string) (*Container, error)
 	CreateContainer(docker.CreateContainerOptions) (*docker.Container, error)
 	StartContainer(id string, hostConfig *docker.HostConfig) error

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -24,7 +24,7 @@ type Runtime interface {
 	StartContainer(id string, hostConfig *HostConfig) error
 	StopContainer(id string, timeout uint) error
 	RemoveContainer(opts RemoveContainerOptions) error
-	InspectImage(image string) (*Image, error)
+	InspectImage(imageName string) (*Image, error)
 	ListImages(opts ListImagesOptions) ([]*Image, error)
 	PullImage(opts PullImageOptions) error
 	RemoveImage(image string) error

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package container
+
+import (
+	"github.com/fsouza/go-dockerclient"
+)
+
+// ContainerRuntimeInterface is the abstract interface for container runtime.
+type ContainerRuntimeInterface interface {
+	ListContainers(options docker.ListContainersOptions) ([]docker.APIContainers, error)
+	InspectContainer(id string) (*docker.Container, error)
+	CreateContainer(docker.CreateContainerOptions) (*docker.Container, error)
+	StartContainer(id string, hostConfig *docker.HostConfig) error
+	StopContainer(id string, timeout uint) error
+	RemoveContainer(opts docker.RemoveContainerOptions) error
+	InspectImage(image string) (*docker.Image, error)
+	ListImages(opts docker.ListImagesOptions) ([]docker.APIImages, error)
+	PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error
+	RemoveImage(image string) error
+	Logs(opts docker.LogsOptions) error
+	Version() (*docker.Env, error)
+	CreateExec(docker.CreateExecOptions) (*docker.Exec, error)
+	StartExec(string, docker.StartExecOptions) error
+}

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -31,7 +31,7 @@ type Runtime interface {
 	PullImage(opts PullImageOptions) error
 	RemoveImage(image string) error
 	Logs(opts LogsOptions) error
-	Version() (*docker.Env, error)
+	Version() ([]string, error)
 	CreateExec(docker.CreateExecOptions) (*docker.Exec, error)
 	StartExec(string, docker.StartExecOptions) error
 }

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -16,13 +16,11 @@ limitations under the License.
 
 package container
 
-import "github.com/fsouza/go-dockerclient"
-
 // Runtime is the abstract interface for container runtime.
 type Runtime interface {
-	ListContainers(options ListContainersOptions) ([]*Container, error)
+	ListContainers(opts ListContainersOptions) ([]*Container, error)
 	InspectContainer(id string) (*Container, error)
-	CreateContainer(options CreateContainerOptions) (*Container, error)
+	CreateContainer(opts CreateContainerOptions) (*Container, error)
 	StartContainer(id string, hostConfig *HostConfig) error
 	StopContainer(id string, timeout uint) error
 	RemoveContainer(opts RemoveContainerOptions) error
@@ -32,6 +30,6 @@ type Runtime interface {
 	RemoveImage(image string) error
 	Logs(opts LogsOptions) error
 	Version() ([]string, error)
-	CreateExec(docker.CreateExecOptions) (*docker.Exec, error)
-	StartExec(string, docker.StartExecOptions) error
+	CreateExec(opts CreateExecOptions) (*Exec, error)
+	StartExec(string, StartExecOptions) error
 }

--- a/pkg/kubelet/container/types.go
+++ b/pkg/kubelet/container/types.go
@@ -142,3 +142,32 @@ type LogsOptions struct {
 	Tail         string    `json:"tail,omitempty"`
 	RawTerminal  bool      `json:"rawTerminal,omitempty"`
 }
+
+// CreateExecOptions specify parameters to the CreateExec function.
+type CreateExecOptions struct {
+	AttachStdin  bool     `json:"attachStdin,omitempty"`
+	AttachStdout bool     `json:"attachStdout,omitempty"`
+	AttachStderr bool     `json:"attachStderr,omitempty"`
+	Tty          bool     `json:"tty,omitempty"`
+	Cmd          []string `json:"cmd,omitempty"`
+	Container    string   `json:"container,omitempty"`
+}
+
+// Exec represents an exec object.
+type Exec struct {
+	ID string `json:"id,omitempty"`
+}
+
+// StartExecOptions specify parameters to StartExec function.
+type StartExecOptions struct {
+	Detach bool `json:"detach,omitempty"`
+
+	Tty bool `json:"tty,omitempty"`
+
+	InputStream  io.Reader `json:"-"`
+	OutputStream io.Writer `json:"-"`
+	ErrorStream  io.Writer `json:"-"`
+
+	// Use raw terminal? Usually true when the container contains a TTY.
+	RawTerminal bool `json:"-"`
+}

--- a/pkg/kubelet/container/types.go
+++ b/pkg/kubelet/container/types.go
@@ -32,7 +32,6 @@ var (
 type Container struct {
 	ID              string            `json:"id"`
 	Name            string            `json:"name,omitempty"`
-	Names           []string          `json:"names,omitempty"`
 	Image           string            `json:"image,omitempty"`
 	ImageID         string            `json:"imageID`
 	Command         string            `json:"command,omitempty"`
@@ -44,6 +43,8 @@ type Container struct {
 	SizeRw          int64             `json:"sizeRw,omitempty"`
 	SizeRootFs      int64             `json:"sizeRootFs,omitempty"`
 	Volumes         map[string]string `json:"volumes,omitempty"`
+	Hostname        string            `json:"hostname,omitempty"`
+	Env             []string          `json:"env,omitempty"`
 }
 
 // Port is a type that represents a port mapping.
@@ -81,7 +82,7 @@ type HostConfig struct {
 	DNS          []string                 `json:"dns,omitempty"`
 	DNSSearch    []string                 `json:"dnsSearch,omitempty"`
 	NetworkMode  string                   `json:"networkMode,omitempty"`
-	IpcMode      string                   `json:"ipcMode,omitempty"`
+	IPCMode      string                   `json:"ipcMode,omitempty"`
 }
 
 // PortBinding represents the host/container port mapping.
@@ -103,7 +104,7 @@ type ListContainersOptions struct {
 // CreateContainerOptions specify parameters to the CreateContainer function.
 type CreateContainerOptions struct {
 	Name         string              `json:"name,omitempty"`
-	Cmd          []string            `json:"cmd,omitempty"`
+	Command      []string            `json:"cmd,omitempty"`
 	Env          []string            `json:"env,omitempty"`
 	ExposedPorts map[string]struct{} `json:"exposedPorts,omitempty"`
 	Hostname     string              `json:"hostname,omitempty"`
@@ -148,8 +149,8 @@ type CreateExecOptions struct {
 	AttachStdin  bool     `json:"attachStdin,omitempty"`
 	AttachStdout bool     `json:"attachStdout,omitempty"`
 	AttachStderr bool     `json:"attachStderr,omitempty"`
-	Tty          bool     `json:"tty,omitempty"`
-	Cmd          []string `json:"cmd,omitempty"`
+	TTY          bool     `json:"tty,omitempty"`
+	Command      []string `json:"command,omitempty"`
 	Container    string   `json:"container,omitempty"`
 }
 
@@ -162,7 +163,7 @@ type Exec struct {
 type StartExecOptions struct {
 	Detach bool `json:"detach,omitempty"`
 
-	Tty bool `json:"tty,omitempty"`
+	TTY bool `json:"tty,omitempty"`
 
 	InputStream  io.Reader `json:"-"`
 	OutputStream io.Writer `json:"-"`

--- a/pkg/kubelet/container/types.go
+++ b/pkg/kubelet/container/types.go
@@ -87,6 +87,7 @@ type PortBinding struct {
 	HostPort string `json:"hostPort,omitempty"`
 }
 
+// Image represents a container image.
 type Image struct {
 	ID string `json:"id"`
 }
@@ -112,4 +113,9 @@ type CreateContainerOptions struct {
 // RemoveContainerOptions specify parameters to the RemoveContainer funcion.
 type RemoveContainerOptions struct {
 	ID string `json:"id"`
+}
+
+// ListImagesOptions specify parameters to the ListImages function.
+type ListImagesOptions struct {
+	All bool
 }

--- a/pkg/kubelet/container/types.go
+++ b/pkg/kubelet/container/types.go
@@ -16,7 +16,14 @@ limitations under the License.
 
 package container
 
-import "time"
+import (
+	"errors"
+	"time"
+)
+
+var (
+	ErrNoSuchImage = errors.New("no such image")
+)
 
 // Container represents a container.
 type Container struct {
@@ -78,6 +85,10 @@ type HostConfig struct {
 type PortBinding struct {
 	HostIP   string `json:"hostIP,omitempty"`
 	HostPort string `json:"hostPort,omitempty"`
+}
+
+type Image struct {
+	ID string `json:"id"`
 }
 
 // ListContainersOptions specify parameters to the ListContainers function.

--- a/pkg/kubelet/container/types.go
+++ b/pkg/kubelet/container/types.go
@@ -18,6 +18,7 @@ package container
 
 import (
 	"errors"
+	"io"
 	"time"
 
 	"github.com/fsouza/go-dockerclient"
@@ -127,4 +128,17 @@ type PullImageOptions struct {
 	Repository       string                   `json:"repostory,omitempty"`
 	Tag              string                   `json:"tag,omitempty"`
 	DockerAuthConfig docker.AuthConfiguration `json:"dockerAuth,omitempty"`
+}
+
+// LogsOptions specify parameters to the Logs function.
+type LogsOptions struct {
+	ID           string    `json:"id,omitempty"`
+	OutputStream io.Writer `json:"-"`
+	ErrorStream  io.Writer `json:"-"`
+	Follow       bool      `json:"follow,omitempty"`
+	Stdout       bool      `json:"stdout,omitempty"`
+	Stderr       bool      `json:"stderr,omitempty"`
+	Timestamps   bool      `json:"timestamp,omitempty"`
+	Tail         string    `json:"tail,omitempty"`
+	RawTerminal  bool      `json:"rawTerminal,omitempty"`
 }

--- a/pkg/kubelet/container/types.go
+++ b/pkg/kubelet/container/types.go
@@ -19,6 +19,7 @@ package container
 import (
 	"errors"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/fsouza/go-dockerclient"
@@ -60,20 +61,38 @@ type State struct {
 
 // NetworkSettings contains network-related information about a container.
 type NetworkSettings struct {
-	IPAddress string `json:"ipAddress,omitempty"`
+	IPAddress    string                 `json:"ipAddress,omitempty"`
+	PortBindings map[Port][]PortBinding `json:"portBindings,omitempty"`
 }
 
 // HostConfig contains the container options related to starting a container on a given host.
 type HostConfig struct {
-	Binds        []string                 `json:"binds,omitempty"`
-	CapAdd       []string                 `json:"capAdd,omitempty"`
-	CapDrop      []string                 `json:"capDrop,omitempty"`
-	Privileged   bool                     `json:"privileged,omitempty"`
-	PortBindings map[string][]PortBinding `json:"portBindings,omitempty"`
-	DNS          []string                 `json:"dns,omitempty"`
-	DNSSearch    []string                 `json:"dnsSearch,omitempty"`
-	NetworkMode  string                   `json:"networkMode,omitempty"`
-	IPCMode      string                   `json:"ipcMode,omitempty"`
+	Binds        []string               `json:"binds,omitempty"`
+	CapAdd       []string               `json:"capAdd,omitempty"`
+	CapDrop      []string               `json:"capDrop,omitempty"`
+	Privileged   bool                   `json:"privileged,omitempty"`
+	PortBindings map[Port][]PortBinding `json:"portBindings,omitempty"`
+	DNS          []string               `json:"dns,omitempty"`
+	DNSSearch    []string               `json:"dnsSearch,omitempty"`
+	NetworkMode  string                 `json:"networkMode,omitempty"`
+	IPCMode      string                 `json:"ipcMode,omitempty"`
+}
+
+// Port represents the port number and the protocol, in the form <number>/<protocol>. For example: 80/tcp.
+type Port string
+
+// Port returns the number of the port.
+func (p Port) Port() string {
+	return strings.Split(string(p), "/")[0]
+}
+
+// Proto returns the name of the protocol.
+func (p Port) Proto() string {
+	parts := strings.Split(string(p), "/")
+	if len(parts) == 1 {
+		return "tcp"
+	}
+	return parts[1]
 }
 
 // PortBinding represents the host/container port mapping.
@@ -94,15 +113,15 @@ type ListContainersOptions struct {
 
 // CreateContainerOptions specify parameters to the CreateContainer function.
 type CreateContainerOptions struct {
-	Name         string              `json:"name,omitempty"`
-	Command      []string            `json:"cmd,omitempty"`
-	Env          []string            `json:"env,omitempty"`
-	ExposedPorts map[string]struct{} `json:"exposedPorts,omitempty"`
-	Hostname     string              `json:"hostname,omitempty"`
-	Image        string              `json:"image,omitempty"`
-	Memory       int64               `json:"memory,omitempty"`
-	CPUShares    int64               `json:"cpuShares,omitempty"`
-	WorkingDir   string              `json:"workingDir,omitempty`
+	Name         string            `json:"name,omitempty"`
+	Command      []string          `json:"cmd,omitempty"`
+	Env          []string          `json:"env,omitempty"`
+	ExposedPorts map[Port]struct{} `json:"exposedPorts,omitempty"`
+	Hostname     string            `json:"hostname,omitempty"`
+	Image        string            `json:"image,omitempty"`
+	Memory       int64             `json:"memory,omitempty"`
+	CPUShares    int64             `json:"cpuShares,omitempty"`
+	WorkingDir   string            `json:"workingDir,omitempty`
 }
 
 // RemoveContainerOptions specify parameters to the RemoveContainer funcion.

--- a/pkg/kubelet/container/types.go
+++ b/pkg/kubelet/container/types.go
@@ -78,3 +78,22 @@ type CreateContainerOptions struct {
 	CPUShares    int64               `json:"cpuShares,omitempty"`
 	WorkingDir   string              `json:"workingDir,omitempty`
 }
+
+// HostConfig contains the container options related to starting a container on a given host.
+type HostConfig struct {
+	Binds        []string                 `json:"binds,omitempty"`
+	CapAdd       []string                 `json:"capAdd,omitempty"`
+	CapDrop      []string                 `json:"capDrop,omitempty"`
+	Privileged   bool                     `json:"privileged,omitempty"`
+	PortBindings map[string][]PortBinding `json:"portBindings,omitempty"`
+	DNS          []string                 `json:"dns,omitempty"`
+	DNSSearch    []string                 `json:"dnsSearch,omitempty"`
+	NetworkMode  string                   `json:"networkMode,omitempty"`
+	IpcMode      string                   `json:"ipcMode,omitempty"`
+}
+
+// PortBinding represents the host/container port mapping.
+type PortBinding struct {
+	HostIP   string `json:"hostIP,omitempty"`
+	HostPort string `json:"hostPort,omitempty"`
+}

--- a/pkg/kubelet/container/types.go
+++ b/pkg/kubelet/container/types.go
@@ -31,20 +31,26 @@ var (
 
 // Container represents a container.
 type Container struct {
-	ID              string            `json:"id"`
-	Name            string            `json:"name,omitempty"`
-	Image           string            `json:"image,omitempty"`
-	ImageID         string            `json:"imageID`
-	Command         string            `json:"command,omitempty"`
-	Created         time.Time         `json:"created,omitempty"`
-	State           State             `json:"state,omitempty"`
-	Status          string            `json:"status,omitempty"`
-	NetworkSettings *NetworkSettings  `json:"networkSettings`
-	SizeRw          int64             `json:"sizeRw,omitempty"`
-	SizeRootFs      int64             `json:"sizeRootFs,omitempty"`
-	Volumes         map[string]string `json:"volumes,omitempty"`
-	Hostname        string            `json:"hostname,omitempty"`
-	Env             []string          `json:"env,omitempty"`
+	// The id of the container.
+	ID string `json:"id"`
+	// The name of the container.
+	Name string `json:"name,omitempty"`
+	// The host name of the container.
+	Hostname string `json:"hostname,omitempty"`
+	// The name of the container's image.
+	Image string `json:"image,omitempty"`
+	// The id of the container's image.
+	ImageID string `json:"image,omitempty"`
+	// The State of the container, including when
+	// the container is created/started.
+	State State `json:"state,omitempty"`
+	// The network settings of the container, including
+	// the ip of the container and its port bindings.
+	NetworkSettings *NetworkSettings `json:"networkSettings`
+	// The volumes binded to the container.
+	Volumes map[string]string `json:"volumes,omitempty"`
+	// The environment variables of the container.
+	Env []string `json:"env,omitempty"`
 }
 
 // State represents the state of a container.
@@ -55,27 +61,39 @@ type State struct {
 	Pid        int       `json:"pid,omitempty"`
 	ExitCode   int       `json:"exitCode,omitempty"`
 	Error      string    `json:"error,omitempty"`
+	CreatedAt  time.Time `json:"created,omitempty"`
 	StartedAt  time.Time `json:"startedAt,omitempty"`
 	FinishedAt time.Time `json:"finishedAt,omitempty"`
 }
 
 // NetworkSettings contains network-related information about a container.
 type NetworkSettings struct {
-	IPAddress    string                 `json:"ipAddress,omitempty"`
+	// The ip address of the container.
+	IPAddress string `json:"ipAddress,omitempty"`
+	// The port bindings of the container.
 	PortBindings map[Port][]PortBinding `json:"portBindings,omitempty"`
 }
 
 // HostConfig contains the container options related to starting a container on a given host.
 type HostConfig struct {
-	Binds        []string               `json:"binds,omitempty"`
-	CapAdd       []string               `json:"capAdd,omitempty"`
-	CapDrop      []string               `json:"capDrop,omitempty"`
-	Privileged   bool                   `json:"privileged,omitempty"`
+	// The bindings of the volumes.
+	Binds []string `json:"binds,omitempty"`
+	// The Linux capabilities added to the container.
+	CapAdd []string `json:"capAdd,omitempty"`
+	// The Linux capabilities dropped from the container.
+	CapDrop []string `json:"capDrop,omitempty"`
+	// If give extended privileges to the container.
+	Privileged bool `json:"privileged,omitempty"`
+	// The port bindings of the container.
 	PortBindings map[Port][]PortBinding `json:"portBindings,omitempty"`
-	DNS          []string               `json:"dns,omitempty"`
-	DNSSearch    []string               `json:"dnsSearch,omitempty"`
-	NetworkMode  string                 `json:"networkMode,omitempty"`
-	IPCMode      string                 `json:"ipcMode,omitempty"`
+	// The custom DNS servers.
+	DNS []string `json:"dns,omitempty"`
+	// The custom DNS search domains.
+	DNSSearch []string `json:"dnsSearch,omitempty"`
+	// The network mode for the container.
+	NetworkMode string `json:"networkMode,omitempty"`
+	// The ipc mode for the container.
+	IPCMode string `json:"ipcMode,omitempty"`
 }
 
 // Port represents the port number and the protocol, in the form <number>/<protocol>. For example: 80/tcp.

--- a/pkg/kubelet/container/types.go
+++ b/pkg/kubelet/container/types.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package container
+
+// Container represents a container.
+type Container struct {
+	ID         string   `json:"id"`
+	Image      string   `json:"image,omitempty"`
+	Command    string   `json:"command,omitempty"`
+	Created    int64    `json:"created,omitempty"`
+	Status     string   `json:"status,omitempty"`
+	Ports      []Port   `json:"ports,omitempty"`
+	SizeRw     int64    `json:"sizeRw,omitempty"`
+	SizeRootFs int64    `json:"sizeRootFs,omitempty"`
+	Names      []string `json:"names,omitempty"`
+}
+
+// Port is a type that represents a port mapping.
+type Port struct {
+	PrivatePort int64  `json:"PrivatePort,omitempty" yaml:"PrivatePort,omitempty"`
+	PublicPort  int64  `json:"PublicPort,omitempty" yaml:"PublicPort,omitempty"`
+	Type        string `json:"Type,omitempty" yaml:"Type,omitempty"`
+	IP          string `json:"IP,omitempty" yaml:"IP,omitempty"`
+}
+
+// ListContainersOptions specify parameters to the ListContainers function.
+type ListContainersOptions struct {
+	All bool
+}

--- a/pkg/kubelet/container/types.go
+++ b/pkg/kubelet/container/types.go
@@ -19,6 +19,8 @@ package container
 import (
 	"errors"
 	"time"
+
+	"github.com/fsouza/go-dockerclient"
 )
 
 var (
@@ -89,12 +91,12 @@ type PortBinding struct {
 
 // Image represents a container image.
 type Image struct {
-	ID string `json:"id"`
+	ID string `json:"id,omitempty"`
 }
 
 // ListContainersOptions specify parameters to the ListContainers function.
 type ListContainersOptions struct {
-	All bool `json:"all"`
+	All bool `json:"all,omitempty"`
 }
 
 // CreateContainerOptions specify parameters to the CreateContainer function.
@@ -112,10 +114,17 @@ type CreateContainerOptions struct {
 
 // RemoveContainerOptions specify parameters to the RemoveContainer funcion.
 type RemoveContainerOptions struct {
-	ID string `json:"id"`
+	ID string `json:"id,omitempty"`
 }
 
 // ListImagesOptions specify parameters to the ListImages function.
 type ListImagesOptions struct {
-	All bool
+	All bool `json:"all,omitempty"`
+}
+
+// PullImageOptions specify parameters to the PullImage function.
+type PullImageOptions struct {
+	Repository       string                   `json:"repostory,omitempty"`
+	Tag              string                   `json:"tag,omitempty"`
+	DockerAuthConfig docker.AuthConfiguration `json:"dockerAuth,omitempty"`
 }

--- a/pkg/kubelet/container/types.go
+++ b/pkg/kubelet/container/types.go
@@ -16,28 +16,52 @@ limitations under the License.
 
 package container
 
+import "time"
+
 // Container represents a container.
 type Container struct {
-	ID         string   `json:"id"`
-	Image      string   `json:"image,omitempty"`
-	Command    string   `json:"command,omitempty"`
-	Created    int64    `json:"created,omitempty"`
-	Status     string   `json:"status,omitempty"`
-	Ports      []Port   `json:"ports,omitempty"`
-	SizeRw     int64    `json:"sizeRw,omitempty"`
-	SizeRootFs int64    `json:"sizeRootFs,omitempty"`
-	Names      []string `json:"names,omitempty"`
+	ID              string            `json:"id"`
+	Name            string            `json:"name,omitempty"`
+	Names           []string          `json:"names,omitempty"`
+	Image           string            `json:"image,omitempty"`
+	ImageID         string            `json:"imageID`
+	Command         string            `json:"command,omitempty"`
+	Created         time.Time         `json:"created,omitempty"`
+	State           State             `json:"state,omitempty"`
+	Status          string            `json:"status,omitempty"`
+	NetworkSettings *NetworkSettings  `json:"networkSettings`
+	Ports           []Port            `json:"ports,omitempty"`
+	SizeRw          int64             `json:"sizeRw,omitempty"`
+	SizeRootFs      int64             `json:"sizeRootFs,omitempty"`
+	Volumes         map[string]string `json:"volumes,omitempty"`
 }
 
 // Port is a type that represents a port mapping.
 type Port struct {
-	PrivatePort int64  `json:"PrivatePort,omitempty" yaml:"PrivatePort,omitempty"`
-	PublicPort  int64  `json:"PublicPort,omitempty" yaml:"PublicPort,omitempty"`
-	Type        string `json:"Type,omitempty" yaml:"Type,omitempty"`
-	IP          string `json:"IP,omitempty" yaml:"IP,omitempty"`
+	PrivatePort int64  `json:"privatePort,omitempty"`
+	PublicPort  int64  `json:"publicPort,omitempty"`
+	Type        string `json:"type,omitempty"`
+	IP          string `json:"ip,omitempty"`
 }
 
 // ListContainersOptions specify parameters to the ListContainers function.
 type ListContainersOptions struct {
 	All bool
+}
+
+// State represents the state of a container.
+type State struct {
+	Running    bool      `json:"running,omitempty"`
+	Paused     bool      `json:"paused,omitempty"`
+	OOMKilled  bool      `json:"oomkilled,omitempty"`
+	Pid        int       `json:"pid,omitempty"`
+	ExitCode   int       `json:"exitCode,omitempty"`
+	Error      string    `json:"error,omitempty"`
+	StartedAt  time.Time `json:"startedAt,omitempty"`
+	FinishedAt time.Time `json:"finishedAt,omitempty"`
+}
+
+// NetworkSettings contains network-related information about a container.
+type NetworkSettings struct {
+	IPAddress string `json:"ipAddress,omitempty"`
 }

--- a/pkg/kubelet/container/types.go
+++ b/pkg/kubelet/container/types.go
@@ -44,11 +44,6 @@ type Port struct {
 	IP          string `json:"ip,omitempty"`
 }
 
-// ListContainersOptions specify parameters to the ListContainers function.
-type ListContainersOptions struct {
-	All bool
-}
-
 // State represents the state of a container.
 type State struct {
 	Running    bool      `json:"running,omitempty"`
@@ -64,19 +59,6 @@ type State struct {
 // NetworkSettings contains network-related information about a container.
 type NetworkSettings struct {
 	IPAddress string `json:"ipAddress,omitempty"`
-}
-
-// CreateContainerOptions specify parameters to the CreateContainer function.
-type CreateContainerOptions struct {
-	Name         string              `json:"name,omitempty"`
-	Cmd          []string            `json:"cmd,omitempty"`
-	Env          []string            `json:"env,omitempty"`
-	ExposedPorts map[string]struct{} `json:"exposedPorts,omitempty"`
-	Hostname     string              `json:"hostname,omitempty"`
-	Image        string              `json:"image,omitempty"`
-	Memory       int64               `json:"memory,omitempty"`
-	CPUShares    int64               `json:"cpuShares,omitempty"`
-	WorkingDir   string              `json:"workingDir,omitempty`
 }
 
 // HostConfig contains the container options related to starting a container on a given host.
@@ -96,4 +78,27 @@ type HostConfig struct {
 type PortBinding struct {
 	HostIP   string `json:"hostIP,omitempty"`
 	HostPort string `json:"hostPort,omitempty"`
+}
+
+// ListContainersOptions specify parameters to the ListContainers function.
+type ListContainersOptions struct {
+	All bool `json:"all"`
+}
+
+// CreateContainerOptions specify parameters to the CreateContainer function.
+type CreateContainerOptions struct {
+	Name         string              `json:"name,omitempty"`
+	Cmd          []string            `json:"cmd,omitempty"`
+	Env          []string            `json:"env,omitempty"`
+	ExposedPorts map[string]struct{} `json:"exposedPorts,omitempty"`
+	Hostname     string              `json:"hostname,omitempty"`
+	Image        string              `json:"image,omitempty"`
+	Memory       int64               `json:"memory,omitempty"`
+	CPUShares    int64               `json:"cpuShares,omitempty"`
+	WorkingDir   string              `json:"workingDir,omitempty`
+}
+
+// RemoveContainerOptions specify parameters to the RemoveContainer funcion.
+type RemoveContainerOptions struct {
+	ID string `json:"id"`
 }

--- a/pkg/kubelet/container/types.go
+++ b/pkg/kubelet/container/types.go
@@ -65,3 +65,16 @@ type State struct {
 type NetworkSettings struct {
 	IPAddress string `json:"ipAddress,omitempty"`
 }
+
+// CreateContainerOptions specify parameters to the CreateContainer function.
+type CreateContainerOptions struct {
+	Name         string              `json:"name,omitempty"`
+	Cmd          []string            `json:"cmd,omitempty"`
+	Env          []string            `json:"env,omitempty"`
+	ExposedPorts map[string]struct{} `json:"exposedPorts,omitempty"`
+	Hostname     string              `json:"hostname,omitempty"`
+	Image        string              `json:"image,omitempty"`
+	Memory       int64               `json:"memory,omitempty"`
+	CPUShares    int64               `json:"cpuShares,omitempty"`
+	WorkingDir   string              `json:"workingDir,omitempty`
+}

--- a/pkg/kubelet/container/types.go
+++ b/pkg/kubelet/container/types.go
@@ -39,20 +39,11 @@ type Container struct {
 	State           State             `json:"state,omitempty"`
 	Status          string            `json:"status,omitempty"`
 	NetworkSettings *NetworkSettings  `json:"networkSettings`
-	Ports           []Port            `json:"ports,omitempty"`
 	SizeRw          int64             `json:"sizeRw,omitempty"`
 	SizeRootFs      int64             `json:"sizeRootFs,omitempty"`
 	Volumes         map[string]string `json:"volumes,omitempty"`
 	Hostname        string            `json:"hostname,omitempty"`
 	Env             []string          `json:"env,omitempty"`
-}
-
-// Port is a type that represents a port mapping.
-type Port struct {
-	PrivatePort int64  `json:"privatePort,omitempty"`
-	PublicPort  int64  `json:"publicPort,omitempty"`
-	Type        string `json:"type,omitempty"`
-	IP          string `json:"ip,omitempty"`
 }
 
 // State represents the state of a container.

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -96,17 +96,6 @@ func ConvertAPIContainer(dc *docker.APIContainers) *container.Container {
 	} else {
 		c.Name = dc.Names[0]
 	}
-
-	// Copy ports field too.
-	c.Ports = make([]container.Port, len(dc.Ports))
-	for i, p := range dc.Ports {
-		c.Ports[i] = container.Port{
-			PrivatePort: p.PrivatePort,
-			PublicPort:  p.PublicPort,
-			Type:        p.Type,
-			IP:          p.IP,
-		}
-	}
 	return c
 }
 
@@ -149,10 +138,10 @@ func ConvertContainer(dc *docker.Container) *container.Container {
 
 // ListContainers implements container.Runtime.ListContainers.
 func (dr *DockerRuntime) ListContainers(options container.ListContainersOptions) ([]*container.Container, error) {
-	var containers []*container.Container
 	dc, err := dr.docker.ListContainers(docker.ListContainersOptions{All: options.All})
-	for _, c := range dc {
-		containers = append(containers, ConvertAPIContainer(&c))
+	containers := make([]*container.Container, len(dc))
+	for i, c := range dc {
+		containers[i] = ConvertAPIContainer(&c)
 	}
 	return containers, err
 }
@@ -244,12 +233,12 @@ func (dr *DockerRuntime) InspectImage(imageName string) (*container.Image, error
 
 // ListImage implements container.Runtime.ListImage.
 func (dr *DockerRuntime) ListImages(opts container.ListImagesOptions) ([]*container.Image, error) {
-	var imgs []*container.Image
 	dockerImages, err := dr.docker.ListImages(docker.ListImagesOptions{All: opts.All})
+	imgs := make([]*container.Image, len(dockerImages))
 	for i := range dockerImages {
-		imgs = append(imgs, &container.Image{
+		imgs[i] = &container.Image{
 			ID: dockerImages[i].ID,
-		})
+		}
 	}
 	return imgs, err
 }

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -64,7 +64,7 @@ type DockerInterface interface {
 	StartExec(string, docker.StartExecOptions) error
 }
 
-// DockerRuntime implements the ContainerRuntime interface for docker.
+// DockerRuntime implements the container.Runtime interface for docker.
 type DockerRuntime struct {
 	docker DockerInterface
 }
@@ -151,7 +151,7 @@ func ConvertContainer(dc *docker.Container) *container.Container {
 	}
 }
 
-// ListContainers implements ContainerRuntime.ListContainers.
+// ListContainers implements container.Runtime.ListContainers.
 func (dr *DockerRuntime) ListContainers(options container.ListContainersOptions) ([]*container.Container, error) {
 	var containers []*container.Container
 	dc, err := dr.docker.ListContainers(docker.ListContainersOptions{All: options.All})
@@ -161,13 +161,13 @@ func (dr *DockerRuntime) ListContainers(options container.ListContainersOptions)
 	return containers, err
 }
 
-// InspectContainer implements ContainerRuntime.InspectContainer.
+// InspectContainer implements container.Runtime.InspectContainer.
 func (dr *DockerRuntime) InspectContainer(id string) (*container.Container, error) {
 	dc, err := dr.docker.InspectContainer(id)
 	return ConvertContainer(dc), err
 }
 
-// CreateContainer implements ContainerRuntime.CreateContainer.
+// CreateContainer implements container.Runtime.CreateContainer.
 func (dr *DockerRuntime) CreateContainer(opts container.CreateContainerOptions) (*container.Container, error) {
 	// Copy exposedPorts.
 	exposedPorts := make(map[docker.Port]struct{})
@@ -193,7 +193,7 @@ func (dr *DockerRuntime) CreateContainer(opts container.CreateContainerOptions) 
 	return ConvertContainer(dc), err
 }
 
-// StartContainer implements ContainerRuntime.StartContainer.
+// StartContainer implements container.Runtime.StartContainer.
 func (dr *DockerRuntime) StartContainer(id string, hc *container.HostConfig) error {
 	dockerHostConfig := &docker.HostConfig{
 		Binds:       hc.Binds,
@@ -221,17 +221,17 @@ func (dr *DockerRuntime) StartContainer(id string, hc *container.HostConfig) err
 	return dr.docker.StartContainer(id, dockerHostConfig)
 }
 
-// StopContainer implements ContainerRuntime.StopContainer.
+// StopContainer implements container.Runtime.StopContainer.
 func (dr *DockerRuntime) StopContainer(id string, timeout uint) error {
 	return dr.docker.StopContainer(id, timeout)
 }
 
-// RemoveContainer implements ContainerRuntime.RemoveContainer.
+// RemoveContainer implements container.Runtime.RemoveContainer.
 func (dr *DockerRuntime) RemoveContainer(opts container.RemoveContainerOptions) error {
 	return dr.docker.RemoveContainer(docker.RemoveContainerOptions{ID: opts.ID})
 }
 
-// InspectImage implements ContainerRuntime.InspectImage.
+// InspectImage implements container.Runtime.InspectImage.
 func (dr *DockerRuntime) InspectImage(image string) (*container.Image, error) {
 	img, err := dr.docker.InspectImage(image)
 	if err != nil {
@@ -246,7 +246,7 @@ func (dr *DockerRuntime) InspectImage(image string) (*container.Image, error) {
 	return &container.Image{ID: img.ID}, nil
 }
 
-// ListImage implements ContainerRuntime.ListImage.
+// ListImage implements container.Runtime.ListImage.
 func (dr *DockerRuntime) ListImages(opts container.ListImagesOptions) ([]*container.Image, error) {
 	var imgs []*container.Image
 	dockerImages, err := dr.docker.ListImages(docker.ListImagesOptions{All: opts.All})
@@ -258,7 +258,7 @@ func (dr *DockerRuntime) ListImages(opts container.ListImagesOptions) ([]*contai
 	return imgs, err
 }
 
-// PullImage implements ContainerRuntime.PullImage.
+// PullImage implements container.Runtime.PullImage.
 func (dr *DockerRuntime) PullImage(opts container.PullImageOptions) error {
 	dockerOpts := docker.PullImageOptions{
 		Repository: opts.Repository,
@@ -267,12 +267,12 @@ func (dr *DockerRuntime) PullImage(opts container.PullImageOptions) error {
 	return dr.docker.PullImage(dockerOpts, opts.DockerAuthConfig)
 }
 
-// RemoveImage implements ContainerRuntime.RemoveImage.
+// RemoveImage implements container.Runtime.RemoveImage.
 func (dr *DockerRuntime) RemoveImage(image string) error {
 	return dr.docker.RemoveImage(image)
 }
 
-// Logs implements ContainerRuntime.Logs.
+// Logs implements container.Runtime.Logs.
 func (dr *DockerRuntime) Logs(opts container.LogsOptions) error {
 	return dr.docker.Logs(docker.LogsOptions{
 		Container:    opts.ID,
@@ -287,13 +287,13 @@ func (dr *DockerRuntime) Logs(opts container.LogsOptions) error {
 	})
 }
 
-// Version implements ContainerRuntime.Version.
+// Version implements container.Runtime.Version.
 func (dr *DockerRuntime) Version() ([]string, error) {
 	env, err := dr.docker.Version()
 	return []string(*env), err
 }
 
-// CreateExec implements ContainerRuntime.CreateExec.
+// CreateExec implements container.Runtime.CreateExec.
 func (dr *DockerRuntime) CreateExec(opts container.CreateExecOptions) (*container.Exec, error) {
 	exec, err := dr.docker.CreateExec(docker.CreateExecOptions{
 		AttachStdin:  opts.AttachStdin,
@@ -306,7 +306,7 @@ func (dr *DockerRuntime) CreateExec(opts container.CreateExecOptions) (*containe
 	return &container.Exec{ID: exec.ID}, err
 }
 
-// StartExec implements ContainerRuntime.StartExec.
+// StartExec implements container.Runtime.StartExec.
 func (dr *DockerRuntime) StartExec(id string, opts container.StartExecOptions) error {
 	dockerOpts := docker.StartExecOptions{
 		Detach:       opts.Detach,

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -81,13 +81,11 @@ func ConvertAPIContainer(dc *docker.APIContainers) *container.Container {
 	}
 
 	c := &container.Container{
-		ID:         dc.ID,
-		Image:      dc.Image,
-		Command:    dc.Command,
-		Created:    time.Unix(dc.Created, 0),
-		Status:     dc.Status,
-		SizeRw:     dc.SizeRw,
-		SizeRootFs: dc.SizeRootFs,
+		ID:    dc.ID,
+		Image: dc.Image,
+		State: container.State{
+			CreatedAt: time.Unix(dc.Created, 0),
+		},
 	}
 
 	// Copy Name.
@@ -109,7 +107,6 @@ func ConvertContainer(dc *docker.Container) *container.Container {
 		ID:      dc.ID,
 		Name:    dc.Name,
 		ImageID: dc.Image,
-		Created: dc.Created,
 		Volumes: dc.Volumes,
 		State: container.State{
 			Running:    dc.State.Running,
@@ -118,6 +115,7 @@ func ConvertContainer(dc *docker.Container) *container.Container {
 			Pid:        dc.State.Pid,
 			ExitCode:   dc.State.ExitCode,
 			Error:      dc.State.Error,
+			CreatedAt:  dc.Created,
 			StartedAt:  dc.State.StartedAt,
 			FinishedAt: dc.State.FinishedAt,
 		},

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -273,8 +273,18 @@ func (dr *DockerRuntime) RemoveImage(image string) error {
 }
 
 // Logs implements ContainerRuntime.Logs.
-func (dr *DockerRuntime) Logs(opts docker.LogsOptions) error {
-	return dr.docker.Logs(opts)
+func (dr *DockerRuntime) Logs(opts container.LogsOptions) error {
+	return dr.docker.Logs(docker.LogsOptions{
+		Container:    opts.ID,
+		OutputStream: opts.OutputStream,
+		ErrorStream:  opts.ErrorStream,
+		Follow:       opts.Follow,
+		Stdout:       opts.Stdout,
+		Stderr:       opts.Stderr,
+		Timestamps:   opts.Timestamps,
+		Tail:         opts.Tail,
+		RawTerminal:  opts.RawTerminal,
+	})
 }
 
 // Version implements ContainerRuntime.Version.
@@ -721,8 +731,8 @@ func GetRecentDockerContainersWithNameAndUUID(client container.Runtime, podFullN
 // Log tailing is possible when number of tailed lines are set and only if 'follow' is false
 // TODO: Make 'RawTerminal' option  flagable.
 func GetKubeletDockerContainerLogs(client container.Runtime, containerID, tail string, follow bool, stdout, stderr io.Writer) (err error) {
-	opts := docker.LogsOptions{
-		Container:    containerID,
+	opts := container.LogsOptions{
+		ID:           containerID,
 		Stdout:       true,
 		Stderr:       true,
 		OutputStream: stdout,

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -256,8 +256,15 @@ func (dr *DockerRuntime) InspectImage(image string) (*container.Image, error) {
 }
 
 // ListImage implements ContainerRuntime.ListImage.
-func (dr *DockerRuntime) ListImages(opts docker.ListImagesOptions) ([]docker.APIImages, error) {
-	return dr.docker.ListImages(opts)
+func (dr *DockerRuntime) ListImages(opts container.ListImagesOptions) ([]*container.Image, error) {
+	var imgs []*container.Image
+	dockerImages, err := dr.docker.ListImages(docker.ListImagesOptions{All: opts.All})
+	for i := range dockerImages {
+		imgs = append(imgs, &container.Image{
+			ID: dockerImages[i].ID,
+		})
+	}
+	return imgs, err
 }
 
 // PullImage implements ContainerRuntime.PullImage.

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -236,8 +236,8 @@ func (dr *DockerRuntime) StopContainer(id string, timeout uint) error {
 }
 
 // RemoveContainer implements ContainerRuntime.RemoveContainer.
-func (dr *DockerRuntime) RemoveContainer(opts docker.RemoveContainerOptions) error {
-	return dr.docker.RemoveContainer(opts)
+func (dr *DockerRuntime) RemoveContainer(opts container.RemoveContainerOptions) error {
+	return dr.docker.RemoveContainer(docker.RemoveContainerOptions{ID: opts.ID})
 }
 
 // InspectImage implements ContainerRuntime.InspectImage.

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -288,8 +288,9 @@ func (dr *DockerRuntime) Logs(opts container.LogsOptions) error {
 }
 
 // Version implements ContainerRuntime.Version.
-func (dr *DockerRuntime) Version() (*docker.Env, error) {
-	return dr.docker.Version()
+func (dr *DockerRuntime) Version() ([]string, error) {
+	env, err := dr.docker.Version()
+	return []string(*env), err
 }
 
 // CreateExec implements ContainerRuntime.CreateExec.
@@ -352,7 +353,7 @@ func (d *dockerContainerCommandRunner) GetDockerServerVersion() ([]uint, error) 
 		return nil, fmt.Errorf("failed to get docker server version - %v", err)
 	}
 	version := []uint{}
-	for _, entry := range *env {
+	for _, entry := range env {
 		if strings.Contains(strings.ToLower(entry), "apiversion") || strings.Contains(strings.ToLower(entry), "api version") {
 			elems := strings.Split(strings.Split(entry, "=")[1], ".")
 			for _, elem := range elems {

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -65,7 +65,7 @@ func TestGetContainerID(t *testing.T) {
 		ID: "foobar",
 	}
 
-	dockerContainers, err := GetKubeletDockerContainers(fakeDocker, false)
+	dockerContainers, err := GetKubeletDockerContainers(NewDockerRuntime(fakeDocker), false)
 	if err != nil {
 		t.Errorf("Expected no error, Got %#v", err)
 	}
@@ -122,7 +122,7 @@ func TestContainerManifestNaming(t *testing.T) {
 
 func TestGetDockerServerVersion(t *testing.T) {
 	fakeDocker := &FakeDockerClient{VersionInfo: docker.Env{"Client version=1.2", "Server version=1.1.3", "Server API version=1.15"}}
-	runner := dockerContainerCommandRunner{fakeDocker}
+	runner := dockerContainerCommandRunner{NewDockerRuntime(fakeDocker)}
 	version, err := runner.GetDockerServerVersion()
 	if err != nil {
 		t.Errorf("got error while getting docker server version - %s", err)
@@ -141,7 +141,7 @@ func TestGetDockerServerVersion(t *testing.T) {
 
 func TestExecSupportExists(t *testing.T) {
 	fakeDocker := &FakeDockerClient{VersionInfo: docker.Env{"Client version=1.2", "Server version=1.3.0", "Server API version=1.15"}}
-	runner := dockerContainerCommandRunner{fakeDocker}
+	runner := dockerContainerCommandRunner{NewDockerRuntime(fakeDocker)}
 	useNativeExec, err := runner.nativeExecSupportExists()
 	if err != nil {
 		t.Errorf("got error while checking for exec support - %s", err)
@@ -153,7 +153,7 @@ func TestExecSupportExists(t *testing.T) {
 
 func TestExecSupportNotExists(t *testing.T) {
 	fakeDocker := &FakeDockerClient{VersionInfo: docker.Env{"Client version=1.2", "Server version=1.1.2", "Server API version=1.14"}}
-	runner := dockerContainerCommandRunner{fakeDocker}
+	runner := dockerContainerCommandRunner{NewDockerRuntime(fakeDocker)}
 	useNativeExec, _ := runner.nativeExecSupportExists()
 	if useNativeExec {
 		t.Errorf("invalid exec support check output.")
@@ -203,7 +203,7 @@ func TestDockerKeyringLookupFails(t *testing.T) {
 	}
 
 	dp := dockerPuller{
-		client:  fakeClient,
+		client:  NewDockerRuntime(fakeClient),
 		keyring: fakeKeyring,
 	}
 
@@ -341,7 +341,7 @@ func (f *imageTrackingDockerClient) InspectImage(name string) (image *docker.Ima
 func TestIsImagePresent(t *testing.T) {
 	cl := &imageTrackingDockerClient{&FakeDockerClient{}, ""}
 	puller := &dockerPuller{
-		client: cl,
+		client: NewDockerRuntime(cl),
 	}
 	_, _ = puller.IsImagePresent("abc:123")
 	if cl.imageName != "abc:123" {
@@ -433,7 +433,7 @@ func TestGetRunningContainers(t *testing.T) {
 	for _, test := range tests {
 		fakeDocker.ContainerMap = test.containers
 		fakeDocker.Err = test.err
-		if results, err := GetRunningContainers(fakeDocker, test.inputIDs); err == nil {
+		if results, err := GetRunningContainers(NewDockerRuntime(fakeDocker), test.inputIDs); err == nil {
 			resultIDs := []string{}
 			for _, result := range results {
 				resultIDs = append(resultIDs, result.ID)

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -459,9 +459,7 @@ func TestConvertAPIContainer(t *testing.T) {
 	test := &docker.APIContainers{
 		ID:         "fooID",
 		Image:      "fooImage",
-		Command:    "fooCommand",
 		Created:    now,
-		Status:     "fooStatus",
 		SizeRw:     8080,
 		SizeRootFs: 7070,
 		Names:      []string{"fooName0"},
@@ -481,20 +479,8 @@ func TestConvertAPIContainer(t *testing.T) {
 	if result.Image != test.Image {
 		t.Errorf("expected: %v, saw: %v", test.Image, result.Image)
 	}
-	if result.Command != test.Command {
-		t.Errorf("expected: %v, saw: %v", test.Command, result.Command)
-	}
-	if result.Created != time.Unix(test.Created, 0) {
-		t.Errorf("expected: %v, saw: %v", time.Unix(test.Created, 0), result.Created)
-	}
-	if result.Status != test.Status {
-		t.Errorf("expected: %v, saw: %v", test.Status, result.Status)
-	}
-	if result.SizeRw != test.SizeRw {
-		t.Errorf("expected: %v, saw: %v", test.SizeRw, result.SizeRw)
-	}
-	if result.SizeRootFs != test.SizeRootFs {
-		t.Errorf("expected: %v, saw: %v", test.SizeRootFs, result.SizeRootFs)
+	if result.State.CreatedAt != time.Unix(test.Created, 0) {
+		t.Errorf("expected: %v, saw: %v", time.Unix(test.Created, 0), result.State.CreatedAt)
 	}
 	test.Names = nil
 	result = ConvertAPIContainer(test)
@@ -569,9 +555,6 @@ func TestConvertContainer(t *testing.T) {
 	if result.Image != test.Config.Image {
 		t.Errorf("expected: %v, saw: %v", test.Config.Image, result.Image)
 	}
-	if result.Created != test.Created {
-		t.Errorf("expected: %v, saw: %v", test.Created, result.Created)
-	}
 	if !reflect.DeepEqual(result.Volumes, test.Volumes) {
 		t.Errorf("expected: %v, saw: %v", test.Volumes, result.Volumes)
 	}
@@ -592,6 +575,9 @@ func TestConvertContainer(t *testing.T) {
 	}
 	if result.State.Error != test.State.Error {
 		t.Errorf("expected: %v, saw: %v", test.State.Error, result.State.Error)
+	}
+	if result.State.CreatedAt != test.Created {
+		t.Errorf("expected: %v, saw: %v", test.Created, result.State.CreatedAt)
 	}
 	if result.State.StartedAt != test.State.StartedAt {
 		t.Errorf("expected: %v, saw: %v", test.State.StartedAt, result.State.StartedAt)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -497,9 +497,9 @@ func makeBinds(pod *api.BoundPod, container *api.Container, podVolumes volumeMap
 	}
 	return binds
 }
-func makePortsAndBindings(ctnr *api.Container) (map[string]struct{}, map[string][]container.PortBinding) {
-	exposedPorts := map[string]struct{}{}
-	portBindings := map[string][]container.PortBinding{}
+func makePortsAndBindings(ctnr *api.Container) (map[container.Port]struct{}, map[container.Port][]container.PortBinding) {
+	exposedPorts := map[container.Port]struct{}{}
+	portBindings := map[container.Port][]container.PortBinding{}
 	for _, port := range ctnr.Ports {
 		exteriorPort := port.HostPort
 		if exteriorPort == 0 {
@@ -520,8 +520,8 @@ func makePortsAndBindings(ctnr *api.Container) (map[string]struct{}, map[string]
 			protocol = "/tcp"
 		}
 		dockerPort := strconv.Itoa(interiorPort) + protocol
-		exposedPorts[dockerPort] = struct{}{}
-		portBindings[dockerPort] = []container.PortBinding{
+		exposedPorts[container.Port(dockerPort)] = struct{}{}
+		portBindings[container.Port(dockerPort)] = []container.PortBinding{
 			{
 				HostPort: strconv.Itoa(exteriorPort),
 				HostIP:   port.HostIP,

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -889,7 +889,7 @@ func parseResolvConf(reader io.Reader) (nameservers []string, searches []string,
 }
 
 // Kill a docker container
-func (kl *Kubelet) killContainer(dockerContainer *docker.APIContainers) error {
+func (kl *Kubelet) killContainer(dockerContainer *container.Container) error {
 	return kl.killContainerByID(dockerContainer.ID, dockerContainer.Names[0])
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -355,7 +355,7 @@ func (kl *Kubelet) listPodsFromDisk() ([]types.UID, error) {
 	return pods, nil
 }
 
-type ByCreated []*docker.Container
+type ByCreated []*container.Container
 
 func (a ByCreated) Len() int           { return len(a) }
 func (a ByCreated) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
@@ -363,7 +363,7 @@ func (a ByCreated) Less(i, j int) bool { return a[i].Created.After(a[j].Created)
 
 // TODO: these removals are racy, we should make dockerclient threadsafe across List/Inspect transactions.
 func (kl *Kubelet) purgeOldest(ids []string) error {
-	dockerData := []*docker.Container{}
+	var dockerData []*container.Container
 	for _, id := range ids {
 		data, err := kl.containerRuntime.InspectContainer(id)
 		if err != nil {
@@ -1272,7 +1272,7 @@ func (kl *Kubelet) cleanupOrphanedPods(pods []api.BoundPod) error {
 
 // Compares the map of current volumes to the map of desired volumes.
 // If an active volume does not have a respective desired volume, clean it up.
-func (kl *Kubelet) cleanupOrphanedVolumes(pods []api.BoundPod, running []*docker.Container) error {
+func (kl *Kubelet) cleanupOrphanedVolumes(pods []api.BoundPod, running []*container.Container) error {
 	desiredVolumes := getDesiredVolumes(pods)
 	currentVolumes := kl.getPodVolumesFromDisk()
 	runningSet := util.StringSet{}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -72,7 +72,7 @@ type volumeMap map[string]volume.Interface
 // New creates a new Kubelet for use in main
 func NewMainKubelet(
 	hostname string,
-	containerRuntime container.ContainerRuntimeInterface,
+	containerRuntime container.Runtime,
 	etcdClient tools.EtcdClient,
 	kubeClient *client.Client,
 	rootDirectory string,
@@ -151,7 +151,7 @@ type serviceLister interface {
 // Kubelet is the main kubelet implementation.
 type Kubelet struct {
 	hostname               string
-	containerRuntime       container.ContainerRuntimeInterface
+	containerRuntime       container.Runtime
 	kubeClient             *client.Client
 	rootDirectory          string
 	podInfraContainerImage string

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -46,7 +46,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
-	"github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
 )
 
@@ -379,7 +378,7 @@ func (kl *Kubelet) purgeOldest(ids []string) error {
 	}
 	dockerData = dockerData[kl.maxContainerCount:]
 	for _, data := range dockerData {
-		if err := kl.containerRuntime.RemoveContainer(docker.RemoveContainerOptions{ID: data.ID}); err != nil {
+		if err := kl.containerRuntime.RemoveContainer(container.RemoveContainerOptions{ID: data.ID}); err != nil {
 			return err
 		}
 	}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -358,7 +358,7 @@ type ByCreated []*container.Container
 
 func (a ByCreated) Len() int           { return len(a) }
 func (a ByCreated) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a ByCreated) Less(i, j int) bool { return a[i].Created.After(a[j].Created) }
+func (a ByCreated) Less(i, j int) bool { return a[i].State.CreatedAt.After(a[j].State.CreatedAt) }
 
 // TODO: these removals are racy, we should make dockerclient threadsafe across List/Inspect transactions.
 func (kl *Kubelet) purgeOldest(ids []string) error {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1431,7 +1431,7 @@ func TestGetContainerInfoWhenDockerToolsFailed(t *testing.T) {
 	kubelet, _ := newTestKubelet(t)
 	kubelet.cadvisorClient = mockCadvisor
 	expectedErr := fmt.Errorf("List containers error")
-	kubelet.dockerClient = &errorTestingDockerClient{listContainersError: expectedErr}
+	kubelet.containerRuntime = dockertools.NewDockerRuntime(&errorTestingDockerClient{listContainersError: expectedErr})
 
 	stats, err := kubelet.GetContainerInfo("qux", "", "foo", nil)
 	if err == nil {
@@ -1451,7 +1451,7 @@ func TestGetContainerInfoWithNoContainers(t *testing.T) {
 	kubelet, _ := newTestKubelet(t)
 	kubelet.cadvisorClient = mockCadvisor
 
-	kubelet.dockerClient = &errorTestingDockerClient{listContainersError: nil}
+	kubelet.containerRuntime = dockertools.NewDockerRuntime(&errorTestingDockerClient{listContainersError: nil})
 	stats, err := kubelet.GetContainerInfo("qux", "", "foo", nil)
 	if err == nil {
 		t.Errorf("Expected error from cadvisor client, got none")
@@ -1477,7 +1477,7 @@ func TestGetContainerInfoWithNoMatchingContainers(t *testing.T) {
 		},
 	}
 
-	kubelet.dockerClient = &errorTestingDockerClient{listContainersError: nil, containerList: containerList}
+	kubelet.containerRuntime = dockertools.NewDockerRuntime(&errorTestingDockerClient{listContainersError: nil, containerList: containerList})
 	stats, err := kubelet.GetContainerInfo("qux", "", "foo", nil)
 	if err == nil {
 		t.Errorf("Expected error from cadvisor client, got none")

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1170,28 +1170,28 @@ func TestMakePortsAndBindings(t *testing.T) {
 	for key, value := range bindings {
 		switch value[0].HostPort {
 		case "8080":
-			if !reflect.DeepEqual(docker.Port("80/tcp"), key) {
+			if !reflect.DeepEqual("80/tcp", key) {
 				t.Errorf("Unexpected docker port: %#v", key)
 			}
 			if value[0].HostIP != "127.0.0.1" {
 				t.Errorf("Unexpected host IP: %s", value[0].HostIP)
 			}
 		case "443":
-			if !reflect.DeepEqual(docker.Port("443/tcp"), key) {
+			if !reflect.DeepEqual("443/tcp", key) {
 				t.Errorf("Unexpected docker port: %#v", key)
 			}
 			if value[0].HostIP != "" {
 				t.Errorf("Unexpected host IP: %s", value[0].HostIP)
 			}
 		case "444":
-			if !reflect.DeepEqual(docker.Port("444/udp"), key) {
+			if !reflect.DeepEqual("444/udp", key) {
 				t.Errorf("Unexpected docker port: %#v", key)
 			}
 			if value[0].HostIP != "" {
 				t.Errorf("Unexpected host IP: %s", value[0].HostIP)
 			}
 		case "445":
-			if !reflect.DeepEqual(docker.Port("445/tcp"), key) {
+			if !reflect.DeepEqual("445/tcp", key) {
 				t.Errorf("Unexpected docker port: %#v", key)
 			}
 			if value[0].HostIP != "" {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -54,7 +54,7 @@ func newTestKubelet(t *testing.T) (*Kubelet, *dockertools.FakeDockerClient) {
 	}
 
 	kubelet := &Kubelet{}
-	kubelet.dockerClient = fakeDocker
+	kubelet.containerRuntime = fakeDocker
 	kubelet.dockerPuller = &dockertools.FakeDockerPuller{}
 	if tempDir, err := ioutil.TempDir("/tmp", "kubelet_test."); err != nil {
 		t.Fatalf("can't make a temp rootdir: %v", err)
@@ -296,7 +296,7 @@ func TestKillContainerWithError(t *testing.T) {
 	for _, c := range fakeDocker.ContainerList {
 		kubelet.readiness.set(c.ID, true)
 	}
-	kubelet.dockerClient = fakeDocker
+	kubelet.containerRuntime = fakeDocker
 	err := kubelet.killContainer(&fakeDocker.ContainerList[0])
 	if err == nil {
 		t.Errorf("expected error, found nil")
@@ -1343,10 +1343,10 @@ func TestGetRootInfo(t *testing.T) {
 	mockCadvisor.On("ContainerInfo", containerPath, cadvisorReq).Return(containerInfo, nil)
 
 	kubelet := Kubelet{
-		dockerClient:   &fakeDocker,
-		dockerPuller:   &dockertools.FakeDockerPuller{},
-		cadvisorClient: mockCadvisor,
-		podWorkers:     newPodWorkers(),
+		containerRuntime: &fakeDocker,
+		dockerPuller:     &dockertools.FakeDockerPuller{},
+		cadvisorClient:   mockCadvisor,
+		podWorkers:       newPodWorkers(),
 	}
 
 	// If the container name is an empty string, then it means the root container.

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -858,23 +858,23 @@ func TestSyncPodDeletesDuplicate(t *testing.T) {
 	dockerContainers := dockertools.DockerContainers{
 		"1234": &container.Container{
 			// the k8s prefix is required for the kubelet to manage the container
-			Names: []string{"/k8s_foo_bar.new.test_12345678_1111"},
-			ID:    "1234",
+			Name: "/k8s_foo_bar.new.test_12345678_1111",
+			ID:   "1234",
 		},
 		"9876": &container.Container{
 			// pod infra container
-			Names: []string{"/k8s_POD_bar.new.test_12345678_2222"},
-			ID:    "9876",
+			Name: "/k8s_POD_bar.new.test_12345678_2222",
+			ID:   "9876",
 		},
 		"4567": &container.Container{
 			// Duplicate for the same container.
-			Names: []string{"/k8s_foo_bar.new.test_12345678_3333"},
-			ID:    "4567",
+			Name: "/k8s_foo_bar.new.test_12345678_3333",
+			ID:   "4567",
 		},
 		"2304": &container.Container{
 			// Container for another pod, untouched.
-			Names: []string{"/k8s_baz_fiz.new.test_6_42"},
-			ID:    "2304",
+			Name: "/k8s_baz_fiz.new.test_6_42",
+			ID:   "2304",
 		},
 	}
 	bound := api.BoundPod{
@@ -908,13 +908,13 @@ func TestSyncPodBadHash(t *testing.T) {
 	dockerContainers := dockertools.DockerContainers{
 		"1234": &container.Container{
 			// the k8s prefix is required for the kubelet to manage the container
-			Names: []string{"/k8s_bar.1234_foo.new.test_12345678_42"},
-			ID:    "1234",
+			Name: "/k8s_bar.1234_foo.new.test_12345678_42",
+			ID:   "1234",
 		},
 		"9876": &container.Container{
 			// pod infra container
-			Names: []string{"/k8s_POD_foo.new.test_12345678_42"},
-			ID:    "9876",
+			Name: "/k8s_POD_foo.new.test_12345678_42",
+			ID:   "9876",
 		},
 	}
 	bound := api.BoundPod{
@@ -956,13 +956,13 @@ func TestSyncPodUnhealthy(t *testing.T) {
 	dockerContainers := dockertools.DockerContainers{
 		"1234": &container.Container{
 			// the k8s prefix is required for the kubelet to manage the container
-			Names: []string{"/k8s_bar_foo.new.test_12345678_42"},
-			ID:    "1234",
+			Name: "/k8s_bar_foo.new.test_12345678_42",
+			ID:   "1234",
 		},
 		"9876": &container.Container{
 			// pod infra container
-			Names: []string{"/k8s_POD_foo.new.test_12345678_42"},
-			ID:    "9876",
+			Name: "/k8s_POD_foo.new.test_12345678_42",
+			ID:   "9876",
 		},
 	}
 	bound := api.BoundPod{
@@ -1709,8 +1709,8 @@ func TestSyncPodEventHandlerFails(t *testing.T) {
 	dockerContainers := dockertools.DockerContainers{
 		"9876": &container.Container{
 			// pod infra container
-			Names: []string{"/k8s_POD_foo.new.test_12345678_42"},
-			ID:    "9876",
+			Name: "/k8s_POD_foo.new.test_12345678_42",
+			ID:   "9876",
 		},
 	}
 	bound := api.BoundPod{

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -54,7 +54,7 @@ func newTestKubelet(t *testing.T) (*Kubelet, *dockertools.FakeDockerClient) {
 	}
 
 	kubelet := &Kubelet{}
-	kubelet.containerRuntime = fakeDocker
+	kubelet.containerRuntime = dockertools.NewDockerRuntime(fakeDocker)
 	kubelet.dockerPuller = &dockertools.FakeDockerPuller{}
 	if tempDir, err := ioutil.TempDir("/tmp", "kubelet_test."); err != nil {
 		t.Fatalf("can't make a temp rootdir: %v", err)
@@ -296,7 +296,7 @@ func TestKillContainerWithError(t *testing.T) {
 	for _, c := range fakeDocker.ContainerList {
 		kubelet.readiness.set(c.ID, true)
 	}
-	kubelet.containerRuntime = fakeDocker
+	kubelet.containerRuntime = dockertools.NewDockerRuntime(fakeDocker)
 	err := kubelet.killContainer(&fakeDocker.ContainerList[0])
 	if err == nil {
 		t.Errorf("expected error, found nil")
@@ -1343,7 +1343,7 @@ func TestGetRootInfo(t *testing.T) {
 	mockCadvisor.On("ContainerInfo", containerPath, cadvisorReq).Return(containerInfo, nil)
 
 	kubelet := Kubelet{
-		containerRuntime: &fakeDocker,
+		containerRuntime: dockertools.NewDockerRuntime(&fakeDocker),
 		dockerPuller:     &dockertools.FakeDockerPuller{},
 		cadvisorClient:   mockCadvisor,
 		podWorkers:       newPodWorkers(),

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -298,8 +298,8 @@ func TestKillContainerWithError(t *testing.T) {
 		kubelet.readiness.set(c.ID, true)
 	}
 	kubelet.containerRuntime = dockertools.NewDockerRuntime(fakeDocker)
-	container := dockertools.ConvertAPIContainer(fakeDocker.ContainerList[0])
-	err := kubelet.killContainer(&container)
+	container := dockertools.ConvertAPIContainer(&fakeDocker.ContainerList[0])
+	err := kubelet.killContainer(container)
 	if err == nil {
 		t.Errorf("expected error, found nil")
 	}
@@ -334,8 +334,8 @@ func TestKillContainer(t *testing.T) {
 		kubelet.readiness.set(c.ID, true)
 	}
 
-	container := dockertools.ConvertAPIContainer(fakeDocker.ContainerList[0])
-	err := kubelet.killContainer(&container)
+	container := dockertools.ConvertAPIContainer(&fakeDocker.ContainerList[0])
+	err := kubelet.killContainer(container)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1138,7 +1138,7 @@ func TestMakeVolumesAndBinds(t *testing.T) {
 }
 
 func TestMakePortsAndBindings(t *testing.T) {
-	container := api.Container{
+	ctnr := api.Container{
 		Ports: []api.Port{
 			{
 				ContainerPort: 80,
@@ -1162,36 +1162,36 @@ func TestMakePortsAndBindings(t *testing.T) {
 			},
 		},
 	}
-	exposedPorts, bindings := makePortsAndBindings(&container)
-	if len(container.Ports) != len(exposedPorts) ||
-		len(container.Ports) != len(bindings) {
-		t.Errorf("Unexpected ports and bindings, %#v %#v %#v", container, exposedPorts, bindings)
+	exposedPorts, bindings := makePortsAndBindings(&ctnr)
+	if len(ctnr.Ports) != len(exposedPorts) ||
+		len(ctnr.Ports) != len(bindings) {
+		t.Errorf("Unexpected ports and bindings, %#v %#v %#v", ctnr, exposedPorts, bindings)
 	}
 	for key, value := range bindings {
 		switch value[0].HostPort {
 		case "8080":
-			if !reflect.DeepEqual("80/tcp", key) {
+			if !reflect.DeepEqual(container.Port("80/tcp"), key) {
 				t.Errorf("Unexpected docker port: %#v", key)
 			}
 			if value[0].HostIP != "127.0.0.1" {
 				t.Errorf("Unexpected host IP: %s", value[0].HostIP)
 			}
 		case "443":
-			if !reflect.DeepEqual("443/tcp", key) {
+			if !reflect.DeepEqual(container.Port("443/tcp"), key) {
 				t.Errorf("Unexpected docker port: %#v", key)
 			}
 			if value[0].HostIP != "" {
 				t.Errorf("Unexpected host IP: %s", value[0].HostIP)
 			}
 		case "444":
-			if !reflect.DeepEqual("444/udp", key) {
+			if !reflect.DeepEqual(container.Port("444/udp"), key) {
 				t.Errorf("Unexpected docker port: %#v", key)
 			}
 			if value[0].HostIP != "" {
 				t.Errorf("Unexpected host IP: %s", value[0].HostIP)
 			}
 		case "445":
-			if !reflect.DeepEqual("445/tcp", key) {
+			if !reflect.DeepEqual(container.Port("445/tcp"), key) {
 				t.Errorf("Unexpected docker port: %#v", key)
 			}
 			if value[0].HostIP != "" {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -298,7 +298,7 @@ func TestKillContainerWithError(t *testing.T) {
 		kubelet.readiness.set(c.ID, true)
 	}
 	kubelet.containerRuntime = dockertools.NewDockerRuntime(fakeDocker)
-	container := dockertools.ToContainer(fakeDocker.ContainerList[0])
+	container := dockertools.ConvertAPIContainer(fakeDocker.ContainerList[0])
 	err := kubelet.killContainer(&container)
 	if err == nil {
 		t.Errorf("expected error, found nil")
@@ -334,7 +334,7 @@ func TestKillContainer(t *testing.T) {
 		kubelet.readiness.set(c.ID, true)
 	}
 
-	container := dockertools.ToContainer(fakeDocker.ContainerList[0])
+	container := dockertools.ConvertAPIContainer(fakeDocker.ContainerList[0])
 	err := kubelet.killContainer(&container)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/pkg/kubelet/probe.go
+++ b/pkg/kubelet/probe.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/probe"
 	execprobe "github.com/GoogleCloudPlatform/kubernetes/pkg/probe/exec"
 	httprobe "github.com/GoogleCloudPlatform/kubernetes/pkg/probe/http"
@@ -32,7 +33,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/exec"
 
-	"github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
 )
 
@@ -48,7 +48,7 @@ func (kl *Kubelet) probeContainer(p *api.Probe,
 	podUID types.UID,
 	status api.PodStatus,
 	container api.Container,
-	dockerContainer *docker.APIContainers,
+	dockerContainer *container.Container,
 	defaultResult probe.Result) (probe.Result, error) {
 	var err error
 	result := probe.Unknown

--- a/pkg/kubelet/probe.go
+++ b/pkg/kubelet/probe.go
@@ -55,7 +55,7 @@ func (kl *Kubelet) probeContainer(p *api.Probe,
 	if p == nil {
 		return probe.Success, nil
 	}
-	if time.Now().Unix()-dockerContainer.Created < p.InitialDelaySeconds {
+	if time.Now().Unix()-dockerContainer.Created.Unix() < p.InitialDelaySeconds {
 		return defaultResult, nil
 	}
 	for i := 0; i < maxProbeRetries; i++ {

--- a/pkg/kubelet/probe.go
+++ b/pkg/kubelet/probe.go
@@ -55,7 +55,7 @@ func (kl *Kubelet) probeContainer(p *api.Probe,
 	if p == nil {
 		return probe.Success, nil
 	}
-	if time.Now().Unix()-dockerContainer.Created.Unix() < p.InitialDelaySeconds {
+	if time.Now().Unix()-dockerContainer.State.CreatedAt.Unix() < p.InitialDelaySeconds {
 		return defaultResult, nil
 	}
 	for i := 0; i < maxProbeRetries; i++ {

--- a/pkg/kubelet/probe_test.go
+++ b/pkg/kubelet/probe_test.go
@@ -231,7 +231,7 @@ func TestProbeContainer(t *testing.T) {
 			kl = makeTestKubelet(test.expectedResult, nil)
 		}
 
-		container := dockertools.ToContainer(*dc)
+		container := dockertools.ConvertAPIContainer(*dc)
 		result, err := kl.probeContainer(test.p, "", types.UID(""), api.PodStatus{}, api.Container{}, &container, test.defaultResult)
 		if test.expectError && err == nil {
 			t.Error("Expected error but did no error was returned.")

--- a/pkg/kubelet/probe_test.go
+++ b/pkg/kubelet/probe_test.go
@@ -231,8 +231,8 @@ func TestProbeContainer(t *testing.T) {
 			kl = makeTestKubelet(test.expectedResult, nil)
 		}
 
-		container := dockertools.ConvertAPIContainer(*dc)
-		result, err := kl.probeContainer(test.p, "", types.UID(""), api.PodStatus{}, api.Container{}, &container, test.defaultResult)
+		container := dockertools.ConvertAPIContainer(dc)
+		result, err := kl.probeContainer(test.p, "", types.UID(""), api.PodStatus{}, api.Container{}, container, test.defaultResult)
 		if test.expectError && err == nil {
 			t.Error("Expected error but did no error was returned.")
 		}

--- a/pkg/kubelet/probe_test.go
+++ b/pkg/kubelet/probe_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/probe"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -230,7 +231,8 @@ func TestProbeContainer(t *testing.T) {
 			kl = makeTestKubelet(test.expectedResult, nil)
 		}
 
-		result, err := kl.probeContainer(test.p, "", types.UID(""), api.PodStatus{}, api.Container{}, dc, test.defaultResult)
+		container := dockertools.ToContainer(*dc)
+		result, err := kl.probeContainer(test.p, "", types.UID(""), api.PodStatus{}, api.Container{}, &container, test.defaultResult)
 		if test.expectError && err == nil {
 			t.Error("Expected error but did no error was returned.")
 		}

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -84,7 +84,7 @@ func TestRunOnce(t *testing.T) {
 			Status: "running",
 		},
 	}
-	kb.containerRuntime = &testDocker{
+	td := &testDocker{
 		listContainersResults: []listContainersResult{
 			{label: "list pod container", containers: []docker.APIContainers{}},
 			{label: "syncPod", containers: []docker.APIContainers{}},
@@ -124,6 +124,7 @@ func TestRunOnce(t *testing.T) {
 		},
 		t: t,
 	}
+	kb.containerRuntime = dockertools.NewDockerRuntime(td)
 	kb.dockerPuller = &dockertools.FakeDockerPuller{}
 	results, err := kb.runOnce([]api.BoundPod{
 		{

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -84,7 +84,7 @@ func TestRunOnce(t *testing.T) {
 			Status: "running",
 		},
 	}
-	kb.dockerClient = &testDocker{
+	kb.containerRuntime = &testDocker{
 		listContainersResults: []listContainersResult{
 			{label: "list pod container", containers: []docker.APIContainers{}},
 			{label: "syncPod", containers: []docker.APIContainers{}},


### PR DESCRIPTION
Rename DockerInterface to ContainerRuntimeInterface.
Rename dockerClient field in Kubelet to containerRuntime.
Rename DockerClient type in KubeletConfig to ContainerRuntime.

As the first step for #4404, here I pulled DockerInterface type and dockerClient out from kubelet.
Next I plan to modify the functions in ContainerRuntimeInterface to make them non-docker-specified.

PTAL. Thanks!
