### PR TITLE
kubelet should take a client interface

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -389,12 +389,20 @@ type KubeletConfig struct {
 func createAndInitKubelet(kc *KubeletConfig, pc *config.PodConfig) (*kubelet.Kubelet, error) {
 	// TODO: block until all sources have delivered at least one update to the channel, or break the sync loop
 	// up into "per source" synchronizations
-
+	// TODO: KubeletConfig.KubeClient should be a client interface, but client interface misses certain methods
+	// used by kubelet. Since NewMainKubelet expects a client interface, we need to make sure we are not passing
+	// a nil pointer to it when what we really want is a nil interface.
+	var kubeClient client.Interface
+	if kc.KubeClient == nil {
+		kubeClient = nil
+	} else {
+		kubeClient = kc.KubeClient
+	}
 	k, err := kubelet.NewMainKubelet(
 		kc.Hostname,
 		kc.DockerClient,
 		kc.EtcdClient,
-		kc.KubeClient,
+		kubeClient,
 		kc.RootDirectory,
 		kc.PodInfraContainerImage,
 		kc.SyncFrequency,

--- a/pkg/client/cache/listwatch.go
+++ b/pkg/client/cache/listwatch.go
@@ -37,7 +37,7 @@ type ListWatch struct {
 	WatchFunc WatchFunc
 }
 
-// ListWatchFromClient creates a new ListWatch from the specified client, resource, namespace and field selector
+// NewListWatchFromClient creates a new ListWatch from the specified client, resource, namespace and field selector.
 func NewListWatchFromClient(client *client.Client, resource string, namespace string, fieldSelector labels.Selector) *ListWatch {
 	listFunc := func() (runtime.Object, error) {
 		return client.Get().Namespace(namespace).Resource(resource).SelectorParam("fields", fieldSelector).Do().Get()


### PR DESCRIPTION
kubelet will need to post node/pod status to apiserver.

Currently, kubelet takes a client.Client struct, an implementation for client.Interface.  It should take an interface for testing.  But there is some problem with list+watch pattern @lavalamp , see TODO.
