### PR TITLE
Update README to include design overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Kubernetes documentation is organized into several categories.
     - details of ```kube-proxy``` iptables
     - how to wire services to external internet
   - **Design Documentation**
-    - in [docs/design](docs/design)
+    - [Design Overview](DESIGN.md)
+    - More in [docs/design](docs/design)
     - for people who want to understand the design choices made
     - describes tradeoffs, alternative designs
     - descriptions of planned features that are too long for a github issue.


### PR DESCRIPTION
To me, DESIGN.md is the most helpful document to actually understand what Kubernetes is. I think it belongs in the main README.
