### PR TITLE
Namespace Controller to support Namespace Termination

### DIFF
--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -71,4 +71,4 @@ DNS_DOMAIN="kubernetes.local"
 DNS_REPLICAS=1
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceAutoProvision,LimitRanger,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,ResourceQuota

--- a/cluster/azure/config-default.sh
+++ b/cluster/azure/config-default.sh
@@ -49,4 +49,4 @@ ELASTICSEARCH_LOGGING_REPLICAS=1
 ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-true}"
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceAutoProvision,LimitRanger,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,ResourceQuota

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -108,4 +108,4 @@ DNS_DOMAIN="kubernetes.local"
 DNS_REPLICAS=1
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceAutoProvision,LimitRanger,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,ResourceQuota

--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -49,7 +49,7 @@ MASTER_USER=vagrant
 MASTER_PASSWD=vagrant
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceAutoProvision,LimitRanger,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,ResourceQuota
 
 # Optional: Install node monitoring.
 ENABLE_NODE_MONITORING=true

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -74,7 +74,7 @@ func NewCMServer() *CMServer {
 		Address:                 util.IP(net.ParseIP("127.0.0.1")),
 		NodeSyncPeriod:          10 * time.Second,
 		ResourceQuotaSyncPeriod: 10 * time.Second,
-		NamespaceSyncPeriod:     10 * time.Second,
+		NamespaceSyncPeriod:     1 * time.Minute,
 		RegisterRetryCount:      10,
 		PodEvictionTimeout:      5 * time.Minute,
 		NodeMilliCPU:            1000,

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -95,3 +95,10 @@ func IsServiceIPSet(service *Service) bool {
 func IsServiceIPRequested(service *Service) bool {
 	return service.Spec.PortalIP == ""
 }
+
+var standardFinalizers = util.NewStringSet(
+	string(FinalizerKubernetes))
+
+func IsStandardFinalizerName(str string) bool {
+	return standardFinalizers.Has(str)
+}

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -198,6 +198,9 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			c.FuzzNoCustom(s) // fuzz self without calling this function again
 			s.Type = api.SecretTypeOpaque
 		},
+		func(s *api.NamespaceSpec, c fuzz.Continue) {
+			s.Finalizers = []api.FinalizerName{api.FinalizerKubernetes}
+		},
 		func(s *api.NamespaceStatus, c fuzz.Continue) {
 			s.Phase = api.NamespaceActive
 		},

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -966,7 +966,16 @@ type NodeList struct {
 
 // NamespaceSpec describes the attributes on a Namespace
 type NamespaceSpec struct {
+	// Finalizers is an opaque list of values that must be empty to permanently remove object from storage
+	Finalizers []FinalizerName
 }
+
+type FinalizerName string
+
+// These are internal finalizer values to Kubernetes, must be qualified name unless defined here
+const (
+	FinalizerKubernetes FinalizerName = "kubernetes"
+)
 
 // NamespaceStatus is information about the current status of a Namespace.
 type NamespaceStatus struct {

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -1426,4 +1426,17 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "namespaces",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "status.phase":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
 }

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -782,8 +782,17 @@ type MinionList struct {
 	Items   []Minion `json:"items" description:"list of nodes"`
 }
 
+type FinalizerName string
+
+// These are internal finalizer values to Kubernetes, must be qualified name unless defined here
+const (
+	FinalizerKubernetes FinalizerName = "kubernetes"
+)
+
 // NamespaceSpec describes the attributes on a Namespace
 type NamespaceSpec struct {
+	// Finalizers is an opaque list of values that must be empty to permanently remove object from storage
+	Finalizers []FinalizerName `json:"finalizers,omitempty" description:"an opaque list of values that must be empty to permanently remove object from storage"`
 }
 
 // NamespaceStatus is information about the current status of a Namespace.

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -1354,4 +1354,17 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "namespaces",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "status.phase":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
 }

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -798,8 +798,17 @@ type MinionList struct {
 	Items    []Minion `json:"items" description:"list of nodes"`
 }
 
+type FinalizerName string
+
+// These are internal finalizer values to Kubernetes, must be qualified name unless defined here
+const (
+	FinalizerKubernetes FinalizerName = "kubernetes"
+)
+
 // NamespaceSpec describes the attributes on a Namespace
 type NamespaceSpec struct {
+	// Finalizers is an opaque list of values that must be empty to permanently remove object from storage
+	Finalizers []FinalizerName `json:"finalizers,omitempty" description:"an opaque list of values that must be empty to permanently remove object from storage"`
 }
 
 // NamespaceStatus is information about the current status of a Namespace.

--- a/pkg/api/v1beta3/conversion.go
+++ b/pkg/api/v1beta3/conversion.go
@@ -60,4 +60,17 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "namespaces",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "status.phase":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
 }

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -950,8 +950,17 @@ type NodeList struct {
 	Items []Node `json:"items" description:"list of nodes"`
 }
 
