### PR TITLE
Make kubectl commands return errors and centralize exit handling

### DIFF
--- a/pkg/kubectl/cmd/clusterinfo.go
+++ b/pkg/kubectl/cmd/clusterinfo.go
@@ -34,20 +34,25 @@ func (f *Factory) NewCmdClusterInfo(out io.Writer) *cobra.Command {
 		Short: "Display cluster info",
 		Long:  "Display addresses of the master and services with label kubernetes.io/cluster-service=true",
 		Run: func(cmd *cobra.Command, args []string) {
-			RunClusterInfo(f, out, cmd)
+			err := RunClusterInfo(f, out, cmd)
+			util.CheckErr(err)
 		},
 	}
 	return cmd
 }
 
-func RunClusterInfo(factory *Factory, out io.Writer, cmd *cobra.Command) {
+func RunClusterInfo(factory *Factory, out io.Writer, cmd *cobra.Command) error {
 	client, err := factory.ClientConfig(cmd)
-	util.CheckErr(err)
+	if err != nil {
+		return err
+	}
 	fmt.Fprintf(out, "Kubernetes master is running at %v\n", client.Host)
 
 	mapper, typer := factory.Object(cmd)
 	cmdNamespace, err := factory.DefaultNamespace(cmd)
-	util.CheckErr(err)
+	if err != nil {
+		return err
+	}
 
 	// TODO: use generalized labels once they are implemented (#341)
 	b := resource.NewBuilder(mapper, typer, factory.ClientMapperForCommand(cmd)).
@@ -68,6 +73,7 @@ func RunClusterInfo(factory *Factory, out io.Writer, cmd *cobra.Command) {
 		}
 		return nil
 	})
