### PR TITLE
Another step to introduce  fields.Selector

### DIFF
--- a/cluster/addons/dns/kube2sky/kube2sky.go
+++ b/cluster/addons/dns/kube2sky/kube2sky.go
@@ -29,6 +29,7 @@ import (
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	kfields "github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	klabels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	tools "github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	kwatch "github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -194,7 +195,7 @@ func main() {
 // across ALL namespaces
 type servicesWatcher interface {
 	List(label klabels.Selector) (*kapi.ServiceList, error)
-	Watch(label, field klabels.Selector, resourceVersion string) (kwatch.Interface, error)
+	Watch(label klabels.Selector, field kfields.Selector, resourceVersion string) (kwatch.Interface, error)
 }
 
 type operation int
@@ -239,7 +240,7 @@ func watchLoop(svcWatcher servicesWatcher, updates chan<- serviceUpdate, resourc
 		updates <- serviceUpdate{Op: SetServices, Services: services.Items}
 	}
 
-	watcher, err := svcWatcher.Watch(klabels.Everything(), klabels.Everything(), *resourceVersion)
+	watcher, err := svcWatcher.Watch(klabels.Everything(), kfields.Everything(), *resourceVersion)
 	if err != nil {
 		log.Printf("Failed to watch for service changes: %v", err)
 		return

--- a/pkg/client/cache/listwatch.go
+++ b/pkg/client/cache/listwatch.go
@@ -19,7 +19,7 @@ package cache
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -39,12 +39,12 @@ type ListWatch struct {
 }
 
 // NewListWatchFromClient creates a new ListWatch from the specified client, resource, namespace and field selector.
-func NewListWatchFromClient(c *client.Client, resource string, namespace string, fieldSelector labels.Selector) *ListWatch {
+func NewListWatchFromClient(c *client.Client, resource string, namespace string, fieldSelector fields.Selector) *ListWatch {
 	listFunc := func() (runtime.Object, error) {
-		return c.Get().Namespace(namespace).Resource(resource).SelectorParam(api.FieldSelectorQueryParam(c.APIVersion()), fieldSelector).Do().Get()
+		return c.Get().Namespace(namespace).Resource(resource).FieldsSelectorParam(api.FieldSelectorQueryParam(c.APIVersion()), fieldSelector).Do().Get()
 	}
 	watchFunc := func(resourceVersion string) (watch.Interface, error) {
-		return c.Get().Prefix("watch").Namespace(namespace).Resource(resource).SelectorParam(api.FieldSelectorQueryParam(c.APIVersion()), fieldSelector).Param("resourceVersion", resourceVersion).Watch()
+		return c.Get().Prefix("watch").Namespace(namespace).Resource(resource).FieldsSelectorParam(api.FieldSelectorQueryParam(c.APIVersion()), fieldSelector).Param("resourceVersion", resourceVersion).Watch()
 	}
 	return &ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
 }

--- a/pkg/client/cache/listwatch_test.go
+++ b/pkg/client/cache/listwatch_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
-func parseSelectorOrDie(s string) labels.Selector {
-	selector, err := labels.Parse(s)
+func parseSelectorOrDie(s string) fields.Selector {
+	selector, err := fields.ParseSelector(s)
 	if err != nil {
 		panic(err)
 	}
@@ -82,7 +82,7 @@ func TestListWatchesCanList(t *testing.T) {
 		location      string
 		resource      string
 		namespace     string
-		fieldSelector labels.Selector
+		fieldSelector fields.Selector
 	}{
 		// Minion
 		{
@@ -96,14 +96,14 @@ func TestListWatchesCanList(t *testing.T) {
 			location:      buildLocation(buildResourcePath("", api.NamespaceAll, "pods"), buildQueryValues(api.NamespaceAll, url.Values{"fields": []string{getHostFieldLabel() + "="}})),
 			resource:      "pods",
 			namespace:     api.NamespaceAll,
-			fieldSelector: labels.Set{getHostFieldLabel(): ""}.AsSelector(),
+			fieldSelector: fields.Set{getHostFieldLabel(): ""}.AsSelector(),
 		},
 		// pod in namespace "foo"
 		{
 			location:      buildLocation(buildResourcePath("", "foo", "pods"), buildQueryValues("foo", url.Values{"fields": []string{getHostFieldLabel() + "="}})),
 			resource:      "pods",
 			namespace:     "foo",
-			fieldSelector: labels.Set{getHostFieldLabel(): ""}.AsSelector(),
+			fieldSelector: fields.Set{getHostFieldLabel(): ""}.AsSelector(),
 		},
 	}
 	for _, item := range table {
@@ -128,7 +128,7 @@ func TestListWatchesCanWatch(t *testing.T) {
 		location      string
 		resource      string
 		namespace     string
-		fieldSelector labels.Selector
+		fieldSelector fields.Selector
 	}{
 		// Minion
 		{
@@ -151,7 +151,7 @@ func TestListWatchesCanWatch(t *testing.T) {
 			rv:            "0",
 			resource:      "pods",
 			namespace:     api.NamespaceAll,
-			fieldSelector: labels.Set{getHostFieldLabel(): ""}.AsSelector(),
+			fieldSelector: fields.Set{getHostFieldLabel(): ""}.AsSelector(),
 		},
 		// pod with namespace foo and assigned field selector
 		{
@@ -159,7 +159,7 @@ func TestListWatchesCanWatch(t *testing.T) {
 			rv:            "0",
 			resource:      "pods",
 			namespace:     "foo",
-			fieldSelector: labels.Set{getHostFieldLabel(): ""}.AsSelector(),
+			fieldSelector: fields.Set{getHostFieldLabel(): ""}.AsSelector(),
 		},
 	}
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -241,8 +242,8 @@ func validateLabels(a, b string) bool {
 }
 
 func validateFields(a, b string) bool {
-	sA, _ := labels.ParseSelector(a)
-	sB, _ := labels.ParseSelector(b)
+	sA, _ := fields.ParseSelector(a)
+	sB, _ := fields.ParseSelector(b)
 	return sA.String() == sB.String()
 }
 

--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -36,7 +37,7 @@ type EndpointsInterface interface {
 	List(selector labels.Selector) (*api.EndpointsList, error)
 	Get(name string) (*api.Endpoints, error)
 	Update(endpoints *api.Endpoints) (*api.Endpoints, error)
-	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
 // endpoints implements EndpointsInterface
@@ -63,7 +64,7 @@ func (c *endpoints) List(selector labels.Selector) (result *api.EndpointsList, e
 	err = c.r.Get().
 		Namespace(c.ns).
 		Resource("endpoints").
-		SelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), selector).
+		LabelsSelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), selector).
 		Do().
 		Into(result)
 	return
@@ -81,14 +82,14 @@ func (c *endpoints) Get(name string) (result *api.Endpoints, err error) {
 }
 
 // Watch returns a watch.Interface that watches the requested endpoints for a service.
-func (c *endpoints) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *endpoints) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
 		Resource("endpoints").
 		Param("resourceVersion", resourceVersion).
-		SelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), label).
-		SelectorParam(api.FieldSelectorQueryParam(c.r.APIVersion()), field).
+		LabelsSelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), label).
+		FieldsSelectorParam(api.FieldSelectorQueryParam(c.r.APIVersion()), field).
 		Watch()
 }
 

--- a/pkg/client/events_test.go
+++ b/pkg/client/events_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
@@ -159,7 +160,7 @@ func TestEventList(t *testing.T) {
 		Response: Response{StatusCode: 200, Body: eventList},
 	}
 	response, err := c.Setup().Events(ns).List(labels.Everything(),
-		labels.Everything())
+		fields.Everything())
 
 	if err != nil {
 		t.Errorf("%#v should be nil.", err)

--- a/pkg/client/fake_endpoints.go
+++ b/pkg/client/fake_endpoints.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -44,7 +45,7 @@ func (c *FakeEndpoints) Get(name string) (*api.Endpoints, error) {
 	return &api.Endpoints{}, nil
 }
 
-func (c *FakeEndpoints) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *FakeEndpoints) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-endpoints", Value: resourceVersion})
 	return c.Fake.Watch, c.Fake.Err
 }

