### PR TITLE
Change Fluentd config to read from head of Docker container logs

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
@@ -1,6 +1,6 @@
 .PHONY:	build push
 
-TAG = 1.0
+TAG = 1.1
 
 build:	
 	sudo docker build -t kubernetes/fluentd-elasticsearch:$(TAG) .

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
@@ -40,10 +40,11 @@
   path /var/lib/docker/containers/*/*-json.log
   pos_file /var/lib/docker/containers/containers.log.pos
   time_format %Y-%m-%dT%H:%M:%S
-  tag docker.container.*
+  tag docker.*
+  read_from_head true
 </source>
 
-<match docker.container.**>
+<match docker.**>
    type elasticsearch
    log_level info
    include_tag_key true

--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.manifest
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.manifest
@@ -2,7 +2,7 @@ version: v1beta2
 id: fluentd-to-elasticsearch
 containers:
   - name: fluentd-es
-    image: kubernetes/fluentd-elasticsearch:1.0
+    image: kubernetes/fluentd-elasticsearch:1.1
     volumeMounts:
       - name: containers
         mountPath: /var/lib/docker/containers


### PR DESCRIPTION
While running my cluster level logging end to end tests I notice that the first few lines are usually missing. This PR adds a read from head directive to the Fluentd config although I still notice the very first line is still missing. The output below is for two pods each of which could be counting from 0, 1, 2, 3... but the counting is only picked up during iteration index 6. Although this PR does not fix the missing first N lines problem I hope the directive will be a stepping stone towards a solution.

```
INFO: Total: 20.000000
INFO: 0: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 7 2015-03-10 00:48:48.702746266+00:00

INFO: 1: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 9 2015-03-10 00:48:56.710035960+00:00

INFO: 2: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 11 2015-03-10 00:49:04.718418436+00:00

INFO: 3: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 9 2015-03-10 00:48:56.711546488+00:00

INFO: 4: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 12 2015-03-10 00:49:08.720993935+00:00

INFO: 5: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 11 2015-03-10 00:49:04.717348901+00:00

INFO: 6: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 12 2015-03-10 00:49:08.721981898+00:00

INFO: 7: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 13 2015-03-10 00:49:12.725510771+00:00

INFO: 8: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 8 2015-03-10 00:48:52.708255196+00:00

INFO: 9: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 6 2015-03-10 00:48:44.702998556+00:00

INFO: 10: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 8 2015-03-10 00:48:52.706961215+00:00

INFO: 11: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 10 2015-03-10 00:49:00.715169656+00:00

INFO: 12: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 14 2015-03-10 00:49:16.727805598+00:00

INFO: 13: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 15 2015-03-10 00:49:20.735325123+00:00

INFO: 14: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 6 2015-03-10 00:48:44.700425226+00:00

INFO: 15: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 7 2015-03-10 00:48:48.704457462+00:00

INFO: 16: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 10 2015-03-10 00:49:00.714103289+00:00

INFO: 17: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 13 2015-03-10 00:49:12.724629021+00:00

INFO: 18: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 14 2015-03-10 00:49:16.729011617+00:00

INFO: 19: synthlogger_255d7362_c6bf_11e4_a4cc_40a8f04fce4d 15 2015-03-10 00:49:20.731157724+00:00

INFO: Finished.
```
