### PR TITLE
auto-scaler types

### DIFF
--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -52,6 +52,8 @@ func init() {
 		&NamespaceList{},
 		&Secret{},
 		&SecretList{},
+		&AutoScaler{},
+		&AutoScalerList{},
 	)
 	// Legacy names are supported
 	Scheme.AddKnownTypeWithName("", "Minion", &Node{})
@@ -85,3 +87,5 @@ func (*Namespace) IsAnAPIObject()                 {}
 func (*NamespaceList) IsAnAPIObject()             {}
 func (*Secret) IsAnAPIObject()                    {}
 func (*SecretList) IsAnAPIObject()                {}
+func (*AutoScaler) IsAnAPIObject()                {}
+func (*AutoScalerList) IsAnAPIObject()            {}

--- a/pkg/api/rest/types.go
+++ b/pkg/api/rest/types.go
@@ -107,3 +107,30 @@ func (nodeStrategy) Validate(obj runtime.Object) errors.ValidationErrorList {
 	node := obj.(*api.Node)
 	return validation.ValidateMinion(node)
 }
+
+// namespaceStrategy implements behavior for nodes
+type namespaceStrategy struct {
+	runtime.ObjectTyper
+	api.NameGenerator
+}
+
+// Namespaces is the default logic that applies when creating and updating Namespace
+// objects.
+var Namespaces RESTCreateStrategy = namespaceStrategy{api.Scheme, api.SimpleNameGenerator}
+
+// NamespaceScoped is false for namespaces.
+func (namespaceStrategy) NamespaceScoped() bool {
+	return false
+}
+
+// ResetBeforeCreate clears fields that are not allowed to be set by end users on creation.
+func (namespaceStrategy) ResetBeforeCreate(obj runtime.Object) {
+	_ = obj.(*api.Namespace)
+	// Namespace allow *all* fields, including status, to be set.
+}
+
+// Validate validates a new namespace.
+func (namespaceStrategy) Validate(obj runtime.Object) errors.ValidationErrorList {
+	namespace := obj.(*api.Namespace)
+	return validation.ValidateNamespace(namespace)
+}

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -219,6 +219,11 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 				ss.ContainerPort.StrVal = "x" + ss.ContainerPort.StrVal // non-empty
 			}
 		},
+		func(a *api.AutoScaler, c fuzz.Continue) {
+			c.Fuzz(&a.TypeMeta)
+			c.Fuzz(&a.ObjectMeta)
+			c.Fuzz(&a.Spec)
+		},
 	)
 	return f
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1443,3 +1443,94 @@ func AddToNodeAddresses(addresses *[]NodeAddress, addAddresses ...NodeAddress) {
 		}
 	}
 }
+
+// AutoScaler monitors other resources that are resizeable and adjusts them according to configuration.
+type AutoScaler struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+
+	// Spec defines the auto-scaler targets and thresholds.
+	Spec AutoScalerSpec `json:"spec,omitempty"`
+
+	// Status defines the actions the auto-scaler has taken.
+	Status AutoScalerStatus `json:"status,omitempty"`
+}
+
+// AutoScalerStatus provides the status of an auto-scaler.
+type AutoScalerStatus struct {
+	// TODO: open for discussion on what meaningful information can be reported in the status
+	// The status may return the replica count here but we may want more information
+	// such as if the count reflects a threshold being passed.
+}
+
+// AutoScalerSpec defines the auto-scaler targets and thresholds.
+type AutoScalerSpec struct {
+	// Thresholds holds a collection of AutoScaleThresholds that drive the auto-scaler.
+	Thresholds []AutoScaleThreshold `json:"thresholds,omitempty"`
+
+	// Enabled turns auto scaling on or off.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// MaxAutoScaleCount defines the max replicas that the auto-scaler can use.  This value must be
+	// >= MinAutoScaleCount.
+	MaxAutoScaleCount int `json:"maxAutoScaleCount,omitempty"`
+
+	// MinAutoScaleCount defines the minimum number replicas that the auto-scaler can reduce to,
+	// 0 means that the application is allowed to idle.
+	MinAutoScaleCount int `json:"minAutoScaleCount,omitempty"`
+
+	// TargetSelector provides the resizeable target(s).  Right now this is a ReplicationController
+	// in the future it could be a job or any resource that implements resize.  If multiple targets
+	// are resolved by the selector the auto-scaler will resize the largest one.
+	TargetSelector map[string]string `json:"targetSelector,omitempty"`
+
+	// MonitorSelector defines a set of capacity that the auto-scaler is monitoring
+	// (replication controllers).  Monitored objects are used by thresholds to examine
+	// statistics.  Example: get statistic X for object Y to see if threshold is passed.
+	MonitorSelector map[string]string `json:"monitorSelector,omitempty"`
+}
+
+// AutoScaleThreshold is a behavior based on statistics used to drive the auto-scaler in scaling decisions.
+type AutoScaleThreshold struct {
+	// Type is the type of threshold being used, intention or value.
+	Type AutoScaleThresholdType `json:"type,omitempty"`
+
+	// IntentionConfig holds the config for intention based thresholds.
+	IntentionConfig AutoScaleIntentionThresholdConfig `json:"intentionConfig,omitempty"`
+}
+
+// AutoScaleIntentionThresholdConfig holds configuration for intention based thresholds.
+// The scaler will adjust by 1 accordingly and maintain once the intention is reached.
+type AutoScaleIntentionThresholdConfig struct {
+	// Intent is the lexicon of what intention is requested.
+	Intent AutoScaleIntentionType `json:"intent,omitempty"`
+
+	// Value is intention dependent in terms of above, below, equal and represents
+	// the value to check against.
+	Value float32 `json:"value,omitempty"`
+}
+
+// AutoScaleThresholdType is either intention based or value based.
+type AutoScaleThresholdType string
+
+// AutoScaleIntentionType is a lexicon for intentions such as "cpu-utilization",
+// "max-rps-per-endpoint".
+type AutoScaleIntentionType string
+
+// Constants for auto-scalers and any auto-scaling child types like intentions
+const (
+	// AutoScaleThresholdTypeIntention is used when defining an intention based threshold.
+	AutoScaleThresholdTypeIntention AutoScaleThresholdType = "Intention"
+
+	// TODO: AutoScaleIntentionType types
+	// example: AutoScaleIntentionTypeMaxRPS AutoScaleIntentionType = "MaxRPS"
+)
+
+// AutoScalerList is a list of AutoScaler items
+type AutoScalerList struct {
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+
+	// Items is a list of AutoScaler objects.
+	Items []AutoScaler `json:"items"`
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1468,25 +1468,22 @@ type AutoScalerSpec struct {
 	// Thresholds holds a collection of AutoScaleThresholds that drive the auto-scaler.
 	Thresholds []AutoScaleThreshold `json:"thresholds,omitempty"`
 
-	// Enabled turns auto scaling on or off.
-	Enabled bool `json:"enabled,omitempty"`
-
 	// MaxAutoScaleCount defines the max replicas that the auto-scaler can use.  This value must be
 	// >= MinAutoScaleCount.
-	MaxAutoScaleCount int `json:"maxAutoScaleCount,omitempty"`
+	MaxAutoScaleCount int64 `json:"maxAutoScaleCount,omitempty"`
 
 	// MinAutoScaleCount defines the minimum number replicas that the auto-scaler can reduce to,
 	// 0 means that the application is allowed to idle.
-	MinAutoScaleCount int `json:"minAutoScaleCount,omitempty"`
+	MinAutoScaleCount int64 `json:"minAutoScaleCount,omitempty"`
 
 	// TargetSelector provides the resizeable target(s).  Right now this is a ReplicationController
 	// in the future it could be a job or any resource that implements resize.  If multiple targets
 	// are resolved by the selector the auto-scaler will resize the largest one.
 	TargetSelector map[string]string `json:"targetSelector,omitempty"`
 
-	// MonitorSelector defines a set of capacity that the auto-scaler is monitoring
+	// MonitorSelector defines a set of resources that the auto-scaler is monitoring
 	// (replication controllers).  Monitored objects are used by thresholds to examine
-	// statistics.  Example: get statistic X for object Y to see if threshold is passed.
+	// statistics.  Example: get statistic X for object Y (the monitored object) to see if threshold is passed.
 	MonitorSelector map[string]string `json:"monitorSelector,omitempty"`
 }
 

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -1369,6 +1369,36 @@ func init() {
 			out.PodID = in.Name
 			return nil
 		},
+		func(in *newer.AutoScalerList, out *AutoScalerList, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Items, &out.Items, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(in *newer.AutoScaler, out *AutoScaler, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+
+			if err := s.Convert(&in.Spec, &out.Spec, 0); err != nil {
+				return err
+			}
+
+			if err := s.Convert(&in.Status, &out.Status, 0); err != nil {
+				return err
+			}
+
+			return nil
+		},
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -1369,23 +1369,35 @@ func init() {
 			out.PodID = in.Name
 			return nil
 		},
-		func(in *newer.AutoScalerList, out *AutoScalerList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.Items, &out.Items, 0); err != nil {
-				return err
-			}
-			return nil
-		},
 		func(in *newer.AutoScaler, out *AutoScaler, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err
 			}
 			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Labels, &out.Labels, 0); err != nil {
+				return err
+			}
+
+			if err := s.Convert(&in.Spec, &out.Spec, 0); err != nil {
+				return err
+			}
+
+			if err := s.Convert(&in.Status, &out.Status, 0); err != nil {
+				return err
+			}
+
+			return nil
+		},
+		func(in *AutoScaler, out *newer.AutoScaler, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Labels, &out.Labels, 0); err != nil {
 				return err
 			}
 

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -59,6 +59,8 @@ func init() {
 		&NamespaceList{},
 		&Secret{},
 		&SecretList{},
+		&AutoScaler{},
+		&AutoScalerList{},
 	)
 	// Future names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta1", "Node", &Minion{})
