### PR TITLE
allow any number of kubeconfig files

### DIFF
--- a/pkg/client/clientcmd/loader_test.go
+++ b/pkg/client/clientcmd/loader_test.go
@@ -78,7 +78,7 @@ var (
 
 func TestNonExistentCommandLineFile(t *testing.T) {
 	loadingRules := ClientConfigLoadingRules{
-		CommandLinePath: "bogus_file",
+		ExplicitPath: "bogus_file",
 	}
 
 	_, err := loadingRules.Load()
@@ -92,9 +92,7 @@ func TestNonExistentCommandLineFile(t *testing.T) {
 
 func TestToleratingMissingFiles(t *testing.T) {
 	loadingRules := ClientConfigLoadingRules{
-		EnvVarPath:           "bogus1",
-		CurrentDirectoryPath: "bogus2",
-		HomeDirectoryPath:    "bogus3",
+		Precedence: []string{"bogus1", "bogus2", "bogus3"},
 	}
 
 	_, err := loadingRules.Load()
@@ -112,7 +110,7 @@ func TestErrorReadingFile(t *testing.T) {
 	}
 
 	loadingRules := ClientConfigLoadingRules{
-		CommandLinePath: commandLineFile.Name(),
+		ExplicitPath: commandLineFile.Name(),
 	}
 
 	_, err := loadingRules.Load()
@@ -132,7 +130,7 @@ func TestErrorReadingNonFile(t *testing.T) {
 	defer os.Remove(tmpdir)
 
 	loadingRules := ClientConfigLoadingRules{
-		CommandLinePath: tmpdir,
+		ExplicitPath: tmpdir,
 	}
 
 	_, err = loadingRules.Load()
@@ -161,8 +159,8 @@ func TestConflictingCurrentContext(t *testing.T) {
 	WriteToFile(mockEnvVarConfig, envVarFile.Name())
 
 	loadingRules := ClientConfigLoadingRules{
-		CommandLinePath: commandLineFile.Name(),
-		EnvVarPath:      envVarFile.Name(),
+		ExplicitPath: commandLineFile.Name(),
+		Precedence:   []string{envVarFile.Name()},
 	}
 
 	mergedConfig, err := loadingRules.Load()
@@ -211,8 +209,8 @@ func TestResolveRelativePaths(t *testing.T) {
 	WriteToFile(pathResolutionConfig2, configFile2)
 
 	loadingRules := ClientConfigLoadingRules{
-		CommandLinePath: configFile1,
-		EnvVarPath:      configFile2,
+		ExplicitPath: configFile1,
+		Precedence:   []string{configFile2},
 	}
 
 	mergedConfig, err := loadingRules.Load()
@@ -286,8 +284,8 @@ func ExampleMergingSomeWithConflict() {
 	WriteToFile(testConfigConflictAlfa, envVarFile.Name())
 
 	loadingRules := ClientConfigLoadingRules{
-		CommandLinePath: commandLineFile.Name(),
-		EnvVarPath:      envVarFile.Name(),
+		ExplicitPath: commandLineFile.Name(),
+		Precedence:   []string{envVarFile.Name()},
 	}
 
 	mergedConfig, err := loadingRules.Load()
@@ -346,10 +344,8 @@ func ExampleMergingEverythingNoConflicts() {
 	WriteToFile(testConfigDelta, homeDirFile.Name())
 
 	loadingRules := ClientConfigLoadingRules{
-		CommandLinePath:      commandLineFile.Name(),
-		EnvVarPath:           envVarFile.Name(),
-		CurrentDirectoryPath: currentDirFile.Name(),
-		HomeDirectoryPath:    homeDirFile.Name(),
+		ExplicitPath: commandLineFile.Name(),
+		Precedence:   []string{envVarFile.Name(), currentDirFile.Name(), homeDirFile.Name()},
 	}
 
 	mergedConfig, err := loadingRules.Load()

--- a/pkg/client/clientcmd/merged_client_builder_test.go
+++ b/pkg/client/clientcmd/merged_client_builder_test.go
@@ -78,11 +78,11 @@ func testWriteAuthInfoFile(auth clientauth.Info, filename string) error {
 }
 
 func testBindClientConfig(cmd *cobra.Command) ClientConfig {
-	loadingRules := NewClientConfigLoadingRules()
-	loadingRules.EnvVarPath = ""
-	loadingRules.HomeDirectoryPath = ""
-	loadingRules.CurrentDirectoryPath = ""
-	cmd.PersistentFlags().StringVar(&loadingRules.CommandLinePath, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
+	loadingRules := NewDefaultClientConfigLoadingRules()
+	loadingRules.Precedence[DefaultEnvVarIndex] = ""
+	loadingRules.Precedence[DefaultCurrentDirIndex] = ""
+	loadingRules.Precedence[DefaultHomeDirIndex] = ""
+	cmd.PersistentFlags().StringVar(&loadingRules.ExplicitPath, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
 
 	overrides := &ConfigOverrides{}
 	BindOverrideFlags(overrides, cmd.PersistentFlags(), RecommendedConfigOverrideFlags(""))

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -314,9 +314,8 @@ func (f *Factory) ClientMapperForCommand(cmd *cobra.Command) resource.ClientMapp
 //           3.  If the command line specifies one and the auth info specifies another, honor the command line technique.
 //   2.  Use default values and potentially prompt for auth information
 func DefaultClientConfig(flags *pflag.FlagSet) clientcmd.ClientConfig {
-	loadingRules := clientcmd.NewClientConfigLoadingRules()
-	loadingRules.EnvVarPath = os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
-	flags.StringVar(&loadingRules.CommandLinePath, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	flags.StringVar(&loadingRules.ExplicitPath, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
 
 	overrides := &clientcmd.ConfigOverrides{}
 	flagNames := clientcmd.RecommendedConfigOverrideFlags("")

--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -19,7 +19,6 @@ package config
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -113,9 +112,8 @@ func (o viewOptions) validate() error {
 func (o *viewOptions) getStartingConfig() (*clientcmdapi.Config, string, error) {
 	switch {
 	case o.merge.Value():
-		loadingRules := clientcmd.NewClientConfigLoadingRules()
-		loadingRules.EnvVarPath = os.Getenv("KUBECONFIG")
-		loadingRules.CommandLinePath = o.pathOptions.specifiedFile
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		loadingRules.ExplicitPath = o.pathOptions.specifiedFile
 
 		overrides := &clientcmd.ConfigOverrides{}
 		clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)


### PR DESCRIPTION
Restricting .kubeconfig files to only four locations made it see exactly where files were coming from, but it made extending the mechanism just about impossible.  This allows a separate precedence order slice that allows easy extensions.  `ExplicitPath` (previously `CommandLinePath`) is special and still called out because if the `ExplicitPath` is set, the referenced file must be present.  Missing files in the rest of the precedence order are simply ignored.
