### PR TITLE
Re-add the defer statements around the monitor() calls in the apiserver.

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -68,9 +68,9 @@ func init() {
 
 // monitor is a helper function for each HTTP request handler to use for
 // instrumenting basic request counter and latency metrics.
-func monitor(handler, verb, resource string, httpCode int, reqStart time.Time) {
-	requestCounter.WithLabelValues(handler, verb, resource, strconv.Itoa(httpCode)).Inc()
-	requestLatencies.WithLabelValues(handler, verb).Observe(float64((time.Since(reqStart)) / time.Microsecond))
+func monitor(handler string, verb, resource *string, httpCode *int, reqStart time.Time) {
+	requestCounter.WithLabelValues(handler, *verb, *resource, strconv.Itoa(*httpCode)).Inc()
+	requestLatencies.WithLabelValues(handler, *verb).Observe(float64((time.Since(reqStart)) / time.Microsecond))
 }
 
 // monitorFilter creates a filter that reports the metrics for a given resource and action.
@@ -78,7 +78,8 @@ func monitorFilter(action, resource string) restful.FilterFunction {
 	return func(req *restful.Request, res *restful.Response, chain *restful.FilterChain) {
 		reqStart := time.Now()
 		chain.ProcessFilter(req, res)
-		monitor("rest", action, resource, res.StatusCode(), reqStart)
+		httpCode := res.StatusCode()
+		monitor("rest", &action, &resource, &httpCode, reqStart)
 	}
 }
 

--- a/pkg/apiserver/proxy.go
+++ b/pkg/apiserver/proxy.go
@@ -90,7 +90,7 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var apiResource string
 	var httpCode int
 	reqStart := time.Now()
-	defer monitor("proxy", verb, apiResource, httpCode, reqStart)
+	defer monitor("proxy", &verb, &apiResource, &httpCode, reqStart)
 
 	requestInfo, err := r.apiRequestInfoResolver.GetAPIRequestInfo(req)
 	if err != nil {

--- a/pkg/apiserver/redirect.go
+++ b/pkg/apiserver/redirect.go
@@ -38,7 +38,7 @@ func (r *RedirectHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var apiResource string
 	var httpCode int
 	reqStart := time.Now()
-	defer monitor("redirect", verb, apiResource, httpCode, reqStart)
+	defer monitor("redirect", &verb, &apiResource, &httpCode, reqStart)
 
 	requestInfo, err := r.apiRequestInfoResolver.GetAPIRequestInfo(req)
 	if err != nil {

--- a/pkg/apiserver/validator.go
+++ b/pkg/apiserver/validator.go
@@ -73,9 +73,11 @@ type ServerStatus struct {
 }
 
 func (v *validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	verb := "get"
+	apiResource := ""
 	var httpCode int
 	reqStart := time.Now()
-	defer monitor("validate", "get", "", httpCode, reqStart)
+	defer monitor("validate", &verb, &apiResource, &httpCode, reqStart)
 
 	reply := []ServerStatus{}
 	for name, server := range v.servers() {

--- a/pkg/apiserver/watch.go
+++ b/pkg/apiserver/watch.go
@@ -87,7 +87,7 @@ func (h *WatchHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var apiResource string
 	var httpCode int
 	reqStart := time.Now()
-	defer monitor("watch", verb, apiResource, httpCode, reqStart)
+	defer monitor("watch", &verb, &apiResource, &httpCode, reqStart)
 
 	if req.Method != "GET" {
 		notFound(w, req)


### PR DESCRIPTION
These are needed for the changes to various labels from later in the function are picked up. They were incorrectly removed in #4507, causing the fields to always be empty in all exported metrics.

If you would prefer a different way of enabling this behavior I'd be happy to change to it, but we can't remove the closures without inserting some other logic to replace them.
