### PR TITLE
Remove global map from healthz

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -32,7 +32,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
 	nodeControllerPkg "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/controller"
 	replicationControllerPkg "github.com/GoogleCloudPlatform/kubernetes/pkg/controller"
-	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master/ports"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/resourcequota"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/service"

--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -26,11 +26,16 @@ import (
 	"runtime"
 
 	"github.com/GoogleCloudPlatform/kubernetes/cmd/kube-controller-manager/app"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version/verflag"
 
 	"github.com/spf13/pflag"
 )
+
+func init() {
+	healthz.DefaultHealthz()
+}
 
 func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
-	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/proxy"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/proxy/config"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"

--- a/cmd/kube-proxy/proxy.go
+++ b/cmd/kube-proxy/proxy.go
@@ -22,11 +22,16 @@ import (
 	"runtime"
 
 	"github.com/GoogleCloudPlatform/kubernetes/cmd/kube-proxy/app"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version/verflag"
 
 	"github.com/spf13/pflag"
 )
+
+func init() {
+	healthz.DefaultHealthz()
+}
 
 func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())

--- a/pkg/healthz/healthz_test.go
+++ b/pkg/healthz/healthz_test.go
@@ -59,12 +59,13 @@ func TestMulitipleChecks(t *testing.T) {
 
 	for i, test := range tests {
 		mux := http.NewServeMux()
+		checks := []HealthzChecker{PingHealthz}
 		if test.addBadCheck {
-			AddHealthzFunc("bad", func(_ *http.Request) error {
+			checks = append(checks, NamedCheck("bad", func(_ *http.Request) error {
 				return errors.New("this will fail")
-			})
+			}))
 		}
-		InstallHandler(mux)
+		InstallHandler(mux, checks...)
 		req, err := http.NewRequest("GET", fmt.Sprintf("http://example.com%v", test.path), nil)
 		if err != nil {
 			t.Fatalf("case[%d] Unexpected error: %v", i, err)

--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -110,9 +110,11 @@ func NewServer(host HostInterface, enableDebuggingHandlers bool) Server {
 
 // InstallDefaultHandlers registers the default set of supported HTTP request patterns with the mux.
 func (s *Server) InstallDefaultHandlers() {
-	healthz.AddHealthzFunc("docker", s.dockerHealthCheck)
-	healthz.AddHealthzFunc("hostname", s.hostnameHealthCheck)
-	healthz.InstallHandler(s.mux)
+	healthz.InstallHandler(s.mux,
+		healthz.PingHealthz,
+		healthz.NamedCheck("docker", s.dockerHealthCheck),
+		healthz.NamedCheck("hostname", s.hostnameHealthCheck),
+	)
 	s.mux.HandleFunc("/podInfo", s.handlePodInfoOld)
 	s.mux.HandleFunc("/api/v1beta1/podInfo", s.handlePodInfoVersioned)
 	s.mux.HandleFunc("/api/v1beta1/nodeInfo", s.handleNodeInfoVersioned)

--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
-	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master/ports"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler"

--- a/plugin/cmd/kube-scheduler/scheduler.go
+++ b/plugin/cmd/kube-scheduler/scheduler.go
@@ -19,12 +19,17 @@ package main
 import (
 	"runtime"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version/verflag"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/cmd/kube-scheduler/app"
 
 	"github.com/spf13/pflag"
 )
+
+func init() {
+	healthz.DefaultHealthz()
+}
 
 func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())


### PR DESCRIPTION
It currently is impossible to use two different healthz handlers on different ports in the same process.  This removes the global variables in favor of requiring the consumer to specify all health checks up front.

As mentioned https://github.com/GoogleCloudPlatform/kubernetes/pull/4646#issuecomment-83785139

@mikedanese
