### PR TITLE
Check Docker init PID is valid before we use it.

### DIFF
--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -121,7 +121,10 @@ func (f *FakeDockerClient) StartContainer(id string, hostConfig *docker.HostConf
 		Name:       id, // For testing purpose, we set name to id
 		Config:     &docker.Config{Image: "testimage"},
 		HostConfig: hostConfig,
-		State:      docker.State{Running: true},
+		State: docker.State{
+			Running: true,
+			Pid:     42,
+		},
 	}
 	return f.Err
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -961,6 +961,10 @@ func (kl *Kubelet) createPodInfraContainer(pod *api.BoundPod) (dockertools.Docke
 		return "", err
 	}
 
+	// Ensure the PID actually exists, else we'll move ourselves.
+	if containerInfo.State.Pid == 0 {
+		return "", fmt.Errorf("failed to get init PID for Docker pod infra container %q", string(id))
+	}
 	return id, util.ApplyOomScoreAdj(containerInfo.State.Pid, podOomScoreAdj)
 }
 


### PR DESCRIPTION
This gives us an error if the PID is not returned as we expect.
