### PR TITLE
Fix for failed ENV injection (missing startup parameter)

### DIFF
--- a/contrib/init/systemd/environ/kubelet
+++ b/contrib/init/systemd/environ/kubelet
@@ -10,5 +10,8 @@ KUBELET_PORT="--port=10250"
 # You may leave this blank to use the actual hostname
 KUBELET_HOSTNAME="--hostname_override=127.0.0.1"
 
+# location of the api-server
+KUBELET_API_SERVER="--api_server=127.0.0.1:8080"
+
 # Add your own!
 KUBELET_ARGS=""

--- a/contrib/init/systemd/kubelet.service
+++ b/contrib/init/systemd/kubelet.service
@@ -11,7 +11,7 @@ EnvironmentFile=-/etc/kubernetes/kubelet
 ExecStart=/usr/bin/kubelet \
 	    $KUBE_LOGTOSTDERR \
 	    $KUBE_LOG_LEVEL \
-	    $KUBE_ETCD_SERVERS \
+	    $KUBELET_API_SERVER \
 	    $KUBELET_ADDRESS \
 	    $KUBELET_PORT \
 	    $KUBELET_HOSTNAME \

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -165,9 +165,7 @@ func (s *KubeletServer) Run(_ []string) error {
 	//
 	// TODO(erictune): convert all cloud provider scripts and Google Container Engine to
 	// use only --api_servers, then delete --etcd_servers flag and the resulting dead code.
-	if len(s.APIServerList) == 0 {
-		glog.Fatalf("--api_server is required.")
-	} else if len(s.EtcdServerList) >0 {
+	if len(s.EtcdServerList) > 0 && len(s.APIServerList) > 0 {
 		glog.Infof("Both --etcd_servers and --api_servers are set.  Not using etcd source.")
 		s.EtcdServerList = util.StringList{}
 	}

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -165,7 +165,9 @@ func (s *KubeletServer) Run(_ []string) error {
 	//
 	// TODO(erictune): convert all cloud provider scripts and Google Container Engine to
 	// use only --api_servers, then delete --etcd_servers flag and the resulting dead code.
-	if len(s.EtcdServerList) > 0 && len(s.APIServerList) > 0 {
+	if len(s.APIServerList) == 0 {
+		glog.Fatalf("--api_server is required.")
+	} else if len(s.EtcdServerList) >0 {
 		glog.Infof("Both --etcd_servers and --api_servers are set.  Not using etcd source.")
 		s.EtcdServerList = util.StringList{}
 	}


### PR DESCRIPTION
Fix for default systemd startup of the kublet, also forcing the hard
requirement for the parameter.  Sans parameter the kubelet will fail
silently trying to obtain service setting that are placed into the
ENV of the PODS.
