### PR TITLE
Minor fixes for scheduler priority configuration

### DIFF
--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -25,6 +25,10 @@ import (
 
 func init() {
 	factory.RegisterAlgorithmProvider(factory.DefaultProvider, defaultPredicates(), defaultPriorities())
+	// EqualPriority is a prioritizer function that gives an equal weight of one to all minions
+	// Register the priority function so that its available
+	// but do not include it as part of the default priorities
+	factory.RegisterPriorityFunction("EqualPriority", algorithm.EqualPriority, 1)
 }
 
 func defaultPredicates() util.StringSet {
@@ -66,7 +70,5 @@ func defaultPriorities() util.StringSet {
 				Weight: 1,
 			},
 		),
-		// EqualPriority is a prioritizer function that gives an equal weight of one to all minions
-		factory.RegisterPriorityFunction("EqualPriority", algorithm.EqualPriority, 0),
 	)
 }

--- a/plugin/pkg/scheduler/factory/plugins.go
+++ b/plugin/pkg/scheduler/factory/plugins.go
@@ -137,7 +137,7 @@ func RegisterPriorityFunction(name string, function algorithm.PriorityFunction, 
 		Function: func(PluginFactoryArgs) algorithm.PriorityFunction {
 			return function
 		},
-		Weight: 1,
+		Weight: weight,
 	})
 }
 


### PR DESCRIPTION
The accidental priority function weight hard-coding was introduced in a recent PR. 

The EqualPriority was registered and a part of the "default" provider with a 0 weight so that it would not run. However, this created an issue where the scheduler would run into errors if the EqualPriority was specified via configuration without a weight.
