### PR TITLE
kubelet: Add container readiness manager.

### DIFF
--- a/pkg/kubelet/container/container_reference_manager.go
+++ b/pkg/kubelet/container/container_reference_manager.go
@@ -36,9 +36,7 @@ type RefManager struct {
 // NewRefManager creates and returns a container reference manager
 // with empty contents.
 func NewRefManager() *RefManager {
-	c := RefManager{}
-	c.containerIDToRef = make(map[string]*api.ObjectReference)
-	return &c
+	return &RefManager{containerIDToRef: make(map[string]*api.ObjectReference)}
 }
 
 // SetRef stores a reference to a pod's container, associating it with the given container ID.

--- a/pkg/kubelet/container/readiness_manager.go
+++ b/pkg/kubelet/container/readiness_manager.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package container
+
+import "sync"
+
+// ReadinessManager maintains the readiness information(probe results) of
+// containers over time to allow for implementation of health thresholds.
+// This manager is thread-safe, no locks are necessary for the caller.
+type ReadinessManager struct {
+	// guards states
+	sync.RWMutex
+	// TODO(yifan): To use strong type.
+	states map[string]bool
+}
+
+// NewReadinessManager creates ane returns a readiness manager with empty
+// contents.
+func NewReadinessManager() *ReadinessManager {
+	return &ReadinessManager{states: make(map[string]bool)}
+}
+
+// GetReadiness returns the readiness value for the container with the given ID.
+// If the readiness value is found, returns it.
+// If the readiness is not found, returns false.
+func (r *ReadinessManager) GetReadiness(id string) bool {
+	r.RLock()
+	defer r.RUnlock()
+	state, found := r.states[id]
+	return state && found
+}
+
+// SetReadiness sets the readiness value for the container with the given ID.
+func (r *ReadinessManager) SetReadiness(id string, value bool) {
+	r.Lock()
+	defer r.Unlock()
+	r.states[id] = value
+}
+
+// RemoveReadiness clears the readiness value for the container with the given ID.
+func (r *ReadinessManager) RemoveReadiness(id string) {
+	r.Lock()
+	defer r.Unlock()
+	delete(r.states, id)
+}

--- a/pkg/kubelet/probe_test.go
+++ b/pkg/kubelet/probe_test.go
@@ -147,7 +147,7 @@ func (p fakeExecProber) Probe(_ exec.Cmd) (probe.Result, error) {
 
 func makeTestKubelet(result probe.Result, err error) *Kubelet {
 	return &Kubelet{
-		readiness: newReadinessStates(),
+		readinessManager: kubecontainer.NewReadinessManager(),
 		prober: probeHolder{
 			exec: fakeExecProber{
 				result: result,
@@ -412,8 +412,8 @@ func TestProbeContainer(t *testing.T) {
 		if test.expectedResult != result {
 			t.Errorf("Expected result was %v but probeContainer() returned %v", test.expectedResult, result)
 		}
-		if test.expectedReadiness != kl.readiness.get(dc.ID) {
-			t.Errorf("Expected readiness was %v but probeContainer() set %v", test.expectedReadiness, kl.readiness.get(dc.ID))
+		if test.expectedReadiness != kl.readinessManager.GetReadiness(dc.ID) {
+			t.Errorf("Expected readiness was %v but probeContainer() set %v", test.expectedReadiness, kl.readinessManager.GetReadiness(dc.ID))
 		}
 	}
 }


### PR DESCRIPTION
Move the readiness managing logic into pkg/kubelet/container package
to facilitate the pluggable container runtime.

This is similar to https://github.com/GoogleCloudPlatform/kubernetes/pull/5982

This PR will enable us to move `killContainer` into container runtime. Why moving it into container runtime? Because by that, the docker container runtime can take care of the pod infra container restart process. (Take a glance of the coming patch here):
https://github.com/yifan-gu/kubernetes/blob/run_container_in_pod/pkg/kubelet/dockertools/docker.go#L1074

I feels maybe we can put these two guys together(`RefManager` and `ReadinessManager`). But I can't think of a good name :(

Thank you in advance for reviewing!
@vmarmol @dchen1107 
