### PR TITLE
Add timeout to kubelet client

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -100,6 +100,7 @@ func NewAPIServer() *APIServer {
 		KubeletConfig: client.KubeletConfig{
 			Port:        10250,
 			EnableHttps: false,
+			HTTPTimeout: time.Duration(5) * time.Second,
 		},
 	}
 

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -82,6 +82,7 @@ func NewCMServer() *CMServer {
 		KubeletConfig: client.KubeletConfig{
 			Port:        ports.KubeletPort,
 			EnableHttps: false,
+			HTTPTimeout: time.Duration(5) * time.Second,
 		},
 	}
 	return &s

--- a/pkg/client/flags.go
+++ b/pkg/client/flags.go
@@ -16,12 +16,17 @@ limitations under the License.
 
 package client
 
+import (
+	"time"
+)
+
 // FlagSet abstracts the flag interface for compatibility with both Golang "flag"
 // and cobra pflags (Posix style).
 type FlagSet interface {
 	StringVar(p *string, name, value, usage string)
 	BoolVar(p *bool, name string, value bool, usage string)
 	UintVar(p *uint, name string, value uint, usage string)
+	DurationVar(p *time.Duration, name string, value time.Duration, usage string)
 }
 
 // BindClientConfigFlags registers a standard set of CLI flags for connecting to a Kubernetes API server.
@@ -38,6 +43,7 @@ func BindClientConfigFlags(flags FlagSet, config *Config) {
 func BindKubeletClientConfigFlags(flags FlagSet, config *KubeletConfig) {
 	flags.BoolVar(&config.EnableHttps, "kubelet_https", config.EnableHttps, "Use https for kubelet connections")
 	flags.UintVar(&config.Port, "kubelet_port", config.Port, "Kubelet port")
+	flags.DurationVar(&config.HTTPTimeout, "kubelet_timeout", config.HTTPTimeout, "Timeout for kubelet operations")
 	flags.StringVar(&config.CertFile, "kubelet_client_certificate", config.CertFile, "Path to a client key file for TLS.")
 	flags.StringVar(&config.KeyFile, "kubelet_client_key", config.KeyFile, "Path to a client key file for TLS.")
 	flags.StringVar(&config.CAFile, "kubelet_certificate_authority", config.CAFile, "Path to a cert. file for the certificate authority.")

--- a/pkg/client/flags_test.go
+++ b/pkg/client/flags_test.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
@@ -57,6 +58,16 @@ func (f *fakeFlagSet) UintVar(p *uint, name string, value uint, usage string) {
 	f.set.Insert(name)
 }
 
+func (f *fakeFlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
+	if p == nil {
+		f.t.Errorf("unexpected nil pointer")
+	}
+	if usage == "" {
+		f.t.Errorf("unexpected empty usage")
+	}
+	f.set.Insert(name)
+}
+
 func TestBindClientConfigFlags(t *testing.T) {
 	flags := &fakeFlagSet{t, util.StringSet{}}
 	config := &Config{}
@@ -70,7 +81,7 @@ func TestBindKubeletClientConfigFlags(t *testing.T) {
 	flags := &fakeFlagSet{t, util.StringSet{}}
 	config := &KubeletConfig{}
 	BindKubeletClientConfigFlags(flags, config)
-	if len(flags.set) != 5 {
+	if len(flags.set) != 6 {
 		t.Errorf("unexpected flag set: %#v", flags)
 	}
 }

--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -86,6 +86,9 @@ type KubeletConfig struct {
 
 	// TLSClientConfig contains settings to enable transport layer security
 	TLSClientConfig
+
+	// HTTPTimeout is used by the client to timeout http requests to Kubelet.
+	HTTPTimeout time.Duration
 }
 
 // TLSClientConfig contains settings to enable transport layer security

--- a/pkg/client/kubelet.go
+++ b/pkg/client/kubelet.go
@@ -84,6 +84,7 @@ func NewKubeletClient(config *KubeletConfig) (KubeletClient, error) {
 
 	c := &http.Client{
 		Transport: transport,
+		Timeout:   config.HTTPTimeout,
 	}
 	return &HTTPKubeletClient{
 		Client:      c,


### PR DESCRIPTION
When a node fails, currently the pods are just deleted by node controller.

Summary of pull request:

1) Recreates those pods (currently checking for RestartPolicyAlways but not sure if the check is needed) so they can be scheduled to other nodes in the cluster.
2) Add timeout to kubelet client. When a node disappears, pod cache update gets stuck for a really long time without a client timeout.
3) Changed scheduler to use reflector for nodes. When using poller, the pods that are created again may end up on the dead node because the scheduler is not yet aware of the node's death.

Ping @ddysher @bgrant0607 
