### PR TITLE
Update skydns's etcd to version 2.0.3

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -20,11 +20,12 @@ desiredState:
         dnsPolicy: "Default"  # Don't use cluster DNS.
         containers:
           - name: etcd
-            image: quay.io/coreos/etcd:latest
+            image: quay.io/coreos/etcd:v2.0.3
             command: [
-                    "/etcd",
-                    "-bind-addr=127.0.0.1",
-                    "-peer-bind-addr=127.0.0.1",
+                    # entrypoint = "/etcd",
+                    "-listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001",
+                    "-initial-cluster-token=skydns-etcd",
+                    "-advertise-client-urls=http://127.0.0.1:4001",
             ]
           - name: kube2sky
             image: kubernetes/kube2sky:1.0


### PR DESCRIPTION
While I'm not sure that all parameters are necessary, I've tested current configuration manually by:
- checking that dns works from withing a pod in the cluster (by doing curl kubernetes-ro)
- checking that etcdctl works against skydns etcd
  I've also discovered that in case of a race in start up of skydns containers (kube2sky starting before etcd) the kube2sky won't connect to etcd at all. I will file a separate issue for that. 
  I've also specified explicitly --initial-cluster-token flag. I'm not sure whether this is strictly needed, however after playing a little bit with the skydns pod, my cluster (on GCE) stopped responding. I need to investigate this a bit further, but I don't know whether there wasn't an interference between various instances of etcd running in the cluster (https://github.com/coreos/etcd/blob/master/Documentation/clustering.md).
