### PR TITLE
Change secret volume plugin reference to name

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -265,8 +265,8 @@ type GitRepoVolumeSource struct {
 // The contents of the target Secret's Data field will be presented in a volume
 // as files using the keys in the Data field as the file names.
 type SecretVolumeSource struct {
-	// Reference to a Secret
-	Target ObjectReference `json:"target"`
+	// Name of the secret in the pod's namespace to use
+	SecretName string `json:"secretName"`
 }
 
 // NFSVolumeSource represents an NFS Mount that lasts the lifetime of a pod

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -1377,6 +1377,14 @@ func init() {
 			out.PodID = in.Name
 			return nil
 		},
+		func(in *newer.SecretVolumeSource, out *SecretVolumeSource, s conversion.Scope) error {
+			out.Target.ID = in.SecretName
+			return nil
+		},
+		func(in *SecretVolumeSource, out *newer.SecretVolumeSource, s conversion.Scope) error {
+			out.SecretName = in.Target.ID
+			return nil
+		},
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/api/v1beta1/conversion_test.go
+++ b/pkg/api/v1beta1/conversion_test.go
@@ -462,3 +462,31 @@ func TestEndpointsConversion(t *testing.T) {
 		}
 	}
 }
+
+func TestSecretVolumeSourceConversion(t *testing.T) {
+	given := current.SecretVolumeSource{
+		Target: current.ObjectReference{
+			ID: "foo",
+		},
+	}
+
+	expected := newer.SecretVolumeSource{
+		SecretName: "foo",
+	}
+
+	got := newer.SecretVolumeSource{}
+	if err := Convert(&given, &got); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if got.SecretName != expected.SecretName {
+		t.Errorf("Expected %v; got %v", expected, got)
+	}
+
+	got2 := current.SecretVolumeSource{}
+	if err := Convert(&got, &got2); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if got2.Target.ID != given.Target.ID {
+		t.Errorf("Expected %v; got %v", given, got2)
+	}
+}

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -171,7 +171,8 @@ type GitRepoVolumeSource struct {
 
 // SecretVolumeSource adapts a Secret into a VolumeSource
 type SecretVolumeSource struct {
-	// Reference to a Secret
+	// Reference to a Secret to use.  Only the ID field of this reference is used; a
+	// secret can only be used by pods in its namespace.
 	Target ObjectReference `json:"target" description:"target is a reference to a secret"`
 }
 

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -1305,6 +1305,14 @@ func init() {
 			out.PodID = in.Name
 			return nil
 		},
+		func(in *newer.SecretVolumeSource, out *SecretVolumeSource, s conversion.Scope) error {
+			out.Target.ID = in.SecretName
+			return nil
+		},
+		func(in *SecretVolumeSource, out *newer.SecretVolumeSource, s conversion.Scope) error {
+			out.SecretName = in.Target.ID
+			return nil
+		},
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/api/v1beta2/conversion_test.go
+++ b/pkg/api/v1beta2/conversion_test.go
@@ -281,3 +281,31 @@ func TestEndpointsConversion(t *testing.T) {
 		}
 	}
 }
