### PR TITLE
Build statically linked binaries for kubernetes. 

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -296,13 +296,13 @@ kube::golang::build_binaries() {
           if [[ ${GOOS} == "windows" ]]; then
             bin="${bin}.exe"
           fi
-          go build -o "${output_path}/${bin}" \
+          CGO_ENABLED=0 go build -installsuffix cgo -o "${output_path}/${bin}" \
               "${goflags[@]:+${goflags[@]}}" \
               -ldflags "${version_ldflags}" \
               "${binary}"
         done
       else
-        go install "${goflags[@]:+${goflags[@]}}" \
+        CGO_ENABLED=0 go install -installsuffix cgo "${goflags[@]:+${goflags[@]}}" \
             -ldflags "${version_ldflags}" \
             "${binaries[@]}"
       fi


### PR DESCRIPTION
Build statically linked binaries. With the change to go 1.4, we probably were generating dynamically linked libraries accidentally.
