### PR TITLE
Do not fail pod status update if failed to get host IP

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1924,9 +1924,10 @@ func (kl *Kubelet) generatePodStatusByPod(pod *api.Pod) (api.PodStatus, error) {
 	podStatus.Host = kl.GetHostname()
 	hostIP, err := kl.GetHostIP()
 	if err != nil {
-		return api.PodStatus{}, fmt.Errorf("Cannot get host IP: %v", err)
+		glog.Errorf("Cannot get host IP: %v", err)
+	} else {
+		podStatus.HostIP = hostIP.String()
 	}
-	podStatus.HostIP = hostIP.String()
 
 	return *podStatus, nil
 }


### PR DESCRIPTION
This is similar how it used work in pod_cache.

This fixes #6046

@dchen1107 