+
+func TestSecretVolumeSourceConversion(t *testing.T) {
+	given := current.SecretVolumeSource{
+		Target: current.ObjectReference{
+			ID: "foo",
+		},
+	}
+
+	expected := newer.SecretVolumeSource{
+		SecretName: "foo",
+	}
+
+	got := newer.SecretVolumeSource{}
+	if err := newer.Scheme.Convert(&given, &got); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if got.SecretName != expected.SecretName {
+		t.Errorf("Expected %v; got %v", expected, got)
+	}
+
+	got2 := current.SecretVolumeSource{}
+	if err := newer.Scheme.Convert(&got, &got2); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if got2.Target.ID != given.Target.ID {
+		t.Errorf("Expected %v; got %v", given, got2)
+	}
+}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -110,7 +110,8 @@ const (
 //
 // https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/secrets.md
 type SecretVolumeSource struct {
-	// Reference to a Secret
+	// Reference to a Secret to use.  Only the ID field of this reference is used; a
+	// secret can only be used by pods in its namespace.
 	Target ObjectReference `json:"target" description:"target is a reference to a secret"`
 }
 

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -274,9 +274,11 @@ type GitRepoVolumeSource struct {
 }
 
 // SecretVolumeSource adapts a Secret into a VolumeSource
+//
+// https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/secrets.md
 type SecretVolumeSource struct {
-	// Reference to a Secret
-	Target ObjectReference `json:"target" description:"target is a reference to a secret"`
+	// Name of the secret in the pod's namespace to use
+	SecretName string `json:"secretName" description:"secretName is the name of a secret in the pod's namespace"`
 }
 
 // NFSVolumeSource represents an NFS mount that lasts the lifetime of a pod

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -331,14 +331,8 @@ func validateGCEPersistentDiskVolumeSource(PD *api.GCEPersistentDiskVolumeSource
 
 func validateSecretVolumeSource(secretSource *api.SecretVolumeSource) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
-	if secretSource.Target.Name == "" {
-		allErrs = append(allErrs, errs.NewFieldRequired("target.name"))
-	}
-	if secretSource.Target.Namespace == "" {
-		allErrs = append(allErrs, errs.NewFieldRequired("target.namespace"))
-	}
-	if secretSource.Target.Kind != "Secret" {
-		allErrs = append(allErrs, errs.NewFieldInvalid("target.kind", secretSource.Target.Kind, "Secret"))
+	if secretSource.SecretName == "" {
+		allErrs = append(allErrs, errs.NewFieldRequired("secretName"))
 	}
 	return allErrs
 }

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -211,7 +211,7 @@ func TestValidateVolumes(t *testing.T) {
 		{Name: "empty", VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}},
 		{Name: "gcepd", VolumeSource: api.VolumeSource{GCEPersistentDisk: &api.GCEPersistentDiskVolumeSource{"my-PD", "ext4", 1, false}}},
 		{Name: "gitrepo", VolumeSource: api.VolumeSource{GitRepo: &api.GitRepoVolumeSource{"my-repo", "hashstring"}}},
-		{Name: "secret", VolumeSource: api.VolumeSource{Secret: &api.SecretVolumeSource{api.ObjectReference{Namespace: api.NamespaceDefault, Name: "my-secret", Kind: "Secret"}}}},
+		{Name: "secret", VolumeSource: api.VolumeSource{Secret: &api.SecretVolumeSource{"my-secret"}}},
 	}
 	names, errs := validateVolumes(successCase)
 	if len(errs) != 0 {

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -62,7 +62,7 @@ func (plugin *secretPlugin) NewBuilder(spec *api.Volume, podRef *api.ObjectRefer
 }
 
 func (plugin *secretPlugin) newBuilderInternal(spec *api.Volume, podRef *api.ObjectReference) (volume.Builder, error) {
-	return &secretVolume{spec.Name, *podRef, plugin, spec.Secret.Target}, nil
+	return &secretVolume{spec.Name, *podRef, plugin, spec.Secret.SecretName}, nil
 }
 
 func (plugin *secretPlugin) NewCleaner(volName string, podUID types.UID) (volume.Cleaner, error) {
@@ -70,16 +70,16 @@ func (plugin *secretPlugin) NewCleaner(volName string, podUID types.UID) (volume
 }
 
 func (plugin *secretPlugin) newCleanerInternal(volName string, podUID types.UID) (volume.Cleaner, error) {
-	return &secretVolume{volName, api.ObjectReference{UID: podUID}, plugin, api.ObjectReference{}}, nil
+	return &secretVolume{volName, api.ObjectReference{UID: podUID}, plugin, ""}, nil
 }
 
 // secretVolume handles retrieving secrets from the API server
 // and placing them into the volume on the host.
 type secretVolume struct {
-	volName   string
-	podRef    api.ObjectReference
-	plugin    *secretPlugin
-	secretRef api.ObjectReference
+	volName    string
+	podRef     api.ObjectReference
+	plugin     *secretPlugin
+	secretName string
 }
 
 func (sv *secretVolume) SetUp() error {
@@ -109,9 +109,9 @@ func (sv *secretVolume) SetUpAt(dir string) error {
 		return fmt.Errorf("Cannot setup secret volume %v because kube client is not configured", sv)
 	}
 
-	secret, err := kubeClient.Secrets(sv.podRef.Namespace).Get(sv.secretRef.Name)
+	secret, err := kubeClient.Secrets(sv.podRef.Namespace).Get(sv.secretName)
 	if err != nil {
-		glog.Errorf("Couldn't get secret %v/%v", sv.secretRef.Namespace, sv.secretRef.Name)
+		glog.Errorf("Couldn't get secret %v/%v", sv.podRef.Namespace, sv.secretName)
 		return err
 	}
 

--- a/pkg/volume/secret/secret_test.go
+++ b/pkg/volume/secret/secret_test.go
@@ -52,7 +52,7 @@ func TestCanSupport(t *testing.T) {
 	if plugin.Name() != secretPluginName {
 		t.Errorf("Wrong name: %s", plugin.Name())
 	}
-	if !plugin.CanSupport(&api.Volume{VolumeSource: api.VolumeSource{Secret: &api.SecretVolumeSource{Target: api.ObjectReference{}}}}) {
+	if !plugin.CanSupport(&api.Volume{VolumeSource: api.VolumeSource{Secret: &api.SecretVolumeSource{SecretName: ""}}}) {
 		t.Errorf("Expected true")
 	}
 }
@@ -69,10 +69,7 @@ func TestPlugin(t *testing.T) {
 		Name: testVolumeName,
 		VolumeSource: api.VolumeSource{
 			Secret: &api.SecretVolumeSource{
-				Target: api.ObjectReference{
-					Namespace: testNamespace,
-					Name:      testName,
-				},
+				SecretName: testName,
 			},
 		},
 	}

--- a/test/e2e/secrets.go
+++ b/test/e2e/secrets.go
@@ -81,11 +81,7 @@ var _ = Describe("Secrets", func() {
 						Name: volumeName,
 						VolumeSource: api.VolumeSource{
 							Secret: &api.SecretVolumeSource{
-								Target: api.ObjectReference{
-									Kind:      "Secret",
-									Namespace: ns,
-									Name:      name,
-								},
+								SecretName: name,
 							},
 						},
 					},


### PR DESCRIPTION
Changes the secret volume plugin to use only the name of a secret instead of a full object reference as discussed in #4954
