### PR TITLE
Unify admission control plug-ins across providers

### DIFF
--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -65,3 +65,6 @@ ENABLE_CLUSTER_DNS=true
 DNS_SERVER_IP="10.0.0.10"
 DNS_DOMAIN="kubernetes.local"
 DNS_REPLICAS=1
+
+# Admission Controllers to invoke prior to persisting objects in cluster
+ADMISSION_CONTROL=NamespaceAutoProvision,LimitRanger,ResourceQuota

--- a/cluster/aws/templates/create-dynamic-salt-files.sh
+++ b/cluster/aws/templates/create-dynamic-salt-files.sh
@@ -33,6 +33,7 @@ enable_cluster_dns: '$(echo "$ENABLE_CLUSTER_DNS" | sed -e "s/'/''/g")'
 dns_replicas: '$(echo "$DNS_REPLICAS" | sed -e "s/'/''/g")'
 dns_server: '$(echo "$DNS_SERVER_IP" | sed -e "s/'/''/g")'
 dns_domain: '$(echo "$DNS_DOMAIN" | sed -e "s/'/''/g")'
+admission_control: '$(echo "$ADMISSION_CONTROL" | sed -e "s/'/''/g")'
 EOF
 
 mkdir -p /srv/salt-overlay/salt/nginx