+type FinalizerName string
+
+// These are internal finalizer values to Kubernetes, must be qualified name unless defined here
+const (
+	FinalizerKubernetes FinalizerName = "kubernetes"
+)
+
 // NamespaceSpec describes the attributes on a Namespace
 type NamespaceSpec struct {
+	// Finalizers is an opaque list of values that must be empty to permanently remove object from storage
+	Finalizers []FinalizerName `json:"finalizers,omitempty" description:"an opaque list of values that must be empty to permanently remove object from storage"`
 }
 
 // NamespaceStatus is information about the current status of a Namespace.

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1011,7 +1011,26 @@ func ValidateResourceQuotaStatusUpdate(newResourceQuota, oldResourceQuota *api.R
 func ValidateNamespace(namespace *api.Namespace) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
 	allErrs = append(allErrs, ValidateObjectMeta(&namespace.ObjectMeta, false, ValidateNamespaceName).Prefix("metadata")...)
+	for i := range namespace.Spec.Finalizers {
+		allErrs = append(allErrs, validateFinalizerName(string(namespace.Spec.Finalizers[i]))...)
+	}
 	return allErrs
+}
+
+// Validate finalizer names
+func validateFinalizerName(stringValue string) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	if !util.IsQualifiedName(stringValue) {
+		return append(allErrs, fmt.Errorf("finalizer name: %v, %v", stringValue, qualifiedNameErrorMsg))
+	}
+
+	if len(strings.Split(stringValue, "/")) == 1 {
+		if !api.IsStandardFinalizerName(stringValue) {
+			return append(allErrs, fmt.Errorf("finalizer name: %v is neither a standard finalizer name nor is it fully qualified", stringValue))
+		}
+	}
+
+	return errs.ValidationErrorList{}
 }
 
 // ValidateNamespaceUpdate tests to make sure a mamespace update can be applied.  Modifies oldNamespace.
