### PR TITLE
kubelet should use --api_servers not --api_server

### DIFF
--- a/contrib/init/systemd/environ/kubelet
+++ b/contrib/init/systemd/environ/kubelet
@@ -11,7 +11,7 @@ KUBELET_PORT="--port=10250"
 KUBELET_HOSTNAME="--hostname_override=127.0.0.1"
 
 # location of the api-server
-KUBELET_API_SERVER="--api_server=http://127.0.0.1:8080"
+KUBELET_API_SERVER="--api_servers=http://127.0.0.1:8080"
 
 # Add your own!
 KUBELET_ARGS=""


### PR DESCRIPTION
(because the later is not a valid option)