@@ -92,3 +94,5 @@ func (*Namespace) IsAnAPIObject()                 {}
 func (*NamespaceList) IsAnAPIObject()             {}
 func (*Secret) IsAnAPIObject()                    {}
 func (*SecretList) IsAnAPIObject()                {}
+func (*AutoScaler) IsAnAPIObject()                {}
+func (*AutoScalerList) IsAnAPIObject()            {}

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -1185,6 +1185,7 @@ type SecretList struct {
 // AutoScaler monitors other resources that are resizeable and adjusts them according to configuration.
 type AutoScaler struct {
 	TypeMeta `json:",inline"`
+	Labels   map[string]string `json:"labels,omitempty"`
 
 	// Spec defines the auto-scaler targets and thresholds.
 	Spec AutoScalerSpec `json:"spec,omitempty"`
@@ -1205,25 +1206,22 @@ type AutoScalerSpec struct {
 	// Thresholds holds a collection of AutoScaleThresholds that drive the auto-scaler.
 	Thresholds []AutoScaleThreshold `json:"thresholds,omitempty"`
 
-	// Enabled turns auto scaling on or off.
-	Enabled bool `json:"enabled,omitempty"`
-
 	// MaxAutoScaleCount defines the max replicas that the auto-scaler can use.  This value must be
 	// >= MinAutoScaleCount.
-	MaxAutoScaleCount int `json:"maxAutoScaleCount,omitempty"`
+	MaxAutoScaleCount int64 `json:"maxAutoScaleCount,omitempty"`
 
 	// MinAutoScaleCount defines the minimum number replicas that the auto-scaler can reduce to,
 	// 0 means that the application is allowed to idle.
-	MinAutoScaleCount int `json:"minAutoScaleCount,omitempty"`
+	MinAutoScaleCount int64 `json:"minAutoScaleCount,omitempty"`
 
 	// TargetSelector provides the resizeable target(s).  Right now this is a ReplicationController
 	// in the future it could be a job or any resource that implements resize.  If multiple targets
 	// are resolved by the selector the auto-scaler will resize the largest one.
 	TargetSelector map[string]string `json:"targetSelector,omitempty"`
 
-	// MonitorSelector defines a set of capacity that the auto-scaler is monitoring
+	// MonitorSelector defines a set of resources that the auto-scaler is monitoring
 	// (replication controllers).  Monitored objects are used by thresholds to examine
-	// statistics.  Example: get statistic X for object Y to see if threshold is passed.
+	// statistics.  Example: get statistic X for object Y (the monitored object) to see if threshold is passed.
 	MonitorSelector map[string]string `json:"monitorSelector,omitempty"`
 }
 

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -1181,3 +1181,92 @@ type SecretList struct {
 
 	Items []Secret `json:"items" description:"items is a list of secret objects"`
 }
+
+// AutoScaler monitors other resources that are resizeable and adjusts them according to configuration.
+type AutoScaler struct {
+	TypeMeta `json:",inline"`
+
+	// Spec defines the auto-scaler targets and thresholds.
+	Spec AutoScalerSpec `json:"spec,omitempty"`
+
+	// Status defines the actions the auto-scaler has taken.
+	Status AutoScalerStatus `json:"status,omitempty"`
+}
+
+// AutoScalerStatus provides the status of an auto-scaler.
+type AutoScalerStatus struct {
+	// TODO: open for discussion on what meaningful information can be reported in the status
+	// The status may return the replica count here but we may want more information
+	// such as if the count reflects a threshold being passed.
+}
+
+// AutoScalerSpec defines the auto-scaler targets and thresholds.
+type AutoScalerSpec struct {
+	// Thresholds holds a collection of AutoScaleThresholds that drive the auto-scaler.
+	Thresholds []AutoScaleThreshold `json:"thresholds,omitempty"`
+
+	// Enabled turns auto scaling on or off.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// MaxAutoScaleCount defines the max replicas that the auto-scaler can use.  This value must be
+	// >= MinAutoScaleCount.
+	MaxAutoScaleCount int `json:"maxAutoScaleCount,omitempty"`
+
+	// MinAutoScaleCount defines the minimum number replicas that the auto-scaler can reduce to,
+	// 0 means that the application is allowed to idle.
+	MinAutoScaleCount int `json:"minAutoScaleCount,omitempty"`
+
+	// TargetSelector provides the resizeable target(s).  Right now this is a ReplicationController
+	// in the future it could be a job or any resource that implements resize.  If multiple targets
+	// are resolved by the selector the auto-scaler will resize the largest one.
+	TargetSelector map[string]string `json:"targetSelector,omitempty"`
+
+	// MonitorSelector defines a set of capacity that the auto-scaler is monitoring
+	// (replication controllers).  Monitored objects are used by thresholds to examine
+	// statistics.  Example: get statistic X for object Y to see if threshold is passed.
+	MonitorSelector map[string]string `json:"monitorSelector,omitempty"`
+}
+
+// AutoScaleThreshold is a behavior based on statistics used to drive the auto-scaler in scaling decisions.
+type AutoScaleThreshold struct {
+	// Type is the type of threshold being used, intention or value.
+	Type AutoScaleThresholdType `json:"type,omitempty"`
+
+	// IntentionConfig holds the config for intention based thresholds.
+	IntentionConfig AutoScaleIntentionThresholdConfig `json:"intentionConfig,omitempty"`
+}
+
+// AutoScaleIntentionThresholdConfig holds configuration for intention based thresholds.
+// The scaler will adjust by 1 accordingly and maintain once the intention is reached.
+type AutoScaleIntentionThresholdConfig struct {
+	// Intent is the lexicon of what intention is requested.
+	Intent AutoScaleIntentionType `json:"intent,omitempty"`
+
+	// Value is intention dependent in terms of above, below, equal and represents
+	// the value to check against.
+	Value float32 `json:"value,omitempty"`
+}
+
+// AutoScaleThresholdType is either intention based or value based.
+type AutoScaleThresholdType string
+
+// AutoScaleIntentionType is a lexicon for intentions such as "cpu-utilization",
+// "max-rps-per-endpoint".
+type AutoScaleIntentionType string
+
+// Constants for auto-scalers and any auto-scaling child types like intentions
+const (
+	// AutoScaleThresholdTypeIntention is used when defining an intention based threshold.
+	AutoScaleThresholdTypeIntention AutoScaleThresholdType = "Intention"
+
+	// TODO: AutoScaleIntentionType types
+	// example: AutoScaleIntentionTypeMaxRPS AutoScaleIntentionType = "MaxRPS"
+)
+
+// AutoScalerList is a list of AutoScaler items
+type AutoScalerList struct {
+	TypeMeta `json:",inline"`
+
+	// Items is a list of AutoScaler objects.
+	Items []AutoScaler `json:"items"`
+}

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -1297,6 +1297,36 @@ func init() {
 			out.PodID = in.Name
 			return nil
 		},
+		func(in *newer.AutoScalerList, out *AutoScalerList, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Items, &out.Items, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(in *newer.AutoScaler, out *AutoScaler, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+
+			if err := s.Convert(&in.Spec, &out.Spec, 0); err != nil {
+				return err
+			}
+
+			if err := s.Convert(&in.Status, &out.Status, 0); err != nil {
+				return err
+			}
+
+			return nil
+		},
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -1297,23 +1297,35 @@ func init() {
 			out.PodID = in.Name
 			return nil
 		},
-		func(in *newer.AutoScalerList, out *AutoScalerList, s conversion.Scope) error {
-			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.Items, &out.Items, 0); err != nil {
-				return err
-			}
-			return nil
-		},
 		func(in *newer.AutoScaler, out *AutoScaler, s conversion.Scope) error {
 			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 				return err
 			}
 			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Labels, &out.Labels, 0); err != nil {
+				return err
+			}
+
+			if err := s.Convert(&in.Spec, &out.Spec, 0); err != nil {
+				return err
+			}
+
+			if err := s.Convert(&in.Status, &out.Status, 0); err != nil {
+				return err
+			}
+
+			return nil
+		},
+		func(in *AutoScaler, out *newer.AutoScaler, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.TypeMeta, &out.ObjectMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Labels, &out.Labels, 0); err != nil {
 				return err
 			}
 

