### PR TITLE
Add waiting for GCE operations to finish before proceeding in various functions.

### DIFF
--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -178,8 +178,7 @@ func (gce *GCECloud) makeTargetPool(name, region string, hosts []string, affinit
 	if err != nil {
 		return "", err
 	}
-	err = gce.waitForRegionOp(op, region)
-	if err != nil {
+	if err = gce.waitForRegionOp(op, region); err != nil {
 		return "", err
 	}
 	link := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/targetPools/%s", gce.projectID, region, name)
@@ -259,10 +258,10 @@ func (gce *GCECloud) UpdateTCPLoadBalancer(name, region string, hosts []string) 
 	}
 
 	op, err := gce.service.TargetPools.AddInstance(gce.projectID, region, name, req).Do()
-	gce.waitForRegionOp(op, region)
 	if err != nil {
 		return err
 	}
+	err = gce.waitForRegionOp(op, region)
 	return err
 }
 


### PR DESCRIPTION
This solves #4689 by adding a wait. Another approach (or extension) would be to add a retry, but I'm not certain it'd be any better.

There's a thing I tried to understand but failed: I tried to add logging to waitForRegionOp method, and outputed via glog.Infof/Warningf/Errorf errors from the operation (if any). I wasn't returning this as an error in err, but thought that it might be useful for future debugging. For some reason adding those debugs makes it impossible to start a cluster on GCE, as various API calls end with BAD GATEWAY errors. 
