### PR TITLE
Reduce TTL for events in etcd from 48hrs to 1hr

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -87,7 +87,7 @@ func NewAPIServer() *APIServer {
 		APIBurst:               200,
 		SecurePort:             6443,
 		APIPrefix:              "/api",
-		EventTTL:               48 * time.Hour,
+		EventTTL:               1 * time.Hour,
 		AuthorizationMode:      "AlwaysAllow",
 		AdmissionControl:       "AlwaysAdmit",
 		EnableLogsSupport:      true,
@@ -136,7 +136,7 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.StorageVersion, "storage_version", s.StorageVersion, "The version to store resources with. Defaults to server preferred")
 	fs.StringVar(&s.CloudProvider, "cloud_provider", s.CloudProvider, "The provider for cloud services.  Empty string for no provider.")
 	fs.StringVar(&s.CloudConfigFile, "cloud_config", s.CloudConfigFile, "The path to the cloud provider configuration file.  Empty string for no configuration file.")
-	fs.DurationVar(&s.EventTTL, "event_ttl", s.EventTTL, "Amount of time to retain events. Default 2 days.")
+	fs.DurationVar(&s.EventTTL, "event_ttl", s.EventTTL, "Amount of time to retain events. Default 1 hour.")
 	fs.StringVar(&s.TokenAuthFile, "token_auth_file", s.TokenAuthFile, "If set, the file that will be used to secure the secure port of the API server via token authentication.")
 	fs.StringVar(&s.AuthorizationMode, "authorization_mode", s.AuthorizationMode, "Selects how to do authorization on the secure port.  One of: "+strings.Join(apiserver.AuthorizationModeChoices, ","))
 	fs.StringVar(&s.AuthorizationPolicyFile, "authorization_policy_file", s.AuthorizationPolicyFile, "File with authorization policy in csv format, used with --authorization_mode=ABAC, on the secure port.")


### PR DESCRIPTION
As the first step of the proposal in #4432, reducing the TTL of events from 48hr to 1 hr

Chart showing memory usage with tons of events and 48 hr TTL: [link](https://docs.google.com/a/google.com/spreadsheets/d/1e6GSPD4fZHCHNWwPXO2Qjq618kilF09ox_L2s9i1aGc/pubchart?oid=1030217379&format=interactive).
Chart showing memory usage with tons of events and 1 hr TTL: [link](https://docs.google.com/a/google.com/spreadsheets/d/1e6GSPD4fZHCHNWwPXO2Qjq618kilF09ox_L2s9i1aGc/pubchart?oid=1339945596&format=interactive).

Charts are shared with kubernetes-dev@googlegroups.com.
