### PR TITLE
Both @satnam6502 and E2E tests confirm: This code is no longer needed

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -739,14 +739,6 @@ function kube-push {
 
 }
 
-function setup-logging-firewall {
-  echo "TODO: setup logging"
-}
-
-function teardown-logging-firewall {
-  echo "TODO: teardown logging"
-}
-
 # -----------------------------------------------------------------------------
 # Cluster specific test helpers used from hack/e2e-test.sh
 
@@ -802,55 +794,6 @@ function restart-kube-proxy {
 # Restart the kube-apiserver on a node ($1)
 function restart-apiserver {
   ssh-to-node "$1" "sudo /etc/init.d/kube-apiserver restart"
-}
-
-function setup-logging-firewall {
-  # If logging with Fluentd to Elasticsearch is enabled then create pods
-  # and services for Elasticsearch (for ingesting logs) and Kibana (for
-  # viewing logs).
-  if [[ "${ENABLE_NODE_LOGGING-}" != "true" ]] || \
-     [[ "${LOGGING_DESTINATION-}" != "elasticsearch" ]] || \
-     [[ "${ENABLE_CLUSTER_LOGGING-}" != "true" ]]; then
-    return
-  fi
-
-  # TODO: Support logging
-  echo "Logging setup is not (yet) supported on AWS"
-
-#  detect-project
-#  gcloud compute firewall-rules create "${INSTANCE_PREFIX}-fluentd-elasticsearch-logging" --project "${PROJECT}" \
-#    --allow tcp:5601 tcp:9200 tcp:9300 --target-tags "${MINION_TAG}" --network="${NETWORK}"
-#
-#  # This should be nearly instant once kube-addons gets a chance to
-#  # run, and we already know we can hit the apiserver, but it's still
-#  # worth checking.
-#  echo "waiting for logging services to be created by the master."
-#  local kubectl="${KUBE_ROOT}/cluster/kubectl.sh"
-#  for i in `seq 1 10`; do
-#    if "${kubectl}" get services -l name=kibana-logging -o template -t {{range.items}}{{.id}}{{end}} | grep -q kibana-logging &&
-#      "${kubectl}" get services -l name=elasticsearch-logging -o template -t {{range.items}}{{.id}}{{end}} | grep -q elasticsearch-logging; then
-#      break
-#    fi
-#    sleep 10
-#  done
-#
-#  local -r region="${ZONE::-2}"
-#  local -r es_ip=$(gcloud compute forwarding-rules --project "${PROJECT}" describe --region "${region}" elasticsearch-logging | grep IPAddress | awk '{print $2}')
-#  local -r kibana_ip=$(gcloud compute forwarding-rules --project "${PROJECT}" describe --region "${region}" kibana-logging | grep IPAddress | awk '{print $2}')
-#  echo
-#  echo -e "${color_green}Cluster logs are ingested into Elasticsearch running at ${color_yellow}http://${es_ip}:9200"
-#  echo -e "${color_green}Kibana logging dashboard will be available at ${color_yellow}http://${kibana_ip}:5601${color_norm}"
-#  echo
-}
-
-function teardown-logging-firewall {
-  if [[ "${ENABLE_NODE_LOGGING-}" != "true" ]] || \
-     [[ "${LOGGING_DESTINATION-}" != "elasticsearch" ]] || \
-     [[ "${ENABLE_CLUSTER_LOGGING-}" != "true" ]]; then
-    return
-  fi
-
-  # TODO: Support logging
 }
 
 # Perform preparations required to run e2e tests

--- a/cluster/azure/util.sh
+++ b/cluster/azure/util.sh
@@ -561,11 +561,3 @@ function restart-kube-proxy {
 function restart-apiserver {
     ssh-to-node "$1" "sudo /etc/init.d/kube-apiserver restart"
 }
-
-function setup-logging-firewall {
-  echo "TODO: setup logging"
-}
-
-function teardown-logging-firewall {
-  echo "TODO: teardown logging"
-}

--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -267,11 +267,3 @@ function kube-down() {
   "${GCLOUD}" preview container clusters delete --project="${PROJECT}" \
     --zone="${ZONE}" "${CLUSTER_NAME}"
 }
-
-function setup-logging-firewall {
-  echo "TODO: setup logging"
-}
-
-function teardown-logging-firewall {
-  echo "TODO: teardown logging"
-}

--- a/cluster/kube-down.sh
+++ b/cluster/kube-down.sh
@@ -27,8 +27,6 @@ source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
 echo "Bringing down cluster using provider: $KUBERNETES_PROVIDER"
 
 verify-prereqs
-teardown-logging-firewall
-
 kube-down
 
 echo "Done"

--- a/cluster/kube-up.sh
+++ b/cluster/kube-up.sh
@@ -39,9 +39,8 @@ kube-up
 echo "... calling validate-cluster" >&2
 "${KUBE_ROOT}/cluster/validate-cluster.sh"
 
-echo "... calling setup-logging-firewall" >&2
-setup-logging-firewall
-
-echo "Done" >&2
+echo -e "Done, listing cluster services:\n" >&2
+"${KUBE_ROOT}/cluster/kubectl.sh" clusterinfo
+echo
 
 exit 0

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -334,11 +334,3 @@ function restart-apiserver {
 function prepare-e2e() {
     echo "libvirt-coreos doesn't need special preparations for e2e tests" 1>&2
 }
-
-function setup-logging-firewall {
-  echo "TODO: setup logging"
-}
-
-function teardown-logging-firewall {
-  echo "TODO: teardown logging"
-}

--- a/cluster/rackspace/util.sh
+++ b/cluster/rackspace/util.sh
@@ -347,14 +347,6 @@ kube-up() {
   echo
 }
 
-function setup-logging-firewall {
-  echo "TODO: setup logging"
-}
-
-function teardown-logging-firewall {
-  echo "TODO: teardown logging"
-}
-
 # Perform preparations required to run e2e tests
 function prepare-e2e() {
   echo "Rackspace doesn't need special preparations for e2e tests"

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -343,11 +343,3 @@ function restart-apiserver {
 function prepare-e2e() {
   echo "Vagrant doesn't need special preparations for e2e tests" 1>&2
 }
-
-function setup-logging-firewall {
-  echo "TODO: setup logging"
-}
-
-function teardown-logging-firewall {
-  echo "TODO: teardown logging"
-}

--- a/cluster/vsphere/util.sh
+++ b/cluster/vsphere/util.sh
@@ -478,11 +478,3 @@ function test-setup {
 function test-teardown {
 	echo "TODO"
 }
-
-function setup-logging-firewall {
-  echo "TODO: setup logging"
-}
-
-function teardown-logging-firewall {
-  echo "TODO: teardown logging"
-}


### PR DESCRIPTION
Deletion is wonderful. The only weird thing was where to put the
message about the proxy URLs. These URLs are actually generic across
providers now, in theory, and the variables are fine to be consumed
outside just GCE (because in theory, all the cloud providers could
provide this now).

So it came down to validate-cluster.sh, or entirely new shell script.
I erred on the side of just jumping it in validate, and we can create
a new script if there are more announcements we need to make.
