### PR TITLE
Replica Controller Name Annotation in Pods

### DIFF
--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -61,6 +62,7 @@ type RealPodControl struct {
 
 // Time period of main replication controller sync loop
 const DefaultSyncPeriod = 5 * time.Second
+const CreatedByAnnotation = "kubernetes.io/created-by"
 
 func (r RealPodControl) createReplica(namespace string, controller api.ReplicationController) {
 	desiredLabels := make(labels.Set)
@@ -71,6 +73,20 @@ func (r RealPodControl) createReplica(namespace string, controller api.Replicati
 	for k, v := range controller.Spec.Template.Annotations {
 		desiredAnnotations[k] = v
 	}
+
+	createdByRef, err := api.GetReference(&controller)
+	if err != nil {
+		util.HandleError(fmt.Errorf("unable to get controller reference: %v", err))
+		return
+	}
+
+	createdByRefJson, err := json.Marshal(createdByRef)
+	if err != nil {
+		util.HandleError(fmt.Errorf("unable to serialize controller reference: %v", err))
+		return
+	}
+
+	desiredAnnotations[CreatedByAnnotation] = string(createdByRefJson)
 
 	// use the dash (if the name isn't too long) to make the pod name a bit prettier
 	prefix := fmt.Sprintf("%s-", controller.Name)

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -40,6 +40,10 @@ type FakePodControl struct {
 	lock           sync.Mutex
 }
 
+func init() {
+	api.ForTesting_ReferencesAllowBlankSelfLinks = true
+}
+
 func (f *FakePodControl) createReplica(namespace string, spec api.ReplicationController) {
 	f.lock.Lock()
 	defer f.lock.Unlock()


### PR DESCRIPTION
As discussed with @bgrant0607 in #3676 these patches are adding a pod annotation ("replicationControllerName") to reference the replica controller that generated a pod.

The PR consists of two patches:
1. adds the annotation to the generated pods
2. considers the pods annotation when counting the replicas

2 probably needs some discussion.

In fact today it is possible that a user-created pod (if matching the selector) could be counted as part of a replica controller (with the side effect of e.g. another pod being killed).

We could discuss if that's a bug or a feature. In my opinion it is a bug (a user-initiated pod should successfully start and not affect a replication controller pod).

Considering the replication controller annotation when counting the pods (patch 2) makes sure that a replication controller only looks after pods that it generated and it is managing.

If we go down this road we may consider some attribute more "official" than an annotation.

Update: I forgot to mention that patch 2 on a running cluster is dangerous (not even backward compatible), probably all the replication controller will spawn new containers (effectively doubling the replicas).

For this reason I think that this annotation/attribute is vital to be introduced ASAP, because if we don't tag the pods spawned by a replication controller now, we'll never be able to introduce it later.