--- a/pkg/api/v1beta2/register.go
+++ b/pkg/api/v1beta2/register.go
@@ -59,6 +59,8 @@ func init() {
 		&NamespaceList{},
 		&Secret{},
 		&SecretList{},
+		&AutoScaler{},
+		&AutoScalerList{},
 	)
 	// Future names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta2", "Node", &Minion{})
@@ -92,3 +94,5 @@ func (*Namespace) IsAnAPIObject()                 {}
 func (*NamespaceList) IsAnAPIObject()             {}
 func (*Secret) IsAnAPIObject()                    {}
 func (*SecretList) IsAnAPIObject()                {}
+func (*AutoScaler) IsAnAPIObject()                {}
+func (*AutoScalerList) IsAnAPIObject()            {}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -1244,3 +1244,92 @@ type SecretList struct {
 
 	Items []Secret `json:"items" description:"items is a list of secret objects"`
 }
+
+// AutoScaler monitors other resources that are resizeable and adjusts them according to configuration.
+type AutoScaler struct {
+	TypeMeta `json:",inline"`
+
+	// Spec defines the auto-scaler targets and thresholds.
+	Spec AutoScalerSpec `json:"spec,omitempty"`
+
+	// Status defines the actions the auto-scaler has taken.
+	Status AutoScalerStatus `json:"status,omitempty"`
+}
+
+// AutoScalerStatus provides the status of an auto-scaler.
+type AutoScalerStatus struct {
+	// TODO: open for discussion on what meaningful information can be reported in the status
+	// The status may return the replica count here but we may want more information
+	// such as if the count reflects a threshold being passed.
+}
+
+// AutoScalerSpec defines the auto-scaler targets and thresholds.
+type AutoScalerSpec struct {
+	// Thresholds holds a collection of AutoScaleThresholds that drive the auto-scaler.
+	Thresholds []AutoScaleThreshold `json:"thresholds,omitempty"`
+
+	// Enabled turns auto scaling on or off.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// MaxAutoScaleCount defines the max replicas that the auto-scaler can use.  This value must be
+	// >= MinAutoScaleCount.
+	MaxAutoScaleCount int `json:"maxAutoScaleCount,omitempty"`
+
+	// MinAutoScaleCount defines the minimum number replicas that the auto-scaler can reduce to,
+	// 0 means that the application is allowed to idle.
+	MinAutoScaleCount int `json:"minAutoScaleCount,omitempty"`
+
+	// TargetSelector provides the resizeable target(s).  Right now this is a ReplicationController
+	// in the future it could be a job or any resource that implements resize.  If multiple targets
+	// are resolved by the selector the auto-scaler will resize the largest one.
+	TargetSelector map[string]string `json:"targetSelector,omitempty"`
+
+	// MonitorSelector defines a set of capacity that the auto-scaler is monitoring
+	// (replication controllers).  Monitored objects are used by thresholds to examine
+	// statistics.  Example: get statistic X for object Y to see if threshold is passed.
+	MonitorSelector map[string]string `json:"monitorSelector,omitempty"`
+}
+
+// AutoScaleThreshold is a behavior based on statistics used to drive the auto-scaler in scaling decisions.
+type AutoScaleThreshold struct {
+	// Type is the type of threshold being used, intention or value.
+	Type AutoScaleThresholdType `json:"type,omitempty"`
+
+	// IntentionConfig holds the config for intention based thresholds.
+	IntentionConfig AutoScaleIntentionThresholdConfig `json:"intentionConfig,omitempty"`
+}
+
+// AutoScaleIntentionThresholdConfig holds configuration for intention based thresholds.
+// The scaler will adjust by 1 accordingly and maintain once the intention is reached.
+type AutoScaleIntentionThresholdConfig struct {
+	// Intent is the lexicon of what intention is requested.
+	Intent AutoScaleIntentionType `json:"intent,omitempty"`
+
+	// Value is intention dependent in terms of above, below, equal and represents
+	// the value to check against.
+	Value float32 `json:"value,omitempty"`
+}
+
+// AutoScaleThresholdType is either intention based or value based.
+type AutoScaleThresholdType string
+
+// AutoScaleIntentionType is a lexicon for intentions such as "cpu-utilization",
+// "max-rps-per-endpoint".
+type AutoScaleIntentionType string
+
+// Constants for auto-scalers and any auto-scaling child types like intentions
+const (
+	// AutoScaleThresholdTypeIntention is used when defining an intention based threshold.
+	AutoScaleThresholdTypeIntention AutoScaleThresholdType = "Intention"
+
+	// TODO: AutoScaleIntentionType types
+	// example: AutoScaleIntentionTypeMaxRPS AutoScaleIntentionType = "MaxRPS"
+)
+
+// AutoScalerList is a list of AutoScaler items
+type AutoScalerList struct {
+	TypeMeta `json:",inline"`
+
+	// Items is a list of AutoScaler objects.
+	Items []AutoScaler `json:"items"`
+}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -1248,6 +1248,7 @@ type SecretList struct {
 // AutoScaler monitors other resources that are resizeable and adjusts them according to configuration.
 type AutoScaler struct {
 	TypeMeta `json:",inline"`
+	Labels   map[string]string `json:"labels,omitempty"`
 
 	// Spec defines the auto-scaler targets and thresholds.
 	Spec AutoScalerSpec `json:"spec,omitempty"`
@@ -1268,25 +1269,22 @@ type AutoScalerSpec struct {
 	// Thresholds holds a collection of AutoScaleThresholds that drive the auto-scaler.
 	Thresholds []AutoScaleThreshold `json:"thresholds,omitempty"`
 
-	// Enabled turns auto scaling on or off.
-	Enabled bool `json:"enabled,omitempty"`
-
 	// MaxAutoScaleCount defines the max replicas that the auto-scaler can use.  This value must be
 	// >= MinAutoScaleCount.
-	MaxAutoScaleCount int `json:"maxAutoScaleCount,omitempty"`
+	MaxAutoScaleCount int64 `json:"maxAutoScaleCount,omitempty"`
 
 	// MinAutoScaleCount defines the minimum number replicas that the auto-scaler can reduce to,
 	// 0 means that the application is allowed to idle.
-	MinAutoScaleCount int `json:"minAutoScaleCount,omitempty"`
+	MinAutoScaleCount int64 `json:"minAutoScaleCount,omitempty"`
 
 	// TargetSelector provides the resizeable target(s).  Right now this is a ReplicationController
 	// in the future it could be a job or any resource that implements resize.  If multiple targets
 	// are resolved by the selector the auto-scaler will resize the largest one.
 	TargetSelector map[string]string `json:"targetSelector,omitempty"`
 
-	// MonitorSelector defines a set of capacity that the auto-scaler is monitoring
+	// MonitorSelector defines a set of resources that the auto-scaler is monitoring
 	// (replication controllers).  Monitored objects are used by thresholds to examine
-	// statistics.  Example: get statistic X for object Y to see if threshold is passed.
+	// statistics.  Example: get statistic X for object Y (the resource) to see if threshold is passed.
 	MonitorSelector map[string]string `json:"monitorSelector,omitempty"`
 }
 

--- a/pkg/api/v1beta3/register.go
+++ b/pkg/api/v1beta3/register.go
@@ -53,6 +53,8 @@ func init() {
 		&NamespaceList{},
 		&Secret{},
 		&SecretList{},
+		&AutoScaler{},
+		&AutoScalerList{},
 	)
 	// Legacy names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta3", "Minion", &Node{})
@@ -86,3 +88,5 @@ func (*Namespace) IsAnAPIObject()                 {}
 func (*NamespaceList) IsAnAPIObject()             {}
 func (*Secret) IsAnAPIObject()                    {}
 func (*SecretList) IsAnAPIObject()                {}
+func (*AutoScaler) IsAnAPIObject()                {}
+func (*AutoScalerList) IsAnAPIObject()            {}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -1316,3 +1316,94 @@ type SecretList struct {
 
 	Items []Secret `json:"items" description:"items is a list of secret objects"`
 }
+
+// AutoScaler monitors other resources that are resizeable and adjusts them according to configuration.
+type AutoScaler struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+
+	// Spec defines the auto-scaler targets and thresholds.
+	Spec AutoScalerSpec `json:"spec,omitempty"`
+
+	// Status defines the actions the auto-scaler has taken.
+	Status AutoScalerStatus `json:"status,omitempty"`
+}
+
+// AutoScalerStatus provides the status of an auto-scaler.
+type AutoScalerStatus struct {
+	// TODO: open for discussion on what meaningful information can be reported in the status
+	// The status may return the replica count here but we may want more information
+	// such as if the count reflects a threshold being passed.
+}
+
+// AutoScalerSpec defines the auto-scaler targets and thresholds.
+type AutoScalerSpec struct {
+	// Thresholds holds a collection of AutoScaleThresholds that drive the auto-scaler.
+	Thresholds []AutoScaleThreshold `json:"thresholds,omitempty"`
+
+	// Enabled turns auto scaling on or off.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// MaxAutoScaleCount defines the max replicas that the auto-scaler can use.  This value must be
+	// >= MinAutoScaleCount.
+	MaxAutoScaleCount int `json:"maxAutoScaleCount,omitempty"`
+
+	// MinAutoScaleCount defines the minimum number replicas that the auto-scaler can reduce to,
+	// 0 means that the application is allowed to idle.
+	MinAutoScaleCount int `json:"minAutoScaleCount,omitempty"`
+
+	// TargetSelector provides the resizeable target(s).  Right now this is a ReplicationController
+	// in the future it could be a job or any resource that implements resize.  If multiple targets
+	// are resolved by the selector the auto-scaler will resize the largest one.
+	TargetSelector map[string]string `json:"targetSelector,omitempty"`
+
+	// MonitorSelector defines a set of capacity that the auto-scaler is monitoring
+	// (replication controllers).  Monitored objects are used by thresholds to examine
+	// statistics.  Example: get statistic X for object Y to see if threshold is passed.
+	MonitorSelector map[string]string `json:"monitorSelector,omitempty"`
+}
+
+// AutoScaleThreshold is a behavior based on statistics used to drive the auto-scaler in scaling decisions.
+type AutoScaleThreshold struct {
+	// Type is the type of threshold being used, intention or value.
+	Type AutoScaleThresholdType `json:"type,omitempty"`
+
+	// IntentionConfig holds the config for intention based thresholds.
+	IntentionConfig AutoScaleIntentionThresholdConfig `json:"intentionConfig,omitempty"`
+}
+
+// AutoScaleIntentionThresholdConfig holds configuration for intention based thresholds.
+// The scaler will adjust by 1 accordingly and maintain once the intention is reached.
+type AutoScaleIntentionThresholdConfig struct {
+	// Intent is the lexicon of what intention is requested.
+	Intent AutoScaleIntentionType `json:"intent,omitempty"`
+
+	// Value is intention dependent in terms of above, below, equal and represents
+	// the value to check against.
+	Value float32 `json:"value,omitempty"`
+}
+
+// AutoScaleThresholdType is either intention based or value based.
+type AutoScaleThresholdType string
+
+// AutoScaleIntentionType is a lexicon for intentions such as "cpu-utilization",
+// "max-rps-per-endpoint".
+type AutoScaleIntentionType string
+
+// Constants for auto-scalers and any auto-scaling child types like intentions
+const (
+	// AutoScaleThresholdTypeIntention is used when defining an intention based threshold.
+	AutoScaleThresholdTypeIntention AutoScaleThresholdType = "Intention"
+
+	// TODO: AutoScaleIntentionType types
+	// example: AutoScaleIntentionTypeMaxRPS AutoScaleIntentionType = "MaxRPS"
+)
+
+// AutoScalerList is a list of AutoScaler items
+type AutoScalerList struct {
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+
+	// Items is a list of AutoScaler objects.
+	Items []AutoScaler `json:"items"`
+}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -1341,25 +1341,22 @@ type AutoScalerSpec struct {
 	// Thresholds holds a collection of AutoScaleThresholds that drive the auto-scaler.
 	Thresholds []AutoScaleThreshold `json:"thresholds,omitempty"`
 
-	// Enabled turns auto scaling on or off.
-	Enabled bool `json:"enabled,omitempty"`
-
 	// MaxAutoScaleCount defines the max replicas that the auto-scaler can use.  This value must be
 	// >= MinAutoScaleCount.
-	MaxAutoScaleCount int `json:"maxAutoScaleCount,omitempty"`
+	MaxAutoScaleCount int64 `json:"maxAutoScaleCount,omitempty"`
 
 	// MinAutoScaleCount defines the minimum number replicas that the auto-scaler can reduce to,
 	// 0 means that the application is allowed to idle.
-	MinAutoScaleCount int `json:"minAutoScaleCount,omitempty"`
+	MinAutoScaleCount int64 `json:"minAutoScaleCount,omitempty"`
 
 	// TargetSelector provides the resizeable target(s).  Right now this is a ReplicationController
 	// in the future it could be a job or any resource that implements resize.  If multiple targets
 	// are resolved by the selector the auto-scaler will resize the largest one.
 	TargetSelector map[string]string `json:"targetSelector,omitempty"`
 
-	// MonitorSelector defines a set of capacity that the auto-scaler is monitoring
+	// MonitorSelector defines a set of resources that the auto-scaler is monitoring
 	// (replication controllers).  Monitored objects are used by thresholds to examine
-	// statistics.  Example: get statistic X for object Y to see if threshold is passed.
+	// statistics.  Example: get statistic X for object Y (the monitored object) to see if threshold is passed.
 	MonitorSelector map[string]string `json:"monitorSelector,omitempty"`
 }
 

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -2289,3 +2289,72 @@ func TestValidateSecret(t *testing.T) {
 		}
 	}
 }
