### PR TITLE
Small cleanups to a number of client behaviors

### DIFF
--- a/pkg/api/latest/latest_test.go
+++ b/pkg/api/latest/latest_test.go
@@ -18,56 +18,12 @@ package latest
 
 import (
 	"encoding/json"
-	"math/rand"
 	"testing"
 
 	internal "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	apitesting "github.com/GoogleCloudPlatform/kubernetes/pkg/api/testing"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta2"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
-
-func TestInternalRoundTrip(t *testing.T) {
-	latest := "v1beta2"
-
-	seed := rand.Int63()
-	apiObjectFuzzer := apitesting.FuzzerFor(t, "", rand.NewSource(seed))
-	for k := range internal.Scheme.KnownTypes("") {
-		obj, err := internal.Scheme.New("", k)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", k, err)
-			continue
-		}
-		apiObjectFuzzer.Fuzz(obj)
-
-		newer, err := internal.Scheme.New(latest, k)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", k, err)
-			continue
-		}
-
-		if err := internal.Scheme.Convert(obj, newer); err != nil {
-			t.Errorf("unable to convert %#v to %#v: %v", obj, newer, err)
-			continue
-		}
-
-		actual, err := internal.Scheme.New("", k)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", k, err)
-			continue
-		}
-
-		if err := internal.Scheme.Convert(newer, actual); err != nil {
-			t.Errorf("unable to convert %#v to %#v: %v", newer, actual, err)
-			continue
-		}
-
-		if !internal.Semantic.DeepEqual(obj, actual) {
-			t.Errorf("%s: diff %s", k, util.ObjectDiff(obj, actual))
-		}
-	}
-}
 
 func TestResourceVersioner(t *testing.T) {
 	pod := internal.Pod{ObjectMeta: internal.ObjectMeta{ResourceVersion: "10"}}

--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
 	"github.com/emicklei/go-restful"
@@ -106,6 +107,9 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage RESTStorage
 		return err
 	}
 	versionedPtr, err := api.Scheme.New(a.version, kind)
+	if conversion.IsNotRegisteredError(err) {
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/httplog/log.go
+++ b/pkg/httplog/log.go
@@ -74,7 +74,7 @@ func (passthroughLogger) Addf(format string, data ...interface{}) {
 
 // DefaultStacktracePred is the default implementation of StacktracePred.
 func DefaultStacktracePred(status int) bool {
-	return (status < http.StatusOK || status >= http.StatusBadRequest) && status != http.StatusSwitchingProtocols
+	return (status < http.StatusOK || status >= http.StatusInternalServerError) && status != http.StatusSwitchingProtocols
 }
 
 // NewLogged turns a normal response writer into a logged response writer.

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -63,7 +63,20 @@ type OutputVersionMapper struct {
 
 // RESTMapping implements meta.RESTMapper by prepending the output version to the preferred version list.
 func (m OutputVersionMapper) RESTMapping(kind string, versions ...string) (*meta.RESTMapping, error) {
-	preferred := append([]string{m.OutputVersion}, versions...)
+	preferred := []string{m.OutputVersion}
+	for _, version := range versions {
+		if len(version) > 0 {
+			preferred = append(preferred, version)
+		}
+	}
+	// if the caller wants to use the default version list, try with the preferred version, and on
+	// error, use the default behavior.
+	if len(preferred) == 1 {
+		if m, err := m.RESTMapper.RESTMapping(kind, preferred...); err == nil {
+			return m, nil
+		}
+		preferred = nil
+	}
 	return m.RESTMapper.RESTMapping(kind, preferred...)
 }
 

--- a/pkg/kubectl/resource/result.go
+++ b/pkg/kubectl/resource/result.go
@@ -133,7 +133,7 @@ func (r *Result) Object() (runtime.Object, error) {
 			return objects[0], nil
 		}
 		// if the item is a list already, don't create another list
-		if _, err := runtime.GetItemsPtr(objects[0]); err == nil {
+		if runtime.IsListType(objects[0]) {
 			return objects[0], nil
 		}
 	}

--- a/pkg/registry/event/rest.go
+++ b/pkg/registry/event/rest.go
@@ -131,13 +131,13 @@ func (rs *REST) getAttrs(obj runtime.Object) (objLabels, objFields labels.Set, e
 }
 
 func (rs *REST) List(ctx api.Context, label, field labels.Selector) (runtime.Object, error) {
-	return rs.registry.List(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs})
+	return rs.registry.ListPredicate(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs})
 }
 
 // Watch returns Events events via a watch.Interface.
 // It implements apiserver.ResourceWatcher.
 func (rs *REST) Watch(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	return rs.registry.Watch(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs}, resourceVersion)
+	return rs.registry.WatchPredicate(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs}, resourceVersion)
 }
 
 // New returns a new api.Event

