### PR TITLE
Kubelet config sources should use the provided hostname, not lookup os.Hostname()

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -222,13 +222,17 @@ func startComponents(manifestURL, apiVersion string) (string, string) {
 	testRootDir := makeTempDirOrDie("kubelet_integ_1.", "")
 	configFilePath := makeTempDirOrDie("config", testRootDir)
 	glog.Infof("Using %s as root dir for kubelet #1", testRootDir)
-	kubeletapp.SimpleRunKubelet(cl, &fakeDocker1, machineList[0], testRootDir, manifestURL, "127.0.0.1", 10250, api.NamespaceDefault, empty_dir.ProbeVolumePlugins(), nil, cadvisorInterface, configFilePath)
+	kcfg := kubeletapp.SimpleKubelet(cl, &fakeDocker1, machineList[0], testRootDir, manifestURL, "127.0.0.1", 10250, api.NamespaceDefault, empty_dir.ProbeVolumePlugins(), nil, cadvisorInterface, configFilePath)
+	kcfg.PodStatusUpdateFrequency = 1 * time.Second
+	kubeletapp.RunKubelet(kcfg)
 	// Kubelet (machine)
 	// Create a second kubelet so that the guestbook example's two redis slaves both
 	// have a place they can schedule.
 	testRootDir = makeTempDirOrDie("kubelet_integ_2.", "")
 	glog.Infof("Using %s as root dir for kubelet #2", testRootDir)
-	kubeletapp.SimpleRunKubelet(cl, &fakeDocker2, machineList[1], testRootDir, "", "127.0.0.1", 10251, api.NamespaceDefault, empty_dir.ProbeVolumePlugins(), nil, cadvisorInterface, "")
+	kcfg = kubeletapp.SimpleKubelet(cl, &fakeDocker2, machineList[1], testRootDir, "", "127.0.0.1", 10251, api.NamespaceDefault, empty_dir.ProbeVolumePlugins(), nil, cadvisorInterface, "")
+	kcfg.PodStatusUpdateFrequency = 1 * time.Second
+	kubeletapp.RunKubelet(kcfg)
 	return apiServer.URL, configFilePath
 }
 

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -262,7 +262,7 @@ func (s *KubeletServer) createAPIServerClient() (*client.Client, error) {
 
 // SimpleRunKubelet is a simple way to start a Kubelet talking to dockerEndpoint, using an API Client.
 // Under the hood it calls RunKubelet (below)
-func SimpleRunKubelet(client *client.Client,
+func SimpleKubelet(client *client.Client,
 	dockerClient dockertools.DockerInterface,
 	hostname, rootDir, manifestURL, address string,
 	port uint,
@@ -270,7 +270,7 @@ func SimpleRunKubelet(client *client.Client,
 	volumePlugins []volume.VolumePlugin,
 	tlsOptions *kubelet.TLSOptions,
 	cadvisorInterface cadvisor.Interface,
-	configFilePath string) {
+	configFilePath string) *KubeletConfig {
 
 	imageGCPolicy := kubelet.ImageGCPolicy{
 		HighThresholdPercent: 90,
@@ -302,7 +302,7 @@ func SimpleRunKubelet(client *client.Client,
 		ConfigFile:               configFilePath,
 		ImageGCPolicy:            imageGCPolicy,
 	}
-	RunKubelet(&kcfg)
+	return &kcfg
 }
 
 // RunKubelet is responsible for setting up and running a kubelet.  It is used in three different applications:

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -358,13 +358,13 @@ func makePodSourceConfig(kc *KubeletConfig) *config.PodConfig {
 	// define file config source
 	if kc.ConfigFile != "" {
 		glog.Infof("Adding manifest file: %v", kc.ConfigFile)
-		config.NewSourceFile(kc.ConfigFile, kc.FileCheckFrequency, cfg.Channel(kubelet.FileSource))
+		config.NewSourceFile(kc.ConfigFile, kc.Hostname, kc.FileCheckFrequency, cfg.Channel(kubelet.FileSource))
 	}
 
 	// define url config source
 	if kc.ManifestURL != "" {
 		glog.Infof("Adding manifest url: %v", kc.ManifestURL)
-		config.NewSourceURL(kc.ManifestURL, kc.HTTPCheckFrequency, cfg.Channel(kubelet.HTTPSource))
+		config.NewSourceURL(kc.ManifestURL, kc.Hostname, kc.HTTPCheckFrequency, cfg.Channel(kubelet.HTTPSource))
 	}
 	if kc.KubeClient != nil {
 		glog.Infof("Watching apiserver")

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -150,7 +150,8 @@ func startComponents(etcdClient tools.EtcdClient, cl *client.Client, addr net.IP
 	if err != nil {
 		glog.Fatalf("Failed to create cAdvisor: %v", err)
 	}
-	kubeletapp.SimpleRunKubelet(cl, dockerClient, machineList[0], "/tmp/kubernetes", "", "127.0.0.1", 10250, *masterServiceNamespace, kubeletapp.ProbeVolumePlugins(), nil, cadvisorInterface, "")
+	kcfg := kubeletapp.SimpleKubelet(cl, dockerClient, machineList[0], "/tmp/kubernetes", "", "127.0.0.1", 10250, *masterServiceNamespace, kubeletapp.ProbeVolumePlugins(), nil, cadvisorInterface, "")
+	kubeletapp.RunKubelet(kcfg)
 }
 
 func newApiClient(addr net.IP, port int) *client.Client {

--- a/pkg/kubelet/config/apiserver_test.go
+++ b/pkg/kubelet/config/apiserver_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
-const hostname string = "mcaa1"
-
 type fakePodLW struct {
 	listResp  runtime.Object
 	watchResp watch.Interface

--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -18,9 +18,7 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"reflect"
-	"strings"
 	"sync"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -363,11 +361,6 @@ func bestPodIdentString(pod *api.Pod) string {
 	return fmt.Sprintf("%s.%s", name, namespace)
 }
 
-func GeneratePodName(name string) (string, error) {
-	hostname, err := os.Hostname() //TODO: kubelet name would be better
-	if err != nil {
-		return "", err
-	}
-	hostname = strings.ToLower(hostname)
+func GeneratePodName(name, hostname string) (string, error) {
 	return fmt.Sprintf("%s-%s", name, hostname), nil
 }

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -32,16 +32,18 @@ import (
 )
 
 type sourceURL struct {
-	url     string
-	updates chan<- interface{}
-	data    []byte
+	url      string
+	hostname string
+	updates  chan<- interface{}
+	data     []byte
 }
 
-func NewSourceURL(url string, period time.Duration, updates chan<- interface{}) {
+func NewSourceURL(url, hostname string, period time.Duration, updates chan<- interface{}) {
 	config := &sourceURL{
-		url:     url,
-		updates: updates,
-		data:    nil,
+		url:      url,
+		hostname: hostname,
+		updates:  updates,
+		data:     nil,
 	}
 	glog.V(1).Infof("Watching URL %s", url)
 	go util.Forever(config.run, period)
@@ -51,6 +53,10 @@ func (s *sourceURL) run() {
 	if err := s.extractFromURL(); err != nil {
 		glog.Errorf("Failed to read URL: %v", err)
 	}
+}
+
+func (s *sourceURL) applyDefaults(pod *api.Pod) error {
+	return applyDefaults(pod, s.url, false, s.hostname)
 }
 
 func (s *sourceURL) extractFromURL() error {
@@ -78,7 +84,7 @@ func (s *sourceURL) extractFromURL() error {
 	s.data = data
 
 	// First try as if it's a single manifest
-	parsed, manifest, pod, singleErr := tryDecodeSingleManifest(data, s.url, false)
+	parsed, manifest, pod, singleErr := tryDecodeSingleManifest(data, s.applyDefaults)
 	if parsed {
 		if singleErr != nil {
 			// It parsed but could not be used.
@@ -90,7 +96,7 @@ func (s *sourceURL) extractFromURL() error {
 	}
 
 	// That didn't work, so try an array of manifests.
-	parsed, manifests, pods, multiErr := tryDecodeManifestList(data, s.url, false)
+	parsed, manifests, pods, multiErr := tryDecodeManifestList(data, s.applyDefaults)
 	if parsed {
 		if multiErr != nil {
 			// It parsed but could not be used.
@@ -112,7 +118,7 @@ func (s *sourceURL) extractFromURL() error {
 	// Try to parse it as Pod(s).
 
 	// First try as it is a single pod.
-	parsed, pod, singlePodErr := tryDecodeSinglePod(data, s.url, false)
+	parsed, pod, singlePodErr := tryDecodeSinglePod(data, s.applyDefaults)
 	if parsed {
 		if singlePodErr != nil {
 			// It parsed but could not be used.
@@ -123,7 +129,7 @@ func (s *sourceURL) extractFromURL() error {
 	}
 
 	// That didn't work, so try a list of pods.
-	parsed, pods, multiPodErr := tryDecodePodList(data, s.url, false)
+	parsed, pods, multiPodErr := tryDecodePodList(data, s.applyDefaults)
 	if parsed {
 		if multiPodErr != nil {
 			// It parsed but could not be used.

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -19,8 +19,6 @@ package config
 import (
 	"encoding/json"
 	"net/http/httptest"
-	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -35,7 +33,7 @@ import (
 
 func TestURLErrorNotExistNoUpdate(t *testing.T) {
 	ch := make(chan interface{})
-	NewSourceURL("http://localhost:49575/_not_found_", time.Millisecond, ch)
+	NewSourceURL("http://localhost:49575/_not_found_", "localhost", time.Millisecond, ch)
 	select {
 	case got := <-ch:
 		t.Errorf("Expected no update, Got %#v", got)
@@ -45,7 +43,7 @@ func TestURLErrorNotExistNoUpdate(t *testing.T) {
 
 func TestExtractFromHttpBadness(t *testing.T) {
 	ch := make(chan interface{}, 1)
-	c := sourceURL{"http://localhost:49575/_not_found_", ch, nil}
+	c := sourceURL{"http://localhost:49575/_not_found_", "other", ch, nil}
 	if err := c.extractFromURL(); err == nil {
 		t.Errorf("Expected error")
 	}
@@ -111,7 +109,7 @@ func TestExtractInvalidManifest(t *testing.T) {
 		testServer := httptest.NewServer(&fakeHandler)
 		defer testServer.Close()
 		ch := make(chan interface{}, 1)
-		c := sourceURL{testServer.URL, ch, nil}
+		c := sourceURL{testServer.URL, "localhost", ch, nil}
 		if err := c.extractFromURL(); err == nil {
 			t.Errorf("%s: Expected error", testCase.desc)
 		}
@@ -119,8 +117,7 @@ func TestExtractInvalidManifest(t *testing.T) {
 }
 
 func TestExtractManifestFromHTTP(t *testing.T) {
-	hostname, _ := os.Hostname()
-	hostname = strings.ToLower(hostname)
+	hostname := "random-hostname"
 
 	var testCases = []struct {
 		desc      string
@@ -263,7 +260,7 @@ func TestExtractManifestFromHTTP(t *testing.T) {
 		testServer := httptest.NewServer(&fakeHandler)
 		defer testServer.Close()
 		ch := make(chan interface{}, 1)
-		c := sourceURL{testServer.URL, ch, nil}
+		c := sourceURL{testServer.URL, hostname, ch, nil}
 		if err := c.extractFromURL(); err != nil {
 			t.Errorf("%s: Unexpected error: %v", testCase.desc, err)
 			continue
@@ -290,8 +287,7 @@ func TestExtractManifestFromHTTP(t *testing.T) {
 }
 
 func TestExtractPodsFromHTTP(t *testing.T) {
-	hostname, _ := os.Hostname()
-	hostname = strings.ToLower(hostname)
+	hostname := "different-value"
 
 	var testCases = []struct {
 		desc     string
@@ -454,7 +450,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 		testServer := httptest.NewServer(&fakeHandler)
 		defer testServer.Close()
 		ch := make(chan interface{}, 1)
-		c := sourceURL{testServer.URL, ch, nil}
+		c := sourceURL{testServer.URL, hostname, ch, nil}
 		if err := c.extractFromURL(); err != nil {
 			t.Errorf("%s: Unexpected error: %v", testCase.desc, err)
 			continue


### PR DESCRIPTION
Also fix race conditions on status sync loops which can result in sporadic failures.

Fixes #5757
