### PR TITLE
Kubelet tests broken on Macs with uppercase names

### DIFF
--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"sync"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -367,5 +368,6 @@ func GeneratePodName(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	hostname = strings.ToLower(hostname)
 	return fmt.Sprintf("%s-%s", name, hostname), nil
 }

--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -172,6 +173,7 @@ func extractFromFile(filename string) (api.BoundPod, error) {
 	if err != nil {
 		return pod, err
 	}
+	hostname = strings.ToLower(hostname)
 
 	if len(pod.UID) == 0 {
 		hasher := md5.New()

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -118,6 +119,7 @@ func TestExtractInvalidManifest(t *testing.T) {
 
 func TestExtractFromHTTP(t *testing.T) {
 	hostname, _ := os.Hostname()
+	hostname = strings.ToLower(hostname)
 
 	var testCases = []struct {
 		desc      string

--- a/pkg/util/node.go
+++ b/pkg/util/node.go
@@ -34,5 +34,5 @@ func GetHostname(hostnameOverride string) string {
 		}
 		hostname = fqdn
 	}
-	return strings.TrimSpace(string(hostname))
+	return strings.ToLower(strings.TrimSpace(string(hostname)))
 }


### PR DESCRIPTION
Hostname behavior across operating systems is inconsistent (Macs can
have uppercase host names, so can some other systems).  In general,
always strings.ToLower(os.Hostname()).
