### PR TITLE
Disable the nfs plugin because it does not cross-compile

### DIFF
--- a/cmd/kubelet/app/plugins.go
+++ b/cmd/kubelet/app/plugins.go
@@ -26,7 +26,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/volume/gce_pd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/volume/git_repo"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/volume/host_path"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/volume/nfs"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/volume/secret"
 )
 
@@ -42,7 +41,6 @@ func ProbeVolumePlugins() []volume.Plugin {
 	allPlugins = append(allPlugins, git_repo.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, host_path.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, secret.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, nfs.ProbeVolumePlugins()...)
 
 	return allPlugins
 }


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/kubernetes/pull/4601 introduced a plug-in that breaks compilation on windows/amd64 during release builds.

disabling compilation of the plug-in until it cross-compiles

/cc @smarterclayton 
