### PR TITLE
Rewrite guestbook example to use kube-dns instead of host:port

### DIFF
--- a/examples/guestbook/frontend-controller.json
+++ b/examples/guestbook/frontend-controller.json
@@ -12,7 +12,7 @@
            "id": "frontend",
            "containers": [{
              "name": "php-redis",
-             "image": "kubernetes/example-guestbook-php-redis",
+             "image": "kubernetes/example-guestbook-php-redis:v2",
              "cpu": 100,
              "memory": 50000000,
              "ports": [{"name": "http-server", "containerPort": 80}]

--- a/examples/guestbook/php-redis/index.php
+++ b/examples/guestbook/php-redis/index.php
@@ -12,21 +12,17 @@ if (isset($_GET['cmd']) === true) {
   if ($_GET['cmd'] == 'set') {
     $client = new Predis\Client([
       'scheme' => 'tcp',
-      'host'   => getenv('REDIS_MASTER_SERVICE_HOST') ?: getenv('SERVICE_HOST'),
-      'port'   => getenv('REDIS_MASTER_SERVICE_PORT'),
+      'host'   => 'redis-master',
+      'port'   => 6379,
     ]);
+    
     $client->set($_GET['key'], $_GET['value']);
     print('{"message": "Updated"}');
   } else {
-    $read_port = getenv('REDIS_MASTER_SERVICE_PORT');
-
-    if (isset($_ENV['REDISSLAVE_SERVICE_PORT'])) {
-      $read_port = getenv('REDISSLAVE_SERVICE_PORT');
-    }
     $client = new Predis\Client([
       'scheme' => 'tcp',
-      'host'   => getenv('REDIS_MASTER_SERVICE_HOST') ?: getenv('SERVICE_HOST'),
-      'port'   => $read_port,
+      'host'   => 'redis-slave',
+      'port'   => 6379,
     ]);
 
     $value = $client->get($_GET['key']);

--- a/examples/guestbook/redis-slave-controller.json
+++ b/examples/guestbook/redis-slave-controller.json
@@ -12,7 +12,7 @@
            "id": "redis-slave",
            "containers": [{
              "name": "redis-slave",
-             "image": "brendanburns/redis-slave",
+             "image": "kubernetes/redis-slave:v2",
              "cpu": 200,
              "ports": [{"containerPort": 6379}]
            }]

--- a/examples/guestbook/redis-slave-service.json
+++ b/examples/guestbook/redis-slave-service.json
@@ -1,5 +1,5 @@
 {
-  "id": "redisslave",
+  "id": "redis-slave",
   "kind": "Service",
   "apiVersion": "v1beta1",
   "port": 6379,

--- a/examples/guestbook/redis-slave/run.sh
+++ b/examples/guestbook/redis-slave/run.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-redis-server --slaveof ${REDIS_MASTER_SERVICE_HOST:-$SERVICE_HOST} $REDIS_MASTER_SERVICE_PORT
+redis-server --slaveof redis-master 6379

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -419,13 +419,13 @@ __EOF__
   kubectl create -f examples/guestbook/redis-master-service.json "${kube_flags[@]}"
   kubectl create -f examples/guestbook/redis-slave-service.json "${kube_flags[@]}"
   # Post-condition: redis-master and redis-slave services are running
-  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:redis-master:redisslave:'
+  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:redis-master:redis-slave:'
 
   ### Delete multiple services at once
   # Pre-condition: redis-master and redis-slave services are running
-  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:redis-master:redisslave:'
+  kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:redis-master:redis-slave:'
   # Command
-  kubectl delete services redis-master redisslave "${kube_flags[@]}" # delete multiple services at once
+  kubectl delete services redis-master redis-slave "${kube_flags[@]}" # delete multiple services at once
   # Post-condition: Only the default kubernetes services are running
   kube::test::get_object_assert services "{{range.items}}{{.$id_field}}:{{end}}" 'kubernetes:kubernetes-ro:'
 

--- a/pkg/kubectl/cmd/delete_test.go
+++ b/pkg/kubectl/cmd/delete_test.go
@@ -172,7 +172,7 @@ func TestDeleteDirectory(t *testing.T) {
 	cmd.Flags().Set("filename", "../../../examples/guestbook")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "frontend-controller\nfrontend\nredis-master-controller\nredis-master\nredis-slave-controller\nredisslave\n" {
+	if buf.String() != "frontend-controller\nfrontend\nredis-master-controller\nredis-master\nredis-slave-controller\nredis-slave\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }


### PR DESCRIPTION
This fixes #5091
