### PR TITLE
Improvements to namespace registry to align with pod model

### DIFF
--- a/pkg/api/rest/types.go
+++ b/pkg/api/rest/types.go
@@ -107,30 +107,3 @@ func (nodeStrategy) Validate(obj runtime.Object) errors.ValidationErrorList {
 	node := obj.(*api.Node)
 	return validation.ValidateMinion(node)
 }
-
-// namespaceStrategy implements behavior for nodes
-type namespaceStrategy struct {
-	runtime.ObjectTyper
-	api.NameGenerator
-}
-
-// Namespaces is the default logic that applies when creating and updating Namespace
-// objects.
-var Namespaces RESTCreateStrategy = namespaceStrategy{api.Scheme, api.SimpleNameGenerator}
-
-// NamespaceScoped is false for namespaces.
-func (namespaceStrategy) NamespaceScoped() bool {
-	return false
-}
-
-// ResetBeforeCreate clears fields that are not allowed to be set by end users on creation.
-func (namespaceStrategy) ResetBeforeCreate(obj runtime.Object) {
-	_ = obj.(*api.Namespace)
-	// Namespace allow *all* fields, including status, to be set.
-}
-
-// Validate validates a new namespace.
-func (namespaceStrategy) Validate(obj runtime.Object) errors.ValidationErrorList {
-	namespace := obj.(*api.Namespace)
-	return validation.ValidateNamespace(namespace)
-}

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1025,3 +1025,15 @@ func ValidateNamespaceUpdate(oldNamespace *api.Namespace, namespace *api.Namespa
 	}
 	return allErrs
 }
+
+// ValidateNamespaceStatusUpdate tests to see if the update is legal for an end user to make. newNamespace is updated with fields
+// that cannot be changed.
+func ValidateNamespaceStatusUpdate(newNamespace, oldNamespace *api.Namespace) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	allErrs = append(allErrs, ValidateObjectMetaUpdate(&oldNamespace.ObjectMeta, &newNamespace.ObjectMeta).Prefix("metadata")...)
+	if newNamespace.Status.Phase != oldNamespace.Status.Phase {
+		allErrs = append(allErrs, errs.NewFieldInvalid("status.phase", newNamespace.Status.Phase, "namespace phase cannot be changed directly"))
+	}
+	newNamespace.Spec = oldNamespace.Spec
+	return allErrs
+}

