### PR TITLE
Expose versioned query parameters and make watch an operation on List

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -43,6 +43,16 @@ kube::util::wait_for_url() {
   return 1
 }
 
+# Create a temp dir that'll be deleted at the end of this bash session.
+#
+# Vars set:
+#   KUBE_TEMP
+kube::util::ensure-temp-dir() {
+  if [[ -z ${KUBE_TEMP-} ]]; then
+    KUBE_TEMP=$(mktemp -d -t kubernetes.XXXXXX)
+  fi
+}
+
 # This figures out the host platform without relying on golang.  We need this as
 # we don't want a golang install to be a prerequisite to building yet we need
 # this info to figure out where the final binaries are placed.

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -33,12 +33,14 @@ function cleanup()
     [[ -n ${PROXY_PID-} ]] && kill ${PROXY_PID} 1>&2 2>/dev/null
 
     kube::etcd::cleanup
+    rm -rf "${KUBE_TEMP}"
 
     kube::log::status "Clean up complete"
 }
 
 trap cleanup EXIT SIGINT
 
+kube::util::ensure-temp-dir
 kube::etcd::start
 
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
@@ -533,6 +535,7 @@ __EOF__
 
   kube::test::describe_object_assert nodes "127.0.0.1" "Name:" "Labels:" "CreationTimestamp:" "Conditions:" "Addresses:" "Capacity:" "Pods:"
 
+
   ###########
   # Minions #
   ###########
@@ -548,12 +551,26 @@ __EOF__
     kube::test::describe_object_assert minions "127.0.0.1" "Name:" "Conditions:" "Addresses:" "Capacity:" "Pods:"
   fi
 
+
   #####################
   # Retrieve multiple #
   #####################
 
   kube::log::status "Testing kubectl(${version}:multiget)"
   kube::test::get_object_assert 'nodes/127.0.0.1 service/kubernetes' "{{range.items}}{{.$id_field}}:{{end}}" '127.0.0.1:kubernetes:'
+
+
+  ###########
+  # Swagger #
+  ###########
+
+  if [[ -n "${version}" ]]; then
+    # Verify schema
+    file="${KUBE_TEMP}/schema-${version}.json"
+    curl -s "http://127.0.0.1:${API_PORT}/swaggerapi/api/${version}" > "${file}"
+    [[ "$(grep "list of returned" "${file}")" ]]
+    [[ "$(grep "list of pods" "${file}")" ]]
+  fi
 
   kube::test::clear_all
 done

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -570,6 +570,7 @@ __EOF__
     curl -s "http://127.0.0.1:${API_PORT}/swaggerapi/api/${version}" > "${file}"
     [[ "$(grep "list of returned" "${file}")" ]]
     [[ "$(grep "list of pods" "${file}")" ]]
+    [[ "$(grep "watch for changes to the described resources" "${file}")" ]]
   fi
 
   kube::test::clear_all

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/davecgh/go-spew/spew"
@@ -62,6 +64,12 @@ var Semantic = conversion.EqualitiesOrDie(
 	},
 	func(a, b util.Time) bool {
 		return a.UTC() == b.UTC()
+	},
+	func(a, b labels.Selector) bool {
+		return a.String() == b.String()
+	},
+	func(a, b fields.Selector) bool {
+		return a.String() == b.String()
 	},
 )
 

