### PR TITLE
WIP: Scripts and configs to run k8s cluster on GCE using CoreOS as VM image

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -26,8 +26,8 @@ MINION_DISK_SIZE=10GB
 # TODO(dchen1107): Filed an internal issue to create an alias
 # for containervm image, so that gcloud will expand this
 # to the latest supported image.
-IMAGE=container-vm-v20150129
-IMAGE_PROJECT=google-containers
+IMAGE=${KUBE_GCE_IMAGE:-container-vm-v20150129}
+IMAGE_PROJECT=${KUBE_GCE_IMAGE_PROJECT:-google-containers}
 NETWORK=${KUBE_GCE_NETWORK:-default}
 INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX:-kubernetes}"
 MASTER_NAME="${INSTANCE_PREFIX}-master"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -26,8 +26,8 @@ MINION_DISK_SIZE=10GB
 # TODO(dchen1107): Filed an internal issue to create an alias
 # for containervm image, so that gcloud will expand this
 # to the latest supported image.
-IMAGE=container-vm-v20150129
-IMAGE_PROJECT=google-containers
+IMAGE=${KUBE_GCE_IMAGE:-container-vm-v20150129}
+IMAGE_PROJECT=${KUBE_GCE_IMAGE_PROJECT:-google-containers}
 NETWORK=${KUBE_GCE_NETWORK:-e2e}
 INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX:-e2e-test-${USER}}"
 MASTER_NAME="${INSTANCE_PREFIX}-master"

