### PR TITLE
Make libvirt-coreos generate a .kubeconfig file and have e2e tests use it

### DIFF
--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -220,6 +220,13 @@ function kube-up {
     rm $domain_xml
   done
 
+  export KUBECONFIG="${HOME}/.kube/.kubeconfig"
+  local kubectl="${KUBE_ROOT}/cluster/kubectl.sh"
+
+  "${kubectl}" config set-cluster libvirt-coreos --server=http://${KUBE_MASTER_IP-}:8080
+  "${kubectl}" config set-context libvirt-coreos --cluster=libvirt-coreos
+  "${kubectl}" config use-context libvirt-coreos --cluster=libvirt-coreos
+
   wait-cluster-readiness
 
   echo "Kubernetes cluster is running. The master is running at:"

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -109,6 +109,10 @@ if [[ -z "${AUTH_CONFIG:-}" ]];  then
       auth_config=(
         "--auth_config=${HOME}/.kube/${INSTANCE_PREFIX}/kubernetes_auth"
       )
+    elif [[ "${KUBERNETES_PROVIDER}" == "libvirt-coreos" ]]; then
+      auth_config=(
+        "--kubeconfig=${HOME}/.kube/.kubeconfig"
+      )
     elif [[ "${KUBERNETES_PROVIDER}" == "conformance_test" ]]; then
       auth_config=(
         "--auth_config=${KUBERNETES_CONFORMANCE_TEST_AUTH_CONFIG:-}"
@@ -117,12 +121,6 @@ if [[ -z "${AUTH_CONFIG:-}" ]];  then
     else
       auth_config=()
     fi
-
-    if [[ "$KUBERNETES_PROVIDER" == "libvirt-coreos" ]]; then
-        host="http://${KUBE_MASTER_IP-}:8080"
-    else
-        host="https://${KUBE_MASTER_IP-}"
-    fi
 else
   echo "Conformance Test.  No cloud-provider-specific preparation."
   KUBERNETES_PROVIDER=""
@@ -130,13 +128,12 @@ else
     "--auth_config=${AUTH_CONFIG:-}"
     "--cert_dir=${CERT_DIR:-}"
   )
-  host="https://${KUBE_MASTER_IP-}"
 fi
 
 # Use the kubectl binary from the same directory as the e2e binary.
 export PATH=$(dirname "${e2e}"):"${PATH}"
 "${e2e}" "${auth_config[@]:+${auth_config[@]}}" \
-  --host="$host" \
+  --host="https://${KUBE_MASTER_IP-}" \
   --provider="${KUBERNETES_PROVIDER}" \
   --gce_project="${PROJECT:-}" \
   --gce_zone="${ZONE:-}" \

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -131,6 +131,9 @@ else
 fi
 
 # Use the kubectl binary from the same directory as the e2e binary.
+# The --host setting is used only when providing --auth_config
+# If --kubeconfig is used, the host to use is retrieved from the .kubeconfig
+# file and the one provided with --host is ignored.
 export PATH=$(dirname "${e2e}"):"${PATH}"
 "${e2e}" "${auth_config[@]:+${auth_config[@]}}" \
   --host="https://${KUBE_MASTER_IP-}" \


### PR DESCRIPTION
Since commit 7db006ab it is mandatory to have either a `kubeconfig` or an `auth_config` passed as parameter to e2e
Without it, e2e issues a bunch of errors:

```
  Expected error:
      <*errors.errorString | 0xc208175230>: {
          s: "error creating client: either kubeConfig or authConfig must be specified to load client config",
      }
      error creating client: either kubeConfig or authConfig must be specified to load client config
  not to have occurred
```

This PR fixes the above mentioned errors on libvirt-coreos cluster.
