### PR TITLE
Make a Kubernetes specific version of an Elasticsearch Docker container

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-controller.yaml.in
+++ b/cluster/addons/fluentd-elasticsearch/es-controller.yaml.in
@@ -12,7 +12,7 @@ desiredState:
         id: es-log-ingestion
         containers:
           - name: elasticsearch-logging
-            image: dockerfile/elasticsearch
+            image: kubernetes/elasticsearch:1.0
             ports:
               - name: es-port
                 containerPort: 9200

--- a/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
@@ -1,0 +1,27 @@
+# A Dockerfile for creating an Elasticsearch instance that is designed
+# to work with Kubernetes logging. Inspired by the Dockerfile
+# dockerfile/elasticsearch
+
+FROM dockerfile/java:openjdk-7-jre
+MAINTAINER Satnam Singh "satnam@google.com"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+    apt-get install -y curl && \
+    apt-get clean
+
+RUN cd / && \
+    curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.4.tar.gz && \
+    tar xf elasticsearch-1.4.4.tar.gz && \
+    mv elasticsearch-1.4.4 /elasticsearch && \
+    rm -rf elasticsearch-1.4.4.tar.gz
+
+ADD elasticsearch.yml /elasticsearch/config/elasticsearch.yml
+
+VOLUME ["/data"]
+WORKDIR /data
+CMD ["/elasticsearch/bin/elasticsearch"]
+
+EXPOSE 9200
+EXPOSE 9300

--- a/cluster/addons/fluentd-elasticsearch/es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Makefile
@@ -1,0 +1,9 @@
+.PHONY:	build push
+
+TAG = 1.0
+
+build:	
+	docker build -t kubernetes/elasticsearch:$(TAG) .
+
+push:	
+	docker push kubernetes/elasticsearch:$(TAG)

--- a/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch.yml
+++ b/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch.yml
@@ -1,0 +1,7 @@
+path:
+  data: /data/data
+  logs: /data/log
+  plugins: /data/plugins
+  work: /data/work
+cluster:
+  name: kubernetes_logging


### PR DESCRIPTION
This is part of the on-going effort to write a reliable end to end test for cluster level logging #3388. This PR is for a Kubernetes controlled image for an Elasticsearch container. The Dockerfile pulls just one version of the JRE (enough to run Elasticsearch) and the pod specification pulls a tagged image. This PR also addresses issue #4746. @alex-mohr @zmerlynn 

The JRE-7 dependency is big (as was the case before with the Java dependency in dockerfile/elasticsearch). As a team we should think about how we can pick a few common base Java elements so through factorization we can reduce the load time and improve the reliability of images.
