### PR TITLE
Fix bug in webserver test container and add extra diagnostics

### DIFF
--- a/contrib/for-tests/network-tester/Makefile
+++ b/contrib/for-tests/network-tester/Makefile
@@ -1,13 +1,15 @@
 all: push
 
+TAG = 1.1
+
 webserver: webserver.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./webserver.go
 
 container: webserver
-	sudo docker build -t kubernetes/nettest .
+	sudo docker build -t kubernetes/nettest:$(TAG) .
 
 push: container
-	sudo docker push kubernetes/nettest
+	sudo docker push kubernetes/nettest:$(TAG)
 
 clean:
 	rm -f webserver


### PR DESCRIPTION
Garbage port numbers were being generated by a bug that interpreted an integer endpoint port as a string. Changed to using `strconv.Itoa` for the conversion.
@ghodss @thockin @lavalamp @ixdy 

```
  Timed out. Cleaning up. Details:
  {
    "Hostname": "nettest-781uq",
    "Sent": null,
    "Received": null,
    "Errors": null,
    "Log": [
        "Unable to read the endpoints for nettest-2443/nettest: endpoints \"nettest\" not found; will try again.",
        "Attempting to contact IP 10.245.1.13 at endpoint number 0 value 8080",
        "Warning: unable to contact the endpoint \"http://10.245.1.13:ᾐ\": Post http://10.245.1.13:ᾐ/write: dial tcp: unknown port tcp/ᾐ",
        "Attempting to contact IP 10.245.2.17 at endpoint number 1 value 8080",
        "Warning: unable to contact the endpoint \"http://10.245.2.17:ᾐ\": Post http://10.245.2.17:ᾐ/write: dial tcp: unknown port tcp/ᾐ",
        "Attempting to contact IP 10.245.2.14 at endpoint number 2 value 8080",
        "Warning: unable to contact the endpoint \"http://10.245.2.14:ᾐ\": Post http://10.245.2.14:ᾐ/write: dial tcp: unknown port tcp/ᾐ",
        "Attempting to contact IP 10.245.1.14 at endpoint number 3 value 8080",
        "Warning: unable to contact the endpoint \"http://10.245.1.14:ᾐ\": Post http://10.245.1.14:ᾐ/write: dial tcp: unknown port tcp/ᾐ",

```
