### PR TITLE
GCE node salt: Use the master FQDN, not the master IP

### DIFF
--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -324,15 +324,15 @@ EOF
 }
 
 function salt-set-apiserver() {
-  local kube_master_ip
-  until kube_master_ip=$(getent hosts ${KUBERNETES_MASTER_NAME} | cut -f1 -d\ ); do
+  local kube_master_fqdn
+  until kube_master_fqdn=$(getent hosts ${KUBERNETES_MASTER_NAME} | awk '{ print $2 }'); do
     echo 'Waiting for DNS resolution of ${KUBERNETES_MASTER_NAME}...'
     sleep 3
   done
 
   cat <<EOF >>/etc/salt/minion.d/grains.conf
-  api_servers: '${kube_master_ip}'
-  apiservers: '${kube_master_ip}'
+  api_servers: '${kube_master_fqdn}'
+  apiservers: '${kube_master_fqdn}'
 EOF
 }
 


### PR DESCRIPTION
This will allow us to upgrade the master by full re-provision, without
even bothering to reserve the IP.
