### PR TITLE
Remove the --machines SaltStack configuration on GCE

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -584,18 +584,7 @@ function kube-up {
   # command returns, but currently it returns before the instances come up due
   # to gcloud's deficiency.
   wait-for-minions-to-run
-
-  # Give the master an initial node list (it's waiting in
-  # startup). This resolves a bit of a chicken-egg issue: The minions
-  # need to know the master's ip, so we boot the master first. The
-  # master still needs to know the initial minion list (until all the
-  # pieces #156 are complete), so we have it wait on the minion
-  # boot. (The minions further wait until the loop below, where CIDRs
-  # get filled in.)
   detect-minion-names
-  local kube_node_names
-  kube_node_names=$(IFS=,; echo "${MINION_NAMES[*]}")
-  add-instance-metadata "${MASTER_NAME}" "kube-node-names=${kube_node_names}"
 
   # Create the routes and set IP ranges to instance metadata, 5 instances at a time.
   for (( i=0; i<${#MINION_NAMES[@]}; i++)); do

--- a/cluster/saltbase/salt/kube-controller-manager/default
+++ b/cluster/saltbase/salt/kube-controller-manager/default
@@ -21,7 +21,6 @@
 {% if grains.cloud is defined -%}
 {% if grains.cloud == 'gce' -%}
   {% set cloud_provider = "--cloud_provider=gce" -%}
-  {% set machines = "--machines=" + pillar['gce_node_names'] -%}
 {% endif -%}
 {% if grains.cloud == 'aws' -%}
   {% set cloud_provider = "--cloud_provider=aws" -%}


### PR DESCRIPTION
Per https://github.com/GoogleCloudPlatform/kubernetes/issues/6072#issuecomment-87074456, this is no longer necessary. We now no longer need a static node list. Woo!
