### PR TITLE
Use a different port for the kubectl proxy in the shell and go tests.

### DIFF
--- a/hack/e2e-suite/update.sh
+++ b/hack/e2e-suite/update.sh
@@ -103,7 +103,7 @@ function validate() {
         continue
       fi
 
-      curl -s --max-time 5 --fail http://localhost:8011/api/v1beta1/proxy/pods/${id}/data.json \
+      curl -s --max-time 5 --fail http://localhost:8010/api/v1beta1/proxy/pods/${id}/data.json \
           | grep -q ${container_image_version} || {
         echo "  ${id} is running the right image but curl to contents failed or returned wrong info"
         continue
@@ -128,7 +128,7 @@ function teardown() {
 trap "teardown" EXIT
 
 # Launch a local proxy to the apiserver
-${KUBECTL} proxy --port=8011 &
+${KUBECTL} proxy --port=8010 &
 kubectl_proxy_pid=$!
 
 # Launch a container


### PR DESCRIPTION
Help narrow down the cause of #4807. Alternatively, we could roll back my change from yesterday that adds the proxying but since no one has done that I'm going to work on rolling forward. 
