### PR TITLE
Add a GenericRESTStorage interface

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -382,6 +382,7 @@ func (m *Master) init(c *Config) {
 	if c.SyncPodStatus {
 		go util.Forever(podCache.UpdateAllContainers, m.cacheTimeout)
 		go util.Forever(podCache.GarbageCollectPodStatus, time.Minute*30)
+		// Note the pod cache needs access to an un-decorated RESTStorage
 		podStorage = podStorage.WithPodStatus(podCache)
 	}
 

--- a/pkg/registry/pod/etcd/etcd_test.go
+++ b/pkg/registry/pod/etcd/etcd_test.go
@@ -704,8 +704,8 @@ func TestEtcdGetDifferentNamespace(t *testing.T) {
 	ctx1 := api.NewDefaultContext()
 	ctx2 := api.WithNamespace(api.NewContext(), "other")
 
-	key1, _ := registry.store.KeyFunc(ctx1, "foo")
-	key2, _ := registry.store.KeyFunc(ctx2, "foo")
+	key1, _ := registry.KeyFunc(ctx1, "foo")
+	key2, _ := registry.KeyFunc(ctx2, "foo")
 
 	fakeClient.Set(key1, runtime.EncodeOrDie(latest.Codec, &api.Pod{ObjectMeta: api.ObjectMeta{Namespace: "default", Name: "foo"}}), 0)
 	fakeClient.Set(key2, runtime.EncodeOrDie(latest.Codec, &api.Pod{ObjectMeta: api.ObjectMeta{Namespace: "other", Name: "foo"}}), 0)
@@ -739,7 +739,7 @@ func TestEtcdGetDifferentNamespace(t *testing.T) {
 func TestEtcdGet(t *testing.T) {
 	registry, _, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
-	key, _ := registry.store.KeyFunc(ctx, "foo")
+	key, _ := registry.KeyFunc(ctx, "foo")
 	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}), 0)
 	obj, err := registry.Get(ctx, "foo")
 	if err != nil {
@@ -754,7 +754,7 @@ func TestEtcdGet(t *testing.T) {
 func TestEtcdGetNotFound(t *testing.T) {
 	registry, _, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
-	key, _ := registry.store.KeyFunc(ctx, "foo")
+	key, _ := registry.KeyFunc(ctx, "foo")
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
@@ -771,7 +771,7 @@ func TestEtcdCreate(t *testing.T) {
 	registry, bindingRegistry, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
 	fakeClient.TestIndex = true
-	key, _ := registry.store.KeyFunc(ctx, "foo")
+	key, _ := registry.KeyFunc(ctx, "foo")
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
@@ -815,7 +815,7 @@ func TestEtcdCreateBindingNoPod(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	fakeClient.TestIndex = true
 
-	key, _ := registry.store.KeyFunc(ctx, "foo")
+	key, _ := registry.KeyFunc(ctx, "foo")
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
@@ -861,7 +861,7 @@ func TestEtcdCreateFailsWithoutNamespace(t *testing.T) {
 func TestEtcdCreateAlreadyExisting(t *testing.T) {
 	registry, _, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
-	key, _ := registry.store.KeyFunc(ctx, "foo")
+	key, _ := registry.KeyFunc(ctx, "foo")
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
@@ -880,7 +880,7 @@ func TestEtcdCreateWithContainersNotFound(t *testing.T) {
 	registry, bindingRegistry, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
 	fakeClient.TestIndex = true
-	key, _ := registry.store.KeyFunc(ctx, "foo")
+	key, _ := registry.KeyFunc(ctx, "foo")
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
@@ -927,7 +927,7 @@ func TestEtcdCreateWithConflict(t *testing.T) {
 	registry, bindingRegistry, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
 	fakeClient.TestIndex = true
-	key, _ := registry.store.KeyFunc(ctx, "foo")
+	key, _ := registry.KeyFunc(ctx, "foo")
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
@@ -964,7 +964,7 @@ func TestEtcdCreateWithExistingContainers(t *testing.T) {
 	registry, bindingRegistry, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
 	fakeClient.TestIndex = true
-	key, _ := registry.store.KeyFunc(ctx, "foo")
+	key, _ := registry.KeyFunc(ctx, "foo")
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
@@ -1046,7 +1046,7 @@ func TestEtcdCreateBinding(t *testing.T) {
 		},
 	}
 	for k, test := range testCases {
-		key, _ := registry.store.KeyFunc(ctx, "foo")
+		key, _ := registry.KeyFunc(ctx, "foo")
 		fakeClient.Data[key] = tools.EtcdResponseWithError{
 			R: &etcd.Response{
 				Node: nil,
@@ -1075,7 +1075,7 @@ func TestEtcdUpdateNotFound(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	fakeClient.TestIndex = true
 
-	key, _ := registry.store.KeyFunc(ctx, "foo")
+	key, _ := registry.KeyFunc(ctx, "foo")
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
 		E: tools.EtcdErrorNotFound,
@@ -1101,7 +1101,7 @@ func TestEtcdUpdateNotScheduled(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	fakeClient.TestIndex = true
 
-	key, _ := registry.store.KeyFunc(ctx, "foo")
+	key, _ := registry.KeyFunc(ctx, "foo")
 	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, validNewPod()), 1)
 
 	podIn := validChangedPod()
@@ -1125,7 +1125,7 @@ func TestEtcdUpdateScheduled(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	fakeClient.TestIndex = true
 
-	key, _ := registry.store.KeyFunc(ctx, "foo")
+	key, _ := registry.KeyFunc(ctx, "foo")
 	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:      "foo",
@@ -1188,7 +1188,7 @@ func TestEtcdUpdateStatus(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	fakeClient.TestIndex = true
 
-	key, _ := registry.store.KeyFunc(ctx, "foo")
+	key, _ := registry.KeyFunc(ctx, "foo")
 	podStart := api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:      "foo",
@@ -1260,7 +1260,7 @@ func TestEtcdDeletePod(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	fakeClient.TestIndex = true
 
-	key, _ := registry.store.KeyFunc(ctx, "foo")
+	key, _ := registry.KeyFunc(ctx, "foo")
 	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &api.Pod{
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 		Status:     api.PodStatus{Host: "machine"},
@@ -1281,7 +1281,7 @@ func TestEtcdDeletePodMultipleContainers(t *testing.T) {
 	registry, _, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
 	fakeClient.TestIndex = true
-	key, _ := registry.store.KeyFunc(ctx, "foo")
+	key, _ := registry.KeyFunc(ctx, "foo")
 	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &api.Pod{
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 		Status:     api.PodStatus{Host: "machine"},
@@ -1302,7 +1302,7 @@ func TestEtcdDeletePodMultipleContainers(t *testing.T) {
 func TestEtcdEmptyList(t *testing.T) {
 	registry, _, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
-	key := registry.store.KeyRootFunc(ctx)
+	key := registry.KeyRootFunc(ctx)
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
@@ -1325,7 +1325,7 @@ func TestEtcdEmptyList(t *testing.T) {
 func TestEtcdListNotFound(t *testing.T) {
 	registry, _, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
-	key := registry.store.KeyRootFunc(ctx)
+	key := registry.KeyRootFunc(ctx)
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
 		E: tools.EtcdErrorNotFound,
@@ -1343,7 +1343,7 @@ func TestEtcdListNotFound(t *testing.T) {
 func TestEtcdList(t *testing.T) {
 	registry, _, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
-	key := registry.store.KeyRootFunc(ctx)
+	key := registry.KeyRootFunc(ctx)
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{


### PR DESCRIPTION
Embed etcdgeneric.Etcd as a GenericRESTStorage (included in this PR) in podetcd.REST, so it doesn't need to duplicate CRUD methods that simply pass through to the storage backend. This pattern should be applicable for all rest resources.
