### PR TITLE
Option to enable profiling on the master daemon processes.

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -179,6 +179,7 @@ func startComponents(manifestURL string) (apiServerURL string) {
 		EtcdHelper:        helper,
 		KubeletClient:     fakeKubeletClient{},
 		EnableLogsSupport: false,
+		EnableProfiling:   true,
 		APIPrefix:         "/api",
 		Authorizer:        apiserver.NewAlwaysAllowAuthorizer(),
 		AdmissionControl:  admit.NewAlwaysAdmit(),

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -74,6 +74,7 @@ type APIServer struct {
 	KubeletConfig              client.KubeletConfig
 	ClusterName                string
 	SyncPodStatus              bool
+	EnableProfiling            bool
 }
 
 // NewAPIServer creates a new APIServer object with default parameters
@@ -152,6 +153,7 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Var(&s.RuntimeConfig, "runtime_config", "A set of key=value pairs that describe runtime configuration that may be passed to the apiserver.")
 	client.BindKubeletClientConfigFlags(fs, &s.KubeletConfig)
 	fs.StringVar(&s.ClusterName, "cluster_name", s.ClusterName, "The instance prefix for the cluster")
+	fs.BoolVar(&s.EnableProfiling, "profiling", false, "Enable profiling via web interface host:port/debug/pprof/")
 }
 
 // TODO: Longer term we should read this from some config store, rather than a flag.
@@ -236,6 +238,7 @@ func (s *APIServer) Run(_ []string) error {
 		EnableLogsSupport:      s.EnableLogsSupport,
 		EnableUISupport:        true,
 		EnableSwaggerSupport:   true,
+		EnableProfiling:        s.EnableProfiling,
 		EnableIndex:            true,
 		APIPrefix:              s.APIPrefix,
 		CorsAllowedOriginList:  s.CorsAllowedOriginList,

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -59,6 +59,7 @@ var (
 	nodeMilliCPU           = flag.Int64("node_milli_cpu", 1000, "The amount of MilliCPU provisioned on each node")
 	nodeMemory             = flag.Int64("node_memory", 3*1024*1024*1024, "The amount of memory (in bytes) provisioned on each node")
 	masterServiceNamespace = flag.String("master_service_namespace", api.NamespaceDefault, "The namespace from which the kubernetes master services should be injected into pods")
+	enableProfiling        = flag.Bool("profiling", false, "Enable profiling via web interface host:port/debug/pprof/")
 )
 
 type delegateHandler struct {
@@ -92,6 +93,7 @@ func runApiServer(cl *client.Client, etcdClient tools.EtcdClient, addr net.IP, p
 		},
 		EnableLogsSupport:    false,
 		EnableSwaggerSupport: true,
+		EnableProfiling:      *enableProfiling,
 		APIPrefix:            "/api",
 		Authorizer:           apiserver.NewAlwaysAllowAuthorizer(),
 

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -54,6 +54,7 @@ func TestClient(t *testing.T) {
 		EtcdHelper:        helper,
 		KubeletClient:     client.FakeKubeletClient{},
 		EnableLogsSupport: false,
+		EnableProfiling:   true,
 		EnableUISupport:   false,
 		APIPrefix:         "/api",
 		Authorizer:        apiserver.NewAlwaysAllowAuthorizer(),


### PR DESCRIPTION
Following https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/devel/profiling.md
I've added options to the master daemons to enable profiling, default is off/false. 
