### PR TITLE
git ignore .kubeconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,10 +40,13 @@ Session.vim
 .vagrant
 network_closure.sh
 
-# compiled binaries in third_party
+# Compiled binaries in third_party
 /third_party/pkg
 
-# also ignore etcd installed by hack/install-etcd.sh
+# Also ignore etcd installed by hack/install-etcd.sh
 /third_party/etcd*
+
+# User cluster configs
+.kubeconfig
 
 .tags*


### PR DESCRIPTION
When running locally, we ask user to create .kubeconfig under kube root; ignore it to make root 'clean'.
