### PR TITLE
Raise the file ulimit for kube-proxy for init.d systems

### DIFF
--- a/cluster/saltbase/salt/kube-proxy/initd
+++ b/cluster/saltbase/salt/kube-proxy/initd
@@ -40,6 +40,9 @@ DAEMON_USER=root
 #
 do_start()
 {
+        # Raise the file descriptor limit - we expect to open a lot of sockets!
+        ulimit -n 65536
+
         # Return
         #   0 if daemon has been started
         #   1 if daemon was already running


### PR DESCRIPTION
The same fix as #5549 (to address #5461), but for init.d systems.