--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -314,6 +314,7 @@ function kube-up {
     echo "readonly DNS_REPLICAS='${DNS_REPLICAS:-}'"
     echo "readonly DNS_SERVER_IP='${DNS_SERVER_IP:-}'"
     echo "readonly DNS_DOMAIN='${DNS_DOMAIN:-}'"
+    echo "readonly ADMISSION_CONTROL='${ADMISSION_CONTROL:-}'"    
     grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/common.sh"
     grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/create-dynamic-salt-files.sh"
     grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/download-release.sh"

--- a/cluster/azure/config-default.sh
+++ b/cluster/azure/config-default.sh
@@ -44,3 +44,6 @@ LOGGING_DESTINATION=elasticsearch # options: elasticsearch, gcp
 # Optional: When set to true, Elasticsearch and Kibana will be setup as part of the cluster bring up.
 ENABLE_CLUSTER_LOGGING=false
 ELASTICSEARCH_LOGGING_REPLICAS=1
+
+# Admission Controllers to invoke prior to persisting objects in cluster
+ADMISSION_CONTROL=NamespaceAutoProvision,LimitRanger,ResourceQuota

--- a/cluster/azure/templates/create-dynamic-salt-files.sh
+++ b/cluster/azure/templates/create-dynamic-salt-files.sh
@@ -23,6 +23,7 @@ cat <<EOF >/srv/salt-overlay/pillar/cluster-params.sls
 instance_prefix: '$(echo "$INSTANCE_PREFIX" | sed -e "s/'/''/g")'
 node_instance_prefix: $NODE_INSTANCE_PREFIX
 portal_net: $PORTAL_NET
+admission_control: '$(echo "$ADMISSION_CONTROL" | sed -e "s/'/''/g")'
 EOF
 
 mkdir -p /srv/salt-overlay/salt/nginx

--- a/cluster/azure/util.sh
+++ b/cluster/azure/util.sh
@@ -349,6 +349,7 @@ function kube-up {
         echo "readonly SALT_TAR_URL='${SALT_TAR_URL}'"
         echo "readonly MASTER_HTPASSWD='${htpasswd}'"
         echo "readonly PORTAL_NET='${PORTAL_NET}'"
+        echo "readonly ADMISSION_CONTROL='${ADMISSION_CONTROL:-}'"        
         grep -v "^#" "${KUBE_ROOT}/cluster/azure/templates/common.sh"
         grep -v "^#" "${KUBE_ROOT}/cluster/azure/templates/create-dynamic-salt-files.sh"
         grep -v "^#" "${KUBE_ROOT}/cluster/azure/templates/download-release.sh"

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -105,3 +105,6 @@ ENABLE_CLUSTER_DNS=true
 DNS_SERVER_IP="10.0.0.10"
 DNS_DOMAIN="kubernetes.local"
 DNS_REPLICAS=1
+
+# Admission Controllers to invoke prior to persisting objects in cluster
+ADMISSION_CONTROL=NamespaceAutoProvision,LimitRanger,ResourceQuota

--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -200,6 +200,7 @@ enable_cluster_dns: '$(echo "$ENABLE_CLUSTER_DNS" | sed -e "s/'/''/g")'
 dns_replicas: '$(echo "$DNS_REPLICAS" | sed -e "s/'/''/g")'
 dns_server: '$(echo "$DNS_SERVER_IP" | sed -e "s/'/''/g")'
 dns_domain: '$(echo "$DNS_DOMAIN" | sed -e "s/'/''/g")'
+admission_control: '$(echo "$ADMISSION_CONTROL" | sed -e "s/'/''/g")'  
 EOF
 
   if [[ "${KUBERNETES_MASTER}" == "true" ]]; then

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -452,6 +452,7 @@ DNS_REPLICAS: $(yaml-quote ${DNS_REPLICAS:-})
 DNS_SERVER_IP: $(yaml-quote ${DNS_SERVER_IP:-})
 DNS_DOMAIN: $(yaml-quote ${DNS_DOMAIN:-})
 MASTER_HTPASSWD: $(yaml-quote ${MASTER_HTPASSWD})
+ADMISSION_CONTROL: $(yaml-quota ${ADMISSION_CONTROL:-})
 EOF
 
   if [[ "${master}" != "true" ]]; then

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -452,7 +452,7 @@ DNS_REPLICAS: $(yaml-quote ${DNS_REPLICAS:-})
 DNS_SERVER_IP: $(yaml-quote ${DNS_SERVER_IP:-})
 DNS_DOMAIN: $(yaml-quote ${DNS_DOMAIN:-})
 MASTER_HTPASSWD: $(yaml-quote ${MASTER_HTPASSWD})
-ADMISSION_CONTROL: $(yaml-quota ${ADMISSION_CONTROL:-})
+ADMISSION_CONTROL: $(yaml-quote ${ADMISSION_CONTROL:-})
 EOF
 
   if [[ "${master}" != "true" ]]; then

--- a/cluster/saltbase/pillar/mine.sls
+++ b/cluster/saltbase/pillar/mine.sls
@@ -1,6 +1,6 @@
+{% if grains.cloud is defined and grains.cloud == 'gce' -%}
 # On GCE, there is no Salt mine. We run standalone.
-{% if grains.cloud != 'gce' -%}
-
+{% else %}
 # Allow everyone to see cached values of who sits at what IP
 {% set networkInterfaceName = "eth0" %}
 {% if grains.networkInterfaceName is defined %}
@@ -9,5 +9,4 @@
 mine_functions:
   network.ip_addrs: [{{networkInterfaceName}}]
   grains.items: []
-
 {% endif -%}

--- a/cluster/saltbase/salt/kube-apiserver/default
+++ b/cluster/saltbase/salt/kube-apiserver/default
@@ -59,8 +59,8 @@
 {% endif -%}
 
 {% set admission_control = "" -%}
-{% if grains.admission_control is defined -%}
- {% set admission_control = "--admission_control=" + grains.admission_control -%}
+{% if pillar['admission_control'] is defined -%}
+ {% set admission_control = "--admission_control=" + pillar['admission_control'] -%}
 {% endif -%}
 
 {% set runtime_config = "" -%}

--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -49,7 +49,7 @@ MASTER_USER=vagrant
 MASTER_PASSWD=vagrant
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceExists,LimitRanger,ResourceQuota,AlwaysAdmit
+ADMISSION_CONTROL=NamespaceAutoProvision,LimitRanger,ResourceQuota
 
 # Optional: Install node monitoring.
 ENABLE_NODE_MONITORING=true

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -83,7 +83,6 @@ grains:
   cloud_provider: vagrant
   roles:
     - kubernetes-master
-  admission_control: '$(echo "$ADMISSION_CONTROL" | sed -e "s/'/''/g")'
   runtime_config: '$(echo "$RUNTIME_CONFIG" | sed -e "s/'/''/g")'
 EOF
 
@@ -102,6 +101,7 @@ cat <<EOF >/srv/salt-overlay/pillar/cluster-params.sls
   dns_server: '$(echo "$DNS_SERVER_IP" | sed -e "s/'/''/g")'
   dns_domain: '$(echo "$DNS_DOMAIN" | sed -e "s/'/''/g")'
   instance_prefix: '$(echo "$INSTANCE_PREFIX" | sed -e "s/'/''/g")'
+  admission_control: '$(echo "$ADMISSION_CONTROL" | sed -e "s/'/''/g")'  
 EOF
 
 # Configure the salt-master

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -64,6 +64,7 @@ EOF
 # Our minions will have a pool role to distinguish them from the master.
 cat <<EOF >/etc/salt/minion.d/grains.conf
 grains:
+  cloud: vagrant
   network_mode: openvswitch
   node_ip: '$(echo "$MINION_IP" | sed -e "s/'/''/g")'
   etcd_servers: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'

--- a/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -45,6 +45,10 @@ type provision struct {
 }
 
 func (p *provision) Admit(a admission.Attributes) (err error) {
+	// only handle create requests
+	if a.GetOperation() != "CREATE" {
+		return nil
+	}
 	defaultVersion, kind, err := latest.RESTMapper.VersionAndKindForResource(a.GetResource())
 	if err != nil {
 		return err


### PR DESCRIPTION
The first commit is from #4749 to make the admission controllers cache backed so they have limited impact.

The second commit enables a common set of admission controllers across salt-based kube providers.

@bgrant0607 - I enable `NamespaceAutoProvision` to ensure a `Namespace` is created when you stick a resource in it if it did not previously exist.  This is per our discussion at the meet-up to ensure that you can traverse to a pod from each segment in a URL path.  Right now, you can stick pods in a namespace that does not exist, which this fixes.  A follow-on to this is to ensure you can't delete the Namespace if it has content in it which I will tackle next week with a larger design around graceful termination at Namespace level.  When we have stricter policy around who can create a `Namespace`, we will need to switch to `NamespaceExists`.  OpenShift runs with that plug-in now since we have policy around who can create a `Namespace` now being enforced.

@dchen1107 @erictune - the latter two plug-ins ensure that our examples on enforcing min/max cpu/memory limits on a pod/container and enforcing hard quota limits in a namespace work on GCE.  This should make our examples work well for our Salt based providers.

Will make this no longer WIP when I get a clean e2e run on GCE.
