### PR TITLE
Add support for fetching node collected information

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -97,6 +97,10 @@ func (fakeKubeletClient) GetPodStatus(host, podNamespace, podID string) (api.Pod
 	return r, nil
 }
 
+func (fakeKubeletClient) GetNodeInfo(host string) (api.NodeInfo, error) {
+	return api.NodeInfo{}, nil
+}
+
 func (fakeKubeletClient) HealthCheck(host string) (probe.Result, error) {
 	return probe.Success, nil
 }

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -34,6 +34,7 @@ func init() {
 		&Service{},
 		&NodeList{},
 		&Node{},
+		&NodeInfo{},
 		&Status{},
 		&Endpoints{},
 		&EndpointsList{},
@@ -70,6 +71,7 @@ func (*ServiceList) IsAnAPIObject()               {}
 func (*Endpoints) IsAnAPIObject()                 {}
 func (*EndpointsList) IsAnAPIObject()             {}
 func (*Node) IsAnAPIObject()                      {}
+func (*NodeInfo) IsAnAPIObject()                  {}
 func (*NodeList) IsAnAPIObject()                  {}
 func (*Binding) IsAnAPIObject()                   {}
 func (*Status) IsAnAPIObject()                    {}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -788,6 +788,14 @@ type NodeSpec struct {
 	ExternalID string `json:"externalID,omitempty"`
 }
 
+// NodeSystemInfo is a set of ids/uuids to uniquely identify the node.
+type NodeSystemInfo struct {
+	// MachineID is the machine-id reported by the node
+	MachineID string `json:"machineID"`
+	// SystemUUID is the system-uuid reported by the node
+	SystemUUID string `json:"systemUUID"`
+}
+
 // NodeStatus is information about the current status of a node.
 type NodeStatus struct {
 	// NodePhase is the current lifecycle phase of the node.
@@ -796,6 +804,8 @@ type NodeStatus struct {
 	Conditions []NodeCondition `json:"conditions,omitempty"`
 	// Queried from cloud provider, if available.
 	Addresses []NodeAddress `json:"addresses,omitempty"`
+	// NodeSystemInfo is a set of ids/uuids to uniquely identify the node
+	NodeInfo NodeSystemInfo `json:"nodeInfo,omitempty"`
 }
 
 // NodeInfo is the information collected on the node.
@@ -803,6 +813,8 @@ type NodeInfo struct {
 	TypeMeta `json:",inline"`
 	// Capacity represents the available resources of a node
 	Capacity ResourceList `json:"capacity,omitempty"`
+	// NodeSystemInfo is a set of ids/uuids to uniquely identify the node
+	NodeSystemInfo `json:",inline,omitempty"`
 }
 
 type NodePhase string

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -798,6 +798,13 @@ type NodeStatus struct {
 	Addresses []NodeAddress `json:"addresses,omitempty"`
 }
 
+// NodeInfo is the information collected on the node.
+type NodeInfo struct {
+	TypeMeta `json:",inline"`
+	// Capacity represents the available resources of a node
+	Capacity ResourceList `json:"capacity,omitempty"`
+}
+
 type NodePhase string
 
 // These are the valid phases of node.

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -699,6 +699,9 @@ func init() {
 			if err := s.Convert(&in.Status.Addresses, &out.Status.Addresses, 0); err != nil {
 				return err
 			}
+			if err := s.Convert(&in.Status.NodeInfo, &out.Status.NodeInfo, 0); err != nil {
+				return err
+			}
 
 			for _, address := range in.Status.Addresses {
 				if address.Type == newer.NodeLegacyHostIP {
@@ -726,6 +729,9 @@ func init() {
 				return err
 			}
 			if err := s.Convert(&in.Status.Addresses, &out.Status.Addresses, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Status.NodeInfo, &out.Status.NodeInfo, 0); err != nil {
 				return err
 			}
 

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -43,6 +43,7 @@ func init() {
 		&EndpointsList{},
 		&Minion{},
 		&MinionList{},
+		&NodeInfo{},
 		&Binding{},
 		&Status{},
 		&Event{},
@@ -77,6 +78,7 @@ func (*ServiceList) IsAnAPIObject()               {}
 func (*Endpoints) IsAnAPIObject()                 {}
 func (*EndpointsList) IsAnAPIObject()             {}
 func (*Minion) IsAnAPIObject()                    {}
+func (*NodeInfo) IsAnAPIObject()                  {}
 func (*MinionList) IsAnAPIObject()                {}
 func (*Binding) IsAnAPIObject()                   {}
 func (*Status) IsAnAPIObject()                    {}

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -628,6 +628,13 @@ type NodeStatus struct {
 	Addresses []NodeAddress `json:"addresses,omitempty" description:"list of addresses reachable to the node"`
 }
 
+// NodeInfo is the information collected on the node.
+type NodeInfo struct {
+	TypeMeta `json:",inline"`
+	// Capacity represents the available resources.
+	Capacity ResourceList `json:"capacity,omitempty" description:"resource capacity of a node represented as a map of resource name to quantity of resource"`
+}
+
 type NodePhase string
 
 // These are the valid phases of node.

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -618,6 +618,14 @@ type EndpointsList struct {
 	Items    []Endpoints `json:"items" description:"list of service endpoint lists"`
 }
 
+// NodeSystemInfo is a set of ids/uuids to uniquely identify the node.
+type NodeSystemInfo struct {
+	// MachineID is the machine-id reported by the node
+	MachineID string `json:"machineID" description:"machine id is the machine-id reported by the node"`
+	// SystemUUID is the system-uuid reported by the node
+	SystemUUID string `json:"systemUUID" description:"system uuid is the system-uuid reported by the node"`
+}
+
 // NodeStatus is information about the current status of a node.
 type NodeStatus struct {
 	// NodePhase is the current lifecycle phase of the node.
@@ -626,6 +634,8 @@ type NodeStatus struct {
 	Conditions []NodeCondition `json:"conditions,omitempty" description:"conditions is an array of current node conditions"`
 	// Queried from cloud provider, if available.
 	Addresses []NodeAddress `json:"addresses,omitempty" description:"list of addresses reachable to the node"`
+	// NodeSystemInfo is a set of ids/uuids to uniquely identify the node
+	NodeInfo NodeSystemInfo `json:"nodeInfo,omitempty" description:"node identity is a set of ids/uuids to uniquely identify the node"`
 }
 
 // NodeInfo is the information collected on the node.
@@ -633,6 +643,8 @@ type NodeInfo struct {
 	TypeMeta `json:",inline"`
 	// Capacity represents the available resources.
 	Capacity ResourceList `json:"capacity,omitempty" description:"resource capacity of a node represented as a map of resource name to quantity of resource"`
+	// NodeSystemInfo is a set of ids/uuids to uniquely identify the node
+	NodeSystemInfo `json:",inline,omitempty" description:"node identity is a set of ids/uuids to uniquely identify the node"`
 }
 
 type NodePhase string

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -619,6 +619,9 @@ func init() {
 			if err := s.Convert(&in.Status.Addresses, &out.Status.Addresses, 0); err != nil {
 				return err
 			}
+			if err := s.Convert(&in.Status.NodeInfo, &out.Status.NodeInfo, 0); err != nil {
+				return err
+			}
 
 			for _, address := range in.Status.Addresses {
 				if address.Type == newer.NodeLegacyHostIP {
@@ -646,6 +649,9 @@ func init() {
 				return err
 			}
 			if err := s.Convert(&in.Status.Addresses, &out.Status.Addresses, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Status.NodeInfo, &out.Status.NodeInfo, 0); err != nil {
 				return err
 			}
 

--- a/pkg/api/v1beta2/register.go
+++ b/pkg/api/v1beta2/register.go
@@ -42,6 +42,7 @@ func init() {
 		&Endpoints{},
 		&EndpointsList{},
 		&Minion{},
+		&NodeInfo{},
 		&MinionList{},
 		&Binding{},
 		&Status{},
@@ -77,6 +78,7 @@ func (*ServiceList) IsAnAPIObject()               {}
 func (*Endpoints) IsAnAPIObject()                 {}
 func (*EndpointsList) IsAnAPIObject()             {}
 func (*Minion) IsAnAPIObject()                    {}
+func (*NodeInfo) IsAnAPIObject()                  {}
 func (*MinionList) IsAnAPIObject()                {}
 func (*Binding) IsAnAPIObject()                   {}
 func (*Status) IsAnAPIObject()                    {}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -623,6 +623,14 @@ type EndpointsList struct {
 	Items    []Endpoints `json:"items" description:"list of service endpoint lists"`
 }
 
+// NodeSystemInfo is a set of ids/uuids to uniquely identify the node.
+type NodeSystemInfo struct {
+	// MachineID is the machine-id reported by the node
+	MachineID string `json:"machineID" description:"machine id is the machine-id reported by the node"`
+	// SystemUUID is the system-uuid reported by the node
+	SystemUUID string `json:"systemUUID" description:"system uuid is the system-uuid reported by the node"`
+}
+
 // NodeStatus is information about the current status of a node.
 //
 // https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/node.md#node-status
@@ -633,6 +641,8 @@ type NodeStatus struct {
 	Conditions []NodeCondition `json:"conditions,omitempty" description:"conditions is an array of current node conditions"`
 	// Queried from cloud provider, if available.
 	Addresses []NodeAddress `json:"addresses,omitempty" description:"list of addresses reachable to the node"`
+	// NodeSystemInfo is a set of ids/uuids to uniquely identify the node
+	NodeInfo NodeSystemInfo `json:"nodeInfo,omitempty" description:"node identity is a set of ids/uuids to uniquely identify the node"`
 }
 
 // NodeInfo is the information collected on the node.
@@ -640,6 +650,8 @@ type NodeInfo struct {
 	TypeMeta `json:",inline"`
 	// Capacity represents the available resources.
 	Capacity ResourceList `json:"capacity,omitempty" description:"resource capacity of a node represented as a map of resource name to quantity of resource"`
+	// NodeSystemInfo is a set of ids/uuids to uniquely identify the node
+	NodeSystemInfo `json:",inline,omitempty" description:"node identity is a set of ids/uuids to uniquely identify the node"`
 }
 
 // Described the current lifecycle phase of a node.

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -635,6 +635,13 @@ type NodeStatus struct {
 	Addresses []NodeAddress `json:"addresses,omitempty" description:"list of addresses reachable to the node"`
 }
 
+// NodeInfo is the information collected on the node.
+type NodeInfo struct {
+	TypeMeta `json:",inline"`
+	// Capacity represents the available resources.
+	Capacity ResourceList `json:"capacity,omitempty" description:"resource capacity of a node represented as a map of resource name to quantity of resource"`
+}
+
 // Described the current lifecycle phase of a node.
 //
 // https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/node.md#node-phase

--- a/pkg/api/v1beta3/register.go
+++ b/pkg/api/v1beta3/register.go
@@ -40,6 +40,7 @@ func init() {
 		&Endpoints{},
 		&EndpointsList{},
 		&Node{},
+		&NodeInfo{},
 		&NodeList{},
 		&Binding{},
 		&Status{},
@@ -75,6 +76,7 @@ func (*ServiceList) IsAnAPIObject()               {}
 func (*Endpoints) IsAnAPIObject()                 {}
 func (*EndpointsList) IsAnAPIObject()             {}
 func (*Node) IsAnAPIObject()                      {}
+func (*NodeInfo) IsAnAPIObject()                  {}
 func (*NodeList) IsAnAPIObject()                  {}
 func (*Binding) IsAnAPIObject()                   {}
 func (*Status) IsAnAPIObject()                    {}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -829,6 +829,13 @@ type NodeStatus struct {
 	Addresses []NodeAddress `json:"addresses,omitempty" description:"list of addresses reachable to the node"`
 }
 
+// NodeInfo is the information collected on the node.
+type NodeInfo struct {
+	TypeMeta `json:",inline"`
+	// Capacity represents the available resources of a node
+	Capacity ResourceList `json:"capacity,omitempty"`
+}
+
 type NodePhase string
 
 // These are the valid phases of node.

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -819,6 +819,14 @@ type NodeSpec struct {
 	ExternalID string `json:"externalID,omitempty" description:"external ID assigned to the node by some machine database (e.g. a cloud provider)"`
 }
 
+// NodeSystemInfo is a set of ids/uuids to uniquely identify the node.
+type NodeSystemInfo struct {
+	// MachineID is the machine-id reported by the node
+	MachineID string `json:"machineID"`
+	// SystemUUID is the system-uuid reported by the node
+	SystemUUID string `json:"systemUUID"`
+}
+
 // NodeStatus is information about the current status of a node.
 type NodeStatus struct {
 	// NodePhase is the current lifecycle phase of the node.
@@ -827,6 +835,8 @@ type NodeStatus struct {
 	Conditions []NodeCondition `json:"conditions,omitempty" description:"list of node conditions observed"`
 	// Queried from cloud provider, if available.
 	Addresses []NodeAddress `json:"addresses,omitempty" description:"list of addresses reachable to the node"`
+	// NodeSystemInfo is a set of ids/uuids to uniquely identify the node
+	NodeInfo NodeSystemInfo `json:"nodeInfo,omitempty"`
 }
 
 // NodeInfo is the information collected on the node.
@@ -834,6 +844,8 @@ type NodeInfo struct {
 	TypeMeta `json:",inline"`
 	// Capacity represents the available resources of a node
 	Capacity ResourceList `json:"capacity,omitempty"`
+	// NodeSystemInfo is a set of ids/uuids to uniquely identify the node
+	NodeSystemInfo `json:",inline,omitempty"`
 }
 
 type NodePhase string

--- a/pkg/cloudprovider/controller/nodecontroller.go
+++ b/pkg/cloudprovider/controller/nodecontroller.go
@@ -329,6 +329,7 @@ func (s *NodeController) updateNodeInfo(node *api.Node) error {
 	for key, value := range nodeInfo.Capacity {
 		node.Spec.Capacity[key] = value
 	}
+	node.Status.NodeInfo = nodeInfo.NodeSystemInfo
 	return nil
 }
 

--- a/pkg/cloudprovider/controller/nodecontroller_test.go
+++ b/pkg/cloudprovider/controller/nodecontroller_test.go
@@ -130,6 +130,10 @@ func (c *FakeKubeletClient) GetPodStatus(host, podNamespace, podID string) (api.
 	return api.PodStatusResult{}, errors.New("Not Implemented")
 }
 
+func (c *FakeKubeletClient) GetNodeInfo(host string) (api.NodeInfo, error) {
+	return api.NodeInfo{}, errors.New("Not Implemented")
+}
+
 func (c *FakeKubeletClient) HealthCheck(host string) (probe.Result, error) {
 	return c.Status, c.Err
 }

--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -361,6 +361,10 @@ func (s *Server) handleNodeInfoVersioned(w http.ResponseWriter, req *http.Reques
 	}
 	data, err := json.Marshal(api.NodeInfo{
 		Capacity: capacity,
+		NodeSystemInfo: api.NodeSystemInfo{
+			MachineID:  info.MachineID,
+			SystemUUID: info.SystemUUID,
+		},
 	})
 	if err != nil {
 		s.error(w, err)


### PR DESCRIPTION
This patch adds the support for collecting node information (mainly cadvisor-reported details, e.g. at the moment NumCores and MemoryCapacity.

If this is acceptable (and as usual I am not attached to this specific implementation, so feel free to suggest even a completely different solution), then I will add more information.
