### PR TITLE
Update images doc to talk about GCR

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -6,7 +6,12 @@ You create your Docker image and push it to a registry before referring to it in
 The `image` property of a container supports the same syntax as the `docker` command does, including private registries and tags.
 
 ## Using a Private Registry
-Keys for private registries are stored in a `.dockercfg` file.  Create a config file by running `docker login <registry>.<domain>` and then copying the resulting `.dockercfg` file to the kubelet working dir.
+
+### Google Container Registry
+Kubernetes has native support for the [Google Container Regisry](https://cloud.google.com/tools/container-registry/), when running on Google Compute Engine.  If you are running your cluster on Google Compute Engine or Google Container Engine, simply use the full image name (e.g. gcr.io/my_project/image:tag) and the kubelet will automatically authenticate and pull down your private image.
+
+### Other Private Registries
+Docker stores keys for private registries in a `.dockercfg` file.  Create a config file by running `docker login <registry>.<domain>` and then copying the resulting `.dockercfg` file to the kubelet working dir.
 The kubelet working dir varies by cloud provider.  It is `/` on GCE and `/home/core` on CoreOS.  You can determine the working dir by running this command:
 `sudo ls -ld /proc/$(pidof kubelet)/cwd` on a kNode.
 


### PR DESCRIPTION
This change updates the images docs to talk about and link to the docs for the Google Container Registry.

NOTE: Still need to update: https://github.com/GoogleCloudPlatform/kubernetes/wiki/User-FAQ#how-do-i-pull-images-from-a-private-registry

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/kubernetes/4452)

<!-- Reviewable:end -->
