### PR TITLE
Do not block admission if namespace already exists

### DIFF
--- a/pkg/client/fake_namespaces.go
+++ b/pkg/client/fake_namespaces.go
@@ -46,7 +46,7 @@ func (c *FakeNamespaces) Delete(name string) error {
 
 func (c *FakeNamespaces) Create(namespace *api.Namespace) (*api.Namespace, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "create-namespace"})
-	return &api.Namespace{}, nil
+	return &api.Namespace{}, c.Fake.Err
 }
 
 func (c *FakeNamespaces) Update(namespace *api.Namespace) (*api.Namespace, error) {

--- a/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
@@ -76,7 +77,7 @@ func (p *provision) Admit(a admission.Attributes) (err error) {
 		return nil
 	}
 	_, err = p.client.Namespaces().Create(namespace)
-	if err != nil {
+	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Resolves https://github.com/GoogleCloudPlatform/kubernetes/issues/5873

If there are concurrent operations that attempt to create a resource in a namespace that had not previously existed, there could be a race on who gets to auto-provision that namespace.  The second call will fail with a reply from their attempt to create a namespace saying it already exists.  Since the goal is to ensure it exists, we should not error on an already exists error.
