### PR TITLE
Add "--labels" option to the "expose" kubectl command.

### DIFF
--- a/docs/kubectl-expose.md
+++ b/docs/kubectl-expose.md
@@ -31,6 +31,7 @@ $ kubectl expose streamer --port=4100 --protocol=udp --service-name=video-stream
       --create-external-load-balancer=false: If true, create an external load balancer for this service. Implementation is cloud provider dependent. Default is 'false'.
       --dry-run=false: If true, only print the object that would be sent, without creating it.
       --generator="service/v1": The name of the API generator to use.  Default is 'service/v1'.
+  -l, --labels="": Labels to apply to the service created by this call.
       --no-headers=false: When using the default output, don't print headers.
   -o, --output="": Output format. One of: json|yaml|template|templatefile.
       --output-version="": Output the formatted object with the given version (default api-version).

--- a/docs/man/man1/kubectl-expose.1
+++ b/docs/man/man1/kubectl-expose.1
@@ -38,6 +38,10 @@ as the selector for a new Service on the specified port.
     The name of the API generator to use.  Default is 'service/v1'.
 
 .PP
+\fB\-l\fP, \fB\-\-labels\fP=""
+    Labels to apply to the service created by this call.
+
+.PP
 \fB\-\-no\-headers\fP=false
     When using the default output, don't print headers.
 

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -56,6 +56,7 @@ func (f *Factory) NewCmdExposeService(out io.Writer) *cobra.Command {
 	cmd.Flags().Int("port", -1, "The port that the service should serve on. Required.")
 	cmd.Flags().Bool("create-external-load-balancer", false, "If true, create an external load balancer for this service. Implementation is cloud provider dependent. Default is 'false'.")
 	cmd.Flags().String("selector", "", "A label selector to use for this service. If empty (the default) infer the selector from the replication controller.")
+	cmd.Flags().StringP("labels", "l", "", "Labels to apply to the service created by this call.")
 	cmd.Flags().Bool("dry-run", false, "If true, only print the object that would be sent, without creating it.")
 	cmd.Flags().String("container-port", "", "Name or number for the port on the container that the service should direct traffic to. Optional.")
 	cmd.Flags().String("public-ip", "", "Name of a public IP address to set for the service. The service will be assigned this IP in addition to its generated service IP.")

--- a/pkg/kubectl/service.go
+++ b/pkg/kubectl/service.go
@@ -45,6 +45,13 @@ func (ServiceGenerator) Generate(params map[string]string) (runtime.Object, erro
 		return nil, fmt.Errorf("'selector' is a required parameter.")
 	}
 	selector := ParseLabels(selectorString)
+
+	labelsString, found := params["labels"]
+	var labels map[string]string
+	if found && len(labelsString) > 0 {
+		labels = ParseLabels(labelsString)
+	}
+
 	name, found := params["name"]
 	if !found {
 		return nil, fmt.Errorf("'name' is a required parameter.")
@@ -59,7 +66,8 @@ func (ServiceGenerator) Generate(params map[string]string) (runtime.Object, erro
 	}
 	service := api.Service{
 		ObjectMeta: api.ObjectMeta{
-			Name: name,
+			Name:   name,
+			Labels: labels,
 		},
 		Spec: api.ServiceSpec{
 			Port:     port,

--- a/pkg/kubectl/service_test.go
+++ b/pkg/kubectl/service_test.go
@@ -78,6 +78,34 @@ func TestGenerateService(t *testing.T) {
 		{
 			params: map[string]string{
 				"selector":       "foo=bar,baz=blah",
+				"labels":         "key1=value1,key2=value2",
+				"name":           "test",
+				"port":           "80",
+				"protocol":       "TCP",
+				"container-port": "1234",
+			},
+			expected: api.Service{
+				ObjectMeta: api.ObjectMeta{
+					Name: "test",
+					Labels: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+				Spec: api.ServiceSpec{
+					Selector: map[string]string{
+						"foo": "bar",
+						"baz": "blah",
+					},
+					Port:          80,
+					Protocol:      "TCP",
+					ContainerPort: util.NewIntOrStringFromInt(1234),
+				},
+			},
+		},
+		{
+			params: map[string]string{
+				"selector":       "foo=bar,baz=blah",
 				"name":           "test",
 				"port":           "80",
 				"protocol":       "UDP",


### PR DESCRIPTION
Adding the ability to label a service during its creation via the "expose" kubectl command.