+	return nil
 
 	// TODO: consider printing more information about cluster
 }

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -34,7 +34,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -253,7 +252,9 @@ func (f *Factory) PrinterForMapping(cmd *cobra.Command, mapping *meta.RESTMappin
 	}
 	if ok {
 		clientConfig, err := f.ClientConfig(cmd)
-		cmdutil.CheckErr(err)
+		if err != nil {
+			return nil, err
+		}
 		defaultVersion := clientConfig.Version
 
 		version := cmdutil.OutputVersion(cmd, defaultVersion)
@@ -327,12 +328,6 @@ func DefaultClientConfig(flags *pflag.FlagSet) clientcmd.ClientConfig {
 	clientConfig := clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, overrides, os.Stdin)
 
 	return clientConfig
-}
-
-func usageError(cmd *cobra.Command, format string, args ...interface{}) {
-	glog.Errorf(format, args...)
-	glog.Errorf("See '%s -h' for help.", cmd.CommandPath())
-	os.Exit(1)
 }
 
 func runHelp(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -39,54 +39,67 @@ $ cat pod.json | kubectl create -f -`
 )
 
 func (f *Factory) NewCmdCreate(out io.Writer) *cobra.Command {
-	flags := &struct {
-		Filenames util.StringList
-	}{}
+	var filenames util.StringList
 	cmd := &cobra.Command{
 		Use:     "create -f filename",
 		Short:   "Create a resource by filename or stdin",
 		Long:    create_long,
 		Example: create_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			schema, err := f.Validator(cmd)
+			err := RunCreate(f, out, cmd, filenames)
 			cmdutil.CheckErr(err)
-
-			cmdNamespace, err := f.DefaultNamespace(cmd)
-			cmdutil.CheckErr(err)
-
-			mapper, typer := f.Object(cmd)
-			r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand(cmd)).
-				ContinueOnError().
-				NamespaceParam(cmdNamespace).RequireNamespace().
-				FilenameParam(flags.Filenames...).
-				Flatten().
-				Do()
-			cmdutil.CheckErr(r.Err())
-
-			count := 0
-			err = r.Visit(func(info *resource.Info) error {
-				data, err := info.Mapping.Codec.Encode(info.Object)
-				if err != nil {
-					return err
-				}
-				if err := schema.ValidateBytes(data); err != nil {
-					return err
-				}
-				obj, err := resource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, data)
-				if err != nil {
-					return err
-				}
-				count++
-				info.Refresh(obj, true)
-				fmt.Fprintf(out, "%s\n", info.Name)
-				return nil
-			})
-			cmdutil.CheckErr(err)
-			if count == 0 {
-				cmdutil.CheckErr(fmt.Errorf("no objects passed to create"))
-			}
 		},
 	}
-	cmd.Flags().VarP(&flags.Filenames, "filename", "f", "Filename, directory, or URL to file to use to create the resource")
+	cmd.Flags().VarP(&filenames, "filename", "f", "Filename, directory, or URL to file to use to create the resource")
 	return cmd
+}
+
+func RunCreate(f *Factory, out io.Writer, cmd *cobra.Command, filenames util.StringList) error {
+	schema, err := f.Validator(cmd)
+	if err != nil {
+		return err
+	}
+
+	cmdNamespace, err := f.DefaultNamespace(cmd)
+	if err != nil {
+		return err
+	}
+
+	mapper, typer := f.Object(cmd)
+	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand(cmd)).
+		ContinueOnError().
+		NamespaceParam(cmdNamespace).RequireNamespace().
+		FilenameParam(filenames...).
+		Flatten().
+		Do()
+	err = r.Err()
+	if err != nil {
+		return err
+	}
+
+	count := 0
+	err = r.Visit(func(info *resource.Info) error {
+		data, err := info.Mapping.Codec.Encode(info.Object)
+		if err != nil {
+			return err
+		}
+		if err := schema.ValidateBytes(data); err != nil {
+			return err
+		}
+		obj, err := resource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, data)
+		if err != nil {
+			return err
+		}
+		count++
+		info.Refresh(obj, true)
+		fmt.Fprintf(out, "%s\n", info.Name)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		return fmt.Errorf("no objects passed to create")
+	}
+	return nil
 }

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -33,20 +33,35 @@ func (f *Factory) NewCmdDescribe(out io.Writer) *cobra.Command {
 This command joins many API calls together to form a detailed description of a
 given resource.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdNamespace, err := f.DefaultNamespace(cmd)
+			err := RunDescribe(f, out, cmd, args)
 			util.CheckErr(err)
-
-			mapper, _ := f.Object(cmd)
-			// TODO: use resource.Builder instead
-			mapping, namespace, name := util.ResourceFromArgs(cmd, args, mapper, cmdNamespace)
-
-			describer, err := f.Describer(cmd, mapping)
-			util.CheckErr(err)
-
-			s, err := describer.Describe(namespace, name)
-			util.CheckErr(err)
-			fmt.Fprintf(out, "%s\n", s)
 		},
 	}
 	return cmd
+}
+
+func RunDescribe(f *Factory, out io.Writer, cmd *cobra.Command, args []string) error {
+	cmdNamespace, err := f.DefaultNamespace(cmd)
+	if err != nil {
+		return err
+	}
+
+	mapper, _ := f.Object(cmd)
+	// TODO: use resource.Builder instead
+	mapping, namespace, name, err := util.ResourceFromArgs(cmd, args, mapper, cmdNamespace)
+	if err != nil {
+		return err
+	}
+
+	describer, err := f.Describer(cmd, mapping)
+	if err != nil {
+		return err
+	}
+
+	s, err := describer.Describe(namespace, name)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "%s\n", s)
+	return nil
 }

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -46,59 +46,7 @@ func (f *Factory) NewCmdExposeService(out io.Writer) *cobra.Command {
 		Long:    expose_long,
 		Example: expose_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 1 {
-				usageError(cmd, "<name> is required for expose")
-			}
-
-			namespace, err := f.DefaultNamespace(cmd)
-			util.CheckErr(err)
-			client, err := f.Client(cmd)
-			util.CheckErr(err)
-
-			generatorName := util.GetFlagString(cmd, "generator")
-
-			generator, found := kubectl.Generators[generatorName]
-			if !found {
-				usageError(cmd, fmt.Sprintf("Generator: %s not found.", generator))
-			}
-			if util.GetFlagInt(cmd, "port") < 1 {
-				usageError(cmd, "--port is required and must be a positive integer.")
-			}
-			names := generator.ParamNames()
-			params := kubectl.MakeParams(cmd, names)
-			if len(util.GetFlagString(cmd, "service-name")) == 0 {
-				params["name"] = args[0]
-			} else {
-				params["name"] = util.GetFlagString(cmd, "service-name")
-			}
-			if _, found := params["selector"]; !found {
-				rc, err := client.ReplicationControllers(namespace).Get(args[0])
-				util.CheckErr(err)
-				params["selector"] = kubectl.MakeLabels(rc.Spec.Selector)
-			}
-			if util.GetFlagBool(cmd, "create-external-load-balancer") {
-				params["create-external-load-balancer"] = "true"
-			}
-
-			err = kubectl.ValidateParams(names, params)
-			util.CheckErr(err)
-
-			service, err := generator.Generate(params)
-			util.CheckErr(err)
-
-			inline := util.GetFlagString(cmd, "overrides")
-			if len(inline) > 0 {
-				service, err = util.Merge(service, inline, "Service")
-				util.CheckErr(err)
-			}
-
-			// TODO: extract this flag to a central location, when such a location exists.
-			if !util.GetFlagBool(cmd, "dry-run") {
-				service, err = client.Services(namespace).Create(service.(*api.Service))
-				util.CheckErr(err)
-			}
-
-			err = f.PrintObject(cmd, service, out)
+			err := RunExpose(f, out, cmd, args)
 			util.CheckErr(err)
 		},
 	}
@@ -114,4 +62,74 @@ func (f *Factory) NewCmdExposeService(out io.Writer) *cobra.Command {
 	cmd.Flags().String("overrides", "", "An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field.")
 	cmd.Flags().String("service-name", "", "The name for the newly created service.")
 	return cmd
+}
+
+func RunExpose(f *Factory, out io.Writer, cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return util.UsageError(cmd, "<name> is required for expose")
+	}
+
+	namespace, err := f.DefaultNamespace(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := f.Client(cmd)
+	if err != nil {
+		return err
+	}
+
+	generatorName := util.GetFlagString(cmd, "generator")
+
+	generator, found := kubectl.Generators[generatorName]
+	if !found {
+		return util.UsageError(cmd, fmt.Sprintf("Generator: %s not found.", generator))
+	}
+	if util.GetFlagInt(cmd, "port") < 1 {
+		return util.UsageError(cmd, "--port is required and must be a positive integer.")
+	}
+	names := generator.ParamNames()
+	params := kubectl.MakeParams(cmd, names)
+	if len(util.GetFlagString(cmd, "service-name")) == 0 {
+		params["name"] = args[0]
+	} else {
+		params["name"] = util.GetFlagString(cmd, "service-name")
+	}
+	if _, found := params["selector"]; !found {
+		rc, err := client.ReplicationControllers(namespace).Get(args[0])
+		if err != nil {
+			return err
+		}
+		params["selector"] = kubectl.MakeLabels(rc.Spec.Selector)
+	}
+	if util.GetFlagBool(cmd, "create-external-load-balancer") {
+		params["create-external-load-balancer"] = "true"
+	}
+
+	err = kubectl.ValidateParams(names, params)
+	if err != nil {
+		return err
+	}
+
+	service, err := generator.Generate(params)
+	if err != nil {
+		return err
+	}
+
+	inline := util.GetFlagString(cmd, "overrides")
+	if len(inline) > 0 {
+		service, err = util.Merge(service, inline, "Service")
+		if err != nil {
+			return err
+		}
+	}
+
+	// TODO: extract this flag to a central location, when such a location exists.
+	if !util.GetFlagBool(cmd, "dry-run") {
+		service, err = client.Services(namespace).Create(service.(*api.Service))
+		if err != nil {
+			return err
+		}
+	}
+
+	return f.PrintObject(cmd, service, out)
 }

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -55,38 +55,8 @@ func (f *Factory) NewCmdLabel(out io.Writer) *cobra.Command {
 		Long:    label_long,
 		Example: label_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) < 2 {
-				usageError(cmd, "<resource> <name> is required")
-			}
-			if len(args) < 3 {
-				usageError(cmd, "at least one label update is required.")
-			}
-			res := args[:2]
-			cmdNamespace, err := f.DefaultNamespace(cmd)
+			err := RunLabel(f, out, cmd, args)
 			util.CheckErr(err)
-
-			mapper, _ := f.Object(cmd)
-			// TODO: use resource.Builder instead
-			mapping, namespace, name := util.ResourceFromArgs(cmd, res, mapper, cmdNamespace)
-			client, err := f.RESTClient(cmd, mapping)
-			util.CheckErr(err)
-
-			labels, remove, err := parseLabels(args[2:])
-			util.CheckErr(err)
-			overwrite := util.GetFlagBool(cmd, "overwrite")
-			resourceVersion := util.GetFlagString(cmd, "resource-version")
-
-			obj, err := updateObject(client, mapping, namespace, name, func(obj runtime.Object) runtime.Object {
-				outObj, err := labelFunc(obj, overwrite, resourceVersion, labels, remove)
-				util.CheckErr(err)
-				return outObj
-			})
-			util.CheckErr(err)
-
-			printer, err := f.PrinterForMapping(cmd, mapping)
-			util.CheckErr(err)
-
-			printer.PrintObj(obj, out)
 		},
 	}
 	util.AddPrinterFlags(cmd)
@@ -95,7 +65,7 @@ func (f *Factory) NewCmdLabel(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func updateObject(client resource.RESTClient, mapping *meta.RESTMapping, namespace, name string, updateFn func(runtime.Object) runtime.Object) (runtime.Object, error) {
+func updateObject(client resource.RESTClient, mapping *meta.RESTMapping, namespace, name string, updateFn func(runtime.Object) (runtime.Object, error)) (runtime.Object, error) {
 	helper := resource.NewHelper(client, mapping)
 
 	obj, err := helper.Get(namespace, name)
@@ -103,7 +73,10 @@ func updateObject(client resource.RESTClient, mapping *meta.RESTMapping, namespa
 		return nil, err
 	}
 
-	obj = updateFn(obj)
+	obj, err = updateFn(obj)
+	if err != nil {
+		return nil, err
+	}
 
 	data, err := helper.Codec.Encode(obj)
 	if err != nil {
@@ -176,4 +149,55 @@ func labelFunc(obj runtime.Object, overwrite bool, resourceVersion string, label
 		meta.ResourceVersion = resourceVersion
 	}
 	return obj, nil
+}
+
+func RunLabel(f *Factory, out io.Writer, cmd *cobra.Command, args []string) error {
+	if len(args) < 2 {
+		return util.UsageError(cmd, "<resource> <name> is required")
+	}
+	if len(args) < 3 {
+		return util.UsageError(cmd, "at least one label update is required.")
+	}
+	res := args[:2]
+	cmdNamespace, err := f.DefaultNamespace(cmd)
+	if err != nil {
+		return err
+	}
+
+	mapper, _ := f.Object(cmd)
+	// TODO: use resource.Builder instead
+	mapping, namespace, name, err := util.ResourceFromArgs(cmd, res, mapper, cmdNamespace)
+	if err != nil {
+		return err
+	}
+	client, err := f.RESTClient(cmd, mapping)
+	if err != nil {
+		return err
+	}
+
+	labels, remove, err := parseLabels(args[2:])
+	if err != nil {
+		return err
+	}
+	overwrite := util.GetFlagBool(cmd, "overwrite")
+	resourceVersion := util.GetFlagString(cmd, "resource-version")
+
+	obj, err := updateObject(client, mapping, namespace, name, func(obj runtime.Object) (runtime.Object, error) {
+		outObj, err := labelFunc(obj, overwrite, resourceVersion, labels, remove)
+		if err != nil {
+			return nil, err
+		}
+		return outObj, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	printer, err := f.PrinterForMapping(cmd, mapping)
+	if err != nil {
+		return err
+	}
+
+	printer.PrintObj(obj, out)
+	return nil
 }

--- a/pkg/kubectl/cmd/log.go
+++ b/pkg/kubectl/cmd/log.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -65,60 +64,63 @@ func (f *Factory) NewCmdLog(out io.Writer) *cobra.Command {
 		Long:    "Print the logs for a container in a pod. If the pod has only one container, the container name is optional.",
 		Example: log_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) == 0 {
-				usageError(cmd, "<pod> is required for log")
-			}
-
-			if len(args) > 2 {
-				usageError(cmd, "log <pod> [<container>]")
-			}
-
-			namespace, err := f.DefaultNamespace(cmd)
-			util.CheckErr(err)
-			client, err := f.Client(cmd)
-			util.CheckErr(err)
-
-			podID := args[0]
-
-			pod, err := client.Pods(namespace).Get(podID)
-			util.CheckErr(err)
-
-			var container string
-			if len(args) == 1 {
-				if len(pod.Spec.Containers) != 1 {
-					if !util.GetFlagBool(cmd, "interactive") {
-						usageError(cmd, "<container> is required for pods with multiple containers")
-					} else {
-						container = selectContainer(pod, os.Stdin, out)
-					}
-				} else {
-					// Get logs for the only container in the pod
-					container = pod.Spec.Containers[0].Name
-				}
-			} else {
-				container = args[1]
-			}
-
-			follow := false
-			if util.GetFlagBool(cmd, "follow") {
-				follow = true
-			}
-
-			readCloser, err := client.RESTClient.Get().
-				Prefix("proxy").
-				Resource("minions").
-				Name(pod.Status.Host).
-				Suffix("containerLogs", namespace, podID, container).
-				Param("follow", strconv.FormatBool(follow)).
-				Stream()
-			util.CheckErr(err)
-
-			defer readCloser.Close()
-			_, err = io.Copy(out, readCloser)
+			err := RunLog(f, out, cmd, args)
 			util.CheckErr(err)
 		},
 	}
 	cmd.Flags().BoolP("follow", "f", false, "Specify if the logs should be streamed.")
 	cmd.Flags().Bool("interactive", true, "If true, prompt the user for input when required. Default true.")
 	return cmd
+}
+
+func RunLog(f *Factory, out io.Writer, cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return util.UsageError(cmd, "<pod> is required for log")
+	}
+
+	if len(args) > 2 {
+		return util.UsageError(cmd, "log <pod> [<container>]")
+	}
+
+	namespace, err := f.DefaultNamespace(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := f.Client(cmd)
+	if err != nil {
+		return err
+	}
+
+	podID := args[0]
+
+	pod, err := client.Pods(namespace).Get(podID)
+	if err != nil {
+		return err
+	}
+
+	var container string
+	if len(args) == 1 {
+	} else {
+		container = args[1]
+	}
+
+	follow := false
+	if util.GetFlagBool(cmd, "follow") {
+		follow = true
+	}
+
+	readCloser, err := client.RESTClient.Get().
+		Prefix("proxy").
+		Resource("minions").
+		Name(pod.Status.Host).
+		Suffix("containerLogs", namespace, podID, container).
+		Param("follow", strconv.FormatBool(follow)).
+		Stream()
+	if err != nil {
+		return err
+	}
+
+	defer readCloser.Close()
+	_, err = io.Copy(out, readCloser)
+	return err
 }

--- a/pkg/kubectl/cmd/namespace.go
+++ b/pkg/kubectl/cmd/namespace.go
@@ -17,10 +17,10 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"io"
-	"os"
 
-	"github.com/golang/glog"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
 	"github.com/spf13/cobra"
 )
 
@@ -34,8 +34,7 @@ func NewCmdNamespace(out io.Writer) *cobra.Command {
 namespace has been superceded by the context.namespace field of .kubeconfig files.  See 'kubectl config set-context --help' for more details.
 `,
 		Run: func(cmd *cobra.Command, args []string) {
-			glog.Errorln("namespace has been superceded by the context.namespace field of .kubeconfig files.  See 'kubectl config set-context --help' for more details.")
-			os.Exit(1)
+			util.CheckErr(fmt.Errorf("namespace has been superceded by the context.namespace field of .kubeconfig files.  See 'kubectl config set-context --help' for more details."))
 		},
 	}
 	return cmd

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -49,73 +49,8 @@ func (f *Factory) NewCmdRollingUpdate(out io.Writer) *cobra.Command {
 		Long:    rollingupdate_long,
 		Example: rollingupdate_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			filename := util.GetFlagString(cmd, "filename")
-			if len(filename) == 0 {
-				usageError(cmd, "Must specify filename for new controller")
-			}
-			period := util.GetFlagDuration(cmd, "update-period")
-			interval := util.GetFlagDuration(cmd, "poll-interval")
-			timeout := util.GetFlagDuration(cmd, "timeout")
-			if len(args) != 1 {
-				usageError(cmd, "Must specify the controller to update")
-			}
-			oldName := args[0]
-			schema, err := f.Validator(cmd)
+			err := RunRollingUpdate(f, out, cmd, args)
 			util.CheckErr(err)
-
-			clientConfig, err := f.ClientConfig(cmd)
-			util.CheckErr(err)
-			cmdApiVersion := clientConfig.Version
-
-			mapper, typer := f.Object(cmd)
-			// TODO: use resource.Builder instead
-			mapping, namespace, newName, data := util.ResourceFromFile(filename, typer, mapper, schema, cmdApiVersion)
-			if mapping.Kind != "ReplicationController" {
-				usageError(cmd, "%s does not specify a valid ReplicationController", filename)
-			}
-			if oldName == newName {
-				usageError(cmd, "%s cannot have the same name as the existing ReplicationController %s",
-					filename, oldName)
-			}
-
-			cmdNamespace, err := f.DefaultNamespace(cmd)
-			util.CheckErr(err)
-			// TODO: use resource.Builder instead
-			err = util.CompareNamespace(cmdNamespace, namespace)
-			util.CheckErr(err)
-
-			client, err := f.Client(cmd)
-			util.CheckErr(err)
-
-			obj, err := mapping.Codec.Decode(data)
-			util.CheckErr(err)
-			newRc := obj.(*api.ReplicationController)
-
-			updater := kubectl.NewRollingUpdater(cmdNamespace, client)
-
-			// fetch rc
-			oldRc, err := client.ReplicationControllers(cmdNamespace).Get(oldName)
-			util.CheckErr(err)
-
-			var hasLabel bool
-			for key, oldValue := range oldRc.Spec.Selector {
-				if newValue, ok := newRc.Spec.Selector[key]; ok && newValue != oldValue {
-					hasLabel = true
-					break
-				}
-			}
-			if !hasLabel {
-				usageError(cmd, "%s must specify a matching key with non-equal value in Selector for %s",
-					filename, oldName)
-			}
-			// TODO: handle resizes during rolling update
-			if newRc.Spec.Replicas == 0 {
-				newRc.Spec.Replicas = oldRc.Spec.Replicas
-			}
-			err = updater.Update(out, oldRc, newRc, period, interval, timeout)
-			util.CheckErr(err)
-
-			fmt.Fprintf(out, "%s\n", newName)
 		},
 	}
 	cmd.Flags().String("update-period", updatePeriod, `Time to wait between updating pods. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`)
