### PR TITLE
Stop importing expvar

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -18,7 +18,6 @@ package master
 
 import (
 	"bytes"
-	_ "expvar"
 	"fmt"
 	"net"
 	"net/http"


### PR DESCRIPTION
As per https://github.com/GoogleCloudPlatform/kubernetes/issues/1625, we have decided to use prometheus, so no need to import expvar.
This never worked anyway, since expvar registers itself on the default mux and we use a different one.
If we ever want it in the future, we will have to make a copy of expvar and then change it to be registered on a custom mux
