### PR TITLE
Change soak test to pull image from gcr.io

### DIFF
--- a/test/soak/serve_hostnames/serve_hostnames.go
+++ b/test/soak/serve_hostnames/serve_hostnames.go
@@ -158,7 +158,7 @@ func main() {
 						Containers: []api.Container{
 							{
 								Name:  "serve-hostname",
-								Image: "kubernetes/serve_hostname:1.1",
+								Image: "gcr.io/google-containers/serve_hostname:1.1",
 								Ports: []api.ContainerPort{{ContainerPort: 9376}},
 							},
 						},


### PR DESCRIPTION
Seems to work.

```
$ kubectl get pods --namespace=serve-hostnames-4127
POD                  IP                  CONTAINER(S)        IMAGE(S)                                      HOST                                                                  LABELS                STATUS              CREATED
serve-hostname-0-0   10.244.0.6          serve-hostname      gcr.io/google-containers/serve_hostname:1.1   kubernetes-minion-904g.c.kubernetes-satnam.internal/104.197.15.218    name=serve-hostname   Running             40 seconds
serve-hostname-1-0   10.244.1.6          serve-hostname      gcr.io/google-containers/serve_hostname:1.1   kubernetes-minion-ag7k.c.kubernetes-satnam.internal/104.197.16.133    name=serve-hostname   Running             40 seconds
serve-hostname-2-0   10.244.2.7          serve-hostname      gcr.io/google-containers/serve_hostname:1.1   kubernetes-minion-to97.c.kubernetes-satnam.internal/130.211.123.231   name=serve-hostname   Running             40 seconds
serve-hostname-3-0   10.244.3.6          serve-hostname      gcr.io/google-containers/serve_hostname:1.1   kubernetes-minion-us7v.c.kubernetes-satnam.internal/104.154.78.159    name=serve-hostname   Running             39 seconds
```
