### PR TITLE
workaround for docker/docker-registry#892 /crasher on CoreOS' cloud-configs

### DIFF
--- a/docs/getting-started-guides/aws/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/aws/cloud-configs/master.yaml
@@ -100,8 +100,11 @@ coreos:
         ExecStartPre=-/usr/bin/docker kill docker-registry
         ExecStartPre=-/usr/bin/docker rm docker-registry
         ExecStartPre=/usr/bin/docker pull quay.io/devops/docker-registry:latest
+        # GUNICORN_OPTS is an workaround for
+        # https://github.com/docker/docker-registry/issues/892
         ExecStart=/usr/bin/docker run --rm --net host --name docker-registry \
             -e STANDALONE=false \
+            -e GUNICORN_OPTS=[--preload] \
             -e MIRROR_SOURCE=https://registry-1.docker.io \
             -e MIRROR_SOURCE_INDEX=https://index.docker.io \
             -e MIRROR_TAGS_CACHE_TTL=1800 \

--- a/docs/getting-started-guides/coreos/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/master.yaml
@@ -102,8 +102,11 @@ coreos:
         ExecStartPre=-/usr/bin/docker kill docker-registry
         ExecStartPre=-/usr/bin/docker rm docker-registry
         ExecStartPre=/usr/bin/docker pull quay.io/devops/docker-registry:latest
+        # GUNICORN_OPTS is an workaround for
+        # https://github.com/docker/docker-registry/issues/892
         ExecStart=/usr/bin/docker run --rm --net host --name docker-registry \
             -e STANDALONE=false \
+            -e GUNICORN_OPTS=[--preload] \
             -e MIRROR_SOURCE=https://registry-1.docker.io \
             -e MIRROR_SOURCE_INDEX=https://index.docker.io \
             -e MIRROR_TAGS_CACHE_TTL=1800 \

--- a/docs/getting-started-guides/coreos/cloud-configs/standalone.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/standalone.yaml
@@ -63,8 +63,11 @@ coreos:
         ExecStartPre=-/usr/bin/docker kill docker-registry
         ExecStartPre=-/usr/bin/docker rm docker-registry
         ExecStartPre=/usr/bin/docker pull quay.io/devops/docker-registry:latest
+        # GUNICORN_OPTS is an workaround for
+        # https://github.com/docker/docker-registry/issues/892
         ExecStart=/usr/bin/docker run --rm --net host --name docker-registry \
             -e STANDALONE=false \
+            -e GUNICORN_OPTS=[--preload] \
             -e MIRROR_SOURCE=https://registry-1.docker.io \
             -e MIRROR_SOURCE_INDEX=https://index.docker.io \
             -e MIRROR_TAGS_CACHE_TTL=1800 \


### PR DESCRIPTION
avoids race conditions (docker/docker-registry#892) when multiple workers are
attempting to run sql migrations simultaneously. dunno why this isn't the
registry's default since this isn't specially hard to trigger so we're just
playing safe here.
