### PR TITLE
Delete master route on kube-down

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -785,6 +785,7 @@ function kube-down {
   local -a routes
   routes=( $(gcloud compute routes list --project "${PROJECT}" \
               --regexp "${NODE_INSTANCE_PREFIX}-.+" | awk 'NR >= 2 { print $1 }') )
+  routes+=("${MASTER_NAME}")
   while (( "${#routes[@]}" > 0 )); do
     echo Deleting routes "${routes[*]::10}"
     gcloud compute routes delete \


### PR DESCRIPTION
Fix jenkins break from #5390, by deleting the route created for the master in kube-down.
