### PR TITLE
Produce a combined coverage report when running Go unit tests, and use goveralls to report coverage results from Travis to Coveralls.io.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
 
 install:
   - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+  - go get github.com/mattn/goveralls
   - ./hack/travis/install-etcd.sh
   - ./hack/verify-gofmt.sh
   - ./hack/verify-boilerplate.sh
@@ -14,7 +15,7 @@ install:
   - ./hack/build-go.sh
 
 script:
-  - KUBE_RACE="-race" KUBE_COVER="-cover -covermode=atomic" KUBE_TIMEOUT='-timeout 60s' ./hack/test-go.sh "" -p=4
+  - KUBE_RACE="-race" KUBE_COVER="y" KUBE_GOVERALLS_BIN="$HOME/gopath/bin/goveralls" KUBE_TIMEOUT='-timeout 60s' ./hack/test-go.sh "" -p=4
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/test-cmd.sh
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/verify-gendocs.sh
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/test-integration.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubernetes
 
-[![GoDoc](https://godoc.org/github.com/GoogleCloudPlatform/kubernetes?status.png)](https://godoc.org/github.com/GoogleCloudPlatform/kubernetes) [![Travis](https://travis-ci.org/GoogleCloudPlatform/kubernetes.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/kubernetes)
+[![GoDoc](https://godoc.org/github.com/GoogleCloudPlatform/kubernetes?status.png)](https://godoc.org/github.com/GoogleCloudPlatform/kubernetes) [![Travis](https://travis-ci.org/GoogleCloudPlatform/kubernetes.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/kubernetes) [![Coverage Status](https://coveralls.io/repos/GoogleCloudPlatform/kubernetes/badge.svg)](https://coveralls.io/r/GoogleCloudPlatform/kubernetes)
 
 Kubernetes is an open source system for managing containerized applications across multiple hosts,
 providing basic mechanisms for deployment, maintenance, and scaling of applications.

--- a/hack/benchmark-go.sh
+++ b/hack/benchmark-go.sh
@@ -20,4 +20,4 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-KUBE_COVER=" " KUBE_RACE=" " "${KUBE_ROOT}/hack/test-go.sh" "" -test.run="^X" -benchtime=1s -bench=. -benchmem
+KUBE_COVER="" KUBE_RACE=" " "${KUBE_ROOT}/hack/test-go.sh" "" -test.run="^X" -benchtime=1s -bench=. -benchmem


### PR DESCRIPTION
Fixes #4510.

I've tested the hack/test-go.sh part of this change in a variety of ways by running
- hack/test-go.sh ""
- hack/test-go.sh dir1/ dir2/ etc
- both of the above with KUBE_COVER=y
- both of the above with KUBE_GOVERALLS_BIN set (though it fails, possibly because it's not running from Travis?)
- hack/test-integration.sh
- hack/benchmark-go.sh]
- build/release.sh.

I have no idea how to test the Travis changes. I guess in the worst case we just won't get any coverage results uploaded, which is no worse than before.
At least running locally now gives a nice HTML report.
