### PR TITLE
Make unexported fields panic (informatively) instead of silently passing

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -60,6 +60,9 @@ var Semantic = conversion.EqualitiesOrDie(
 		}
 		return a.Amount.Cmp(b.Amount) == 0
 	},
+	func(a, b util.Time) bool {
+		return a.Unix() == b.Unix()
+	},
 )
 
 var standardResources = util.NewStringSet(

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -27,7 +27,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	// "reflect"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -64,7 +64,7 @@ func TestRequestWithErrorWontChange(t *testing.T) {
 	if changed != &r {
 		t.Errorf("returned request should point to the same object")
 	}
-	if !api.Semantic.DeepDerivative(changed, &original) {
+	if !reflect.DeepEqual(changed, &original) {
 		t.Errorf("expected %#v, got %#v", &original, changed)
 	}
 }

--- a/pkg/registry/controller/rest_test.go
+++ b/pkg/registry/controller/rest_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -378,7 +379,7 @@ func TestFillCurrentState(t *testing.T) {
 	if controller.Status.Replicas != 2 {
 		t.Errorf("expected 2, got: %d", controller.Status.Replicas)
 	}
-	if !api.Semantic.DeepEqual(fakeLister.s, labels.Set(controller.Spec.Selector).AsSelector()) {
+	if !reflect.DeepEqual(fakeLister.s, labels.Set(controller.Spec.Selector).AsSelector()) {
 		t.Errorf("unexpected output: %#v %#v", labels.Set(controller.Spec.Selector).AsSelector(), fakeLister.s)
 	}
 }


### PR DESCRIPTION
Closes #3928.
