### PR TITLE
nodecontroller sync cloud was not setting external id in all code paths

### DIFF
--- a/pkg/cloudprovider/controller/nodecontroller.go
+++ b/pkg/cloudprovider/controller/nodecontroller.go
@@ -166,12 +166,17 @@ func (s *NodeController) SyncCloud() error {
 	if err != nil {
 		return err
 	}
+	matches, err = s.PopulateIPs(matches)
+	if err != nil {
+		return err
+	}
 	nodes, err := s.kubeClient.Nodes().List()
 	if err != nil {
 		return err
 	}
 	nodeMap := make(map[string]*api.Node)
-	for _, node := range nodes.Items {
+	for i := range nodes.Items {
+		node := nodes.Items[i]
 		nodeMap[node.Name] = &node
 	}
 

--- a/pkg/cloudprovider/fake/fake.go
+++ b/pkg/cloudprovider/fake/fake.go
@@ -30,7 +30,7 @@ type FakeCloud struct {
 	Err           error
 	Calls         []string
 	IP            net.IP
-	ExtID         string
+	ExtID         map[string]string
 	Machines      []string
 	NodeResources *api.NodeResources
 	ClusterList   []string
@@ -113,9 +113,10 @@ func (f *FakeCloud) IPAddress(instance string) (net.IP, error) {
 
 // ExternalID is a test-spy implementation of Instances.ExternalID.
 // It adds an entry "external-id" into the internal method call record.
+// It returns an external id to the mapped instance name, if not found, it will return "ext-{instance}"
 func (f *FakeCloud) ExternalID(instance string) (string, error) {
 	f.addCall("external-id")
-	return f.ExtID, f.Err
+	return f.ExtID[instance], f.Err
 }
 
 // List is a test-spy implementation of Instances.List.


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/4989

The node controller was not setting external id for a node depending on which code path was followed to do the create.

Updated the tests to capture this use case.

Without this fix, each node in the vagrant based cloud provider never was able to move to the Ready state.

/cc @dchen1107 @ddysher 
