### PR TITLE
Support Rackspace (packet mangling) load balancers

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -683,14 +683,6 @@ const (
 	AffinityTypeNone AffinityType = "None"
 )
 
-// LoadBalancerInfo defines whether the LoadBalancer is rewriting or
-// pass through
-type LoadBalancerInfo struct {
-	DestIP   string `json:"destIP,omitempty" description:"External IP of the Load Balancer"`
-	SourceIP string `json:"sourceIP,omitempty" description:"Source IP of the Load Balancer"`
-	Rewrite  bool   `json:"rewrite,omitempty" description:"Does the LB rewrite packets"`
-}
-
 // ServiceStatus represents the current status of a service
 type ServiceStatus struct{}
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -683,6 +683,14 @@ const (
 	AffinityTypeNone AffinityType = "None"
 )
 
+// LoadBalancerInfo defines whether the LoadBalancer is rewriting or
+// pass through
+type LoadBalancerInfo struct {
+	DestIP   string `json:"destIP,omitempty" description:"External IP of the Load Balancer"`
+	SourceIP string `json:"sourceIP,omitempty" description:"Source IP of the Load Balancer"`
+	Rewrite  bool   `json:"rewrite,omitempty" description:"Does the LB rewrite packets"`
+}
+
 // ServiceStatus represents the current status of a service
 type ServiceStatus struct{}
 
