### PR TITLE
Suppress 'use of closed network connection' error in iowatcher

### DIFF
--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"io"
+	"net/url"
+	"strings"
+)
+
+// IsProbableEOF returns true if the given error resembles a connection termination
+// scenario that would justify assuming that the watch is empty.
+// These errors are what the Go http stack returns back to us which are general
+// connection closure errors (strongly correlated) and callers that need to
+// differentiate probable errors in connection behavior between normal "this is
+// disconnected" should use the method.
+func IsProbableEOF(err error) bool {
+	if uerr, ok := err.(*url.Error); ok {
+		err = uerr.Err
+	}
+	switch {
+	case err == io.EOF:
+		return true
+	case err.Error() == "http: can't write HTTP request on broken connection":
+		return true
+	case strings.Contains(err.Error(), "connection reset by peer"):
+		return true
+	case strings.Contains(strings.ToLower(err.Error()), "use of closed network connection"):
+		return true
+	}
+	return false
+}

--- a/pkg/watch/iowatcher.go
+++ b/pkg/watch/iowatcher.go
@@ -101,7 +101,12 @@ func (sw *StreamWatcher) receive() {
 			case io.ErrUnexpectedEOF:
 				glog.V(1).Infof("Unexpected EOF during watch stream event decoding: %v", err)
 			default:
-				glog.Errorf("Unable to decode an event from the watch stream: %v", err)
+				msg := "Unable to decode an event from the watch stream: %v"
+				if util.IsProbableEOF(err) {
+					glog.V(5).Infof(msg, err)
+				} else {
+					glog.Errorf(msg, err)
+				}
 			}
 			return
 		}


### PR DESCRIPTION
I'm seeing a lot of these in logs:

```
E0325 10:49:02.245307    4160 iowatcher.go:93] Unable to decode an event from the watch stream: read tcp 192.168.121.139:8443: use of closed network connection
E0325 10:49:02.245352    4160 iowatcher.go:93] Unable to decode an event from the watch stream: read tcp 192.168.121.139:8443: use of closed network connection
E0325 10:49:02.245393    4160 iowatcher.go:93] Unable to decode an event from the watch stream: read tcp 192.168.121.139:8443: use of closed network connection
E0325 10:49:02.245432    4160 iowatcher.go:93] Unable to decode an event from the watch stream: read tcp 192.168.121.139:8443: use of closed network connection
```
