### PR TITLE
tolerate empty .kubeconfig files

### DIFF
--- a/pkg/client/clientcmd/loader.go
+++ b/pkg/client/clientcmd/loader.go
@@ -183,7 +183,12 @@ func LoadFromFile(filename string) (*clientcmdapi.Config, error) {
 // Load takes a byte slice and deserializes the contents into Config object.
 // Encapsulates deserialization without assuming the source is a file.
 func Load(data []byte) (*clientcmdapi.Config, error) {
-	config := &clientcmdapi.Config{}
+	config := clientcmdapi.NewConfig()
+	// if there's no data in a file, return the default object instead of failing (DecodeInto reject empty input)
+	if len(data) == 0 {
+		return config, nil
+	}
+
 	if err := clientcmdlatest.Codec.DecodeInto(data, config); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #4658.

Empty kubeconfig files produce an error because DecodeInto rejects empty input.  In the case of an empty .kubeconfig file, it makes sense to continue merging and loading other .kubeconfig files and simply accept that current .kubeconfig is empty.
