### PR TITLE
Upgrade to etcd v.2.0.5

### DIFF
--- a/cluster/ubuntu-cluster/build.sh
+++ b/cluster/ubuntu-cluster/build.sh
@@ -49,7 +49,7 @@ cp flannel/bin/flanneld binaries/
 
 # ectd
 echo "Download etcd release ..."
-ETCD_V="v2.0.0"
+ETCD_V="v2.0.5"
 ETCD="etcd-${ETCD_V}-linux-amd64"
 if [ ! -f etcd.tar.gz ] ; then
     curl -L  https://github.com/coreos/etcd/releases/download/$ETCD_V/$ETCD.tar.gz -o etcd.tar.gz


### PR DESCRIPTION
This is an attempt to upgrade the master to use etcd v2.0.5
Not working yet: will confer with @dchen1107 about else needs to be done.
Issue #5779
