### PR TITLE
Move field errors to pkg/util/fielderrors

### DIFF
--- a/pkg/api/errors/errors.go
+++ b/pkg/api/errors/errors.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 )
 
 // HTTP Status codes not in the golang http package.
@@ -133,10 +134,10 @@ func NewConflict(kind, name string, err error) error {
 }
 
 // NewInvalid returns an error indicating the item is invalid and cannot be processed.
-func NewInvalid(kind, name string, errs ValidationErrorList) error {
+func NewInvalid(kind, name string, errs fielderrors.ValidationErrorList) error {
 	causes := make([]api.StatusCause, 0, len(errs))
 	for i := range errs {
-		if err, ok := errs[i].(*ValidationError); ok {
+		if err, ok := errs[i].(*fielderrors.ValidationError); ok {
 			causes = append(causes, api.StatusCause{
 				Type:    api.CauseType(err.Type),
 				Message: err.Error(),

--- a/pkg/api/errors/errors_test.go
+++ b/pkg/api/errors/errors_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 )
 
 func TestErrorNew(t *testing.T) {
@@ -78,11 +79,11 @@ func TestErrorNew(t *testing.T) {
 
 func TestNewInvalid(t *testing.T) {
 	testCases := []struct {
-		Err     *ValidationError
+		Err     *fielderrors.ValidationError
 		Details *api.StatusDetails
 	}{
 		{
-			NewFieldDuplicate("field[0].name", "bar"),
+			fielderrors.NewFieldDuplicate("field[0].name", "bar"),
 			&api.StatusDetails{
 				Kind: "kind",
 				ID:   "name",
@@ -93,7 +94,7 @@ func TestNewInvalid(t *testing.T) {
 			},
 		},
 		{
-			NewFieldInvalid("field[0].name", "bar", "detail"),
+			fielderrors.NewFieldInvalid("field[0].name", "bar", "detail"),
 			&api.StatusDetails{
 				Kind: "kind",
 				ID:   "name",
@@ -104,7 +105,7 @@ func TestNewInvalid(t *testing.T) {
 			},
 		},
 		{
-			NewFieldNotFound("field[0].name", "bar"),
+			fielderrors.NewFieldNotFound("field[0].name", "bar"),
 			&api.StatusDetails{
 				Kind: "kind",
 				ID:   "name",
@@ -115,7 +116,7 @@ func TestNewInvalid(t *testing.T) {
 			},
 		},
 		{
-			NewFieldNotSupported("field[0].name", "bar"),
+			fielderrors.NewFieldNotSupported("field[0].name", "bar"),
 			&api.StatusDetails{
 				Kind: "kind",
 				ID:   "name",
@@ -126,7 +127,7 @@ func TestNewInvalid(t *testing.T) {
 			},
 		},
 		{
-			NewFieldRequired("field[0].name"),
+			fielderrors.NewFieldRequired("field[0].name"),
 			&api.StatusDetails{
 				Kind: "kind",
 				ID:   "name",
@@ -140,7 +141,7 @@ func TestNewInvalid(t *testing.T) {
 	for i, testCase := range testCases {
 		vErr, expected := testCase.Err, testCase.Details
 		expected.Causes[0].Message = vErr.Error()
-		err := NewInvalid("kind", "name", ValidationErrorList{vErr})
+		err := NewInvalid("kind", "name", fielderrors.ValidationErrorList{vErr})
 		status := err.(*StatusError).ErrStatus
 		if status.Code != 422 || status.Reason != api.StatusReasonInvalid {
 			t.Errorf("%d: unexpected status: %#v", i, status)

--- a/pkg/api/rest/create.go
+++ b/pkg/api/rest/create.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 )
 
 // RESTCreateStrategy defines the minimum validation, accepted input, and
@@ -38,7 +39,7 @@ type RESTCreateStrategy interface {
 	ResetBeforeCreate(obj runtime.Object)
 	// Validate is invoked after default fields in the object have been filled in before
 	// the object is persisted.
-	Validate(obj runtime.Object) errors.ValidationErrorList
+	Validate(obj runtime.Object) fielderrors.ValidationErrorList
 }
 
 // BeforeCreate ensures that common operations for all resources are performed on creation. It only returns

--- a/pkg/api/rest/types.go
+++ b/pkg/api/rest/types.go
@@ -18,9 +18,9 @@ package rest
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 )
 
 // ObjectFunc is a function to act on a given object. An error may be returned
@@ -67,7 +67,7 @@ func (svcStrategy) ResetBeforeCreate(obj runtime.Object) {
 }
 
 // Validate validates a new service.
-func (svcStrategy) Validate(obj runtime.Object) errors.ValidationErrorList {
+func (svcStrategy) Validate(obj runtime.Object) fielderrors.ValidationErrorList {
 	service := obj.(*api.Service)
 	return validation.ValidateService(service)
 }
@@ -76,7 +76,7 @@ func (svcStrategy) AllowCreateOnUpdate() bool {
 	return true
 }
 
-func (svcStrategy) ValidateUpdate(obj, old runtime.Object) errors.ValidationErrorList {
+func (svcStrategy) ValidateUpdate(obj, old runtime.Object) fielderrors.ValidationErrorList {
 	return validation.ValidateServiceUpdate(old.(*api.Service), obj.(*api.Service))
 }
 
@@ -103,7 +103,7 @@ func (nodeStrategy) ResetBeforeCreate(obj runtime.Object) {
 }
 
 // Validate validates a new node.
-func (nodeStrategy) Validate(obj runtime.Object) errors.ValidationErrorList {
+func (nodeStrategy) Validate(obj runtime.Object) fielderrors.ValidationErrorList {
 	node := obj.(*api.Node)
 	return validation.ValidateMinion(node)
 }

--- a/pkg/api/rest/update.go
+++ b/pkg/api/rest/update.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 )
 
 // RESTUpdateStrategy defines the minimum validation, accepted input, and
@@ -34,7 +35,7 @@ type RESTUpdateStrategy interface {
 	AllowCreateOnUpdate() bool
 	// ValidateUpdate is invoked after default fields in the object have been filled in before
 	// the object is persisted.
-	ValidateUpdate(obj, old runtime.Object) errors.ValidationErrorList
+	ValidateUpdate(obj, old runtime.Object) fielderrors.ValidationErrorList
 }
 
 // BeforeUpdate ensures that common operations for all resources are performed on update. It only returns

--- a/pkg/api/validation/events.go
+++ b/pkg/api/validation/events.go
@@ -18,8 +18,8 @@ package validation
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	errs "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	errs "github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 )
 
 // ValidateEvent makes sure that the event makes sense.

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -23,11 +23,11 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	errs "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/capabilities"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	errs "github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 
 	"github.com/golang/glog"
 )

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -22,14 +22,15 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/capabilities"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	utilerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
+	errors "github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 )
 
-func expectPrefix(t *testing.T, prefix string, errs errors.ValidationErrorList) {
+func expectPrefix(t *testing.T, prefix string, errs fielderrors.ValidationErrorList) {
 	for i := range errs {
 		if f, p := errs[i].(*errors.ValidationError).Field, prefix; !strings.HasPrefix(f, p) {
 			t.Errorf("expected prefix '%s' for field '%s' (%v)", p, f, errs[i])

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,10 +19,10 @@ package config
 import (
 	"fmt"
 
-	errs "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	errs "github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 )
 
 type RESTClientPoster interface {

--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -24,13 +24,13 @@ import (
 	"sync"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	apierrs "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/config"
 	utilerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 	"github.com/golang/glog"
 )
 
@@ -310,7 +310,7 @@ func filterInvalidPods(pods []api.Pod, source string, recorder record.EventRecor
 		} else {
 			name := kubelet.GetPodFullName(pod)
 			if names.Has(name) {
-				errlist = append(errlist, apierrs.NewFieldDuplicate("name", pod.Name))
+				errlist = append(errlist, fielderrors.NewFieldDuplicate("name", pod.Name))
 			} else {
 				names.Insert(name)
 			}

--- a/pkg/labels/selector.go
+++ b/pkg/labels/selector.go
@@ -22,8 +22,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 )
 
 // Selector represents a label selector.
@@ -758,14 +758,14 @@ const qualifiedNameErrorMsg string = "must match regex [" + util.DNS1123Subdomai
 
 func validateLabelKey(k string) error {
 	if !util.IsQualifiedName(k) {
-		return errors.NewFieldInvalid("label key", k, qualifiedNameErrorMsg)
+		return fielderrors.NewFieldInvalid("label key", k, qualifiedNameErrorMsg)
 	}
 	return nil
 }
 
 func validateLabelValue(v string) error {
 	if !util.IsValidLabelValue(v) {
-		return errors.NewFieldInvalid("label value", v, qualifiedNameErrorMsg)
+		return fielderrors.NewFieldInvalid("label value", v, qualifiedNameErrorMsg)
 	}
 	return nil
 }

--- a/pkg/registry/controller/rest.go
+++ b/pkg/registry/controller/rest.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
@@ -50,7 +50,7 @@ func (rcStrategy) ResetBeforeCreate(obj runtime.Object) {
 }
 
 // Validate validates a new replication controller.
-func (rcStrategy) Validate(obj runtime.Object) errors.ValidationErrorList {
+func (rcStrategy) Validate(obj runtime.Object) fielderrors.ValidationErrorList {
 	controller := obj.(*api.ReplicationController)
 	return validation.ValidateReplicationController(controller)
 }
@@ -62,7 +62,7 @@ func (rcStrategy) AllowCreateOnUpdate() bool {
 }
 
 // ValidateUpdate is the default update validation for an end user.
-func (rcStrategy) ValidateUpdate(obj, old runtime.Object) errors.ValidationErrorList {
+func (rcStrategy) ValidateUpdate(obj, old runtime.Object) fielderrors.ValidationErrorList {
 	return validation.ValidateReplicationControllerUpdate(old.(*api.ReplicationController), obj.(*api.ReplicationController))
 }
 

--- a/pkg/registry/generic/etcd/etcd_test.go
+++ b/pkg/registry/generic/etcd/etcd_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 
 	"github.com/coreos/go-etcd/etcd"
 )
@@ -43,10 +44,10 @@ func (t *testRESTStrategy) NamespaceScoped() bool     { return t.namespaceScoped
 func (t *testRESTStrategy) AllowCreateOnUpdate() bool { return t.allowCreateOnUpdate }
 
 func (t *testRESTStrategy) ResetBeforeCreate(obj runtime.Object) {}
-func (t *testRESTStrategy) Validate(obj runtime.Object) errors.ValidationErrorList {
+func (t *testRESTStrategy) Validate(obj runtime.Object) fielderrors.ValidationErrorList {
 	return nil
 }
-func (t *testRESTStrategy) ValidateUpdate(obj, old runtime.Object) errors.ValidationErrorList {
+func (t *testRESTStrategy) ValidateUpdate(obj, old runtime.Object) fielderrors.ValidationErrorList {
 	return nil
 }
 

--- a/pkg/registry/namespace/rest.go
+++ b/pkg/registry/namespace/rest.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 )
 
 // namespaceStrategy implements behavior for Namespaces
@@ -52,7 +52,7 @@ func (namespaceStrategy) ResetBeforeCreate(obj runtime.Object) {
 }
 
 // Validate validates a new namespace.
-func (namespaceStrategy) Validate(obj runtime.Object) errors.ValidationErrorList {
+func (namespaceStrategy) Validate(obj runtime.Object) fielderrors.ValidationErrorList {
 	namespace := obj.(*api.Namespace)
 	return validation.ValidateNamespace(namespace)
 }
@@ -63,7 +63,7 @@ func (namespaceStrategy) AllowCreateOnUpdate() bool {
 }
 
 // ValidateUpdate is the default update validation for an end user.
-func (namespaceStrategy) ValidateUpdate(obj, old runtime.Object) errors.ValidationErrorList {
+func (namespaceStrategy) ValidateUpdate(obj, old runtime.Object) fielderrors.ValidationErrorList {
 	return validation.ValidateNamespaceUpdate(obj.(*api.Namespace), old.(*api.Namespace))
 }
 
@@ -73,7 +73,7 @@ type namespaceStatusStrategy struct {
 
 var StatusStrategy = namespaceStatusStrategy{Strategy}
 
-func (namespaceStatusStrategy) ValidateUpdate(obj, old runtime.Object) errors.ValidationErrorList {
+func (namespaceStatusStrategy) ValidateUpdate(obj, old runtime.Object) fielderrors.ValidationErrorList {
 	// TODO: merge valid fields after update
 	return validation.ValidateNamespaceStatusUpdate(obj.(*api.Namespace), old.(*api.Namespace))
 }

--- a/pkg/registry/pod/etcd/etcd.go
+++ b/pkg/registry/pod/etcd/etcd.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/pod"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 )
 
 // rest implements a RESTStorage for pods against etcd
@@ -102,10 +103,10 @@ func (r *BindingREST) Create(ctx api.Context, obj runtime.Object) (out runtime.O
 	binding := obj.(*api.Binding)
 	// TODO: move me to a binding strategy
 	if len(binding.Target.Kind) != 0 && (binding.Target.Kind != "Node" && binding.Target.Kind != "Minion") {
-		return nil, errors.NewInvalid("binding", binding.Name, errors.ValidationErrorList{errors.NewFieldInvalid("to.kind", binding.Target.Kind, "must be empty, 'Node', or 'Minion'")})
+		return nil, errors.NewInvalid("binding", binding.Name, fielderrors.ValidationErrorList{fielderrors.NewFieldInvalid("to.kind", binding.Target.Kind, "must be empty, 'Node', or 'Minion'")})
 	}
 	if len(binding.Target.Name) == 0 {
-		return nil, errors.NewInvalid("binding", binding.Name, errors.ValidationErrorList{errors.NewFieldRequired("to.name")})
+		return nil, errors.NewInvalid("binding", binding.Name, fielderrors.ValidationErrorList{fielderrors.NewFieldRequired("to.name")})
 	}
 	err = r.assignPod(ctx, binding.Name, binding.Target.Name, binding.Annotations)
 	out = &api.Status{Status: api.StatusSuccess}

--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 )
 
 // podStrategy implements behavior for Pods
@@ -57,7 +58,7 @@ func (podStrategy) ResetBeforeCreate(obj runtime.Object) {
 }
 
 // Validate validates a new pod.
-func (podStrategy) Validate(obj runtime.Object) errors.ValidationErrorList {
+func (podStrategy) Validate(obj runtime.Object) fielderrors.ValidationErrorList {
 	pod := obj.(*api.Pod)
 	return validation.ValidatePod(pod)
 }
@@ -68,7 +69,7 @@ func (podStrategy) AllowCreateOnUpdate() bool {
 }
 
 // ValidateUpdate is the default update validation for an end user.
-func (podStrategy) ValidateUpdate(obj, old runtime.Object) errors.ValidationErrorList {
+func (podStrategy) ValidateUpdate(obj, old runtime.Object) fielderrors.ValidationErrorList {
 	return validation.ValidatePodUpdate(obj.(*api.Pod), old.(*api.Pod))
 }
 
@@ -83,7 +84,7 @@ type podStatusStrategy struct {
 
 var StatusStrategy = podStatusStrategy{Strategy}
 
-func (podStatusStrategy) ValidateUpdate(obj, old runtime.Object) errors.ValidationErrorList {
+func (podStatusStrategy) ValidateUpdate(obj, old runtime.Object) fielderrors.ValidationErrorList {
 	// TODO: merge valid fields after update
 	return validation.ValidatePodStatusUpdate(obj.(*api.Pod), old.(*api.Pod))
 }

--- a/pkg/registry/resourcequota/rest.go
+++ b/pkg/registry/resourcequota/rest.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 )
 
 // resourcequotaStrategy implements behavior for ResourceQuota objects
@@ -50,7 +50,7 @@ func (resourcequotaStrategy) ResetBeforeCreate(obj runtime.Object) {
 }
 
 // Validate validates a new resourcequota.
-func (resourcequotaStrategy) Validate(obj runtime.Object) errors.ValidationErrorList {
+func (resourcequotaStrategy) Validate(obj runtime.Object) fielderrors.ValidationErrorList {
 	resourcequota := obj.(*api.ResourceQuota)
 	return validation.ValidateResourceQuota(resourcequota)
 }
@@ -61,7 +61,7 @@ func (resourcequotaStrategy) AllowCreateOnUpdate() bool {
 }
 
 // ValidateUpdate is the default update validation for an end user.
-func (resourcequotaStrategy) ValidateUpdate(obj, old runtime.Object) errors.ValidationErrorList {
+func (resourcequotaStrategy) ValidateUpdate(obj, old runtime.Object) fielderrors.ValidationErrorList {
 	return validation.ValidateResourceQuotaUpdate(obj.(*api.ResourceQuota), old.(*api.ResourceQuota))
 }
 
@@ -71,7 +71,7 @@ type resourcequotaStatusStrategy struct {
 
 var StatusStrategy = resourcequotaStatusStrategy{Strategy}
 
-func (resourcequotaStatusStrategy) ValidateUpdate(obj, old runtime.Object) errors.ValidationErrorList {
+func (resourcequotaStatusStrategy) ValidateUpdate(obj, old runtime.Object) fielderrors.ValidationErrorList {
 	return validation.ValidateResourceQuotaStatusUpdate(obj.(*api.ResourceQuota), old.(*api.ResourceQuota))
 }
 

--- a/pkg/registry/service/rest.go
+++ b/pkg/registry/service/rest.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/minion"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/golang/glog"
 )
@@ -100,7 +101,7 @@ func (rs *REST) Create(ctx api.Context, obj runtime.Object) (runtime.Object, err
 	} else if api.IsServiceIPSet(service) {
 		// Try to respect the requested IP.
 		if err := rs.portalMgr.Allocate(net.ParseIP(service.Spec.PortalIP)); err != nil {
-			el := errors.ValidationErrorList{errors.NewFieldInvalid("spec.portalIP", service.Spec.PortalIP, err.Error())}
+			el := fielderrors.ValidationErrorList{fielderrors.NewFieldInvalid("spec.portalIP", service.Spec.PortalIP, err.Error())}
 			return nil, errors.NewInvalid("Service", service.Name, el)
 		}
 	}

--- a/pkg/tools/etcd_helper_watch.go
+++ b/pkg/tools/etcd_helper_watch.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
 	"github.com/coreos/go-etcd/etcd"
@@ -51,7 +52,7 @@ func ParseWatchResourceVersion(resourceVersion, kind string) (uint64, error) {
 	version, err := strconv.ParseUint(resourceVersion, 10, 64)
 	if err != nil {
 		// TODO: Does this need to be a ValidationErrorList?  I can't convince myself it does.
-		return 0, errors.NewInvalid(kind, "", errors.ValidationErrorList{errors.NewFieldInvalid("resourceVersion", resourceVersion, err.Error())})
+		return 0, errors.NewInvalid(kind, "", fielderrors.ValidationErrorList{fielderrors.NewFieldInvalid("resourceVersion", resourceVersion, err.Error())})
 	}
 	return version + 1, nil
 }

--- a/pkg/util/fielderrors/fielderrors.go
+++ b/pkg/util/fielderrors/fielderrors.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package errors
+package fielderrors
 
 import (
 	"fmt"

--- a/pkg/util/fielderrors/fielderrors_test.go
+++ b/pkg/util/fielderrors/fielderrors_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package errors
+package fielderrors
 
 import (
 	"strings"


### PR DESCRIPTION
Allows pkg/api to take a reference to labels.Selector and fields.Selector

@sdminonne fixes the circular reference discussed earlier
