### PR TITLE
Adjust POS file for Fluentd to Cloud Logging

### DIFF
--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.manifest
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.manifest
@@ -2,7 +2,7 @@ version: v1beta2
 id: fluentd-to-gcp
 containers:
   - name: fluentd-gcp-container
-    image: kubernetes/fluentd-gcp:1.1
+    image: kubernetes/fluentd-gcp:1.2
     volumeMounts:
       - name: containers
         mountPath: /var/lib/docker/containers

--- a/contrib/logging/fluentd-gcp-image/Makefile
+++ b/contrib/logging/fluentd-gcp-image/Makefile
@@ -6,7 +6,7 @@
 .PHONY:	build push
 
 
-TAG = 1.1
+TAG = 1.2
 
 build:	
 	sudo docker build -t kubernetes/fluentd-gcp:$(TAG) .

--- a/contrib/logging/fluentd-gcp-image/google-fluentd.conf
+++ b/contrib/logging/fluentd-gcp-image/google-fluentd.conf
@@ -17,7 +17,7 @@
   format none
   time_key time
   path /var/lib/docker/containers/*/*-json.log
-  pos_file /var/lib/docker/containers/containers.log.pos
+  pos_file /var/lib/docker/containers/gcp-containers.log.pos
   time_format %Y-%m-%dT%H:%M:%S
   tag docker.*
   read_from_head true
@@ -37,7 +37,7 @@
   format none
   time_key time
   path /varlog/kubelet.log
-  pos_file /varlog/kubelet.log.pos
+  pos_file /varlog/gcp-kubelet.log.pos
   tag kubelet
 </source>
 


### PR DESCRIPTION
This is a stepping stone towards supporting both Fluentd -> Elasticsearch and Fluentd -> Cloud Logging on the same cluster. For this to work the two collectors have to use different pos files.

This is an unusual scenario but it is needed for our end to end test clusters.
