### PR TITLE
Use proxy instead of load balancer for Elasticsearch and Kibana

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-service.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-service.yaml
@@ -8,4 +8,3 @@ labels:
   kubernetes.io/cluster-service: "true"
 selector:
   name: elasticsearch-logging
-createExternalLoadBalancer: true

--- a/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
@@ -12,7 +12,7 @@ desiredState:
         id: kibana-viewer
         containers:
           - name: kibana-logging
-            image: kubernetes/kibana:1.0
+            image: kubernetes/kibana:1.1
             ports:
               - name: kibana-port
                 containerPort: 80

--- a/cluster/addons/fluentd-elasticsearch/kibana-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/kibana-image/Makefile
@@ -1,6 +1,6 @@
 .PHONY:	build push
 
-TAG = 1.0
+TAG = 1.1
 
 build:	
 	docker build -t kubernetes/kibana:$(TAG) .

--- a/cluster/addons/fluentd-elasticsearch/kibana-service.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-service.yaml
@@ -8,4 +8,3 @@ labels:
   kubernetes.io/cluster-service: "true"
 selector:
   name: kibana-logging
-createExternalLoadBalancer: true

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -898,12 +898,9 @@ function setup-logging-firewall {
     sleep 10
   done
 
-  local -r region="${ZONE:0:${#ZONE}-2}"
-  local -r es_ip=$(gcloud compute forwarding-rules --project "${PROJECT}" describe --region "${region}" "${INSTANCE_PREFIX}"-elasticsearch-logging | grep IPAddress | awk '{print $2}')
-  local -r kibana_ip=$(gcloud compute forwarding-rules --project "${PROJECT}" describe --region "${region}" "${INSTANCE_PREFIX}"-kibana-logging | grep IPAddress | awk '{print $2}')
   echo
-  echo -e "${color_green}Cluster logs are ingested into Elasticsearch running at ${color_yellow}http://${es_ip}:9200"
-  echo -e "${color_green}Kibana logging dashboard will be available at ${color_yellow}http://${kibana_ip}:5601${color_norm}"
+  echo -e "${color_green}Cluster logs are ingested into Elasticsearch running at ${color_yellow}https://https://${KUBE_MASTER_IP}/api/v1beta1/proxy/services/elasticsearch-logging/"
+  echo -e "${color_green}Kibana logging dashboard will be available at ${color_yellow}https://${KUBE_MASTER_IP}/api/v1beta1/proxy/services/kibana-logging/${color_norm} (note the trailing slash)"
   echo
 }
 


### PR DESCRIPTION
This change:
- Removes the external load balancer from the Elasticsearch and Kibana services for cluster level logging and uses the proxy instead (are you happy now @thockin ?).
- Updates our `kubernetes/kibana` image to specify the Elasticsearch service using its proxy address and removes the nginx proxy_pass config which is no logner needed.
- Updates the reporting text in `util.sh` to report the URL of the cluster level services.

If the trailing lash is missing from `https://MASTER/api/v1beta1/proxy/services/kibana-logging/` the Kibana page will not load properly. Something is broken -- either with us or Kibana.

FYI: @vishh @piosz 
