### PR TITLE
Add monit process monitoring for kubelet and docker

### DIFF
--- a/cluster/saltbase/salt/monit/docker
+++ b/cluster/saltbase/salt/monit/docker
@@ -1,0 +1,6 @@
+check process docker with pidfile /var/run/docker.pid
+group docker 
+start program = "/etc/init.d/docker start"
+stop program = "/etc/init.d/docker stop"
+if does not exist then restart
+

--- a/cluster/saltbase/salt/monit/init.sls
+++ b/cluster/saltbase/salt/monit/init.sls
@@ -4,6 +4,7 @@ monit:
   pkg:
     - installed
 
+{% if "kubernetes-master" in grains.get('roles', []) %}
 /etc/monit/conf.d/etcd:
   file:
     - managed
@@ -11,6 +12,25 @@ monit:
     - user: root
     - group: root
     - mode: 644
+{% endif %}
+
+/etc/monit/conf.d/docker:
+  file:
+    - managed
+    - source: salt://monit/docker
+    - user: root
+    - group: root
+    - mode: 644
+
+{% if "kubernetes-pool" in grains.get('roles', []) %}
+/etc/monit/conf.d/kubelet:
+  file:
+    - managed
+    - source: salt://monit/kubelet
+    - user: root
+    - group: root
+    - mode: 644
+{% endif %}
 
 monit-service:
   service:
@@ -18,6 +38,6 @@ monit-service:
     - name: monit 
     - watch:
       - pkg: monit 
-      - file: /etc/monit/conf.d/etcd
+      - file: /etc/monit/conf.d/*
 
 {% endif %}

--- a/cluster/saltbase/salt/monit/kubelet
+++ b/cluster/saltbase/salt/monit/kubelet
@@ -1,0 +1,6 @@
+check process kubelet with pidfile /var/run/kubelet.pid
+group kubelet 
+start program = "/etc/init.d/kubelet start"
+stop program = "/etc/init.d/kubelet stop"
+if does not exist then restart
+

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -25,6 +25,7 @@ base:
 {% else %}
     - sdn
 {% endif %}
+    - monit
 
   'roles:kubernetes-master':
     - match: grain


### PR DESCRIPTION
This uses monit to monitor kubelet and docker processes, if they are killed for any reason, it restarts them.

Based on #2884
