### PR TITLE
Infer KUBERNETES_MASTER from hostname rather than requiring it to be explicit

### DIFF
--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -66,6 +66,13 @@ for k,v in yaml.load(sys.stdin).iteritems():
     done
   fi
 
+  # Infer master status from presence in node pool
+  if [[ $(hostname) = ${NODE_INSTANCE_PREFIX}* ]]; then
+    KUBERNETES_MASTER="false"
+  else
+    KUBERNETES_MASTER="true"
+  fi
+
   if [[ "${KUBERNETES_MASTER}" == "true" ]]; then
     # TODO(zmerlynn): This block of code should disappear once #4561 & #4562 are done
     if [[ -z "${KUBERNETES_NODE_NAMES:-}" ]]; then

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -435,7 +435,6 @@ function build-kube-env {
   rm -f ${file}
   cat >$file <<EOF
 ENV_TIMESTAMP: $(yaml-quote $(date -uIs))
-KUBERNETES_MASTER: $(yaml-quote ${master})
 INSTANCE_PREFIX: $(yaml-quote ${INSTANCE_PREFIX})
 NODE_INSTANCE_PREFIX: $(yaml-quote ${NODE_INSTANCE_PREFIX})
 SERVER_BINARY_TAR_URL: $(yaml-quote ${SERVER_BINARY_TAR_URL})


### PR DESCRIPTION
This allows GKE to have the same YAML on both the master and nodes
