### PR TITLE
Remove unneeded make rule name.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ check test:
 #
 # Example:
 #   make test_integration
-test_integration test_integ:
+test_integration:
 	hack/test-integration.sh
 .PHONY: test_integration test_integ
 


### PR DESCRIPTION
Rule "test_integ" is not redundant with "test_integration" and is not needed because make supports tab-completion.
