### PR TITLE
Fixed an issue on searching events by a given fieldSelector. The issue b...

### DIFF
--- a/pkg/client/events.go
+++ b/pkg/client/events.go
@@ -146,12 +146,17 @@ func (e *events) Search(objOrRef runtime.Object) (*api.EventList, error) {
 	if e.namespace != "" && ref.Namespace != e.namespace {
 		return nil, fmt.Errorf("won't be able to find any events of namespace '%v' in namespace '%v'", ref.Namespace, e.namespace)
 	}
+	stringRefKind := string(ref.Kind)
+	var refKind *string
+	if stringRefKind != "" {
+		refKind = &stringRefKind
+	}
 	stringRefUID := string(ref.UID)
 	var refUID *string
 	if stringRefUID != "" {
 		refUID = &stringRefUID
 	}
-	fieldSelector := e.GetFieldSelector(&ref.Name, &ref.Namespace, &ref.Kind, refUID)
+	fieldSelector := e.GetFieldSelector(&ref.Name, &ref.Namespace, refKind, refUID)
 	return e.List(labels.Everything(), fieldSelector)
 }
 


### PR DESCRIPTION
...reak

the events reported for kubectl describe pods completely.

Fixed #5957 

With the fix, events are reported:

```
$ cluster/kubectl.sh describe pods monitoring-heapster-controller-h3x9k
current-context: "golden-system-455_kubernetes"
Running: cluster/../cluster/gce/../../cluster/../_output/dockerized/bin/linux/amd64/kubectl describe pods monitoring-heapster-controller-h3x9k
Name:               monitoring-heapster-controller-h3x9k
Image(s):           kubernetes/heapster:v0.9
Host:               kubernetes-minion-agug.c.golden-system-455.internal/104.197.6.91
Labels:             kubernetes.io/cluster-service=true,name=heapster,uses=monitoring-influxdb
Status:             Running
Replication Controllers:    monitoring-heapster-controller (1/1 replicas created)
Conditions:
  Type      Status
  Ready     True 
Events:
  FirstSeen             LastSeen            Count   From                                SubobjectPath           Reason  Message
  Thu, 26 Mar 2015 09:12:52 -0700   Thu, 26 Mar 2015 09:12:52 -0700 1   {kubelet kubernetes-minion-agug.c.golden-system-455.internal}   spec.containers{heapster}   created Created with docker id 8b29f11cb1f7187910668551cdd4037aa40af3b69536ed934c685d0704cf05dd
  Thu, 26 Mar 2015 09:12:52 -0700   Thu, 26 Mar 2015 09:12:52 -0700 1   {kubelet kubernetes-minion-agug.c.golden-system-455.internal}   spec.containers{heapster}   started Started with docker id 8b29f11cb1f7187910668551cdd4037aa40af3b69536ed934c685d0704cf05dd
...
```
