### PR TITLE
Updating to the latest go-restful code and regenerating the swagger spec

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -170,8 +170,8 @@
 		},
 		{
 			"ImportPath": "github.com/emicklei/go-restful",
-			"Comment": "v1.1.3-10-g62dc65d",
-			"Rev": "62dc65d6e51525418cad2bb6f292d3cf7c5e9d0a"
+			"Comment": "v1.1.3-26-g977ac8f",
+			"Rev": "977ac8fcbcd2ee33319246f7c91d4b426402dc70"
 		},
 		{
 			"ImportPath": "github.com/evanphx/json-patch",

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/CHANGES.md
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/CHANGES.md
@@ -1,5 +1,19 @@
 Change history of go-restful
 =
+2015-03-20
+- add configurable logging
+
+2015-03-18
+- if not specified, the Operation is derived from the Route function
+
+2015-03-17
+- expose Parameter creation functions
+- make trace logger an interface
+- fix OPTIONSFilter
+- customize rendering of ServiceError
+- JSR311 router now handles wildcards
+- add Notes to Route
+
 2014-11-27
 - (api add) PrettyPrint per response. (as proposed in #167)
 

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/README.md
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/README.md
@@ -53,6 +53,7 @@ func (u UserResource) findUser(request *restful.Request, response *restful.Respo
 - API declaration for Swagger UI (see swagger package)
 - Panic recovery to produce HTTP 500, customizable using RecoverHandler(...)
 - Route errors produce HTTP 404/405/406/415 errors, customizable using ServiceErrorHandler(...)
+- Configurable (trace) logging
 	
 ### Resources
 
@@ -64,8 +65,8 @@ func (u UserResource) findUser(request *restful.Request, response *restful.Respo
 - [gopkg.in](https://gopkg.in/emicklei/go-restful.v1)
 - [showcase: Mora - MongoDB REST Api server](https://github.com/emicklei/mora)
 
-[![Build Status](https://drone.io/github.com/emicklei/go-restful/status.png)](https://drone.io/github.com/emicklei/go-restful/latest)[![library users](https://sourcegraph.com/api/repos/github.com/emicklei/go-restful/badges/library-users.png)](https://sourcegraph.com/github.com/emicklei/go-restful) [![authors](https://sourcegraph.com/api/repos/github.com/emicklei/go-restful/badges/authors.png)](https://sourcegraph.com/github.com/emicklei/go-restful) [![xrefs](https://sourcegraph.com/api/repos/github.com/emicklei/go-restful/badges/xrefs.png)](https://sourcegraph.com/github.com/emicklei/go-restful)
+[![Build Status](https://drone.io/github.com/emicklei/go-restful/status.png)](https://drone.io/github.com/emicklei/go-restful/latest)
 
-(c) 2012 - 2014, http://ernestmicklei.com. MIT License
+(c) 2012 - 2015, http://ernestmicklei.com. MIT License
 
 Type ```git shortlog -s``` for a full list of contributors.

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/constants.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/constants.go
@@ -5,8 +5,9 @@ package restful
 // that can be found in the LICENSE file.
 
 const (
-	MIME_XML  = "application/xml"  // Accept or Content-Type used in Consumes() and/or Produces()
-	MIME_JSON = "application/json" // Accept or Content-Type used in Consumes() and/or Produces()
+	MIME_XML   = "application/xml"          // Accept or Content-Type used in Consumes() and/or Produces()
+	MIME_JSON  = "application/json"         // Accept or Content-Type used in Consumes() and/or Produces()
+	MIME_OCTET = "application/octet-stream" // If Content-Type is not present in request, use the default
 
 	HEADER_Allow                         = "Allow"
 	HEADER_Accept                        = "Accept"

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/container.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/container.go
@@ -7,10 +7,12 @@ package restful
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"net/http"
+	"os"
 	"runtime"
 	"strings"
+
+	"github.com/emicklei/go-restful/log"
 )
 
 // Container holds a collection of WebServices and a http.ServeMux to dispatch http requests.
@@ -107,7 +109,8 @@ func (c *Container) Add(service *WebService) *Container {
 	// cannot have duplicate root paths
 	for _, each := range c.webServices {
 		if each.RootPath() == service.RootPath() {
-			log.Fatalf("[restful] WebService with duplicate root path detected:['%v']", each)
+			log.Printf("[restful] WebService with duplicate root path detected:['%v']", each)
+			os.Exit(1)
 		}
 	}
 	// if rootPath was not set then lazy initialize it
@@ -132,7 +135,7 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 		}
 		buffer.WriteString(fmt.Sprintf("    %s:%d\r\n", file, line))
 	}
-	log.Println(buffer.String())
+	log.Print(buffer.String())
 	httpWriter.WriteHeader(http.StatusInternalServerError)
 	httpWriter.Write(buffer.Bytes())
 }
@@ -171,7 +174,7 @@ func (c *Container) dispatch(httpWriter http.ResponseWriter, httpRequest *http.R
 			var err error
 			writer, err = NewCompressingResponseWriter(httpWriter, encoding)
 			if err != nil {
-				log.Println("[restful] unable to install compressor:", err)
+				log.Print("[restful] unable to install compressor: ", err)
 				httpWriter.WriteHeader(http.StatusInternalServerError)
 				return
 			}

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/cors_filter.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/cors_filter.go
@@ -32,7 +32,7 @@ func (c CrossOriginResourceSharing) Filter(req *Request, resp *Response, chain *
 	origin := req.Request.Header.Get(HEADER_Origin)
 	if len(origin) == 0 {
 		if trace {
-			traceLogger.Println("no Http header Origin set")
+			traceLogger.Print("no Http header Origin set")
 		}
 		chain.ProcessFilter(req, resp)
 		return

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/doc.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/doc.go
@@ -165,9 +165,16 @@ If you expect to read large amounts of payload data, and you do not use this fea
 Trouble shooting
 
 This package has the means to produce detail logging of the complete Http request matching process and filter invocation.
-Enabling this feature requires you to set a log.Logger instance such as:
+Enabling this feature requires you to set an implementation of restful.StdLogger (e.g. log.Logger) instance such as:
 
 	restful.TraceLogger(log.New(os.Stdout, "[restful] ", log.LstdFlags|log.Lshortfile))
+
+Logging
+
+The restful.SetLogger() method allows you to override the logger used by the package. By default restful
+uses the standard library `log` package and logs to stdout. Different logging packages are supported as
+long as they conform to `StdLogger` interface defined in the `log` sub-package, writing an adapter for your
+preferred package is simple.
 
 Resources
 
@@ -179,6 +186,6 @@ Resources
 
 [showcases]: https://github.com/emicklei/mora, https://github.com/emicklei/landskape
 
-(c) 2012-2014, http://ernestmicklei.com. MIT License
+(c) 2012-2015, http://ernestmicklei.com. MIT License
 */
 package restful

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/jsr311.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/jsr311.go
@@ -55,22 +55,22 @@ func (r RouterJSR311) detectRoute(routes []Route, httpRequest *http.Request) (*R
 		return nil, NewError(http.StatusMethodNotAllowed, "405: Method Not Allowed")
 	}
 	inputMediaOk := methodOk
+
 	// content-type
 	contentType := httpRequest.Header.Get(HEADER_ContentType)
-	if httpRequest.ContentLength > 0 {
-		inputMediaOk = []Route{}
-		for _, each := range methodOk {
-			if each.matchesContentType(contentType) {
-				inputMediaOk = append(inputMediaOk, each)
-			}
-		}
-		if len(inputMediaOk) == 0 {
-			if trace {
-				traceLogger.Printf("no Route found (from %d) that matches HTTP Content-Type: %s\n", len(methodOk), contentType)
-			}
-			return nil, NewError(http.StatusUnsupportedMediaType, "415: Unsupported Media Type")
+	inputMediaOk = []Route{}
+	for _, each := range methodOk {
+		if each.matchesContentType(contentType) {
+			inputMediaOk = append(inputMediaOk, each)
 		}
 	}
+	if len(inputMediaOk) == 0 {
+		if trace {
+			traceLogger.Printf("no Route found (from %d) that matches HTTP Content-Type: %s\n", len(methodOk), contentType)
+		}
+		return nil, NewError(http.StatusUnsupportedMediaType, "415: Unsupported Media Type")
+	}
+
 	// accept
 	outputMediaOk := []Route{}
 	accept := httpRequest.Header.Get(HEADER_Accept)

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/log/log.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/log/log.go
@@ -1,0 +1,31 @@
+package log
+
+import (
+	stdlog "log"
+	"os"
+)
+
+// Logger corresponds to a minimal subset of the interface satisfied by stdlib log.Logger
+type StdLogger interface {
+	Print(v ...interface{})
+	Printf(format string, v ...interface{})
+}
+
+var Logger StdLogger
+
+func init() {
+	// default Logger
+	SetLogger(stdlog.New(os.Stdout, "[restful] ", stdlog.LstdFlags|stdlog.Lshortfile))
+}
+
+func SetLogger(customLogger StdLogger) {
+	Logger = customLogger
+}
+
+func Print(v ...interface{}) {
+	Logger.Print(v...)
+}
+
+func Printf(format string, v ...interface{}) {
+	Logger.Printf(format, v...)
+}

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/logger.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/logger.go
@@ -1,16 +1,32 @@
 package restful
 
-import "log"
-
 // Copyright 2014 Ernest Micklei. All rights reserved.
 // Use of this source code is governed by a license
 // that can be found in the LICENSE file.
+import (
+	"github.com/emicklei/go-restful/log"
+)
 
 var trace bool = false
-var traceLogger *log.Logger
+var traceLogger log.StdLogger
+
+func init() {
+	traceLogger = log.Logger // use the package logger by default
+}
 
 // TraceLogger enables detailed logging of Http request matching and filter invocation. Default no logger is set.
-func TraceLogger(logger *log.Logger) {
+// You may call EnableTracing() directly to enable trace logging to the package-wide logger.
+func TraceLogger(logger log.StdLogger) {
 	traceLogger = logger
-	trace = logger != nil
+	EnableTracing(logger != nil)
+}
+
+// expose the setter for the global logger on the top-level package
+func SetLogger(customLogger log.StdLogger) {
+	log.SetLogger(customLogger)
+}
+
+// EnableTracing can be used to Trace logging on and off.
+func EnableTracing(enabled bool) {
+	trace = enabled
 }

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/route.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/route.go
@@ -88,8 +88,24 @@ func (r Route) matchesAccept(mimeTypesWithQuality string) bool {
 	return false
 }
 
-// Return whether the mimeType matches to what this Route can consume.
+// Return whether this Route can consume content with a type specified by mimeTypes (can be empty).
 func (r Route) matchesContentType(mimeTypes string) bool {
+
+	if len(r.Consumes) == 0 {
+		// did not specify what it can consume ;  any media type (“*/*”) is assumed
+		return true
+	}
+
+	if len(mimeTypes) == 0 {
+		// idempotent methods with (most-likely or garanteed) empty content match missing Content-Type
+		m := r.Method
+		if m == "GET" || m == "HEAD" || m == "OPTIONS" || m == "DELETE" || m == "TRACE" {
+			return true
+		}
+		// proceed with default
+		mimeTypes = MIME_OCTET
+	}
+
 	parts := strings.Split(mimeTypes, ",")
 	for _, each := range parts {
 		var contentType string
@@ -100,8 +116,8 @@ func (r Route) matchesContentType(mimeTypes string) bool {
 		}
 		// trim before compare
 		contentType = strings.Trim(contentType, " ")
-		for _, other := range r.Consumes {
-			if other == "*/*" || other == contentType {
+		for _, consumeableType := range r.Consumes {
+			if consumeableType == "*/*" || consumeableType == contentType {
 				return true
 			}
 		}

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/route_builder.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/route_builder.go
@@ -5,9 +5,12 @@ package restful
 // that can be found in the LICENSE file.
 
 import (
-	"log"
+	"os"
 	"reflect"
+	"runtime"
 	"strings"
+
+	"github.com/emicklei/go-restful/log"
 )
 
 // RouteBuilder is a helper to construct Routes.
@@ -126,6 +129,7 @@ func (b *RouteBuilder) Param(parameter *Parameter) *RouteBuilder {
 }
 
 // Operation allows you to document what the acutal method/function call is of the Route.
+// Unless called, the operation name is derived from the RouteFunction set using To(..).
 func (b *RouteBuilder) Operation(name string) *RouteBuilder {
 	b.operation = name
 	return b
@@ -133,7 +137,7 @@ func (b *RouteBuilder) Operation(name string) *RouteBuilder {
 
 // ReturnsError is deprecated, use Returns instead.
 func (b *RouteBuilder) ReturnsError(code int, message string, model interface{}) *RouteBuilder {
-	log.Println("ReturnsError is deprecated, use Returns instead.")
+	log.Print("ReturnsError is deprecated, use Returns instead.")
 	return b.Returns(code, message, model)
 }
 
@@ -186,10 +190,17 @@ func (b *RouteBuilder) copyDefaults(rootProduces, rootConsumes []string) {
 func (b *RouteBuilder) Build() Route {
 	pathExpr, err := newPathExpression(b.currentPath)
 	if err != nil {
-		log.Fatalf("[restful] Invalid path:%s because:%v", b.currentPath, err)
+		log.Printf("[restful] Invalid path:%s because:%v", b.currentPath, err)
+		os.Exit(1)
 	}
 	if b.function == nil {
-		log.Fatalf("[restful] No function specified for route:" + b.currentPath)
+		log.Printf("[restful] No function specified for route:" + b.currentPath)
+		os.Exit(1)
+	}
+	operationName := b.operation
+	if len(operationName) == 0 && b.function != nil {
+		// extract from definition
+		operationName = nameOfFunction(b.function)
 	}
 	route := Route{
 		Method:         b.httpMethod,
@@ -202,7 +213,7 @@ func (b *RouteBuilder) Build() Route {
 		pathExpr:       pathExpr,
 		Doc:            b.doc,
 		Notes:          b.notes,
-		Operation:      b.operation,
+		Operation:      operationName,
 		ParameterDocs:  b.parameters,
 		ResponseErrors: b.errorMap,
 		ReadSample:     b.readSample,
@@ -213,4 +224,17 @@ func (b *RouteBuilder) Build() Route {
 
 func concatPath(path1, path2 string) string {
 	return strings.TrimRight(path1, "/") + "/" + strings.TrimLeft(path2, "/")
+}
+
+// nameOfFunction returns the short name of the function f for documentation.
+// It uses a runtime feature for debugging ; its value may change for later Go versions.
+func nameOfFunction(f interface{}) string {
+	fun := runtime.FuncForPC(reflect.ValueOf(f).Pointer())
+	tokenized := strings.Split(fun.Name(), ".")
+	last := tokenized[len(tokenized)-1]
+	last = strings.TrimSuffix(last, ")·fm") // < Go 1.5
+	last = strings.TrimSuffix(last, ")-fm") // Go 1.5
+	last = strings.TrimSuffix(last, "·fm")  // < Go 1.5
+	last = strings.TrimSuffix(last, "-fm")  // Go 1.5
+	return last
 }

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/route_builder_test.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/route_builder_test.go
@@ -52,4 +52,7 @@ func TestRouteBuilder(t *testing.T) {
 	if r.Consumes[0] != json {
 		t.Error("consumes invalid")
 	}
+	if r.Operation != "dummy" {
+		t.Error("Operation not set")
+	}
 }

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/CHANGES.md
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/CHANGES.md
@@ -1,5 +1,9 @@
 Change history of swagger
 =
+2015-03-17
+- preserve order of Routes per WebService in Swagger listing
+- fix use of $ref and type in Swagger models
+- add api version to listing
 
 2014-11-14
 - operation parameters are now sorted using ordering path,query,form,header,body

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/config.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/config.go
@@ -6,6 +6,9 @@ import (
 	"github.com/emicklei/go-restful"
 )
 
+// PostBuildDeclarationMapFunc can be used to modify the api declaration map.
+type PostBuildDeclarationMapFunc func(apiDeclarationMap map[string]ApiDeclaration)
+
 type Config struct {
 	// url where the services are available, e.g. http://localhost:8080
 	// if left empty then the basePath of Swagger is taken from the actual request
@@ -24,4 +27,6 @@ type Config struct {
 	DisableCORS bool
 	// Top-level API version. Is reflected in the resource listing.
 	ApiVersion string
+	// If set then call this handler after building the complete ApiDeclaration Map
+	PostBuildHandler PostBuildDeclarationMapFunc
 }

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/model_builder_test.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/model_builder_test.go
@@ -14,6 +14,29 @@ func (y YesNo) MarshalJSON() ([]byte, error) {
 	return []byte("no"), nil
 }
 
+// clear && go test -v -test.run TestRef_Issue190 ...swagger
+func TestRef_Issue190(t *testing.T) {
+	type User struct {
+		items []string
+	}
+	testJsonFromStruct(t, User{}, `{
+  "swagger.User": {
+   "id": "swagger.User",
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "items": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  }
+ }`)
+}
+
 // clear && go test -v -test.run TestCustomMarshaller_Issue96 ...swagger
 func TestCustomMarshaller_Issue96(t *testing.T) {
 	type Vote struct {
@@ -96,7 +119,7 @@ func TestS2(t *testing.T) {
     "Ids": {
      "type": "array",
      "items": {
-      "$ref": "string"
+      "type": "string"
      }
     }
    }
@@ -131,7 +154,7 @@ func TestS3(t *testing.T) {
    ],
    "properties": {
     "Nested": {
-     "type": "swagger.NestedS3"
+     "$ref": "swagger.NestedS3"
     }
    }
   }
@@ -180,7 +203,7 @@ func TestSampleToModelAsJson(t *testing.T) {
      }
     },
     "root": {
-     "type": "swagger.item",
+     "$ref": "swagger.item",
      "description": "root desc"
     }
    }
@@ -284,7 +307,7 @@ func TestAnonymousStruct(t *testing.T) {
    ],
    "properties": {
     "A": {
-     "type": "swagger.X.A"
+     "$ref": "swagger.X.A"
     }
    }
   },
@@ -320,7 +343,7 @@ func TestAnonymousPtrStruct(t *testing.T) {
    ],
    "properties": {
     "A": {
-     "type": "swagger.X.A"
+     "$ref": "swagger.X.A"
     }
    }
   },
@@ -474,7 +497,7 @@ func TestIssue85(t *testing.T) {
     "Names": {
      "type": "array",
      "items": {
-      "$ref": "string"
+      "type": "string"
      }
     }
    }
@@ -531,7 +554,7 @@ func TestEmbeddedStructA1(t *testing.T) {
    ],
    "properties": {
     "B": {
-     "type": "swagger.A1.B"
+     "$ref": "swagger.A1.B"
     }
    }
   },
@@ -605,7 +628,7 @@ func TestStructA3(t *testing.T) {
    ],
    "properties": {
     "B": {
-     "type": "swagger.D"
+     "$ref": "swagger.D"
     }
    }
   },
@@ -695,7 +718,7 @@ func TestIssue158(t *testing.T) {
    ],
    "properties": {
     "address": {
-     "type": "swagger.Address"
+     "$ref": "swagger.Address"
     },
     "name": {
      "type": "string"

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/swagger_test.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/swagger_test.go
@@ -23,9 +23,11 @@ func TestServiceToApi(t *testing.T) {
 	ws.Route(ws.DELETE("/a").To(dummy).Writes(sample{}))
 	ws.ApiVersion("1.2.3")
 	cfg := Config{
-		WebServicesUrl: "http://here.com",
-		ApiPath:        "/apipath",
-		WebServices:    []*restful.WebService{ws}}
+		WebServicesUrl:   "http://here.com",
+		ApiPath:          "/apipath",
+		WebServices:      []*restful.WebService{ws},
+		PostBuildHandler: func(in map[string]ApiDeclaration) {},
+	}
 	sws := newSwaggerService(cfg)
 	decl := sws.composeDeclaration(ws, "/tests")
 	// checks

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/swagger_webservice.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/swagger_webservice.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/emicklei/go-restful"
 	// "github.com/emicklei/hopwatch"
-	"log"
 	"net/http"
 	"reflect"
 	"sort"
 	"strings"
+
+	"github.com/emicklei/go-restful/log"
 )
 
 type SwaggerService struct {
@@ -24,7 +25,10 @@ func newSwaggerService(config Config) *SwaggerService {
 }
 
 // LogInfo is the function that is called when this package needs to log. It defaults to log.Printf
-var LogInfo = log.Printf
+var LogInfo = func(format string, v ...interface{}) {
+	// use the restful package-wide logger
+	log.Printf(format, v...)
+}
 
 // InstallSwaggerService add the WebService that provides the API documentation of all services
 // conform the Swagger documentation specifcation. (https://github.com/wordnik/swagger-core/wiki).
@@ -71,6 +75,11 @@ func RegisterSwaggerService(config Config, wsContainer *restful.Container) {
 				sws.apiDeclarationMap[each.RootPath()] = sws.composeDeclaration(each, each.RootPath())
 			}
 		}
+	}
+
+	// if specified then call the PostBuilderHandler
+	if config.PostBuildHandler != nil {
+		config.PostBuildHandler(sws.apiDeclarationMap)
 	}
 
 	// Check paths for UI serving

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/utils_test.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/utils_test.go
@@ -32,6 +32,8 @@ func compareJson(t *testing.T, actualJsonAsString string, expectedJsonAsString s
 		fmt.Println(withLineNumbers(expectedJsonAsString))
 		fmt.Println("---- actual -----")
 		fmt.Println(withLineNumbers(actualJsonAsString))
+		fmt.Println("---- raw -----")
+		fmt.Println(actualJsonAsString)
 		t.Error("there are differences")
 		return false
 	}

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/web_service.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/web_service.go
@@ -1,10 +1,14 @@
 package restful
 
+import (
+	"os"
+
+	"github.com/emicklei/go-restful/log"
+)
+
 // Copyright 2013 Ernest Micklei. All rights reserved.
 // Use of this source code is governed by a license
 // that can be found in the LICENSE file.
-
-import "log"
 
 // WebService holds a collection of Route values that bind a Http Method + URL Path to a function.
 type WebService struct {
@@ -26,7 +30,8 @@ func (w *WebService) compilePathExpression() {
 	}
 	compiled, err := newPathExpression(w.rootPath)
 	if err != nil {
-		log.Fatalf("[restful] invalid path:%s because:%v", w.rootPath, err)
+		log.Printf("[restful] invalid path:%s because:%v", w.rootPath, err)
+		os.Exit(1)
 	}
 	w.pathExpr = compiled
 }

--- a/api/swagger-spec/v1beta1.json
+++ b/api/swagger-spec/v1beta1.json
@@ -4020,7 +4020,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -4060,7 +4060,7 @@
       "description": "name of the pod to bind"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -4068,7 +4068,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -4105,13 +4105,13 @@
     ],
     "properties": {
      "capabilities": {
-      "type": "v1beta1.Capabilities",
+      "$ref": "v1beta1.Capabilities",
       "description": "capabilities for container; cannot be updated"
      },
      "command": {
       "type": "array",
       "items": {
-       "$ref": "string"
+       "type": "string"
       },
       "description": "command argv array; not executed within a shell; defaults to entrypoint or command in the image; cannot be updated"
      },
@@ -4132,15 +4132,15 @@
       "description": "Docker image name"
      },
      "imagePullPolicy": {
-      "type": "v1beta1.PullPolicy",
+      "$ref": "v1beta1.PullPolicy",
       "description": "image pull policy; one of PullAlways, PullNever, PullIfNotPresent; defaults to PullAlways if :latest tag is specified, or PullIfNotPresent otherwise; cannot be updated"
      },
      "lifecycle": {
-      "type": "v1beta1.Lifecycle",
+      "$ref": "v1beta1.Lifecycle",
       "description": "actions that the management system should take in response to container lifecycle events; cannot be updated"
      },
      "livenessProbe": {
-      "type": "v1beta1.LivenessProbe",
+      "$ref": "v1beta1.LivenessProbe",
       "description": "periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated"
      },
      "memory": {
@@ -4164,11 +4164,11 @@
       "description": "whether or not the container is granted privileged status; defaults to false; cannot be updated"
      },
      "readinessProbe": {
-      "type": "v1beta1.LivenessProbe",
+      "$ref": "v1beta1.LivenessProbe",
       "description": "periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated"
      },
      "resources": {
-      "type": "v1beta1.ResourceRequirements",
+      "$ref": "v1beta1.ResourceRequirements",
       "description": "Compute Resources required by this container; cannot be updated"
      },
      "terminationMessagePath": {
@@ -4205,7 +4205,7 @@
       "description": "list of containers belonging to the pod; containers cannot currently be added or removed"
      },
      "dnsPolicy": {
-      "type": "v1beta1.DNSPolicy",
+      "$ref": "v1beta1.DNSPolicy",
       "description": "DNS policy for containers within the pod; one of 'ClusterFirst' or 'Default'"
      },
      "hostNetwork": {
@@ -4217,11 +4217,11 @@
       "description": "manifest name; must be a DNS_SUBDOMAIN; cannot be updated"
      },
      "restartPolicy": {
-      "type": "v1beta1.RestartPolicy",
+      "$ref": "v1beta1.RestartPolicy",
       "description": "restart policy for all containers within the pod; one of RestartPolicyAlways, RestartPolicyOnFailure, RestartPolicyNever"
      },
      "uuid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "manifest UUID, populated by the system, read-only"
      },
      "version": {
@@ -4262,7 +4262,7 @@
       "description": "name for the port that can be referred to by services; must be a DNS_LABEL and unique without the pod"
      },
      "protocol": {
-      "type": "v1beta1.Protocol",
+      "$ref": "v1beta1.Protocol",
       "description": "protocol for port; must be UDP or TCP; TCP if unspecified"
      }
     }
@@ -4274,7 +4274,7 @@
     ],
     "properties": {
      "medium": {
-      "type": "v1beta1.StorageType",
+      "$ref": "v1beta1.StorageType",
       "description": "type of storage used to back the volume; must be an empty string (default) or Memory"
      }
     }
@@ -4314,7 +4314,7 @@
       "description": "specific resourceVersion to which this reference is made, if any: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "uid of the referent"
      }
     }
@@ -4326,7 +4326,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -4344,7 +4344,7 @@
      "endpoints": {
       "type": "array",
       "items": {
-       "$ref": "string"
+       "type": "string"
       },
       "description": "list of endpoints corresponding to a service, of the form address:port, such as 10.10.1.1:1909"
      },
@@ -4365,11 +4365,11 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "protocol": {
-      "type": "v1beta1.Protocol",
+      "$ref": "v1beta1.Protocol",
       "description": "IP protocol for endpoint ports; must be UDP or TCP; TCP if unspecified"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -4384,7 +4384,7 @@
       "description": "list of references to objects providing the endpoints"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -4396,7 +4396,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -4435,7 +4435,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -4443,7 +4443,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -4472,7 +4472,7 @@
     "id": "v1beta1.Event",
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -4509,7 +4509,7 @@
       "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs; cannot be updated"
      },
      "involvedObject": {
-      "type": "v1beta1.ObjectReference",
+      "$ref": "v1beta1.ObjectReference",
       "description": "object that this event is about"
      },
      "kind": {
@@ -4533,7 +4533,7 @@
       "description": "short, machine understandable string that gives the reason for the transition into the object's current status"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -4553,7 +4553,7 @@
       "description": "time at which the client recorded the event"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -4565,7 +4565,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -4604,7 +4604,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -4612,7 +4612,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -4623,7 +4623,7 @@
      "command": {
       "type": "array",
       "items": {
-       "$ref": "string"
+       "type": "string"
       },
       "description": "command line to execute inside the container; working directory for the command is root ('/') in the container's file system; the command is exec'd, not run inside a shell; exit status of 0 is treated as live/healthy and non-zero is unhealthy"
      }
@@ -4696,15 +4696,15 @@
     "id": "v1beta1.Handler",
     "properties": {
      "exec": {
-      "type": "v1beta1.ExecAction",
+      "$ref": "v1beta1.ExecAction",
       "description": "exec-based handler"
      },
      "httpGet": {
-      "type": "v1beta1.HTTPGetAction",
+      "$ref": "v1beta1.HTTPGetAction",
       "description": "HTTP-based handler"
      },
      "tcpSocket": {
-      "type": "v1beta1.TCPSocketAction",
+      "$ref": "v1beta1.TCPSocketAction",
       "description": "TCP-based handler; TCP hooks not yet supported"
      }
     }
@@ -4725,11 +4725,11 @@
     "id": "v1beta1.Lifecycle",
     "properties": {
      "postStart": {
-      "type": "v1beta1.Handler",
+      "$ref": "v1beta1.Handler",
       "description": "called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes"
      },
      "preStop": {
-      "type": "v1beta1.Handler",
+      "$ref": "v1beta1.Handler",
       "description": "called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes"
      }
     }
@@ -4738,7 +4738,7 @@
     "id": "v1beta1.LimitRange",
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -4770,7 +4770,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -4778,11 +4778,11 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "spec": {
-      "type": "v1beta1.LimitRangeSpec",
+      "$ref": "v1beta1.LimitRangeSpec",
       "description": "spec defines the limits enforced"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -4791,15 +4791,15 @@
     "id": "v1beta1.LimitRangeItem",
     "properties": {
      "max": {
-      "type": "v1beta1.ResourceList",
+      "$ref": "v1beta1.ResourceList",
       "description": "max usage constraints on this kind by resource name"
      },
      "min": {
-      "type": "v1beta1.ResourceList",
+      "$ref": "v1beta1.ResourceList",
       "description": "min usage constraints on this kind by resource name"
      },
      "type": {
-      "type": "v1beta1.LimitType",
+      "$ref": "v1beta1.LimitType",
       "description": "type of resource that this limit applies to"
      }
     }
@@ -4811,7 +4811,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -4850,7 +4850,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -4858,7 +4858,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -4882,11 +4882,11 @@
     "id": "v1beta1.LivenessProbe",
     "properties": {
      "exec": {
-      "type": "v1beta1.ExecAction",
+      "$ref": "v1beta1.ExecAction",
       "description": "parameters for exec-based liveness probe"
      },
      "httpGet": {
-      "type": "v1beta1.HTTPGetAction",
+      "$ref": "v1beta1.HTTPGetAction",
       "description": "parameters for HTTP-based liveness probe"
      },
      "initialDelaySeconds": {
@@ -4895,7 +4895,7 @@
       "description": "number of seconds after the container has started before liveness probes are initiated"
      },
      "tcpSocket": {
-      "type": "v1beta1.TCPSocketAction",
+      "$ref": "v1beta1.TCPSocketAction",
       "description": "parameters for TCP-based liveness probe"
      },
      "timeoutSeconds": {
@@ -4909,7 +4909,7 @@
     "id": "v1beta1.Minion",
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -4945,7 +4945,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta1.Minion.labels",
+      "$ref": "v1beta1.Minion.labels",
       "description": "map of string keys and values that can be used to organize and categorize minions; labels of a minion assigned by the scheduler must match the scheduled pod's nodeSelector"
      },
      "namespace": {
@@ -4957,11 +4957,11 @@
       "description": "IP range assigned to the node"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "resources": {
-      "type": "v1beta1.NodeResources",
+      "$ref": "v1beta1.NodeResources",
       "description": "characterization of node resources"
      },
      "selfLink": {
@@ -4969,11 +4969,11 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "status": {
-      "type": "v1beta1.NodeStatus",
+      "$ref": "v1beta1.NodeStatus",
       "description": "current status of node"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      },
      "unschedulable": {
@@ -4993,7 +4993,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5039,7 +5039,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5047,7 +5047,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -5077,7 +5077,7 @@
     "id": "v1beta1.Namespace",
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5105,7 +5105,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta1.Namespace.labels",
+      "$ref": "v1beta1.Namespace.labels",
       "description": "map of string keys and values that can be used to organize and categorize namespaces"
      },
      "namespace": {
@@ -5113,7 +5113,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5121,15 +5121,15 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "spec": {
-      "type": "v1beta1.NamespaceSpec",
+      "$ref": "v1beta1.NamespaceSpec",
       "description": "spec defines the behavior of the Namespace"
      },
      "status": {
-      "type": "v1beta1.NamespaceStatus",
+      "$ref": "v1beta1.NamespaceStatus",
       "description": "status describes the current status of a Namespace; read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -5145,7 +5145,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5184,7 +5184,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5192,7 +5192,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -5213,7 +5213,7 @@
     "id": "v1beta1.NamespaceStatus",
     "properties": {
      "phase": {
-      "type": "v1beta1.NamespacePhase",
+      "$ref": "v1beta1.NamespacePhase",
       "description": "phase is the current lifecycle phase of the namespace"
      }
     }
@@ -5230,7 +5230,7 @@
       "description": "string representation of the address"
      },
      "type": {
-      "type": "v1beta1.NodeAddressType",
+      "$ref": "v1beta1.NodeAddressType",
       "description": "type of the node address, e.g. external ip, internal ip, hostname, etc"
      }
     }
@@ -5243,7 +5243,7 @@
     ],
     "properties": {
      "kind": {
-      "type": "v1beta1.NodeConditionKind",
+      "$ref": "v1beta1.NodeConditionKind",
       "description": "kind of the condition, one of Reachable, Ready"
      },
      "lastProbeTime": {
@@ -5263,7 +5263,7 @@
       "description": "(brief) reason for the condition's last transition"
      },
      "status": {
-      "type": "v1beta1.ConditionStatus",
+      "$ref": "v1beta1.ConditionStatus",
       "description": "status of the condition, one of Full, None, Unknown"
      }
     }
@@ -5272,7 +5272,7 @@
     "id": "v1beta1.NodeResources",
     "properties": {
      "capacity": {
-      "type": "v1beta1.ResourceList",
+      "$ref": "v1beta1.ResourceList",
       "description": "resource capacity of a node represented as a map of resource name to quantity of resource"
      }
     }
@@ -5295,11 +5295,11 @@
       "description": "conditions is an array of current node conditions"
      },
      "nodeInfo": {
-      "type": "v1beta1.NodeSystemInfo",
+      "$ref": "v1beta1.NodeSystemInfo",
       "description": "node identity is a set of ids/uuids to uniquely identify the node"
      },
      "phase": {
-      "type": "v1beta1.NodePhase",
+      "$ref": "v1beta1.NodePhase",
       "description": "node phase is the current lifecycle phase of the node"
      }
     }
@@ -5349,7 +5349,7 @@
       "description": "specific resourceVersion to which this reference is made, if any: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "uid of the referent"
      }
     }
@@ -5358,7 +5358,7 @@
     "id": "v1beta1.Pod",
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5370,7 +5370,7 @@
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
      "currentState": {
-      "type": "v1beta1.PodState",
+      "$ref": "v1beta1.PodState",
       "description": "current state of the pod; populated by the system, read-only"
      },
      "deletionTimestamp": {
@@ -5378,7 +5378,7 @@
       "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "desiredState": {
-      "type": "v1beta1.PodState",
+      "$ref": "v1beta1.PodState",
       "description": "specification of the desired state of the pod"
      },
      "generateName": {
@@ -5394,7 +5394,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta1.Pod.labels",
+      "$ref": "v1beta1.Pod.labels",
       "description": "map of string keys and values that can be used to organize and categorize pods; may match selectors of replication controllers and services"
      },
      "namespace": {
@@ -5402,11 +5402,11 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "nodeSelector": {
-      "type": "v1beta1.Pod.nodeSelector",
+      "$ref": "v1beta1.Pod.nodeSelector",
       "description": "selector which must match a node's labels for the pod to be scheduled on that node"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5414,7 +5414,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -5435,11 +5435,11 @@
     ],
     "properties": {
      "kind": {
-      "type": "v1beta1.PodConditionKind",
+      "$ref": "v1beta1.PodConditionKind",
       "description": "kind of the condition, currently only Ready"
      },
      "status": {
-      "type": "v1beta1.ConditionStatus",
+      "$ref": "v1beta1.ConditionStatus",
       "description": "status of the condition, one of Full, None, Unknown"
      }
     }
@@ -5451,7 +5451,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5490,7 +5490,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5498,7 +5498,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -5522,11 +5522,11 @@
       "description": "IP address of the host to which the pod is assigned; empty if not yet scheduled"
      },
      "info": {
-      "type": "v1beta1.PodInfo",
+      "$ref": "v1beta1.PodInfo",
       "description": "map of container name to container status"
      },
      "manifest": {
-      "type": "v1beta1.ContainerManifest",
+      "$ref": "v1beta1.ContainerManifest",
       "description": "manifest of containers and volumes comprising the pod"
      },
      "message": {
@@ -5538,7 +5538,7 @@
       "description": "IP address allocated to the pod; routable at least within the cluster; empty if not yet allocated"
      },
      "status": {
-      "type": "v1beta1.PodStatus",
+      "$ref": "v1beta1.PodStatus",
       "description": "current condition of the pod, Waiting, Running, or Terminated"
      }
     }
@@ -5547,19 +5547,19 @@
     "id": "v1beta1.PodTemplate",
     "properties": {
      "annotations": {
-      "type": "v1beta1.PodTemplate.annotations",
+      "$ref": "v1beta1.PodTemplate.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about pods created from the template"
      },
      "desiredState": {
-      "type": "v1beta1.PodState",
+      "$ref": "v1beta1.PodState",
       "description": "specification of the desired state of pods created from this template"
      },
      "labels": {
-      "type": "v1beta1.PodTemplate.labels",
+      "$ref": "v1beta1.PodTemplate.labels",
       "description": "map of string keys and values that can be used to organize and categorize the pods created from the template; must match the selector of the replication controller to which the template belongs; may match selectors of services"
      },
      "nodeSelector": {
-      "type": "v1beta1.PodTemplate.nodeSelector",
+      "$ref": "v1beta1.PodTemplate.nodeSelector",
       "description": "a selector which must be true for the pod to fit on a node"
      }
     }
@@ -5580,7 +5580,7 @@
     "id": "v1beta1.ReplicationController",
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5592,7 +5592,7 @@
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
      "currentState": {
-      "type": "v1beta1.ReplicationControllerState",
+      "$ref": "v1beta1.ReplicationControllerState",
       "description": "current state of the replication controller; populated by the system, read-only"
      },
      "deletionTimestamp": {
@@ -5600,7 +5600,7 @@
       "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "desiredState": {
-      "type": "v1beta1.ReplicationControllerState",
+      "$ref": "v1beta1.ReplicationControllerState",
       "description": "specification of the desired state of the replication controller"
      },
      "generateName": {
@@ -5616,7 +5616,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta1.ReplicationController.labels",
+      "$ref": "v1beta1.ReplicationController.labels",
       "description": "map of string keys and values that can be used to organize and categorize replication controllers"
      },
      "namespace": {
@@ -5624,7 +5624,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5632,7 +5632,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -5648,7 +5648,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5687,7 +5687,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5695,7 +5695,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -5707,11 +5707,11 @@
     ],
     "properties": {
      "podTemplate": {
-      "type": "v1beta1.PodTemplate",
+      "$ref": "v1beta1.PodTemplate",
       "description": "template for pods to be created by this replication controller when the observed number of replicas is less than the desired number of replicas"
      },
      "replicaSelector": {
-      "type": "v1beta1.ReplicationControllerState.replicaSelector",
+      "$ref": "v1beta1.ReplicationControllerState.replicaSelector",
       "description": "label keys and values that must match in order to be controlled by this replication controller"
      },
      "replicas": {
@@ -5729,7 +5729,7 @@
     "id": "v1beta1.ResourceQuota",
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5757,7 +5757,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta1.ResourceQuota.labels",
+      "$ref": "v1beta1.ResourceQuota.labels",
       "description": "map of string keys and values that can be used to organize and categorize resource quotas"
      },
      "namespace": {
@@ -5765,7 +5765,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5773,15 +5773,15 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "spec": {
-      "type": "v1beta1.ResourceQuotaSpec",
+      "$ref": "v1beta1.ResourceQuotaSpec",
       "description": "spec defines the desired quota"
      },
      "status": {
-      "type": "v1beta1.ResourceQuotaStatus",
+      "$ref": "v1beta1.ResourceQuotaStatus",
       "description": "status defines the actual enforced quota and current usage"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -5797,7 +5797,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5836,7 +5836,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5844,7 +5844,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -5853,7 +5853,7 @@
     "id": "v1beta1.ResourceQuotaSpec",
     "properties": {
      "hard": {
-      "type": "v1beta1.ResourceList",
+      "$ref": "v1beta1.ResourceList",
       "description": "hard is the set of desired hard limits for each named resource"
      }
     }
@@ -5862,11 +5862,11 @@
     "id": "v1beta1.ResourceQuotaStatus",
     "properties": {
      "hard": {
-      "type": "v1beta1.ResourceList",
+      "$ref": "v1beta1.ResourceList",
       "description": "hard is the set of enforced hard limits for each named resource"
      },
      "used": {
-      "type": "v1beta1.ResourceList",
+      "$ref": "v1beta1.ResourceList",
       "description": "used is the current observed total usage of the resource in the namespace"
      }
     }
@@ -5875,11 +5875,11 @@
     "id": "v1beta1.ResourceRequirements",
     "properties": {
      "limits": {
-      "type": "v1beta1.ResourceList",
+      "$ref": "v1beta1.ResourceList",
       "description": "Maximum amount of compute resources allowed"
      },
      "requests": {
-      "type": "v1beta1.ResourceList",
+      "$ref": "v1beta1.ResourceList",
       "description": "Minimum amount of resources requested"
      }
     }
@@ -5888,15 +5888,15 @@
     "id": "v1beta1.RestartPolicy",
     "properties": {
      "always": {
-      "type": "v1beta1.RestartPolicyAlways",
+      "$ref": "v1beta1.RestartPolicyAlways",
       "description": "always restart the container after termination"
      },
      "never": {
-      "type": "v1beta1.RestartPolicyNever",
+      "$ref": "v1beta1.RestartPolicyNever",
       "description": "never restart the container"
      },
      "onFailure": {
-      "type": "v1beta1.RestartPolicyOnFailure",
+      "$ref": "v1beta1.RestartPolicyOnFailure",
       "description": "restart the container if it fails for any reason, but not if it succeeds (exit 0)"
      }
     }
@@ -5917,7 +5917,7 @@
     "id": "v1beta1.Secret",
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5929,7 +5929,7 @@
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
      "data": {
-      "type": "v1beta1.Secret.data",
+      "$ref": "v1beta1.Secret.data",
       "description": "data contains the secret data.  Each key must be a valid DNS_SUBDOMAIN.  Each value must be a base64 encoded string"
      },
      "deletionTimestamp": {
@@ -5953,7 +5953,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5961,11 +5961,11 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "type": {
-      "type": "v1beta1.SecretType",
+      "$ref": "v1beta1.SecretType",
       "description": "type facilitates programmatic handling of secret data"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -5981,7 +5981,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -6020,7 +6020,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -6028,7 +6028,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -6040,7 +6040,7 @@
     ],
     "properties": {
      "target": {
-      "type": "v1beta1.ObjectReference",
+      "$ref": "v1beta1.ObjectReference",
       "description": "target is a reference to a secret"
      }
     }
@@ -6053,7 +6053,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -6089,7 +6089,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta1.Service.labels",
+      "$ref": "v1beta1.Service.labels",
       "description": "map of string keys and values that can be used to organize and categorize services"
      },
      "namespace": {
@@ -6106,7 +6106,7 @@
       "description": "IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused, and creation of the service will fail otherwise; cannot be updated; 'None' can be specified for a headless service when proxying is not required"
      },
      "protocol": {
-      "type": "v1beta1.Protocol",
+      "$ref": "v1beta1.Protocol",
       "description": "protocol for port; must be UDP or TCP; TCP if unspecified"
      },
      "proxyPort": {
@@ -6117,16 +6117,16 @@
      "publicIPs": {
       "type": "array",
       "items": {
-       "$ref": "string"
+       "type": "string"
       },
       "description": "externally visible IPs (e.g. load balancers) that should be proxied to this service"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selector": {
-      "type": "v1beta1.Service.selector",
+      "$ref": "v1beta1.Service.selector",
       "description": "label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified"
      },
      "selfLink": {
@@ -6134,11 +6134,11 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "sessionAffinity": {
-      "type": "v1beta1.AffinityType",
+      "$ref": "v1beta1.AffinityType",
       "description": "enable client IP based session affinity; must be ClientIP or None; defaults to None"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -6158,7 +6158,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta1.TypeMeta.annotations",
+      "$ref": "v1beta1.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -6197,7 +6197,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -6205,7 +6205,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only; cannot be updated"
      }
     }
@@ -6230,7 +6230,7 @@
       "description": "volume name; must be a DNS_LABEL and unique within the pod"
      },
      "source": {
-      "type": "v1beta1.VolumeSource",
+      "$ref": "v1beta1.VolumeSource",
       "description": "location and type of volume to mount; at most one of HostDir, EmptyDir, GCEPersistentDisk, or GitRepo; default is EmptyDir"
      }
     }
@@ -6276,27 +6276,27 @@
     ],
     "properties": {
      "emptyDir": {
-      "type": "v1beta1.EmptyDirVolumeSource",
+      "$ref": "v1beta1.EmptyDirVolumeSource",
       "description": "temporary directory that shares a pod's lifetime"
      },
      "gitRepo": {
-      "type": "v1beta1.GitRepoVolumeSource",
+      "$ref": "v1beta1.GitRepoVolumeSource",
       "description": "git repository at a particular revision"
      },
      "hostDir": {
-      "type": "v1beta1.HostPathVolumeSource",
+      "$ref": "v1beta1.HostPathVolumeSource",
       "description": "pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host"
      },
      "nfs": {
-      "type": "v1beta1.NFSVolumeSource",
+      "$ref": "v1beta1.NFSVolumeSource",
       "description": "NFS volume that will be mounted in the host machine "
      },
      "persistentDisk": {
-      "type": "v1beta1.GCEPersistentDiskVolumeSource",
+      "$ref": "v1beta1.GCEPersistentDiskVolumeSource",
       "description": "GCE disk resource attached to the host machine on demand"
      },
      "secret": {
-      "type": "v1beta1.SecretVolumeSource",
+      "$ref": "v1beta1.SecretVolumeSource",
       "description": "secret to populate volume with"
      }
     }

--- a/api/swagger-spec/v1beta1.json
+++ b/api/swagger-spec/v1beta1.json
@@ -235,6 +235,44 @@
       "consumes": [
        "*/*"
       ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Endpoints",
+      "nickname": "deleteEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Endpoints",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "*v1beta1.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
      }
     ]
    },
@@ -961,6 +999,14 @@
         "description": "name of the Node",
         "required": true,
         "allowMultiple": false
+       },
+       {
+        "type": "*v1beta1.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
        }
       ],
       "produces": [
@@ -1375,6 +1421,14 @@
         "description": "name of the Namespace",
         "required": true,
         "allowMultiple": false
+       },
+       {
+        "type": "*v1beta1.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
        }
       ],
       "produces": [
@@ -1401,6 +1455,78 @@
         "paramType": "path",
         "name": "name",
         "description": "name of the Namespace",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/namespaces/{name}/finalize",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "replace the specified Namespace",
+      "nickname": "replaceNamespace",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Namespace",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.Namespace",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta1/namespaces/{name}/status",
+    "description": "API at /api/v1beta1 version v1beta1",
+    "operations": [
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "replace the specified Namespace",
+      "nickname": "replaceNamespace",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Namespace",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.Namespace",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
         "required": true,
         "allowMultiple": false
        }
@@ -1571,6 +1697,14 @@
         "paramType": "path",
         "name": "name",
         "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "*v1beta1.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
         "required": true,
         "allowMultiple": false
        }
@@ -2044,6 +2178,14 @@
         "name": "namespace",
         "description": "object name and auth scope, such as for teams and projects",
         "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "*v1beta1.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
         "allowMultiple": false
        }
       ],
@@ -2677,6 +2819,14 @@
         "description": "object name and auth scope, such as for teams and projects",
         "required": false,
         "allowMultiple": false
+       },
+       {
+        "type": "*v1beta1.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
        }
       ],
       "produces": [
@@ -2940,6 +3090,14 @@
         "name": "namespace",
         "description": "object name and auth scope, such as for teams and projects",
         "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "*v1beta1.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
         "allowMultiple": false
        }
       ],
@@ -3850,6 +4008,10 @@
    }
   ],
   "models": {
+   "*v1beta1.DeleteOptions": {
+    "id": "*v1beta1.DeleteOptions",
+    "properties": {}
+   },
    "v1beta1.Binding": {
     "id": "v1beta1.Binding",
     "required": [
@@ -3868,6 +4030,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -4042,6 +4208,10 @@
       "type": "v1beta1.DNSPolicy",
       "description": "DNS policy for containers within the pod; one of 'ClusterFirst' or 'Default'"
      },
+     "hostNetwork": {
+      "type": "boolean",
+      "description": "host networking requested for this pod"
+     },
      "id": {
       "type": "string",
       "description": "manifest name; must be a DNS_SUBDOMAIN; cannot be updated"
@@ -4167,6 +4337,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "endpoints": {
       "type": "array",
       "items": {
@@ -4232,6 +4406,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -4309,6 +4487,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "firstTimestamp": {
       "type": "string",
@@ -4394,6 +4576,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "generateName": {
       "type": "string",
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
@@ -4442,6 +4628,10 @@
       "description": "command line to execute inside the container; working directory for the command is root ('/') in the container's file system; the command is exec'd, not run inside a shell; exit status of 0 is treated as live/healthy and non-zero is unhealthy"
      }
     }
+   },
+   "v1beta1.FinalizerName": {
+    "id": "v1beta1.FinalizerName",
+    "properties": {}
    },
    "v1beta1.GCEPersistentDiskVolumeSource": {
     "id": "v1beta1.GCEPersistentDiskVolumeSource",
@@ -4559,6 +4749,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "generateName": {
       "type": "string",
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
@@ -4627,6 +4821,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -4722,6 +4920,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "externalID": {
       "type": "string",
       "description": "external id of the node assigned by some machine database (e.g. a cloud provider)"
@@ -4802,6 +5004,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "generateName": {
       "type": "string",
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
@@ -4846,6 +5052,27 @@
      }
     }
    },
+   "v1beta1.NFSVolumeSource": {
+    "id": "v1beta1.NFSVolumeSource",
+    "required": [
+     "server",
+     "path"
+    ],
+    "properties": {
+     "path": {
+      "type": "string",
+      "description": "the path that is exported by the NFS server"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "forces the NFS export to be mounted with read-only permissions"
+     },
+     "server": {
+      "type": "string",
+      "description": "the hostname or IP address of the NFS server"
+     }
+    }
+   },
    "v1beta1.Namespace": {
     "id": "v1beta1.Namespace",
     "properties": {
@@ -4860,6 +5087,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -4925,6 +5156,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "generateName": {
       "type": "string",
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
@@ -4964,7 +5199,15 @@
    },
    "v1beta1.NamespaceSpec": {
     "id": "v1beta1.NamespaceSpec",
-    "properties": {}
+    "properties": {
+     "finalizers": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.FinalizerName"
+      },
+      "description": "an opaque list of values that must be empty to permanently remove object from storage"
+     }
+    }
    },
    "v1beta1.NamespaceStatus": {
     "id": "v1beta1.NamespaceStatus",
@@ -5130,6 +5373,10 @@
       "type": "v1beta1.PodState",
       "description": "current state of the pod; populated by the system, read-only"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "desiredState": {
       "type": "v1beta1.PodState",
       "description": "specification of the desired state of the pod"
@@ -5214,6 +5461,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -5344,6 +5595,10 @@
       "type": "v1beta1.ReplicationControllerState",
       "description": "current state of the replication controller; populated by the system, read-only"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "desiredState": {
       "type": "v1beta1.ReplicationControllerState",
       "description": "specification of the desired state of the replication controller"
@@ -5403,6 +5658,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -5481,6 +5740,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "generateName": {
       "type": "string",
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
@@ -5544,6 +5807,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -5610,6 +5877,10 @@
      "limits": {
       "type": "v1beta1.ResourceList",
       "description": "Maximum amount of compute resources allowed"
+     },
+     "requests": {
+      "type": "v1beta1.ResourceList",
+      "description": "Minimum amount of resources requested"
      }
     }
    },
@@ -5660,6 +5931,10 @@
      "data": {
       "type": "v1beta1.Secret.data",
       "description": "data contains the secret data.  Each key must be a valid DNS_SUBDOMAIN.  Each value must be a base64 encoded string"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -5716,6 +5991,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -5793,6 +6072,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "generateName": {
       "type": "string",
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
@@ -5820,7 +6103,7 @@
      },
      "portalIP": {
       "type": "string",
-      "description": "IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused, and creation of the service will fail otherwise; cannot be updated"
+      "description": "IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused, and creation of the service will fail otherwise; cannot be updated; 'None' can be specified for a headless service when proxying is not required"
      },
      "protocol": {
       "type": "v1beta1.Protocol",
@@ -5885,6 +6168,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -5984,7 +6271,8 @@
      "emptyDir",
      "persistentDisk",
      "gitRepo",
-     "secret"
+     "secret",
+     "nfs"
     ],
     "properties": {
      "emptyDir": {
@@ -5998,6 +6286,10 @@
      "hostDir": {
       "type": "v1beta1.HostPathVolumeSource",
       "description": "pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host"
+     },
+     "nfs": {
+      "type": "v1beta1.NFSVolumeSource",
+      "description": "NFS volume that will be mounted in the host machine "
      },
      "persistentDisk": {
       "type": "v1beta1.GCEPersistentDiskVolumeSource",

--- a/api/swagger-spec/v1beta2.json
+++ b/api/swagger-spec/v1beta2.json
@@ -4020,7 +4020,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -4060,7 +4060,7 @@
       "description": "name of the pod to bind"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -4068,7 +4068,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -4105,13 +4105,13 @@
     ],
     "properties": {
      "capabilities": {
-      "type": "v1beta2.Capabilities",
+      "$ref": "v1beta2.Capabilities",
       "description": "capabilities for container; cannot be updated"
      },
      "command": {
       "type": "array",
       "items": {
-       "$ref": "string"
+       "type": "string"
       },
       "description": "command argv array; not executed within a shell; defaults to entrypoint or command in the image; cannot be updated"
      },
@@ -4132,15 +4132,15 @@
       "description": "Docker image name"
      },
      "imagePullPolicy": {
-      "type": "v1beta2.PullPolicy",
+      "$ref": "v1beta2.PullPolicy",
       "description": "image pull policy; one of PullAlways, PullNever, PullIfNotPresent; defaults to PullAlways if :latest tag is specified, or PullIfNotPresent otherwise; cannot be updated"
      },
      "lifecycle": {
-      "type": "v1beta2.Lifecycle",
+      "$ref": "v1beta2.Lifecycle",
       "description": "actions that the management system should take in response to container lifecycle events; cannot be updated"
      },
      "livenessProbe": {
-      "type": "v1beta2.LivenessProbe",
+      "$ref": "v1beta2.LivenessProbe",
       "description": "periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated"
      },
      "memory": {
@@ -4164,11 +4164,11 @@
       "description": "whether or not the container is granted privileged status; defaults to false; cannot be updated"
      },
      "readinessProbe": {
-      "type": "v1beta2.LivenessProbe",
+      "$ref": "v1beta2.LivenessProbe",
       "description": "periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated"
      },
      "resources": {
-      "type": "v1beta2.ResourceRequirements",
+      "$ref": "v1beta2.ResourceRequirements",
       "description": "Compute Resources required by this container; cannot be updated"
      },
      "terminationMessagePath": {
@@ -4205,7 +4205,7 @@
       "description": "list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed"
      },
      "dnsPolicy": {
-      "type": "v1beta2.DNSPolicy",
+      "$ref": "v1beta2.DNSPolicy",
       "description": "DNS policy for containers within the pod; one of 'ClusterFirst' or 'Default'"
      },
      "hostNetwork": {
@@ -4217,11 +4217,11 @@
       "description": "manifest name; must be a DNS_SUBDOMAIN; cannot be updated"
      },
      "restartPolicy": {
-      "type": "v1beta2.RestartPolicy",
+      "$ref": "v1beta2.RestartPolicy",
       "description": "restart policy for all containers within the pod; one of RestartPolicyAlways, RestartPolicyOnFailure, RestartPolicyNever"
      },
      "uuid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "manifest UUID; cannot be updated"
      },
      "version": {
@@ -4262,7 +4262,7 @@
       "description": "name for the port that can be referred to by services; must be a DNS_LABEL and unique without the pod"
      },
      "protocol": {
-      "type": "v1beta2.Protocol",
+      "$ref": "v1beta2.Protocol",
       "description": "protocol for port; must be UDP or TCP; TCP if unspecified"
      }
     }
@@ -4274,7 +4274,7 @@
     ],
     "properties": {
      "medium": {
-      "type": "v1beta2.StorageType",
+      "$ref": "v1beta2.StorageType",
       "description": "type of storage used to back the volume; must be an empty string (default) or Memory"
      }
     }
@@ -4314,7 +4314,7 @@
       "description": "specific resourceVersion to which this reference is made, if any: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "uid of the referent"
      }
     }
@@ -4326,7 +4326,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -4344,7 +4344,7 @@
      "endpoints": {
       "type": "array",
       "items": {
-       "$ref": "string"
+       "type": "string"
       },
       "description": "list of endpoints corresponding to a service, of the form address:port, such as 10.10.1.1:1909"
      },
@@ -4365,11 +4365,11 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "protocol": {
-      "type": "v1beta2.Protocol",
+      "$ref": "v1beta2.Protocol",
       "description": "IP protocol for endpoint ports; must be UDP or TCP; TCP if unspecified"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -4384,7 +4384,7 @@
       "description": "list of references to objects providing the endpoints"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -4396,7 +4396,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -4435,7 +4435,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -4443,7 +4443,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -4468,7 +4468,7 @@
     "id": "v1beta2.Event",
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -4505,7 +4505,7 @@
       "description": "name of the object; must be a DNS_SUBDOMAIN and unique among all objects of the same kind within the same namespace; used in resource URLs; cannot be updated"
      },
      "involvedObject": {
-      "type": "v1beta2.ObjectReference",
+      "$ref": "v1beta2.ObjectReference",
       "description": "object that this event is about"
      },
      "kind": {
@@ -4529,7 +4529,7 @@
       "description": "short, machine understandable string that gives the reason for the transition into the object's current status"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -4549,7 +4549,7 @@
       "description": "time at which the client recorded the event"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -4561,7 +4561,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -4600,7 +4600,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -4608,7 +4608,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -4619,7 +4619,7 @@
      "command": {
       "type": "array",
       "items": {
-       "$ref": "string"
+       "type": "string"
       },
       "description": "command line to execute inside the container; working directory for the command is root ('/') in the container's file system; the command is exec'd, not run inside a shell; exit status of 0 is treated as live/healthy and non-zero is unhealthy"
      }
@@ -4692,15 +4692,15 @@
     "id": "v1beta2.Handler",
     "properties": {
      "exec": {
-      "type": "v1beta2.ExecAction",
+      "$ref": "v1beta2.ExecAction",
       "description": "exec-based handler"
      },
      "httpGet": {
-      "type": "v1beta2.HTTPGetAction",
+      "$ref": "v1beta2.HTTPGetAction",
       "description": "HTTP-based handler"
      },
      "tcpSocket": {
-      "type": "v1beta2.TCPSocketAction",
+      "$ref": "v1beta2.TCPSocketAction",
       "description": "TCP-based handler; TCP hooks not yet supported"
      }
     }
@@ -4721,11 +4721,11 @@
     "id": "v1beta2.Lifecycle",
     "properties": {
      "postStart": {
-      "type": "v1beta2.Handler",
+      "$ref": "v1beta2.Handler",
       "description": "called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes"
      },
      "preStop": {
-      "type": "v1beta2.Handler",
+      "$ref": "v1beta2.Handler",
       "description": "called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes"
      }
     }
@@ -4734,7 +4734,7 @@
     "id": "v1beta2.LimitRange",
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -4766,7 +4766,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -4774,11 +4774,11 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "spec": {
-      "type": "v1beta2.LimitRangeSpec",
+      "$ref": "v1beta2.LimitRangeSpec",
       "description": "spec defines the limits enforced"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -4787,15 +4787,15 @@
     "id": "v1beta2.LimitRangeItem",
     "properties": {
      "max": {
-      "type": "v1beta2.ResourceList",
+      "$ref": "v1beta2.ResourceList",
       "description": "max usage constraints on this kind by resource name"
      },
      "min": {
-      "type": "v1beta2.ResourceList",
+      "$ref": "v1beta2.ResourceList",
       "description": "min usage constraints on this kind by resource name"
      },
      "type": {
-      "type": "v1beta2.LimitType",
+      "$ref": "v1beta2.LimitType",
       "description": "type of resource that this limit applies to"
      }
     }
@@ -4807,7 +4807,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -4846,7 +4846,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -4854,7 +4854,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -4878,11 +4878,11 @@
     "id": "v1beta2.LivenessProbe",
     "properties": {
      "exec": {
-      "type": "v1beta2.ExecAction",
+      "$ref": "v1beta2.ExecAction",
       "description": "parameters for exec-based liveness probe"
      },
      "httpGet": {
-      "type": "v1beta2.HTTPGetAction",
+      "$ref": "v1beta2.HTTPGetAction",
       "description": "parameters for HTTP-based liveness probe"
      },
      "initialDelaySeconds": {
@@ -4891,7 +4891,7 @@
       "description": "number of seconds after the container has started before liveness probes are initiated"
      },
      "tcpSocket": {
-      "type": "v1beta2.TCPSocketAction",
+      "$ref": "v1beta2.TCPSocketAction",
       "description": "parameters for TCP-based liveness probe"
      },
      "timeoutSeconds": {
@@ -4905,7 +4905,7 @@
     "id": "v1beta2.Minion",
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -4941,7 +4941,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta2.Minion.labels",
+      "$ref": "v1beta2.Minion.labels",
       "description": "map of string keys and values that can be used to organize and categorize minions; labels of a minion assigned by the scheduler must match the scheduled pod's nodeSelector"
      },
      "namespace": {
@@ -4953,11 +4953,11 @@
       "description": "IP range assigned to the node"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "resources": {
-      "type": "v1beta2.NodeResources",
+      "$ref": "v1beta2.NodeResources",
       "description": "characterization of node resources"
      },
      "selfLink": {
@@ -4965,11 +4965,11 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "status": {
-      "type": "v1beta2.NodeStatus",
+      "$ref": "v1beta2.NodeStatus",
       "description": "current status of node"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      },
      "unschedulable": {
@@ -4989,7 +4989,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5028,7 +5028,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5036,7 +5036,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -5066,7 +5066,7 @@
     "id": "v1beta2.Namespace",
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5094,7 +5094,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta2.Namespace.labels",
+      "$ref": "v1beta2.Namespace.labels",
       "description": "map of string keys and values that can be used to organize and categorize namespaces"
      },
      "namespace": {
@@ -5102,7 +5102,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5110,15 +5110,15 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "spec": {
-      "type": "v1beta2.NamespaceSpec",
+      "$ref": "v1beta2.NamespaceSpec",
       "description": "spec defines the behavior of the Namespace"
      },
      "status": {
-      "type": "v1beta2.NamespaceStatus",
+      "$ref": "v1beta2.NamespaceStatus",
       "description": "status describes the current status of a Namespace; read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -5134,7 +5134,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5173,7 +5173,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5181,7 +5181,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -5202,7 +5202,7 @@
     "id": "v1beta2.NamespaceStatus",
     "properties": {
      "phase": {
-      "type": "v1beta2.NamespacePhase",
+      "$ref": "v1beta2.NamespacePhase",
       "description": "phase is the current lifecycle phase of the namespace"
      }
     }
@@ -5219,7 +5219,7 @@
       "description": "string representation of the address"
      },
      "type": {
-      "type": "v1beta2.NodeAddressType",
+      "$ref": "v1beta2.NodeAddressType",
       "description": "type of the node address, e.g. external ip, internal ip, hostname, etc"
      }
     }
@@ -5232,7 +5232,7 @@
     ],
     "properties": {
      "kind": {
-      "type": "v1beta2.NodeConditionKind",
+      "$ref": "v1beta2.NodeConditionKind",
       "description": "kind of the condition, one of Reachable, Ready"
      },
      "lastProbeTime": {
@@ -5252,7 +5252,7 @@
       "description": "(brief) reason for the condition's last transition"
      },
      "status": {
-      "type": "v1beta2.ConditionStatus",
+      "$ref": "v1beta2.ConditionStatus",
       "description": "status of the condition, one of Full, None, Unknown"
      }
     }
@@ -5261,7 +5261,7 @@
     "id": "v1beta2.NodeResources",
     "properties": {
      "capacity": {
-      "type": "v1beta2.ResourceList",
+      "$ref": "v1beta2.ResourceList",
       "description": "resource capacity of a node represented as a map of resource name to quantity of resource"
      }
     }
@@ -5284,11 +5284,11 @@
       "description": "conditions is an array of current node conditions"
      },
      "nodeInfo": {
-      "type": "v1beta2.NodeSystemInfo",
+      "$ref": "v1beta2.NodeSystemInfo",
       "description": "node identity is a set of ids/uuids to uniquely identify the node"
      },
      "phase": {
-      "type": "v1beta2.NodePhase",
+      "$ref": "v1beta2.NodePhase",
       "description": "node phase is the current lifecycle phase of the node"
      }
     }
@@ -5338,7 +5338,7 @@
       "description": "specific resourceVersion to which this reference is made, if any: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "uid of the referent"
      }
     }
@@ -5347,7 +5347,7 @@
     "id": "v1beta2.Pod",
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5359,7 +5359,7 @@
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
      "currentState": {
-      "type": "v1beta2.PodState",
+      "$ref": "v1beta2.PodState",
       "description": "current state of the pod; populated by the system, read-only"
      },
      "deletionTimestamp": {
@@ -5367,7 +5367,7 @@
       "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "desiredState": {
-      "type": "v1beta2.PodState",
+      "$ref": "v1beta2.PodState",
       "description": "specification of the desired state of the pod"
      },
      "generateName": {
@@ -5383,7 +5383,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta2.Pod.labels",
+      "$ref": "v1beta2.Pod.labels",
       "description": "map of string keys and values that can be used to organize and categorize pods; may match selectors of replication controllers and services"
      },
      "namespace": {
@@ -5391,11 +5391,11 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "nodeSelector": {
-      "type": "v1beta2.Pod.nodeSelector",
+      "$ref": "v1beta2.Pod.nodeSelector",
       "description": "selector which must match a node's labels for the pod to be scheduled on that node"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5403,7 +5403,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -5424,11 +5424,11 @@
     ],
     "properties": {
      "kind": {
-      "type": "v1beta2.PodConditionKind",
+      "$ref": "v1beta2.PodConditionKind",
       "description": "kind of the condition, currently only Ready"
      },
      "status": {
-      "type": "v1beta2.ConditionStatus",
+      "$ref": "v1beta2.ConditionStatus",
       "description": "status of the condition, one of Full, None, Unknown"
      }
     }
@@ -5440,7 +5440,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5479,7 +5479,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5487,7 +5487,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -5511,11 +5511,11 @@
       "description": "IP address of the host to which the pod is assigned; empty if not yet scheduled"
      },
      "info": {
-      "type": "v1beta2.PodInfo",
+      "$ref": "v1beta2.PodInfo",
       "description": "map of container name to container status"
      },
      "manifest": {
-      "type": "v1beta2.ContainerManifest",
+      "$ref": "v1beta2.ContainerManifest",
       "description": "manifest of containers and volumes comprising the pod"
      },
      "message": {
@@ -5527,7 +5527,7 @@
       "description": "IP address allocated to the pod; routable at least within the cluster; empty if not yet allocated"
      },
      "status": {
-      "type": "v1beta2.PodStatus",
+      "$ref": "v1beta2.PodStatus",
       "description": "current condition of the pod, Waiting, Running, or Terminated"
      }
     }
@@ -5536,19 +5536,19 @@
     "id": "v1beta2.PodTemplate",
     "properties": {
      "annotations": {
-      "type": "v1beta2.PodTemplate.annotations",
+      "$ref": "v1beta2.PodTemplate.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about pods created from the template"
      },
      "desiredState": {
-      "type": "v1beta2.PodState",
+      "$ref": "v1beta2.PodState",
       "description": "specification of the desired state of pods created from this template"
      },
      "labels": {
-      "type": "v1beta2.PodTemplate.labels",
+      "$ref": "v1beta2.PodTemplate.labels",
       "description": "map of string keys and values that can be used to organize and categorize the pods created from the template; must match the selector of the replication controller to which the template belongs; may match selectors of services"
      },
      "nodeSelector": {
-      "type": "v1beta2.PodTemplate.nodeSelector",
+      "$ref": "v1beta2.PodTemplate.nodeSelector",
       "description": "a selector which must be true for the pod to fit on a node"
      }
     }
@@ -5569,7 +5569,7 @@
     "id": "v1beta2.ReplicationController",
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5581,7 +5581,7 @@
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
      "currentState": {
-      "type": "v1beta2.ReplicationControllerState",
+      "$ref": "v1beta2.ReplicationControllerState",
       "description": "current state of the replication controller; populated by the system, read-only"
      },
      "deletionTimestamp": {
@@ -5589,7 +5589,7 @@
       "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "desiredState": {
-      "type": "v1beta2.ReplicationControllerState",
+      "$ref": "v1beta2.ReplicationControllerState",
       "description": "specification of the desired state of the replication controller"
      },
      "generateName": {
@@ -5605,7 +5605,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta2.ReplicationController.labels",
+      "$ref": "v1beta2.ReplicationController.labels",
       "description": "map of string keys and values that can be used to organize and categorize replication controllers"
      },
      "namespace": {
@@ -5613,7 +5613,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5621,7 +5621,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -5637,7 +5637,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5676,7 +5676,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5684,7 +5684,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -5696,11 +5696,11 @@
     ],
     "properties": {
      "podTemplate": {
-      "type": "v1beta2.PodTemplate",
+      "$ref": "v1beta2.PodTemplate",
       "description": "template for pods to be created by this replication controller when the observed number of replicas is less than the desired number of replicas"
      },
      "replicaSelector": {
-      "type": "v1beta2.ReplicationControllerState.replicaSelector",
+      "$ref": "v1beta2.ReplicationControllerState.replicaSelector",
       "description": "label keys and values that must match in order to be controlled by this replication controller"
      },
      "replicas": {
@@ -5718,7 +5718,7 @@
     "id": "v1beta2.ResourceQuota",
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5746,7 +5746,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta2.ResourceQuota.labels",
+      "$ref": "v1beta2.ResourceQuota.labels",
       "description": "map of string keys and values that can be used to organize and categorize resource quotas"
      },
      "namespace": {
@@ -5754,7 +5754,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5762,15 +5762,15 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "spec": {
-      "type": "v1beta2.ResourceQuotaSpec",
+      "$ref": "v1beta2.ResourceQuotaSpec",
       "description": "spec defines the desired quota"
      },
      "status": {
-      "type": "v1beta2.ResourceQuotaStatus",
+      "$ref": "v1beta2.ResourceQuotaStatus",
       "description": "status defines the actual enforced quota and current usage"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -5786,7 +5786,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5825,7 +5825,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5833,7 +5833,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -5842,7 +5842,7 @@
     "id": "v1beta2.ResourceQuotaSpec",
     "properties": {
      "hard": {
-      "type": "v1beta2.ResourceList",
+      "$ref": "v1beta2.ResourceList",
       "description": "hard is the set of desired hard limits for each named resource"
      }
     }
@@ -5851,11 +5851,11 @@
     "id": "v1beta2.ResourceQuotaStatus",
     "properties": {
      "hard": {
-      "type": "v1beta2.ResourceList",
+      "$ref": "v1beta2.ResourceList",
       "description": "hard is the set of enforced hard limits for each named resource"
      },
      "used": {
-      "type": "v1beta2.ResourceList",
+      "$ref": "v1beta2.ResourceList",
       "description": "used is the current observed total usage of the resource in the namespace"
      }
     }
@@ -5864,11 +5864,11 @@
     "id": "v1beta2.ResourceRequirements",
     "properties": {
      "limits": {
-      "type": "v1beta2.ResourceList",
+      "$ref": "v1beta2.ResourceList",
       "description": "Maximum amount of compute resources allowed"
      },
      "requests": {
-      "type": "v1beta2.ResourceList",
+      "$ref": "v1beta2.ResourceList",
       "description": "Minimum amount of resources requested"
      }
     }
@@ -5877,15 +5877,15 @@
     "id": "v1beta2.RestartPolicy",
     "properties": {
      "always": {
-      "type": "v1beta2.RestartPolicyAlways",
+      "$ref": "v1beta2.RestartPolicyAlways",
       "description": "always restart the container after termination"
      },
      "never": {
-      "type": "v1beta2.RestartPolicyNever",
+      "$ref": "v1beta2.RestartPolicyNever",
       "description": "never restart the container"
      },
      "onFailure": {
-      "type": "v1beta2.RestartPolicyOnFailure",
+      "$ref": "v1beta2.RestartPolicyOnFailure",
       "description": "restart the container if it fails for any reason, but not if it succeeds (exit 0)"
      }
     }
@@ -5906,7 +5906,7 @@
     "id": "v1beta2.Secret",
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -5918,7 +5918,7 @@
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
      "data": {
-      "type": "v1beta2.Secret.data",
+      "$ref": "v1beta2.Secret.data",
       "description": "data contains the secret data.  Each key must be a valid DNS_SUBDOMAIN.  Each value must be a base64 encoded string"
      },
      "deletionTimestamp": {
@@ -5942,7 +5942,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -5950,11 +5950,11 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "type": {
-      "type": "v1beta2.SecretType",
+      "$ref": "v1beta2.SecretType",
       "description": "type facilitates programmatic handling of secret data"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -5970,7 +5970,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -6009,7 +6009,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -6017,7 +6017,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -6029,7 +6029,7 @@
     ],
     "properties": {
      "target": {
-      "type": "v1beta2.ObjectReference",
+      "$ref": "v1beta2.ObjectReference",
       "description": "target is a reference to a secret"
      }
     }
@@ -6042,7 +6042,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -6078,7 +6078,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta2.Service.labels",
+      "$ref": "v1beta2.Service.labels",
       "description": "map of string keys and values that can be used to organize and categorize services"
      },
      "namespace": {
@@ -6095,7 +6095,7 @@
       "description": "IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused, and creation of the service will fail otherwise; cannot be updated; 'None' can be specified for a headless service when proxying is not required"
      },
      "protocol": {
-      "type": "v1beta2.Protocol",
+      "$ref": "v1beta2.Protocol",
       "description": "protocol for port; must be UDP or TCP; TCP if unspecified"
      },
      "proxyPort": {
@@ -6106,16 +6106,16 @@
      "publicIPs": {
       "type": "array",
       "items": {
-       "$ref": "string"
+       "type": "string"
       },
       "description": "externally visible IPs (e.g. load balancers) that should be proxied to this service"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selector": {
-      "type": "v1beta2.Service.selector",
+      "$ref": "v1beta2.Service.selector",
       "description": "label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified"
      },
      "selfLink": {
@@ -6123,11 +6123,11 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "sessionAffinity": {
-      "type": "v1beta2.AffinityType",
+      "$ref": "v1beta2.AffinityType",
       "description": "enable client IP based session affinity; must be ClientIP or None; defaults to None"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -6147,7 +6147,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta2.TypeMeta.annotations",
+      "$ref": "v1beta2.TypeMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about the object"
      },
      "apiVersion": {
@@ -6186,7 +6186,7 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "type": "uint64",
+      "$ref": "uint64",
       "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
@@ -6194,7 +6194,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system, read-only"
      }
     }
@@ -6219,7 +6219,7 @@
       "description": "volume name; must be a DNS_LABEL and unique within the pod"
      },
      "source": {
-      "type": "v1beta2.VolumeSource",
+      "$ref": "v1beta2.VolumeSource",
       "description": "location and type of volume to mount; at most one of HostDir, EmptyDir, GCEPersistentDisk, or GitRepo; default is EmptyDir"
      }
     }
@@ -6257,27 +6257,27 @@
     ],
     "properties": {
      "emptyDir": {
-      "type": "v1beta2.EmptyDirVolumeSource",
+      "$ref": "v1beta2.EmptyDirVolumeSource",
       "description": "temporary directory that shares a pod's lifetime"
      },
      "gitRepo": {
-      "type": "v1beta2.GitRepoVolumeSource",
+      "$ref": "v1beta2.GitRepoVolumeSource",
       "description": "git repository at a particular revision"
      },
      "hostDir": {
-      "type": "v1beta2.HostPathVolumeSource",
+      "$ref": "v1beta2.HostPathVolumeSource",
       "description": "pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host"
      },
      "nfs": {
-      "type": "v1beta2.NFSVolumeSource",
+      "$ref": "v1beta2.NFSVolumeSource",
       "description": "NFS volume that will be mounted in the host machine"
      },
      "persistentDisk": {
-      "type": "v1beta2.GCEPersistentDiskVolumeSource",
+      "$ref": "v1beta2.GCEPersistentDiskVolumeSource",
       "description": "GCE disk resource attached to the host machine on demand"
      },
      "secret": {
-      "type": "v1beta2.SecretVolumeSource",
+      "$ref": "v1beta2.SecretVolumeSource",
       "description": "secret to populate volume"
      }
     }

--- a/api/swagger-spec/v1beta2.json
+++ b/api/swagger-spec/v1beta2.json
@@ -235,6 +235,44 @@
       "consumes": [
        "*/*"
       ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Endpoints",
+      "nickname": "deleteEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Endpoints",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "*v1beta2.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
      }
     ]
    },
@@ -961,6 +999,14 @@
         "description": "name of the Node",
         "required": true,
         "allowMultiple": false
+       },
+       {
+        "type": "*v1beta2.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
        }
       ],
       "produces": [
@@ -1375,6 +1421,14 @@
         "description": "name of the Namespace",
         "required": true,
         "allowMultiple": false
+       },
+       {
+        "type": "*v1beta2.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
        }
       ],
       "produces": [
@@ -1401,6 +1455,78 @@
         "paramType": "path",
         "name": "name",
         "description": "name of the Namespace",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/namespaces/{name}/finalize",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "replace the specified Namespace",
+      "nickname": "replaceNamespace",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Namespace",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.Namespace",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta2/namespaces/{name}/status",
+    "description": "API at /api/v1beta2 version v1beta2",
+    "operations": [
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "replace the specified Namespace",
+      "nickname": "replaceNamespace",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Namespace",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.Namespace",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
         "required": true,
         "allowMultiple": false
        }
@@ -1571,6 +1697,14 @@
         "paramType": "path",
         "name": "name",
         "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "*v1beta2.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
         "required": true,
         "allowMultiple": false
        }
@@ -2044,6 +2178,14 @@
         "name": "namespace",
         "description": "object name and auth scope, such as for teams and projects",
         "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "*v1beta2.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
         "allowMultiple": false
        }
       ],
@@ -2677,6 +2819,14 @@
         "description": "object name and auth scope, such as for teams and projects",
         "required": false,
         "allowMultiple": false
+       },
+       {
+        "type": "*v1beta2.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
        }
       ],
       "produces": [
@@ -2940,6 +3090,14 @@
         "name": "namespace",
         "description": "object name and auth scope, such as for teams and projects",
         "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "*v1beta2.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
         "allowMultiple": false
        }
       ],
