### PR TITLE
Adding method  to labels.Selector to add Requirement

### DIFF
--- a/pkg/labels/selector.go
+++ b/pkg/labels/selector.go
@@ -36,6 +36,9 @@ type Selector interface {
 
 	// String returns a human readable string that represents this selector.
 	String() string
+
+	// Add add a specific requirement for the selector
+	Add(key string, operator Operator, values []string) Selector
 }
 
 // Everything returns a selector that matches all labels.
@@ -187,6 +190,18 @@ func (r *Requirement) String() string {
 		buffer.WriteString(")")
 	}
 	return buffer.String()
+}
+
+// Add adds a requirement to the selector. It copies the current selector returning a new one
+func (lsel LabelSelector) Add(key string, operator Operator, values []string) Selector {
+	var reqs []Requirement
+	for _, item := range lsel {
+		reqs = append(reqs, item)
+	}
+	if r, err := NewRequirement(key, operator, util.NewStringSet(values...)); err == nil {
+		reqs = append(reqs, *r)
+	}
+	return LabelSelector(reqs)
 }
 
 // Matches for a LabelSelector returns true if all

--- a/pkg/labels/selector_test.go
+++ b/pkg/labels/selector_test.go
@@ -465,3 +465,37 @@ func getRequirement(key string, op Operator, vals util.StringSet, t *testing.T) 
 	}
 	return *req
 }
+
+func TestAdd(t *testing.T) {
+	testCases := []struct {
+		sel         Selector
+		key         string
+		operator    Operator
+		values      []string
+		refSelector Selector
+	}{
+		{
+			LabelSelector{},
+			"key",
+			InOperator,
+			[]string{"value"},
+			LabelSelector{Requirement{"key", InOperator, util.NewStringSet("value")}},
+		},
+		{
+			LabelSelector{Requirement{"key", InOperator, util.NewStringSet("value")}},
+			"key2",
+			EqualsOperator,
+			[]string{"value2"},
+			LabelSelector{
+				Requirement{"key", InOperator, util.NewStringSet("value")},
+				Requirement{"key2", EqualsOperator, util.NewStringSet("value2")},
+			},
+		},
+	}
+	for _, ts := range testCases {
+		ts.sel = ts.sel.Add(ts.key, ts.operator, ts.values)
+		if !reflect.DeepEqual(ts.sel, ts.refSelector) {
+			t.Errorf("Expected %t found %t", ts.refSelector, ts.sel)
+		}
+	}
+}


### PR DESCRIPTION
Currently in API label selector are still implemented as map[string]string
So adding a _requirement_ can be done via `sel[key]=value`.

See for example: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/api/validation/validation_test.go#L1133

Moving to the new labels.Selector requires to have a similar mechanism but for the new type

Thanks to have a look

PS: doc have to be re-generated as well. But my only two files are `pkg/labels/selector*.go`
