### PR TITLE
Client support to delete events

### DIFF
--- a/pkg/client/events.go
+++ b/pkg/client/events.go
@@ -40,6 +40,7 @@ type EventInterface interface {
 	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
 	// Search finds events about the specified object
 	Search(objOrRef runtime.Object) (*api.EventList, error)
+	Delete(name string) error
 }
 
 // events implements Events interface
@@ -160,4 +161,9 @@ func (e *events) Search(objOrRef runtime.Object) (*api.EventList, error) {
 		fields["involvedObject.uid"] = string(ref.UID)
 	}
 	return e.List(labels.Everything(), fields.AsSelector())
+}
+
+// Delete deletes an existing event.
+func (e *events) Delete(name string) error {
+	return e.client.Delete().Resource("events").Name(name).Do().Error()
 }

--- a/pkg/client/events_test.go
+++ b/pkg/client/events_test.go
@@ -175,3 +175,13 @@ func TestEventList(t *testing.T) {
 		t.Errorf("%#v != %#v.", e, r)
 	}
 }
+
+func TestEventDelete(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: "/events/foo"},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup().Events(ns).Delete("foo")
+	c.Validate(t, nil, err)
+}

--- a/pkg/client/fake_events.go
+++ b/pkg/client/fake_events.go
@@ -64,3 +64,8 @@ func (c *FakeEvents) Search(objOrRef runtime.Object) (*api.EventList, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "search-events"})
 	return &c.Fake.EventsList, nil
 }
+
+func (c *FakeEvents) Delete(name string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-event", Value: name})
+	return nil
+}


### PR DESCRIPTION
When I delete a Namespace, I need to support graceful termination of the content in the namespace.  

As a result, I need the mechanism to delete each resource type that is associated with a namespace via a client as part of graceful clean-up.  Right now, the Events type has server support to delete an event, but it did not expose it on our client object.  

Adding this as a prereq to implementing #5195 
