### PR TITLE
Redirector.ResourceLocation shouldn't return `"", nil`

### DIFF
--- a/pkg/apiserver/proxy.go
+++ b/pkg/apiserver/proxy.go
@@ -147,12 +147,6 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		httpCode = status.Code
 		return
 	}
-	if location == "" {
-		httplog.LogOf(req, w).Addf("ResourceLocation for %v returned ''", id)
-		notFound(w, req)
-		httpCode = http.StatusNotFound
-		return
-	}
 
 	destURL, err := url.Parse(location)
 	if err != nil {


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/kubernetes/issues/3823 I'm not sure if we should log the `"", nil` case, but it doesn't make sense to return this