--- a/pkg/master/publish.go
+++ b/pkg/master/publish.go
@@ -80,7 +80,7 @@ func (m *Master) roServiceWriterLoop(stop chan struct{}) {
 // createMasterNamespaceIfNeeded will create the namespace that contains the master services if it doesn't already exist
 func (m *Master) createMasterNamespaceIfNeeded(ns string) error {
 	ctx := api.NewContext()
-	if _, err := m.namespaceRegistry.Get(ctx, api.NamespaceDefault); err == nil {
+	if _, err := m.namespaceRegistry.GetNamespace(ctx, api.NamespaceDefault); err == nil {
 		// the namespace already exists
 		return nil
 	}

--- a/pkg/registry/namespace/etcd/etcd.go
+++ b/pkg/registry/namespace/etcd/etcd.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
+	etcdgeneric "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/namespace"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// rest implements a RESTStorage for namespaces against etcd
+type REST struct {
+	store *etcdgeneric.Etcd
+}
+
+// NewREST returns a RESTStorage object that will work against namespaces
+func NewREST(h tools.EtcdHelper) *REST {
+	store := &etcdgeneric.Etcd{
+		NewFunc:     func() runtime.Object { return &api.Namespace{} },
+		NewListFunc: func() runtime.Object { return &api.NamespaceList{} },
+		KeyRootFunc: func(ctx api.Context) string {
+			return "/registry/namespaces"
+		},
+		KeyFunc: func(ctx api.Context, name string) (string, error) {
+			return "/registry/namespaces/" + name, nil
+		},
+		ObjectNameFunc: func(obj runtime.Object) (string, error) {
+			return obj.(*api.Namespace).Name, nil
+		},
+		PredicateFunc: func(label labels.Selector, field fields.Selector) generic.Matcher {
+			return namespace.MatchNamespace(label, field)
+		},
+		EndpointName: "namespaces",
+		Helper:       h,
+	}
+	store.CreateStrategy = namespace.Strategy
+	store.UpdateStrategy = namespace.Strategy
+	store.ReturnDeletedObject = true
+
+	return &REST{store: store}
+}
+
+// New returns a new object
+func (r *REST) New() runtime.Object {
+	return r.store.NewFunc()
+}
+
+// NewList returns a new list object
+func (r *REST) NewList() runtime.Object {
+	return r.store.NewListFunc()
+}
+
+// List obtains a list of namespaces with labels that match selector.
+func (r *REST) List(ctx api.Context, label labels.Selector, field fields.Selector) (runtime.Object, error) {
+	return r.store.List(ctx, label, field)
+}
+
+// Watch begins watching for new, changed, or deleted namespaces
+func (r *REST) Watch(ctx api.Context, label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return r.store.Watch(ctx, label, field, resourceVersion)
+}
+
+// Get gets a specific namespace specified by its name
+func (r *REST) Get(ctx api.Context, name string) (runtime.Object, error) {
+	return r.store.Get(ctx, name)
+}
+
+// Create creates a namespace based on a specification.
+func (r *REST) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
+	return r.store.Create(ctx, obj)
+}
+
+// Update changes a namespace specification.
+func (r *REST) Update(ctx api.Context, obj runtime.Object) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, obj)
+}
+
+// Delete deletes an existing namespace specified by its name
+func (r *REST) Delete(ctx api.Context, name string) (runtime.Object, error) {
+	return r.store.Delete(ctx, name)
+}

--- a/pkg/registry/namespace/etcd/etcd.go
+++ b/pkg/registry/namespace/etcd/etcd.go
@@ -25,12 +25,11 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/namespace"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
 // rest implements a RESTStorage for namespaces against etcd
 type REST struct {
-	store *etcdgeneric.Etcd
+	*etcdgeneric.Etcd
 }
 
 // NewREST returns a RESTStorage object that will work against namespaces
@@ -57,45 +56,5 @@ func NewREST(h tools.EtcdHelper) *REST {
 	store.UpdateStrategy = namespace.Strategy
 	store.ReturnDeletedObject = true
 
-	return &REST{store: store}
-}
-
-// New returns a new object
-func (r *REST) New() runtime.Object {
-	return r.store.NewFunc()
-}
-
-// NewList returns a new list object
-func (r *REST) NewList() runtime.Object {
-	return r.store.NewListFunc()
-}
-
-// List obtains a list of namespaces with labels that match selector.
-func (r *REST) List(ctx api.Context, label labels.Selector, field fields.Selector) (runtime.Object, error) {
-	return r.store.List(ctx, label, field)
-}
-
-// Watch begins watching for new, changed, or deleted namespaces
-func (r *REST) Watch(ctx api.Context, label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	return r.store.Watch(ctx, label, field, resourceVersion)
-}
-
-// Get gets a specific namespace specified by its name
-func (r *REST) Get(ctx api.Context, name string) (runtime.Object, error) {
-	return r.store.Get(ctx, name)
-}
-
-// Create creates a namespace based on a specification.
-func (r *REST) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
-	return r.store.Create(ctx, obj)
-}
-
-// Update changes a namespace specification.
-func (r *REST) Update(ctx api.Context, obj runtime.Object) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, obj)
-}
-
-// Delete deletes an existing namespace specified by its name
-func (r *REST) Delete(ctx api.Context, name string) (runtime.Object, error) {
-	return r.store.Delete(ctx, name)
+	return &REST{Etcd: store}
 }

