### PR TITLE
Add a prefix to the POS file for Fluentd to Elasticsearch

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
@@ -1,6 +1,6 @@
 .PHONY:	build push
 
-TAG = 1.2
+TAG = 1.3
 
 build:	
 	sudo docker build -t kubernetes/fluentd-elasticsearch:$(TAG) .

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
@@ -38,7 +38,7 @@
   format json
   time_key time
   path /var/lib/docker/containers/*/*-json.log
-  pos_file /var/lib/docker/containers/containers.log.pos
+  pos_file /var/lib/docker/containers/es-containers.log.pos
   time_format %Y-%m-%dT%H:%M:%S
   tag docker.*
   read_from_head true
@@ -62,7 +62,7 @@
   type tail
   format none
   path /varlog/kubelet.log
-  pos_file /varlog/kubelet.log.pos
+  pos_file /varlog/es-kubelet.log.pos
   tag kubelet
 </source>
 

--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.manifest
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.manifest
@@ -2,7 +2,7 @@ version: v1beta2
 id: fluentd-to-elasticsearch
 containers:
   - name: fluentd-es
-    image: kubernetes/fluentd-elasticsearch:1.2
+    image: kubernetes/fluentd-elasticsearch:1.3
     env:
       - name: FLUENTD_ARGS
         value: -qq


### PR DESCRIPTION
This change is to keep the POS files distinct between the ES and Cloud Logging collectors to allow both of them to run at the same time.
