### PR TITLE
First cut at a "conformance test".

### DIFF
--- a/cmd/e2e/e2e.go
+++ b/cmd/e2e/e2e.go
@@ -51,7 +51,7 @@ func main() {
 	util.InitFlags()
 	goruntime.GOMAXPROCS(goruntime.NumCPU())
 	if *provider == "" {
-		glog.Error("e2e needs the have the --provider flag set")
+		glog.Info("The --provider flag is not set.  Treating as a conformance test.  Some tests may not be run.")
 		os.Exit(1)
 	}
 	if *times <= 0 {

--- a/hack/conformance-test.sh
+++ b/hack/conformance-test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The conformance test is provided to let users run an e2e test
+# against an already-setup cluster for which there is no automated
+# setup, teardown, and other cluster/... scripts.
+#
+# The user must export these environment variables:
+# KUBE_MASTER_IP to the ip address of the master.
+# AUTH_CONFIG to the argument of the "--auth_config=" flag.
+# If certs required, set CERT_DIR.
+# 
+# Example to test against a local vagrant cluster:
+# declare -x AUTH_CONFIG="$HOME/.kubernetes_vagrant_auth"
+# declare -x KUBE_MASTER_IP=10.245.1.2
+# hack/conformance-test.sh
+if [[ -z "KUBE_MASTER_IP" ]]; then
+  echo "Must set KUBE_MASTER_IP before running conformance test."
+  exit 1
+fi
+if [[ -z "AUTH_CONFIG" ]]; then
+  echo "Must set AUTH_CONFIG before running conformance test."
+  exit 1
+fi
+hack/ginkgo-e2e.sh
+exit $?


### PR DESCRIPTION
A conformance test is a test you run against a cluster that is already
set up.  We would use it to test a hosted kubernetes service to make
sure that it meets a bar for quality.  Also, a getting-started-guide
author, who has not implemented a complete set of cluster/...
scripts (that is, the getting-started-guide has some non-automated steps)
can use this to see which e2e tests pass on a cluster.

To be done in future PRs:
- disable tests which can't possibly run in a conformance test
  because they require things like cluster ssh.
- document that when we accept a getting-started-guide, that
  people should run the conformance test against their cluster
  (unless they already have cluster/... scripts.
