### PR TITLE
Fix `kubernetes` and `kubernetes-ro` services creation

### DIFF
--- a/pkg/registry/service/rest.go
+++ b/pkg/registry/service/rest.go
@@ -110,11 +110,13 @@ func (rs *REST) Create(ctx api.Context, obj runtime.Object) (runtime.Object, err
 	if service.Spec.CreateExternalLoadBalancer {
 		err := rs.createExternalLoadBalancer(ctx, service)
 		if err != nil {
+			rs.portalMgr.Release(net.ParseIP(service.Spec.PortalIP))
 			return nil, err
 		}
 	}
 
 	if err := rs.registry.CreateService(ctx, service); err != nil {
+		rs.portalMgr.Release(net.ParseIP(service.Spec.PortalIP))
 		err = rest.CheckGeneratedNameError(rest.Services, err, service)
 		return nil, err
 	}


### PR DESCRIPTION
If `kube-apiserver` is started before `etcd` is reachable, `kube-apiserver`
fails to create those services.
However, in the `Create` function, an IP has already been reserved for them.
When `etcd` comes back, the `Create` function fails because it considers that
the IP is already used.

If the service couldn't be created, the reserved IP should be released.

Here is what we see in the logs when `kube-apiserver` starts:

```
Feb 27 16:47:56 kubernetes-master kube-apiserver[588]: I0227 16:47:56.820371     588 master.go:277] Setting master service IPs based on PortalNet subnet to "10.11.0.1" (read-only) and "10.11.0.2" (read-write).
Feb 27 16:47:56 kubernetes-master kube-apiserver[588]: E0227 16:47:56.823132     588 rest.go:66] can't list services to init service REST: 501: All the given peers are not reachable (Tried to connect to each peer twice and failed) [0]
```

Here is what we have when `kube-apiserver` tries to create the `kubernetes` and `kubernetes-ro` services while etcd is not reachable:

```
Feb 27 16:47:56 kubernetes-master kube-apiserver[588]: E0227 16:47:56.927156     588 publish.go:62] Can't create master namespace: 501: All the given peers are not reachable (Tried to connect to each peer twice and failed) [0]
Feb 27 16:47:56 kubernetes-master kube-apiserver[588]: E0227 16:47:56.947359     588 publish.go:37] Can't create master namespace: 501: All the given peers are not reachable (Tried to connect to each peer twice and failed) [0]
Feb 27 16:47:56 kubernetes-master kube-apiserver[588]: E0227 16:47:56.994605     588 publish.go:66] Can't create ro service: 501: All the given peers are not reachable (Tried to connect to each peer twice and failed) [0]
Feb 27 16:47:57 kubernetes-master kube-apiserver[588]: E0227 16:47:57.034900     588 publish.go:41] Can't create rw service: 501: All the given peers are not reachable (Tried to connect to each peer twice and failed) [0]
Feb 27 16:47:57 kubernetes-master kube-apiserver[588]: E0227 16:47:57.075293     588 publish.go:69] Can't create ro endpoints: 501: All the given peers are not reachable (Tried to connect to each peer twice and failed) [0]
Feb 27 16:47:57 kubernetes-master kube-apiserver[588]: E0227 16:47:57.115825     588 publish.go:44] Can't create rw endpoints: 501: All the given peers are not reachable (Tried to connect to each peer twice and failed) [0]
```

The issue that this PR fixes is that the loop that keeps on re-creating those services never recover.
Here is what we have in the logs:

```
Feb 27 16:48:07 kubernetes-master kube-apiserver[588]: E0227 16:48:07.129928     588 publish.go:66] Can't create ro service: Service "kubernetes-ro" is invalid: spec.portalIP: invalid value '10.11.0.1': IP 10.11.0.1 is already allocated
Feb 27 16:48:07 kubernetes-master kube-apiserver[588]: E0227 16:48:07.170138     588 publish.go:37] Can't create master namespace: namespaces "default" already exists
Feb 27 16:48:07 kubernetes-master kube-apiserver[588]: E0227 16:48:07.171495     588 publish.go:41] Can't create rw service: Service "kubernetes" is invalid: spec.portalIP: invalid value '10.11.0.2': IP 10.11.0.2 is already allocated
Feb 27 16:48:17 kubernetes-master kube-apiserver[588]: E0227 16:48:17.172379     588 publish.go:66] Can't create ro service: Service "kubernetes-ro" is invalid: spec.portalIP: invalid value '10.11.0.1': IP 10.11.0.1 is already allocated
Feb 27 16:48:17 kubernetes-master kube-apiserver[588]: E0227 16:48:17.238840     588 publish.go:41] Can't create rw service: Service "kubernetes" is invalid: spec.portalIP: invalid value '10.11.0.2': IP 10.11.0.2 is already allocated
Feb 27 16:48:27 kubernetes-master kube-apiserver[588]: E0227 16:48:27.177629     588 publish.go:66] Can't create ro service: Service "kubernetes-ro" is invalid: spec.portalIP: invalid value '10.11.0.1': IP 10.11.0.1 is already allocated
Feb 27 16:48:27 kubernetes-master kube-apiserver[588]: E0227 16:48:27.242475     588 publish.go:41] Can't create rw service: Service "kubernetes" is invalid: spec.portalIP: invalid value '10.11.0.2': IP 10.11.0.2 is already allocated
Feb 27 16:48:37 kubernetes-master kube-apiserver[588]: E0227 16:48:37.180366     588 publish.go:66] Can't create ro service: Service "kubernetes-ro" is invalid: spec.portalIP: invalid value '10.11.0.1': IP 10.11.0.1 is already allocated
Feb 27 16:48:37 kubernetes-master kube-apiserver[588]: E0227 16:48:37.244944     588 publish.go:41] Can't create rw service: Service "kubernetes" is invalid: spec.portalIP: invalid value '10.11.0.2': IP 10.11.0.2 is already allocated
```

What this fix does is that, if a service cannot be created, it doesn’t keep an allocated IP for it.
