### PR TITLE
Don't allow duplicate values in NodeAddresses

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1405,3 +1405,19 @@ const (
 
 	PortHeader = "port"
 )
+
+// Appends the NodeAddresses to the passed-by-pointer slice, only if they do not already exist
+func AddToNodeAddresses(addresses *[]NodeAddress, addAddresses ...NodeAddress) {
+	for _, add := range addAddresses {
+		exists := false
+		for _, existing := range *addresses {
+			if existing.Address == add.Address && existing.Type == add.Type {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			*addresses = append(*addresses, add)
+		}
+	}
+}

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -730,7 +730,7 @@ func init() {
 			}
 
 			if in.HostIP != "" {
-				out.Status.Addresses = append(out.Status.Addresses,
+				newer.AddToNodeAddresses(&out.Status.Addresses,
 					newer.NodeAddress{Type: newer.NodeLegacyHostIP, Address: in.HostIP})
 			}
 			out.Spec.PodCIDR = in.PodCIDR

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -650,7 +650,7 @@ func init() {
 			}
 
 			if in.HostIP != "" {
-				out.Status.Addresses = append(out.Status.Addresses,
+				newer.AddToNodeAddresses(&out.Status.Addresses,
 					newer.NodeAddress{Type: newer.NodeLegacyHostIP, Address: in.HostIP})
 			}
 			out.Spec.PodCIDR = in.PodCIDR

--- a/pkg/cloudprovider/controller/nodecontroller.go
+++ b/pkg/cloudprovider/controller/nodecontroller.go
@@ -278,7 +278,7 @@ func (s *NodeController) PopulateAddresses(nodes *api.NodeList) (*api.NodeList, 
 				glog.Errorf("error getting instance ip address for %s: %v", node.Name, err)
 			} else {
 				address := api.NodeAddress{Type: api.NodeLegacyHostIP, Address: hostIP.String()}
-				node.Status.Addresses = append(node.Status.Addresses, address)
+				api.AddToNodeAddresses(&node.Status.Addresses, address)
 			}
 		}
 	} else {
@@ -287,7 +287,7 @@ func (s *NodeController) PopulateAddresses(nodes *api.NodeList) (*api.NodeList, 
 			addr := net.ParseIP(node.Name)
 			if addr != nil {
 				address := api.NodeAddress{Type: api.NodeLegacyHostIP, Address: addr.String()}
-				node.Status.Addresses = append(node.Status.Addresses, address)
+				api.AddToNodeAddresses(&node.Status.Addresses, address)
 			} else {
 				addrs, err := lookupIP(node.Name)
 				if err != nil {
@@ -296,7 +296,7 @@ func (s *NodeController) PopulateAddresses(nodes *api.NodeList) (*api.NodeList, 
 					glog.Errorf("No ip address for node %v", node.Name)
 				} else {
 					address := api.NodeAddress{Type: api.NodeLegacyHostIP, Address: addrs[0].String()}
-					node.Status.Addresses = append(node.Status.Addresses, address)
+					api.AddToNodeAddresses(&node.Status.Addresses, address)
 				}
 			}
 		}


### PR DESCRIPTION
I was seeing duplicate values in the NodeAddress collection.  I think this is because on each poll loop the legacy hostip is appended to the node.Status.Addresses, which persists.

I created a helper function to only-add-if-not-present, and I changed all (?) of the append calls to use it
