### PR TITLE
Vagrant: Kubernetes master needs more than 512MB of ram

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,8 +50,11 @@ else # sorry Windows folks, I can't help you
   $vm_cpus = 2
 end
 
-# Give VM 512MB of RAM
-$vm_mem = 512
+# Give VM 1024MB of RAM
+# In Fedora VM, tmpfs device is mapped to /tmp.  tmpfs is given 50% of RAM allocation.
+# When doing Salt provisioning, we copy approximately 200MB of content in /tmp before anything else happens.
+# This causes problems if anything else was in /tmp or the other directories that are bound to tmpfs device (i.e /run, etc.)
+$vm_mem = 1024
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   def customize_vm(config)


### PR DESCRIPTION
The default RAM allocated to a VM is too small and can run into issues during Salt provisioning - most notably during updates of an existing cluster.  In particular, on Fedora VM, /tmp is mounted to tmpfs device, which is 50% of allocated RAM.  With 256 MB on tmpfs device which is being shared by multiple directories on the Fedora box, during a `kube-push.sh` `saltbase/install.sh` could get stuck when doing an update and run out of room on /tmp.

In practice, 512 MB of RAM is too small to run an effective master when populating etcd.  On the minion, you could easily run into problems depending on the sample pods you were running.

Bumping this 2x for now.

/cc @smarterclayton 
