### PR TITLE
Update SkyDNS version

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -35,7 +35,7 @@ desiredState:
                     "-domain={{ pillar['dns_domain'] }}",
             ]
           - name: skydns
-            image: kubernetes/skydns:2014-12-23-001
+            image: kubernetes/skydns:2015-03-11-001
             command: [
                     # entrypoint = "/skydns",
                     "-machines=http://localhost:4001",


### PR DESCRIPTION
I had some trouble with the kubernetes docker image for SkyDNS being outdated. In my experience the version in `kubernetes/skydns:2014-12-23-001` will not behave correctly if it manages to startup before etcd, for details see skynetservices/skydns#142

 Updating to SkyDNS latest fixes this.
