### PR TITLE
Soak test based on serve_hostname image

### DIFF
--- a/test/soak/serve_hostnames/Makefile
+++ b/test/soak/serve_hostnames/Makefile
@@ -1,0 +1,2 @@
+all:	
+	go build serve_hostnames.go


### PR DESCRIPTION
This is a simple soak test that performs the following actions when executed for the GCE provider:
- Obtains information about what cluster to use for the test from `$HOME/.kube/.kubeconfig`
- Examines how many nodes are on the cluster (say N).
- Creates a fresh namespace for the test using a random suffix.
- Instantiates M (default 1) `serve_hostname` pods on each node.
- Creates a service that captures the pods `serve-hostname-N-M`.
- Repeatedly issues Q (default 1,000) queries to the service.
- Reports the distribution of how many queries were handled by each pod (we expect and even distribution).
- It does this in a loop forever.

Keeping this running constitutes a simple soak test.

```
$ ./serve_hostnames --per_node=5
Nodes found on this cluster:
0: kubernetes-minion-8ezp.c.kubernetes-satnam.internal
1: kubernetes-minion-fga5.c.kubernetes-satnam.internal
2: kubernetes-minion-p2u9.c.kubernetes-satnam.internal
3: kubernetes-minion-viip.c.kubernetes-satnam.internal
Using namespace serve-hostnames-8826 for this test.
Creating pod serve-hostnames-8826/serve-hostname-0-0 on node kubernetes-minion-8ezp.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-0-1 on node kubernetes-minion-8ezp.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-0-2 on node kubernetes-minion-8ezp.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-0-3 on node kubernetes-minion-8ezp.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-0-4 on node kubernetes-minion-8ezp.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-1-0 on node kubernetes-minion-fga5.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-1-1 on node kubernetes-minion-fga5.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-1-2 on node kubernetes-minion-fga5.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-1-3 on node kubernetes-minion-fga5.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-1-4 on node kubernetes-minion-fga5.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-2-0 on node kubernetes-minion-p2u9.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-2-1 on node kubernetes-minion-p2u9.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-2-2 on node kubernetes-minion-p2u9.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-2-3 on node kubernetes-minion-p2u9.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-2-4 on node kubernetes-minion-p2u9.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-3-0 on node kubernetes-minion-viip.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-3-1 on node kubernetes-minion-viip.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-3-2 on node kubernetes-minion-viip.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-3-3 on node kubernetes-minion-viip.c.kubernetes-satnam.internal ... [done]
Creating pod serve-hostnames-8826/serve-hostname-3-4 on node kubernetes-minion-viip.c.kubernetes-satnam.internal ... [done]
Creating service serve-hostnames ... [done]
Wait for the serve-hostname pods to be ready
serve-hostnames-8826/serve-hostname-0-0 is running
serve-hostnames-8826/serve-hostname-0-1 is running
serve-hostnames-8826/serve-hostname-0-2 is running
serve-hostnames-8826/serve-hostname-0-3 is running
serve-hostnames-8826/serve-hostname-0-4 is running
serve-hostnames-8826/serve-hostname-1-0 is running
serve-hostnames-8826/serve-hostname-1-1 is running
serve-hostnames-8826/serve-hostname-1-2 is running
serve-hostnames-8826/serve-hostname-1-3 is running
serve-hostnames-8826/serve-hostname-1-4 is running
serve-hostnames-8826/serve-hostname-2-0 is running
serve-hostnames-8826/serve-hostname-2-1 is running
serve-hostnames-8826/serve-hostname-2-2 is running
serve-hostnames-8826/serve-hostname-2-3 is running
serve-hostnames-8826/serve-hostname-2-4 is running
serve-hostnames-8826/serve-hostname-3-0 is running
serve-hostnames-8826/serve-hostname-3-1 is running
serve-hostnames-8826/serve-hostname-3-2 is running
serve-hostnames-8826/serve-hostname-3-3 is running
serve-hostnames-8826/serve-hostname-3-4 is running
Waiting for the endpoints to propagate... finished waiting
serve-hostname-1-2: 61  serve-hostname-0-3: 51  serve-hostname-2-1: 46  serve-hostname-2-0: 42  serve-hostname-1-1: 44  serve-hostname-0-1: 42  serve-hostname-0-0: 62  serve-hostname-1-0: 49  serve-hostname-1-4: 39  serve-hostname-2-3: 64  serve-hostname-3-3: 40  serve-hostname-2-2: 56  serve-hostname-1-3: 43  serve-hostname-0-4: 58  serve-hostname-0-2: 46  serve-hostname-2-4: 57  serve-hostname-3-1: 59  serve-hostname-3-2: 51  serve-hostname-3-4: 42  serve-hostname-3-0: 48  
Took 51.191636354s
serve-hostname-3-1: 55  serve-hostname-1-3: 50  serve-hostname-1-4: 52  serve-hostname-1-0: 49  serve-hostname-2-1: 41  serve-hostname-0-1: 42  serve-hostname-2-2: 46  serve-hostname-0-4: 47  serve-hostname-0-3: 38  serve-hostname-2-3: 38  serve-hostname-0-0: 58  serve-hostname-1-2: 63  serve-hostname-3-3: 59  serve-hostname-2-4: 65  serve-hostname-3-0: 51  serve-hostname-1-1: 49  serve-hostname-3-2: 48  serve-hostname-2-0: 48  serve-hostname-0-2: 48  serve-hostname-3-4: 53  
Took 52.022849323s
serve-hostname-3-2: 58  serve-hostname-1-2: 48  serve-hostname-1-1: 48  serve-hostname-2-1: 53  serve-hostname-1-0: 46  serve-hostname-1-3: 52  serve-hostname-3-1: 45  serve-hostname-2-4: 43  serve-hostname-2-3: 48  serve-hostname-2-0: 70  serve-hostname-3-4: 47  serve-hostname-0-1: 51  serve-hostname-0-3: 64  serve-hostname-0-0: 50  serve-hostname-0-4: 41  serve-hostname-2-2: 44  serve-hostname-3-3: 43  serve-hostname-3-0: 54  serve-hostname-0-2: 54  serve-hostname-1-4: 41  
Took 51.382949407s
serve-hostname-0-0: 45  serve-hostname-0-3: 51  serve-hostname-3-2: 40  serve-hostname-1-3: 61  serve-hostname-2-1: 47  serve-hostname-1-2: 49  serve-hostname-3-0: 57  serve-hostname-2-3: 53  serve-hostname-1-4: 54  serve-hostname-3-1: 58  serve-hostname-2-4: 42  serve-hostname-0-1: 64  serve-hostname-0-2: 40  serve-hostname-1-0: 55  serve-hostname-2-0: 43  serve-hostname-3-3: 50  serve-hostname-0-4: 53  serve-hostname-2-2: 57  serve-hostname-1-1: 44  serve-hostname-3-4: 37  
Took 52.76047085s
serve-hostname-1-0: 45  serve-hostname-3-2: 56  serve-hostname-0-1: 48  serve-hostname-2-3: 55  serve-hostname-0-4: 62  serve-hostname-3-3: 58  serve-hostname-2-0: 59  serve-hostname-0-0: 47  serve-hostname-3-1: 42  serve-hostname-1-1: 43  serve-hostname-2-1: 69  serve-hostname-3-0: 48  serve-hostname-1-2: 53  serve-hostname-1-3: 47  serve-hostname-1-4: 43  serve-hostname-2-4: 48  serve-hostname-2-2: 44  serve-hostname-0-2: 48  serve-hostname-3-4: 41  serve-hostname-0-3: 44  
Took 51.717851856s
serve-hostname-2-2: 46  serve-hostname-1-3: 43  serve-hostname-1-1: 49  serve-hostname-3-4: 55  serve-hostname-0-3: 52  serve-hostname-1-0: 47  serve-hostname-3-1: 45  serve-hostname-0-1: 54  serve-hostname-1-4: 32  serve-hostname-0-2: 64  serve-hostname-2-1: 52  serve-hostname-3-2: 47  serve-hostname-3-3: 51  serve-hostname-3-0: 55  serve-hostname-2-3: 54  serve-hostname-0-0: 42  serve-hostname-1-2: 66  serve-hostname-0-4: 55  serve-hostname-2-0: 46  serve-hostname-2-4: 45  
Took 52.904848788s
serve-hostname-0-0: 46  serve-hostname-2-1: 54  serve-hostname-0-3: 30  serve-hostname-3-4: 52  serve-hostname-2-0: 55  serve-hostname-1-0: 49  serve-hostname-3-0: 55  serve-hostname-0-1: 51  serve-hostname-1-2: 43  serve-hostname-3-1: 56  serve-hostname-1-1: 48  serve-hostname-0-2: 51  serve-hostname-3-2: 46  serve-hostname-1-3: 52  serve-hostname-1-4: 46  serve-hostname-2-3: 62  serve-hostname-3-3: 48  serve-hostname-2-2: 56  serve-hostname-2-4: 49  serve-hostname-0-4: 51  
Took 52.712764611s
serve-hostname-3-4: 61  serve-hostname-0-4: 52  serve-hostname-0-3: 44  serve-hostname-1-0: 60  serve-hostname-1-1: 42  serve-hostname-2-2: 45  serve-hostname-1-3: 55  serve-hostname-3-2: 56  serve-hostname-3-3: 59  serve-hostname-3-1: 53  serve-hostname-1-4: 62  serve-hostname-0-2: 40  serve-hostname-0-0: 45  serve-hostname-1-2: 46  serve-hostname-2-1: 36  serve-hostname-0-1: 44  serve-hostname-3-0: 62  serve-hostname-2-4: 45  serve-hostname-2-0: 54  serve-hostname-2-3: 39  
Took 53.611146825s
serve-hostname-1-4: 55  serve-hostname-0-0: 37  serve-hostname-3-2: 51  serve-hostname-3-0: 58  serve-hostname-1-2: 41  serve-hostname-2-3: 47  serve-hostname-1-1: 53  serve-hostname-1-3: 50  serve-hostname-0-2: 52  serve-hostname-1-0: 49  serve-hostname-0-1: 52  serve-hostname-0-3: 53  serve-hostname-2-0: 43  serve-hostname-3-3: 48  serve-hostname-3-1: 58  serve-hostname-3-4: 49  serve-hostname-0-4: 60  serve-hostname-2-4: 47  serve-hostname-2-2: 54  serve-hostname-2-1: 43  
Took 52.354442773s


```
