### PR TITLE
Trim whitespace from kubectl in e2e/kubectl.go

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -188,5 +188,6 @@ func runKubectl(args ...string) string {
 		return ""
 	}
 	Logf(stdout.String())
-	return stdout.String()
+	// TODO: trimspace should be unnecessary after switching to use kubectl binary directly
+	return strings.TrimSpace(stdout.String())
 }


### PR DESCRIPTION
Avoids spurious comparison errors while we are still shelling out to `cluster/kubectl.sh`. This fixes kubectl.go on GKE jenkins. cc @zmerlynn 
