### PR TITLE
Fix broken kubelet_test.go.

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -931,7 +931,7 @@ func TestSyncPodBadHash(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	verifyCalls(t, fakeDocker, []string{"list", "stop", "list", "create", "start", "stop", "create", "start"})
+	verifyCalls(t, fakeDocker, []string{"list", "stop", "list", "create", "start", "stop", "create", "start", "inspect_container"})
 
 	// A map interation is used to delete containers, so must not depend on
 	// order here.


### PR DESCRIPTION
The test got broken due to two PRs: #4647 #4563 that got merged at the same time. One was calling createPodInfraContainer on specification change (implemented as hash difference), while the other added inspect_container call from createPodInfraContainer. 
One of the tests in kubelet_test was changing hash of a container and due to that additional "inspect_container" gets issued. 