--- a/pkg/registry/namespace/etcd/etcd_test.go
+++ b/pkg/registry/namespace/etcd/etcd_test.go
@@ -1,0 +1,321 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest/resttest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/namespace"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	"github.com/coreos/go-etcd/etcd"
+)
+
+func newHelper(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper) {
+	fakeEtcdClient := tools.NewFakeEtcdClient(t)
+	fakeEtcdClient.TestIndex = true
+	helper := tools.EtcdHelper{Client: fakeEtcdClient, Codec: latest.Codec, ResourceVersioner: tools.RuntimeVersionAdapter{latest.ResourceVersioner}}
+	return fakeEtcdClient, helper
+}
+
+func newStorage(t *testing.T) (*REST, *tools.FakeEtcdClient, tools.EtcdHelper) {
+	fakeEtcdClient, h := newHelper(t)
+	storage := NewREST(h)
+	return storage, fakeEtcdClient, h
+}
+
+func validNewNamespace() *api.Namespace {
+	return &api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name: "foo",
+		},
+	}
+}
+
+func validChangedNamespace() *api.Namespace {
+	namespace := validNewNamespace()
+	namespace.ResourceVersion = "1"
+	namespace.Labels = map[string]string{
+		"foo": "bar",
+	}
+	return namespace
+}
+
+func TestStorage(t *testing.T) {
+	storage, _, _ := newStorage(t)
+	namespace.NewRegistry(storage)
+}
+
+func TestCreate(t *testing.T) {
+	fakeEtcdClient, helper := newHelper(t)
+	storage := NewREST(helper)
+	test := resttest.New(t, storage, fakeEtcdClient.SetError)
+	namespace := validNewNamespace()
+	namespace.ObjectMeta = api.ObjectMeta{}
+	test.TestCreate(
+		// valid
+		namespace,
+		// invalid
+		&api.Namespace{
+			ObjectMeta: api.ObjectMeta{Namespace: "nope"},
+		},
+	)
+}
+
+func expectNamespace(t *testing.T, out runtime.Object) (*api.Namespace, bool) {
+	namespace, ok := out.(*api.Namespace)
+	if !ok || namespace == nil {
+		t.Errorf("Expected an api.Namespace object, was %#v", out)
+		return nil, false
+	}
+	return namespace, true
+}
+
+func TestCreateSetsFields(t *testing.T) {
+	fakeEtcdClient, helper := newHelper(t)
+	storage := NewREST(helper)
+	namespace := validNewNamespace()
+	_, err := storage.Create(api.NewDefaultContext(), namespace)
+	if err != fakeEtcdClient.Err {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	actual := &api.Namespace{}
+	if err := helper.ExtractObj("/registry/namespaces/foo", actual, false); err != nil {
+		t.Fatalf("unexpected extraction error: %v", err)
+	}
+	if actual.Name != namespace.Name {
+		t.Errorf("unexpected namespace: %#v", actual)
+	}
+	if len(actual.UID) == 0 {
+		t.Errorf("expected namespace UID to be set: %#v", actual)
+	}
+	if actual.Status.Phase != api.NamespaceActive {
+		t.Errorf("expected namespace phase to be set to active, but %v", actual.Status.Phase)
+	}
+}
+
+func TestListEmptyNamespaceList(t *testing.T) {
+	fakeEtcdClient, helper := newHelper(t)
+	fakeEtcdClient.ChangeIndex = 1
+	fakeEtcdClient.Data["/registry/namespaces"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{},
+		E: fakeEtcdClient.NewError(tools.EtcdErrorCodeNotFound),
+	}
+
+	storage := NewREST(helper)
+	namespaces, err := storage.List(api.NewContext(), labels.Everything(), fields.Everything())
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(namespaces.(*api.NamespaceList).Items) != 0 {
+		t.Errorf("Unexpected non-zero namespace list: %#v", namespaces)
+	}
+	if namespaces.(*api.NamespaceList).ResourceVersion != "1" {
+		t.Errorf("Unexpected resource version: %#v", namespaces)
+	}
+}
+
+func TestListNamespaceList(t *testing.T) {
+	fakeEtcdClient, helper := newHelper(t)
+	fakeEtcdClient.Data["/registry/namespaces"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{
+					{
+						Value: runtime.EncodeOrDie(latest.Codec, &api.Namespace{
+							ObjectMeta: api.ObjectMeta{Name: "foo"},
+						}),
+					},
+					{
+						Value: runtime.EncodeOrDie(latest.Codec, &api.Namespace{
+							ObjectMeta: api.ObjectMeta{Name: "bar"},
+						}),
+					},
+				},
+			},
+		},
+	}
+	storage := NewREST(helper)
+	namespacesObj, err := storage.List(api.NewDefaultContext(), labels.Everything(), fields.Everything())
+	namespaces := namespacesObj.(*api.NamespaceList)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(namespaces.Items) != 2 {
+		t.Errorf("Unexpected namespaces list: %#v", namespaces)
+	}
+	if namespaces.Items[0].Name != "foo" || namespaces.Items[0].Status.Phase != api.NamespaceActive {
+		t.Errorf("Unexpected namespace: %#v", namespaces.Items[0])
+	}
+	if namespaces.Items[1].Name != "bar" {
+		t.Errorf("Unexpected namespace: %#v", namespaces.Items[1])
+	}
+}
+
+func TestListNamespaceListSelection(t *testing.T) {
+	fakeEtcdClient, helper := newHelper(t)
+	fakeEtcdClient.Data["/registry/namespaces"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{
+					{Value: runtime.EncodeOrDie(latest.Codec, &api.Namespace{
+						ObjectMeta: api.ObjectMeta{Name: "foo"},
+					})},
+					{Value: runtime.EncodeOrDie(latest.Codec, &api.Namespace{
+						ObjectMeta: api.ObjectMeta{Name: "bar"},
+					})},
+					{Value: runtime.EncodeOrDie(latest.Codec, &api.Namespace{
+						ObjectMeta: api.ObjectMeta{Name: "baz"},
+						Status:     api.NamespaceStatus{Phase: api.NamespaceTerminating},
+					})},
+					{Value: runtime.EncodeOrDie(latest.Codec, &api.Namespace{
+						ObjectMeta: api.ObjectMeta{
+							Name:   "qux",
+							Labels: map[string]string{"label": "qux"},
+						},
+					})},
+					{Value: runtime.EncodeOrDie(latest.Codec, &api.Namespace{
+						ObjectMeta: api.ObjectMeta{Name: "zot"},
+					})},
+				},
+			},
+		},
+	}
+	storage := NewREST(helper)
+	ctx := api.NewDefaultContext()
+	table := []struct {
+		label, field string
+		expectedIDs  util.StringSet
+	}{
+		{
+			expectedIDs: util.NewStringSet("foo", "bar", "baz", "qux", "zot"),
+		}, {
+			field:       "name=zot",
+			expectedIDs: util.NewStringSet("zot"),
+		}, {
+			label:       "label=qux",
+			expectedIDs: util.NewStringSet("qux"),
+		}, {
+			field:       "status.phase=Terminating",
+			expectedIDs: util.NewStringSet("baz"),
+		},
+	}
+
+	for index, item := range table {
+		label, err := labels.Parse(item.label)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
+		field, err := fields.ParseSelector(item.field)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
+		namespacesObj, err := storage.List(ctx, label, field)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		namespaces := namespacesObj.(*api.NamespaceList)
+
+		set := util.NewStringSet()
+		for i := range namespaces.Items {
+			set.Insert(namespaces.Items[i].Name)
+		}
+		if e, a := len(item.expectedIDs), len(set); e != a {
+			t.Errorf("%v: Expected %v, got %v", index, item.expectedIDs, set)
+		}
+	}
+}
+
+func TestNamespaceDecode(t *testing.T) {
+	storage := NewREST(tools.EtcdHelper{})
+	expected := validNewNamespace()
+	expected.Status.Phase = api.NamespaceActive
+	body, err := latest.Codec.Encode(expected)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	actual := storage.New()
+	if err := latest.Codec.DecodeInto(body, actual); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !api.Semantic.DeepEqual(expected, actual) {
+		t.Errorf("mismatch: %s", util.ObjectDiff(expected, actual))
+	}
+}
+
+func TestGet(t *testing.T) {
+	expect := validNewNamespace()
+	expect.Status.Phase = api.NamespaceActive
+	fakeEtcdClient, helper := newHelper(t)
+	fakeEtcdClient.Data["/registry/namespaces/foo"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Value: runtime.EncodeOrDie(latest.Codec, expect),
+			},
+		},
+	}
+	storage := NewREST(helper)
+	obj, err := storage.Get(api.NewContext(), "foo")
+	namespace := obj.(*api.Namespace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expect.Status.Phase = api.NamespaceActive
+	if e, a := expect, namespace; !api.Semantic.DeepEqual(e, a) {
+		t.Errorf("Unexpected namespace: %s", util.ObjectDiff(e, a))
+	}
+}
+
+func TestDeleteNamespace(t *testing.T) {
+	fakeEtcdClient, helper := newHelper(t)
+	fakeEtcdClient.ChangeIndex = 1
+	fakeEtcdClient.Data["/registry/namespaces/foo"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Value: runtime.EncodeOrDie(latest.Codec, &api.Namespace{
+					ObjectMeta: api.ObjectMeta{
+						Name: "foo",
+					},
+					Status: api.NamespaceStatus{Phase: api.NamespaceActive},
+				}),
+				ModifiedIndex: 1,
+				CreatedIndex:  1,
+			},
+		},
+	}
+	storage := NewREST(helper)
+	_, err := storage.Delete(api.NewDefaultContext(), "foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// TODO: when we add life-cycle, this will go to Terminating, and then we need to test Terminating to gone
+}

