### PR TITLE
Resolves #4633.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,12 +69,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   # Kubernetes master
-  config.vm.define "master" do |config|
-    customize_vm config
-
-    config.vm.provision "shell", run: "always", path: "#{ENV['KUBE_TEMP']}/master-start.sh"
-    config.vm.network "private_network", ip: "#{$master_ip}"
-    config.vm.hostname = ENV['MASTER_NAME']
+  config.vm.define "master" do |c|
+    customize_vm c
+    if ENV['KUBE_TEMP'] then
+      script = "#{ENV['KUBE_TEMP']}/master-start.sh"
+      c.vm.provision "shell", run: "always", path: script
+    end
+    c.vm.network "private_network", ip: "#{$master_ip}"
+    c.vm.hostname = ENV['MASTER_NAME']
   end
 
   # Kubernetes minion
@@ -84,10 +86,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       minion_index = n+1
       minion_ip = $minion_ips[n]
-      minion.vm.provision "shell", run: "always", path: "#{ENV['KUBE_TEMP']}/minion-start-#{n}.sh"
+      if ENV['KUBE_TEMP'] then
+        script = "#{ENV['KUBE_TEMP']}/minion-start-#{n}.sh"
+        minion.vm.provision "shell", run: "always", path: script
+      end
       minion.vm.network "private_network", ip: "#{minion_ip}"
       minion.vm.hostname = "#{ENV['INSTANCE_PREFIX']}-minion-#{minion_index}"
     end
   end
-
 end


### PR DESCRIPTION
Fixes broken vagrant ssh commands.

Also renames the inner scope 'config' to 'c' so there is not a name collision with the outer scoped variable.
