### PR TITLE
Cannot find a file in the repository

### DIFF
--- a/build/build-image/cross/Dockerfile
+++ b/build/build-image/cross/Dockerfile
@@ -17,6 +17,8 @@
 
 FROM  golang:1.4
 MAINTAINER  Joe Beda <jbeda@google.com>
+RUN sed -i 's/http.debian.net/ftp.debian.org/g' /etc/apt/sources.list
+RUN apt-get update
 
 ENV KUBE_CROSSPLATFORMS \
   linux/386 linux/arm \


### PR DESCRIPTION
- details

root@ruo91:/opt/kubernetes# build/release.sh
+++ Verifying Prerequisites....
You don't have a local copy of the golang docker image. This image is 450MB.
Download it now? [y/n] y

+++ Pulling docker image: golang:1.4
511136ea3c5a: Pull complete
8771fbfe935c: Pull complete
0e30e84e9513: Pull complete
c90a56bfe7dd: Pull complete
6b030fdd4748: Pull complete
5b691e49c664: Pull complete
1ea09c2dbbab: Pull complete
d560761777e0: Pull complete
6c9ce5fcafa4: Pull complete
fdaf64c52e5d: Pull complete
d6429349e0af: Pull complete
b77e2c7c5469: Pull complete
4fb0e42c842e: Pull complete
2fb1c97e2c4f: Pull complete
7b9d831c9cf1: Pull complete
golang:1.4: The image you are pulling has been verified. Important: image verification is a tech preview feature and should not be relied on to provide security.

Status: Downloaded newer image for golang:1.4
+++ Building Docker image kube-build:cross.
+++ Building Docker image kube-build:build-92a0e.
+++ Docker build command failed for kube-build:build-92a0e

Sending build context to Docker daemon 3.613 MB
Sending build context to Docker daemon
Step 0 : FROM kube-build:cross
 ---> 4581629479f4
Step 1 : MAINTAINER Joe Beda jbeda@google.com
 ---> Running in a370f67abcc3
 ---> 6bf8ecba4b48
Removing intermediate container a370f67abcc3
Step 2 : ENV GOARM 5
 ---> Running in a2157f517669
 ---> 3a9213f23fbd
Removing intermediate container a2157f517669
Step 3 : ENV GOOS linux
 ---> Running in f11522d32459
 ---> f7448d870cbb
Removing intermediate container f11522d32459
Step 4 : ENV GOARCH amd64
 ---> Running in 5a0a68392f40
 ---> 33d6f643adfd
Removing intermediate container 5a0a68392f40
Step 5 : RUN go get golang.org/x/tools/cmd/cover github.com/tools/godep
 ---> Running in 804525cb8c8b
 ---> 3a5fb05c335d
Removing intermediate container 804525cb8c8b
Step 6 : RUN rm -rf /var/lib/apt/lists/
 ---> Running in aa193ab18c51
 ---> 4e998db98ac0
Removing intermediate container aa193ab18c51
Step 7 : RUN apt-get update && apt-get install -y rsync
 ---> Running in 73854dbd492e
Get:1 http://security.debian.org jessie/updates InRelease [84.1 kB]
Get:2 http://security.debian.org jessie/updates/main amd64 Packages [20 B]
Get:3 http://http.debian.net jessie InRelease [199 kB]
Get:4 http://http.debian.net jessie-updates InRelease [117 kB]
Err http://http.debian.net jessie/main amd64 Packages

Err http://http.debian.net jessie-updates/main amd64 Packages

Err http://http.debian.net jessie/main amd64 Packages

Err http://http.debian.net jessie-updates/main amd64 Packages

Err http://http.debian.net jessie/main amd64 Packages

Err http://http.debian.net jessie/main amd64 Packages

Err http://http.debian.net jessie-updates/main amd64 Packages
  403  Forbidden [IP: 193.140.100.100 80]
Err http://http.debian.net jessie/main amd64 Packages
  406  Not Acceptable
Fetched 400 kB in 7s (55.1 kB/s)
W: Failed to fetch http://http.debian.net/debian/dists/jessie/main/binary-amd64/Packages  406  Not Acceptable

W: Failed to fetch http://http.debian.net/debian/dists/jessie-updates/main/binary-amd64/Packages  403  Forbidden [IP: 193.140.100.100 80]

E: Some index files failed to download. They have been ignored, or old ones used instead.
time="2015-02-17T11:29:46Z" level="info" msg="The command [/bin/sh -c apt-get update && apt-get install -y rsync] returned a non-zero code: 100"

To retry manually, run:

docker build -t kube-build:build-92a0e /opt/kubernetes-source/_output/images/kube-build:build-92a0e

!!! Error in build/../build/common.sh:342
  'return 1' exited with status 1
Call stack:
  1: build/../build/common.sh:342 kube::build::build_image(...)
  2: build/release.sh:31 main(...)
Exiting with status 1
