### PR TITLE
Remove waiter.sh script from coreos master.yaml

### DIFF
--- a/docs/getting-started-guides/coreos/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/master.yaml
@@ -1,12 +1,6 @@
 #cloud-config
 
 ---
-write_files:
-- path: /opt/bin/waiter.sh
-  owner: root
-  content: |
-    #! /usr/bin/bash
-    until curl http://127.0.0.1:4001/v2/machines; do sleep 2; done
 coreos:
   units:
     - name: setup-network-environment.service
@@ -82,8 +76,7 @@ coreos:
         Before=setup-network-environment.service
 
         [Service]
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/waiter.sh
-        ExecStart=/usr/bin/bash /opt/bin/waiter.sh
+        ExecStart=/usr/bin/bash -c "until curl http://127.0.0.1:4001/v2/machines; do sleep 2; done"
         RemainAfterExit=true
         Type=oneshot
     - name: flannel.service


### PR DESCRIPTION
The waiter.sh script can be implemented as a oneliner within the etcd-waiter.service file. This is much simpler than create the script and ensuring that it has the correct permissions before running it.
