### PR TITLE
Publish a gs://kubernetes-release/release/latest.txt when we publish a build

### DIFF
--- a/build/push-official-release.sh
+++ b/build/push-official-release.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 KUBE_RELEASE_VERSION=${1-}
 
-VERSION_REGEX="v[0-9]+.[0-9]+(.[0-9]+)?"
+VERSION_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
 [[ ${KUBE_RELEASE_VERSION} =~ $VERSION_REGEX ]] || {
   echo "!!! You must specify the version you are releasing in the form of '$VERSION_REGEX'" >&2
   exit 1
@@ -34,9 +34,11 @@ KUBE_GCS_UPLOAD_RELEASE=y
 KUBE_GCS_RELEASE_BUCKET=kubernetes-release
 KUBE_GCS_PROJECT=google-containers
 KUBE_GCS_RELEASE_PREFIX=release/${KUBE_RELEASE_VERSION}
+KUBE_GCS_LATEST_FILE="release/latest.txt"
+KUBE_GCS_LATEST_CONTENTS=${KUBE_RELEASE_VERSION}
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "$KUBE_ROOT/build/common.sh"
 
-
 kube::release::gcs::release
+kube::release::gcs::publish_latest_official


### PR DESCRIPTION
Adds a kube::release::gcs::publish_latest_official that checks the
current contents of this file in GCS, verifies that we're pushing a
newer build, and updates it if so. (i.e. it handles the case of
pushing a 0.13.1 and then later pushing a 0.12.3.) This follows the
pattern of the ci/ build, which Jenkins just updates unconditionally.

I already updated the file for 0.13.1. After this we can update the
get-k8s script, so we don't have to keep updating it.
