### PR TITLE
Remove BoundPods from Kubelet

### DIFF
--- a/pkg/api/conversion.go
+++ b/pkg/api/conversion.go
@@ -39,12 +39,8 @@ func init() {
 			*out = *in.Copy()
 			return nil
 		},
-		// Convert ContainerManifest to BoundPod
-		//
-		// This function generates a dummy selfLink using the same method as the
-		// boundPod registry, in order for the Kubelet to work with well-formed
-		// boundPods during the integration test.
-		func(in *ContainerManifest, out *BoundPod, s conversion.Scope) error {
+		// Convert ContainerManifest to Pod
+		func(in *ContainerManifest, out *Pod, s conversion.Scope) error {
 			out.Spec.Containers = in.Containers
 			out.Spec.Volumes = in.Volumes
 			out.Spec.RestartPolicy = in.RestartPolicy
@@ -53,12 +49,12 @@ func init() {
 			out.UID = in.UUID
 
 			if in.ID != "" {
-				out.SelfLink = "/api/v1beta1/boundPods/" + in.ID
+				out.SelfLink = "/api/v1beta1/pods/" + in.ID
 			}
 
 			return nil
 		},
-		func(in *BoundPod, out *ContainerManifest, s conversion.Scope) error {
+		func(in *Pod, out *ContainerManifest, s conversion.Scope) error {
 			out.Containers = in.Spec.Containers
 			out.Volumes = in.Spec.Volumes
 			out.RestartPolicy = in.Spec.RestartPolicy
@@ -70,7 +66,7 @@ func init() {
 		},
 
 		// ContainerManifestList
-		func(in *ContainerManifestList, out *BoundPods, s conversion.Scope) error {
+		func(in *ContainerManifestList, out *PodList, s conversion.Scope) error {
 			if err := s.Convert(&in.Items, &out.Items, 0); err != nil {
 				return err
 			}
@@ -80,7 +76,7 @@ func init() {
 			}
 			return nil
 		},
-		func(in *BoundPods, out *ContainerManifestList, s conversion.Scope) error {
+		func(in *PodList, out *ContainerManifestList, s conversion.Scope) error {
 			if err := s.Convert(&in.Items, &out.Items, 0); err != nil {
 				return err
 			}

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -44,7 +44,6 @@ func init() {
 		&ContainerManifest{},
 		&ContainerManifestList{},
 		&BoundPod{},
-		&BoundPods{},
 		&List{},
 		&LimitRange{},
 		&LimitRangeList{},
@@ -79,7 +78,6 @@ func (*EventList) IsAnAPIObject()                 {}
 func (*ContainerManifest) IsAnAPIObject()         {}
 func (*ContainerManifestList) IsAnAPIObject()     {}
 func (*BoundPod) IsAnAPIObject()                  {}
-func (*BoundPods) IsAnAPIObject()                 {}
 func (*List) IsAnAPIObject()                      {}
 func (*LimitRange) IsAnAPIObject()                {}
 func (*LimitRangeList) IsAnAPIObject()            {}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1249,7 +1249,7 @@ type EventList struct {
 // ContainerManifest corresponds to the Container Manifest format, documented at:
 // https://developers.google.com/compute/docs/containers/container_vms#container_manifest
 // This is used as the representation of Kubernetes workloads.
-// DEPRECATED: Replaced with BoundPod
+// DEPRECATED: Replaced with Pod
 type ContainerManifest struct {
 	// Required: This must be a supported version string, such as "v1beta1".
 	Version string `json:"version"`
@@ -1268,7 +1268,7 @@ type ContainerManifest struct {
 }
 
 // ContainerManifestList is used to communicate container manifests to kubelet.
-// DEPRECATED: Replaced with BoundPods
+// DEPRECATED: Replaced with Pods
 type ContainerManifestList struct {
 	TypeMeta `json:",inline"`
 	ListMeta `json:"metadata,omitempty"`
@@ -1279,25 +1279,14 @@ type ContainerManifestList struct {
 // BoundPod is a collection of containers that should be run on a host. A BoundPod
 // defines how a Pod may change after a Binding is created. A Pod is a request to
 // execute a pod, whereas a BoundPod is the specification that would be run on a server.
+//
+// TODO(wojtek-t): Get rid of this type.
 type BoundPod struct {
 	TypeMeta   `json:",inline"`
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the behavior of a pod.
 	Spec PodSpec `json:"spec,omitempty"`
-}
-
-// BoundPods is a list of Pods bound to a common server. The resource version of
-// the pod list is guaranteed to only change when the list of bound pods changes.
-type BoundPods struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
-
-	// Host is the name of a node that these pods were bound to.
-	Host string `json:"host"`
-
-	// Items is the list of all pods bound to a given host.
-	Items []BoundPod `json:"items"`
 }
 
 // List holds a list of objects, which may not be known by the server.

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -1079,7 +1079,7 @@ type BoundPods struct {
 	Host string `json:"host" description:"name of a node that these pods were bound to"`
 
 	// Items is the list of all pods bound to a given host.
-	Items []BoundPod `json:"items" description:"list of all pods bound to a given host"`
+	Items []Pod `json:"items" description:"list of all pods bound to a given host"`
 }
 
 // List holds a list of objects, which may not be known by the server.

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -1141,7 +1141,7 @@ type BoundPods struct {
 	Host string `json:"host" description:"name of a node that these pods were bound to"`
 
 	// Items is the list of all pods bound to a given host.
-	Items []BoundPod `json:"items" description:"list of all pods bound to a given host"`
+	Items []Pod `json:"items" description:"list of all pods bound to a given host"`
 }
 
 // List holds a list of objects, which may not be known by the server.

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -671,7 +671,7 @@ type BoundPods struct {
 	Host string `json:"host" description:"name of a node that these pods were bound to"`
 
 	// Items is the list of all pods bound to a given host.
-	Items []BoundPod `json:"items" description:"list of all pods bound to a given host"`
+	Items []Pod `json:"items" description:"list of all pods bound to a given host"`
 }
 
 // ReplicationControllerSpec is the specification of a replication controller.

--- a/pkg/kubelet/config/apiserver.go
+++ b/pkg/kubelet/config/apiserver.go
@@ -23,7 +23,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/golang/glog"
 )
 
 // NewSourceApiserver creates a config source that watches and pulls from the apiserver.
@@ -35,19 +34,14 @@ func NewSourceApiserver(client *client.Client, hostname string, updates chan<- i
 // newSourceApiserverFromLW holds creates a config source that watches an pulls from the apiserver.
 func newSourceApiserverFromLW(lw cache.ListerWatcher, updates chan<- interface{}) {
 	send := func(objs []interface{}) {
-		var bpods []api.BoundPod
+		var pods []api.Pod
 		for _, o := range objs {
 			pod := o.(*api.Pod)
-			bpod := api.BoundPod{}
-			if err := api.Scheme.Convert(pod, &bpod); err != nil {
-				glog.Errorf("Unable to interpret Pod from apiserver as a BoundPod: %v: %+v", err, pod)
-				continue
-			}
-			// Make a dummy self link so that references to this bound pod will work.
-			bpod.SelfLink = "/api/v1beta1/boundPods/" + bpod.Name
-			bpods = append(bpods, bpod)
+			// Make a dummy self link so that references to this pod will work.
+			pod.SelfLink = "/api/v1beta1/pods/" + pod.Name
+			pods = append(pods, *pod)
 		}
-		updates <- kubelet.PodUpdate{bpods, kubelet.SET, kubelet.ApiserverSource}
+		updates <- kubelet.PodUpdate{pods, kubelet.SET, kubelet.ApiserverSource}
 	}
 	cache.NewReflector(lw, &api.Pod{}, cache.NewUndeltaStore(send, cache.MetaNamespaceKeyFunc), 0).Run()
 }

--- a/pkg/kubelet/config/apiserver_test.go
+++ b/pkg/kubelet/config/apiserver_test.go
@@ -54,14 +54,14 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "q"},
 		Spec:       api.PodSpec{Containers: []api.Container{{Image: "image/blah"}}}}
 
-	expectedBoundPod1v1 := api.BoundPod{
-		ObjectMeta: api.ObjectMeta{Name: "p", SelfLink: "/api/v1beta1/boundPods/p"},
+	expectedPod1v1 := api.Pod{
+		ObjectMeta: api.ObjectMeta{Name: "p", SelfLink: "/api/v1beta1/pods/p"},
 		Spec:       api.PodSpec{Containers: []api.Container{{Image: "image/one"}}}}
-	expectedBoundPod1v2 := api.BoundPod{
-		ObjectMeta: api.ObjectMeta{Name: "p", SelfLink: "/api/v1beta1/boundPods/p"},
+	expectedPod1v2 := api.Pod{
+		ObjectMeta: api.ObjectMeta{Name: "p", SelfLink: "/api/v1beta1/pods/p"},
 		Spec:       api.PodSpec{Containers: []api.Container{{Image: "image/two"}}}}
-	expectedBoundPod2 := api.BoundPod{
-		ObjectMeta: api.ObjectMeta{Name: "q", SelfLink: "/api/v1beta1/boundPods/q"},
+	expectedPod2 := api.Pod{
+		ObjectMeta: api.ObjectMeta{Name: "q", SelfLink: "/api/v1beta1/pods/q"},
 		Spec:       api.PodSpec{Containers: []api.Container{{Image: "image/blah"}}}}
 
 	// Setup fake api client.
@@ -80,7 +80,7 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 		t.Errorf("Unable to read from channel when expected")
 	}
 	update := got.(kubelet.PodUpdate)
-	expected := CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, expectedBoundPod1v1)
+	expected := CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, expectedPod1v1)
 	if !api.Semantic.DeepEqual(expected, update) {
 		t.Errorf("Expected %#v; Got %#v", expected, update)
 	}
@@ -93,8 +93,8 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 	}
 	update = got.(kubelet.PodUpdate)
 	// Could be sorted either of these two ways:
-	expectedA := CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, expectedBoundPod1v1, expectedBoundPod2)
-	expectedB := CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, expectedBoundPod2, expectedBoundPod1v1)
+	expectedA := CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, expectedPod1v1, expectedPod2)
+	expectedB := CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, expectedPod2, expectedPod1v1)
 
 	if !api.Semantic.DeepEqual(expectedA, update) && !api.Semantic.DeepEqual(expectedB, update) {
 		t.Errorf("Expected %#v or %#v, Got %#v", expectedA, expectedB, update)
@@ -107,8 +107,8 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 		t.Errorf("Unable to read from channel when expected")
 	}
 	update = got.(kubelet.PodUpdate)
-	expectedA = CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, expectedBoundPod1v2, expectedBoundPod2)
-	expectedB = CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, expectedBoundPod2, expectedBoundPod1v2)
+	expectedA = CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, expectedPod1v2, expectedPod2)
+	expectedB = CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, expectedPod2, expectedPod1v2)
 
 	if !api.Semantic.DeepEqual(expectedA, update) && !api.Semantic.DeepEqual(expectedB, update) {
 		t.Errorf("Expected %#v or %#v, Got %#v", expectedA, expectedB, update)
@@ -121,7 +121,7 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 		t.Errorf("Unable to read from channel when expected")
 	}
 	update = got.(kubelet.PodUpdate)
