### PR TITLE
Split TLS loading to allow 3rd parties to load keys easily

### DIFF
--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -18,7 +18,6 @@ package client
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -272,19 +271,6 @@ func HTTPWrappersForConfig(config *Config, rt http.RoundTripper) (http.RoundTrip
 		rt = NewUserAgentRoundTripper(config.UserAgent, rt)
 	}
 	return rt, nil
-}
-
-// dataFromSliceOrFile returns data from the slice (if non-empty), or from the file,
-// or an error if an error occurred reading the file
-func dataFromSliceOrFile(data []byte, file string) ([]byte, error) {
-	if len(data) > 0 {
-		return data, nil
-	}
-	fileData, err := ioutil.ReadFile(file)
-	if err != nil {
-		return []byte{}, err
-	}
-	return fileData, nil
 }
 
 // DefaultServerURL converts a host, host:port, or URL string to the default base server API path


### PR DESCRIPTION
The LoadTLSFiles method is useful for configuration code that needs
to read the current client config and get values out for creating
other config files.
