### PR TITLE
Add capacity information to 'kubectl describe minion'

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -323,6 +323,12 @@ func (d *MinionDescriber) Describe(namespace, name string) (string, error) {
 					c.Message)
 			}
 		}
+		if len(minion.Spec.Capacity) > 0 {
+			fmt.Fprintf(out, "Capacity:\n")
+			for resource, value := range minion.Spec.Capacity {
+				fmt.Fprintf(out, " %s:\t%s\n", resource, value.String())
+			}
+		}
 		fmt.Fprintf(out, "Pods:\t(%d in total)\n", len(pods))
 		for _, pod := range pods {
 			if pod.Status.Host != name {


### PR DESCRIPTION
Sample output:

```
# kubectl describe  mi e2e-test-jnagal-minion-4p47
Name:   e2e-test-jnagal-minion-4p47
Conditions:
  Type  Status  LastProbeTime   LastTransitionTime  Reason  Message
  Ready Full Mon, 02 Mar 2015 18:43:37 +0000 Fri, 27 Feb 2015 22:22:05 +0000 Node health check succeeded: kubelet /healthz endpoint returns ok 
Capacity:
 cpu:   1
 memory:    1825361100
Pods:   (3 in total)
...
```
