### PR TITLE
use default namespace to do rollingupdate

### DIFF
--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -89,13 +89,10 @@ func (f *Factory) NewCmdRollingUpdate(out io.Writer) *cobra.Command {
 			checkErr(err)
 			newRc := obj.(*api.ReplicationController)
 
-			if len(namespace) == 0 {
-				namespace = api.NamespaceDefault
-			}
-			updater := kubectl.NewRollingUpdater(namespace, client)
+			updater := kubectl.NewRollingUpdater(cmdNamespace, client)
 
 			// fetch rc
-			oldRc, err := client.ReplicationControllers(namespace).Get(oldName)
+			oldRc, err := client.ReplicationControllers(cmdNamespace).Get(oldName)
 			checkErr(err)
 
 			var hasLabel bool


### PR DESCRIPTION
rollingupdate command uses namespace specified from resource file (such as `redis.json`) instead of current namespace, so the command fails except the default namespace.

```
$ kubectl --namespace=test create -f examples/guestbook-go/redis-master-controller.json
redis-master-controller

# modifiy examples/guestbook-go/redis-master-controller.json

$ kubectl --namespace=test rollingupdate redis-master-controller -f redis-master-controller.json
F0221 20:50:44.122863   17881 rollingupdate.go:99] replicationController "redis-master-controller" not found

$ kubectl --namespace=test get rc
CONTROLLER                CONTAINER(S)        IMAGE(S)            SELECTOR                 REPLICAS
redis-master-controller   redis-master        gurpartap/redis     name=redis,role=master   1
```
