### PR TITLE
Use UTC when marshalling times and Local when unmarshalling

### DIFF
--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -78,7 +78,7 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	t.Time = pt
+	t.Time = pt.Local()
 	return nil
 }
 
@@ -89,7 +89,7 @@ func (t Time) MarshalJSON() ([]byte, error) {
 		return []byte("null"), nil
 	}
 
-	return json.Marshal(t.Format(time.RFC3339))
+	return json.Marshal(t.UTC().Format(time.RFC3339))
 }
 
 // Fuzz satisfies fuzz.Interface.

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"encoding/json"
-	"reflect"
 	"testing"
 	"time"
 
@@ -35,7 +34,7 @@ func TestTimeMarshalYAML(t *testing.T) {
 		result string
 	}{
 		{Time{}, "t: null\n"},
-		{Date(1998, time.May, 5, 5, 5, 5, 50, time.UTC), "t: 1998-05-05T05:05:05Z\n"},
+		{Date(1998, time.May, 5, 1, 5, 5, 50, time.FixedZone("test", -4*60*60)), "t: 1998-05-05T05:05:05Z\n"},
 		{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC), "t: 1998-05-05T05:05:05Z\n"},
 	}
 
@@ -57,7 +56,7 @@ func TestTimeUnmarshalYAML(t *testing.T) {
 		result Time
 	}{
 		{"t: null\n", Time{}},
-		{"t: 1998-05-05T05:05:05Z\n", Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC)},
+		{"t: 1998-05-05T05:05:05Z\n", Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()}},
 	}
 
 	for _, c := range cases {
@@ -99,7 +98,7 @@ func TestTimeUnmarshalJSON(t *testing.T) {
 		result Time
 	}{
 		{"{\"t\":null}", Time{}},
-		{"{\"t\":\"1998-05-05T05:05:05Z\"}", Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC)},
+		{"{\"t\":\"1998-05-05T05:05:05Z\"}", Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()}},
 	}
 
 	for _, c := range cases {
@@ -118,25 +117,31 @@ func TestTimeMarshalJSONUnmarshalYAML(t *testing.T) {
 		input Time
 	}{
 		{Time{}},
-		{Date(1998, time.May, 5, 5, 5, 5, 50, time.UTC).Rfc3339Copy()},
-		{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Rfc3339Copy()},
+		{Date(1998, time.May, 5, 5, 5, 5, 50, time.Local).Rfc3339Copy()},
+		{Date(1998, time.May, 5, 5, 5, 5, 0, time.Local).Rfc3339Copy()},
 	}
 
-	for _, c := range cases {
+	for i, c := range cases {
 		input := TimeHolder{c.input}
 		jsonMarshalled, err := json.Marshal(&input)
 		if err != nil {
-			t.Errorf("1: Failed to marshal input: '%v': %v", input, err)
+			t.Errorf("%d-1: Failed to marshal input: '%v': %v", i, input, err)
 		}
 
 		var result TimeHolder
 		err = yaml.Unmarshal(jsonMarshalled, &result)
 		if err != nil {
-			t.Errorf("2: Failed to unmarshal '%+v': %v", string(jsonMarshalled), err)
+			t.Errorf("%d-2: Failed to unmarshal '%+v': %v", i, string(jsonMarshalled), err)
 		}
 
-		if !reflect.DeepEqual(input, result) {
-			t.Errorf("3: Failed to marshal input '%+v': got %+v", input, result)
+		iN, iO := input.T.Zone()
+		oN, oO := result.T.Zone()
+		if iN != oN || iO != oO {
+			t.Errorf("%d-3: Time zones differ before and after serialization %s:%d %s:%d", i, iN, iO, oN, oO)
+		}
+
+		if input.T.UnixNano() != result.T.UnixNano() {
+			t.Errorf("%d-4: Failed to marshal input '%#v': got %#v", i, input, result)
 		}
 	}
 }


### PR DESCRIPTION
Marshal to UTC and read into Local, which means clients automatically
show local time and stored values are always consistent.

Closes remaining issue from #5183
