### PR TITLE
Delete target pools and forwarding rules with -q in guestbook.sh

### DIFF
--- a/hack/e2e-suite/guestbook.sh
+++ b/hack/e2e-suite/guestbook.sh
@@ -38,9 +38,10 @@ GUESTBOOK="${KUBE_ROOT}/examples/guestbook"
 function teardown() {
   ${KUBECTL} stop -f "${GUESTBOOK}"
   if [[ "${KUBERNETES_PROVIDER}" == "gce" ]]; then
-    gcloud compute forwarding-rules delete "${INSTANCE_PREFIX}-default-frontend" || true
-    gcloud compute target-pools delete "${INSTANCE_PREFIX}-default-frontend" || true
-  fi  
+    local REGION=${ZONE%-*}
+    gcloud compute forwarding-rules delete -q --region ${REGION} "${INSTANCE_PREFIX}-default-frontend" || true
+    gcloud compute target-pools delete -q --region ${REGION} "${INSTANCE_PREFIX}-default-frontend" || true
+  fi
 }
 
 prepare-e2e


### PR DESCRIPTION
Without -q gcloud prompts for confirmation before deleting rules, failing the e2e suite on local runs. This PR also adds checks for a default compute/region setting, without which gcloud will fail even with -q because it doesn't know which region to use. 
