### PR TITLE
pkg/kubelet/kubelet.go: Fix syncPod().

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -934,7 +934,7 @@ func TestSyncPodBadHash(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	verifyCalls(t, fakeDocker, []string{"list", "stop", "list", "create", "start", "stop", "create", "start", "inspect_container"})
+	verifyCalls(t, fakeDocker, []string{"list", "stop", "list", "create", "start", "stop"})
 
 	// A map interation is used to delete containers, so must not depend on
 	// order here.


### PR DESCRIPTION
We should not recreat infra container too soon, because otherwise
the remaining container will be in a different ns as the infra.

This is just a quick fix. A better way I think is to compare the current infra container with the expecting one to see if we need to kill the current one.
AFAIK, the expecting infra might only differ with the current one in the port mappings, I am going to work on this.
