### PR TITLE
Configure the kubelet to bind a simple healthz server to a localhost port for monitoring by monit

### DIFF
--- a/cluster/saltbase/salt/monit/docker
+++ b/cluster/saltbase/salt/monit/docker
@@ -1,8 +1,9 @@
 check process docker with pidfile /var/run/docker.pid
-group docker 
+group docker
 start program = "/etc/init.d/docker start"
 stop program = "/etc/init.d/docker stop"
 if does not exist then restart
-if failed unixsocket /var/run/docker.sock
+if failed
+  unixsocket /var/run/docker.sock
   protocol HTTP request "/version"
-  then restart
+then restart

--- a/cluster/saltbase/salt/monit/etcd
+++ b/cluster/saltbase/salt/monit/etcd
@@ -1,5 +1,5 @@
 check process etcd with pidfile /var/run/etcd.pid
-group etcd 
+group etcd
 start program = "/etc/init.d/etcd start"
 stop program = "/etc/init.d/etcd stop"
 if failed

--- a/cluster/saltbase/salt/monit/kube-proxy
+++ b/cluster/saltbase/salt/monit/kube-proxy
@@ -3,7 +3,9 @@ group kube-proxy
 start program = "/etc/init.d/kube-proxy start"
 stop program = "/etc/init.d/kube-proxy stop"
 if does not exist then restart
-if failed port 10249
-  protocol HTTP request "/healthz"
-  with timeout 10 seconds
-  then restart
+if failed
+  host 127.0.0.1
+  port 10249
+  protocol HTTP
+  request "/healthz"
+then restart

--- a/cluster/saltbase/salt/monit/kubelet
+++ b/cluster/saltbase/salt/monit/kubelet
@@ -1,9 +1,11 @@
 check process kubelet with pidfile /var/run/kubelet.pid
-group kubelet 
+group kubelet
 start program = "/etc/init.d/kubelet start"
 stop program = "/etc/init.d/kubelet stop"
 if does not exist then restart
-if failed port 10250
-  protocol HTTP request "/healthz"
-  with timeout 10 seconds
-  then restart
+if failed
+  host 127.0.0.1
+  port 10248
+  protocol HTTP
+  request "/healthz"
+then restart

--- a/pkg/master/ports/ports.go
+++ b/pkg/master/ports/ports.go
@@ -17,7 +17,13 @@ limitations under the License.
 package ports
 
 const (
-	// KubeletPort is the default port for the kubelet status server on each host machine.
+	// KubeletStatusPort is the default port for the kubelet healthz server.
+	// May be overridden by a flag at startup.
+	KubeletStatusPort = 10248
+	// ProxyPort is the default port for the proxy healthz server.
+	// May be overriden by a flag at startup.
+	ProxyStatusPort = 10249
+	// KubeletPort is the default port for the kubelet server on each host machine.
 	// May be overridden by a flag at startup.
 	KubeletPort = 10250
 	// SchedulerPort is the default port for the scheduler status server.
@@ -26,7 +32,4 @@ const (
 	// ControllerManagerPort is the default port for the controller manager status server.
 	// May be overridden by a flag at startup.
 	ControllerManagerPort = 10252
-	// ProxyPort is the default port for the proxy status server.
-	// May be overriden by a flag at startup.
-	ProxyPort = 10249
 )


### PR DESCRIPTION
This is in preparation for the standard kubelet port to switch to SSL only (and eventually to only accepting connections on the SSL port that present a proper client SSL cert).

Also standardize the formatting of the monit config files a bit.
