### PR TITLE
libvirt-coreos: Make kube-push able to push non-release kubernetes binaries

### DIFF
--- a/cluster/libvirt-coreos/user_data_master.yml
+++ b/cluster/libvirt-coreos/user_data_master.yml
@@ -69,7 +69,8 @@ coreos:
         ConditionPathIsDirectory=/opt/kubernetes/addons
         Description=Kubernetes addons
         Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-        Requires=opt-kubernetes.mount kube-apiserver.service
+        Requires=opt-kubernetes.mount
+        Wants=kube-apiserver.service
 
         [Service]
         Type=oneshot

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -123,7 +123,7 @@ function initialize-pool {
   # fi
 
   mkdir -p "$POOL_PATH/kubernetes"
-  kube-push
+  kube-push-internal
 
   mkdir -p "$POOL_PATH/kubernetes/manifests"
   if [[ "$ENABLE_NODE_LOGGING" == "true" ]]; then
@@ -258,8 +258,35 @@ function upload-server-tars {
 
 # Update a kubernetes cluster with latest source
 function kube-push {
+  kube-push-internal
+  ssh-to-node "$MASTER_NAME" "sudo systemctl restart kube-apiserver kube-controller-manager kube-scheduler"
+  for ((i=0; i < NUM_MINIONS; i++)); do
+    ssh-to-node "${MINION_NAMES[$i]}" "sudo systemctl restart kubelet kube-proxy"
+  done
+  wait-cluster-readiness
+}
+
+function kube-push-internal {
+  case "${KUBE_PUSH:-release}" in
+    release)
+      kube-push-release;;
+    local)
+      kube-push-local;;
+    *)
+      echo "The only known push methods are \"release\" to use the relase tarball or \"local\" to use the binaries built by make. KUBE_PUSH is set \"$KUBE_PUSH\"" >&2
+      return 1;;
+  esac
+}
+
+function kube-push-release {
   find-release-tars
   upload-server-tars
+}
+
+function kube-push-local {
+  rm -rf "$POOL_PATH/kubernetes/bin/*"
+  mkdir -p "$POOL_PATH/kubernetes/bin"
+  cp "${KUBE_ROOT}/_output/local/go/bin"/* "$POOL_PATH/kubernetes/bin"
 }
 
 # Execute prior to running tests to build a release if required for env

--- a/docs/getting-started-guides/libvirt-coreos.md
+++ b/docs/getting-started-guides/libvirt-coreos.md
@@ -91,6 +91,11 @@ The `KUBERNETES_PROVIDER` environment variable tells all of the various cluster 
 
 The `NUM_MINIONS` environment variable may be set to specify the number of minions to start. If it is not set, the number of minions defaults to 3.
 
+The `KUBE_PUSH` environment variable may be set to specify which kubernetes binaries must be deployed on the cluster. Its possible values are:
+
+* `release` (default if `KUBE_PUSH` is not set) will deploy the binaries of `_output/release-tars/kubernetes-server-….tar.gz`. This is built with `make release` or `make release-skip-tests`.
+* `local` will deploy the binaries of `_output/local/go/bin`. These are built with `make`.
+
 You can check that your machines are there and running with:
 
 ```
@@ -149,10 +154,15 @@ Destroy the libvirt-CoreOS cluster
 cluster/kube-down.sh
 ```
 
-Uptade the libvirt-CoreOS cluster with a new Kubernetes release:
+Update the libvirt-CoreOS cluster with a new Kubernetes release produced by `make release` or `make release-skip-tests`:
 
 ```
 cluster/kube-push.sh
+```
+
+Update the libvirt-CoreOS cluster with the locally built Kubernetes binaries produced by `make`:
+```
+KUBE_PUSH=local cluster/kube-push.sh
 ```
 
 Interact with the cluster


### PR DESCRIPTION
In all cluster scripts, `kube-up` and `kube-push` are deploying to the cluster the release of kubernetes found in the tarball built by `make release`.
This is legitimate for production clusters on remote clouds.
But during development, a developer may want to quickly start a test cluster on VMs with its current build.

This PR adds the ability to push what’s built by `make` to a libvirt-coreos cluster.

`make` runs faster than `make release` because `make release` needs to create docker images and builds kubernetes for several architectures.

With that PR, deploying a locally modified kubernetes to an already running libvirt-coreos cluster can be done with

```
make && KUBE_PUSH=local cluster/kube-push.sh
```

and this shouldn’t last more than few seconds.

In addition, kube-push will take care of restarting the processes so that at the end of the command, it the newly deployed version which is running.
