### PR TITLE
Don't check status of a failed delete operation

### DIFF
--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -284,6 +284,7 @@ func (gce *GCECloud) DeleteTCPLoadBalancer(name, region string) error {
 	op, err = gce.service.TargetPools.Delete(gce.projectID, region, name).Do()
 	if err != nil {
 		glog.Warningln("Failed to delete Target Pool %s, got error %s.", name, err.Error())
+		return err
 	}
 	err = gce.waitForRegionOp(op, region)
 	if err != nil {


### PR DESCRIPTION
Since compute.Do() can return (nil, error), I think things are pretty much up in the air when the error in that tuple is not nil. Stack trace available: https://github.com/GoogleCloudPlatform/kubernetes/issues/5374.
