### PR TITLE
contrib/podex: add daemon mode

### DIFF
--- a/contrib/podex/podex.go
+++ b/contrib/podex/podex.go
@@ -262,8 +262,12 @@ func getImageMetadata(host, namespace, repo, tag string) (*imageMetadata, error)
 	req.Header.Add("X-Docker-Token", "true")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("error getting X-Docker-Token from index.docker.io: %v", err)
+		return nil, fmt.Errorf("error making request to %q: %v", host, err)
 	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("error getting X-Docker-Token from %s: %q", host, resp.Status)
+	}
+
 	endpoints := resp.Header.Get("X-Docker-Endpoints")
 	token := resp.Header.Get("X-Docker-Token")
 	req, err = http.NewRequest("GET", fmt.Sprintf("https://%s/v1/repositories/%s/%s/tags/%s", endpoints, namespace, repo, tag), nil)


### PR DESCRIPTION
You can try it there:
http://104.154.49.168:8080/pods/nginx

See below:

```
$ podex -daemon
$ curl localhost:8080/pods/nginx
{
  "apiVersion": "v1beta1",
  "desiredState": {
    "manifest": {
      "containers": [
        {
          "image": "nginx",
          "name": "nginx",
          "ports": [
            {
              "containerPort": 443,
              "name": "nginx-tcp-443"
            },
            {
              "containerPort": 80,
              "name": "nginx-tcp-80"
            }
          ]
        }
      ],
      "version": "v1beta2"
    }
  },
  "id": "nginx",
  "kind": "Pod"
}
```
