### PR TITLE
Adds ability to define a prefix for etcd paths

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -51,6 +51,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/probe"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/service"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/wait"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/empty_dir"
@@ -160,7 +161,7 @@ func startComponents(firstManifestURL, secondManifestURL, apiVersion string) (st
 
 	cl := client.NewOrDie(&client.Config{Host: apiServer.URL, Version: apiVersion})
 
-	helper, err := master.NewEtcdHelper(etcdClient, "")
+	helper, err := master.NewEtcdHelper(etcdClient, "", etcdtest.PathPrefix())
 	if err != nil {
 		glog.Fatalf("Unable to get etcd helper: %v", err)
 	}

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -81,7 +81,7 @@ func (h *delegateHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func runApiServer(etcdClient tools.EtcdClient, addr net.IP, port int, masterServiceNamespace string) {
 	handler := delegateHandler{}
 
-	helper, err := master.NewEtcdHelper(etcdClient, "")
+	helper, err := master.NewEtcdHelper(etcdClient, "", master.DefaultEtcdPathPrefix)
 	if err != nil {
 		glog.Fatalf("Unable to get etcd helper: %v", err)
 	}

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -53,6 +53,9 @@ KUBE_RACE=${KUBE_RACE:-}   # use KUBE_RACE="-race" to enable race testing
 KUBE_GOVERALLS_BIN=${KUBE_GOVERALLS_BIN:-}
 # Comma separated list of API Versions that should be tested.
 KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1beta1,v1beta3"}
+# Prefixes for etcd paths (standard and customized)
+ETCD_STANDARD_PREFIX="registry"
+ETCD_CUSTOM_PREFIX="kubernetes.io/registry"
 
 kube::test::usage() {
   kube::log::usage_from_stdin <<EOF
@@ -203,10 +206,13 @@ reportCoverageToCoveralls() {
 
 # Convert the CSV to an array of API versions to test
 IFS=',' read -a apiVersions <<< "${KUBE_TEST_API_VERSIONS}"
+ETCD_PREFIX=${ETCD_STANDARD_PREFIX}
 for apiVersion in "${apiVersions[@]}"; do
   echo "Running tests for APIVersion: $apiVersion"
-  KUBE_API_VERSION="${apiVersion}" runTests "$@"
+  KUBE_API_VERSION="${apiVersion}" ETCD_PREFIX=${ETCD_STANDARD_PREFIX} runTests "$@"
 done
+echo "Using custom etcd path prefix: ${ETCD_CUSTOM_PREFIX}"
+KUBE_API_VERSION="${apiVersions[-1]}" ETCD_PREFIX=${ETCD_CUSTOM_PREFIX} runTests "$@"
 
 # We might run the tests for multiple versions, but we want to report only
 # one of them to coveralls. Here we report coverage from the last run.

--- a/pkg/api/rest/resttest/resttest.go
+++ b/pkg/api/rest/resttest/resttest.go
@@ -271,7 +271,6 @@ func (t *Tester) TestDeleteNoGraceful(createFn func() runtime.Object, wasGracefu
 	if err != nil {
 		t.Fatalf("object does not have ObjectMeta: %v\n%#v", err, existing)
 	}
-
 	ctx := api.WithNamespace(api.NewContext(), objectMeta.Namespace)
 	_, err = t.storage.(rest.GracefulDeleter).Delete(ctx, objectMeta.Name, api.NewDeleteOptions(10))
 	if err != nil {

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -71,6 +71,10 @@ import (
 	"github.com/golang/glog"
 )
 
+const (
+	DefaultEtcdPathPrefix = "/registry"
+)
+
 // Config is a structure used to configure a Master.
 type Config struct {
 	EtcdHelper        tools.EtcdHelper
@@ -178,7 +182,7 @@ type Master struct {
 
 // NewEtcdHelper returns an EtcdHelper for the provided arguments or an error if the version
 // is incorrect.
-func NewEtcdHelper(client tools.EtcdGetSet, version string) (helper tools.EtcdHelper, err error) {
+func NewEtcdHelper(client tools.EtcdGetSet, version string, prefix string) (helper tools.EtcdHelper, err error) {
 	if version == "" {
 		version = latest.Version
 	}
@@ -186,7 +190,7 @@ func NewEtcdHelper(client tools.EtcdGetSet, version string) (helper tools.EtcdHe
 	if err != nil {
 		return helper, err
 	}
-	return tools.NewEtcdHelper(client, versionInterfaces.Codec), nil
+	return tools.NewEtcdHelper(client, versionInterfaces.Codec, prefix), nil
 }
 
 // setDefaults fills in any fields not set that are required to have valid data.
@@ -363,7 +367,7 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 func (m *Master) init(c *Config) {
 	// TODO: make initialization of the helper part of the Master, and allow some storage
 	// objects to have a newer storage version than the user's default.
-	newerHelper, err := NewEtcdHelper(c.EtcdHelper.Client, "v1beta3")
+	newerHelper, err := NewEtcdHelper(c.EtcdHelper.Client, "v1beta3", DefaultEtcdPathPrefix)
 	if err != nil {
 		glog.Fatalf("Unable to setup storage for v1beta3: %v", err)
 	}

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 )
 
 func TestGetServersToValidate(t *testing.T) {
@@ -30,7 +31,7 @@ func TestGetServersToValidate(t *testing.T) {
 	config := Config{}
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.Machines = []string{"http://machine1:4001", "http://machine2", "http://machine3:4003"}
-	config.EtcdHelper = tools.EtcdHelper{fakeClient, latest.Codec, nil}
+	config.EtcdHelper = tools.EtcdHelper{fakeClient, latest.Codec, nil, etcdtest.PathPrefix()}
 
 	master.nodeRegistry = registrytest.NewMinionRegistry([]string{"node1", "node2"}, api.NodeResources{})
 

--- a/pkg/registry/controller/etcd/etcd.go
+++ b/pkg/registry/controller/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // controllerPrefix is the location for controllers in etcd, only exposed
 // for testing
-var controllerPrefix = "/registry/controllers"
+var controllerPrefix = "/controllers"
 
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(h tools.EtcdHelper) *REST {

--- a/pkg/registry/endpoint/etcd/etcd.go
+++ b/pkg/registry/endpoint/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewStorage returns a RESTStorage object that will work against endpoints.
 func NewStorage(h tools.EtcdHelper) *REST {
-	prefix := "/registry/services/endpoints"
+	prefix := "/services/endpoints"
 	return &REST{
 		&etcdgeneric.Etcd{
 			NewFunc:     func() runtime.Object { return &api.Endpoints{} },

--- a/pkg/registry/etcd/etcd.go
+++ b/pkg/registry/etcd/etcd.go
@@ -35,9 +35,9 @@ import (
 
 const (
 	// ControllerPath is the path to controller resources in etcd
-	ControllerPath string = "/registry/controllers"
+	ControllerPath string = "/controllers"
 	// ServicePath is the path to service resources in etcd
-	ServicePath string = "/registry/services/specs"
+	ServicePath string = "/services/specs"
 )
 
 // TODO: Need to add a reconciler loop that makes sure that things in pods are reflected into

--- a/pkg/registry/event/registry.go
+++ b/pkg/registry/event/registry.go
@@ -32,16 +32,17 @@ type registry struct {
 // NewEtcdRegistry returns a registry which will store Events in the given
 // EtcdHelper. ttl is the time that Events will be retained by the system.
 func NewEtcdRegistry(h tools.EtcdHelper, ttl uint64) generic.Registry {
+	prefix := "/events"
 	return registry{
 		Etcd: &etcdgeneric.Etcd{
 			NewFunc:      func() runtime.Object { return &api.Event{} },
 			NewListFunc:  func() runtime.Object { return &api.EventList{} },
 			EndpointName: "events",
 			KeyRootFunc: func(ctx api.Context) string {
-				return etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/events")
+				return etcdgeneric.NamespaceKeyRootFunc(ctx, prefix)
 			},
 			KeyFunc: func(ctx api.Context, id string) (string, error) {
-				return etcdgeneric.NamespaceKeyFunc(ctx, "/registry/events", id)
+				return etcdgeneric.NamespaceKeyFunc(ctx, prefix, id)
 			},
 			TTLFunc: func(runtime.Object, bool) (uint64, error) {
 				return ttl, nil

--- a/pkg/registry/event/registry_test.go
+++ b/pkg/registry/event/registry_test.go
@@ -27,6 +27,7 @@ import (
 	etcdgeneric "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/coreos/go-etcd/etcd"
@@ -37,7 +38,8 @@ var testTTL uint64 = 60
 func NewTestEventEtcdRegistry(t *testing.T) (*tools.FakeEtcdClient, generic.Registry) {
 	f := tools.NewFakeEtcdClient(t)
 	f.TestIndex = true
-	h := tools.NewEtcdHelper(f, testapi.Codec())
+
+	h := tools.NewEtcdHelper(f, testapi.Codec(), etcdtest.PathPrefix())
 	return f, NewEtcdRegistry(h, testTTL)
 }
 
@@ -70,7 +72,8 @@ func TestEventCreate(t *testing.T) {
 
 	ctx := api.NewDefaultContext()
 	key := "foo"
-	path, err := etcdgeneric.NamespaceKeyFunc(ctx, "/registry/events", key)
+	path, err := etcdgeneric.NamespaceKeyFunc(ctx, "/events", key)
+	path = etcdtest.AddPrefix(path)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -166,7 +169,8 @@ func TestEventUpdate(t *testing.T) {
 
 	ctx := api.NewDefaultContext()
 	key := "foo"
-	path, err := etcdgeneric.NamespaceKeyFunc(ctx, "/registry/events", key)
+	path, err := etcdgeneric.NamespaceKeyFunc(ctx, "/events", key)
+	path = etcdtest.AddPrefix(path)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/pkg/registry/limitrange/registry.go
+++ b/pkg/registry/limitrange/registry.go
@@ -31,16 +31,17 @@ type registry struct {
 
 // NewEtcdRegistry returns a registry which will store LimitRange in the given helper
 func NewEtcdRegistry(h tools.EtcdHelper) generic.Registry {
+	prefix := "/limitranges"
 	return registry{
 		Etcd: &etcdgeneric.Etcd{
 			NewFunc:      func() runtime.Object { return &api.LimitRange{} },
 			NewListFunc:  func() runtime.Object { return &api.LimitRangeList{} },
 			EndpointName: "limitranges",
 			KeyRootFunc: func(ctx api.Context) string {
-				return etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/limitranges")
+				return etcdgeneric.NamespaceKeyRootFunc(ctx, prefix)
 			},
 			KeyFunc: func(ctx api.Context, id string) (string, error) {
-				return etcdgeneric.NamespaceKeyFunc(ctx, "/registry/limitranges", id)
+				return etcdgeneric.NamespaceKeyFunc(ctx, prefix, id)
 			},
 			Helper: h,
 		},

--- a/pkg/registry/limitrange/registry_test.go
+++ b/pkg/registry/limitrange/registry_test.go
@@ -28,6 +28,7 @@ import (
 	etcdgeneric "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/coreos/go-etcd/etcd"
@@ -36,7 +37,7 @@ import (
 func NewTestLimitRangeEtcdRegistry(t *testing.T) (*tools.FakeEtcdClient, generic.Registry) {
 	f := tools.NewFakeEtcdClient(t)
 	f.TestIndex = true
-	h := tools.NewEtcdHelper(f, testapi.Codec())
+	h := tools.NewEtcdHelper(f, testapi.Codec(), etcdtest.PathPrefix())
 	return f, NewEtcdRegistry(h)
 }
 
@@ -81,7 +82,9 @@ func TestLimitRangeCreate(t *testing.T) {
 
 	ctx := api.NewDefaultContext()
 	key := "foo"
-	path, err := etcdgeneric.NamespaceKeyFunc(ctx, "/registry/limitranges", key)
+	prefix := etcdtest.AddPrefix("limitranges")
+
+	path, err := etcdgeneric.NamespaceKeyFunc(ctx, prefix, key)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/pkg/registry/minion/etcd/etcd.go
+++ b/pkg/registry/minion/etcd/etcd.go
@@ -50,7 +50,7 @@ func (r *StatusREST) Update(ctx api.Context, obj runtime.Object) (runtime.Object
 
 // NewStorage returns a RESTStorage object that will work against nodes.
 func NewStorage(h tools.EtcdHelper, connection client.ConnectionInfoGetter) (*REST, *StatusREST) {
-	prefix := "/registry/minions"
+	prefix := "/minions"
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.Node{} },
 		NewListFunc: func() runtime.Object { return &api.NodeList{} },

--- a/pkg/registry/minion/etcd/etcd_test.go
+++ b/pkg/registry/minion/etcd/etcd_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 
 	"github.com/coreos/go-etcd/etcd"
 )
@@ -49,7 +50,7 @@ func (fakeConnectionInfoGetter) GetConnectionInfo(host string) (string, uint, ht
 func newHelper(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper) {
 	fakeEtcdClient := tools.NewFakeEtcdClient(t)
 	fakeEtcdClient.TestIndex = true
-	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec)
+	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec, etcdtest.PathPrefix())
 	return fakeEtcdClient, helper
 }
 
@@ -107,6 +108,7 @@ func TestDelete(t *testing.T) {
 
 	node := validChangedNode()
 	key, _ := storage.KeyFunc(ctx, node.Name)
+	key = etcdtest.AddPrefix(key)
 	createFn := func() runtime.Object {
 		fakeEtcdClient.Data[key] = tools.EtcdResponseWithError{
 			R: &etcd.Response{
@@ -131,6 +133,7 @@ func TestEtcdListNodes(t *testing.T) {
 	ctx := api.NewContext()
 	storage, fakeClient := newStorage(t)
 	key := storage.KeyRootFunc(ctx)
+	key = etcdtest.AddPrefix(key)
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
@@ -165,6 +168,7 @@ func TestEtcdListNodesMatch(t *testing.T) {
 	ctx := api.NewContext()
 	storage, fakeClient := newStorage(t)
 	key := storage.KeyRootFunc(ctx)
+	key = etcdtest.AddPrefix(key)
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
@@ -209,6 +213,7 @@ func TestEtcdGetNode(t *testing.T) {
 	storage, fakeClient := newStorage(t)
 	node := validNewNode()
 	key, _ := storage.KeyFunc(ctx, node.Name)
+	key = etcdtest.AddPrefix(key)
 
 	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, node), 0)
 	nodeObj, err := storage.Get(ctx, node.Name)
@@ -229,6 +234,7 @@ func TestEtcdUpdateEndpoints(t *testing.T) {
 	node := validChangedNode()
 
 	key, _ := storage.KeyFunc(ctx, node.Name)
+	key = etcdtest.AddPrefix(key)
 	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, validNewNode()), 0)
 
 	_, _, err := storage.Update(ctx, node)
@@ -255,7 +261,8 @@ func TestEtcdUpdateEndpoints(t *testing.T) {
 func TestEtcdGetNodeNotFound(t *testing.T) {
 	ctx := api.NewContext()
 	storage, fakeClient := newStorage(t)
-	fakeClient.Data["/registry/minions/foo"] = tools.EtcdResponseWithError{
+	key := etcdtest.AddPrefix("minions/foo")
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
 		},
@@ -273,6 +280,7 @@ func TestEtcdDeleteNode(t *testing.T) {
 	storage, fakeClient := newStorage(t)
 	node := validNewNode()
 	key, _ := storage.KeyFunc(ctx, node.Name)
+	key = etcdtest.AddPrefix(key)
 	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, node), 0)
 	_, err := storage.Delete(ctx, node.Name, nil)
 	if err != nil {

--- a/pkg/registry/namespace/etcd/etcd.go
+++ b/pkg/registry/namespace/etcd/etcd.go
@@ -18,6 +18,7 @@ package etcd
 
 import (
 	"fmt"
+	"path"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
@@ -48,14 +49,15 @@ type FinalizeREST struct {
 
 // NewStorage returns a RESTStorage object that will work against namespaces
 func NewStorage(h tools.EtcdHelper) (*REST, *StatusREST, *FinalizeREST) {
+	prefix := "/namespaces"
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.Namespace{} },
 		NewListFunc: func() runtime.Object { return &api.NamespaceList{} },
 		KeyRootFunc: func(ctx api.Context) string {
-			return "/registry/namespaces"
+			return prefix
 		},
 		KeyFunc: func(ctx api.Context, name string) (string, error) {
-			return "/registry/namespaces/" + name, nil
+			return path.Join(prefix, name), nil
 		},
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*api.Namespace).Name, nil

--- a/pkg/registry/namespace/etcd/etcd_test.go
+++ b/pkg/registry/namespace/etcd/etcd_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/namespace"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/coreos/go-etcd/etcd"
@@ -35,7 +36,7 @@ import (
 func newHelper(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper) {
 	fakeEtcdClient := tools.NewFakeEtcdClient(t)
 	fakeEtcdClient.TestIndex = true
-	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec)
+	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec, etcdtest.PathPrefix())
 	return fakeEtcdClient, helper
 }
 
@@ -102,7 +103,12 @@ func TestCreateSetsFields(t *testing.T) {
 	}
 
 	actual := &api.Namespace{}
-	if err := helper.ExtractObj("/registry/namespaces/foo", actual, false); err != nil {
+	ctx := api.NewDefaultContext()
+	key, err := storage.Etcd.KeyFunc(ctx, "foo")
+	if err != nil {
+		t.Fatalf("unexpected key error: %v", err)
+	}
+	if err := helper.ExtractObj(key, actual, false); err != nil {
 		t.Fatalf("unexpected extraction error: %v", err)
 	}
 	if actual.Name != namespace.Name {
@@ -119,7 +125,8 @@ func TestCreateSetsFields(t *testing.T) {
 func TestListEmptyNamespaceList(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
 	fakeEtcdClient.ChangeIndex = 1
-	fakeEtcdClient.Data["/registry/namespaces"] = tools.EtcdResponseWithError{
+	key := etcdtest.AddPrefix("/namespaces")
+	fakeEtcdClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
 		E: fakeEtcdClient.NewError(tools.EtcdErrorCodeNotFound),
 	}
@@ -139,7 +146,8 @@ func TestListEmptyNamespaceList(t *testing.T) {
 
 func TestListNamespaceList(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
-	fakeEtcdClient.Data["/registry/namespaces"] = tools.EtcdResponseWithError{
+	key := etcdtest.AddPrefix("/namespaces")
+	fakeEtcdClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
@@ -177,7 +185,8 @@ func TestListNamespaceList(t *testing.T) {
 
 func TestListNamespaceListSelection(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
-	fakeEtcdClient.Data["/registry/namespaces"] = tools.EtcdResponseWithError{
+	key := etcdtest.AddPrefix("/namespaces")
+	fakeEtcdClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
@@ -275,15 +284,20 @@ func TestNamespaceDecode(t *testing.T) {
 func TestGet(t *testing.T) {
 	expect := validNewNamespace()
 	expect.Status.Phase = api.NamespaceActive
-	fakeEtcdClient, helper := newHelper(t)
-	fakeEtcdClient.Data["/registry/namespaces/foo"] = tools.EtcdResponseWithError{
+	storage, fakeEtcdClient, _ := newStorage(t)
+	ctx := api.NewDefaultContext()
+	key, err := storage.Etcd.KeyFunc(ctx, "foo")
+	key = etcdtest.AddPrefix(key)
+	if err != nil {
+		t.Fatalf("unexpected key error: %v", err)
+	}
+	fakeEtcdClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
 				Value: runtime.EncodeOrDie(latest.Codec, expect),
 			},
 		},
 	}
-	storage, _, _ := NewStorage(helper)
 	obj, err := storage.Get(api.NewContext(), "foo")
 	namespace := obj.(*api.Namespace)
 	if err != nil {
@@ -299,7 +313,11 @@ func TestGet(t *testing.T) {
 func TestDeleteNamespace(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
 	fakeEtcdClient.ChangeIndex = 1
-	fakeEtcdClient.Data["/registry/namespaces/foo"] = tools.EtcdResponseWithError{
+	storage, _, _ := NewStorage(helper)
+	ctx := api.NewDefaultContext()
+	key, err := storage.Etcd.KeyFunc(ctx, "foo")
+	key = etcdtest.AddPrefix(key)
+	fakeEtcdClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
 				Value: runtime.EncodeOrDie(latest.Codec, &api.Namespace{
@@ -313,8 +331,7 @@ func TestDeleteNamespace(t *testing.T) {
 			},
 		},
 	}
-	storage, _, _ := NewStorage(helper)
-	_, err := storage.Delete(api.NewDefaultContext(), "foo", nil)
+	_, err = storage.Delete(api.NewDefaultContext(), "foo", nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -325,7 +342,8 @@ func TestDeleteNamespaceWithIncompleteFinalizers(t *testing.T) {
 	now := util.Now()
 	fakeEtcdClient, helper := newHelper(t)
 	fakeEtcdClient.ChangeIndex = 1
-	fakeEtcdClient.Data["/registry/namespaces/foo"] = tools.EtcdResponseWithError{
+	key := etcdtest.AddPrefix("/namespaces/foo")
+	fakeEtcdClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
 				Value: runtime.EncodeOrDie(latest.Codec, &api.Namespace{
@@ -354,7 +372,8 @@ func TestDeleteNamespaceWithCompleteFinalizers(t *testing.T) {
 	now := util.Now()
 	fakeEtcdClient, helper := newHelper(t)
 	fakeEtcdClient.ChangeIndex = 1
-	fakeEtcdClient.Data["/registry/namespaces/foo"] = tools.EtcdResponseWithError{
+	key := etcdtest.AddPrefix("/namespaces/foo")
+	fakeEtcdClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
 				Value: runtime.EncodeOrDie(latest.Codec, &api.Namespace{

--- a/pkg/registry/persistentvolume/etcd/etcd.go
+++ b/pkg/registry/persistentvolume/etcd/etcd.go
@@ -17,6 +17,8 @@ limitations under the License.
 package etcd
 
 import (
+	"path"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
@@ -34,7 +36,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against PersistentVolume objects.
 func NewStorage(h tools.EtcdHelper) (*REST, *StatusREST) {
-	prefix := "/registry/persistentvolumes"
+	prefix := "/persistentvolumes"
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.PersistentVolume{} },
 		NewListFunc: func() runtime.Object { return &api.PersistentVolumeList{} },
@@ -42,7 +44,7 @@ func NewStorage(h tools.EtcdHelper) (*REST, *StatusREST) {
 			return prefix
 		},
 		KeyFunc: func(ctx api.Context, name string) (string, error) {
-			return prefix + "/" + name, nil
+			return path.Join(prefix, name), nil
 		},
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*api.PersistentVolume).Name, nil

--- a/pkg/registry/persistentvolumeclaim/etcd/etcd.go
+++ b/pkg/registry/persistentvolumeclaim/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against PersistentVolumeClaim objects.
 func NewStorage(h tools.EtcdHelper) (*REST, *StatusREST) {
-	prefix := "/registry/persistentvolumeclaims"
+	prefix := "/persistentvolumeclaims"
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.PersistentVolumeClaim{} },
 		NewListFunc: func() runtime.Object { return &api.PersistentVolumeClaimList{} },

--- a/pkg/registry/pod/etcd/etcd.go
+++ b/pkg/registry/pod/etcd/etcd.go
@@ -56,7 +56,7 @@ type REST struct {
 
 // NewStorage returns a RESTStorage object that will work against pods.
 func NewStorage(h tools.EtcdHelper, k client.ConnectionInfoGetter) PodStorage {
-	prefix := "/registry/pods"
+	prefix := "/pods"
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.Pod{} },
 		NewListFunc: func() runtime.Object { return &api.PodList{} },

--- a/pkg/registry/podtemplate/etcd/etcd.go
+++ b/pkg/registry/podtemplate/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against pod templates.
 func NewREST(h tools.EtcdHelper) *REST {
-	prefix := "/registry/podtemplates"
+	prefix := "/podtemplates"
 	store := etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.PodTemplate{} },
 		NewListFunc: func() runtime.Object { return &api.PodTemplateList{} },

--- a/pkg/registry/podtemplate/etcd/etcd_test.go
+++ b/pkg/registry/podtemplate/etcd/etcd_test.go
@@ -23,12 +23,13 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest/resttest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 )
 
 func newHelper(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper) {
 	fakeEtcdClient := tools.NewFakeEtcdClient(t)
 	fakeEtcdClient.TestIndex = true
-	helper := tools.NewEtcdHelper(fakeEtcdClient, v1beta3.Codec)
+	helper := tools.NewEtcdHelper(fakeEtcdClient, v1beta3.Codec, etcdtest.PathPrefix())
 	return fakeEtcdClient, helper
 }
 
@@ -79,8 +80,9 @@ func TestUpdate(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
 	storage := NewREST(helper)
 	test := resttest.New(t, storage, fakeEtcdClient.SetError)
+	key := etcdtest.AddPrefix("podtemplates/default/foo")
 
-	fakeEtcdClient.ExpectNotFoundGet("/registry/podtemplates/default/foo")
+	fakeEtcdClient.ExpectNotFoundGet(key)
 	fakeEtcdClient.ChangeIndex = 2
 	pod := validNewPodTemplate("foo")
 	existing := validNewPodTemplate("exists")

--- a/pkg/registry/resourcequota/etcd/etcd.go
+++ b/pkg/registry/resourcequota/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewStorage returns a RESTStorage object that will work against ResourceQuota objects.
 func NewStorage(h tools.EtcdHelper) (*REST, *StatusREST) {
-	prefix := "/registry/resourcequotas"
+	prefix := "/resourcequotas"
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.ResourceQuota{} },
 		NewListFunc: func() runtime.Object { return &api.ResourceQuotaList{} },

--- a/pkg/registry/secret/registry.go
+++ b/pkg/registry/secret/registry.go
@@ -31,16 +31,17 @@ type registry struct {
 
 // NewEtcdRegistry returns a registry which will store Secret in the given helper
 func NewEtcdRegistry(h tools.EtcdHelper) generic.Registry {
+	prefix := "/secrets"
 	return registry{
 		Etcd: &etcdgeneric.Etcd{
 			NewFunc:      func() runtime.Object { return &api.Secret{} },
 			NewListFunc:  func() runtime.Object { return &api.SecretList{} },
 			EndpointName: "secrets",
 			KeyRootFunc: func(ctx api.Context) string {
-				return etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/secrets")
+				return etcdgeneric.NamespaceKeyRootFunc(ctx, prefix)
 			},
 			KeyFunc: func(ctx api.Context, id string) (string, error) {
-				return etcdgeneric.NamespaceKeyFunc(ctx, "/registry/secrets", id)
+				return etcdgeneric.NamespaceKeyFunc(ctx, prefix, id)
 			},
 			Helper: h,
 		},

--- a/pkg/registry/secret/registry_test.go
+++ b/pkg/registry/secret/registry_test.go
@@ -27,6 +27,7 @@ import (
 	etcdgeneric "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/coreos/go-etcd/etcd"
@@ -35,7 +36,7 @@ import (
 func NewTestSecretEtcdRegistry(t *testing.T) (*tools.FakeEtcdClient, generic.Registry) {
 	f := tools.NewFakeEtcdClient(t)
 	f.TestIndex = true
-	h := tools.NewEtcdHelper(f, testapi.Codec())
+	h := tools.NewEtcdHelper(f, testapi.Codec(), etcdtest.PathPrefix())
 	return f, NewEtcdRegistry(h)
 }
 
@@ -65,10 +66,11 @@ func TestSecretCreate(t *testing.T) {
 		R: &etcd.Response{},
 		E: tools.EtcdErrorNotFound,
 	}
-
 	ctx := api.NewDefaultContext()
 	key := "foo"
-	path, err := etcdgeneric.NamespaceKeyFunc(ctx, "/registry/secrets", key)
+	path, err := etcdgeneric.NamespaceKeyFunc(ctx, "/secrets", key)
+	path = etcdtest.AddPrefix(path)
+
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/pkg/tools/etcd_helper.go
+++ b/pkg/tools/etcd_helper.go
@@ -23,7 +23,9 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os/exec"
+	"path"
 	"reflect"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
@@ -38,15 +40,18 @@ type EtcdHelper struct {
 	Codec  runtime.Codec
 	// optional, no atomic operations can be performed without this interface
 	Versioner EtcdVersioner
+	// prefix for all etcd keys
+	PathPrefix string
 }
 
 // NewEtcdHelper creates a helper that works against objects that use the internal
 // Kubernetes API objects.
-func NewEtcdHelper(client EtcdGetSet, codec runtime.Codec) EtcdHelper {
+func NewEtcdHelper(client EtcdGetSet, codec runtime.Codec, prefix string) EtcdHelper {
 	return EtcdHelper{
-		Client:    client,
-		Codec:     codec,
-		Versioner: APIObjectVersioner{},
+		Client:     client,
+		Codec:      codec,
+		Versioner:  APIObjectVersioner{},
+		PathPrefix: prefix,
 	}
 }
 
@@ -136,6 +141,7 @@ func (h *EtcdHelper) ExtractToList(key string, listObj runtime.Object) error {
 	if err != nil {
 		return err
 	}
+	key = h.PrefixEtcdKey(key)
 	nodes, index, err := h.listEtcdNode(key)
 	if err != nil {
 		return err
@@ -158,7 +164,7 @@ func (h *EtcdHelper) ExtractObjToList(key string, listObj runtime.Object) error 
 	if err != nil {
 		return err
 	}
-
+	key = h.PrefixEtcdKey(key)
 	response, err := h.Client.Get(key, false, false)
 	if err != nil {
 		if IsEtcdNotFound(err) {
@@ -185,6 +191,7 @@ func (h *EtcdHelper) ExtractObjToList(key string, listObj runtime.Object) error 
 // a zero object of the requested type, or an error, depending on ignoreNotFound. Treats
 // empty responses and nil response nodes exactly like a not found error.
 func (h *EtcdHelper) ExtractObj(key string, objPtr runtime.Object, ignoreNotFound bool) error {
+	key = h.PrefixEtcdKey(key)
 	_, _, err := h.bodyAndExtractObj(key, objPtr, ignoreNotFound)
 	return err
 }
@@ -233,6 +240,7 @@ func (h *EtcdHelper) extractObj(response *etcd.Response, inErr error, objPtr run
 // and 0 means forever. If no error is returned and out is not nil, out will be set to the read value
 // from etcd.
 func (h *EtcdHelper) CreateObj(key string, obj, out runtime.Object, ttl uint64) error {
+	key = h.PrefixEtcdKey(key)
 	data, err := h.Codec.Encode(obj)
 	if err != nil {
 		return err
@@ -242,6 +250,7 @@ func (h *EtcdHelper) CreateObj(key string, obj, out runtime.Object, ttl uint64) 
 			return errors.New("resourceVersion may not be set on objects to be created")
 		}
 	}
+
 	response, err := h.Client.Create(key, string(data), ttl)
 	if err != nil {
 		return err
@@ -257,15 +266,18 @@ func (h *EtcdHelper) CreateObj(key string, obj, out runtime.Object, ttl uint64) 
 
 // Delete removes the specified key.
 func (h *EtcdHelper) Delete(key string, recursive bool) error {
+	key = h.PrefixEtcdKey(key)
 	_, err := h.Client.Delete(key, recursive)
 	return err
 }
 
 // DeleteObj removes the specified key and returns the value that existed at that spot.
 func (h *EtcdHelper) DeleteObj(key string, out runtime.Object) error {
+	key = h.PrefixEtcdKey(key)
 	if _, err := conversion.EnforcePtr(out); err != nil {
 		panic("unable to convert output object to pointer")
 	}
+
 	response, err := h.Client.Delete(key, false)
 	if !IsEtcdNotFound(err) {
 		// if the object that existed prior to the delete is returned by etcd, update out.
@@ -285,6 +297,7 @@ func (h *EtcdHelper) SetObj(key string, obj, out runtime.Object, ttl uint64) err
 	if err != nil {
 		return err
 	}
+	key = h.PrefixEtcdKey(key)
 
 	create := true
 	if h.Versioner != nil {
@@ -346,6 +359,7 @@ func (h *EtcdHelper) GuaranteedUpdate(key string, ptrToType runtime.Object, igno
 		// Panic is appropriate, because this is a programming error.
 		panic("need ptr to type")
 	}
+	key = h.PrefixEtcdKey(key)
 	for {
 		obj := reflect.New(v.Type()).Interface().(runtime.Object)
 		origBody, index, err := h.bodyAndExtractObj(key, obj, ignoreNotFound)
@@ -384,6 +398,13 @@ func (h *EtcdHelper) GuaranteedUpdate(key string, ptrToType runtime.Object, igno
 		_, _, err = h.extractObj(response, err, ptrToType, false, false)
 		return err
 	}
+}
+
+func (h *EtcdHelper) PrefixEtcdKey(key string) string {
+	if strings.HasPrefix(key, path.Join("/", h.PathPrefix)) {
+		return key
+	}
+	return path.Join("/", h.PathPrefix, key)
 }
 
 // GetEtcdVersion performs a version check against the provided Etcd server, returning a triplet

--- a/pkg/tools/etcd_helper_test.go
+++ b/pkg/tools/etcd_helper_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"reflect"
 	"sync"
 	"testing"
@@ -29,6 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/stretchr/testify/assert"
 )
@@ -79,7 +81,9 @@ func getEncodedPod(name string) string {
 
 func TestExtractToList(t *testing.T) {
 	fakeClient := NewFakeEtcdClient(t)
-	fakeClient.Data["/some/key"] = EtcdResponseWithError{
+	helper := NewEtcdHelper(fakeClient, testapi.Codec(), etcdtest.PathPrefix())
+	key := etcdtest.AddPrefix("/some/key")
+	fakeClient.Data[key] = EtcdResponseWithError{
 		R: &etcd.Response{
 			EtcdIndex: 10,
 			Node: &etcd.Node{
@@ -135,7 +139,6 @@ func TestExtractToList(t *testing.T) {
 	}
 
 	var got api.PodList
-	helper := NewEtcdHelper(fakeClient, testapi.Codec())
 	err := helper.ExtractToList("/some/key", &got)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
@@ -148,7 +151,9 @@ func TestExtractToList(t *testing.T) {
 // TestExtractToListAcrossDirectories ensures that the client excludes directories and flattens tree-response - simulates cross-namespace query
 func TestExtractToListAcrossDirectories(t *testing.T) {
 	fakeClient := NewFakeEtcdClient(t)
-	fakeClient.Data["/some/key"] = EtcdResponseWithError{
+	helper := NewEtcdHelper(fakeClient, testapi.Codec(), etcdtest.PathPrefix())
+	key := etcdtest.AddPrefix("/some/key")
+	fakeClient.Data[key] = EtcdResponseWithError{
 		R: &etcd.Response{
 			EtcdIndex: 10,
 			Node: &etcd.Node{
@@ -218,7 +223,6 @@ func TestExtractToListAcrossDirectories(t *testing.T) {
 	}
 
 	var got api.PodList
-	helper := NewEtcdHelper(fakeClient, testapi.Codec())
 	err := helper.ExtractToList("/some/key", &got)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
@@ -230,7 +234,9 @@ func TestExtractToListAcrossDirectories(t *testing.T) {
 
 func TestExtractToListExcludesDirectories(t *testing.T) {
 	fakeClient := NewFakeEtcdClient(t)
-	fakeClient.Data["/some/key"] = EtcdResponseWithError{
+	helper := NewEtcdHelper(fakeClient, testapi.Codec(), etcdtest.PathPrefix())
+	key := etcdtest.AddPrefix("/some/key")
+	fakeClient.Data[key] = EtcdResponseWithError{
 		R: &etcd.Response{
 			EtcdIndex: 10,
 			Node: &etcd.Node{
@@ -288,7 +294,6 @@ func TestExtractToListExcludesDirectories(t *testing.T) {
 	}
 
 	var got api.PodList
-	helper := NewEtcdHelper(fakeClient, testapi.Codec())
 	err := helper.ExtractToList("/some/key", &got)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
@@ -300,6 +305,8 @@ func TestExtractToListExcludesDirectories(t *testing.T) {
 
 func TestExtractObj(t *testing.T) {
 	fakeClient := NewFakeEtcdClient(t)
+	helper := NewEtcdHelper(fakeClient, testapi.Codec(), etcdtest.PathPrefix())
+	key := etcdtest.AddPrefix("/some/key")
 	expect := api.Pod{
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 		Spec: api.PodSpec{
@@ -307,8 +314,7 @@ func TestExtractObj(t *testing.T) {
 			DNSPolicy:     api.DNSClusterFirst,
 		},
 	}
-	fakeClient.Set("/some/key", runtime.EncodeOrDie(testapi.Codec(), &expect), 0)
-	helper := NewEtcdHelper(fakeClient, testapi.Codec())
+	fakeClient.Set(key, runtime.EncodeOrDie(testapi.Codec(), &expect), 0)
 	var got api.Pod
 	err := helper.ExtractObj("/some/key", &got, false)
 	if err != nil {
@@ -321,7 +327,9 @@ func TestExtractObj(t *testing.T) {
 
 func TestExtractObjNotFoundErr(t *testing.T) {
 	fakeClient := NewFakeEtcdClient(t)
-	fakeClient.Data["/some/key"] = EtcdResponseWithError{
+	helper := NewEtcdHelper(fakeClient, testapi.Codec(), etcdtest.PathPrefix())
+	key1 := etcdtest.AddPrefix("/some/key")
+	fakeClient.Data[key1] = EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
 		},
@@ -329,19 +337,20 @@ func TestExtractObjNotFoundErr(t *testing.T) {
 			ErrorCode: 100,
 		},
 	}
-	fakeClient.Data["/some/key2"] = EtcdResponseWithError{
+	key2 := etcdtest.AddPrefix("/some/key2")
+	fakeClient.Data[key2] = EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: nil,
 		},
 	}
-	fakeClient.Data["/some/key3"] = EtcdResponseWithError{
+	key3 := etcdtest.AddPrefix("/some/key3")
+	fakeClient.Data[key3] = EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
 				Value: "",
 			},
 		},
 	}
-	helper := NewEtcdHelper(fakeClient, codec)
 	try := func(key string) {
 		var got api.Pod
 		err := helper.ExtractObj(key, &got, false)
@@ -362,7 +371,7 @@ func TestExtractObjNotFoundErr(t *testing.T) {
 func TestCreateObj(t *testing.T) {
 	obj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
 	fakeClient := NewFakeEtcdClient(t)
-	helper := NewEtcdHelper(fakeClient, testapi.Codec())
+	helper := NewEtcdHelper(fakeClient, testapi.Codec(), etcdtest.PathPrefix())
 	returnedObj := &api.Pod{}
 	err := helper.CreateObj("/some/key", obj, returnedObj, 5)
 	if err != nil {
@@ -372,7 +381,8 @@ func TestCreateObj(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error %#v", err)
 	}
-	node := fakeClient.Data["/some/key"].R.Node
+	key := etcdtest.AddPrefix("/some/key")
+	node := fakeClient.Data[key].R.Node
 	if e, a := string(data), node.Value; e != a {
 		t.Errorf("Wanted %v, got %v", e, a)
 	}
@@ -387,7 +397,7 @@ func TestCreateObj(t *testing.T) {
 func TestCreateObjNilOutParam(t *testing.T) {
 	obj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
 	fakeClient := NewFakeEtcdClient(t)
-	helper := NewEtcdHelper(fakeClient, testapi.Codec())
+	helper := NewEtcdHelper(fakeClient, testapi.Codec(), etcdtest.PathPrefix())
 	err := helper.CreateObj("/some/key", obj, nil, 5)
 	if err != nil {
 		t.Errorf("Unexpected error %#v", err)
@@ -397,7 +407,7 @@ func TestCreateObjNilOutParam(t *testing.T) {
 func TestSetObj(t *testing.T) {
 	obj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
 	fakeClient := NewFakeEtcdClient(t)
-	helper := NewEtcdHelper(fakeClient, testapi.Codec())
+	helper := NewEtcdHelper(fakeClient, testapi.Codec(), etcdtest.PathPrefix())
 	returnedObj := &api.Pod{}
 	err := helper.SetObj("/some/key", obj, returnedObj, 5)
 	if err != nil {
@@ -408,7 +418,8 @@ func TestSetObj(t *testing.T) {
 		t.Errorf("Unexpected error %#v", err)
 	}
 	expect := string(data)
-	got := fakeClient.Data["/some/key"].R.Node.Value
+	key := etcdtest.AddPrefix("/some/key")
+	got := fakeClient.Data[key].R.Node.Value
 	if expect != got {
 		t.Errorf("Wanted %v, got %v", expect, got)
 	}
@@ -424,7 +435,7 @@ func TestSetObjFailCAS(t *testing.T) {
 	obj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"}}
 	fakeClient := NewFakeEtcdClient(t)
 	fakeClient.CasErr = fakeClient.NewError(123)
-	helper := NewEtcdHelper(fakeClient, testapi.Codec())
+	helper := NewEtcdHelper(fakeClient, testapi.Codec(), etcdtest.PathPrefix())
 	err := helper.SetObj("/some/key", obj, nil, 5)
 	if err == nil {
 		t.Errorf("Expecting error.")
@@ -435,7 +446,9 @@ func TestSetObjWithVersion(t *testing.T) {
 	obj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"}}
 	fakeClient := NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
-	fakeClient.Data["/some/key"] = EtcdResponseWithError{
+	helper := NewEtcdHelper(fakeClient, testapi.Codec(), etcdtest.PathPrefix())
+	key := etcdtest.AddPrefix("/some/key")
+	fakeClient.Data[key] = EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
 				Value:         runtime.EncodeOrDie(testapi.Codec(), obj),
@@ -444,7 +457,6 @@ func TestSetObjWithVersion(t *testing.T) {
 		},
 	}
 
-	helper := NewEtcdHelper(fakeClient, testapi.Codec())
 	returnedObj := &api.Pod{}
 	err := helper.SetObj("/some/key", obj, returnedObj, 7)
 	if err != nil {
@@ -455,7 +467,7 @@ func TestSetObjWithVersion(t *testing.T) {
 		t.Fatalf("Unexpected error %#v", err)
 	}
 	expect := string(data)
-	got := fakeClient.Data["/some/key"].R.Node.Value
+	got := fakeClient.Data[key].R.Node.Value
 	if expect != got {
 		t.Errorf("Wanted %v, got %v", expect, got)
 	}
@@ -470,9 +482,10 @@ func TestSetObjWithVersion(t *testing.T) {
 func TestSetObjWithoutResourceVersioner(t *testing.T) {
 	obj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
 	fakeClient := NewFakeEtcdClient(t)
-	helper := EtcdHelper{fakeClient, testapi.Codec(), nil}
+	helper := EtcdHelper{fakeClient, testapi.Codec(), nil, etcdtest.PathPrefix()}
 	returnedObj := &api.Pod{}
 	err := helper.SetObj("/some/key", obj, returnedObj, 3)
+	key := etcdtest.AddPrefix("/some/key")
 	if err != nil {
 		t.Errorf("Unexpected error %#v", err)
 	}
@@ -481,7 +494,7 @@ func TestSetObjWithoutResourceVersioner(t *testing.T) {
 		t.Errorf("Unexpected error %#v", err)
 	}
 	expect := string(data)
-	got := fakeClient.Data["/some/key"].R.Node.Value
+	got := fakeClient.Data[key].R.Node.Value
 	if expect != got {
 		t.Errorf("Wanted %v, got %v", expect, got)
 	}
@@ -496,7 +509,7 @@ func TestSetObjWithoutResourceVersioner(t *testing.T) {
 func TestSetObjNilOutParam(t *testing.T) {
 	obj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
 	fakeClient := NewFakeEtcdClient(t)
-	helper := EtcdHelper{fakeClient, testapi.Codec(), nil}
+	helper := EtcdHelper{fakeClient, testapi.Codec(), nil, etcdtest.PathPrefix()}
 	err := helper.SetObj("/some/key", obj, nil, 3)
 	if err != nil {
 		t.Errorf("Unexpected error %#v", err)
@@ -506,10 +519,11 @@ func TestSetObjNilOutParam(t *testing.T) {
 func TestGuaranteedUpdate(t *testing.T) {
 	fakeClient := NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
-	helper := NewEtcdHelper(fakeClient, codec)
+	helper := NewEtcdHelper(fakeClient, codec, etcdtest.PathPrefix())
+	key := etcdtest.AddPrefix("/some/key")
 
 	// Create a new node.
-	fakeClient.ExpectNotFoundGet("/some/key")
+	fakeClient.ExpectNotFoundGet(key)
 	obj := &TestResource{ObjectMeta: api.ObjectMeta{Name: "foo"}, Value: 1}
 	err := helper.GuaranteedUpdate("/some/key", &TestResource{}, true, func(in runtime.Object) (runtime.Object, uint64, error) {
 		return obj, 0, nil
@@ -522,7 +536,7 @@ func TestGuaranteedUpdate(t *testing.T) {
 		t.Errorf("Unexpected error %#v", err)
 	}
 	expect := string(data)
-	got := fakeClient.Data["/some/key"].R.Node.Value
+	got := fakeClient.Data[key].R.Node.Value
 	if expect != got {
 		t.Errorf("Wanted %v, got %v", expect, got)
 	}
@@ -547,7 +561,7 @@ func TestGuaranteedUpdate(t *testing.T) {
 		t.Errorf("Unexpected error %#v", err)
 	}
 	expect = string(data)
-	got = fakeClient.Data["/some/key"].R.Node.Value
+	got = fakeClient.Data[key].R.Node.Value
 	if expect != got {
 		t.Errorf("Wanted %v, got %v", expect, got)
 	}
@@ -560,10 +574,11 @@ func TestGuaranteedUpdate(t *testing.T) {
 func TestGuaranteedUpdateNoChange(t *testing.T) {
 	fakeClient := NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
-	helper := NewEtcdHelper(fakeClient, codec)
+	helper := NewEtcdHelper(fakeClient, codec, etcdtest.PathPrefix())
+	key := etcdtest.AddPrefix("/some/key")
 
 	// Create a new node.
-	fakeClient.ExpectNotFoundGet("/some/key")
+	fakeClient.ExpectNotFoundGet(key)
 	obj := &TestResource{ObjectMeta: api.ObjectMeta{Name: "foo"}, Value: 1}
 	err := helper.GuaranteedUpdate("/some/key", &TestResource{}, true, func(in runtime.Object) (runtime.Object, uint64, error) {
 		return obj, 0, nil
@@ -591,10 +606,11 @@ func TestGuaranteedUpdateNoChange(t *testing.T) {
 func TestGuaranteedUpdateKeyNotFound(t *testing.T) {
 	fakeClient := NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
-	helper := NewEtcdHelper(fakeClient, codec)
+	helper := NewEtcdHelper(fakeClient, codec, etcdtest.PathPrefix())
+	key := etcdtest.AddPrefix("/some/key")
 
 	// Create a new node.
-	fakeClient.ExpectNotFoundGet("/some/key")
+	fakeClient.ExpectNotFoundGet(key)
 	obj := &TestResource{ObjectMeta: api.ObjectMeta{Name: "foo"}, Value: 1}
 
 	f := func(in runtime.Object) (runtime.Object, uint64, error) {
@@ -617,9 +633,10 @@ func TestGuaranteedUpdateKeyNotFound(t *testing.T) {
 func TestGuaranteedUpdate_CreateCollision(t *testing.T) {
 	fakeClient := NewFakeEtcdClient(t)
 	fakeClient.TestIndex = true
-	helper := NewEtcdHelper(fakeClient, codec)
+	helper := NewEtcdHelper(fakeClient, codec, etcdtest.PathPrefix())
+	key := etcdtest.AddPrefix("/some/key")
 
-	fakeClient.ExpectNotFoundGet("/some/key")
+	fakeClient.ExpectNotFoundGet(key)
 
 	const concurrency = 10
 	var wgDone sync.WaitGroup
@@ -654,7 +671,7 @@ func TestGuaranteedUpdate_CreateCollision(t *testing.T) {
 	wgDone.Wait()
 
 	// Check that stored TestResource has received all updates.
-	body := fakeClient.Data["/some/key"].R.Node.Value
+	body := fakeClient.Data[key].R.Node.Value
 	stored := &TestResource{}
 	if err := codec.DecodeInto([]byte(body), stored); err != nil {
 		t.Errorf("Error decoding stored value: %v", body)
@@ -707,4 +724,24 @@ func TestGetEtcdVersion_ErrorStatus(t *testing.T) {
 	var err error
 	_, _, err = GetEtcdVersion(testServer.URL)
 	assert.NotNil(t, err)
+}
+
+func TestPrefixEtcdKey(t *testing.T) {
+	fakeClient := NewFakeEtcdClient(t)
+	prefix := path.Join("/", etcdtest.PathPrefix())
+	helper := NewEtcdHelper(fakeClient, testapi.Codec(), prefix)
+
+	baseKey := "/some/key"
+
+	// Verify prefix is added
+	keyBefore := baseKey
+	keyAfter := helper.PrefixEtcdKey(keyBefore)
+
+	assert.Equal(t, keyAfter, path.Join(prefix, baseKey), "Prefix incorrectly added by EtcdHelper")
+
+	// Verify prefix is not added
+	keyBefore = path.Join(prefix, baseKey)
+	keyAfter = helper.PrefixEtcdKey(keyBefore)
+
+	assert.Equal(t, keyBefore, keyAfter, "Prefix incorrectly added by EtcdHelper")
 }

--- a/pkg/tools/etcd_helper_watch.go
+++ b/pkg/tools/etcd_helper_watch.go
@@ -71,6 +71,7 @@ func ParseWatchResourceVersion(resourceVersion, kind string) (uint64, error) {
 // watch.Interface. resourceVersion may be used to specify what version to begin
 // watching (e.g., for reconnecting without missing any updates).
 func (h *EtcdHelper) WatchList(key string, resourceVersion uint64, filter FilterFunc) (watch.Interface, error) {
+	key = h.PrefixEtcdKey(key)
 	w := newEtcdWatcher(true, exceptKey(key), filter, h.Codec, h.Versioner, nil)
 	go w.etcdWatch(h.Client, key, resourceVersion)
 	return w, nil
@@ -80,6 +81,7 @@ func (h *EtcdHelper) WatchList(key string, resourceVersion uint64, filter Filter
 // API objects and sent down the returned watch.Interface.
 // Errors will be sent down the channel.
 func (h *EtcdHelper) Watch(key string, resourceVersion uint64, filter FilterFunc) (watch.Interface, error) {
+	key = h.PrefixEtcdKey(key)
 	w := newEtcdWatcher(false, nil, filter, h.Codec, h.Versioner, nil)
 	go w.etcdWatch(h.Client, key, resourceVersion)
 	return w, nil
@@ -102,6 +104,7 @@ func (h *EtcdHelper) Watch(key string, resourceVersion uint64, filter FilterFunc
 //
 // Errors will be sent down the channel.
 func (h *EtcdHelper) WatchAndTransform(key string, resourceVersion uint64, transform TransformFunc) watch.Interface {
+	key = h.PrefixEtcdKey(key)
 	w := newEtcdWatcher(false, nil, Everything, h.Codec, h.Versioner, transform)
 	go w.etcdWatch(h.Client, key, resourceVersion)
 	return w

--- a/pkg/tools/etcdtest/doc.go
+++ b/pkg/tools/etcdtest/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcdtest

--- a/pkg/tools/etcdtest/etcdtest.go
+++ b/pkg/tools/etcdtest/etcdtest.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcdtest
+
+import (
+	"os"
+	"path"
+)
+
+// Returns the prefix set via the ETCD_PREFIX environment variable (if any).
+func PathPrefix() string {
+	return path.Join("/", os.Getenv("ETCD_PREFIX"))
+}
+
+// Adds the ETCD_PREFIX to the provided key
+func AddPrefix(in string) string {
+	return path.Join(PathPrefix(), in)
+}

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/admit"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/auth/authenticator/token/tokentest"
 )
@@ -377,7 +378,7 @@ func TestAuthModeAlwaysAllow(t *testing.T) {
 
 	// Set up a master
 
-	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version())
+	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version(), etcdtest.PathPrefix())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -516,8 +517,7 @@ func TestAuthModeAlwaysDeny(t *testing.T) {
 	deleteAllEtcdKeys()
 
 	// Set up a master
-
-	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version())
+	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version(), etcdtest.PathPrefix())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -583,8 +583,7 @@ func TestAliceNotForbiddenOrUnauthorized(t *testing.T) {
 	// This file has alice and bob in it.
 
 	// Set up a master
-
-	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version())
+	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version(), etcdtest.PathPrefix())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -672,8 +671,7 @@ func TestBobIsForbidden(t *testing.T) {
 	// This file has alice and bob in it.
 
 	// Set up a master
-
-	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version())
+	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version(), etcdtest.PathPrefix())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -733,8 +731,7 @@ func TestUnknownUserIsUnauthorized(t *testing.T) {
 	// This file has alice and bob in it.
 
 	// Set up a master
-
-	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version())
+	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version(), etcdtest.PathPrefix())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -810,8 +807,7 @@ func TestNamespaceAuthorization(t *testing.T) {
 	deleteAllEtcdKeys()
 
 	// This file has alice and bob in it.
-
-	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version())
+	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version(), etcdtest.PathPrefix())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -925,8 +921,7 @@ func TestKindAuthorization(t *testing.T) {
 	// This file has alice and bob in it.
 
 	// Set up a master
-
-	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version())
+	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version(), etcdtest.PathPrefix())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1028,8 +1023,7 @@ func TestReadOnlyAuthorization(t *testing.T) {
 	// This file has alice and bob in it.
 
 	// Set up a master
-
-	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version())
+	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version(), etcdtest.PathPrefix())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/etcd_tools_test.go
+++ b/test/integration/etcd_tools_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
@@ -92,8 +93,9 @@ func TestExtractObj(t *testing.T) {
 
 func TestWatch(t *testing.T) {
 	client := newEtcdClient()
-	helper := tools.NewEtcdHelper(client, testapi.Codec())
+	helper := tools.NewEtcdHelper(client, testapi.Codec(), etcdtest.PathPrefix())
 	withEtcdKey(func(key string) {
+		key = etcdtest.AddPrefix(key)
 		resp, err := client.Set(key, runtime.EncodeOrDie(testapi.Codec(), &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}), 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/test/integration/scheduler_test.go
+++ b/test/integration/scheduler_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/wait"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/admit"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler"
@@ -45,7 +46,7 @@ func init() {
 }
 
 func TestUnschedulableNodes(t *testing.T) {
-	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version())
+	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version(), etcdtest.PathPrefix())
 	if err != nil {
 		t.Fatalf("Couldn't create etcd helper: %v", err)
 	}

--- a/test/integration/secret_test.go
+++ b/test/integration/secret_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/admit"
 )
 
@@ -50,7 +51,7 @@ func deleteSecretOrErrorf(t *testing.T, c *client.Client, ns, name string) {
 
 // TestSecrets tests apiserver-side behavior of creation of secret objects and their use by pods.
 func TestSecrets(t *testing.T) {
-	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version())
+	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version(), etcdtest.PathPrefix())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/admit"
 
 	"github.com/coreos/go-etcd/etcd"
@@ -66,7 +67,7 @@ func deleteAllEtcdKeys() {
 }
 
 func runAMaster(t *testing.T) (*master.Master, *httptest.Server) {
-	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version())
+	helper, err := master.NewEtcdHelper(newEtcdClient(), testapi.Version(), etcdtest.PathPrefix())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
The API server can be supplied (via a command line flag) with a custom
prefix that is prepended to etcd resources paths.

Refs: #3476
