### PR TITLE
Allow `kubectl expose` to be polymorphic to the source of the selector

### DIFF
--- a/docs/kubectl-expose.md
+++ b/docs/kubectl-expose.md
@@ -7,11 +7,11 @@ Take a replicated application and expose it as Kubernetes Service
 
 Take a replicated application and expose it as Kubernetes Service.
 
-Looks up a ReplicationController by name, and uses the selector for that replication controller
-as the selector for a new Service on the specified port.
+Looks up a replication controller or service by name and uses the selector for that resource as the
+selector for a new Service on the specified port.
 
 ```
-kubectl expose NAME --port=port [--protocol=TCP|UDP] [--container-port=number-or-name] [--service-name=name] [--public-ip=ip] [--create-external-load-balancer=bool]
+kubectl expose RESOURCE NAME --port=port [--protocol=TCP|UDP] [--container-port=number-or-name] [--service-name=name] [--public-ip=ip] [--create-external-load-balancer=bool]
 ```
 
 ### Examples
@@ -19,6 +19,9 @@ kubectl expose NAME --port=port [--protocol=TCP|UDP] [--container-port=number-or
 ```
 // Creates a service for a replicated nginx, which serves on port 80 and connects to the containers on port 8000.
 $ kubectl expose nginx --port=80 --container-port=8000
+
+// Creates a second service based on the above service, exposing the container port 8443 as port 443 with the name "nginx-https"
+$ kubectl expose service nginx --port=443 --container-port=8443 --service-name=nginx-https
 
 // Create a service for a replicated streaming application on port 4100 balancing UDP traffic and named 'video-stream'.
 $ kubectl expose streamer --port=4100 --protocol=udp --service-name=video-stream

--- a/docs/man/man1/kubectl-expose.1
+++ b/docs/man/man1/kubectl-expose.1
@@ -16,8 +16,8 @@ kubectl expose \- Take a replicated application and expose it as Kubernetes Serv
 Take a replicated application and expose it as Kubernetes Service.
 
 .PP
-Looks up a ReplicationController by name, and uses the selector for that replication controller
-as the selector for a new Service on the specified port.
+Looks up a replication controller or service by name and uses the selector for that resource as the
+selector for a new Service on the specified port.
 
 
 .SH OPTIONS
@@ -196,6 +196,9 @@ as the selector for a new Service on the specified port.
 .nf
 // Creates a service for a replicated nginx, which serves on port 80 and connects to the containers on port 8000.
 $ kubectl expose nginx \-\-port=80 \-\-container\-port=8000
+
+// Creates a second service based on the above service, exposing the container port 8443 as port 443 with the name "nginx\-https"
+$ kubectl expose service nginx \-\-port=443 \-\-container\-port=8443 \-\-service\-name=nginx\-https
 
 // Create a service for a replicated streaming application on port 4100 balancing UDP traffic and named 'video\-stream'.
 $ kubectl expose streamer \-\-port=4100 \-\-protocol=udp \-\-service\-name=video\-stream

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -131,11 +131,13 @@ for version in "${kube_api_versions[@]}"; do
   labels_field="labels"
   service_selector_field="selector"
   rc_replicas_field="desiredState.replicas"
+  port_field="port"
   if [ "$version" = "v1beta3" ]; then
     id_field="metadata.name"
     labels_field="metadata.labels"
     service_selector_field="spec.selector"
     rc_replicas_field="spec.replicas"
+    port_field="spec.port"
   fi
 
   # Passing no arguments to create is an error
@@ -472,6 +474,26 @@ __EOF__
   kubectl resize  --replicas=3 replicationcontrollers frontend-controller "${kube_flags[@]}"
   # Post-condition: 3 replicas
   kube::test::get_object_assert 'rc frontend-controller' "{{.$rc_replicas_field}}" '3'
+
+  ### Expose replication controller as service
+  # Pre-condition: 3 replicas
+  kube::test::get_object_assert 'rc frontend-controller' "{{.$rc_replicas_field}}" '3'
+  # Command
+  kubectl expose rc frontend-controller --port=80 "${kube_flags[@]}"
+  # Post-condition: service exists
+  kube::test::get_object_assert 'service frontend-controller' "{{.$port_field}}" '80'
+  # Command
+  kubectl expose service frontend-controller --port=443 --service-name=frontend-controller-2 "${kube_flags[@]}"
+  # Post-condition: service exists
+  kube::test::get_object_assert 'service frontend-controller-2' "{{.$port_field}}" '443'
+  # Command
+  kubectl create -f examples/limitrange/valid-pod.json "${kube_flags[@]}"
+  kubectl expose pod valid-pod --port=444 --service-name=frontend-controller-3 "${kube_flags[@]}"
+  # Post-condition: service exists
+  kube::test::get_object_assert 'service frontend-controller-3' "{{.$port_field}}" '444'
+  # Cleanup services
+  kubectl delete pod valid-pod "${kube_flags[@]}"
+  kubectl delete service frontend-controller{,-2,-3} "${kube_flags[@]}"
 
   ### Delete replication controller with id
   # Pre-condition: frontend replication controller is running


### PR DESCRIPTION
Allows exposing new resource types to be exposed (OpenShift deployment
controllers, copying services, and other resources that will have
pod label selectors).

Also fixed a bug where the selector wasn't exposed because of parameter
defaulting.