+
+// TestValidateAutoScaler tests validation methods for autoscalers, their spec, and thresholds
+func TestValidateAutoScaler(t *testing.T) {
+	validAutoScaler := func() *api.AutoScaler {
+		return &api.AutoScaler{
+			ObjectMeta: api.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: api.AutoScalerSpec{
+				TargetSelector:  map[string]string{"name": "test"},
+				MonitorSelector: map[string]string{"name": "test"},
+			},
+		}
+	}
+
+	var (
+		noMetaName             = validAutoScaler()
+		noMetaNamespace        = validAutoScaler()
+		noTargetSelector       = validAutoScaler()
+		badMinMax              = validAutoScaler()
+		noMonitorSelector      = validAutoScaler()
+		invalidIntentThreshold = validAutoScaler()
+		validIntentThreshold   = validAutoScaler()
+	)
+
+	noMetaName.ObjectMeta.Name = ""
+	noMetaNamespace.ObjectMeta.Namespace = ""
+	noTargetSelector.Spec.TargetSelector = make(map[string]string, 0)
+	badMinMax.Spec.MinAutoScaleCount = 1
+	badMinMax.Spec.MaxAutoScaleCount = 0
+	noMonitorSelector.Spec.MonitorSelector = make(map[string]string, 0)
+	invalidIntentThreshold.Spec.Thresholds = []api.AutoScaleThreshold{
+		{
+			Type:            api.AutoScaleThresholdTypeIntention,
+			IntentionConfig: api.AutoScaleIntentionThresholdConfig{},
+		},
+	}
+	validIntentThreshold.Spec.Thresholds = []api.AutoScaleThreshold{
+		{
+			Type: api.AutoScaleThresholdTypeIntention,
+			IntentionConfig: api.AutoScaleIntentionThresholdConfig{
+				Intent: "test",
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		errors     int
+		autoScaler *api.AutoScaler
+	}{
+		"valid":                  {0, validAutoScaler()},
+		"noMetaName":             {1, noMetaName},
+		"noMetaNamespace":        {1, noMetaNamespace},
+		"noTargetSelector":       {1, noTargetSelector},
+		"badMinMax":              {1, badMinMax},
+		"noMonitorSelector":      {1, noMonitorSelector},
+		"invalidIntentThreshold": {1, invalidIntentThreshold},
+		"validIntentThreshold":   {0, validIntentThreshold},
+	}
+
+	for testName, test := range tests {
+		result := ValidateAutoScaler(test.autoScaler)
+
+		if test.errors != len(result) {
+			t.Errorf("%s failed, expected %d errors but got %d : %v", testName, test.errors, len(result), result)
+		}
+	}
+}

--- a/pkg/registry/autoscaler/doc.go
+++ b/pkg/registry/autoscaler/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package autoscaler provides Registry interface and its REST
+// implementation for storing AutoScaler api objects.
+package autoscaler

--- a/pkg/registry/autoscaler/etcd/etcd.go
+++ b/pkg/registry/autoscaler/etcd/etcd.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/autoscaler"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
+	etcdgeneric "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// rest implements a RESTStorage for pods against etcd
+type REST struct {
+	store *etcdgeneric.Etcd
+}
+
+func NewREST(h tools.EtcdHelper) *REST {
+	prefix := "/registry/autoScalers"
+	return &REST{
+		store: &etcdgeneric.Etcd{
+			NewFunc:     func() runtime.Object { return &api.AutoScaler{} },
+			NewListFunc: func() runtime.Object { return &api.AutoScalerList{} },
+			KeyRootFunc: func(ctx api.Context) string {
+				return etcdgeneric.NamespaceKeyRootFunc(ctx, prefix)
+			},
+			KeyFunc: func(ctx api.Context, name string) (string, error) {
+				return etcdgeneric.NamespaceKeyFunc(ctx, prefix, name)
+			},
+			ObjectNameFunc: func(obj runtime.Object) (string, error) {
+				return obj.(*api.AutoScaler).Name, nil
+			},
+			PredicateFunc: func(label labels.Selector, field fields.Selector) generic.Matcher {
+				return autoscaler.MatchAutoScaler(label, field)
+			},
+			CreateStrategy: autoscaler.AutoScalers,
+			UpdateStrategy: autoscaler.AutoScalers,
+			EndpointName:   "autoScalers",
+
+			Helper: h,
+		},
+	}
+}
+
+// New returns a new object
+func (r *REST) New() runtime.Object {
+	return r.store.NewFunc()
+}
+
+// NewList returns a new list object
+func (r *REST) NewList() runtime.Object {
+	return r.store.NewListFunc()
+}
+
+// List obtains a list of autoscalers with labels that match selector.
+func (r *REST) List(ctx api.Context, label labels.Selector, field fields.Selector) (runtime.Object, error) {
+	return r.store.List(ctx, label, field)
+}
+
+// Watch begins watching for new, changed, or deleted autoscalers.
+func (r *REST) Watch(ctx api.Context, label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return r.store.Watch(ctx, label, field, resourceVersion)
+}
+
+// Get gets a specific autoscalers specified by its ID.
+func (r *REST) Get(ctx api.Context, name string) (runtime.Object, error) {
+	return r.store.Get(ctx, name)
+}
+
+// Create creates a autoscalers based on a specification.
+func (r *REST) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
+	return r.store.Create(ctx, obj)
+}
+
+// Update changes a autoscalers specification.
+func (r *REST) Update(ctx api.Context, obj runtime.Object) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, obj)
+}
+
+// Delete deletes an existing autoscalers specified by its ID.
+func (r *REST) Delete(ctx api.Context, name string) (runtime.Object, error) {
+	return r.store.Delete(ctx, name)
+}

