### PR TITLE
Change the way the density test is disabled

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -166,11 +166,11 @@ func RunRC(c *client.Client, name string, ns, image string, replicas int) {
 	Expect(current).To(Equal(replicas))
 }
 
-// This test suite can take a long time to run, so by default it is disabled
-// by being marked as Pending.  To enable this suite, remove the P from the
-// front of PDescribe (PDescribe->Describe) and then all tests will
-// be available
-var _ = PDescribe("Density", func() {
+// This test suite can take a long time to run, so by default it is added to
+// the ginkgo.skip list (see driver.go).
+// To run this suite you must explicitly ask for it by setting the
+// -t/--test flag or ginkgo.focus flag.
+var _ = Describe("Density", func() {
 	var c *client.Client
 	var minionCount int
 	var RCName string

--- a/test/e2e/driver.go
+++ b/test/e2e/driver.go
@@ -70,6 +70,11 @@ func RunE2ETests(kubeConfig, authConfig, certDir, host, repoRoot, provider strin
 		config.GinkgoConfig.FocusString = `\b(` + strings.Join(testRegexps, "|") + `)\b`
 	}
 
+	// Disable density test unless it's explicitly requested.
+	if config.GinkgoConfig.FocusString == "" && config.GinkgoConfig.SkipString == "" {
+		config.GinkgoConfig.SkipString = "Density"
+	}
+
 	// TODO: Make orderseed work again.
 
 	var passed testResult = true


### PR DESCRIPTION
With this change, the density/thrash test can be run against your existing cluster with this line:

KUBE_CONFIG_FILE=config-default.sh hack/ginkgo-e2e.sh --ginkgo.focus=Density

cc @davidopp 
