### PR TITLE
Change cloud provider CreateTCPLoadBalancer to return endpoint as string

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -720,6 +720,9 @@ type ServiceSpec struct {
 	CreateExternalLoadBalancer bool `json:"createExternalLoadBalancer,omitempty"`
 	// PublicIPs are used by external load balancers, or can be set by
 	// users to handle external traffic that arrives at a node.
+	// For load balancers, the publicIP will usually be the IP address of the load balancer,
+	// but some load balancers (notably AWS ELB) use a hostname instead of an IP address.
+	// For hostnames, the user will use a CNAME record (instead of using an A record with the IP)
 	PublicIPs []string `json:"publicIPs,omitempty"`
 
 	// ContainerPort is the name or number of the port on the container to direct traffic to.

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -47,8 +47,8 @@ type TCPLoadBalancer interface {
 	// TCPLoadBalancerExists returns whether the specified load balancer exists.
 	// TODO: Break this up into different interfaces (LB, etc) when we have more than one type of service
 	TCPLoadBalancerExists(name, region string) (bool, error)
-	// CreateTCPLoadBalancer creates a new tcp load balancer. Returns the IP address of the balancer
-	CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (net.IP, error)
+	// CreateTCPLoadBalancer creates a new tcp load balancer. Returns the IP address or hostname of the balancer
+	CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (string, error)
 	// UpdateTCPLoadBalancer updates hosts under the specified load balancer.
 	UpdateTCPLoadBalancer(name, region string, hosts []string) error
 	// DeleteTCPLoadBalancer deletes a specified load balancer.

--- a/pkg/cloudprovider/fake/fake.go
+++ b/pkg/cloudprovider/fake/fake.go
@@ -95,10 +95,10 @@ func (f *FakeCloud) TCPLoadBalancerExists(name, region string) (bool, error) {
 
 // CreateTCPLoadBalancer is a test-spy implementation of TCPLoadBalancer.CreateTCPLoadBalancer.
 // It adds an entry "create" into the internal method call record.
-func (f *FakeCloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (net.IP, error) {
+func (f *FakeCloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (string, error) {
 	f.addCall("create")
 	f.Balancers = append(f.Balancers, FakeBalancer{name, region, externalIP, port, hosts})
-	return f.ExternalIP, f.Err
+	return f.ExternalIP.String(), f.Err
 }
 
 // UpdateTCPLoadBalancer is a test-spy implementation of TCPLoadBalancer.UpdateTCPLoadBalancer.

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -222,10 +222,10 @@ func translateAffinityType(affinityType api.AffinityType) GCEAffinityType {
 }
 
 // CreateTCPLoadBalancer is an implementation of TCPLoadBalancer.CreateTCPLoadBalancer.
-func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (net.IP, error) {
+func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, port int, hosts []string, affinityType api.AffinityType) (string, error) {
 	pool, err := gce.makeTargetPool(name, region, hosts, translateAffinityType(affinityType))
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	req := &compute.ForwardingRule{
 		Name:       name,
@@ -238,17 +238,17 @@ func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.I
 	}
 	op, err := gce.service.ForwardingRules.Insert(gce.projectID, region, req).Do()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	err = gce.waitForRegionOp(op, region)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	fwd, err := gce.service.ForwardingRules.Get(gce.projectID, region, name).Do()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return net.ParseIP(fwd.IPAddress), nil
+	return fwd.IPAddress, nil
 }
 
 // UpdateTCPLoadBalancer is an implementation of TCPLoadBalancer.UpdateTCPLoadBalancer.

--- a/pkg/registry/service/rest.go
+++ b/pkg/registry/service/rest.go
@@ -272,11 +272,11 @@ func (rs *REST) createExternalLoadBalancer(ctx api.Context, service *api.Service
 			}
 		}
 	} else {
-		ip, err := balancer.CreateTCPLoadBalancer(name, zone.Region, nil, service.Spec.Port, hostsFromMinionList(hosts), affinityType)
+		endpoint, err := balancer.CreateTCPLoadBalancer(name, zone.Region, nil, service.Spec.Port, hostsFromMinionList(hosts), affinityType)
 		if err != nil {
 			return err
 		}
-		service.Spec.PublicIPs = []string{ip.String()}
+		service.Spec.PublicIPs = []string{endpoint}
 	}
 	return nil
 }


### PR DESCRIPTION
Some load balancers (particularly AWS ELB) define the public endpoint
as a hostname (instead of using IP addresses).

This is a partial fix for #5224; there will also be some proxy work.
