### PR TITLE
Resolve env vars in kubelet; add downward API env for pod name

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -737,7 +738,7 @@ func (kl *Kubelet) runContainer(pod *api.Pod, container *api.Container, podVolum
 		glog.Errorf("Couldn't make a ref to pod %v, container %v: '%v'", pod.Name, container.Name, err)
 	}
 
-	envVariables, err := kl.makeEnvironmentVariables(pod.Namespace, container)
+	envVariables, err := kl.makeEnvironmentVariables(pod, container)
 	if err != nil {
 		return "", err
 	}
@@ -893,8 +894,17 @@ func (kl *Kubelet) getServiceEnvVarMap(ns string) (map[string]string, error) {
 	return m, nil
 }
 
-// Make the service environment variables for a pod in the given namespace.
-func (kl *Kubelet) makeEnvironmentVariables(ns string, container *api.Container) ([]string, error) {
+func (kl *Kubelet) getDownwardAPIEnvVarMap(pod *api.Pod) map[string]string {
+	return map[string]string{
+		"K8S_API_POD_NAME": pod.Name,
+	}
+}
+
+var parameterExp = regexp.MustCompile(`(^|[^\\])\$\{([a-zA-Z0-9\_]+)\}`)
+
+// Make the service environment variables for the given pod.
+func (kl *Kubelet) makeEnvironmentVariables(pod *api.Pod, container *api.Container) ([]string, error) {
+
 	var result []string
 	// Note:  These are added to the docker.Config, but are not included in the checksum computed
 	// by dockertools.BuildDockerName(...).  That way, we can still determine whether an
@@ -905,9 +915,52 @@ func (kl *Kubelet) makeEnvironmentVariables(ns string, container *api.Container)
 	// To avoid this users can: (1) wait between starting a service and starting; or (2) detect
 	// missing service env var and exit and be restarted; or (3) use DNS instead of env vars
 	// and keep trying to resolve the DNS name of the service (recommended).
-	serviceEnv, err := kl.getServiceEnvVarMap(ns)
+	serviceEnv, err := kl.getServiceEnvVarMap(pod.Namespace)
 	if err != nil {
 		return result, err
+	}
+
+	downwardAPIEnv := kl.getDownwardAPIEnvVarMap(pod)
+	resolvedVars := make(map[string]string)
+
+	sources := []map[string]string{
+		resolvedVars,
+		serviceEnv,
+		downwardAPIEnv,
+	}
+
+	// iterate through the container's Env
+	for _, value := range container.Env {
+		envValue := value.Value
+		for _, match := range parameterExp.FindAllStringSubmatch(envValue, -1) {
+			if len(match) > 2 {
+				// default back to the value of the var name if it cannot be resolved
+				varName := match[2]
+				varValue := match[2]
+				resolved := false
+
+				for _, source := range sources {
+					sourceValue, ok := source[varName]
+					if ok {
+						varValue = sourceValue
+						resolved = true
+						break
+					}
+				}
+
+				if resolved {
+					glog.V(3).Infof("Resolved var %v to %v for pod %v/%v", varName, varValue, pod.Namespace, pod.Name)
+					envValue = strings.Replace(envValue, match[0], match[1]+varValue, 1)
+				} else {
+					// TODO: add pod info to message
+					glog.Errorf("Couldn't resolve var %v for pod %v/%v", varName, pod.Namespace, pod.Name)
+				}
+			}
+		}
+
+		// Remove escapes
+		envValue = strings.Replace(envValue, "\\${", "${", -1)
+		resolvedVars[value.Name] = envValue
 	}
 
 	for _, value := range container.Env {
@@ -917,7 +970,7 @@ func (kl *Kubelet) makeEnvironmentVariables(ns string, container *api.Container)
 		// env vars.
 		// TODO: remove this net line once all platforms use apiserver+Pods.
 		delete(serviceEnv, value.Name)
-		result = append(result, fmt.Sprintf("%s=%s", value.Name, value.Value))
+		result = append(result, fmt.Sprintf("%s=%s", value.Name, resolvedVars[value.Name]))
 	}
 
 	// Append remaining service env vars.

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -19,6 +19,7 @@ package kubelet
 import (
 	"bytes"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -55,6 +56,7 @@ import (
 func init() {
 	api.ForTesting_ReferencesAllowBlankSelfLinks = true
 	util.ReallyCrash = true
+	flag.Set("v", "5")
 }
 
 type TestKubelet struct {
@@ -1981,7 +1983,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 
 	testCases := []struct {
 		name                   string         // the name of the test case
-		ns                     string         // the namespace to generate environment for
+		pod                    *api.Pod       // the namespace to generate environment for
 		container              *api.Container // the container to use
 		masterServiceNamespace string         // the namespace to read master service info from
 		nilLister              bool           // whether the lister should be nil
@@ -1990,7 +1992,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 	}{
 		{
 			"api server = Y, kubelet = Y",
-			"test1",
+			&api.Pod{ObjectMeta: api.ObjectMeta{Namespace: "test1"}},
 			&api.Container{
 				Env: []api.EnvVar{
 					{Name: "FOO", Value: "BAR"},
@@ -2031,7 +2033,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 		},
 		{
 			"api server = Y, kubelet = N",
-			"test1",
+			&api.Pod{ObjectMeta: api.ObjectMeta{Namespace: "test1"}},
 			&api.Container{
 				Env: []api.EnvVar{
 					{Name: "FOO", Value: "BAR"},
@@ -2058,7 +2060,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 		},
 		{
 			"api server = N; kubelet = Y",
-			"test1",
+			&api.Pod{ObjectMeta: api.ObjectMeta{Namespace: "test1"}},
 			&api.Container{
 				Env: []api.EnvVar{
 					{Name: "FOO", Value: "BAZ"},
@@ -2092,7 +2094,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 		},
 		{
 			"master service in pod ns",
-			"test2",
+			&api.Pod{ObjectMeta: api.ObjectMeta{Namespace: "test2"}},
 			&api.Container{
 				Env: []api.EnvVar{
 					{Name: "FOO", Value: "ZAP"},
@@ -2126,7 +2128,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 		},
 		{
 			"pod in master service ns",
-			"kubernetes",
+			&api.Pod{ObjectMeta: api.ObjectMeta{Namespace: "kubernetes"}},
 			&api.Container{},
 			"kubernetes",
 			false,
@@ -2154,6 +2156,65 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 				"KUBERNETES_RO_PORT_8087_TCP_ADDR=1.2.3.7"),
 			21,
 		},
+		{
+			"simple substitution",
+			&api.Pod{ObjectMeta: api.ObjectMeta{Namespace: "unknown", Name: "test-pod"}},
+			&api.Container{
+				Env: []api.EnvVar{
+					{Name: "BAR", Value: "bar"},
+					{Name: "FOO", Value: "${BAR}"},
+				},
+			},
+			"kubernetes",
+			true,
+			util.NewStringSet(
+				"BAR=bar",
+				"FOO=bar",
+			),
+			2,
+		},
+		{
+			"slightly more complex substitution",
+			&api.Pod{ObjectMeta: api.ObjectMeta{Namespace: "unknown", Name: "test-pod"}},
+			&api.Container{
+				Env: []api.EnvVar{
+					{Name: "BAR", Value: "bar"},
+					{Name: "FOO", Value: "${BAR}"},
+					{Name: "ZOO", Value: "${FOO}-${BAR}"},
+					{Name: "BOO", Value: "--${FOO}"},
+					{Name: "MOO", Value: "${FOO"},
+					{Name: "UNRESOLVED", Value: "${SOMETHING}"},
+					{Name: "ESCAPED", Value: "\\${BAR}"},
+				},
+			},
+			"kubernetes",
+			true,
+			util.NewStringSet(
+				"BAR=bar",
+				"FOO=bar",
+				"ZOO=bar-bar",
+				"BOO=--bar",
+				"MOO=${FOO",
+				"UNRESOLVED=${SOMETHING}",
+				"ESCAPED=${BAR}",
+			),
+			7,
+		},
+		{
+			"downward API",
+			&api.Pod{ObjectMeta: api.ObjectMeta{Namespace: "unknown", Name: "test-pod"}},
+			&api.Container{
+				Env: []api.EnvVar{
+					{Name: "POD_NAME", Value: "${K8S_API_POD_NAME}"},
+				},
+			},
+			"kubernetes",
+			true,
+			util.NewStringSet(
+				"POD_NAME=test-pod",
+			),
+			1,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -2166,7 +2227,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			kl.serviceLister = testServiceLister{services}
 		}
 
-		result, err := kl.makeEnvironmentVariables(tc.ns, tc.container)
+		result, err := kl.makeEnvironmentVariables(tc.pod, tc.container)
 		if err != nil {
 			t.Errorf("[%v] Unexpected error: %v", tc.name, err)
 		}


### PR DESCRIPTION
As discussed in #2316; also relevant to #386 
