### PR TITLE
Remove firewall rules for monitoring. Enable monitoring in other cluster providers

### DIFF
--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -46,7 +46,7 @@ ENABLE_DOCKER_REGISTRY_CACHE=true
 # Optional: Install node monitoring.
 ENABLE_NODE_MONITORING="${KUBE_ENABLE_NODE_MONITORING:-true}"
 
-# Optional: When set to true, heapster will be setup as part of the cluster bring up.
+# Optional: When set to true, heapster, Influxdb and Grafana will be setup as part of the cluster bring up.
 ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-true}"
 
 # Optional: Enable node logging.

--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -699,24 +699,6 @@ function restart-apiserver {
   ssh-to-node "$1" "sudo /etc/init.d/kube-apiserver restart"
 }
 
-# Setup monitoring firewalls using heapster and InfluxDB
-function setup-monitoring-firewall {
-  if [[ "${ENABLE_CLUSTER_MONITORING}" != "true" ]]; then
-    return
-  fi
-
-  # TODO: Support monitoring firewall
-  echo "Cluster monitoring setup is not (yet) supported on AWS"
-}
-
-function teardown-monitoring-firewall {
-  if [[ "${ENABLE_CLUSTER_MONITORING}" != "true" ]]; then
-    return
-  fi
-
-  # TODO: Support monitoring firewall
-}
-
 function setup-logging-firewall {
   # If logging with Fluentd to Elasticsearch is enabled then create pods
   # and services for Elasticsearch (for ingesting logs) and Kibana (for

--- a/cluster/azure/config-default.sh
+++ b/cluster/azure/config-default.sh
@@ -45,5 +45,8 @@ LOGGING_DESTINATION=elasticsearch # options: elasticsearch, gcp
 ENABLE_CLUSTER_LOGGING=false
 ELASTICSEARCH_LOGGING_REPLICAS=1
 
+# Optional: When set to true, heapster, Influxdb and grafana will be setup as part of the cluster bring up.
+ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-true}"
+
 # Admission Controllers to invoke prior to persisting objects in cluster
 ADMISSION_CONTROL=NamespaceAutoProvision,LimitRanger,ResourceQuota

--- a/cluster/azure/util.sh
+++ b/cluster/azure/util.sh
@@ -562,15 +562,6 @@ function restart-apiserver {
     ssh-to-node "$1" "sudo /etc/init.d/kube-apiserver restart"
 }
 
-# Setup monitoring using heapster and InfluxDB
-function setup-monitoring-firewall {
-    echo "not implemented"  >/dev/null
-}
-
-function teardown-monitoring-firewall {
-    echo "not implemented"  >/dev/null
-}
-
 function setup-logging-firewall {
   echo "TODO: setup logging"
 }

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -86,7 +86,7 @@ ENABLE_DOCKER_REGISTRY_CACHE=true
 # Optional: Install node monitoring.
 ENABLE_NODE_MONITORING="${KUBE_ENABLE_NODE_MONITORING:-true}"
 
-# Optional: When set to true, heapster will be setup as part of the cluster bring up.
+# Optional: When set to true, heapster, Influxdb and Grafana will be setup as part of the cluster bring up.
 ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-true}"
 
 # Optional: Enable node logging.

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -925,32 +925,6 @@ function restart-apiserver {
   ssh-to-node "$1" "sudo /etc/init.d/kube-apiserver restart"
 }
 
-# Setup monitoring firewalls using heapster and InfluxDB
-function setup-monitoring-firewall {
-  if [[ "${ENABLE_CLUSTER_MONITORING}" != "true" ]]; then
-    return
-  fi
-
-  echo "Setting up firewalls to Heapster based cluster monitoring."
-
-  detect-project
-  gcloud compute firewall-rules create "${INSTANCE_PREFIX}-monitoring-heapster" --project "${PROJECT}" \
-    --allow tcp:80 tcp:8083 tcp:8086 --target-tags="${MINION_TAG}" --network="${NETWORK}"
-
-  echo
-  echo -e "${color_green}Grafana dashboard will be available at ${color_yellow}https://${KUBE_MASTER_IP}/api/v1beta1/proxy/services/monitoring-grafana/${color_green}. Wait for the monitoring dashboard to be online.${color_norm}"
-  echo
-}
-
-function teardown-monitoring-firewall {
-  if [[ "${ENABLE_CLUSTER_MONITORING}" != "true" ]]; then
-    return
-  fi
-
-  detect-project
-  gcloud compute firewall-rules delete -q "${INSTANCE_PREFIX}-monitoring-heapster" --project "${PROJECT}" || true
-}
-
 function setup-logging-firewall {
   # If logging with Fluentd to Elasticsearch is enabled then create pods
   # and services for Elasticsearch (for ingesting logs) and Kibana (for

--- a/cluster/gke/config-default.sh
+++ b/cluster/gke/config-default.sh
@@ -29,3 +29,6 @@ LOGGING_DESTINATION=gcp # options: elasticsearch, gcp
 # Optional: When set to true, Elasticsearch and Kibana will be setup as part of the cluster bring up.
 ENABLE_CLUSTER_LOGGING=false
 ELASTICSEARCH_LOGGING_REPLICAS=1
+
+# Optional: When set to true, heapster, Influxdb and Grafana will be setup as part of the cluster bring up.
+ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-false}"

