### PR TITLE
Fix network tester build error

### DIFF
--- a/contrib/for-tests/network-tester/webserver.go
+++ b/contrib/for-tests/network-tester/webserver.go
@@ -218,7 +218,7 @@ func contactOthers(state *State) {
 		}
 
 		for _, e := range endpoints.Endpoints {
-			contactSingle("http://"+e, state)
+			contactSingle("http://"+e.IP+":"+string(e.Port), state)
 		}
 
 		time.Sleep(5 * time.Second)


### PR DESCRIPTION
This probably started happening after some of the recent endpoint refactorings.

```
mbp:kubernetes sam$ go build ./...
contrib/for-tests/network-tester/webserver.go:221: invalid operation: "http://" + e (mismatched types string and api.Endpoint)
```

Further highlights the need for #1581.
