### PR TITLE
fix goroutine leak

### DIFF
--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -392,8 +392,10 @@ type resultFunc func() (runtime.Object, error)
 // finishRequest makes a given resultFunc asynchronous and handles errors returned by the response.
 // Any api.Status object returned is considered an "error", which interrupts the normal response flow.
 func finishRequest(timeout time.Duration, fn resultFunc) (result runtime.Object, err error) {
-	ch := make(chan runtime.Object)
-	errCh := make(chan error)
+	// these channels need to be buffered to prevent the goroutine below from hanging indefinitely
+	// when the select statement reads something other than the one the goroutine sends on.
+	ch := make(chan runtime.Object, 1)
+	errCh := make(chan error, 1)
 	go func() {
 		if result, err := fn(); err != nil {
 			errCh <- err


### PR DESCRIPTION
Found this on account of #5274. I had 1496 goroutines running when apiserver crashed.