--- a/pkg/client/fake_events.go
+++ b/pkg/client/fake_events.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -42,7 +43,7 @@ func (c *FakeEvents) Update(event *api.Event) (*api.Event, error) {
 }
 
 // List returns a list of events matching the selectors.
-func (c *FakeEvents) List(label, field labels.Selector) (*api.EventList, error) {
+func (c *FakeEvents) List(label labels.Selector, field fields.Selector) (*api.EventList, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "list-events"})
 	return &c.Fake.EventsList, nil
 }
@@ -54,7 +55,7 @@ func (c *FakeEvents) Get(id string) (*api.Event, error) {
 }
 
 // Watch starts watching for events matching the given selectors.
-func (c *FakeEvents) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *FakeEvents) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-events", Value: resourceVersion})
 	return c.Fake.Watch, c.Fake.Err
 }

--- a/pkg/client/fake_limit_ranges.go
+++ b/pkg/client/fake_limit_ranges.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -54,7 +55,7 @@ func (c *FakeLimitRanges) Update(limitRange *api.LimitRange) (*api.LimitRange, e
 	return &api.LimitRange{}, nil
 }
 
-func (c *FakeLimitRanges) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *FakeLimitRanges) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-limitRange", Value: resourceVersion})
 	return c.Fake.Watch, nil
 }

--- a/pkg/client/fake_namespaces.go
+++ b/pkg/client/fake_namespaces.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -53,7 +54,7 @@ func (c *FakeNamespaces) Update(namespace *api.Namespace) (*api.Namespace, error
 	return &api.Namespace{}, nil
 }
 
