### PR TITLE
WIP: Add version comparison capability to Stores

### DIFF
--- a/pkg/client/cache/fifo.go
+++ b/pkg/client/cache/fifo.go
@@ -35,6 +35,8 @@ type FIFO struct {
 	// keyFunc is used to make the key used for queued item insertion and retrieval, and
 	// should be deterministic.
 	keyFunc KeyFunc
+	// isOlder is used to accept or reject objects which are older than what's already stored.
+	isOlder IsOlder
 }
 
 // Add inserts an item, and puts it in the queue. The item is only enqueued
@@ -46,7 +48,15 @@ func (f *FIFO) Add(obj interface{}) error {
 	}
 	f.lock.Lock()
 	defer f.lock.Unlock()
-	if _, exists := f.items[id]; !exists {
+	if oldObject, exists := f.items[id]; !exists {
+		// reject attempts to add older entries
+		if older, err := f.isOlder(obj, oldObject); err != nil {
+			return fmt.Errorf("couldn't compare objects: %v", err)
+		} else {
+			if older {
+				return nil
+			}
+		}
 		f.queue = append(f.queue, id)
 	}
 	f.items[id] = obj
@@ -153,11 +163,12 @@ func (f *FIFO) Replace(list []interface{}) error {
 
 // NewFIFO returns a Store which can be used to queue up items to
 // process.
-func NewFIFO(keyFunc KeyFunc) *FIFO {
+func NewFIFO(keyFunc KeyFunc, isOlder IsOlder) *FIFO {
 	f := &FIFO{
 		items:   map[string]interface{}{},
 		queue:   []string{},
 		keyFunc: keyFunc,
+		isOlder: isOlder,
 	}
 	f.cond.L = &f.lock
 	return f

--- a/pkg/client/cache/store.go
+++ b/pkg/client/cache/store.go
@@ -49,8 +49,8 @@ type Store interface {
 // KeyFunc knows how to make a key from an object. Implementations should be deterministic.
 type KeyFunc func(obj interface{}) (string, error)
 
-// IsOlder returns true if a is older than b, and returns false if a is equal to or newer than b.
-type IsOlder func(a, b interface{}) (bool, error)
+// CanReplace returns true if a can replace b, and returns false otherwise.
+type CanReplace func(a, b interface{}) (bool, error)
 
 // MetaNamespaceKeyFunc is a convenient default KeyFunc which knows how to make
 // keys for API objects which implement meta.Interface.
@@ -66,10 +66,10 @@ func MetaNamespaceKeyFunc(obj interface{}) (string, error) {
 	return meta.Name(), nil
 }
 
-// MetaNamespaceIsOlder is an IsOlder implementation which requires both a and b to
-// implement meta.Interface. It returns true if ResourceVersion of a is less than
+// ReplaceIfNewer is a CanReplace implementation which requires both a and b to
+// implement meta.Interface. It returns true if ResourceVersion of a is greater than
 // ResourceVersion of b, and returns false otherwise.
-func MetaNamespaceIsOlder(a, b interface{}) (bool, error) {
+func ReplaceIfNewer(a, b interface{}) (bool, error) {
 	metaA, errA := meta.Accessor(a)
 	if errA != nil {
 		return false, fmt.Errorf("object has no meta: %v", errA)
@@ -80,14 +80,14 @@ func MetaNamespaceIsOlder(a, b interface{}) (bool, error) {
 		return false, fmt.Errorf("object has no meta: %v", errB)
 	}
 
-	return metaA.ResourceVersion() < metaB.ResourceVersion(), nil
+	return metaA.ResourceVersion() > metaB.ResourceVersion(), nil
 }
 
-// DefaultIsOlder is a simple IsOlder implementation which will always return false, resulting
+// AlwaysReplace is a simple CanReplace implementation which will always return true, resulting
 // in a always being accepted into Store implementations (which is the expected behavior for
 // users of Store who don't care about versioning in detail).
-func DefaultIsOlder(a, b interface{}) (bool, error) {
-	return false, nil
+func AlwaysReplace(a, b interface{}) (bool, error) {
+	return true, nil
 }
 
 type cache struct {
@@ -96,8 +96,8 @@ type cache struct {
 	// keyFunc is used to make the key for objects stored in and retrieved from items, and
 	// should be deterministic.
 	keyFunc KeyFunc
-	// isOlder is used to accept or reject objects which are older than what's already stored.
-	isOlder IsOlder
+	// canReplace is used to drive acceptance of objects passed to Add or Update.
+	canReplace CanReplace
 	// indexers maps a name to an IndexFunc
 	indexers Indexers
 	// indices maps a name to an Index
@@ -115,13 +115,14 @@ func (c *cache) Add(obj interface{}) error {
 	defer c.lock.Unlock()
 	oldObject := c.items[key]
 
-	// reject attempts to add older entries
-	if older, err := c.isOlder(obj, oldObject); err != nil {
+	// Reject invalid attempts to add objects
+	canReplace, err := c.canReplace(obj, oldObject)
+	if err != nil {
 		return fmt.Errorf("couldn't compare objects: %v", err)
-	} else {
-		if older {
-			return nil
-		}
+	}
+
+	if !canReplace {
+		return nil
 	}
 
 	c.items[key] = obj
@@ -193,13 +194,14 @@ func (c *cache) Update(obj interface{}) error {
 	defer c.lock.Unlock()
 	oldObject := c.items[key]
 
-	// reject attempts to add older entries
-	if older, err := c.isOlder(obj, oldObject); err != nil {
+	// Reject attempts to update invalid entries
+	canReplace, err := c.canReplace(obj, oldObject)
+	if err != nil {
 		return fmt.Errorf("couldn't compare objects: %v", err)
-	} else {
-		if older {
-			return nil
-		}
+	}
+
+	if !canReplace {
+		return nil
 	}
 
 	c.items[key] = obj
@@ -302,8 +304,8 @@ func (c *cache) Replace(list []interface{}) error {
 }
 
 // NewStore returns a Store implemented simply with a map and a lock.
-func NewStore(keyFunc KeyFunc, isOlder IsOlder) Store {
-	return &cache{items: map[string]interface{}{}, keyFunc: keyFunc, isOlder: isOlder, indexers: Indexers{}, indices: Indices{}}
+func NewStore(keyFunc KeyFunc, canReplace CanReplace) Store {
+	return &cache{items: map[string]interface{}{}, keyFunc: keyFunc, canReplace: canReplace, indexers: Indexers{}, indices: Indices{}}
 }
 
 // NewIndexer returns an Indexer implemented simply with a map and a lock.

--- a/pkg/client/cache/store.go
+++ b/pkg/client/cache/store.go
@@ -49,6 +49,9 @@ type Store interface {
 // KeyFunc knows how to make a key from an object. Implementations should be deterministic.
 type KeyFunc func(obj interface{}) (string, error)
 
+// IsOlder returns true if a is older than b, and returns false if a is equal to or newer than b.
+type IsOlder func(a, b interface{}) (bool, error)
+
 // MetaNamespaceKeyFunc is a convenient default KeyFunc which knows how to make
 // keys for API objects which implement meta.Interface.
 // The key uses the format: <namespace>/<name>
@@ -63,12 +66,38 @@ func MetaNamespaceKeyFunc(obj interface{}) (string, error) {
 	return meta.Name(), nil
 }
 
+// MetaNamespaceIsOlder is an IsOlder implementation which requires both a and b to
+// implement meta.Interface. It returns true if ResourceVersion of a is less than
+// ResourceVersion of b, and returns false otherwise.
+func MetaNamespaceIsOlder(a, b interface{}) (bool, error) {
+	metaA, errA := meta.Accessor(a)
+	if errA != nil {
+		return false, fmt.Errorf("object has no meta: %v", errA)
+	}
+
+	metaB, errB := meta.Accessor(b)
+	if errB != nil {
+		return false, fmt.Errorf("object has no meta: %v", errB)
+	}
+
+	return metaA.ResourceVersion() < metaB.ResourceVersion(), nil
+}
+
+// DefaultIsOlder is a simple IsOlder implementation which will always return false, resulting
+// in a always being accepted into Store implementations (which is the expected behavior for
+// users of Store who don't care about versioning in detail).
+func DefaultIsOlder(a, b interface{}) (bool, error) {
+	return false, nil
+}
+
 type cache struct {
 	lock  sync.RWMutex
 	items map[string]interface{}
 	// keyFunc is used to make the key for objects stored in and retrieved from items, and
 	// should be deterministic.
 	keyFunc KeyFunc
+	// isOlder is used to accept or reject objects which are older than what's already stored.
+	isOlder IsOlder
 	// indexers maps a name to an IndexFunc
 	indexers Indexers
 	// indices maps a name to an Index
@@ -85,6 +114,16 @@ func (c *cache) Add(obj interface{}) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	oldObject := c.items[key]
+
+	// reject attempts to add older entries
+	if older, err := c.isOlder(obj, oldObject); err != nil {
+		return fmt.Errorf("couldn't compare objects: %v", err)
+	} else {
+		if older {
+			return nil
+		}
+	}
+
 	c.items[key] = obj
 	c.updateIndices(oldObject, obj)
 	return nil
@@ -153,6 +192,16 @@ func (c *cache) Update(obj interface{}) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	oldObject := c.items[key]
+
+	// reject attempts to add older entries
+	if older, err := c.isOlder(obj, oldObject); err != nil {
+		return fmt.Errorf("couldn't compare objects: %v", err)
+	} else {
+		if older {
+			return nil
+		}
+	}
+
 	c.items[key] = obj
 	c.updateIndices(oldObject, obj)
 	return nil
@@ -253,8 +302,8 @@ func (c *cache) Replace(list []interface{}) error {
 }
 
 // NewStore returns a Store implemented simply with a map and a lock.
-func NewStore(keyFunc KeyFunc) Store {
-	return &cache{items: map[string]interface{}{}, keyFunc: keyFunc, indexers: Indexers{}, indices: Indices{}}
+func NewStore(keyFunc KeyFunc, isOlder IsOlder) Store {
+	return &cache{items: map[string]interface{}{}, keyFunc: keyFunc, isOlder: isOlder, indexers: Indexers{}, indices: Indices{}}
 }
 
 // NewIndexer returns an Indexer implemented simply with a map and a lock.

--- a/pkg/client/cache/undelta_store.go
+++ b/pkg/client/cache/undelta_store.go
@@ -81,9 +81,9 @@ func (u *UndeltaStore) Replace(list []interface{}) error {
 }
 
 // NewUndeltaStore returns an UndeltaStore implemented with a Store.
-func NewUndeltaStore(pushFunc func([]interface{}), keyFunc KeyFunc) *UndeltaStore {
+func NewUndeltaStore(pushFunc func([]interface{}), keyFunc KeyFunc, isOlder IsOlder) *UndeltaStore {
 	return &UndeltaStore{
-		ActualStore: NewStore(keyFunc),
+		ActualStore: NewStore(keyFunc, isOlder),
 		PushFunc:    pushFunc,
 	}
 }

--- a/pkg/client/cache/undelta_store.go
+++ b/pkg/client/cache/undelta_store.go
@@ -81,9 +81,9 @@ func (u *UndeltaStore) Replace(list []interface{}) error {
 }
 
 // NewUndeltaStore returns an UndeltaStore implemented with a Store.
-func NewUndeltaStore(pushFunc func([]interface{}), keyFunc KeyFunc, isOlder IsOlder) *UndeltaStore {
+func NewUndeltaStore(pushFunc func([]interface{}), keyFunc KeyFunc, canReplace CanReplace) *UndeltaStore {
 	return &UndeltaStore{
-		ActualStore: NewStore(keyFunc, isOlder),
+		ActualStore: NewStore(keyFunc, canReplace),
 		PushFunc:    pushFunc,
 	}
 }

--- a/pkg/kubelet/config/apiserver.go
+++ b/pkg/kubelet/config/apiserver.go
@@ -53,5 +53,5 @@ func newSourceApiserverFromLW(lw cache.ListerWatcher, updates chan<- interface{}
 		}
 		updates <- kubelet.PodUpdate{bpods, kubelet.SET, kubelet.ApiserverSource}
 	}
-	cache.NewReflector(lw, &api.Pod{}, cache.NewUndeltaStore(send, cache.MetaNamespaceKeyFunc, cache.DefaultIsOlder)).Run()
+	cache.NewReflector(lw, &api.Pod{}, cache.NewUndeltaStore(send, cache.MetaNamespaceKeyFunc, cache.AlwaysReplace)).Run()
 }

--- a/pkg/kubelet/config/apiserver.go
+++ b/pkg/kubelet/config/apiserver.go
@@ -53,5 +53,5 @@ func newSourceApiserverFromLW(lw cache.ListerWatcher, updates chan<- interface{}
 		}
 		updates <- kubelet.PodUpdate{bpods, kubelet.SET, kubelet.ApiserverSource}
 	}
-	cache.NewReflector(lw, &api.Pod{}, cache.NewUndeltaStore(send, cache.MetaNamespaceKeyFunc)).Run()
+	cache.NewReflector(lw, &api.Pod{}, cache.NewUndeltaStore(send, cache.MetaNamespaceKeyFunc, cache.DefaultIsOlder)).Run()
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -93,7 +93,7 @@ func NewMainKubelet(
 		return nil, fmt.Errorf("invalid minimum GC age %d", minimumGCAge)
 	}
 
-	serviceStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	serviceStore := cache.NewStore(cache.MetaNamespaceKeyFunc, cache.DefaultIsOlder)
 	if kubeClient != nil {
 		cache.NewReflector(&cache.ListWatch{kubeClient, labels.Everything(), "services", api.NamespaceAll}, &api.Service{}, serviceStore).Run()
 	}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -93,7 +93,7 @@ func NewMainKubelet(
 		return nil, fmt.Errorf("invalid minimum GC age %d", minimumGCAge)
 	}
 
-	serviceStore := cache.NewStore(cache.MetaNamespaceKeyFunc, cache.DefaultIsOlder)
+	serviceStore := cache.NewStore(cache.MetaNamespaceKeyFunc, cache.AlwaysReplace)
 	if kubeClient != nil {
 		cache.NewReflector(&cache.ListWatch{kubeClient, labels.Everything(), "services", api.NamespaceAll}, &api.Service{}, serviceStore).Run()
 	}

--- a/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -76,7 +76,7 @@ func (p *provision) Admit(a admission.Attributes) (err error) {
 }
 
 func NewProvision(c client.Interface) admission.Interface {
-	store := cache.NewStore(cache.MetaNamespaceKeyFunc, cache.DefaultIsOlder)
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc, cache.AlwaysReplace)
 	reflector := cache.NewReflector(
 		&cache.ListWatch{
 			Client:        c.(*client.Client),

--- a/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -76,7 +76,7 @@ func (p *provision) Admit(a admission.Attributes) (err error) {
 }
 
 func NewProvision(c client.Interface) admission.Interface {
-	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc, cache.DefaultIsOlder)
 	reflector := cache.NewReflector(
 		&cache.ListWatch{
 			Client:        c.(*client.Client),

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -79,7 +79,7 @@ func (e *exists) Admit(a admission.Attributes) (err error) {
 }
 
 func NewExists(c client.Interface) admission.Interface {
-	store := cache.NewStore(cache.MetaNamespaceKeyFunc, cache.DefaultIsOlder)
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc, cache.AlwaysReplace)
 	// TODO: look into a list/watch that can work with client.Interface, maybe pass it a ListFunc and a WatchFunc
 	reflector := cache.NewReflector(
 		&cache.ListWatch{

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -79,7 +79,7 @@ func (e *exists) Admit(a admission.Attributes) (err error) {
 }
 
 func NewExists(c client.Interface) admission.Interface {
-	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc, cache.DefaultIsOlder)
 	// TODO: look into a list/watch that can work with client.Interface, maybe pass it a ListFunc and a WatchFunc
 	reflector := cache.NewReflector(
 		&cache.ListWatch{

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -35,9 +35,9 @@ import (
 )
 
 var (
-	PodLister     = &cache.StoreToPodLister{cache.NewStore(cache.MetaNamespaceKeyFunc, cache.DefaultIsOlder)}
-	MinionLister  = &cache.StoreToNodeLister{cache.NewStore(cache.MetaNamespaceKeyFunc, cache.DefaultIsOlder)}
-	ServiceLister = &cache.StoreToServiceLister{cache.NewStore(cache.MetaNamespaceKeyFunc, cache.DefaultIsOlder)}
+	PodLister     = &cache.StoreToPodLister{cache.NewStore(cache.MetaNamespaceKeyFunc, cache.AlwaysReplace)}
+	MinionLister  = &cache.StoreToNodeLister{cache.NewStore(cache.MetaNamespaceKeyFunc, cache.AlwaysReplace)}
+	ServiceLister = &cache.StoreToServiceLister{cache.NewStore(cache.MetaNamespaceKeyFunc, cache.AlwaysReplace)}
 )
 
 // ConfigFactory knows how to fill out a scheduler config with its support functions.
@@ -57,7 +57,7 @@ type ConfigFactory struct {
 func NewConfigFactory(client *client.Client) *ConfigFactory {
 	return &ConfigFactory{
 		Client:        client,
-		PodQueue:      cache.NewFIFO(cache.MetaNamespaceKeyFunc, cache.DefaultIsOlder),
+		PodQueue:      cache.NewFIFO(cache.MetaNamespaceKeyFunc, cache.AlwaysReplace),
 		PodLister:     PodLister,
 		MinionLister:  MinionLister,
 		ServiceLister: ServiceLister,

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -35,9 +35,9 @@ import (
 )
 
 var (
-	PodLister     = &cache.StoreToPodLister{cache.NewStore(cache.MetaNamespaceKeyFunc)}
-	MinionLister  = &cache.StoreToNodeLister{cache.NewStore(cache.MetaNamespaceKeyFunc)}
-	ServiceLister = &cache.StoreToServiceLister{cache.NewStore(cache.MetaNamespaceKeyFunc)}
+	PodLister     = &cache.StoreToPodLister{cache.NewStore(cache.MetaNamespaceKeyFunc, cache.DefaultIsOlder)}
+	MinionLister  = &cache.StoreToNodeLister{cache.NewStore(cache.MetaNamespaceKeyFunc, cache.DefaultIsOlder)}
+	ServiceLister = &cache.StoreToServiceLister{cache.NewStore(cache.MetaNamespaceKeyFunc, cache.DefaultIsOlder)}
 )
 
 // ConfigFactory knows how to fill out a scheduler config with its support functions.
@@ -57,7 +57,7 @@ type ConfigFactory struct {
 func NewConfigFactory(client *client.Client) *ConfigFactory {
 	return &ConfigFactory{
 		Client:        client,
-		PodQueue:      cache.NewFIFO(cache.MetaNamespaceKeyFunc),
+		PodQueue:      cache.NewFIFO(cache.MetaNamespaceKeyFunc, cache.DefaultIsOlder),
 		PodLister:     PodLister,
 		MinionLister:  MinionLister,
 		ServiceLister: ServiceLister,


### PR DESCRIPTION
Support pluggable version comparison functions in Store implementations. This
allows extending the semantics of FIFO and cache to support rejecting stale updates.
