### PR TITLE
Sync static pods from Kubelet to the API server

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -244,7 +244,8 @@ func SimpleRunKubelet(client *client.Client,
 	masterServiceNamespace string,
 	volumePlugins []volume.Plugin,
 	tlsOptions *kubelet.TLSOptions,
-	cadvisorInterface cadvisor.Interface) {
+	cadvisorInterface cadvisor.Interface,
+	configFilePath string) {
 	kcfg := KubeletConfig{
 		KubeClient:             client,
 		DockerClient:           dockerClient,
@@ -264,6 +265,7 @@ func SimpleRunKubelet(client *client.Client,
 		VolumePlugins:           volumePlugins,
 		TLSOptions:              tlsOptions,
 		CadvisorInterface:       cadvisorInterface,
+		ConfigFile:              configFilePath,
 	}
 	RunKubelet(&kcfg)
 }

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -151,7 +151,7 @@ func startComponents(etcdClient tools.EtcdClient, cl *client.Client, addr net.IP
 	if err != nil {
 		glog.Fatalf("Failed to create cAdvisor: %v", err)
 	}
-	kubeletapp.SimpleRunKubelet(cl, dockerClient, machineList[0], "/tmp/kubernetes", "", "127.0.0.1", 10250, *masterServiceNamespace, kubeletapp.ProbeVolumePlugins(), nil, cadvisorInterface)
+	kubeletapp.SimpleRunKubelet(cl, dockerClient, machineList[0], "/tmp/kubernetes", "", "127.0.0.1", 10250, *masterServiceNamespace, kubeletapp.ProbeVolumePlugins(), nil, cadvisorInterface, "")
 }
 
 func newApiClient(addr net.IP, port int) *client.Client {

--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -206,7 +206,7 @@ func extractFromFile(filename string) (api.Pod, error) {
 	if glog.V(4) {
 		glog.Infof("Got pod from file %q: %#v", filename, pod)
 	} else {
-		glog.V(1).Infof("Got pod from file %q: %s.%s (%s)", filename, pod.Namespace, pod.Name, pod.UID)
+		glog.V(5).Infof("Got pod from file %q: %s.%s (%s)", filename, pod.Namespace, pod.Name, pod.UID)
 	}
 	return pod, nil
 }

--- a/pkg/kubelet/mirror_manager.go
+++ b/pkg/kubelet/mirror_manager.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/golang/glog"
+)
+
+// Kubelet discover pod updates from 3 sources: file, http, and apiserver.
+// Pods from non-apiserver sources are called static pods, and API server is
+// not aware of the existence of static pods. In order to monitor the status of
+// such pods, kubelet create a mirror pod for each static pod via the API
+// server.
+//
+// A mirror pod has the same pod full name (name and namespace) as its static
+// counterpart (albeit different metadata such as UID, etc). By leveraging the
+// fact that kubelet reports the pod status using the pod full name, the status
+// of the mirror pod always reflects the acutal status of the static pod.
+// When a static pod gets deleted, the associated orphaned mirror pods will
+// also be removed.
+//
+// This file includes functions to manage the mirror pods.
+
+type mirrorManager interface {
+	CreateMirrorPod(api.Pod, string) error
+	DeleteMirrorPod(string) error
+}
+
+type basicMirrorManager struct {
+	// mirror pods are stored in the kubelet directly because they need to be
+	// in sync with the internal pods.
+	apiserverClient client.Interface
+}
+
+func newBasicMirrorManager(apiserverClient client.Interface) *basicMirrorManager {
+	return &basicMirrorManager{apiserverClient: apiserverClient}
+}
+
+// Creates a mirror pod.
+func (self *basicMirrorManager) CreateMirrorPod(pod api.Pod, hostname string) error {
+	if self.apiserverClient == nil {
+		return nil
+	}
+	// Indicate that the pod should be scheduled to the current node.
+	pod.Spec.Host = hostname
+	pod.Annotations[ConfigMirrorAnnotationKey] = MirrorType
+
+	_, err := self.apiserverClient.Pods(NamespaceDefault).Create(&pod)
+	return err
+}
+
+// Deletes a mirror pod.
+func (self *basicMirrorManager) DeleteMirrorPod(podFullName string) error {
+	if self.apiserverClient == nil {
+		return nil
+	}
+	name, namespace, err := ParsePodFullName(podFullName)
+	if err != nil {
+		glog.Errorf("Failed to parse a pod full name %q", podFullName)
+		return err
+	}
+	glog.V(4).Infof("Deleting a mirror pod %q", podFullName)
+	if err := self.apiserverClient.Pods(namespace).Delete(name); err != nil {
+		glog.Errorf("Failed deleting a mirror pod %q: %v", podFullName, err)
+	}
+	return nil
+}
+
+// Delete all orphaned mirror pods.
+func deleteOrphanedMirrorPods(pods []api.Pod, mirrorPods util.StringSet, manager mirrorManager) {
+	existingPods := util.NewStringSet()
+	for _, pod := range pods {
+		existingPods.Insert(GetPodFullName(&pod))
+	}
+	for podFullName := range mirrorPods {
+		if !existingPods.Has(podFullName) {
+			manager.DeleteMirrorPod(podFullName)
+		}
+	}
+}
+
+// Helper functions.
+func getPodSource(pod *api.Pod) (string, error) {
+	if pod.Annotations != nil {
+		if source, ok := pod.Annotations[ConfigSourceAnnotationKey]; ok {
+			return source, nil
+		}
+	}
+	return "", fmt.Errorf("cannot get source of pod %q", pod.UID)
+}
+
+func isStaticPod(pod *api.Pod) bool {
+	source, err := getPodSource(pod)
+	return err == nil && source != ApiserverSource
+}
+
+func isMirrorPod(pod *api.Pod) bool {
+	if value, ok := pod.Annotations[ConfigMirrorAnnotationKey]; !ok {
+		return false
+	} else {
+		return value == MirrorType
+	}
+}
+
+// This function separate the mirror pods from regular pods to
+// facilitate pods syncing and mirror pod creation/deletion.
+func filterAndCategorizePods(pods []api.Pod) ([]api.Pod, util.StringSet) {
+	filteredPods := []api.Pod{}
+	mirrorPods := util.NewStringSet()
+	for _, pod := range pods {
+		name := GetPodFullName(&pod)
+		if isMirrorPod(&pod) {
+			mirrorPods.Insert(name)
+		} else {
+			filteredPods = append(filteredPods, pod)
+		}
+	}
+	return filteredPods, mirrorPods
+}

--- a/pkg/kubelet/mirror_manager_test.go
+++ b/pkg/kubelet/mirror_manager_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+type fakeMirrorManager struct {
+	mirrorPodLock sync.RWMutex
+	// Note that a real mirror manager does not store the mirror pods in
+	// itself. This fake manager does this to track calls.
+	mirrorPods   util.StringSet
+	createCounts map[string]int
+	deleteCounts map[string]int
+}
+
+func (self *fakeMirrorManager) CreateMirrorPod(pod api.Pod, _ string) error {
+	self.mirrorPodLock.Lock()
+	defer self.mirrorPodLock.Unlock()
+	podFullName := GetPodFullName(&pod)
+	self.mirrorPods.Insert(podFullName)
+	self.createCounts[podFullName]++
+	return nil
+}
+
+func (self *fakeMirrorManager) DeleteMirrorPod(podFullName string) error {
+	self.mirrorPodLock.Lock()
+	defer self.mirrorPodLock.Unlock()
+	self.mirrorPods.Delete(podFullName)
+	self.deleteCounts[podFullName]++
+	return nil
+}
+
+func newFakeMirrorMananger() *fakeMirrorManager {
+	m := fakeMirrorManager{}
+	m.mirrorPods = util.NewStringSet()
+	m.createCounts = make(map[string]int)
+	m.deleteCounts = make(map[string]int)
+	return &m
+}
+
+func (self *fakeMirrorManager) HasPod(podFullName string) bool {
+	self.mirrorPodLock.RLock()
+	defer self.mirrorPodLock.RUnlock()
+	return self.mirrorPods.Has(podFullName)
+}
+
+func (self *fakeMirrorManager) NumOfPods() int {
+	self.mirrorPodLock.RLock()
+	defer self.mirrorPodLock.RUnlock()
+	return self.mirrorPods.Len()
+}
+
+func (self *fakeMirrorManager) GetPods() []string {
+	self.mirrorPodLock.RLock()
+	defer self.mirrorPodLock.RUnlock()
+	return self.mirrorPods.List()
+}
+
+func (self *fakeMirrorManager) GetCounts(podFullName string) (int, int) {
+	self.mirrorPodLock.RLock()
+	defer self.mirrorPodLock.RUnlock()
+	return self.createCounts[podFullName], self.deleteCounts[podFullName]
+}
+
+// Tests that mirror pods are filtered out properly from the pod update.
+func TestFilterOutMirrorPods(t *testing.T) {
+	mirrorPod := api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			UID:       "987654321",
+			Name:      "bar",
+			Namespace: "default",
+			Annotations: map[string]string{
+				ConfigSourceAnnotationKey: "api",
+				ConfigMirrorAnnotationKey: "mirror",
+			},
+		},
+	}
+	staticPod := api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			UID:         "123456789",
+			Name:        "bar",
+			Namespace:   "default",
+			Annotations: map[string]string{ConfigSourceAnnotationKey: "file"},
+		},
+	}
+
+	expectedPods := []api.Pod{
+		{
+			ObjectMeta: api.ObjectMeta{
+				UID:         "999999999",
+				Name:        "taco",
+				Namespace:   "default",
+				Annotations: map[string]string{ConfigSourceAnnotationKey: "api"},
+			},
+		},
+		staticPod,
+	}
+	updates := append(expectedPods, mirrorPod)
+	actualPods, actualMirrorPods := filterAndCategorizePods(updates)
+	if !reflect.DeepEqual(expectedPods, actualPods) {
+		t.Errorf("expected %#v, got %#v", expectedPods, actualPods)
+	}
+	if !actualMirrorPods.Has(GetPodFullName(&mirrorPod)) {
+		t.Errorf("mirror pod is not recorded")
+	}
+}
+
+func TestParsePodFullName(t *testing.T) {
+	type nameTuple struct {
+		Name      string
+		Namespace string
+	}
+	successfulCases := map[string]nameTuple{
+		"bar_foo":         {Name: "bar", Namespace: "foo"},
+		"bar.org_foo.com": {Name: "bar.org", Namespace: "foo.com"},
+		"bar-bar_foo":     {Name: "bar-bar", Namespace: "foo"},
+	}
+	failedCases := []string{"barfoo", "bar_foo_foo", ""}
+
+	for podFullName, expected := range successfulCases {
+		name, namespace, err := ParsePodFullName(podFullName)
+		if err != nil {
+			t.Errorf("unexpected error when parsing the full name: %v", err)
+			continue
+		}
+		if name != expected.Name || namespace != expected.Namespace {
+			t.Errorf("expected name %q, namespace %q; got name %q, namespace %q",
+				expected.Name, expected.Namespace, name, namespace)
+		}
+	}
+	for _, podFullName := range failedCases {
+		_, _, err := ParsePodFullName(podFullName)
+		if err == nil {
+			t.Errorf("expected error when parsing the full name, got none")
+		}
+	}
+}

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -46,7 +46,7 @@ func createPodWorkers() (*podWorkers, map[types.UID][]string) {
 
 	podWorkers := newPodWorkers(
 		fakeDockerCache,
-		func(pod *api.Pod, containers dockertools.DockerContainers) error {
+		func(pod *api.Pod, hasMirrorPod bool, containers dockertools.DockerContainers) error {
 			func() {
 				lock.Lock()
 				defer lock.Unlock()
@@ -54,7 +54,8 @@ func createPodWorkers() (*podWorkers, map[types.UID][]string) {
 			}()
 			return nil
 		},
-		recorder)
+		recorder,
+	)
 	return podWorkers, processed
 }
 
@@ -82,7 +83,7 @@ func TestUpdatePod(t *testing.T) {
 	numPods := 20
 	for i := 0; i < numPods; i++ {
 		for j := i; j < numPods; j++ {
-			podWorkers.UpdatePod(newPod(string(j), string(i)), func() {})
+			podWorkers.UpdatePod(newPod(string(j), string(i)), false, func() {})
 		}
 	}
 	drainWorkers(podWorkers, numPods)
@@ -115,7 +116,7 @@ func TestForgetNonExistingPodWorkers(t *testing.T) {
 
 	numPods := 20
 	for i := 0; i < numPods; i++ {
-		podWorkers.UpdatePod(newPod(string(i), "name"), func() {})
+		podWorkers.UpdatePod(newPod(string(i), "name"), false, func() {})
 	}
 	drainWorkers(podWorkers, numPods)
 

--- a/pkg/kubelet/runonce.go
+++ b/pkg/kubelet/runonce.go
@@ -104,7 +104,9 @@ func (kl *Kubelet) runPod(pod api.Pod, retryDelay time.Duration) error {
 			return nil
 		}
 		glog.Infof("pod %q containers not running: syncing", pod.Name)
-		if err = kl.syncPod(&pod, dockerContainers); err != nil {
+		// We don't create mirror pods in this mode; pass a dummy boolean value
+		// to sycnPod.
+		if err = kl.syncPod(&pod, false, dockerContainers); err != nil {
 			return fmt.Errorf("error syncing pod: %v", err)
 		}
 		if retry >= RunOnceMaxRetries {

--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream/spdy"
 	"github.com/golang/glog"
@@ -84,7 +85,7 @@ type HostInterface interface {
 	GetRootInfo(req *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error)
 	GetDockerVersion() ([]uint, error)
 	GetMachineInfo() (*cadvisorApi.MachineInfo, error)
-	GetPods() ([]api.Pod, error)
+	GetPods() ([]api.Pod, util.StringSet, error)
 	GetPodByName(namespace, name string) (*api.Pod, bool)
 	GetPodStatus(name string, uid types.UID) (api.PodStatus, error)
 	RunInContainer(name string, uid types.UID, container string, cmd []string) ([]byte, error)
@@ -258,9 +259,9 @@ func (s *Server) handleContainerLogs(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-// handlePods returns a list of pod bounds to the Kubelet and their spec
+// handlePods returns a list of pod bound to the Kubelet and their spec
 func (s *Server) handlePods(w http.ResponseWriter, req *http.Request) {
-	pods, err := s.host.GetPods()
+	pods, _, err := s.host.GetPods()
 	if err != nil {
 		s.error(w, err)
 		return

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream/spdy"
 	cadvisorApi "github.com/google/cadvisor/info/v1"
@@ -44,7 +45,7 @@ type fakeKubelet struct {
 	containerInfoFunc                  func(podFullName string, uid types.UID, containerName string, req *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error)
 	rootInfoFunc                       func(query *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error)
 	machineInfoFunc                    func() (*cadvisorApi.MachineInfo, error)
-	podsFunc                           func() ([]api.Pod, error)
+	podsFunc                           func() ([]api.Pod, util.StringSet, error)
 	logFunc                            func(w http.ResponseWriter, req *http.Request)
 	runFunc                            func(podFullName string, uid types.UID, containerName string, cmd []string) ([]byte, error)
 	dockerVersionFunc                  func() ([]uint, error)
@@ -79,7 +80,7 @@ func (fk *fakeKubelet) GetMachineInfo() (*cadvisorApi.MachineInfo, error) {
 	return fk.machineInfoFunc()
 }
 
-func (fk *fakeKubelet) GetPods() ([]api.Pod, error) {
+func (fk *fakeKubelet) GetPods() ([]api.Pod, util.StringSet, error) {
 	return fk.podsFunc()
 }
 

--- a/pkg/kubelet/types.go
+++ b/pkg/kubelet/types.go
@@ -18,11 +18,13 @@ package kubelet
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 )
 
 const ConfigSourceAnnotationKey = "kubernetes.io/config.source"
+const ConfigMirrorAnnotationKey = "kubernetes.io/config.mirror"
 
 // PodOperation defines what changes will be made on a pod configuration.
 type PodOperation int
@@ -49,6 +51,9 @@ const (
 	// Updates from all sources
 	AllSource = "*"
 
+	// Used for ConfigMirrorAnnotationKey.
+	MirrorType = "mirror"
+
 	NamespaceDefault = api.NamespaceDefault
 )
 
@@ -67,7 +72,7 @@ type PodUpdate struct {
 	Source string
 }
 
-// GetPodFullName returns a name that uniquely identifies a pod across all config sources.
+// GetPodFullName returns a name that uniquely identifies a pod.
 func GetPodFullName(pod *api.Pod) string {
 	// Use underscore as the delimiter because it is not allowed in pod name
 	// (DNS subdomain format), while allowed in the container name format.
@@ -77,4 +82,13 @@ func GetPodFullName(pod *api.Pod) string {
 // Build the pod full name from pod name and namespace.
 func BuildPodFullName(name, namespace string) string {
 	return name + "_" + namespace
+}
+
+// Parse the pod full name.
+func ParsePodFullName(podFullName string) (string, string, error) {
+	parts := strings.Split(podFullName, "_")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("failed to parse the pod full name %q", podFullName)
+	}
+	return parts[0], parts[1], nil
 }


### PR DESCRIPTION
Currently, API server is not aware of the static pods (manifests from
sources other than the API server, e.g. file and http) at all. This is
inconvenient since users cannot check the static pods through kubectl.
It is also suboptimal because scheduler is unaware of the resource
consumption by these static pods on the node.

This change syncs the information back to the API server by creating a
mirror pod via API server for each static pod.
- Kubelet creates containers for the mirror pod, instead of the static
  pod, which is filtered out before SyncPods.
- If a mirror pod gets deleted, Kubelet will re-create one. The
  containers will also be re-created after syncing the new mirror pod.
- If a static pod gets removed from the source (e.g. manifest file
  removed from the directory), the orphaned mirror pod will be deleted
  by Kubelet.

This fixes #4090.