@@ -123,4 +58,94 @@ func (f *Factory) NewCmdRollingUpdate(out io.Writer) *cobra.Command {
 	cmd.Flags().String("timeout", timeout, `Max time to wait for a controller to update before giving up. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`)
 	cmd.Flags().StringP("filename", "f", "", "Filename or URL to file to use to create the new controller.")
 	return cmd
+}
+
+func RunRollingUpdate(f *Factory, out io.Writer, cmd *cobra.Command, args []string) error {
+	filename := util.GetFlagString(cmd, "filename")
+	if len(filename) == 0 {
+		return util.UsageError(cmd, "Must specify filename for new controller")
+	}
+	period := util.GetFlagDuration(cmd, "update-period")
+	interval := util.GetFlagDuration(cmd, "poll-interval")
+	timeout := util.GetFlagDuration(cmd, "timeout")
+	if len(args) != 1 {
+		return util.UsageError(cmd, "Must specify the controller to update")
+	}
+	oldName := args[0]
+	schema, err := f.Validator(cmd)
+	if err != nil {
+		return err
+	}
+
+	clientConfig, err := f.ClientConfig(cmd)
+	if err != nil {
+		return err
+	}
+	cmdApiVersion := clientConfig.Version
+
+	mapper, typer := f.Object(cmd)
+	// TODO: use resource.Builder instead
+	mapping, namespace, newName, data, err := util.ResourceFromFile(filename, typer, mapper, schema, cmdApiVersion)
+	if err != nil {
+		return err
+	}
+	if mapping.Kind != "ReplicationController" {
+		return util.UsageError(cmd, "%s does not specify a valid ReplicationController", filename)
+	}
+	if oldName == newName {
+		return util.UsageError(cmd, "%s cannot have the same name as the existing ReplicationController %s",
+			filename, oldName)
+	}
+
+	cmdNamespace, err := f.DefaultNamespace(cmd)
+	if err != nil {
+		return err
+	}
+	// TODO: use resource.Builder instead
+	err = util.CompareNamespace(cmdNamespace, namespace)
+	if err != nil {
+		return err
+	}
+
+	client, err := f.Client(cmd)
+	if err != nil {
+		return err
+	}
+
+	obj, err := mapping.Codec.Decode(data)
+	if err != nil {
+		return err
+	}
+	newRc := obj.(*api.ReplicationController)
+
+	updater := kubectl.NewRollingUpdater(cmdNamespace, client)
+
+	// fetch rc
+	oldRc, err := client.ReplicationControllers(cmdNamespace).Get(oldName)
+	if err != nil {
+		return err
+	}
+
+	var hasLabel bool
+	for key, oldValue := range oldRc.Spec.Selector {
+		if newValue, ok := newRc.Spec.Selector[key]; ok && newValue != oldValue {
+			hasLabel = true
+			break
+		}
+	}
+	if !hasLabel {
+		return util.UsageError(cmd, "%s must specify a matching key with non-equal value in Selector for %s",
+			filename, oldName)
+	}
+	// TODO: handle resizes during rolling update
+	if newRc.Spec.Replicas == 0 {
+		newRc.Spec.Replicas = oldRc.Spec.Replicas
+	}
+	err = updater.Update(out, oldRc, newRc, period, interval, timeout)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "%s\n", newName)
+	return nil
 }

