### PR TITLE
more kubectl doc update

### DIFF
--- a/cmd/gendocs/gen_kubectl_docs.go
+++ b/cmd/gendocs/gen_kubectl_docs.go
@@ -31,9 +31,6 @@ import (
 func printOptions(out *bytes.Buffer, command *cobra.Command, name string) {
 	flags := command.NonInheritedFlags()
 	flags.SetOutput(out)
-	if command.Runnable() {
-		fmt.Fprintf(out, "%s\n\n", command.UseLine())
-	}
 	if flags.HasFlags() {
 		fmt.Fprintf(out, "### Options\n\n```\n")
 		flags.PrintDefaults()
@@ -68,7 +65,16 @@ func genMarkdown(command *cobra.Command, parent, docsDir string) {
 	fmt.Fprintf(out, "## %s\n\n", name)
 	fmt.Fprintf(out, "%s\n\n", short)
 	fmt.Fprintf(out, "### Synopsis\n\n")
-	fmt.Fprintf(out, "%s\n\n", long)
+	fmt.Fprintf(out, "```\n%s\n```\n\n", long)
+
+	if command.Runnable() {
+		fmt.Fprintf(out, "%s\n\n", command.UseLine())
+	}
+
+	if len(command.Example) > 0 {
+		fmt.Fprintf(out, "### Examples\n\n")
+		fmt.Fprintf(out, "```\n%s\n```\n\n", command.Example)
+	}
 
 	printOptions(out, command, name)
 

--- a/cmd/genman/gen_kubectl_man.go
+++ b/cmd/genman/gen_kubectl_man.go
@@ -100,18 +100,18 @@ func printFlags(out *bytes.Buffer, flags *pflag.FlagSet) {
 }
 
 func printOptions(out *bytes.Buffer, command *cobra.Command) {
-	var flags *pflag.FlagSet
-	if command.HasFlags() {
-		flags = command.Flags()
-	} else if !command.HasParent() && command.HasPersistentFlags() {
-		flags = command.PersistentFlags()
+	flags := command.NonInheritedFlags()
+	if flags.HasFlags() {
+		fmt.Fprintf(out, "# OPTIONS\n")
+		printFlags(out, flags)
+		fmt.Fprintf(out, "\n")
 	}
-	if flags == nil {
-		return
+	flags = command.InheritedFlags()
+	if flags.HasFlags() {
+		fmt.Fprintf(out, "# OPTIONS INHERITED FROM PARENT COMMANDS\n")
+		printFlags(out, flags)
+		fmt.Fprintf(out, "\n")
 	}
-	fmt.Fprintf(out, "# OPTIONS\n")
-	printFlags(out, flags)
-	fmt.Fprintf(out, "\n")
 }
 
 func genMarkdown(command *cobra.Command, parent, docsDir string) {

--- a/cmd/genman/gen_kubectl_man.go
+++ b/cmd/genman/gen_kubectl_man.go
@@ -133,6 +133,11 @@ func genMarkdown(command *cobra.Command, parent, docsDir string) {
 	preamble(out, name, short, long)
 	printOptions(out, command)
 
+	if len(command.Example) > 0 {
+		fmt.Fprintf(out, "# EXAMPLE\n")
+		fmt.Fprintf(out, "```\n%s\n```\n", command.Example)
+	}
+
 	if len(command.Commands()) > 0 || len(parent) > 0 {
 		fmt.Fprintf(out, "# SEE ALSO\n")
 		if len(parent) > 0 {

--- a/docs/kubectl-config-set-cluster.md
+++ b/docs/kubectl-config-set-cluster.md
@@ -4,12 +4,14 @@ Sets a cluster entry in .kubeconfig
 
 ### Synopsis
 
+```
 Sets a cluster entry in .kubeconfig
 	Specifying a name that already exists will merge new fields on top of existing values for those fields.
 	e.g. 
 		kubectl config set-cluster e2e --certificate-authority=~/.kube/e2e/.kubernetes.ca.cert
 		only sets the certificate-authority field on the e2e cluster entry without touching other values.
 		
+```
 
 kubectl config set-cluster name [--server=server] [--certificate-authority=path/to/certficate/authority] [--api-version=apiversion] [--insecure-skip-tls-verify=true]
 

--- a/docs/kubectl-config-set-context.md
+++ b/docs/kubectl-config-set-context.md
@@ -4,12 +4,13 @@ Sets a context entry in .kubeconfig
 
 ### Synopsis
 
+```
 Sets a context entry in .kubeconfig
 	Specifying a name that already exists will merge new fields on top of existing values for those fields.
 	e.g. 
 		kubectl config set-context gce --user=cluster-admin
 		only sets the user field on the gce context entry without touching other values.
-		
+```
 
 kubectl config set-context name [--cluster=cluster-nickname] [--user=user-nickname] [--namespace=namespace]
 

--- a/docs/kubectl-config-set-credentials.md
+++ b/docs/kubectl-config-set-credentials.md
@@ -4,6 +4,7 @@ Sets a user entry in .kubeconfig
 
 ### Synopsis
 
+```
 Sets a user entry in .kubeconfig
 
   Specifying a name that already exists will merge new fields on top of existing
@@ -23,6 +24,7 @@ Sets a user entry in .kubeconfig
 
   Bearer token and basic auth are mutually exclusive.
 
+```
 
 kubectl config set-credentials name [--auth-path=authfile] [--client-certificate=certfile] [--client-key=keyfile] [--token=bearer_token] [--username=basic_user] [--password=basic_password]
 

--- a/docs/kubectl-config-set.md
+++ b/docs/kubectl-config-set.md
@@ -4,12 +4,14 @@ Sets an individual value in a .kubeconfig file
 
 ### Synopsis
 
+```
 Sets an individual value in a .kubeconfig file
 
 		property-name is a dot delimited name where each token represents either a attribute name or a map key.  Map keys may not contain dots.
 		property-value is the new value you wish to set.
 
 		
+```
 
 kubectl config set property-name property-value
 

--- a/docs/kubectl-config-unset.md
+++ b/docs/kubectl-config-unset.md
@@ -4,10 +4,12 @@ Unsets an individual value in a .kubeconfig file
 
 ### Synopsis
 
+```
 Unsets an individual value in a .kubeconfig file
 
 		property-name is a dot delimited name where each token represents either a attribute name or a map key.  Map keys may not contain dots.
 		
+```
 
 kubectl config unset property-name
 

--- a/docs/kubectl-config-use-context.md
+++ b/docs/kubectl-config-use-context.md
@@ -4,7 +4,9 @@ Sets the current-context in a .kubeconfig file
 
 ### Synopsis
 
+```
 Sets the current-context in a .kubeconfig file
+```
 
 kubectl config use-context context-name
 

--- a/docs/kubectl-config-view.md
+++ b/docs/kubectl-config-view.md
@@ -4,15 +4,21 @@ displays merged .kubeconfig settings or a specified .kubeconfig file.
 
 ### Synopsis
 
+```
 displays merged .kubeconfig settings or a specified .kubeconfig file.
-Examples:
-  // Show merged .kubeconfig settings.
-  $ kubectl config view
-
-  // Show only local ./.kubeconfig settings
-  $ kubectl config view --local
+```
 
 kubectl config view
+
+### Examples
+
+```
+// Show merged .kubeconfig settings.
+$ kubectl config view
+
+// Show only local ./.kubeconfig settings
+$ kubectl config view --local
+```
 
 ### Options
 

--- a/docs/kubectl-config.md
+++ b/docs/kubectl-config.md
@@ -4,7 +4,9 @@ config modifies .kubeconfig files
 
 ### Synopsis
 
+```
 config modifies .kubeconfig files using subcommands like "kubectl config set current-context my-context"
+```
 
 kubectl config <subcommand>
 

--- a/docs/kubectl-create.md
+++ b/docs/kubectl-create.md
@@ -4,19 +4,23 @@ Create a resource by filename or stdin
 
 ### Synopsis
 
+```
 Create a resource by filename or stdin.
 
 JSON and YAML formats are accepted.
-
-Examples:
-
-    // Create a pod using the data in pod.json.
-    $ kubectl create -f pod.json
-
-    // Create a pod based on the JSON passed into stdin.
-    $ cat pod.json | kubectl create -f -
+```
 
 kubectl create -f filename
+
+### Examples
+
+```
+// Create a pod using the data in pod.json.
+$ kubectl create -f pod.json
+
+// Create a pod based on the JSON passed into stdin.
+$ cat pod.json | kubectl create -f -
+```
 
 ### Options
 

--- a/docs/kubectl-delete.md
+++ b/docs/kubectl-delete.md
@@ -4,6 +4,7 @@ Delete a resource by filename, stdin, or resource and ID.
 
 ### Synopsis
 
+```
 Delete a resource by filename, stdin, resource and ID, or by resources and label selector.
 
 JSON and YAML formats are accepted.
@@ -14,25 +15,28 @@ arguments are used and the filename is ignored.
 Note that the delete command does NOT do resource version checks, so if someone
 submits an update to a resource right when you submit a delete, their update
 will be lost along with the rest of the resource.
-
-Examples:
-
-    // Delete a pod using the type and ID specified in pod.json.
-    $ kubectl delete -f pod.json
-
-    // Delete a pod based on the type and ID in the JSON passed into stdin.
-    $ cat pod.json | kubectl delete -f -
-
-    // Delete pods and services with label name=myLabel.
-    $ kubectl delete pods,services -l name=myLabel
-
-    // Delete a pod with ID 1234-56-7890-234234-456456.
-    $ kubectl delete pod 1234-56-7890-234234-456456
-
-    // Delete all pods
-    $ kubectl delete pods --all
+```
 
 kubectl delete ([-f filename] | (<resource> [(<id> | -l <label> | --all)]
+
+### Examples
+
+```
+// Delete a pod using the type and ID specified in pod.json.
+$ kubectl delete -f pod.json
+
+// Delete a pod based on the type and ID in the JSON passed into stdin.
+$ cat pod.json | kubectl delete -f -
+
+// Delete pods and services with label name=myLabel.
+$ kubectl delete pods,services -l name=myLabel
+
+// Delete a pod with ID 1234-56-7890-234234-456456.
+$ kubectl delete pod 1234-56-7890-234234-456456
+
+// Delete all pods
+$ kubectl delete pods --all
+```
 
 ### Options
 

--- a/docs/kubectl-describe.md
+++ b/docs/kubectl-describe.md
@@ -4,10 +4,12 @@ Show details of a specific resource
 
 ### Synopsis
 
+```
 Show details of a specific resource.
 
 This command joins many API calls together to form a detailed description of a
 given resource.
+```
 
 kubectl describe <resource> <id>
 

--- a/docs/kubectl-exec.md
+++ b/docs/kubectl-exec.md
@@ -4,16 +4,21 @@ Execute a command in a container.
 
 ### Synopsis
 
+```
 Execute a command in a container.
-Examples:
-  $ kubectl exec -p 123456-7890 -c ruby-container date
-  <returns output from running 'date' in ruby-container from pod 123456-7890>
-
-  $ kubectl exec -p 123456-7890 -c ruby-container -i -t -- bash -il
-  <switches to raw terminal mode, sends stdin to 'bash' in ruby-container from
-   pod 123456-780 and sends stdout/stderr from 'bash' back to the client
+```
 
 kubectl exec -p <pod> -c <container> -- <command> [<args...>]
+
+### Examples
+
+```
+// get output from running 'date' in ruby-container from pod 123456-7890
+$ kubectl exec -p 123456-7890 -c ruby-container date
+
+//switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-780 and sends stdout/stderr from 'bash' back to the client
+$ kubectl exec -p 123456-7890 -c ruby-container -i -t -- bash -il
+```
 
 ### Options
 

--- a/docs/kubectl-expose.md
+++ b/docs/kubectl-expose.md
@@ -4,20 +4,24 @@ Take a replicated application and expose it as Kubernetes Service
 
 ### Synopsis
 
+```
 Take a replicated application and expose it as Kubernetes Service.
 		
 Looks up a ReplicationController by name, and uses the selector for that replication controller
 as the selector for a new Service on the specified port.
-
-Examples:
-
-    // Creates a service for a replicated nginx, which serves on port 80 and connects to the containers on port 8000.
-    $ kubectl expose nginx --port=80 --container-port=8000
-
-    // Create a service for a replicated streaming application on port 4100 balancing UDP traffic and named 'video-stream'.
-    $ kubectl expose streamer --port=4100 --protocol=udp --service-name=video-stream
+```
 
 kubectl expose <name> --port=<port> [--protocol=TCP|UDP] [--container-port=<number-or-name>] [--service-name=<name>] [--public-ip=<ip>] [--create-external-load-balancer]
+
+### Examples
+
+```
+// Creates a service for a replicated nginx, which serves on port 80 and connects to the containers on port 8000.
+$ kubectl expose nginx --port=80 --container-port=8000
+
+// Create a service for a replicated streaming application on port 4100 balancing UDP traffic and named 'video-stream'.
+$ kubectl expose streamer --port=4100 --protocol=udp --service-name=video-stream
+```
 
 ### Options
 

--- a/docs/kubectl-get.md
+++ b/docs/kubectl-get.md
@@ -4,6 +4,7 @@ Display one or many resources
 
 ### Synopsis
 
+```
 Display one or many resources.
 
 Possible resources include pods (po), replication controllers (rc), services
@@ -11,25 +12,28 @@ Possible resources include pods (po), replication controllers (rc), services
 
 By specifying the output as 'template' and providing a Go template as the value
 of the --template flag, you can filter the attributes of the fetched resource(s).
-
-Examples:
-
-    // List all pods in ps output format.
-    $ kubectl get pods
-
-    // List a single replication controller with specified ID in ps output format.
-    $ kubectl get replicationController 1234-56-7890-234234-456456
-
-    // List a single pod in JSON output format.
-    $ kubectl get -o json pod 1234-56-7890-234234-456456
-
-    // Return only the status value of the specified pod.
-    $ kubectl get -o template pod 1234-56-7890-234234-456456 --template={{.currentState.status}}
-
-    // List all replication controllers and services together in ps output format.
-    $ kubectl get rc,services
+```
 
 kubectl get [(-o|--output=)json|yaml|template|...] <resource> [<id>]
+
+### Examples
+
+```
+// List all pods in ps output format.
+$ kubectl get pods
+
+// List a single replication controller with specified ID in ps output format.
+$ kubectl get replicationController 1234-56-7890-234234-456456
+
+// List a single pod in JSON output format.
+$ kubectl get -o json pod 1234-56-7890-234234-456456
+
+// Return only the status value of the specified pod.
+$ kubectl get -o template pod 1234-56-7890-234234-456456 --template={{.currentState.status}}
+
+// List all replication controllers and services together in ps output format.
+$ kubectl get rc,services
+```
 
 ### Options
 

--- a/docs/kubectl-label.md
+++ b/docs/kubectl-label.md
@@ -4,26 +4,31 @@ Update the labels on a resource
 
 ### Synopsis
 
+```
 Update the labels on a resource.
 
 If --overwrite is true, then existing labels can be overwritten, otherwise attempting to overwrite a label will result in an error.
 If --resource-version is specified, then updates will use this resource version, otherwise the existing resource-version will be used.
-
-Examples:
-  // Update pod 'foo' with the label 'unhealthy' and the value 'true'.
-  $ kubectl label pods foo unhealthy=true
-
-  // Update pod 'foo' with the label 'status' and the value 'unhealthy', overwriting any existing value.
-  $ kubectl label --overwrite pods foo status=unhealthy
-  
-  // Update pod 'foo' only if the resource is unchanged from version 1.
-  $ kubectl label pods foo status=unhealthy --resource-version=1
-  
-  // Update pod 'foo' by removing a label named 'bar' if it exists.
-  // Does not require the --overwrite flag.
-  $ kubectl label pods foo bar-
+```
 
 kubectl label [--overwrite] <resource> <name> <key-1>=<val-1> ... <key-n>=<val-n> [--resource-version=<version>]
+
+### Examples
+
+```
+// Update pod 'foo' with the label 'unhealthy' and the value 'true'.
+$ kubectl label pods foo unhealthy=true
+
+// Update pod 'foo' with the label 'status' and the value 'unhealthy', overwriting any existing value.
+$ kubectl label --overwrite pods foo status=unhealthy
+
+// Update pod 'foo' only if the resource is unchanged from version 1.
+$ kubectl label pods foo status=unhealthy --resource-version=1
+
+// Update pod 'foo' by removing a label named 'bar' if it exists.
+// Does not require the --overwrite flag.
+$ kubectl label pods foo bar-
+```
 
 ### Options
 

--- a/docs/kubectl-log.md
+++ b/docs/kubectl-log.md
@@ -4,17 +4,21 @@ Print the logs for a container in a pod.
 
 ### Synopsis
 
+```
 Print the logs for a container in a pod. If the pod has only one container, the container name is optional.
-
-Examples:
-
-    // Returns snapshot of ruby-container logs from pod 123456-7890.
-    $ kubectl log 123456-7890 ruby-container
-
-    // Starts streaming of ruby-container logs from pod 123456-7890.
-    $ kubectl log -f 123456-7890 ruby-container
+```
 
 kubectl log [-f] <pod> [<container>]
+
+### Examples
+
+```
+// Returns snapshot of ruby-container logs from pod 123456-7890.
+$ kubectl log 123456-7890 ruby-container
+
+// Starts streaming of ruby-container logs from pod 123456-7890.
+$ kubectl log -f 123456-7890 ruby-container
+```
 
 ### Options
 

--- a/docs/kubectl-namespace.md
+++ b/docs/kubectl-namespace.md
@@ -4,10 +4,12 @@ SUPERCEDED: Set and view the current Kubernetes namespace
 
 ### Synopsis
 
+```
 SUPERCEDED:  Set and view the current Kubernetes namespace scope for command line requests.
 
 namespace has been superceded by the context.namespace field of .kubeconfig files.  See 'kubectl config set-context --help' for more details.
 
+```
 
 kubectl namespace [<namespace>]
 

--- a/docs/kubectl-port-forward.md
+++ b/docs/kubectl-port-forward.md
@@ -4,23 +4,27 @@ Forward 1 or more local ports to a pod.
 
 ### Synopsis
 
+```
 Forward 1 or more local ports to a pod.
-Examples:
-  $ kubectl port-forward -p mypod 5000 6000
-  <listens on ports 5000 and 6000 locally, forwarding data to/from ports 5000
-   and 6000 in the pod>
-
-	$ kubectl port-forward -p mypod 8888:5000
-	<listens on port 8888 locally, forwarding to 5000 in the pod>
-
-	$ kubectl port-forward -p mypod :5000
-	<listens on a random port locally, forwarding to 5000 in the pod>
-
-	$ kubectl port-forward -p mypod 0:5000
-	<listens on a random port locally, forwarding to 5000 in the pod>
-   
+```
 
 kubectl port-forward -p <pod> [<local port>:]<remote port> [<port>...]
+
+### Examples
+
+```
+$ kubectl port-forward -p mypod 5000 6000
+<listens on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in the pod>
+
+$ kubectl port-forward -p mypod 8888:5000
+<listens on port 8888 locally, forwarding to 5000 in the pod>
+
+$ kubectl port-forward -p mypod :5000
+<listens on a random port locally, forwarding to 5000 in the pod>
+
+$ kubectl port-forward -p mypod 0:5000
+<listens on a random port locally, forwarding to 5000 in the pod> 
+```
 
 ### Options
 

--- a/docs/kubectl-proxy.md
+++ b/docs/kubectl-proxy.md
@@ -4,7 +4,9 @@ Run a proxy to the Kubernetes API server
 
 ### Synopsis
 
+```
 Run a proxy to the Kubernetes API server.
+```
 
 kubectl proxy
 

--- a/docs/kubectl-resize.md
+++ b/docs/kubectl-resize.md
@@ -4,22 +4,26 @@ Set a new size for a Replication Controller.
 
 ### Synopsis
 
+```
 Set a new size for a Replication Controller.
 
 Resize also allows users to specify one or more preconditions for the resize action.
 If --current-replicas or --resource-version is specified, it is validated before the
 resize is attempted, and it is guaranteed that the precondition holds true when the
 resize is sent to the server.
-
-Examples:
-
-    // Resize replication controller named 'foo' to 3.
-    $ kubectl resize --replicas=3 replicationcontrollers foo
-
-    // If the replication controller named foo's current size is 2, resize foo to 3.
-    $ kubectl resize --current-replicas=2 --replicas=3 replicationcontrollers foo
+```
 
 kubectl resize [--resource-version=<version>] [--current-replicas=<count>] --replicas=<count> <resource> <id>
+
+### Examples
+
+```
+// Resize replication controller named 'foo' to 3.
+$ kubectl resize --replicas=3 replicationcontrollers foo
+
+// If the replication controller named foo's current size is 2, resize foo to 3.
+$ kubectl resize --current-replicas=2 --replicas=3 replicationcontrollers foo
+```
 
 ### Options
 

--- a/docs/kubectl-rollingupdate.md
+++ b/docs/kubectl-rollingupdate.md
@@ -4,21 +4,25 @@ Perform a rolling update of the given ReplicationController.
 
 ### Synopsis
 
+```
 Perform a rolling update of the given ReplicationController.
 
 Replaces the specified controller with new controller, updating one pod at a time to use the
 new PodTemplate. The new-controller.json must specify the same namespace as the
 existing controller and overwrite at least one (common) label in its replicaSelector.
-
-Examples:
-
-    // Update pods of frontend-v1 using new controller data in frontend-v2.json.
-    $ kubectl rollingupdate frontend-v1 -f frontend-v2.json
-
-    // Update pods of frontend-v1 using JSON data passed into stdin.
-    $ cat frontend-v2.json | kubectl rollingupdate frontend-v1 -f -
+```
 
 kubectl rollingupdate <old-controller-name> -f <new-controller.json>
+
+### Examples
+
+```
+// Update pods of frontend-v1 using new controller data in frontend-v2.json.
+$ kubectl rollingupdate frontend-v1 -f frontend-v2.json
+
+// Update pods of frontend-v1 using JSON data passed into stdin.
+$ cat frontend-v2.json | kubectl rollingupdate frontend-v1 -f -
+```
 
 ### Options
 

--- a/docs/kubectl-run-container.md
+++ b/docs/kubectl-run-container.md
@@ -4,24 +4,28 @@ Run a particular image on the cluster.
 
 ### Synopsis
 
+```
 Create and run a particular image, possibly replicated.
 Creates a replication controller to manage the created container(s).
-
-Examples:
-
-    // Starts a single instance of nginx.
-    $ kubectl run-container nginx --image=dockerfile/nginx
-
-    // Starts a replicated instance of nginx.
-    $ kubectl run-container nginx --image=dockerfile/nginx --replicas=5
-
-    // Dry run. Print the corresponding API objects without creating them.
-    $ kubectl run-container nginx --image=dockerfile/nginx --dry-run
-  
-    // Start a single instance of nginx, but overload the desired state with a partial set of values parsed from JSON.
-    $ kubectl run-container nginx --image=dockerfile/nginx --overrides='{ "apiVersion": "v1beta1", "desiredState": { ... } }'
+```
 
 kubectl run-container <name> --image=<image> [--port=<port>] [--replicas=replicas] [--dry-run=<bool>] [--overrides=<inline-json>]
+
+### Examples
+
+```
+// Starts a single instance of nginx.
+$ kubectl run-container nginx --image=dockerfile/nginx
+
+// Starts a replicated instance of nginx.
+$ kubectl run-container nginx --image=dockerfile/nginx --replicas=5
+
+// Dry run. Print the corresponding API objects without creating them.
+$ kubectl run-container nginx --image=dockerfile/nginx --dry-run
+
+// Start a single instance of nginx, but overload the desired state with a partial set of values parsed from JSON.
+$ kubectl run-container nginx --image=dockerfile/nginx --overrides='{ "apiVersion": "v1beta1", "desiredState": { ... } }'
+```
 
 ### Options
 

--- a/docs/kubectl-stop.md
+++ b/docs/kubectl-stop.md
@@ -4,23 +4,27 @@ Gracefully shut down a resource by id or filename.
 
 ### Synopsis
 
+```
 Gracefully shut down a resource by id or filename.
 
 Attempts to shut down and delete a resource that supports graceful termination.
 If the resource is resizable it will be resized to 0 before deletion.
-
-Examples:
-
-    // Shut down foo.
-    $ kubectl stop replicationcontroller foo
-
-    // Shut down the service defined in service.json
-    $ kubectl stop -f service.json
-
-    // Shut down all resources in the path/to/resources directory
-    $ kubectl stop -f path/to/resources
+```
 
 kubectl stop (<resource> <id>|-f filename)
+
+### Examples
+
+```
+// Shut down foo.
+$ kubectl stop replicationcontroller foo
+
+// Shut down the service defined in service.json
+$ kubectl stop -f service.json
+
+// Shut down all resources in the path/to/resources directory
+$ kubectl stop -f path/to/resources
+```
 
 ### Options
 

--- a/docs/kubectl-update.md
+++ b/docs/kubectl-update.md
@@ -4,22 +4,26 @@ Update a resource by filename or stdin.
 
 ### Synopsis
 
+```
 Update a resource by filename or stdin.
 
 JSON and YAML formats are accepted.
-
-Examples:
-
-    // Update a pod using the data in pod.json.
-    $ kubectl update -f pod.json
-
-    // Update a pod based on the JSON passed into stdin.
-    $ cat pod.json | kubectl update -f -
-
-    // Update a pod by downloading it, applying the patch, then updating. Requires apiVersion be specified.
-    $ kubectl update pods my-pod --patch='{ "apiVersion": "v1beta1", "desiredState": { "manifest": [{ "cpu": 100 }]}}'
+```
 
 kubectl update -f filename
+
+### Examples
+
+```
+// Update a pod using the data in pod.json.
+$ kubectl update -f pod.json
+
+// Update a pod based on the JSON passed into stdin.
+$ cat pod.json | kubectl update -f -
+
+// Update a pod by downloading it, applying the patch, then updating. Requires apiVersion be specified.
+$ kubectl update pods my-pod --patch='{ "apiVersion": "v1beta1", "desiredState": { "manifest": [{ "cpu": 100 }]}}'
+```
 
 ### Options
 

--- a/docs/kubectl-version.md
+++ b/docs/kubectl-version.md
@@ -4,7 +4,9 @@ Print the client and server version information.
 
 ### Synopsis
 
+```
 Print the client and server version information.
+```
 
 kubectl version
 

--- a/docs/kubectl.md
+++ b/docs/kubectl.md
@@ -4,9 +4,11 @@ kubectl controls the Kubernetes cluster manager
 
 ### Synopsis
 
+```
 kubectl controls the Kubernetes cluster manager.
 
 Find more information at https://github.com/GoogleCloudPlatform/kubernetes.
+```
 
 kubectl
 

--- a/docs/man/man1/kubectl-config-set-cluster.1
+++ b/docs/man/man1/kubectl-config-set-cluster.1
@@ -20,22 +20,122 @@ Sets a cluster entry in .kubeconfig
         only sets the certificate\-authority field on the e2e cluster entry without touching other values.
 
 
-.SH OPTIONS
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
 .PP
 \fB\-\-api\-version\fP=""
-    api\-version for the cluster entry in .kubeconfig
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
 
 .PP
 \fB\-\-certificate\-authority\fP=""
-    certificate\-authority for the cluster entry in .kubeconfig
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-\-envvar\fP=false
+    use the .kubeconfig from $KUBECONFIG
+
+.PP
+\fB\-\-global\fP=false
+    use the .kubeconfig from /home/username
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for config
 
 .PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
-    insecure\-skip\-tls\-verify for the cluster entry in .kubeconfig
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
 .PP
-\fB\-\-server\fP=""
-    server for the cluster entry in .kubeconfig
+\fB\-\-kubeconfig\fP=""
+    use a particular .kubeconfig file
+
+.PP
+\fB\-\-local\fP=false
+    use the .kubeconfig in the current directory
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-config-set-context.1
+++ b/docs/man/man1/kubectl-config-set-context.1
@@ -20,18 +20,122 @@ Sets a context entry in .kubeconfig
         only sets the user field on the gce context entry without touching other values.
 
 
-.SH OPTIONS
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
 .PP
 \fB\-\-cluster\fP=""
-    cluster for the context entry in .kubeconfig
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-\-envvar\fP=false
+    use the .kubeconfig from $KUBECONFIG
+
+.PP
+\fB\-\-global\fP=false
+    use the .kubeconfig from /home/username
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for config
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    use a particular .kubeconfig file
+
+.PP
+\fB\-\-local\fP=false
+    use the .kubeconfig in the current directory
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
 
 .PP
 \fB\-\-namespace\fP=""
-    namespace for the context entry in .kubeconfig
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
 
 .PP
 \fB\-\-user\fP=""
-    user for the context entry in .kubeconfig
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-config-set-credentials.1
+++ b/docs/man/man1/kubectl-config-set-credentials.1
@@ -45,30 +45,122 @@ Basic auth flags:
 Bearer token and basic auth are mutually exclusive.
 
 
-.SH OPTIONS
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-auth\-path\fP=""
-    auth\-path for the user entry in .kubeconfig
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
 
 .PP
 \fB\-\-client\-certificate\fP=""
-    client\-certificate for the user entry in .kubeconfig
+    Path to a client key file for TLS.
 
 .PP
 \fB\-\-client\-key\fP=""
-    client\-key for the user entry in .kubeconfig
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-\-envvar\fP=false
+    use the .kubeconfig from $KUBECONFIG
+
+.PP
+\fB\-\-global\fP=false
+    use the .kubeconfig from /home/username
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for config
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    use a particular .kubeconfig file
+
+.PP
+\fB\-\-local\fP=false
+    use the .kubeconfig in the current directory
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
 
 .PP
 \fB\-\-password\fP=""
-    password for the user entry in .kubeconfig
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
 
 .PP
 \fB\-\-token\fP=""
-    token for the user entry in .kubeconfig
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
 
 .PP
 \fB\-\-username\fP=""
-    username for the user entry in .kubeconfig
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-config-set.1
+++ b/docs/man/man1/kubectl-config-set.1
@@ -26,6 +26,124 @@ Sets an individual value in a .kubeconfig file
 .RE
 
 
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-\-envvar\fP=false
+    use the .kubeconfig from $KUBECONFIG
+
+.PP
+\fB\-\-global\fP=false
+    use the .kubeconfig from /home/username
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for config
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    use a particular .kubeconfig file
+
+.PP
+\fB\-\-local\fP=false
+    use the .kubeconfig in the current directory
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
 .SH SEE ALSO
 .PP
 \fBkubectl\-config(1)\fP,

--- a/docs/man/man1/kubectl-config-unset.1
+++ b/docs/man/man1/kubectl-config-unset.1
@@ -25,6 +25,124 @@ Unsets an individual value in a .kubeconfig file
 .RE
 
 
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-\-envvar\fP=false
+    use the .kubeconfig from $KUBECONFIG
+
+.PP
+\fB\-\-global\fP=false
+    use the .kubeconfig from /home/username
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for config
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    use a particular .kubeconfig file
+
+.PP
+\fB\-\-local\fP=false
+    use the .kubeconfig in the current directory
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
 .SH SEE ALSO
 .PP
 \fBkubectl\-config(1)\fP,

--- a/docs/man/man1/kubectl-config-use-context.1
+++ b/docs/man/man1/kubectl-config-use-context.1
@@ -16,6 +16,124 @@ kubectl config use\-context \- Sets the current\-context in a .kubeconfig file
 Sets the current\-context in a .kubeconfig file
 
 
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-\-envvar\fP=false
+    use the .kubeconfig from $KUBECONFIG
+
+.PP
+\fB\-\-global\fP=false
+    use the .kubeconfig from /home/username
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for config
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    use a particular .kubeconfig file
+
+.PP
+\fB\-\-local\fP=false
+    use the .kubeconfig in the current directory
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
 .SH SEE ALSO
 .PP
 \fBkubectl\-config(1)\fP,

--- a/docs/man/man1/kubectl-config-view.1
+++ b/docs/man/man1/kubectl-config-view.1
@@ -14,13 +14,6 @@ kubectl config view \- displays merged .kubeconfig settings or a specified .kube
 .SH DESCRIPTION
 .PP
 displays merged .kubeconfig settings or a specified .kubeconfig file.
-Examples:
-  // Show merged .kubeconfig settings.
-  $ kubectl config view
-
-.PP
-// Show only local ./.kubeconfig settings
-  $ kubectl config view \-\-local
 
 
 .SH OPTIONS
@@ -44,6 +37,139 @@ Examples:
 \fB\-t\fP, \fB\-\-template\fP=""
     Template string or path to template file to use when \-o=template or \-o=templatefile.  The template format is golang templates [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]]
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-\-envvar\fP=false
+    use the .kubeconfig from $KUBECONFIG
+
+.PP
+\fB\-\-global\fP=false
+    use the .kubeconfig from /home/username
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for config
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    use a particular .kubeconfig file
+
+.PP
+\fB\-\-local\fP=false
+    use the .kubeconfig in the current directory
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+// Show merged .kubeconfig settings.
+$ kubectl config view
+
+// Show only local ./.kubeconfig settings
+$ kubectl config view \-\-local
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-config.1
+++ b/docs/man/man1/kubectl-config.1
@@ -16,6 +16,126 @@ kubectl config \- config modifies .kubeconfig files
 config modifies .kubeconfig files using subcommands like "kubectl config set current\-context my\-context"
 
 
+.SH OPTIONS
+.PP
+\fB\-\-envvar\fP=false
+    use the .kubeconfig from $KUBECONFIG
+
+.PP
+\fB\-\-global\fP=false
+    use the .kubeconfig from /home/username
+
+.PP
+\fB\-\-local\fP=false
+    use the .kubeconfig in the current directory
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
 .SH SEE ALSO
 .PP
 \fBkubectl(1)\fP, \fBkubectl\-config\-view(1)\fP, \fBkubectl\-config\-set\-cluster(1)\fP, \fBkubectl\-config\-set\-credentials(1)\fP, \fBkubectl\-config\-set\-context(1)\fP, \fBkubectl\-config\-set(1)\fP, \fBkubectl\-config\-unset(1)\fP, \fBkubectl\-config\-use\-context(1)\fP,

--- a/docs/man/man1/kubectl-create.1
+++ b/docs/man/man1/kubectl-create.1
@@ -18,9 +18,120 @@ Create a resource by filename or stdin.
 .PP
 JSON and YAML formats are accepted.
 
-.PP
-Examples:
 
+.SH OPTIONS
+.PP
+\fB\-f\fP, \fB\-\-filename\fP=[]
+    Filename, directory, or URL to file to use to create the resource
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
+.SH EXAMPLE
 .PP
 .RS
 
@@ -33,12 +144,6 @@ $ cat pod.json | kubectl create \-f \-
 
 .fi
 .RE
-
-
-.SH OPTIONS
-.PP
-\fB\-f\fP, \fB\-\-filename\fP=[]
-    Filename, directory, or URL to file to use to create the resource
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-delete.1
+++ b/docs/man/man1/kubectl-delete.1
@@ -27,9 +27,128 @@ Note that the delete command does NOT do resource version checks, so if someone
 submits an update to a resource right when you submit a delete, their update
 will be lost along with the rest of the resource.
 
-.PP
-Examples:
 
+.SH OPTIONS
+.PP
+\fB\-\-all\fP=false
+    [\-all] to select all the specified resources
+
+.PP
+\fB\-f\fP, \fB\-\-filename\fP=[]
+    Filename, directory, or URL to a file containing the resource to delete
+
+.PP
+\fB\-l\fP, \fB\-\-selector\fP=""
+    Selector (label query) to filter on
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
+.SH EXAMPLE
 .PP
 .RS
 
@@ -51,20 +170,6 @@ $ kubectl delete pods \-\-all
 
 .fi
 .RE
-
-
-.SH OPTIONS
-.PP
-\fB\-\-all\fP=false
-    [\-all] to select all the specified resources
-
-.PP
-\fB\-f\fP, \fB\-\-filename\fP=[]
-    Filename, directory, or URL to a file containing the resource to delete
-
-.PP
-\fB\-l\fP, \fB\-\-selector\fP=""
-    Selector (label query) to filter on
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-describe.1
+++ b/docs/man/man1/kubectl-describe.1
@@ -20,6 +20,112 @@ This command joins many API calls together to form a detailed description of a
 given resource.
 
 
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
 .SH SEE ALSO
 .PP
 \fBkubectl(1)\fP,

--- a/docs/man/man1/kubectl-exec.1
+++ b/docs/man/man1/kubectl-exec.1
@@ -14,14 +14,6 @@ kubectl exec \- Execute a command in a container.
 .SH DESCRIPTION
 .PP
 Execute a command in a container.
-Examples:
-  $ kubectl exec \-p 123456\-7890 \-c ruby\-container date
-  <returns output from running 'date' in ruby-container from pod 123456-7890>
-
-.PP
-$ kubectl exec \-p 123456\-7890 \-c ruby\-container \-i \-t \-\- bash \-il
-  <switches to raw terminal mode, sends stdin to 'bash' in ruby\-container from
-   pod 123456\-780 and sends stdout/stderr from 'bash' back to the client
 
 
 .SH OPTIONS
@@ -40,6 +32,127 @@ $ kubectl exec \-p 123456\-7890 \-c ruby\-container \-i \-t \-\- bash \-il
 .PP
 \fB\-t\fP, \fB\-\-tty\fP=false
     Stdin is a TTY
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+// get output from running 'date' in ruby\-container from pod 123456\-7890
+$ kubectl exec \-p 123456\-7890 \-c ruby\-container date
+
+//switch to raw terminal mode, sends stdin to 'bash' in ruby\-container from pod 123456\-780 and sends stdout/stderr from 'bash' back to the client
+$ kubectl exec \-p 123456\-7890 \-c ruby\-container \-i \-t \-\- bash \-il
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-expose.1
+++ b/docs/man/man1/kubectl-expose.1
@@ -19,22 +19,6 @@ Take a replicated application and expose it as Kubernetes Service.
 Looks up a ReplicationController by name, and uses the selector for that replication controller
 as the selector for a new Service on the specified port.
 
-.PP
-Examples:
-
-.PP
-.RS
-
-.nf
-// Creates a service for a replicated nginx, which serves on port 80 and connects to the containers on port 8000.
-$ kubectl expose nginx \-\-port=80 \-\-container\-port=8000
-
-// Create a service for a replicated streaming application on port 4100 balancing UDP traffic and named 'video\-stream'.
-$ kubectl expose streamer \-\-port=4100 \-\-protocol=udp \-\-service\-name=video\-stream
-
-.fi
-.RE
-
 
 .SH OPTIONS
 .PP
@@ -93,6 +77,127 @@ $ kubectl expose streamer \-\-port=4100 \-\-protocol=udp \-\-service\-name=video
 \fB\-t\fP, \fB\-\-template\fP=""
     Template string or path to template file to use when \-o=template or \-o=templatefile.  The template format is golang templates [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]]
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+// Creates a service for a replicated nginx, which serves on port 80 and connects to the containers on port 8000.
+$ kubectl expose nginx \-\-port=80 \-\-container\-port=8000
+
+// Create a service for a replicated streaming application on port 4100 balancing UDP traffic and named 'video\-stream'.
+$ kubectl expose streamer \-\-port=4100 \-\-protocol=udp \-\-service\-name=video\-stream
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-get.1
+++ b/docs/man/man1/kubectl-get.1
@@ -23,31 +23,6 @@ Possible resources include pods (po), replication controllers (rc), services
 By specifying the output as 'template' and providing a Go template as the value
 of the \-\-template flag, you can filter the attributes of the fetched resource(s).
 
-.PP
-Examples:
-
-.PP
-.RS
-
-.nf
-// List all pods in ps output format.
-$ kubectl get pods
-
-// List a single replication controller with specified ID in ps output format.
-$ kubectl get replicationController 1234\-56\-7890\-234234\-456456
-
-// List a single pod in JSON output format.
-$ kubectl get \-o json pod 1234\-56\-7890\-234234\-456456
-
-// Return only the status value of the specified pod.
-$ kubectl get \-o template pod 1234\-56\-7890\-234234\-456456 \-\-template=\{\{.currentState.status\}\}
-
-// List all replication controllers and services together in ps output format.
-$ kubectl get rc,services
-
-.fi
-.RE
-
 
 .SH OPTIONS
 .PP
@@ -78,6 +53,136 @@ $ kubectl get rc,services
 .PP
 \fB\-\-watch\-only\fP=false
     Watch for changes to the requested object(s), without listing/getting first.
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+// List all pods in ps output format.
+$ kubectl get pods
+
+// List a single replication controller with specified ID in ps output format.
+$ kubectl get replicationController 1234\-56\-7890\-234234\-456456
+
+// List a single pod in JSON output format.
+$ kubectl get \-o json pod 1234\-56\-7890\-234234\-456456
+
+// Return only the status value of the specified pod.
+$ kubectl get \-o template pod 1234\-56\-7890\-234234\-456456 \-\-template=\{\{.currentState.status\}\}
+
+// List all replication controllers and services together in ps output format.
+$ kubectl get rc,services
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-label.1
+++ b/docs/man/man1/kubectl-label.1
@@ -19,24 +19,6 @@ Update the labels on a resource.
 If \-\-overwrite is true, then existing labels can be overwritten, otherwise attempting to overwrite a label will result in an error.
 If \-\-resource\-version is specified, then updates will use this resource version, otherwise the existing resource\-version will be used.
 
-.PP
-Examples:
-  // Update pod 'foo' with the label 'unhealthy' and the value 'true'.
-  $ kubectl label pods foo unhealthy=true
-
-.PP
-// Update pod 'foo' with the label 'status' and the value 'unhealthy', overwriting any existing value.
-  $ kubectl label \-\-overwrite pods foo status=unhealthy
-
-.PP
-// Update pod 'foo' only if the resource is unchanged from version 1.
-  $ kubectl label pods foo status=unhealthy \-\-resource\-version=1
-
-.PP
-// Update pod 'foo' by removing a label named 'bar' if it exists.
-  // Does not require the \-\-overwrite flag.
-  $ kubectl label pods foo bar\-
-
 
 .SH OPTIONS
 .PP
@@ -63,6 +45,134 @@ Examples:
 \fB\-t\fP, \fB\-\-template\fP=""
     Template string or path to template file to use when \-o=template or \-o=templatefile.  The template format is golang templates [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]]
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+// Update pod 'foo' with the label 'unhealthy' and the value 'true'.
+$ kubectl label pods foo unhealthy=true
+
+// Update pod 'foo' with the label 'status' and the value 'unhealthy', overwriting any existing value.
+$ kubectl label \-\-overwrite pods foo status=unhealthy
+
+// Update pod 'foo' only if the resource is unchanged from version 1.
+$ kubectl label pods foo status=unhealthy \-\-resource\-version=1
+
+// Update pod 'foo' by removing a label named 'bar' if it exists.
+// Does not require the \-\-overwrite flag.
+$ kubectl label pods foo bar\-
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-log.1
+++ b/docs/man/man1/kubectl-log.1
@@ -15,9 +15,120 @@ kubectl log \- Print the logs for a container in a pod.
 .PP
 Print the logs for a container in a pod. If the pod has only one container, the container name is optional.
 
-.PP
-Examples:
 
+.SH OPTIONS
+.PP
+\fB\-f\fP, \fB\-\-follow\fP=false
+    Specify if the logs should be streamed.
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
+.SH EXAMPLE
 .PP
 .RS
 
@@ -30,12 +141,6 @@ $ kubectl log \-f 123456\-7890 ruby\-container
 
 .fi
 .RE
-
-
-.SH OPTIONS
-.PP
-\fB\-f\fP, \fB\-\-follow\fP=false
-    Specify if the logs should be streamed.
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-namespace.1
+++ b/docs/man/man1/kubectl-namespace.1
@@ -19,6 +19,112 @@ SUPERCEDED:  Set and view the current Kubernetes namespace scope for command lin
 namespace has been superceded by the context.namespace field of .kubeconfig files.  See 'kubectl config set\-context \-\-help' for more details.
 
 
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
 .SH SEE ALSO
 .PP
 \fBkubectl(1)\fP,

--- a/docs/man/man1/kubectl-port-forward.1
+++ b/docs/man/man1/kubectl-port-forward.1
@@ -14,15 +14,128 @@ kubectl port\-forward \- Forward 1 or more local ports to a pod.
 .SH DESCRIPTION
 .PP
 Forward 1 or more local ports to a pod.
-Examples:
-  $ kubectl port\-forward \-p mypod 5000 6000
-  <listens on ports 5000 and 6000 locally, forwarding data to/from ports 5000
-   and 6000 in the pod>
 
+
+.SH OPTIONS
+.PP
+\fB\-p\fP, \fB\-\-pod\fP=""
+    Pod name
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
+.SH EXAMPLE
 .PP
 .RS
 
 .nf
+$ kubectl port\-forward \-p mypod 5000 6000
+<listens on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in the pod>
+
 $ kubectl port\-forward \-p mypod 8888:5000
 <listens on port 8888 locally, forwarding to 5000 in the pod>
 
@@ -30,16 +143,10 @@ $ kubectl port\-forward \-p mypod :5000
 <listens on a random port locally, forwarding to 5000 in the pod>
 
 $ kubectl port\-forward \-p mypod 0:5000
-<listens on a random port locally, forwarding to 5000 in the pod>
+<listens on a random port locally, forwarding to 5000 in the pod> 
 
 .fi
 .RE
-
-
-.SH OPTIONS
-.PP
-\fB\-p\fP, \fB\-\-pod\fP=""
-    Pod name
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-proxy.1
+++ b/docs/man/man1/kubectl-proxy.1
@@ -34,6 +34,112 @@ Run a proxy to the Kubernetes API server.
     Prefix to serve static files under, if static file directory is specified.
 
 
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
 .SH SEE ALSO
 .PP
 \fBkubectl(1)\fP,

--- a/docs/man/man1/kubectl-resize.1
+++ b/docs/man/man1/kubectl-resize.1
@@ -21,22 +21,6 @@ If \-\-current\-replicas or \-\-resource\-version is specified, it is validated 
 resize is attempted, and it is guaranteed that the precondition holds true when the
 resize is sent to the server.
 
-.PP
-Examples:
-
-.PP
-.RS
-
-.nf
-// Resize replication controller named 'foo' to 3.
-$ kubectl resize \-\-replicas=3 replicationcontrollers foo
-
-// If the replication controller named foo's current size is 2, resize foo to 3.
-$ kubectl resize \-\-current\-replicas=2 \-\-replicas=3 replicationcontrollers foo
-
-.fi
-.RE
-
 
 .SH OPTIONS
 .PP
@@ -50,6 +34,127 @@ $ kubectl resize \-\-current\-replicas=2 \-\-replicas=3 replicationcontrollers f
 .PP
 \fB\-\-resource\-version\fP=""
     Precondition for resource version. Requires that the current resource version match this value in order to resize.
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+// Resize replication controller named 'foo' to 3.
+$ kubectl resize \-\-replicas=3 replicationcontrollers foo
+
+// If the replication controller named foo's current size is 2, resize foo to 3.
+$ kubectl resize \-\-current\-replicas=2 \-\-replicas=3 replicationcontrollers foo
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-rollingupdate.1
+++ b/docs/man/man1/kubectl-rollingupdate.1
@@ -20,22 +20,6 @@ Replaces the specified controller with new controller, updating one pod at a tim
 new PodTemplate. The new\-controller.json must specify the same namespace as the
 existing controller and overwrite at least one (common) label in its replicaSelector.
 
-.PP
-Examples:
-
-.PP
-.RS
-
-.nf
-// Update pods of frontend\-v1 using new controller data in frontend\-v2.json.
-$ kubectl rollingupdate frontend\-v1 \-f frontend\-v2.json
-
-// Update pods of frontend\-v1 using JSON data passed into stdin.
-$ cat frontend\-v2.json | kubectl rollingupdate frontend\-v1 \-f \-
-
-.fi
-.RE
-
 
 .SH OPTIONS
 .PP
@@ -53,6 +37,127 @@ $ cat frontend\-v2.json | kubectl rollingupdate frontend\-v1 \-f \-
 .PP
 \fB\-\-update\-period\fP="1m0s"
     Time to wait between updating pods. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+// Update pods of frontend\-v1 using new controller data in frontend\-v2.json.
+$ kubectl rollingupdate frontend\-v1 \-f frontend\-v2.json
+
+// Update pods of frontend\-v1 using JSON data passed into stdin.
+$ cat frontend\-v2.json | kubectl rollingupdate frontend\-v1 \-f \-
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-run-container.1
+++ b/docs/man/man1/kubectl-run-container.1
@@ -16,28 +16,6 @@ kubectl run\-container \- Run a particular image on the cluster.
 Create and run a particular image, possibly replicated.
 Creates a replication controller to manage the created container(s).
 
-.PP
-Examples:
-
-.PP
-.RS
-
-.nf
-// Starts a single instance of nginx.
-$ kubectl run\-container nginx \-\-image=dockerfile/nginx
-
-// Starts a replicated instance of nginx.
-$ kubectl run\-container nginx \-\-image=dockerfile/nginx \-\-replicas=5
-
-// Dry run. Print the corresponding API objects without creating them.
-$ kubectl run\-container nginx \-\-image=dockerfile/nginx \-\-dry\-run
-
-// Start a single instance of nginx, but overload the desired state with a partial set of values parsed from JSON.
-$ kubectl run\-container nginx \-\-image=dockerfile/nginx \-\-overrides='\{ "apiVersion": "v1beta1", "desiredState": \{ ... \} \}'
-
-.fi
-.RE
-
 
 .SH OPTIONS
 .PP
@@ -84,6 +62,133 @@ $ kubectl run\-container nginx \-\-image=dockerfile/nginx \-\-overrides='\{ "api
 \fB\-t\fP, \fB\-\-template\fP=""
     Template string or path to template file to use when \-o=template or \-o=templatefile.  The template format is golang templates [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]]
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+// Starts a single instance of nginx.
+$ kubectl run\-container nginx \-\-image=dockerfile/nginx
+
+// Starts a replicated instance of nginx.
+$ kubectl run\-container nginx \-\-image=dockerfile/nginx \-\-replicas=5
+
+// Dry run. Print the corresponding API objects without creating them.
+$ kubectl run\-container nginx \-\-image=dockerfile/nginx \-\-dry\-run
+
+// Start a single instance of nginx, but overload the desired state with a partial set of values parsed from JSON.
+$ kubectl run\-container nginx \-\-image=dockerfile/nginx \-\-overrides='\{ "apiVersion": "v1beta1", "desiredState": \{ ... \} \}'
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-stop.1
+++ b/docs/man/man1/kubectl-stop.1
@@ -19,9 +19,120 @@ Gracefully shut down a resource by id or filename.
 Attempts to shut down and delete a resource that supports graceful termination.
 If the resource is resizable it will be resized to 0 before deletion.
 
-.PP
-Examples:
 
+.SH OPTIONS
+.PP
+\fB\-f\fP, \fB\-\-filename\fP=[]
+    Filename, directory, or URL to file of resource(s) to be stopped
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
+.SH EXAMPLE
 .PP
 .RS
 
@@ -37,12 +148,6 @@ $ kubectl stop \-f path/to/resources
 
 .fi
 .RE
-
-
-.SH OPTIONS
-.PP
-\fB\-f\fP, \fB\-\-filename\fP=[]
-    Filename, directory, or URL to file of resource(s) to be stopped
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-update.1
+++ b/docs/man/man1/kubectl-update.1
@@ -18,9 +18,124 @@ Update a resource by filename or stdin.
 .PP
 JSON and YAML formats are accepted.
 
-.PP
-Examples:
 
+.SH OPTIONS
+.PP
+\fB\-f\fP, \fB\-\-filename\fP=[]
+    Filename, directory, or URL to file to use to update the resource.
+
+.PP
+\fB\-\-patch\fP=""
+    A JSON document to override the existing resource. The resource is downloaded, patched with the JSON, then updated.
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
+.SH EXAMPLE
 .PP
 .RS
 
@@ -36,16 +151,6 @@ $ kubectl update pods my\-pod \-\-patch='\{ "apiVersion": "v1beta1", "desiredSta
 
 .fi
 .RE
-
-
-.SH OPTIONS
-.PP
-\fB\-f\fP, \fB\-\-filename\fP=[]
-    Filename, directory, or URL to file to use to update the resource.
-
-.PP
-\fB\-\-patch\fP=""
-    A JSON document to override the existing resource. The resource is downloaded, patched with the JSON, then updated.
 
 
 .SH SEE ALSO

--- a/docs/man/man1/kubectl-version.1
+++ b/docs/man/man1/kubectl-version.1
@@ -22,6 +22,112 @@ Print the client and server version information.
     Client version only (no server required).
 
 
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-version\fP=""
+    The API version to use when talking to the server
+
+.PP
+\fB\-a\fP, \fB\-\-auth\-path\fP=""
+    Path to the auth info file. If missing, prompt the user. Only used if using https.
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP=false
+    help for kubectl
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to the kubeconfig file to use for CLI requests.
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
+
+.PP
+\fB\-\-log\_dir\fP=""
+    If non\-empty, write log files in this directory
+
+.PP
+\fB\-\-log\_flush\_frequency\fP=5s
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-password\fP=""
+    Password for basic authentication to the API server.
+
+.PP
+\fB\-s\fP, \fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server.
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+.PP
+\fB\-\-username\fP=""
+    Username for basic authentication to the API server.
+
+.PP
+\fB\-\-v\fP=0
+    log level for V logs
+
+.PP
+\fB\-\-validate\fP=false
+    If true, use a schema to validate the input before sending it
+
+.PP
+\fB\-\-vmodule\fP=
+    comma\-separated list of pattern=N settings for file\-filtered logging
+
+
 .SH SEE ALSO
 .PP
 \fBkubectl(1)\fP,

--- a/pkg/kubectl/cmd/config/create_context.go
+++ b/pkg/kubectl/cmd/config/create_context.go
@@ -46,8 +46,7 @@ func NewCmdConfigSetContext(out io.Writer, pathOptions *pathOptions) *cobra.Comm
 	Specifying a name that already exists will merge new fields on top of existing values for those fields.
 	e.g. 
 		kubectl config set-context gce --user=cluster-admin
-		only sets the user field on the gce context entry without touching other values.
-		`,
+		only sets the user field on the gce context entry without touching other values.`,
 
 		Run: func(cmd *cobra.Command, args []string) {
 			if !options.complete(cmd) {

--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -41,13 +41,12 @@ func NewCmdConfigView(out io.Writer, pathOptions *pathOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "view",
 		Short: "displays merged .kubeconfig settings or a specified .kubeconfig file.",
-		Long: `displays merged .kubeconfig settings or a specified .kubeconfig file.
-Examples:
-  // Show merged .kubeconfig settings.
-  $ kubectl config view
+		Long:  "displays merged .kubeconfig settings or a specified .kubeconfig file.",
+		Example: `// Show merged .kubeconfig settings.
+$ kubectl config view
 
-  // Show only local ./.kubeconfig settings
-  $ kubectl config view --local`,
+// Show only local ./.kubeconfig settings
+$ kubectl config view --local`,
 		Run: func(cmd *cobra.Command, args []string) {
 			options.complete()
 

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -26,24 +26,26 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
+const (
+	create_long = `Create a resource by filename or stdin.
+
+JSON and YAML formats are accepted.`
+	create_example = `// Create a pod using the data in pod.json.
+$ kubectl create -f pod.json
+
+// Create a pod based on the JSON passed into stdin.
+$ cat pod.json | kubectl create -f -`
+)
+
 func (f *Factory) NewCmdCreate(out io.Writer) *cobra.Command {
 	flags := &struct {
 		Filenames util.StringList
 	}{}
 	cmd := &cobra.Command{
-		Use:   "create -f filename",
-		Short: "Create a resource by filename or stdin",
-		Long: `Create a resource by filename or stdin.
-
-JSON and YAML formats are accepted.
-
-Examples:
-
-    // Create a pod using the data in pod.json.
-    $ kubectl create -f pod.json
-
-    // Create a pod based on the JSON passed into stdin.
-    $ cat pod.json | kubectl create -f -`,
+		Use:     "create -f filename",
+		Short:   "Create a resource by filename or stdin",
+		Long:    create_long,
+		Example: create_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			schema, err := f.Validator(cmd)
 			checkErr(err)

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -28,14 +28,8 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
-func (f *Factory) NewCmdDelete(out io.Writer) *cobra.Command {
-	flags := &struct {
-		Filenames util.StringList
-	}{}
-	cmd := &cobra.Command{
-		Use:   "delete ([-f filename] | (<resource> [(<id> | -l <label> | --all)]",
-		Short: "Delete a resource by filename, stdin, or resource and ID.",
-		Long: `Delete a resource by filename, stdin, resource and ID, or by resources and label selector.
+const (
+	delete_long = `Delete a resource by filename, stdin, resource and ID, or by resources and label selector.
 
 JSON and YAML formats are accepted.
 
@@ -44,25 +38,32 @@ arguments are used and the filename is ignored.
 
 Note that the delete command does NOT do resource version checks, so if someone
 submits an update to a resource right when you submit a delete, their update
-will be lost along with the rest of the resource.
+will be lost along with the rest of the resource.`
+	delete_example = `// Delete a pod using the type and ID specified in pod.json.
+$ kubectl delete -f pod.json
 
-Examples:
+// Delete a pod based on the type and ID in the JSON passed into stdin.
+$ cat pod.json | kubectl delete -f -
 
-    // Delete a pod using the type and ID specified in pod.json.
-    $ kubectl delete -f pod.json
+// Delete pods and services with label name=myLabel.
+$ kubectl delete pods,services -l name=myLabel
 
-    // Delete a pod based on the type and ID in the JSON passed into stdin.
-    $ cat pod.json | kubectl delete -f -
+// Delete a pod with ID 1234-56-7890-234234-456456.
+$ kubectl delete pod 1234-56-7890-234234-456456
 
-    // Delete pods and services with label name=myLabel.
-    $ kubectl delete pods,services -l name=myLabel
+// Delete all pods
+$ kubectl delete pods --all`
+)
 
-    // Delete a pod with ID 1234-56-7890-234234-456456.
-    $ kubectl delete pod 1234-56-7890-234234-456456
-
-    // Delete all pods
-    $ kubectl delete pods --all`,
-
+func (f *Factory) NewCmdDelete(out io.Writer) *cobra.Command {
+	flags := &struct {
+		Filenames util.StringList
+	}{}
+	cmd := &cobra.Command{
+		Use:     "delete ([-f filename] | (<resource> [(<id> | -l <label> | --all)]",
+		Short:   "Delete a resource by filename, stdin, or resource and ID.",
+		Long:    delete_long,
+		Example: delete_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdNamespace, err := f.DefaultNamespace(cmd)
 			checkErr(err)

--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -30,6 +30,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	exec_example = `// get output from running 'date' in ruby-container from pod 123456-7890
+$ kubectl exec -p 123456-7890 -c ruby-container date
+
+//switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-780 and sends stdout/stderr from 'bash' back to the client
+$ kubectl exec -p 123456-7890 -c ruby-container -i -t -- bash -il`
+)
+
 func (f *Factory) NewCmdExec(cmdIn io.Reader, cmdOut, cmdErr io.Writer) *cobra.Command {
 	flags := &struct {
 		pod       string
@@ -39,16 +47,10 @@ func (f *Factory) NewCmdExec(cmdIn io.Reader, cmdOut, cmdErr io.Writer) *cobra.C
 	}{}
 
 	cmd := &cobra.Command{
-		Use:   "exec -p <pod> -c <container> -- <command> [<args...>]",
-		Short: "Execute a command in a container.",
-		Long: `Execute a command in a container.
-Examples:
-  $ kubectl exec -p 123456-7890 -c ruby-container date
-  <returns output from running 'date' in ruby-container from pod 123456-7890>
-
-  $ kubectl exec -p 123456-7890 -c ruby-container -i -t -- bash -il
-  <switches to raw terminal mode, sends stdin to 'bash' in ruby-container from
-   pod 123456-780 and sends stdout/stderr from 'bash' back to the client`,
+		Use:     "exec -p <pod> -c <container> -- <command> [<args...>]",
+		Short:   "Execute a command in a container.",
+		Long:    "Execute a command in a container.",
+		Example: exec_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(flags.pod) == 0 {
 				usageError(cmd, "<pod> is required for exec")

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -26,22 +26,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (f *Factory) NewCmdExposeService(out io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "expose <name> --port=<port> [--protocol=TCP|UDP] [--container-port=<number-or-name>] [--service-name=<name>] [--public-ip=<ip>] [--create-external-load-balancer]",
-		Short: "Take a replicated application and expose it as Kubernetes Service",
-		Long: `Take a replicated application and expose it as Kubernetes Service.
+const (
+	expose_long = `Take a replicated application and expose it as Kubernetes Service.
 		
 Looks up a ReplicationController by name, and uses the selector for that replication controller
-as the selector for a new Service on the specified port.
+as the selector for a new Service on the specified port.`
 
-Examples:
+	expose_example = `// Creates a service for a replicated nginx, which serves on port 80 and connects to the containers on port 8000.
+$ kubectl expose nginx --port=80 --container-port=8000
 
-    // Creates a service for a replicated nginx, which serves on port 80 and connects to the containers on port 8000.
-    $ kubectl expose nginx --port=80 --container-port=8000
+// Create a service for a replicated streaming application on port 4100 balancing UDP traffic and named 'video-stream'.
+$ kubectl expose streamer --port=4100 --protocol=udp --service-name=video-stream`
+)
 
-    // Create a service for a replicated streaming application on port 4100 balancing UDP traffic and named 'video-stream'.
-    $ kubectl expose streamer --port=4100 --protocol=udp --service-name=video-stream`,
+func (f *Factory) NewCmdExposeService(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "expose <name> --port=<port> [--protocol=TCP|UDP] [--container-port=<number-or-name>] [--service-name=<name>] [--public-ip=<ip>] [--create-external-load-balancer]",
+		Short:   "Take a replicated application and expose it as Kubernetes Service",
+		Long:    expose_long,
+		Example: expose_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 1 {
 				usageError(cmd, "<name> is required for expose")

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -30,36 +30,38 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCmdGet creates a command object for the generic "get" action, which
-// retrieves one or more resources from a server.
-func (f *Factory) NewCmdGet(out io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "get [(-o|--output=)json|yaml|template|...] <resource> [<id>]",
-		Short: "Display one or many resources",
-		Long: `Display one or many resources.
+const (
+	get_long = `Display one or many resources.
 
 Possible resources include pods (po), replication controllers (rc), services
 (se), minions (mi), or events (ev).
 
 By specifying the output as 'template' and providing a Go template as the value
-of the --template flag, you can filter the attributes of the fetched resource(s).
+of the --template flag, you can filter the attributes of the fetched resource(s).`
+	get_example = `// List all pods in ps output format.
+$ kubectl get pods
 
-Examples:
+// List a single replication controller with specified ID in ps output format.
+$ kubectl get replicationController 1234-56-7890-234234-456456
 
-    // List all pods in ps output format.
-    $ kubectl get pods
+// List a single pod in JSON output format.
+$ kubectl get -o json pod 1234-56-7890-234234-456456
 
-    // List a single replication controller with specified ID in ps output format.
-    $ kubectl get replicationController 1234-56-7890-234234-456456
+// Return only the status value of the specified pod.
+$ kubectl get -o template pod 1234-56-7890-234234-456456 --template={{.currentState.status}}
 
-    // List a single pod in JSON output format.
-    $ kubectl get -o json pod 1234-56-7890-234234-456456
+// List all replication controllers and services together in ps output format.
+$ kubectl get rc,services`
+)
 
-    // Return only the status value of the specified pod.
-    $ kubectl get -o template pod 1234-56-7890-234234-456456 --template={{.currentState.status}}
-
-    // List all replication controllers and services together in ps output format.
-    $ kubectl get rc,services`,
+// NewCmdGet creates a command object for the generic "get" action, which
+// retrieves one or more resources from a server.
+func (f *Factory) NewCmdGet(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "get [(-o|--output=)json|yaml|template|...] <resource> [<id>]",
+		Short:   "Display one or many resources",
+		Long:    get_long,
+		Example: get_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			RunGet(f, out, cmd, args)
 		},

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -29,28 +29,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (f *Factory) NewCmdLabel(out io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "label [--overwrite] <resource> <name> <key-1>=<val-1> ... <key-n>=<val-n> [--resource-version=<version>]",
-		Short: "Update the labels on a resource",
-		Long: `Update the labels on a resource.
+const (
+	label_long = `Update the labels on a resource.
 
 If --overwrite is true, then existing labels can be overwritten, otherwise attempting to overwrite a label will result in an error.
-If --resource-version is specified, then updates will use this resource version, otherwise the existing resource-version will be used.
+If --resource-version is specified, then updates will use this resource version, otherwise the existing resource-version will be used.`
+	label_example = `// Update pod 'foo' with the label 'unhealthy' and the value 'true'.
+$ kubectl label pods foo unhealthy=true
 
-Examples:
-  // Update pod 'foo' with the label 'unhealthy' and the value 'true'.
-  $ kubectl label pods foo unhealthy=true
+// Update pod 'foo' with the label 'status' and the value 'unhealthy', overwriting any existing value.
+$ kubectl label --overwrite pods foo status=unhealthy
 
-  // Update pod 'foo' with the label 'status' and the value 'unhealthy', overwriting any existing value.
-  $ kubectl label --overwrite pods foo status=unhealthy
-  
-  // Update pod 'foo' only if the resource is unchanged from version 1.
-  $ kubectl label pods foo status=unhealthy --resource-version=1
-  
-  // Update pod 'foo' by removing a label named 'bar' if it exists.
-  // Does not require the --overwrite flag.
-  $ kubectl label pods foo bar-`,
+// Update pod 'foo' only if the resource is unchanged from version 1.
+$ kubectl label pods foo status=unhealthy --resource-version=1
+
+// Update pod 'foo' by removing a label named 'bar' if it exists.
+// Does not require the --overwrite flag.
+$ kubectl label pods foo bar-`
+)
+
+func (f *Factory) NewCmdLabel(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "label [--overwrite] <resource> <name> <key-1>=<val-1> ... <key-n>=<val-n> [--resource-version=<version>]",
+		Short:   "Update the labels on a resource",
+		Long:    label_long,
+		Example: label_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) < 2 {
 				usageError(cmd, "<resource> <name> is required")

--- a/pkg/kubectl/cmd/log.go
+++ b/pkg/kubectl/cmd/log.go
@@ -24,19 +24,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	log_example = `// Returns snapshot of ruby-container logs from pod 123456-7890.
+$ kubectl log 123456-7890 ruby-container
+
+// Starts streaming of ruby-container logs from pod 123456-7890.
+$ kubectl log -f 123456-7890 ruby-container`
+)
+
 func (f *Factory) NewCmdLog(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "log [-f] <pod> [<container>]",
-		Short: "Print the logs for a container in a pod.",
-		Long: `Print the logs for a container in a pod. If the pod has only one container, the container name is optional.
-
-Examples:
-
-    // Returns snapshot of ruby-container logs from pod 123456-7890.
-    $ kubectl log 123456-7890 ruby-container
-
-    // Starts streaming of ruby-container logs from pod 123456-7890.
-    $ kubectl log -f 123456-7890 ruby-container`,
+		Use:     "log [-f] <pod> [<container>]",
+		Short:   "Print the logs for a container in a pod.",
+		Long:    "Print the logs for a container in a pod. If the pod has only one container, the container name is optional.",
+		Example: log_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
 				usageError(cmd, "<pod> is required for log")

--- a/pkg/kubectl/cmd/portforward.go
+++ b/pkg/kubectl/cmd/portforward.go
@@ -26,6 +26,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	portforward_example = `$ kubectl port-forward -p mypod 5000 6000
+<listens on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in the pod>
+
+$ kubectl port-forward -p mypod 8888:5000
+<listens on port 8888 locally, forwarding to 5000 in the pod>
+
+$ kubectl port-forward -p mypod :5000
+<listens on a random port locally, forwarding to 5000 in the pod>
+
+$ kubectl port-forward -p mypod 0:5000
+<listens on a random port locally, forwarding to 5000 in the pod> `
+)
+
 func (f *Factory) NewCmdPortForward() *cobra.Command {
 	flags := &struct {
 		pod       string
@@ -33,23 +47,10 @@ func (f *Factory) NewCmdPortForward() *cobra.Command {
 	}{}
 
 	cmd := &cobra.Command{
-		Use:   "port-forward -p <pod> [<local port>:]<remote port> [<port>...]",
-		Short: "Forward 1 or more local ports to a pod.",
-		Long: `Forward 1 or more local ports to a pod.
-Examples:
-  $ kubectl port-forward -p mypod 5000 6000
-  <listens on ports 5000 and 6000 locally, forwarding data to/from ports 5000
-   and 6000 in the pod>
-
-	$ kubectl port-forward -p mypod 8888:5000
-	<listens on port 8888 locally, forwarding to 5000 in the pod>
-
-	$ kubectl port-forward -p mypod :5000
-	<listens on a random port locally, forwarding to 5000 in the pod>
-
-	$ kubectl port-forward -p mypod 0:5000
-	<listens on a random port locally, forwarding to 5000 in the pod>
-   `,
+		Use:     "port-forward -p <pod> [<local port>:]<remote port> [<port>...]",
+		Short:   "Forward 1 or more local ports to a pod.",
+		Long:    "Forward 1 or more local ports to a pod.",
+		Example: portforward_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(flags.pod) == 0 {
 				usageError(cmd, "<pod> is required for exec")

--- a/pkg/kubectl/cmd/resize.go
+++ b/pkg/kubectl/cmd/resize.go
@@ -25,24 +25,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (f *Factory) NewCmdResize(out io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "resize [--resource-version=<version>] [--current-replicas=<count>] --replicas=<count> <resource> <id>",
-		Short: "Set a new size for a Replication Controller.",
-		Long: `Set a new size for a Replication Controller.
+const (
+	resize_long = `Set a new size for a Replication Controller.
 
 Resize also allows users to specify one or more preconditions for the resize action.
 If --current-replicas or --resource-version is specified, it is validated before the
 resize is attempted, and it is guaranteed that the precondition holds true when the
-resize is sent to the server.
+resize is sent to the server.`
+	resize_example = `// Resize replication controller named 'foo' to 3.
+$ kubectl resize --replicas=3 replicationcontrollers foo
 
-Examples:
+// If the replication controller named foo's current size is 2, resize foo to 3.
+$ kubectl resize --current-replicas=2 --replicas=3 replicationcontrollers foo`
+)
 
-    // Resize replication controller named 'foo' to 3.
-    $ kubectl resize --replicas=3 replicationcontrollers foo
-
-    // If the replication controller named foo's current size is 2, resize foo to 3.
-    $ kubectl resize --current-replicas=2 --replicas=3 replicationcontrollers foo`,
+func (f *Factory) NewCmdResize(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "resize [--resource-version=<version>] [--current-replicas=<count>] --replicas=<count> <resource> <id>",
+		Short:   "Set a new size for a Replication Controller.",
+		Long:    resize_long,
+		Example: resize_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			count := util.GetFlagInt(cmd, "replicas")
 			if len(args) != 2 || count < 0 {

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -27,28 +27,27 @@ import (
 )
 
 const (
-	updatePeriod = "1m0s"
-	timeout      = "5m0s"
-	pollInterval = "3s"
+	updatePeriod       = "1m0s"
+	timeout            = "5m0s"
+	pollInterval       = "3s"
+	rollingupdate_long = `Perform a rolling update of the given ReplicationController.
+
+Replaces the specified controller with new controller, updating one pod at a time to use the
+new PodTemplate. The new-controller.json must specify the same namespace as the
+existing controller and overwrite at least one (common) label in its replicaSelector.`
+	rollingupdate_example = `// Update pods of frontend-v1 using new controller data in frontend-v2.json.
+$ kubectl rollingupdate frontend-v1 -f frontend-v2.json
+
+// Update pods of frontend-v1 using JSON data passed into stdin.
+$ cat frontend-v2.json | kubectl rollingupdate frontend-v1 -f -`
 )
 
 func (f *Factory) NewCmdRollingUpdate(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rollingupdate <old-controller-name> -f <new-controller.json>",
-		Short: "Perform a rolling update of the given ReplicationController.",
-		Long: `Perform a rolling update of the given ReplicationController.
-
-Replaces the specified controller with new controller, updating one pod at a time to use the
-new PodTemplate. The new-controller.json must specify the same namespace as the
-existing controller and overwrite at least one (common) label in its replicaSelector.
-
-Examples:
-
-    // Update pods of frontend-v1 using new controller data in frontend-v2.json.
-    $ kubectl rollingupdate frontend-v1 -f frontend-v2.json
-
-    // Update pods of frontend-v1 using JSON data passed into stdin.
-    $ cat frontend-v2.json | kubectl rollingupdate frontend-v1 -f -`,
+		Use:     "rollingupdate <old-controller-name> -f <new-controller.json>",
+		Short:   "Perform a rolling update of the given ReplicationController.",
+		Long:    rollingupdate_long,
+		Example: rollingupdate_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			filename := util.GetFlagString(cmd, "filename")
 			if len(filename) == 0 {

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -26,26 +26,28 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	run_long = `Create and run a particular image, possibly replicated.
+Creates a replication controller to manage the created container(s).`
+	run_example = `// Starts a single instance of nginx.
+$ kubectl run-container nginx --image=dockerfile/nginx
+
+// Starts a replicated instance of nginx.
+$ kubectl run-container nginx --image=dockerfile/nginx --replicas=5
+
+// Dry run. Print the corresponding API objects without creating them.
+$ kubectl run-container nginx --image=dockerfile/nginx --dry-run
+
+// Start a single instance of nginx, but overload the desired state with a partial set of values parsed from JSON.
+$ kubectl run-container nginx --image=dockerfile/nginx --overrides='{ "apiVersion": "v1beta1", "desiredState": { ... } }'`
+)
+
 func (f *Factory) NewCmdRunContainer(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "run-container <name> --image=<image> [--port=<port>] [--replicas=replicas] [--dry-run=<bool>] [--overrides=<inline-json>]",
-		Short: "Run a particular image on the cluster.",
-		Long: `Create and run a particular image, possibly replicated.
-Creates a replication controller to manage the created container(s).
-
-Examples:
-
-    // Starts a single instance of nginx.
-    $ kubectl run-container nginx --image=dockerfile/nginx
-
-    // Starts a replicated instance of nginx.
-    $ kubectl run-container nginx --image=dockerfile/nginx --replicas=5
-
-    // Dry run. Print the corresponding API objects without creating them.
-    $ kubectl run-container nginx --image=dockerfile/nginx --dry-run
-  
-    // Start a single instance of nginx, but overload the desired state with a partial set of values parsed from JSON.
-    $ kubectl run-container nginx --image=dockerfile/nginx --overrides='{ "apiVersion": "v1beta1", "desiredState": { ... } }'`,
+		Use:     "run-container <name> --image=<image> [--port=<port>] [--replicas=replicas] [--dry-run=<bool>] [--overrides=<inline-json>]",
+		Short:   "Run a particular image on the cluster.",
+		Long:    run_long,
+		Example: run_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 1 {
 				usageError(cmd, "<name> is required for run-container")

--- a/pkg/kubectl/cmd/stop.go
+++ b/pkg/kubectl/cmd/stop.go
@@ -25,28 +25,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	stop_long = `Gracefully shut down a resource by id or filename.
+
+Attempts to shut down and delete a resource that supports graceful termination.
+If the resource is resizable it will be resized to 0 before deletion.`
+	stop_example = `// Shut down foo.
+$ kubectl stop replicationcontroller foo
+
+// Shut down the service defined in service.json
+$ kubectl stop -f service.json
+
+// Shut down all resources in the path/to/resources directory
+$ kubectl stop -f path/to/resources`
+)
+
 func (f *Factory) NewCmdStop(out io.Writer) *cobra.Command {
 	flags := &struct {
 		Filenames util.StringList
 	}{}
 	cmd := &cobra.Command{
-		Use:   "stop (<resource> <id>|-f filename)",
-		Short: "Gracefully shut down a resource by id or filename.",
-		Long: `Gracefully shut down a resource by id or filename.
-
-Attempts to shut down and delete a resource that supports graceful termination.
-If the resource is resizable it will be resized to 0 before deletion.
-
-Examples:
-
-    // Shut down foo.
-    $ kubectl stop replicationcontroller foo
-
-    // Shut down the service defined in service.json
-    $ kubectl stop -f service.json
-
-    // Shut down all resources in the path/to/resources directory
-    $ kubectl stop -f path/to/resources`,
+		Use:     "stop (<resource> <id>|-f filename)",
+		Short:   "Gracefully shut down a resource by id or filename.",
+		Long:    stop_long,
+		Example: stop_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdNamespace, err := f.DefaultNamespace(cmd)
 			checkErr(err)

--- a/pkg/kubectl/cmd/update.go
+++ b/pkg/kubectl/cmd/update.go
@@ -26,27 +26,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	update_long = `Update a resource by filename or stdin.
+
+JSON and YAML formats are accepted.`
+	update_example = `// Update a pod using the data in pod.json.
+$ kubectl update -f pod.json
+
+// Update a pod based on the JSON passed into stdin.
+$ cat pod.json | kubectl update -f -
+
+// Update a pod by downloading it, applying the patch, then updating. Requires apiVersion be specified.
+$ kubectl update pods my-pod --patch='{ "apiVersion": "v1beta1", "desiredState": { "manifest": [{ "cpu": 100 }]}}'`
+)
+
 func (f *Factory) NewCmdUpdate(out io.Writer) *cobra.Command {
 	flags := &struct {
 		Filenames util.StringList
 	}{}
 	cmd := &cobra.Command{
-		Use:   "update -f filename",
-		Short: "Update a resource by filename or stdin.",
-		Long: `Update a resource by filename or stdin.
-
-JSON and YAML formats are accepted.
-
-Examples:
-
-    // Update a pod using the data in pod.json.
-    $ kubectl update -f pod.json
-
-    // Update a pod based on the JSON passed into stdin.
-    $ cat pod.json | kubectl update -f -
-
-    // Update a pod by downloading it, applying the patch, then updating. Requires apiVersion be specified.
-    $ kubectl update pods my-pod --patch='{ "apiVersion": "v1beta1", "desiredState": { "manifest": [{ "cpu": 100 }]}}'`,
+		Use:     "update -f filename",
+		Short:   "Update a resource by filename or stdin.",
+		Long:    update_long,
+		Example: update_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			schema, err := f.Validator(cmd)
 			checkErr(err)


### PR DESCRIPTION
new examples section in the docs, rather than part of the long synopsis.
include flags in the man pages.
