### PR TITLE
Added cluster-service label to monitoring services

### DIFF
--- a/cluster/addons/cluster-monitoring/grafana-service.yaml
+++ b/cluster/addons/cluster-monitoring/grafana-service.yaml
@@ -3,5 +3,8 @@ kind: Service
 id: monitoring-grafana
 port: 80
 containerPort: 80
+labels:
+  name: grafana
+  kubernetes.io/cluster-service: "true"
 selector: 
   name: influxGrafana

--- a/cluster/addons/cluster-monitoring/heapster-service.yaml
+++ b/cluster/addons/cluster-monitoring/heapster-service.yaml
@@ -3,5 +3,8 @@ kind: Service
 id: monitoring-heapster
 port: 80
 containerPort: 8082
+labels:
+  name: heapster
+  kubernetes.io/cluster-service: "true"
 selector: 
   name: heapster

--- a/cluster/addons/cluster-monitoring/influxdb-service.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb-service.yaml
@@ -3,5 +3,8 @@ kind: Service
 id: monitoring-influxdb
 port: 80
 containerPort: 8086
+labels:
+  name: influxdb
+  kubernetes.io/cluster-service: "true"
 selector: 
   name: influxGrafana


### PR DESCRIPTION
Monitoring services will be now displayed in kubectl cluster command (#4657).

This partially addresses #4620
