### PR TITLE
prevent default merging when specifying a specific kubeconfig for config view

### DIFF
--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -26,12 +26,13 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 type viewOptions struct {
 	pathOptions *pathOptions
-	merge       bool
+	merge       util.BoolFlag
 }
 
 func NewCmdConfigView(out io.Writer, pathOptions *pathOptions) *cobra.Command {
@@ -48,7 +49,9 @@ Examples:
   // Show only local ./.kubeconfig settings
   $ kubectl config view --local`,
 		Run: func(cmd *cobra.Command, args []string) {
-			printer, _, err := util.PrinterForCommand(cmd)
+			options.complete()
+
+			printer, _, err := cmdutil.PrinterForCommand(cmd)
 			if err != nil {
 				glog.FatalDepth(1, err)
 			}
@@ -63,11 +66,24 @@ Examples:
 		},
 	}
 
-	util.AddPrinterFlags(cmd)
+	cmdutil.AddPrinterFlags(cmd)
 	// Default to yaml
 	cmd.Flags().Set("output", "yaml")
-	cmd.Flags().BoolVar(&options.merge, "merge", true, "merge together the full hierarchy of .kubeconfig files")
+
+	options.merge.Default(true)
+	cmd.Flags().Var(&options.merge, "merge", "merge together the full hierarchy of .kubeconfig files")
 	return cmd
+}
+
+func (o *viewOptions) complete() bool {
+	// if --kubeconfig, --global, or --local is specified, then merging doesn't make sense since you're declaring precise intent
+	if (len(o.pathOptions.specifiedFile) > 0) || o.pathOptions.global || o.pathOptions.local {
+		if !o.merge.Provided() {
+			o.merge.Set("false")
+		}
+	}
+
+	return true
 }
 
 func (o viewOptions) loadConfig() (*clientcmdapi.Config, error) {
@@ -87,7 +103,7 @@ func (o viewOptions) validate() error {
 // getStartingConfig returns the Config object built from the sources specified by the options, the filename read (only if it was a single file), and an error if something goes wrong
 func (o *viewOptions) getStartingConfig() (*clientcmdapi.Config, string, error) {
 	switch {
-	case o.merge:
+	case o.merge.Value():
 		loadingRules := clientcmd.NewClientConfigLoadingRules()
 		loadingRules.EnvVarPath = os.Getenv("KUBECONFIG")
 		loadingRules.CommandLinePath = o.pathOptions.specifiedFile


### PR DESCRIPTION
When specifying `kubectl config view --global`, files are still merged together for display by default.  This is very confusing.

With this change, if a specific file is requested (--global, --local, or --kubeconffig) and --merge is not specifically provided, then no merging takes place.

@jlowdermilk @satnam6502  I think this helps address some of the confusion.  --global and --local will actually print out those specific files instead of also merging.
