### PR TITLE
Ignore changes to creation timestamp from clients on update

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -219,7 +219,10 @@ func ValidateObjectMetaUpdate(old, meta *api.ObjectMeta) errs.ValidationErrorLis
 	if len(meta.UID) == 0 {
 		meta.UID = old.UID
 	}
-	if meta.CreationTimestamp.IsZero() {
+	// ignore changes to timestamp
+	if old.CreationTimestamp.IsZero() {
+		old.CreationTimestamp = meta.CreationTimestamp
+	} else {
 		meta.CreationTimestamp = old.CreationTimestamp
 	}
 

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -19,6 +19,7 @@ package validation
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
@@ -50,6 +51,27 @@ func TestValidateObjectMetaCustomName(t *testing.T) {
 	}
 	if !strings.Contains(errs[0].Error(), "name-gen") {
 		t.Errorf("unexpected error message: %v", errs)
+	}
+}
+
+func TestValidateObjectMetaUpdateIgnoresCreationTimestamp(t *testing.T) {
+	if errs := ValidateObjectMetaUpdate(
+		&api.ObjectMeta{Name: "test", CreationTimestamp: util.NewTime(time.Unix(10, 0))},
+		&api.ObjectMeta{Name: "test"},
+	); len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if errs := ValidateObjectMetaUpdate(
+		&api.ObjectMeta{Name: "test"},
+		&api.ObjectMeta{Name: "test", CreationTimestamp: util.NewTime(time.Unix(10, 0))},
+	); len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if errs := ValidateObjectMetaUpdate(
+		&api.ObjectMeta{Name: "test", CreationTimestamp: util.NewTime(time.Unix(11, 0))},
+		&api.ObjectMeta{Name: "test", CreationTimestamp: util.NewTime(time.Unix(10, 0))},
+	); len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
 	}
 }
 


### PR DESCRIPTION
CreationTimestamp is not an authoritative field (like UID) so mismatches
can be safely ignored.

Fixes #5183
