### PR TITLE
Retry #4337: Make gce kubeconfig context include project

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -508,7 +508,7 @@ function kube-up {
   local kube_auth="kubernetes_auth"
 
   local kubectl="${KUBE_ROOT}/cluster/kubectl.sh"
-  local context="${INSTANCE_PREFIX}"
+  local context="${PROJECT}_${INSTANCE_PREFIX}"
   local user="${INSTANCE_PREFIX}-admin"
   local config_dir="${HOME}/.kube/${context}"
 

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -93,7 +93,7 @@ elif [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
   )
 elif [[ "${KUBERNETES_PROVIDER}" == "gce" ]]; then
   auth_config=(
-    "--auth_config=${HOME}/.kube/${INSTANCE_PREFIX}/kubernetes_auth"
+    "--auth_config=${HOME}/.kube/${PROJECT}_${INSTANCE_PREFIX}/kubernetes_auth"
   )
 else
   auth_config=()


### PR DESCRIPTION
Updated gingkgo-e2e auth_config this time. Ran e2e tests, 19/20 passing ("Pods should contain environment variables for services" still flaky). cc @zmerlynn 
