### PR TITLE
Skip PD e2e test on non gce clusters

### DIFF
--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -55,6 +55,12 @@ var _ = Describe("PD", func() {
 	})
 
 	It("should schedule a pod w/ a RW PD, remove it, then schedule it on another host", func() {
+		if testContext.provider != "gce" {
+			By(fmt.Sprintf("Skipping PD test, which is only supported for provider gce (not %s)",
+				testContext.provider))
+			return
+		}
+
 		host0Pod := testPDPod(diskName, host0Name, false)
 		host1Pod := testPDPod(diskName, host1Name, false)
 
@@ -104,6 +110,12 @@ var _ = Describe("PD", func() {
 	})
 
 	It("should schedule a pod w/ a readonly PD on two hosts, then remove both.", func() {
+		if testContext.provider != "gce" {
+			By(fmt.Sprintf("Skipping PD test, which is only supported for provider gce (not %s)",
+				testContext.provider))
+			return
+		}
+
 		rwPod := testPDPod(diskName, host0Name, false)
 		host0ROPod := testPDPod(diskName, host0Name, true)
 		host1ROPod := testPDPod(diskName, host1Name, true)


### PR DESCRIPTION
The PD tests are very gce specific because they rely on GCEPersistentDisk and they use gcloud.
So, they should be skipped on non-gce setup.
