### PR TITLE
bump(github.com/matttproud/golang_protobuf_extensions/ext)

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -284,7 +284,7 @@
 		},
 		{
 			"ImportPath": "github.com/matttproud/golang_protobuf_extensions/ext",
-			"Rev": "7a864a042e844af638df17ebbabf8183dace556a"
+			"Rev": "ba7d65ac66e9da93a714ca18f6d1bc7a0c09100c"
 		},
 		{
 			"ImportPath": "github.com/miekg/dns",

--- a/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/ext/all_test.go
+++ b/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/ext/all_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"testing/quick"
 
-	. "code.google.com/p/goprotobuf/proto"
-	. "code.google.com/p/goprotobuf/proto/testdata"
+	. "github.com/golang/protobuf/proto"
+	. "github.com/golang/protobuf/proto/testdata"
 )
 
 func TestWriteDelimited(t *testing.T) {

--- a/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/ext/decode.go
+++ b/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/ext/decode.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"io"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 var errInvalidVarint = errors.New("invalid varint32 encountered")

--- a/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/ext/encode.go
+++ b/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/ext/encode.go
@@ -18,7 +18,7 @@ import (
 	"encoding/binary"
 	"io"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 // WriteDelimited encodes and dumps a message to the provided writer prefixed

--- a/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/ext/fixtures_test.go
+++ b/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/ext/fixtures_test.go
@@ -1,5 +1,5 @@
 // Copyright 2010 The Go Authors.  All rights reserved.
-// http://code.google.com/p/goprotobuf/
+// http://github.com/golang/protobuf/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -30,11 +30,11 @@
 package ext
 
 import (
-	. "code.google.com/p/goprotobuf/proto"
-	. "code.google.com/p/goprotobuf/proto/testdata"
+	. "github.com/golang/protobuf/proto"
+	. "github.com/golang/protobuf/proto/testdata"
 )
 
-// FROM https://code.google.com/p/goprotobuf/source/browse/proto/all_test.go.
+// FROM https://github.com/golang/protobuf/blob/master/proto/all_test.go.
 
 func initGoTestField() *GoTestField {
 	f := new(GoTestField)


### PR DESCRIPTION
After this and the Prometheus client get rebased, the deprecated protobuf google code repository can be dropped from the deps.
