### PR TITLE
Provision network before kubelet

### DIFF
--- a/cluster/saltbase/salt/kubelet/init.sls
+++ b/cluster/saltbase/salt/kubelet/init.sls
@@ -72,3 +72,6 @@ kubelet:
       - file: /etc/init.d/kubelet
 {% endif %}
       - file: /var/lib/kubelet/kubernetes_auth
+{% if pillar.get('enable_node_monitoring', '').lower() == 'true' %}
+      - file: /etc/kubernetes/manifests/cadvisor.manifest
+{% endif %}

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -6,6 +6,11 @@ base:
   'roles:kubernetes-pool':
     - match: grain
     - docker
+{% if grains['cloud'] is defined and grains['cloud'] == 'azure' %}
+    - openvpn-client
+{% else %}
+    - sdn
+{% endif %}
     - kubelet
     - kube-proxy
 {% if pillar.get('enable_node_monitoring', '').lower() == 'true' %}
@@ -20,11 +25,6 @@ base:
   {% endif %}
 {% endif %}
     - logrotate
-{% if grains['cloud'] is defined and grains['cloud'] == 'azure' %}
-    - openvpn-client
-{% else %}
-    - sdn
-{% endif %}
     - monit
 
   'roles:kubernetes-master':


### PR DESCRIPTION
Fixes #5043 

On initial setup of the minion, the kubelet would go into a fail state when the network was being defined for the first time.

Fixes the Salt ordering to execute the sdn configuration before the kubelet.

Also fixes the Kubelet to wait for the cadvisor.manifest before running if node monitoring is enabled.
