### PR TITLE
Add node's IP range cidr to NodeSpec

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -778,6 +778,9 @@ type EndpointsList struct {
 type NodeSpec struct {
 	// Capacity represents the available resources of a node
 	Capacity ResourceList `json:"capacity,omitempty"`
+	// PodCIDR represents the pod IP range assigned to the node
+	// Note: assigning IP ranges to nodes might need to be revisited when we support migratable IPs.
+	PodCIDR string `json:"cidr,omitempty"`
 }
 
 // NodeStatus is information about the current status of a node.
@@ -844,7 +847,7 @@ const (
 // ResourceList is a set of (resource name, quantity) pairs.
 type ResourceList map[ResourceName]resource.Quantity
 
-// Node is a worker node in Kubernetenes
+// Node is a worker node in Kubernetes
 // The name of the node according to etcd is in ObjectMeta.Name.
 type Node struct {
 	TypeMeta   `json:",inline"`

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -698,6 +698,7 @@ func init() {
 			}
 
 			out.HostIP = in.Status.HostIP
+			out.PodCIDR = in.Spec.PodCIDR
 			return s.Convert(&in.Spec.Capacity, &out.NodeResources.Capacity, 0)
 		},
 		func(in *Minion, out *newer.Node, s conversion.Scope) error {
@@ -718,6 +719,7 @@ func init() {
 			}
 
 			out.Status.HostIP = in.HostIP
+			out.Spec.PodCIDR = in.PodCIDR
 			return s.Convert(&in.NodeResources.Capacity, &out.Spec.Capacity, 0)
 		},
 		func(in *newer.LimitRange, out *LimitRange, s conversion.Scope) error {

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -684,6 +684,8 @@ type Minion struct {
 	HostIP string `json:"hostIP,omitempty" description:"IP address of the node"`
 	// Resources available on the node
 	NodeResources NodeResources `json:"resources,omitempty" description:"characterization of node resources"`
+	// Pod IP range assigned to the node
+	PodCIDR string `json:"cidr,omitempty" description:"IP range assigned to the node"`
 	// Status describes the current status of a node
 	Status NodeStatus `json:"status,omitempty" description:"current status of node"`
 	// Labels for the node

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -618,6 +618,7 @@ func init() {
 			}
 
 			out.HostIP = in.Status.HostIP
+			out.PodCIDR = in.Spec.PodCIDR
 			return s.Convert(&in.Spec.Capacity, &out.NodeResources.Capacity, 0)
 		},
 		func(in *Minion, out *newer.Node, s conversion.Scope) error {
@@ -638,6 +639,7 @@ func init() {
 			}
 
 			out.Status.HostIP = in.HostIP
+			out.Spec.PodCIDR = in.PodCIDR
 			return s.Convert(&in.NodeResources.Capacity, &out.Spec.Capacity, 0)
 		},
 		func(in *newer.LimitRange, out *LimitRange, s conversion.Scope) error {

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -646,6 +646,8 @@ type Minion struct {
 	TypeMeta `json:",inline"`
 	// Queried from cloud provider, if available.
 	HostIP string `json:"hostIP,omitempty" description:"IP address of the node"`
+	// Pod IP range assigned to the node
+	PodCIDR string `json:"cidr,omitempty" description:"IP range assigned to the node"`
 	// Resources available on the node
 	NodeResources NodeResources `json:"resources,omitempty" description:"characterization of node resources"`
 	// Status describes the current status of a node

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -812,6 +812,8 @@ type NodeSpec struct {
 	// Capacity represents the available resources of a node
 	// see https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/resources.md for more details.
 	Capacity ResourceList `json:"capacity,omitempty"`
+	// PodCIDR represents the pod IP range assigned to the node
+	PodCIDR string `json:"cidr,omitempty"`
 }
 
 // NodeStatus is information about the current status of a node.


### PR DESCRIPTION
@bgrant0607 @fbalejko: This is something you guys already talked about I believe.

The idea here is to add a new method to cloudprovider.Instances interface to push the range setting from api.NodeSpec to the actual node in the cloud. The goal being to allow adding more instances to a running cluster.
Please review the API part for now. 
