### PR TITLE
Refactor pkg/kubelet/kubelet.go: syncPod().

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -878,11 +878,6 @@ func TestSyncPodDeletesDuplicate(t *testing.T) {
 			Names: []string{"/k8s_foo_bar.new.test_12345678_3333"},
 			ID:    "4567",
 		},
-		"2304": &docker.APIContainers{
-			// Container for another pod, untouched.
-			Names: []string{"/k8s_baz_fiz.new.test_6_42"},
-			ID:    "2304",
-		},
 	}
 	bound := api.BoundPod{
 		ObjectMeta: api.ObjectMeta{

--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -84,7 +84,8 @@ func (p *podWorkers) managePodLoop(podUpdates <-chan workUpdate) {
 				glog.Errorf("Error listing containers while syncing pod: %v", err)
 				return
 			}
-			err = p.syncPodFn(newWork.pod, containers)
+
+			err = p.syncPodFn(newWork.pod, containers.FindContainersByPod(newWork.pod.UID, GetPodFullName(newWork.pod)))
 			if err != nil {
 				glog.Errorf("Error syncing pod %s, skipping: %v", newWork.pod.UID, err)
 				p.recorder.Eventf(newWork.pod, "failedSync", "Error syncing pod, skipping: %v", err)


### PR DESCRIPTION
Makes the syncPod() takes only the containers that belongs to the pod.
