### PR TITLE
Further vagrant reliability improvements.

### DIFF
--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.service
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.service
@@ -5,6 +5,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 [Service]
 EnvironmentFile=/etc/sysconfig/kube-apiserver
 ExecStart=/usr/local/bin/kube-apiserver "$DAEMON_ARGS"
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.service
+++ b/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.service
@@ -3,9 +3,9 @@ Description=Kubernetes Controller Manager
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 
 [Service]
-Type=simple
 EnvironmentFile=-/etc/sysconfig/kube-controller-manager
 ExecStart=/usr/local/bin/kube-controller-manager "$DAEMON_ARGS"
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/cluster/saltbase/salt/kube-proxy/kube-proxy.service
+++ b/cluster/saltbase/salt/kube-proxy/kube-proxy.service
@@ -5,6 +5,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 [Service]
 EnvironmentFile=/etc/sysconfig/kube-proxy
 ExecStart=/usr/local/bin/kube-proxy "$DAEMON_ARGS"
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/cluster/saltbase/salt/kube-scheduler/kube-scheduler.service
+++ b/cluster/saltbase/salt/kube-scheduler/kube-scheduler.service
@@ -6,6 +6,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 Type=simple
 EnvironmentFile=-/etc/sysconfig/kube-scheduler
 ExecStart=/usr/local/bin/kube-scheduler "$DAEMON_ARGS"
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/cluster/saltbase/salt/kubelet/kubelet.service
+++ b/cluster/saltbase/salt/kubelet/kubelet.service
@@ -1,10 +1,13 @@
 [Unit]
 Description=Kubernetes Kubelet Server
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+After=docker.service
+Requires=docker.service
 
 [Service]
 EnvironmentFile=/etc/sysconfig/kubelet
 ExecStart=/usr/local/bin/kubelet "$DAEMON_ARGS"
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/cluster/saltbase/salt/sdn/init.sls
+++ b/cluster/saltbase/salt/sdn/init.sls
@@ -1,8 +1,13 @@
 {% if grains.network_mode is defined and grains.network_mode == 'openvswitch' %}
 
+
 sdn:
-  cmd.wait:
-    - name: /kubernetes-vagrant/network_closure.sh
-    - watch:
-      - sls: docker
+  cmd.script:
+    - source: /kubernetes-vagrant/network_closure.sh
+    - require:
+      - pkg: docker-io
+    - cwd: /
+    - user: root
+    - group: root
+    - shell: /bin/bash
 {% endif %}

--- a/cluster/vagrant/provision-network.sh
+++ b/cluster/vagrant/provision-network.sh
@@ -31,8 +31,8 @@ cat <<EOF > ${POST_NETWORK_SCRIPT}
 
 set -e
 
-# Only do this operation once, otherwise, we get docker.service files output on disk, and the command line arguments get applied multiple times
-grep -q kbr0 /etc/sysconfig/docker || {
+# Only do this operation if the bridge is not defined
+ifconfig | grep -q kbr0 || {
   CONTAINER_SUBNETS=(${MASTER_CONTAINER_SUBNET} ${MINION_CONTAINER_SUBNETS[@]})
   CONTAINER_IPS=(${MASTER_IP} ${MINION_IPS[@]})
 


### PR DESCRIPTION
PR makes the following reliability improvements:
1. Ensures systemd has a restart policy on all kubernetes components
2. Ensures kubelet starts after docker
3. Ensures network closure is run to establish the network after a vagrant halt and re-up
