### PR TITLE
Reduce cadvisor e2e test timeout

### DIFF
--- a/test/e2e/cadvisor.go
+++ b/test/e2e/cadvisor.go
@@ -27,8 +27,8 @@ import (
 
 const (
 	timeout       = 1 * time.Minute
-	maxRetries    = 10
-	sleepDuration = time.Minute
+	maxRetries    = 6
+	sleepDuration = 10 * time.Second
 )
 
 var _ = Describe("Cadvisor", func() {


### PR DESCRIPTION
Cadvisor is now integrated into the kubelet binary.

Fixes #4774
