### PR TITLE
Add Docker caching support to CoreOS' clusters.

### DIFF
--- a/docs/getting-started-guides/aws/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/aws/cloud-configs/master.yaml
@@ -104,6 +104,39 @@ coreos:
         ExecStartPre=/usr/bin/chmod +x /opt/bin/flanneld
         ExecStartPre=-/usr/bin/etcdctl mk /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "vxlan"}}'
         ExecStart=/opt/bin/flanneld
+    - name: docker-cache.service
+      command: start
+      content: |
+        [Unit]
+        Description=Docker cache proxy
+        Requires=early-docker.service
+        After=early-docker.service
+        Before=early-docker.target
+
+        [Service]
+        Restart=always
+        TimeoutStartSec=0
+        RestartSec=5
+        Environment="TMPDIR=/var/tmp/"
+        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
+        ExecStartPre=-/usr/bin/docker kill docker-registry
+        ExecStartPre=-/usr/bin/docker rm docker-registry
+        ExecStartPre=/usr/bin/docker pull quay.io/devops/docker-registry:latest
+        ExecStart=/usr/bin/docker run --rm --net host --name docker-registry \
+            -e STANDALONE=false \
+            -e MIRROR_SOURCE=https://registry-1.docker.io \
+            -e MIRROR_SOURCE_INDEX=https://index.docker.io \
+            -e MIRROR_TAGS_CACHE_TTL=1800 \
+            quay.io/devops/docker-registry:latest
+    - name: docker.service
+      drop-ins:
+        - name: 51-docker-mirror.conf
+          content: |
+            [Unit]
+            Requires=docker-cache.service
+            After=docker-cache.service
+            [Service]
+            Environment=DOCKER_OPTS='--registry-mirror=http://$private_ipv4:5000'
     - name: kube-apiserver.service
       command: start
       content: |

--- a/docs/getting-started-guides/aws/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/aws/cloud-configs/master.yaml
@@ -8,6 +8,9 @@ write_files:
     #! /usr/bin/bash
     until curl http://127.0.0.1:4001/v2/machines; do sleep 2; done
 coreos:
+  fleet:
+    etcd-servers: http://localhost:4001
+    metadata: "role=master"
   units:
     - name: setup-network-environment.service
       command: start
@@ -46,27 +49,6 @@ coreos:
         --http-read-timeout 86400 \
         --peer-addr ${DEFAULT_IPV4}:7001 \
         --snapshot true
-        Restart=always
-        RestartSec=10s
-    - name: fleet.socket
-      command: start
-      content: |
-        [Socket]
-        ListenStream=/var/run/fleet.sock
-    - name: fleet.service
-      command: start
-      content: |
-        [Unit]
-        Description=fleet daemon
-        Wants=etcd.service
-        After=etcd.service
-        Wants=fleet.socket
-        After=fleet.socket
-
-        [Service]
-        Environment="FLEET_ETCD_SERVERS=http://127.0.0.1:4001"
-        Environment="FLEET_METADATA=role=master"
-        ExecStart=/usr/bin/fleetd
         Restart=always
         RestartSec=10s
     - name: etcd-waiter.service

--- a/docs/getting-started-guides/aws/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/aws/cloud-configs/node.yaml
@@ -34,20 +34,11 @@ coreos:
         ExecStart=/opt/bin/flanneld -etcd-endpoints http://<master-private-ip>:4001
     - name: docker.service
       command: start
-      content: |
-        [Unit]
-        After=flannel.service
-        Wants=flannel.service
-        Description=Docker Application Container Engine
-        Documentation=http://docs.docker.io
-
-        [Service]
-        EnvironmentFile=/run/flannel/subnet.env
-        ExecStartPre=/bin/mount --make-rprivate /
-        ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd://
-
-        [Install]
-        WantedBy=multi-user.target
+      drop-ins:
+        - name: 51-docker-mirror.conf
+          content: |
+            [Service]
+            Environment=DOCKER_OPTS='--registry-mirror=http://<master-private-ip>:5000'
     - name: setup-network-environment.service
       command: start
       content: |

