### PR TITLE
Increase the kubectl e2e test timeout to 10 minutes

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -36,7 +36,7 @@ const (
 	kittenImage         = "kubernetes/update-demo:kitten"
 	updateDemoSelector  = "name=update-demo"
 	updateDemoContainer = "update-demo"
-	validateTimeout     = 60 * time.Second
+	validateTimeout     = 10 * time.Minute // TODO: Make this 30 seconds once #4566 is resolved.
 	kubectlProxyPort    = 8011
 )
 


### PR DESCRIPTION
To give docker plenty of time to pull the image. We've seen increasing pull times lately causing the e2e tests to flake.

Fixes #4996.
