### PR TITLE
Properly reap replication controllers in e2e test

### DIFF
--- a/pkg/kubectl/stop_test.go
+++ b/pkg/kubectl/stop_test.go
@@ -43,10 +43,10 @@ func TestReplicationControllerStop(t *testing.T) {
 	if s != expected {
 		t.Errorf("expected %s, got %s", expected, s)
 	}
-	if len(fake.Actions) != 4 {
+	if len(fake.Actions) != 5 {
 		t.Errorf("unexpected actions: %v, expected 4 actions (get, update, get, delete)", fake.Actions)
 	}
-	for i, action := range []string{"get", "update", "get", "delete"} {
+	for i, action := range []string{"get", "get", "update", "get", "delete"} {
 		if fake.Actions[i].Action != action+"-controller" {
 			t.Errorf("unexpected action: %v, expected %s-controller", fake.Actions[i], action)
 		}

--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	. "github.com/onsi/ginkgo"
@@ -123,13 +124,13 @@ var _ = Describe("Networking", func() {
 		defer func() {
 			defer GinkgoRecover()
 			By("Cleaning up the replication controller")
-			rc.Spec.Replicas = 0
-			rc, err = c.ReplicationControllers(ns).Update(rc)
+			// Resize the replication controller to zero to get rid of pods.
+			rcReaper, err := kubectl.ReaperFor("ReplicationController", c)
 			if err != nil {
-				Fail(fmt.Sprintf("unable to modify replica count for rc %v: %v", rc.Name, err))
+				Fail(fmt.Sprintf("unable to stop rc %v: %v", rc.Name, err))
 			}
-			if err = c.ReplicationControllers(ns).Delete(rc.Name); err != nil {
-				Fail(fmt.Sprintf("unable to delete rc %v: %v", rc.Name, err))
+			if _, err = rcReaper.Stop(ns, rc.Name); err != nil {
+				Fail(fmt.Sprintf("unable to stop rc %v: %v", rc.Name, err))
 			}
 		}()
 


### PR DESCRIPTION
1. ReplicationControllerReaper uses a resizer to bring replica count to 0. This also gives us retries if we fail to update Spec.Replicas.
2. Modifies e2e tests that use the `update->delete` pattern to invoke `stop` on the ReplicationControllerReaper instead, because `update->delete` leaks pods that interfere with subsequent tests. 
