### PR TITLE
Add debugging information when docker.Container name is for #4472

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1234,6 +1234,9 @@ func (kl *Kubelet) cleanupOrphanedVolumes(pods []api.BoundPod, running []*docker
 	currentVolumes := kl.getPodVolumesFromDisk()
 	runningSet := util.StringSet{}
 	for ix := range running {
+		if len(running[ix].Name) == 0 {
+			glog.V(2).Infof("Found running container ix=%d with info: %+v", ix, running[ix])
+		}
 		_, uid, _, _ := dockertools.ParseDockerName(running[ix].Name)
 		runningSet.Insert(string(uid))
 	}


### PR DESCRIPTION
I suspect the I couldn't reproduce the issue on my machine by running integration tests. Also all docker containers should have a name before docker 1.0 release. Also the problem only happens on cleanupOrphanedVolumes path on travis machines. I suspect there are some very old containers without name running on those node, but want to prove it. 