--- a/pkg/registry/generic/etcd/etcd.go
+++ b/pkg/registry/generic/etcd/etcd.go
@@ -23,6 +23,7 @@ import (
 	kubeerr "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	etcderr "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors/etcd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
@@ -69,6 +70,9 @@ type Etcd struct {
 	// Return the TTL objects should be persisted with. Update is true if this
 	// is an operation against an existing object.
 	TTLFunc func(obj runtime.Object, update bool) (uint64, error)
+
+	// Returns a matcher corresponding to the provided labels and fields.
+	PredicateFunc func(label, field labels.Selector) generic.Matcher
 
 	// Called on all objects returned from the underlying store, after
 	// the exit hooks are invoked. Decorators are intended for integrations
@@ -119,10 +123,23 @@ func NamespaceKeyFunc(ctx api.Context, prefix string, name string) (string, erro
 	return key, nil
 }
 
-// List returns a list of all the items matching m.
-// TODO: rename this to ListPredicate, take the default predicate function on the constructor, and
-// introduce a List method that uses the default predicate function
-func (e *Etcd) List(ctx api.Context, m generic.Matcher) (runtime.Object, error) {
+// New implements RESTStorage
+func (e *Etcd) New() runtime.Object {
+	return e.NewFunc()
+}
+
+// NewList implements RESTLister
+func (e *Etcd) NewList() runtime.Object {
+	return e.NewListFunc()
+}
+
+// List returns a list of items matching labels and field
+func (e *Etcd) List(ctx api.Context, label, field labels.Selector) (runtime.Object, error) {
+	return e.ListPredicate(ctx, e.PredicateFunc(label, field))
+}
+
+// ListPredicate returns a list of all the items matching m.
+func (e *Etcd) ListPredicate(ctx api.Context, m generic.Matcher) (runtime.Object, error) {
 	list := e.NewListFunc()
 	err := e.Helper.ExtractToList(e.KeyRootFunc(ctx), list)
 	if err != nil {
@@ -339,11 +356,15 @@ func (e *Etcd) Delete(ctx api.Context, name string) (runtime.Object, error) {
 	return &api.Status{Status: api.StatusSuccess}, nil
 }
 
-// Watch starts a watch for the items that m matches.
+// WatchPredicate starts a watch for the items that m matches.
 // TODO: Detect if m references a single object instead of a list.
-// TODO: rename this to WatchPredicate, take the default predicate function on the constructor, and
-// introduce a Watch method that uses the default predicate function
-func (e *Etcd) Watch(ctx api.Context, m generic.Matcher, resourceVersion string) (watch.Interface, error) {
+func (e *Etcd) Watch(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	return e.WatchPredicate(ctx, e.PredicateFunc(label, field), resourceVersion)
+}
+
+// WatchPredicate starts a watch for the items that m matches.
+// TODO: Detect if m references a single object instead of a list.
+func (e *Etcd) WatchPredicate(ctx api.Context, m generic.Matcher, resourceVersion string) (watch.Interface, error) {
 	version, err := tools.ParseWatchResourceVersion(resourceVersion, e.EndpointName)
 	if err != nil {
 		return nil, err

--- a/pkg/registry/generic/etcd/etcd_test.go
+++ b/pkg/registry/generic/etcd/etcd_test.go
@@ -172,7 +172,7 @@ func TestEtcdList(t *testing.T) {
 	for name, item := range table {
 		fakeClient, registry := NewTestGenericEtcdRegistry(t)
 		fakeClient.Data[registry.KeyRootFunc(api.NewContext())] = item.in
-		list, err := registry.List(api.NewContext(), item.m)
+		list, err := registry.ListPredicate(api.NewContext(), item.m)
 		if e, a := item.succeed, err == nil; e != a {
 			t.Errorf("%v: expected %v, got %v", name, e, a)
 			continue
@@ -660,7 +660,7 @@ func TestEtcdWatch(t *testing.T) {
 	}
 
 	fakeClient, registry := NewTestGenericEtcdRegistry(t)
-	wi, err := registry.Watch(api.NewContext(), EverythingMatcher{}, "1")
+	wi, err := registry.WatchPredicate(api.NewContext(), EverythingMatcher{}, "1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/registry/generic/registry.go
+++ b/pkg/registry/generic/registry.go
@@ -75,12 +75,12 @@ type DecoratorFunc func(obj runtime.Object) error
 // layer.
 // DEPRECATED: replace with direct implementation of RESTStorage
 type Registry interface {
-	List(api.Context, Matcher) (runtime.Object, error)
+	ListPredicate(api.Context, Matcher) (runtime.Object, error)
 	CreateWithName(ctx api.Context, id string, obj runtime.Object) error
 	UpdateWithName(ctx api.Context, id string, obj runtime.Object) error
 	Get(ctx api.Context, id string) (runtime.Object, error)
 	Delete(ctx api.Context, id string) (runtime.Object, error)
-	Watch(ctx api.Context, m Matcher, resourceVersion string) (watch.Interface, error)
+	WatchPredicate(ctx api.Context, m Matcher, resourceVersion string) (watch.Interface, error)
 }
 
 // FilterList filters any list object that conforms to the api conventions,

--- a/pkg/registry/limitrange/rest.go
+++ b/pkg/registry/limitrange/rest.go
@@ -135,11 +135,11 @@ func (rs *REST) getAttrs(obj runtime.Object) (objLabels, objFields labels.Set, e
 }
 
 func (rs *REST) List(ctx api.Context, label, field labels.Selector) (runtime.Object, error) {
-	return rs.registry.List(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs})
+	return rs.registry.ListPredicate(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs})
 }
 
 func (rs *REST) Watch(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	return rs.registry.Watch(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs}, resourceVersion)
+	return rs.registry.WatchPredicate(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs}, resourceVersion)
 }
 
 // New returns a new api.LimitRange

--- a/pkg/registry/namespace/rest.go
+++ b/pkg/registry/namespace/rest.go
@@ -109,11 +109,11 @@ func (rs *REST) getAttrs(obj runtime.Object) (objLabels, objFields labels.Set, e
 }
 
 func (rs *REST) List(ctx api.Context, label, field labels.Selector) (runtime.Object, error) {
-	return rs.registry.List(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs})
+	return rs.registry.ListPredicate(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs})
 }
 
 func (rs *REST) Watch(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	return rs.registry.Watch(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs}, resourceVersion)
+	return rs.registry.WatchPredicate(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs}, resourceVersion)
 }
 
 // New returns a new api.Namespace

--- a/pkg/registry/pod/etcd/etcd.go
+++ b/pkg/registry/pod/etcd/etcd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/constraint"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
 	etcdgeneric "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/pod"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
@@ -52,6 +53,9 @@ func NewREST(h tools.EtcdHelper, factory pod.BoundPodFactory) (*REST, *BindingRE
 		},
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*api.Pod).Name, nil
+		},
+		PredicateFunc: func(label, field labels.Selector) generic.Matcher {
+			return pod.MatchPod(label, field)
 		},
 		EndpointName: "pods",
 
@@ -92,12 +96,12 @@ func (r *REST) NewList() runtime.Object {
 
 // List obtains a list of pods with labels that match selector.
 func (r *REST) List(ctx api.Context, label, field labels.Selector) (runtime.Object, error) {
-	return r.store.List(ctx, pod.MatchPod(label, field))
+	return r.store.List(ctx, label, field)
 }
 
 // Watch begins watching for new, changed, or deleted pods.
 func (r *REST) Watch(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	return r.store.Watch(ctx, pod.MatchPod(label, field), resourceVersion)
+	return r.store.Watch(ctx, label, field, resourceVersion)
 }
 
 // Get gets a specific pod specified by its ID.

--- a/pkg/registry/registrytest/generic.go
+++ b/pkg/registry/registrytest/generic.go
@@ -42,7 +42,7 @@ func NewGeneric(list runtime.Object) *GenericRegistry {
 	}
 }
 
-func (r *GenericRegistry) List(ctx api.Context, m generic.Matcher) (runtime.Object, error) {
+func (r *GenericRegistry) ListPredicate(ctx api.Context, m generic.Matcher) (runtime.Object, error) {
 	r.Lock()
 	defer r.Unlock()
 	if r.Err != nil {
@@ -51,7 +51,7 @@ func (r *GenericRegistry) List(ctx api.Context, m generic.Matcher) (runtime.Obje
 	return generic.FilterList(r.ObjectList, m, nil)
 }
 
-func (r *GenericRegistry) Watch(ctx api.Context, m generic.Matcher, resourceVersion string) (watch.Interface, error) {
+func (r *GenericRegistry) WatchPredicate(ctx api.Context, m generic.Matcher, resourceVersion string) (watch.Interface, error) {
 	// TODO: wire filter down into the mux; it needs access to current and previous state :(
 	return r.Broadcaster.Watch(), nil
 }

--- a/pkg/registry/resourcequota/rest.go
+++ b/pkg/registry/resourcequota/rest.go
@@ -138,11 +138,11 @@ func (rs *REST) getAttrs(obj runtime.Object) (objLabels, objFields labels.Set, e
 }
 
 func (rs *REST) List(ctx api.Context, label, field labels.Selector) (runtime.Object, error) {
-	return rs.registry.List(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs})
+	return rs.registry.ListPredicate(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs})
 }
 
 func (rs *REST) Watch(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	return rs.registry.Watch(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs}, resourceVersion)
+	return rs.registry.WatchPredicate(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs}, resourceVersion)
 }
 
 // New returns a new api.ResourceQuota

--- a/pkg/registry/secret/rest.go
+++ b/pkg/registry/secret/rest.go
@@ -145,11 +145,11 @@ func (rs *REST) getAttrs(obj runtime.Object) (objLabels, objFields labels.Set, e
 }
 
 func (rs *REST) List(ctx api.Context, label, field labels.Selector) (runtime.Object, error) {
-	return rs.registry.List(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs})
+	return rs.registry.ListPredicate(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs})
 }
 
 func (rs *REST) Watch(ctx api.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	return rs.registry.Watch(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs}, resourceVersion)
+	return rs.registry.WatchPredicate(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs}, resourceVersion)
 }
 
 // New returns a new api.Secret

--- a/pkg/tools/etcd_tools.go
+++ b/pkg/tools/etcd_tools.go
@@ -398,10 +398,11 @@ func (h *EtcdHelper) AtomicUpdate(key string, ptrToType runtime.Object, ignoreNo
 
 		// First time this key has been used, try creating new value.
 		if index == 0 {
-			_, err = h.Client.Create(key, string(data), 0)
+			response, err := h.Client.Create(key, string(data), 0)
 			if IsEtcdNodeExist(err) {
 				continue
 			}
+			_, _, err = h.extractObj(response, err, ptrToType, false, false)
 			return err
 		}
 


### PR DESCRIPTION
This is extracted from #5012 and contains small fixes and cleanups. The most
significant changes are allowing kubectl to properly handle objects that don't
exist in v1beta1/v1beta2