-	expected = CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, expectedBoundPod2)
+	expected = CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, expectedPod2)
 	if !api.Semantic.DeepEqual(expected, update) {
 		t.Errorf("Expected %#v, Got %#v", expected, update)
 	}

--- a/pkg/kubelet/config/config_test.go
+++ b/pkg/kubelet/config/config_test.go
@@ -39,7 +39,7 @@ func expectEmptyChannel(t *testing.T, ch <-chan interface{}) {
 	}
 }
 
-type sortedPods []api.BoundPod
+type sortedPods []api.Pod
 
 func (s sortedPods) Len() int {
 	return len(s)
@@ -51,8 +51,8 @@ func (s sortedPods) Less(i, j int) bool {
 	return s[i].Namespace < s[j].Namespace
 }
 
-func CreateValidPod(name, namespace, source string) api.BoundPod {
-	return api.BoundPod{
+func CreateValidPod(name, namespace, source string) api.Pod {
+	return api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			UID:         types.UID(name), // for the purpose of testing, this is unique enough
 			Name:        name,
@@ -66,8 +66,8 @@ func CreateValidPod(name, namespace, source string) api.BoundPod {
 	}
 }
 
-func CreatePodUpdate(op kubelet.PodOperation, source string, pods ...api.BoundPod) kubelet.PodUpdate {
-	newPods := make([]api.BoundPod, len(pods))
+func CreatePodUpdate(op kubelet.PodOperation, source string, pods ...api.Pod) kubelet.PodUpdate {
+	newPods := make([]api.Pod, len(pods))
 	for i := range pods {
 		newPods[i] = pods[i]
 	}
@@ -160,7 +160,7 @@ func TestInvalidPodFiltered(t *testing.T) {
 	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.ADD, NoneSource, CreateValidPod("foo", "new", "test")))
 
 	// add an invalid update
-	podUpdate = CreatePodUpdate(kubelet.UPDATE, NoneSource, api.BoundPod{ObjectMeta: api.ObjectMeta{Name: "foo"}})
+	podUpdate = CreatePodUpdate(kubelet.UPDATE, NoneSource, api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}})
 	channel <- podUpdate
 	expectNoPodUpdate(t, ch)
 }
@@ -219,7 +219,7 @@ func TestNewPodAddedUpdatedRemoved(t *testing.T) {
 	channel <- podUpdate
 	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.UPDATE, NoneSource, pod))
 
