### PR TITLE
Implement Kubelet support for HostNetwork by pod source

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -184,6 +184,8 @@ func (s *APIServer) Run(_ []string) error {
 
 	capabilities.Initialize(capabilities.Capabilities{
 		AllowPrivileged: s.AllowPrivileged,
+		// TODO(vmarmol): Implement support for HostNetworkSources.
+		HostNetworkSources: []string{},
 	})
 
 	cloud := cloudprovider.InitCloudProvider(s.CloudProvider, s.CloudConfigFile)

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -24,6 +24,9 @@ import (
 // For now these are global.  Eventually they may be per-user
 type Capabilities struct {
 	AllowPrivileged bool
+
+	// List of pod sources for which using host network is allowed.
+	HostNetworkSources []string
 }
 
 var once sync.Once
@@ -46,7 +49,8 @@ func SetForTests(c Capabilities) {
 func Get() Capabilities {
 	if capabilities == nil {
 		Initialize(Capabilities{
-			AllowPrivileged: false,
+			AllowPrivileged:    false,
+			HostNetworkSources: []string{},
 		})
 	}
 	return *capabilities

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1040,7 +1040,12 @@ func (kl *Kubelet) createPodInfraContainer(pod *api.Pod) (dockertools.DockerID, 
 	if ref != nil {
 		kl.recorder.Eventf(ref, "pulled", "Successfully pulled image %q", container.Image)
 	}
-	id, err := kl.runContainer(pod, container, nil, "", "")
+	// TODO(vmarmol): Auth.
+	netNamespace := ""
+	if pod.Spec.HostNetwork {
+		netNamespace = "host"
+	}
+	id, err := kl.runContainer(pod, container, nil, netNamespace, "")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kubelet/types.go
+++ b/pkg/kubelet/types.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package kubelet
 
-import "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
 
 const ConfigSourceAnnotationKey = "kubernetes.io/config.source"
 const ConfigMirrorAnnotationKey = "kubernetes.io/config.mirror"
@@ -63,4 +67,23 @@ type PodUpdate struct {
 	Pods   []api.Pod
 	Op     PodOperation
 	Source string
+}
+
+// Gets all validated sources from the specified sources.
+func GetValidatedSources(sources []string) ([]string, error) {
+	validated := make([]string, 0, len(sources))
+	for _, source := range sources {
+		switch source {
+		case AllSource:
+			return []string{FileSource, HTTPSource, ApiserverSource}, nil
+		case FileSource, HTTPSource, ApiserverSource:
+			validated = append(validated, source)
+			break
+		case "":
+			break
+		default:
+			return []string{}, fmt.Errorf("unknown pod source %q", source)
+		}
+	}
+	return validated, nil
 }

--- a/pkg/kubelet/types_test.go
+++ b/pkg/kubelet/types_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetValidatedSources(t *testing.T) {
+	// Empty.
+	sources, err := GetValidatedSources([]string{""})
+	require.NoError(t, err)
+	require.Len(t, sources, 0)
+
+	// Success.
+	sources, err = GetValidatedSources([]string{FileSource, ApiserverSource})
+	require.NoError(t, err)
+	require.Len(t, sources, 2)
+
+	// All.
+	sources, err = GetValidatedSources([]string{AllSource})
+	require.NoError(t, err)
+	require.Len(t, sources, 3)
+
+	// Unknown source.
+	sources, err = GetValidatedSources([]string{"taco"})
+	require.Error(t, err)
+}

--- a/pkg/kubelet/util.go
+++ b/pkg/kubelet/util.go
@@ -27,9 +27,10 @@ import (
 )
 
 // TODO: move this into pkg/capabilities
-func SetupCapabilities(allowPrivileged bool) {
+func SetupCapabilities(allowPrivileged bool, hostNetworkSources []string) {
 	capabilities.Initialize(capabilities.Capabilities{
-		AllowPrivileged: allowPrivileged,
+		AllowPrivileged:    allowPrivileged,
+		HostNetworkSources: hostNetworkSources,
 	})
 }
 


### PR DESCRIPTION
This implements support on the Kubelet only. The apiserver changes are left as a TODO.
