### PR TITLE
Make networking e2e test run in its own namespace

### DIFF
--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -39,6 +39,9 @@ var _ = Describe("Networking", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	// Create a unique namespace for this test.
+	ns := "nettest-" + randomSuffix()
+
 	It("should function for pods", func() {
 		if testContext.provider == "vagrant" {
 			By("Skipping test which is broken for vagrant (See https://github.com/GoogleCloudPlatform/kubernetes/issues/3580)")
@@ -54,10 +57,7 @@ var _ = Describe("Networking", func() {
 			Fail(fmt.Sprintf("unexpected error code. expected 200, got: %v (%v)", resp.StatusCode, resp))
 		}
 
-		ns := api.NamespaceDefault
-		// TODO(satnam6502): Replace call of randomSuffix with call to NewUUID when service
-		//                   names have the same form as pod and replication controller names.
-		name := "nettest-" + randomSuffix()
+		name := "nettest"
 
 		svc, err := c.Services(ns).Create(&api.Service{
 			ObjectMeta: api.ObjectMeta{
@@ -74,7 +74,7 @@ var _ = Describe("Networking", func() {
 				},
 			},
 		})
-		By(fmt.Sprintf("Creating service with name %s", svc.Name))
+		By(fmt.Sprintf("Creating service with name %s in namespace %s", svc.Name, ns))
 		if err != nil {
 			Fail(fmt.Sprintf("unable to create test service %s: %v", svc.Name, err))
 		}
@@ -109,7 +109,7 @@ var _ = Describe("Networking", func() {
 							{
 								Name:    "webserver",
 								Image:   "kubernetes/nettest:latest",
-								Command: []string{"-service=" + name},
+								Command: []string{"-service=" + name, "-namespace=" + ns},
 								Ports:   []api.ContainerPort{{ContainerPort: 8080}},
 							},
 						},
@@ -140,7 +140,7 @@ var _ = Describe("Networking", func() {
 		var body []byte
 		for i := 0; i < maxAttempts && !passed; i++ {
 			time.Sleep(2 * time.Second)
-			body, err = c.Get().Prefix("proxy").Resource("services").Name(svc.Name).Suffix("status").Do().Raw()
+			body, err = c.Get().Namespace(ns).Prefix("proxy").Resource("services").Name(svc.Name).Suffix("status").Do().Raw()
 			if err != nil {
 				fmt.Printf("Attempt %v/%v: service/pod still starting. (error: '%v')\n", i, maxAttempts, err)
 				continue
@@ -154,7 +154,7 @@ var _ = Describe("Networking", func() {
 				fmt.Printf("Attempt %v/%v: test still running\n", i, maxAttempts)
 				break
 			case "fail":
-				if body, err = c.Get().Prefix("proxy").Resource("services").Name(svc.Name).Suffix("read").Do().Raw(); err != nil {
+				if body, err = c.Get().Namespace(ns).Prefix("proxy").Resource("services").Name(svc.Name).Suffix("read").Do().Raw(); err != nil {
 					Fail(fmt.Sprintf("Failed on attempt %v. Cleaning up. Error reading details: %v", i, err))
 				} else {
 					Fail(fmt.Sprintf("Failed on attempt %v. Cleaning up. Details:\n%v", i, string(body)))
@@ -164,7 +164,13 @@ var _ = Describe("Networking", func() {
 		}
 
 		if !passed {
-			if body, err = c.Get().Prefix("proxy").Resource("services").Name(svc.Name).Suffix("read").Do().Raw(); err != nil {
+			if body, err = c.Get().
+				Namespace(ns).
+				Prefix("proxy").
+				Resource("services").
+				Name(svc.Name).
+				Suffix("read").
+				Do().Raw(); err != nil {
 				Fail(fmt.Sprintf("Timed out. Cleaning up. Error reading details: %v", err))
 			} else {
 				Fail(fmt.Sprintf("Timed out. Cleaning up. Details:\n%v", string(body)))
@@ -184,6 +190,7 @@ var _ = Describe("Networking", func() {
 		for _, test := range tests {
 			By(fmt.Sprintf("testing: %s", test.path))
 			data, err := c.RESTClient.Get().
+				Namespace(ns).
 				AbsPath(test.path).
 				Do().
 				Raw()


### PR DESCRIPTION
This is one of many steps I want to take to improve the reliability of the network e2e test.
@ixdy @quinton-hoole @zmerlynn 
