### PR TITLE
Headless Services: Adding option to specify None for PortalIP

### DIFF
--- a/cluster/addons/dns/kube2sky/kube2sky.go
+++ b/cluster/addons/dns/kube2sky/kube2sky.go
@@ -51,6 +51,12 @@ func removeDNS(record string, etcdClient *etcd.Client) error {
 }
 
 func addDNS(record string, service *kapi.Service, etcdClient *etcd.Client) error {
+	// if PortalIP is not set, a DNS entry should not be created
+	if !kapi.IsServiceIPSet(service) {
+		log.Printf("Skipping dns record for headless service: %s\n", service.Name)
+		return nil
+	}
+
 	svc := skymsg.Service{
 		Host:     service.Spec.PortalIP,
 		Port:     service.Spec.Port,

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -84,3 +84,14 @@ func IsStandardResourceName(str string) bool {
 func NewDeleteOptions(grace int64) *DeleteOptions {
 	return &DeleteOptions{GracePeriodSeconds: &grace}
 }
+
+// this function aims to check if the service portal IP is set or not
+// the objective is not to perform validation here
+func IsServiceIPSet(service *Service) bool {
+	return service.Spec.PortalIP != PortalIPNone && service.Spec.PortalIP != ""
+}
+
+// this function aims to check if the service portal IP is requested or not
+func IsServiceIPRequested(service *Service) bool {
+	return service.Spec.PortalIP == ""
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -710,6 +710,12 @@ type ReplicationControllerList struct {
 	Items []ReplicationController `json:"items"`
 }
 
+const (
+	// PortalIPNone - do not assign a portal IP
+	// no proxying required and no environment variables should be created for pods
+	PortalIPNone = "None"
+)
+
 // ServiceList holds a list of services.
 type ServiceList struct {
 	TypeMeta `json:",inline"`
@@ -749,6 +755,8 @@ type ServiceSpec struct {
 	// PortalIP is usually assigned by the master.  If specified by the user
 	// we will try to respect it or else fail the request.  This field can
 	// not be changed by updates.
+	// Valid values are None, empty string (""), or a valid IP address
+	// None can be specified for headless services when proxying is not required
 	PortalIP string `json:"portalIP,omitempty"`
 
 	// CreateExternalLoadBalancer indicates whether a load balancer should be created for this service.

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -578,6 +578,12 @@ const (
 	AffinityTypeNone AffinityType = "None"
 )
 
+const (
+	// PortalIPNone - do not assign a portal IP
+	// no proxying required and no environment variables should be created for pods
+	PortalIPNone = "None"
+)
+
 // ServiceList holds a list of services.
 type ServiceList struct {
 	TypeMeta `json:",inline"`
@@ -615,7 +621,9 @@ type Service struct {
 	// PortalIP is usually assigned by the master.  If specified by the user
 	// we will try to respect it or else fail the request.  This field can
 	// not be changed by updates.
-	PortalIP string `json:"portalIP,omitempty" description:"IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused, and creation of the service will fail otherwise; cannot be updated"`
+	// Valid values are None, empty string (""), or a valid IP address
+	// None can be specified for headless services when proxying is not required
+	PortalIP string `json:"portalIP,omitempty" description:"IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused, and creation of the service will fail otherwise; cannot be updated; 'None' can be specified for a headless service when proxying is not required"`
 
 	// DEPRECATED: has no implementation.
 	ProxyPort int `json:"proxyPort,omitempty" description:"if non-zero, a pre-allocated host port used for this service by the proxy on each node; assigned by the master and ignored on input"`

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -581,6 +581,12 @@ const (
 	AffinityTypeNone AffinityType = "None"
 )
 
+const (
+	// PortalIPNone - do not assign a portal IP
+	// no proxying required and no environment variables should be created for pods
+	PortalIPNone = "None"
+)
+
 // ServiceList holds a list of services.
 type ServiceList struct {
 	TypeMeta `json:",inline"`
@@ -620,7 +626,9 @@ type Service struct {
 	// PortalIP is usually assigned by the master.  If specified by the user
 	// we will try to respect it or else fail the request.  This field can
 	// not be changed by updates.
-	PortalIP string `json:"portalIP,omitempty" description:"IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused, and creation of the service will fail otherwise; cannot be updated"`
+	// Valid values are None, empty string (""), or a valid IP address
+	// None can be specified for headless services when proxying is not required
+	PortalIP string `json:"portalIP,omitempty" description:"IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused, and creation of the service will fail otherwise; cannot be updated; 'None' can be specified for a headless service when proxying is not required"`
 
 	// DEPRECATED: has no implementation.
 	ProxyPort int `json:"proxyPort,omitempty" description:"if non-zero, a pre-allocated host port used for this service by the proxy on each node; assigned by the master and ignored on input"`

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -743,7 +743,9 @@ type ServiceSpec struct {
 	// PortalIP is usually assigned by the master.  If specified by the user
 	// we will try to respect it or else fail the request.  This field can
 	// not be changed by updates.
-	PortalIP string `json:"portalIP,omitempty description: IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused, and creation of the service will fail otherwise; cannot be updated"`
+	// Valid values are None, empty string (""), or a valid IP address
+	// None can be specified for headless services when proxying is not required
+	PortalIP string `json:"portalIP,omitempty description: IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused, and creation of the service will fail otherwise; cannot be updated; 'None' can be specified for a headless service when proxying is not required"`
 
 	// CreateExternalLoadBalancer indicates whether a load balancer should be created for this service.
 	CreateExternalLoadBalancer bool `json:"createExternalLoadBalancer,omitempty" description:"set up a cloud-provider-specific load balancer on an external IP"`
@@ -774,6 +776,12 @@ type Service struct {
 	// Status represents the current status of a service.
 	Status ServiceStatus `json:"status,omitempty" description:"most recently observed status of the service; populated by the system, read-only; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"`
 }
+
+const (
+	// PortalIPNone - do not assign a portal IP
+	// no proxying required and no environment variables should be created for pods
+	PortalIPNone = "None"
+)
 
 // ServiceList holds a list of services.
 type ServiceList struct {

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -1135,6 +1135,13 @@ func TestValidateService(t *testing.T) {
 			numErrs: 1,
 		},
 		{
+			name: "invalid portal ip",
+			makeSvc: func(s *api.Service) {
+				s.Spec.PortalIP = "invalid"
+			},
+			numErrs: 1,
+		},
+		{
 			name: "missing port",
 			makeSvc: func(s *api.Service) {
 				s.Spec.Port = 0
@@ -1188,6 +1195,20 @@ func TestValidateService(t *testing.T) {
 			name: "valid 3",
 			makeSvc: func(s *api.Service) {
 				s.Spec.ContainerPort = util.NewIntOrStringFromString("http")
+			},
+			numErrs: 0,
+		},
+		{
+			name: "valid portal ip - none ",
+			makeSvc: func(s *api.Service) {
+				s.Spec.PortalIP = "None"
+			},
+			numErrs: 0,
+		},
+		{
+			name: "valid portal ip - empty",
+			makeSvc: func(s *api.Service) {
+				s.Spec.PortalIP = ""
 			},
 			numErrs: 0,
 		},

--- a/pkg/kubelet/envvars/envvars.go
+++ b/pkg/kubelet/envvars/envvars.go
@@ -30,6 +30,12 @@ import (
 func FromServices(services *api.ServiceList) []api.EnvVar {
 	var result []api.EnvVar
 	for _, service := range services.Items {
+		// ignore services where PortalIP is "None" or empty
+		// the services passed to this method should be pre-filtered
+		// only services that have the portal IP set should be included here
+		if !api.IsServiceIPSet(&service) {
+			continue
+		}
 		// Host
 		name := makeEnvVariableName(service.Name) + "_SERVICE_HOST"
 		result = append(result, api.EnvVar{Name: name, Value: service.Spec.PortalIP})

--- a/pkg/kubelet/envvars/envvars_test.go
+++ b/pkg/kubelet/envvars/envvars_test.go
@@ -54,6 +54,24 @@ func TestFromServices(t *testing.T) {
 					PortalIP: "9.8.7.6",
 				},
 			},
+			{
+				ObjectMeta: api.ObjectMeta{Name: "svrc-portalip-none"},
+				Spec: api.ServiceSpec{
+					Port:     8082,
+					Selector: map[string]string{"bar": "baz"},
+					Protocol: "TCP",
+					PortalIP: "None",
+				},
+			},
+			{
+				ObjectMeta: api.ObjectMeta{Name: "svrc-portalip-empty"},
+				Spec: api.ServiceSpec{
+					Port:     8082,
+					Selector: map[string]string{"bar": "baz"},
+					Protocol: "TCP",
+					PortalIP: "",
+				},
+			},
 		},
 	}
 	vars := envvars.FromServices(&sl)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -845,6 +845,10 @@ func (kl *Kubelet) getServiceEnvVarMap(ns string) (map[string]string, error) {
 
 	// project the services in namespace ns onto the master services
 	for _, service := range services.Items {
+		// ignore services where PortalIP is "None" or empty
+		if !api.IsServiceIPSet(&service) {
+			continue
+		}
 		serviceName := service.Name
 
 		switch service.Namespace {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1829,6 +1829,20 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			},
 		},
 		{
+			ObjectMeta: api.ObjectMeta{Name: "kubernetes-ro", Namespace: api.NamespaceDefault},
+			Spec: api.ServiceSpec{
+				Port:     8082,
+				PortalIP: "None",
+			},
+		},
+		{
+			ObjectMeta: api.ObjectMeta{Name: "kubernetes-ro", Namespace: api.NamespaceDefault},
+			Spec: api.ServiceSpec{
+				Port:     8082,
+				PortalIP: "",
+			},
+		},
+		{
 			ObjectMeta: api.ObjectMeta{Name: "test", Namespace: "test1"},
 			Spec: api.ServiceSpec{
 				Port:     8083,
@@ -1850,6 +1864,19 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			},
 		},
 		{
+			ObjectMeta: api.ObjectMeta{Name: "test", Namespace: "test2"},
+			Spec: api.ServiceSpec{
+				Port:     8085,
+				PortalIP: "None",
+			},
+		},
+		{
+			ObjectMeta: api.ObjectMeta{Name: "test", Namespace: "test2"},
+			Spec: api.ServiceSpec{
+				Port: 8085,
+			},
+		},
+		{
 			ObjectMeta: api.ObjectMeta{Name: "kubernetes", Namespace: "kubernetes"},
 			Spec: api.ServiceSpec{
 				Port:     8086,
@@ -1868,6 +1895,20 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			Spec: api.ServiceSpec{
 				Port:     8088,
 				PortalIP: "1.2.3.8",
+			},
+		},
+		{
+			ObjectMeta: api.ObjectMeta{Name: "not-special", Namespace: "kubernetes"},
+			Spec: api.ServiceSpec{
+				Port:     8088,
+				PortalIP: "None",
+			},
+		},
+		{
+			ObjectMeta: api.ObjectMeta{Name: "not-special", Namespace: "kubernetes"},
+			Spec: api.ServiceSpec{
+				Port:     8088,
+				PortalIP: "",
 			},
 		},
 	}

--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -468,6 +468,10 @@ func (proxier *Proxier) OnUpdate(services []api.Service) {
 	glog.V(4).Infof("Received update notice: %+v", services)
 	activeServices := make(map[types.NamespacedName]bool) // use a map as a set
 	for _, service := range services {
+		// if PortalIP is "None" or empty, skip proxying
+		if !api.IsServiceIPSet(&service) {
+			continue
+		}
 		serviceName := types.NamespacedName{service.Namespace, service.Name}
 		activeServices[serviceName] = true
 		info, exists := proxier.getServiceInfo(serviceName)

--- a/pkg/registry/service/rest_test.go
+++ b/pkg/registry/service/rest_test.go
@@ -735,6 +735,7 @@ func TestCreate(t *testing.T) {
 		&api.Service{
 			Spec: api.ServiceSpec{
 				Selector:        map[string]string{"bar": "baz"},
+				PortalIP:        "None",
 				Port:            6502,
 				Protocol:        "TCP",
 				SessionAffinity: "None",
@@ -743,6 +744,16 @@ func TestCreate(t *testing.T) {
 		// invalid
 		&api.Service{
 			Spec: api.ServiceSpec{},
+		},
+		// invalid
+		&api.Service{
+			Spec: api.ServiceSpec{
+				Selector:        map[string]string{"bar": "baz"},
+				Port:            6502,
+				Protocol:        "TCP",
+				PortalIP:        "invalid",
+				SessionAffinity: "None",
+			},
 		},
 	)
 }


### PR DESCRIPTION
Some quick changes to gather early feedback on whether this is acceptable as a solution. I will constantize the "None" value of PortalIP. I am currently thinking about including the constant in every api version.
