### PR TITLE
CoreOS flannel configuration

### DIFF
--- a/docs/getting-started-guides/coreos/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/node.yaml
@@ -4,6 +4,8 @@ coreos:
   fleet:
     etcd-servers: http://<master-private-ip>:4001
     metadata: "role=node"
+  flannel:
+    etcd_endpoints: http://<master-private-ip>:4001
   units:
     - name: etcd.service
       mask: true
@@ -11,19 +13,6 @@ coreos:
       command: start
     - name: flanneld.service
       command: start
-      drop-ins:
-        - name: 50-network-config.conf
-          content: |
-            [Service]
-            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "vxlan"}}'
-            ExecStart=
-            ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
-                /usr/bin/docker run --net=host --privileged=true --rm \
-                    --volume=/run/flannel:/run/flannel \
-                    --env=NOTIFY_SOCKET=/run/flannel/sd.sock \
-                    --env-file=/run/flannel/options.env \
-                    --volume=${ETCD_SSL_DIR}:/etc/ssl/etcd:ro \
-                    quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld -etcd-endpoints http://<master-private-ip>:4001 --ip-masq=true --iface=eth1
     - name: docker.service
       command: start
       drop-ins:


### PR DESCRIPTION
Use CoreOS flannel configuration instead of drop-in unit, see https://coreos.com/docs/cluster-management/setup/cloudinit-cloud-config/. The previous file with the drop-in unit did not work for me. `flanneld` was still starting with the local etcd servers.
