### PR TITLE
bugfix in util.sh, fix silent hang

### DIFF
--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -70,7 +70,7 @@ function test-build-release() {
 function verify-prereqs() {
   echo "... in verify-prereqs()" >&2
 
-  ${GCLOUD} preview --help >/dev/null 2>&1 || {
+  ${GCLOUD} preview --help >/dev/null || {
     echo "Either the GCLOUD environment variable is wrong, or the 'preview' component"
     echo "is not installed. (Fix with 'gcloud components update preview')"
   }


### PR DESCRIPTION
`gcloud preview --help >/dev/null 2>&1` would silently hang if the
 preview component was not installed. Instead, let stderr flow normally.

to reproduce the bug and verify the fix:
1. `gcloud components remove preview` #answer yes
2. `gcloud preview --help >/dev/null 2>&1` #note the hang, ^C
3A. `gcloud preview --help >/dev/null` #now prompts you to install preview component

the fix also works when run via `kube-up.sh`

alternatively: `gcloud -q preview --help >/dev/null 2>&1` will silently install
 the missing preview component
