### PR TITLE
Expose last sync resource version on reflector

### DIFF
--- a/pkg/client/cache/reflector_test.go
+++ b/pkg/client/cache/reflector_test.go
@@ -112,6 +112,11 @@ func TestReflector_watchHandler(t *testing.T) {
 	if e, a := "32", resumeRV; e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
+
+	// last sync resource version should be the last version synced with store
+	if e, a := "32", g.LastSyncResourceVersion(); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
 }
 
 func TestReflector_watchHandlerTimeout(t *testing.T) {


### PR DESCRIPTION
I have a use case where I reflect N object types (Namespace / Policy / RoleBindings) into N stores.

I then build an additional in-memory store that is the product of knowing who can LIST which Namespace objects based on the N stores at some regular synch interval.  

In order to optimize this code path, I want to know the last resource version synced with each of the N stores in order to avoid iterating over each store to compare if any individual resource changed.  If I know the reflector has not synced from a different resource version from when I last looked to update my ACL cache based on the N stores, then I know there was no underlying state change I need to process to update the in-memory cache.

This is the outcome of some discussions we had at the last meet-up.  It keeps the meaning of resource version opaque to clients, and let's me avoid a lot of churn iterating stores to check if there was a meaningful change.

/cc @smarterclayton @lavalamp @erictune @deads2k 
