### PR TITLE
Kubelet: allow docker to examine terminated container

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -687,9 +687,6 @@ func GetDockerPodStatus(client DockerInterface, manifest api.PodSpec, podFullNam
 		}
 	}
 
-	if podStatus.PodIP == "" {
-		return nil, ErrNoPodInfraContainerInPod
-	}
 	if len(statuses) == 0 && podStatus.PodIP == "" {
 		return nil, ErrNoContainersInPod
 	}


### PR DESCRIPTION
Removing the if statement so that docker can continue returning the status of
terminated containers.
