### PR TITLE
gooracle complaint for unused variable

### DIFF
--- a/test/e2e/certs.go
+++ b/test/e2e/certs.go
@@ -20,18 +20,14 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("MasterCerts", func() {
-	var c *client.Client
-
 	BeforeEach(func() {
 		var err error
-		c, err = loadClient()
+		_, err = loadClient()
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
GoOracle was complaining about `c` being an unused variable.  Looked unused to me.
