### PR TITLE
Added API variables so Kibana could access ES through the API server

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
@@ -13,6 +13,11 @@ desiredState:
         containers:
           - name: kibana-logging
             image: gcr.io/google_containers/kibana:1.1
+            env: 
+              - name: "ES_SCHEME"
+                value: "https"
+              - name: "ES_HOST"
+                value: "\"+window.location.hostname+\"/api/v1beta1/proxy/services/elasticsearch-logging"
             ports:
               - name: kibana-port
                 containerPort: 80

--- a/cluster/addons/fluentd-elasticsearch/kibana-image/run_kibana_nginx.sh
+++ b/cluster/addons/fluentd-elasticsearch/kibana-image/run_kibana_nginx.sh
@@ -43,6 +43,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+#Report all environment variables containing 'elasticsearch' and ES related
+set | grep -i elasticsearch
+set | grep -i ES_SCHEME
+set | grep -i ES_HOST
+
 cat << EOF > /usr/share/nginx/html/config.js
 /** @scratch /configuration/config.js/1
  *
@@ -75,11 +80,7 @@ function (Settings) {
      *  +elasticsearch: {server: "http://localhost:9200", withCredentials: true}+
      *
      */
-
-
-    elasticsearch: "https://"+window.location.hostname+"/api/v1beta1/proxy/services/elasticsearch-logging",
-
-
+    elasticsearch: "${ES_SCHEME}://${ES_HOST}",
     /** @scratch /configuration/config.js/5
      *
      * ==== default_route


### PR DESCRIPTION
I noticed an issue when I was trying to get the fluentd-es-kibana addon running on my bare metal Kubernetes cluster. It appears that the Kibana container is statically configured to point to the local container to get to the API server.  From the Kibana docker image run_kibana_nginx.sh...

elasticsearch: "https://"+window.location.hostname+"/api/v1beta1/proxy/services/elasticsearch-logging"

In my case, the API server lives on the master which doesn't host any other pods at all.  That being said, I suggest adding the following ENV variables to the Kibana replication controller definition...

-API_PROTOCOL
-API_SERVER
-API_PORT

The PR has these values in the RC definition set to what the container defaults to now.  That is...

API_PROTOCOL = HTTPS
-API_SERVER = localhost (logic in the script changes this to the local IP of the pod)
-API_PORT = "" (blank or default of 80)

I tested this by building a new docker image and ensured that the same URL is generated by Kibana for accessing data in ES.  Besides adding the 'localhost' logic I just changed the way that the URL was generated by concatenating the ENV variables.  I also put the set commands back in to spit certain ENV variables out to console so I could catch them with 'docker logs' during debugging.
