### PR TITLE
Adding conversion functions for event field selectors

### DIFF
--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -1398,4 +1398,26 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "events",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "involvedObject.kind",
+				"involvedObject.namespace",
+				"involvedObject.uid",
+				"involvedObject.apiVersion",
+				"involvedObject.resourceVersion",
+				"involvedObject.fieldPath",
+				"reason",
+				"source":
+				return label, value, nil
+			case "involvedObject.id":
+				return "involvedObject.name", value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
 }

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -1314,4 +1314,26 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta2", "events",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "involvedObject.kind",
+				"involvedObject.namespace",
+				"involvedObject.uid",
+				"involvedObject.apiVersion",
+				"involvedObject.resourceVersion",
+				"involvedObject.fieldPath",
+				"reason",
+				"source":
+				return label, value, nil
+			case "involvedObject.id":
+				return "involvedObject.name", value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
 }

--- a/pkg/api/v1beta3/conversion.go
+++ b/pkg/api/v1beta3/conversion.go
@@ -27,11 +27,30 @@ func init() {
 	err := newer.Scheme.AddFieldLabelConversionFunc("v1beta3", "pods",
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "name":
-				fallthrough
-			case "status.phase":
-				fallthrough
-			case "spec.host":
+			case "name",
+				"status.phase",
+				"spec.host":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta3", "events",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "involvedObject.kind",
+				"involvedObject.namespace",
+				"involvedObject.name",
+				"involvedObject.uid",
+				"involvedObject.apiVersion",
+				"involvedObject.resourceVersion",
+				"involvedObject.fieldPath",
+				"reason",
+				"source":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)

--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -322,13 +322,14 @@ func (s *Scheme) Convert(in, out interface{}) error {
 // Converts the given field label and value for an apiResource field selector from
 // versioned representation to an unversioned one.
 func (s *Scheme) ConvertFieldLabel(version, apiResource, label, value string) (string, string, error) {
-	if typeFuncMap, ok := s.fieldLabelConversionFuncs[version]; ok {
-		if conversionFunc, ok := typeFuncMap[apiResource]; ok {
-			return conversionFunc(label, value)
-		}
+	if s.fieldLabelConversionFuncs[version] == nil {
+		return "", "", fmt.Errorf("No conversion function found for version: %s", version)
 	}
-	// Don't fail on types we haven't added conversion funcs for yet.
-	return label, value, nil
+	conversionFunc, ok := s.fieldLabelConversionFuncs[version][apiResource]
+	if !ok {
+		return "", "", fmt.Errorf("No conversion function found for version %s and api resource %s", version, apiResource)
+	}
+	return conversionFunc(label, value)
 }
 
 // ConvertToVersion attempts to convert an input object to its matching Kind in another


### PR DESCRIPTION
Builds on https://github.com/GoogleCloudPlatform/kubernetes/pull/4575 (which added conversion funcs for pods)
Users can now use versioned event fields and do not need to know about our internal API!

We now have conversion functions for all resources on which we support field selectors.