--- a/pkg/registry/namespace/rest.go
+++ b/pkg/registry/namespace/rest.go
@@ -38,7 +38,7 @@ type namespaceStrategy struct {
 // objects via the REST API.
 var Strategy = namespaceStrategy{api.Scheme, api.SimpleNameGenerator}
 
-// NamespaceScoped is true for namespaces.
+// NamespaceScoped is false for namespaces.
 func (namespaceStrategy) NamespaceScoped() bool {
 	return false
 }

--- a/pkg/registry/namespace/rest_test.go
+++ b/pkg/registry/namespace/rest_test.go
@@ -17,169 +17,24 @@ limitations under the License.
 package namespace
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
-type testRegistry struct {
-	*registrytest.GenericRegistry
-}
-
-func NewTestREST() (testRegistry, *REST) {
-	reg := testRegistry{registrytest.NewGeneric(nil)}
-	return reg, NewREST(reg)
-}
-
-func testNamespace(name string) *api.Namespace {
-	return &api.Namespace{
-		ObjectMeta: api.ObjectMeta{
-			Name: name,
-		},
+func TestNamespaceStrategy(t *testing.T) {
+	if Strategy.NamespaceScoped() {
+		t.Errorf("Namespaces should not be namespace scoped")
 	}
-}
-
-func TestRESTCreate(t *testing.T) {
-	table := []struct {
-		ctx       api.Context
-		namespace *api.Namespace
-		valid     bool
-	}{
-		{
-			ctx:       api.NewContext(),
-			namespace: testNamespace("foo"),
-			valid:     true,
-		}, {
-			ctx:       api.NewContext(),
-			namespace: testNamespace("bar"),
-			valid:     true,
-		},
+	if Strategy.AllowCreateOnUpdate() {
+		t.Errorf("Namespaces should not allow create on update")
 	}
-
-	for _, item := range table {
-		_, rest := NewTestREST()
-		c, err := rest.Create(item.ctx, item.namespace)
-		if !item.valid {
-			if err == nil {
-				t.Errorf("unexpected non-error for %v", item.namespace.Name)
-			}
-			continue
-		}
-		if err != nil {
-			t.Errorf("%v: Unexpected error %v", item.namespace.Name, err)
-			continue
-		}
-		if !api.HasObjectMetaSystemFieldValues(&item.namespace.ObjectMeta) {
-			t.Errorf("storage did not populate object meta field values")
-		}
-		if e, a := item.namespace, c; !reflect.DeepEqual(e, a) {
-			t.Errorf("diff: %s", util.ObjectDiff(e, a))
-		}
-		// Ensure we implement the interface
-		_ = apiserver.ResourceWatcher(rest)
+	namespace := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		Status:     api.NamespaceStatus{Phase: api.NamespaceTerminating},
 	}
-}
-
-func TestRESTUpdate(t *testing.T) {
-	_, rest := NewTestREST()
-	namespaceA := testNamespace("foo")
-	_, err := rest.Create(api.NewDefaultContext(), namespaceA)
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-	got, err := rest.Get(api.NewDefaultContext(), namespaceA.Name)
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-	if e, a := namespaceA, got; !reflect.DeepEqual(e, a) {
-		t.Errorf("diff: %s", util.ObjectDiff(e, a))
-	}
-	namespaceB := testNamespace("foo")
-	_, _, err = rest.Update(api.NewDefaultContext(), namespaceB)
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-	got2, err := rest.Get(api.NewDefaultContext(), namespaceB.Name)
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-	if e, a := namespaceB, got2; !reflect.DeepEqual(e, a) {
-		t.Errorf("diff: %s", util.ObjectDiff(e, a))
-	}
-
-}
-
-func TestRESTDelete(t *testing.T) {
-	_, rest := NewTestREST()
-	namespaceA := testNamespace("foo")
-	_, err := rest.Create(api.NewContext(), namespaceA)
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-	c, err := rest.Delete(api.NewContext(), namespaceA.Name)
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-	if stat := c.(*api.Status); stat.Status != api.StatusSuccess {
-		t.Errorf("unexpected status: %v", stat)
-	}
-}
-
-func TestRESTGet(t *testing.T) {
-	_, rest := NewTestREST()
-	namespaceA := testNamespace("foo")
-	_, err := rest.Create(api.NewContext(), namespaceA)
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-	got, err := rest.Get(api.NewContext(), namespaceA.Name)
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-	if e, a := namespaceA, got; !reflect.DeepEqual(e, a) {
-		t.Errorf("diff: %s", util.ObjectDiff(e, a))
-	}
-}
-
-func TestRESTList(t *testing.T) {
-	reg, rest := NewTestREST()
-	namespaceA := testNamespace("foo")
-	namespaceB := testNamespace("bar")
-	namespaceC := testNamespace("baz")
-	reg.ObjectList = &api.NamespaceList{
-		Items: []api.Namespace{*namespaceA, *namespaceB, *namespaceC},
-	}
-	got, err := rest.List(api.NewContext(), labels.Everything(), fields.Everything())
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-	expect := &api.NamespaceList{
-		Items: []api.Namespace{*namespaceA, *namespaceB, *namespaceC},
-	}
-	if e, a := expect, got; !reflect.DeepEqual(e, a) {
-		t.Errorf("diff: %s", util.ObjectDiff(e, a))
-	}
-}
-
-func TestRESTWatch(t *testing.T) {
-	namespaceA := testNamespace("foo")
-	reg, rest := NewTestREST()
-	wi, err := rest.Watch(api.NewContext(), labels.Everything(), fields.Everything(), "0")
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-	go func() {
-		reg.Broadcaster.Action(watch.Added, namespaceA)
-	}()
-	got := <-wi.ResultChan()
-	if e, a := namespaceA, got.Object; !reflect.DeepEqual(e, a) {
-		t.Errorf("diff: %s", util.ObjectDiff(e, a))
+	Strategy.ResetBeforeCreate(namespace)
+	if namespace.Status.Phase != api.NamespaceActive {
+		t.Errorf("Namespaces do not allow setting phase on create")
 	}
 }


### PR DESCRIPTION
This is more clean-up to the namespace registry implementation that is a prerequisite to me adding more control-plane operations around namespace lifecycle.

This updates the namespace implementation to align with what was done for pods.

/cc @smarterclayton 