-func (c *FakeNamespaces) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *FakeNamespaces) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-namespaces", Value: resourceVersion})
 	return c.Fake.Watch, nil
 }

--- a/pkg/client/fake_pods.go
+++ b/pkg/client/fake_pods.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -54,7 +55,7 @@ func (c *FakePods) Update(pod *api.Pod) (*api.Pod, error) {
 	return &api.Pod{}, nil
 }
 
-func (c *FakePods) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *FakePods) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-pods", Value: resourceVersion})
 	return c.Fake.Watch, c.Fake.Err
 }

--- a/pkg/client/fake_replication_controllers.go
+++ b/pkg/client/fake_replication_controllers.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -54,7 +55,7 @@ func (c *FakeReplicationControllers) Delete(controller string) error {
 	return nil
 }
 
-func (c *FakeReplicationControllers) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *FakeReplicationControllers) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-controllers", Value: resourceVersion})
 	return c.Fake.Watch, nil
 }

--- a/pkg/client/fake_resource_quotas.go
+++ b/pkg/client/fake_resource_quotas.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -60,7 +61,7 @@ func (c *FakeResourceQuotas) Status(resourceQuota *api.ResourceQuota) (*api.Reso
 	return &api.ResourceQuota{}, nil
 }
 
-func (c *FakeResourceQuotas) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *FakeResourceQuotas) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-resourceQuota", Value: resourceVersion})
 	return c.Fake.Watch, nil
 }

--- a/pkg/client/fake_secrets.go
+++ b/pkg/client/fake_secrets.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -29,7 +30,7 @@ type FakeSecrets struct {
 	Namespace string
 }
 
-func (c *FakeSecrets) List(labels, fields labels.Selector) (*api.SecretList, error) {
+func (c *FakeSecrets) List(labels labels.Selector, field fields.Selector) (*api.SecretList, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "list-secrets"})
 	return &c.Fake.SecretList, c.Fake.Err
 }
@@ -54,7 +55,7 @@ func (c *FakeSecrets) Delete(secret string) error {
 	return nil
 }
 
-func (c *FakeSecrets) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *FakeSecrets) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-secrets", Value: resourceVersion})
 	return c.Fake.Watch, c.Fake.Err
 }

--- a/pkg/client/fake_services.go
+++ b/pkg/client/fake_services.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -54,7 +55,7 @@ func (c *FakeServices) Delete(service string) error {
 	return nil
 }
 
-func (c *FakeServices) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *FakeServices) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-services", Value: resourceVersion})
 	return c.Fake.Watch, c.Fake.Err
 }

--- a/pkg/client/limit_ranges.go
+++ b/pkg/client/limit_ranges.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -37,7 +38,7 @@ type LimitRangeInterface interface {
 	Delete(name string) error
 	Create(limitRange *api.LimitRange) (*api.LimitRange, error)
 	Update(limitRange *api.LimitRange) (*api.LimitRange, error)
-	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
 // limitRanges implements LimitRangesNamespacer interface
@@ -57,7 +58,7 @@ func newLimitRanges(c *Client, namespace string) *limitRanges {
 // List takes a selector, and returns the list of limitRanges that match that selector.
 func (c *limitRanges) List(selector labels.Selector) (result *api.LimitRangeList, err error) {
 	result = &api.LimitRangeList{}
-	err = c.r.Get().Namespace(c.ns).Resource("limitRanges").SelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), selector).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource("limitRanges").LabelsSelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), selector).Do().Into(result)
 	return
 }
 
@@ -96,13 +97,13 @@ func (c *limitRanges) Update(limitRange *api.LimitRange) (result *api.LimitRange
 }
 
 // Watch returns a watch.Interface that watches the requested resource
-func (c *limitRanges) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *limitRanges) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
 		Resource("limitRanges").
 		Param("resourceVersion", resourceVersion).
-		SelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), label).
-		SelectorParam(api.FieldSelectorQueryParam(c.r.APIVersion()), field).
+		LabelsSelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), label).
+		FieldsSelectorParam(api.FieldSelectorQueryParam(c.r.APIVersion()), field).
 		Watch()
 }

--- a/pkg/client/limit_ranges_test.go
+++ b/pkg/client/limit_ranges_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 )
 
@@ -198,6 +199,6 @@ func TestLimitRangeWatch(t *testing.T) {
 		Request:  testRequest{Method: "GET", Path: "/watch/limitRanges", Query: url.Values{"resourceVersion": []string{}}},
 		Response: Response{StatusCode: 200},
 	}