--- a/docs/getting-started-guides/aws/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/aws/cloud-configs/node.yaml
@@ -1,23 +1,14 @@
 #cloud-config
 
 coreos:
+  fleet:
+    etcd-servers: http://<master-private-ip>:4001
+    metadata: "role=node"
   units:
     - name: etcd.service
       mask: true
     - name: fleet.service
       command: start
-      content: |
-        [Unit]
-        Description=fleet daemon
-        Wants=fleet.socket
-        After=fleet.socket
-
-        [Service]
-        Environment="FLEET_ETCD_SERVERS=http://<master-private-ip>:4001"
-        Environment="FLEET_METADATA=role=node"
-        ExecStart=/usr/bin/fleetd
-        Restart=always
-        RestartSec=10s
     - name: flannel.service
       command: start
       content: |

--- a/docs/getting-started-guides/coreos/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/master.yaml
@@ -104,6 +104,39 @@ coreos:
         ExecStartPre=/usr/bin/chmod +x /opt/bin/flanneld
         ExecStartPre=-/usr/bin/etcdctl mk /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "vxlan"}}'
         ExecStart=/opt/bin/flanneld
+    - name: docker-cache.service
+      command: start
+      content: |
+        [Unit]
+        Description=Docker cache proxy
+        Requires=early-docker.service
+        After=early-docker.service
+        Before=early-docker.target
+
+        [Service]
+        Restart=always
+        TimeoutStartSec=0
+        RestartSec=5
+        Environment="TMPDIR=/var/tmp/"
+        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
+        ExecStartPre=-/usr/bin/docker kill docker-registry
+        ExecStartPre=-/usr/bin/docker rm docker-registry
+        ExecStartPre=/usr/bin/docker pull quay.io/devops/docker-registry:latest
+        ExecStart=/usr/bin/docker run --rm --net host --name docker-registry \
+            -e STANDALONE=false \
+            -e MIRROR_SOURCE=https://registry-1.docker.io \
+            -e MIRROR_SOURCE_INDEX=https://index.docker.io \
+            -e MIRROR_TAGS_CACHE_TTL=1800 \
+            quay.io/devops/docker-registry:latest
+    - name: docker.service
+      drop-ins:
+        - name: 51-docker-mirror.conf
+          content: |
+            [Unit]
+            Requires=docker-cache.service
+            After=docker-cache.service
+            [Service]
+            Environment=DOCKER_OPTS='--registry-mirror=http://$private_ipv4:5000'
     - name: kube-apiserver.service
       command: start
       content: |

--- a/docs/getting-started-guides/coreos/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/master.yaml
@@ -8,6 +8,9 @@ write_files:
     #! /usr/bin/bash
     until curl http://127.0.0.1:4001/v2/machines; do sleep 2; done
 coreos:
+  fleet:
+    etcd-servers: http://localhost:4001
+    metadata: "role=master"
   units:
     - name: setup-network-environment.service
       command: start
@@ -48,27 +51,8 @@ coreos:
         --snapshot true
         Restart=always
         RestartSec=10s
-    - name: fleet.socket
-      command: start
-      content: |
-        [Socket]
-        ListenStream=/var/run/fleet.sock
     - name: fleet.service
       command: start
-      content: |
-        [Unit]
-        Description=fleet daemon
-        Wants=etcd.service
-        After=etcd.service
-        Wants=fleet.socket
-        After=fleet.socket
-
-        [Service]
-        Environment="FLEET_ETCD_SERVERS=http://127.0.0.1:4001"
-        Environment="FLEET_METADATA=role=master"
-        ExecStart=/usr/bin/fleetd
-        Restart=always
-        RestartSec=10s
     - name: etcd-waiter.service
       command: start
       content: |
@@ -159,7 +143,7 @@ coreos:
         --logtostderr=true
         Restart=always
         RestartSec=10
-    - name: kube-controller-manager.service 
+    - name: kube-controller-manager.service
       command: start
       content: |
         [Unit]

--- a/docs/getting-started-guides/coreos/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/node.yaml
@@ -22,7 +22,7 @@ coreos:
       command: start
       content: |
         [Unit]
