### PR TITLE
Update to heapster version v0.7.

### DIFF
--- a/cluster/addons/cluster-monitoring/grafana-service.yaml
+++ b/cluster/addons/cluster-monitoring/grafana-service.yaml
@@ -1,7 +1,7 @@
-apiVersion: "v1beta1"
-kind: "Service"
-id: "monitoring-grafana"
+apiVersion: v1beta1
+kind: Service
+id: monitoring-grafana
 port: 80
 containerPort: 80
 selector: 
-  name: "influxGrafana"
+  name: influxGrafana

--- a/cluster/addons/cluster-monitoring/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/heapster-controller.yaml
@@ -1,24 +1,25 @@
-apiVersion: "v1beta1"
-id: "monitoring-heapster-controller"
-kind: "ReplicationController"
+apiVersion: v1beta1
+id: monitoring-heapster-controller
+kind: ReplicationController
 desiredState: 
   replicas: 1
   replicaSelector:    
-    name: "heapster"
+    name: heapster
   podTemplate:
     desiredState:
       manifest:
-        version: "v1beta1"
-        id: "monitoring-heapster-controller"
+        version: v1beta1
+        id: monitoring-heapster
         containers:
-          - name: "heapster"
-            image: "kubernetes/heapster:v0.6"
+          - name: heapster
+            image: kubernetes/heapster:v0.7
             env: 
               - name: "INFLUXDB_HOST"
                 value: "monitoring-influxdb"
-
     labels: 
-      name: "heapster"
-      uses: "monitoring-influxdb"
+      name: heapster
+      uses: monitoring-influxdb
+      kubernetes.io/cluster-service: "true"
 labels: 
-  name: "heapster"
+  name: heapster
+  kubernetes.io/cluster-service: "true"

--- a/cluster/addons/cluster-monitoring/heapster-service.yaml
+++ b/cluster/addons/cluster-monitoring/heapster-service.yaml
@@ -1,7 +1,7 @@
-apiVersion: "v1beta1"
-kind: "Service"
-id: "monitoring-heapster"
+apiVersion: v1beta1
+kind: Service
+id: monitoring-heapster
 port: 80
 containerPort: 8082
 selector: 
-  name: "heapster"
+  name: heapster

--- a/cluster/addons/cluster-monitoring/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb-grafana-controller.yaml
@@ -1,34 +1,39 @@
-apiVersion: "v1beta1"
-kind: "ReplicationController"
-id: "monitoring-influx-grafana-controller"
+apiVersion: v1beta1
+kind: ReplicationController
+id: monitoring-influx-grafana-controller
 desiredState: 
   replicas: 1
   replicaSelector:
-    name: "influxGrafana"
+    name: influxGrafana
   podTemplate:
     labels:
-      name: "influxGrafana"
+      name: influxGrafana
+      kubernetes.io/cluster-service: "true"
     desiredState:
       manifest:
-        version: "v1beta1"
-        id: "monitoring-influx-grafana-controller"
+        version: v1beta1
+        id: monitoring-influx-grafana
         containers: 
-          - name: "influxdb"
-            image: "kubernetes/heapster_influxdb:v0.3"
+          - name: influxdb
+            image: kubernetes/heapster_influxdb:v0.3
             ports: 
               - containerPort: 8083
                 hostPort: 8083
               - containerPort: 8086
                 hostPort: 8086
-          - name: "grafana"
-            image: "kubernetes/heapster_grafana:v0.3"
-            ports: 
-              - containerPort: 80
-                hostPort: 80
+          - name: grafana
+            image: kubernetes/heapster_grafana:v0.4
             env: 
               - name: "HTTP_USER"
                 value: "admin"
               - name: "HTTP_PASS"
                 value: "**None**"
+              - name: "INFLUXDB_PROTO"
+                value: "https"
+              - name: "INFLUXDB_HOST"
+                value: '"+window.location.hostname+"/api/v1beta1/proxy/services/monitoring-influxdb'
+              - name: "INFLUXDB_PORT"
+                value: ""
 labels:
-  name: "influxGrafana"
+  name: influxGrafana
+  kubernetes.io/cluster-service: "true"

--- a/cluster/addons/cluster-monitoring/influxdb-service.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb-service.yaml
@@ -1,7 +1,7 @@
-apiVersion: "v1beta1"
-kind: "Service"
-id: "monitoring-influxdb"
+apiVersion: v1beta1
+kind: Service
+id: monitoring-influxdb
 port: 80
 containerPort: 8086
 selector: 
-  name: "influxGrafana"
+  name: influxGrafana


### PR DESCRIPTION
Added the new label required for cluster addon services.
Made Grafana UI accessble via the proxy on the api-server.

Tested using the e2e test.