-	_, err := c.Setup().LimitRanges(api.NamespaceAll).Watch(labels.Everything(), labels.Everything(), "")
+	_, err := c.Setup().LimitRanges(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/namespaces.go
+++ b/pkg/client/namespaces.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -35,7 +36,7 @@ type NamespaceInterface interface {
 	List(selector labels.Selector) (*api.NamespaceList, error)
 	Delete(name string) error
 	Update(item *api.Namespace) (*api.Namespace, error)
-	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
 // namespaces implements NamespacesInterface
@@ -58,7 +59,7 @@ func (c *namespaces) Create(namespace *api.Namespace) (*api.Namespace, error) {
 // List lists all the namespaces in the cluster.
 func (c *namespaces) List(selector labels.Selector) (*api.NamespaceList, error) {
 	result := &api.NamespaceList{}
-	err := c.r.Get().Resource("namespaces").SelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), selector).Do().Into(result)
+	err := c.r.Get().Resource("namespaces").LabelsSelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), selector).Do().Into(result)
 	return result, err
 }
 
@@ -90,12 +91,12 @@ func (c *namespaces) Delete(name string) error {
 }
 
 // Watch returns a watch.Interface that watches the requested namespaces.
-func (c *namespaces) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *namespaces) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Resource("namespaces").
 		Param("resourceVersion", resourceVersion).
-		SelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), label).
-		SelectorParam(api.FieldSelectorQueryParam(c.r.APIVersion()), field).
+		LabelsSelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), label).
+		FieldsSelectorParam(api.FieldSelectorQueryParam(c.r.APIVersion()), field).
 		Watch()
 }

--- a/pkg/client/namespaces_test.go
+++ b/pkg/client/namespaces_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 )
 
@@ -139,6 +140,6 @@ func TestNamespaceWatch(t *testing.T) {
 		Request:  testRequest{Method: "GET", Path: "/watch/namespaces", Query: url.Values{"resourceVersion": []string{}}},
 		Response: Response{StatusCode: 200},
 	}
-	_, err := c.Setup().Namespaces().Watch(labels.Everything(), labels.Everything(), "")
+	_, err := c.Setup().Namespaces().Watch(labels.Everything(), fields.Everything(), "")
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/pods.go
+++ b/pkg/client/pods.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -37,7 +38,7 @@ type PodInterface interface {
 	Delete(name string) error
 	Create(pod *api.Pod) (*api.Pod, error)
 	Update(pod *api.Pod) (*api.Pod, error)
-	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 	Bind(binding *api.Binding) error
 }
 
@@ -58,7 +59,7 @@ func newPods(c *Client, namespace string) *pods {
 // List takes a selector, and returns the list of pods that match that selector.
 func (c *pods) List(selector labels.Selector) (result *api.PodList, err error) {
 	result = &api.PodList{}
-	err = c.r.Get().Namespace(c.ns).Resource("pods").SelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), selector).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource("pods").LabelsSelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), selector).Do().Into(result)
 	return
 }
 
@@ -97,14 +98,14 @@ func (c *pods) Update(pod *api.Pod) (result *api.Pod, err error) {
 }
 
 // Watch returns a watch.Interface that watches the requested pods.
-func (c *pods) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *pods) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
 		Resource("pods").
 		Param("resourceVersion", resourceVersion).
-		SelectorParam("labels", label).
-		SelectorParam("fields", field).
+		LabelsSelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), label).
+		FieldsSelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), field).
 		Watch()
 }
 

--- a/pkg/client/replication_controllers.go
+++ b/pkg/client/replication_controllers.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -37,7 +38,7 @@ type ReplicationControllerInterface interface {
 	Create(ctrl *api.ReplicationController) (*api.ReplicationController, error)
 	Update(ctrl *api.ReplicationController) (*api.ReplicationController, error)
 	Delete(name string) error
-	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
 // replicationControllers implements ReplicationControllersNamespacer interface
@@ -54,7 +55,7 @@ func newReplicationControllers(c *Client, namespace string) *replicationControll
 // List takes a selector, and returns the list of replication controllers that match that selector.
 func (c *replicationControllers) List(selector labels.Selector) (result *api.ReplicationControllerList, err error) {
 	result = &api.ReplicationControllerList{}
-	err = c.r.Get().Namespace(c.ns).Resource("replicationControllers").SelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), selector).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource("replicationControllers").LabelsSelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), selector).Do().Into(result)
 	return
 }
 
@@ -93,13 +94,13 @@ func (c *replicationControllers) Delete(name string) error {
 }
 
 // Watch returns a watch.Interface that watches the requested controllers.
-func (c *replicationControllers) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *replicationControllers) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
 		Resource("replicationControllers").
 		Param("resourceVersion", resourceVersion).
-		SelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), label).
-		SelectorParam(api.FieldSelectorQueryParam(c.r.APIVersion()), field).
+		LabelsSelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), label).
+		FieldsSelectorParam(api.FieldSelectorQueryParam(c.r.APIVersion()), field).
 		Watch()
 }

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -288,8 +288,19 @@ func (r *Request) ParseSelectorParam(paramName, item string) *Request {
 	return r.setParam(paramName, selector)
 }
 
