### PR TITLE
Fix vagrant cluster/kube-up

### DIFF
--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -113,14 +113,13 @@ if [[ "$KUBERNETES_PROVIDER" == "gke" ]]; then
     "--cluster=${CLUSTER_NAME}"
   )
 elif [[ "$KUBERNETES_PROVIDER" == "vagrant" ]]; then
-  # When we are using vagrant it has hard coded auth.  We repeat that here so that
-  # we don't clobber auth that might be used for a publicly facing cluster.
+  # When we are using vagrant it has hard coded kubeconfig, and do not clobber public endpoints
   config=(
-    "--auth-path=$HOME/.kubernetes_vagrant_auth"
-  )
+    "--kubeconfig=$HOME/.kubernetes_vagrant_kubeconfig"
+  )  
 fi
 
-echo "current-context: \"$(${kubectl} config view -o template --template='{{index . "current-context"}}')\"" >&2
+echo "current-context: \"$(${kubectl} "${config[@]:+${config[@]}}" config view -o template --template='{{index . "current-context"}}')\"" >&2
 
 echo "Running:" "${kubectl}" "${config[@]:+${config[@]}}" "${@+$@}" >&2
 "${kubectl}" "${config[@]:+${config[@]}}" "${@+$@}"

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -163,7 +163,7 @@ function verify-cluster {
     local count="0"
     until [[ "$count" == "1" ]]; do
       local minions
-      minions=$("${KUBE_ROOT}/cluster/kubectl.sh" get minions -o template -t '{{range.items}}{{.id}}:{{end}}')
+      minions=$("${KUBE_ROOT}/cluster/kubectl.sh --kubeconfig=${HOME}/.kubernetes_vagrant_kubeconfig" get minions -o template -t '{{range.items}}{{.id}}:{{end}}')
       count=$(echo $minions | grep -c "${MINION_IPS[i]}") || {
         printf "."
         sleep 2
@@ -208,6 +208,27 @@ function kube-up {
   "CertFile": "$HOME/$kube_cert",
   "KeyFile": "$HOME/$kube_key"
 }
+EOF
+
+   cat <<EOF >"${HOME}/.kubernetes_vagrant_kubeconfig"
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://${MASTER_IP}:443
+  name: vagrant
+contexts:
+- context:
+    cluster: vagrant
+    namespace: default
+    user: vagrant
+  name: vagrant
+current-context: "vagrant"
+kind: Config
+preferences: {}
+users:
+- name: vagrant
+  user:
+    auth-path: ${HOME}/.kubernetes_vagrant_auth
 EOF
 
    chmod 0600 ~/.kubernetes_vagrant_auth "${HOME}/${kube_cert}" \


### PR DESCRIPTION
The recent changes to cluster/kube-up.sh broke Vagrant.

This changes vagrant to generate a kubeconfig file and always use that when using that provider.

This way it doesn't clash with other providers.

/cc @deads2k 
