### PR TITLE
Create docker.Container obj with Name. Integration test is using fake_do...

### DIFF
--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -118,6 +118,7 @@ func (f *FakeDockerClient) StartContainer(id string, hostConfig *docker.HostConf
 	f.called = append(f.called, "start")
 	f.Container = &docker.Container{
 		ID:         id,
+		Name:       id, // For testing purpose, we set name to id
 		Config:     &docker.Config{Image: "testimage"},
 		HostConfig: hostConfig,
 		State:      docker.State{Running: true},


### PR DESCRIPTION
...cker_client

to create and start a fake container. When StartContainer, it pass a name as docker
ID for testing purpose, but leave Name uninitialized. This PR fixes such issue.

Fixed #4472.
