### PR TITLE
Improve ResourceLocation API, allow proxy to use authenticated transport

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -106,6 +106,10 @@ func (fakeKubeletClient) GetNodeInfo(host string) (api.NodeInfo, error) {
 	return api.NodeInfo{}, nil
 }
 
+func (fakeKubeletClient) GetConnectionInfo(host string) (string, uint, http.RoundTripper, error) {
+	return "", 0, nil, errors.New("Not Implemented")
+}
+
 func (fakeKubeletClient) HealthCheck(host string) (probe.Result, error) {
 	return probe.Success, nil
 }

--- a/pkg/api/rest/rest.go
+++ b/pkg/api/rest/rest.go
@@ -17,6 +17,9 @@ limitations under the License.
 package rest
 
 import (
+	"net/http"
+	"net/url"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
@@ -142,6 +145,6 @@ type StandardStorage interface {
 
 // Redirector know how to return a remote resource's location.
 type Redirector interface {
-	// ResourceLocation should return the remote location of the given resource, or an error.
-	ResourceLocation(ctx api.Context, name string) (remoteLocation string, err error)
+	// ResourceLocation should return the remote location of the given resource, and an optional transport to use to request it, or an error.
+	ResourceLocation(ctx api.Context, id string) (remoteLocation *url.URL, transport http.RoundTripper, err error)
 }

--- a/pkg/apiserver/proxy_test.go
+++ b/pkg/apiserver/proxy_test.go
@@ -275,9 +275,10 @@ func TestProxy(t *testing.T) {
 		}))
 		defer proxyServer.Close()
 
+		serverURL, _ := url.Parse(proxyServer.URL)
 		simpleStorage := &SimpleRESTStorage{
 			errors:                    map[string]error{},
-			resourceLocation:          proxyServer.URL,
+			resourceLocation:          serverURL,
 			expectedResourceNamespace: item.reqNamespace,
 		}
 
@@ -335,9 +336,10 @@ func TestProxyUpgrade(t *testing.T) {
 	}))
 	defer backendServer.Close()
 
+	serverURL, _ := url.Parse(backendServer.URL)
 	simpleStorage := &SimpleRESTStorage{
 		errors:                    map[string]error{},
-		resourceLocation:          backendServer.URL,
+		resourceLocation:          serverURL,
 		expectedResourceNamespace: "myns",
 	}
 

