### PR TITLE
Mark old kubectl/resource.go methods as deprecated

### DIFF
--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -37,6 +37,7 @@ given resource.`,
 			checkErr(err)
 
 			mapper, _ := f.Object(cmd)
+			// TODO: use resource.Builder instead
 			mapping, namespace, name := util.ResourceFromArgs(cmd, args, mapper, cmdNamespace)
 
 			describer, err := f.Describer(cmd, mapping)

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -66,6 +66,7 @@ func (f *Factory) NewCmdLabel(out io.Writer) *cobra.Command {
 			checkErr(err)
 
 			mapper, _ := f.Object(cmd)
+			// TODO: use resource.Builder instead
 			mapping, namespace, name := util.ResourceFromArgs(cmd, res, mapper, cmdNamespace)
 			client, err := f.RESTClient(cmd, mapping)
 			checkErr(err)

--- a/pkg/kubectl/cmd/resize.go
+++ b/pkg/kubectl/cmd/resize.go
@@ -55,6 +55,7 @@ func (f *Factory) NewCmdResize(out io.Writer) *cobra.Command {
 			checkErr(err)
 
 			mapper, _ := f.Object(cmd)
+			// TODO: use resource.Builder instead
 			mapping, namespace, name := util.ResourceFromArgs(cmd, args, mapper, cmdNamespace)
 
 			resizer, err := f.Resizer(cmd, mapping)

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -68,6 +68,7 @@ func (f *Factory) NewCmdRollingUpdate(out io.Writer) *cobra.Command {
 			cmdApiVersion := clientConfig.Version
 
 			mapper, typer := f.Object(cmd)
+			// TODO: use resource.Builder instead
 			mapping, namespace, newName, data := util.ResourceFromFile(filename, typer, mapper, schema, cmdApiVersion)
 			if mapping.Kind != "ReplicationController" {
 				usageError(cmd, "%s does not specify a valid ReplicationController", filename)
@@ -79,6 +80,7 @@ func (f *Factory) NewCmdRollingUpdate(out io.Writer) *cobra.Command {
 
 			cmdNamespace, err := f.DefaultNamespace(cmd)
 			checkErr(err)
+			// TODO: use resource.Builder instead
 			err = util.CompareNamespace(cmdNamespace, namespace)
 			checkErr(err)
 

--- a/pkg/kubectl/cmd/update.go
+++ b/pkg/kubectl/cmd/update.go
@@ -110,6 +110,7 @@ func updateWithPatch(cmd *cobra.Command, args []string, f *Factory, patch string
 	checkErr(err)
 
 	mapper, _ := f.Object(cmd)
+	// TODO: use resource.Builder instead
 	mapping, namespace, name := cmdutil.ResourceFromArgs(cmd, args, mapper, cmdNamespace)
 	client, err := f.RESTClient(cmd, mapping)
 	checkErr(err)

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -66,26 +65,6 @@ func GetFlagBool(cmd *cobra.Command, flag string) bool {
 	return false
 }
 
-// Returns nil if the flag wasn't set.
-func GetFlagBoolPtr(cmd *cobra.Command, flag string) *bool {
-	f := cmd.Flags().Lookup(flag)
-	if f == nil {
-		glog.Fatalf("Flag accessed but not defined for command %s: %s", cmd.Name(), flag)
-	}
-	// Check if flag was not set at all.
-	if !f.Changed && f.DefValue == f.Value.String() {
-		return nil
-	}
-	var ret bool
-	// Caseless compare.
-	if strings.ToLower(f.Value.String()) == "true" {
-		ret = true
-	} else {
-		ret = false
-	}
-	return &ret
-}
-
 // Assumes the flag has a default value.
 func GetFlagInt(cmd *cobra.Command, flag string) int {
 	f := cmd.Flags().Lookup(flag)
@@ -107,33 +86,6 @@ func GetFlagDuration(cmd *cobra.Command, flag string) time.Duration {
 	v, err := time.ParseDuration(f.Value.String())
 	checkErr(err)
 	return v
-}
-
-// Returns the first non-empty string out of the ones provided. If all
-// strings are empty, returns an empty string.
-func FirstNonEmptyString(args ...string) string {
-	for _, s := range args {
-		if len(s) > 0 {
-			return s
-		}
-	}
-	return ""
-}
-
-// Return a list of file names of a certain type within a given directory.
-// TODO: replace with resource.Builder
-func GetFilesFromDir(directory string, fileType string) []string {
-	files := []string{}
-
-	err := filepath.Walk(directory, func(path string, f os.FileInfo, err error) error {
-		if filepath.Ext(path) == fileType {
-			files = append(files, path)
-		}
-		return err
-	})
-
-	checkErr(err)
-	return files
 }
 
 // ReadConfigData reads the bytes from the specified filesytem or network

--- a/pkg/kubectl/cmd/util/resource.go
+++ b/pkg/kubectl/cmd/util/resource.go
@@ -18,123 +18,18 @@ package util
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
-
-// ResourcesFromArgsOrFile computes a list of Resources by extracting info from filename or args. It will
-// handle label selectors provided.
-func ResourcesFromArgsOrFile(
-	cmd *cobra.Command,
-	args []string,
-	filename, selector string,
-	typer runtime.ObjectTyper,
-	mapper meta.RESTMapper,
-	clientBuilder func(cmd *cobra.Command, mapping *meta.RESTMapping) (resource.RESTClient, error),
-	schema validation.Schema,
-	requireNames bool,
-	cmdNamespace,
-	cmdVersion string,
-) resource.Visitor {
-
-	// handling filename & resource id
-	if len(selector) == 0 {
-		if requireNames || len(filename) > 0 {
-			mapping, namespace, name := ResourceFromArgsOrFile(cmd, args, filename, typer, mapper, schema, cmdNamespace, cmdVersion)
-			client, err := clientBuilder(cmd, mapping)
-			checkErr(err)
-			return resource.NewInfo(client, mapping, namespace, name)
-		}
-		if len(args) == 2 {
-			mapping, namespace, name := ResourceOrTypeFromArgs(cmd, args, mapper, cmdNamespace, cmdVersion)
-			client, err := clientBuilder(cmd, mapping)
-			checkErr(err)
-			return resource.NewInfo(client, mapping, namespace, name)
-		}
-	}
-
-	labelSelector, err := labels.ParseSelector(selector)
-	checkErr(err)
-
-	namespace := cmdNamespace
-	visitors := resource.VisitorList{}
-
-	if len(args) < 1 {
-		usageError(cmd, "Must specify the type of resource")
-	}
-	if len(args) > 1 {
-		usageError(cmd, "Too many arguments")
-	}
-	types := SplitResourceArgument(args[0])
-	for _, arg := range types {
-		resourceName := arg
-		if len(resourceName) == 0 {
-			usageError(cmd, "Unknown resource %s", resourceName)
-		}
-		version, kind, err := mapper.VersionAndKindForResource(resourceName)
-		checkErr(err)
-
-		mapping, err := mapper.RESTMapping(kind, version)
-		checkErr(err)
-
-		client, err := clientBuilder(cmd, mapping)
-		checkErr(err)
-
-		visitors = append(visitors, resource.NewSelector(client, mapping, namespace, labelSelector))
-	}
-	return visitors
-}
-
-// ResourceFromArgsOrFile expects two arguments or a valid file with a given type, and extracts
-// the fields necessary to uniquely locate a resource. Displays a usageError if that contract is
-// not satisfied, or a generic error if any other problems occur.
-func ResourceFromArgsOrFile(cmd *cobra.Command, args []string, filename string, typer runtime.ObjectTyper, mapper meta.RESTMapper, schema validation.Schema, cmdNamespace, cmdVersion string) (mapping *meta.RESTMapping, namespace, name string) {
-	// If command line args are passed in, use those preferentially.
-	if len(args) > 0 && len(args) != 2 {
-		usageError(cmd, "If passing in command line parameters, must be resource and name")
-	}
-
-	if len(args) == 2 {
-		resource := args[0]
-		namespace = cmdNamespace
-		name = args[1]
-		if len(name) == 0 || len(resource) == 0 {
-			usageError(cmd, "Must specify filename or command line params")
-		}
-
-		defaultVersion, kind, err := mapper.VersionAndKindForResource(resource)
-		if err != nil {
-			// The error returned by mapper is "no resource defined", which is a usage error
-			usageError(cmd, err.Error())
-		}
-		mapping, err = mapper.RESTMapping(kind, cmdVersion, defaultVersion)
-		checkErr(err)
-		return
-	}
-
-	if len(filename) == 0 {
-		usageError(cmd, "Must specify filename or command line params")
-	}
-
-	mapping, namespace, name, _ = ResourceFromFile(filename, typer, mapper, schema, cmdVersion)
-	if len(name) == 0 {
-		checkErr(fmt.Errorf("the resource in the provided file has no name (or ID) defined"))
-	}
-
-	return
-}
 
 // ResourceFromArgs expects two arguments with a given type, and extracts the fields necessary
 // to uniquely locate a resource. Displays a usageError if that contract is not satisfied, or
 // a generic error if any other problems occur.
+// DEPRECATED: Use resource.Builder
 func ResourceFromArgs(cmd *cobra.Command, args []string, mapper meta.RESTMapper, cmdNamespace string) (mapping *meta.RESTMapping, namespace, name string) {
 	if len(args) != 2 {
 		usageError(cmd, "Must provide resource and name command line params")
@@ -155,39 +50,10 @@ func ResourceFromArgs(cmd *cobra.Command, args []string, mapper meta.RESTMapper,
 	return
 }
 
-// ResourceFromArgs expects two arguments with a given type, and extracts the fields necessary
-// to uniquely locate a resource. Displays a usageError if that contract is not satisfied, or
-// a generic error if any other problems occur.
-func ResourceOrTypeFromArgs(cmd *cobra.Command, args []string, mapper meta.RESTMapper, cmdNamespace, cmdVersion string) (mapping *meta.RESTMapping, namespace, name string) {
-	if len(args) == 0 || len(args) > 2 {
-		usageError(cmd, "Must provide resource or a resource and name as command line params")
-	}
-
-	resource := args[0]
-	if len(resource) == 0 {
-		usageError(cmd, "Must provide resource or a resource and name as command line params")
-	}
-
-	namespace = cmdNamespace
-	if len(args) == 2 {
-		name = args[1]
-		if len(name) == 0 {
-			usageError(cmd, "Must provide resource or a resource and name as command line params")
-		}
-	}
-
-	defaultVersion, kind, err := mapper.VersionAndKindForResource(resource)
-	checkErr(err)
-
-	mapping, err = mapper.RESTMapping(kind, cmdVersion, defaultVersion)
-	checkErr(err)
-
-	return
-}
-
 // ResourceFromFile retrieves the name and namespace from a valid file. If the file does not
 // resolve to a known type an error is returned. The returned mapping can be used to determine
 // the correct REST endpoint to modify this resource with.
+// DEPRECATED: Use resource.Builder
 func ResourceFromFile(filename string, typer runtime.ObjectTyper, mapper meta.RESTMapper, schema validation.Schema, cmdVersion string) (mapping *meta.RESTMapping, namespace, name string, data []byte) {
 	configData, err := ReadConfigData(filename)
 	checkErr(err)
@@ -229,6 +95,7 @@ func ResourceFromFile(filename string, typer runtime.ObjectTyper, mapper meta.RE
 // CompareNamespace returns an error if the namespace the user has provided on the CLI
 // or via the default namespace file does not match the namespace of an input file. This
 // prevents a user from unintentionally updating the wrong namespace.
+// DEPRECATED: Use resource.Builder
 func CompareNamespace(defaultNamespace, namespace string) error {
 	if len(namespace) > 0 {
 		if defaultNamespace != namespace {
@@ -236,10 +103,4 @@ func CompareNamespace(defaultNamespace, namespace string) error {
 		}
 	}
 	return nil
-}
-
-func SplitResourceArgument(arg string) []string {
-	set := util.NewStringSet()
-	set.Insert(strings.Split(arg, ",")...)
-	return set.List()
 }


### PR DESCRIPTION
Every command should use resource.Builder instead to have consistent
behavior.
