### PR TITLE
Add kubernetes.io/cluster-service label to cluster level logging service...

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-controller.yaml.in
+++ b/cluster/addons/fluentd-elasticsearch/es-controller.yaml.in
@@ -27,6 +27,7 @@ desiredState:
               emptyDir: {}
     labels:
       name: elasticsearch-logging
+      kubernetes.io/cluster-service: "true"
 labels:
   name: elasticsearch-logging
- 
+  kubernetes.io/cluster-service: "true"

--- a/cluster/addons/fluentd-elasticsearch/es-service.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-service.yaml
@@ -5,6 +5,7 @@ containerPort: es-port
 port: 9200
 labels:
   name: elasticsearch-logging
+  kubernetes.io/cluster-service: "true"
 selector:
   name: elasticsearch-logging
 createExternalLoadBalancer: true

--- a/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
@@ -18,5 +18,7 @@ desiredState:
                 containerPort: 80
     labels:
       name: kibana-logging
+      kubernetes.io/cluster-service: "true"
 labels:
   name: kibana-logging
+  kubernetes.io/cluster-service: "true"

--- a/cluster/addons/fluentd-elasticsearch/kibana-service.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-service.yaml
@@ -5,6 +5,7 @@ containerPort: kibana-port
 port: 5601
 labels:
   name: kibana-logging
+  kubernetes.io/cluster-service: "true"
 selector:
   name: kibana-logging
 createExternalLoadBalancer: true


### PR DESCRIPTION
...s

Regarding #4620 this adds the `kubernetes.io/cluster-service` label to cluster-level logging services.
@thockin @vishh 

```
$ cluster/kubectl.sh get pods -l kubernetes.io/cluster-service=true
current-context: "kubernetes-satnam_kubernetes"
Running: cluster/../cluster/gce/../../_output/dockerized/bin/linux/amd64/kubectl get pods -l kubernetes.io/cluster-service=true
POD                                      IP                  CONTAINER(S)            IMAGE(S)                           HOST                                                                 LABELS                                                          STATUS
elasticsearch-logging-controller-fplln   10.244.1.3          elasticsearch-logging   dockerfile/elasticsearch           kubernetes-minion-f3hk.c.kubernetes-satnam.internal/104.154.78.159   kubernetes.io/cluster-service=true,name=elasticsearch-logging   Running
kibana-logging-controller-ls6k1          10.244.2.4          kibana-logging          kubernetes/kibana:1.0              kubernetes-minion-itb8.c.kubernetes-satnam.internal/104.154.91.224   kubernetes.io/cluster-service=true,name=kibana-logging          Running
kube-dns-oh43e                           10.244.2.3          etcd                    quay.io/coreos/etcd:latest         kubernetes-minion-itb8.c.kubernetes-satnam.internal/104.154.91.224   k8s-app=kube-dns,kubernetes.io/cluster-service=true             Running
                                                             kube2sky                kubernetes/kube2sky:1.0                                                                                                                                                 
                                                             skydns                  kubernetes/skydns:2014-12-23-001                                                                                                                                        
$ cluster/kubectl.sh get services -l kubernetes.io/cluster-service=true
current-context: "kubernetes-satnam_kubernetes"
Running: cluster/../cluster/gce/../../_output/dockerized/bin/linux/amd64/kubectl get services -l kubernetes.io/cluster-service=true
NAME                    LABELS                                                          SELECTOR                     IP                  PORT
elasticsearch-logging   kubernetes.io/cluster-service=true,name=elasticsearch-logging   name=elasticsearch-logging   10.0.99.205         9200
kibana-logging          kubernetes.io/cluster-service=true,name=kibana-logging          name=kibana-logging          10.0.71.218         5601
kube-dns                k8s-app=kube-dns,kubernetes.io/cluster-service=true             k8s-app=kube-dns             10.0.0.10           53
$ cluster/kubectl.sh get replicationControllers -l kubernetes.io/cluster-service=true
current-context: "kubernetes-satnam_kubernetes"
Running: cluster/../cluster/gce/../../_output/dockerized/bin/linux/amd64/kubectl get replicationControllers -l kubernetes.io/cluster-service=true
CONTROLLER                         CONTAINER(S)            IMAGE(S)                           SELECTOR                     REPLICAS
elasticsearch-logging-controller   elasticsearch-logging   dockerfile/elasticsearch           name=elasticsearch-logging   1
kibana-logging-controller          kibana-logging          kubernetes/kibana:1.0              name=kibana-logging          1
kube-dns                           etcd                    quay.io/coreos/etcd:latest         k8s-app=kube-dns             1
                                   kube2sky                kubernetes/kube2sky:1.0                                         
                                   skydns                  kubernetes/skydns:2014-12-23-001                   
```
