### PR TITLE
Remove unused ServerSource.

### DIFF
--- a/pkg/kubelet/types.go
+++ b/pkg/kubelet/types.go
@@ -44,8 +44,6 @@ const (
 	FileSource = "file"
 	// Updates from querying a web page
 	HTTPSource = "http"
-	// Updates received to the kubelet server
-	ServerSource = "server"
 	// Updates from Kubernetes API Server
 	ApiserverSource = "api"
 	// Updates from all sources


### PR DESCRIPTION
We no longer use server as a source in the Kubelet.
