### PR TITLE
[ubuntu-cluster] fix a serious bug when node both act as master and minion

### DIFF
--- a/cluster/ubuntu-cluster/configure.sh
+++ b/cluster/ubuntu-cluster/configure.sh
@@ -143,7 +143,6 @@ do
     mm[$i]=$name
     let ii++
 done
-echo 
 
 # input node IPs
 while true; do
@@ -168,7 +167,13 @@ while true; do
             sed -i "s/MASTER_IP/${masterIP}/g" default_scripts/kube-proxy        
             
             # For master set MINION IPs in kube-controller-manager
-	        minionIPs="$minionIPs,$myIP"
+            if [ -z "$minionIPs" ]; then
+                #one node act as both minion and master role
+                minionIPs="$myIP"
+            else
+                minionIPs="$minionIPs,$myIP"
+            fi
+
 	        sed -i "s/MINION_IPS/${minionIPs}/g" default_scripts/kube-controller-manager
 	        
 	        cpMaster


### PR DESCRIPTION
We found a serious bug (a extra comma) may break the ubuntu-cluster install process when a node acts both as master and minion.

We are still working on PR https://github.com/GoogleCloudPlatform/kubernetes/pull/5498 based on advices from @rjnagal. In order to make ubuntu-cluster fully automatically. But we hope owners can merge this PR first, for usage consideration.
