### PR TITLE
Fix rolling update if namespace is empty.

### DIFF
--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -90,6 +90,9 @@ Examples:
 			checkErr(err)
 			newRc := obj.(*api.ReplicationController)
 
+			if len(namespace) == 0 {
+				namespace = api.NamespaceDefault
+			}
 			updater := kubectl.NewRollingUpdater(namespace, client)
 
 			// fetch rc


### PR DESCRIPTION
I'm going to merge this on green as it is breaking e2e.
