### PR TITLE
Use FormatInt instead of string for external id.

### DIFF
--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -333,7 +333,7 @@ func (gce *GCECloud) ExternalID(instance string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(inst.Id), nil
+	return strconv.FormatUint(inst.Id, 10), nil
 }
 
 // fqdnSuffix is hacky function to compute the delta between hostame and hostname -f.


### PR DESCRIPTION
In gce, instance id is an integer, string(id) will convert it to binary string.  We should use a readable string.

/cc @simon3z @brendandburns 
