### PR TITLE
Un-revert #4551 which moved the certs.sh e2e test to ginkgo and fix the e2e auth breakage it caused

### DIFF
--- a/cmd/e2e/e2e.go
+++ b/cmd/e2e/e2e.go
@@ -29,11 +29,14 @@ import (
 var (
 	authConfig = flag.String("auth_config", os.Getenv("HOME")+"/.kubernetes_auth", "Path to the auth info file.")
 	certDir    = flag.String("cert_dir", "", "Path to the directory containing the certs. Default is empty, which doesn't use certs.")
-	reportDir  = flag.String("report_dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
+	gceProject = flag.String("gce_project", "", "The GCE project being used, if applicable")
+	gceZone    = flag.String("gce_zone", "", "GCE zone being used, if applicable")
 	host       = flag.String("host", "", "The host to connect to")
-	repoRoot   = flag.String("repo_root", "./", "Root directory of kubernetes repository, for finding test files. Default assumes working directory is repository root")
+	masterName = flag.String("kube_master", "", "Name of the kubernetes master. Only required if provider is gce or gke")
 	provider   = flag.String("provider", "", "The name of the Kubernetes provider")
 	orderseed  = flag.Int64("orderseed", 0, "If non-zero, seed of random test shuffle order. (Otherwise random.)")
+	repoRoot   = flag.String("repo_root", "./", "Root directory of kubernetes repository, for finding test files. Default assumes working directory is repository root")
+	reportDir  = flag.String("report_dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
 	times      = flag.Int("times", 1, "Number of times each test is eligible to be run. Individual order is determined by shuffling --times instances of each test using --orderseed (like a multi-deck shoe of cards).")
 	testList   util.StringList
 )
@@ -53,5 +56,10 @@ func main() {
 		glog.Error("Invalid --times (negative or no testing requested)!")
 		os.Exit(1)
 	}
-	e2e.RunE2ETests(*authConfig, *certDir, *host, *repoRoot, *provider, *orderseed, *times, *reportDir, testList)
+	gceConfig := &e2e.GCEConfig{
+		ProjectID:  *gceProject,
+		Zone:       *gceZone,
+		MasterName: *masterName,
+	}
+	e2e.RunE2ETests(*authConfig, *certDir, *host, *repoRoot, *provider, gceConfig, *orderseed, *times, *reportDir, testList)
 }

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -106,5 +106,8 @@ fi
 "${e2e}" "${auth_config[@]:+${auth_config[@]}}" \
   --host="https://${KUBE_MASTER_IP-}" \
   --provider="${KUBERNETES_PROVIDER}" \
+  --gce_project="${PROJECT:-}" \
+  --gce_zone="${ZONE:-}" \
+  --kube_master="${KUBE_MASTER:-}" \
   ${E2E_REPORT_DIR+"--report_dir=${E2E_REPORT_DIR}"} \
   "${@:-}"

--- a/test/e2e/certs.go
+++ b/test/e2e/certs.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MasterCerts", func() {
+	var c *client.Client
+
+	BeforeEach(func() {
+		var err error
+		c, err = loadClient()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should have all expected certs on the master", func() {
+		if testContext.provider != "gce" && testContext.provider != "gke" {
+			By(fmt.Sprintf("Skipping MasterCerts test for cloud provider %s (only supported for gce and gke)", testContext.provider))
+			return
+		}
+
+		for _, certFile := range []string{"kubecfg.key", "kubecfg.crt", "ca.crt"} {
+			cmd := exec.Command("gcloud", "compute", "ssh", "--project", testContext.gceConfig.ProjectID,
+				"--zone", testContext.gceConfig.Zone, testContext.gceConfig.MasterName,
+				"--command", fmt.Sprintf("ls /srv/kubernetes/%s", certFile))
+			if _, err := cmd.CombinedOutput(); err != nil {
+				Fail(fmt.Sprintf("Error checking for cert file %s on master: %v", certFile, err))
+			}
+		}
+	})
+})

--- a/test/e2e/driver.go
+++ b/test/e2e/driver.go
@@ -32,6 +32,12 @@ import (
 
 type testResult bool
 
+type GCEConfig struct {
+	ProjectID  string
+	Zone       string
+	MasterName string
+}
+
 func init() {
 	// Turn on verbose by default to get spec names
 	config.DefaultReporterConfig.Verbose = true
@@ -47,8 +53,8 @@ func (t *testResult) Fail() { *t = false }
 
 // Run each Go end-to-end-test. This function assumes the
 // creation of a test cluster.
-func RunE2ETests(authConfig, certDir, host, repoRoot, provider string, orderseed int64, times int, reportDir string, testList []string) {
-	testContext = testContextType{authConfig, certDir, host, repoRoot, provider}
+func RunE2ETests(authConfig, certDir, host, repoRoot, provider string, gceConfig *GCEConfig, orderseed int64, times int, reportDir string, testList []string) {
+	testContext = testContextType{authConfig, certDir, host, repoRoot, provider, *gceConfig}
 	util.ReallyCrash = true
 	util.InitLogs()
 	defer util.FlushLogs()

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -37,6 +37,7 @@ type testContextType struct {
 	host       string
 	repoRoot   string
 	provider   string
+	gceConfig  GCEConfig
 }
 
 var testContext testContextType


### PR DESCRIPTION
The fix is simply moving where the project/zone/kube_master variables are set to empty in hack/ginkgo-e2e.sh. Unfortunately I had chosen a spot that is after they get set in some cases, so I've moved them to the top.

cc @zmerlynn @satnam6502 
