### PR TITLE
Simplify generating kubeconfig with embeded cert data

### DIFF
--- a/docs/kubectl-config-set-cluster.md
+++ b/docs/kubectl-config-set-cluster.md
@@ -7,13 +7,19 @@ Sets a cluster entry in .kubeconfig
 ```
 Sets a cluster entry in .kubeconfig
 	Specifying a name that already exists will merge new fields on top of existing values for those fields.
-	e.g. 
+	e.g.
 		kubectl config set-cluster e2e --certificate-authority=~/.kube/e2e/.kubernetes.ca.cert
 		only sets the certificate-authority field on the e2e cluster entry without touching other values.
 		
 ```
 
 kubectl config set-cluster name [--server=server] [--certificate-authority=path/to/certficate/authority] [--api-version=apiversion] [--insecure-skip-tls-verify=true]
+
+### Options
+
+```
+      --embed-certs=false: embed-certs for the cluster entry in .kubeconfig
+```
 
 ### Options inherrited from parent commands
 

--- a/docs/kubectl-config-set-credentials.md
+++ b/docs/kubectl-config-set-credentials.md
@@ -28,6 +28,12 @@ Sets a user entry in .kubeconfig
 
 kubectl config set-credentials name [--auth-path=authfile] [--client-certificate=certfile] [--client-key=keyfile] [--token=bearer_token] [--username=basic_user] [--password=basic_password]
 
+### Options
+
+```
+      --embed-certs=false: embed client cert/key for the user entry in .kubeconfig
+```
+
 ### Options inherrited from parent commands
 
 ```

--- a/docs/man/man1/kubectl-config-set-cluster.1
+++ b/docs/man/man1/kubectl-config-set-cluster.1
@@ -20,6 +20,12 @@ Sets a cluster entry in .kubeconfig
         only sets the certificate\-authority field on the e2e cluster entry without touching other values.
 
 
+.SH OPTIONS
+.PP
+\fB\-\-embed\-certs\fP=false
+    embed\-certs for the cluster entry in .kubeconfig
+
+
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
 \fB\-\-alsologtostderr\fP=false

--- a/docs/man/man1/kubectl-config-set-credentials.1
+++ b/docs/man/man1/kubectl-config-set-credentials.1
@@ -45,6 +45,12 @@ Basic auth flags:
 Bearer token and basic auth are mutually exclusive.
 
 
+.SH OPTIONS
+.PP
+\fB\-\-embed\-certs\fP=false
+    embed client cert/key for the user entry in .kubeconfig
+
+
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
 \fB\-\-alsologtostderr\fP=false

--- a/pkg/client/clientcmd/overrides.go
+++ b/pkg/client/clientcmd/overrides.go
@@ -81,6 +81,7 @@ const (
 	FlagCertFile     = "client-certificate"
 	FlagKeyFile      = "client-key"
 	FlagCAFile       = "certificate-authority"
+	FlagEmbedCerts   = "embed-certs"
 	FlagBearerToken  = "token"
 	FlagUsername     = "username"
 	FlagPassword     = "password"


### PR DESCRIPTION
Add `kubectl config` support for generating single-source kubeconfig (cert data embeded). The initially suggested approach in #4517 of using `kubectl config set` doesn't work, as cobra|pflags cannot handle parsing multi-line strings as single arguments. This change adds a `--embed-certs` flag to the `set-credentials` and `set-cluster` commands which tell `kubectl config` to write raw cert data instead of path to cert file. Example:

```
$ kubectl config set-cluster --certificate-authority=/tmp/cadata --embed-certs=true

$ kubectl config set-credentials --client-certificate=/tmp/kubecfg.crt --client-key=/tmp/kubecfg.key --embed-certs=true
```

cc @liggitt, @deads2k 
