### PR TITLE
Update Fluentd to Cloud Logging image

### DIFF
--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.manifest
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.manifest
@@ -2,7 +2,7 @@ version: v1beta2
 id: fluentd-to-gcp
 containers:
   - name: fluentd-gcp-container
-    image: kubernetes/fluentd-gcp
+    image: kubernetes/fluentd-gcp:1.0
     volumeMounts:
       - name: containers
         mountPath: /var/lib/docker/containers

--- a/contrib/logging/fluentd-gcp-image/Dockerfile
+++ b/contrib/logging/fluentd-gcp-image/Dockerfile
@@ -14,18 +14,9 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV OPTS_APT -y --force-yes --no-install-recommends
 
 RUN apt-get -q update && \
-    apt-get -y install apt-utils adduser && \
-    apt-get clean
-
-ADD google-fluentd_1.0.0-0_amd64.deb /etc/google-fluentd/pkg/google-fluentd_1.0.0-0_amd64.deb
-RUN dpkg -i /etc/google-fluentd/pkg/google-fluentd_1.0.0-0_amd64.deb
-RUN /opt/google-fluentd/embedded/bin/gem install google-api-client
-ADD out_google_cloud.rb /etc/google-fluentd/plugin/out_google_cloud.rb 
-ADD agent.conf /etc/google-fluentd/google-fluentd.conf
-COPY catch-all-inputs.tar.gz /tmp/catch-all-inputs.tar.gz 
-RUN tar -C /etc/google-fluentd -zxf /tmp/catch-all-inputs.tar.gz
-RUN sed -i~ -e "s/\(USER\|GROUP\)=google-fluentd/\1=root/;" /etc/init.d/google-fluentd
-RUN sed -i~ -e 's/ --use-v1-config//' /etc/init.d/google-fluentd
+    apt-get -y install curl && \
+    apt-get clean && \
+    curl -s https://storage.googleapis.com/signals-agents/logging/google-fluentd-install.sh | sudo bash
 
 # Copy the Fluentd configuration file for logging Docker container logs.
 COPY google-fluentd.conf /etc/google-fluentd/google-fluentd.conf

--- a/contrib/logging/fluentd-gcp-image/Makefile
+++ b/contrib/logging/fluentd-gcp-image/Makefile
@@ -5,9 +5,12 @@
 
 .PHONY:	build push
 
+
+TAG = 1.0
+
 build:	
-	sudo docker build -t kubernetes/fluentd-gcp .
+	sudo docker build -t kubernetes/fluentd-gcp:$(TAG) .
 
 push:	
-	sudo docker push kubernetes/fluentd-gcp
+	sudo docker push kubernetes/fluentd-gcp:$(TAG)
 


### PR DESCRIPTION
This PR updates our `kubernetes/fluentd-gcp` image for the node level Docker container log collector that targets Cloud Logging. It also adds an explicit tag to the image (important for reliability). The Dockerfile has been changed to fetch the install bits over HTTP.
@a-robinson @alex-mohr and always thanks to @mr-salty for his prompt answers to my questions.
This addresses issue #4846 
