### PR TITLE
Use docker's ParseRepositoryTag when pulling

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -88,58 +88,63 @@
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/archive",
-			"Comment": "v1.4.1-656-g2115131",
-			"Rev": "211513156dc1ace48e630b4bf4ea0fcfdc8d9abf"
+			"Comment": "v1.4.1-1714-ged66853",
+			"Rev": "ed6685369740035b0af9675bf9add52d0af7657b"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/fileutils",
-			"Comment": "v1.4.1-656-g2115131",
-			"Rev": "211513156dc1ace48e630b4bf4ea0fcfdc8d9abf"
+			"Comment": "v1.4.1-1714-ged66853",
+			"Rev": "ed6685369740035b0af9675bf9add52d0af7657b"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/ioutils",
-			"Comment": "v1.4.1-656-g2115131",
-			"Rev": "211513156dc1ace48e630b4bf4ea0fcfdc8d9abf"
+			"Comment": "v1.4.1-1714-ged66853",
+			"Rev": "ed6685369740035b0af9675bf9add52d0af7657b"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/mount",
-			"Comment": "v1.4.1-656-g2115131",
-			"Rev": "211513156dc1ace48e630b4bf4ea0fcfdc8d9abf"
+			"Comment": "v1.4.1-1714-ged66853",
+			"Rev": "ed6685369740035b0af9675bf9add52d0af7657b"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/pkg/parsers",
+			"Comment": "v1.4.1-1714-ged66853",
+			"Rev": "ed6685369740035b0af9675bf9add52d0af7657b"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/pools",
-			"Comment": "v1.4.1-656-g2115131",
-			"Rev": "211513156dc1ace48e630b4bf4ea0fcfdc8d9abf"
+			"Comment": "v1.4.1-1714-ged66853",
+			"Rev": "ed6685369740035b0af9675bf9add52d0af7657b"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/promise",
-			"Comment": "v1.4.1-656-g2115131",
-			"Rev": "211513156dc1ace48e630b4bf4ea0fcfdc8d9abf"
+			"Comment": "v1.4.1-1714-ged66853",
+			"Rev": "ed6685369740035b0af9675bf9add52d0af7657b"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/symlink",
-			"Comment": "v1.4.1-656-g2115131",
-			"Rev": "211513156dc1ace48e630b4bf4ea0fcfdc8d9abf"
+			"Comment": "v1.4.1-1714-ged66853",
+			"Rev": "ed6685369740035b0af9675bf9add52d0af7657b"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/system",
-			"Comment": "v1.4.1-656-g2115131",
-			"Rev": "211513156dc1ace48e630b4bf4ea0fcfdc8d9abf"
+			"Comment": "v1.4.1-1714-ged66853",
+			"Rev": "ed6685369740035b0af9675bf9add52d0af7657b"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/term",
-			"Comment": "v1.4.1-656-g2115131",
-			"Rev": "211513156dc1ace48e630b4bf4ea0fcfdc8d9abf"
+			"Comment": "v1.4.1-1714-ged66853",
+			"Rev": "ed6685369740035b0af9675bf9add52d0af7657b"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/units",
-			"Comment": "v1.4.1-656-g2115131",
-			"Rev": "211513156dc1ace48e630b4bf4ea0fcfdc8d9abf"
+			"Comment": "v1.4.1-1714-ged66853",
+			"Rev": "ed6685369740035b0af9675bf9add52d0af7657b"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar",
-			"Comment": "v1.4.1-656-g2115131",
-			"Rev": "211513156dc1ace48e630b4bf4ea0fcfdc8d9abf"
+			"Comment": "v1.4.1-1714-ged66853",
+			"Rev": "ed6685369740035b0af9675bf9add52d0af7657b"
 		},
 		{
 			"ImportPath": "github.com/docker/libcontainer",

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/MAINTAINERS
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/MAINTAINERS
@@ -1,2 +1,0 @@
-Cristian Staretu <cristian.staretu@gmail.com> (@unclejack)
-Tibor Vass <teabee89@gmail.com> (@tiborvass)

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/archive_unix.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/archive_unix.go
@@ -4,10 +4,25 @@ package archive
 
 import (
 	"errors"
+	"os"
 	"syscall"
 
 	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 )
+
+// canonicalTarNameForPath returns platform-specific filepath
+// to canonical posix-style path for tar archival. p is relative
+// path.
+func CanonicalTarNameForPath(p string) (string, error) {
+	return p, nil // already unix-style
+}
+
+// chmodTarEntry is used to adjust the file permissions used in tar header based
+// on the platform the archival is done.
+
+func chmodTarEntry(perm os.FileMode) os.FileMode {
+	return perm // noop for unix as golang APIs provide perm bits correctly
+}
 
 func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (nlink uint32, inode uint64, err error) {
 	s, ok := stat.(*syscall.Stat_t)

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/archive_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/archive_windows.go
@@ -3,8 +3,38 @@
 package archive
 
 import (
+	"fmt"
+	"os"
+	"strings"
+
 	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 )
+
+// canonicalTarNameForPath returns platform-specific filepath
+// to canonical posix-style path for tar archival. p is relative
+// path.
+func CanonicalTarNameForPath(p string) (string, error) {
+	// windows: convert windows style relative path with backslashes
+	// into forward slashes. since windows does not allow '/' or '\'
+	// in file names, it is mostly safe to replace however we must
+	// check just in case
+	if strings.Contains(p, "/") {
+		return "", fmt.Errorf("windows path contains forward slash: %s", p)
+	}
+	return strings.Replace(p, string(os.PathSeparator), "/", -1), nil
+
+}
+
+// chmodTarEntry is used to adjust the file permissions used in tar header based
+// on the platform the archival is done.
+func chmodTarEntry(perm os.FileMode) os.FileMode {
+	// Clear r/w on grp/others: no precise equivalen of group/others on NTFS.
+	perm &= 0711
+	// Add the x bit: make everything +x from windows
+	perm |= 0100
+
+	return perm
+}
 
 func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (nlink uint32, inode uint64, err error) {
 	// do nothing. no notion of Rdev, Inode, Nlink in stat on Windows

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/changes_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/changes_test.go
@@ -25,13 +25,6 @@ func copyDir(src, dst string) error {
 	return nil
 }
 
-// Helper to sort []Change by path
-type byPath struct{ changes []Change }
-
-func (b byPath) Less(i, j int) bool { return b.changes[i].Path < b.changes[j].Path }
-func (b byPath) Len() int           { return len(b.changes) }
-func (b byPath) Swap(i, j int)      { b.changes[i], b.changes[j] = b.changes[j], b.changes[i] }
-
 type FileType uint32
 
 const (
@@ -220,7 +213,7 @@ func TestChangesDirsMutated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sort.Sort(byPath{changes})
+	sort.Sort(changesByPath(changes))
 
 	expectedChanges := []Change{
 		{"/dir1", ChangeDelete},

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/diff.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/diff.go
@@ -81,7 +81,7 @@ func UnpackLayer(dest string, layer ArchiveReader) (size int64, err error) {
 		if err != nil {
 			return 0, err
 		}
-		if strings.HasPrefix(rel, "..") {
+		if strings.HasPrefix(rel, "../") {
 			return 0, breakoutError(fmt.Errorf("%q is outside of %q", hdr.Name, dest))
 		}
 		base := filepath.Base(path)

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/MAINTAINERS
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/MAINTAINERS
@@ -1,1 +1,0 @@
-Michael Crosby <michael@crosbymichael.com> (@crosbymichael)

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/sharedsubtree_linux_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/sharedsubtree_linux_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-// nothing is propogated in or out
+// nothing is propagated in or out
 func TestSubtreePrivate(t *testing.T) {
 	tmp := path.Join(os.TempDir(), "mount-tests")
 	if err := os.MkdirAll(tmp, 0777); err != nil {

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/parsers.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/parsers.go
@@ -1,0 +1,137 @@
+package parsers
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// FIXME: Change this not to receive default value as parameter
+func ParseHost(defaultTCPAddr, defaultUnixAddr, addr string) (string, error) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		addr = fmt.Sprintf("unix://%s", defaultUnixAddr)
+	}
+	addrParts := strings.Split(addr, "://")
+	if len(addrParts) == 1 {
+		addrParts = []string{"tcp", addrParts[0]}
+	}
+
+	switch addrParts[0] {
+	case "tcp":
+		return ParseTCPAddr(addrParts[1], defaultTCPAddr)
+	case "unix":
+		return ParseUnixAddr(addrParts[1], defaultUnixAddr)
+	case "fd":
+		return addr, nil
+	default:
+		return "", fmt.Errorf("Invalid bind address format: %s", addr)
+	}
+}
+
+func ParseUnixAddr(addr string, defaultAddr string) (string, error) {
+	addr = strings.TrimPrefix(addr, "unix://")
+	if strings.Contains(addr, "://") {
+		return "", fmt.Errorf("Invalid proto, expected unix: %s", addr)
+	}
+	if addr == "" {
+		addr = defaultAddr
+	}
+	return fmt.Sprintf("unix://%s", addr), nil
+}
+
+func ParseTCPAddr(addr string, defaultAddr string) (string, error) {
+	addr = strings.TrimPrefix(addr, "tcp://")
+	if strings.Contains(addr, "://") || addr == "" {
+		return "", fmt.Errorf("Invalid proto, expected tcp: %s", addr)
+	}
+
+	hostParts := strings.Split(addr, ":")
+	if len(hostParts) != 2 {
+		return "", fmt.Errorf("Invalid bind address format: %s", addr)
+	}
+	host := hostParts[0]
+	if host == "" {
+		host = defaultAddr
+	}
+
+	p, err := strconv.Atoi(hostParts[1])
+	if err != nil && p == 0 {
+		return "", fmt.Errorf("Invalid bind address format: %s", addr)
+	}
+	return fmt.Sprintf("tcp://%s:%d", host, p), nil
+}
+
+// Get a repos name and returns the right reposName + tag|digest
+// The tag can be confusing because of a port in a repository name.
+//     Ex: localhost.localdomain:5000/samalba/hipache:latest
+//     Digest ex: localhost:5000/foo/bar@sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb
+func ParseRepositoryTag(repos string) (string, string) {
+	n := strings.Index(repos, "@")
+	if n >= 0 {
+		parts := strings.Split(repos, "@")
+		return parts[0], parts[1]
+	}
+	n = strings.LastIndex(repos, ":")
+	if n < 0 {
+		return repos, ""
+	}
+	if tag := repos[n+1:]; !strings.Contains(tag, "/") {
+		return repos[:n], tag
+	}
+	return repos, ""
+}
+
+func PartParser(template, data string) (map[string]string, error) {
+	// ip:public:private
+	var (
+		templateParts = strings.Split(template, ":")
+		parts         = strings.Split(data, ":")
+		out           = make(map[string]string, len(templateParts))
+	)
+	if len(parts) != len(templateParts) {
+		return nil, fmt.Errorf("Invalid format to parse.  %s should match template %s", data, template)
+	}
+
+	for i, t := range templateParts {
+		value := ""
+		if len(parts) > i {
+			value = parts[i]
+		}
+		out[t] = value
+	}
+	return out, nil
+}
+
+func ParseKeyValueOpt(opt string) (string, string, error) {
+	parts := strings.SplitN(opt, "=", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Unable to parse key/value option: %s", opt)
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
+}
+
+func ParsePortRange(ports string) (uint64, uint64, error) {
+	if ports == "" {
+		return 0, 0, fmt.Errorf("Empty string specified for ports.")
+	}
+	if !strings.Contains(ports, "-") {
+		start, err := strconv.ParseUint(ports, 10, 16)
+		end := start
+		return start, end, err
+	}
+
+	parts := strings.Split(ports, "-")
+	start, err := strconv.ParseUint(parts[0], 10, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	end, err := strconv.ParseUint(parts[1], 10, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	if end < start {
+		return 0, 0, fmt.Errorf("Invalid range specified for the Port: %s", ports)
+	}
+	return start, end, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/symlink/MAINTAINERS
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/symlink/MAINTAINERS
@@ -1,3 +1,0 @@
-Tibor Vass <teabee89@gmail.com> (@tiborvass)
-Cristian Staretu <cristian.staretu@gmail.com> (@unclejack)
-Tianon Gravi <admwiggin@gmail.com> (@tianon)

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/MAINTAINERS
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/MAINTAINERS
@@ -1,2 +1,0 @@
-Michael Crosby <michael@crosbymichael.com> (@crosbymichael)
-Victor Vieux <vieux@docker.com> (@vieux)

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/lstat.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/lstat.go
@@ -6,7 +6,7 @@ import (
 	"syscall"
 )
 
-func Lstat(path string) (*Stat, error) {
+func Lstat(path string) (*Stat_t, error) {
 	s := &syscall.Stat_t{}
 	err := syscall.Lstat(path, s)
 	if err != nil {

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/lstat_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/lstat_windows.go
@@ -2,7 +2,7 @@
 
 package system
 
-func Lstat(path string) (*Stat, error) {
+func Lstat(path string) (*Stat_t, error) {
 	// should not be called on cli code path
 	return nil, ErrNotSupportedPlatform
 }

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat.go
@@ -4,7 +4,7 @@ import (
 	"syscall"
 )
 
-type Stat struct {
+type Stat_t struct {
 	mode uint32
 	uid  uint32
 	gid  uint32
@@ -13,30 +13,30 @@ type Stat struct {
 	mtim syscall.Timespec
 }
 
-func (s Stat) Mode() uint32 {
+func (s Stat_t) Mode() uint32 {
 	return s.mode
 }
 
-func (s Stat) Uid() uint32 {
+func (s Stat_t) Uid() uint32 {
 	return s.uid
 }
 
-func (s Stat) Gid() uint32 {
+func (s Stat_t) Gid() uint32 {
 	return s.gid
 }
 
-func (s Stat) Rdev() uint64 {
+func (s Stat_t) Rdev() uint64 {
 	return s.rdev
 }
 
-func (s Stat) Size() int64 {
+func (s Stat_t) Size() int64 {
 	return s.size
 }
 
-func (s Stat) Mtim() syscall.Timespec {
+func (s Stat_t) Mtim() syscall.Timespec {
 	return s.mtim
 }
 
-func (s Stat) GetLastModification() syscall.Timespec {
+func (s Stat_t) GetLastModification() syscall.Timespec {
 	return s.Mtim()
 }

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_linux.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_linux.go
@@ -4,11 +4,20 @@ import (
 	"syscall"
 )
 
-func fromStatT(s *syscall.Stat_t) (*Stat, error) {
-	return &Stat{size: s.Size,
+func fromStatT(s *syscall.Stat_t) (*Stat_t, error) {
+	return &Stat_t{size: s.Size,
 		mode: s.Mode,
 		uid:  s.Uid,
 		gid:  s.Gid,
 		rdev: s.Rdev,
 		mtim: s.Mtim}, nil
+}
+
+func Stat(path string) (*Stat_t, error) {
+	s := &syscall.Stat_t{}
+	err := syscall.Stat(path, s)
+	if err != nil {
+		return nil, err
+	}
+	return fromStatT(s)
 }

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_unsupported.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_unsupported.go
@@ -6,8 +6,8 @@ import (
 	"syscall"
 )
 
-func fromStatT(s *syscall.Stat_t) (*Stat, error) {
-	return &Stat{size: s.Size,
+func fromStatT(s *syscall.Stat_t) (*Stat_t, error) {
+	return &Stat_t{size: s.Size,
 		mode: uint32(s.Mode),
 		uid:  s.Uid,
 		gid:  s.Gid,

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_windows.go
@@ -7,6 +7,11 @@ import (
 	"syscall"
 )
 
-func fromStatT(s *syscall.Win32FileAttributeData) (*Stat, error) {
+func fromStatT(s *syscall.Win32FileAttributeData) (*Stat_t, error) {
 	return nil, errors.New("fromStatT should not be called on windows path")
+}
+
+func Stat(path string) (*Stat_t, error) {
+	// should not be called on cli code path
+	return nil, ErrNotSupportedPlatform
 }

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/MAINTAINERS
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/MAINTAINERS
@@ -1,1 +1,0 @@
-Solomon Hykes <solomon@docker.com> (@shykes)

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/units/MAINTAINERS
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/units/MAINTAINERS
@@ -1,2 +1,0 @@
-Victor Vieux <vieux@docker.com> (@vieux)
-Jessie Frazelle <jess@docker.com> (@jfrazelle)

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -179,29 +179,6 @@ func TestDockerContainerCommand(t *testing.T) {
 	}
 }
 
-var parseImageNameTests = []struct {
-	imageName string
-	name      string
-	tag       string
-}{
-	{"ubuntu", "ubuntu", ""},
-	{"ubuntu:2342", "ubuntu", "2342"},
-	{"ubuntu:latest", "ubuntu", "latest"},
-	{"foo/bar:445566", "foo/bar", "445566"},
-	{"registry.example.com:5000/foobar", "registry.example.com:5000/foobar", ""},
-	{"registry.example.com:5000/foobar:5342", "registry.example.com:5000/foobar", "5342"},
-	{"registry.example.com:5000/foobar:latest", "registry.example.com:5000/foobar", "latest"},
-}
-
-func TestParseImageName(t *testing.T) {
-	for _, tt := range parseImageNameTests {
-		name, tag := parseImageName(tt.imageName)
-		if name != tt.name || tag != tt.tag {
-			t.Errorf("Expected name/tag: %s/%s, got %s/%s", tt.name, tt.tag, name, tag)
-		}
-	}
-}
-
 func TestDockerKeyringLookupFails(t *testing.T) {
 	fakeKeyring := &credentialprovider.FakeKeyring{}
 	fakeClient := &FakeDockerClient{
@@ -217,7 +194,7 @@ func TestDockerKeyringLookupFails(t *testing.T) {
 	if err == nil {
 		t.Errorf("unexpected non-error")
 	}
-	msg := "image pull failed for host/repository/image, this may be because there are no credentials on this request.  details: (test error)"
+	msg := "image pull failed for host/repository/image:version, this may be because there are no credentials on this request.  details: (test error)"
 	if err.Error() != msg {
 		t.Errorf("expected: %s, saw: %s", msg, err.Error())
 	}


### PR DESCRIPTION
Docker 1.6 adds support for referencing images by their immutable digest, which is of the form `<repo>@<digest>`. Digests are of the form `<algorithm>:<value>`, and because they contain a `:`, `parseImageName` doesn't return the proper repo and tag_or_digest. This fixes that issue.
