### PR TITLE
Fix implementation of REDIRECT

### DIFF
--- a/pkg/apiserver/redirect.go
+++ b/pkg/apiserver/redirect.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiserver
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -85,7 +86,7 @@ func (r *RedirectHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.Header().Set("Location", location)
+	w.Header().Set("Location", fmt.Sprintf("http://%s", location))
 	w.WriteHeader(http.StatusTemporaryRedirect)
 	httpCode = http.StatusTemporaryRedirect
 }

--- a/pkg/apiserver/redirect_test.go
+++ b/pkg/apiserver/redirect_test.go
@@ -71,7 +71,7 @@ func TestRedirect(t *testing.T) {
 		if err == nil || err.(*url.Error).Err != dontFollow {
 			t.Errorf("Unexpected err %#v", err)
 		}
-		if e, a := item.id, resp.Header.Get("Location"); e != a {
+		if e, a := "http://"+item.id, resp.Header.Get("Location"); e != a {
 			t.Errorf("Expected %v, got %v", e, a)
 		}
 	}
@@ -124,7 +124,7 @@ func TestRedirectWithNamespaces(t *testing.T) {
 		if err == nil || err.(*url.Error).Err != dontFollow {
 			t.Errorf("Unexpected err %#v", err)
 		}
-		if e, a := item.id, resp.Header.Get("Location"); e != a {
+		if e, a := "http://"+item.id, resp.Header.Get("Location"); e != a {
 			t.Errorf("Expected %v, got %v", e, a)
 		}
 	}


### PR DESCRIPTION
Currently `REDIRECT` does not give a correct response. It returns a relative location like 1.2.3.4:56 which will use the same protocol as the original request (i.e. HTTPS when we actually need HTTP) and it will merge the path in the GET into this location (which is wrong). We should be returning an absolute path with HTTP like http://1.2.3.4.:56 
This PR fixed our redirect implementation.
