### PR TITLE
Some improvements to #5687

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -194,11 +194,6 @@ runTests() {
   kube::log::status "Combined coverage report: ${coverage_html_file}"
 }
 
-runTestsForVersion() {
-  export KUBE_API_VERSION="$1"
-  runTests "${@:2}"
-}
-
 reportCoverageToCoveralls() {
   if [[ -x "${KUBE_GOVERALLS_BIN}" ]]; then
     ${KUBE_GOVERALLS_BIN} -coverprofile="${COMBINED_COVER_PROFILE}" || true
@@ -209,7 +204,7 @@ reportCoverageToCoveralls() {
 IFS=',' read -a apiVersions <<< "${KUBE_TEST_API_VERSIONS}"
 for apiVersion in "${apiVersions[@]}"; do
   echo "Running tests for APIVersion: $apiVersion"
-  runTestsForVersion $apiVersion "${@}"
+  KUBE_API_VERSION="${apiVersion}" runTests "$@"
 done
 
 # We might run the tests for multiple versions, but we want to report only

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -55,7 +55,7 @@ runTests() {
 trap cleanup EXIT
 
 # Convert the CSV to an array of API versions to test
-IFS=',' read -a apiVersions <<< ${KUBE_TEST_API_VERSIONS}
+IFS=',' read -a apiVersions <<< "${KUBE_TEST_API_VERSIONS}"
 for apiVersion in "${apiVersions[@]}"; do
-  runTests $apiVersion
+  runTests "${apiVersion}"
 done


### PR DESCRIPTION
From https://github.com/GoogleCloudPlatform/kubernetes/pull/5687#issuecomment-86390348:

> Don't use IFS. Ever.

Can you please explain why? I tried to search for a reason but could not find anything.

> Use arrays for multiple values.

I could not find a good way to pass arrays. I found this http://stackoverflow.com/questions/1063347/passing-arrays-as-parameters-in-bash, but it doesnt seem clean to me. I wonder why passing a CSV is a bad idea?

> It's setting KUBE_TEST_API_VERSIONS to something unconditionally even if it wasn't really being set before.

Yes. It uses a default value

> runTestsForVersion is exporting KUBE_API_VERSION and leaving it exported after the function returns.

fixed

> And missing double quotes in about all variable accesses even though most (or all?) are supposed to expand to a single token (the ones that don't should be using arrays anyways.)

fixed. let me know if I missed a spot.
