### PR TITLE
kubelet post node status to master

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -210,7 +210,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 	nodeResources := &api.NodeResources{}
 
 	nodeController := nodeControllerPkg.NewNodeController(nil, "", machineList, nodeResources, cl, fakeKubeletClient{}, 10, 5*time.Minute)
-	nodeController.Run(5*time.Second, true, true)
+	nodeController.Run(5*time.Second, true, false)
 
 	// Kubelet (localhost)
 	testRootDir := makeTempDirOrDie("kubelet_integ_1.")

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -76,7 +76,7 @@ func NewCMServer() *CMServer {
 		NodeMilliCPU:            1000,
 		NodeMemory:              resource.MustParse("3Gi"),
 		SyncNodeList:            true,
-		SyncNodeStatus:          true,
+		SyncNodeStatus:          false,
 		KubeletConfig: client.KubeletConfig{
 			Port:        ports.KubeletPort,
 			EnableHttps: false,

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -53,6 +53,7 @@ type KubeletServer struct {
 	SyncFrequency                  time.Duration
 	FileCheckFrequency             time.Duration
 	HTTPCheckFrequency             time.Duration
+	StatusUpdateFrequency          time.Duration
 	ManifestURL                    string
 	EnableServer                   bool
 	Address                        util.IP
@@ -82,12 +83,13 @@ type KubeletServer struct {
 // NewKubeletServer will create a new KubeletServer with default values.
 func NewKubeletServer() *KubeletServer {
 	return &KubeletServer{
-		SyncFrequency:      10 * time.Second,
-		FileCheckFrequency: 20 * time.Second,
-		HTTPCheckFrequency: 20 * time.Second,
-		EnableServer:       true,
-		Address:            util.IP(net.ParseIP("127.0.0.1")),
-		Port:               ports.KubeletPort,
+		SyncFrequency:         10 * time.Second,
+		FileCheckFrequency:    20 * time.Second,
+		HTTPCheckFrequency:    20 * time.Second,
+		StatusUpdateFrequency: 20 * time.Second,
+		EnableServer:          true,
+		Address:               util.IP(net.ParseIP("127.0.0.1")),
+		Port:                  ports.KubeletPort,
 		PodInfraContainerImage:  kubelet.PodInfraContainerImage,
 		RootDirectory:           defaultRootDir,
 		RegistryBurst:           10,
@@ -104,6 +106,7 @@ func NewKubeletServer() *KubeletServer {
 func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.Config, "config", s.Config, "Path to the config file or directory of files")
 	fs.DurationVar(&s.SyncFrequency, "sync_frequency", s.SyncFrequency, "Max period between synchronizing running containers and config")
+	fs.DurationVar(&s.StatusUpdateFrequency, "status_update_frequency", s.StatusUpdateFrequency, "Duration between posting node status to master")
 	fs.DurationVar(&s.FileCheckFrequency, "file_check_frequency", s.FileCheckFrequency, "Duration between checking config files for new data")
 	fs.DurationVar(&s.HTTPCheckFrequency, "http_check_frequency", s.HTTPCheckFrequency, "Duration between checking http for new data")
 	fs.StringVar(&s.ManifestURL, "manifest_url", s.ManifestURL, "URL for accessing the container manifest")
@@ -157,6 +160,7 @@ func (s *KubeletServer) Run(_ []string) error {
 		RootDirectory:                  s.RootDirectory,
 		ConfigFile:                     s.Config,
 		ManifestURL:                    s.ManifestURL,
+		StatusUpdateFrequency:          s.StatusUpdateFrequency,
 		FileCheckFrequency:             s.FileCheckFrequency,
 		HTTPCheckFrequency:             s.HTTPCheckFrequency,
 		PodInfraContainerImage:         s.PodInfraContainerImage,
@@ -250,6 +254,7 @@ func SimpleRunKubelet(client *client.Client,
 		Address:                 util.IP(net.ParseIP(address)),
 		EnableServer:            true,
 		EnableDebuggingHandlers: true,
+		StatusUpdateFrequency:   3 * time.Second,
 		SyncFrequency:           3 * time.Second,
 		MinimumGCAge:            10 * time.Second,
 		MaxContainerCount:       5,
@@ -345,6 +350,7 @@ type KubeletConfig struct {
 	RootDirectory                  string
 	ConfigFile                     string
 	ManifestURL                    string
+	StatusUpdateFrequency          time.Duration
 	FileCheckFrequency             time.Duration
 	HTTPCheckFrequency             time.Duration
 	Hostname                       string
@@ -408,7 +414,8 @@ func createAndInitKubelet(kc *KubeletConfig, pc *config.PodConfig) (*kubelet.Kub
 		kc.VolumePlugins,
 		kc.StreamingConnectionIdleTimeout,
 		kc.Recorder,
-		cadvisorInterface)
+		cadvisorInterface,
+		kc.StatusUpdateFrequency)
 
 	if err != nil {
 		return nil, err

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -903,7 +903,7 @@ type Node struct {
 	Status NodeStatus `json:"status,omitempty"`
 }
 
-// NodeList is a list of minions.
+// NodeList is a list of nodes.
 type NodeList struct {
 	TypeMeta `json:",inline"`
 	ListMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Post node status to master (currently only NodeStatus.Conditions).   This is disabled by default, nothing will be impacted; to enable posting, we need to: 
1. set `status_update_frequency` in Kubelet to non-zero
2. set `sync_node_status` in NodeController to false

Integration test doesn't test new behaviors yet, to test it, we need to pass different params, as stated above. E.g.

```
1. kubeletapp.SimpleRunKubelet(cl, nil, &fakeDocker1, machineList[0], testRootDir, manifestURL, "127.0.0.1", 10250, api.NamespaceDefault, empty_dir.ProbeVolumePlugins(), nil, *2*)
2. nodeController.Run(5*time.Second, true, *false*)
```

Things to consider: 
1. other node status field, mostly NodeAddress.
2. issue like #5243 

Manually tested new behavior w/ integration test and e2e test, works prettly well.