@@ -3850,6 +4008,10 @@
    }
   ],
   "models": {
+   "*v1beta2.DeleteOptions": {
+    "id": "*v1beta2.DeleteOptions",
+    "properties": {}
+   },
    "v1beta2.Binding": {
     "id": "v1beta2.Binding",
     "required": [
@@ -3868,6 +4030,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -4042,6 +4208,10 @@
       "type": "v1beta2.DNSPolicy",
       "description": "DNS policy for containers within the pod; one of 'ClusterFirst' or 'Default'"
      },
+     "hostNetwork": {
+      "type": "boolean",
+      "description": "host networking requested for this pod"
+     },
      "id": {
       "type": "string",
       "description": "manifest name; must be a DNS_SUBDOMAIN; cannot be updated"
@@ -4167,6 +4337,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "endpoints": {
       "type": "array",
       "items": {
@@ -4232,6 +4406,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -4305,6 +4483,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "firstTimestamp": {
       "type": "string",
@@ -4390,6 +4572,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "generateName": {
       "type": "string",
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
@@ -4438,6 +4624,10 @@
       "description": "command line to execute inside the container; working directory for the command is root ('/') in the container's file system; the command is exec'd, not run inside a shell; exit status of 0 is treated as live/healthy and non-zero is unhealthy"
      }
     }
+   },
+   "v1beta2.FinalizerName": {
+    "id": "v1beta2.FinalizerName",
+    "properties": {}
    },
    "v1beta2.GCEPersistentDiskVolumeSource": {
     "id": "v1beta2.GCEPersistentDiskVolumeSource",
@@ -4555,6 +4745,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "generateName": {
       "type": "string",
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
@@ -4623,6 +4817,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -4718,6 +4916,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "externalID": {
       "type": "string",
       "description": "external id of the node assigned by some machine database (e.g. a cloud provider)"
@@ -4798,6 +5000,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "generateName": {
       "type": "string",
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
@@ -4835,6 +5041,27 @@
      }
     }
    },
+   "v1beta2.NFSVolumeSource": {
+    "id": "v1beta2.NFSVolumeSource",
+    "required": [
+     "server",
+     "path"
+    ],
+    "properties": {
+     "path": {
+      "type": "string",
+      "description": "the path that is exported by the NFS server"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "forces the NFS export to be mounted with read-only permissions"
+     },
+     "server": {
+      "type": "string",
+      "description": "the hostname or IP address of the NFS server"
+     }
+    }
+   },
    "v1beta2.Namespace": {
     "id": "v1beta2.Namespace",
     "properties": {
@@ -4849,6 +5076,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -4914,6 +5145,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "generateName": {
       "type": "string",
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
@@ -4953,7 +5188,15 @@
    },
    "v1beta2.NamespaceSpec": {
     "id": "v1beta2.NamespaceSpec",
-    "properties": {}
+    "properties": {
+     "finalizers": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta2.FinalizerName"
+      },
+      "description": "an opaque list of values that must be empty to permanently remove object from storage"
+     }
+    }
    },
    "v1beta2.NamespaceStatus": {
     "id": "v1beta2.NamespaceStatus",
@@ -5119,6 +5362,10 @@
       "type": "v1beta2.PodState",
       "description": "current state of the pod; populated by the system, read-only"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "desiredState": {
       "type": "v1beta2.PodState",
       "description": "specification of the desired state of the pod"
@@ -5203,6 +5450,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -5333,6 +5584,10 @@
       "type": "v1beta2.ReplicationControllerState",
       "description": "current state of the replication controller; populated by the system, read-only"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "desiredState": {
       "type": "v1beta2.ReplicationControllerState",
       "description": "specification of the desired state of the replication controller"
@@ -5392,6 +5647,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -5470,6 +5729,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "generateName": {
       "type": "string",
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
@@ -5533,6 +5796,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -5599,6 +5866,10 @@
      "limits": {
       "type": "v1beta2.ResourceList",
       "description": "Maximum amount of compute resources allowed"
+     },
+     "requests": {
+      "type": "v1beta2.ResourceList",
+      "description": "Minimum amount of resources requested"
      }
     }
    },
@@ -5649,6 +5920,10 @@
      "data": {
       "type": "v1beta2.Secret.data",
       "description": "data contains the secret data.  Each key must be a valid DNS_SUBDOMAIN.  Each value must be a base64 encoded string"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -5705,6 +5980,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -5782,6 +6061,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "generateName": {
       "type": "string",
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
@@ -5809,7 +6092,7 @@
      },
      "portalIP": {
       "type": "string",
-      "description": "IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused, and creation of the service will fail otherwise; cannot be updated"
+      "description": "IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused, and creation of the service will fail otherwise; cannot be updated; 'None' can be specified for a headless service when proxying is not required"
      },
      "protocol": {
       "type": "v1beta2.Protocol",
@@ -5874,6 +6157,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -5965,7 +6252,8 @@
      "emptyDir",
      "persistentDisk",
      "gitRepo",
-     "secret"
+     "secret",
+     "nfs"
     ],
     "properties": {
      "emptyDir": {
@@ -5979,6 +6267,10 @@
      "hostDir": {
       "type": "v1beta2.HostPathVolumeSource",
       "description": "pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host"
+     },
+     "nfs": {
+      "type": "v1beta2.NFSVolumeSource",
+      "description": "NFS volume that will be mounted in the host machine"
      },
      "persistentDisk": {
       "type": "v1beta2.GCEPersistentDiskVolumeSource",

--- a/api/swagger-spec/v1beta3.json
+++ b/api/swagger-spec/v1beta3.json
@@ -235,6 +235,44 @@
       "consumes": [
        "*/*"
       ]
+     },
+     {
+      "type": "void",
+      "method": "DELETE",
+      "summary": "delete a Endpoints",
+      "nickname": "deleteEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Endpoints",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "*v1beta3.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
      }
     ]
    },
@@ -1075,6 +1113,14 @@
         "description": "name of the Namespace",
         "required": true,
         "allowMultiple": false
+       },
+       {
+        "type": "*v1beta3.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
        }
       ],
       "produces": [
@@ -1101,6 +1147,78 @@
         "paramType": "path",
         "name": "name",
         "description": "name of the Namespace",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/namespaces/{name}/finalize",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "replace the specified Namespace",
+      "nickname": "replaceNamespace",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Namespace",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.Namespace",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/namespaces/{name}/status",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "void",
+      "method": "PUT",
+      "summary": "replace the specified Namespace",
+      "nickname": "replaceNamespace",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Namespace",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.Namespace",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
         "required": true,
         "allowMultiple": false
        }
@@ -1271,6 +1389,14 @@
         "paramType": "path",
         "name": "name",
         "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "*v1beta3.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
         "required": true,
         "allowMultiple": false
        }
@@ -1743,6 +1869,14 @@
         "paramType": "path",
         "name": "namespaces",
         "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "*v1beta3.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
         "required": true,
         "allowMultiple": false
        }
@@ -2415,6 +2549,14 @@
         "description": "object name and auth scope, such as for teams and projects",
         "required": true,
         "allowMultiple": false
+       },
+       {
+        "type": "*v1beta3.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
        }
       ],
       "produces": [
@@ -2715,6 +2857,14 @@
         "paramType": "path",
         "name": "namespaces",
         "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "*v1beta3.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
         "required": true,
         "allowMultiple": false
        }
@@ -3740,6 +3890,10 @@
    }
   ],
   "models": {
+   "*v1beta3.DeleteOptions": {
+    "id": "*v1beta3.DeleteOptions",
+    "properties": {}
+   },
    "v1beta3.Binding": {
     "id": "v1beta3.Binding",
     "required": [
@@ -3757,6 +3911,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -3968,6 +4126,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "endpoints": {
       "type": "array",
       "items": {
@@ -4079,6 +4241,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "firstTimestamp": {
       "type": "string",
@@ -4194,6 +4360,10 @@
      }
     }
    },
+   "v1beta3.FinalizerName": {
+    "id": "v1beta3.FinalizerName",
+    "properties": {}
+   },
    "v1beta3.HTTPGetAction": {
     "id": "v1beta3.HTTPGetAction",
     "properties": {
@@ -4255,6 +4425,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -4372,6 +4546,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "generateName": {
       "type": "string",
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
@@ -4447,7 +4625,15 @@
    },
    "v1beta3.NamespaceSpec": {
     "id": "v1beta3.NamespaceSpec",
-    "properties": {}
+    "properties": {
+     "finalizers": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta3.FinalizerName"
+      },
+      "description": "an opaque list of values that must be empty to permanently remove object from storage"
+     }
+    }
    },
    "v1beta3.NamespaceStatus": {
     "id": "v1beta3.NamespaceStatus",
@@ -4472,6 +4658,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -4704,6 +4894,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "generateName": {
       "type": "string",
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
@@ -4806,7 +5000,7 @@
       "items": {
        "$ref": "v1beta3.Container"
       },
-      "description": "list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed"
+      "description": "list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod"
      },
      "dnsPolicy": {
       "type": "v1beta3.DNSPolicy",
@@ -4815,6 +5009,10 @@
      "host": {
       "type": "string",
       "description": "host requested for this pod"
+     },
+     "hostNetwork": {
+      "type": "boolean",
+      "description": "host networking requested for this pod"
      },
      "nodeSelector": {
       "type": "v1beta3.PodSpec.nodeSelector",
@@ -4883,6 +5081,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -4959,6 +5161,10 @@
      "creationTimestamp": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -5090,6 +5296,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "generateName": {
       "type": "string",
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
@@ -5191,6 +5401,10 @@
      "limits": {
       "type": "v1beta3.ResourceList",
       "description": "Maximum amount of compute resources allowed"
+     },
+     "requests": {
+      "type": "v1beta3.ResourceList",
+      "description": "Minimum amount of resources requested"
      }
     }
    },
@@ -5212,6 +5426,10 @@
      "data": {
       "type": "v1beta3.Secret.data",
       "description": "data contains the secret data.  Each key must be a valid DNS_SUBDOMAIN.  Each value must be a base64 encoded string"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
      },
      "generateName": {
       "type": "string",
@@ -5301,6 +5519,10 @@
       "type": "string",
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
      "generateName": {
       "type": "string",
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
@@ -5382,10 +5604,6 @@
      "portalIP"
     ],
     "properties": {
-     "containerPort": {
-      "type": "string",
-      "description": "number or name of the port to access on the containers belonging to pods targeted by the service; defaults to the container's first open port"
-     },
      "createExternalLoadBalancer": {
       "type": "boolean",
       "description": "set up a cloud-provider-specific load balancer on an external IP"
@@ -5416,6 +5634,10 @@
      "sessionAffinity": {
       "type": "v1beta3.AffinityType",
       "description": "enable client IP based session affinity; must be ClientIP or None; defaults to None"
+     },
+     "targetPort": {
+      "type": "string",
+      "description": "number or name of the port to access on the containers belonging to pods targeted by the service; defaults to the container's first open port"
      }
     }
    },
@@ -5444,7 +5666,8 @@
      "emptyDir",
      "gcePersistentDisk",
      "gitRepo",
-     "secret"
+     "secret",
+     "nfs"
     ],
     "properties": {
      "emptyDir": {
@@ -5466,6 +5689,10 @@
      "name": {
       "type": "string",
       "description": "volume name; must be a DNS_LABEL and unique within the pod"
+     },
+     "nfs": {
+      "type": "v1beta3.NFSVolumeSource",
+      "description": "NFS volume that will be mounted in the host machine"
      },
      "secret": {
       "type": "v1beta3.SecretVolumeSource",

--- a/api/swagger-spec/v1beta3.json
+++ b/api/swagger-spec/v1beta3.json
@@ -3901,7 +3901,7 @@
     ],
     "properties": {
      "annotations": {
-      "type": "v1beta3.ObjectMeta.annotations",
+      "$ref": "v1beta3.ObjectMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
      },
      "apiVersion": {
@@ -3925,7 +3925,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta3.ObjectMeta.labels",
+      "$ref": "v1beta3.ObjectMeta.labels",
       "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
      },
      "name": {
@@ -3945,11 +3945,11 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "target": {
-      "type": "v1beta3.ObjectReference",
+      "$ref": "v1beta3.ObjectReference",
       "description": "an object to bind to"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
@@ -3986,13 +3986,13 @@
     ],
     "properties": {
      "capabilities": {
-      "type": "v1beta3.Capabilities",
+      "$ref": "v1beta3.Capabilities",
       "description": "capabilities for container; cannot be updated"
      },
      "command": {
       "type": "array",
       "items": {
-       "$ref": "string"
+       "type": "string"
       },
       "description": "command argv array; not executed within a shell; defaults to entrypoint or command in the image; cannot be updated"
      },
@@ -4008,15 +4008,15 @@
       "description": "Docker image name"
      },
      "imagePullPolicy": {
-      "type": "v1beta3.PullPolicy",
+      "$ref": "v1beta3.PullPolicy",
       "description": "image pull policy; one of PullAlways, PullNever, PullIfNotPresent; defaults to PullAlways if :latest tag is specified, or PullIfNotPresent otherwise; cannot be updated"
      },
      "lifecycle": {
-      "type": "v1beta3.Lifecycle",
+      "$ref": "v1beta3.Lifecycle",
       "description": "actions that the management system should take in response to container lifecycle events; cannot be updated"
      },
      "livenessProbe": {
-      "type": "v1beta3.Probe",
+      "$ref": "v1beta3.Probe",
       "description": "periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated"
      },
      "name": {
@@ -4035,11 +4035,11 @@
       "description": "whether or not the container is granted privileged status; defaults to false; cannot be updated"
      },
      "readinessProbe": {
-      "type": "v1beta3.Probe",
+      "$ref": "v1beta3.Probe",
       "description": "periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated"
      },
      "resources": {
-      "type": "v1beta3.ResourceRequirements",
+      "$ref": "v1beta3.ResourceRequirements",
       "description": "Compute Resources required by this container; cannot be updated"
      },
      "terminationMessagePath": {
@@ -4084,7 +4084,7 @@
       "description": "name for the port that can be referred to by services; must be a DNS_LABEL and unique without the pod"
      },
      "protocol": {
-      "type": "v1beta3.Protocol",
+      "$ref": "v1beta3.Protocol",
       "description": "protocol for port; must be UDP or TCP; TCP if unspecified"
      }
     }
@@ -4106,7 +4106,7 @@
       "description": "destination port of this endpoint"
      },
      "targetRef": {
-      "type": "v1beta3.ObjectReference",
+      "$ref": "v1beta3.ObjectReference",
       "description": "reference to object providing the endpoint"
      }
     }
@@ -4115,7 +4115,7 @@
     "id": "v1beta3.Endpoints",
     "properties": {
      "annotations": {
-      "type": "v1beta3.ObjectMeta.annotations",
+      "$ref": "v1beta3.ObjectMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
      },
      "apiVersion": {
@@ -4146,7 +4146,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta3.ObjectMeta.labels",
+      "$ref": "v1beta3.ObjectMeta.labels",
       "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
      },
      "name": {
@@ -4158,7 +4158,7 @@
       "description": "namespace of the object; cannot be updated"
      },
      "protocol": {
-      "type": "v1beta3.Protocol",
+      "$ref": "v1beta3.Protocol",
       "description": "IP protocol for endpoint ports; must be UDP or TCP; TCP if unspecified"
      },
      "resourceVersion": {
@@ -4170,7 +4170,7 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
@@ -4226,7 +4226,7 @@
     "id": "v1beta3.Event",
     "properties": {
      "annotations": {
-      "type": "v1beta3.ObjectMeta.annotations",
+      "$ref": "v1beta3.ObjectMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
      },
      "apiVersion": {
@@ -4255,7 +4255,7 @@
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
      },
      "involvedObject": {
-      "type": "v1beta3.ObjectReference",
+      "$ref": "v1beta3.ObjectReference",
       "description": "object this event is about"
      },
      "kind": {
@@ -4263,7 +4263,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta3.ObjectMeta.labels",
+      "$ref": "v1beta3.ObjectMeta.labels",
       "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
      },
      "lastTimestamp": {
@@ -4295,11 +4295,11 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "source": {
-      "type": "v1beta3.EventSource",
+      "$ref": "v1beta3.EventSource",
       "description": "component reporting this event"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
@@ -4354,7 +4354,7 @@
      "command": {
       "type": "array",
       "items": {
-       "$ref": "string"
+       "type": "string"
       },
       "description": "command line to execute inside the container; working directory for the command is root ('/') in the container's file system; the command is exec'd, not run inside a shell; exit status of 0 is treated as live/healthy and non-zero is unhealthy"
      }
@@ -4385,15 +4385,15 @@
     "id": "v1beta3.Handler",
     "properties": {
      "exec": {
-      "type": "v1beta3.ExecAction",
+      "$ref": "v1beta3.ExecAction",
       "description": "exec-based handler"
      },
      "httpGet": {
-      "type": "v1beta3.HTTPGetAction",
+      "$ref": "v1beta3.HTTPGetAction",
       "description": "HTTP-based handler"
      },
      "tcpSocket": {
-      "type": "v1beta3.TCPSocketAction",
+      "$ref": "v1beta3.TCPSocketAction",
       "description": "TCP-based handler; TCP hooks not yet supported"
      }
     }
@@ -4402,11 +4402,11 @@
     "id": "v1beta3.Lifecycle",
     "properties": {
      "postStart": {
-      "type": "v1beta3.Handler",
+      "$ref": "v1beta3.Handler",
       "description": "called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes"
      },
      "preStop": {
-      "type": "v1beta3.Handler",
+      "$ref": "v1beta3.Handler",
       "description": "called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes"
      }
     }
@@ -4415,7 +4415,7 @@
     "id": "v1beta3.LimitRange",
     "properties": {
      "annotations": {
-      "type": "v1beta3.ObjectMeta.annotations",
+      "$ref": "v1beta3.ObjectMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
      },
      "apiVersion": {
@@ -4439,7 +4439,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta3.ObjectMeta.labels",
+      "$ref": "v1beta3.ObjectMeta.labels",
       "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
      },
      "name": {
@@ -4459,11 +4459,11 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "spec": {
-      "type": "v1beta3.LimitRangeSpec",
+      "$ref": "v1beta3.LimitRangeSpec",
       "description": "spec defines the limits enforced; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
@@ -4472,15 +4472,15 @@
     "id": "v1beta3.LimitRangeItem",
     "properties": {
      "max": {
-      "type": "v1beta3.ResourceList",
+      "$ref": "v1beta3.ResourceList",
       "description": "max usage constraints on this kind by resource name"
      },
      "min": {
-      "type": "v1beta3.ResourceList",
+      "$ref": "v1beta3.ResourceList",
       "description": "min usage constraints on this kind by resource name"
      },
      "type": {
-      "type": "v1beta3.LimitType",
+      "$ref": "v1beta3.LimitType",
       "description": "type of resource that this limit applies to"
      }
     }
@@ -4535,7 +4535,7 @@
     "id": "v1beta3.Namespace",
     "properties": {
      "annotations": {
-      "type": "v1beta3.ObjectMeta.annotations",
+      "$ref": "v1beta3.ObjectMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
      },
      "apiVersion": {
@@ -4559,7 +4559,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta3.ObjectMeta.labels",
+      "$ref": "v1beta3.ObjectMeta.labels",
       "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
      },
      "name": {
@@ -4579,15 +4579,15 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "spec": {
-      "type": "v1beta3.NamespaceSpec",
+      "$ref": "v1beta3.NamespaceSpec",
       "description": "spec defines the behavior of the Namespace; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
      },
      "status": {
-      "type": "v1beta3.NamespaceStatus",
+      "$ref": "v1beta3.NamespaceStatus",
       "description": "status describes the current status of a Namespace; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
@@ -4639,7 +4639,7 @@
     "id": "v1beta3.NamespaceStatus",
     "properties": {
      "phase": {
-      "type": "v1beta3.NamespacePhase",
+      "$ref": "v1beta3.NamespacePhase",
       "description": "phase is the current lifecycle phase of the namespace"
      }
     }
@@ -4648,7 +4648,7 @@
     "id": "v1beta3.Node",
     "properties": {
      "annotations": {
-      "type": "v1beta3.ObjectMeta.annotations",
+      "$ref": "v1beta3.ObjectMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
      },
      "apiVersion": {
@@ -4672,7 +4672,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta3.ObjectMeta.labels",
+      "$ref": "v1beta3.ObjectMeta.labels",
       "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
      },
      "name": {
@@ -4692,15 +4692,15 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "spec": {
-      "type": "v1beta3.NodeSpec",
+      "$ref": "v1beta3.NodeSpec",
       "description": "specification of a node; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
      },
      "status": {
-      "type": "v1beta3.NodeStatus",
+      "$ref": "v1beta3.NodeStatus",
       "description": "most recently observed status of the node; populated by the system, read-only; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
@@ -4716,7 +4716,7 @@
       "type": "string"
      },
      "type": {
-      "type": "v1beta3.NodeAddressType"
+      "$ref": "v1beta3.NodeAddressType"
      }
     }
    },
@@ -4744,11 +4744,11 @@
       "description": "(brief) reason for the condition's last transition"
      },
      "status": {
-      "type": "v1beta3.ConditionStatus",
+      "$ref": "v1beta3.ConditionStatus",
       "description": "status of the condition, one of Full, None, Unknown"
      },
      "type": {
-      "type": "v1beta3.NodeConditionType",
+      "$ref": "v1beta3.NodeConditionType",
       "description": "type of node condition, one of Reachable, Ready"
      }
     }
@@ -4788,7 +4788,7 @@
     "id": "v1beta3.NodeSpec",
     "properties": {
      "capacity": {
-      "type": "v1beta3.ResourceList",
+      "$ref": "v1beta3.ResourceList",
       "description": "compute resource capacity of the node; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/resources.md"
      },
      "externalID": {
@@ -4823,10 +4823,10 @@
       "description": "list of node conditions observed"
      },
      "nodeInfo": {
-      "type": "v1beta3.NodeSystemInfo"
+      "$ref": "v1beta3.NodeSystemInfo"
      },
      "phase": {
-      "type": "v1beta3.NodePhase",
+      "$ref": "v1beta3.NodePhase",
       "description": "most recently observed lifecycle phase of the node"
      }
     }
@@ -4874,7 +4874,7 @@
       "description": "specific resourceVersion to which this reference is made, if any: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "uid of the referent"
      }
     }
@@ -4883,7 +4883,7 @@
     "id": "v1beta3.Pod",
     "properties": {
      "annotations": {
-      "type": "v1beta3.ObjectMeta.annotations",
+      "$ref": "v1beta3.ObjectMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
      },
      "apiVersion": {
@@ -4907,7 +4907,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta3.ObjectMeta.labels",
+      "$ref": "v1beta3.ObjectMeta.labels",
       "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
      },
      "name": {
@@ -4927,15 +4927,15 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "spec": {
-      "type": "v1beta3.PodSpec",
+      "$ref": "v1beta3.PodSpec",
       "description": "specification of the desired behavior of the pod; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
      },
      "status": {
-      "type": "v1beta3.PodStatus",
+      "$ref": "v1beta3.PodStatus",
       "description": "most recently observed status of the pod; populated by the system, read-only; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
@@ -4948,11 +4948,11 @@
     ],
     "properties": {
      "status": {
-      "type": "v1beta3.ConditionStatus",
+      "$ref": "v1beta3.ConditionStatus",
       "description": "status of the condition, one of Full, None, Unknown"
      },
      "type": {
-      "type": "v1beta3.PodConditionType",
+      "$ref": "v1beta3.PodConditionType",
       "description": "kind of the condition"
      }
     }
@@ -5003,7 +5003,7 @@
       "description": "list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod"
      },
      "dnsPolicy": {
-      "type": "v1beta3.DNSPolicy",
+      "$ref": "v1beta3.DNSPolicy",
       "description": "DNS policy for containers within the pod; one of 'ClusterFirst' or 'Default'"
      },
      "host": {
@@ -5015,11 +5015,11 @@
       "description": "host networking requested for this pod"
      },
      "nodeSelector": {
-      "type": "v1beta3.PodSpec.nodeSelector",
+      "$ref": "v1beta3.PodSpec.nodeSelector",
       "description": "selector which must match a node's labels for the pod to be scheduled on that node"
      },
      "restartPolicy": {
-      "type": "v1beta3.RestartPolicy",
+      "$ref": "v1beta3.RestartPolicy",
       "description": "restart policy for all containers within the pod; one of RestartPolicyAlways, RestartPolicyOnFailure, RestartPolicyNever"
      },
      "volumes": {
@@ -5054,7 +5054,7 @@
       "description": "IP address of the host to which the pod is assigned; empty if not yet scheduled"
      },
      "info": {
-      "type": "v1beta3.PodInfo",
+      "$ref": "v1beta3.PodInfo",
       "description": "map of container name to container status"
      },
      "message": {
@@ -5062,7 +5062,7 @@
       "description": "human readable message indicating details about why the pod is in this condition"
      },
      "phase": {
-      "type": "v1beta3.PodPhase",
+      "$ref": "v1beta3.PodPhase",
       "description": "current condition of the pod."
      },
      "podIP": {
@@ -5075,7 +5075,7 @@
     "id": "v1beta3.PodTemplateSpec",
     "properties": {
      "annotations": {
-      "type": "v1beta3.ObjectMeta.annotations",
+      "$ref": "v1beta3.ObjectMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
      },
      "creationTimestamp": {
@@ -5091,7 +5091,7 @@
       "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
      },
      "labels": {
-      "type": "v1beta3.ObjectMeta.labels",
+      "$ref": "v1beta3.ObjectMeta.labels",
       "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
      },
      "name": {
@@ -5111,11 +5111,11 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "spec": {
-      "type": "v1beta3.PodSpec",
+      "$ref": "v1beta3.PodSpec",
       "description": "specification of the desired behavior of the pod; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
@@ -5124,11 +5124,11 @@
     "id": "v1beta3.Probe",
     "properties": {
      "exec": {
-      "type": "v1beta3.ExecAction",
+      "$ref": "v1beta3.ExecAction",
       "description": "exec-based handler"
      },
      "httpGet": {
-      "type": "v1beta3.HTTPGetAction",
+      "$ref": "v1beta3.HTTPGetAction",
       "description": "HTTP-based handler"
      },
      "initialDelaySeconds": {
@@ -5137,7 +5137,7 @@
       "description": "number of seconds after the container has started before liveness probes are initiated"
      },
      "tcpSocket": {
-      "type": "v1beta3.TCPSocketAction",
+      "$ref": "v1beta3.TCPSocketAction",
       "description": "TCP-based handler; TCP hooks not yet supported"
      },
      "timeoutSeconds": {
@@ -5151,7 +5151,7 @@
     "id": "v1beta3.ReplicationController",
     "properties": {
      "annotations": {
-      "type": "v1beta3.ObjectMeta.annotations",
+      "$ref": "v1beta3.ObjectMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
      },
      "apiVersion": {
@@ -5175,7 +5175,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta3.ObjectMeta.labels",
+      "$ref": "v1beta3.ObjectMeta.labels",
       "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
      },
      "name": {
@@ -5195,15 +5195,15 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "spec": {
-      "type": "v1beta3.ReplicationControllerSpec",
+      "$ref": "v1beta3.ReplicationControllerSpec",
       "description": "specification of the desired behavior of the replication controller; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
      },
      "status": {
-      "type": "v1beta3.ReplicationControllerStatus",
+      "$ref": "v1beta3.ReplicationControllerStatus",
       "description": "most recently observed status of the replication controller; populated by the system, read-only; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
@@ -5251,15 +5251,15 @@
       "description": "number of replicas desired"
      },
      "selector": {
-      "type": "v1beta3.ReplicationControllerSpec.selector",
+      "$ref": "v1beta3.ReplicationControllerSpec.selector",
       "description": "label keys and values that must match in order to be controlled by this replication controller"
      },
      "template": {
-      "type": "v1beta3.PodTemplateSpec",
+      "$ref": "v1beta3.PodTemplateSpec",
       "description": "object that describes the pod that will be created if insufficient replicas are detected; takes precendence over templateRef"
      },
      "templateRef": {
-      "type": "v1beta3.ObjectReference",
+      "$ref": "v1beta3.ObjectReference",
       "description": "reference to an object that describes the pod that will be created if insufficient replicas are detected"
      }
     }
@@ -5285,7 +5285,7 @@
     "id": "v1beta3.ResourceQuota",
     "properties": {
      "annotations": {
-      "type": "v1beta3.ObjectMeta.annotations",
+      "$ref": "v1beta3.ObjectMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
      },
      "apiVersion": {
@@ -5309,7 +5309,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta3.ObjectMeta.labels",
+      "$ref": "v1beta3.ObjectMeta.labels",
       "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
      },
      "name": {
@@ -5329,15 +5329,15 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "spec": {
-      "type": "v1beta3.ResourceQuotaSpec",
+      "$ref": "v1beta3.ResourceQuotaSpec",
       "description": "spec defines the desired quota; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
      },
      "status": {
-      "type": "v1beta3.ResourceQuotaStatus",
+      "$ref": "v1beta3.ResourceQuotaStatus",
       "description": "status defines the actual enforced quota and current usage; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
@@ -5377,7 +5377,7 @@
     "id": "v1beta3.ResourceQuotaSpec",
     "properties": {
      "hard": {
-      "type": "v1beta3.ResourceList",
+      "$ref": "v1beta3.ResourceList",
       "description": "hard is the set of desired hard limits for each named resource"
      }
     }
@@ -5386,11 +5386,11 @@
     "id": "v1beta3.ResourceQuotaStatus",
     "properties": {
      "hard": {
-      "type": "v1beta3.ResourceList",
+      "$ref": "v1beta3.ResourceList",
       "description": "hard is the set of enforced hard limits for each named resource"
      },
      "used": {
-      "type": "v1beta3.ResourceList",
+      "$ref": "v1beta3.ResourceList",
       "description": "used is the current observed total usage of the resource in the namespace"
      }
     }
@@ -5399,11 +5399,11 @@
     "id": "v1beta3.ResourceRequirements",
     "properties": {
      "limits": {
-      "type": "v1beta3.ResourceList",
+      "$ref": "v1beta3.ResourceList",
       "description": "Maximum amount of compute resources allowed"
      },
      "requests": {
-      "type": "v1beta3.ResourceList",
+      "$ref": "v1beta3.ResourceList",
       "description": "Minimum amount of resources requested"
      }
     }
@@ -5412,7 +5412,7 @@
     "id": "v1beta3.Secret",
     "properties": {
      "annotations": {
-      "type": "v1beta3.ObjectMeta.annotations",
+      "$ref": "v1beta3.ObjectMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
      },
      "apiVersion": {
@@ -5424,7 +5424,7 @@
       "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
      "data": {
-      "type": "v1beta3.Secret.data",
+      "$ref": "v1beta3.Secret.data",
       "description": "data contains the secret data.  Each key must be a valid DNS_SUBDOMAIN.  Each value must be a base64 encoded string"
      },
      "deletionTimestamp": {
@@ -5440,7 +5440,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta3.ObjectMeta.labels",
+      "$ref": "v1beta3.ObjectMeta.labels",
       "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
      },
      "name": {
@@ -5460,11 +5460,11 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "type": {
-      "type": "v1beta3.SecretType",
+      "$ref": "v1beta3.SecretType",
       "description": "type facilitates programmatic handling of secret data"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
@@ -5508,7 +5508,7 @@
     "id": "v1beta3.Service",
     "properties": {
      "annotations": {
-      "type": "v1beta3.ObjectMeta.annotations",
+      "$ref": "v1beta3.ObjectMeta.annotations",
       "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
      },
      "apiVersion": {
@@ -5532,7 +5532,7 @@
       "description": "kind of object, in CamelCase; cannot be updated"
      },
      "labels": {
-      "type": "v1beta3.ObjectMeta.labels",
+      "$ref": "v1beta3.ObjectMeta.labels",
       "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
      },
      "name": {
@@ -5552,15 +5552,15 @@
       "description": "URL for the object; populated by the system, read-only"
      },
      "spec": {
-      "type": "v1beta3.ServiceSpec",
+      "$ref": "v1beta3.ServiceSpec",
       "description": "specification of the desired behavior of the service; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
      },
      "status": {
-      "type": "v1beta3.ServiceStatus",
+      "$ref": "v1beta3.ServiceStatus",
       "description": "most recently observed status of the service; populated by the system, read-only; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
      },
      "uid": {
-      "type": "types.UID",
+      "$ref": "types.UID",
       "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
@@ -5617,22 +5617,22 @@
       "type": "string"
      },
      "protocol": {
-      "type": "v1beta3.Protocol",
+      "$ref": "v1beta3.Protocol",
       "description": "protocol for port; must be UDP or TCP; TCP if unspecified"
      },
      "publicIPs": {
       "type": "array",
       "items": {
-       "$ref": "string"
+       "type": "string"
       },
       "description": "externally visible IPs (e.g. load balancers) that should be proxied to this service"
      },
      "selector": {
-      "type": "v1beta3.ServiceSpec.selector",
+      "$ref": "v1beta3.ServiceSpec.selector",
       "description": "label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified"
      },
      "sessionAffinity": {
-      "type": "v1beta3.AffinityType",
+      "$ref": "v1beta3.AffinityType",
       "description": "enable client IP based session affinity; must be ClientIP or None; defaults to None"
      },
      "targetPort": {
@@ -5671,19 +5671,19 @@
     ],
     "properties": {
      "emptyDir": {
-      "type": "v1beta3.EmptyDirVolumeSource",
+      "$ref": "v1beta3.EmptyDirVolumeSource",
       "description": "temporary directory that shares a pod's lifetime"
      },
      "gcePersistentDisk": {
-      "type": "v1beta3.GCEPersistentDiskVolumeSource",
+      "$ref": "v1beta3.GCEPersistentDiskVolumeSource",
       "description": "GCE disk resource attached to the host machine on demand"
      },
      "gitRepo": {
-      "type": "v1beta3.GitRepoVolumeSource",
+      "$ref": "v1beta3.GitRepoVolumeSource",
       "description": "git repository at a particular revision"
      },
      "hostPath": {
-      "type": "v1beta3.HostPathVolumeSource",
+      "$ref": "v1beta3.HostPathVolumeSource",
       "description": "pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host"
      },
      "name": {
@@ -5691,11 +5691,11 @@
       "description": "volume name; must be a DNS_LABEL and unique within the pod"
      },
      "nfs": {
-      "type": "v1beta3.NFSVolumeSource",
+      "$ref": "v1beta3.NFSVolumeSource",
       "description": "NFS volume that will be mounted in the host machine"
      },
      "secret": {
-      "type": "v1beta3.SecretVolumeSource",
+      "$ref": "v1beta3.SecretVolumeSource",
       "description": "secret to populate volume"
      }
     }


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/3757 and https://github.com/GoogleCloudPlatform/kubernetes/issues/3756.
Will also fix a few issues from https://github.com/GoogleCloudPlatform/kubernetes/issues/4083

First and third commit generated by running:
./hack/update-swagger-spec

Second commit generated by running:
godep restore
go get -u github.com/emicklei/go-restful
godep update github.com/emicklei/go-restful
