### PR TITLE
Cassandra Cluster Example Add Check for Null Endpoints (redo2)

### DIFF
--- a/examples/cassandra/README.md
+++ b/examples/cassandra/README.md
@@ -295,10 +295,13 @@ public class KubernetesSeedProvider implements SeedProvider {
 	    ObjectMapper mapper = new ObjectMapper();
 	    Endpoints endpoints = mapper.readValue(url, Endpoints.class);
 	    if (endpoints != null) {
+            // Here is a problem point, endpoints.endpoints can be null in first node cases.
+            if (endpoints.endpoints != null){
 		for (String endpoint : endpoints.endpoints) {
 		    String[] parts = endpoint.split(":");
 		    list.add(InetAddress.getByName(parts[0]));
 		}
+            }
 	    }
         } catch (IOException ex) {
 	    logger.warn("Request to kubernetes apiserver failed"); 

--- a/examples/cassandra/java/io/k8s/cassandra/KubernetesSeedProvider.java
+++ b/examples/cassandra/java/io/k8s/cassandra/KubernetesSeedProvider.java
@@ -70,10 +70,13 @@ public class KubernetesSeedProvider implements SeedProvider {
 	    ObjectMapper mapper = new ObjectMapper();
 	    Endpoints endpoints = mapper.readValue(url, Endpoints.class);
 	    if (endpoints != null) {
+            // Here is a problem point, endpoints.endpoints can be null in first node cases.
+            if (endpoints.endpoints != null){
 		for (String endpoint : endpoints.endpoints) {
 		    String[] parts = endpoint.split(":");
 		    list.add(InetAddress.getByName(parts[0]));
 		}
+            }
 	    }
         } catch (IOException ex) {
 	    logger.warn("Request to kubernetes apiserver failed"); 


### PR DESCRIPTION
Fix for Issue: Cassandra Cluster Example Custom Seed Cores on First Node #5737

Also note: for this change to be effective, the following jar must be rebuilt and checked in:

```
kubernetes/examples/cassandra/image/kubernetes-cassandra.jar
```

However, this example does not have any visible java build and testing infrastructure.

redo of pull previous closed PR: 5764
