### PR TITLE
Improve vagrant reliability

### DIFF
--- a/cluster/saltbase/salt/kubelet/init.sls
+++ b/cluster/saltbase/salt/kubelet/init.sls
@@ -72,7 +72,3 @@ kubelet:
       - file: /etc/init.d/kubelet
 {% endif %}
       - file: /var/lib/kubelet/kubernetes_auth
-{% if grains.network_mode is defined and grains.network_mode == 'openvswitch' %}
-      - sls: sdn
-{% endif %}
-

--- a/cluster/saltbase/salt/sdn/init.sls
+++ b/cluster/saltbase/salt/sdn/init.sls
@@ -1,15 +1,8 @@
 {% if grains.network_mode is defined and grains.network_mode == 'openvswitch' %}
 
-openvswitch:
-  pkg:
-    - installed
-  service.running:
-    - enable: True
-
 sdn:
   cmd.wait:
     - name: /kubernetes-vagrant/network_closure.sh
     - watch:
-      - pkg: docker-io
-      - pkg: openvswitch
+      - sls: docker
 {% endif %}

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -37,7 +37,9 @@ base:
     - monit
     - nginx
     - kube-client-tools
+{% if grains['cloud'] is defined and grains['cloud'] != 'vagrant' %}
     - logrotate
+{% endif %}
     - kube-addons
 {% if grains['cloud'] is defined and grains['cloud'] == 'azure' %}
     - openvpn

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -60,6 +60,14 @@ done
 mkdir -p /etc/salt/minion.d
 cat <<EOF >/etc/salt/minion.d/master.conf
 master: '$(echo "$MASTER_NAME" | sed -e "s/'/''/g")'
+master: '$(echo "$MASTER_NAME" | sed -e "s/'/''/g")'
+auth_timeout: 10
+auth_tries: 2
+auth_safemode: True
+ping_interval: 1
+random_reauth_delay: 3
+state_aggregrate:
+  - pkg
 EOF
 
 cat <<EOF >/etc/salt/minion.d/grains.conf

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -34,9 +34,26 @@ for (( i=0; i<${#MINION_NAMES[@]}; i++)); do
 done
 
 # Let the minion know who its master is
+# Recover the salt-minion if the salt-master network changes
+## auth_timeout - how long we want to wait for a time out
+## auth_tries - how many times we will retry before restarting salt-minion
+## auth_safemode - if our cert is rejected, we will restart salt minion
+## ping_interval - restart the minion if we cannot ping the master after 1 minute
+## random_reauth_delay - wait 0-3 seconds when reauthenticating
+## recon_default - how long to wait before reconnecting
+## recon_max - how long you will wait upper bound
+## state_aggregrate - try to do a single yum command to install all referenced packages where possible at once, should improve startup times
+##
 mkdir -p /etc/salt/minion.d
 cat <<EOF >/etc/salt/minion.d/master.conf
 master: '$(echo "$MASTER_NAME" | sed -e "s/'/''/g")'
+auth_timeout: 10
+auth_tries: 2
+auth_safemode: True
+ping_interval: 1
+random_reauth_delay: 3
+state_aggregrate:
+  - pkg
 EOF
 
 cat <<EOF >/etc/salt/minion.d/log-level-debug.conf

--- a/cluster/vagrant/provision-network.sh
+++ b/cluster/vagrant/provision-network.sh
@@ -39,6 +39,11 @@ grep -q kbr0 /etc/sysconfig/docker || {
   # Stop docker before making these updates
   systemctl stop docker
 
+  # Install openvswitch
+  yum install -y openvswitch
+  systemctl enable openvswitch
+  systemctl start openvswitch
+
   # create new docker bridge
   ip link set dev ${DOCKER_BRIDGE} down || true
   brctl delbr ${DOCKER_BRIDGE} || true
@@ -85,6 +90,7 @@ grep -q kbr0 /etc/sysconfig/docker || {
   echo "OPTIONS='-b=kbr0 --selinux-enabled ${DOCKER_OPTS}'" >/etc/sysconfig/docker
   systemctl daemon-reload
   systemctl start docker
+
 }
 EOF
 


### PR DESCRIPTION
This change does the following:
1. Stops Salt from getting in a ReqTimeoutError loop if there is a network interruption with master that caused it to wait 60 seconds before each timeout.  It made things painful if there was any slight hiccup.
2. Turns on state_aggregrate to attempt to consolidate number of yum requests where multiple packages are installed.  Should improve start-up time.
3. Fixes a race condition that could happen with docker and openvswitch configuration on the master.
4. Disabled logrotate on vagrant since we do not generate the traffic to warrant its need.  Improves start-up time of cluster by installing one less thing.

Prior to this change, I was always getting network hangs during kube-up and kube-push and it actually prevented me from SSH into the kubernetes-master.  Basically, you had a dead cluster.  After this change, I brought a cluster up and down 3 times with no issue and was able to update the cluster each time with no issue.

Fixes #4669 

/cc @smarterclayton - this fixes Vagrant stability issues I was experiencing after fixing Vagrant networking on master.
