### PR TITLE
moving ParseSelector to Parse for labels only.

### DIFF
--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -31,7 +31,7 @@ kube::test::get_object_assert() {
   local request=$2
   local expected=$3
 
-  res=$(kubectl get "${kube_flags[@]}" $object -o template -t "$request")
+  res=$(eval kubectl get "${kube_flags[@]}" $object -o template -t "$request")
 
   if [[ "$res" =~ ^$expected$ ]]; then
       echo -n ${green}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -194,11 +194,11 @@ for version in "${kube_api_versions[@]}"; do
 
   ### Delete POD valid-pod with label
   # Pre-condition: valid-pod POD is running
-  kube::test::get_object_assert 'pods -l name=valid-pod' "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
+  kube::test::get_object_assert "pods -l'name in (valid-pod)'" '{{range.items}}{{.$id_field}}:{{end}}' 'valid-pod:'
   # Command
-  kubectl delete pods -l name=valid-pod "${kube_flags[@]}"
+  kubectl delete pods -l'name in (valid-pod)' "${kube_flags[@]}"
   # Post-condition: no POD is running
-  kube::test::get_object_assert 'pods -l name=valid-pod' "{{range.items}}{{.$id_field}}:{{end}}" ''
+  kube::test::get_object_assert "pods -l'name in (valid-pod)'" '{{range.items}}{{.$id_field}}:{{end}}' ''
 
   ### Create POD valid-pod from JSON
   # Pre-condition: no POD is running
@@ -220,7 +220,7 @@ for version in "${kube_api_versions[@]}"; do
   # Pre-condition: valid-pod POD is running
   kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
   # Command
-  ! kubectl delete --all pods -l name=valid-pod "${kube_flags[@]}"
+  ! kubectl delete --all pods -l'name in (valid-pod)' "${kube_flags[@]}"
   # Post-condition: valid-pod POD is running
   kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
 
@@ -230,7 +230,7 @@ for version in "${kube_api_versions[@]}"; do
   # Command
   kubectl delete --all pods "${kube_flags[@]}" # --all remove all the pods
   # Post-condition: no POD is running
-  kube::test::get_object_assert 'pods -l name=valid-pod' "{{range.items}}{{.$id_field}}:{{end}}" ''
+  kube::test::get_object_assert "pods -l'name in (valid-pod)'" '{{range.items}}{{.$id_field}}:{{end}}' ''
 
   ### Create two PODs
   # Pre-condition: no POD is running
@@ -318,7 +318,7 @@ for version in "${kube_api_versions[@]}"; do
   # Pre-condition: valid-pod POD is running
   kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
   # Command
-  kubectl delete pods -lname=valid-pod-super-sayan "${kube_flags[@]}"
+  kubectl delete pods -l'name in (valid-pod-super-sayan)' "${kube_flags[@]}"
   # Post-condition: no POD is running
   kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" ''
 

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -81,7 +81,7 @@ func GetResource(r RESTGetter, ctxFn ContextFunc, namer ScopeNamer, codec runtim
 }
 
 func parseSelectorQueryParams(query url.Values, version, apiResource string) (label, field labels.Selector, err error) {
-	label, err = labels.ParseSelector(query.Get("labels"))
+	label, err = labels.Parse(query.Get("labels"))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/client/cache/listwatch_test.go
+++ b/pkg/client/cache/listwatch_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func parseSelectorOrDie(s string) labels.Selector {
-	selector, err := labels.ParseSelector(s)
+	selector, err := labels.Parse(s)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -139,8 +139,10 @@ func (c *testClient) ValidateCommon(t *testing.T, err error) {
 		validator, ok := c.QueryValidator[key]
 		if !ok {
 			switch key {
-			case "labels", "fields":
+			case "labels":
 				validator = validateLabels
+			case "fields":
+				validator = validateFields
 			default:
 				validator = func(a, b string) bool { return a == b }
 			}
@@ -227,6 +229,18 @@ func TestListPods(t *testing.T) {
 }
 
 func validateLabels(a, b string) bool {
+	sA, eA := labels.Parse(a)
+	if eA != nil {
+		return false
+	}
+	sB, eB := labels.Parse(b)
+	if eB != nil {
+		return false
+	}
+	return sA.String() == sB.String()
+}
+
+func validateFields(a, b string) bool {
 	sA, _ := labels.ParseSelector(a)
 	sB, _ := labels.ParseSelector(b)
 	return sA.String() == sB.String()

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -236,7 +236,16 @@ func (r *Request) ParseSelectorParam(paramName, item string) *Request {
 	if r.err != nil {
 		return r
 	}
-	sel, err := labels.ParseSelector(item)
+	var sel labels.Selector
+	var err error
+	switch paramName {
+	case "labels":
+		sel, err = labels.Parse(item)
+	case "fields":
+		sel, err = labels.ParseSelector(item)
+	default:
+		err = fmt.Errorf("unknown parameter name '%s'", paramName)
+	}
 	if err != nil {
 		r.err = err
 		return r

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -142,7 +142,7 @@ func TestRequestSetTwiceError(t *testing.T) {
 }
 
 func TestRequestParseSelectorParam(t *testing.T) {
-	r := (&Request{}).ParseSelectorParam("foo", "a")
+	r := (&Request{}).ParseSelectorParam("foo", "a=")
 	if r.err == nil || r.params != nil {
 		t.Errorf("should have set err and left params nil: %#v", r)
 	}

--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -164,7 +164,7 @@ func (b *Builder) ResourceTypes(types ...string) *Builder {
 // This will not affect files loaded from disk or URL. If the parameter is empty it is
 // a no-op - to select all resources invoke `b.Selector(labels.Everything)`.
 func (b *Builder) SelectorParam(s string) *Builder {
-	selector, err := labels.ParseSelector(s)
+	selector, err := labels.Parse(s)
 	if err != nil {
 		b.errs = append(b.errs, fmt.Errorf("the provided selector %q is not valid: %v", s, err))
 		return b

--- a/pkg/registry/generic/registry_test.go
+++ b/pkg/registry/generic/registry_test.go
@@ -73,7 +73,7 @@ func TestSelectionPredicate(t *testing.T) {
 	}
 
 	for name, item := range table {
-		parsedLabel, err := labels.ParseSelector(item.labelSelector)
+		parsedLabel, err := labels.Parse(item.labelSelector)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/registry/pod/etcd/etcd_test.go
+++ b/pkg/registry/pod/etcd/etcd_test.go
@@ -351,7 +351,7 @@ func TestListPodListSelection(t *testing.T) {
 	}
 
 	for index, item := range table {
-		label, err := labels.ParseSelector(item.label)
+		label, err := labels.Parse(item.label)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 			continue


### PR DESCRIPTION
@smarterclayton @thockin 

In this PR `labels.ParseSelector` is systematically replaced with `labels.Parse`. For the moment I didn't create the `fields` package as agreed in https://github.com/GoogleCloudPlatform/kubernetes/issues/341#issuecomment-75712472

In this PR I've also slightly modified `selector.go` following @smarterclayton suggestion and [this](https://code.google.com/p/go-wiki/wiki/CodeReviewComments).
