### PR TITLE
Update locally.md - modify incorrect etcd link

### DIFF
--- a/docs/getting-started-guides/locally.md
+++ b/docs/getting-started-guides/locally.md
@@ -15,7 +15,7 @@ works fine with docker.
 
 #### etcd
 
-You need an [etcd](https://github.com/coreos/etcd/releases/tag/v0.4.6) in your path, please make sure it is installed and in your ``$PATH``.
+You need an [etcd](https://github.com/coreos/etcd/releases) in your path, please make sure it is installed and in your ``$PATH``.
 
 #### go
 


### PR DESCRIPTION
Remove /tag/0.4.6 from etcd link, since kubernetes requires etcd v2.0 or later