--- a/cluster/gce/coreos/README.md
+++ b/cluster/gce/coreos/README.md
@@ -1,0 +1,46 @@
+# Kubernetes on CoreOS on GCE
+
+The goal is to develop standard set of fully automated scripts and configs that can launch a kubernetes cluster on GCE using CoreOS on the master and the minions.  This is work in progress.  Some of the features in the current version are:
+
+* **cloud-config**: uses cloud config YAML files instead of Salt
+* **etcd clustering**: uses CoreOS' public discovery service to create an etcd cluster
+* **security**: secure etcd peering and kubernetes API server to client communication using self-signed certificates
+
+### Warning
+Please note that the certificates used in this setup are self-signed, which is far from the ideal solution. Please use with caution.
+
+A major feature missing in this version is the "kube-push" functionality (that is, updating kubernetes binaries on an existing cluster).  Other features on the TODO list include logging, node and cluster monitoring, and DNS setup.
+
+## User instructions
+
+### Notes
+The script invokes two "gcloud compute ssh" commands per VM instance -- to copy data over and to reboot the machine.  For convenient cluster setup, it is recommended that "gcloud compute ssh" works without password from the machine where the users intend to run "kube-up.sh".  Please refer to ["gcloud compute ssh](https://cloud.google.com/sdk/gcloud/reference/compute/ssh) and ["Connecting to an instance using ssh"](https://cloud.google.com/compute/docs/instances#sshing) for more details.
+
+### Commands
+Please refer to [kubernetes docs](docs/getting-started-guides/binary_release.md) for instructions on checking out and building from sources.  It is assumed that the user can run a kubernetes cluster on GCE using "containervm" image for the VMs.
+
+```bash
+export KUBERNETES_PROVIDER="gce"
+export KUBE_GCE_IMAGE="coreos-stable-557-2-0-v20150210"
+export KUBE_GCE_IMAGE_PROJECT=coreos-cloud
+cluster/kube-up.sh
+```
+
+Optionally, you can set the following environment variables to further control the cluster setup:
+```bash
+export KUBE_GCE_INSTANCE_PREFIX="$USER-k8s"
+export KUBE_GCE_NETWORK="$USER-k8s-network"
+export KUBE_GCE_ZONE="us-central1-f"
+export NUM_MINIONS=2
+```
+
+For a list of available CoreOS images:
+```bash
+gcloud compute images list --project coreos-cloud
+```
+
+For basic sanity-checking of the cluster:
+```bash
+cluster/kubectl.sh get minions
+cluster/kubectl.sh get events
+```

--- a/cluster/gce/coreos/config-default.sh
+++ b/cluster/gce/coreos/config-default.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "$(dirname "${BASH_SOURCE}")/../config-default.sh"
+KUBE_APISERVER_SECURE_PORT=6443
+
+# Optional: Install node monitoring.
+# TODO Enable node monitoring for CoreOS-based clusters.
+ENABLE_NODE_MONITORING="false"
+
+# Optional: When set to true, heapster will be setup as part of the cluster bring up.
+# TODO Enable cluster monitoring for CoreOS-based clusters.
+ENABLE_CLUSTER_MONITORING="false"
+
+# Optional: Enable node logging.
+# TODO: Enable logging for CoreOS-based clusters.
+ENABLE_NODE_LOGGING="false"
+
+# Optional: When set to true, Elasticsearch and Kibana will be setup as part of the cluster bring up.
+ENABLE_CLUSTER_LOGGING="false"
+
+# Don't require https for registries in our local RFC1918 network
+EXTRA_DOCKER_OPTS="--insecure-registry 10.0.0.0/8"
+
+# Optional: Install cluster DNS.
+# TODO: Enable cluster DNS for CoreOS-based clusters.
+ENABLE_CLUSTER_DNS=false
+

--- a/cluster/gce/coreos/config-test.sh
+++ b/cluster/gce/coreos/config-test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "$(dirname "${BASH_SOURCE}")/../config-test.sh"
+KUBE_APISERVER_SECURE_PORT=6443
+
+# Optional: Install node monitoring.
+# TODO Enable node monitoring for CoreOS-based clusters.
+ENABLE_NODE_MONITORING="false"
+
+# Optional: When set to true, heapster will be setup as part of the cluster bring up.
+# TODO Enable cluster monitoring for CoreOS-based clusters.
+ENABLE_CLUSTER_MONITORING="false"
+
+# Optional: Enable node logging.
+# TODO: Enable logging for CoreOS-based clusters.
+ENABLE_NODE_LOGGING="false"
+
+# Optional: When set to true, Elasticsearch and Kibana will be setup as part of the cluster bring up.
+ENABLE_CLUSTER_LOGGING="false"
+
+# Don't require https for registries in our local RFC1918 network
+EXTRA_DOCKER_OPTS="--insecure-registry 10.0.0.0/8"
+
+# Optional: Install cluster DNS.
+# TODO: Enable cluster DNS for CoreOS-based clusters.
+ENABLE_CLUSTER_DNS=false
+

--- a/cluster/gce/coreos/container_bridge.sh
+++ b/cluster/gce/coreos/container_bridge.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+BRIDGE_NAME=cbr0  # k8s convention to differentiate from docker0
+BRIDGE_MTU=1460  # bytes, a constant for GCE VMs.
+
+# Checks if the bridge name exists, and creates one if necessary.
+# Assumes BRIDGE_NAME is set.
+function ensure_bridge() {
+	if ! ip link show ${BRIDGE_NAME} > /dev/null 2>&1 ; then
+		echo "++++ Creating bridge ${BRIDGE_NAME} ..."
+		brctl addbr ${BRIDGE_NAME}
+	fi
+}
+
+# Configures the bridge with IP address and MTU, and brings it up.
+# Assumes MINION_IP_RANGE, BRIDGE_NAME and BRIDGE_MTU.
+# Assumes the bridge already exists.
+function configure_bridge() {
+	local parts=(${MINION_IP_RANGE//\// })
+	local bridge_ip=${parts[0]/%0/1}
+	local length=${parts[1]}
+
+	ip addr add ${bridge_ip}/${length} dev ${BRIDGE_NAME}
+	ip link set dev ${BRIDGE_NAME} mtu ${BRIDGE_MTU}
+	ip link set dev ${BRIDGE_NAME} up
+}
+
+function configure_iptables() {
+	iptables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE ! -d 10.0.0.0/8
+}
+
+echo "+++ Ensure the bridge exists ..."
+ensure_bridge
+
+echo "+++ Configure the bridge ..."
+configure_bridge
+
+echo "+++ Configure iptables for egress ..."
+configure_iptables
+
+echo "+++ Done!"
+

--- a/cluster/gce/coreos/master.yaml
+++ b/cluster/gce/coreos/master.yaml
@@ -1,0 +1,169 @@
+#cloud-config
+
+coreos:
+  units:
+    - name: kubernetes-node-params.service
+      command: start
+      content: |
+        [Unit]
+        Description=Kubernetes Configuration Fetcher
+        Requires=network-online.target
+        After=network-online.target
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/bin/curl --fail --silent --show-error \
+        -H "X-Google-Metadata-Request: True" \
+        -o /etc/kubernetes-node-params \
+        http://169.254.169.254/computeMetadata/v1/instance/attributes/kubernetes-node-params
+
+    - name: etcd.service
+      command: start
+      content: |
+        [Unit]
+        Description=etcd
+        Requires=kubernetes-node-params.service
+        After=kubernetes-node-params.service
+
+        [Service]
+        EnvironmentFile=/etc/kubernetes-node-params
+        PermissionsStartOnly=true
+        ExecStartPre=/usr/bin/mkdir -p /opt/kubernetes/.kube
+        ExecStartPre=/usr/bin/mv /etc/${MASTER_NAME}.tar.gz /opt/kubernetes/.kube
+        ExecStartPre=/usr/bin/tar xzf /opt/kubernetes/.kube/${MASTER_NAME}.tar.gz -C /opt/kubernetes/.kube --overwrite
+        ExecStart=/usr/bin/etcd \
+        --name ${MASTER_NAME} \
+        --discovery ${ETCD_DISCOVERY} \
+        --addr $private_ipv4:4001 \
+        --bind-addr 0.0.0.0 \
+        --data-dir /var/lib/etcd \
+        --peer-addr $private_ipv4:2380 \
+        --peer-bind-addr $private_ipv4:2380 \
+        --peer-ca-file=/opt/kubernetes/.kube/ca.crt \
+        --peer-cert-file=/opt/kubernetes/.kube/issued/${MASTER_NAME}.crt \
+        --peer-key-file=/opt/kubernetes/.kube/private/${MASTER_NAME}.key
+        Restart=always
+        RestartSec=10s
+
+    - name: fleet.socket
+      command: start
+      content: |
+        [Socket]
+        ListenStream=/var/run/fleet.sock
+
+    - name: fleet.service
+      command: start
+      content: |
+        [Unit]
+        Description=fleet daemon
+        Wants=etcd.service
+        After=etcd.service
+        Wants=fleet.socket
+        After=fleet.socket
+        [Service]
+        EnvironmentFile=/etc/kubernetes-node-params
+        ExecStart=/usr/bin/fleetd
+        Restart=always
+        RestartSec=10s
+
+# TODO: Organize these into targets.
+    - name: kubernetes-install-master.service
+      command: start
+      content: |
+        [Unit]
+        Description=Kubernetes Installer Scripts
+        Requires=network-online.target
+        After=network-online.target
+        Requires=kubernetes-node-params.service
+        After=kubernetes-node-params.service
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        EnvironmentFile=/etc/kubernetes-node-params
+        ExecStartPre=/usr/bin/mkdir -p /opt/kubernetes/pkg
+        ExecStartPre=/usr/bin/curl --location --create-dirs --output /opt/kubernetes/pkg/kubernetes-server-linux-amd64.tar.gz ${SERVER_BINARY_TAR_URL}
+        ExecStart=/usr/bin/tar xf /opt/kubernetes/pkg/kubernetes-server-linux-amd64.tar.gz -C /opt --overwrite
+
+    - name: kube-apiserver.service
+      command: start
+      content: |
+        [Unit]
+        Description=Kubernetes API Server
+        Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+        Requires=etcd.service
+        Requires=kubernetes-install-master.service
+        Requires=kubernetes-node-params.service
+        After=etcd.service
+        After=kubernetes-install-master.service
+        After=kubernetes-node-params.service
+
+        [Service]
+        EnvironmentFile=/etc/kubernetes-node-params
+        ExecStartPre=/usr/bin/cp /opt/kubernetes/.kube/issued/${MASTER_NAME}.crt /opt/kubernetes/.kube/apiserver.crt
+        ExecStartPre=/usr/bin/bash -c "cat /opt/kubernetes/.kube/ca.crt >> /opt/kubernetes/.kube/apiserver.crt"
+        ExecStart=/opt/kubernetes/server/bin/kube-apiserver \
+            --address=0.0.0.0 \
+            --port=8080 \
+            --secure_port=${KUBE_APISERVER_SECURE_PORT} \
+            --etcd_servers=http://127.0.0.1:4001 \
+            --tls_cert_file=/opt/kubernetes/.kube/apiserver.crt \
+            --tls_private_key_file=/opt/kubernetes/.kube/private/${MASTER_NAME}.key \
+            --cloud_provider=gce \
+            --allow_privileged=false \
+            --portal_net=${PORTAL_NET} \
+            --v=2 \
+            --logtostderr=true
+
+    - name: kube-scheduler.service
+      command: start
+      content: |
+        [Unit]
+        Description=Kubernetes Scheduler
+        Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+        Requires=kube-apiserver.service
+        After=kube-apiserver.service
+
+        [Service]
+        EnvironmentFile=/etc/kubernetes-node-params
+        ExecStart=/opt/kubernetes/server/bin/kube-scheduler \
+            --master=127.0.0.1:8080 \
+            --v=2 \
+            --logtostderr=true
+        Restart=always
+        RestartSec=10
+
+    - name: kube-controller-manager.service
+      command: start
+      content: |
+        [Unit]
+        Description=Kubernetes Controller Manager
+        Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+        Requires=kube-apiserver.service
+        After=kube-apiserver.service
+
+        [Service]
+        EnvironmentFile=/etc/kubernetes-node-params
+        ExecStart=/opt/kubernetes/server/bin/kube-controller-manager \
+            --master=127.0.0.1:8080 \
+            --cloud_provider=gce \
+            --minion_regexp='${NODE_INSTANCE_PREFIX}.*' \
+            --v=2 \
+            --logtostderr=true
+        Restart=always
+        RestartSec=10
+
+    - name: https-redirector.service
+      command: start
+      content: |
+        [Unit]
+        Description=HTTPS Port Redirector
+        Requires=kube-apiserver.service
+        After=kube-apiserver.service
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        EnvironmentFile=/etc/kubernetes-node-params
+        ExecStart=/sbin/iptables -A PREROUTING -t nat -p tcp --dport 443 -j REDIRECT --to-port ${KUBE_APISERVER_SECURE_PORT}

--- a/cluster/gce/coreos/minion.yaml
+++ b/cluster/gce/coreos/minion.yaml
@@ -1,0 +1,170 @@
+#cloud-config
+
+coreos:
+  units:
+    - name: kubernetes-node-params.service
+      command: start
+      content: |
+        [Unit]
+        Description=Fetch kubernetes-node-params
+        Requires=network-online.target
+        After=network-online.target
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/bin/curl --fail --silent --show-error \
+        -H "X-Google-Metadata-Request: True" \
+        -o /etc/kubernetes-node-params \
+        http://169.254.169.254/computeMetadata/v1/instance/attributes/kubernetes-node-params
+
+    - name: etcd.service
+      command: start
+      content: |
+        [Unit]
+        Description=etcd
+        Requires=kubernetes-node-params.service
+        After=kubernetes-node-params.service
+        [Service]
+        EnvironmentFile=/etc/kubernetes-node-params
+        PermissionsStartOnly=true
+        ExecStartPre=/usr/bin/mkdir -p /opt/kubernetes/.kube
+        ExecStartPre=/usr/bin/mv /etc/${KUBE_MINION_HOSTNAME}.tar.gz /opt/kubernetes/.kube
+        ExecStartPre=/usr/bin/tar xzf /opt/kubernetes/.kube/${KUBE_MINION_HOSTNAME}.tar.gz -C /opt/kubernetes/.kube --overwrite
+        ExecStart=/usr/bin/etcd \
+        --name ${KUBE_MINION_HOSTNAME} \
+        --discovery ${ETCD_DISCOVERY} \
+        --addr $private_ipv4:4001 \
+        --bind-addr 0.0.0.0 \
+        --data-dir /var/lib/etcd \
+        --peer-addr $private_ipv4:2380 \
+        --peer-bind-addr $private_ipv4:2380 \
+        --peer-ca-file=/opt/kubernetes/.kube/ca.crt \
+        --peer-cert-file=/opt/kubernetes/.kube/issued/${KUBE_MINION_HOSTNAME}.crt \
+        --peer-key-file=/opt/kubernetes/.kube/private/${KUBE_MINION_HOSTNAME}.key
+        Restart=always
+        RestartSec=10s
+
+    - name: fleet.socket
+      command: start
+      content: |
+        [Socket]
+        ListenStream=/var/run/fleet.sock
+
+    - name: fleet.service
+      command: start
+      content: |
+        [Unit]
+        Description=fleet daemon
+        Requires=kubernetes-node-params.service
+        After=kubernetes-node-params.service
+        Requires=fleet.socket
+        After=fleet.socket
+        [Service]
+        EnvironmentFile=/etc/kubernetes-node-params
+        ExecStart=/usr/bin/fleetd
+        Restart=always
+        RestartSec=10s
+
+    - name: container-bridge.service
+      command: start
+      content: |
+        [Unit]
+        Description=Fetches and runs container_bridge.sh script
+        Requires=network-online.target
+        After=network-online.target
+        Requires=kubernetes-node-params.service
+        After=kubernetes-node-params.service
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        EnvironmentFile=/etc/kubernetes-node-params
+        ExecStartPre=/usr/bin/mkdir -p /opt/kubernetes
+        ExecStartPre=/bin/curl --fail --silent --show-error \
+        -H "X-Google-Metadata-Request: True" \
+        -o /opt/kubernetes/container_bridge.sh \
+        http://169.254.169.254/computeMetadata/v1/instance/attributes/container-bridge-sh
+        ExecStartPre=/usr/bin/chmod 0755 /opt/kubernetes/container_bridge.sh
+        ExecStart=/opt/kubernetes/container_bridge.sh
+
+    - name: docker.service
+      command: start
+      content: |
+        [Unit]
+        Description=Docker Application Container Engine
+        Documentation=http://docs.docker.com
+        Requires=network-online.target
+        After=network-online.target
+        Requires=docker.socket
+        After=docker.socket
+        Requires=container-bridge.service
+        After=container-bridge.service
+
+        [Service]
+        LimitNOFILE=1048576
+        LimitNPROC=1048576
+        Environment=TMPDIR=/var/tmp
+        EnvironmentFile=/etc/kubernetes-node-params
+        ExecStart=/usr/bin/docker -D -d \
+        --host=unix:///var/run/docker.sock \
+        --bridge="cbr0" \
+        --iptables=false \
+        --ip-masq=false
+
+        Restart=always
+        RestartSec=10
+
+    - name: kubernetes-install-minion.service
+      command: start
+      content: |
+        [Unit]
+        Description=Install Kubernetes Server
+        Requires=network-online.target
+        After=network-online.target
+        Requires=kubernetes-node-params.service
+        After=kubernetes-node-params.service
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        EnvironmentFile=/etc/kubernetes-node-params
+        ExecStartPre=/usr/bin/mkdir -p /opt/kubernetes/pkg
+        ExecStartPre=/usr/bin/curl --location --create-dirs --output /opt/kubernetes/pkg/kubernetes-server-linux-amd64.tar.gz ${SERVER_BINARY_TAR_URL}
+        ExecStart=/usr/bin/tar xf /opt/kubernetes/pkg/kubernetes-server-linux-amd64.tar.gz -C /opt --overwrite
+
+    - name: kubelet.service
+      command: start
+      content: |
+        [Unit]
+        Description=Kubelet
+        Requires=kubernetes-install-minion.service
+        After=kubernetes-install-minion.service
+        Requires=docker.socket
+        After=docker.socket
+
+        [Service]
+        EnvironmentFile=/etc/kubernetes-node-params
+        ExecStart=/opt/kubernetes/server/bin/kubelet \
+        --api_servers=http://${KUBE_MASTER_INTERNAL_IP}:8080 \
+        --address=0.0.0.0 \
+        --hostname_override=${KUBE_MINION_HOSTNAME} \
+        --allow_privileged=false \
+        --v=2 \
+        --logtostderr=true
+
+    - name: kube-proxy.service
+      command: start
+      content: |
+        [Unit]
+        Description=Kubelet
+        Requires=kubelet.service
+        After=kubelet.service
+
+        [Service]
+        EnvironmentFile=/etc/kubernetes-node-params
+        ExecStart=/opt/kubernetes/server/bin/kube-proxy \
+        --master=http://${KUBE_MASTER_INTERNAL_IP}:8080 \
+        --v=2 \
+        --logtostderr=true
+

--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -71,7 +71,7 @@ for (( i=0; i<${#MINION_NAMES[@]}; i++)); do
     name="${MINION_NAMES[$i]}"
     if [ "$KUBERNETES_PROVIDER" != "vsphere" ] && [ "$KUBERNETES_PROVIDER" != "vagrant" ] && [ "$KUBERNETES_PROVIDER" != "libvirt-coreos" ]; then
       # Grab fully qualified name
-      name=$(grep "${MINION_NAMES[$i]}\." "${MINIONS_FILE}")
+      name=$(grep "${MINION_NAMES[$i]}\.*" "${MINIONS_FILE}")
     fi
 
     # Make sure the kubelet is healthy.


### PR DESCRIPTION
This is a work-in-progress, because all e2e tests do not pass.

Tested:

The end-to-end test runs to completion with the following setup:

export KUBERNETES_PROVIDER="gce"
export KUBE_GCE_IMAGE="coreos-stable-557-2-0-v20150210"
export KUBE_GCE_IMAGE_PROJECT=coreos-cloud
hack/e2e-test.sh

e2e test summary:
...
Ran 26 of 26 Specs in 3892.090 seconds

FAIL! -- 17 Passed | 9 Failed | 0 Pending | 0 Skipped F0305
23:48:33.498276    6334 driver.go:87] At least one test failed

2015/03/05 23:48:33 Error running Ginkgo tests: exit status 255
