### PR TITLE
Standalone kubeconfig for gce kube-up

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Common utilites for kube-up/kube-down
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+# Generate kubeconfig data for the created cluster.
+# Assumed vars:
+#   KUBE_USER
+#   KUBE_PASSWORD
+#   KUBE_MASTER_IP
+#   KUBECONFIG
+#
+#   KUBE_CERT
+#   KUBE_KEY
+#   CA_CERT
+#   CONTEXT
+function create-kubeconfig() {
+  local kubectl="${KUBE_ROOT}/cluster/kubectl.sh"
+
+  # We expect KUBECONFIG to be defined, which determines the file we write to.
+  "${kubectl}" config set-cluster "${CONTEXT}" --server="https://${KUBE_MASTER_IP}" \
+                                               --certificate-authority="${CA_CERT}" \
+                                               --embed-certs=true
+  "${kubectl}" config set-credentials "${CONTEXT}" --username="${KUBE_USER}" \
+                                                --password="${KUBE_PASSWORD}" \
+                                                --client-certificate="${KUBE_CERT}" \
+                                                --client-key="${KUBE_KEY}" \
+                                                --embed-certs=true
+  "${kubectl}" config set-context "${CONTEXT}" --cluster="${CONTEXT}" --user="${CONTEXT}"
+  "${kubectl}" config use-context "${CONTEXT}"  --cluster="${CONTEXT}"
+
+   echo "Wrote config for ${CONTEXT} to ${KUBE_ROOT}/.kubeconfig"
+}
+
+# Clear kubeconfig data for a context
+# Assumed vars:
+#   KUBECONFIG
+#   CONTEXT
+function clear-kubeconfig() {
+  local kubectl="${KUBE_ROOT}/cluster/kubectl.sh"
+  "${kubectl}" config unset "clusters.${CONTEXT}"
+  "${kubectl}" config unset "users.${CONTEXT}"
+  "${kubectl}" config unset "contexts.${CONTEXT}"
+
+  local current
+  current=$("${kubectl}" config view -o template --template='{{ index . "current-context" }}')
+  if [[ "${current}" == "${CONTEXT}" ]]; then
+    "${kubectl}" config unset current-context
+  fi
+
+  echo "Cleared config for ${CONTEXT} from ${KUBE_ROOT}/.kubeconfig"
+}

--- a/cmd/e2e/e2e.go
+++ b/cmd/e2e/e2e.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	goruntime "runtime"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/test/e2e"
 	"github.com/golang/glog"
