### PR TITLE
Use VBoxManage instead of virtualbox in cluster/vagrant/util.sh 

### DIFF
--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -33,7 +33,7 @@ function detect-minions {
 # Verify prereqs on host machine  Also sets exports USING_KUBE_SCRIPTS=true so
 # that our Vagrantfile doesn't error out.
 function verify-prereqs {
-  for x in vagrant virtualbox; do
+  for x in vagrant VBoxManage; do
     if ! which "$x" >/dev/null; then
       echo "Can't find $x in PATH, please fix and retry."
       exit 1


### PR DESCRIPTION
Use VBoxManage instead of virtualbox in cluster/vagrant/util.sh verify-prereqs function. The executable virtualbox does not exist.

The user manual doesn't mention a virtualbox neither. Only "VirtualBox, VBoxManage, VBoxSDL or VBoxHeadless" "These are symbolic links to VBox.sh"
https://www.virtualbox.org/manual/ch02.html#startingvboxonlinux

Host system: OpenSuse 13.2