-        After=network-online.target 
+        After=network-online.target
         Wants=network-online.target
         Description=flannel is an etcd backed overlay network for containers
 
@@ -34,20 +34,11 @@ coreos:
         ExecStart=/opt/bin/flanneld -etcd-endpoints http://<master-private-ip>:4001
     - name: docker.service
       command: start
-      content: |
-        [Unit]
-        After=flannel.service
-        Wants=flannel.service
-        Description=Docker Application Container Engine
-        Documentation=http://docs.docker.io
-
-        [Service]
-        EnvironmentFile=/run/flannel/subnet.env
-        ExecStartPre=/bin/mount --make-rprivate /
-        ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd://
-
-        [Install]
-        WantedBy=multi-user.target
+      drop-ins:
+        - name: 51-docker-mirror.conf
+          content: |
+            [Service]
+            Environment=DOCKER_OPTS='--registry-mirror=http://<master-private-ip>:5000'
     - name: setup-network-environment.service
       command: start
       content: |

--- a/docs/getting-started-guides/coreos/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/node.yaml
@@ -1,23 +1,14 @@
 #cloud-config
 
 coreos:
+  fleet:
+    etcd-servers: http://<master-private-ip>:4001
+    metadata: "role=node"
   units:
     - name: etcd.service
       mask: true
     - name: fleet.service
       command: start
-      content: |
-        [Unit]
-        Description=fleet daemon
-        Wants=fleet.socket
-        After=fleet.socket
-
-        [Service]
-        Environment="FLEET_ETCD_SERVERS=http://<master-private-ip>:4001"
-        Environment="FLEET_METADATA=role=node"
-        ExecStart=/usr/bin/fleetd
-        Restart=always
-        RestartSec=10s
     - name: flannel.service
       command: start
       content: |

--- a/docs/getting-started-guides/coreos/cloud-configs/standalone.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/standalone.yaml
@@ -49,22 +49,40 @@ coreos:
         ExecStartPre=/usr/bin/chmod +x /opt/bin/flanneld
         ExecStartPre=-/usr/bin/etcdctl mk /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "vxlan"}}'
         ExecStart=/opt/bin/flanneld
-    - name: docker.service
+    - name: docker-cache.service
       command: start
       content: |
         [Unit]
-        After=flannel.service
-        Wants=flannel.service
-        Description=Docker Application Container Engine
-        Documentation=http://docs.docker.io
+        Description=Docker cache proxy
+        Requires=early-docker.service
+        After=early-docker.service
+        Before=early-docker.target
 
         [Service]
-        EnvironmentFile=/run/flannel/subnet.env
-        ExecStartPre=/bin/mount --make-rprivate /
-        ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd://
-
-        [Install]
-        WantedBy=multi-user.target
+        Restart=always
+        TimeoutStartSec=0
+        RestartSec=5
+        Environment="TMPDIR=/var/tmp/"
+        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
+        ExecStartPre=-/usr/bin/docker kill docker-registry
+        ExecStartPre=-/usr/bin/docker rm docker-registry
+        ExecStartPre=/usr/bin/docker pull quay.io/devops/docker-registry:latest
+        ExecStart=/usr/bin/docker run --rm --net host --name docker-registry \
+            -e STANDALONE=false \
+            -e MIRROR_SOURCE=https://registry-1.docker.io \
+            -e MIRROR_SOURCE_INDEX=https://index.docker.io \
+            -e MIRROR_TAGS_CACHE_TTL=1800 \
+            quay.io/devops/docker-registry:latest
+    - name: docker.service
+      command: start
+      drop-ins:
+        - name: 51-docker-mirror.conf
+          content: |
+            [Unit]
+            Requires=docker-cache.service
+            After=docker-cache.service
+            [Service]
+            Environment=DOCKER_OPTS='--registry-mirror=http://$private_ipv4:5000'
     - name: kube-apiserver.service
       command: start
       content: |


### PR DESCRIPTION
```
a more idiomatic take on #4378. as a bonus, and to be nice on
resources, an ultra lightweight docker-registry container is
consumed.
```
