### PR TITLE
Cadvisor interface returns richer errors to the kubelet server #4127

### DIFF
--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -400,7 +400,13 @@ func (s *Server) serveStats(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "unknown resource.", http.StatusNotFound)
 		return
 	}
-	if err != nil {
+	switch err {
+	case nil:
+		break
+	case ErrNoKubeletContainers, ErrContainerNotFound:
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	default:
 		s.error(w, err)
 		return
 	}

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -221,6 +221,25 @@ func TestContainerInfoWithUidNamespace(t *testing.T) {
 	}
 }
 
+func TestContainerNotFound(t *testing.T) {
+	fw := newServerTest()
+	podID := "somepod"
+	expectedNamespace := "custom"
+	expectedContainerName := "slowstartcontainer"
+	expectedUid := "9b01b80f-8fb4-11e4-95ab-4200af06647"
+	fw.fakeKubelet.containerInfoFunc = func(podID string, uid types.UID, containerName string, req *info.ContainerInfoRequest) (*info.ContainerInfo, error) {
+		return nil, ErrContainerNotFound
+	}
+	resp, err := http.Get(fw.testHTTPServer.URL + fmt.Sprintf("/stats/%v/%v/%v/%v", expectedNamespace, podID, expectedUid, expectedContainerName))
+	if err != nil {
+		t.Fatalf("Got error GETing: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("Received status %d expecting %d", resp.StatusCode, http.StatusNotFound)
+	}
+	defer resp.Body.Close()
+}
+
 func TestRootInfo(t *testing.T) {
 	fw := newServerTest()
 	expectedInfo := &info.ContainerInfo{}


### PR DESCRIPTION
There are a few different errors that might pop up when servicing the kubelet's /stats endpoint for a specific container. This PR broadly classifies them under the 3 buckets mentioned and returns a 404 for the first 2 cases, thereby avoiding a stack trace. The 3rd case will continue to return a 500:
1. No Containers on Kubelet
   - No containers on node
   - No containers managed by kubelet (i.e containig k8 prefix)
2. Specified container not found
   - Specified container doesn't exist
   - Specified container exists, but is under a different pod
   - Pod not found (race condition between when we check for the pod in the server and we match containers up with pods)
3. No stats
   - Cadvisor isn't running 
   - Got stats for multiple containers but only expect one
#4489 addresses building these errors conditions out, the purpose of this PR is to avoid a confusing stack trace, return a more appropriate http status and log more information.
