### PR TITLE
Switch events history to use LRU cache instead of map

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -110,6 +110,10 @@
 			"Rev": "44145f04b68cf362d9c4df2182967c2275eaefed"
 		},
 		{
+			"ImportPath": "github.com/golang/groupcache/lru",
+			"Rev": "604ed5785183e59ae2789449d89e73f3a2a77987"
+		},
+		{
 			"ImportPath": "github.com/golang/protobuf/proto",
 			"Rev": "7f07925444bb51fa4cf9dfe6f7661876f8852275"
 		},

--- a/Godeps/_workspace/src/github.com/golang/groupcache/lru/lru.go
+++ b/Godeps/_workspace/src/github.com/golang/groupcache/lru/lru.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2013 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package lru implements an LRU cache.
+package lru
+
+import "container/list"
+
+// Cache is an LRU cache. It is not safe for concurrent access.
+type Cache struct {
+	// MaxEntries is the maximum number of cache entries before
+	// an item is evicted. Zero means no limit.
+	MaxEntries int
+
+	// OnEvicted optionally specificies a callback function to be
+	// executed when an entry is purged from the cache.
+	OnEvicted func(key Key, value interface{})
+
+	ll    *list.List
+	cache map[interface{}]*list.Element
+}
+
+// A Key may be any value that is comparable. See http://golang.org/ref/spec#Comparison_operators
+type Key interface{}
+
+type entry struct {
+	key   Key
+	value interface{}
+}
+
+// New creates a new Cache.
+// If maxEntries is zero, the cache has no limit and it's assumed
+// that eviction is done by the caller.
+func New(maxEntries int) *Cache {
+	return &Cache{
+		MaxEntries: maxEntries,
+		ll:         list.New(),
+		cache:      make(map[interface{}]*list.Element),
+	}
+}
+
+// Add adds a value to the cache.
+func (c *Cache) Add(key Key, value interface{}) {
+	if c.cache == nil {
+		c.cache = make(map[interface{}]*list.Element)
+		c.ll = list.New()
+	}
+	if ee, ok := c.cache[key]; ok {
+		c.ll.MoveToFront(ee)
+		ee.Value.(*entry).value = value
+		return
+	}
+	ele := c.ll.PushFront(&entry{key, value})
+	c.cache[key] = ele
+	if c.MaxEntries != 0 && c.ll.Len() > c.MaxEntries {
+		c.RemoveOldest()
+	}
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key Key) (value interface{}, ok bool) {
+	if c.cache == nil {
+		return
+	}
+	if ele, hit := c.cache[key]; hit {
+		c.ll.MoveToFront(ele)
+		return ele.Value.(*entry).value, true
+	}
+	return
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key Key) {
+	if c.cache == nil {
+		return
+	}
+	if ele, hit := c.cache[key]; hit {
+		c.removeElement(ele)
+	}
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *Cache) RemoveOldest() {
+	if c.cache == nil {
+		return
+	}
+	ele := c.ll.Back()
+	if ele != nil {
+		c.removeElement(ele)
+	}
+}
+
+func (c *Cache) removeElement(e *list.Element) {
+	c.ll.Remove(e)
+	kv := e.Value.(*entry)
+	delete(c.cache, kv.key)
+	if c.OnEvicted != nil {
+		c.OnEvicted(kv.key, kv.value)
+	}
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	if c.cache == nil {
+		return 0
+	}
+	return c.ll.Len()
+}

