### PR TITLE
Change PodWorkers to have desired cache.

### DIFF
--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/fsouza/go-dockerclient"
@@ -245,4 +246,8 @@ func NewFakeDockerCache(client DockerInterface) DockerCache {
 
 func (f *FakeDockerCache) RunningContainers() (DockerContainers, error) {
 	return GetKubeletDockerContainers(f.client, false)
+}
+
+func (f *FakeDockerCache) ForceUpdateIfOlder(time.Time) error {
+	return nil
 }


### PR DESCRIPTION
Whenever an update of a pod comes and per-pod goroutine is busy we cache the update (however only the last update is cached). When the per-pod goroutine finishes its work it checks whether there is any cached update that should be processed and processes it.
Thanks to this change, we don't rely on the fact that an update will be resend if we are currently processing the previous update.

/cc @vmarmol 
