### PR TITLE
Fix monit config for etcd

### DIFF
--- a/cluster/saltbase/salt/monit/etcd
+++ b/cluster/saltbase/salt/monit/etcd
@@ -3,7 +3,7 @@ group etcd
 start program = "/etc/init.d/etcd start"
 stop program = "/etc/init.d/etcd stop"
 if failed
-  host 127.0.0.1
+  host kubernetes-master
   port 4001
   protocol http
   request "/v2/keys/"


### PR DESCRIPTION
After some network configuration changes localhost as added in #3857 (Issue #3852) is no longer valid. 
Monit can handle hostnames, so changing it to kubernetes-master fixes the issue, as long at least until we're move to multiple master architecture, or move etcd out of master server.
