### PR TITLE
Revert "fix kubectl config view to respect serialization formats"

### DIFF
--- a/pkg/kubectl/cmd/config/config_test.go
+++ b/pkg/kubectl/cmd/config/config_test.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -46,36 +45,6 @@ type configCommandTest struct {
 	startingConfig  clientcmdapi.Config
 	expectedConfig  clientcmdapi.Config
 	expectedOutputs []string
-}
-
-func ExampleView() {
-	expectedConfig := newRedFederalCowHammerConfig()
-	test := configCommandTest{
-		args:           []string{"view"},
-		startingConfig: newRedFederalCowHammerConfig(),
-		expectedConfig: expectedConfig,
-	}
-
-	output := test.run(nil)
-	fmt.Printf("%v", output)
-	// Output:
-	// apiVersion: v1
-	// clusters:
-	// - cluster:
-	//     server: http://cow.org:8080
-	//   name: cow-cluster
-	// contexts:
-	// - context:
-	//     cluster: cow-cluster
-	//     user: red-user
-	//   name: federal-context
-	// current-context: ""
-	// kind: Config
-	// preferences: {}
-	// users:
-	// - name: red-user
-	//   user:
-	//     token: red-token
 }
 
 func TestSetCurrentContext(t *testing.T) {
@@ -571,7 +540,7 @@ func testConfigCommand(args []string, startingConfig clientcmdapi.Config) (strin
 	return buf.String(), *config
 }
 
-func (test configCommandTest) run(t *testing.T) string {
+func (test configCommandTest) run(t *testing.T) {
 	out, actualConfig := testConfigCommand(test.args, test.startingConfig)
 
 	testSetNilMapsToEmpties(reflect.ValueOf(&test.expectedConfig))
@@ -587,8 +556,6 @@ func (test configCommandTest) run(t *testing.T) string {
 			t.Errorf("expected '%s' in output, got '%s'", expectedOutput, out)
 		}
 	}
-
-	return out
 }
 func testSetNilMapsToEmpties(curr reflect.Value) {
 	actualCurrValue := curr

--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -26,8 +26,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api/latest"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
 	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
@@ -52,20 +50,14 @@ $ kubectl config view --local`,
 		Run: func(cmd *cobra.Command, args []string) {
 			options.complete()
 
-			printer, generic, err := cmdutil.PrinterForCommand(cmd)
+			printer, _, err := cmdutil.PrinterForCommand(cmd)
 			if err != nil {
 				glog.FatalDepth(1, err)
 			}
-			if generic {
-				version := cmdutil.OutputVersion(cmd, latest.Version)
-				printer = kubectl.NewVersionedPrinter(printer, clientcmdapi.Scheme, version)
-			}
-
 			config, err := options.loadConfig()
 			if err != nil {
 				glog.FatalDepth(1, err)
 			}
-
 			err = printer.PrintObj(config, out)
 			if err != nil {
 				glog.FatalDepth(1, err)


### PR DESCRIPTION
Reverts GoogleCloudPlatform/kubernetes#4660

This changes `kubectl config view -o template` in a way that breaks e2e. This [call](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/cluster/gce/util.sh#L239) used to work and now doesn't, so validate cluster fails.
