### PR TITLE
Revert "Upgrade etcd to v2.0.5 on the master"

### DIFF
--- a/cluster/saltbase/salt/etcd/init.sls
+++ b/cluster/saltbase/salt/etcd/init.sls
@@ -10,10 +10,10 @@
 #    shasum <tar>
 # 6. Update this file with new tar version and new hash
 
-{% set etcd_version="v2.0.5" %}
+{% set etcd_version="v2.0.0" %}
 {% set etcd_tar_url="https://storage.googleapis.com/kubernetes-release/etcd/etcd-%s-linux-amd64.tar.gz"
   | format(etcd_version)  %}
-{% set etcd_tar_hash="sha1=34b185efa954327d6cdfe6be5b1eb5fcfb7c478c" %}
+{% set etcd_tar_hash="sha1=b3cd41d1748bf882a58a98c9585fd5849b943811" %}
 
 etcd-tar:
   archive:


### PR DESCRIPTION
Reverts GoogleCloudPlatform/kubernetes#5801

I've got feedback that our tests are experiencing lots of  `get.go:67] Error received from API: 501: All the given peers are not reachable (Tried to connect to each peer twice and failed) [0]"` errors so to be safe I am reverting.
