### PR TITLE
Stop using overlay driver for docker in coreos cloud-configs.

### DIFF
--- a/docs/getting-started-guides/coreos/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/node.yaml
@@ -44,7 +44,7 @@ coreos:
         [Service]
         EnvironmentFile=/run/flannel/subnet.env
         ExecStartPre=/bin/mount --make-rprivate /
-        ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd://
+        ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -H fd://
 
         [Install]
         WantedBy=multi-user.target

--- a/docs/getting-started-guides/coreos/cloud-configs/standalone.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/standalone.yaml
@@ -61,7 +61,7 @@ coreos:
         [Service]
         EnvironmentFile=/run/flannel/subnet.env
         ExecStartPre=/bin/mount --make-rprivate /
-        ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd://
+        ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -H fd://
 
         [Install]
         WantedBy=multi-user.target


### PR DESCRIPTION
WARNING: I HAVE NO IDEA WHAT I'M DOING.

Alright, maybe I know a little bit. I know that coreos uses btrfs, and
that docker has officially disabled the overlay driver on btrfs:

https://github.com/docker/docker/issues/9820

That "fix" hasn't yet hit the stable coreos build, but on alpha,
docker can't even start with this flag. In stable/beta, docker
functions, but fails to start debian-based containers for some reason.

If there's a particular reason that overlay is being used here, then
the underlying FS needs to be ext4 (not totally sure what 'underlying'
means here, but I'm going with it). But if not, we can just remove
this flag and be done with it.
