### PR TITLE
Remove unneeded --etc_servers flags.

### DIFF
--- a/cluster/libvirt-coreos/user_data_minion.yml
+++ b/cluster/libvirt-coreos/user_data_minion.yml
@@ -16,7 +16,6 @@ coreos:
         ExecStart=/opt/kubernetes/bin/kubelet \
         --address=0.0.0.0 \
         --hostname_override=${MINION_IPS[$i]} \
-        --etcd_servers=http://127.0.0.1:4001 \
         --api_servers=http://${MASTER_IP}:8080 \
         $( [[ "$ENABLE_CLUSTER_DNS" == "true" ]] && echo "--cluster_dns=${DNS_SERVER_IP}" ) \
         $( [[ "$ENABLE_CLUSTER_DNS" == "true" ]] && echo "--cluster_domain=${DNS_DOMAIN}" ) \
@@ -38,7 +37,6 @@ coreos:
 
         [Service]
         ExecStart=/opt/kubernetes/bin/kube-proxy \
-        --etcd_servers=http://127.0.0.1:4001 \
         --master=http://${MASTER_IP}:7080
         Restart=always
         RestartSec=2


### PR DESCRIPTION
Kubelet already has --api_servers flag.
Kube-proxy already has --master flag.
