### PR TITLE
Rewrote guestbook-go example to use kube-dns

### DIFF
--- a/examples/guestbook-go/README.md
+++ b/examples/guestbook-go/README.md
@@ -82,7 +82,7 @@ redis-slave-controller                 redis-slave             gurpartap/redis  
 The redis slave configures itself by looking for the Kubernetes service environment variables in the container environment. In particular, the redis slave is started with the following command:
 
 ```shell
-redis-server --slaveof $REDIS_MASTER_SERVICE_HOST $REDIS_MASTER_SERVICE_PORT
+redis-server --slaveof redis-master 6379
 ```
 
 Once that's up you can list the pods in the cluster, to verify that the master and slaves are running:
@@ -125,7 +125,7 @@ $ cluster/kubectl.sh create -f examples/guestbook-go/guestbook-controller.json
 
 $ cluster/kubectl.sh get replicationControllers
 CONTROLLER                             CONTAINER(S)            IMAGE(S)                            SELECTOR                     REPLICAS
-guestbook-controller                   guestbook               kubernetes/guestbook                name=guestbook               3
+guestbook-controller                   guestbook               kubernetes/guestbook:v2             name=guestbook               3
 redis-master-controller                redis-master            gurpartap/redis                     name=redis,role=master       1
 redis-slave-controller                 redis-slave             gurpartap/redis                     name=redis,role=slave        2
 ```
@@ -135,9 +135,9 @@ Once that's up (it may take ten to thirty seconds to create the pods) you can li
 ```shell
 $ cluster/kubectl.sh get pods
 POD                                          IP                  CONTAINER(S)            IMAGE(S)                            HOST                                                             LABELS                                   STATUS
-guestbook-controller-182tv                   10.244.2.8          guestbook               kubernetes/guestbook                kubernetes-minion-3.c.lucid-walker-725.internal/104.154.52.39    name=guestbook                           Running
-guestbook-controller-jzjpe                   10.244.0.7          guestbook               kubernetes/guestbook                kubernetes-minion-1.c.lucid-walker-725.internal/104.154.37.86    name=guestbook                           Running
-guestbook-controller-zwk1b                   10.244.3.8          guestbook               kubernetes/guestbook                kubernetes-minion-4.c.lucid-walker-725.internal/104.154.49.134   name=guestbook                           Running
+guestbook-controller-182tv                   10.244.2.8          guestbook               kubernetes/guestbook:v2             kubernetes-minion-3.c.lucid-walker-725.internal/104.154.52.39    name=guestbook                           Running
+guestbook-controller-jzjpe                   10.244.0.7          guestbook               kubernetes/guestbook:v2             kubernetes-minion-1.c.lucid-walker-725.internal/104.154.37.86    name=guestbook                           Running
+guestbook-controller-zwk1b                   10.244.3.8          guestbook               kubernetes/guestbook:v2             kubernetes-minion-4.c.lucid-walker-725.internal/104.154.49.134   name=guestbook                           Running
 redis-master-pod-hh2gd                       10.244.3.7          redis-master            gurpartap/redis                     kubernetes-minion-4.c.lucid-walker-725.internal/104.154.49.134   name=redis,role=master                   Running
 redis-slave-controller-i7hvs                 10.244.2.7          redis-slave             gurpartap/redis                     kubernetes-minion-3.c.lucid-walker-725.internal/104.154.52.39    name=redis,role=slave                    Running
 redis-slave-controller-nyxxv                 10.244.1.6          redis-slave             gurpartap/redis                     kubernetes-minion-2.c.lucid-walker-725.internal/130.211.144.5    name=redis,role=slave                    Running

