### PR TITLE
fix error where we can't use kubectl update patch

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -159,9 +159,14 @@ for version in "${kube_api_versions[@]}"; do
           "apiVersion": "v1beta1",
           "id": "service-${version}-test",
           "port": 80,
-          "protocol": "TCP"
+          "protocol": "TCP",
+          "selector": {
+              "version": "old"
+          }
       }
 __EOF__
+  kubectl update service service-${version}-test --patch="{\"selector\":{\"version\":\"${version}\"},\"apiVersion\":\"${version}\"}" 
+  kubectl get service service-${version}-test -o json | kubectl update -f -
   kubectl get services "${kube_flags[@]}"
   kubectl get services "service-${version}-test" "${kube_flags[@]}"
   kubectl delete service frontend "${kube_flags[@]}"

--- a/pkg/kubectl/cmd/update.go
+++ b/pkg/kubectl/cmd/update.go
@@ -54,15 +54,6 @@ Examples:
 			cmdNamespace, err := f.DefaultNamespace(cmd)
 			checkErr(err)
 
-			mapper, typer := f.Object(cmd)
-			r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand(cmd)).
-				ContinueOnError().
-				NamespaceParam(cmdNamespace).RequireNamespace().
-				FilenameParam(flags.Filenames...).
-				Flatten().
-				Do()
-			checkErr(r.Err())
-
 			patch := cmdutil.GetFlagString(cmd, "patch")
 			if len(flags.Filenames) == 0 && len(patch) == 0 {
 				usageError(cmd, "Must specify --filename or --patch to update")
@@ -77,6 +68,15 @@ Examples:
 				fmt.Fprintf(out, "%s\n", name)
 				return
 			}
+
+			mapper, typer := f.Object(cmd)
+			r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand(cmd)).
+				ContinueOnError().
+				NamespaceParam(cmdNamespace).RequireNamespace().
+				FilenameParam(flags.Filenames...).
+				Flatten().
+				Do()
+			checkErr(r.Err())
 
 			err = r.Visit(func(info *resource.Info) error {
 				data, err := info.Mapping.Codec.Encode(info.Object)


### PR DESCRIPTION
We can't try to get a resource.Result from the filenames past in until we have decided that we are not doing a patch update, else we call FilenameParam with an empty list and get

```
I0214 22:29:30.432388   52487 update.go:65] you must provide one or more resources by argument or filename
```