--- a/pkg/api/meta/restmapper.go
+++ b/pkg/api/meta/restmapper.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// TODO: move everything in this file to pkg/api/rest
 package meta
 
 import (

--- a/pkg/api/meta/restmapper_test.go
+++ b/pkg/api/meta/restmapper_test.go
@@ -38,8 +38,16 @@ func (fakeCodec) DecodeInto([]byte, runtime.Object) error {
 
 type fakeConvertor struct{}
 
+func (fakeConvertor) Convert(in, out interface{}) error {
+	return nil
+}
+
 func (fakeConvertor) ConvertToVersion(in runtime.Object, _ string) (runtime.Object, error) {
 	return in, nil
+}
+
+func (fakeConvertor) ConvertFieldLabel(version, kind, label, value string) (string, string, error) {
+	return label, value, nil
 }
 
 var validCodec = fakeCodec{}

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -52,11 +52,12 @@ func init() {
 		&NamespaceList{},
 		&Secret{},
 		&SecretList{},
-		&DeleteOptions{},
 		&PersistentVolume{},
 		&PersistentVolumeList{},
 		&PersistentVolumeClaim{},
 		&PersistentVolumeClaimList{},
+		&DeleteOptions{},
+		&ListOptions{},
 	)
 	// Legacy names are supported
 	Scheme.AddKnownTypeWithName("", "Minion", &Node{})
@@ -90,8 +91,9 @@ func (*Namespace) IsAnAPIObject()                 {}
 func (*NamespaceList) IsAnAPIObject()             {}
 func (*Secret) IsAnAPIObject()                    {}
 func (*SecretList) IsAnAPIObject()                {}
-func (*DeleteOptions) IsAnAPIObject()             {}
 func (*PersistentVolume) IsAnAPIObject()          {}
 func (*PersistentVolumeList) IsAnAPIObject()      {}
 func (*PersistentVolumeClaim) IsAnAPIObject()     {}
 func (*PersistentVolumeClaimList) IsAnAPIObject() {}
+func (*DeleteOptions) IsAnAPIObject()             {}
+func (*ListOptions) IsAnAPIObject()               {}

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -129,7 +129,7 @@ func TestList(t *testing.T) {
 }
 
 var nonRoundTrippableTypes = util.NewStringSet("ContainerManifest", "ContainerManifestList")
-var nonInternalRoundTrippableTypes = util.NewStringSet("List")
+var nonInternalRoundTrippableTypes = util.NewStringSet("List", "ListOptions")
 
 func TestRoundTripTypes(t *testing.T) {
 	// api.Scheme.Log(t)

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -87,6 +89,11 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 		func(j *api.ListMeta, c fuzz.Continue) {
 			j.ResourceVersion = strconv.FormatUint(c.RandUint64(), 10)
 			j.SelfLink = c.RandString()
+		},
+		func(j *api.ListOptions, c fuzz.Continue) {
+			// TODO: add some parsing
+			j.LabelSelector, _ = labels.Parse("a=b")
+			j.FieldSelector, _ = fields.ParseSelector("a=b")
 		},
 		func(j *api.PodPhase, c fuzz.Continue) {
 			statuses := []api.PodPhase{api.PodPending, api.PodRunning, api.PodFailed, api.PodUnknown}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1170,7 +1170,8 @@ type DeleteOptions struct {
 	GracePeriodSeconds *int64 `json:"gracePeriodSeconds"`
 }
 
-// ListOptions is the query options to a standard REST list call
+// ListOptions is the query options to a standard REST list call, and has future support for
+// watch calls.
 type ListOptions struct {
 	TypeMeta `json:",inline"`
 
@@ -1178,6 +1179,10 @@ type ListOptions struct {
 	LabelSelector labels.Selector
 	// A selector based on fields
 	FieldSelector fields.Selector
+	// If true, watch for changes to this list
+	Watch bool
+	// The resource version to watch (no effect on list yet)
+	ResourceVersion string
 }
 
 // Status is a return value for calls that don't return other objects.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -18,6 +18,8 @@ package api
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -1166,6 +1168,16 @@ type DeleteOptions struct {
 	// The value zero indicates delete immediately. If this value is nil, the default grace period for the
 	// specified type will be used.
 	GracePeriodSeconds *int64 `json:"gracePeriodSeconds"`
+}
+
+// ListOptions is the query options to a standard REST list call
+type ListOptions struct {
+	TypeMeta `json:",inline"`
+
+	// A selector based on labels
+	LabelSelector labels.Selector
+	// A selector based on fields
+	FieldSelector fields.Selector
 }
 
 // Status is a return value for calls that don't return other objects.

--- a/pkg/api/unversioned.go
+++ b/pkg/api/unversioned.go
@@ -40,18 +40,20 @@ func PreV1Beta3(version string) bool {
 	return version == "v1beta1" || version == "v1beta2"
 }
 
+// TODO: remove me when watch is refactored
 func LabelSelectorQueryParam(version string) string {
 	if PreV1Beta3(version) {
 		return "labels"
 	}
-	return "label-selector"
+	return "labelSelector"
 }
 
+// TODO: remove me when watch is refactored
 func FieldSelectorQueryParam(version string) string {
 	if PreV1Beta3(version) {
 		return "fields"
 	}
-	return "field-selector"
+	return "fieldSelector"
 }
 
 // String returns available api versions as a human-friendly version string.

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -1494,7 +1494,7 @@ func init() {
 	}
 
 	// Add field conversion funcs.
-	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "pods",
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "Pod",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "name":
@@ -1514,7 +1514,7 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "replicationControllers",
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "ReplicationController",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "name":
@@ -1529,7 +1529,7 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "events",
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "Event",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "involvedObject.kind",
@@ -1551,7 +1551,7 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "namespaces",
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "Namespace",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "status.phase":

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -59,11 +59,12 @@ func init() {
 		&NamespaceList{},
 		&Secret{},
 		&SecretList{},
-		&DeleteOptions{},
 		&PersistentVolume{},
 		&PersistentVolumeList{},
 		&PersistentVolumeClaim{},
 		&PersistentVolumeClaimList{},
+		&DeleteOptions{},
+		&ListOptions{},
 	)
 	// Future names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta1", "Node", &Minion{})
@@ -97,8 +98,9 @@ func (*Namespace) IsAnAPIObject()                 {}
 func (*NamespaceList) IsAnAPIObject()             {}
 func (*Secret) IsAnAPIObject()                    {}
 func (*SecretList) IsAnAPIObject()                {}
-func (*DeleteOptions) IsAnAPIObject()             {}
 func (*PersistentVolume) IsAnAPIObject()          {}
 func (*PersistentVolumeList) IsAnAPIObject()      {}
 func (*PersistentVolumeClaim) IsAnAPIObject()     {}
 func (*PersistentVolumeClaimList) IsAnAPIObject() {}
+func (*DeleteOptions) IsAnAPIObject()             {}
+func (*ListOptions) IsAnAPIObject()               {}

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -993,6 +993,10 @@ type ListOptions struct {
 	LabelSelector string `json:"labels" description:"a selector to restrict the list of returned objects by their labels; defaults to everything"`
 	// A selector based on fields
 	FieldSelector string `json:"fields" description:"a selector to restrict the list of returned objects by their fields; defaults to everything"`
+	// If true, watch for changes to the selected resources
+	Watch bool `json:"watch" description:"watch for changes to the described resources and return them as a stream of add, update, and remove notifications; specify resourceVersion"`
+	// The desired resource version to watch
+	ResourceVersion string `json:"resourceVersion" description:"when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history"`
 }
 
 // Status is a return value for calls that don't return other objects.

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -985,6 +985,16 @@ type DeleteOptions struct {
 	GracePeriodSeconds *int64 `json:"gracePeriodSeconds" description:"the duration in seconds to wait before deleting this object; defaults to a per object value if not specified; zero means delete immediately"`
 }
 
+// ListOptions is the query options to a standard REST list call
+type ListOptions struct {
+	TypeMeta `json:",inline"`
+
+	// A selector based on labels
+	LabelSelector string `json:"labels" description:"a selector to restrict the list of returned objects by their labels; defaults to everything"`
+	// A selector based on fields
+	FieldSelector string `json:"fields" description:"a selector to restrict the list of returned objects by their fields; defaults to everything"`
+}
+
 // Status is a return value for calls that don't return other objects.
 // TODO: this could go in apiserver, but I'm including it here so clients needn't
 // import both.

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -1420,7 +1420,7 @@ func init() {
 	}
 
 	// Add field conversion funcs.
-	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta2", "pods",
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta2", "Pod",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "name":
@@ -1440,7 +1440,7 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta2", "replicationControllers",
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta2", "ReplicationController",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "name":
@@ -1455,7 +1455,7 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta2", "events",
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta2", "Event",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "involvedObject.kind",
@@ -1477,7 +1477,7 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "namespaces",
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "Namespace",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "status.phase":

--- a/pkg/api/v1beta2/register.go
+++ b/pkg/api/v1beta2/register.go
@@ -59,11 +59,12 @@ func init() {
 		&NamespaceList{},
 		&Secret{},
 		&SecretList{},
-		&DeleteOptions{},
 		&PersistentVolume{},
 		&PersistentVolumeList{},
 		&PersistentVolumeClaim{},
 		&PersistentVolumeClaimList{},
+		&DeleteOptions{},
+		&ListOptions{},
 	)
 	// Future names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta2", "Node", &Minion{})
@@ -102,3 +103,4 @@ func (*PersistentVolumeList) IsAnAPIObject()      {}
 func (*PersistentVolumeClaim) IsAnAPIObject()     {}
 func (*PersistentVolumeClaimList) IsAnAPIObject() {}
 func (*DeleteOptions) IsAnAPIObject()             {}
+func (*ListOptions) IsAnAPIObject()               {}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -1007,6 +1007,10 @@ type ListOptions struct {
 	LabelSelector string `json:"labels" description:"a selector to restrict the list of returned objects by their labels; defaults to everything"`
 	// A selector based on fields
 	FieldSelector string `json:"fields" description:"a selector to restrict the list of returned objects by their fields; defaults to everything"`
+	// If true, watch for changes to the selected resources
+	Watch bool `json:"watch" description:"watch for changes to the described resources and return them as a stream of add, update, and remove notifications; specify resourceVersion"`
+	// The desired resource version to watch
+	ResourceVersion string `json:"resourceVersion" description:"when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history"`
 }
 
 // Status is a return value for calls that don't return other objects.

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -999,6 +999,16 @@ type DeleteOptions struct {
 	GracePeriodSeconds *int64 `json:"gracePeriodSeconds" description:"the duration in seconds to wait before deleting this object; defaults to a per object value if not specified; zero means delete immediately"`
 }
 
+// ListOptions is the query options to a standard REST list call
+type ListOptions struct {
+	TypeMeta `json:",inline"`
+
+	// A selector based on labels
+	LabelSelector string `json:"labels" description:"a selector to restrict the list of returned objects by their labels; defaults to everything"`
+	// A selector based on fields
+	FieldSelector string `json:"fields" description:"a selector to restrict the list of returned objects by their fields; defaults to everything"`
+}
+
 // Status is a return value for calls that don't return other objects.
 // TODO: this could go in apiserver, but I'm including it here so clients needn't
 // import both.

--- a/pkg/api/v1beta3/conversion.go
+++ b/pkg/api/v1beta3/conversion.go
@@ -24,7 +24,7 @@ import (
 
 func init() {
 	// Add field conversion funcs.
-	err := newer.Scheme.AddFieldLabelConversionFunc("v1beta3", "pods",
+	err := newer.Scheme.AddFieldLabelConversionFunc("v1beta3", "Pod",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "name",
@@ -39,7 +39,7 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta3", "replicationControllers",
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta3", "ReplicationController",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "name":
@@ -54,7 +54,7 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta3", "events",
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta3", "Event",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "involvedObject.kind",
@@ -75,7 +75,7 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "namespaces",
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "Namespace",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "status.phase":

--- a/pkg/api/v1beta3/register.go
+++ b/pkg/api/v1beta3/register.go
@@ -53,11 +53,12 @@ func init() {
 		&NamespaceList{},
 		&Secret{},
 		&SecretList{},
-		&DeleteOptions{},
 		&PersistentVolume{},
 		&PersistentVolumeList{},
 		&PersistentVolumeClaim{},
 		&PersistentVolumeClaimList{},
+		&DeleteOptions{},
+		&ListOptions{},
 	)
 	// Legacy names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta3", "Minion", &Node{})
@@ -96,3 +97,4 @@ func (*PersistentVolumeList) IsAnAPIObject()      {}
 func (*PersistentVolumeClaim) IsAnAPIObject()     {}
 func (*PersistentVolumeClaimList) IsAnAPIObject() {}
 func (*DeleteOptions) IsAnAPIObject()             {}
+func (*ListOptions) IsAnAPIObject()               {}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -1166,6 +1166,10 @@ type ListOptions struct {
 	LabelSelector string `json:"labelSelector" description:"a selector to restrict the list of returned objects by their labels; defaults to everything"`
 	// A selector based on fields
 	FieldSelector string `json:"fieldSelector" description:"a selector to restrict the list of returned objects by their fields; defaults to everything"`
+	// If true, watch for changes to the selected resources
+	Watch bool `json:"watch" description:"watch for changes to the described resources and return them as a stream of add, update, and remove notifications; specify resourceVersion"`
+	// The desired resource version to watch
+	ResourceVersion string `json:"resourceVersion" description:"when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history"`
 }
 
 // Status is a return value for calls that don't return other objects.

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -1158,6 +1158,16 @@ type DeleteOptions struct {
 	GracePeriodSeconds *int64 `json:"gracePeriodSeconds" description:"the duration in seconds to wait before deleting this object; defaults to a per object value if not specified; zero means delete immediately"`
 }
 
+// ListOptions is the query options to a standard REST list call
+type ListOptions struct {
+	TypeMeta `json:",inline"`
+
+	// A selector based on labels
+	LabelSelector string `json:"labelSelector" description:"a selector to restrict the list of returned objects by their labels; defaults to everything"`
+	// A selector based on fields
+	FieldSelector string `json:"fieldSelector" description:"a selector to restrict the list of returned objects by their fields; defaults to everything"`
+}
+
 // Status is a return value for calls that don't return other objects.
 type Status struct {
 	TypeMeta `json:",inline"`

--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -670,6 +670,12 @@ func addParams(route *restful.RouteBuilder, params []*restful.Parameter) {
 	}
 }
 
+// addObjectParams converts a runtime.Object into a set of go-restful Param() definitions on the route.
+// The object must be a pointer to a struct; only fields at the top level of the struct that are not
+// themselves interfaces or structs are used; only fields with a json tag that is non empty (the standard
+// Go JSON behavior for omitting a field) become query parameters. The name of the query parameter is
+// the JSON field name. If a description struct tag is set on the field, that description is used on the
+// query parameter. In essence, it converts a standard JSON top level object into a query param schema.
 func addObjectParams(ws *restful.WebService, route *restful.RouteBuilder, obj runtime.Object) error {
 	sv, err := conversion.EnforcePtr(obj)
 	if err != nil {

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -102,12 +102,19 @@ type APIGroupVersion struct {
 	Root    string
 	Version string
 
+	// ServerVersion controls the Kubernetes APIVersion used for common objects in the apiserver
+	// schema like api.Status, api.DeleteOptions, and api.ListOptions. Other implementors may
+	// define a version "v1beta1" but want to use the Kubernetes "v1beta3" internal objects. If
+	// empty, defaults to Version.
+	ServerVersion string
+
 	Mapper meta.RESTMapper
 
-	Codec   runtime.Codec
-	Typer   runtime.ObjectTyper
-	Creater runtime.ObjectCreater
-	Linker  runtime.SelfLinker
+	Codec     runtime.Codec
+	Typer     runtime.ObjectTyper
+	Creater   runtime.ObjectCreater
+	Convertor runtime.ObjectConvertor
+	Linker    runtime.SelfLinker
 
 	Admit   admission.Interface
 	Context api.RequestContextMapper

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -204,7 +204,11 @@ func APIVersionHandler(versions ...string) restful.RouteFunction {
 	}
 }
 
-// write renders a returned runtime.Object to the response as a stream or an encoded object.
+// write renders a returned runtime.Object to the response as a stream or an encoded object. If the object
+// returned by the response implements rest.ResourceStreamer that interface will be used to render the
+// response. The Accept header and current API version will be passed in, and the output will be copied
+// directly to the response body. If content type is returned it is used, otherwise the content type will
+// be "application/octet-stream". All other objects are sent to standard JSON serialization.
 func write(statusCode int, apiVersion string, codec runtime.Codec, object runtime.Object, w http.ResponseWriter, req *http.Request) {
 	if stream, ok := object.(rest.ResourceStreamer); ok {
 		out, contentType, err := stream.InputStream(apiVersion, req.Header.Get("Accept"))

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
@@ -54,11 +55,21 @@ func convert(obj runtime.Object) (runtime.Object, error) {
 	return obj, nil
 }
 
-// This creates a fake API version, similar to api/latest.go
+// This creates a fake API version, similar to api/latest.go for a v1beta1 equivalent api. It is distinct
+// from the Kubernetes API versions to allow clients to properly distinguish the two.
 const testVersion = "version"
 
-var versions = []string{testVersion}
-var codec = runtime.CodecFor(api.Scheme, testVersion)
+// The equivalent of the Kubernetes v1beta3 API.
+const testVersion2 = "version2"
+
+var versions = []string{testVersion, testVersion2}
+var legacyCodec = runtime.CodecFor(api.Scheme, testVersion)
+var codec = runtime.CodecFor(api.Scheme, testVersion2)
+
+// these codecs reflect ListOptions/DeleteOptions coming from the serverAPIversion
+var versionServerCodec = runtime.CodecFor(api.Scheme, "v1beta1")
+var version2ServerCodec = runtime.CodecFor(api.Scheme, "v1beta3")
+
 var accessor = meta.NewAccessor()
 var versioner runtime.ResourceVersioner = accessor
 var selfLinker runtime.SelfLinker = accessor
@@ -69,6 +80,12 @@ var requestContextMapper api.RequestContextMapper
 func interfacesFor(version string) (*meta.VersionInterfaces, error) {
 	switch version {
 	case testVersion:
+		return &meta.VersionInterfaces{
+			Codec:            legacyCodec,
+			ObjectConvertor:  api.Scheme,
+			MetadataAccessor: accessor,
+		}, nil
+	case testVersion2:
 		return &meta.VersionInterfaces{
 			Codec:            codec,
 			ObjectConvertor:  api.Scheme,
@@ -100,7 +117,10 @@ func init() {
 	api.Scheme.AddKnownTypes("", &Simple{}, &SimpleList{}, &api.Status{}, &api.ListOptions{})
 	// "version" version
 	// TODO: Use versioned api objects?
-	api.Scheme.AddKnownTypes(testVersion, &Simple{}, &SimpleList{}, &v1beta1.DeleteOptions{}, &v1beta1.Status{}, &v1beta1.ListOptions{})
+	api.Scheme.AddKnownTypes(testVersion, &Simple{}, &SimpleList{}, &v1beta1.Status{})
+	// "version2" version
+	// TODO: Use versioned api objects?
+	api.Scheme.AddKnownTypes(testVersion2, &Simple{}, &SimpleList{}, &v1beta3.Status{})
 
 	nsMapper := newMapper()
 	legacyNsMapper := newMapper()
@@ -118,6 +138,18 @@ func init() {
 	namespaceMapper = nsMapper
 	admissionControl = admit.NewAlwaysAdmit()
 	requestContextMapper = api.NewRequestContextMapper()
+
+	//mapper.(*meta.DefaultRESTMapper).Add(meta.RESTScopeNamespaceLegacy, "Simple", testVersion, false)
+	api.Scheme.AddFieldLabelConversionFunc(testVersion, "Simple",
+		func(label, value string) (string, string, error) {
+			return label, value, nil
+		},
+	)
+	api.Scheme.AddFieldLabelConversionFunc(testVersion2, "Simple",
+		func(label, value string) (string, string, error) {
+			return label, value, nil
+		},
+	)
 }
 
 // defaultAPIServer exposes nested objects for testability.
@@ -129,46 +161,61 @@ type defaultAPIServer struct {
 
 // uses the default settings
 func handle(storage map[string]rest.Storage) http.Handler {
-	return handleInternal(storage, admissionControl, mapper, selfLinker)
+	return handleInternal(true, storage, admissionControl, selfLinker)
+}
+
+// uses the default settings for a v1beta3 compatible api
+func handleNew(storage map[string]rest.Storage) http.Handler {
+	return handleInternal(false, storage, admissionControl, selfLinker)
 }
 
 // tests with a deny admission controller
 func handleDeny(storage map[string]rest.Storage) http.Handler {
-	return handleInternal(storage, deny.NewAlwaysDeny(), mapper, selfLinker)
+	return handleInternal(true, storage, deny.NewAlwaysDeny(), selfLinker)
 }
 
 // tests using the new namespace scope mechanism
 func handleNamespaced(storage map[string]rest.Storage) http.Handler {
-	return handleInternal(storage, admissionControl, namespaceMapper, selfLinker)
+	return handleInternal(false, storage, admissionControl, selfLinker)
 }
 
 // tests using a custom self linker
 func handleLinker(storage map[string]rest.Storage, selfLinker runtime.SelfLinker) http.Handler {
-	return handleInternal(storage, admissionControl, mapper, selfLinker)
+	return handleInternal(true, storage, admissionControl, selfLinker)
 }
 
-func handleInternal(storage map[string]rest.Storage, admissionControl admission.Interface, mapper meta.RESTMapper, selfLinker runtime.SelfLinker) http.Handler {
+func handleInternal(legacy bool, storage map[string]rest.Storage, admissionControl admission.Interface, selfLinker runtime.SelfLinker) http.Handler {
 	group := &APIGroupVersion{
 		Storage: storage,
 
-		Mapper: mapper,
-
-		Root:    "/api",
-		Version: testVersion,
+		Root: "/api",
 
 		Creater:   api.Scheme,
 		Convertor: api.Scheme,
 		Typer:     api.Scheme,
-		Codec:     codec,
 		Linker:    selfLinker,
 
 		Admit:   admissionControl,
 		Context: requestContextMapper,
 	}
+	if legacy {
+		group.Version = testVersion
+		group.ServerVersion = "v1beta1"
+		group.Codec = legacyCodec
+		group.Mapper = legacyNamespaceMapper
+	} else {
+		group.Version = testVersion2
+		group.ServerVersion = "v1beta3"
+		group.Codec = codec
+		group.Mapper = namespaceMapper
+	}
+
 	container := restful.NewContainer()
 	container.Router(restful.CurlyRouter{})
 	mux := container.ServeMux
-	group.InstallREST(container)
+	if err := group.InstallREST(container); err != nil {
+		panic(fmt.Sprintf("unable to install container %s: %v", group.Version, err))
+	}
 	ws := new(restful.WebService)
 	InstallSupport(mux, ws)
 	container.Add(ws)
@@ -557,27 +604,27 @@ func TestList(t *testing.T) {
 		},
 		// list items in a namespace, v1beta3+
 		{
-			url:       "/api/version/namespaces/default/simple",
+			url:       "/api/version2/namespaces/default/simple",
 			namespace: "default",
-			selfLink:  "/api/version/namespaces/default/simple",
+			selfLink:  "/api/version2/namespaces/default/simple",
 		},
 		{
-			url:       "/api/version/namespaces/other/simple",
+			url:       "/api/version2/namespaces/other/simple",
 			namespace: "other",
-			selfLink:  "/api/version/namespaces/other/simple",
+			selfLink:  "/api/version2/namespaces/other/simple",
 		},
 		{
-			url:       "/api/version/namespaces/other/simple?labels=a%3Db&fields=c%3Dd",
+			url:       "/api/version2/namespaces/other/simple?labelSelector=a%3Db&fieldSelector=c%3Dd",
 			namespace: "other",
-			selfLink:  "/api/version/namespaces/other/simple",
+			selfLink:  "/api/version2/namespaces/other/simple",
 			label:     "a=b",
 			field:     "c=d",
 		},
 		// list items across all namespaces
 		{
-			url:       "/api/version/simple",
+			url:       "/api/version2/simple",
 			namespace: "",
-			selfLink:  "/api/version/simple",
+			selfLink:  "/api/version2/simple",
 		},
 	}
 	for i, testCase := range testCases {
@@ -593,7 +640,7 @@ func TestList(t *testing.T) {
 		if testCase.legacy {
 			handler = handleLinker(storage, selfLinker)
 		} else {
-			handler = handleInternal(storage, admissionControl, namespaceMapper, selfLinker)
+			handler = handleInternal(false, storage, admissionControl, selfLinker)
 		}
 		server := httptest.NewServer(handler)
 		defer server.Close()
@@ -605,6 +652,9 @@ func TestList(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusOK {
 			t.Errorf("%d: unexpected status: %d, Expected: %d, %#v", i, resp.StatusCode, http.StatusOK, resp)
+			body, _ := ioutil.ReadAll(resp.Body)
+			t.Logf("%d: body: %s", string(body))
+			continue
 		}
 		// TODO: future, restore get links
 		if !selfLinker.called {
@@ -875,16 +925,16 @@ func TestGetNamespaceSelfLink(t *testing.T) {
 	}
 	selfLinker := &setTestSelfLinker{
 		t:           t,
-		expectedSet: "/api/version/namespaces/foo/simple/id",
+		expectedSet: "/api/version2/namespaces/foo/simple/id",
 		name:        "id",
 		namespace:   "foo",
 	}
 	storage["simple"] = &simpleStorage
-	handler := handleInternal(storage, admissionControl, namespaceMapper, selfLinker)
+	handler := handleInternal(false, storage, admissionControl, selfLinker)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/api/version/namespaces/foo/simple/id")
+	resp, err := http.Get(server.URL + "/api/version2/namespaces/foo/simple/id")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -959,7 +1009,7 @@ func TestDeleteWithOptions(t *testing.T) {
 	item := &api.DeleteOptions{
 		GracePeriodSeconds: &grace,
 	}
-	body, err := codec.Encode(item)
+	body, err := versionServerCodec.Encode(item)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1020,7 +1070,7 @@ func TestLegacyDeleteIgnoresOptions(t *testing.T) {
 	defer server.Close()
 
 	item := api.NewDeleteOptions(300)
-	body, err := codec.Encode(item)
+	body, err := versionServerCodec.Encode(item)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1629,7 +1679,7 @@ func TestCreateInvokesAdmissionControl(t *testing.T) {
 		namespace:   "other",
 		expectedSet: "/api/version/foo/bar?namespace=other",
 	}
-	handler := handleInternal(map[string]rest.Storage{"foo": &storage}, deny.NewAlwaysDeny(), mapper, selfLinker)
+	handler := handleInternal(true, map[string]rest.Storage{"foo": &storage}, deny.NewAlwaysDeny(), selfLinker)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 	client := http.Client{}

--- a/pkg/apiserver/proxy_test.go
+++ b/pkg/apiserver/proxy_test.go
@@ -294,7 +294,7 @@ func TestProxy(t *testing.T) {
 			server           *httptest.Server
 			proxyTestPattern string
 		}{
-			{namespaceServer, "/api/version/proxy/namespaces/" + item.reqNamespace + "/foo/id" + item.path},
+			{namespaceServer, "/api/version2/proxy/namespaces/" + item.reqNamespace + "/foo/id" + item.path},
 			{legacyNamespaceServer, "/api/version/proxy/foo/id" + item.path + "?namespace=" + item.reqNamespace},
 		}
 
@@ -348,7 +348,7 @@ func TestProxyUpgrade(t *testing.T) {
 	server := httptest.NewServer(namespaceHandler)
 	defer server.Close()
 
-	ws, err := websocket.Dial("ws://"+server.Listener.Addr().String()+"/api/version/proxy/namespaces/myns/foo/123", "", "http://127.0.0.1/")
+	ws, err := websocket.Dial("ws://"+server.Listener.Addr().String()+"/api/version2/proxy/namespaces/myns/foo/123", "", "http://127.0.0.1/")
 	if err != nil {
 		t.Fatalf("websocket dial err: %s", err)
 	}

--- a/pkg/apiserver/redirect_test.go
+++ b/pkg/apiserver/redirect_test.go
@@ -105,7 +105,7 @@ func TestRedirectWithNamespaces(t *testing.T) {
 	for _, item := range table {
 		simpleStorage.errors["resourceLocation"] = item.err
 		simpleStorage.resourceLocation = &url.URL{Host: item.id}
-		resp, err := client.Get(server.URL + "/api/version/redirect/namespaces/other/foo/" + item.id)
+		resp, err := client.Get(server.URL + "/api/version2/redirect/namespaces/other/foo/" + item.id)
 		if resp == nil {
 			t.Fatalf("Unexpected nil resp")
 		}

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -19,7 +19,6 @@ package apiserver
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	gpath "path"
 	"time"
 
@@ -27,8 +26,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
 	"github.com/emicklei/go-restful"
@@ -64,9 +61,15 @@ type RequestScope struct {
 	Namer ScopeNamer
 	ContextFunc
 	runtime.Codec
+	Creater   runtime.ObjectCreater
+	Convertor runtime.ObjectConvertor
+
 	Resource   string
 	Kind       string
 	APIVersion string
+
+	// The version of apiserver resources to use
+	ServerAPIVersion string
 }
 
 // GetResource returns a function that handles retrieving a single resource from a rest.Storage object.
@@ -94,24 +97,6 @@ func GetResource(r rest.Getter, scope RequestScope) restful.RouteFunction {
 	}
 }
 
-func parseSelectorQueryParams(query url.Values, version, apiResource string) (label labels.Selector, field fields.Selector, err error) {
-	labelString := query.Get(api.LabelSelectorQueryParam(version))
-	label, err = labels.Parse(labelString)
-	if err != nil {
-		return nil, nil, errors.NewBadRequest(fmt.Sprintf("The 'labels' selector parameter (%s) could not be parsed: %v", labelString, err))
-	}
-
-	convertToInternalVersionFunc := func(label, value string) (newLabel, newValue string, err error) {
-		return api.Scheme.ConvertFieldLabel(version, apiResource, label, value)
-	}
-	fieldString := query.Get(api.FieldSelectorQueryParam(version))
-	field, err = fields.ParseAndTransformSelector(fieldString, convertToInternalVersionFunc)
-	if err != nil {
-		return nil, nil, errors.NewBadRequest(fmt.Sprintf("The 'fields' selector parameter (%s) could not be parsed: %v", fieldString, err))
-	}
-	return label, field, nil
-}
-
 // ListResource returns a function that handles retrieving a list of resources from a rest.Storage object.
 func ListResource(r rest.Lister, scope RequestScope) restful.RouteFunction {
 	return func(req *restful.Request, res *restful.Response) {
@@ -125,13 +110,38 @@ func ListResource(r rest.Lister, scope RequestScope) restful.RouteFunction {
 		ctx := scope.ContextFunc(req)
 		ctx = api.WithNamespace(ctx, namespace)
 
-		label, field, err := parseSelectorQueryParams(req.Request.URL.Query(), scope.APIVersion, scope.Resource)
+		// TODO: extract me into a method
+		query := req.Request.URL.Query()
+		versioned, err := scope.Creater.New(scope.ServerAPIVersion, "ListOptions")
 		if err != nil {
+			// programmer error
+			errorJSON(err, scope.Codec, w)
+			return
+		}
+		if err := scope.Convertor.Convert(&query, versioned); err != nil {
+			// bad request
+			errorJSON(err, scope.Codec, w)
+			return
+		}
+		out, err := scope.Convertor.ConvertToVersion(versioned, "")
+		if err != nil {
+			// programmer error
+			errorJSON(err, scope.Codec, w)
+			return
+		}
+		opts := *out.(*api.ListOptions)
+
+		// transform fields
+		fn := func(label, value string) (newLabel, newValue string, err error) {
+			return scope.Convertor.ConvertFieldLabel(scope.APIVersion, scope.Kind, label, value)
+		}
+		if opts.FieldSelector, err = opts.FieldSelector.Transform(fn); err != nil {
+			// invalid field
 			errorJSON(err, scope.Codec, w)
 			return
 		}
 
-		result, err := r.List(ctx, label, field)
+		result, err := r.List(ctx, opts.LabelSelector, opts.FieldSelector)
 		if err != nil {
 			errorJSON(err, scope.Codec, w)
 			return

--- a/pkg/apiserver/watch.go
+++ b/pkg/apiserver/watch.go
@@ -17,51 +17,20 @@ limitations under the License.
 package apiserver
 
 import (
-	"fmt"
 	"net/http"
-	"net/url"
-	"path"
+	"reflect"
 	"regexp"
 	"strings"
-	"time"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	watchjson "github.com/GoogleCloudPlatform/kubernetes/pkg/watch/json"
 
+	"github.com/emicklei/go-restful"
 	"github.com/golang/glog"
 	"golang.org/x/net/websocket"
 )
-
-// TODO: convert me to resthandler custom verb
-type WatchHandler struct {
-	storage   map[string]rest.Storage
-	mapper    meta.RESTMapper
-	convertor runtime.ObjectConvertor
-	codec     runtime.Codec
-	linker    runtime.SelfLinker
-	info      *APIRequestInfoResolver
-}
-
-// setSelfLinkAddName sets the self link, appending the object's name to the canonical path & type.
-func (h *WatchHandler) setSelfLinkAddName(obj runtime.Object, req *http.Request) error {
-	name, err := h.linker.Name(obj)
-	if err != nil {
-		return err
-	}
-	newURL := *req.URL
-	newURL.Path = path.Join(req.URL.Path, name)
-	newURL.RawQuery = ""
-	newURL.Fragment = ""
-	return h.linker.SetSelfLink(obj, newURL.String())
-}
 
 var connectionUpgradeRegex = regexp.MustCompile("(^|.*,\\s*)upgrade($|\\s*,)")
 
@@ -69,103 +38,18 @@ func isWebsocketRequest(req *http.Request) bool {
 	return connectionUpgradeRegex.MatchString(strings.ToLower(req.Header.Get("Connection"))) && strings.ToLower(req.Header.Get("Upgrade")) == "websocket"
 }
 
-// ServeHTTP processes watch requests.
-func (h *WatchHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	var verb string
-	var apiResource string
-	var httpCode int
-	reqStart := time.Now()
-	defer monitor("watch", &verb, &apiResource, &httpCode, reqStart)
-
-	if req.Method != "GET" {
-		httpCode = errorJSON(errors.NewBadRequest(
-			fmt.Sprintf("unsupported method for watch: %s", req.Method)), h.codec, w)
-		return
-	}
-
-	requestInfo, err := h.info.GetAPIRequestInfo(req)
-	if err != nil {
-		httpCode = errorJSON(errors.NewBadRequest(
-			fmt.Sprintf("failed to find api request info: %s", err.Error())), h.codec, w)
-		return
-	}
-	verb = requestInfo.Verb
-	ctx := api.WithNamespace(api.NewContext(), requestInfo.Namespace)
-
-	storage := h.storage[requestInfo.Resource]
-	if storage == nil {
-		httpCode = errorJSON(errors.NewNotFound(requestInfo.Resource, "Resource"), h.codec, w)
-		return
-	}
-	apiResource = requestInfo.Resource
-	watcher, ok := storage.(rest.Watcher)
-	if !ok {
-		httpCode = errorJSON(errors.NewMethodNotSupported(requestInfo.Resource, "watch"), h.codec, w)
-		return
-	}
-	kind := requestInfo.Kind
-	if len(kind) == 0 {
-		if _, kind, err = h.mapper.VersionAndKindForResource(apiResource); err != nil {
-			glog.Errorf("No kind found for %s: %v", apiResource, err)
-		}
-	}
-
-	scope := RequestScope{
-		Convertor:  h.convertor,
-		Kind:       kind,
-		Resource:   apiResource,
-		APIVersion: requestInfo.APIVersion,
-		// TODO: this must be parameterized per version, and is incorrect for implementors
-		// outside of Kubernetes. Fix by refactoring watch under resthandler as a custome
-		// resource.
-		ServerAPIVersion: requestInfo.APIVersion,
-	}
-	label, field, err := parseSelectorQueryParams(req.URL.Query(), scope)
-	if err != nil {
-		httpCode = errorJSON(err, h.codec, w)
-		return
-	}
-
-	resourceVersion := req.URL.Query().Get("resourceVersion")
-	watching, err := watcher.Watch(ctx, label, field, resourceVersion)
-	if err != nil {
-		httpCode = errorJSON(err, h.codec, w)
-		return
-	}
-	httpCode = http.StatusOK
-
-	// TODO: This is one watch per connection. We want to multiplex, so that
-	// multiple watches of the same thing don't create two watches downstream.
-	watchServer := &WatchServer{watching, h.codec, func(obj runtime.Object) {
-		if err := h.setSelfLinkAddName(obj, req); err != nil {
-			glog.Errorf("Failed to set self link for object %#v", obj)
+// serveWatch handles serving requests to the server
+func serveWatch(watcher watch.Interface, scope RequestScope, w http.ResponseWriter, req *restful.Request) {
+	watchServer := &WatchServer{watcher, scope.Codec, func(obj runtime.Object) {
+		if err := setSelfLink(obj, req, scope.Namer); err != nil {
+			glog.V(5).Infof("Failed to set self link for object %v: %v", reflect.TypeOf(obj), err)
 		}
 	}}
-	if isWebsocketRequest(req) {
-		websocket.Handler(watchServer.HandleWS).ServeHTTP(httplog.Unlogged(w), req)
+	if isWebsocketRequest(req.Request) {
+		websocket.Handler(watchServer.HandleWS).ServeHTTP(httplog.Unlogged(w), req.Request)
 	} else {
-		watchServer.ServeHTTP(w, req)
+		watchServer.ServeHTTP(w, req.Request)
 	}
-}
-
-// TODO: remove when watcher is refactored to fit under api_installer
-func parseSelectorQueryParams(query url.Values, scope RequestScope) (label labels.Selector, field fields.Selector, err error) {
-	labelString := query.Get(api.LabelSelectorQueryParam(scope.ServerAPIVersion))
-	label, err = labels.Parse(labelString)
-	if err != nil {
-		return nil, nil, errors.NewBadRequest(fmt.Sprintf("The 'labels' selector parameter (%s) could not be parsed: %v", labelString, err))
-	}
-
-	fn := func(label, value string) (newLabel, newValue string, err error) {
-		return scope.Convertor.ConvertFieldLabel(scope.APIVersion, scope.Kind, label, value)
-	}
-	fieldString := query.Get(api.FieldSelectorQueryParam(scope.ServerAPIVersion))
-	field, err = fields.ParseAndTransformSelector(fieldString, fn)
-	if err != nil {
-		return nil, nil, errors.NewBadRequest(fmt.Sprintf("The 'fields' selector parameter (%s) could not be parsed: %v", fieldString, err))
-	}
-	glog.Infof("Found %#v %#v from %v in scope %#v", label, field, query, scope)
-	return label, field, nil
 }
 
 // WatchServer serves a watch.Interface over a websocket or vanilla HTTP.

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
@@ -47,14 +46,6 @@ var watchTestTable = []struct {
 	{watch.Added, &Simple{ObjectMeta: api.ObjectMeta{Name: "foo"}}},
 	{watch.Modified, &Simple{ObjectMeta: api.ObjectMeta{Name: "bar"}}},
 	{watch.Deleted, &Simple{ObjectMeta: api.ObjectMeta{Name: "bar"}}},
-}
-
-func init() {
-	mapper.(*meta.DefaultRESTMapper).Add(meta.RESTScopeNamespaceLegacy, "Simple", testVersion, false)
-	api.Scheme.AddFieldLabelConversionFunc(testVersion, "Simple",
-		func(label, value string) (string, string, error) {
-			return label, value, nil
-		})
 }
 
 func TestWatchWebsocket(t *testing.T) {

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -194,13 +194,13 @@ func TestWatchParamParsing(t *testing.T) {
 			fieldSelector:   "",
 			namespace:       api.NamespaceAll,
 		}, {
-			rawQuery:        "namespace=default&resourceVersion=314159&" + api.FieldSelectorQueryParam(testVersion) + "=Host%3D&" + api.LabelSelectorQueryParam(testVersion) + "=name%3Dfoo",
+			rawQuery:        "namespace=default&resourceVersion=314159&fields=Host%3D&labels=name%3Dfoo",
 			resourceVersion: "314159",
 			labelSelector:   "name=foo",
 			fieldSelector:   "Host=",
 			namespace:       api.NamespaceDefault,
 		}, {
-			rawQuery:        "namespace=watchother&" + api.FieldSelectorQueryParam(testVersion) + "=id%3dfoo&resourceVersion=1492",
+			rawQuery:        "namespace=watchother&fields=id%3dfoo&resourceVersion=1492",
 			resourceVersion: "1492",
 			labelSelector:   "",
 			fieldSelector:   "id=foo",

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -572,9 +572,10 @@ func (m *Master) defaultAPIGroupVersion() *apiserver.APIGroupVersion {
 
 		Mapper: latest.RESTMapper,
 
-		Creater: api.Scheme,
-		Typer:   api.Scheme,
-		Linker:  latest.SelfLinker,
+		Creater:   api.Scheme,
+		Convertor: api.Scheme,
+		Typer:     api.Scheme,
+		Linker:    latest.SelfLinker,
 
 		Admit:   m.admissionControl,
 		Context: m.requestContextMapper,

--- a/pkg/runtime/conversion.go
+++ b/pkg/runtime/conversion.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Defines conversions between generic types and structs to map query strings
+// to struct objects.
 package runtime
 
 import (

--- a/pkg/runtime/conversion.go
+++ b/pkg/runtime/conversion.go
@@ -40,6 +40,7 @@ func JSONKeyMapper(key string, sourceTag, destTag reflect.StructTag) (string, st
 var DefaultStringConversions = []interface{}{
 	convertStringSliceToString,
 	convertStringSliceToInt,
+	convertStringSliceToBool,
 	convertStringSliceToInt64,
 }
 
@@ -61,6 +62,19 @@ func convertStringSliceToInt(input *[]string, out *int, s conversion.Scope) erro
 		return err
 	}
 	*out = i
+	return nil
+}
+
+func convertStringSliceToBool(input *[]string, out *bool, s conversion.Scope) error {
+	if len(*input) == 0 {
+		*out = false
+	}
+	switch strings.ToLower((*input)[0]) {
+	case "true", "1":
+		*out = true
+	default:
+		*out = true
+	}
 	return nil
 }
 

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -35,7 +35,9 @@ type Codec interface {
 
 // ObjectConvertor converts an object to a different version.
 type ObjectConvertor interface {
+	Convert(in, out interface{}) error
 	ConvertToVersion(in Object, outVersion string) (out Object, err error)
+	ConvertFieldLabel(version, kind, label, value string) (string, string, error)
 }
 
 // ObjectTyper contains methods for extracting the APIVersion and Kind

--- a/pkg/watch/json/types.go
+++ b/pkg/watch/json/types.go
@@ -37,6 +37,11 @@ type watchEvent struct {
 	Object runtime.RawExtension `json:"object,omitempty"`
 }
 
+// NewWatchEvent returns the serialization form of watchEvent for structured schemas
+func NewWatchEvent() interface{} {
+	return &watchEvent{}
+}
+
 // Object converts a watch.Event into an appropriately serializable JSON object
 func Object(codec runtime.Codec, event *watch.Event) (interface{}, error) {
 	obj, ok := event.Object.(runtime.Object)


### PR DESCRIPTION
Sub-resources are needed to properly secure proxying to the node (as per agreement in authz discussions), because we need to tie "resource" and "verb" to an action.  The `/proxy` endpoint is too open to give to anyone but cluster admins.  As part of https://github.com/GoogleCloudPlatform/kubernetes/issues/3481 and the general "bastioning" of the API server, we want to introduce new sub resources that allow specific, typed access to a backend.  Examples:
- Proxy to a pod's port: `/pods/foo/proxy/5000/some/resource`
- Proxy to a service's port: `/services/foo/proxy/5000/some/resource/path`
- Expose logs for a pod: `/pods/foo/logs?container=test` -> returns "text/plain" stream
- Expose logs for a resource backed by a pod `/jobs/foo/logs` -> 
- Parameterize pod logs with query options: `/pods/foo/logs?container=test&since=30s`
- Handle remote execution: `/pods/foo/exec?container=test&cmd=/bin/bash&arg=-c&arg=echo+$foo` -> upgrades connection to SPDY/HTTP2
- Handle portforwarding: `/pods/foo/portforward/5000?container=test`
- Allow binaries to be posted to an endpoint (with a given type) and converted by RESTStorage or apiserver into the underlying object - essentially hand off the request body to storage.

This requires three pieces of function:
- Allow query parameters to be properly versioned across a set of distinct resources and verbs
- Return an input stream from a RESTStorage Get or Post call
- Upgrade an HTTP connection to a higher protocol (exec) or hijack it (port forward) or use it to proxy other requests (proxy)

Ideally we would also ensure we have methods that allow proper introspection through swagger
- Handle content type negotiation when returning an input stream
- Annotate request parameters with metadata for query params

This pull request will contain the changes to enable that functionality through a set of targeted refactors.  @csrwng @lavalamp @bgrant0607 @liggitt