-// SelectorParam adds the given selector as a query parameter with the name paramName.
-func (r *Request) SelectorParam(paramName string, s labels.Selector) *Request {
+// FieldsSelectorParam adds the given selector as a query parameter with the name paramName.
+func (r *Request) FieldsSelectorParam(paramName string, s fields.Selector) *Request {
+	if r.err != nil {
+		return r
+	}
+	if s.Empty() {
+		return r
+	}
+	return r.setParam(paramName, s.String())
+}
+
+// LabelsSelectorParam adds the given selector as a query parameter
+func (r *Request) LabelsSelectorParam(paramName string, s labels.Selector) *Request {
 	if r.err != nil {
 		return r
 	}

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -50,7 +50,7 @@ func TestRequestWithErrorWontChange(t *testing.T) {
 	original := Request{err: errors.New("test")}
 	r := original
 	changed := r.Param("foo", "bar").
-		SelectorParam(api.LabelSelectorQueryParam(testapi.Version()), labels.Set{"a": "b"}.AsSelector()).
+		LabelsSelectorParam(api.LabelSelectorQueryParam(testapi.Version()), labels.Set{"a": "b"}.AsSelector()).
 		UintParam("uint", 1).
 		AbsPath("/abs").
 		Prefix("test").
@@ -664,7 +664,7 @@ func TestDoRequestNewWayReader(t *testing.T) {
 		Resource("bar").
 		Name("baz").
 		Prefix("foo").
-		SelectorParam(api.LabelSelectorQueryParam(c.APIVersion()), labels.Set{"name": "foo"}.AsSelector()).
+		LabelsSelectorParam(api.LabelSelectorQueryParam(c.APIVersion()), labels.Set{"name": "foo"}.AsSelector()).
 		Timeout(time.Second).
 		Body(bytes.NewBuffer(reqBodyExpected)).
 		Do().Get()
@@ -700,7 +700,7 @@ func TestDoRequestNewWayObj(t *testing.T) {
 		Suffix("baz").
 		Name("bar").
 		Resource("foo").
-		SelectorParam(api.LabelSelectorQueryParam(c.APIVersion()), labels.Set{"name": "foo"}.AsSelector()).
+		LabelsSelectorParam(api.LabelSelectorQueryParam(c.APIVersion()), labels.Set{"name": "foo"}.AsSelector()).
 		Timeout(time.Second).
 		Body(reqObj).
 		Do().Get()

--- a/pkg/client/resource_quotas.go
+++ b/pkg/client/resource_quotas.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -38,7 +39,7 @@ type ResourceQuotaInterface interface {
 	Create(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error)
 	Update(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error)
 	Status(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error)
-	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
 // resourceQuotas implements ResourceQuotasNamespacer interface
@@ -58,7 +59,7 @@ func newResourceQuotas(c *Client, namespace string) *resourceQuotas {
 // List takes a selector, and returns the list of resourceQuotas that match that selector.
 func (c *resourceQuotas) List(selector labels.Selector) (result *api.ResourceQuotaList, err error) {
 	result = &api.ResourceQuotaList{}
-	err = c.r.Get().Namespace(c.ns).Resource("resourceQuotas").SelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), selector).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource("resourceQuotas").LabelsSelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), selector).Do().Into(result)
 	return
 }
 
@@ -108,13 +109,13 @@ func (c *resourceQuotas) Status(resourceQuota *api.ResourceQuota) (result *api.R
 }
 
 // Watch returns a watch.Interface that watches the requested resource
-func (c *resourceQuotas) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *resourceQuotas) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
 		Resource("resourceQuotas").
 		Param("resourceVersion", resourceVersion).
-		SelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), label).
-		SelectorParam(api.FieldSelectorQueryParam(c.r.APIVersion()), field).
+		LabelsSelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), label).
+		FieldsSelectorParam(api.FieldSelectorQueryParam(c.r.APIVersion()), field).
 		Watch()
 }

--- a/pkg/client/resource_quotas_test.go
+++ b/pkg/client/resource_quotas_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 )
 
@@ -209,6 +210,6 @@ func TestResourceQuotaWatch(t *testing.T) {
 		Request:  testRequest{Method: "GET", Path: "/watch/resourceQuotas", Query: url.Values{"resourceVersion": []string{}}},
 		Response: Response{StatusCode: 200},
 	}
