### PR TITLE
Add extra diagnostics to networking e2e test

### DIFF
--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -150,13 +150,16 @@ var _ = Describe("Networking", func() {
 		var body []byte
 		for i := 0; i < maxAttempts && !passed; i++ {
 			time.Sleep(2 * time.Second)
+			Logf("About to make a proxy status call")
+			start := time.Now()
 			body, err = c.Get().
 				Namespace(ns).
 				Prefix("proxy").
 				Resource("services").
 				Name(svc.Name).
 				Suffix("status").
-				Do().Raw()
+				DoRaw()
+			Logf("Proxy status call returned in %v", time.Since(start))
 			if err != nil {
 				Logf("Attempt %v/%v: service/pod still starting. (error: '%v')", i, maxAttempts, err)
 				continue
@@ -174,7 +177,7 @@ var _ = Describe("Networking", func() {
 					Namespace(ns).Prefix("proxy").
 					Resource("services").
 					Name(svc.Name).Suffix("read").
-					Do().Raw(); err != nil {
+					DoRaw(); err != nil {
 					Failf("Failed on attempt %v. Cleaning up. Error reading details: %v", i, err)
 				} else {
 					Failf("Failed on attempt %v. Cleaning up. Details:\n%s", i, string(body))
@@ -190,7 +193,7 @@ var _ = Describe("Networking", func() {
 				Resource("services").
 				Name(svc.Name).
 				Suffix("read").
-				Do().Raw(); err != nil {
+				DoRaw(); err != nil {
 				Failf("Timed out. Cleaning up. Error reading details: %v", err)
 			} else {
 				Failf("Timed out. Cleaning up. Details:\n%s", string(body))
@@ -212,7 +215,7 @@ var _ = Describe("Networking", func() {
 			data, err := c.RESTClient.Get().
 				Namespace(ns).
 				AbsPath(test.path).
-				Do().Raw()
+				DoRaw()
 			if err != nil {
 				Failf("Failed: %v\nBody: %s", err, string(data))
 			}


### PR DESCRIPTION
Sometimes this test hangs. These additions let us see if this is due to the proxy call handing that checks the status of the pods. I have also replaced the `Do.Raw()` calls with `DoRaw()` out of paranoia.

Test run which now reports the time taken to perform the proxy status call:

```
$ hack/ginkgo-e2e.sh -t Networking
Setting up for KUBERNETES_PROVIDER="gce".
Project: kubernetes-satnam
Zone: us-central1-b
Running Suite: Kubernetes e2e Suite run 1 of 1
==============================================
Random Seed: 1426889346 - Will randomize all specs
Will run 2 of 30 specs

SSSSSSSSSSSSSSS
------------------------------
Networking 
  should function for pods
  /usr/local/google/home/satnam/gocode/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/networking.go:203
[BeforeEach] Networking
  /usr/local/google/home/satnam/gocode/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/networking.go:39
>>> testContext.kubeConfig: /usr/local/google/home/satnam/.kube/.kubeconfig
[It] should function for pods
  /usr/local/google/home/satnam/gocode/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/networking.go:203
STEP: Creating service with name nettest in namespace nettest-3661
STEP: Creating a webserver pod on each node
INFO: Creating pod nettest-0 on node e2e-test-satnam-minion-1e1n.c.kubernetes-satnam.internal
INFO: Creating pod nettest-1 on node e2e-test-satnam-minion-4o42.c.kubernetes-satnam.internal
STEP: Wait for the webserver pods to be ready
STEP: waiting up to 5m0s for pod nettest-0 status to be running
INFO: Waiting for pod nettest-0 in namespace nettest-3661 status to be "running" (found "Pending") (469.384534ms)
STEP: waiting up to 5m0s for pod nettest-1 status to be running
STEP: Waiting for connectivity to be verified
INFO: About to make a proxy status call
INFO: Proxy status call returned in 39.783068ms
INFO: About to make a proxy status call
INFO: Proxy status call returned in 40.965755ms
INFO: About to make a proxy status call
INFO: Proxy status call returned in 39.907691ms
INFO: About to make a proxy status call
INFO: Proxy status call returned in 39.755599ms
INFO: About to make a proxy status call
INFO: Proxy status call returned in 42.029866ms
INFO: Attempt 4/60: test still running
INFO: About to make a proxy status call
INFO: Proxy status call returned in 71.432361ms
INFO: Attempt 5/60: test still running
INFO: About to make a proxy status call
INFO: Proxy status call returned in 42.1984ms
INFO: Passed on attempt 6. Cleaning up.
STEP: Cleaning up the webserver pods
STEP: Cleaning up the service

• [SLOW TEST:21.281 seconds]
Networking
/usr/local/google/home/satnam/gocode/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/networking.go:224
  should function for pods
  /usr/local/google/home/satnam/gocode/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/networking.go:203
------------------------------
SSSSSSS
------------------------------
Networking 
  should provide unchanging URLs
  /usr/local/google/home/satnam/gocode/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/networking.go:223
[BeforeEach] Networking
  /usr/local/google/home/satnam/gocode/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/networking.go:39
>>> testContext.kubeConfig: /usr/local/google/home/satnam/.kube/.kubeconfig
[It] should provide unchanging URLs
  /usr/local/google/home/satnam/gocode/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/networking.go:223
STEP: testing: /validate
STEP: testing: /healthz
•SSSSSS
Ran 2 of 30 Specs in 21.657 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 28 Skipped I0320 15:09:27.879426    1224 driver.go:89] All tests pass

```
