### PR TITLE
Use the first token of hostname for generating static pod names

### DIFF
--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -361,7 +361,3 @@ func bestPodIdentString(pod *api.Pod) string {
 	}
 	return fmt.Sprintf("%s.%s", name, namespace)
 }
-
-func GeneratePodName(name, hostname string) (string, error) {
-	return fmt.Sprintf("%s-%s", name, hostname), nil
-}


### PR DESCRIPTION
This increases the readability of pods by avoiding long names.

This fixes #5936