-	_, err := c.Setup().ResourceQuotas(api.NamespaceAll).Watch(labels.Everything(), labels.Everything(), "")
+	_, err := c.Setup().ResourceQuotas(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/secrets.go
+++ b/pkg/client/secrets.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -33,9 +34,9 @@ type SecretsInterface interface {
 	Create(secret *api.Secret) (*api.Secret, error)
 	Update(secret *api.Secret) (*api.Secret, error)
 	Delete(name string) error
-	List(label, field labels.Selector) (*api.SecretList, error)
+	List(label labels.Selector, field fields.Selector) (*api.SecretList, error)
 	Get(name string) (*api.Secret, error)
-	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
 // events implements Secrets interface
@@ -69,14 +70,14 @@ func (s *secrets) Create(secret *api.Secret) (*api.Secret, error) {
 }
 
 // List returns a list of secrets matching the selectors.
-func (s *secrets) List(label, field labels.Selector) (*api.SecretList, error) {
+func (s *secrets) List(label labels.Selector, field fields.Selector) (*api.SecretList, error) {
 	result := &api.SecretList{}
 
 	err := s.client.Get().
 		Namespace(s.namespace).
 		Resource("secrets").
-		SelectorParam(api.LabelSelectorQueryParam(s.client.APIVersion()), label).
-		SelectorParam(api.FieldSelectorQueryParam(s.client.APIVersion()), field).
+		LabelsSelectorParam(api.LabelSelectorQueryParam(s.client.APIVersion()), label).
+		FieldsSelectorParam(api.FieldSelectorQueryParam(s.client.APIVersion()), field).
 		Do().
 		Into(result)
 
@@ -101,14 +102,14 @@ func (s *secrets) Get(name string) (*api.Secret, error) {
 }
 
 // Watch starts watching for secrets matching the given selectors.
-func (s *secrets) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (s *secrets) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	return s.client.Get().
 		Prefix("watch").
 		Namespace(s.namespace).
 		Resource("secrets").
 		Param("resourceVersion", resourceVersion).
-		SelectorParam(api.LabelSelectorQueryParam(s.client.APIVersion()), label).
-		SelectorParam(api.FieldSelectorQueryParam(s.client.APIVersion()), field).
+		LabelsSelectorParam(api.LabelSelectorQueryParam(s.client.APIVersion()), label).
+		FieldsSelectorParam(api.FieldSelectorQueryParam(s.client.APIVersion()), field).
 		Watch()
 }
 

--- a/pkg/client/services.go
+++ b/pkg/client/services.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -37,7 +38,7 @@ type ServiceInterface interface {
 	Create(srv *api.Service) (*api.Service, error)
 	Update(srv *api.Service) (*api.Service, error)
 	Delete(name string) error
-	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
 // services implements PodsNamespacer interface
@@ -57,7 +58,7 @@ func (c *services) List(selector labels.Selector) (result *api.ServiceList, err 
 	err = c.r.Get().
 		Namespace(c.ns).
 		Resource("services").
-		SelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), selector).
+		LabelsSelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), selector).
 		Do().
 		Into(result)
 	return
@@ -98,13 +99,13 @@ func (c *services) Delete(name string) error {
 }
 
 // Watch returns a watch.Interface that watches the requested services.
-func (c *services) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *services) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
 		Resource("services").
 		Param("resourceVersion", resourceVersion).
-		SelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), label).
-		SelectorParam(api.FieldSelectorQueryParam(c.r.APIVersion()), field).
+		LabelsSelectorParam(api.LabelSelectorQueryParam(c.r.APIVersion()), label).
+		FieldsSelectorParam(api.FieldSelectorQueryParam(c.r.APIVersion()), field).
 		Watch()
 }

