### PR TITLE
make mark-new-release.sh do branching and tell you exactly what to do ne...

### DIFF
--- a/build/mark-new-version.sh
+++ b/build/mark-new-version.sh
@@ -45,10 +45,10 @@ if ! git diff-files --quiet pkg/version/base.go; then
 fi
 
 release_branch="release-${VERSION_MAJOR}.${VERSION_MINOR}"
+current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 if [[ "${VERSION_PATCH}" != "0" ]]; then
-  branch=$(git rev-parse --abbrev-ref HEAD)
-  if [[ ${branch} != "${release_branch}" ]]; then
+  if [[ ${current_branch} != "${release_branch}" ]]; then
     echo "!!! You are trying to tag to an existing minor release but are not on the release branch: ${release_branch}"
     exit 1
   fi
@@ -98,11 +98,11 @@ echo ""
 echo "- Push the tag:"
 echo "   git push git@github.com:GoogleCloudPlatform/kubernetes.git v${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
 if [[ "${VERSION_PATCH}" == "0" ]]; then
-  echo "- Submit HEAD as a PR to master"
+  echo "- Submit branch: ${current_branch} as a PR to master"
   echo "- Merge that PR"
   echo "- Push the new release branch"
   echo "   git push git@github.com:GoogleCloudPlatform/kubernetes.git ${release_branch}"
 else
-  echo "- Submit HEAD as a PR to ${release_branch}"
+  echo "- Submit branch: ${current_branch} as a PR to ${release_branch}"
   echo "- Merge that PR"
 fi

--- a/build/mark-new-version.sh
+++ b/build/mark-new-version.sh
@@ -24,7 +24,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 NEW_VERSION=${1-}
 
-VERSION_REGEX="v([0-9]+).([0-9]+)(.([0-9]+))?"
+VERSION_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
 [[ ${NEW_VERSION} =~ $VERSION_REGEX ]] || {
   echo "!!! You must specify the version in the form of '$VERSION_REGEX'" >&2
   exit 1
@@ -32,13 +32,7 @@ VERSION_REGEX="v([0-9]+).([0-9]+)(.([0-9]+))?"
 
 VERSION_MAJOR="${BASH_REMATCH[1]}"
 VERSION_MINOR="${BASH_REMATCH[2]}"
-VERSION_PATCH="${BASH_REMATCH[4]}"
-
-# force .0 if no patch version specified
-if [[ -z ${VERSION_PATCH:-} ]]; then
-  VERSION_PATCH="0"
-  NEW_VERSION="${NEW_VERSION}.0"
-fi
+VERSION_PATCH="${BASH_REMATCH[3]}"
 
 if ! git diff-index --quiet --cached HEAD; then
   echo "!!! You must not have any changes in your index when running this command"
@@ -70,9 +64,10 @@ fi
 
 VERSION_FILE="${KUBE_ROOT}/pkg/version/base.go"
 
+GIT_MINOR="${VERSION_MINOR}.${VERSION_PATCH}"
 echo "+++ Updating to ${NEW_VERSION}"
 "$SED" -r -i -e "s/gitMajor\s+string = \"[^\"]*\"/gitMajor string = \"${VERSION_MAJOR}\"/" "${VERSION_FILE}"
-"$SED" -r -i -e "s/gitMinor\s+string = \"[^\"]*\"/gitMinor string = \"${VERSION_MINOR}.${VERSION_PATCH}\"/" "${VERSION_FILE}"
+"$SED" -r -i -e "s/gitMinor\s+string = \"[^\"]*\"/gitMinor string = \"${GIT_MINOR}\"/" "${VERSION_FILE}"
 "$SED" -r -i -e "s/gitVersion\s+string = \"[^\"]*\"/gitVersion string = \"$NEW_VERSION\"/" "${VERSION_FILE}"
 gofmt -s -w "${VERSION_FILE}"
 
@@ -85,7 +80,7 @@ git tag -a -m "Kubernetes version $NEW_VERSION" "${NEW_VERSION}"
 
 echo "+++ Updating to ${NEW_VERSION}-dev"
 "$SED" -r -i -e "s/gitMajor\s+string = \"[^\"]*\"/gitMajor string = \"${VERSION_MAJOR}\"/" "${VERSION_FILE}"
-"$SED" -r -i -e "s/gitMinor\s+string = \"[^\"]*\"/gitMinor string = \"${VERSION_MINOR}.${VERSION_PATCH}\+\"/" "${VERSION_FILE}"
+"$SED" -r -i -e "s/gitMinor\s+string = \"[^\"]*\"/gitMinor string = \"${GIT_MINOR}\+\"/" "${VERSION_FILE}"
 "$SED" -r -i -e "s/gitVersion\s+string = \"[^\"]*\"/gitVersion string = \"$NEW_VERSION-dev\"/" "${VERSION_FILE}"
 gofmt -s -w "${VERSION_FILE}"
 


### PR DESCRIPTION
...xt

We keep getting tags and branches wonky.  This will land

v0.14.0 as an ancestor of master
v0.14.1 will NOT be an ancestor of master

I can do the later, it only a touch of git gymnastics, not really hard, but
we only occasionably do that today. (0.13.1 is an ancestor of master,
but 0.13.2 is not)
