### PR TITLE
kubelet: Move KillContainer to container runtime.

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -1049,3 +1049,21 @@ func RunContainer(client DockerInterface, container *api.Container, pod *api.Pod
 	}
 	return dockerContainer.ID, nil
 }
+
+// KillContainer kills a docker container with the given containerID.
+// TODO(yifan): To use strong type for the containerID.
+func KillContainer(client DockerInterface, containerID string,
+	refManager *kubecontainer.RefManager, readinessManager *kubecontainer.ReadinessManager, recorder record.EventRecorder) error {
+	glog.V(2).Infof("Killing container with id %q", containerID)
+	readinessManager.RemoveReadiness(containerID)
+	// Wait 10s for graceful stop before force killing.
+	err := client.StopContainer(containerID, 10)
+	ref, ok := refManager.GetRef(containerID)
+	if !ok {
+		glog.Warningf("No ref for pod '%v'", containerID)
+	} else {
+		// TODO: pass reason down here, and state, or move this call up the stack.
+		recorder.Eventf(ref, "killing", "Killing %v", containerID)
+	}
+	return err
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -811,24 +811,12 @@ func parseResolvConf(reader io.Reader) (nameservers []string, searches []string,
 	return nameservers, searches, nil
 }
 
-// Kill a docker container
 func (kl *Kubelet) killContainer(c *kubecontainer.Container) error {
-	return kl.killContainerByID(string(c.ID))
+	return dockertools.KillContainer(kl.dockerClient, string(c.ID), kl.containerRefManager, kl.readinessManager, kl.recorder)
 }
 
 func (kl *Kubelet) killContainerByID(ID string) error {
-	glog.V(2).Infof("Killing container with id %q", ID)
-	kl.readinessManager.RemoveReadiness(ID)
-	err := kl.dockerClient.StopContainer(ID, 10)
-
-	ref, ok := kl.containerRefManager.GetRef(ID)
-	if !ok {
-		glog.Warningf("No ref for pod '%v'", ID)
-	} else {
-		// TODO: pass reason down here, and state, or move this call up the stack.
-		kl.recorder.Eventf(ref, "killing", "Killing %v", ID)
-	}
-	return err
+	return dockertools.KillContainer(kl.dockerClient, ID, kl.containerRefManager, kl.readinessManager, kl.recorder)
 }
 
 const (


### PR DESCRIPTION
Following https://github.com/GoogleCloudPlatform/kubernetes/pull/6039

@vmarmol @dchen1107 
