### PR TITLE
Check docker unixsocket periodically through monit. If failed, restart d...

### DIFF
--- a/cluster/saltbase/salt/monit/docker
+++ b/cluster/saltbase/salt/monit/docker
@@ -3,4 +3,6 @@ group docker
 start program = "/etc/init.d/docker start"
 stop program = "/etc/init.d/docker stop"
 if does not exist then restart
-
+if failed unixsocket /var/run/docker.sock
+  protocol HTTP request "/version"
+  then restart


### PR DESCRIPTION
...ocker.

Fixed #5313. I manually tested this by removing socket file. Below is related monit log:

```
[UTC Mar 11 23:42:52] info     : 'docker' process is running with pid 25769
[UTC Mar 11 23:42:52] error    : 'docker' failed, cannot open a connection to UNIX[/var/run/docker]
[UTC Mar 11 23:42:52] info     : 'docker' trying to restart
[UTC Mar 11 23:42:52] info     : 'docker' stop: /etc/init.d/docker
[UTC Mar 11 23:42:53] info     : 'docker' start: /etc/init.d/docker
```

cc/ @zmerlynn 
