### PR TITLE
Update the ubuntu-cluster docs and scripts to 0.12.0

### DIFF
--- a/cluster/ubuntu-cluster/build.sh
+++ b/cluster/ubuntu-cluster/build.sh
@@ -17,8 +17,14 @@
 # Download the etcd, flannel, and K8s binaries automatically
 # Run as root only
 
-# author @resouer
+# author @resouer @WIZARD-CXY
 set -e
+
+function cleanup {
+    # cleanup work
+    rm -rf flannel kubernetes* etcd* binaries
+}
+trap cleanup SIGHUP SIGINT SIGTERM
 
 # check root
 if [ "$(id -u)" != "0" ]; then

--- a/cluster/ubuntu-cluster/build.sh
+++ b/cluster/ubuntu-cluster/build.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# simple use the sed to replace some ip settings on user's demand
+# Download the etcd, flannel, and K8s binaries automatically
 # Run as root only
 
 # author @resouer
@@ -51,10 +51,12 @@ if [ ! -f etcd.tar.gz ] ; then
 fi
 cp $ETCD/etcd $ETCD/etcdctl binaries
 
-# kuber
+# k8s
 echo "Download kubernetes release ..."
+
+K8S_V="v0.12.0"
 if [ ! -f kubernetes.tar.gz ] ; then
-    curl -L https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v0.10.1/kubernetes.tar.gz -o kubernetes.tar.gz
+    curl -L https://github.com/GoogleCloudPlatform/kubernetes/releases/download/$K8S_V/kubernetes.tar.gz -o kubernetes.tar.gz
     tar xzf kubernetes.tar.gz
 fi
 pushd kubernetes/server

--- a/docs/getting-started-guides/README.md
+++ b/docs/getting-started-guides/README.md
@@ -14,7 +14,7 @@ AWS            | Saltstack    | Ubuntu | OVS         | [docs](../../docs/getting
 Vmware         | CoreOS       | CoreOS | flannel     | [docs](../../docs/getting-started-guides/coreos.md)    | Community (@kelseyhightower) |
 Azure          | Saltstack    | Ubuntu | OpenVPN     | [docs](../../docs/getting-started-guides/azure.md)     | Community (@jeffmendoza)     |
 Bare-metal     | custom       | Ubuntu | _none_      | [docs](../../docs/getting-started-guides/ubuntu_single_node.md) | Community (@jainvipin)       |
-Bare-metal     | custom       | Ubuntu Cluster | _none_ | [docs](../../docs/getting-started-guides/ubuntu_multinodes_cluster.md) | community (@resouer @WIZARD-CXY) | use k8s version 0.10.1
+Bare-metal     | custom       | Ubuntu Cluster | flannel | [docs](../../docs/getting-started-guides/ubuntu_multinodes_cluster.md) | Community (@resouer @WIZARD-CXY) | use k8s version 0.12.0
 Local          |              |        | _none_      | [docs](../../docs/getting-started-guides/locally.md)   | Inactive                     |
 Ovirt          |              |        |             | [docs](../../docs/getting-started-guides/ovirt.md)     | Inactive                     |
 Rackspace      | CoreOS       | CoreOS | Rackspace   | [docs](../../docs/getting-started-guides/rackspace.md) | Inactive                     |

--- a/docs/getting-started-guides/ubuntu_multinodes_cluster.md
+++ b/docs/getting-started-guides/ubuntu_multinodes_cluster.md
@@ -20,10 +20,15 @@ This document describes how to deploy kubernetes on multiple ubuntu nodes, inclu
 On your laptop, copy `cluster/ubuntu-cluster` directory to your workspace.
 
 The `build.sh` will download and build all the needed binaries into `./binaries`.
+
+You can customize your etcd version or K8s version in the build.sh by changing  variable `ETCD_V` and `K8S_V`, default etcd version is 2.0.0 and K8s version is 0.12.0.
+
+
 ```
 $ cd cluster/ubuntu-cluster
 $ sudo ./build.sh
 ```
+
 Please copy all the files in `./binaries` into `/opt/bin` of every machine you want to run as Kubernetes cluster node.
 
 

--- a/docs/getting-started-guides/ubuntu_multinodes_cluster.md
+++ b/docs/getting-started-guides/ubuntu_multinodes_cluster.md
@@ -11,7 +11,7 @@ This document describes how to deploy kubernetes on multiple ubuntu nodes, inclu
 
 *3 These guide is tested OK on Ubuntu 14.04 LTS 64bit server, but it should also work on most Ubuntu versions*
 
-*4 Dependences of this guide: etcd-2.0.0, flannel-0.2.0, k8s-0.10.1, but it should also work on higher versions*
+*4 Dependences of this guide: etcd-2.0.0, flannel-0.2.0, k8s-0.12.0, but it may work with higher versions*
 
 
 ### **Main Steps**
@@ -21,7 +21,7 @@ On your laptop, copy `cluster/ubuntu-cluster` directory to your workspace.
 
 The `build.sh` will download and build all the needed binaries into `./binaries`.
 
-You can customize your etcd version or K8s version in the build.sh by changing  variable `ETCD_V` and `K8S_V`, default etcd version is 2.0.0 and K8s version is 0.12.0.
+You can customize your etcd version or K8s version in the build.sh by changing  variable `ETCD_V` and `K8S_V` in build.sh, default etcd version is 2.0.0 and K8s version is 0.12.0.
 
 
 ```


### PR DESCRIPTION
Change log
1 Users can configure the K8s version by changing some ENV in build.sh as the doc described.
2 Make the build.sh more robust to do some cleanup work after error
3 fix typos in docs and scripts

Tested OK by guest-example

We will merge the ubuntu-cluster and ubuntu single node doc and script in the next PR.

This pull request is almost the same with the #5018 , just clean up some commits
@erictune
