### PR TITLE
Batch updates of multiple Pods.

### DIFF
--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -60,7 +60,7 @@ type PodConfig struct {
 // NewPodConfig creates an object that can merge many configuration sources into a stream
 // of normalized updates to a pod configuration.
 func NewPodConfig(mode PodConfigNotificationMode) *PodConfig {
-	updates := make(chan kubelet.PodUpdate, 1)
+	updates := make(chan kubelet.PodUpdate, 50)
 	storage := newPodStorage(updates, mode)
 	podConfig := &PodConfig{
 		pods:    storage,

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1399,13 +1399,13 @@ func (kl *Kubelet) syncLoop(updates <-chan PodUpdate, handler SyncHandler) {
 		}
 		// If we already caught some update, try to wait for some short time
 		// to possibly batch it with other incoming updates.
-		for ; unsyncedPod; {
+		for unsyncedPod {
 			select {
-				case u := <-updates:
-					kl.updatePods(u)
-				case <-time.After(5 * time.Millisecond):
-					// Break the for loop.
-					unsyncedPod = false
+			case u := <-updates:
+				kl.updatePods(u)
+			case <-time.After(5 * time.Millisecond):
+				// Break the for loop.
+				unsyncedPod = false
 			}
 		}
 
@@ -1418,16 +1418,16 @@ func (kl *Kubelet) syncLoop(updates <-chan PodUpdate, handler SyncHandler) {
 
 func (kl *Kubelet) updatePods(u PodUpdate) {
 	switch u.Op {
-		case SET:
-			glog.V(3).Infof("SET: Containers changed")
-			kl.pods = u.Pods
-			kl.pods = filterHostPortConflicts(kl.pods)
-		case UPDATE:
-			glog.V(3).Infof("Update: Containers changed")
-			kl.pods = updateBoundPods(u.Pods, kl.pods)
-			kl.pods = filterHostPortConflicts(kl.pods)
-		default:
-			panic("syncLoop does not support incremental changes")
+	case SET:
+		glog.V(3).Infof("SET: Containers changed")
+		kl.pods = u.Pods
+		kl.pods = filterHostPortConflicts(kl.pods)
+	case UPDATE:
+		glog.V(3).Infof("Update: Containers changed")
+		kl.pods = updateBoundPods(u.Pods, kl.pods)
+		kl.pods = filterHostPortConflicts(kl.pods)
+	default:
+		panic("syncLoop does not support incremental changes")
 	}
 }
 


### PR DESCRIPTION
Try to batch updates of multiple Pods in Kubelet, to avoid multiple (expensive) calls to Docker.
This is slightly (by ~10-20%) reducing the latency of starting the last Pod when we're starting 50 equal pods on the same node.
