### PR TITLE
Jenkins e2e tests: only fail on infrastructure errors and disable colors

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -80,10 +80,15 @@ fi
 # Have cmd/e2e run by goe2e.sh generate JUnit report in ${WORKSPACE}/junit*.xml
 export E2E_REPORT_DIR=${WORKSPACE}
 
+### Set up ###
 go run ./hack/e2e.go ${E2E_OPT} -v --down
 go run ./hack/e2e.go ${E2E_OPT} -v --up
 go run ./hack/e2e.go -v --ctl="version --match-server-version=false"
-status=0
-go run ./hack/e2e.go ${E2E_OPT} -v --test || status=$?
+
+### Run tests ###
+# Jenkins will look at the junit*.xml files for test failures, so don't exit
+# with a nonzero error code if it was only tests that failed.
+go run ./hack/e2e.go ${E2E_OPT} -v --test --test_args="--ginkgo.noColor" || true
+
+### Clean up ###
 go run ./hack/e2e.go ${E2E_OPT} -v --down
-exit $status


### PR DESCRIPTION
Since Jenkins has hopefully been set up properly to read test failures
from junit*.xml files, only exit with a nonzero status when there are
infrastructure failures. If there are only test failures, the nonzero
exit status will be ignored.
