### PR TITLE
Update go-restful to include emicklei/go-restful#197

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -170,8 +170,8 @@
 		},
 		{
 			"ImportPath": "github.com/emicklei/go-restful",
-			"Comment": "v1.1.3-26-g977ac8f",
-			"Rev": "977ac8fcbcd2ee33319246f7c91d4b426402dc70"
+			"Comment": "v1.1.3-29-gc68bc68",
+			"Rev": "c68bc68d7689f127ab554a42378aece0ea3df4b3"
 		},
 		{
 			"ImportPath": "github.com/evanphx/json-patch",

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/response.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/response.go
@@ -150,6 +150,11 @@ func (r *Response) WriteAsXml(value interface{}) error {
 
 // WriteAsJson is a convenience method for writing a value in json
 func (r *Response) WriteAsJson(value interface{}) error {
+	return r.WriteJson(value, MIME_JSON) // no charset
+}
+
+// WriteJson is a convenience method for writing a value in Json with a given Content-Type
+func (r *Response) WriteJson(value interface{}, contentType string) error {
 	var output []byte
 	var err error
 
@@ -165,7 +170,7 @@ func (r *Response) WriteAsJson(value interface{}) error {
 	if err != nil {
 		return r.WriteErrorString(http.StatusInternalServerError, err.Error())
 	}
-	r.Header().Set(HEADER_ContentType, MIME_JSON)
+	r.Header().Set(HEADER_ContentType, contentType)
 	if r.statusCode > 0 { // a WriteHeader was intercepted
 		r.ResponseWriter.WriteHeader(r.statusCode)
 	}

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/route.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/route.go
@@ -79,8 +79,8 @@ func (r Route) matchesAccept(mimeTypesWithQuality string) bool {
 		if withoutQuality == "*/*" {
 			return true
 		}
-		for _, other := range r.Produces {
-			if other == withoutQuality {
+		for _, producibleType := range r.Produces {
+			if producibleType == "*/*" || producibleType == withoutQuality {
 				return true
 			}
 		}

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/route_test.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/route_test.go
@@ -31,6 +31,17 @@ func TestMatchesAcceptXml(t *testing.T) {
 	}
 }
 
+// accept should match produces
+func TestMatchesAcceptAny(t *testing.T) {
+	r := Route{Produces: []string{"*/*"}}
+	if !r.matchesAccept("application/json") {
+		t.Errorf("accept should match json")
+	}
+	if !r.matchesAccept("application/xml") {
+		t.Errorf("accept should match xml")
+	}
+}
+
 // content type should match consumes
 func TestMatchesContentTypeXml(t *testing.T) {
 	r := Route{Consumes: []string{"application/xml"}}


### PR DESCRIPTION
ProxyRoute return "406: Not Acceptable" when not include "*/*" in Accept request header.

https://github.com/GoogleCloudPlatform/kubernetes/blob/cfb6f1199bae1c0c7968c7322dd1f0037624236c/pkg/apiserver/api_installer.go#L637
