### PR TITLE
Fix nil pointer dereference in kube-apiserver when etcd is not there

### DIFF
--- a/pkg/master/pod_cache.go
+++ b/pkg/master/pod_cache.go
@@ -214,6 +214,7 @@ func (p *PodCache) GarbageCollectPodStatus() {
 	pods, err := p.pods.ListPods(api.NewContext(), labels.Everything())
 	if err != nil {
 		glog.Errorf("Error getting pod list: %v", err)
+		return
 	}
 	keys := map[objKey]bool{}
 	for _, pod := range pods.Items {


### PR DESCRIPTION
If `kube-apiserver` is started before `etcd` is reachable, `kube-apiserver` generates the following error:

```
Feb 27 16:24:15 kubernetes-master kube-apiserver[577]: I0227 16:24:15.458667     577 util.go:62] Recovered from panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
Feb 27 16:24:15 kubernetes-master kube-apiserver[577]: /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/util.go:56
Feb 27 16:24:15 kubernetes-master kube-apiserver[577]: /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/util.go:47
Feb 27 16:24:15 kubernetes-master kube-apiserver[577]: /usr/src/go/src/runtime/asm_amd64.s:401
Feb 27 16:24:15 kubernetes-master kube-apiserver[577]: /usr/src/go/src/runtime/panic.go:387
Feb 27 16:24:15 kubernetes-master kube-apiserver[577]: /usr/src/go/src/runtime/panic.go:42
Feb 27 16:24:15 kubernetes-master kube-apiserver[577]: /usr/src/go/src/runtime/sigpanic_unix.go:26
Feb 27 16:24:15 kubernetes-master kube-apiserver[577]: /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/master/pod_cache.go:221
Feb 27 16:24:15 kubernetes-master kube-apiserver[577]: /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/master/master.go:395
Feb 27 16:24:15 kubernetes-master kube-apiserver[577]: /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/util.go:101
Feb 27 16:24:15 kubernetes-master kube-apiserver[577]: /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/util.go:102
Feb 27 16:24:15 kubernetes-master kube-apiserver[577]: /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/util.go:86
Feb 27 16:24:15 kubernetes-master kube-apiserver[577]: /usr/src/go/src/runtime/asm_amd64.s:2232
```

This is coming from `pod_cache.go:GarbageCollectPodStatus`, where, if `etcd` is not reachable, `p.pods.ListPods` doesn’t return a non-nil pod list.
