### PR TITLE
Fix commands order & add guide in k8s-ubuntu-cluster readme

### DIFF
--- a/cluster/ubuntu-cluster/configure.sh
+++ b/cluster/ubuntu-cluster/configure.sh
@@ -153,29 +153,8 @@ while true; do
     echo
 
 	case $option in
-	    [2] )
-        	read -p "IP address of this machine > " myIP
-            echo
-            etcdName=${mm[$myIP]}
-            inList $etcdName $myIP 
-            configEtcd $etcdName $myIP $cluster
-            # set MINION IPs in kube-controller-manager
-            sed -i "s/MINION_IPS/${minionIPs}/g" default_scripts/kube-controller-manager  
-	        cpMaster
-	        break
-	        ;;
-	    [3] )     
-        	read -p "IP address of this machine > " myIP
-            echo           
-            etcdName=${mm[$myIP]}
-            inList $etcdName $myIP 
-            configEtcd $etcdName $myIP $cluster
-            # set MINION IP in default_scripts/kubelet
-            sed -i "s/MY_IP/${myIP}/g" default_scripts/kubelet
-	        cpMinion
-	        break
-	        ;;
 	    [1] )
+            # as both master and minion
         	read -p "IP address of this machine > " myIP
             echo 
             etcdName=${mm[$myIP]}
@@ -192,6 +171,30 @@ while true; do
 	        cpMinion
 	        break
 	        ;;
+        [2] )
+            # as master
+        	read -p "IP address of this machine > " myIP
+            echo
+            etcdName=${mm[$myIP]}
+            inList $etcdName $myIP 
+            configEtcd $etcdName $myIP $cluster
+            # set MINION IPs in kube-controller-manager
+            sed -i "s/MINION_IPS/${minionIPs}/g" default_scripts/kube-controller-manager  
+	        cpMaster
+	        break
+            ;;
+        [3] )     
+            # as minion
+        	read -p "IP address of this machine > " myIP
+            echo           
+            etcdName=${mm[$myIP]}
+            inList $etcdName $myIP 
+            configEtcd $etcdName $myIP $cluster
+            # set MINION IP in default_scripts/kubelet
+            sed -i "s/MY_IP/${myIP}/g" default_scripts/kubelet
+	        cpMinion
+	        break
+	        ;;    
 	    * )
 	        echo "Please choose 1 or 2 or 3."
 	        ;;

--- a/cluster/ubuntu-cluster/configure.sh
+++ b/cluster/ubuntu-cluster/configure.sh
@@ -156,15 +156,15 @@ while true; do
 	    [1] )
             # as both master and minion
         	read -p "IP address of this machine > " myIP
-            echo 
+            echo
             etcdName=${mm[$myIP]}
-            inList $etcdName $myIP 
+            inList $etcdName $myIP
             configEtcd $etcdName $myIP $cluster
             # For minion set MINION IP in default_scripts/kubelet
-            sed -i "s/MY_IP/${myIP}/g" default_scripts/kubelet 
+            sed -i "s/MY_IP/${myIP}/g" default_scripts/kubelet
             
             # For master set MINION IPs in kube-controller-manager
-	        minionIPs="$minionIPs,$myIP"       
+	        minionIPs="$minionIPs,$myIP"
 	        sed -i "s/MINION_IPS/${minionIPs}/g" default_scripts/kube-controller-manager
 	        
 	        cpMaster
@@ -176,25 +176,25 @@ while true; do
         	read -p "IP address of this machine > " myIP
             echo
             etcdName=${mm[$myIP]}
-            inList $etcdName $myIP 
+            inList $etcdName $myIP
             configEtcd $etcdName $myIP $cluster
             # set MINION IPs in kube-controller-manager
-            sed -i "s/MINION_IPS/${minionIPs}/g" default_scripts/kube-controller-manager  
+            sed -i "s/MINION_IPS/${minionIPs}/g" default_scripts/kube-controller-manager
 	        cpMaster
 	        break
             ;;
-        [3] )     
+        [3] )
             # as minion
         	read -p "IP address of this machine > " myIP
-            echo           
+            echo
             etcdName=${mm[$myIP]}
-            inList $etcdName $myIP 
+            inList $etcdName $myIP
             configEtcd $etcdName $myIP $cluster
             # set MINION IP in default_scripts/kubelet
             sed -i "s/MY_IP/${myIP}/g" default_scripts/kubelet
 	        cpMinion
 	        break
-	        ;;    
+	        ;;
 	    * )
 	        echo "Please choose 1 or 2 or 3."
 	        ;;

--- a/docs/getting-started-guides/README.md
+++ b/docs/getting-started-guides/README.md
@@ -14,6 +14,7 @@ AWS            | Saltstack    | Ubuntu | [docs](../../docs/getting-started-guide
 Vmware         | CoreOS       | CoreOS | [docs](../../docs/getting-started-guides/coreos.md)    | Community (@kelseyhightower) |
 Azure          | Saltstack    | Ubuntu | [docs](../../docs/getting-started-guides/azure.md)     | Community (@jeffmendoza)     |
 Bare-metal     | custom       | Ubuntu | [docs](../../docs/getting-started-guides/ubuntu_single_node.md) | Community (@jainvipin)       |
+Bare-metal     | custom       | Ubuntu Cluster | [docs](../../docs/getting-started-guides/ubuntu_multinodes_cluster.md) | community (@resouer @WIZARD-CXY) | use k8s version 0.10.1
 Local          |              |        | [docs](../../docs/getting-started-guides/locally.md)   | Inactive                     |
 Ovirt          |              |        | [docs](../../docs/getting-started-guides/ovirt.md)     | Inactive                     |
 Rackspace      | CoreOS       | CoreOS | [docs](../../docs/getting-started-guides/rackspace.md) | Inactive                     |


### PR DESCRIPTION
Our previous PR (https://github.com/GoogleCloudPlatform/kubernetes/pull/3922) messed up the commands order and I'd like to sort them rightly here.

BTW, I & my colleague are willing to maintain this part in the future (including continually test it on latest k8s  and upgrade it to fully automatic), so I add a line in the readme to make it work.
