### PR TITLE
Revert #5479, don't force no cgo.

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -296,13 +296,13 @@ kube::golang::build_binaries() {
           if [[ ${GOOS} == "windows" ]]; then
             bin="${bin}.exe"
           fi
-          CGO_ENABLED=0 go build -installsuffix cgo -o "${output_path}/${bin}" \
+          go build -o "${output_path}/${bin}" \
               "${goflags[@]:+${goflags[@]}}" \
               -ldflags "${version_ldflags}" \
               "${binary}"
         done
       else
-        CGO_ENABLED=0 go install -installsuffix cgo "${goflags[@]:+${goflags[@]}}" \
+        go install "${goflags[@]:+${goflags[@]}}" \
             -ldflags "${version_ldflags}" \
             "${binaries[@]}"
       fi


### PR DESCRIPTION
We allow cgo when available since some of our server components (mainly
Kubelet) rely on it. The current driving factor for the static binaries
was building Docker images from scratch. We will instead use images
built from small busybox bases.

Fixes #5517
