### PR TITLE
Reduce some tab spacing in kubectl

### DIFF
--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -238,6 +238,6 @@ func ExamplePrintReplicationController() {
 		fmt.Printf("Unexpected error: %v", err)
 	}
 	// Output:
-	// CONTROLLER          CONTAINER(S)        IMAGE(S)            SELECTOR            REPLICAS
-	// foo                 foo                 someimage           foo=bar             1
+	// CONTROLLER   CONTAINER(S)   IMAGE(S)    SELECTOR   REPLICAS
+	// foo          foo            someimage   foo=bar    1
 }

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -550,7 +550,7 @@ func printResourceQuotaList(list *api.ResourceQuotaList, w io.Writer) error {
 
 // PrintObj prints the obj in a human-friendly format according to the type of the obj.
 func (h *HumanReadablePrinter) PrintObj(obj runtime.Object, output io.Writer) error {
-	w := tabwriter.NewWriter(output, 20, 5, 3, ' ', 0)
+	w := tabwriter.NewWriter(output, 10, 4, 3, ' ', 0)
 	defer w.Flush()
 	t := reflect.TypeOf(obj)
 	if handler := h.handlerMap[t]; handler != nil {


### PR DESCRIPTION
`kubectl get pods` in the old way:

```
$ go run cmd/kubectl/kubectl.go get pods
POD                 IP                  CONTAINER(S)        IMAGE(S)                                                   HOST                                    LABELS
       STATUS              CREATED
noop-worker         10.3.113.2          noop-worker         docker-registry01.dev.box.net/jenkins/noop-worker:latest   compute-node02.dev.box.net/10.3.89.74   name=noop,type=worker
       Running             2 weeks
noop-worker-cert    10.3.112.2          noop-worker         docker-registry01.dev.box.net/jenkins/noop-worker          compute-node01.dev.box.net/10.3.89.73   name=noop-cert,type=wo
rker   Running             3 weeks
                                        cert-fetcher        docker-registry01.dev.box.net/jenkins/certfetcher
```

New way with this PR:

```
$ go run cmd/kubectl/kubectl.go get pods
POD                IP           CONTAINER(S)   IMAGE(S)                                                   HOST                                    LABELS                       STATUS
    CREATED
noop-worker        10.3.113.2   noop-worker    docker-registry01.dev.box.net/jenkins/noop-worker:latest   compute-node02.dev.box.net/10.3.89.74   name=noop,type=worker        Runnin
g   2 weeks
noop-worker-cert   10.3.112.2   noop-worker    docker-registry01.dev.box.net/jenkins/noop-worker          compute-node01.dev.box.net/10.3.89.73   name=noop-cert,type=worker   Runnin
g   3 weeks
                                cert-fetcher   docker-registry01.dev.box.net/jenkins/certfetcher
```

It's a small change (mostly reducing minimum column width from 20 to 10) but it helps when you have long fields (like a long image name or lots of labels).
