### PR TITLE
Upgrade to latest containervm image: v20150305

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -26,7 +26,7 @@ MINION_DISK_SIZE=10GB
 # TODO(dchen1107): Filed an internal issue to create an alias
 # for containervm image, so that gcloud will expand this
 # to the latest supported image.
-IMAGE=container-vm-v20150129
+IMAGE=container-vm-v20150305
 IMAGE_PROJECT=google-containers
 NETWORK=${KUBE_GCE_NETWORK:-default}
 INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX:-kubernetes}"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -26,7 +26,7 @@ MINION_DISK_SIZE=10GB
 # TODO(dchen1107): Filed an internal issue to create an alias
 # for containervm image, so that gcloud will expand this
 # to the latest supported image.
-IMAGE=container-vm-v20150129
+IMAGE=container-vm-v20150305
 IMAGE_PROJECT=google-containers
 NETWORK=${KUBE_GCE_NETWORK:-e2e}
 INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX:-e2e-test-${USER}}"


### PR DESCRIPTION
Ran e2e test successfully with this change:

Ran 25 of 25 Specs in 2621.911 seconds
SUCCESS! -- 25 Passed | 0 Failed | 0 Pending | 0 Skipped I0306 13:09:30.478150    9816 driver.go:89] All tests pass
