### PR TITLE
kubelet: Remove docker container in prober's interface

### DIFF
--- a/pkg/kubelet/probe_test.go
+++ b/pkg/kubelet/probe_test.go
@@ -400,7 +400,7 @@ func TestProbeContainer(t *testing.T) {
 		} else {
 			kl = makeTestKubelet(test.expectedResult, nil)
 		}
-		result, err := kl.probeContainer(&api.Pod{}, api.PodStatus{}, test.testContainer, dc)
+		result, err := kl.probeContainer(&api.Pod{}, api.PodStatus{}, test.testContainer, dc.ID, dc.Created)
 		if test.expectError && err == nil {
 			t.Error("Expected error but did no error was returned.")
 		}


### PR DESCRIPTION
Also change
`kubelet.docketIDToRef[dockertools.DockerID]*api.ObjectReference{}` to
`kubelet.containerIDToRef[string]*api.ObjectReference{}`.

This is one of the steps we need to take to replace `dockerContainer` with more generic container types. #5526

Whether to use `api.Container` or creating another one in the runtime is still under discussion:
https://github.com/GoogleCloudPlatform/kubernetes/pull/5572#discussion_r26685846

Feedback welcome! Thank you!
