### PR TITLE
APIServer: Updating special verb handlers to accept full request path rather than a trimmed one

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -141,7 +141,7 @@ func NewAPIGroupVersion(storage map[string]RESTStorage, codec runtime.Codec, roo
 		admit:   admissionControl,
 		context: contextMapper,
 		mapper:  mapper,
-		info:    &APIRequestInfoResolver{util.NewStringSet(root), latest.RESTMapper},
+		info:    &APIRequestInfoResolver{util.NewStringSet(strings.TrimPrefix(root, "/")), latest.RESTMapper},
 	}
 }
 

--- a/pkg/apiserver/watch.go
+++ b/pkg/apiserver/watch.go
@@ -39,7 +39,6 @@ import (
 type WatchHandler struct {
 	storage map[string]RESTStorage
 	codec   runtime.Codec
-	prefix  string
 	linker  runtime.SelfLinker
 	info    *APIRequestInfoResolver
 }
@@ -51,7 +50,7 @@ func (h *WatchHandler) setSelfLinkAddName(obj runtime.Object, req *http.Request)
 		return err
 	}
 	newURL := *req.URL
-	newURL.Path = path.Join(h.prefix, req.URL.Path, name)
+	newURL.Path = path.Join(req.URL.Path, name)
 	newURL.RawQuery = ""
 	newURL.Fragment = ""
 	return h.linker.SetSelfLink(obj, newURL.String())


### PR DESCRIPTION
Standard REST method (get, put, etc) handlers already get the full path.
Special verb (watch, proxy, etc) handlers, on the other hand, were being called after stripping "/api/{version}" from the request path.
Updated the code so that all handlers behave consistently (all handlers get the full path)
Watch handler needs the full path to figure out the APIVersion to handle the field selector query parameter appropriately (https://github.com/GoogleCloudPlatform/kubernetes/pull/4575).
