### PR TITLE
Don't use hostPort in integration test.

### DIFF
--- a/cmd/integration/controller.json
+++ b/cmd/integration/controller.json
@@ -13,7 +13,7 @@
              "containers": [{
                "name": "nginx",
                "image": "dockerfile/nginx",
-               "ports": [{"containerPort": 80, "hostPort": 8080}]
+               "ports": [{"containerPort": 80}]
              }]
            }
          },


### PR DESCRIPTION
The integration test will fail if I check in my pending PR
to remove boundPods.  Kubernetes eventually does the right
thing, but getting the integration test to check expectations
is hard because the scheduling behavior is unpredictable.

The boundPods removal is needed to fix P1 bug and speeds up
the scheduler considerably.