--- a/pkg/apiserver/redirect_test.go
+++ b/pkg/apiserver/redirect_test.go
@@ -53,7 +53,7 @@ func TestRedirect(t *testing.T) {
 
 	for _, item := range table {
 		simpleStorage.errors["resourceLocation"] = item.err
-		simpleStorage.resourceLocation = item.id
+		simpleStorage.resourceLocation = &url.URL{Host: item.id}
 		resp, err := client.Get(server.URL + "/api/version/redirect/foo/" + item.id)
 		if resp == nil {
 			t.Fatalf("Unexpected nil resp")
@@ -104,7 +104,7 @@ func TestRedirectWithNamespaces(t *testing.T) {
 
 	for _, item := range table {
 		simpleStorage.errors["resourceLocation"] = item.err
-		simpleStorage.resourceLocation = item.id
+		simpleStorage.resourceLocation = &url.URL{Host: item.id}
 		resp, err := client.Get(server.URL + "/api/version/redirect/namespaces/other/foo/" + item.id)
 		if resp == nil {
 			t.Fatalf("Unexpected nil resp")

--- a/pkg/client/kubelet.go
+++ b/pkg/client/kubelet.go
@@ -40,6 +40,7 @@ type KubeletClient interface {
 	KubeletHealthChecker
 	PodInfoGetter
 	NodeInfoGetter
+	ConnectionInfoGetter
 }
 
 // KubeletHealthchecker is an interface for healthchecking kubelets
@@ -57,6 +58,10 @@ type PodInfoGetter interface {
 
 type NodeInfoGetter interface {
 	GetNodeInfo(host string) (api.NodeInfo, error)
+}
+
+type ConnectionInfoGetter interface {
+	GetConnectionInfo(host string) (scheme string, port uint, transport http.RoundTripper, error error)
 }
 
 // HTTPKubeletClient is the default implementation of PodInfoGetter and KubeletHealthchecker, accesses the kubelet over HTTP.
@@ -90,6 +95,14 @@ func NewKubeletClient(config *KubeletConfig) (KubeletClient, error) {
 		Port:        config.Port,
 		EnableHttps: config.EnableHttps,
 	}, nil
+}
+
+func (c *HTTPKubeletClient) GetConnectionInfo(host string) (string, uint, http.RoundTripper, error) {
+	scheme := "http"
+	if c.EnableHttps {
+		scheme = "https"
+	}
+	return scheme, c.Port, c.Client.Transport, nil
 }
 
 func (c *HTTPKubeletClient) url(host, path, query string) string {
@@ -167,4 +180,8 @@ func (c FakeKubeletClient) GetNodeInfo(host string) (api.NodeInfo, error) {
 
 func (c FakeKubeletClient) HealthCheck(host string) (probe.Result, error) {
 	return probe.Unknown, errors.New("Not Implemented")
+}
+
+func (c FakeKubeletClient) GetConnectionInfo(host string) (string, uint, http.RoundTripper, error) {
+	return "", 0, nil, errors.New("Not Implemented")
 }

--- a/pkg/cloudprovider/controller/nodecontroller_test.go
+++ b/pkg/cloudprovider/controller/nodecontroller_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"reflect"
 	"sort"
 	"testing"
@@ -133,6 +134,10 @@ func (c *FakeKubeletClient) GetPodStatus(host, podNamespace, podID string) (api.
 
 func (c *FakeKubeletClient) GetNodeInfo(host string) (api.NodeInfo, error) {
 	return api.NodeInfo{}, errors.New("Not Implemented")
+}
+
+func (c *FakeKubeletClient) GetConnectionInfo(host string) (string, uint, http.RoundTripper, error) {
+	return "", 0, nil, errors.New("Not Implemented")
 }
 
 func (c *FakeKubeletClient) HealthCheck(host string) (probe.Result, error) {

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -368,7 +368,7 @@ func (m *Master) init(c *Config) {
 	m.endpointRegistry = registry
 	m.nodeRegistry = registry
 
-	nodeStorage := minion.NewStorage(m.nodeRegistry)
+	nodeStorage := minion.NewStorage(m.nodeRegistry, c.KubeletClient)
 	// TODO: unify the storage -> registry and storage -> client patterns
 	nodeStorageClient := RESTStorageToNodes(nodeStorage)
 	podCache := NewPodCache(

--- a/pkg/registry/pod/etcd/etcd.go
+++ b/pkg/registry/pod/etcd/etcd.go
@@ -18,6 +18,8 @@ package etcd
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
@@ -75,8 +77,11 @@ func NewStorage(h tools.EtcdHelper) (*REST, *BindingREST, *StatusREST) {
 	return &REST{*store}, &BindingREST{store: store}, &StatusREST{store: &statusStore}
 }
 
+// Implement Redirector.
+var _ = rest.Redirector(&REST{})
+
 // ResourceLocation returns a pods location from its HostIP
-func (r *REST) ResourceLocation(ctx api.Context, name string) (string, error) {
+func (r *REST) ResourceLocation(ctx api.Context, name string) (*url.URL, http.RoundTripper, error) {
 	return pod.ResourceLocation(r, ctx, name)
 }
 

--- a/pkg/registry/pod/etcd/etcd_test.go
+++ b/pkg/registry/pod/etcd/etcd_test.go
@@ -683,13 +683,19 @@ func TestResourceLocation(t *testing.T) {
 		storage = storage.WithPodStatus(cache)
 
 		redirector := rest.Redirector(storage)
-		location, err := redirector.ResourceLocation(api.NewDefaultContext(), tc.query)
+		location, _, err := redirector.ResourceLocation(api.NewDefaultContext(), tc.query)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
+		if location == nil {
+			t.Errorf("Unexpected nil: %v", location)
+		}
 
-		if location != tc.location {
-			t.Errorf("Expected %v, but got %v", tc.location, location)
+		if location.Scheme != "" {
+			t.Errorf("Expected '%v', but got '%v'", "", location.Scheme)
+		}
+		if location.Host != tc.location {
+			t.Errorf("Expected %v, but got %v", tc.location, location.Host)
 		}
 	}
 }

--- a/pkg/registry/service/rest_test.go
+++ b/pkg/registry/service/rest_test.go
@@ -385,11 +385,14 @@ func TestServiceRegistryResourceLocation(t *testing.T) {
 		},
 	})
 	redirector := rest.Redirector(storage)
-	location, err := redirector.ResourceLocation(ctx, "foo")
+	location, _, err := redirector.ResourceLocation(ctx, "foo")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if e, a := "foo:80", location; e != a {
+	if location == nil {
+		t.Errorf("Unexpected nil: %v", location)
+	}
+	if e, a := "//foo:80", location.String(); e != a {
 		t.Errorf("Expected %v, but got %v", e, a)
 	}
 	if e, a := "foo", registry.GottenID; e != a {
@@ -398,7 +401,7 @@ func TestServiceRegistryResourceLocation(t *testing.T) {
 
 	// Test error path
 	registry.Err = fmt.Errorf("fake error")
-	if _, err = redirector.ResourceLocation(ctx, "foo"); err == nil {
+	if _, _, err = redirector.ResourceLocation(ctx, "foo"); err == nil {
 		t.Errorf("unexpected nil error")
 	}
 }

--- a/pkg/util/httpstream/httpstream.go
+++ b/pkg/util/httpstream/httpstream.go
@@ -19,6 +19,7 @@ package httpstream
 import (
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -77,4 +78,14 @@ type Stream interface {
 	Reset() error
 	// Headers returns the headers used to create the stream.
 	Headers() http.Header
+}
+
+// IsUpgradeRequest returns true if the given request is a connection upgrade request
+func IsUpgradeRequest(req *http.Request) bool {
+	for _, h := range req.Header[http.CanonicalHeaderKey(HeaderConnection)] {
+		if strings.Contains(strings.ToLower(h), strings.ToLower(HeaderUpgrade)) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This is a first step to making /proxy able to work against a secured node. It does the following:
- [x] Make ResourceLocation return a structured URL object (clarifies issues with returning URLs without schemes)
- [x] Allow ResourceLocation to return an optional round tripper to use when contacting the remote URL
- [x] Allow /proxy to connect to TLS backends
- [x] Fix issue with /proxy prepending `/ns/<namespace>` even when `namespace` was empty
- [x] Stop assuming http for connections to nodes