--- a/pkg/registry/autoscaler/etcd/etcd_test.go
+++ b/pkg/registry/autoscaler/etcd/etcd_test.go
@@ -1,0 +1,445 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"fmt"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest/resttest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	"github.com/coreos/go-etcd/etcd"
+)
+
+func newHelper(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper) {
+	fakeEtcdClient := tools.NewFakeEtcdClient(t)
+	fakeEtcdClient.TestIndex = true
+	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec)
+	return fakeEtcdClient, helper
+}
+
+func newStorage(t *testing.T) (*REST, *tools.FakeEtcdClient, tools.EtcdHelper) {
+	fakeEtcdClient, h := newHelper(t)
+	return NewREST(h), fakeEtcdClient, h
+}
+
+func validNewAutoScaler() *api.AutoScaler {
+	return &api.AutoScaler{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "foo",
+			Namespace: api.NamespaceDefault,
+		},
+		Spec: api.AutoScalerSpec{
+			TargetSelector:  map[string]string{"foo": "bar"},
+			MonitorSelector: map[string]string{"fizz": "buzz"},
+		},
+	}
+}
+
+func TestCreate(t *testing.T) {
+	storage, fakeEtcdClient, _ := newStorage(t)
+	test := resttest.New(t, storage, fakeEtcdClient.SetError)
+	autoScaler := validNewAutoScaler()
+	autoScaler.ObjectMeta = api.ObjectMeta{}
+	test.TestCreate(
+		//valid
+		autoScaler,
+		//invalid
+		&api.AutoScaler{},
+	)
+}
+
+func TestCreateRegistryError(t *testing.T) {
+	fakeEtcdClient, helper := newHelper(t)
+	fakeEtcdClient.Err = fmt.Errorf("test error")
+	storage := NewREST(helper)
+
+	autoScaler := validNewAutoScaler()
+	_, err := storage.Create(api.NewDefaultContext(), autoScaler)
+	if err != fakeEtcdClient.Err {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateSetsFields(t *testing.T) {
+	fakeEtcdClient, helper := newHelper(t)
+	storage := NewREST(helper)
+	autoScaler := validNewAutoScaler()
+	_, err := storage.Create(api.NewDefaultContext(), autoScaler)
+	if err != fakeEtcdClient.Err {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	actual := &api.AutoScaler{}
+	if err := helper.ExtractObj("/registry/autoScalers/default/foo", actual, false); err != nil {
+		t.Fatalf("unexpected extraction error: %v", err)
+	}
+	if actual.Name != autoScaler.Name {
+		t.Errorf("unexpected autoScaler: %#v", actual)
+	}
+	if len(actual.UID) == 0 {
+		t.Errorf("expected UID to be set: %#v", actual)
+	}
+}
+
+func TestListError(t *testing.T) {
+	fakeEtcdClient, helper := newHelper(t)
+	fakeEtcdClient.Err = fmt.Errorf("test error")
+	storage := NewREST(helper)
+	scalers, err := storage.List(api.NewDefaultContext(), labels.Everything(), fields.Everything())
+	if err != fakeEtcdClient.Err {
+		t.Fatalf("Expected %#v, Got %#v", fakeEtcdClient.Err, err)
+	}
+	if scalers != nil {
+		t.Errorf("Unexpected non-nil autoscaler list: %#v", scalers)
+	}
+}
+
+func TestListEmptyAutoScalerList(t *testing.T) {
+	fakeEtcdClient, helper := newHelper(t)
+	fakeEtcdClient.ChangeIndex = 1
+	fakeEtcdClient.Data["/registry/autoScalers"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{},
+		E: fakeEtcdClient.NewError(tools.EtcdErrorCodeNotFound),
+	}
+
+	storage := NewREST(helper)
+	scalers, err := storage.List(api.NewContext(), labels.Everything(), fields.Everything())
+	if err != nil {
+		t.Fatalf("Unexpected error: %#v", err)
+	}
+	if len(scalers.(*api.AutoScalerList).Items) != 0 {
+		t.Errorf("Unexpected non-zero list: %#v", scalers)
+	}
+	if scalers.(*api.AutoScalerList).ResourceVersion != "1" {
+		t.Errorf("Unexpected resource version: %#v", scalers)
+	}
+}
+
+func TestListAutoScalerList(t *testing.T) {
+	fakeEtcdClient, helper := newHelper(t)
+	fakeEtcdClient.ChangeIndex = 1
+	autoScaler := validNewAutoScaler()
+	fakeEtcdClient.Data["/registry/autoScalers/default"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{
+					{
+						Value: runtime.EncodeOrDie(latest.Codec, autoScaler),
+					},
+				},
+			},
+		},
+	}
+
+	storage := NewREST(helper)
+	scalers, err := storage.List(api.NewDefaultContext(), labels.Everything(), fields.Everything())
+	scalerList := scalers.(*api.AutoScalerList)
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %#v", err)
+	}
+	if len(scalerList.Items) != 1 {
+		t.Errorf("Unexpected list: %#v", scalers)
+	}
+	if scalerList.Items[0].Name != autoScaler.Name {
+		t.Errorf("Unexpected autoscaler: %#v", scalerList.Items[0])
+	}
+}
+
+func TestListAutoScalerListSelection(t *testing.T) {
+	fakeEtcdClient, helper := newHelper(t)
+
+	validScaler1 := validNewAutoScaler()
+	validScaler1.Name = "scaler1"
+	validScaler2 := validNewAutoScaler()
+	validScaler2.Name = "scaler2"
+	validScaler3 := validNewAutoScaler()
+	validScaler3.Name = "scaler3"
+	validScaler3.ObjectMeta.Labels = map[string]string{"label": "test"}
+
+	fakeEtcdClient.Data["/registry/autoScalers/default"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{
+					{
+						Value: runtime.EncodeOrDie(latest.Codec, validScaler1),
+					},
+					{
+						Value: runtime.EncodeOrDie(latest.Codec, validScaler2),
+					},
+					{
+						Value: runtime.EncodeOrDie(latest.Codec, validScaler3),
+					},
+				},
+			},
+		},
+	}
+
+	storage := NewREST(helper)
+	ctx := api.NewDefaultContext()
+
+	testCases := []struct {
+		name, label, field string
+		expectedNames      util.StringSet
+	}{
+		{
+			name:          "everything",
+			expectedNames: util.NewStringSet(validScaler1.Name, validScaler2.Name, validScaler3.Name),
+		},
+		{
+			name:          "field selector found",
+			field:         "name=scaler1",
+			expectedNames: util.NewStringSet(validScaler1.Name),
+		},
+		{
+			name:          "field selector not found",
+			field:         "foo=bar",
+			expectedNames: util.NewStringSet(),
+		},
+		{
+			name:          "label selector not found",
+			label:         "biz=baz",
+			expectedNames: util.NewStringSet(),
+		},
+		{
+			name:          "label selector found",
+			label:         "label=test",
+			expectedNames: util.NewStringSet(validScaler3.Name),
+		},
+	}
+
+	for _, tc := range testCases {
+		label, err := labels.Parse(tc.label)
+		if err != nil {
+			t.Errorf("%s failed with error: %v", tc.name, err)
+			continue
+		}
+
+		field, err := fields.ParseSelector(tc.field)
+		if err != nil {
+			t.Errorf("%s failed with error: %v", tc.name, err)
+			continue
+		}
+
+		autoScalerObjs, err := storage.List(ctx, label, field)
+		if err != nil {
+			t.Errorf("%s failed with error: %v", tc.name, err)
+			continue
+		}
+		autoScalerList := autoScalerObjs.(*api.AutoScalerList)
+
+		if e, a := len(tc.expectedNames), len(autoScalerList.Items); e != a {
+			t.Errorf("%s failed.  Unexpected number of objects were returned.  Expected: %d got: %d", tc.name, e, a)
+			continue
+		}
+
+		for _, autoScaler := range autoScalerList.Items {
+			if !tc.expectedNames.Has(autoScaler.Name) {
+				t.Errorf("%s failed: unexpected name was returned: %s", tc.name, autoScaler.Name)
+			}
+		}
+	}
+}
+
+func TestAutoScalerDecode(t *testing.T) {
+	storage := NewREST(tools.EtcdHelper{})
+	expected := validNewAutoScaler()
+	body, err := latest.Codec.Encode(expected)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	actual := storage.New()
+	if err := latest.Codec.DecodeInto(body, actual); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !api.Semantic.DeepEqual(expected, actual) {
+		t.Errorf("mismatch: %s", util.ObjectDiff(expected, actual))
+	}
+}
+
+func TestGet(t *testing.T) {
+	expect := validNewAutoScaler()
+
+	fakeEtcdClient, helper := newHelper(t)
+	fakeEtcdClient.Data["/registry/autoScalers/test/foo"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Value: runtime.EncodeOrDie(latest.Codec, expect),
+			},
+		},
+	}
+
+	storage := NewREST(helper)
+	obj, err := storage.Get(api.WithNamespace(api.NewContext(), "test"), "foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	autoScaler := obj.(*api.AutoScaler)
+	if e, a := expect, autoScaler; !api.Semantic.DeepEqual(e, a) {
+		t.Errorf("Unexpected autoscaler: %s", util.ObjectDiff(e, a))
+	}
+}
+
+func TestUpdateWithConflictingNamespace(t *testing.T) {
+	expect := validNewAutoScaler()
+
+	fakeEtcdClient, helper := newHelper(t)
+	fakeEtcdClient.Data["/registry/autoScalers/default/foo"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Value:         runtime.EncodeOrDie(latest.Codec, expect),
+				ModifiedIndex: 1,
+			},
+		},
+	}
+	storage := NewREST(helper)
+	expect.Namespace = "not-default"
+	expect.ResourceVersion = "1"
+	obj, created, err := storage.Update(api.NewDefaultContext(), expect)
+
+	if obj != nil || created {
+		t.Error("Expected a nil object, but we got a value or created")
+	}
+	if err == nil {
+		t.Errorf("Expected an error, but we didn't get one")
+	} else if strings.Index(err.Error(), "the namespace of the provided object does not match the namespace sent on the request") == -1 {
+		t.Errorf("Expected 'AutoScaler.Namespace does not match the provided context' error, got '%v'", err.Error())
+	}
+}
+
+func TestDelete(t *testing.T) {
+	expect := validNewAutoScaler()
+
+	fakeEtcdClient, helper := newHelper(t)
+	fakeEtcdClient.Data["/registry/autoScalers/default/foo"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Value:         runtime.EncodeOrDie(latest.Codec, expect),
+				ModifiedIndex: 1,
+			},
+		},
+	}
+	storage := NewREST(helper)
+	result, err := storage.Delete(api.NewDefaultContext(), expect.Name)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.(*api.Status).Status != api.StatusSuccess {
+		t.Errorf("expected success status but got: %v", result)
+	}
+}
+
+func TestWatch(t *testing.T) {
+	fakeEtcdClient, helper := newHelper(t)
+	storage := NewREST(helper)
+	watching, err := storage.Watch(api.NewDefaultContext(), labels.Everything(), fields.Everything(), "1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fakeEtcdClient.WaitForWatchCompletion()
+	select {
+	case _, ok := <-watching.ResultChan():
+		if !ok {
+			t.Errorf("watching channel should be open")
+		}
+	default:
+	}
+	fakeEtcdClient.WatchInjectError <- nil
+	if _, ok := <-watching.ResultChan(); ok {
+		t.Errorf("watching channel should be closed")
+	}
+	watching.Stop()
+}
+
+func TestWatchWithSelectorMatch(t *testing.T) {
+	fakeEtcdClient, helper := newHelper(t)
+	storage := NewREST(helper)
+	watching, err := storage.Watch(api.NewDefaultContext(),
+		labels.SelectorFromSet(labels.Set{"name": "foo"}),
+		fields.Everything(),
+		"1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fakeEtcdClient.WaitForWatchCompletion()
+
+	autoScaler := validNewAutoScaler()
+	autoScaler.Labels = map[string]string{"name": "foo"}
+	encoded, _ := latest.Codec.Encode(autoScaler)
+	fakeEtcdClient.WatchResponse <- &etcd.Response{
+		Action: "create",
+		Node: &etcd.Node{
+			Value: string(encoded),
+		},
+	}
+
+	select {
+	case _, ok := <-watching.ResultChan():
+		if !ok {
+			t.Errorf("watching channel should be open")
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("unexpected timeout from result channel")
+	}
+
+	watching.Stop()
+}
+
+func TestWatchWithSelectorNoMatch(t *testing.T) {
+	fakeEtcdClient, helper := newHelper(t)
+	storage := NewREST(helper)
+	watching, err := storage.Watch(api.NewDefaultContext(),
+		labels.SelectorFromSet(labels.Set{"name": "foo"}),
+		fields.Everything(),
+		"1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fakeEtcdClient.WaitForWatchCompletion()
+
+	autoScaler := validNewAutoScaler()
+	encoded, _ := latest.Codec.Encode(autoScaler)
+	fakeEtcdClient.WatchResponse <- &etcd.Response{
+		Action: "create",
+		Node: &etcd.Node{
+			Value: string(encoded),
+		},
+	}
+
+	select {
+	case <-watching.ResultChan():
+		t.Errorf("unexpected object returned during watch")
+	case <-time.After(time.Millisecond * 100):
+		//expected
+	}
+
+	watching.Stop()
+}

--- a/pkg/registry/autoscaler/registry.go
+++ b/pkg/registry/autoscaler/registry.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaler
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
+	etcdgeneric "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+)
+
+// registry implements custom changes to generic.Etcd.
+type registry struct {
+	*etcdgeneric.Etcd
+}
+
+// NewEtcdRegistry returns a registry which will store AutoScalers in the given helper
+func NewEtcdRegistry(h tools.EtcdHelper) generic.Registry {
+	return registry{
+		Etcd: &etcdgeneric.Etcd{
+			NewFunc:      func() runtime.Object { return &api.AutoScaler{} },
+			NewListFunc:  func() runtime.Object { return &api.AutoScalerList{} },
+			EndpointName: "autoscalers",
+			KeyRootFunc: func(ctx api.Context) string {
+				return etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/autoscalers")
+			},
+			KeyFunc: func(ctx api.Context, id string) (string, error) {
+				return etcdgeneric.NamespaceKeyFunc(ctx, "/registry/autoscalers", id)
+			},
+			Helper: h,
+		},
+	}
+}

--- a/pkg/registry/autoscaler/rest.go
+++ b/pkg/registry/autoscaler/rest.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaler
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// REST provides the RESTStorage access patterns to work with AutoScaler objects.
+type REST struct {
+	registry generic.Registry
+}
+
+// NewREST returns a new REST. You must use a registry created by
+// NewEtcdRegistry unless you're testing.
+func NewREST(registry generic.Registry) *REST {
+	return &REST{
+		registry: registry,
+	}
+}
+
+// New returns a new AutoScaler.
+func (*REST) New() runtime.Object {
+	return &api.AutoScaler{}
+}
+
+// NewList returns a new AutoScaler.
+func (*REST) NewList() runtime.Object {
+	return &api.AutoScalerList{}
+}
+
+// List selects resources in the storage which match to the selector.
+func (rs *REST) List(ctx api.Context, label labels.Selector, field fields.Selector) (runtime.Object, error) {
+	return rs.registry.ListPredicate(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs})
+}
+
+// getAttrs is passed to the predicate functions
+func (rs *REST) getAttrs(obj runtime.Object) (objLabels labels.Set, objFields fields.Set, err error) {
+	autoScaler, ok := obj.(*api.AutoScaler)
+	if !ok {
+		return nil, nil, fmt.Errorf("invalid object type")
+	}
+	return labels.Set(autoScaler.Labels), fields.Set{}, nil
+}
+
+// Get finds an AutoScaler in the storage by id and returns it.
+func (rs *REST) Get(ctx api.Context, id string) (runtime.Object, error) {
+	obj, err := rs.registry.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	autoScaler, ok := obj.(*api.AutoScaler)
+	if !ok {
+		return nil, fmt.Errorf("invalid object type")
+	}
+	return autoScaler, err
+}
+
+// Delete finds an AutoScaler in the storage and deletes it.
+func (rs *REST) Delete(ctx api.Context, id string) (runtime.Object, error) {
+	obj, err := rs.registry.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	_, ok := obj.(*api.AutoScaler)
+	if !ok {
+		return nil, fmt.Errorf("invalid object type")
+	}
+	return rs.registry.Delete(ctx, id)
+}
+
+// Create creates a new AutoScaler.
+func (rs *REST) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
+	if err := rest.BeforeCreate(rest.AutoScalers, ctx, obj); err != nil {
+		return nil, err
+	}
+
+	//should never fail here, BeforeCreate does a cast to do validation
+	autoScaler := obj.(*api.AutoScaler)
+	if err := rs.registry.CreateWithName(ctx, autoScaler.Name, autoScaler); err != nil {
+		return nil, err
+	}
+
+	return rs.registry.Get(ctx, autoScaler.Name)
+}
+
+// Update updates an AutoScaler object.
+func (rs *REST) Update(ctx api.Context, obj runtime.Object) (runtime.Object, bool, error) {
+	autoScaler, ok := obj.(*api.AutoScaler)
+	if !ok {
+		return nil, false, fmt.Errorf("invalid object type")
+	}
+
+	if !api.ValidNamespace(ctx, &autoScaler.ObjectMeta) {
+		return nil, false, errors.NewConflict("autoscaler", autoScaler.Namespace, fmt.Errorf("AutoScaler.Namespace does not match the provided context"))
+	}
+
+	oldObj, err := rs.registry.Get(ctx, autoScaler.Name)
+	if err != nil {
+		return nil, false, err
+	}
+
+	editAutoScaler := oldObj.(*api.AutoScaler)
+	if errs := validation.ValidateAutoScalerUpdate(editAutoScaler, autoScaler); len(errs) > 0 {
+		return nil, false, errors.NewInvalid("autoscaler", editAutoScaler.Name, errs)
+	}
+
+	// passed update validation (ensures immutable meta is not trying to be changed),
+	// now copy over the relevant fields that can be updated
+	editAutoScaler.Spec = autoScaler.Spec
+
+	err = rs.registry.UpdateWithName(ctx, editAutoScaler.Name, editAutoScaler)
+	if err != nil {
+		return nil, false, err
+	}
+	out, err := rs.registry.Get(ctx, editAutoScaler.Name)
+	return out, false, err
+}
+
+// Watch provides the ability to watch auto-scalers for changes
+func (rs *REST) Watch(ctx api.Context, label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return rs.registry.WatchPredicate(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs}, resourceVersion)
+}

--- a/pkg/registry/autoscaler/rest_test.go
+++ b/pkg/registry/autoscaler/rest_test.go
@@ -17,215 +17,54 @@ limitations under the License.
 package autoscaler
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 )
 
