### PR TITLE
Rename type Port to ContainerPort

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -538,7 +538,7 @@ func runServiceTest(client *client.Client) {
 				{
 					Name:  "c1",
 					Image: "foo",
-					Ports: []api.Port{
+					Ports: []api.ContainerPort{
 						{ContainerPort: 1234},
 					},
 					ImagePullPolicy: "PullIfNotPresent",

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -239,8 +239,8 @@ type SecretVolumeSource struct {
 	Target ObjectReference `json:"target"`
 }
 
-// Port represents a network port in a single container
-type Port struct {
+// ContainerPort represents a network port in a single container
+type ContainerPort struct {
 	// Optional: If specified, this must be a DNS_LABEL.  Each named port
 	// in a pod must have a unique name.
 	Name string `json:"name,omitempty"`
@@ -346,9 +346,9 @@ type Container struct {
 	// Optional: Defaults to whatever is defined in the image.
 	Command []string `json:"command,omitempty"`
 	// Optional: Defaults to Docker's default.
-	WorkingDir string   `json:"workingDir,omitempty"`
-	Ports      []Port   `json:"ports,omitempty"`
-	Env        []EnvVar `json:"env,omitempty"`
+	WorkingDir string          `json:"workingDir,omitempty"`
+	Ports      []ContainerPort `json:"ports,omitempty"`
+	Env        []EnvVar        `json:"env,omitempty"`
 	// Compute resource requirements.
 	Resources      ResourceRequirements `json:"resources,omitempty"`
 	VolumeMounts   []VolumeMount        `json:"volumeMounts,omitempty"`

--- a/pkg/api/v1beta1/defaults.go
+++ b/pkg/api/v1beta1/defaults.go
@@ -32,7 +32,7 @@ func init() {
 				}
 			}
 		},
-		func(obj *Port) {
+		func(obj *ContainerPort) {
 			if obj.Protocol == "" {
 				obj.Protocol = ProtocolTCP
 			}

--- a/pkg/api/v1beta1/defaults_test.go
+++ b/pkg/api/v1beta1/defaults_test.go
@@ -73,7 +73,7 @@ func TestSetDefaulPodSpec(t *testing.T) {
 func TestSetDefaultContainer(t *testing.T) {
 	bp := &current.BoundPod{}
 	bp.Spec.Containers = []current.Container{{}}
-	bp.Spec.Containers[0].Ports = []current.Port{{}}
+	bp.Spec.Containers[0].Ports = []current.ContainerPort{{}}
 
 	obj2 := roundTrip(t, runtime.Object(bp))
 	bp2 := obj2.(*current.BoundPod)

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -161,8 +161,8 @@ type SecretVolumeSource struct {
 	Target ObjectReference `json:"target" description:"target is a reference to a secret"`
 }
 
-// Port represents a network port in a single container
-type Port struct {
+// ContainerPort represents a network port in a single container
+type ContainerPort struct {
 	// Optional: If specified, this must be a DNS_LABEL.  Each named port
 	// in a pod must have a unique name.
 	Name string `json:"name,omitempty" description:"name for the port that can be referred to by services; must be a DNS_LABEL and unique without the pod"`
@@ -283,7 +283,7 @@ type Container struct {
 	Command []string `json:"command,omitempty" description:"command argv array; not executed within a shell; defaults to entrypoint or command in the image"`
 	// Optional: Defaults to Docker's default.
 	WorkingDir string               `json:"workingDir,omitempty" description:"container's working directory; defaults to image's default"`
-	Ports      []Port               `json:"ports,omitempty" description:"list of ports to expose from the container"`
+	Ports      []ContainerPort      `json:"ports,omitempty" description:"list of ports to expose from the container"`
 	Env        []EnvVar             `json:"env,omitempty" description:"list of environment variables to set in the container"`
 	Resources  ResourceRequirements `json:"resources,omitempty" description:"Compute Resources required by this container"`
 	// Optional: Defaults to unlimited.

--- a/pkg/api/v1beta2/defaults.go
+++ b/pkg/api/v1beta2/defaults.go
@@ -34,7 +34,7 @@ func init() {
 				}
 			}
 		},
-		func(obj *Port) {
+		func(obj *ContainerPort) {
 			if obj.Protocol == "" {
 				obj.Protocol = ProtocolTCP
 			}

--- a/pkg/api/v1beta2/defaults_test.go
+++ b/pkg/api/v1beta2/defaults_test.go
@@ -73,7 +73,7 @@ func TestSetDefaulPodSpec(t *testing.T) {
 func TestSetDefaultContainer(t *testing.T) {
 	bp := &current.BoundPod{}
 	bp.Spec.Containers = []current.Container{{}}
-	bp.Spec.Containers[0].Ports = []current.Port{{}}
+	bp.Spec.Containers[0].Ports = []current.ContainerPort{{}}
 
 	obj2 := roundTrip(t, runtime.Object(bp))
 	bp2 := obj2.(*current.BoundPod)

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -99,8 +99,8 @@ const (
 	ProtocolUDP Protocol = "UDP"
 )
 
-// Port represents a network port in a single container.
-type Port struct {
+// ContainerPort represents a network port in a single container.
+type ContainerPort struct {
 	// Optional: If specified, this must be a DNS_LABEL.  Each named port
 	// in a pod must have a unique name.
 	Name string `json:"name,omitempty" description:"name for the port that can be referred to by services; must be a DNS_LABEL and unique without the pod"`
@@ -242,7 +242,7 @@ type Container struct {
 	Command []string `json:"command,omitempty" description:"command argv array; not executed within a shell; defaults to entrypoint or command in the image"`
 	// Optional: Defaults to Docker's default.
 	WorkingDir string               `json:"workingDir,omitempty" description:"container's working directory; defaults to image's default"`
-	Ports      []Port               `json:"ports,omitempty" description:"list of ports to expose from the container"`
+	Ports      []ContainerPort      `json:"ports,omitempty" description:"list of ports to expose from the container"`
 	Env        []EnvVar             `json:"env,omitempty" description:"list of environment variables to set in the container"`
 	Resources  ResourceRequirements `json:"resources,omitempty" description:"Compute Resources required by this container"`
 	// Optional: Defaults to unlimited.

--- a/pkg/api/v1beta3/defaults.go
+++ b/pkg/api/v1beta3/defaults.go
@@ -32,7 +32,7 @@ func init() {
 				}
 			}
 		},
-		func(obj *Port) {
+		func(obj *ContainerPort) {
 			if obj.Protocol == "" {
 				obj.Protocol = ProtocolTCP
 			}

--- a/pkg/api/v1beta3/defaults_test.go
+++ b/pkg/api/v1beta3/defaults_test.go
@@ -73,7 +73,7 @@ func TestSetDefaulPodSpec(t *testing.T) {
 func TestSetDefaultContainer(t *testing.T) {
 	bp := &current.BoundPod{}
 	bp.Spec.Containers = []current.Container{{}}
-	bp.Spec.Containers[0].Ports = []current.Port{{}}
+	bp.Spec.Containers[0].Ports = []current.ContainerPort{{}}
 
 	obj2 := roundTrip(t, runtime.Object(bp))
 	bp2 := obj2.(*current.BoundPod)

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -254,8 +254,8 @@ type SecretVolumeSource struct {
 	Target ObjectReference `json:"target" description:"target is a reference to a secret"`
 }
 
-// Port represents a network port in a single container.
-type Port struct {
+// ContainerPort represents a network port in a single container.
+type ContainerPort struct {
 	// Optional: If specified, this must be a DNS_LABEL.  Each named port
 	// in a pod must have a unique name.
 	Name string `json:"name,omitempty"`
@@ -367,7 +367,7 @@ type Container struct {
 	Command []string `json:"command,omitempty"`
 	// Optional: Defaults to Docker's default.
 	WorkingDir     string               `json:"workingDir,omitempty"`
-	Ports          []Port               `json:"ports,omitempty"`
+	Ports          []ContainerPort      `json:"ports,omitempty"`
 	Env            []EnvVar             `json:"env,omitempty"`
 	Resources      ResourceRequirements `json:"resources,omitempty" description:"Compute Resources required by this container"`
 	VolumeMounts   []VolumeMount        `json:"volumeMounts,omitempty"`

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -325,7 +325,7 @@ func validateSecretVolumeSource(secretSource *api.SecretVolumeSource) errs.Valid
 
 var supportedPortProtocols = util.NewStringSet(string(api.ProtocolTCP), string(api.ProtocolUDP))
 
-func validatePorts(ports []api.Port) errs.ValidationErrorList {
+func validatePorts(ports []api.ContainerPort) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
 
 	allNames := util.StringSet{}
@@ -410,7 +410,7 @@ func validateProbe(probe *api.Probe) errs.ValidationErrorList {
 
 // AccumulateUniquePorts runs an extraction function on each Port of each Container,
 // accumulating the results and returning an error if any ports conflict.
-func AccumulateUniquePorts(containers []api.Container, accumulator map[int]bool, extract func(*api.Port) int) errs.ValidationErrorList {
+func AccumulateUniquePorts(containers []api.Container, accumulator map[int]bool, extract func(*api.ContainerPort) int) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
 
 	for ci, ctr := range containers {
@@ -435,7 +435,7 @@ func AccumulateUniquePorts(containers []api.Container, accumulator map[int]bool,
 // a slice of containers.
 func checkHostPortConflicts(containers []api.Container) errs.ValidationErrorList {
 	allPorts := map[int]bool{}
-	return AccumulateUniquePorts(containers, allPorts, func(p *api.Port) int { return p.HostPort })
+	return AccumulateUniquePorts(containers, allPorts, func(p *api.ContainerPort) int { return p.HostPort })
 }
 
 func validateExecAction(exec *api.ExecAction) errs.ValidationErrorList {

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -195,7 +195,7 @@ func TestValidateVolumes(t *testing.T) {
 }
 
 func TestValidatePorts(t *testing.T) {
-	successCase := []api.Port{
+	successCase := []api.ContainerPort{
 		{Name: "abc", ContainerPort: 80, HostPort: 80, Protocol: "TCP"},
 		{Name: "easy", ContainerPort: 82, Protocol: "TCP"},
 		{Name: "as", ContainerPort: 83, Protocol: "UDP"},
@@ -207,7 +207,7 @@ func TestValidatePorts(t *testing.T) {
 		t.Errorf("expected success: %v", errs)
 	}
 
-	nonCanonicalCase := []api.Port{
+	nonCanonicalCase := []api.ContainerPort{
 		{ContainerPort: 80, Protocol: "TCP"},
 	}
 	if errs := validatePorts(nonCanonicalCase); len(errs) != 0 {
@@ -215,22 +215,22 @@ func TestValidatePorts(t *testing.T) {
 	}
 
 	errorCases := map[string]struct {
-		P []api.Port
+		P []api.ContainerPort
 		T errors.ValidationErrorType
 		F string
 		D string
 	}{
-		"name > 63 characters": {[]api.Port{{Name: strings.Repeat("a", 64), ContainerPort: 80, Protocol: "TCP"}}, errors.ValidationErrorTypeInvalid, "[0].name", dnsLabelErrorMsg},
-		"name not a DNS label": {[]api.Port{{Name: "a.b.c", ContainerPort: 80, Protocol: "TCP"}}, errors.ValidationErrorTypeInvalid, "[0].name", dnsLabelErrorMsg},
-		"name not unique": {[]api.Port{
+		"name > 63 characters": {[]api.ContainerPort{{Name: strings.Repeat("a", 64), ContainerPort: 80, Protocol: "TCP"}}, errors.ValidationErrorTypeInvalid, "[0].name", dnsLabelErrorMsg},
+		"name not a DNS label": {[]api.ContainerPort{{Name: "a.b.c", ContainerPort: 80, Protocol: "TCP"}}, errors.ValidationErrorTypeInvalid, "[0].name", dnsLabelErrorMsg},
+		"name not unique": {[]api.ContainerPort{
 			{Name: "abc", ContainerPort: 80, Protocol: "TCP"},
 			{Name: "abc", ContainerPort: 81, Protocol: "TCP"},
 		}, errors.ValidationErrorTypeDuplicate, "[1].name", ""},
-		"zero container port":    {[]api.Port{{ContainerPort: 0, Protocol: "TCP"}}, errors.ValidationErrorTypeInvalid, "[0].containerPort", portRangeErrorMsg},
-		"invalid container port": {[]api.Port{{ContainerPort: 65536, Protocol: "TCP"}}, errors.ValidationErrorTypeInvalid, "[0].containerPort", portRangeErrorMsg},
-		"invalid host port":      {[]api.Port{{ContainerPort: 80, HostPort: 65536, Protocol: "TCP"}}, errors.ValidationErrorTypeInvalid, "[0].hostPort", portRangeErrorMsg},
-		"invalid protocol":       {[]api.Port{{ContainerPort: 80, Protocol: "ICMP"}}, errors.ValidationErrorTypeNotSupported, "[0].protocol", ""},
-		"protocol required":      {[]api.Port{{Name: "abc", ContainerPort: 80}}, errors.ValidationErrorTypeRequired, "[0].protocol", ""},
+		"zero container port":    {[]api.ContainerPort{{ContainerPort: 0, Protocol: "TCP"}}, errors.ValidationErrorTypeInvalid, "[0].containerPort", portRangeErrorMsg},
+		"invalid container port": {[]api.ContainerPort{{ContainerPort: 65536, Protocol: "TCP"}}, errors.ValidationErrorTypeInvalid, "[0].containerPort", portRangeErrorMsg},
+		"invalid host port":      {[]api.ContainerPort{{ContainerPort: 80, HostPort: 65536, Protocol: "TCP"}}, errors.ValidationErrorTypeInvalid, "[0].hostPort", portRangeErrorMsg},
+		"invalid protocol":       {[]api.ContainerPort{{ContainerPort: 80, Protocol: "ICMP"}}, errors.ValidationErrorTypeNotSupported, "[0].protocol", ""},
+		"protocol required":      {[]api.ContainerPort{{Name: "abc", ContainerPort: 80}}, errors.ValidationErrorTypeRequired, "[0].protocol", ""},
 	}
 	for k, v := range errorCases {
 		errs := validatePorts(v.P)
@@ -433,9 +433,9 @@ func TestValidateContainers(t *testing.T) {
 		},
 		"zero-length image": {{Name: "abc", Image: "", ImagePullPolicy: "IfNotPresent"}},
 		"host port not unique": {
-			{Name: "abc", Image: "image", Ports: []api.Port{{ContainerPort: 80, HostPort: 80, Protocol: "TCP"}},
+			{Name: "abc", Image: "image", Ports: []api.ContainerPort{{ContainerPort: 80, HostPort: 80, Protocol: "TCP"}},
 				ImagePullPolicy: "IfNotPresent"},
-			{Name: "def", Image: "image", Ports: []api.Port{{ContainerPort: 81, HostPort: 80, Protocol: "TCP"}},
+			{Name: "def", Image: "image", Ports: []api.ContainerPort{{ContainerPort: 81, HostPort: 80, Protocol: "TCP"}},
 				ImagePullPolicy: "IfNotPresent"},
 		},
 		"invalid env var name": {
@@ -587,7 +587,7 @@ func TestValidateManifest(t *testing.T) {
 							"memory": resource.MustParse("1"),
 						},
 					},
-					Ports: []api.Port{
+					Ports: []api.ContainerPort{
 						{Name: "p1", ContainerPort: 80, HostPort: 8080, Protocol: "TCP"},
 						{Name: "p2", ContainerPort: 81, Protocol: "TCP"},
 						{ContainerPort: 82, Protocol: "TCP"},
@@ -934,7 +934,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					Containers: []api.Container{
 						{
 							Image: "foo:V1",
-							Ports: []api.Port{
+							Ports: []api.ContainerPort{
 								{HostPort: 8080, ContainerPort: 80},
 							},
 						},
@@ -947,7 +947,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					Containers: []api.Container{
 						{
 							Image: "foo:V2",
-							Ports: []api.Port{
+							Ports: []api.ContainerPort{
 								{HostPort: 8000, ContainerPort: 80},
 							},
 						},

--- a/pkg/constraint/constraint_test.go
+++ b/pkg/constraint/constraint_test.go
@@ -26,7 +26,7 @@ import (
 func containerWithHostPorts(ports ...int) api.Container {
 	c := api.Container{}
 	for _, p := range ports {
-		c.Ports = append(c.Ports, api.Port{HostPort: p})
+		c.Ports = append(c.Ports, api.ContainerPort{HostPort: p})
 	}
 	return c
 }

--- a/pkg/kubectl/run.go
+++ b/pkg/kubectl/run.go
@@ -82,7 +82,7 @@ func (BasicReplicationController) Generate(params map[string]string) (runtime.Ob
 
 		// Don't include the port if it was not specified.
 		if port > 0 {
-			controller.Spec.Template.Spec.Containers[0].Ports = []api.Port{
+			controller.Spec.Template.Spec.Containers[0].Ports = []api.ContainerPort{
 				{
 					ContainerPort: port,
 				},

--- a/pkg/kubectl/run_test.go
+++ b/pkg/kubectl/run_test.go
@@ -84,7 +84,7 @@ func TestGenerate(t *testing.T) {
 								{
 									Name:  "foo",
 									Image: "someimage",
-									Ports: []api.Port{
+									Ports: []api.ContainerPort{
 										{
 											ContainerPort: 80,
 										},

--- a/pkg/kubelet/handlers_test.go
+++ b/pkg/kubelet/handlers_test.go
@@ -38,7 +38,7 @@ func TestResolvePortString(t *testing.T) {
 	expected := 80
 	name := "foo"
 	container := &api.Container{
-		Ports: []api.Port{
+		Ports: []api.ContainerPort{
 			{Name: name, ContainerPort: expected},
 		},
 	}
@@ -55,7 +55,7 @@ func TestResolvePortStringUnknown(t *testing.T) {
 	expected := 80
 	name := "foo"
 	container := &api.Container{
-		Ports: []api.Port{
+		Ports: []api.ContainerPort{
 			{Name: "bar", ContainerPort: expected},
 		},
 	}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -892,7 +892,7 @@ const (
 
 // createPodInfraContainer starts the pod infra container for a pod. Returns the docker container ID of the newly created container.
 func (kl *Kubelet) createPodInfraContainer(pod *api.BoundPod) (dockertools.DockerID, error) {
-	var ports []api.Port
+	var ports []api.ContainerPort
 	// Docker only exports ports from the pod infra container.  Let's
 	// collect all of the relevant ports and export them.
 	for _, container := range pod.Spec.Containers {
@@ -1406,7 +1406,7 @@ func (s podsByCreationTime) Less(i, j int) bool {
 func filterHostPortConflicts(pods []api.BoundPod) []api.BoundPod {
 	filtered := []api.BoundPod{}
 	ports := map[int]bool{}
-	extract := func(p *api.Port) int { return p.HostPort }
+	extract := func(p *api.ContainerPort) int { return p.HostPort }
 
 	// Respect the pod creation order when resolving conflicts.
 	sort.Sort(podsByCreationTime(pods))

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1143,7 +1143,7 @@ func TestMakeVolumesAndBinds(t *testing.T) {
 
 func TestMakePortsAndBindings(t *testing.T) {
 	container := api.Container{
-		Ports: []api.Port{
+		Ports: []api.ContainerPort{
 			{
 				ContainerPort: 80,
 				HostPort:      8080,
@@ -1207,12 +1207,12 @@ func TestMakePortsAndBindings(t *testing.T) {
 
 func TestCheckHostPortConflicts(t *testing.T) {
 	successCaseAll := []api.BoundPod{
-		{Spec: api.PodSpec{Containers: []api.Container{{Ports: []api.Port{{HostPort: 80}}}}}},
-		{Spec: api.PodSpec{Containers: []api.Container{{Ports: []api.Port{{HostPort: 81}}}}}},
-		{Spec: api.PodSpec{Containers: []api.Container{{Ports: []api.Port{{HostPort: 82}}}}}},
+		{Spec: api.PodSpec{Containers: []api.Container{{Ports: []api.ContainerPort{{HostPort: 80}}}}}},
+		{Spec: api.PodSpec{Containers: []api.Container{{Ports: []api.ContainerPort{{HostPort: 81}}}}}},
+		{Spec: api.PodSpec{Containers: []api.Container{{Ports: []api.ContainerPort{{HostPort: 82}}}}}},
 	}
 	successCaseNew := api.BoundPod{
-		Spec: api.PodSpec{Containers: []api.Container{{Ports: []api.Port{{HostPort: 83}}}}},
+		Spec: api.PodSpec{Containers: []api.Container{{Ports: []api.ContainerPort{{HostPort: 83}}}}},
 	}
 	expected := append(successCaseAll, successCaseNew)
 	if actual := filterHostPortConflicts(expected); !reflect.DeepEqual(actual, expected) {
@@ -1220,12 +1220,12 @@ func TestCheckHostPortConflicts(t *testing.T) {
 	}
 
 	failureCaseAll := []api.BoundPod{
-		{Spec: api.PodSpec{Containers: []api.Container{{Ports: []api.Port{{HostPort: 80}}}}}},
-		{Spec: api.PodSpec{Containers: []api.Container{{Ports: []api.Port{{HostPort: 81}}}}}},
-		{Spec: api.PodSpec{Containers: []api.Container{{Ports: []api.Port{{HostPort: 82}}}}}},
+		{Spec: api.PodSpec{Containers: []api.Container{{Ports: []api.ContainerPort{{HostPort: 80}}}}}},
+		{Spec: api.PodSpec{Containers: []api.Container{{Ports: []api.ContainerPort{{HostPort: 81}}}}}},
+		{Spec: api.PodSpec{Containers: []api.Container{{Ports: []api.ContainerPort{{HostPort: 82}}}}}},
 	}
 	failureCaseNew := api.BoundPod{
-		Spec: api.PodSpec{Containers: []api.Container{{Ports: []api.Port{{HostPort: 81}}}}},
+		Spec: api.PodSpec{Containers: []api.Container{{Ports: []api.ContainerPort{{HostPort: 81}}}}},
 	}
 	if actual := filterHostPortConflicts(append(failureCaseAll, failureCaseNew)); !reflect.DeepEqual(failureCaseAll, actual) {
 		t.Errorf("Expected %#v, Got %#v", expected, actual)
@@ -3090,7 +3090,7 @@ func TestPortForward(t *testing.T) {
 // Tests that upon host port conflict, the newer pod is removed.
 func TestFilterHostPortConflicts(t *testing.T) {
 	// Reuse the pod spec with the same port to create a conflict.
-	spec := api.PodSpec{Containers: []api.Container{{Ports: []api.Port{{HostPort: 80}}}}}
+	spec := api.PodSpec{Containers: []api.Container{{Ports: []api.ContainerPort{{HostPort: 80}}}}}
 	var pods = []api.BoundPod{
 		{
 			ObjectMeta: api.ObjectMeta{

--- a/pkg/kubelet/probe_test.go
+++ b/pkg/kubelet/probe_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestFindPortByName(t *testing.T) {
 	container := api.Container{
-		Ports: []api.Port{
+		Ports: []api.ContainerPort{
 			{
 				Name:     "foo",
 				HostPort: 8080,
@@ -71,7 +71,7 @@ func TestGetURLParts(t *testing.T) {
 	for _, test := range testCases {
 		state := api.PodStatus{PodIP: "127.0.0.1"}
 		container := api.Container{
-			Ports: []api.Port{{Name: "found", HostPort: 93}},
+			Ports: []api.ContainerPort{{Name: "found", HostPort: 93}},
 			LivenessProbe: &api.Probe{
 				Handler: api.Handler{
 					HTTPGet: test.probe,
@@ -114,7 +114,7 @@ func TestGetTCPAddrParts(t *testing.T) {
 	for _, test := range testCases {
 		host := "1.2.3.4"
 		container := api.Container{
-			Ports: []api.Port{{Name: "found", HostPort: 93}},
+			Ports: []api.ContainerPort{{Name: "found", HostPort: 93}},
 			LivenessProbe: &api.Probe{
 				Handler: api.Handler{
 					TCPSocket: test.probe,

--- a/pkg/registry/controller/rest_test.go
+++ b/pkg/registry/controller/rest_test.go
@@ -171,7 +171,7 @@ func TestControllerParsing(t *testing.T) {
 					Containers: []api.Container{
 						{
 							Image: "dockerfile/nginx",
-							Ports: []api.Port{
+							Ports: []api.ContainerPort{
 								{
 									ContainerPort: 80,
 									HostPort:      8080,

--- a/pkg/registry/pod/etcd/etcd_test.go
+++ b/pkg/registry/pod/etcd/etcd_test.go
@@ -592,7 +592,7 @@ func TestResourceLocation(t *testing.T) {
 				ObjectMeta: api.ObjectMeta{Name: "foo"},
 				Spec: api.PodSpec{
 					Containers: []api.Container{
-						{Name: "ctr", Ports: []api.Port{{ContainerPort: 9376}}},
+						{Name: "ctr", Ports: []api.ContainerPort{{ContainerPort: 9376}}},
 					},
 				},
 			},
@@ -604,7 +604,7 @@ func TestResourceLocation(t *testing.T) {
 				ObjectMeta: api.ObjectMeta{Name: "foo"},
 				Spec: api.PodSpec{
 					Containers: []api.Container{
-						{Name: "ctr", Ports: []api.Port{{ContainerPort: 9376}}},
+						{Name: "ctr", Ports: []api.ContainerPort{{ContainerPort: 9376}}},
 					},
 				},
 			},
@@ -617,7 +617,7 @@ func TestResourceLocation(t *testing.T) {
 				Spec: api.PodSpec{
 					Containers: []api.Container{
 						{Name: "ctr1"},
-						{Name: "ctr2", Ports: []api.Port{{ContainerPort: 9376}}},
+						{Name: "ctr2", Ports: []api.ContainerPort{{ContainerPort: 9376}}},
 					},
 				},
 			},
@@ -629,8 +629,8 @@ func TestResourceLocation(t *testing.T) {
 				ObjectMeta: api.ObjectMeta{Name: "foo"},
 				Spec: api.PodSpec{
 					Containers: []api.Container{
-						{Name: "ctr1", Ports: []api.Port{{ContainerPort: 9376}}},
-						{Name: "ctr2", Ports: []api.Port{{ContainerPort: 1234}}},
+						{Name: "ctr1", Ports: []api.ContainerPort{{ContainerPort: 9376}}},
+						{Name: "ctr2", Ports: []api.ContainerPort{{ContainerPort: 1234}}},
 					},
 				},
 			},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -60,9 +60,9 @@ func (st *schedulerTester) expectFailure(pod api.Pod) {
 }
 
 func newPod(host string, hostPorts ...int) api.Pod {
-	networkPorts := []api.Port{}
+	networkPorts := []api.ContainerPort{}
 	for _, port := range hostPorts {
-		networkPorts = append(networkPorts, api.Port{HostPort: port})
+		networkPorts = append(networkPorts, api.ContainerPort{HostPort: port})
 	}
 	return api.Pod{
 		Status: api.PodStatus{

--- a/pkg/service/endpoints_controller_test.go
+++ b/pkg/service/endpoints_controller_test.go
@@ -39,7 +39,7 @@ func newPodList(count int) *api.PodList {
 			Spec: api.PodSpec{
 				Containers: []api.Container{
 					{
-						Ports: []api.Port{
+						Ports: []api.ContainerPort{
 							{
 								ContainerPort: 8080,
 							},
@@ -69,7 +69,7 @@ func TestFindPort(t *testing.T) {
 		Spec: api.PodSpec{
 			Containers: []api.Container{
 				{
-					Ports: []api.Port{
+					Ports: []api.ContainerPort{
 						{
 							Name:          "foo",
 							ContainerPort: 8080,
@@ -90,7 +90,7 @@ func TestFindPort(t *testing.T) {
 		Spec: api.PodSpec{
 			Containers: []api.Container{
 				{
-					Ports: []api.Port{},
+					Ports: []api.ContainerPort{},
 				},
 			},
 		},

--- a/test/e2e/events.go
+++ b/test/e2e/events.go
@@ -64,7 +64,7 @@ var _ = Describe("Events", func() {
 					{
 						Name:  "p",
 						Image: "kubernetes/serve_hostname",
-						Ports: []api.Port{{ContainerPort: 80}},
+						Ports: []api.ContainerPort{{ContainerPort: 80}},
 					},
 				},
 			},

--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -109,7 +109,7 @@ var _ = Describe("Networking", func() {
 								Name:    "webserver",
 								Image:   "kubernetes/nettest:latest",
 								Command: []string{"-service=" + name},
-								Ports:   []api.Port{{ContainerPort: 8080}},
+								Ports:   []api.ContainerPort{{ContainerPort: 8080}},
 							},
 						},
 					},

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -108,7 +108,7 @@ var _ = Describe("Pods", func() {
 					{
 						Name:  "nginx",
 						Image: "dockerfile/nginx",
-						Ports: []api.Port{{ContainerPort: 80}},
+						Ports: []api.ContainerPort{{ContainerPort: 80}},
 						LivenessProbe: &api.Probe{
 							Handler: api.Handler{
 								HTTPGet: &api.HTTPGetAction{
@@ -165,7 +165,7 @@ var _ = Describe("Pods", func() {
 					{
 						Name:  "nginx",
 						Image: "dockerfile/nginx",
-						Ports: []api.Port{{ContainerPort: 80}},
+						Ports: []api.ContainerPort{{ContainerPort: 80}},
 						LivenessProbe: &api.Probe{
 							Handler: api.Handler{
 								HTTPGet: &api.HTTPGetAction{
@@ -236,7 +236,7 @@ var _ = Describe("Pods", func() {
 					{
 						Name:  "srv",
 						Image: "kubernetes/serve_hostname",
-						Ports: []api.Port{{ContainerPort: 9376}},
+						Ports: []api.ContainerPort{{ContainerPort: 9376}},
 					},
 				},
 			},

--- a/test/e2e/rc.go
+++ b/test/e2e/rc.go
@@ -86,7 +86,7 @@ func ServeImageOrFail(c *client.Client, test string, image string) {
 						{
 							Name:  name,
 							Image: image,
-							Ports: []api.Port{{ContainerPort: 9376, HostPort: 8080}},
+							Ports: []api.ContainerPort{{ContainerPort: 9376, HostPort: 8080}},
 						},
 					},
 				},

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -297,7 +297,7 @@ func addEndpointPodOrFail(c *client.Client, ns, name string, labels map[string]s
 				{
 					Name:  "test",
 					Image: "kubernetes/pause",
-					Ports: []api.Port{{ContainerPort: 80}},
+					Ports: []api.ContainerPort{{ContainerPort: 80}},
 				},
 			},
 		},


### PR DESCRIPTION
Clearing way for multi-port services.  Sadly I had to do this by hand - I just could not get gorename to fix up
users of it.
