### PR TITLE
Fix race in integration test

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -308,10 +308,12 @@ func podRunning(c *client.Client, podNamespace string, podID string) wait.Condit
 			return false, nil
 		}
 		if err != nil {
-			return false, err
+			// This could be a connection error so we want to retry, but log the error.
+			glog.Errorf("Error when reading pod %q: %v", podID, err)
+			return false, nil
 		}
 		if pod.Status.Phase != api.PodRunning {
-			return false, errors.New(fmt.Sprintf("Pod status is %q", pod.Status.Phase))
+			return false, nil
 		}
 		return true, nil
 	}


### PR DESCRIPTION
podRunning() method never waited for the whole duration of timeout. Instead it returned when the first Status.Phase was read and not equal to PodRunning.

This fixes #5872
