### PR TITLE
Fix hack/test-cmd.sh so that it passes on a local machine

### DIFF
--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -23,7 +23,7 @@ readonly   red=$(tput setaf 1)
 readonly green=$(tput setaf 2)
 
 kube::test::clear_all() {
-  kubectl delete rc,pods --all
+  kubectl delete "${kube_flags[@]}" rc,pods --all
 }
 
 kube::test::get_object_assert() {
@@ -31,7 +31,7 @@ kube::test::get_object_assert() {
   local request=$2
   local expected=$3
 
-  res=$(kubectl get $object -o template -t "$request")
+  res=$(kubectl get "${kube_flags[@]}" $object -o template -t "$request")
 
   if [[ "$res" =~ ^$expected$ ]]; then
       echo -n ${green}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -128,6 +128,16 @@ for version in "${kube_api_versions[@]}"; do
     )
     [ "$(kubectl get minions -t $'{{ .apiVersion }}' "${kube_flags[@]}")" == "${version}" ]
   fi
+  id_field="id"
+  labels_field="labels"
+  service_selector_field="selector"
+  rc_replicas_field="desiredState.replicas"
+  if [ "$version" = "v1beta3" ]; then
+    id_field="metadata.name"
+    labels_field="metadata.labels"
+    service_selector_field="spec.selector"
+    rc_replicas_field="spec.replicas"
+  fi
 
   # passing no arguments to create is an error
   ! kubectl create
@@ -140,177 +150,177 @@ for version in "${kube_api_versions[@]}"; do
 
   ### Create POD valid-pod from JSON
   # Pre-condition: no POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" ''
   # Command
-  kubectl create -f examples/limitrange/valid-pod.json "${kube_flags[@]}"
+  kubectl create "${kube_flags[@]}" -f examples/limitrange/valid-pod.json
   # Post-condition: valid-pod POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
-  kube::test::get_object_assert 'pod valid-pod' '{{.id}}' 'valid-pod'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
+  kube::test::get_object_assert 'pod valid-pod' "{{.$id_field}}" 'valid-pod'
 
   ### Dump current valid-pod POD
   output_pod=$(kubectl get pod valid-pod -o yaml --output-version=v1beta1 "${kube_flags[@]}")
 
   ### Delete POD valid-pod by id
   # Pre-condition: valid-pod POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
   # Command
   kubectl delete pod valid-pod "${kube_flags[@]}"
   # Post-condition: no POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" ''
 
   ### Create POD valid-pod from dumped YAML
   # Pre-condition: no POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" ''
   # Command
   echo "${output_pod}" | kubectl create -f - "${kube_flags[@]}"
   # Post-condition: valid-pod POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
 
   ### Delete POD valid-pod from JSON
   # Pre-condition: valid-pod POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
   # Command
   kubectl delete -f examples/limitrange/valid-pod.json "${kube_flags[@]}"
   # Post-condition: no POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" ''
 
   ### Create POD redis-master from JSON
   # Pre-condition: no POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" ''
   # Command
   kubectl create -f examples/limitrange/valid-pod.json "${kube_flags[@]}"
   # Post-condition: valid-pod POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
 
   ### Delete POD valid-pod with label
   # Pre-condition: valid-pod POD is running
-  kube::test::get_object_assert 'pods -l name=valid-pod' '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert 'pods -l name=valid-pod' "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
   # Command
   kubectl delete pods -l name=valid-pod "${kube_flags[@]}"
   # Post-condition: no POD is running
-  kube::test::get_object_assert 'pods -l name=valid-pod' '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert 'pods -l name=valid-pod' "{{range.items}}{{.$id_field}}:{{end}}" ''
 
   ### Create POD valid-pod from JSON
   # Pre-condition: no POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" ''
   # Command
   kubectl create -f examples/limitrange/valid-pod.json "${kube_flags[@]}"
   # Post-condition: valid-pod POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
 
   ### Delete PODs with no parameter mustn't kill everything
   # Pre-condition: valid-pod POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
   # Command
   ! kubectl delete pods "${kube_flags[@]}"
   # Post-condition: valid-pod POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
 
   ### Delete PODs with --all and a label selector is not permitted
   # Pre-condition: valid-pod POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
   # Command
   ! kubectl delete --all pods -l name=valid-pod "${kube_flags[@]}"
   # Post-condition: valid-pod POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
 
   ### Delete all PODs
   # Pre-condition: valid-pod POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
   # Command
   kubectl delete --all pods "${kube_flags[@]}" # --all remove all the pods
   # Post-condition: no POD is running
-  kube::test::get_object_assert 'pods -l name=valid-pod' '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert 'pods -l name=valid-pod' "{{range.items}}{{.$id_field}}:{{end}}" ''
 
   ### Create two PODs
   # Pre-condition: no POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" ''
   # Command
   kubectl create -f examples/limitrange/valid-pod.json "${kube_flags[@]}"
   kubectl create -f examples/redis/redis-proxy.yaml "${kube_flags[@]}"
   # Post-condition: valid-pod and redis-proxy PODs are running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'redis-proxy:valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'redis-proxy:valid-pod:'
 
   ### Delete multiple PODs at once
   # Pre-condition: valid-pod and redis-proxy PODs are running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'redis-proxy:valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'redis-proxy:valid-pod:'
   # Command
   kubectl delete pods valid-pod redis-proxy "${kube_flags[@]}" # delete multiple pods at once
   # Post-condition: no POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" ''
 
   ### Create two PODs
   # Pre-condition: no POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" ''
   # Command
   kubectl create -f examples/limitrange/valid-pod.json "${kube_flags[@]}"
   kubectl create -f examples/redis/redis-proxy.yaml "${kube_flags[@]}"
   # Post-condition: valid-pod and redis-proxy PODs are running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'redis-proxy:valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'redis-proxy:valid-pod:'
 
   ### Stop multiple PODs at once
   # Pre-condition: valid-pod and redis-proxy PODs are running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'redis-proxy:valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'redis-proxy:valid-pod:'
   # Command
   kubectl stop pods valid-pod redis-proxy "${kube_flags[@]}" # stop multiple pods at once
   # Post-condition: no POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" ''
 
   ### Create valid-pod POD
   # Pre-condition: no POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" ''
   # Command
   kubectl create -f examples/limitrange/valid-pod.json "${kube_flags[@]}"
   # Post-condition: valid-pod POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
 
   ### Label the valid-pod POD
   # Pre-condition: valid-pod is not labelled
-  kube::test::get_object_assert 'pod valid-pod' '{{range.labels}}{{.}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert 'pod valid-pod' "{{range.$labels_field}}{{.}}:{{end}}" 'valid-pod:'
   # Command
   kubectl label pods valid-pod new-name=new-valid-pod "${kube_flags[@]}"
   # Post-conditon: valid-pod is labelled
-  kube::test::get_object_assert 'pod valid-pod' '{{range.labels}}{{.}}:{{end}}' 'valid-pod:new-valid-pod:'
+  kube::test::get_object_assert 'pod valid-pod' "{{range.$labels_field}}{{.}}:{{end}}" 'valid-pod:new-valid-pod:'
 
   ### Delete POD by label
   # Pre-condition: valid-pod POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
   # Command
   kubectl delete pods -lnew-name=new-valid-pod "${kube_flags[@]}"
   # Post-condition: no POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" ''
 
   ### Create valid-pod POD
   # Pre-condition: no POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" ''
   # Command
   kubectl create -f examples/limitrange/valid-pod.json "${kube_flags[@]}"
   # Post-condition: valid-pod POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
 
   ### Overwriting an existing label is not permitted
   # Pre-condition: name is valid-pod
-  kube::test::get_object_assert 'pod valid-pod' '{{.labels.name}}' 'valid-pod'
+  kube::test::get_object_assert 'pod valid-pod' "{{.${labels_field}.name}}" 'valid-pod'
   # Command
   ! kubectl label pods valid-pod name=valid-pod-super-sayan "${kube_flags[@]}"
   # Post-condition: name is still valid-pod
-  kube::test::get_object_assert 'pod valid-pod' '{{.labels.name}}' 'valid-pod'
+  kube::test::get_object_assert 'pod valid-pod' "{{.${labels_field}.name}}" 'valid-pod'
 
   ### --overwrite must be used to overwrite existing label
   # Pre-condition: name is valid-pod
-  kube::test::get_object_assert 'pod valid-pod' '{{.labels.name}}' 'valid-pod'
+  kube::test::get_object_assert 'pod valid-pod' "{{.${labels_field}.name}}" 'valid-pod'
   # Command
   kubectl label --overwrite pods valid-pod name=valid-pod-super-sayan "${kube_flags[@]}"
   # Post-condition: name is valid-pod-super-sayan
-  kube::test::get_object_assert 'pod valid-pod' '{{.labels.name}}' 'valid-pod-super-sayan'
+  kube::test::get_object_assert 'pod valid-pod' "{{.${labels_field}.name}}" 'valid-pod-super-sayan'
 
   ### Delete POD by label
   # Pre-condition: valid-pod POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
   # Command
   kubectl delete pods -lname=valid-pod-super-sayan "${kube_flags[@]}"
   # Post-condition: no POD is running
-  kube::test::get_object_assert pods '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert pods "{{range.items}}{{.$id_field}}:{{end}}" ''
 
 
   ##############
@@ -319,19 +329,19 @@ for version in "${kube_api_versions[@]}"; do
 
   ### Create POD valid-pod in specific namespace
   # Pre-condition: no POD is running
-  kube::test::get_object_assert 'pods --namespace=other' '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert 'pods --namespace=other' "{{range.items}}{{.$id_field}}:{{end}}" ''
   # Command
   kubectl create "${kube_flags[@]}" --namespace=other -f examples/limitrange/valid-pod.json
   # Post-condition: valid-pod POD is running
-  kube::test::get_object_assert 'pods --namespace=other' '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert 'pods --namespace=other' "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
 
   ### Delete POD valid-pod in specific namespace
   # Pre-condition: valid-pod POD is running
-  kube::test::get_object_assert 'pods --namespace=other' '{{range.items}}{{.id}}:{{end}}' 'valid-pod:'
+  kube::test::get_object_assert 'pods --namespace=other' "{{range.items}}{{.$id_field}}:{{end}}" 'valid-pod:'
   # Command
   kubectl delete "${kube_flags[@]}" pod --namespace=other valid-pod
   # Post-condition: no POD is running
-  kube::test::get_object_assert 'pods --namespace=other' '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert 'pods --namespace=other' "{{range.items}}{{.$id_field}}:{{end}}" ''
 
 
   ############
@@ -342,34 +352,34 @@ for version in "${kube_api_versions[@]}"; do
 
   ### Create redis-master service from JSON
   # Pre-condition: Only the default kubernetes services are running
-  kube::test::get_object_assert services '{{range.items}}{{.id}}:{{end}}' 'kubernetes:kubernetes-ro:'
+  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:'
   # Command
   kubectl create -f examples/guestbook/redis-master-service.json "${kube_flags[@]}"
   # Post-condition: redis-master service is running
-  kube::test::get_object_assert services '{{range.items}}{{.id}}:{{end}}' 'kubernetes:kubernetes-ro:redis-master:'
+  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:redis-master:'
 
   ### Dump current redis-master service
   output_service=$(kubectl get service redis-master -o json --output-version=v1beta3 "${kube_flags[@]}")
 
   ### Delete redis-master-service by id
   # Pre-condition: redis-master service is running
-  kube::test::get_object_assert services '{{range.items}}{{.id}}:{{end}}' 'kubernetes:kubernetes-ro:redis-master:'
+  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:redis-master:'
   # Command
   kubectl delete service redis-master "${kube_flags[@]}"
   # Post-condition: Only the default kubernetes services are running
-  kube::test::get_object_assert services '{{range.items}}{{.id}}:{{end}}' 'kubernetes:kubernetes-ro:'
+  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:'
 
   ### Create redis-master-service from dumped JSON
   # Pre-condition: Only the default kubernetes services are running
-  kube::test::get_object_assert services '{{range.items}}{{.id}}:{{end}}' 'kubernetes:kubernetes-ro:'
+  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:'
   # Command
   echo "${output_service}" | kubectl create -f - "${kube_flags[@]}"
   # Post-condition: redis-master service is running
-  kube::test::get_object_assert services '{{range.items}}{{.id}}:{{end}}' 'kubernetes:kubernetes-ro:redis-master:'
+  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:redis-master:'
 
   ### Create redis-master-${version}-test service
   # Pre-condition: redis-master-service service is running
-  kube::test::get_object_assert services '{{range.items}}{{.id}}:{{end}}' 'kubernetes:kubernetes-ro:redis-master:'
+  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:redis-master:'
   # Command
   kubectl create -f - "${kube_flags[@]}" << __EOF__
       {
@@ -381,43 +391,43 @@ for version in "${kube_api_versions[@]}"; do
       }
 __EOF__
   # Post-condition:redis-master-service service is running
-  kube::test::get_object_assert services '{{range.items}}{{.id}}:{{end}}' 'kubernetes:kubernetes-ro:redis-master:service-.*-test:'
+  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:redis-master:service-.*-test:'
 
   # Command
   kubectl update service "${kube_flags[@]}" service-${version}-test --patch="{\"selector\":{\"my\":\"test-label\"},\"apiVersion\":\"v1beta1\"}"
   # Post-condition: selector.version == ${version}
   # This test works only in v1beta1 and v1beta2
   # https://github.com/GoogleCloudPlatform/kubernetes/issues/4771
-  kube::test::get_object_assert "service service-${version}-test" "{{range.selector}}{{.}}{{end}}" "test-label"
+  kube::test::get_object_assert "service service-${version}-test" "{{range.$service_selector_field}}{{.}}{{end}}" "test-label"
 
   ### Identity
   kubectl get service "${kube_flags[@]}" service-${version}-test -o json | kubectl update "${kube_flags[@]}" -f -
 
   ### Delete services by id
   # Pre-condition: redis-master-service service is running
-  kube::test::get_object_assert services '{{range.items}}{{.id}}:{{end}}' 'kubernetes:kubernetes-ro:redis-master:service-.*-test:'
+  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:redis-master:service-.*-test:'
   # Command
   kubectl delete service redis-master "${kube_flags[@]}"
   kubectl delete service "service-${version}-test" "${kube_flags[@]}"
   # Post-condition: Only the default kubernetes services are running
-  kube::test::get_object_assert services '{{range.items}}{{.id}}:{{end}}' 'kubernetes:kubernetes-ro:'
+  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:'
 
   ### Create two services
   # Pre-condition: Only the default kubernetes services are running
-  kube::test::get_object_assert services '{{range.items}}{{.id}}:{{end}}' 'kubernetes:kubernetes-ro:'
+  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:'
   # Command
   kubectl create -f examples/guestbook/redis-master-service.json "${kube_flags[@]}"
   kubectl create -f examples/guestbook/redis-slave-service.json "${kube_flags[@]}"
   # Post-condition: redis-master and redis-slave services are running
-  kube::test::get_object_assert services '{{range.items}}{{.id}}:{{end}}' 'kubernetes:kubernetes-ro:redis-master:redisslave:'
+  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:redis-master:redisslave:'
 
   ### Delete multiple services at once
   # Pre-condition: redis-master and redis-slave services are running
-  kube::test::get_object_assert services '{{range.items}}{{.id}}:{{end}}' 'kubernetes:kubernetes-ro:redis-master:redisslave:'
+  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:redis-master:redisslave:'
   # Command
   kubectl delete services redis-master redisslave "${kube_flags[@]}" # delete multiple services at once
   # Post-condition: Only the default kubernetes services are running
-  kube::test::get_object_assert services '{{range.items}}{{.id}}:{{end}}' 'kubernetes:kubernetes-ro:'
+  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:'
 
 
   ###########################
@@ -428,60 +438,60 @@ __EOF__
 
   ### Create replication controller frontend from JSON
   # Pre-condition: no replication controller is running
-  kube::test::get_object_assert rc "{{range.items}}{{.id}}:{{end}}" ''
+  kube::test::get_object_assert rc "{{range.items}}{{.$id_field}}:{{end}}" ''
   # Command
   kubectl create -f examples/guestbook/frontend-controller.json "${kube_flags[@]}"
   # Post-condition: frontend replication controller is running
-  kube::test::get_object_assert rc "{{range.items}}{{.id}}:{{end}}" 'frontend-controller:'
+  kube::test::get_object_assert rc "{{range.items}}{{.$id_field}}:{{end}}" 'frontend-controller:'
 
   ### Resize replication controller frontend with current-replicas and replicas
   # Pre-condition: 3 replicas
-  kube::test::get_object_assert 'rc frontend-controller' '{{.desiredState.replicas}}' '3'
+  kube::test::get_object_assert 'rc frontend-controller' "{{.$rc_replicas_field}}" '3'
   # Command
   kubectl resize --current-replicas=3 --replicas=2 replicationcontrollers frontend-controller "${kube_flags[@]}"
   # Post-condition: 2 replicas
-  kube::test::get_object_assert 'rc frontend-controller' '{{.desiredState.replicas}}' '2'
+  kube::test::get_object_assert 'rc frontend-controller' "{{.$rc_replicas_field}}" '2'
 
   ### Resize replication controller frontend with (wrong) current-replicas and replicas
   # Pre-condition: 2 replicas
-  kube::test::get_object_assert 'rc frontend-controller' '{{.desiredState.replicas}}' '2'
+  kube::test::get_object_assert 'rc frontend-controller' "{{.$rc_replicas_field}}" '2'
   # Command
   ! kubectl resize --current-replicas=3 --replicas=2 replicationcontrollers frontend-controller "${kube_flags[@]}"
   # Post-condition: nothing changed
-  kube::test::get_object_assert 'rc frontend-controller' '{{.desiredState.replicas}}' '2'
+  kube::test::get_object_assert 'rc frontend-controller' "{{.$rc_replicas_field}}" '2'
 
   ### Resize replication controller frontend with replicas only
   # Pre-condition: 2 replicas
-  kube::test::get_object_assert 'rc frontend-controller' '{{.desiredState.replicas}}' '2'
+  kube::test::get_object_assert 'rc frontend-controller' "{{.$rc_replicas_field}}" '2'
   # Command
   kubectl resize  --replicas=3 replicationcontrollers frontend-controller "${kube_flags[@]}"
   # Post-condition: 3 replicas
-  kube::test::get_object_assert 'rc frontend-controller' '{{.desiredState.replicas}}' '3'
+  kube::test::get_object_assert 'rc frontend-controller' "{{.$rc_replicas_field}}" '3'
 
   ### Delete replication controller with id
   # Pre-condition: frontend replication controller is running
-  kube::test::get_object_assert rc '{{range.items}}{{.id}}:{{end}}' 'frontend-controller:'
+  kube::test::get_object_assert rc "{{range.items}}{{.$id_field}}:{{end}}" 'frontend-controller:'
   # Command
   kubectl delete rc frontend-controller "${kube_flags[@]}"
   # Post-condition: no replication controller is running
-  kube::test::get_object_assert rc '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert rc "{{range.items}}{{.$id_field}}:{{end}}" ''
 
   ### Create two replication controllers
   # Pre-condition: no replication controller is running
-  kube::test::get_object_assert rc '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert rc "{{range.items}}{{.$id_field}}:{{end}}" ''
   # Command
   kubectl create -f examples/guestbook/frontend-controller.json "${kube_flags[@]}"
   kubectl create -f examples/guestbook/redis-slave-controller.json "${kube_flags[@]}"
   # Post-condition: frontend and redis-slave
-  kube::test::get_object_assert rc '{{range.items}}{{.id}}:{{end}}' 'frontend-controller:redis-slave-controller:'
+  kube::test::get_object_assert rc "{{range.items}}{{.$id_field}}:{{end}}" 'frontend-controller:redis-slave-controller:'
 
   ### Delete multiple controllers at once
   # Pre-condition: frontend and redis-slave
-  kube::test::get_object_assert rc '{{range.items}}{{.id}}:{{end}}' 'frontend-controller:redis-slave-controller:'
+  kube::test::get_object_assert rc "{{range.items}}{{.$id_field}}:{{end}}" 'frontend-controller:redis-slave-controller:'
   # Command
   kubectl delete rc frontend-controller redis-slave-controller "${kube_flags[@]}" # delete multiple controllers at once
   # Post-condition: no replication controller is running
-  kube::test::get_object_assert rc '{{range.items}}{{.id}}:{{end}}' ''
+  kube::test::get_object_assert rc "{{range.items}}{{.$id_field}}:{{end}}" ''
 
 
   #########
@@ -490,7 +500,7 @@ __EOF__
 
   kube::log::status "Testing kubectl(${version}:nodes)"
 
-  kube::test::get_object_assert nodes '{{range.items}}{{.id}}:{{end}}' '127.0.0.1:'
+  kube::test::get_object_assert nodes "{{range.items}}{{.$id_field}}:{{end}}" '127.0.0.1:'
 
   ###########
   # Minions #
@@ -499,7 +509,7 @@ __EOF__
   if [[ "${version}" != "v1beta3" ]]; then
     kube::log::status "Testing kubectl(${version}:minions)"
 
-    kube::test::get_object_assert minions '{{range.items}}{{.id}}:{{end}}' '127.0.0.1:'
+    kube::test::get_object_assert minions "{{range.items}}{{.$id_field}}:{{end}}" '127.0.0.1:'
 
     # TODO: I should be a MinionList instead of List
     kube::test::get_object_assert minions '{{.kind}}' 'List'


### PR DESCRIPTION
Before this change test-cmd.sh did not pass when run on a local machine because some commands were using current context instead of a local cluster started during the initialization phase.
Another problem was that it was using that are not present in v1beta3. For an unknown reason it was passing on travis ([example](https://travis-ci.org/GoogleCloudPlatform/kubernetes/jobs/52755393)) even with unsupported fields. If someone can explain this to me I'd be very grateful!

This fixes #4908.
