### PR TITLE
Adding GetFieldSelector() to client.EventInterface

### DIFF
--- a/pkg/client/events_test.go
+++ b/pkg/client/events_test.go
@@ -34,7 +34,11 @@ func TestEventSearch(t *testing.T) {
 			Method: "GET",
 			Path:   "/events",
 			Query: url.Values{
-				"fields": []string{"involvedObject.kind=Pod,involvedObject.name=foo,involvedObject.namespace=baz"},
+				"fields": []string{
+					"involvedObject.kind=Pod,",
+					getInvolvedObjectNameFieldLabel(testapi.Version()) + "=foo,",
+					"involvedObject.namespace=baz",
+				},
 				"labels": []string{},
 			},
 		},

--- a/pkg/client/fake_events.go
+++ b/pkg/client/fake_events.go
@@ -70,3 +70,8 @@ func (c *FakeEvents) Delete(name string) error {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-event", Value: name})
 	return nil
 }
+
+func (c *FakeEvents) GetFieldSelector(involvedObjectName, involvedObjectNamespace, involvedObjectKind, involvedObjectUID *string) fields.Selector {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-field-selector"})
+	return fields.Everything()
+}

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/golang/glog"
 )
@@ -204,13 +203,10 @@ func (d *PodDescriber) Describe(namespace, name string) (string, error) {
 
 	pod, err := pc.Get(name)
 	if err != nil {
-		events, err2 := d.Events(namespace).List(
+		eventsInterface := d.Events(namespace)
+		events, err2 := eventsInterface.List(
 			labels.Everything(),
-			fields.Set{
-				"involvedObject.name":      name,
-				"involvedObject.namespace": namespace,
-			}.AsSelector(),
-		)
+			eventsInterface.GetFieldSelector(&name, &namespace, nil, nil))
 		if err2 == nil && len(events.Items) > 0 {
 			return tabbedString(func(out io.Writer) error {
 				fmt.Fprintf(out, "Pod '%v': error '%v', but found events.\n", name, err)

--- a/pkg/registry/event/rest.go
+++ b/pkg/registry/event/rest.go
@@ -117,7 +117,6 @@ func (rs *REST) getAttrs(obj runtime.Object) (objLabels labels.Set, objFields fi
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid object type")
 	}
-	// TODO: internal version leaks through here. This should be versioned.
 	return labels.Set{}, fields.Set{
 		"involvedObject.kind":            event.InvolvedObject.Kind,
 		"involvedObject.namespace":       event.InvolvedObject.Namespace,


### PR DESCRIPTION
This is required so that kubectl can call client.EventInterface.List() with the appropriate field selector.
