### PR TITLE
Do not pass --kubeconfig during kube-up of vagrant

### DIFF
--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -163,7 +163,7 @@ function verify-cluster {
     local count="0"
     until [[ "$count" == "1" ]]; do
       local minions
-      minions=$("${KUBE_ROOT}/cluster/kubectl.sh --kubeconfig=${HOME}/.kubernetes_vagrant_kubeconfig" get minions -o template -t '{{range.items}}{{.id}}:{{end}}')
+      minions=$("${KUBE_ROOT}/cluster/kubectl.sh" get minions -o template -t '{{range.items}}{{.id}}:{{end}}')
       count=$(echo $minions | grep -c "${MINION_IPS[i]}") || {
         printf "."
         sleep 2
@@ -214,6 +214,7 @@ EOF
 apiVersion: v1
 clusters:
 - cluster:
+    certificate-authority: ${HOME}/$ca_cert
     server: https://${MASTER_IP}:443
   name: vagrant
 contexts:


### PR DESCRIPTION
Bash sucks.

I hit the same issue that was encountered in #4522 and was able to resolve issue.

Basically, don't pass a --kubeconfig when calling kubectl.sh as it gets very confused, and in this context, the --kubeconfig is going to be picked up by the KUBERNETES_PROVIDER that is set during cluster/kube-up.sh

@smarterclayton - can this have a fast merge?
