### PR TITLE
fixing ui url

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -21,7 +21,7 @@ Other details:
 * [API](api-conventions.md)
 * [Client libraries](client-libraries.md)
 * [Command-line interface](kubectl.md)
-* [UI](ux.md)
+* [UI](ui.md)
 * [Images and registries](images.md)
 * [Container environment](container-environment.md)
 * [Logging](logging.md)


### PR DESCRIPTION
- fixes the link on `overview` docs
