### PR TITLE
fix kubectl config view to respect serialization formats

### DIFF
--- a/pkg/kubectl/cmd/config/config_test.go
+++ b/pkg/kubectl/cmd/config/config_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -45,6 +46,36 @@ type configCommandTest struct {
 	startingConfig  clientcmdapi.Config
 	expectedConfig  clientcmdapi.Config
 	expectedOutputs []string
+}
+
+func ExampleView() {
+	expectedConfig := newRedFederalCowHammerConfig()
+	test := configCommandTest{
+		args:           []string{"view"},
+		startingConfig: newRedFederalCowHammerConfig(),
+		expectedConfig: expectedConfig,
+	}
+
+	output := test.run(nil)
+	fmt.Printf("%v", output)
+	// Output:
+	// apiVersion: v1
+	// clusters:
+	// - cluster:
+	//     server: http://cow.org:8080
+	//   name: cow-cluster
+	// contexts:
+	// - context:
+	//     cluster: cow-cluster
+	//     user: red-user
+	//   name: federal-context
+	// current-context: ""
+	// kind: Config
+	// preferences: {}
+	// users:
+	// - name: red-user
+	//   user:
+	//     token: red-token
 }
 
 func TestSetCurrentContext(t *testing.T) {
@@ -540,7 +571,7 @@ func testConfigCommand(args []string, startingConfig clientcmdapi.Config) (strin
 	return buf.String(), *config
 }
 
-func (test configCommandTest) run(t *testing.T) {
+func (test configCommandTest) run(t *testing.T) string {
 	out, actualConfig := testConfigCommand(test.args, test.startingConfig)
 
 	testSetNilMapsToEmpties(reflect.ValueOf(&test.expectedConfig))
@@ -556,6 +587,8 @@ func (test configCommandTest) run(t *testing.T) {
 			t.Errorf("expected '%s' in output, got '%s'", expectedOutput, out)
 		}
 	}
+
+	return out
 }
 func testSetNilMapsToEmpties(curr reflect.Value) {
 	actualCurrValue := curr

--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
 	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
@@ -51,14 +53,20 @@ Examples:
 		Run: func(cmd *cobra.Command, args []string) {
 			options.complete()
 
-			printer, _, err := cmdutil.PrinterForCommand(cmd)
+			printer, generic, err := cmdutil.PrinterForCommand(cmd)
 			if err != nil {
 				glog.FatalDepth(1, err)
 			}
+			if generic {
+				version := cmdutil.OutputVersion(cmd, latest.Version)
+				printer = kubectl.NewVersionedPrinter(printer, clientcmdapi.Scheme, version)
+			}
+
 			config, err := options.loadConfig()
 			if err != nil {
 				glog.FatalDepth(1, err)
 			}
+
 			err = printer.PrintObj(config, out)
 			if err != nil {
 				glog.FatalDepth(1, err)


### PR DESCRIPTION
The scheme wasn't being passed through to a versioned printer, so the in-memory format of kubeconfig was being serialized.  Since the formats are significantly different, this didn't allow round tripping.  See: https://github.com/GoogleCloudPlatform/kubernetes/pull/3275#discussion_r22724773 for why the serialization format uses arrays and the in-memory version uses maps.

@derekwaynecarr This allows the round tripping you wanted to make with `kubectl config view > my/new/.kubeconfig`
