### PR TITLE
Support user supplied health functions in pkg/healthz

### DIFF
--- a/pkg/healthz/healthz.go
+++ b/pkg/healthz/healthz.go
@@ -17,25 +17,100 @@ limitations under the License.
 package healthz
 
 import (
+	"bytes"
+	"fmt"
 	"net/http"
+	"sync"
 )
+
+var (
+	// guards names and checks
+	lock = sync.RWMutex{}
+	// used to ensure checks are performed in the order added
+	names  = []string{}
+	checks = map[string]*healthzCheck{}
+)
+
+func init() {
+	http.HandleFunc("/healthz", handleRootHealthz)
+	// add ping health check by default
+	AddHealthzFunc("ping", func(_ *http.Request) error {
+		return nil
+	})
+}
+
+// AddHealthzFunc adds a health check under the url /healhz/{name}
+func AddHealthzFunc(name string, check func(r *http.Request) error) {
+	lock.Lock()
+	defer lock.Unlock()
+	if _, found := checks[name]; !found {
+		names = append(names, name)
+	}
+	checks[name] = &healthzCheck{name, check}
+}
+
+// InstallHandler registers a handler for health checking on the path "/healthz" to mux.
+func InstallHandler(mux mux) {
+	lock.RLock()
+	defer lock.RUnlock()
+	mux.HandleFunc("/healthz", handleRootHealthz)
+	for _, check := range checks {
+		mux.HandleFunc(fmt.Sprintf("/healthz/%v", check.name), adaptCheckToHandler(check.check))
+	}
+}
 
 // mux is an interface describing the methods InstallHandler requires.
 type mux interface {
 	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))
 }
 
-func init() {
-	http.HandleFunc("/healthz", handleHealthz)
+type healthzCheck struct {
+	name  string
+	check func(r *http.Request) error
 }
 
-func handleHealthz(w http.ResponseWriter, r *http.Request) {
-	// TODO Support user supplied health functions too.
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("ok"))
+func handleRootHealthz(w http.ResponseWriter, r *http.Request) {
+	lock.RLock()
+	defer lock.RUnlock()
+	failed := false
+	var verboseOut bytes.Buffer
+	for _, name := range names {
+		check, found := checks[name]
+		if !found {
+			// this should not happen
+			http.Error(w, fmt.Sprintf("Internal server error: check \"%q\" not registered", name), http.StatusInternalServerError)
+			return
+		}
+		err := check.check(r)
+		if err != nil {
+			fmt.Fprintf(&verboseOut, "[-]%v failed: %v\n", check.name, err)
+			failed = true
+		} else {
+			fmt.Fprintf(&verboseOut, "[+]%v ok\n", check.name)
+		}
+	}
+	// always be verbose on failure
+	if failed {
+		http.Error(w, fmt.Sprintf("%vhealthz check failed", verboseOut.String()), http.StatusInternalServerError)
+		return
+	}
+
+	if _, found := r.URL.Query()["verbose"]; !found {
+		fmt.Fprint(w, "ok")
+		return
+	} else {
+		verboseOut.WriteTo(w)
+		fmt.Fprint(w, "healthz check passed\n")
+	}
 }
 
-// InstallHandler registers a handler for health checking on the path "/healthz" to mux.
-func InstallHandler(mux mux) {
-	mux.HandleFunc("/healthz", handleHealthz)
+func adaptCheckToHandler(c func(r *http.Request) error) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		err := c(r)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Internal server error: %v", err), http.StatusInternalServerError)
+		} else {
+			fmt.Fprint(w, "ok")
+		}
+	}
 }


### PR DESCRIPTION
This was an old TODO from July,  `// TODO Support user supplied health functions too.` and I believe it is still relevant and this is what was intended.

This breaks up /healtz into a set of pluggable health checks. The ping health check is added by default. As an example, if you add a docker health check and a diskspace health check, the added routes will be

```
/healthz
/healthz/ping
/healthz/docker
/healthz/diskspace
```

Which will, upon passing, return "ok" and on failure an internal server error with an explanation of the failure. The root path `/healthz` is the aggregate of the all health checks and will return "ok" if all health checks are passing. The root path also supports a verbose query param which displays the checks that have been added as well as their statuses:

```
curl localhost:10250/healthz?verbose
[+]ping ok
[+]docker ok
[-]diskspace failed: too many files, not enough inodes!
healthz check failed
```

I'll be moving the two user defined health checks (docker, and hostname) in the kubelet after #4497 is merged but this does not conflict.
