### PR TITLE
Enabling v1beta3 api version by default in master

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -194,7 +194,6 @@ func startComponents(firstManifestURL, secondManifestURL, apiVersion string) (st
 		ReadOnlyPort:      portNumber,
 		PublicAddress:     publicAddress,
 		CacheTimeout:      2 * time.Second,
-		EnableV1Beta3:     true,
 	})
 	handler.delegate = m.Handler
 

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -199,7 +199,11 @@ func (s *APIServer) Run(_ []string) error {
 		glog.Fatalf("Failure to start kubelet client: %v", err)
 	}
 
-	_, v1beta3 := s.RuntimeConfig["api/v1beta3"]
+	disableV1beta3 := false
+	v1beta3FlagValue, ok := s.RuntimeConfig["api/v1beta3"]
+	if ok && v1beta3FlagValue == "false" {
+		disableV1beta3 = true
+	}
 
 	// TODO: expose same flags as client.BindClientConfigFlags but for a server
 	clientConfig := &client.Config{
@@ -274,7 +278,7 @@ func (s *APIServer) Run(_ []string) error {
 		Authenticator:          authenticator,
 		Authorizer:             authorizer,
 		AdmissionControl:       admissionController,
-		EnableV1Beta3:          v1beta3,
+		DisableV1Beta3:         disableV1beta3,
 		MasterServiceNamespace: s.MasterServiceNamespace,
 		ClusterName:            s.ClusterName,
 		ExternalHost:           s.ExternalHost,

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -78,8 +78,8 @@ type Config struct {
 	EnableUISupport   bool
 	// allow downstream consumers to disable swagger
 	EnableSwaggerSupport bool
-	// allow v1beta3 to be conditionally enabled
-	EnableV1Beta3 bool
+	// allow v1beta3 to be conditionally disabled
+	DisableV1Beta3 bool
 	// allow downstream consumers to disable the index route
 	EnableIndex            bool
 	EnableProfiling        bool
@@ -277,7 +277,7 @@ func New(c *Config) *Master {
 		authenticator:         c.Authenticator,
 		authorizer:            c.Authorizer,
 		admissionControl:      c.AdmissionControl,
-		v1beta3:               c.EnableV1Beta3,
+		v1beta3:               !c.DisableV1Beta3,
 		requestContextMapper:  c.RequestContextMapper,
 
 		cacheTimeout: c.CacheTimeout,
@@ -409,7 +409,7 @@ func (m *Master) init(c *Config) {
 	if err := m.api_v1beta2().InstallREST(m.handlerContainer); err != nil {
 		glog.Fatalf("Unable to setup API v1beta2: %v", err)
 	}
-	if c.EnableV1Beta3 {
+	if m.v1beta3 {
 		if err := m.api_v1beta3().InstallREST(m.handlerContainer); err != nil {
 			glog.Fatalf("Unable to setup API v1beta3: %v", err)
 		}

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -55,7 +55,6 @@ func TestClient(t *testing.T) {
 		EnableLogsSupport: false,
 		EnableProfiling:   true,
 		EnableUISupport:   false,
-		EnableV1Beta3:     true,
 		APIPrefix:         "/api",
 		Authorizer:        apiserver.NewAlwaysAllowAuthorizer(),
 		AdmissionControl:  admit.NewAlwaysAdmit(),


### PR DESCRIPTION
Repurposing enableV1beta3 to disableV1beta3 in master config to enable v1beta3 by default.
v1beta3 can be turned off by using "--runtime_config=noapi/v1beta3".
For https://github.com/GoogleCloudPlatform/kubernetes/issues/5475
