### PR TITLE
fixed kube-proxy starting

### DIFF
--- a/contrib/init/systemd/kube-proxy.service
+++ b/contrib/init/systemd/kube-proxy.service
@@ -2,6 +2,8 @@
 Description=Kubernetes Kube-Proxy Server
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 
+After=network.target
+
 [Service]
 EnvironmentFile=-/etc/kubernetes/config
 EnvironmentFile=-/etc/kubernetes/proxy


### PR DESCRIPTION
We need to start kube-proxy after network has been initialized
