### PR TITLE
master_ip needs updating even for minion to be discovered by master

### DIFF
--- a/cluster/ubuntu-cluster/configure.sh
+++ b/cluster/ubuntu-cluster/configure.sh
@@ -196,6 +196,7 @@ while true; do
             configEtcd $etcdName $myIP $cluster
             # set MINION IP in default_scripts/kubelet
             sed -i "s/MY_IP/${myIP}/g" default_scripts/kubelet
+            sed -i "s/MASTER_IP/${masterIP}/g" default_scripts/kubelet
 	        cpMinion
 	        break
 	        ;;


### PR DESCRIPTION
This is a follow-up fix to PR #5245
Without this change when I want to configure a node only as a minion, it fails to connect to master because /etc/default/kubelet hasn't replaced MASTER_IP appropriately.

ping @erictune @WIZARD-CXY @resouer @jlowdermilk