-// testRegistry provides the REST implementation for unit tests
-type testRegistry struct {
-	*registrytest.GenericRegistry
-}
-
-func newTestREST() (testRegistry, *REST) {
-	reg := testRegistry{registrytest.NewGeneric(nil)}
-	return reg, NewREST(reg)
-}
-
-func newValidAutoScaler(name string) *api.AutoScaler {
-	return &api.AutoScaler{
+func TestMatchAutoScaler(t *testing.T) {
+	autoScaler := &api.AutoScaler{
 		ObjectMeta: api.ObjectMeta{
-			Name:      name,
-			Namespace: "default",
-		},
-		Spec: api.AutoScalerSpec{
-			TargetSelector:  map[string]string{"target": "selector"},
-			MonitorSelector: map[string]string{"monitor": "selector"},
-		},
-	}
-}
-
-func TestRESTCreate(t *testing.T) {
-	_, rest := newTestREST()
-
-	testCases := []struct {
-		name       string
-		ctx        api.Context
-		autoScaler *api.AutoScaler
-		valid      bool
-	}{
-		{
-			name:       "valid create",
-			ctx:        api.NewDefaultContext(),
-			autoScaler: newValidAutoScaler("valid"),
-			valid:      true,
-		},
-		{
-			name:       "empty context",
-			ctx:        api.NewContext(),
-			autoScaler: newValidAutoScaler("emptyContext"),
-			valid:      false,
-		},
-		{
-			name:       "non-default context",
-			ctx:        api.WithNamespace(api.NewContext(), "nondefault"),
-			autoScaler: newValidAutoScaler("nonDefault"),
-			valid:      false,
+			Name: "foo",
+			Labels: map[string]string{
+				"labelTest": "bar",
+			},
 		},
 	}
 
-	for _, tc := range testCases {
-		obj, err := rest.Create(tc.ctx, tc.autoScaler)
-
-		if tc.valid && err != nil {
-			t.Errorf("test case %s failed: expected no errors but found: %v", tc.name, err)
-			continue
-		}
-
-		if !tc.valid && err == nil {
-			t.Errorf("test case %s failed: expected errors but found none", tc.name)
-			continue
-		}
-
-		// at this point, if it is an invalid test case and it has errors we're good to go
-		// the rest of the validations are for fields
-		if !tc.valid {
-			continue
-		}
-
-		if !api.HasObjectMetaSystemFieldValues(&tc.autoScaler.ObjectMeta) {
-			t.Errorf("storage did not populate object meta field values")
-		}
-
-		if e, a := tc.autoScaler, obj; !reflect.DeepEqual(e, a) {
-			t.Errorf("diff: %s", util.ObjectDiff(e, a))
-		}
-	}
-}
-
-func TestRESTUpdate(t *testing.T) {
-	_, rest := newTestREST()
-	autoScaler := newValidAutoScaler("foo")
-	ctx := api.NewDefaultContext()
-
-	_, err := rest.Create(ctx, autoScaler)
-	if err != nil {
-		t.Fatalf("unable to create auto-scaler: %v", err)
+	//invalid object type
+	matcher := MatchAutoScaler(labels.Everything(), fields.Everything())
+	if match, _ := matcher.Matches(&api.Pod{}); match {
+		t.Errorf("Did not expect match")
 	}
 
-	autoScaler.Spec.TargetSelector["target"] = "updated"
-	updated, created, err := rest.Update(ctx, autoScaler)
-
-	if err != nil {
-		t.Fatalf("unable to create auto-scaler: %v", err)
-	}
-	if updated == nil {
-		t.Errorf("Expected non-nil object")
-	}
-	if created {
-		t.Errorf("expected created to be false")
+	//invalid field match
+	nameSelector, _ := fields.ParseSelector("name=foobar")
+	matcher = MatchAutoScaler(labels.Everything(), nameSelector)
+	if match, _ := matcher.Matches(autoScaler); match {
+		t.Errorf("Did not expect match")
 	}
 
-	updatedAutoScaler := updated.(*api.AutoScaler)
-	if updatedAutoScaler.Spec.TargetSelector["target"] != "updated" {
-		t.Errorf("expected target selector to be updated")
-	}
-}
-
-func TestRESTDelete(t *testing.T) {
-	_, rest := newTestREST()
-	autoScaler := newValidAutoScaler("foo")
-	_, err := rest.Create(api.NewDefaultContext(), autoScaler)
-	if err != nil {
-		t.Fatalf("unable to create auto-scaler: %v", err)
+	//valid field match
+	nameSelector, _ = fields.ParseSelector("name=foo")
+	matcher = MatchAutoScaler(labels.Everything(), nameSelector)
+	if match, _ := matcher.Matches(autoScaler); !match {
+		t.Errorf("Expected match")
 	}
 
-	stat, err := rest.Delete(api.NewDefaultContext(), autoScaler.Name)
-	if err != nil {
-		t.Fatalf("unable to delete auto-scaler: %v", err)
+	//invalid label match
+	labelSelector, _ := labels.ParseSelector("labelTest=foo")
+	matcher = MatchAutoScaler(labelSelector, fields.Everything())
+	if match, _ := matcher.Matches(autoScaler); match {
+		t.Errorf("Did not expect match")
 	}
-	if status := stat.(*api.Status); status.Status != api.StatusSuccess {
-		t.Errorf("unexepcted status: %v", status)
-	}
-}
 
-func TestRESTGet(t *testing.T) {
-	_, rest := newTestREST()
-	autoScaler := newValidAutoScaler("foo")
-	_, err := rest.Create(api.NewDefaultContext(), autoScaler)
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-	got, err := rest.Get(api.NewDefaultContext(), autoScaler.Name)
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-	if e, a := autoScaler, got; !reflect.DeepEqual(e, a) {
-		t.Errorf("diff: %s", util.ObjectDiff(e, a))
-	}
-}
-
-func TestRESTgetAttrs(t *testing.T) {
-	_, rest := newTestREST()
-	autoScaler := newValidAutoScaler("foo")
-	autoScaler.ObjectMeta.Labels = make(map[string]string, 1)
-	autoScaler.ObjectMeta.Labels["foo"] = "bar"
-
-	label, field, err := rest.getAttrs(autoScaler)
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-	if e, a := label, labels.Set(autoScaler.ObjectMeta.Labels); !reflect.DeepEqual(e, a) {
-		t.Errorf("diff: %s", util.ObjectDiff(e, a))
-	}
-	expect := fields.Set{}
-	if e, a := expect, field; !reflect.DeepEqual(e, a) {
-		t.Errorf("diff: %s", util.ObjectDiff(e, a))
-	}
-}
-
-func TestRESTList(t *testing.T) {
-	reg, rest := newTestREST()
-
-	var (
-		autoScalerA = newValidAutoScaler("a")
-		autoScalerB = newValidAutoScaler("b")
-		autoScalerC = newValidAutoScaler("c")
-	)
-
-	reg.ObjectList = &api.AutoScalerList{
-		Items: []api.AutoScaler{*autoScalerA, *autoScalerB, *autoScalerC},
-	}
-	got, err := rest.List(api.NewContext(), labels.Everything(), fields.Everything())
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-	expect := &api.AutoScalerList{
-		Items: []api.AutoScaler{*autoScalerA, *autoScalerB, *autoScalerC},
-	}
-	if e, a := expect, got; !reflect.DeepEqual(e, a) {
-		t.Errorf("diff: %s", util.ObjectDiff(e, a))
-	}
-}
-
-func TestRESTWatch(t *testing.T) {
-	autoScaler := newValidAutoScaler("foo")
-	reg, rest := newTestREST()
-	wi, err := rest.Watch(api.NewContext(), labels.Everything(), fields.Everything(), "0")
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-	go func() {
-		reg.Broadcaster.Action(watch.Added, autoScaler)
-	}()
-	got := <-wi.ResultChan()
-	if e, a := autoScaler, got.Object; !reflect.DeepEqual(e, a) {
-		t.Errorf("diff: %s", util.ObjectDiff(e, a))
+	//valid label match
+	labelSelector, _ = labels.ParseSelector("labelTest=bar")
+	matcher = MatchAutoScaler(labelSelector, fields.Everything())
+	if match, _ := matcher.Matches(autoScaler); !match {
+		t.Errorf("Expected match")
 	}
 }

--- a/pkg/registry/autoscaler/rest_test.go
+++ b/pkg/registry/autoscaler/rest_test.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaler
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// testRegistry provides the REST implementation for unit tests
+type testRegistry struct {
+	*registrytest.GenericRegistry
+}
+
+func newTestREST() (testRegistry, *REST) {
+	reg := testRegistry{registrytest.NewGeneric(nil)}
+	return reg, NewREST(reg)
+}
+
+func newValidAutoScaler(name string) *api.AutoScaler {
+	return &api.AutoScaler{
+		ObjectMeta: api.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: api.AutoScalerSpec{
+			TargetSelector:  map[string]string{"target": "selector"},
+			MonitorSelector: map[string]string{"monitor": "selector"},
+		},
+	}
+}
+
+func TestRESTCreate(t *testing.T) {
+	_, rest := newTestREST()
+
+	testCases := []struct {
+		name       string
+		ctx        api.Context
+		autoScaler *api.AutoScaler
+		valid      bool
+	}{
+		{
+			name:       "valid create",
+			ctx:        api.NewDefaultContext(),
+			autoScaler: newValidAutoScaler("valid"),
+			valid:      true,
+		},
+		{
+			name:       "empty context",
+			ctx:        api.NewContext(),
+			autoScaler: newValidAutoScaler("emptyContext"),
+			valid:      false,
+		},
+		{
+			name:       "non-default context",
+			ctx:        api.WithNamespace(api.NewContext(), "nondefault"),
+			autoScaler: newValidAutoScaler("nonDefault"),
+			valid:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		obj, err := rest.Create(tc.ctx, tc.autoScaler)
+
+		if tc.valid && err != nil {
+			t.Errorf("test case %s failed: expected no errors but found: %v", tc.name, err)
+			continue
+		}
+
+		if !tc.valid && err == nil {
+			t.Errorf("test case %s failed: expected errors but found none", tc.name)
+			continue
+		}
+
+		// at this point, if it is an invalid test case and it has errors we're good to go
+		// the rest of the validations are for fields
+		if !tc.valid {
+			continue
+		}
+
+		if !api.HasObjectMetaSystemFieldValues(&tc.autoScaler.ObjectMeta) {
+			t.Errorf("storage did not populate object meta field values")
+		}
+
+		if e, a := tc.autoScaler, obj; !reflect.DeepEqual(e, a) {
+			t.Errorf("diff: %s", util.ObjectDiff(e, a))
+		}
+	}
+}
+
+func TestRESTUpdate(t *testing.T) {
+	_, rest := newTestREST()
+	autoScaler := newValidAutoScaler("foo")
+	ctx := api.NewDefaultContext()
+
+	_, err := rest.Create(ctx, autoScaler)
+	if err != nil {
+		t.Fatalf("unable to create auto-scaler: %v", err)
+	}
+
+	autoScaler.Spec.TargetSelector["target"] = "updated"
+	updated, created, err := rest.Update(ctx, autoScaler)
+
+	if err != nil {
+		t.Fatalf("unable to create auto-scaler: %v", err)
+	}
+	if updated == nil {
+		t.Errorf("Expected non-nil object")
+	}
+	if created {
+		t.Errorf("expected created to be false")
+	}
+
+	updatedAutoScaler := updated.(*api.AutoScaler)
+	if updatedAutoScaler.Spec.TargetSelector["target"] != "updated" {
+		t.Errorf("expected target selector to be updated")
+	}
+}
+
+func TestRESTDelete(t *testing.T) {
+	_, rest := newTestREST()
+	autoScaler := newValidAutoScaler("foo")
+	_, err := rest.Create(api.NewDefaultContext(), autoScaler)
+	if err != nil {
+		t.Fatalf("unable to create auto-scaler: %v", err)
+	}
+
+	stat, err := rest.Delete(api.NewDefaultContext(), autoScaler.Name)
+	if err != nil {
+		t.Fatalf("unable to delete auto-scaler: %v", err)
+	}
+	if status := stat.(*api.Status); status.Status != api.StatusSuccess {
+		t.Errorf("unexepcted status: %v", status)
+	}
+}
+
+func TestRESTGet(t *testing.T) {
+	_, rest := newTestREST()
+	autoScaler := newValidAutoScaler("foo")
+	_, err := rest.Create(api.NewDefaultContext(), autoScaler)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	got, err := rest.Get(api.NewDefaultContext(), autoScaler.Name)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	if e, a := autoScaler, got; !reflect.DeepEqual(e, a) {
+		t.Errorf("diff: %s", util.ObjectDiff(e, a))
+	}
+}
+
+func TestRESTgetAttrs(t *testing.T) {
+	_, rest := newTestREST()
+	autoScaler := newValidAutoScaler("foo")
+	autoScaler.ObjectMeta.Labels = make(map[string]string, 1)
+	autoScaler.ObjectMeta.Labels["foo"] = "bar"
+
+	label, field, err := rest.getAttrs(autoScaler)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	if e, a := label, labels.Set(autoScaler.ObjectMeta.Labels); !reflect.DeepEqual(e, a) {
+		t.Errorf("diff: %s", util.ObjectDiff(e, a))
+	}
+	expect := fields.Set{}
+	if e, a := expect, field; !reflect.DeepEqual(e, a) {
+		t.Errorf("diff: %s", util.ObjectDiff(e, a))
+	}
+}
+
+func TestRESTList(t *testing.T) {
+	reg, rest := newTestREST()
+
+	var (
+		autoScalerA = newValidAutoScaler("a")
+		autoScalerB = newValidAutoScaler("b")
+		autoScalerC = newValidAutoScaler("c")
+	)
+
+	reg.ObjectList = &api.AutoScalerList{
+		Items: []api.AutoScaler{*autoScalerA, *autoScalerB, *autoScalerC},
+	}
+	got, err := rest.List(api.NewContext(), labels.Everything(), fields.Everything())
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	expect := &api.AutoScalerList{
+		Items: []api.AutoScaler{*autoScalerA, *autoScalerB, *autoScalerC},
+	}
+	if e, a := expect, got; !reflect.DeepEqual(e, a) {
+		t.Errorf("diff: %s", util.ObjectDiff(e, a))
+	}
+}
+
+func TestRESTWatch(t *testing.T) {
+	autoScaler := newValidAutoScaler("foo")
+	reg, rest := newTestREST()
+	wi, err := rest.Watch(api.NewContext(), labels.Everything(), fields.Everything(), "0")
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	go func() {
+		reg.Broadcaster.Action(watch.Added, autoScaler)
+	}()
+	got := <-wi.ResultChan()
+	if e, a := autoScaler, got.Object; !reflect.DeepEqual(e, a) {
+		t.Errorf("diff: %s", util.ObjectDiff(e, a))
+	}
+}


### PR DESCRIPTION
Step 1 of auto-scaler implementation.  Types and rest impl.  

To try and keep these small(ish) I will submit separate PRs for the kubectl wiring and controller implementations.  

See proposal at: https://github.com/GoogleCloudPlatform/kubernetes/pull/2863

@davidopp @bgrant0607 @smarterclayton @jlowdermilk @fbalejko @pmorie PTAL
