### PR TITLE
Added -E to sudo command in local-up-cluster.sh

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -105,7 +105,7 @@ cleanup()
 trap cleanup EXIT
 
 APISERVER_LOG=/tmp/kube-apiserver.log
-sudo "${GO_OUT}/kube-apiserver" \
+sudo -E "${GO_OUT}/kube-apiserver" \
   --v=${LOG_LEVEL} \
   --address="${API_HOST}" \
   --port="${API_PORT}" \
@@ -120,14 +120,14 @@ echo "Waiting for apiserver to come up"
 kube::util::wait_for_url "http://${API_HOST}:${API_PORT}/api/v1beta1/pods" "apiserver: " 1 10 || exit 1
 
 CTLRMGR_LOG=/tmp/kube-controller-manager.log
-sudo "${GO_OUT}/kube-controller-manager" \
+sudo -E "${GO_OUT}/kube-controller-manager" \
   --v=${LOG_LEVEL} \
   --machines="127.0.0.1" \
   --master="${API_HOST}:${API_PORT}" >"${CTLRMGR_LOG}" 2>&1 &
 CTLRMGR_PID=$!
 
 KUBELET_LOG=/tmp/kubelet.log
-sudo "${GO_OUT}/kubelet" \
+sudo -E "${GO_OUT}/kubelet" \
   --v=${LOG_LEVEL} \
   --etcd_servers="http://127.0.0.1:4001" \
   --hostname_override="127.0.0.1" \
@@ -138,13 +138,13 @@ sudo "${GO_OUT}/kubelet" \
 KUBELET_PID=$!
 
 PROXY_LOG=/tmp/kube-proxy.log
-sudo "${GO_OUT}/kube-proxy" \
+sudo -E "${GO_OUT}/kube-proxy" \
   --v=${LOG_LEVEL} \
   --master="http://${API_HOST}:${API_PORT}" >"${PROXY_LOG}" 2>&1 &
 PROXY_PID=$!
 
 SCHEDULER_LOG=/tmp/kube-scheduler.log
-sudo "${GO_OUT}/kube-scheduler" \
+sudo -E "${GO_OUT}/kube-scheduler" \
   --v=${LOG_LEVEL} \
   --master="http://${API_HOST}:${API_PORT}" >"${SCHEDULER_LOG}" 2>&1 &
 SCHEDULER_PID=$!


### PR DESCRIPTION
Kubernetes running on OSX using boot2docker fails because Kubelet cannot find docker.sock.

Running `$(boot2docker shellinit)` correctly enables the local docker client to talk to the docker daemon running the VM, but Kubelet does not know about those shell variables.

Running under sudo requires the -E argument to inherit the local shell vars, including the ones that let Kubelet's docker client know how to connect to the docker daemon.

Developers would also have to either import the generated, unsigned TLS cert for the VM or disable TLS in Docker.  See https://github.com/boot2docker/boot2docker#tls-support.