@@ -1022,6 +1041,7 @@ func ValidateNamespaceUpdate(oldNamespace *api.Namespace, namespace *api.Namespa
 	// TODO: move reset function to its own location
 	// Ignore metadata changes now that they have been tested
 	oldNamespace.ObjectMeta = namespace.ObjectMeta
+	oldNamespace.Spec.Finalizers = namespace.Spec.Finalizers
 
 	// TODO: Add a 'real' ValidationError type for this error and provide print actual diffs.
 	if !api.Semantic.DeepEqual(oldNamespace, namespace) {
@@ -1036,9 +1056,20 @@ func ValidateNamespaceUpdate(oldNamespace *api.Namespace, namespace *api.Namespa
 func ValidateNamespaceStatusUpdate(newNamespace, oldNamespace *api.Namespace) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
 	allErrs = append(allErrs, ValidateObjectMetaUpdate(&oldNamespace.ObjectMeta, &newNamespace.ObjectMeta).Prefix("metadata")...)
-	if newNamespace.Status.Phase != oldNamespace.Status.Phase {
-		allErrs = append(allErrs, errs.NewFieldInvalid("status.phase", newNamespace.Status.Phase, "namespace phase cannot be changed directly"))
-	}
 	newNamespace.Spec = oldNamespace.Spec
+	return allErrs
+}
+
+// ValidateNamespaceFinalizeUpdate tests to see if the update is legal for an end user to make. newNamespace is updated with fields
+// that cannot be changed.
+func ValidateNamespaceFinalizeUpdate(newNamespace, oldNamespace *api.Namespace) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	allErrs = append(allErrs, ValidateObjectMetaUpdate(&oldNamespace.ObjectMeta, &newNamespace.ObjectMeta).Prefix("metadata")...)
+	for i := range newNamespace.Spec.Finalizers {
+		allErrs = append(allErrs, validateFinalizerName(string(newNamespace.Spec.Finalizers[i]))...)
+	}
+	newNamespace.ObjectMeta = oldNamespace.ObjectMeta
+	newNamespace.Status = oldNamespace.Status
+	fmt.Printf("NEW NAMESPACE FINALIZERS : %v\n", newNamespace.Spec.Finalizers)
 	return allErrs
 }

--- a/pkg/client/fake_namespaces.go
+++ b/pkg/client/fake_namespaces.go
@@ -29,7 +29,7 @@ type FakeNamespaces struct {
 	Fake *Fake
 }
 
-func (c *FakeNamespaces) List(selector labels.Selector) (*api.NamespaceList, error) {
+func (c *FakeNamespaces) List(labels labels.Selector, field fields.Selector) (*api.NamespaceList, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "list-namespaces"})
 	return api.Scheme.CopyOrDie(&c.Fake.NamespacesList).(*api.NamespaceList), nil
 }
@@ -57,4 +57,14 @@ func (c *FakeNamespaces) Update(namespace *api.Namespace) (*api.Namespace, error
 func (c *FakeNamespaces) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-namespaces", Value: resourceVersion})
 	return c.Fake.Watch, nil
+}
+
+func (c *FakeNamespaces) Finalize(namespace *api.Namespace) (*api.Namespace, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "finalize-namespace", Value: namespace.Name})
+	return &api.Namespace{}, nil
+}
+
+func (c *FakeNamespaces) Status(namespace *api.Namespace) (*api.Namespace, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "status-namespace", Value: namespace.Name})
+	return &api.Namespace{}, nil
 }

--- a/pkg/client/namespaces_test.go
+++ b/pkg/client/namespaces_test.go
@@ -91,7 +91,7 @@ func TestNamespaceList(t *testing.T) {
 		},
 		Response: Response{StatusCode: 200, Body: namespaceList},
 	}
-	response, err := c.Setup().Namespaces().List(labels.Everything())
+	response, err := c.Setup().Namespaces().List(labels.Everything(), fields.Everything())
 
 	if err != nil {
 		t.Errorf("%#v should be nil.", err)
@@ -117,12 +117,37 @@ func TestNamespaceUpdate(t *testing.T) {
 				"name": "baz",
 			},
 		},
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{api.FinalizerKubernetes},
+		},
 	}
 	c := &testClient{
 		Request:  testRequest{Method: "PUT", Path: "/namespaces/foo"},
 		Response: Response{StatusCode: 200, Body: requestNamespace},
 	}
 	receivedNamespace, err := c.Setup().Namespaces().Update(requestNamespace)
