### PR TITLE
Support other names for GNU tar

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -678,7 +678,11 @@ function kube::release::create_tarball() {
   # Find gnu tar if it is available
   local tar=tar
   if which gtar &>/dev/null; then
-    tar=gtar
+      tar=gtar
+  else
+      if which gnutar &>/dev/null; then
+	  tar=gnutar
+      fi
   fi
 
   local tar_cmd=("$tar" "czf" "${tarfile}" "-C" "${stagingdir}" "kubernetes")


### PR DESCRIPTION
The build is only looking for GNU tar as gtar on OSX, which is the name used when installed using brew. Macports installs it as gnutar, so check for that name if gtar is not found.
