### PR TITLE
Minimal status mutation change

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -647,6 +647,23 @@ func ValidatePodUpdate(newPod, oldPod *api.Pod) errs.ValidationErrorList {
 	return allErrs
 }
 
+// ValidatePodStatusUpdate tests to see if the update is legal for an end user to make. newPod is updated with fields
+// that cannot be changed.
+func ValidatePodStatusUpdate(newPod, oldPod *api.Pod) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+
+	allErrs = append(allErrs, ValidateObjectMetaUpdate(&oldPod.ObjectMeta, &newPod.ObjectMeta).Prefix("metadata")...)
+
+	// TODO: allow change when bindings are properly decoupled from pods
+	if newPod.Status.Host != oldPod.Status.Host {
+		allErrs = append(allErrs, errs.NewFieldInvalid("status.host", newPod.Status.Host, "pod host cannot be changed directly"))
+	}
+
+	newPod.Spec = oldPod.Spec
+
+	return allErrs
+}
+
 var supportedSessionAffinityType = util.NewStringSet(string(api.AffinityTypeClientIP), string(api.AffinityTypeNone))
 
 // ValidateService tests if required fields in the service are set.

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -369,7 +369,7 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 func (m *Master) init(c *Config) {
 
 	boundPodFactory := &pod.BasicBoundPodFactory{}
-	podStorage, bindingStorage := podetcd.NewREST(c.EtcdHelper, boundPodFactory)
+	podStorage, bindingStorage, podStatusStorage := podetcd.NewREST(c.EtcdHelper, boundPodFactory)
 	podRegistry := pod.NewRegistry(podStorage)
 
 	eventRegistry := event.NewEtcdRegistry(c.EtcdHelper, uint64(c.EventTTL.Seconds()))
@@ -401,8 +401,9 @@ func (m *Master) init(c *Config) {
 
 	// TODO: Factor out the core API registration
 	m.storage = map[string]apiserver.RESTStorage{
-		"pods":     podStorage,
-		"bindings": bindingStorage,
+		"pods":        podStorage,
+		"pods/status": podStatusStorage,
+		"bindings":    bindingStorage,
 
 		"replicationControllers": controller.NewREST(registry, podRegistry),
 		"services":               service.NewREST(m.serviceRegistry, c.Cloud, m.nodeRegistry, m.portalNet, c.ClusterName),

--- a/pkg/registry/etcd/etcd_test.go
+++ b/pkg/registry/etcd/etcd_test.go
@@ -41,7 +41,7 @@ func NewTestEtcdRegistry(client tools.EtcdClient) *Registry {
 
 func NewTestEtcdRegistryWithPods(client tools.EtcdClient) *Registry {
 	helper := tools.EtcdHelper{client, latest.Codec, tools.RuntimeVersionAdapter{latest.ResourceVersioner}}
-	podStorage, _ := podetcd.NewREST(helper, nil)
+	podStorage, _, _ := podetcd.NewREST(helper, nil)
 	registry := NewRegistry(helper, pod.NewRegistry(podStorage))
 	return registry
 }

--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -71,6 +71,17 @@ func (podStrategy) ValidateUpdate(obj, old runtime.Object) errors.ValidationErro
 	return validation.ValidatePodUpdate(obj.(*api.Pod), old.(*api.Pod))
 }
 
+type podStatusStrategy struct {
+	podStrategy
+}
+
+var StatusStrategy = podStatusStrategy{Strategy}
+
+func (podStatusStrategy) ValidateUpdate(obj, old runtime.Object) errors.ValidationErrorList {
+	// TODO: merge valid fields after update
+	return validation.ValidatePodStatusUpdate(obj.(*api.Pod), old.(*api.Pod))
+}
+
 // PodStatusGetter is an interface used by Pods to fetch and retrieve status info.
 type PodStatusGetter interface {
 	GetPodStatus(namespace, name string) (*api.PodStatus, error)


### PR DESCRIPTION
```
PUT /api/v1beta3/namespaces/default/pods/foo/status
{
  "metadata": {...}, // allowed for valid values
  "spec": {}, // ignored
  "status": {...}, // allowed, except for Host
}
```

Exposes the simplest possibly change. Needs a slight refactoring
to RESTUpdateStrategy to split merging.

Sets the stage for #2726
