### PR TITLE
Updating proxy to return 301 to add a "/" at the end for #4958 (attempt 2)

### DIFF
--- a/pkg/apiserver/proxy_test.go
+++ b/pkg/apiserver/proxy_test.go
@@ -367,3 +367,59 @@ func TestProxyUpgrade(t *testing.T) {
 		t.Fatalf("expected '%#v', got '%#v'", e, a)
 	}
 }
+
+func TestRedirectOnMissingTrailingSlash(t *testing.T) {
+	table := []struct {
+		// The requested path
+		path string
+		// The path requested on the proxy server.
+		proxyServerPath string
+	}{
+		{"/trailing/slash/", "/trailing/slash/"},
+		{"/", "/"},
+		// "/" should be added at the end.
+		{"", "/"},
+		// "/" should not be added at a non-root path.
+		{"/some/path", "/some/path"},
+	}
+
+	for _, item := range table {
+		proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if req.URL.Path != item.proxyServerPath {
+				t.Errorf("Unexpected request on path: %s, expected path: %s, item: %v", req.URL.Path, item.proxyServerPath, item)
+			}
+		}))
+		defer proxyServer.Close()
+
+		serverURL, _ := url.Parse(proxyServer.URL)
+		simpleStorage := &SimpleRESTStorage{
+			errors:                    map[string]error{},
+			resourceLocation:          serverURL,
+			expectedResourceNamespace: "ns",
+		}
+
+		handler := handleNamespaced(map[string]rest.Storage{"foo": simpleStorage})
+		server := httptest.NewServer(handler)
+		defer server.Close()
+
+		proxyTestPattern := "/api/version2/proxy/namespaces/ns/foo/id" + item.path
+		req, err := http.NewRequest(
+			"GET",
+			server.URL+proxyTestPattern,
+			strings.NewReader(""),
+		)
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+			continue
+		}
+		// Note: We are using a default client here, that follows redirects.
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Unexpected errorCode: %v, expected: 200. Response: %v, item: %v", resp.StatusCode, resp, item)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #4958
Reverting https://github.com/GoogleCloudPlatform/kubernetes/pull/6114.
The tests broke last time because the base URL had to be updated to "/api/version2/proxy/" from "/api/version/proxy/" after https://github.com/GoogleCloudPlatform/kubernetes/pull/5763
