### PR TITLE
pkg/kubelet: recreate infra pod if the pod is changed

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1047,6 +1047,7 @@ func (kl *Kubelet) syncPod(pod *api.BoundPod, dockerContainers dockertools.Docke
 		glog.Errorf("Unable to get pod with name %q and uid %q info with error(%v)", podFullName, uid, err)
 	}
 
+	podChanged := false
 	for _, container := range pod.Spec.Containers {
 		expectedHash := dockertools.HashContainer(&container)
 		dockerContainerName := dockertools.BuildDockerName(uid, podFullName, &container)
@@ -1055,8 +1056,8 @@ func (kl *Kubelet) syncPod(pod *api.BoundPod, dockerContainers dockertools.Docke
 			glog.V(3).Infof("pod %q container %q exists as %v", podFullName, container.Name, containerID)
 
 			// look for changes in the container.
-			podChanged := hash != 0 && hash != expectedHash
-			if !podChanged {
+			containerChanged := hash != 0 && hash != expectedHash
+			if !containerChanged {
 				// TODO: This should probably be separated out into a separate goroutine.
 				// If the container's liveness probe is unsuccessful, set readiness to false. If liveness is succesful, do a readiness check and set
 				// readiness accordingly. If the initalDelay since container creation on liveness probe has not passed the probe will return Success.
@@ -1088,6 +1089,7 @@ func (kl *Kubelet) syncPod(pod *api.BoundPod, dockerContainers dockertools.Docke
 				}
 				glog.Infof("pod %q container %q is unhealthy. Container will be killed and re-created.", podFullName, container.Name, live)
 			} else {
+				podChanged = true
 				glog.Infof("pod %q container %q hash changed (%d vs %d). Container will be killed and re-created.", podFullName, container.Name, hash, expectedHash)
 			}
 			if err := kl.killContainer(dockerContainer); err != nil {
@@ -1095,16 +1097,6 @@ func (kl *Kubelet) syncPod(pod *api.BoundPod, dockerContainers dockertools.Docke
 				continue
 			}
 			killedContainers[containerID] = empty{}
-
-			if podChanged {
-				// Also kill associated pod infra container if the pod changed.
-				if podInfraContainer, found, _ := dockerContainers.FindPodContainer(podFullName, uid, dockertools.PodInfraContainerName); found {
-					if err := kl.killContainer(podInfraContainer); err != nil {
-						glog.V(1).Infof("Failed to kill pod infra container %q: %v", podInfraContainer.ID, err)
-						continue
-					}
-				}
-			}
 		}
 
 		// Check RestartPolicy for container
@@ -1165,6 +1157,20 @@ func (kl *Kubelet) syncPod(pod *api.BoundPod, dockerContainers dockertools.Docke
 			continue
 		}
 		containersToKeep[containerID] = empty{}
+	}
+
+	if podChanged {
+		// Also kill associated pod infra container if the pod changed.
+		if podInfraContainer, found, _ := dockerContainers.FindPodContainer(podFullName, uid, dockertools.PodInfraContainerName); found {
+			if err := kl.killContainer(podInfraContainer); err != nil {
+				glog.V(1).Infof("Failed to kill pod infra container %q: %v", podInfraContainer.ID, err)
+			}
+		}
+		podInfraContainerID, err = kl.createPodInfraContainer(pod)
+		if err != nil {
+			glog.Errorf("Failed to recreate pod infra container: %v for pod %q", err, podFullName)
+		}
+		containersToKeep[podInfraContainerID] = empty{}
 	}
 
 	// Kill any containers in this pod which were not identified above (guards against duplicates).

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -931,7 +931,7 @@ func TestSyncPodBadHash(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	verifyCalls(t, fakeDocker, []string{"list", "stop", "stop", "list", "create", "start"})
+	verifyCalls(t, fakeDocker, []string{"list", "stop", "list", "create", "start", "stop", "create", "start"})
 
 	// A map interation is used to delete containers, so must not depend on
 	// order here.


### PR DESCRIPTION
I was looking through the code and found this potential issue. I know the infra container would be recreated in next sync. I do not know if it is desired.

Also I did not handle the failure during the recreation as the old code.

/cc @dchen1107 
