### PR TITLE
Node addresses

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -789,12 +789,12 @@ type NodeSpec struct {
 
 // NodeStatus is information about the current status of a node.
 type NodeStatus struct {
-	// Queried from cloud provider, if available.
-	HostIP string `json:"hostIP,omitempty"`
 	// NodePhase is the current lifecycle phase of the node.
 	Phase NodePhase `json:"phase,omitempty"`
 	// Conditions is an array of current node conditions.
 	Conditions []NodeCondition `json:"conditions,omitempty"`
+	// Queried from cloud provider, if available.
+	Addresses []NodeAddress `json:"addresses,omitempty"`
 }
 
 type NodePhase string
@@ -828,6 +828,22 @@ type NodeCondition struct {
 	LastTransitionTime util.Time         `json:"lastTransitionTime,omitempty"`
 	Reason             string            `json:"reason,omitempty"`
 	Message            string            `json:"message,omitempty"`
+}
+
+type NodeAddressType string
+
+// These are valid address types of node. NodeLegacyHostIP is used to transit
+// from out-dated HostIP field to NodeAddress.
+const (
+	NodeLegacyHostIP NodeAddressType = "LegacyHostIP"
+	NodeHostName     NodeAddressType = "Hostname"
+	NodeExternalIP   NodeAddressType = "ExternalIP"
+	NodeInternalIP   NodeAddressType = "InternalIP"
+)
+
+type NodeAddress struct {
+	Type    NodeAddressType `json:"type"`
+	Address string          `json:"address"`
 }
 
 // NodeResources is an object for conveying resource information about a node.

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -696,8 +696,15 @@ func init() {
 			if err := s.Convert(&in.Status.Conditions, &out.Status.Conditions, 0); err != nil {
 				return err
 			}
+			if err := s.Convert(&in.Status.Addresses, &out.Status.Addresses, 0); err != nil {
+				return err
+			}
 
-			out.HostIP = in.Status.HostIP
+			for _, address := range in.Status.Addresses {
+				if address.Type == newer.NodeLegacyHostIP {
+					out.HostIP = address.Address
+				}
+			}
 			out.PodCIDR = in.Spec.PodCIDR
 			out.ExternalID = in.Spec.ExternalID
 			return s.Convert(&in.Spec.Capacity, &out.NodeResources.Capacity, 0)
@@ -718,12 +725,19 @@ func init() {
 			if err := s.Convert(&in.Status.Conditions, &out.Status.Conditions, 0); err != nil {
 				return err
 			}
+			if err := s.Convert(&in.Status.Addresses, &out.Status.Addresses, 0); err != nil {
+				return err
+			}
 
-			out.Status.HostIP = in.HostIP
+			if in.HostIP != "" {
+				out.Status.Addresses = append(out.Status.Addresses,
+					newer.NodeAddress{Type: newer.NodeLegacyHostIP, Address: in.HostIP})
+			}
 			out.Spec.PodCIDR = in.PodCIDR
 			out.Spec.ExternalID = in.ExternalID
 			return s.Convert(&in.NodeResources.Capacity, &out.Spec.Capacity, 0)
 		},
+
 		func(in *newer.LimitRange, out *LimitRange, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err
@@ -748,6 +762,7 @@ func init() {
 			}
 			return nil
 		},
+
 		func(in *Namespace, out *newer.Namespace, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err
@@ -763,6 +778,7 @@ func init() {
 			}
 			return nil
 		},
+
 		func(in *newer.LimitRangeSpec, out *LimitRangeSpec, s conversion.Scope) error {
 			*out = LimitRangeSpec{}
 			out.Limits = make([]LimitRangeItem, len(in.Limits), len(in.Limits))
@@ -783,6 +799,7 @@ func init() {
 			}
 			return nil
 		},
+
 		func(in *newer.LimitRangeItem, out *LimitRangeItem, s conversion.Scope) error {
 			*out = LimitRangeItem{}
 			out.Type = LimitType(in.Type)
@@ -805,6 +822,7 @@ func init() {
 			}
 			return nil
 		},
+
 		func(in *newer.ResourceQuota, out *ResourceQuota, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err
@@ -835,6 +853,7 @@ func init() {
 			}
 			return nil
 		},
+
 		func(in *newer.ResourceQuotaUsage, out *ResourceQuotaUsage, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err
@@ -859,6 +878,7 @@ func init() {
 			}
 			return nil
 		},
+
 		func(in *newer.ResourceQuotaSpec, out *ResourceQuotaSpec, s conversion.Scope) error {
 			*out = ResourceQuotaSpec{}
 			if err := s.Convert(&in.Hard, &out.Hard, 0); err != nil {
@@ -873,6 +893,7 @@ func init() {
 			}
 			return nil
 		},
+
 		func(in *newer.ResourceQuotaStatus, out *ResourceQuotaStatus, s conversion.Scope) error {
 			*out = ResourceQuotaStatus{}
 			if err := s.Convert(&in.Hard, &out.Hard, 0); err != nil {
@@ -893,6 +914,7 @@ func init() {
 			}
 			return nil
 		},
+
 		// Object ID <-> Name
 		// TODO: amend the conversion package to allow overriding specific fields.
 		func(in *ObjectReference, out *newer.ObjectReference, s conversion.Scope) error {
@@ -1133,6 +1155,7 @@ func init() {
 			out.TimeoutSeconds = in.TimeoutSeconds
 			return nil
 		},
+
 		func(in *newer.Endpoints, out *Endpoints, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -623,6 +623,8 @@ type NodeStatus struct {
 	Phase NodePhase `json:"phase,omitempty" description:"node phase is the current lifecycle phase of the node"`
 	// Conditions is an array of current node conditions.
 	Conditions []NodeCondition `json:"conditions,omitempty" description:"conditions is an array of current node conditions"`
+	// Queried from cloud provider, if available.
+	Addresses []NodeAddress `json:"addresses,omitempty" description:"list of addresses reachable to the node"`
 }
 
 type NodePhase string
@@ -658,6 +660,20 @@ type NodeCondition struct {
 	Message            string            `json:"message,omitempty" description:"human readable message indicating details about last transition"`
 }
 
+type NodeAddressType string
+
+// These are valid address types of node.
+const (
+	NodeHostName   NodeAddressType = "Hostname"
+	NodeExternalIP NodeAddressType = "ExternalIP"
+	NodeInternalIP NodeAddressType = "InternalIP"
+)
+
+type NodeAddress struct {
+	Type    NodeAddressType `json:"type" description:"type of the node address, e.g. external ip, internal ip, hostname, etc"`
+	Address string          `json:"address" description:"string representation of the address"`
+}
+
 // NodeResources represents resources on a Kubernetes system node
 // see https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/resources.md for more details.
 type NodeResources struct {
@@ -680,6 +696,7 @@ type ResourceList map[ResourceName]util.IntOrString
 // The name of the minion according to etcd is in ID.
 type Minion struct {
 	TypeMeta `json:",inline"`
+	// DEPRECATED: Use Status.Addresses instead.
 	// Queried from cloud provider, if available.
 	HostIP string `json:"hostIP,omitempty" description:"IP address of the node"`
 	// Resources available on the node

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -616,8 +616,15 @@ func init() {
 			if err := s.Convert(&in.Status.Conditions, &out.Status.Conditions, 0); err != nil {
 				return err
 			}
+			if err := s.Convert(&in.Status.Addresses, &out.Status.Addresses, 0); err != nil {
+				return err
+			}
 
-			out.HostIP = in.Status.HostIP
+			for _, address := range in.Status.Addresses {
+				if address.Type == newer.NodeLegacyHostIP {
+					out.HostIP = address.Address
+				}
+			}
 			out.PodCIDR = in.Spec.PodCIDR
 			out.ExternalID = in.Spec.ExternalID
 			return s.Convert(&in.Spec.Capacity, &out.NodeResources.Capacity, 0)
@@ -638,12 +645,19 @@ func init() {
 			if err := s.Convert(&in.Status.Conditions, &out.Status.Conditions, 0); err != nil {
 				return err
 			}
+			if err := s.Convert(&in.Status.Addresses, &out.Status.Addresses, 0); err != nil {
+				return err
+			}
 
-			out.Status.HostIP = in.HostIP
+			if in.HostIP != "" {
+				out.Status.Addresses = append(out.Status.Addresses,
+					newer.NodeAddress{Type: newer.NodeLegacyHostIP, Address: in.HostIP})
+			}
 			out.Spec.PodCIDR = in.PodCIDR
 			out.Spec.ExternalID = in.ExternalID
 			return s.Convert(&in.NodeResources.Capacity, &out.Spec.Capacity, 0)
 		},
+
 		func(in *newer.LimitRange, out *LimitRange, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err
@@ -668,6 +682,7 @@ func init() {
 			}
 			return nil
 		},
+
 		func(in *Namespace, out *newer.Namespace, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err
@@ -683,6 +698,7 @@ func init() {
 			}
 			return nil
 		},
+
 		func(in *newer.LimitRangeSpec, out *LimitRangeSpec, s conversion.Scope) error {
 			*out = LimitRangeSpec{}
 			out.Limits = make([]LimitRangeItem, len(in.Limits), len(in.Limits))
@@ -703,6 +719,7 @@ func init() {
 			}
 			return nil
 		},
+
 		func(in *newer.LimitRangeItem, out *LimitRangeItem, s conversion.Scope) error {
 			*out = LimitRangeItem{}
 			out.Type = LimitType(in.Type)
@@ -725,6 +742,7 @@ func init() {
 			}
 			return nil
 		},
+
 		func(in *newer.ResourceQuota, out *ResourceQuota, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err
@@ -755,6 +773,7 @@ func init() {
 			}
 			return nil
 		},
+
 		func(in *newer.ResourceQuotaUsage, out *ResourceQuotaUsage, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err
@@ -779,6 +798,7 @@ func init() {
 			}
 			return nil
 		},
+
 		func(in *newer.ResourceQuotaSpec, out *ResourceQuotaSpec, s conversion.Scope) error {
 			*out = ResourceQuotaSpec{}
 			if err := s.Convert(&in.Hard, &out.Hard, 0); err != nil {
@@ -793,6 +813,7 @@ func init() {
 			}
 			return nil
 		},
+
 		func(in *newer.ResourceQuotaStatus, out *ResourceQuotaStatus, s conversion.Scope) error {
 			*out = ResourceQuotaStatus{}
 			if err := s.Convert(&in.Hard, &out.Hard, 0); err != nil {
@@ -813,6 +834,7 @@ func init() {
 			}
 			return nil
 		},
+
 		// Object ID <-> Name
 		// TODO: amend the conversion package to allow overriding specific fields.
 		func(in *ObjectReference, out *newer.ObjectReference, s conversion.Scope) error {
@@ -1049,6 +1071,7 @@ func init() {
 			out.TimeoutSeconds = in.TimeoutSeconds
 			return nil
 		},
+
 		func(in *newer.Endpoints, out *Endpoints, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -587,6 +587,8 @@ type NodeStatus struct {
 	Phase NodePhase `json:"phase,omitempty" description:"node phase is the current lifecycle phase of the node"`
 	// Conditions is an array of current node conditions.
 	Conditions []NodeCondition `json:"conditions,omitempty" description:"conditions is an array of current node conditions"`
+	// Queried from cloud provider, if available.
+	Addresses []NodeAddress `json:"addresses,omitempty" description:"list of addresses reachable to the node"`
 }
 
 type NodePhase string
@@ -622,6 +624,20 @@ type NodeCondition struct {
 	Message            string            `json:"message,omitempty" description:"human readable message indicating details about last transition"`
 }
 
+type NodeAddressType string
+
+// These are valid address types of node.
+const (
+	NodeHostName   NodeAddressType = "Hostname"
+	NodeExternalIP NodeAddressType = "ExternalIP"
+	NodeInternalIP NodeAddressType = "InternalIP"
+)
+
+type NodeAddress struct {
+	Type    NodeAddressType `json:"type" description:"type of the node address, e.g. external ip, internal ip, hostname, etc"`
+	Address string          `json:"address" description:"string representation of the address"`
+}
+
 // NodeResources represents resources on a Kubernetes system node
 // see https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/resources.md for more details.
 type NodeResources struct {
@@ -644,12 +660,13 @@ type ResourceList map[ResourceName]util.IntOrString
 // The name of the minion according to etcd is in ID.
 type Minion struct {
 	TypeMeta `json:",inline"`
+	// DEPRECATED: Use Status.Addresses instead.
 	// Queried from cloud provider, if available.
 	HostIP string `json:"hostIP,omitempty" description:"IP address of the node"`
-	// Pod IP range assigned to the node
-	PodCIDR string `json:"cidr,omitempty" description:"IP range assigned to the node"`
 	// Resources available on the node
 	NodeResources NodeResources `json:"resources,omitempty" description:"characterization of node resources"`
+	// Pod IP range assigned to the node
+	PodCIDR string `json:"cidr,omitempty" description:"IP range assigned to the node"`
 	// Status describes the current status of a node
 	Status NodeStatus `json:"status,omitempty" description:"current status of node"`
 	// Labels for the node

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -820,12 +820,12 @@ type NodeSpec struct {
 
 // NodeStatus is information about the current status of a node.
 type NodeStatus struct {
-	// Queried from cloud provider, if available.
-	HostIP string `json:"hostIP,omitempty"`
 	// NodePhase is the current lifecycle phase of the node.
 	Phase NodePhase `json:"phase,omitempty"`
 	// Conditions is an array of current node conditions.
 	Conditions []NodeCondition `json:"conditions,omitempty"`
+	// Queried from cloud provider, if available.
+	Addresses []NodeAddress `json:"addresses,omitempty"`
 }
 
 type NodePhase string
@@ -859,6 +859,20 @@ type NodeCondition struct {
 	LastTransitionTime util.Time         `json:"lastTransitionTime,omitempty"`
 	Reason             string            `json:"reason,omitempty"`
 	Message            string            `json:"message,omitempty"`
+}
+
+type NodeAddressType string
+
+// These are valid address type of node.
+const (
+	NodeHostName   NodeAddressType = "Hostname"
+	NodeExternalIP NodeAddressType = "ExternalIP"
+	NodeInternalIP NodeAddressType = "InternalIP"
+)
+
+type NodeAddress struct {
+	Type    NodeAddressType `json:"type"`
+	Address string          `json:"address"`
 }
 
 // ResourceName is the name identifying various resources in a ResourceList.

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -1919,7 +1919,9 @@ func TestValidateMinion(t *testing.T) {
 				Labels: validSelector,
 			},
 			Status: api.NodeStatus{
-				HostIP: "something",
+				Addresses: []api.NodeAddress{
+					{Type: api.NodeLegacyHostIP, Address: "something"},
+				},
 			},
 		},
 		{
@@ -1927,7 +1929,9 @@ func TestValidateMinion(t *testing.T) {
 				Name: "abc",
 			},
 			Status: api.NodeStatus{
-				HostIP: "something",
+				Addresses: []api.NodeAddress{
+					{Type: api.NodeLegacyHostIP, Address: "something"},
+				},
 			},
 		},
 	}
@@ -1944,7 +1948,7 @@ func TestValidateMinion(t *testing.T) {
 				Labels: validSelector,
 			},
 			Status: api.NodeStatus{
-				HostIP: "something",
+				Addresses: []api.NodeAddress{},
 			},
 		},
 		"invalid-labels": {
@@ -2073,7 +2077,9 @@ func TestValidateMinionUpdate(t *testing.T) {
 				Labels: map[string]string{"bar": "foo"},
 			},
 			Status: api.NodeStatus{
-				HostIP: "1.2.3.4",
+				Addresses: []api.NodeAddress{
+					{Type: api.NodeLegacyHostIP, Address: "1.2.3.4"},
+				},
 			},
 		}, api.Node{
 			ObjectMeta: api.ObjectMeta{

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -730,9 +730,6 @@ func TestCreateMinion(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{
 			Name: "minion-1",
 		},
-		Status: api.NodeStatus{
-			HostIP: "123.321.456.654",
-		},
 		Spec: api.NodeSpec{
 			Capacity: api.ResourceList{
 				api.ResourceCPU:    resource.MustParse("1000m"),

--- a/pkg/master/pod_cache_test.go
+++ b/pkg/master/pod_cache_test.go
@@ -224,7 +224,9 @@ func makeHealthyNode(name string, ip string) *api.Node {
 	return &api.Node{
 		ObjectMeta: api.ObjectMeta{Name: name},
 		Status: api.NodeStatus{
-			HostIP: ip,
+			Addresses: []api.NodeAddress{
+				{Type: api.NodeLegacyHostIP, Address: ip},
+			},
 			Conditions: []api.NodeCondition{
 				{Type: api.NodeReady, Status: api.ConditionFull},
 			},

--- a/pkg/registry/minion/rest.go
+++ b/pkg/registry/minion/rest.go
@@ -121,13 +121,6 @@ func (rs *REST) Update(ctx api.Context, obj runtime.Object) (runtime.Object, boo
 		return nil, false, err
 	}
 
-	// This is hacky, but minion HostIP has been moved from spec to status since v1beta2. When updating
-	// minion from older client, HostIP will be lost.  Fix it here temporarily until we strip out status
-	// info from user input.
-	if minion.Status.HostIP == "" {
-		minion.Status.HostIP = oldMinion.Status.HostIP
-	}
-
 	if errs := validation.ValidateMinionUpdate(oldMinion, minion); len(errs) > 0 {
 		return nil, false, kerrors.NewInvalid("minion", minion.Name, errs)
 	}

--- a/pkg/registry/minion/rest_test.go
+++ b/pkg/registry/minion/rest_test.go
@@ -121,7 +121,9 @@ func TestMinionRegistryValidatesCreate(t *testing.T) {
 				Labels: validSelector,
 			},
 			Status: api.NodeStatus{
-				HostIP: "something",
+				Addresses: []api.NodeAddress{
+					{Type: api.NodeLegacyHostIP, Address: "something"},
+				},
 			},
 		},
 		"invalid-labels": {
@@ -158,7 +160,9 @@ func TestCreate(t *testing.T) {
 		// valid
 		&api.Node{
 			Status: api.NodeStatus{
-				HostIP: "something",
+				Addresses: []api.NodeAddress{
+					{Type: api.NodeLegacyHostIP, Address: "something"},
+				},
 			},
 		},
 		// invalid


### PR DESCRIPTION
Deprecate Node.HostIP, use Node.Addresses.

This is mostly the api side of change.  We need to update cloudprovider, etc. to differentiate different addresses.

I've aggressively removed HostIP from v1beta1/beta2.  It causes troubles for conversions.  Node is generally created from node controller, so I'd expect the change to have minimal user impact.  If this is not desirable, we can leave it there and do the conversion of Node.HostIP <-> Node.Addresses.

@bgrant0607 @smarterclayton 
