### PR TITLE
update --api_servers to include the protocol

### DIFF
--- a/contrib/init/systemd/environ/kubelet
+++ b/contrib/init/systemd/environ/kubelet
@@ -11,7 +11,7 @@ KUBELET_PORT="--port=10250"
 KUBELET_HOSTNAME="--hostname_override=127.0.0.1"
 
 # location of the api-server
-KUBELET_API_SERVER="--api_server=127.0.0.1:8080"
+KUBELET_API_SERVER="--api_server=http://127.0.0.1:8080"
 
 # Add your own!
 KUBELET_ARGS=""


### PR DESCRIPTION
Works:
--api_servers=127.0.0.1:8080
--api_servers=http://127.0.0.1:8080
--api_servers=http://localhost:8080

Fails:
--api_servers=localhost:8080

Include the http:// in the example, so users aren't likely to hit the
problem
