### PR TITLE
#4544 - Fix inadvertent whitespace in v1beta3 enablement

### DIFF
--- a/pkg/util/configuration_map.go
+++ b/pkg/util/configuration_map.go
@@ -40,9 +40,9 @@ func (m *ConfigurationMap) Set(value string) error {
 		}
 		arr := strings.SplitN(s, "=", 2)
 		if len(arr) == 2 {
-			(*m)[arr[0]] = arr[1]
+			(*m)[strings.TrimSpace(arr[0])] = strings.TrimSpace(arr[1])
 		} else {
-			(*m)[arr[0]] = ""
+			(*m)[strings.TrimSpace(arr[0])] = ""
 		}
 	}
 	return nil


### PR DESCRIPTION
This was an attempt to fix an issue that I discovered when enabling v1beta3 in the apiserver config.  I accidentally had an extra trailing whitespace in the KUBE_API_ARGS and v1beta3 was never recognized. I tried to find a way to trim this value when it's loaded into the api server but was not successful.  So the proposed solution will avoid inadvertent white spaces in the --runtime_config= string.
