### PR TITLE
Delete cluster level logging services during kube down

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -911,6 +911,10 @@ function teardown-logging-firewall {
 
   detect-project
   gcloud compute firewall-rules delete -q "${INSTANCE_PREFIX}-fluentd-elasticsearch-logging" --project "${PROJECT}" || true
+  # Also delete the logging services which will remove the associated forwarding rules (TCP load balancers).
+  local kubectl="${KUBE_ROOT}/cluster/kubectl.sh"
+  "${kubectl}" delete services elasticsearch-logging || true
+  "${kubectl}" delete services kibana-logging || true
 }
 
 # Perform preparations required to run e2e tests


### PR DESCRIPTION
Currently `kube-down.sh` does not delete the cluster level logging services (if enabled). This leaves behind the forwarding rules in the GCE project (perhaps similarly for other providers). This change explicitly deletes these services which causes the forwarding rules to also be deleted. This then makes `kube-up.sh ; kube-down.sh` leave the project in its initial state without any residue hanging around. This is part of addressing issue #3388 to produce an end to end test for cluster level logging.