@@ -27,7 +28,8 @@ import (
 )
 
 var (
-	authConfig = flag.String("auth_config", os.Getenv("HOME")+"/.kubernetes_auth", "Path to the auth info file.")
+	kubeConfig = flag.String(clientcmd.RecommendedConfigPathFlag, "", "Path to kubeconfig containing embeded authinfo. Will use cluster/user info from 'current-context'")
+	authConfig = flag.String("auth_config", "", "Path to the auth info file.")
 	certDir    = flag.String("cert_dir", "", "Path to the directory containing the certs. Default is empty, which doesn't use certs.")
 	gceProject = flag.String("gce_project", "", "The GCE project being used, if applicable")
 	gceZone    = flag.String("gce_zone", "", "GCE zone being used, if applicable")
@@ -61,5 +63,5 @@ func main() {
 		Zone:       *gceZone,
 		MasterName: *masterName,
 	}
-	e2e.RunE2ETests(*authConfig, *certDir, *host, *repoRoot, *provider, gceConfig, *orderseed, *times, *reportDir, testList)
+	e2e.RunE2ETests(*kubeConfig, *authConfig, *certDir, *host, *repoRoot, *provider, gceConfig, *orderseed, *times, *reportDir, testList)
 }

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -93,7 +93,7 @@ elif [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
   )
 elif [[ "${KUBERNETES_PROVIDER}" == "gce" ]]; then
   auth_config=(
-    "--auth_config=${HOME}/.kube/${PROJECT}_${INSTANCE_PREFIX}/kubernetes_auth"
+    "--kubeconfig=${HOME}/.kube/.kubeconfig"
   )
 elif [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then
   auth_config=(

--- a/pkg/client/clientcmd/auth_loaders.go
+++ b/pkg/client/clientcmd/auth_loaders.go
@@ -80,7 +80,7 @@ func promptForString(field string, r io.Reader) string {
 	return result
 }
 
-// NewDefaultAuthLoader is an AuthLoader that parses an AuthInfo object from a file path. It prompts user and creates file if it doesn't exist.
+// NewPromptingAuthLoader is an AuthLoader that parses an AuthInfo object from a file path. It prompts user and creates file if it doesn't exist.
 func NewPromptingAuthLoader(reader io.Reader) *PromptingAuthLoader {
 	return &PromptingAuthLoader{reader}
 }

--- a/test/e2e/driver.go
+++ b/test/e2e/driver.go
@@ -53,8 +53,8 @@ func (t *testResult) Fail() { *t = false }
 
 // Run each Go end-to-end-test. This function assumes the
 // creation of a test cluster.
-func RunE2ETests(authConfig, certDir, host, repoRoot, provider string, gceConfig *GCEConfig, orderseed int64, times int, reportDir string, testList []string) {
-	testContext = testContextType{authConfig, certDir, host, repoRoot, provider, *gceConfig}
+func RunE2ETests(kubeConfig, authConfig, certDir, host, repoRoot, provider string, gceConfig *GCEConfig, orderseed int64, times int, reportDir string, testList []string) {
+	testContext = testContextType{kubeConfig, authConfig, certDir, host, repoRoot, provider, *gceConfig}
 	util.ReallyCrash = true
 	util.InitLogs()
 	defer util.FlushLogs()

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 
 	. "github.com/onsi/ginkgo"
 )
@@ -182,12 +183,17 @@ func getData(c *client.Client, podID string) (*updateDemoData, error) {
 }
 
 func kubectlCmd(args ...string) *exec.Cmd {
-	defaultArgs := []string{"--auth-path=" + testContext.authConfig}
-	if testContext.certDir != "" {
-		defaultArgs = append(defaultArgs,
-			fmt.Sprintf("--certificate-authority=%s", filepath.Join(testContext.certDir, "ca.crt")),
-			fmt.Sprintf("--client-certificate=%s", filepath.Join(testContext.certDir, "kubecfg.crt")),
-			fmt.Sprintf("--client-key=%s", filepath.Join(testContext.certDir, "kubecfg.key")))
+	defaultArgs := []string{}
+	if testContext.kubeConfig != "" {
+		defaultArgs = append(defaultArgs, "--"+clientcmd.RecommendedConfigPathFlag+"="+testContext.kubeConfig)
+	} else {
+		defaultArgs = append(defaultArgs, "--"+clientcmd.FlagAuthPath+"="+testContext.authConfig)
+		if testContext.certDir != "" {
+			defaultArgs = append(defaultArgs,
+				fmt.Sprintf("--certificate-authority=%s", filepath.Join(testContext.certDir, "ca.crt")),
+				fmt.Sprintf("--client-certificate=%s", filepath.Join(testContext.certDir, "kubecfg.crt")),
+				fmt.Sprintf("--client-key=%s", filepath.Join(testContext.certDir, "kubecfg.key")))
+		}
 	}
 	kubectlArgs := append(defaultArgs, args...)
 	// TODO: Remove this once gcloud writes a proper entry in the kubeconfig file.

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/clientauth"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -38,6 +38,7 @@ const (
 )
 
 type testContextType struct {
+	kubeConfig string
 	authConfig string
 	certDir    string
 	host       string
@@ -117,32 +118,44 @@ func waitForPodSuccess(c *client.Client, podName string, contName string) error 
 }
 
 func loadConfig() (*client.Config, error) {
-	config := &client.Config{
-		Host: testContext.host,
+	switch {
+	case testContext.kubeConfig != "":
+		fmt.Printf(">>> testContext.kubeConfig: %s\n", testContext.kubeConfig)
+		c, err := clientcmd.LoadFromFile(testContext.kubeConfig)
+		if err != nil {
+			return nil, fmt.Errorf("error loading kubeConfig: %v", err.Error())
+		}
+		return clientcmd.NewDefaultClientConfig(*c, &clientcmd.ConfigOverrides{}).ClientConfig()
+	case testContext.authConfig != "":
+		config := &client.Config{
+			Host: testContext.host,
+		}
+		info, err := clientauth.LoadFromFile(testContext.authConfig)
+		if err != nil {
+			return nil, fmt.Errorf("error loading authConfig: %v", err.Error())
+		}
+		// If the certificate directory is provided, set the cert paths to be there.
+		if testContext.certDir != "" {
+			Logf("Expecting certs in %v.", testContext.certDir)
+			info.CAFile = filepath.Join(testContext.certDir, "ca.crt")
+			info.CertFile = filepath.Join(testContext.certDir, "kubecfg.crt")
+			info.KeyFile = filepath.Join(testContext.certDir, "kubecfg.key")
+		}
+		mergedConfig, err := info.MergeWithConfig(*config)
+		return &mergedConfig, err
+	default:
+		return nil, fmt.Errorf("either kubeConfig or authConfig must be specified to load client config")
 	}
-	info, err := clientauth.LoadFromFile(testContext.authConfig)
-	if err != nil {
-		return nil, fmt.Errorf("Error loading auth: %v", err.Error())
-	}
-	// If the certificate directory is provided, set the cert paths to be there.
-	if testContext.certDir != "" {
-		Logf("Expecting certs in %v.", testContext.certDir)
-		info.CAFile = filepath.Join(testContext.certDir, "ca.crt")
-		info.CertFile = filepath.Join(testContext.certDir, "kubecfg.crt")
-		info.KeyFile = filepath.Join(testContext.certDir, "kubecfg.key")
-	}
-	mergedConfig, err := info.MergeWithConfig(*config)
-	return &mergedConfig, err
 }
 
 func loadClient() (*client.Client, error) {
 	config, err := loadConfig()
 	if err != nil {
-		return nil, fmt.Errorf("Error creating client: %v", err.Error())
+		return nil, fmt.Errorf("error creating client: %v", err.Error())
 	}
 	c, err := client.New(config)
 	if err != nil {
-		return nil, fmt.Errorf("Error creating client: %v", err.Error())
+		return nil, fmt.Errorf("error creating client: %v", err.Error())
 	}
 	return c, nil
 }


### PR DESCRIPTION
Make gce create and clear standalone `.kubeconfig` (embedded certs) on `kube-up`, `kube-down` respectively. Also updated e2e test driver to pull auth info from either a `.kubeconfig` file or a `.kubernetes_auth` with optional certs directory.

This closes #5040, and enables the following workflow
1. spin up cluster on host1 with `kube-up.sh`
2. copy `$HOME/.kube/.kubeconfig` to host2
3. use kubectl on host2 to talk to cluster

e2e tests passing on gce, gke. cc @zmerlynn, @satnam6502