--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -122,7 +123,7 @@ func (rm *ReplicationManager) Run(period time.Duration) {
 func (rm *ReplicationManager) watchControllers(resourceVersion *string) {
 	watching, err := rm.kubeClient.ReplicationControllers(api.NamespaceAll).Watch(
 		labels.Everything(),
-		labels.Everything(),
+		fields.Everything(),
 		*resourceVersion,
 	)
 	if err != nil {

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/golang/glog"
 )
@@ -205,7 +206,7 @@ func (d *PodDescriber) Describe(namespace, name string) (string, error) {
 	if err != nil {
 		events, err2 := d.Events(namespace).List(
 			labels.Everything(),
-			labels.Set{
+			fields.Set{
 				"involvedObject.name":      name,
 				"involvedObject.namespace": namespace,
 			}.AsSelector(),

--- a/pkg/kubectl/resource/helper.go
+++ b/pkg/kubectl/resource/helper.go
@@ -19,6 +19,7 @@ package resource
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -65,19 +66,19 @@ func (m *Helper) List(namespace, apiVersion string, selector labels.Selector) (r
 	return m.RESTClient.Get().
 		NamespaceIfScoped(namespace, m.NamespaceScoped).
 		Resource(m.Resource).
-		SelectorParam(api.LabelSelectorQueryParam(apiVersion), selector).
+		LabelsSelectorParam(api.LabelSelectorQueryParam(apiVersion), selector).
 		Do().
 		Get()
 }
 
-func (m *Helper) Watch(namespace, resourceVersion, apiVersion string, labelSelector, fieldSelector labels.Selector) (watch.Interface, error) {
+func (m *Helper) Watch(namespace, resourceVersion, apiVersion string, labelSelector labels.Selector, fieldSelector fields.Selector) (watch.Interface, error) {
 	return m.RESTClient.Get().
 		Prefix("watch").
 		NamespaceIfScoped(namespace, m.NamespaceScoped).
 		Resource(m.Resource).
 		Param("resourceVersion", resourceVersion).
-		SelectorParam(api.LabelSelectorQueryParam(apiVersion), labelSelector).
-		SelectorParam(api.FieldSelectorQueryParam(apiVersion), fieldSelector).
+		LabelsSelectorParam(api.LabelSelectorQueryParam(apiVersion), labelSelector).
+		FieldsSelectorParam(api.FieldSelectorQueryParam(apiVersion), fieldSelector).
 		Watch()
 }
 

--- a/pkg/kubectl/resource/selector.go
+++ b/pkg/kubectl/resource/selector.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
@@ -71,7 +72,7 @@ func (r *Selector) Visit(fn VisitorFunc) error {
 }
 
 func (r *Selector) Watch(resourceVersion string) (watch.Interface, error) {
-	return NewHelper(r.Client, r.Mapping).Watch(r.Namespace, resourceVersion, r.ResourceMapping().APIVersion, r.Selector, labels.Everything())
+	return NewHelper(r.Client, r.Mapping).Watch(r.Namespace, resourceVersion, r.ResourceMapping().APIVersion, r.Selector, fields.Everything())
 }
 
 // ResourceMapping returns the mapping for this resource and implements ResourceMapping

--- a/pkg/kubelet/config/apiserver.go
+++ b/pkg/kubelet/config/apiserver.go
@@ -21,13 +21,13 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 )
 
 // NewSourceApiserver creates a config source that watches and pulls from the apiserver.
 func NewSourceApiserver(client *client.Client, hostname string, updates chan<- interface{}) {
-	lw := cache.NewListWatchFromClient(client, "pods", api.NamespaceAll, labels.OneTermEqualSelector(getHostFieldLabel(client.APIVersion()), hostname))
+	lw := cache.NewListWatchFromClient(client, "pods", api.NamespaceAll, fields.OneTermEqualSelector(getHostFieldLabel(client.APIVersion()), hostname))
 	newSourceApiserverFromLW(lw, updates)
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -38,6 +38,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/cadvisor"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/envvars"
@@ -157,7 +158,7 @@ func NewMainKubelet(
 				return kubeClient.Services(api.NamespaceAll).List(labels.Everything())
 			},
 			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
-				return kubeClient.Services(api.NamespaceAll).Watch(labels.Everything(), labels.Everything(), resourceVersion)
+				return kubeClient.Services(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), resourceVersion)
 			},
 		}
 		cache.NewReflector(listWatch, &api.Service{}, serviceStore, 0).Run()

--- a/pkg/proxy/config/api.go
+++ b/pkg/proxy/config/api.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/wait"
@@ -32,13 +33,13 @@ import (
 // ServicesWatcher is capable of listing and watching for changes to services across ALL namespaces
 type ServicesWatcher interface {
 	List(label labels.Selector) (*api.ServiceList, error)
-	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
 // EndpointsWatcher is capable of listing and watching for changes to endpoints across ALL namespaces
 type EndpointsWatcher interface {
 	List(label labels.Selector) (*api.EndpointsList, error)
-	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
 // SourceAPI implements a configuration source for services and endpoints that
@@ -114,7 +115,7 @@ func (s *servicesReflector) run(resourceVersion *string) {
 		s.services <- ServiceUpdate{Op: SET, Services: services.Items}
 	}
 
-	watcher, err := s.watcher.Watch(labels.Everything(), labels.Everything(), *resourceVersion)
+	watcher, err := s.watcher.Watch(labels.Everything(), fields.Everything(), *resourceVersion)
 	if err != nil {
 		glog.Errorf("Unable to watch for services changes: %v", err)
 		if !client.IsTimeout(err) {
@@ -184,7 +185,7 @@ func (s *endpointsReflector) run(resourceVersion *string) {
 		s.endpoints <- EndpointsUpdate{Op: SET, Endpoints: endpoints.Items}
 	}
 
-	watcher, err := s.watcher.Watch(labels.Everything(), labels.Everything(), *resourceVersion)
+	watcher, err := s.watcher.Watch(labels.Everything(), fields.Everything(), *resourceVersion)
 	if err != nil {
 		glog.Errorf("Unable to watch for endpoints changes: %v", err)
 		if !client.IsTimeout(err) {

--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -91,7 +92,7 @@ func NewLimitRanger(client client.Interface, limitFunc LimitFunc) admission.Inte
 			return client.LimitRanges(api.NamespaceAll).List(labels.Everything())
 		},
 		WatchFunc: func(resourceVersion string) (watch.Interface, error) {
-			return client.LimitRanges(api.NamespaceAll).Watch(labels.Everything(), labels.Everything(), resourceVersion)
+			return client.LimitRanges(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), resourceVersion)
 		},
 	}
 	indexer, reflector := cache.NewNamespaceKeyedIndexerAndReflector(lw, &api.LimitRange{}, 0)

--- a/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -89,7 +90,7 @@ func NewProvision(c client.Interface) admission.Interface {
 				return c.Namespaces().List(labels.Everything())
 			},
 			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
-				return c.Namespaces().Watch(labels.Everything(), labels.Everything(), resourceVersion)
+				return c.Namespaces().Watch(labels.Everything(), fields.Everything(), resourceVersion)
 			},
 		},
 		&api.Namespace{},

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -88,7 +89,7 @@ func NewExists(c client.Interface) admission.Interface {
 				return c.Namespaces().List(labels.Everything())
 			},
 			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
-				return c.Namespaces().Watch(labels.Everything(), labels.Everything(), resourceVersion)
+				return c.Namespaces().Watch(labels.Everything(), fields.Everything(), resourceVersion)
 			},
 		},
 		&api.Namespace{},

--- a/plugin/pkg/admission/resourcequota/admission.go
+++ b/plugin/pkg/admission/resourcequota/admission.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/resourcequota"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
@@ -50,7 +51,7 @@ func NewResourceQuota(client client.Interface) admission.Interface {
 			return client.ResourceQuotas(api.NamespaceAll).List(labels.Everything())
 		},
 		WatchFunc: func(resourceVersion string) (watch.Interface, error) {
-			return client.ResourceQuotas(api.NamespaceAll).Watch(labels.Everything(), labels.Everything(), resourceVersion)
+			return client.ResourceQuotas(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), resourceVersion)
 		},
 	}
 	indexer, reflector := cache.NewNamespaceKeyedIndexerAndReflector(lw, &api.ResourceQuota{}, 0)

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	algorithm "github.com/GoogleCloudPlatform/kubernetes/pkg/scheduler"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler"
@@ -174,11 +174,11 @@ func (f *ConfigFactory) CreateFromKeys(predicateKeys, priorityKeys util.StringSe
 // Returns a cache.ListWatch that finds all pods that need to be
 // scheduled.
 func (factory *ConfigFactory) createUnassignedPodLW() *cache.ListWatch {
-	return cache.NewListWatchFromClient(factory.Client, "pods", api.NamespaceAll, labels.Set{getHostFieldLabel(factory.Client.APIVersion()): ""}.AsSelector())
+	return cache.NewListWatchFromClient(factory.Client, "pods", api.NamespaceAll, fields.Set{getHostFieldLabel(factory.Client.APIVersion()): ""}.AsSelector())
 }
 
-func parseSelectorOrDie(s string) labels.Selector {
-	selector, err := labels.ParseSelector(s)
+func parseSelectorOrDie(s string) fields.Selector {
+	selector, err := fields.ParseSelector(s)
 	if err != nil {
 		panic(err)
 	}

--- a/test/e2e/events.go
+++ b/test/e2e/events.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
@@ -96,7 +97,7 @@ var _ = Describe("Events", func() {
 		By("checking for scheduler event about the pod")
 		events, err := c.Events(api.NamespaceDefault).List(
 			labels.Everything(),
-			labels.Set{
+			fields.Set{
 				"involvedObject.kind":      "Pod",
 				"involvedObject.uid":       string(podWithUid.UID),
 				"involvedObject.namespace": api.NamespaceDefault,
@@ -113,7 +114,7 @@ var _ = Describe("Events", func() {
 		By("checking for kubelet event about the pod")
 		events, err = c.Events(api.NamespaceDefault).List(
 			labels.Everything(),
-			labels.Set{
+			fields.Set{
 				"involvedObject.uid":       string(podWithUid.UID),
 				"involvedObject.kind":      "Pod",
 				"involvedObject.namespace": api.NamespaceDefault,

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -130,7 +131,7 @@ var _ = Describe("Pods", func() {
 		}
 		Expect(len(pods.Items)).To(Equal(0))
 		w, err := podClient.Watch(
-			labels.SelectorFromSet(labels.Set(map[string]string{"time": value})), labels.Everything(), pods.ListMeta.ResourceVersion)
+			labels.SelectorFromSet(labels.Set(map[string]string{"time": value})), fields.Everything(), pods.ListMeta.ResourceVersion)
 		if err != nil {
 			Fail(fmt.Sprintf("Failed to set up watch: %v", err))
 		}


### PR DESCRIPTION
@nikhiljindal @bgrant0607 @smarterclayton @lavalamp in my previous https://github.com/GoogleCloudPlatform/kubernetes/pull/5171 I simply forgot to move some part of the API.
Note tha in this PR I modified also `pkg/client/request.go`.  `SelectorParam(string, labels.Selector)` is now splitted in `FieldsSelectorParam(fields.Selector)` and `LabelsSelectorParam(labels.Selector)`
