### PR TITLE
Update gce.md OSX instructions per issue #5852

### DIFF
--- a/docs/getting-started-guides/gce.md
+++ b/docs/getting-started-guides/gce.md
@@ -20,7 +20,7 @@ The example below creates a Kubernetes cluster with 4 worker node Virtual Machin
 3. Ensure that your `gcloud` components are up-to-date by running `gcloud components update`.
 4. If you want to build your own release, you need to have [Docker
 installed](https://docs.docker.com/installation/).  On Mac OS X you can use
-boot2docker.
+[boot2docker](http://boot2docker.io/). (see also: https://docs.docker.com/installation/mac/)
 5. Get or build a [binary release](binary_release.md)
 
 ### Starting a Cluster


### PR DESCRIPTION
Update /docs/getting-started-guides/gce.md prerequisites to include relevant urls for osx.
See https://github.com/GoogleCloudPlatform/kubernetes/issues/5852 for the related issue.
