### PR TITLE
Do no start kube-proxy until after network is started

### DIFF
--- a/contrib/init/systemd/kube-proxy.service
+++ b/contrib/init/systemd/kube-proxy.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Kubernetes Kube-Proxy Server
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+After=network.target
 
 [Service]
 EnvironmentFile=-/etc/kubernetes/config


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1200919

The kube-proxy will die if it starts before the network.
