### PR TITLE
Change volume.NewBuilder podUID argument to ObjectRef

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -780,7 +780,7 @@ func main() {
 	//              1 pod infra container + 2 pods from the URL +
 	//              1 pod infra container + 1 pod from the service test.
 	if len(createdPods) != 9 {
-		glog.Fatalf("Unexpected list of created pods:\n\n%#v\n\n%#v\n\n%#v\n\n", createdPods.List(), fakeDocker1.Created, fakeDocker2.Created)
+		glog.Fatalf("Expected 9 pods; got %v\n\nlist of created pods:\n\n%#v\n\nDocker 1 Created:\n\n%#v\n\nDocker 2 Created:\n\n%#v\n\n", len(createdPods), createdPods.List(), fakeDocker1.Created, fakeDocker2.Created)
 	}
 	glog.Infof("OK - found created pods: %#v", createdPods.List())
 }

--- a/pkg/api/conversion.go
+++ b/pkg/api/conversion.go
@@ -40,6 +40,10 @@ func init() {
 			return nil
 		},
 		// Convert ContainerManifest to BoundPod
+		//
+		// This function generates a dummy selfLink using the same method as the
+		// boundPod registry, in order for the Kubelet to work with well-formed
+		// boundPods during the integration test.
 		func(in *ContainerManifest, out *BoundPod, s conversion.Scope) error {
 			out.Spec.Containers = in.Containers
 			out.Spec.Volumes = in.Volumes
@@ -47,6 +51,11 @@ func init() {
 			out.Spec.DNSPolicy = in.DNSPolicy
 			out.Name = in.ID
 			out.UID = in.UUID
+
+			if in.ID != "" {
+				out.SelfLink = "/api/v1beta1/boundPods/" + in.ID
+			}
+
 			return nil
 		},
 		func(in *BoundPod, out *ContainerManifest, s conversion.Scope) error {

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -137,6 +137,7 @@ func TestExtractFromHTTP(t *testing.T) {
 						UID:       "111",
 						Name:      "foo" + "-" + hostname,
 						Namespace: "foobar",
+						SelfLink:  "/api/v1beta1/boundPods/foo",
 					},
 					Spec: api.PodSpec{
 						RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
@@ -177,6 +178,7 @@ func TestExtractFromHTTP(t *testing.T) {
 						UID:       "111",
 						Name:      "foo" + "-" + hostname,
 						Namespace: "foobar",
+						SelfLink:  "/api/v1beta1/boundPods/foo",
 					},
 					Spec: api.PodSpec{
 						RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
@@ -204,6 +206,7 @@ func TestExtractFromHTTP(t *testing.T) {
 						UID:       "111",
 						Name:      "foo" + "-" + hostname,
 						Namespace: "foobar",
+						SelfLink:  "/api/v1beta1/boundPods/foo",
 					},
 					Spec: api.PodSpec{
 						RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
@@ -220,6 +223,7 @@ func TestExtractFromHTTP(t *testing.T) {
 						UID:       "222",
 						Name:      "bar" + "-" + hostname,
 						Namespace: "foobar",
+						SelfLink:  "/api/v1beta1/boundPods/bar",
 					},
 					Spec: api.PodSpec{
 						RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},

--- a/pkg/kubelet/volume/empty_dir/empty_dir.go
+++ b/pkg/kubelet/volume/empty_dir/empty_dir.go
@@ -69,12 +69,12 @@ func (plugin *emptyDirPlugin) CanSupport(spec *api.Volume) bool {
 	return false
 }
 
-func (plugin *emptyDirPlugin) NewBuilder(spec *api.Volume, podUID types.UID) (volume.Builder, error) {
+func (plugin *emptyDirPlugin) NewBuilder(spec *api.Volume, podRef *api.ObjectReference) (volume.Builder, error) {
 	if plugin.legacyMode {
 		// Legacy mode instances can be cleaned up but not created anew.
 		return nil, fmt.Errorf("legacy mode: can not create new instances")
 	}
-	return &emptyDir{podUID, spec.Name, plugin, false}, nil
+	return &emptyDir{podRef.UID, spec.Name, plugin, false}, nil
 }
 
 func (plugin *emptyDirPlugin) NewCleaner(volName string, podUID types.UID) (volume.Cleaner, error) {

--- a/pkg/kubelet/volume/empty_dir/empty_dir_test.go
+++ b/pkg/kubelet/volume/empty_dir/empty_dir_test.go
@@ -56,7 +56,7 @@ func TestPlugin(t *testing.T) {
 		Name:         "vol1",
 		VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}},
 	}
-	builder, err := plug.NewBuilder(spec, types.UID("poduid"))
+	builder, err := plug.NewBuilder(spec, &api.ObjectReference{UID: types.UID("poduid")})
 	if err != nil {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestPluginBackCompat(t *testing.T) {
 	spec := &api.Volume{
 		Name: "vol1",
 	}
-	builder, err := plug.NewBuilder(spec, types.UID("poduid"))
+	builder, err := plug.NewBuilder(spec, &api.ObjectReference{UID: types.UID("poduid")})
 	if err != nil {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestPluginLegacy(t *testing.T) {
 		t.Errorf("Expected false")
 	}
 
-	if _, err := plug.NewBuilder(&api.Volume{VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}}, types.UID("poduid")); err == nil {
+	if _, err := plug.NewBuilder(&api.Volume{VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}}, &api.ObjectReference{UID: types.UID("poduid")}); err == nil {
 		t.Errorf("Expected failiure")
 	}
 

--- a/pkg/kubelet/volume/gce_pd/gce_pd.go
+++ b/pkg/kubelet/volume/gce_pd/gce_pd.go
@@ -70,9 +70,9 @@ func (plugin *gcePersistentDiskPlugin) CanSupport(spec *api.Volume) bool {
 	return false
 }
 
-func (plugin *gcePersistentDiskPlugin) NewBuilder(spec *api.Volume, podUID types.UID) (volume.Builder, error) {
+func (plugin *gcePersistentDiskPlugin) NewBuilder(spec *api.Volume, podRef *api.ObjectReference) (volume.Builder, error) {
 	// Inject real implementations here, test through the internal function.
-	return plugin.newBuilderInternal(spec, podUID, &GCEDiskUtil{}, mount.New())
+	return plugin.newBuilderInternal(spec, podRef.UID, &GCEDiskUtil{}, mount.New())
 }
 
 func (plugin *gcePersistentDiskPlugin) newBuilderInternal(spec *api.Volume, podUID types.UID, manager pdManager, mounter mount.Interface) (volume.Builder, error) {

--- a/pkg/kubelet/volume/gce_pd/gce_pd_test.go
+++ b/pkg/kubelet/volume/gce_pd/gce_pd_test.go
@@ -145,7 +145,7 @@ func TestPluginLegacy(t *testing.T) {
 		t.Errorf("Expected false")
 	}
 
-	if _, err := plug.NewBuilder(&api.Volume{VolumeSource: api.VolumeSource{GCEPersistentDisk: &api.GCEPersistentDiskVolumeSource{}}}, types.UID("poduid")); err == nil {
+	if _, err := plug.NewBuilder(&api.Volume{VolumeSource: api.VolumeSource{GCEPersistentDisk: &api.GCEPersistentDiskVolumeSource{}}}, &api.ObjectReference{UID: types.UID("poduid")}); err == nil {
 		t.Errorf("Expected failiure")
 	}
 

--- a/pkg/kubelet/volume/git_repo/git_repo.go
+++ b/pkg/kubelet/volume/git_repo/git_repo.go
@@ -69,13 +69,13 @@ func (plugin *gitRepoPlugin) CanSupport(spec *api.Volume) bool {
 	return false
 }
 
-func (plugin *gitRepoPlugin) NewBuilder(spec *api.Volume, podUID types.UID) (volume.Builder, error) {
+func (plugin *gitRepoPlugin) NewBuilder(spec *api.Volume, podRef *api.ObjectReference) (volume.Builder, error) {
 	if plugin.legacyMode {
 		// Legacy mode instances can be cleaned up but not created anew.
 		return nil, fmt.Errorf("legacy mode: can not create new instances")
 	}
 	return &gitRepo{
-		podUID:     podUID,
+		podUID:     podRef.UID,
 		volName:    spec.Name,
 		source:     spec.GitRepo.Repository,
 		revision:   spec.GitRepo.Revision,

--- a/pkg/kubelet/volume/git_repo/git_repo_test.go
+++ b/pkg/kubelet/volume/git_repo/git_repo_test.go
@@ -117,7 +117,7 @@ func TestPlugin(t *testing.T) {
 			},
 		},
 	}
-	builder, err := plug.NewBuilder(spec, types.UID("poduid"))
+	builder, err := plug.NewBuilder(spec, &api.ObjectReference{UID: types.UID("poduid")})
 	if err != nil {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestPluginLegacy(t *testing.T) {
 		t.Errorf("Expected false")
 	}
 
-	if _, err := plug.NewBuilder(&api.Volume{VolumeSource: api.VolumeSource{GitRepo: &api.GitRepoVolumeSource{}}}, types.UID("poduid")); err == nil {
+	if _, err := plug.NewBuilder(&api.Volume{VolumeSource: api.VolumeSource{GitRepo: &api.GitRepoVolumeSource{}}}, &api.ObjectReference{UID: types.UID("poduid")}); err == nil {
 		t.Errorf("Expected failiure")
 	}
 

--- a/pkg/kubelet/volume/host_path/host_path.go
+++ b/pkg/kubelet/volume/host_path/host_path.go
@@ -52,7 +52,7 @@ func (plugin *hostPathPlugin) CanSupport(spec *api.Volume) bool {
 	return false
 }
 
-func (plugin *hostPathPlugin) NewBuilder(spec *api.Volume, podUID types.UID) (volume.Builder, error) {
+func (plugin *hostPathPlugin) NewBuilder(spec *api.Volume, podRef *api.ObjectReference) (volume.Builder, error) {
 	return &hostPath{spec.HostPath.Path}, nil
 }
 

--- a/pkg/kubelet/volume/host_path/host_path_test.go
+++ b/pkg/kubelet/volume/host_path/host_path_test.go
@@ -55,7 +55,7 @@ func TestPlugin(t *testing.T) {
 		Name:         "vol1",
 		VolumeSource: api.VolumeSource{HostPath: &api.HostPathVolumeSource{"/vol1"}},
 	}
-	builder, err := plug.NewBuilder(spec, types.UID("poduid"))
+	builder, err := plug.NewBuilder(spec, &api.ObjectReference{UID: types.UID("poduid")})
 	if err != nil {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}

--- a/pkg/kubelet/volume/plugins.go
+++ b/pkg/kubelet/volume/plugins.go
@@ -49,8 +49,8 @@ type Plugin interface {
 	// NewBuilder creates a new volume.Builder from an API specification.
 	// Ownership of the spec pointer in *not* transferred.
 	// - spec: The api.Volume spec
-	// - podUID: The UID of the enclosing pod
-	NewBuilder(spec *api.Volume, podUID types.UID) (Builder, error)
+	// - podRef: a reference to the enclosing pod
+	NewBuilder(spec *api.Volume, podRef *api.ObjectReference) (Builder, error)
 
 	// NewCleaner creates a new volume.Cleaner from recoverable state.
 	// - name: The volume name, as per the api.Volume spec.

--- a/pkg/kubelet/volume/secret/secret_test.go
+++ b/pkg/kubelet/volume/secret/secret_test.go
@@ -99,7 +99,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Can't find the plugin by name")
 	}
 
-	builder, err := plugin.NewBuilder(volumeSpec, types.UID(testPodUID))
+	builder, err := plugin.NewBuilder(volumeSpec, &api.ObjectReference{UID: types.UID(testPodUID)})
 	if err != nil {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}

--- a/pkg/kubelet/volume/testing.go
+++ b/pkg/kubelet/volume/testing.go
@@ -71,8 +71,8 @@ func (plugin *FakePlugin) CanSupport(spec *api.Volume) bool {
 	return true
 }
 
-func (plugin *FakePlugin) NewBuilder(spec *api.Volume, podUID types.UID) (Builder, error) {
-	return &FakeVolume{podUID, spec.Name, plugin}, nil
+func (plugin *FakePlugin) NewBuilder(spec *api.Volume, podRef *api.ObjectReference) (Builder, error) {
+	return &FakeVolume{podRef.UID, spec.Name, plugin}, nil
 }
 
 func (plugin *FakePlugin) NewCleaner(volName string, podUID types.UID) (Cleaner, error) {


### PR DESCRIPTION
Two new volumes in development (for Secrets and PersistentVolumeClaims) both require the pod's namespace to lookup other values (respectively, the secret data and the persistent volume backing a claim -- both of which live in the same namespace as the volume).

@thockin @erictune @pmorie @smarterclayton 
