### PR TITLE
Removed resource specification from guestbook example

### DIFF
--- a/examples/guestbook/README.md
+++ b/examples/guestbook/README.md
@@ -42,7 +42,6 @@ Note that, although the redis server runs just with a single replica, we use rep
           "containers": [{
             "name": "redis-master",
             "image": "dockerfile/redis",
-            "cpu": 100,
             "ports": [{
               "containerPort": 6379,   # containerPort: Where traffic to redis ultimately is routed to.
             }]
@@ -162,7 +161,6 @@ Use the file `examples/guestbook/redis-slave-controller.json`, which looks like 
            "containers": [{
              "name": "redis-slave",
              "image": "kubernetes/redis-slave:v2",
-             "cpu": 200,
              "ports": [{"containerPort": 6379}]
            }]
          }
@@ -268,8 +266,6 @@ The pod is described in the file `examples/guestbook/frontend-controller.json`:
            "containers": [{
              "name": "php-redis",
              "image": "kubernetes/example-guestbook-php-redis:v2",
-             "cpu": 100,
-             "memory": 50000000,
              "ports": [{"name": "http-server", "containerPort": 80}]
            }]
          }

--- a/examples/guestbook/frontend-controller.json
+++ b/examples/guestbook/frontend-controller.json
@@ -13,8 +13,6 @@
            "containers": [{
              "name": "php-redis",
              "image": "kubernetes/example-guestbook-php-redis:v2",
-             "cpu": 100,
-             "memory": 50000000,
              "ports": [{"name": "http-server", "containerPort": 80}]
            }]
          }

--- a/examples/guestbook/redis-master-controller.json
+++ b/examples/guestbook/redis-master-controller.json
@@ -13,7 +13,6 @@
           "containers": [{
             "name": "redis-master",
             "image": "dockerfile/redis",
-            "cpu": 100,
             "ports": [{"containerPort": 6379}]
           }]
         }

--- a/examples/guestbook/redis-slave-controller.json
+++ b/examples/guestbook/redis-slave-controller.json
@@ -13,7 +13,6 @@
            "containers": [{
              "name": "redis-slave",
              "image": "kubernetes/redis-slave:v2",
-             "cpu": 200,
              "ports": [{"containerPort": 6379}]
            }]
          }


### PR DESCRIPTION
The reason is partially #5503 but also I think it makes guestbook more
complicated and is not necessary there.
