### PR TITLE
Rename the JSON for GCEPersistentDisk, fix examples

### DIFF
--- a/examples/gce-pd/v1beta3/testpd.yaml
+++ b/examples/gce-pd/v1beta3/testpd.yaml
@@ -15,7 +15,7 @@ spec:
           mountPath: /testpd
   volumes:
     - name: testpd
-      persistentDisk:
+      gcePersistentDisk:
         # This GCE PD must already exist.
         pdName: %insert_pd_name_here%
         fsType: ext4

--- a/examples/mysql-wordpress-pd/v1beta3/mysql.yaml
+++ b/examples/mysql-wordpress-pd/v1beta3/mysql.yaml
@@ -33,7 +33,7 @@ spec:
               mountPath: /var/lib/mysql
       volumes:
         - name: mysql-persistent-storage
-          persistentDisk:
+          gcePersistentDisk:
             # This GCE PD must already exist.
             pdName: mysql-disk
             fsType: ext4

--- a/examples/mysql-wordpress-pd/v1beta3/wordpress.yaml
+++ b/examples/mysql-wordpress-pd/v1beta3/wordpress.yaml
@@ -30,7 +30,7 @@ spec:
               mountPath: /var/www/html
       volumes:
         - name: wordpress-persistent-storage
-          persistentDisk:
+          gcePersistentDisk:
             # This GCE PD must already exist.
             pdName: wordpress-disk
             fsType: ext4

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -186,7 +186,7 @@ type VolumeSource struct {
 	EmptyDir *EmptyDirVolumeSource `json:"emptyDir"`
 	// GCEPersistentDisk represents a GCE Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod.
-	GCEPersistentDisk *GCEPersistentDiskVolumeSource `json:"persistentDisk"`
+	GCEPersistentDisk *GCEPersistentDiskVolumeSource `json:"gcePersistentDisk"`
 	// GitRepo represents a git repository at a particular revision.
 	GitRepo *GitRepoVolumeSource `json:"gitRepo"`
 	// Secret represents a secret that should populate this volume.


### PR DESCRIPTION
I know the internal JSON tags are slated for death.  Until then, make them
correct.  Also fix some examples of v1b3 conversions that did not rename the
JSON field.
