### PR TITLE
Modify Fluentd to ES setup to pass flags

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
@@ -34,4 +34,4 @@ RUN /usr/sbin/td-agent-gem install fluent-plugin-elasticsearch
 COPY td-agent.conf /etc/td-agent/td-agent.conf
 
 # Run the Fluentd service.
-CMD /usr/sbin/td-agent -qq > /var/log/td-agent/td-agent.log
+CMD /usr/sbin/td-agent "$FLUENTD_ARGS" > /var/log/td-agent/td-agent.log

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
@@ -1,6 +1,6 @@
 .PHONY:	build push
 
-TAG = 1.1
+TAG = 1.2
 
 build:	
 	sudo docker build -t kubernetes/fluentd-elasticsearch:$(TAG) .

--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.manifest
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.manifest
@@ -2,7 +2,10 @@ version: v1beta2
 id: fluentd-to-elasticsearch
 containers:
   - name: fluentd-es
-    image: kubernetes/fluentd-elasticsearch:1.1
+    image: kubernetes/fluentd-elasticsearch:1.2
+    env:
+      - name: FLUENTD_ARGS
+        value: -qq
     volumeMounts:
       - name: containers
         mountPath: /var/lib/docker/containers


### PR DESCRIPTION
Another change to our Fluentd to Elasticsearch setup. This makes it easier to change things like the logging level used by Fluentd which in turn makes it easier to debug problems.
