### PR TITLE
kubelet: record an event with a clear reason on host port conflict

### DIFF
--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -44,6 +44,11 @@ func Now() Time {
 	return Time{time.Now()}
 }
 
+// Before reports whether the time instant t is before u.
+func (t Time) Before(u Time) bool {
+	return t.Time.Before(u.Time)
+}
+
 // Unix returns the local time corresponding to the given Unix time
 // by wrapping time.Unix.
 func Unix(sec int64, nsec int64) Time {


### PR DESCRIPTION
Currently, kubelet silently ignores pods that caused host port conflict. This
commit surfaces the error by recording an event.

It also makes sure that kubelet iterates through the pods in the order of the
creation timestamp, which ensures that pods created later are ignored on
conflict.

This is the first step towards resolving issue #4623.
