### PR TITLE
Fix e2e test on vagrant provider

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -91,7 +91,8 @@ if [[ -z "${AUTH_CONFIG:-}" ]];  then
       # When we are using vagrant it has hard coded auth.  We repeat that here so that
       # we don't clobber auth that might be used for a publicly facing cluster.
       auth_config=(
-        "--auth_config=$HOME/.kubernetes_vagrant_auth"
+        "--auth_config=${HOME}/.kubernetes_vagrant_auth"
+        "--kubeconfig=${HOME}/.kubernetes_vagrant_kubeconfig"
       )
     elif [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
       # With GKE, our auth and certs are in gcloud's config directory.


### PR DESCRIPTION
Some e2e tests fail on vagrant provider because kubecli accesses to localhost. This is fixed by passing kubeconfg.

```
kubectl
/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/kubectl.go:93
  should scale a replication controller [It]
  /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/kubectl.go:79

  Error running &{/home/sabo/go/src/github.com/GoogleCloudPlatform/kubernetes/hack/../_output/dockerized/bin/linux/amd64//kubectl [kubectl --auth-path=/home/sabo/.kubernetes_vagrant_auth create -f examples/update-demo/v1beta1/nautilus-rc.yaml] []  <nil>  F0314 03:37:10.104830   21777 create.go:50] Client error processing command: Post http://localhost:8080/api/v1beta1/replicationControllers?namespace=default: dial tcp 127.0.0.1:8080: connection refused
   [] <nil> 0xc20814f820 exit status 255 <nil> true [0xc208062028 0xc208062048 0xc208062068] [0xc208062028 0xc208062048 0xc208062068] [0xc208062040 0xc208062060] [0x6081c0 0x6081c0] 0xc2080bda40}:
  Command stdout:

  stderr:
  F0314 03:37:10.104830   21777 create.go:50] Client error processing command: Post http://localhost:8080/api/v1beta1/replicationControllers?namespace=default: dial tcp 127.0.0.1:8080: connection refused
```

```
kubectl
/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/kubectl.go:93
  should do a rolling update of a replication controller [It]
  /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/kubectl.go:91

  Error running &{/home/sabo/go/src/github.com/GoogleCloudPlatform/kubernetes/hack/../_output/dockerized/bin/linux/amd64//kubectl [kubectl --auth-path=/home/sabo/.kubernetes_vagrant_auth create -f examples/update-demo/v1beta1/nautilus-rc.yaml] []  <nil>  F0314 03:37:09.802343   21755 create.go:50] Client error processing command: Post http://localhost:8080/api/v1beta1/replicationControllers?namespace=default: dial tcp 127.0.0.1:8080: connection refused
   [] <nil> 0xc208021aa0 exit status 255 <nil> true [0xc20803c048 0xc20803c088 0xc20803c0c8] [0xc20803c048 0xc20803c088 0xc20803c0c8] [0xc20803c078 0xc20803c0a8] [0x6081c0 0x6081c0] 0xc2080ac0c0}:
  Command stdout:

  stderr:
  F0314 03:37:09.802343   21755 create.go:50] Client error processing command: Post http://localhost:8080/api/v1beta1/replicationControllers?namespace=default: dial tcp 127.0.0.1:8080: connection refused
```

```
kubectl
/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/kubectl.go:93
  should create and stop a replication controller [It]
  /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/kubectl.go:65

  Error running &{/home/sabo/go/src/github.com/GoogleCloudPlatform/kubernetes/hack/../_output/dockerized/bin/linux/amd64//kubectl [kubectl --auth-path=/home/sabo/.kubernetes_vagrant_auth create -f examples/update-demo/v1beta1/nautilus-rc.yaml] []  <nil>  F0314 03:37:09.541300   21732 create.go:50] Client error processing command: Post http://localhost:8080/api/v1beta1/replicationControllers?namespace=default: dial tcp 127.0.0.1:8080: connection refused
   [] <nil> 0xc2080215e0 exit status 255 <nil> true [0xc208062028 0xc208062048 0xc208062068] [0xc208062028 0xc208062048 0xc208062068] [0xc208062040 0xc208062060] [0x6081c0 0x6081c0] 0xc2080ac0c0}:
  Command stdout:

  stderr:
  F0314 03:37:09.541300   21732 create.go:50] Client error processing command: Post http://localhost:8080/api/v1beta1/replicationControllers?namespace=default: dial tcp 127.0.0.1:8080: connection refused
```
