### PR TITLE
Updating test-go.sh and test-integration.sh to be able to run the tests for multiple API versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,12 @@ sudo: false
 
 language: go
 
-go:
-  - 1.4
-  - 1.3
+matrix:
+  include:
+    - go: 1.4
+      env: KUBE_TEST_API_VERSIONS="v1beta1"
+    - go: 1.3
+      env: KUBE_TEST_API_VERSIONS="v1beta3"
 
 install:
   - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
@@ -18,10 +21,10 @@ install:
   - GOPATH=$PWD/Godeps/_workspace:$GOPATH go install ./...
 
 script:
-  - KUBE_RACE="-race" KUBE_COVER="y" KUBE_GOVERALLS_BIN="$HOME/gopath/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 ./hack/test-go.sh -- -p=2
+  - KUBE_RACE="-race" KUBE_COVER="y" KUBE_GOVERALLS_BIN="$HOME/gopath/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_API_VERSIONS=$KUBE_TEST_API_VERSIONS ./hack/test-go.sh -- -p=2
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/test-cmd.sh
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/verify-gendocs.sh
-  - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/test-integration.sh
+  - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH KUBE_TEST_API_VERSIONS=$KUBE_TEST_API_VERSIONS ./hack/test-integration.sh
 
 notifications:
   irc: "chat.freenode.net#google-containers"


### PR DESCRIPTION
We are not yet ready to run it twice (lots of tests break for v1beta3).
This PR just sets us up so that we can do that whenever we are ready.

I want to make sure that I am not breaking coveralls by this change.
When I run this locally (calling runTestsForVersion twice), it just produces 2 html files, which I think is fine.

@ixdy: Can you confirm?
