### PR TITLE
Compare and swap swallows errors

### DIFF
--- a/pkg/tools/etcd_tools.go
+++ b/pkg/tools/etcd_tools.go
@@ -333,6 +333,9 @@ func (h *EtcdHelper) SetObj(key string, obj, out runtime.Object, ttl uint64) err
 		if err == nil && version != 0 {
 			create = false
 			response, err = h.Client.CompareAndSwap(key, string(data), ttl, "", version)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
The change in this commit:
https://github.com/GoogleCloudPlatform/kubernetes/commit/e1ca63f56922b290e61bd0b6f4544b0e2f0d2261

Resulted in compare and swap to swallow the error due to shadow variable behavior.  

The err outside of that if-block is actually different than the one inside of it because of the version, err := declaration.

This caused admission controller for quota to let operations through that should have failed because compare and swap reported no error back to the calling client.

/cc @smarterclayton 
