### PR TITLE
Fix waiting for GCE Operations

### DIFF
--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce_cloud
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -191,6 +192,9 @@ func (gce *GCECloud) waitForRegionOp(op *compute.Operation, region string) error
 		if err != nil {
 			return err
 		}
+	}
+	if pollOp.Error != nil && len(pollOp.Error.Errors) > 0 {
+		return errors.New(pollOp.Error.Errors[0].Message)
 	}
 	return nil
 }


### PR DESCRIPTION
GCE Operation status "DONE" does not necessarily mean the operation succeeded - one has to also check if any errors are populated, see https://cloud.google.com/compute/docs/reference/latest/regionOperations (there are only DONE/PEDNING/RUNNING statuses so clearly no indication of whether it failed or suceeded, while the error field description says "[Output Only] If errors occurred during processing of this operation, this field will be populated."). 
The mistake was made probably because GCE Go API returns an Operation object and an error, but the latter is only set when it was not possible to get the Operation object and does not imply anything about the content of the Operation.
