### PR TITLE
Docs: update links

### DIFF
--- a/docs/design/secrets.md
+++ b/docs/design/secrets.md
@@ -72,7 +72,7 @@ service would also consume the secrets associated with the MySQL service.
 
 ### Use-Case: Secrets associated with service accounts
 
-[Service Accounts](https://github.com/GoogleCloudPlatform/kubernetes/pull/2297) are proposed as a
+[Service Accounts](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/service_accounts.md) are proposed as a
 mechanism to decouple capabilities and security contexts from individual human users.  A
 `ServiceAccount` contains references to some number of secrets.  A `Pod` can specify that it is
 associated with a `ServiceAccount`.  Secrets should have a `Type` field to allow the Kubelet and
@@ -236,7 +236,7 @@ memory overcommit on the node.
 
 #### Secret data on the node: isolation
 
-Every pod will have a [security context](https://github.com/GoogleCloudPlatform/kubernetes/pull/3910).
+Every pod will have a [security context](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/security_context.md).
 Secret data on the node should be isolated according to the security context of the container.  The
 Kubelet volume plugin API will be changed so that a volume plugin receives the security context of
 a volume along with the volume spec.  This will allow volume plugins to implement setting the
@@ -248,7 +248,7 @@ Several proposals / upstream patches are notable as background for this proposal
 
 1.  [Docker vault proposal](https://github.com/docker/docker/issues/10310)
 2.  [Specification for image/container standardization based on volumes](https://github.com/docker/docker/issues/9277)
-3.  [Kubernetes service account proposal](https://github.com/GoogleCloudPlatform/kubernetes/pull/2297)
+3.  [Kubernetes service account proposal](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/service_accounts.md)
 4.  [Secrets proposal for docker (1)](https://github.com/docker/docker/pull/6075)
 5.  [Secrets proposal for docker (2)](https://github.com/docker/docker/pull/6697)
 


### PR DESCRIPTION
Update links to security contexts and service accounts to point to actual docs instead of pull requests now that those proposals have been merged
