### PR TITLE
Move gendocs earlier in the travis chain so users know they forgot a "standard" step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ install:
   - ./hack/travis/install-std-race.sh
   - ./hack/build-go.sh
   - GOPATH=$PWD/Godeps/_workspace:$GOPATH go install ./...
+  - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/verify-gendocs.sh
 
 script:
   - KUBE_RACE="-race" KUBE_COVER="y" KUBE_GOVERALLS_BIN="$HOME/gopath/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_API_VERSIONS=$KUBE_TEST_API_VERSIONS ./hack/test-go.sh -- -p=2
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/test-cmd.sh
-  - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/verify-gendocs.sh
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH KUBE_TEST_API_VERSIONS=$KUBE_TEST_API_VERSIONS ./hack/test-integration.sh
 
 notifications:

--- a/shippable.yml
+++ b/shippable.yml
@@ -28,11 +28,11 @@ install:
   - ./hack/travis/install-std-race.sh
   - ./hack/build-go.sh
   - GOPATH=$PWD/Godeps/_workspace:$GOPATH go install ./...
+  - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/verify-gendocs.sh
 
 script:
   - KUBE_RACE="-race" KUBE_COVER="y" KUBE_GOVERALLS_BIN="$HOME/gopath/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_API_VERSIONS=$KUBE_TEST_API_VERSIONS ./hack/test-go.sh -- -p=2
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/test-cmd.sh
-  - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/verify-gendocs.sh
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH KUBE_TEST_API_VERSIONS=$KUBE_TEST_API_VERSIONS ./hack/test-integration.sh
 
 notifications:


### PR DESCRIPTION
This gives them the nice gray travis failure instead of the red one (gray means bad
code, red means broken test).
