### PR TITLE
Kubelet: support retrieving stats using UID of mirror pods

### DIFF
--- a/pkg/kubelet/mirror_manager_test.go
+++ b/pkg/kubelet/mirror_manager_test.go
@@ -121,7 +121,7 @@ func TestFilterOutMirrorPods(t *testing.T) {
 	if !reflect.DeepEqual(expectedPods, actualPods) {
 		t.Errorf("expected %#v, got %#v", expectedPods, actualPods)
 	}
-	if !actualMirrorPods.Has(GetPodFullName(&mirrorPod)) {
+	if _, ok := actualMirrorPods.mirror[GetPodFullName(&mirrorPod)]; !ok {
 		t.Errorf("mirror pod is not recorded")
 	}
 }

--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -37,7 +37,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream/spdy"
 	"github.com/golang/glog"
@@ -83,7 +82,7 @@ type HostInterface interface {
 	GetRootInfo(req *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error)
 	GetDockerVersion() ([]uint, error)
 	GetCachedMachineInfo() (*cadvisorApi.MachineInfo, error)
-	GetPods() ([]api.Pod, util.StringSet)
+	GetPods() ([]api.Pod, mirrorPods)
 	GetPodByName(namespace, name string) (*api.Pod, bool)
 	GetPodStatus(name string, uid types.UID) (api.PodStatus, error)
 	RunInContainer(name string, uid types.UID, container string, cmd []string) ([]byte, error)

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream/spdy"
 	cadvisorApi "github.com/google/cadvisor/info/v1"
@@ -45,7 +44,7 @@ type fakeKubelet struct {
 	containerInfoFunc                  func(podFullName string, uid types.UID, containerName string, req *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error)
 	rootInfoFunc                       func(query *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error)
 	machineInfoFunc                    func() (*cadvisorApi.MachineInfo, error)
-	podsFunc                           func() ([]api.Pod, util.StringSet)
+	podsFunc                           func() ([]api.Pod, mirrorPods)
 	logFunc                            func(w http.ResponseWriter, req *http.Request)
 	runFunc                            func(podFullName string, uid types.UID, containerName string, cmd []string) ([]byte, error)
 	dockerVersionFunc                  func() ([]uint, error)
@@ -80,7 +79,7 @@ func (fk *fakeKubelet) GetCachedMachineInfo() (*cadvisorApi.MachineInfo, error) 
 	return fk.machineInfoFunc()
 }
 
-func (fk *fakeKubelet) GetPods() ([]api.Pod, util.StringSet) {
+func (fk *fakeKubelet) GetPods() ([]api.Pod, mirrorPods) {
 	return fk.podsFunc()
 }
 


### PR DESCRIPTION
Kubelet supports retrieving stats for pods/containers with and without UID.
This does not always work for the static pods because users may get the UIDs of
the mirror pods from the API server, and use them to query Kubelet. In this
case, Kubelet would fail to locate the containers due to mismatched UIDs.

This change adds a intenral mirror to static pod UID mapping and teaches all
public-facing functions to perform UID lookup before proceeding. This allows
users to use either mirror or static pod's UID to retrieve stats.

This fixes #5688