--- a/Godeps/_workspace/src/github.com/golang/groupcache/lru/lru_test.go
+++ b/Godeps/_workspace/src/github.com/golang/groupcache/lru/lru_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2013 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lru
+
+import (
+	"testing"
+)
+
+type simpleStruct struct {
+	int
+	string
+}
+
+type complexStruct struct {
+	int
+	simpleStruct
+}
+
+var getTests = []struct {
+	name       string
+	keyToAdd   interface{}
+	keyToGet   interface{}
+	expectedOk bool
+}{
+	{"string_hit", "myKey", "myKey", true},
+	{"string_miss", "myKey", "nonsense", false},
+	{"simple_struct_hit", simpleStruct{1, "two"}, simpleStruct{1, "two"}, true},
+	{"simeple_struct_miss", simpleStruct{1, "two"}, simpleStruct{0, "noway"}, false},
+	{"complex_struct_hit", complexStruct{1, simpleStruct{2, "three"}},
+		complexStruct{1, simpleStruct{2, "three"}}, true},
+}
+
+func TestGet(t *testing.T) {
+	for _, tt := range getTests {
+		lru := New(0)
+		lru.Add(tt.keyToAdd, 1234)
+		val, ok := lru.Get(tt.keyToGet)
+		if ok != tt.expectedOk {
+			t.Fatalf("%s: cache hit = %v; want %v", tt.name, ok, !ok)
+		} else if ok && val != 1234 {
+			t.Fatalf("%s expected get to return 1234 but got %v", tt.name, val)
+		}
+	}
+}
+
+func TestRemove(t *testing.T) {
+	lru := New(0)
+	lru.Add("myKey", 1234)
+	if val, ok := lru.Get("myKey"); !ok {
+		t.Fatal("TestRemove returned no match")
+	} else if val != 1234 {
+		t.Fatalf("TestRemove failed.  Expected %d, got %v", 1234, val)
+	}
+
+	lru.Remove("myKey")
+	if _, ok := lru.Get("myKey"); ok {
+		t.Fatal("TestRemove returned a removed entry")
+	}
+}

--- a/pkg/client/record/event.go
+++ b/pkg/client/record/event.go
@@ -59,7 +59,7 @@ func StartRecording(recorder EventRecorder, source api.EventSource) watch.Interf
 		event = &eventCopy
 		event.Source = source
 
-		previousEvent := GetEvent(event)
+		previousEvent := getEvent(event)
 		updateExistingEvent := previousEvent.Count > 0
 		if updateExistingEvent {
 			event.Count = previousEvent.Count + 1
@@ -102,7 +102,7 @@ func recordEvent(recorder EventRecorder, event *api.Event, updateExistingEvent b
 		newEvent, err = recorder.Create(event)
 	}
 	if err == nil {
-		AddOrUpdateEvent(newEvent)
+		addOrUpdateEvent(newEvent)
 		return true
 	}
 

--- a/pkg/client/record/events_cache_test.go
+++ b/pkg/client/record/events_cache_test.go
@@ -45,7 +45,7 @@ func TestAddOrUpdateEventNoExisting(t *testing.T) {
 	}
 
 	// Act
-	result := AddOrUpdateEvent(&event)
+	result := addOrUpdateEvent(&event)
 
 	// Assert
 	compareEventWithHistoryEntry(&event, &result, t)
@@ -99,9 +99,9 @@ func TestAddOrUpdateEventExisting(t *testing.T) {
 	}
 
 	// Act
-	AddOrUpdateEvent(&event1)
-	result1 := AddOrUpdateEvent(&event2)
-	result2 := GetEvent(&event1)
+	addOrUpdateEvent(&event1)
+	result1 := addOrUpdateEvent(&event2)
+	result2 := getEvent(&event1)
 
 	// Assert
 	compareEventWithHistoryEntry(&event2, &result1, t)
@@ -128,7 +128,7 @@ func TestGetEventNoExisting(t *testing.T) {
 	}
 
 	// Act
-	existingEvent := GetEvent(&event)
+	existingEvent := getEvent(&event)
 
 	// Assert
 	if existingEvent.Count != 0 {
@@ -157,16 +157,16 @@ func TestGetEventExisting(t *testing.T) {
 		FirstTimestamp: eventTime,
 		LastTimestamp:  eventTime,
 	}
-	AddOrUpdateEvent(&event)
+	addOrUpdateEvent(&event)
 
 	// Act
-	existingEvent := GetEvent(&event)
+	existingEvent := getEvent(&event)
 
 	// Assert
 	compareEventWithHistoryEntry(&event, &existingEvent, t)
 }
 
-func compareEventWithHistoryEntry(expected *api.Event, actual *History, t *testing.T) {
+func compareEventWithHistoryEntry(expected *api.Event, actual *history, t *testing.T) {
 
 	if actual.Count != expected.Count {
 		t.Fatalf("There should be one existing instance of this event in the hash table.")


### PR DESCRIPTION
Currently events history cache uses a map for tracking previously seen events. This means if the component (e.g. kubelet) runs for a long period of time and generates a ton of unique events, the hash table could grow very large in memory.

To prevent this from happening, this PR switches the events history cache to use a LRU cache. When the max num of entries is hit, it starts evicting the oldest entries.

I arbitrarily set the `maxLruCacheEntries` to `4096`; let me know if you think this would be too high/low, etc.

Will update documentation (PR #4372) accordingly, once this is merged.

cc @dchen1107  @erictune 