--- a/examples/guestbook-go/_src/main.go
+++ b/examples/guestbook-go/_src/main.go
@@ -71,7 +71,7 @@ func HandleError(result interface{}, err error) (r interface{}) {
 }
 
 func main() {
-	pool = simpleredis.NewConnectionPoolHost(os.Getenv("REDIS_MASTER_SERVICE_HOST") + ":" + os.Getenv("REDIS_MASTER_SERVICE_PORT"))
+	pool = simpleredis.NewConnectionPoolHost("redis-master:6379")
 	defer pool.Close()
 
 	r := mux.NewRouter()

--- a/examples/guestbook-go/_src/script/build.sh
+++ b/examples/guestbook-go/_src/script/build.sh
@@ -20,5 +20,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+guestbook_version=${1:-latest}
 docker build --rm --force-rm -t kubernetes/guestbook-builder .
-docker run --rm kubernetes/guestbook-builder | docker build -t kubernetes/guestbook -
+docker run --rm kubernetes/guestbook-builder | docker build -t "kubernetes/guestbook:${guestbook_version}" -

--- a/examples/guestbook-go/_src/script/clean.sh
+++ b/examples/guestbook-go/_src/script/clean.sh
@@ -20,6 +20,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+guestbook_version=${1:-latest}
 docker rm -f guestbook-builder 2> /dev/null || true
 docker rmi -f kubernetes/guestbook-builder || true
-docker rmi -f kubernetes/guestbook || true
+docker rmi -f "kubernetes/guestbook:${guestbook_version}" || true

--- a/examples/guestbook-go/_src/script/release.sh
+++ b/examples/guestbook-go/_src/script/release.sh
@@ -26,15 +26,15 @@ base_dir=$(cd "${base_dir}" && pwd)
 guestbook_version=${1:-latest}
 
 echo " ---> Cleaning up before building..."
-"${base_dir}/clean.sh" 2> /dev/null
+"${base_dir}/clean.sh" "${guestbook_version}" 2> /dev/null
 
 echo " ---> Building..."
-"${base_dir}/build.sh"
+"${base_dir}/build.sh" "${guestbook_version}"
 
 echo " ---> Pushing kubernetes/guestbook:${guestbook_version}..."
 "${base_dir}/push.sh" "${guestbook_version}"
 
 echo " ---> Cleaning up..."
-"${base_dir}/clean.sh"
+"${base_dir}/clean.sh" "${guestbook_version}"
 
 echo " ---> Done."

--- a/examples/guestbook-go/guestbook-controller.json
+++ b/examples/guestbook-go/guestbook-controller.json
@@ -11,7 +11,7 @@
           "version": "v1beta1",
           "id": "guestbook-controller",
           "containers": [{
-            "image": "kubernetes/guestbook",
+            "image": "kubernetes/guestbook:v2",
             "name": "guestbook",
             "ports": [{ "name": "http-server", "containerPort": 3000 }]
           }]

--- a/examples/guestbook-go/redis-slave-controller.json
+++ b/examples/guestbook-go/redis-slave-controller.json
@@ -13,7 +13,7 @@
           "containers": [{
             "name": "redis-slave",
             "image": "gurpartap/redis",
-            "command": ["sh", "-c", "redis-server /etc/redis/redis.conf --slaveof $REDIS_MASTER_SERVICE_HOST $REDIS_MASTER_SERVICE_PORT"],
+            "command": ["sh", "-c", "redis-server /etc/redis/redis.conf --slaveof redis-master 6379"],
             "ports": [{ "name": "redis-server", "containerPort": 6379 }]
           }]
         }

--- a/examples/guestbook-go/v1beta3/guestbook-controller.json
+++ b/examples/guestbook-go/v1beta3/guestbook-controller.json
@@ -21,7 +21,7 @@
          "spec":{
             "containers":[
                {
-                  "image":"kubernetes/guestbook",
+                  "image":"kubernetes/guestbook:v2",
                   "name":"guestbook",
                   "ports":[
                      {

--- a/examples/guestbook-go/v1beta3/redis-slave-controller.json
+++ b/examples/guestbook-go/v1beta3/redis-slave-controller.json
@@ -30,7 +30,7 @@
                   "command":[
                      "sh",
                      "-c",
-                     "redis-server /etc/redis/redis.conf --slaveof $REDIS_MASTER_SERVICE_HOST $REDIS_MASTER_SERVICE_PORT"
+                     "redis-server /etc/redis/redis.conf --slaveof redis-master 6379"
                   ],
                   "ports":[
                      {

--- a/examples/guestbook/README.md
+++ b/examples/guestbook/README.md
@@ -272,7 +272,7 @@ The pod is described in the file `examples/guestbook/frontend-controller.json`:
        },
        "labels": {
          "name": "frontend",
-         "uses": "redis-slave,redis-master",
+         "uses": "redis-slave-or-redis-master",
          "app": "frontend"
        }
       }},

--- a/examples/guestbook/v1beta3/frontend-controller.json
+++ b/examples/guestbook/v1beta3/frontend-controller.json
@@ -22,7 +22,7 @@
             "containers":[
                {
                   "name":"php-redis",
-                  "image":"kubernetes/example-guestbook-php-redis",
+                  "image":"kubernetes/example-guestbook-php-redis:v2",
                   "ports":[
                      {
                         "containerPort":80,

--- a/examples/guestbook/v1beta3/redis-slave-controller.json
+++ b/examples/guestbook/v1beta3/redis-slave-controller.json
@@ -22,7 +22,7 @@
             "containers":[
                {
                   "name":"slave",
-                  "image":"brendanburns/redis-slave",
+                  "image":"kubernetes/redis-slave:v2",
                   "ports":[
                      {
                         "containerPort":6379,


### PR DESCRIPTION
This is follow up of #5284.

I also built a new dcoker image: kubernetes/guestbook:v2.
