### PR TITLE
Refactor build/parse DockerName from Kubelet. #3511

### DIFF
--- a/pkg/kubelet/container_gc.go
+++ b/pkg/kubelet/container_gc.go
@@ -213,13 +213,14 @@ func (self *realContainerGC) evictableContainers() (containersByEvictUnit, []con
 			createTime: data.Created,
 		}
 
-		_, uid, name, _, err := dockertools.ParseDockerName(container.Names[0])
+		containerName, _, err := dockertools.ParseDockerName(container.Names[0])
+
 		if err != nil {
 			unidentifiedContainers = append(unidentifiedContainers, containerInfo)
 		} else {
 			key := evictUnit{
-				uid:  uid,
-				name: name,
+				uid:  containerName.PodUID,
+				name: containerName.ContainerName,
 			}
 			evictUnits[key] = append(evictUnits[key], containerInfo)
 		}

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -92,13 +92,13 @@ func verifyPackUnpack(t *testing.T, podNamespace, podUID, podName, containerName
 	util.DeepHashObject(hasher, *container)
 	computedHash := uint64(hasher.Sum32())
 	podFullName := fmt.Sprintf("%s_%s", podName, podNamespace)
-	name := BuildDockerName(types.UID(podUID), podFullName, container)
-	returnedPodFullName, returnedUID, returnedContainerName, hash, err := ParseDockerName(name)
+	name := BuildDockerName(KubeletContainerName{podFullName, types.UID(podUID), container.Name}, container)
+	returned, hash, err := ParseDockerName(name)
 	if err != nil {
 		t.Errorf("Failed to parse Docker container name %q: %v", name, err)
 	}
-	if podFullName != returnedPodFullName || podUID != string(returnedUID) || containerName != returnedContainerName || computedHash != hash {
-		t.Errorf("For (%s, %s, %s, %d), unpacked (%s, %s, %s, %d)", podFullName, podUID, containerName, computedHash, returnedPodFullName, returnedUID, returnedContainerName, hash)
+	if podFullName != returned.PodFullName || podUID != string(returned.PodUID) || containerName != returned.ContainerName || computedHash != hash {
+		t.Errorf("For (%s, %s, %s, %d), unpacked (%s, %s, %s, %d)", podFullName, podUID, containerName, computedHash, returned.PodFullName, returned.PodUID, returned.ContainerName, hash)
 	}
 }
 
@@ -117,12 +117,12 @@ func TestContainerManifestNaming(t *testing.T) {
 	name := fmt.Sprintf("k8s_%s_%s_%s_%s_42", container.Name, podName, podNamespace, podUID)
 	podFullName := fmt.Sprintf("%s_%s", podName, podNamespace)
 
-	returnedPodFullName, returnedPodUID, returnedContainerName, hash, err := ParseDockerName(name)
+	returned, hash, err := ParseDockerName(name)
 	if err != nil {
 		t.Errorf("Failed to parse Docker container name %q: %v", name, err)
 	}
-	if returnedPodFullName != podFullName || string(returnedPodUID) != podUID || returnedContainerName != container.Name || hash != 0 {
-		t.Errorf("unexpected parse: %s %s %s %d", returnedPodFullName, returnedPodUID, returnedContainerName, hash)
+	if returned.PodFullName != podFullName || string(returned.PodUID) != podUID || returned.ContainerName != container.Name || hash != 0 {
+		t.Errorf("unexpected parse: %s %s %s %d", returned.PodFullName, returned.PodUID, returned.ContainerName, hash)
 	}
 }
 

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -148,11 +148,11 @@ func (self *podAndContainerCollector) Collect(ch chan<- prometheus.Metric) {
 	// Get a set of running pods.
 	runningPods := make(map[types.UID]struct{})
 	for _, cont := range runningContainers {
-		_, uid, _, _, err := dockertools.ParseDockerName(cont.Names[0])
+		containerName, _, err := dockertools.ParseDockerName(cont.Names[0])
 		if err != nil {
 			continue
 		}
-		runningPods[uid] = struct{}{}
+		runningPods[containerName.PodUID] = struct{}{}
 	}
 
 	ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
This commit fixes #3511.
Functions Build/ParseDockerName now work with struct instead of the long list of arguments.

I don't include hash into the struct, so it can be used in both ParseDockerName and BuildDockerName. It this case the DockerName struct is identical to the podContainer struct https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/kubelet/kubelet.go#L1410

Maybe we can use only one of them?
