### PR TITLE
Namespace Controller to support Namespace Termination

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -34,6 +34,7 @@ import (
 	replicationControllerPkg "github.com/GoogleCloudPlatform/kubernetes/pkg/controller"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master/ports"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/namespace"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/resourcequota"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/service"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -52,6 +53,7 @@ type CMServer struct {
 	MinionRegexp            string
 	NodeSyncPeriod          time.Duration
 	ResourceQuotaSyncPeriod time.Duration
+	NamespaceSyncPeriod     time.Duration
 	RegisterRetryCount      int
 	MachineList             util.StringList
 	SyncNodeList            bool
@@ -73,6 +75,7 @@ func NewCMServer() *CMServer {
 		Address:                 util.IP(net.ParseIP("127.0.0.1")),
 		NodeSyncPeriod:          10 * time.Second,
 		ResourceQuotaSyncPeriod: 10 * time.Second,
+		NamespaceSyncPeriod:     10 * time.Second,
 		RegisterRetryCount:      10,
 		PodEvictionTimeout:      5 * time.Minute,
 		NodeMilliCPU:            1000,
@@ -99,6 +102,7 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
 		"The period for syncing nodes from cloudprovider. Longer periods will result in "+
 		"fewer calls to cloud provider, but may delay addition of new nodes to cluster.")
 	fs.DurationVar(&s.ResourceQuotaSyncPeriod, "resource_quota_sync_period", s.ResourceQuotaSyncPeriod, "The period for syncing quota usage status in the system")
+	fs.DurationVar(&s.NamespaceSyncPeriod, "namespace_sync_period", s.NamespaceSyncPeriod, "The period for syncing namespace life-cycle updates")
 	fs.DurationVar(&s.PodEvictionTimeout, "pod_eviction_timeout", s.PodEvictionTimeout, "The grace peroid for deleting pods on failed nodes.")
 	fs.IntVar(&s.RegisterRetryCount, "register_retry_count", s.RegisterRetryCount, ""+
 		"The number of retries for initial node registration.  Retry interval equals node_sync_period.")
@@ -176,6 +180,9 @@ func (s *CMServer) Run(_ []string) error {
 
 	resourceQuotaManager := resourcequota.NewResourceQuotaManager(kubeClient)
 	resourceQuotaManager.Run(s.ResourceQuotaSyncPeriod)
+
+	namespaceManager := namespace.NewNamespaceManager(kubeClient)
+	namespaceManager.Run(s.NamespaceSyncPeriod)
 
 	select {}
 	return nil

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -76,3 +76,10 @@ var standardResources = util.NewStringSet(
 func IsStandardResourceName(str string) bool {
 	return standardResources.Has(str)
 }
+
+var standardFinalizers = util.NewStringSet(
+	string(FinalizerKubernetes))
+
+func IsStandardFinalizerName(str string) bool {
+	return standardFinalizers.Has(str)
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -934,12 +934,23 @@ type NodeList struct {
 
 // NamespaceSpec describes the attributes on a Namespace
 type NamespaceSpec struct {
+	// Finalizers is a list of named finalize actions that must complete prior to namespace deletion.
+	Finalizers []FinalizerName
 }
+
+type FinalizerName string
+
+// These are internal finalizers to Kubernetes, must be qualified name unless defined here
+const (
+	FinalizerKubernetes FinalizerName = "kubernetes"
+)
 
 // NamespaceStatus is information about the current status of a Namespace.
 type NamespaceStatus struct {
 	// Phase is the current lifecycle phase of the namespace.
 	Phase NamespacePhase `json:"phase,omitempty"`
+	// Finalizers is the list of named finalize actions that have completed
+	Finalizers []FinalizerName `json:"finalizers"`
 }
 
 type NamespacePhase string

--- a/pkg/api/v1beta1/defaults.go
+++ b/pkg/api/v1beta1/defaults.go
@@ -95,6 +95,22 @@ func init() {
 				obj.Path = "/"
 			}
 		},
+		func(obj *NamespaceSpec) {
+			hasKubeFinalizer := false
+			for i := range obj.Finalizers {
+				if obj.Finalizers[i] == FinalizerKubernetes {
+					hasKubeFinalizer = true
+					break
+				}
+			}
+			if !hasKubeFinalizer {
+				if len(obj.Finalizers) == 0 {
+					obj.Finalizers = []FinalizerName{FinalizerKubernetes}
+				} else {
+					obj.Finalizers = append(obj.Finalizers, FinalizerKubernetes)
+				}
+			}
+		},
 		func(obj *NamespaceStatus) {
 			if obj.Phase == "" {
 				obj.Phase = NamespaceActive

--- a/pkg/api/v1beta1/defaults_test.go
+++ b/pkg/api/v1beta1/defaults_test.go
@@ -121,4 +121,17 @@ func TestSetDefaultNamespace(t *testing.T) {
 	if s2.Status.Phase != current.NamespaceActive {
 		t.Errorf("Expected phase %v, got %v", current.NamespaceActive, s2.Status.Phase)
 	}
+	if len(s2.Spec.Finalizers) == 0 {
+		t.Errorf("Expected kubernetes finalizer")
+	}
+	hasKubeFinalizer := false
+	for i := range s2.Spec.Finalizers {
+		if s2.Spec.Finalizers[i] == current.FinalizerKubernetes {
+			hasKubeFinalizer = true
+			break
+		}
+	}
+	if !hasKubeFinalizer {
+		t.Errorf("Expected kubernetes finalizer %v, got %v", current.FinalizerKubernetes, s2.Spec.Finalizers)
+	}
 }

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -764,14 +764,25 @@ type MinionList struct {
 	Items   []Minion `json:"items" description:"list of nodes"`
 }
 
+type FinalizerName string
+
+// These are internal finalizers to Kubernetes, must be qualified name unless defined here
+const (
+	FinalizerKubernetes FinalizerName = "kubernetes"
+)
+
 // NamespaceSpec describes the attributes on a Namespace
 type NamespaceSpec struct {
+	// Finalizers is the list of named entities that must finalize the object
+	Finalizers []FinalizerName `json:"finalizers,omitempty" description:"finalizers are the list of entities that must finalize the object prior to its deletion`
 }
 
 // NamespaceStatus is information about the current status of a Namespace.
 type NamespaceStatus struct {
 	// Phase is the current lifecycle phase of the namespace.
 	Phase NamespacePhase `json:"phase,omitempty" description:"phase is the current lifecycle phase of the namespace"`
+	// Finalizers is the list of Finalizer objects that have finalized the object
+	Finalizers []FinalizerName `json:"finalizers,omitempty" description:"finalizers are the list of entities that have finalized the object prior to its deletion`
 }
 
 type NamespacePhase string

--- a/pkg/api/v1beta2/defaults.go
+++ b/pkg/api/v1beta2/defaults.go
@@ -97,6 +97,22 @@ func init() {
 				obj.Path = "/"
 			}
 		},
+		func(obj *NamespaceSpec) {
+			hasKubeFinalizer := false
+			for i := range obj.Finalizers {
+				if obj.Finalizers[i] == FinalizerKubernetes {
+					hasKubeFinalizer = true
+					break
+				}
+			}
+			if !hasKubeFinalizer {
+				if len(obj.Finalizers) == 0 {
+					obj.Finalizers = []FinalizerName{FinalizerKubernetes}
+				} else {
+					obj.Finalizers = append(obj.Finalizers, FinalizerKubernetes)
+				}
+			}
+		},
 		func(obj *NamespaceStatus) {
 			if obj.Phase == "" {
 				obj.Phase = NamespaceActive

--- a/pkg/api/v1beta2/defaults_test.go
+++ b/pkg/api/v1beta2/defaults_test.go
@@ -121,4 +121,17 @@ func TestSetDefaultNamespace(t *testing.T) {
 	if s2.Status.Phase != current.NamespaceActive {
 		t.Errorf("Expected phase %v, got %v", current.NamespaceActive, s2.Status.Phase)
 	}
+	if len(s2.Spec.Finalizers) == 0 {
+		t.Errorf("Expected kubernetes finalizer")
+	}
+	hasKubeFinalizer := false
+	for i := range s2.Spec.Finalizers {
+		if s2.Spec.Finalizers[i] == current.FinalizerKubernetes {
+			hasKubeFinalizer = true
+			break
+		}
+	}
+	if !hasKubeFinalizer {
+		t.Errorf("Expected kubernetes finalizer %v, got %v", current.FinalizerKubernetes, s2.Spec.Finalizers)
+	}
 }

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -780,14 +780,25 @@ type MinionList struct {
 	Items    []Minion `json:"items" description:"list of nodes"`
 }
 
+type FinalizerName string
+
+// These are internal finalizers to Kubernetes, must be qualified name unless defined here
+const (
+	FinalizerKubernetes FinalizerName = "kubernetes"
+)
+
 // NamespaceSpec describes the attributes on a Namespace
 type NamespaceSpec struct {
+	// Finalizers is the list of named entities that must finalize the object
+	Finalizers []FinalizerName `json:"finalizers,omitempty" description:"finalizers are the list of entities that must finalize the object prior to its deletion`
 }
 
 // NamespaceStatus is information about the current status of a Namespace.
 type NamespaceStatus struct {
 	// Phase is the current lifecycle phase of the namespace.
 	Phase NamespacePhase `json:"phase,omitempty" description:"phase is the current lifecycle phase of the namespace"`
+	// Finalizers is the list of Finalizer objects that have finalized the object
+	Finalizers []FinalizerName `json:"finalizers,omitempty" description:"finalizers are the list of entities that have finalized the object prior to its deletion`
 }
 
 type NamespacePhase string

--- a/pkg/api/v1beta3/defaults.go
+++ b/pkg/api/v1beta3/defaults.go
@@ -94,6 +94,22 @@ func init() {
 				obj.ContainerPort = util.NewIntOrStringFromInt(obj.Port)
 			}
 		},
+		func(obj *NamespaceSpec) {
+			hasKubeFinalizer := false
+			for i := range obj.Finalizers {
+				if obj.Finalizers[i] == FinalizerKubernetes {
+					hasKubeFinalizer = true
+					break
+				}
+			}
+			if !hasKubeFinalizer {
+				if len(obj.Finalizers) == 0 {
+					obj.Finalizers = []FinalizerName{FinalizerKubernetes}
+				} else {
+					obj.Finalizers = append(obj.Finalizers, FinalizerKubernetes)
+				}
+			}
+		},
 		func(obj *NamespaceStatus) {
 			if obj.Phase == "" {
 				obj.Phase = NamespaceActive

--- a/pkg/api/v1beta3/defaults_test.go
+++ b/pkg/api/v1beta3/defaults_test.go
@@ -138,4 +138,17 @@ func TestSetDefaultNamespace(t *testing.T) {
 	if s2.Status.Phase != current.NamespaceActive {
 		t.Errorf("Expected phase %v, got %v", current.NamespaceActive, s2.Status.Phase)
 	}
+	if len(s2.Spec.Finalizers) == 0 {
+		t.Errorf("Expected kubernetes finalizer")
+	}
+	hasKubeFinalizer := false
+	for i := range s2.Spec.Finalizers {
+		if s2.Spec.Finalizers[i] == current.FinalizerKubernetes {
+			hasKubeFinalizer = true
+			break
+		}
+	}
+	if !hasKubeFinalizer {
+		t.Errorf("Expected kubernetes finalizer %v, got %v", current.FinalizerKubernetes, s2.Spec.Finalizers)
+	}
 }

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -943,14 +943,25 @@ type NodeList struct {
 	Items []Node `json:"items" description:"list of nodes"`
 }
 
+type FinalizerName string
+
+// These are internal finalizers to Kubernetes, must be qualified name unless defined here
+const (
+	FinalizerKubernetes FinalizerName = "kubernetes"
+)
+
 // NamespaceSpec describes the attributes on a Namespace
 type NamespaceSpec struct {
+	// Finalizers is the list of named entities that must finalize the object
+	Finalizers []FinalizerName `json:"finalizers,omitempty" description:"finalizers are the list of entities that must finalize the object prior to its deletion`
 }
 
 // NamespaceStatus is information about the current status of a Namespace.
 type NamespaceStatus struct {
 	// Phase is the current lifecycle phase of the namespace.
 	Phase NamespacePhase `json:"phase,omitempty" description:"phase is the current lifecycle phase of the namespace"`
+	// Finalizers is the list of Finalizer objects that have finalized the object
+	Finalizers []FinalizerName `json:"finalizers,omitempty" description:"finalizers are the list of entities that have finalized the object prior to its deletion`
 }
 
 type NamespacePhase string

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -2260,6 +2260,90 @@ func TestValidateNamespace(t *testing.T) {
 	}
 }
 
+func TestValidateNamespaceFinalizeUpdate(t *testing.T) {
+	tests := []struct {
+		oldNamespace api.Namespace
+		namespace    api.Namespace
+		valid        bool
+	}{
+		{api.Namespace{}, api.Namespace{}, true},
+		{api.Namespace{
+			ObjectMeta: api.ObjectMeta{
+				Name: "foo"}},
+			api.Namespace{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo"},
+				Status: api.NamespaceStatus{
+					Finalizers: []api.FinalizerName{"Foo"},
+				},
+			}, false},
+		{api.Namespace{
+			ObjectMeta: api.ObjectMeta{
+				Name: "foo"},
+			Spec: api.NamespaceSpec{
+				Finalizers: []api.FinalizerName{"foo.com/bar"},
+			},
+		},
+			api.Namespace{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo"},
+				Status: api.NamespaceStatus{
+					Finalizers: []api.FinalizerName{"foo.com/bar"},
+				},
+			}, true},
+	}
+	for i, test := range tests {
+		errs := ValidateNamespaceFinalizeUpdate(&test.namespace, &test.oldNamespace)
+		if test.valid && len(errs) > 0 {
+			t.Errorf("%d: Unexpected error: %v", i, errs)
+			t.Logf("%#v vs %#v", test.oldNamespace, test.namespace)
+		}
+		if !test.valid && len(errs) == 0 {
+			t.Errorf("%d: Unexpected non-error", i)
+		}
+	}
+}
+
+func TestValidateNamespaceStatusUpdate(t *testing.T) {
+	tests := []struct {
+		oldNamespace api.Namespace
+		namespace    api.Namespace
+		valid        bool
+	}{
+		{api.Namespace{}, api.Namespace{}, true},
+		{api.Namespace{
+			ObjectMeta: api.ObjectMeta{
+				Name: "foo"}},
+			api.Namespace{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo"},
+				Status: api.NamespaceStatus{
+					Phase: api.NamespaceTerminating,
+				},
+			}, true},
+		{api.Namespace{
+			ObjectMeta: api.ObjectMeta{
+				Name: "foo"}},
+			api.Namespace{
+				ObjectMeta: api.ObjectMeta{
+					Name: "bar"},
+				Status: api.NamespaceStatus{
+					Phase: api.NamespaceTerminating,
+				},
+			}, false},
+	}
+	for i, test := range tests {
+		errs := ValidateNamespaceStatusUpdate(&test.oldNamespace, &test.namespace)
+		if test.valid && len(errs) > 0 {
+			t.Errorf("%d: Unexpected error: %v", i, errs)
+			t.Logf("%#v vs %#v", test.oldNamespace.ObjectMeta, test.namespace.ObjectMeta)
+		}
+		if !test.valid && len(errs) == 0 {
+			t.Errorf("%d: Unexpected non-error", i)
+		}
+	}
+}
+
 func TestValidateNamespaceUpdate(t *testing.T) {
 	tests := []struct {
 		oldNamespace api.Namespace

--- a/pkg/client/fake_namespaces.go
+++ b/pkg/client/fake_namespaces.go
@@ -53,6 +53,11 @@ func (c *FakeNamespaces) Update(namespace *api.Namespace) (*api.Namespace, error
 	return &api.Namespace{}, nil
 }
 
+func (c *FakeNamespaces) Finalize(namespace *api.Namespace) (*api.Namespace, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "finalize-namespace", Value: namespace.Name})
+	return &api.Namespace{}, nil
+}
+
 func (c *FakeNamespaces) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-namespaces", Value: resourceVersion})
 	return c.Fake.Watch, nil

--- a/pkg/client/fake_namespaces.go
+++ b/pkg/client/fake_namespaces.go
@@ -28,7 +28,7 @@ type FakeNamespaces struct {
 	Fake *Fake
 }
 
-func (c *FakeNamespaces) List(selector labels.Selector) (*api.NamespaceList, error) {
+func (c *FakeNamespaces) List(labels, fields labels.Selector) (*api.NamespaceList, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "list-namespaces"})
 	return api.Scheme.CopyOrDie(&c.Fake.NamespacesList).(*api.NamespaceList), nil
 }

--- a/pkg/client/namespaces.go
+++ b/pkg/client/namespaces.go
@@ -32,7 +32,7 @@ type NamespacesInterface interface {
 type NamespaceInterface interface {
 	Create(item *api.Namespace) (*api.Namespace, error)
 	Get(name string) (result *api.Namespace, err error)
-	List(selector labels.Selector) (*api.NamespaceList, error)
+	List(label, field labels.Selector) (*api.NamespaceList, error)
 	Delete(name string) error
 	Update(item *api.Namespace) (*api.Namespace, error)
 	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
@@ -56,9 +56,9 @@ func (c *namespaces) Create(namespace *api.Namespace) (*api.Namespace, error) {
 }
 
 // List lists all the namespaces in the cluster.
-func (c *namespaces) List(selector labels.Selector) (*api.NamespaceList, error) {
+func (c *namespaces) List(label, field labels.Selector) (*api.NamespaceList, error) {
 	result := &api.NamespaceList{}
-	err := c.r.Get().Resource("namespaces").SelectorParam("labels", selector).Do().Into(result)
+	err := c.r.Get().Resource("namespaces").SelectorParam("labels", label).SelectorParam("fields", field).Do().Into(result)
 	return result, err
 }
 

--- a/pkg/client/namespaces.go
+++ b/pkg/client/namespaces.go
@@ -36,6 +36,7 @@ type NamespaceInterface interface {
 	Delete(name string) error
 	Update(item *api.Namespace) (*api.Namespace, error)
 	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+	Finalize(item *api.Namespace) (*api.Namespace, error)
 }
 
 // namespaces implements NamespacesInterface
@@ -70,6 +71,17 @@ func (c *namespaces) Update(namespace *api.Namespace) (result *api.Namespace, er
 		return
 	}
 	err = c.r.Put().Resource("namespaces").Name(namespace.Name).Body(namespace).Do().Into(result)
+	return
+}
+
+// Finalize takes the representation of a namespace to update.  Returns the server's representation of the namespace, and an error, if it occurs.
+func (c *namespaces) Finalize(namespace *api.Namespace) (result *api.Namespace, err error) {
+	result = &api.Namespace{}
+	if len(namespace.ResourceVersion) == 0 {
+		err = fmt.Errorf("invalid update object, missing resource version: %v", namespace)
+		return
+	}
+	err = c.r.Put().Resource("namespaces").Name(namespace.Name).SubResource("finalize").Body(namespace).Do().Into(result)
 	return
 }
 

--- a/pkg/client/namespaces_test.go
+++ b/pkg/client/namespaces_test.go
@@ -90,7 +90,7 @@ func TestNamespaceList(t *testing.T) {
 		},
 		Response: Response{StatusCode: 200, Body: namespaceList},
 	}
-	response, err := c.Setup().Namespaces().List(labels.Everything())
+	response, err := c.Setup().Namespaces().List(labels.Everything(), labels.Everything())
 
 	if err != nil {
 		t.Errorf("%#v should be nil.", err)

--- a/pkg/client/namespaces_test.go
+++ b/pkg/client/namespaces_test.go
@@ -116,12 +116,37 @@ func TestNamespaceUpdate(t *testing.T) {
 				"name": "baz",
 			},
 		},
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{api.FinalizerKubernetes},
+		},
 	}
 	c := &testClient{
 		Request:  testRequest{Method: "PUT", Path: "/namespaces/foo"},
 		Response: Response{StatusCode: 200, Body: requestNamespace},
 	}
 	receivedNamespace, err := c.Setup().Namespaces().Update(requestNamespace)
+	c.Validate(t, receivedNamespace, err)
+}
+
+func TestNamespaceFinalize(t *testing.T) {
+	requestNamespace := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			ResourceVersion: "1",
+			Labels: map[string]string{
+				"foo":  "bar",
+				"name": "baz",
+			},
+		},
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{api.FinalizerKubernetes},
+		},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: "/namespaces/foo/finalize"},
+		Response: Response{StatusCode: 200, Body: requestNamespace},
+	}
+	receivedNamespace, err := c.Setup().Namespaces().Finalize(requestNamespace)
 	c.Validate(t, receivedNamespace, err)
 }
 

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -380,7 +380,7 @@ func (m *Master) init(c *Config) {
 	resourceQuotaStorage, resourceQuotaStatusStorage := resourcequotaetcd.NewREST(c.EtcdHelper)
 	secretRegistry := secret.NewEtcdRegistry(c.EtcdHelper)
 
-	namespaceStorage := namespaceetcd.NewREST(c.EtcdHelper)
+	namespaceStorage, namespaceStatusStorage, namespaceFinalizeStorage := namespaceetcd.NewREST(c.EtcdHelper)
 	m.namespaceRegistry = namespace.NewRegistry(namespaceStorage)
 
 	// TODO: split me up into distinct storage registries
@@ -424,6 +424,8 @@ func (m *Master) init(c *Config) {
 		"resourceQuotas":        resourceQuotaStorage,
 		"resourceQuotas/status": resourceQuotaStatusStorage,
 		"namespaces":            namespaceStorage,
+		"namespaces/status":     namespaceStatusStorage,
+		"namespaces/finalize":   namespaceFinalizeStorage,
 		"secrets":               secret.NewREST(secretRegistry),
 	}
 

--- a/pkg/namespace/doc.go
+++ b/pkg/namespace/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// namespace contains a controller that handles namespace lifecycle
+package namespace

--- a/pkg/namespace/namespace_controller.go
+++ b/pkg/namespace/namespace_controller.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+	"github.com/golang/glog"
+)
+
+// NamespaceManager is responsible for performing actions dependent upon a namespace phase
+type NamespaceManager struct {
+	kubeClient client.Interface
+	store      cache.Store
+	syncTime   <-chan time.Time
+
+	// To allow injection for testing.
+	syncHandler func(namespace api.Namespace) error
+}
+
+// NewNamespaceManager creates a new NamespaceManager
+func NewNamespaceManager(kubeClient client.Interface) *NamespaceManager {
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	//fieldSelector, _ := labels.ParseSelector("status.phase=Terminating")
+	fieldSelector := labels.Everything()
+	reflector := cache.NewReflector(
+		&cache.ListWatch{
+			ListFunc: func() (runtime.Object, error) {
+				return kubeClient.Namespaces().List(labels.Everything(), fieldSelector)
+			},
+			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+				return kubeClient.Namespaces().Watch(labels.Everything(), fieldSelector, resourceVersion)
+			},
+		},
+		&api.Namespace{},
+		store,
+		0,
+	)
+	reflector.Run()
+	nm := &NamespaceManager{
+		kubeClient: kubeClient,
+		store:      store,
+	}
+	// set the synchronization handler
+	nm.syncHandler = nm.terminateNamespace
+	return nm
+}
+
+// Run begins syncing at the specified period interval
+func (nm *NamespaceManager) Run(period time.Duration) {
+	nm.syncTime = time.Tick(period)
+	go util.Forever(func() { nm.synchronize() }, period)
+}
+
+// Iterate over the each namespace that is in terminating phase and perform necessary clean-up
+func (nm *NamespaceManager) synchronize() {
+	namespaceObjs := nm.store.List()
+	wg := sync.WaitGroup{}
+	wg.Add(len(namespaceObjs))
+	for ix := range namespaceObjs {
+		go func(ix int) {
+			defer wg.Done()
+			namespace := namespaceObjs[ix].(*api.Namespace)
+			glog.V(4).Infof("periodic sync of namespace: %v", namespace.Name)
+			err := nm.syncHandler(*namespace)
+			if err != nil {
+				glog.Errorf("Error synchronizing: %v", err)
+			}
+		}(ix)
+	}
+	wg.Wait()
+}
+
+// finalized returns true if the spec.finalizers is equal to the status.finalizers
+func finalized(namespace api.Namespace) bool {
+	specSet := util.NewStringSet()
+	for i := range namespace.Spec.Finalizers {
+		specSet.Insert(string(namespace.Spec.Finalizers[i]))
+	}
+	statusSet := util.NewStringSet()
+	for i := range namespace.Status.Finalizers {
+		statusSet.Insert(string(namespace.Status.Finalizers[i]))
+	}
+	return statusSet.HasAll(specSet.List()...)
+}
+
+// finalize will finalize the namespace for kubernetes
+func finalize(kubeClient client.Interface, namespace api.Namespace) (*api.Namespace, error) {
+	namespaceFinalize := api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name:            namespace.Name,
+			ResourceVersion: namespace.ResourceVersion,
+		},
+		Status: api.NamespaceStatus{},
+	}
+	namespaceFinalize.Status.Finalizers = make([]api.FinalizerName, len(namespace.Status.Finalizers), len(namespace.Status.Finalizers)+1)
+	copy(namespaceFinalize.Status.Finalizers, namespace.Status.Finalizers)
+	namespaceFinalize.Status.Finalizers = append(namespaceFinalize.Status.Finalizers, api.FinalizerKubernetes)
+
+	return kubeClient.Namespaces().Finalize(&namespaceFinalize)
+}
+
+// deleteAllContent will delete all content known to the system in a namespace
+func deleteAllContent(kubeClient client.Interface, namespace string) (err error) {
+	err = deleteServices(kubeClient, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteReplicationControllers(kubeClient, namespace)
+	if err != nil {
+		return err
+	}
+	err = deletePods(kubeClient, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteSecrets(kubeClient, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteLimitRanges(kubeClient, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteResourceQuotas(kubeClient, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteEvents(kubeClient, namespace)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// terminateNamespace attempts to do graceful termination of a namespace
+func (nm *NamespaceManager) terminateNamespace(namespace api.Namespace) (err error) {
+
+	// remove this when https://github.com/GoogleCloudPlatform/kubernetes/pull/5389 merges since our
+	// watch will already be filtered
+	if namespace.Status.Phase != api.NamespaceTerminating {
+		return fmt.Errorf("Namespace %v is not in the terminating phase.", namespace.Name)
+	}
+
+	// if the namespace is already finalized, delete it
+	if finalized(namespace) {
+		err = nm.kubeClient.Namespaces().Delete(namespace.Name)
+		return err
+	}
+
+	// there may still be content for us to remove
+	err = deleteAllContent(nm.kubeClient, namespace.Name)
+	if err != nil {
+		return err
+	}
+
+	// we have removed content, so mark it finalized by us
+	result, err := finalize(nm.kubeClient, namespace)
+	if err != nil {
+		return err
+	}
+
+	// now check if all finalizers have reported that we delete now
+	if finalized(*result) {
+		err = nm.kubeClient.Namespaces().Delete(namespace.Name)
+		return err
+	}
+
+	return nil
+}
+
+func deleteLimitRanges(kubeClient client.Interface, ns string) error {
+	items, err := kubeClient.LimitRanges(ns).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := kubeClient.LimitRanges(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteResourceQuotas(kubeClient client.Interface, ns string) error {
+	resourceQuotas, err := kubeClient.ResourceQuotas(ns).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range resourceQuotas.Items {
+		err := kubeClient.ResourceQuotas(ns).Delete(resourceQuotas.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteServices(kubeClient client.Interface, ns string) error {
+	items, err := kubeClient.Services(ns).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := kubeClient.Services(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteReplicationControllers(kubeClient client.Interface, ns string) error {
+	items, err := kubeClient.ReplicationControllers(ns).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := kubeClient.ReplicationControllers(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deletePods(kubeClient client.Interface, ns string) error {
+	items, err := kubeClient.Pods(ns).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := kubeClient.Pods(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteEvents(kubeClient client.Interface, ns string) error {
+	items, err := kubeClient.Events(ns).List(labels.Everything(), labels.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := kubeClient.Events(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteSecrets(kubeClient client.Interface, ns string) error {
+	items, err := kubeClient.Secrets(ns).List(labels.Everything(), labels.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := kubeClient.Secrets(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/namespace/namespace_controller_test.go
+++ b/pkg/namespace/namespace_controller_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace

--- a/pkg/registry/namespace/rest.go
+++ b/pkg/registry/namespace/rest.go
@@ -78,6 +78,16 @@ func (namespaceStatusStrategy) ValidateUpdate(obj, old runtime.Object) errors.Va
 	return validation.ValidateNamespaceStatusUpdate(obj.(*api.Namespace), old.(*api.Namespace))
 }
 
+type namespaceFinalizeStrategy struct {
+	namespaceStrategy
+}
+
+var FinalizeStrategy = namespaceFinalizeStrategy{Strategy}
+
+func (namespaceFinalizeStrategy) ValidateUpdate(obj, old runtime.Object) errors.ValidationErrorList {
+	return validation.ValidateNamespaceFinalizeUpdate(obj.(*api.Namespace), old.(*api.Namespace))
+}
+
 // MatchNamespace returns a generic matcher for a given label and field selector.
 func MatchNamespace(label labels.Selector, field fields.Selector) generic.Matcher {
 	return generic.MatcherFunc(func(obj runtime.Object) (bool, error) {

--- a/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -86,7 +86,7 @@ func NewProvision(c client.Interface) admission.Interface {
 	reflector := cache.NewReflector(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return c.Namespaces().List(labels.Everything())
+				return c.Namespaces().List(labels.Everything(), labels.Everything())
 			},
 			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
 				return c.Namespaces().Watch(labels.Everything(), labels.Everything(), resourceVersion)

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -85,7 +85,7 @@ func NewExists(c client.Interface) admission.Interface {
 	reflector := cache.NewReflector(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return c.Namespaces().List(labels.Everything())
+				return c.Namespaces().List(labels.Everything(), labels.Everything())
 			},
 			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
 				return c.Namespaces().Watch(labels.Everything(), labels.Everything(), resourceVersion)


### PR DESCRIPTION
This PR adds the ability to delete content in a `Namespace` as part of `Namespace` termination.

See #5195 for details on the design principles behind the implementation.

When coupled with #5288 it provides a complete solution for delete of a `Namespace` cascading to its managed content.

The general flow is as follows:

1) user deletes namespace X, results in namespace X.Status.Phase=Terminating
2) namespace controller watches for terminating namespaces, finds X
3) namespace controller purges all content from X
4) namespace controller finalizes namespace X to report it has completed its clean-up
5) if all finalizers for namespace X have reported status, namespace controller deletes the namespace
6) namespace repository allows deletion to occur if spec.finalizers == status.finalizers

The list of namespace.spec.finalizers is immutable post-creation.  The system will always ensure the "kubernetes" finalizer is present to enforce the controller being able to support deletion life-cycle.  The repository does not allow deletion of a resource if its spec.finalizers != status.finalizers.  

This lets downstream components like OpenShift that add additional namespace resources to take part in termination of the namespace by deleting its content.  In that case, when OpenShift provisions a namespace it adds a namespace.spec.finalizer=openshift.com/origin that must report back in a finalize operation before the namespace is allowed to be purged.