@@ -704,6 +712,8 @@ type ServiceSpec struct {
 	// we will try to respect it or else fail the request.  This field can
 	// not be changed by updates.
 	PortalIP string `json:"portalIP,omitempty"`
+
+	Rewrite bool `json:"rewrite,omitempty" description:"Does the load balancer rewrite packets or pass them through"`
 
 	// CreateExternalLoadBalancer indicates whether a load balancer should be created for this service.
 	CreateExternalLoadBalancer bool `json:"createExternalLoadBalancer,omitempty"`

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -646,6 +646,7 @@ func init() {
 			out.PublicIPs = in.Spec.PublicIPs
 			out.ContainerPort = in.Spec.ContainerPort
 			out.PortalIP = in.Spec.PortalIP
+			out.Rewrite = in.Spec.Rewrite
 			if err := s.Convert(&in.Spec.SessionAffinity, &out.SessionAffinity, 0); err != nil {
 				return err
 			}
@@ -672,6 +673,7 @@ func init() {
 			out.Spec.PublicIPs = in.PublicIPs
 			out.Spec.ContainerPort = in.ContainerPort
 			out.Spec.PortalIP = in.PortalIP
+			out.Spec.Rewrite = in.Rewrite
 			if err := s.Convert(&in.SessionAffinity, &out.Spec.SessionAffinity, 0); err != nil {
 				return err
 			}

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -545,14 +545,6 @@ const (
 	AffinityTypeNone AffinityType = "None"
 )
 
-// LoadBalancerInfo defines whether the LoadBalancer is rewriting or
-// pass through
-type LoadBalancerInfo struct {
-	DestIP   string `json:"destIP,omitempty" description:"External IP of the Load Balancer"`
-	SourceIP string `json:"sourceIP,omitempty" description:"Source IP of the Load Balancer"`
-	Rewrite  bool   `json:"rewrite,omitempty" description:"Does the LB rewrite packets"`
-}
-
 // ServiceList holds a list of services.
 type ServiceList struct {
 	TypeMeta `json:",inline"`

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -545,6 +545,14 @@ const (
 	AffinityTypeNone AffinityType = "None"
 )
 
+// LoadBalancerInfo defines whether the LoadBalancer is rewriting or
+// pass through
+type LoadBalancerInfo struct {
+	DestIP   string `json:"destIP,omitempty" description:"External IP of the Load Balancer"`
+	SourceIP string `json:"sourceIP,omitempty" description:"Source IP of the Load Balancer"`
+	Rewrite  bool   `json:"rewrite,omitempty" description:"Does the LB rewrite packets"`
+}
+
 // ServiceList holds a list of services.
 type ServiceList struct {
 	TypeMeta `json:",inline"`
@@ -585,6 +593,8 @@ type Service struct {
 
 	// DEPRECATED: has no implementation.
 	ProxyPort int `json:"proxyPort,omitempty" description:"if non-zero, a pre-allocated host port used for this service by the proxy on each node; assigned by the master and ignored on input"`
+
+	Rewrite bool `json:"rewrite,omitempty" description:"Does the load balancer rewrite packets or pass them through"`
 
 	// Optional: Supports "ClientIP" and "None".  Used to maintain session affinity.
 	SessionAffinity AffinityType `json:"sessionAffinity,omitempty" description:"enable client IP based session affinity; must be ClientIP or None; defaults to None"`

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -566,6 +566,7 @@ func init() {
 			out.PublicIPs = in.Spec.PublicIPs
 			out.ContainerPort = in.Spec.ContainerPort
 			out.PortalIP = in.Spec.PortalIP
+			out.Rewrite = in.Spec.Rewrite
 			if err := s.Convert(&in.Spec.SessionAffinity, &out.SessionAffinity, 0); err != nil {
 				return err
 			}
@@ -592,6 +593,7 @@ func init() {
 			out.Spec.PublicIPs = in.PublicIPs
 			out.Spec.ContainerPort = in.ContainerPort
 			out.Spec.PortalIP = in.PortalIP
+			out.Spec.Rewrite = in.Rewrite
 			if err := s.Convert(&in.SessionAffinity, &out.Spec.SessionAffinity, 0); err != nil {
 				return err
 			}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -509,14 +509,6 @@ const (
 	AffinityTypeNone AffinityType = "None"
 )
 
-// LoadBalancerInfo defines whether the LoadBalancer is rewriting or
-// pass through
-type LoadBalancerInfo struct {
-	DestIP   string `json:"destIP,omitempty" description:"External IP of the Load Balancer"`
-	SourceIP string `json:"sourceIP,omitempty" description:"Source IP of the Load Balancer"`
-	Rewrite  bool   `json:"rewrite,omitempty" description:"Does the LB rewrite packets"`
-}
-
 // ServiceList holds a list of services.
 type ServiceList struct {
 	TypeMeta `json:",inline"`

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -509,6 +509,14 @@ const (
 	AffinityTypeNone AffinityType = "None"
 )
 
+// LoadBalancerInfo defines whether the LoadBalancer is rewriting or
+// pass through
+type LoadBalancerInfo struct {
+	DestIP   string `json:"destIP,omitempty" description:"External IP of the Load Balancer"`
+	SourceIP string `json:"sourceIP,omitempty" description:"Source IP of the Load Balancer"`
+	Rewrite  bool   `json:"rewrite,omitempty" description:"Does the LB rewrite packets"`
+}
+
 // ServiceList holds a list of services.
 type ServiceList struct {
 	TypeMeta `json:",inline"`
@@ -536,6 +544,8 @@ type Service struct {
 
 	// PublicIPs are used by external load balancers.
 	PublicIPs []string `json:"publicIPs,omitempty" description:"externally visible IPs from which to select the address for the external load balancer"`
+
+	Rewrite bool `json:"rewrite,omitempty" description:"Does the load balancer rewrite packets or pass them through"`
 
 	// ContainerPort is the name or number of the port on the container to direct traffic to.
 	// This is useful if the containers the service points to have multiple open ports.

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -709,14 +709,6 @@ const (
 	AffinityTypeNone AffinityType = "None"
 )
 
-// LoadBalancerInfo defines whether the LoadBalancer is rewriting or
-// pass through
-type LoadBalancerInfo struct {
-	DestIP   string `json:"destIP,omitempty" description:"External IP of the Load Balancer"`
-	SourceIP string `json:"sourceIP,omitempty" description:"Source IP of the Load Balancer"`
-	Rewrite  bool   `json:"rewrite,omitempty" description:"Does the LB rewrite packets"`
-}
-
 // ServiceStatus represents the current status of a service
 type ServiceStatus struct{}
 

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -709,6 +709,14 @@ const (
 	AffinityTypeNone AffinityType = "None"
 )
 
+// LoadBalancerInfo defines whether the LoadBalancer is rewriting or
+// pass through
+type LoadBalancerInfo struct {
+	DestIP   string `json:"destIP,omitempty" description:"External IP of the Load Balancer"`
+	SourceIP string `json:"sourceIP,omitempty" description:"Source IP of the Load Balancer"`
+	Rewrite  bool   `json:"rewrite,omitempty" description:"Does the LB rewrite packets"`
+}
+
 // ServiceStatus represents the current status of a service
 type ServiceStatus struct{}
 
@@ -728,6 +736,8 @@ type ServiceSpec struct {
 	// we will try to respect it or else fail the request.  This field can
 	// not be changed by updates.
 	PortalIP string `json:"portalIP,omitempty"`
+
+	Rewrite bool `json:"rewrite,omitempty" description:"Does the load balancer rewrite packets or pass them through"`
 
 	// CreateExternalLoadBalancer indicates whether a load balancer should be created for this service.
 	CreateExternalLoadBalancer bool `json:"createExternalLoadBalancer,omitempty"`

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -48,7 +48,7 @@ type TCPLoadBalancer interface {
 	// TODO: Break this up into different interfaces (LB, etc) when we have more than one type of service
 	TCPLoadBalancerExists(name, region string) (bool, error)
 	// CreateTCPLoadBalancer creates a new tcp load balancer. Returns the IP address of the balancer
-	CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (net.IP, error)
+	CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (*api.LoadBalancerInfo, error)
 	// UpdateTCPLoadBalancer updates hosts under the specified load balancer.
 	UpdateTCPLoadBalancer(name, region string, hosts []string) error
 	// DeleteTCPLoadBalancer deletes a specified load balancer.

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -42,13 +42,20 @@ type Clusters interface {
 	Master(clusterName string) (string, error)
 }
 
+// LoadBalancerInfo defines whether the LoadBalancer is rewriting or pass through
+type LoadBalancerInfo struct {
+	DestIP   string `json:"destIP,omitempty" description:"External IP of the Load Balancer"`
+	SourceIP string `json:"sourceIP,omitempty" description:"Source IP of the Load Balancer"`
+	Rewrite  bool   `json:"rewrite,omitempty" description:"Does the LB rewrite packets"`
+}
+
 // TCPLoadBalancer is an abstract, pluggable interface for TCP load balancers.
 type TCPLoadBalancer interface {
 	// TCPLoadBalancerExists returns whether the specified load balancer exists.
 	// TODO: Break this up into different interfaces (LB, etc) when we have more than one type of service
 	TCPLoadBalancerExists(name, region string) (bool, error)
 	// CreateTCPLoadBalancer creates a new tcp load balancer. Returns the IP address of the balancer
-	CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (*api.LoadBalancerInfo, error)
+	CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (*LoadBalancerInfo, error)
 	// UpdateTCPLoadBalancer updates hosts under the specified load balancer.
 	UpdateTCPLoadBalancer(name, region string, hosts []string) error
 	// DeleteTCPLoadBalancer deletes a specified load balancer.

--- a/pkg/cloudprovider/fake/fake.go
+++ b/pkg/cloudprovider/fake/fake.go
@@ -84,10 +84,10 @@ func (f *FakeCloud) TCPLoadBalancerExists(name, region string) (bool, error) {
 
 // CreateTCPLoadBalancer is a test-spy implementation of TCPLoadBalancer.CreateTCPLoadBalancer.
 // It adds an entry "create" into the internal method call record.
-func (f *FakeCloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (*api.LoadBalancerInfo, error) {
+func (f *FakeCloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (*cloudprovider.LoadBalancerInfo, error) {
 	f.addCall("create")
 
-	loadBalancerInfo := &api.LoadBalancerInfo{Rewrite: false}
+	loadBalancerInfo := &cloudprovider.LoadBalancerInfo{Rewrite: false}
 	loadBalancerInfo.DestIP = f.ExternalIP.String()
 	return loadBalancerInfo, f.Err
 }

--- a/pkg/cloudprovider/fake/fake.go
+++ b/pkg/cloudprovider/fake/fake.go
@@ -84,9 +84,12 @@ func (f *FakeCloud) TCPLoadBalancerExists(name, region string) (bool, error) {
 
 // CreateTCPLoadBalancer is a test-spy implementation of TCPLoadBalancer.CreateTCPLoadBalancer.
 // It adds an entry "create" into the internal method call record.
-func (f *FakeCloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (net.IP, error) {
+func (f *FakeCloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (*api.LoadBalancerInfo, error) {
 	f.addCall("create")
-	return f.ExternalIP, f.Err
+
+	loadBalancerInfo := &api.LoadBalancerInfo{Rewrite: false}
+	loadBalancerInfo.DestIP = f.ExternalIP.String()
+	return loadBalancerInfo, f.Err
 }
 
 // UpdateTCPLoadBalancer is a test-spy implementation of TCPLoadBalancer.UpdateTCPLoadBalancer.

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -215,7 +215,7 @@ func translateAffinityType(affinityType api.AffinityType) GCEAffinityType {
 }
 
 // CreateTCPLoadBalancer is an implementation of TCPLoadBalancer.CreateTCPLoadBalancer.
-func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (*api.LoadBalancerInfo, error) {
+func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (*cloudprovider.LoadBalancerInfo, error) {
 	pool, err := gce.makeTargetPool(name, region, hosts, translateAffinityType(affinityType))
 	if err != nil {
 		return nil, err
@@ -241,7 +241,7 @@ func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.I
 	if err != nil {
 		return nil, err
 	}
-	loadBalancerInfo := &api.LoadBalancerInfo{Rewrite: false}
+	loadBalancerInfo := &cloudprovider.LoadBalancerInfo{Rewrite: false}
 	loadBalancerInfo.DestIP = fwd.IPAddress
 	return loadBalancerInfo, nil
 }

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -215,7 +215,7 @@ func translateAffinityType(affinityType api.AffinityType) GCEAffinityType {
 }
 
 // CreateTCPLoadBalancer is an implementation of TCPLoadBalancer.CreateTCPLoadBalancer.
-func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (net.IP, error) {
+func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (*api.LoadBalancerInfo, error) {
 	pool, err := gce.makeTargetPool(name, region, hosts, translateAffinityType(affinityType))
 	if err != nil {
 		return nil, err
@@ -241,7 +241,9 @@ func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.I
 	if err != nil {
 		return nil, err
 	}
-	return net.ParseIP(fwd.IPAddress), nil
+	loadBalancerInfo := &api.LoadBalancerInfo{Rewrite: false}
+	loadBalancerInfo.DestIP = fwd.IPAddress
+	return loadBalancerInfo, nil
 }
 
 // UpdateTCPLoadBalancer is an implementation of TCPLoadBalancer.UpdateTCPLoadBalancer.

--- a/pkg/cloudprovider/openstack/openstack.go
+++ b/pkg/cloudprovider/openstack/openstack.go
@@ -416,7 +416,7 @@ func (lb *LoadBalancer) TCPLoadBalancerExists(name, region string) (bool, error)
 // a list of regions (from config) and query/create loadbalancers in
 // each region.
 
-func (lb *LoadBalancer) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinity api.AffinityType) (net.IP, error) {
+func (lb *LoadBalancer) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinity api.AffinityType) (*api.LoadBalancerInfo, error) {
 	glog.V(2).Infof("CreateTCPLoadBalancer(%v, %v, %v, %v, %v)", name, region, externalIP, port, hosts)
 	if affinity != api.AffinityTypeNone {
 		return nil, fmt.Errorf("unsupported load balancer affinity: %v", affinity)
@@ -484,7 +484,9 @@ func (lb *LoadBalancer) CreateTCPLoadBalancer(name, region string, externalIP ne
 		return nil, err
 	}
 
-	return net.ParseIP(vip.Address), nil
+	loadBalancerInfo := &api.LoadBalancerInfo{Rewrite: false}
+	loadBalancerInfo.DestIP = vip.Address
+	return loadBalancerInfo, nil
 }
 
 func (lb *LoadBalancer) UpdateTCPLoadBalancer(name, region string, hosts []string) error {

--- a/pkg/cloudprovider/openstack/openstack.go
+++ b/pkg/cloudprovider/openstack/openstack.go
@@ -416,7 +416,7 @@ func (lb *LoadBalancer) TCPLoadBalancerExists(name, region string) (bool, error)
 // a list of regions (from config) and query/create loadbalancers in
 // each region.
 
-func (lb *LoadBalancer) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinity api.AffinityType) (*api.LoadBalancerInfo, error) {
+func (lb *LoadBalancer) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinity api.AffinityType) (*cloudprovider.LoadBalancerInfo, error) {
 	glog.V(2).Infof("CreateTCPLoadBalancer(%v, %v, %v, %v, %v)", name, region, externalIP, port, hosts)
 	if affinity != api.AffinityTypeNone {
 		return nil, fmt.Errorf("unsupported load balancer affinity: %v", affinity)
@@ -484,7 +484,7 @@ func (lb *LoadBalancer) CreateTCPLoadBalancer(name, region string, externalIP ne
 		return nil, err
 	}
 
-	loadBalancerInfo := &api.LoadBalancerInfo{Rewrite: false}
+	loadBalancerInfo := &cloudprovider.LoadBalancerInfo{Rewrite: false}
 	loadBalancerInfo.DestIP = vip.Address
 	return loadBalancerInfo, nil
 }

--- a/pkg/cloudprovider/rackspace/rackspace.go
+++ b/pkg/cloudprovider/rackspace/rackspace.go
@@ -472,7 +472,7 @@ func (lb *LoadBalancer) TCPLoadBalancerExists(name, region string) (bool, error)
 // a list of regions (from config) and query/create loadbalancers in
 // each region.
 
-func (lb *LoadBalancer) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinity api.AffinityType) (*api.LoadBalancerInfo, error) {
+func (lb *LoadBalancer) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinity api.AffinityType) (*cloudprovider.LoadBalancerInfo, error) {
 	glog.V(2).Infof("CreateTCPLoadBalancer(%v, %v, %v, %v, %v)", name, region, externalIP, port, hosts)
 	if affinity != api.AffinityTypeNone {
 		return nil, fmt.Errorf("unsupported load balancer affinity: %v", affinity)
@@ -525,7 +525,7 @@ func (lb *LoadBalancer) CreateTCPLoadBalancer(name, region string, externalIP ne
 	}
 
 	glog.V(2).Infof("LB Source Address is %+v", pool.SourceAddrs)
-	loadBalancerInfo := &api.LoadBalancerInfo{Rewrite: true}
+	loadBalancerInfo := &cloudprovider.LoadBalancerInfo{Rewrite: true}
 	loadBalancerInfo.DestIP = pool.VIPs[0].Address
 	loadBalancerInfo.SourceIP = pool.SourceAddrs.IPv4Private
 	return loadBalancerInfo, nil

--- a/pkg/cloudprovider/rackspace/rackspace.go
+++ b/pkg/cloudprovider/rackspace/rackspace.go
@@ -31,6 +31,9 @@ import (
 	"github.com/rackspace/gophercloud/rackspace"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/flavors"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
+	"github.com/rackspace/gophercloud/rackspace/lb/v1/lbs"
+	"github.com/rackspace/gophercloud/rackspace/lb/v1/nodes"
+	"github.com/rackspace/gophercloud/rackspace/lb/v1/vips"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
@@ -393,8 +396,221 @@ func (os *Rackspace) Clusters() (cloudprovider.Clusters, bool) {
 	return nil, false
 }
 
+type LoadBalancer struct {
+	network *gophercloud.ServiceClient
+	compute *gophercloud.ServiceClient
+	opts    LoadBalancerOpts
+}
+
 func (os *Rackspace) TCPLoadBalancer() (cloudprovider.TCPLoadBalancer, bool) {
-	return nil, false
+	// TODO: Search for and support Rackspace loadbalancer API, and others.
+	network, err := rackspace.NewLBV1(os.provider, gophercloud.EndpointOpts{
+		Region: os.region,
+	})
+	if err != nil {
+		glog.Warningf("Failed to find LB endpoint: %v", err)
+		return nil, false
+	}
+
+	compute, err := rackspace.NewComputeV2(os.provider, gophercloud.EndpointOpts{
+		Region: os.region,
+	})
+	if err != nil {
+		glog.Warningf("Failed to find compute endpoint: %v", err)
+		return nil, false
+	}
+
+	glog.V(1).Info("Claiming to support TCPLoadBalancer")
+
+	return &LoadBalancer{network, compute, os.lbOpts}, true
+}
+
+func getVipByName(client *gophercloud.ServiceClient, name string) (*lbs.LoadBalancer, error) {
+	pager := lbs.List(client, nil)
+
+	vipList := make([]lbs.LoadBalancer, 0)
+
+	err := pager.EachPage(func(page pagination.Page) (bool, error) {
+		list, err := lbs.ExtractLBs(page)
+		if err != nil {
+			return false, err
+		}
+		for _, v := range list {
+			if v.Name == name {
+				vipList = append(vipList, v)
+			}
+		}
+
+		if len(vipList) > 1 {
+			return false, ErrMultipleResults
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(vipList) == 0 {
+		return nil, ErrNotFound
+	} else if len(vipList) > 1 {
+		return nil, ErrMultipleResults
+	}
+
+	return &vipList[0], nil
+}
+
+func (lb *LoadBalancer) TCPLoadBalancerExists(name, region string) (bool, error) {
+	vip, err := getVipByName(lb.network, name)
+	if err == ErrNotFound {
+		return false, nil
+	}
+	return vip != nil, err
+}
+
+// TODO: This code currently ignores 'region' and always creates a
+// loadbalancer in only the current Rackspace region.  We should take
+// a list of regions (from config) and query/create loadbalancers in
+// each region.
+
+func (lb *LoadBalancer) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinity api.AffinityType) (*api.LoadBalancerInfo, error) {
+	glog.V(2).Infof("CreateTCPLoadBalancer(%v, %v, %v, %v, %v)", name, region, externalIP, port, hosts)
+	if affinity != api.AffinityTypeNone {
+		return nil, fmt.Errorf("unsupported load balancer affinity: %v", affinity)
+	}
+
+	vipList := []vips.VIP{
+		{
+			Type:    vips.PUBLIC,
+			Version: vips.IPV4,
+		},
+	}
+
+	pool, err := lbs.Create(lb.network, lbs.CreateOpts{
+		Name:     name,
+		Protocol: "TCP_CLIENT_FIRST",
+		VIPs:     vipList,
+		Port:     port,
+	}).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	nodeList := make(nodes.CreateOpts, 0, 1)
+	for _, host := range hosts {
+		addr, err := getAddressByName(lb.compute, host)
+		if err != nil {
+			return nil, err
+		}
+
+		nodeList = append(nodeList, nodes.CreateOpt{
+			Port:      port,
+			Address:   addr,
+			Condition: nodes.ENABLED,
+			Type:      nodes.PRIMARY,
+		})
+	}
+
+	glog.V(2).Infof("Waiting for LB to be ready")
+	poll, _ := lbs.Get(lb.network, pool.ID).Extract()
+	for poll.Status != lbs.ACTIVE {
+		time.Sleep(time.Second * 5)
+		poll, _ = lbs.Get(lb.network, pool.ID).Extract()
+	}
+
+	glog.V(2).Infof("Adding nodes to LB %v with ID %v", name, pool.ID)
+	_, err = nodes.Create(lb.network, pool.ID, nodeList).ExtractNodes()
+	if err != nil {
+		lbs.Delete(lb.network, pool.ID)
+		return nil, err
+	}
+
+	glog.V(2).Infof("LB Source Address is %+v", pool.SourceAddrs)
+	loadBalancerInfo := &api.LoadBalancerInfo{Rewrite: true}
+	loadBalancerInfo.DestIP = pool.VIPs[0].Address
+	loadBalancerInfo.SourceIP = pool.SourceAddrs.IPv4Private
+	return loadBalancerInfo, nil
+}
+
+func (lb *LoadBalancer) UpdateTCPLoadBalancer(name, region string, hosts []string) error {
+	glog.V(2).Infof("UpdateTCPLoadBalancer(%v, %v, %v)", name, region, hosts)
+
+	vip, err := getVipByName(lb.network, name)
+	if err != nil {
+		return err
+	}
+
+	// Set of member (addresses) that _should_ exist
+	addrs := map[string]bool{}
+	for _, host := range hosts {
+		addr, err := getAddressByName(lb.compute, host)
+		if err != nil {
+			return err
+		}
+
+		addrs[addr] = true
+	}
+
+	// Iterate over members that _do_ exist
+	pager := nodes.List(lb.network, vip.ID, nil)
+	err = pager.EachPage(func(page pagination.Page) (bool, error) {
+		memList, err := nodes.ExtractNodes(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, member := range memList {
+			if _, found := addrs[member.Address]; found {
+				// Member already exists
+				delete(addrs, member.Address)
+			} else {
+				// Member needs to be deleted
+				err = nodes.Delete(lb.network, vip.ID, member.ID).ExtractErr()
+				if err != nil {
+					return false, err
+				}
+			}
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Anything left in addrs is a new member that needs to be added
+	nodeList := make(nodes.CreateOpts, 0, 1)
+	for addr := range addrs {
+		nodeList = append(nodeList, nodes.CreateOpt{
+			Address: addr,
+			Port:    vip.Port,
+		})
+	}
+	_, err = nodes.Create(lb.network, vip.ID, nodeList).ExtractNodes()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (lb *LoadBalancer) DeleteTCPLoadBalancer(name, region string) error {
+	glog.V(2).Infof("DeleteTCPLoadBalancer(%v, %v)", name, region)
+
+	vip, err := getVipByName(lb.network, name)
+	if err != nil {
+		return err
+	}
+
+	pool, err := lbs.Get(lb.network, vip.ID).Extract()
+	if err != nil {
+		return err
+	}
+
+	// Ignore errors for everything following here
+
+	lbs.Delete(lb.network, pool.ID)
+
+	return nil
 }
 
 func (os *Rackspace) Zones() (cloudprovider.Zones, bool) {

--- a/pkg/cloudprovider/rackspace/rackspace_test.go
+++ b/pkg/cloudprovider/rackspace/rackspace_test.go
@@ -157,6 +157,31 @@ func TestInstances(t *testing.T) {
 	t.Logf("Found GetNodeResources(%s) = %s\n", srvs[0], rsrcs)
 }
 
+func TestTCPLoadBalancer(t *testing.T) {
+	cfg, ok := configFromEnv()
+	if !ok {
+		t.Skipf("No config found in environment")
+	}
+
+	os, err := newRackspace(cfg)
+	if err != nil {
+		t.Fatalf("Failed to construct/authenticate Rackspace: %s", err)
+	}
+
+	lb, ok := os.TCPLoadBalancer()
+	if !ok {
+		t.Fatalf("TCPLoadBalancer() returned false - perhaps your stack doesn't support Neutron?")
+	}
+
+	exists, err := lb.TCPLoadBalancerExists("noexist", "region")
+	if err != nil {
+		t.Fatalf("TCPLoadBalancerExists(\"noexist\") returned error: %s", err)
+	}
+	if exists {
+		t.Fatalf("TCPLoadBalancerExists(\"noexist\") returned true")
+	}
+}
+
 func TestZones(t *testing.T) {
 	os := Rackspace{
 		provider: &gophercloud.ProviderClient{

--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -576,7 +576,7 @@ func (proxier *Proxier) closePortal(service string, info *serviceInfo) error {
 	// Collect errors and report them all at the end.
 	el := proxier.closeOnePortal(info.portalIP, info.portalPort, info.protocol, proxier.listenIP, info.proxyPort, service, false)
 	for _, publicIP := range info.publicIP {
-		el = append(el, proxier.closeOnePortal(net.ParseIP(publicIP), info.portalPort, info.protocol, proxier.listenIP, info.proxyPort, service, false)...)
+		el = append(el, proxier.closeOnePortal(net.ParseIP(publicIP), info.portalPort, info.protocol, proxier.listenIP, info.proxyPort, service, info.rewrite)...)
 	}
 	if len(el) == 0 {
 		glog.Infof("Closed iptables portals for service %q", service)

--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -44,6 +44,7 @@ type serviceInfo struct {
 	publicIP            []string
 	sessionAffinityType api.AffinityType
 	stickyMaxAgeMinutes int
+	rewrite             bool
 }
 
 // How long we wait for a connection to a backend in seconds
@@ -490,6 +491,7 @@ func (proxier *Proxier) OnUpdate(services []api.Service) {
 		info.portalIP = serviceIP
 		info.portalPort = service.Spec.Port
 		info.publicIP = service.Spec.PublicIPs
+		info.rewrite = service.Spec.Rewrite
 		info.sessionAffinityType = service.Spec.SessionAffinity
 		// TODO: paramaterize this in the types api file as an attribute of sticky session.   For now it's hardcoded to 3 hours.
 		info.stickyMaxAgeMinutes = 180
@@ -531,12 +533,13 @@ func ipsEqual(lhs, rhs []string) bool {
 }
 
 func (proxier *Proxier) openPortal(service string, info *serviceInfo) error {
-	err := proxier.openOnePortal(info.portalIP, info.portalPort, info.protocol, proxier.listenIP, info.proxyPort, service)
+	err := proxier.openOnePortal(info.portalIP, info.portalPort, info.protocol, proxier.listenIP, info.proxyPort, service, false)
 	if err != nil {
 		return err
 	}
 	for _, publicIP := range info.publicIP {
-		err = proxier.openOnePortal(net.ParseIP(publicIP), info.portalPort, info.protocol, proxier.listenIP, info.proxyPort, service)
+		glog.V(1).Infof("LB for %v: Rewrite is %v, IP is %v", service, info.rewrite, publicIP)
+		err = proxier.openOnePortal(net.ParseIP(publicIP), info.portalPort, info.protocol, proxier.listenIP, info.proxyPort, service, info.rewrite)
 		if err != nil {
 			return err
 		}
@@ -544,9 +547,9 @@ func (proxier *Proxier) openPortal(service string, info *serviceInfo) error {
 	return nil
 }
 
-func (proxier *Proxier) openOnePortal(portalIP net.IP, portalPort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, name string) error {
+func (proxier *Proxier) openOnePortal(portalIP net.IP, portalPort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, name string, rewrite bool) error {
 	// Handle traffic from containers.
-	args := proxier.iptablesContainerPortalArgs(portalIP, portalPort, protocol, proxyIP, proxyPort, name)
+	args := proxier.iptablesContainerPortalArgs(portalIP, portalPort, protocol, proxyIP, proxyPort, name, rewrite)
 	existed, err := proxier.iptables.EnsureRule(iptables.TableNAT, iptablesContainerPortalChain, args...)
 	if err != nil {
 		glog.Errorf("Failed to install iptables %s rule for service %q", iptablesContainerPortalChain, name)
@@ -557,7 +560,7 @@ func (proxier *Proxier) openOnePortal(portalIP net.IP, portalPort int, protocol 
 	}
 
 	// Handle traffic from the host.
-	args = proxier.iptablesHostPortalArgs(portalIP, portalPort, protocol, proxyIP, proxyPort, name)
+	args = proxier.iptablesHostPortalArgs(portalIP, portalPort, protocol, proxyIP, proxyPort, name, rewrite)
 	existed, err = proxier.iptables.EnsureRule(iptables.TableNAT, iptablesHostPortalChain, args...)
 	if err != nil {
 		glog.Errorf("Failed to install iptables %s rule for service %q", iptablesHostPortalChain, name)
@@ -571,9 +574,9 @@ func (proxier *Proxier) openOnePortal(portalIP net.IP, portalPort int, protocol 
 
 func (proxier *Proxier) closePortal(service string, info *serviceInfo) error {
 	// Collect errors and report them all at the end.
-	el := proxier.closeOnePortal(info.portalIP, info.portalPort, info.protocol, proxier.listenIP, info.proxyPort, service)
+	el := proxier.closeOnePortal(info.portalIP, info.portalPort, info.protocol, proxier.listenIP, info.proxyPort, service, false)
 	for _, publicIP := range info.publicIP {
-		el = append(el, proxier.closeOnePortal(net.ParseIP(publicIP), info.portalPort, info.protocol, proxier.listenIP, info.proxyPort, service)...)
+		el = append(el, proxier.closeOnePortal(net.ParseIP(publicIP), info.portalPort, info.protocol, proxier.listenIP, info.proxyPort, service, false)...)
 	}
 	if len(el) == 0 {
 		glog.Infof("Closed iptables portals for service %q", service)
@@ -583,18 +586,18 @@ func (proxier *Proxier) closePortal(service string, info *serviceInfo) error {
 	return errors.NewAggregate(el)
 }
 
-func (proxier *Proxier) closeOnePortal(portalIP net.IP, portalPort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, name string) []error {
+func (proxier *Proxier) closeOnePortal(portalIP net.IP, portalPort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, name string, rewrite bool) []error {
 	el := []error{}
 
 	// Handle traffic from containers.
-	args := proxier.iptablesContainerPortalArgs(portalIP, portalPort, protocol, proxyIP, proxyPort, name)
+	args := proxier.iptablesContainerPortalArgs(portalIP, portalPort, protocol, proxyIP, proxyPort, name, rewrite)
 	if err := proxier.iptables.DeleteRule(iptables.TableNAT, iptablesContainerPortalChain, args...); err != nil {
 		glog.Errorf("Failed to delete iptables %s rule for service %q", iptablesContainerPortalChain, name)
 		el = append(el, err)
 	}
 
 	// Handle traffic from the host.
-	args = proxier.iptablesHostPortalArgs(portalIP, portalPort, protocol, proxyIP, proxyPort, name)
+	args = proxier.iptablesHostPortalArgs(portalIP, portalPort, protocol, proxyIP, proxyPort, name, rewrite)
 	if err := proxier.iptables.DeleteRule(iptables.TableNAT, iptablesHostPortalChain, args...); err != nil {
 		glog.Errorf("Failed to delete iptables %s rule for service %q", iptablesHostPortalChain, name)
 		el = append(el, err)
@@ -662,7 +665,7 @@ var zeroIPv6 = net.ParseIP("::0")
 var localhostIPv6 = net.ParseIP("::1")
 
 // Build a slice of iptables args that are common to from-container and from-host portal rules.
-func iptablesCommonPortalArgs(destIP net.IP, destPort int, protocol api.Protocol, service string) []string {
+func iptablesCommonPortalArgs(destIP net.IP, destPort int, protocol api.Protocol, service string, rewrite bool) []string {
 	// This list needs to include all fields as they are eventually spit out
 	// by iptables-save.  This is because some systems do not support the
 	// 'iptables -C' arg, and so fall back on parsing iptables-save output.
@@ -676,15 +679,19 @@ func iptablesCommonPortalArgs(destIP net.IP, destPort int, protocol api.Protocol
 		"--comment", service,
 		"-p", strings.ToLower(string(protocol)),
 		"-m", strings.ToLower(string(protocol)),
-		"-d", fmt.Sprintf("%s/32", destIP.String()),
 		"--dport", fmt.Sprintf("%d", destPort),
+	}
+	if rewrite {
+		args = append(args, "-s", fmt.Sprintf("%s/32", destIP.String()))
+	} else {
+		args = append(args, "-d", fmt.Sprintf("%s/32", destIP.String()))
 	}
 	return args
 }
 
 // Build a slice of iptables args for a from-container portal rule.
-func (proxier *Proxier) iptablesContainerPortalArgs(destIP net.IP, destPort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, service string) []string {
-	args := iptablesCommonPortalArgs(destIP, destPort, protocol, service)
+func (proxier *Proxier) iptablesContainerPortalArgs(destIP net.IP, destPort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, service string, rewrite bool) []string {
+	args := iptablesCommonPortalArgs(destIP, destPort, protocol, service, rewrite)
 
 	// This is tricky.
 	//
@@ -730,8 +737,8 @@ func (proxier *Proxier) iptablesContainerPortalArgs(destIP net.IP, destPort int,
 }
 
 // Build a slice of iptables args for a from-host portal rule.
-func (proxier *Proxier) iptablesHostPortalArgs(destIP net.IP, destPort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, service string) []string {
-	args := iptablesCommonPortalArgs(destIP, destPort, protocol, service)
+func (proxier *Proxier) iptablesHostPortalArgs(destIP net.IP, destPort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, service string, rewrite bool) []string {
+	args := iptablesCommonPortalArgs(destIP, destPort, protocol, service, rewrite)
 
 	// This is tricky.
 	//

--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -664,6 +664,14 @@ var localhostIPv4 = net.ParseIP("127.0.0.1")
 var zeroIPv6 = net.ParseIP("::0")
 var localhostIPv6 = net.ParseIP("::1")
 
+func getDestinationFlag(rewrite bool) string {
+	if rewrite {
+		return "-s"
+	} else {
+		return "-d"
+	}
+}
+
 // Build a slice of iptables args that are common to from-container and from-host portal rules.
 func iptablesCommonPortalArgs(destIP net.IP, destPort int, protocol api.Protocol, service string, rewrite bool) []string {
 	// This list needs to include all fields as they are eventually spit out
@@ -679,12 +687,8 @@ func iptablesCommonPortalArgs(destIP net.IP, destPort int, protocol api.Protocol
 		"--comment", service,
 		"-p", strings.ToLower(string(protocol)),
 		"-m", strings.ToLower(string(protocol)),
+		getDestinationFlag(rewrite), fmt.Sprintf("%s/32", destIP.String()),
 		"--dport", fmt.Sprintf("%d", destPort),
-	}
-	if rewrite {
-		args = append(args, "-s", fmt.Sprintf("%s/32", destIP.String()))
-	} else {
-		args = append(args, "-d", fmt.Sprintf("%s/32", destIP.String()))
 	}
 	return args
 }

--- a/pkg/registry/service/rest.go
+++ b/pkg/registry/service/rest.go
@@ -264,12 +264,18 @@ func (rs *REST) createExternalLoadBalancer(ctx api.Context, service *api.Service
 			}
 		}
 	} else {
-		ip, err := balancer.CreateTCPLoadBalancer(service.Name, zone.Region, nil, service.Spec.Port, hostsFromMinionList(hosts), affinityType)
+		lb, err := balancer.CreateTCPLoadBalancer(service.Name, zone.Region, nil, service.Spec.Port, hostsFromMinionList(hosts), affinityType)
 		if err != nil {
 			return err
 		}
-		service.Spec.PublicIPs = []string{ip.String()}
+		if lb.Rewrite {
+			service.Spec.PublicIPs = []string{lb.SourceIP}
+		} else {
+			service.Spec.PublicIPs = []string{lb.DestIP}
+		}
+		service.Spec.Rewrite = lb.Rewrite
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
This introduces a flag to allow cloud providers to signal that their load
balancers are rewriting (NATing) incoming packets. This allows us to
support Rackspace cloud LBs out of the box, and should make it easier to
handle AWS down the line.

This has a dependency on #4478; and used to be #4215, split out as per @thockin.
