### PR TITLE
auth_config path for aws for ginkgo

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -97,7 +97,7 @@ elif [[ "${KUBERNETES_PROVIDER}" == "gce" ]]; then
   )
 elif [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then
   auth_config=(
-    "--auth_config=${HOME}/.kubernetes_auth"
+    "--auth_config=${HOME}/.kube/${INSTANCE_PREFIX}/kubernetes_auth"
   )
 else
   auth_config=()


### PR DESCRIPTION
I missed this place which is still using the old auth_config path
