### PR TITLE
Fix hack/verify-description.sh to actually surface the error

### DIFF
--- a/hack/verify-description.sh
+++ b/hack/verify-description.sh
@@ -37,7 +37,10 @@ find_files() {
     \) -name '*.go'
 }
 
-find_files | egrep "pkg/api/v.[^/]*/types\.go" | grep -v v1beta3 | while read file ; do
+files=`find_files | egrep "pkg/api/v.[^/]*/types\.go" | grep -v v1beta3`
+
+for file in $files
+do
     if [[ "$("${KUBE_ROOT}/hooks/description.sh" "${file}")" -eq "0" ]]; then
       echo "API file is missing the required field descriptions: ${file}"
       result=1


### PR DESCRIPTION
This PR fixes the test (#4542). The PR needs to wait until all existing errors in types.go to be corrected before merging.
