### PR TITLE
Release 0.13.1

### DIFF
--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -36,8 +36,8 @@ package version
 var (
 	// TODO: Deprecate gitMajor and gitMinor, use only gitVersion instead.
 	gitMajor     string = "0"              // major version, always numeric
-	gitMinor     string = "13.1"           // minor version, numeric possibly followed by "+"
-	gitVersion   string = "v0.13.1"        // version from git, output of $(git describe)
+	gitMinor     string = "13.1+"          // minor version, numeric possibly followed by "+"
+	gitVersion   string = "v0.13.1-dev"    // version from git, output of $(git describe)
 	gitCommit    string = ""               // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 )

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -36,8 +36,8 @@ package version
 var (
 	// TODO: Deprecate gitMajor and gitMinor, use only gitVersion instead.
 	gitMajor     string = "0"              // major version, always numeric
-	gitMinor     string = "12.0+"          // minor version, numeric possibly followed by "+"
-	gitVersion   string = "v0.12.0-dev"    // version from git, output of $(git describe)
+	gitMinor     string = "13.1"           // minor version, numeric possibly followed by "+"
+	gitVersion   string = "v0.13.1"        // version from git, output of $(git describe)
 	gitCommit    string = ""               // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 )

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -110,6 +110,7 @@ func (f *ConfigFactory) CreateFromKeys(predicateKeys, priorityKeys util.StringSe
 		PodLister:     f.PodLister,
 		ServiceLister: f.ServiceLister,
 		NodeLister:    f.NodeLister,
+		NodeInfo:      f.NodeLister,
 	}
 	predicateFuncs, err := getFitPredicateFunctions(predicateKeys, pluginArgs)
 	if err != nil {


### PR DESCRIPTION
**HEADS UP**: This is actually a _roll up_ of everything up to fa235193, plus one commit. I realize this procedure is a bit odd for a dot release, but @brendanburns left a lot of stuff out of 0.13.0, so we decided to do a quick turn .1 that caught up.
