### PR TITLE
Check for server certs instead of kubecfg certs in e2e tests

### DIFF
--- a/test/e2e/certs.go
+++ b/test/e2e/certs.go
@@ -41,7 +41,7 @@ var _ = Describe("MasterCerts", func() {
 			return
 		}
 
-		for _, certFile := range []string{"kubecfg.key", "kubecfg.crt", "ca.crt"} {
+		for _, certFile := range []string{"server.key", "server.cert", "ca.crt"} {
 			cmd := exec.Command("gcloud", "compute", "ssh", "--project", testContext.gceConfig.ProjectID,
 				"--zone", testContext.gceConfig.Zone, testContext.gceConfig.MasterName,
 				"--command", fmt.Sprintf("ls /srv/kubernetes/%s", certFile))


### PR DESCRIPTION
According to make-ca-cert.sh script, the server certs and kubecfg certs are
placed in the same directory on the master.  certs.go in e2e suite should work
fine if it checks for server certs instead of kubecfg's.

This is related to PR #5113, where kubecfg certs are not present on the master.
