### PR TITLE
Fix error provisioning kube-apiserver on vagrant

### DIFF
--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -23,7 +23,7 @@ export NUM_MINIONS
 # The IP of the master
 export MASTER_IP="10.245.1.2"
 
-export INSTANCE_PREFIX=kubernetes
+export INSTANCE_PREFIX="kubernetes"
 export MASTER_NAME="${INSTANCE_PREFIX}-master"
 
 # Map out the IPs, names and container subnets of each minion

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -101,6 +101,7 @@ cat <<EOF >/srv/salt-overlay/pillar/cluster-params.sls
   dns_replicas: '$(echo "$DNS_REPLICAS" | sed -e "s/'/''/g")'
   dns_server: '$(echo "$DNS_SERVER_IP" | sed -e "s/'/''/g")'
   dns_domain: '$(echo "$DNS_DOMAIN" | sed -e "s/'/''/g")'
+  instance_prefix: '$(echo "$INSTANCE_PREFIX" | sed -e "s/'/''/g")'
 EOF
 
 # Configure the salt-master


### PR DESCRIPTION
Fixes #4302 

There was a change to add a "instance_prefix" to the salt-pillar, and this value was not previously getting cascaded down to the pillar file.  As a result, it caused a jinja template error when setting the default file for the kube-apiserver.
