### PR TITLE
fix broken link in services.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # OSX leaves these everywhere on SMB shares
 ._*
 
+# OSX trash
+.DS_Store
+
 # Eclipse files
 .classpath
 .project

--- a/docs/services.md
+++ b/docs/services.md
@@ -261,9 +261,9 @@ When a client connects to the portal the iptables rule kicks in, and redirects
 the packets to the `Service proxy`'s own port.  The `Service proxy` chooses a
 backend, and starts proxying traffic from the client to the backend.
 
-The means that `Service` owners can choose any `Service` port they want without
+This means that `Service` owners can choose any `Service` port they want without
 risk of collision.  Clients can simply connect to an IP and port, without
 being aware of which `Pods` they are actually accessing.
 
-![Services detailed diagram](Services_detail.png)
+![Services detailed diagram](services_detail.png)
 


### PR DESCRIPTION
fix broken link in https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/services.md , also add .DS_Store to gitignore
