### PR TITLE
Fix event recorder not to log events without a reference

### DIFF
--- a/pkg/client/record/event.go
+++ b/pkg/client/record/event.go
@@ -197,6 +197,7 @@ func (i *recorderImpl) Event(object runtime.Object, reason, message string) {
 	ref, err := api.GetReference(object)
 	if err != nil {
 		glog.Errorf("Could not construct reference to: '%#v' due to: '%v'. Will not report event: '%v' '%v'", object, err, reason, message)
+		return
 	}
 
 	e := makeEvent(ref, reason, message)


### PR DESCRIPTION
#4974 removed a return statement that prevented panics when an ObjectReference couldn't be obtained from an object passed to `Event`.
