### PR TITLE
add PATCH verb to apiserver

### DIFF
--- a/pkg/apiserver/interfaces.go
+++ b/pkg/apiserver/interfaces.go
@@ -77,6 +77,11 @@ type RESTUpdater interface {
 	Update(ctx api.Context, obj runtime.Object) (runtime.Object, bool, error)
 }
 
+type RESTPatcher interface {
+	RESTGetter
+	RESTUpdater
+}
+
 // RESTResult indicates the result of a REST transformation.
 type RESTResult struct {
 	// The result of this operation. May be nil if the operation has no meaningful

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
 	"github.com/emicklei/go-restful"
+	"github.com/evanphx/json-patch"
 	"github.com/golang/glog"
 )
 
@@ -185,6 +186,83 @@ func CreateResource(r RESTCreater, ctxFn ContextFunc, namer ScopeNamer, codec ru
 	}
 }
 
+// PatchResource returns a function that will handle a resource patch
+// TODO: Eventually PatchResource should just use AtomicUpdate and this routine should be a bit cleaner
+func PatchResource(r RESTPatcher, ctxFn ContextFunc, namer ScopeNamer, codec runtime.Codec, typer runtime.ObjectTyper, resource string, admit admission.Interface) restful.RouteFunction {
+	return func(req *restful.Request, res *restful.Response) {
+		w := res.ResponseWriter
+		glog.Infof("hi")
+
+		// TODO: we either want to remove timeout or document it (if we document, move timeout out of this function and declare it in api_installer)
+		timeout := parseTimeout(req.Request.URL.Query().Get("timeout"))
+
+		namespace, name, err := namer.Name(req)
+		if err != nil {
+			notFound(w, req.Request)
+			return
+		}
+
+		obj := r.New()
+		// PATCH requires same permission as UPDATE
+		err = admit.Admit(admission.NewAttributesRecord(obj, namespace, resource, "UPDATE"))
+		if err != nil {
+			errorJSON(err, codec, w)
+			return
+		}
+
+		ctx := ctxFn(req)
+		ctx = api.WithNamespace(ctx, namespace)
+
+		original, err := r.Get(ctx, name)
+		if err != nil {
+			errorJSON(err, codec, w)
+			return
+		}
+
+		originalObjJs, err := codec.Encode(original)
+		if err != nil {
+			errorJSON(err, codec, w)
+			return
+		}
+		patchJs, err := readBody(req.Request)
+		if err != nil {
+			errorJSON(err, codec, w)
+			return
+		}
+		patchedObjJs, err := jsonpatch.MergePatch(originalObjJs, patchJs)
+		if err != nil {
+			errorJSON(err, codec, w)
+			return
+		}
+
+		if err := codec.DecodeInto(patchedObjJs, obj); err != nil {
+			errorJSON(err, codec, w)
+			return
+		}
+		if err := checkName(obj, name, namespace, namer); err != nil {
+			errorJSON(err, codec, w)
+			return
+		}
+
+		result, err := finishRequest(timeout, func() (runtime.Object, error) {
+			// update should never create as previous get would fail
+			obj, _, err := r.Update(ctx, obj)
+			return obj, err
+		})
+		if err != nil {
+			errorJSON(err, codec, w)
+			return
+		}
+
+		if err := setSelfLink(result, req, namer); err != nil {
+			errorJSON(err, codec, w)
+			return
+		}
+
+		writeJSON(http.StatusOK, codec, result, w)
+	}
+}
+
 // UpdateResource returns a function that will handle a resource update
 func UpdateResource(r RESTUpdater, ctxFn ContextFunc, namer ScopeNamer, codec runtime.Codec, typer runtime.ObjectTyper, resource string, admit admission.Interface) restful.RouteFunction {
 	return func(req *restful.Request, res *restful.Response) {
@@ -214,18 +292,9 @@ func UpdateResource(r RESTUpdater, ctxFn ContextFunc, namer ScopeNamer, codec ru
 			return
 		}
 
-		// check the provided name against the request
-		if objNamespace, objName, err := namer.ObjectName(obj); err == nil {
-			if objName != name {
-				errorJSON(errors.NewBadRequest("the name of the object does not match the name on the URL"), codec, w)
-				return
-			}
-			if len(namespace) > 0 {
-				if len(objNamespace) > 0 && objNamespace != namespace {
-					errorJSON(errors.NewBadRequest("the namespace of the object does not match the namespace on the request"), codec, w)
-					return
-				}
-			}
+		if err := checkName(obj, name, namespace, namer); err != nil {
+			errorJSON(err, codec, w)
+			return
 		}
 
 		err = admit.Admit(admission.NewAttributesRecord(obj, namespace, resource, "UPDATE"))
@@ -374,6 +443,21 @@ func setSelfLink(obj runtime.Object, req *restful.Request, namer ScopeNamer) err
 	newURL.Fragment = ""
 
 	return namer.SetSelfLink(obj, newURL.String())
+}
+
+// checkName checks the provided name against the request
+func checkName(obj runtime.Object, name, namespace string, namer ScopeNamer) error {
+	if objNamespace, objName, err := namer.ObjectName(obj); err == nil {
+		if objName != name {
+			return errors.NewBadRequest("the name of the object does not match the name on the URL")
+		}
+		if len(namespace) > 0 {
+			if len(objNamespace) > 0 && objNamespace != namespace {
+				return errors.NewBadRequest("the namespace of the object does not match the namespace on the request")
+			}
+		}
+	}
+	return nil
 }
 
 // setListSelfLink sets the self link of a list to the base URL, then sets the self links

--- a/pkg/client/restclient.go
+++ b/pkg/client/restclient.go
@@ -105,6 +105,11 @@ func (c *RESTClient) Put() *Request {
 	return c.Verb("PUT")
 }
 
+// Patch begins a PATCH request. Short for c.Verb("Patch").
+func (c *RESTClient) Patch() *Request {
+	return c.Verb("PATCH")
+}
+
 // Get begins a GET request. Short for c.Verb("GET").
 func (c *RESTClient) Get() *Request {
 	return c.Verb("GET")

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -202,12 +202,12 @@ func getTestRequests() []struct {
 		{"PUT", "/api/v1beta1/pods/a" + timeoutFlag, aPod, code200},
 		{"GET", "/api/v1beta1/pods", "", code200},
 		{"GET", "/api/v1beta1/pods/a", "", code200},
+		{"PATCH", "/api/v1beta1/pods/a", "{%v}", code200},
 		{"DELETE", "/api/v1beta1/pods/a" + timeoutFlag, "", code200},
 
 		// Non-standard methods (not expected to work,
 		// but expected to pass/fail authorization prior to
 		// failing validation.
-		{"PATCH", "/api/v1beta1/pods/a", "", code405},
 		{"OPTIONS", "/api/v1beta1/pods", "", code405},
 		{"OPTIONS", "/api/v1beta1/pods/a", "", code405},
 		{"HEAD", "/api/v1beta1/pods", "", code405},


### PR DESCRIPTION
This add's a PATCH verb to all resources who's RESTStorage implements RESTGetter and RESTUpdater. Patch implements the merge patch defined in [rfc7386](https://tools.ietf.org/html/rfc7386). I'm opening this to discuss what how the pkg/client.Client Patch api should look, or if it should be included in the Client api. The difficulty is that when a patch is converted into an api type, information is lost to zero values of fields, thus a patch must be applied as a json string or a `map[string]interface{}` in order to maintain all information. I will be refactoring `kubectl update --patch` as well.

```
 curl localhost:8080/api/v1beta1/pods/web \
    --request PATCH  \
    -H "Content-Type:application/merge-patch+json" \
    -d '{"labels":{"new":"label"}}'
```

Fixes #4578
