### PR TITLE
Fix flakiness in monitoring e2e test.

### DIFF
--- a/test/e2e/monitoring.go
+++ b/test/e2e/monitoring.go
@@ -137,7 +137,7 @@ func getInfluxdbData(c *influxdb.Client, query string) (map[string]bool, error) 
 		return nil, err
 	}
 	if len(series) != 1 {
-		Failf("expected only one series from Influxdb for query %q. Got %+v", query, series)
+		return nil, fmt.Errorf("expected only one series from Influxdb for query %q. Got %+v", query, series)
 	}
 	if len(series[0].GetColumns()) != 2 {
 		Failf("Expected two columns for query %q. Found %v", query, series[0].GetColumns())


### PR DESCRIPTION
Failing early was preventing us from hitting the retry path.
This seems to fix the existing flakiness. There are some other cleanups in monitoring. 
Will do those separately.
