### PR TITLE
Support input streams being returned by the APIserver

### DIFF
--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta2"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 // Version is the string that represents the current external default version.
@@ -122,9 +123,15 @@ func init() {
 		"Namespace": true,
 	}
 
+	// these kinds should be excluded from the list of resources
+	ignoredKinds := util.NewStringSet("ListOptions", "DeleteOptions", "Status", "ContainerManifest")
+
 	// enumerate all supported versions, get the kinds, and register with the mapper how to address our resources
 	for _, version := range versions {
 		for kind := range api.Scheme.KnownTypes(version) {
+			if ignoredKinds.Has(kind) {
+				continue
+			}
 			mixedCase, found := versionMixedCase[version]
 			if !found {
 				mixedCase = false

--- a/pkg/api/rest/rest.go
+++ b/pkg/api/rest/rest.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rest
 
 import (
+	"io"
 	"net/http"
 	"net/url"
 
@@ -147,4 +148,22 @@ type StandardStorage interface {
 type Redirector interface {
 	// ResourceLocation should return the remote location of the given resource, and an optional transport to use to request it, or an error.
 	ResourceLocation(ctx api.Context, id string) (remoteLocation *url.URL, transport http.RoundTripper, err error)
+}
+
+// ResourceStreamer is an interface implemented by objects that prefer to be streamed from the server
+// instead of decoded directly.
+type ResourceStreamer interface {
+	// InputStream should return an io.Reader if the provided object supports streaming. The desired
+	// api version and a accept header (may be empty) are passed to the call. If no error occurs,
+	// the caller may return a content type string with the reader that indicates the type of the
+	// stream.
+	InputStream(apiVersion, acceptHeader string) (io.ReadCloser, string, error)
+}
+
+// StorageMetadata is an optional interface that callers can implement to provide additional
+// information about their Storage objects.
+type StorageMetadata interface {
+	// ProducesMIMETypes returns a list of the MIME types the specified HTTP verb (GET, POST, DELETE,
+	// PATCH) can respond with.
+	ProducesMIMETypes(verb string) []string
 }

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -409,7 +409,7 @@ func TestWatchControllers(t *testing.T) {
 
 	select {
 	case <-received:
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 		t.Errorf("Expected 1 call but got 0")
 	}
 }

--- a/pkg/conversion/decode.go
+++ b/pkg/conversion/decode.go
@@ -58,7 +58,8 @@ func (s *Scheme) Decode(data []byte) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := s.converter.Convert(obj, objOut, 0, s.generateConvertMeta(version, s.InternalVersion)); err != nil {
+		flags, meta := s.generateConvertMeta(version, s.InternalVersion, obj)
+		if err := s.converter.Convert(obj, objOut, flags, meta); err != nil {
 			return nil, err
 		}
 		obj = objOut
@@ -101,7 +102,8 @@ func (s *Scheme) DecodeInto(data []byte, obj interface{}) error {
 	if err := json.Unmarshal(data, external); err != nil {
 		return err
 	}
-	if err := s.converter.Convert(external, obj, 0, s.generateConvertMeta(dataVersion, objVersion)); err != nil {
+	flags, meta := s.generateConvertMeta(dataVersion, objVersion, external)
+	if err := s.converter.Convert(external, obj, flags, meta); err != nil {
 		return err
 	}
 

--- a/pkg/conversion/encode.go
+++ b/pkg/conversion/encode.go
@@ -67,7 +67,8 @@ func (s *Scheme) EncodeToVersion(obj interface{}, destVersion string) (data []by
 		if err != nil {
 			return nil, err
 		}
-		err = s.converter.Convert(obj, objOut, 0, s.generateConvertMeta(objVersion, destVersion))
+		flags, meta := s.generateConvertMeta(objVersion, destVersion, obj)
+		err = s.converter.Convert(obj, objOut, flags, meta)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/runtime/conversion.go
+++ b/pkg/runtime/conversion.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
+)
+
+// JSONKeyMapper uses the struct tags on a conversion to determine the key value for
+// the other side. Use when mapping from a map[string]* to a struct or vice versa.
+func JSONKeyMapper(key string, sourceTag, destTag reflect.StructTag) (string, string) {
+	if s := destTag.Get("json"); len(s) > 0 {
+		return strings.SplitN(s, ",", 2)[0], key
+	}
+	if s := sourceTag.Get("json"); len(s) > 0 {
+		return key, strings.SplitN(s, ",", 2)[0]
+	}
+	return key, key
+}
+
+// DefaultStringConversions are helpers for converting []string and string to real values.
+var DefaultStringConversions = []interface{}{
+	convertStringSliceToString,
+	convertStringSliceToInt,
+	convertStringSliceToInt64,
+}
+
+func convertStringSliceToString(input *[]string, out *string, s conversion.Scope) error {
+	if len(*input) == 0 {
+		*out = ""
+	}
+	*out = (*input)[0]
+	return nil
+}
+
+func convertStringSliceToInt(input *[]string, out *int, s conversion.Scope) error {
+	if len(*input) == 0 {
+		*out = 0
+	}
+	str := (*input)[0]
+	i, err := strconv.Atoi(str)
+	if err != nil {
+		return err
+	}
+	*out = i
+	return nil
+}
+
+func convertStringSliceToInt64(input *[]string, out *int64, s conversion.Scope) error {
+	if len(*input) == 0 {
+		*out = 0
+	}
+	str := (*input)[0]
+	i, err := strconv.ParseInt(str, 10, 64)
+	if err != nil {
+		return err
+	}
+	*out = i
+	return nil
+}

--- a/pkg/runtime/conversion_test.go
+++ b/pkg/runtime/conversion_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+)
+
+type InternalComplex struct {
+	TypeMeta
+	String    string
+	Integer   int
+	Integer64 int64
+	Int64     int64
+}
+
+type ExternalComplex struct {
+	TypeMeta  `json:",inline"`
+	String    string `json:"string" description:"testing"`
+	Integer   int    `json:"int"`
+	Integer64 int64  `json:",omitempty"`
+	Int64     int64
+}
+
+func (*InternalComplex) IsAnAPIObject() {}
+func (*ExternalComplex) IsAnAPIObject() {}
+
+func TestStringMapConversion(t *testing.T) {
+	scheme := runtime.NewScheme()
+	scheme.Log(t)
+	scheme.AddKnownTypeWithName("", "Complex", &InternalComplex{})
+	scheme.AddKnownTypeWithName("external", "Complex", &ExternalComplex{})
+
+	testCases := map[string]struct {
+		input    map[string][]string
+		errFn    func(error) bool
+		expected runtime.Object
+	}{
+		"ignores omitempty": {
+			input: map[string][]string{
+				"String":    {"not_used"},
+				"string":    {"value"},
+				"int":       {"1"},
+				"Integer64": {"2"},
+			},
+			expected: &ExternalComplex{String: "value", Integer: 1},
+		},
+		"returns error on bad int": {
+			input: map[string][]string{
+				"int": {"a"},
+			},
+			errFn:    func(err error) bool { return err != nil },
+			expected: &ExternalComplex{},
+		},
+		"parses int64": {
+			input: map[string][]string{
+				"Int64": {"-1"},
+			},
+			expected: &ExternalComplex{Int64: -1},
+		},
+		"returns error on bad int64": {
+			input: map[string][]string{
+				"Int64": {"a"},
+			},
+			errFn:    func(err error) bool { return err != nil },
+			expected: &ExternalComplex{},
+		},
+	}
+
+	for k, tc := range testCases {
+		out := &ExternalComplex{}
+		if err := scheme.Convert(&tc.input, out); (tc.errFn == nil && err != nil) || (tc.errFn != nil && !tc.errFn(err)) {
+			t.Errorf("%s: unexpected error: %v", k, err)
+			continue
+		} else if err != nil {
+			continue
+		}
+		if !reflect.DeepEqual(out, tc.expected) {
+			t.Errorf("%s: unexpected output: %#v", k, out)
+		}
+	}
+}

--- a/pkg/runtime/helper.go
+++ b/pkg/runtime/helper.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
 )
 
+// TODO: move me to pkg/api/meta
 func IsListType(obj Object) bool {
 	_, err := GetItemsPtr(obj)
 	return err == nil
@@ -32,6 +33,7 @@ func IsListType(obj Object) bool {
 // If 'list' doesn't have an Items member, it's not really a list type
 // and an error will be returned.
 // This function will either return a pointer to a slice, or an error, but not both.
+// TODO: move me to pkg/api/meta
 func GetItemsPtr(list Object) (interface{}, error) {
 	v, err := conversion.EnforcePtr(list)
 	if err != nil {
@@ -57,6 +59,7 @@ func GetItemsPtr(list Object) (interface{}, error) {
 
 // ExtractList returns obj's Items element as an array of runtime.Objects.
 // Returns an error if obj is not a List type (does not have an Items member).
+// TODO: move me to pkg/api/meta
 func ExtractList(obj Object) ([]Object, error) {
 	itemsPtr, err := GetItemsPtr(obj)
 	if err != nil {
@@ -90,6 +93,7 @@ var objectSliceType = reflect.TypeOf([]Object{})
 // objects.
 // Returns an error if list is not a List type (does not have an Items member),
 // or if any of the objects are not of the right type.
+// TODO: move me to pkg/api/meta
 func SetList(list Object, objects []Object) error {
 	itemsPtr, err := GetItemsPtr(list)
 	if err != nil {

--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -217,6 +217,13 @@ func NewScheme() *Scheme {
 	); err != nil {
 		panic(err)
 	}
+	// Enable map[string][]string conversions by default
+	if err := s.raw.AddConversionFuncs(DefaultStringConversions...); err != nil {
+		panic(err)
+	}
+	if err := s.raw.RegisterInputDefaults(&map[string][]string{}, JSONKeyMapper, conversion.AllowDifferentFieldTypeNames|conversion.IgnoreMissingFields); err != nil {
+		panic(err)
+	}
 	return s
 }
 


### PR DESCRIPTION
Sets proper mime types on the response, sets the stage for transforming
query parameters into a structured object.

Extracted from #5763
