### PR TITLE
Switch selector parse errors to return HTTP 400 instead of the default (500)

### DIFF
--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -82,17 +82,19 @@ func GetResource(r RESTGetter, ctxFn ContextFunc, namer ScopeNamer, codec runtim
 }
 
 func parseSelectorQueryParams(query url.Values, version, apiResource string) (label, field labels.Selector, err error) {
-	label, err = labels.Parse(query.Get("labels"))
+	labelString := query.Get("labels")
+	label, err = labels.Parse(labelString)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.NewBadRequest(fmt.Sprintf("The 'labels' selector parameter (%s) could not be parsed: %v", labelString, err))
 	}
 
 	convertToInternalVersionFunc := func(label, value string) (newLabel, newValue string, err error) {
 		return api.Scheme.ConvertFieldLabel(version, apiResource, label, value)
 	}
-	field, err = labels.ParseAndTransformSelector(query.Get("fields"), convertToInternalVersionFunc)
+	fieldString := query.Get("fields")
+	field, err = labels.ParseAndTransformSelector(fieldString, convertToInternalVersionFunc)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.NewBadRequest(fmt.Sprintf("The 'fields' selector parameter (%s) could not be parsed: %v", fieldString, err))
 	}
 	return label, field, nil
 }


### PR DESCRIPTION
Closes https://github.com/GoogleCloudPlatform/kubernetes/issues/2111 in conjunction with #5054 which was submitted earlier today.

@erictune @bgrant0607 
