### PR TITLE
kubelet: fix #4472

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -582,6 +582,10 @@ func BuildDockerName(podUID types.UID, podFullName string, container *api.Contai
 // Unpacks a container name, returning the pod full name and container name we would have used to
 // construct the docker name. If the docker name isn't the one we created, we may return empty strings.
 func ParseDockerName(name string) (podFullName string, podUID types.UID, containerName string, hash uint64) {
+	// TODO: return error if the name is nil or empty?
+	if len(name) == 0 {
+		return
+	}
 	// For some reason docker appears to be appending '/' to names.
 	// If it's there, strip it.
 	if name[0] == '/' {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1232,8 +1232,10 @@ func (kl *Kubelet) cleanupOrphanedVolumes(pods []api.BoundPod, running []*docker
 	currentVolumes := kl.getPodVolumesFromDisk()
 	runningSet := util.StringSet{}
 	for ix := range running {
-		_, uid, _, _ := dockertools.ParseDockerName(running[ix].Name)
-		runningSet.Insert(string(uid))
+		if len(running[ix].Name) != 0 {
+			_, uid, _, _ := dockertools.ParseDockerName(running[ix].Name)
+			runningSet.Insert(string(uid))
+		}
 	}
 	for name, vol := range currentVolumes {
 		if _, ok := desiredVolumes[name]; !ok {


### PR DESCRIPTION
By examine the log from
https://travis-ci.org/GoogleCloudPlatform/kubernetes/jobs/50980094
https://travis-ci.org/GoogleCloudPlatform/kubernetes/jobs/50971293
https://travis-ci.org/GoogleCloudPlatform/kubernetes/jobs/50903684,

we are parsing nil name, which cause the panic.

I am not sure why we get the empty name (a nil string since the struct is from json).

But checking the len of the name before parsing is better than no checking anyway.
