### PR TITLE
Kubelet: pass the acutal pod for status update

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -108,7 +108,7 @@ type SyncHandler interface {
 	// Syncs current state to match the specified pods. SyncPodType specified what
 	// type of sync is occuring per pod. StartTime specifies the time at which
 	// syncing began (for use in monitoring).
-	SyncPods(pods []api.Pod, podSyncTypes map[types.UID]metrics.SyncPodType, mirrorPods map[string]*api.Pod,
+	SyncPods(pods []api.Pod, podSyncTypes map[types.UID]metrics.SyncPodType, mirrorPods map[string]api.Pod,
 		startTime time.Time) error
 }
 
@@ -1219,7 +1219,7 @@ type podContainerChangesSpec struct {
 	containersToKeep    map[dockertools.DockerID]int
 }
 
-func (kl *Kubelet) computePodContainerChanges(pod *api.Pod, hasMirrorPod bool, runningPod kubecontainer.Pod) (podContainerChangesSpec, error) {
+func (kl *Kubelet) computePodContainerChanges(pod *api.Pod, runningPod kubecontainer.Pod) (podContainerChangesSpec, error) {
 	podFullName := kubecontainer.GetPodFullName(pod)
 	uid := pod.UID
 	glog.V(4).Infof("Syncing Pod %+v, podFullName: %q, uid: %q", pod, podFullName, uid)
@@ -1329,21 +1329,30 @@ func (kl *Kubelet) computePodContainerChanges(pod *api.Pod, hasMirrorPod bool, r
 	}, nil
 }
 
-func (kl *Kubelet) syncPod(pod *api.Pod, hasMirrorPod bool, runningPod kubecontainer.Pod) error {
+func (kl *Kubelet) syncPod(pod *api.Pod, mirrorPod *api.Pod, runningPod kubecontainer.Pod) error {
 	podFullName := kubecontainer.GetPodFullName(pod)
 	uid := pod.UID
 
 	// Before returning, regenerate status and store it in the cache.
 	defer func() {
+		if isStaticPod(pod) && mirrorPod == nil {
+			// No need to cache the status because the mirror pod does not
+			// exist yet.
+			return
+		}
 		status, err := kl.generatePodStatusByPod(pod)
 		if err != nil {
 			glog.Errorf("Unable to generate status for pod with name %q and uid %q info with error(%v)", podFullName, uid, err)
 		} else {
-			kl.statusManager.SetPodStatus(podFullName, status)
+			podToUpdate := pod
+			if mirrorPod != nil {
+				podToUpdate = mirrorPod
+			}
+			kl.statusManager.SetPodStatus(podToUpdate, status)
 		}
 	}()
 
-	containerChanges, err := kl.computePodContainerChanges(pod, hasMirrorPod, runningPod)
+	containerChanges, err := kl.computePodContainerChanges(pod, runningPod)
 	glog.V(3).Infof("Got container changes for pod %q: %+v", podFullName, containerChanges)
 	if err != nil {
 		return err
@@ -1421,7 +1430,7 @@ func (kl *Kubelet) syncPod(pod *api.Pod, hasMirrorPod bool, runningPod kubeconta
 		kl.pullImageAndRunContainer(pod, &pod.Spec.Containers[container], &podVolumes, podInfraContainerID)
 	}
 
-	if !hasMirrorPod && isStaticPod(pod) {
+	if mirrorPod == nil && isStaticPod(pod) {
 		glog.V(4).Infof("Creating a mirror pod %q", podFullName)
 		if err := kl.podManager.CreateMirrorPod(*pod, kl.hostname); err != nil {
 			glog.Errorf("Failed creating a mirror pod %q: %#v", podFullName, err)
@@ -1503,7 +1512,7 @@ func (kl *Kubelet) cleanupOrphanedVolumes(pods []api.Pod, running []*docker.Cont
 
 // SyncPods synchronizes the configured list of pods (desired state) with the host current state.
 func (kl *Kubelet) SyncPods(allPods []api.Pod, podSyncTypes map[types.UID]metrics.SyncPodType,
-	mirrorPods map[string]*api.Pod, start time.Time) error {
+	mirrorPods map[string]api.Pod, start time.Time) error {
 	defer func() {
 		metrics.SyncPodsLatency.Observe(metrics.SinceInMicroseconds(start))
 	}()
@@ -1544,8 +1553,11 @@ func (kl *Kubelet) SyncPods(allPods []api.Pod, podSyncTypes map[types.UID]metric
 		desiredPods[uid] = empty{}
 
 		// Run the sync in an async manifest worker.
-		_, hasMirrorPod := mirrorPods[podFullName]
-		kl.podWorkers.UpdatePod(pod, hasMirrorPod, func() {
+		var mirrorPod *api.Pod = nil
+		if m, ok := mirrorPods[podFullName]; ok {
+			mirrorPod = &m
+		}
+		kl.podWorkers.UpdatePod(pod, mirrorPod, func() {
 			metrics.SyncPodLatency.WithLabelValues(podSyncTypes[pod.UID].String()).Observe(metrics.SinceInMicroseconds(start))
 		})
 
@@ -1687,21 +1699,21 @@ func (kl *Kubelet) handleNotFittingPods(pods []api.Pod) {
 	fitting, notFitting := checkHostPortConflicts(pods)
 	for _, pod := range notFitting {
 		kl.recorder.Eventf(&pod, "hostPortConflict", "Cannot start the pod due to host port conflict.")
-		kl.statusManager.SetPodStatus(kubecontainer.GetPodFullName(&pod), api.PodStatus{
+		kl.statusManager.SetPodStatus(&pod, api.PodStatus{
 			Phase:   api.PodFailed,
 			Message: "Pod cannot be started due to host port conflict"})
 	}
 	fitting, notFitting = kl.checkNodeSelectorMatching(fitting)
 	for _, pod := range notFitting {
 		kl.recorder.Eventf(&pod, "nodeSelectorMismatching", "Cannot start the pod due to node selector mismatch.")
-		kl.statusManager.SetPodStatus(kubecontainer.GetPodFullName(&pod), api.PodStatus{
+		kl.statusManager.SetPodStatus(&pod, api.PodStatus{
 			Phase:   api.PodFailed,
 			Message: "Pod cannot be started due to node selector mismatch"})
 	}
 	fitting, notFitting = kl.checkCapacityExceeded(fitting)
 	for _, pod := range notFitting {
 		kl.recorder.Eventf(&pod, "capacityExceeded", "Cannot start the pod due to exceeded capacity.")
-		kl.statusManager.SetPodStatus(kubecontainer.GetPodFullName(&pod), api.PodStatus{
+		kl.statusManager.SetPodStatus(&pod, api.PodStatus{
 			Phase:   api.PodFailed,
 			Message: "Pod cannot be started due to exceeded capacity"})
 	}

--- a/pkg/kubelet/pod_manager.go
+++ b/pkg/kubelet/pod_manager.go
@@ -46,7 +46,7 @@ type podManager interface {
 	GetPods() []api.Pod
 	GetPodByFullName(podFullName string) (*api.Pod, bool)
 	GetPodByName(namespace, name string) (*api.Pod, bool)
-	GetPodsAndMirrorMap() ([]api.Pod, map[string]*api.Pod)
+	GetPodsAndMirrorMap() ([]api.Pod, map[string]api.Pod)
 	SetPods(pods []api.Pod)
 	UpdatePods(u PodUpdate, podSyncTypes map[types.UID]metrics.SyncPodType)
 	DeleteOrphanedMirrorPods()
@@ -194,15 +194,15 @@ func (self *basicPodManager) GetPods() []api.Pod {
 }
 
 // GetPodsAndMirrorMap returns the a copy of the regular pods and the mirror
-// pod map indexed by full name for existence check.
-func (self *basicPodManager) GetPodsAndMirrorMap() ([]api.Pod, map[string]*api.Pod) {
+// pods indexed by full name.
+func (self *basicPodManager) GetPodsAndMirrorMap() ([]api.Pod, map[string]api.Pod) {
 	self.lock.RLock()
 	defer self.lock.RUnlock()
-	mirrorPodByFullName := make(map[string]*api.Pod)
-	for key, value := range self.mirrorPodByFullName {
-		mirrorPodByFullName[key] = value
+	mirrorPods := make(map[string]api.Pod)
+	for key, pod := range self.mirrorPodByFullName {
+		mirrorPods[key] = *pod
 	}
-	return self.getPods(), mirrorPodByFullName
+	return self.getPods(), mirrorPods
 }
 
 // GetPodByName provides the (non-mirror) pod that matches namespace and name,

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -47,7 +47,7 @@ func createPodWorkers() (*podWorkers, map[types.UID][]string) {
 
 	podWorkers := newPodWorkers(
 		fakeDockerCache,
-		func(pod *api.Pod, hasMirrorPod bool, runningPod container.Pod) error {
+		func(pod *api.Pod, mirrorPod *api.Pod, runningPod container.Pod) error {
 			func() {
 				lock.Lock()
 				defer lock.Unlock()
@@ -84,7 +84,7 @@ func TestUpdatePod(t *testing.T) {
 	numPods := 20
 	for i := 0; i < numPods; i++ {
 		for j := i; j < numPods; j++ {
-			podWorkers.UpdatePod(newPod(string(j), string(i)), false, func() {})
+			podWorkers.UpdatePod(newPod(string(j), string(i)), nil, func() {})
 		}
 	}
 	drainWorkers(podWorkers, numPods)
@@ -117,7 +117,7 @@ func TestForgetNonExistingPodWorkers(t *testing.T) {
 
 	numPods := 20
 	for i := 0; i < numPods; i++ {
-		podWorkers.UpdatePod(newPod(string(i), "name"), false, func() {})
+		podWorkers.UpdatePod(newPod(string(i), "name"), nil, func() {})
 	}
 	drainWorkers(podWorkers, numPods)
 

--- a/pkg/kubelet/runonce.go
+++ b/pkg/kubelet/runonce.go
@@ -108,7 +108,7 @@ func (kl *Kubelet) runPod(pod api.Pod, retryDelay time.Duration) error {
 		glog.Infof("pod %q containers not running: syncing", pod.Name)
 		// We don't create mirror pods in this mode; pass a dummy boolean value
 		// to sycnPod.
-		if err = kl.syncPod(&pod, false, p); err != nil {
+		if err = kl.syncPod(&pod, nil, p); err != nil {
 			return fmt.Errorf("error syncing pod: %v", err)
 		}
 		if retry >= RunOnceMaxRetries {

--- a/pkg/kubelet/status_manager_test.go
+++ b/pkg/kubelet/status_manager_test.go
@@ -25,9 +25,13 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 )
 
-const (
-	podFullName string = "podName_namespace"
-)
+var testPod *api.Pod = &api.Pod{
+	ObjectMeta: api.ObjectMeta{
+		UID:       "12345678",
+		Name:      "foo",
+		Namespace: "new",
+	},
+}
 
 func newTestStatusManager() *statusManager {
 	return newStatusManager(&client.Fake{})
@@ -58,16 +62,16 @@ func verifyActions(t *testing.T, kubeClient client.Interface, expectedActions []
 
 func TestNewStatus(t *testing.T) {
 	syncer := newTestStatusManager()
-	syncer.SetPodStatus(podFullName, getRandomPodStatus())
+	syncer.SetPodStatus(testPod, getRandomPodStatus())
 	syncer.SyncBatch()
 	verifyActions(t, syncer.kubeClient, []string{"update-status-pod"})
 }
 
 func TestChangedStatus(t *testing.T) {
 	syncer := newTestStatusManager()
-	syncer.SetPodStatus(podFullName, getRandomPodStatus())
+	syncer.SetPodStatus(testPod, getRandomPodStatus())
 	syncer.SyncBatch()
-	syncer.SetPodStatus(podFullName, getRandomPodStatus())
+	syncer.SetPodStatus(testPod, getRandomPodStatus())
 	syncer.SyncBatch()
 	verifyActions(t, syncer.kubeClient, []string{"update-status-pod", "update-status-pod"})
 }
@@ -75,9 +79,9 @@ func TestChangedStatus(t *testing.T) {
 func TestUnchangedStatus(t *testing.T) {
 	syncer := newTestStatusManager()
 	podStatus := getRandomPodStatus()
-	syncer.SetPodStatus(podFullName, podStatus)
+	syncer.SetPodStatus(testPod, podStatus)
 	syncer.SyncBatch()
-	syncer.SetPodStatus(podFullName, podStatus)
+	syncer.SetPodStatus(testPod, podStatus)
 	syncer.SyncBatch()
 	verifyActions(t, syncer.kubeClient, []string{"update-status-pod"})
 }


### PR DESCRIPTION
Pod status update should include the ObjectMeta of the pod. This change is
required for #5738 to merge.