-	podUpdate = CreatePodUpdate(kubelet.REMOVE, NoneSource, api.BoundPod{ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "new"}})
+	podUpdate = CreatePodUpdate(kubelet.REMOVE, NoneSource, api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "new"}})
 	channel <- podUpdate
 	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.REMOVE, NoneSource, pod))
 }

--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -66,7 +66,7 @@ func (s *sourceFile) extractFromPath() error {
 			return err
 		}
 		// Emit an update with an empty PodList to allow FileSource to be marked as seen
-		s.updates <- kubelet.PodUpdate{[]api.BoundPod{}, kubelet.SET, kubelet.FileSource}
+		s.updates <- kubelet.PodUpdate{[]api.Pod{}, kubelet.SET, kubelet.FileSource}
 		return fmt.Errorf("path does not exist, ignoring")
 	}
 
@@ -83,7 +83,7 @@ func (s *sourceFile) extractFromPath() error {
 		if err != nil {
 			return err
 		}
-		s.updates <- kubelet.PodUpdate{[]api.BoundPod{pod}, kubelet.SET, kubelet.FileSource}
+		s.updates <- kubelet.PodUpdate{[]api.Pod{pod}, kubelet.SET, kubelet.FileSource}
 
 	default:
 		return fmt.Errorf("path is not a directory or file")
@@ -95,13 +95,13 @@ func (s *sourceFile) extractFromPath() error {
 // Get as many pod configs as we can from a directory.  Return an error iff something
 // prevented us from reading anything at all.  Do not return an error if only some files
 // were problematic.
-func extractFromDir(name string) ([]api.BoundPod, error) {
+func extractFromDir(name string) ([]api.Pod, error) {
 	dirents, err := filepath.Glob(filepath.Join(name, "[^.]*"))
 	if err != nil {
 		return nil, fmt.Errorf("glob failed: %v", err)
 	}
 
-	pods := make([]api.BoundPod, 0)
+	pods := make([]api.Pod, 0)
 	if len(dirents) == 0 {
 		return pods, nil
 	}
@@ -131,8 +131,8 @@ func extractFromDir(name string) ([]api.BoundPod, error) {
 	return pods, nil
 }
 
-func extractFromFile(filename string) (api.BoundPod, error) {
-	var pod api.BoundPod
+func extractFromFile(filename string) (api.Pod, error) {
+	var pod api.Pod
 
 	glog.V(3).Infof("Reading config file %q", filename)
 	file, err := os.Open(filename)
@@ -153,10 +153,10 @@ func extractFromFile(filename string) (api.BoundPod, error) {
 	// becomes nicer).  Until then, we assert that the ContainerManifest
 	// structure on disk is always v1beta1.  Read that, convert it to a
 	// "current" ContainerManifest (should be ~identical), then convert
-	// that to a BoundPod (which is a well-understood conversion).  This
-	// avoids writing a v1beta1.ContainerManifest -> api.BoundPod
+	// that to a Pod (which is a well-understood conversion).  This
+	// avoids writing a v1beta1.ContainerManifest -> api.Pod
 	// conversion which would be identical to the api.ContainerManifest ->
-	// api.BoundPod conversion.
+	// api.Pod conversion.
 	oldManifest := &v1beta1.ContainerManifest{}
 	if err := yaml.Unmarshal(data, oldManifest); err != nil {
 		return pod, fmt.Errorf("can't unmarshal file %q: %v", filename, err)

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 )
 
-func ExampleManifestAndPod(id string) (v1beta1.ContainerManifest, api.BoundPod) {
+func ExampleManifestAndPod(id string) (v1beta1.ContainerManifest, api.Pod) {
 	manifest := v1beta1.ContainerManifest{
 		ID:   id,
 		UUID: types.UID(id),
@@ -52,7 +52,7 @@ func ExampleManifestAndPod(id string) (v1beta1.ContainerManifest, api.BoundPod) 
 			},
 		},
 	}
-	expectedPod := api.BoundPod{
+	expectedPod := api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:      id,
 			UID:       types.UID(id),
@@ -130,7 +130,7 @@ func TestReadFromFile(t *testing.T) {
 	select {
 	case got := <-ch:
 		update := got.(kubelet.PodUpdate)
-		expected := CreatePodUpdate(kubelet.SET, kubelet.FileSource, api.BoundPod{
+		expected := CreatePodUpdate(kubelet.SET, kubelet.FileSource, api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name:      "",
 				UID:       "12345",
@@ -179,7 +179,7 @@ func TestReadFromFileWithoutID(t *testing.T) {
 	select {
 	case got := <-ch:
 		update := got.(kubelet.PodUpdate)
-		expected := CreatePodUpdate(kubelet.SET, kubelet.FileSource, api.BoundPod{
+		expected := CreatePodUpdate(kubelet.SET, kubelet.FileSource, api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name:      "",
 				UID:       "12345",
@@ -219,7 +219,7 @@ func TestReadV1Beta2FromFile(t *testing.T) {
 	select {
 	case got := <-ch:
 		update := got.(kubelet.PodUpdate)
-		expected := CreatePodUpdate(kubelet.SET, kubelet.FileSource, api.BoundPod{
+		expected := CreatePodUpdate(kubelet.SET, kubelet.FileSource, api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name:      "",
 				UID:       "12345",
@@ -303,7 +303,7 @@ func TestExtractFromDir(t *testing.T) {
 	manifest2, expectedPod2 := ExampleManifestAndPod("2")
 
 	manifests := []v1beta1.ContainerManifest{manifest, manifest2}
-	pods := []api.BoundPod{expectedPod, expectedPod2}
+	pods := []api.Pod{expectedPod, expectedPod2}
 	files := make([]*os.File, len(manifests))
 
 	dirName, err := ioutil.TempDir("", "foo")
@@ -357,7 +357,7 @@ func TestExtractFromDir(t *testing.T) {
 		t.Fatalf("Expected %#v, Got %#v", expected, update)
 	}
 	for i := range update.Pods {
-		if errs := validation.ValidateBoundPod(&update.Pods[i]); len(errs) != 0 {
+		if errs := validation.ValidatePod(&update.Pods[i]); len(errs) != 0 {
 			t.Errorf("Expected no validation errors on %#v, Got %q", update.Pods[i], errs)
 		}
 	}

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -132,12 +132,12 @@ func TestExtractFromHTTP(t *testing.T) {
 				Containers: []v1beta1.Container{{Name: "1", Image: "foo", ImagePullPolicy: v1beta1.PullAlways}}},
 			expected: CreatePodUpdate(kubelet.SET,
 				kubelet.HTTPSource,
-				api.BoundPod{
+				api.Pod{
 					ObjectMeta: api.ObjectMeta{
 						UID:       "111",
 						Name:      "foo" + "-" + hostname,
 						Namespace: "foobar",
-						SelfLink:  "/api/v1beta1/boundPods/foo",
+						SelfLink:  "/api/v1beta1/pods/foo",
 					},
 					Spec: api.PodSpec{
 						RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
@@ -155,7 +155,7 @@ func TestExtractFromHTTP(t *testing.T) {
 			manifests: api.ContainerManifest{Version: "v1beta1", UUID: "111"},
 			expected: CreatePodUpdate(kubelet.SET,
 				kubelet.HTTPSource,
-				api.BoundPod{
+				api.Pod{
 					ObjectMeta: api.ObjectMeta{
 						UID:       "111",
 						Name:      "111" + "-" + hostname,
@@ -173,12 +173,12 @@ func TestExtractFromHTTP(t *testing.T) {
 				Containers: []v1beta1.Container{{Name: "1", Image: "foo", ImagePullPolicy: v1beta1.PullAlways}}},
 			expected: CreatePodUpdate(kubelet.SET,
 				kubelet.HTTPSource,
-				api.BoundPod{
+				api.Pod{
 					ObjectMeta: api.ObjectMeta{
 						UID:       "111",
 						Name:      "foo" + "-" + hostname,
 						Namespace: "foobar",
-						SelfLink:  "/api/v1beta1/boundPods/foo",
+						SelfLink:  "/api/v1beta1/pods/foo",
 					},
 					Spec: api.PodSpec{
 						RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
@@ -201,12 +201,12 @@ func TestExtractFromHTTP(t *testing.T) {
 			},
 			expected: CreatePodUpdate(kubelet.SET,
 				kubelet.HTTPSource,
-				api.BoundPod{
+				api.Pod{
 					ObjectMeta: api.ObjectMeta{
 						UID:       "111",
 						Name:      "foo" + "-" + hostname,
 						Namespace: "foobar",
-						SelfLink:  "/api/v1beta1/boundPods/foo",
+						SelfLink:  "/api/v1beta1/pods/foo",
 					},
 					Spec: api.PodSpec{
 						RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
@@ -218,12 +218,12 @@ func TestExtractFromHTTP(t *testing.T) {
 							ImagePullPolicy:        "Always"}},
 					},
 				},
-				api.BoundPod{
+				api.Pod{
 					ObjectMeta: api.ObjectMeta{
 						UID:       "222",
 						Name:      "bar" + "-" + hostname,
 						Namespace: "foobar",
-						SelfLink:  "/api/v1beta1/boundPods/bar",
+						SelfLink:  "/api/v1beta1/pods/bar",
 					},
 					Spec: api.PodSpec{
 						RestartPolicy: api.RestartPolicy{Always: &api.RestartPolicyAlways{}},
@@ -274,7 +274,7 @@ func TestExtractFromHTTP(t *testing.T) {
 			t.Errorf("%s: Expected: %#v, Got: %#v", testCase.desc, testCase.expected, update)
 		}
 		for i := range update.Pods {
-			if errs := validation.ValidateBoundPod(&update.Pods[i]); len(errs) != 0 {
+			if errs := validation.ValidatePod(&update.Pods[i]); len(errs) != 0 {
 				t.Errorf("%s: Expected no validation errors on %#v, Got %v", testCase.desc, update.Pods[i], errors.NewAggregate(errs))
 			}
 		}

--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -28,7 +28,7 @@ import (
 	"github.com/golang/glog"
 )
 
-type syncPodFnType func(*api.BoundPod, dockertools.DockerContainers) error
+type syncPodFnType func(*api.Pod, dockertools.DockerContainers) error
 
 type podWorkers struct {
 	// Protects podUpdates field.
@@ -58,7 +58,7 @@ type podWorkers struct {
 
 type workUpdate struct {
 	// The pod state to reflect.
-	pod *api.BoundPod
+	pod *api.Pod
 
 	// Function to call when the update is complete.
 	updateCompleteFn func()
@@ -106,7 +106,7 @@ func (p *podWorkers) managePodLoop(podUpdates <-chan workUpdate) {
 }
 
 // Apply the new setting to the specified pod. updateComplete is called when the update is completed.
-func (p *podWorkers) UpdatePod(pod *api.BoundPod, updateComplete func()) {
+func (p *podWorkers) UpdatePod(pod *api.Pod, updateComplete func()) {
 	uid := pod.UID
 	var podUpdates chan workUpdate
 	var exists bool

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 )
 
-func newPod(uid, name string) *api.BoundPod {
-	return &api.BoundPod{
+func newPod(uid, name string) *api.Pod {
+	return &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			UID:  types.UID(uid),
 			Name: name,
@@ -46,7 +46,7 @@ func createPodWorkers() (*podWorkers, map[types.UID][]string) {
 
 	podWorkers := newPodWorkers(
 		fakeDockerCache,
-		func(pod *api.BoundPod, containers dockertools.DockerContainers) error {
+		func(pod *api.Pod, containers dockertools.DockerContainers) error {
 			func() {
 				lock.Lock()
 				defer lock.Unlock()

--- a/pkg/kubelet/probe.go
+++ b/pkg/kubelet/probe.go
@@ -41,7 +41,7 @@ const maxProbeRetries = 3
 // probeContainer probes the liveness/readiness of the given container.
 // If the container's liveness probe is unsuccessful, set readiness to false.
 // If liveness is successful, do a readiness check and set readiness accordingly.
-func (kl *Kubelet) probeContainer(pod *api.BoundPod, status api.PodStatus, container api.Container, dockerContainer *docker.APIContainers) (probe.Result, error) {
+func (kl *Kubelet) probeContainer(pod *api.Pod, status api.PodStatus, container api.Container, dockerContainer *docker.APIContainers) (probe.Result, error) {
 	// Probe liveness.
 	live, err := kl.probeContainerLiveness(pod, status, container, dockerContainer)
 	if err != nil {
@@ -78,7 +78,7 @@ func (kl *Kubelet) probeContainer(pod *api.BoundPod, status api.PodStatus, conta
 
 // probeContainerLiveness probes the liveness of a container.
 // If the initalDelay since container creation on liveness probe has not passed the probe will return probe.Success.
-func (kl *Kubelet) probeContainerLiveness(pod *api.BoundPod, status api.PodStatus, container api.Container, dockerContainer *docker.APIContainers) (probe.Result, error) {
+func (kl *Kubelet) probeContainerLiveness(pod *api.Pod, status api.PodStatus, container api.Container, dockerContainer *docker.APIContainers) (probe.Result, error) {
 	p := container.LivenessProbe
 	if p == nil {
 		return probe.Success, nil
@@ -91,7 +91,7 @@ func (kl *Kubelet) probeContainerLiveness(pod *api.BoundPod, status api.PodStatu
 
 // probeContainerLiveness probes the readiness of a container.
 // If the initial delay on the readiness probe has not passed the probe will return probe.Failure.
-func (kl *Kubelet) probeContainerReadiness(pod *api.BoundPod, status api.PodStatus, container api.Container, dockerContainer *docker.APIContainers) (probe.Result, error) {
+func (kl *Kubelet) probeContainerReadiness(pod *api.Pod, status api.PodStatus, container api.Container, dockerContainer *docker.APIContainers) (probe.Result, error) {
 	p := container.ReadinessProbe
 	if p == nil {
 		return probe.Success, nil
@@ -104,7 +104,7 @@ func (kl *Kubelet) probeContainerReadiness(pod *api.BoundPod, status api.PodStat
 
 // runProbeWithRetries tries to probe the container in a finite loop, it returns the last result
 // if it never succeeds.
-func (kl *Kubelet) runProbeWithRetries(p *api.Probe, pod *api.BoundPod, status api.PodStatus, container api.Container, retires int) (probe.Result, error) {
+func (kl *Kubelet) runProbeWithRetries(p *api.Probe, pod *api.Pod, status api.PodStatus, container api.Container, retires int) (probe.Result, error) {
 	var err error
 	var result probe.Result
 	for i := 0; i < retires; i++ {
@@ -116,7 +116,7 @@ func (kl *Kubelet) runProbeWithRetries(p *api.Probe, pod *api.BoundPod, status a
 	return result, err
 }
 
-func (kl *Kubelet) runProbe(p *api.Probe, pod *api.BoundPod, status api.PodStatus, container api.Container) (probe.Result, error) {
+func (kl *Kubelet) runProbe(p *api.Probe, pod *api.Pod, status api.PodStatus, container api.Container) (probe.Result, error) {
 	timeout := time.Duration(p.TimeoutSeconds) * time.Second
 	if p.Exec != nil {
 		return kl.prober.exec.Probe(kl.newExecInContainer(pod, container))
@@ -190,7 +190,7 @@ type execInContainer struct {
 	run func() ([]byte, error)
 }
 
-func (kl *Kubelet) newExecInContainer(pod *api.BoundPod, container api.Container) exec.Cmd {
+func (kl *Kubelet) newExecInContainer(pod *api.Pod, container api.Container) exec.Cmd {
 	uid := pod.UID
 	podFullName := GetPodFullName(pod)
 	return execInContainer{func() ([]byte, error) {

--- a/pkg/kubelet/probe_test.go
+++ b/pkg/kubelet/probe_test.go
@@ -400,7 +400,7 @@ func TestProbeContainer(t *testing.T) {
 		} else {
 			kl = makeTestKubelet(test.expectedResult, nil)
 		}
-		result, err := kl.probeContainer(&api.BoundPod{}, api.PodStatus{}, test.testContainer, dc)
+		result, err := kl.probeContainer(&api.Pod{}, api.PodStatus{}, test.testContainer, dc)
 		if test.expectError && err == nil {
 			t.Error("Expected error but did no error was returned.")
 		}

--- a/pkg/kubelet/runonce.go
+++ b/pkg/kubelet/runonce.go
@@ -33,7 +33,7 @@ const (
 )
 
 type RunPodResult struct {
-	Pod *api.BoundPod
+	Pod *api.Pod
 	Err error
 }
 
@@ -51,7 +51,7 @@ func (kl *Kubelet) RunOnce(updates <-chan PodUpdate) ([]RunPodResult, error) {
 }
 
 // runOnce runs a given set of pods and returns their status.
-func (kl *Kubelet) runOnce(pods []api.BoundPod, retryDelay time.Duration) (results []RunPodResult, err error) {
+func (kl *Kubelet) runOnce(pods []api.Pod, retryDelay time.Duration) (results []RunPodResult, err error) {
 	if kl.dockerPuller == nil {
 		kl.dockerPuller = dockertools.NewDockerPuller(kl.dockerClient, kl.pullQPS, kl.pullBurst)
 	}
@@ -87,7 +87,7 @@ func (kl *Kubelet) runOnce(pods []api.BoundPod, retryDelay time.Duration) (resul
 }
 
 // runPod runs a single pod and wait until all containers are running.
-func (kl *Kubelet) runPod(pod api.BoundPod, retryDelay time.Duration) error {
+func (kl *Kubelet) runPod(pod api.Pod, retryDelay time.Duration) error {
 	delay := retryDelay
 	retry := 0
 	for {
@@ -119,7 +119,7 @@ func (kl *Kubelet) runPod(pod api.BoundPod, retryDelay time.Duration) error {
 }
 
 // isPodRunning returns true if all containers of a manifest are running.
-func (kl *Kubelet) isPodRunning(pod api.BoundPod, dockerContainers dockertools.DockerContainers) (bool, error) {
+func (kl *Kubelet) isPodRunning(pod api.Pod, dockerContainers dockertools.DockerContainers) (bool, error) {
 	for _, container := range pod.Spec.Containers {
 		dockerContainer, found, _ := dockerContainers.FindPodContainer(GetPodFullName(&pod), pod.UID, container.Name)
 		if !found {

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -128,7 +128,7 @@ func TestRunOnce(t *testing.T) {
 		t: t,
 	}
 	kb.dockerPuller = &dockertools.FakeDockerPuller{}
-	results, err := kb.runOnce([]api.BoundPod{
+	results, err := kb.runOnce([]api.Pod{
 		{
 			ObjectMeta: api.ObjectMeta{
 				UID:       "12345678",

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -39,12 +39,12 @@ import (
 )
 
 type fakeKubelet struct {
-	podByNameFunc                      func(namespace, name string) (*api.BoundPod, bool)
+	podByNameFunc                      func(namespace, name string) (*api.Pod, bool)
 	statusFunc                         func(name string) (api.PodStatus, error)
 	containerInfoFunc                  func(podFullName string, uid types.UID, containerName string, req *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error)
 	rootInfoFunc                       func(query *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error)
 	machineInfoFunc                    func() (*cadvisorApi.MachineInfo, error)
-	boundPodsFunc                      func() ([]api.BoundPod, error)
+	podsFunc                           func() ([]api.Pod, error)
 	logFunc                            func(w http.ResponseWriter, req *http.Request)
 	runFunc                            func(podFullName string, uid types.UID, containerName string, cmd []string) ([]byte, error)
 	dockerVersionFunc                  func() ([]uint, error)
@@ -55,7 +55,7 @@ type fakeKubelet struct {
 	hostnameFunc                       func() string
 }
 
-func (fk *fakeKubelet) GetPodByName(namespace, name string) (*api.BoundPod, bool) {
+func (fk *fakeKubelet) GetPodByName(namespace, name string) (*api.Pod, bool) {
 	return fk.podByNameFunc(namespace, name)
 }
 
@@ -79,8 +79,8 @@ func (fk *fakeKubelet) GetMachineInfo() (*cadvisorApi.MachineInfo, error) {
 	return fk.machineInfoFunc()
 }
 
-func (fk *fakeKubelet) GetBoundPods() ([]api.BoundPod, error) {
-	return fk.boundPodsFunc()
+func (fk *fakeKubelet) GetPods() ([]api.Pod, error) {
+	return fk.podsFunc()
 }
 
 func (fk *fakeKubelet) ServeLogs(w http.ResponseWriter, req *http.Request) {
@@ -125,8 +125,8 @@ func newServerTest() *serverTestFramework {
 	}
 	fw.updateReader = startReading(fw.updateChan)
 	fw.fakeKubelet = &fakeKubelet{
-		podByNameFunc: func(namespace, name string) (*api.BoundPod, bool) {
-			return &api.BoundPod{
+		podByNameFunc: func(namespace, name string) (*api.Pod, bool) {
+			return &api.Pod{
 				ObjectMeta: api.ObjectMeta{
 					Namespace: namespace,
 					Name:      name,
@@ -510,8 +510,8 @@ func TestHealthCheck(t *testing.T) {
 }
 
 func setPodByNameFunc(fw *serverTestFramework, namespace, pod, container string) {
-	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*api.BoundPod, bool) {
-		return &api.BoundPod{
+	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*api.Pod, bool) {
+		return &api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Namespace: namespace,
 				Name:      pod,

--- a/pkg/kubelet/types.go
+++ b/pkg/kubelet/types.go
@@ -62,13 +62,13 @@ const (
 // functionally similar, this helps our unit tests properly check that the correct PodUpdates
 // are generated.
 type PodUpdate struct {
-	Pods   []api.BoundPod
+	Pods   []api.Pod
 	Op     PodOperation
 	Source string
 }
 
 // GetPodFullName returns a name that uniquely identifies a pod across all config sources.
-func GetPodFullName(pod *api.BoundPod) string {
+func GetPodFullName(pod *api.Pod) string {
 	// Use underscore as the delimiter because it is not allowed in pod name
 	// (DNS subdomain format), while allowed in the container name format.
 	return fmt.Sprintf("%s_%s", pod.Name, pod.Namespace)

--- a/pkg/kubelet/volumes.go
+++ b/pkg/kubelet/volumes.go
@@ -72,7 +72,7 @@ func (kl *Kubelet) newVolumeBuilderFromPlugins(spec *api.Volume, podRef *api.Obj
 	return builder
 }
 
-func (kl *Kubelet) mountExternalVolumes(pod *api.BoundPod) (volumeMap, error) {
+func (kl *Kubelet) mountExternalVolumes(pod *api.Pod) (volumeMap, error) {
 	podVolumes := make(volumeMap)
 	for i := range pod.Spec.Volumes {
 		volSpec := &pod.Spec.Volumes[i]

--- a/test/e2e/events.go
+++ b/test/e2e/events.go
@@ -115,7 +115,7 @@ var _ = Describe("Events", func() {
 			labels.Everything(),
 			labels.Set{
 				"involvedObject.uid":       string(podWithUid.UID),
-				"involvedObject.kind":      "BoundPod",
+				"involvedObject.kind":      "Pod",
 				"involvedObject.namespace": api.NamespaceDefault,
 				"source":                   "kubelet",
 			}.AsSelector(),


### PR DESCRIPTION
This PR is changing Kubelet to use Pods instead of BoundPods.

This is partially addressing #5392.

cc @bgrant0607 @vmarmol @dchen1107 @erictune 
