### PR TITLE
Validate api version in kubectl --patch and --override

### DIFF
--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
 	"github.com/evanphx/json-patch"
@@ -161,10 +161,13 @@ func Merge(dst runtime.Object, fragment, kind string) (runtime.Object, error) {
 	if !ok {
 		return nil, fmt.Errorf("apiVersion must be a string")
 	}
+	i, err := latest.InterfacesFor(versionString)
+	if err != nil {
+		return nil, err
+	}
 
-	codec := runtime.CodecFor(api.Scheme, versionString)
 	// encode dst into versioned json and apply fragment directly too it
-	target, err := codec.Encode(dst)
+	target, err := i.Codec.Encode(dst)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +175,7 @@ func Merge(dst runtime.Object, fragment, kind string) (runtime.Object, error) {
 	if err != nil {
 		return nil, err
 	}
-	out, err := codec.Decode(patched)
+	out, err := i.Codec.Decode(patched)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubectl/cmd/util/helpers_test.go
+++ b/pkg/kubectl/cmd/util/helpers_test.go
@@ -131,6 +131,12 @@ func TestMerge(t *testing.T) {
 			},
 		},
 		{
+			kind:      "Service",
+			obj:       &api.Service{},
+			fragment:  `{ "apiVersion": "badVersion" }`,
+			expectErr: true,
+		},
+		{
 			kind: "Service",
 			obj: &api.Service{
 				Spec: api.ServiceSpec{


### PR DESCRIPTION
InterfacesFor() returns an error when the apiVersion is not found where CodecFor does not. This breaks ./hack/test-cmd.sh until #4793 is merged. Also related to #4771.