--- a/pkg/kubectl/cmd/version.go
+++ b/pkg/kubectl/cmd/version.go
@@ -30,17 +30,25 @@ func (f *Factory) NewCmdVersion(out io.Writer) *cobra.Command {
 		Use:   "version",
 		Short: "Print the client and server version information.",
 		Run: func(cmd *cobra.Command, args []string) {
-			if util.GetFlagBool(cmd, "client") {
-				kubectl.GetClientVersion(out)
-				return
-			}
-
-			client, err := f.Client(cmd)
+			err := RunVersion(f, out, cmd)
 			util.CheckErr(err)
-
-			kubectl.GetVersion(out, client)
 		},
 	}
 	cmd.Flags().BoolP("client", "c", false, "Client version only (no server required).")
 	return cmd
+}
+
+func RunVersion(f *Factory, out io.Writer, cmd *cobra.Command) error {
+	if util.GetFlagBool(cmd, "client") {
+		kubectl.GetClientVersion(out)
+		return nil
+	}
+
+	client, err := f.Client(cmd)
+	if err != nil {
+		return err
+	}
+
+	kubectl.GetVersion(out, client)
+	return nil
 }


### PR DESCRIPTION
Closes #2146. Gets rid of sprinkled `CheckErr` calls in `kubectl` commands. Commands now return errors, and error parsing/exit handling is done once for each command in the toplevel `Command.Run` function.

cc @smarterclayton, @ghodss, @lavalamp 
