### PR TITLE
kubectl describe nodes id reports related events

### DIFF
--- a/pkg/api/validation/events.go
+++ b/pkg/api/validation/events.go
@@ -25,7 +25,9 @@ import (
 // ValidateEvent makes sure that the event makes sense.
 func ValidateEvent(event *api.Event) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
-	if event.Namespace != event.InvolvedObject.Namespace {
+	// TODO: There is no namespace required for minion
+	if event.InvolvedObject.Kind != "Node" &&
+		event.Namespace != event.InvolvedObject.Namespace {
 		allErrs = append(allErrs, errs.NewFieldInvalid("involvedObject.namespace", event.InvolvedObject.Namespace, "namespace does not match involvedObject"))
 	}
 	if !util.IsDNS1123Subdomain(event.Namespace) {

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/golang/glog"
 )
 
@@ -366,7 +367,14 @@ func (d *NodeDescriber) Describe(namespace, name string) (string, error) {
 		pods = append(pods, pod)
 	}
 
-	events, _ := d.Events(namespace).Search(node)
+	var events *api.EventList
+	if ref, err := api.GetReference(node); err != nil {
+		glog.Errorf("Unable to construct reference to '%#v': %v", node, err)
+	} else {
+		// TODO: We haven't decided the namespace for Node object yet.
+		ref.UID = types.UID(ref.Name)
+		events, _ = d.Events("").Search(ref)
+	}
 
 	return describeNode(node, pods, events)
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2131,11 +2131,12 @@ func (kl *Kubelet) BirthCry() {
 	// Make an event that kubelet restarted.
 	// TODO: get the real minion object of ourself,
 	// and use the real minion name and UID.
+	// TODO: what is namespace for node?
 	ref := &api.ObjectReference{
-		Kind:      "Minion",
+		Kind:      "Node",
 		Name:      kl.hostname,
 		UID:       types.UID(kl.hostname),
-		Namespace: api.NamespaceDefault,
+		Namespace: "",
 	}
 	kl.recorder.Eventf(ref, "starting", "Starting kubelet.")
 }


### PR DESCRIPTION
With the PR, kubectl describe nodes <id> has events now:

```
Running: cluster/../cluster/gce/../../cluster/../_output/dockerized/bin/linux/amd64/kubectl describe minions kubernetes-minion-agug.c.golden-system-455.internal
Name:           kubernetes-minion-agug.c.golden-system-455.internal
Labels:         <none>
CreationTimestamp:  Mon, 23 Mar 2015 14:46:27 -0700
Conditions:
  Type      Status  LastProbeTime               LastTransitionTime          Reason                  Message
  Ready     True    Thu, 26 Mar 2015 16:33:17 -0700     Thu, 26 Mar 2015 16:27:54 -0700     kubelet is posting ready status     
Addresses:  104.197.6.91
Capacity:
 cpu:       1
 memory:    3800824Ki
ExternalID: 12082605094712375514
Pods:       (4 in total)
  fluentd-to-elasticsearch-kubernetes-minion-agug.c.golden-system-455.internal
  kibana-logging-controller-cegta
  monitoring-heapster-controller-h3x9k
  monitoring-influx-grafana-controller-182tv
Events:
  FirstSeen             LastSeen            Count   From                                SubobjectPath   Reason      Message
  Thu, 26 Mar 2015 15:39:53 -0700   Thu, 26 Mar 2015 15:39:53 -0700 1   {kubelet kubernetes-minion-agug.c.golden-system-455.internal}           starting    Starting kubelet.
  Thu, 26 Mar 2015 15:40:16 -0700   Thu, 26 Mar 2015 15:40:16 -0700 1   {kubelet kubernetes-minion-agug.c.golden-system-455.internal}           starting    Starting kubelet.
  Thu, 26 Mar 2015 15:40:32 -0700   Thu, 26 Mar 2015 15:40:32 -0700 1   {kubelet kubernetes-minion-agug.c.golden-system-455.internal}           starting    Starting kubelet.
  Thu, 26 Mar 2015 15:55:36 -0700   Thu, 26 Mar 2015 15:55:36 -0700 1   {kubelet kubernetes-minion-agug.c.golden-system-455.internal}           starting    Starting kubelet.
  Thu, 26 Mar 2015 16:25:31 -0700   Thu, 26 Mar 2015 16:25:31 -0700 1   {kubelet kubernetes-minion-agug.c.golden-system-455.internal}           starting    Starting kubelet.
```

Fix #6001

cc/ @vishh @saad-ali 
