### PR TITLE
Client support to delete events

### DIFF
--- a/pkg/client/events.go
+++ b/pkg/client/events.go
@@ -40,6 +40,7 @@ type EventInterface interface {
 	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
 	// Search finds events about the specified object
 	Search(objOrRef runtime.Object) (*api.EventList, error)
+	Delete(name string) error
 }
 
 // events implements Events interface
@@ -160,4 +161,14 @@ func (e *events) Search(objOrRef runtime.Object) (*api.EventList, error) {
 		fields["involvedObject.uid"] = string(ref.UID)
 	}
 	return e.List(labels.Everything(), fields.AsSelector())
+}
+
+// Delete deletes an existing event.
+func (e *events) Delete(name string) error {
+	return e.client.Delete().
+		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
+		Resource("events").
+		Name(name).
+		Do().
+		Error()
 }

--- a/pkg/client/events_test.go
+++ b/pkg/client/events_test.go
@@ -175,3 +175,13 @@ func TestEventList(t *testing.T) {
 		t.Errorf("%#v != %#v.", e, r)
 	}
 }
+
+func TestEventDelete(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: "/events/foo"},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup().Events(ns).Delete("foo")
+	c.Validate(t, nil, err)
+}

--- a/pkg/client/fake_events.go
+++ b/pkg/client/fake_events.go
@@ -64,3 +64,8 @@ func (c *FakeEvents) Search(objOrRef runtime.Object) (*api.EventList, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "search-events"})
 	return &c.Fake.EventsList, nil
 }
+
+func (c *FakeEvents) Delete(name string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-event", Value: name})
+	return nil
+}


### PR DESCRIPTION
Ability to delete Event objects from a client.Interface.

This is a prereq to implementing graceful termination of a Namespace - where we need to delete the Event objects in that namespace.  

See #5195 for more details on that future use case.
