### PR TITLE
Remove cmd from kubectl/cmd/factory

### DIFF
--- a/pkg/kubectl/cmd/apiversions.go
+++ b/pkg/kubectl/cmd/apiversions.go
@@ -30,15 +30,15 @@ func (f *Factory) NewCmdApiVersions(out io.Writer) *cobra.Command {
 		Use:   "apiversions",
 		Short: "Print available API versions.",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := RunApiVersions(f, out, cmd)
+			err := RunApiVersions(f, out)
 			util.CheckErr(err)
 		},
 	}
 	return cmd
 }
 
-func RunApiVersions(f *Factory, out io.Writer, cmd *cobra.Command) error {
-	client, err := f.Client(cmd)
+func RunApiVersions(f *Factory, out io.Writer) error {
+	client, err := f.Client()
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/clusterinfo.go
+++ b/pkg/kubectl/cmd/clusterinfo.go
@@ -42,14 +42,14 @@ func (f *Factory) NewCmdClusterInfo(out io.Writer) *cobra.Command {
 }
 
 func RunClusterInfo(factory *Factory, out io.Writer, cmd *cobra.Command) error {
-	client, err := factory.ClientConfig(cmd)
+	client, err := factory.ClientConfig()
 	if err != nil {
 		return err
 	}
 	fmt.Fprintf(out, "Kubernetes master is running at %v\n", client.Host)
 
-	mapper, typer := factory.Object(cmd)
-	cmdNamespace, err := factory.DefaultNamespace(cmd)
+	mapper, typer := factory.Object()
+	cmdNamespace, err := factory.DefaultNamespace()
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -33,8 +33,6 @@ import (
 	. "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-
-	"github.com/spf13/cobra"
 )
 
 type internalType struct {
@@ -120,25 +118,25 @@ func NewTestFactory() (*Factory, *testFactory, runtime.Codec) {
 		Typer:     scheme,
 	}
 	return &Factory{
-		Object: func(*cobra.Command) (meta.RESTMapper, runtime.ObjectTyper) {
+		Object: func() (meta.RESTMapper, runtime.ObjectTyper) {
 			return t.Mapper, t.Typer
 		},
-		RESTClient: func(*cobra.Command, *meta.RESTMapping) (resource.RESTClient, error) {
+		RESTClient: func(*meta.RESTMapping) (resource.RESTClient, error) {
 			return t.Client, t.Err
 		},
-		Describer: func(*cobra.Command, *meta.RESTMapping) (kubectl.Describer, error) {
+		Describer: func(*meta.RESTMapping) (kubectl.Describer, error) {
 			return t.Describer, t.Err
 		},
-		Printer: func(cmd *cobra.Command, mapping *meta.RESTMapping, noHeaders bool) (kubectl.ResourcePrinter, error) {
+		Printer: func(mapping *meta.RESTMapping, noHeaders bool) (kubectl.ResourcePrinter, error) {
 			return t.Printer, t.Err
 		},
-		Validator: func(cmd *cobra.Command) (validation.Schema, error) {
+		Validator: func() (validation.Schema, error) {
 			return t.Validator, t.Err
 		},
-		DefaultNamespace: func(cmd *cobra.Command) (string, error) {
+		DefaultNamespace: func() (string, error) {
 			return t.Namespace, t.Err
 		},
-		ClientConfig: func(cmd *cobra.Command) (*client.Config, error) {
+		ClientConfig: func() (*client.Config, error) {
 			return t.ClientConfig, t.Err
 		},
 	}, t, codec
@@ -149,25 +147,25 @@ func NewAPIFactory() (*Factory, *testFactory, runtime.Codec) {
 		Validator: validation.NullSchema{},
 	}
 	return &Factory{
-		Object: func(*cobra.Command) (meta.RESTMapper, runtime.ObjectTyper) {
+		Object: func() (meta.RESTMapper, runtime.ObjectTyper) {
 			return latest.RESTMapper, api.Scheme
 		},
-		RESTClient: func(*cobra.Command, *meta.RESTMapping) (resource.RESTClient, error) {
+		RESTClient: func(*meta.RESTMapping) (resource.RESTClient, error) {
 			return t.Client, t.Err
 		},
-		Describer: func(*cobra.Command, *meta.RESTMapping) (kubectl.Describer, error) {
+		Describer: func(*meta.RESTMapping) (kubectl.Describer, error) {
 			return t.Describer, t.Err
 		},
-		Printer: func(cmd *cobra.Command, mapping *meta.RESTMapping, noHeaders bool) (kubectl.ResourcePrinter, error) {
+		Printer: func(mapping *meta.RESTMapping, noHeaders bool) (kubectl.ResourcePrinter, error) {
 			return t.Printer, t.Err
 		},
-		Validator: func(cmd *cobra.Command) (validation.Schema, error) {
+		Validator: func() (validation.Schema, error) {
 			return t.Validator, t.Err
 		},
-		DefaultNamespace: func(cmd *cobra.Command) (string, error) {
+		DefaultNamespace: func() (string, error) {
 			return t.Namespace, t.Err
 		},
-		ClientConfig: func(cmd *cobra.Command) (*client.Config, error) {
+		ClientConfig: func() (*client.Config, error) {
 			return t.ClientConfig, t.Err
 		},
 	}, t, latest.Codec
@@ -194,7 +192,7 @@ func TestClientVersions(t *testing.T) {
 		mapping := &meta.RESTMapping{
 			APIVersion: version,
 		}
-		c, err := f.RESTClient(nil, mapping)
+		c, err := f.RESTClient(mapping)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -55,17 +55,17 @@ func (f *Factory) NewCmdCreate(out io.Writer) *cobra.Command {
 }
 
 func RunCreate(f *Factory, out io.Writer, cmd *cobra.Command, filenames util.StringList) error {
-	schema, err := f.Validator(cmd)
+	schema, err := f.Validator()
 	if err != nil {
 		return err
 	}
 
-	cmdNamespace, err := f.DefaultNamespace(cmd)
+	cmdNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
 
-	mapper, typer := f.Object(cmd)
+	mapper, typer := f.Object()
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand(cmd)).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).RequireNamespace().

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -74,11 +74,11 @@ func (f *Factory) NewCmdDelete(out io.Writer) *cobra.Command {
 }
 
 func RunDelete(f *Factory, out io.Writer, cmd *cobra.Command, args []string, filenames util.StringList) error {
-	cmdNamespace, err := f.DefaultNamespace(cmd)
+	cmdNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
-	mapper, typer := f.Object(cmd)
+	mapper, typer := f.Object()
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand(cmd)).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -41,19 +41,19 @@ given resource.`,
 }
 
 func RunDescribe(f *Factory, out io.Writer, cmd *cobra.Command, args []string) error {
-	cmdNamespace, err := f.DefaultNamespace(cmd)
+	cmdNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
 
-	mapper, _ := f.Object(cmd)
+	mapper, _ := f.Object()
 	// TODO: use resource.Builder instead
 	mapping, namespace, name, err := util.ResourceFromArgs(cmd, args, mapper, cmdNamespace)
 	if err != nil {
 		return err
 	}
 
-	describer, err := f.Describer(cmd, mapping)
+	describer, err := f.Describer(mapping)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -67,12 +67,12 @@ func RunExec(f *Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cobra.C
 		return util.UsageError(cmd, "COMMAND is required for exec")
 	}
 
-	namespace, err := f.DefaultNamespace(cmd)
+	namespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
 
-	client, err := f.Client(cmd)
+	client, err := f.Client()
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func RunExec(f *Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cobra.C
 		}
 	}
 
-	config, err := f.ClientConfig(cmd)
+	config, err := f.ClientConfig()
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -69,11 +69,11 @@ func RunExpose(f *Factory, out io.Writer, cmd *cobra.Command, args []string) err
 		return util.UsageError(cmd, "<name> is required for expose")
 	}
 
-	namespace, err := f.DefaultNamespace(cmd)
+	namespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
-	client, err := f.Client(cmd)
+	client, err := f.Client()
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -78,9 +78,9 @@ func (f *Factory) NewCmdGet(out io.Writer) *cobra.Command {
 // TODO: convert all direct flag accessors to a struct and pass that instead of cmd
 func RunGet(f *Factory, out io.Writer, cmd *cobra.Command, args []string) error {
 	selector := util.GetFlagString(cmd, "selector")
-	mapper, typer := f.Object(cmd)
+	mapper, typer := f.Object()
 
-	cmdNamespace, err := f.DefaultNamespace(cmd)
+	cmdNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func RunGet(f *Factory, out io.Writer, cmd *cobra.Command, args []string) error 
 	}
 
 	if generic {
-		clientConfig, err := f.ClientConfig(cmd)
+		clientConfig, err := f.ClientConfig()
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -159,18 +159,18 @@ func RunLabel(f *Factory, out io.Writer, cmd *cobra.Command, args []string) erro
 		return util.UsageError(cmd, "at least one label update is required.")
 	}
 	res := args[:2]
-	cmdNamespace, err := f.DefaultNamespace(cmd)
+	cmdNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
 
-	mapper, _ := f.Object(cmd)
+	mapper, _ := f.Object()
 	// TODO: use resource.Builder instead
 	mapping, namespace, name, err := util.ResourceFromArgs(cmd, res, mapper, cmdNamespace)
 	if err != nil {
 		return err
 	}
-	client, err := f.RESTClient(cmd, mapping)
+	client, err := f.RESTClient(mapping)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/log.go
+++ b/pkg/kubectl/cmd/log.go
@@ -82,11 +82,11 @@ func RunLog(f *Factory, out io.Writer, cmd *cobra.Command, args []string) error 
 		return util.UsageError(cmd, "log POD [CONTAINER]")
 	}
 
-	namespace, err := f.DefaultNamespace(cmd)
+	namespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
-	client, err := f.Client(cmd)
+	client, err := f.Client()
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/portforward.go
+++ b/pkg/kubectl/cmd/portforward.go
@@ -68,12 +68,12 @@ func RunPortForward(f *Factory, cmd *cobra.Command, args []string) error {
 		return util.UsageError(cmd, "at least 1 PORT is required for port-forward")
 	}
 
-	namespace, err := f.DefaultNamespace(cmd)
+	namespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
 
-	client, err := f.Client(cmd)
+	client, err := f.Client()
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func RunPortForward(f *Factory, cmd *cobra.Command, args []string) error {
 		glog.Fatalf("Unable to execute command because pod is not running. Current status=%v", pod.Status.Phase)
 	}
 
-	config, err := f.ClientConfig(cmd)
+	config, err := f.ClientConfig()
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -58,7 +58,7 @@ func RunProxy(f *Factory, out io.Writer, cmd *cobra.Command) error {
 	port := util.GetFlagInt(cmd, "port")
 	fmt.Fprintf(out, "Starting to serve on localhost:%d", port)
 
-	clientConfig, err := f.ClientConfig(cmd)
+	clientConfig, err := f.ClientConfig()
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/resize.go
+++ b/pkg/kubectl/cmd/resize.go
@@ -68,19 +68,19 @@ func RunResize(f *Factory, out io.Writer, cmd *cobra.Command, args []string) err
 		return util.UsageError(cmd, "--replicas=COUNT RESOURCE ID")
 	}
 
-	cmdNamespace, err := f.DefaultNamespace(cmd)
+	cmdNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
 
-	mapper, _ := f.Object(cmd)
+	mapper, _ := f.Object()
 	// TODO: use resource.Builder instead
 	mapping, namespace, name, err := util.ResourceFromArgs(cmd, args, mapper, cmdNamespace)
 	if err != nil {
 		return err
 	}
 
-	resizer, err := f.Resizer(cmd, mapping)
+	resizer, err := f.Resizer(mapping)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -72,18 +72,18 @@ func RunRollingUpdate(f *Factory, out io.Writer, cmd *cobra.Command, args []stri
 		return util.UsageError(cmd, "Must specify the controller to update")
 	}
 	oldName := args[0]
-	schema, err := f.Validator(cmd)
+	schema, err := f.Validator()
 	if err != nil {
 		return err
 	}
 
-	clientConfig, err := f.ClientConfig(cmd)
+	clientConfig, err := f.ClientConfig()
 	if err != nil {
 		return err
 	}
 	cmdApiVersion := clientConfig.Version
 
-	mapper, typer := f.Object(cmd)
+	mapper, typer := f.Object()
 	// TODO: use resource.Builder instead
 	mapping, namespace, newName, data, err := util.ResourceFromFile(filename, typer, mapper, schema, cmdApiVersion)
 	if err != nil {
@@ -97,7 +97,7 @@ func RunRollingUpdate(f *Factory, out io.Writer, cmd *cobra.Command, args []stri
 			filename, oldName)
 	}
 
-	cmdNamespace, err := f.DefaultNamespace(cmd)
+	cmdNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func RunRollingUpdate(f *Factory, out io.Writer, cmd *cobra.Command, args []stri
 		return err
 	}
 
-	client, err := f.Client(cmd)
+	client, err := f.Client()
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -69,12 +69,12 @@ func RunRunContainer(f *Factory, out io.Writer, cmd *cobra.Command, args []strin
 		return util.UsageError(cmd, "NAME is required for run-container")
 	}
 
-	namespace, err := f.DefaultNamespace(cmd)
+	namespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
 
-	client, err := f.Client(cmd)
+	client, err := f.Client()
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/stop.go
+++ b/pkg/kubectl/cmd/stop.go
@@ -54,9 +54,9 @@ func (f *Factory) NewCmdStop(out io.Writer) *cobra.Command {
 		Long:    stop_long,
 		Example: stop_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdNamespace, err := f.DefaultNamespace(cmd)
+			cmdNamespace, err := f.DefaultNamespace()
 			cmdutil.CheckErr(err)
-			mapper, typer := f.Object(cmd)
+			mapper, typer := f.Object()
 			r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand(cmd)).
 				ContinueOnError().
 				NamespaceParam(cmdNamespace).RequireNamespace().
@@ -69,7 +69,7 @@ func (f *Factory) NewCmdStop(out io.Writer) *cobra.Command {
 			cmdutil.CheckErr(r.Err())
 
 			r.Visit(func(info *resource.Info) error {
-				reaper, err := f.Reaper(cmd, info.Mapping)
+				reaper, err := f.Reaper(info.Mapping)
 				cmdutil.CheckErr(err)
 				s, err := reaper.Stop(info.Namespace, info.Name)
 				if err != nil {

--- a/pkg/kubectl/cmd/update.go
+++ b/pkg/kubectl/cmd/update.go
@@ -58,12 +58,12 @@ func (f *Factory) NewCmdUpdate(out io.Writer) *cobra.Command {
 }
 
 func RunUpdate(f *Factory, out io.Writer, cmd *cobra.Command, args []string, filenames util.StringList) error {
-	schema, err := f.Validator(cmd)
+	schema, err := f.Validator()
 	if err != nil {
 		return err
 	}
 
-	cmdNamespace, err := f.DefaultNamespace(cmd)
+	cmdNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func RunUpdate(f *Factory, out io.Writer, cmd *cobra.Command, args []string, fil
 		return nil
 	}
 
-	mapper, typer := f.Object(cmd)
+	mapper, typer := f.Object()
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand(cmd)).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).RequireNamespace().
@@ -118,18 +118,18 @@ func RunUpdate(f *Factory, out io.Writer, cmd *cobra.Command, args []string, fil
 }
 
 func updateWithPatch(cmd *cobra.Command, args []string, f *Factory, patch string) (string, error) {
-	cmdNamespace, err := f.DefaultNamespace(cmd)
+	cmdNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return "", err
 	}
 
-	mapper, _ := f.Object(cmd)
+	mapper, _ := f.Object()
 	// TODO: use resource.Builder instead
 	mapping, namespace, name, err := cmdutil.ResourceFromArgs(cmd, args, mapper, cmdNamespace)
 	if err != nil {
 		return "", err
 	}
-	client, err := f.RESTClient(cmd, mapping)
+	client, err := f.RESTClient(mapping)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kubectl/cmd/version.go
+++ b/pkg/kubectl/cmd/version.go
@@ -44,7 +44,7 @@ func RunVersion(f *Factory, out io.Writer, cmd *cobra.Command) error {
 		return nil
 	}
 
-	client, err := f.Client(cmd)
+	client, err := f.Client()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I removed the `cmd` arguments from the factory methods as requested in issue #4470
