### PR TITLE
Fix a regression introduced lately: When any given PodInfraContainer on ...

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -423,7 +423,6 @@ func (c DockerContainers) RemoveContainerWithID(containerID DockerID) {
 // FindContainersByPod returns the containers that belong to the pod.
 func (c DockerContainers) FindContainersByPod(podUID types.UID, podFullName string) DockerContainers {
 	containers := make(DockerContainers)
-
 	for _, dockerContainer := range c {
 		if len(dockerContainer.Names) == 0 {
 			continue


### PR DESCRIPTION
...a node

is killed, kubelet kills all remaining containers no matter which pod that
container belongs to.

Fixed #5373

Also updated unittest to reproduce the issue without the fix. 