+	c.Validate(t, receivedNamespace, err)
+}
+
+func TestNamespaceFinalize(t *testing.T) {
+	requestNamespace := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			ResourceVersion: "1",
+			Labels: map[string]string{
+				"foo":  "bar",
+				"name": "baz",
+			},
+		},
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{api.FinalizerKubernetes},
+		},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: "/namespaces/foo/finalize"},
+		Response: Response{StatusCode: 200, Body: requestNamespace},
+	}
+	receivedNamespace, err := c.Setup().Namespaces().Finalize(requestNamespace)
 	c.Validate(t, receivedNamespace, err)
 }
 

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -358,7 +358,7 @@ func (m *Master) init(c *Config) {
 	resourceQuotaStorage, resourceQuotaStatusStorage := resourcequotaetcd.NewStorage(c.EtcdHelper)
 	secretRegistry := secret.NewEtcdRegistry(c.EtcdHelper)
 
-	namespaceStorage := namespaceetcd.NewStorage(c.EtcdHelper)
+	namespaceStorage, namespaceStatusStorage, namespaceFinalizeStorage := namespaceetcd.NewStorage(c.EtcdHelper)
 	m.namespaceRegistry = namespace.NewRegistry(namespaceStorage)
 
 	// TODO: split me up into distinct storage registries
@@ -402,6 +402,8 @@ func (m *Master) init(c *Config) {
 		"resourceQuotas":        resourceQuotaStorage,
 		"resourceQuotas/status": resourceQuotaStatusStorage,
 		"namespaces":            namespaceStorage,
+		"namespaces/status":     namespaceStatusStorage,
+		"namespaces/finalize":   namespaceFinalizeStorage,
 		"secrets":               secret.NewStorage(secretRegistry),
 	}
 

--- a/pkg/namespace/doc.go
+++ b/pkg/namespace/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// namespace contains a controller that handles namespace lifecycle
+package namespace

--- a/pkg/namespace/namespace_controller.go
+++ b/pkg/namespace/namespace_controller.go
@@ -159,7 +159,7 @@ func (nm *NamespaceManager) syncNamespace(namespace api.Namespace) (err error) {
 	}
 
 	// if there is a deletion timestamp, and the status is not terminating, then update status
-	if namespace.DeletionTimestamp != nil && namespace.Status.Phase != api.NamespaceTerminating {
+	if !namespace.DeletionTimestamp.IsZero() && namespace.Status.Phase != api.NamespaceTerminating {
 		newNamespace := api.Namespace{}
 		newNamespace.ObjectMeta = namespace.ObjectMeta
 		newNamespace.Status = namespace.Status

--- a/pkg/namespace/namespace_controller.go
+++ b/pkg/namespace/namespace_controller.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+	"github.com/golang/glog"
+)
+
+// NamespaceManager is responsible for performing actions dependent upon a namespace phase
+type NamespaceManager struct {
+	kubeClient client.Interface
+	store      cache.Store
+	syncTime   <-chan time.Time
+
+	// To allow injection for testing.
+	syncHandler func(namespace api.Namespace) error
+}
+
+// NewNamespaceManager creates a new NamespaceManager
+func NewNamespaceManager(kubeClient client.Interface) *NamespaceManager {
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	reflector := cache.NewReflector(
+		&cache.ListWatch{
+			ListFunc: func() (runtime.Object, error) {
+				return kubeClient.Namespaces().List(labels.Everything(), fields.Everything())
+			},
+			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+				return kubeClient.Namespaces().Watch(labels.Everything(), fields.Everything(), resourceVersion)
+			},
+		},
+		&api.Namespace{},
+		store,
+		0,
+	)
+	reflector.Run()
+	nm := &NamespaceManager{
+		kubeClient: kubeClient,
+		store:      store,
+	}
+	// set the synchronization handler
+	nm.syncHandler = nm.syncNamespace
+	return nm
+}
+
+// Run begins syncing at the specified period interval
+func (nm *NamespaceManager) Run(period time.Duration) {
+	nm.syncTime = time.Tick(period)
+	go util.Forever(func() { nm.synchronize() }, period)
+}
+
+// Iterate over the each namespace that is in terminating phase and perform necessary clean-up
+func (nm *NamespaceManager) synchronize() {
+	namespaceObjs := nm.store.List()
+	wg := sync.WaitGroup{}
+	wg.Add(len(namespaceObjs))
+	for ix := range namespaceObjs {
+		go func(ix int) {
+			defer wg.Done()
+			namespace := namespaceObjs[ix].(*api.Namespace)
+			glog.V(4).Infof("periodic sync of namespace: %v", namespace.Name)
+			err := nm.syncHandler(*namespace)
+			if err != nil {
+				glog.Errorf("Error synchronizing: %v", err)
+			}
+		}(ix)
+	}
+	wg.Wait()
+}
+
+// finalized returns true if the spec.finalizers is empty list
+func finalized(namespace api.Namespace) bool {
+	return len(namespace.Spec.Finalizers) == 0
+}
+
+// finalize will finalize the namespace for kubernetes
+func finalize(kubeClient client.Interface, namespace api.Namespace) (*api.Namespace, error) {
+	namespaceFinalize := api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name:            namespace.Name,
+			ResourceVersion: namespace.ResourceVersion,
+		},
+		Spec: api.NamespaceSpec{},
+	}
+	finalizerSet := util.NewStringSet()
+	for i := range namespace.Spec.Finalizers {
+		if namespace.Spec.Finalizers[i] != api.FinalizerKubernetes {
+			finalizerSet.Insert(string(namespace.Spec.Finalizers[i]))
+		}
+	}
+	namespaceFinalize.Spec.Finalizers = make([]api.FinalizerName, len(finalizerSet), len(finalizerSet))
+	for _, value := range finalizerSet.List() {
+		namespaceFinalize.Spec.Finalizers = append(namespaceFinalize.Spec.Finalizers, api.FinalizerName(value))
+	}
+	return kubeClient.Namespaces().Finalize(&namespaceFinalize)
+}
+
+// deleteAllContent will delete all content known to the system in a namespace
+func deleteAllContent(kubeClient client.Interface, namespace string) (err error) {
+	err = deleteServices(kubeClient, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteReplicationControllers(kubeClient, namespace)
+	if err != nil {
+		return err
+	}
+	err = deletePods(kubeClient, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteSecrets(kubeClient, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteLimitRanges(kubeClient, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteResourceQuotas(kubeClient, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteEvents(kubeClient, namespace)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// syncNamespace makes namespace life-cycle decisions
+func (nm *NamespaceManager) syncNamespace(namespace api.Namespace) (err error) {
+	if namespace.DeletionTimestamp == nil {
+		return nil
+	}
+
+	// if there is a deletion timestamp, and the status is not terminating, then update status
+	if namespace.DeletionTimestamp != nil && namespace.Status.Phase != api.NamespaceTerminating {
+		newNamespace := api.Namespace{}
+		newNamespace.ObjectMeta = namespace.ObjectMeta
+		newNamespace.Status = namespace.Status
+		newNamespace.Status.Phase = api.NamespaceTerminating
+		result, err := nm.kubeClient.Namespaces().Status(&newNamespace)
+		if err != nil {
+			return err
+		}
+		// work with the latest copy so we can proceed to clean up right away without another interval
+		namespace = *result
+	}
+
+	// if the namespace is already finalized, delete it
+	if finalized(namespace) {
+		err = nm.kubeClient.Namespaces().Delete(namespace.Name)
+		return err
+	}
+
+	// there may still be content for us to remove
+	err = deleteAllContent(nm.kubeClient, namespace.Name)
+	if err != nil {
+		return err
+	}
+
+	// we have removed content, so mark it finalized by us
+	result, err := finalize(nm.kubeClient, namespace)
+	if err != nil {
+		return err
+	}
+
+	// now check if all finalizers have reported that we delete now
+	if finalized(*result) {
+		err = nm.kubeClient.Namespaces().Delete(namespace.Name)
+		return err
+	}
+
+	return nil
+}
+
+func deleteLimitRanges(kubeClient client.Interface, ns string) error {
+	items, err := kubeClient.LimitRanges(ns).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := kubeClient.LimitRanges(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteResourceQuotas(kubeClient client.Interface, ns string) error {
+	resourceQuotas, err := kubeClient.ResourceQuotas(ns).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range resourceQuotas.Items {
+		err := kubeClient.ResourceQuotas(ns).Delete(resourceQuotas.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteServices(kubeClient client.Interface, ns string) error {
+	items, err := kubeClient.Services(ns).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := kubeClient.Services(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteReplicationControllers(kubeClient client.Interface, ns string) error {
+	items, err := kubeClient.ReplicationControllers(ns).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := kubeClient.ReplicationControllers(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deletePods(kubeClient client.Interface, ns string) error {
+	items, err := kubeClient.Pods(ns).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := kubeClient.Pods(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteEvents(kubeClient client.Interface, ns string) error {
+	items, err := kubeClient.Events(ns).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := kubeClient.Events(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteSecrets(kubeClient client.Interface, ns string) error {
+	items, err := kubeClient.Secrets(ns).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := kubeClient.Secrets(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/namespace/namespace_controller_test.go
+++ b/pkg/namespace/namespace_controller_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+func TestFinalized(t *testing.T) {
+	testNamespace := api.Namespace{
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{"a", "b"},
+		},
+	}
+	if finalized(testNamespace) {
+		t.Errorf("Unexpected result, namespace is not finalized")
+	}
+	testNamespace.Spec.Finalizers = []api.FinalizerName{}
+	if !finalized(testNamespace) {
+		t.Errorf("Expected object to be finalized")
+	}
+}
+
+func TestFinalize(t *testing.T) {
+	mockClient := &client.Fake{}
+	testNamespace := api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "test",
+			ResourceVersion: "1",
+		},
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{"kubernetes", "other"},
+		},
+	}
+	finalize(mockClient, testNamespace)
+	if len(mockClient.Actions) != 1 {
+		t.Errorf("Expected 1 mock client action, but got %v", len(mockClient.Actions))
+	}
+	if mockClient.Actions[0].Action != "finalize-namespace" {
+		t.Errorf("Expected finalize-namespace action %v", mockClient.Actions[0].Action)
+	}
+}
+
+func TestSyncNamespaceThatIsTerminating(t *testing.T) {
+	mockClient := &client.Fake{}
+	nm := NewNamespaceManager(mockClient)
+	now := util.Now()
+	testNamespace := api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name:              "test",
+			ResourceVersion:   "1",
+			DeletionTimestamp: &now,
+		},
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{"kubernetes"},
+		},
+		Status: api.NamespaceStatus{
+			Phase: api.NamespaceTerminating,
+		},
+	}
+	err := nm.syncNamespace(testNamespace)
+	if err != nil {
+		t.Errorf("Unexpected error when synching namespace %v", err)
+	}
+	expectedActionSet := util.NewStringSet(
+		"list-services",
+		"list-pods",
+		"list-resourceQuotas",
+		"list-controllers",
+		"list-secrets",
+		"list-limitRanges",
+		"list-events",
+		"finalize-namespace",
+		"delete-namespace")
+	actionSet := util.NewStringSet()
+	for i := range mockClient.Actions {
+		actionSet.Insert(mockClient.Actions[i].Action)
+	}
+	if !actionSet.HasAll(expectedActionSet.List()...) {
+		t.Errorf("Expected actions: %v, but got: %v", expectedActionSet, actionSet)
+	}
+}
+
+func TestSyncNamespaceThatIsActive(t *testing.T) {
+	mockClient := &client.Fake{}
+	nm := NewNamespaceManager(mockClient)
+	testNamespace := api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "test",
+			ResourceVersion: "1",
+		},
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{"kubernetes"},
+		},
+		Status: api.NamespaceStatus{
+			Phase: api.NamespaceActive,
+		},
+	}
+	err := nm.syncNamespace(testNamespace)
+	if err != nil {
+		t.Errorf("Unexpected error when synching namespace %v", err)
+	}
+	actionSet := util.NewStringSet()
+	for i := range mockClient.Actions {
+		actionSet.Insert(mockClient.Actions[i].Action)
+	}
+	if len(actionSet) != 0 {
+		t.Errorf("Expected no action from controller, but got: %v", actionSet)
+	}
+}

--- a/pkg/namespace/namespace_controller_test.go
+++ b/pkg/namespace/namespace_controller_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
@@ -61,7 +62,7 @@ func TestFinalize(t *testing.T) {
 
 func TestSyncNamespaceThatIsTerminating(t *testing.T) {
 	mockClient := &client.Fake{}
-	nm := NewNamespaceManager(mockClient)
+	nm := NamespaceManager{kubeClient: mockClient, store: cache.NewStore(cache.MetaNamespaceKeyFunc)}
 	now := util.Now()
 	testNamespace := api.Namespace{
 		ObjectMeta: api.ObjectMeta{
@@ -101,7 +102,7 @@ func TestSyncNamespaceThatIsTerminating(t *testing.T) {
 
 func TestSyncNamespaceThatIsActive(t *testing.T) {
 	mockClient := &client.Fake{}
-	nm := NewNamespaceManager(mockClient)
+	nm := NamespaceManager{kubeClient: mockClient, store: cache.NewStore(cache.MetaNamespaceKeyFunc)}
 	testNamespace := api.Namespace{
 		ObjectMeta: api.ObjectMeta{
 			Name:            "test",

--- a/pkg/registry/namespace/etcd/etcd.go
+++ b/pkg/registry/namespace/etcd/etcd.go
@@ -105,7 +105,7 @@ func (r *REST) Delete(ctx api.Context, name string, options *api.DeleteOptions) 
 }
 
 func (r *StatusREST) New() runtime.Object {
-	return &api.Namespace{}
+	return r.store.New()
 }
 
 // Update alters the status subset of an object.
@@ -114,7 +114,7 @@ func (r *StatusREST) Update(ctx api.Context, obj runtime.Object) (runtime.Object
 }
 
 func (r *FinalizeREST) New() runtime.Object {
-	return &api.Namespace{}
+	return r.store.New()
 }
 
 // Update alters the status finalizers subset of an object.

--- a/pkg/registry/namespace/etcd/etcd.go
+++ b/pkg/registry/namespace/etcd/etcd.go
@@ -17,6 +17,8 @@ limitations under the License.
 package etcd
 
 import (
+	"fmt"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
@@ -25,15 +27,27 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/namespace"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 // rest implements a RESTStorage for namespaces against etcd
 type REST struct {
 	*etcdgeneric.Etcd
+	status *etcdgeneric.Etcd
+}
+
+// StatusREST implements the REST endpoint for changing the status of a namespace.
+type StatusREST struct {
+	store *etcdgeneric.Etcd
+}
+
+// FinalizeREST implements the REST endpoint for finalizing a namespace.
+type FinalizeREST struct {
+	store *etcdgeneric.Etcd
 }
 
 // NewStorage returns a RESTStorage object that will work against namespaces
-func NewStorage(h tools.EtcdHelper) *REST {
+func NewStorage(h tools.EtcdHelper) (*REST, *StatusREST, *FinalizeREST) {
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.Namespace{} },
 		NewListFunc: func() runtime.Object { return &api.NamespaceList{} },
@@ -56,5 +70,54 @@ func NewStorage(h tools.EtcdHelper) *REST {
 	store.UpdateStrategy = namespace.Strategy
 	store.ReturnDeletedObject = true
 
-	return &REST{Etcd: store}
+	statusStore := *store
+	statusStore.UpdateStrategy = namespace.StatusStrategy
+
+	finalizeStore := *store
+	finalizeStore.UpdateStrategy = namespace.FinalizeStrategy
+
+	return &REST{Etcd: store, status: &statusStore}, &StatusREST{store: &statusStore}, &FinalizeREST{store: &finalizeStore}
+}
+
+// Delete enforces life-cycle rules for namespace termination
+func (r *REST) Delete(ctx api.Context, name string, options *api.DeleteOptions) (runtime.Object, error) {
+	nsObj, err := r.Get(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	namespace := nsObj.(*api.Namespace)
+
+	// upon first request to delete, we switch the phase to start namespace termination
+	if namespace.DeletionTimestamp == nil {
+		now := util.Now()
+		namespace.DeletionTimestamp = &now
+		namespace.Status.Phase = api.NamespaceTerminating
+		result, _, err := r.status.Update(ctx, namespace)
+		return result, err
+	}
+
+	// prior to final deletion, we must ensure that finalizers is empty
+	if len(namespace.Spec.Finalizers) != 0 {
+		err = fmt.Errorf("Unable to delete namespace %v because finalizers is not empty %v", namespace.Name, namespace.Spec.Finalizers)
+	}
+	return r.Etcd.Delete(ctx, name, nil)
+}
+
+func (r *StatusREST) New() runtime.Object {
+	return &api.Namespace{}
+}
+
+// Update alters the status subset of an object.
+func (r *StatusREST) Update(ctx api.Context, obj runtime.Object) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, obj)
+}
+
+func (r *FinalizeREST) New() runtime.Object {
+	return &api.Namespace{}
+}
+
+// Update alters the status finalizers subset of an object.
+func (r *FinalizeREST) Update(ctx api.Context, obj runtime.Object) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, obj)
 }

--- a/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -87,7 +87,7 @@ func NewProvision(c client.Interface) admission.Interface {
 	reflector := cache.NewReflector(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return c.Namespaces().List(labels.Everything())
+				return c.Namespaces().List(labels.Everything(), fields.Everything())
 			},
 			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
 				return c.Namespaces().Watch(labels.Everything(), fields.Everything(), resourceVersion)

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -86,7 +86,7 @@ func NewExists(c client.Interface) admission.Interface {
 	reflector := cache.NewReflector(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return c.Namespaces().List(labels.Everything())
+				return c.Namespaces().List(labels.Everything(), fields.Everything())
 			},
 			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
 				return c.Namespaces().Watch(labels.Everything(), fields.Everything(), resourceVersion)

--- a/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -91,7 +91,7 @@ func NewLifecycle(c client.Interface) admission.Interface {
 	reflector := cache.NewReflector(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return c.Namespaces().List(labels.Everything())
+				return c.Namespaces().List(labels.Everything(), fields.Everything())
 			},
 			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
 				return c.Namespaces().Watch(labels.Everything(), fields.Everything(), resourceVersion)


### PR DESCRIPTION
This PR adds the ability to delete content in a Namespace as part of Namespace termination.

See #5195 for details on the design principles behind the implementation.

When coupled with #5288 it provides a complete solution for delete of a Namespace cascading to its managed content.

The general flow is as follows:

1) user deletes namespace X, results in namespace X.Status.Phase=Terminating
2) namespace controller watches for terminating namespaces, finds X
3) namespace controller purges all content from X
4) namespace controller finalizes namespace X to report it has completed its clean-up
5) if all finalizers for namespace X have reported status, namespace controller deletes the namespace
6) namespace repository allows deletion to occur if spec.finalizers == status.finalizers

The list of namespace.spec.finalizers is immutable post-creation. The system will always ensure the "kubernetes" finalizer is present to enforce the controller being able to support deletion life-cycle. The repository does not allow deletion of a resource if its spec.finalizers != status.finalizers.

This lets downstream components like OpenShift that add additional namespace resources to take part in termination of the namespace by deleting its content. In that case, when OpenShift provisions a namespace it adds a namespace.spec.finalizer=openshift.com/origin that must report back in a finalize operation before the namespace is allowed to be purged.