--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -114,12 +114,6 @@ function kube-up() {
     --network="${NETWORK}"
 }
 
-# Called during cluster/kube-up.sh
-function setup-monitoring-firewall() {
-  echo "... in setup-monitoring-firewall()" >&2
-  # TODO(mbforbes): This isn't currently supported in GKE.
-}
-
 # Execute prior to running tests to initialize required structure. This is
 # called from hack/e2e-go only when running -up (it is run after kube-up, so
 # the cluster already exists at this point).
@@ -259,12 +253,6 @@ function test-teardown() {
 
   # Then actually turn down the cluster.
   "${KUBE_ROOT}/cluster/kube-down.sh"
-}
-
-# Tears down monitoring.
-function teardown-monitoring-firewall() {
-  echo "... in teardown-monitoring-firewall()" >&2
-  # TODO(mbforbes): This isn't currently supported in GKE.
 }
 
 # Actually take down the cluster. This is called from test-teardown.

--- a/cluster/kube-down.sh
+++ b/cluster/kube-down.sh
@@ -27,7 +27,6 @@ source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
 echo "Bringing down cluster using provider: $KUBERNETES_PROVIDER"
 
 verify-prereqs
-teardown-monitoring-firewall
 teardown-logging-firewall
 
 kube-down

--- a/cluster/kube-up.sh
+++ b/cluster/kube-up.sh
@@ -39,9 +39,6 @@ kube-up
 echo "... calling validate-cluster" >&2
 "${KUBE_ROOT}/cluster/validate-cluster.sh"
 
-echo "... calling setup-monitoring-firewall" >&2
-setup-monitoring-firewall
-
 echo "... calling setup-logging-firewall" >&2
 setup-logging-firewall
 

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -286,14 +286,6 @@ function get-password {
   echo "TODO get-password"
 }
 
-function setup-monitoring-firewall {
-  echo "TODO" 1>&2
-}
-
-function teardown-monitoring-firewall {
-  echo "TODO" 1>&2
-}
-
 # Perform preparations required to run e2e tests
 function prepare-e2e() {
     echo "libvirt-coreos doesn't need special preparations for e2e tests" 1>&2

--- a/cluster/rackspace/config-default.sh
+++ b/cluster/rackspace/config-default.sh
@@ -49,6 +49,9 @@ LOGGING_DESTINATION=elasticsearch
 ENABLE_CLUSTER_LOGGING=false
 ELASTICSEARCH_LOGGING_REPLICAS=1
 
+# Optional: When set to true, heapster, Influxdb and Grafana will be setup as part of the cluster bring up.
+ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-true}"
+
 # Optional: Install cluster DNS.
 ENABLE_CLUSTER_DNS=true
 DNS_SERVER_IP="10.0.0.10"

--- a/cluster/rackspace/util.sh
+++ b/cluster/rackspace/util.sh
@@ -347,14 +347,6 @@ kube-up() {
   echo
 }
 
-function setup-monitoring-firewall {
-    echo "TODO"
-}
-
-function teardown-monitoring-firewall {
-  echo "TODO"
-}
-
 function setup-logging-firewall {
   echo "TODO: setup logging"
 }

--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -62,6 +62,9 @@ LOGGING_DESTINATION=elasticsearch
 ENABLE_CLUSTER_LOGGING=false
 ELASTICSEARCH_LOGGING_REPLICAS=1
 
+# Optional: When set to true, heapster, Influxdb and Grafana will be setup as part of the cluster bring up.
+ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-true}"
+
 # Extra options to set on the Docker command line.  This is useful for setting
 # --insecure-registry for local registries.
 DOCKER_OPTS=""

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -333,14 +333,6 @@ function restart-apiserver {
   ssh-to-node "$1" "sudo systemctl restart kube-apiserver"
 }
 
-function setup-monitoring-firewall {
-  echo "TODO" 1>&2
-}
-
-function teardown-monitoring-firewall {
-  echo "TODO" 1>&2
-}
-
 # Perform preparations required to run e2e tests
 function prepare-e2e() {
   echo "Vagrant doesn't need special preparations for e2e tests" 1>&2

--- a/cluster/vsphere/config-default.sh
+++ b/cluster/vsphere/config-default.sh
@@ -44,6 +44,9 @@ LOGGING_DESTINATION=elasticsearch
 ENABLE_CLUSTER_LOGGING=false
 ELASTICSEARCH_LOGGING_REPLICAS=1
 
+# Optional: When set to true, heapster, Influxdb and Grafana will be setup as part of the cluster bring up.
+ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-true}"
+
 # Optional: Install cluster DNS.
 ENABLE_CLUSTER_DNS=true
 DNS_SERVER_IP="10.244.240.240"

--- a/cluster/vsphere/util.sh
+++ b/cluster/vsphere/util.sh
@@ -479,14 +479,6 @@ function test-teardown {
 	echo "TODO"
 }
 
-function setup-monitoring-firewall {
-    echo "TODO"
-}
-
-function teardown-monitoring-firewall {
-  echo "TODO"
-}
-
 function setup-logging-firewall {
   echo "TODO: setup logging"
 }


### PR DESCRIPTION
Heapster and Grafana are now accessible via the API server proxy. There is no need for firewall rules.
This change also helps enable monitoring outside of GCE.
