### PR TITLE
Add NFS Volume Plugin Info to Docs

### DIFF
--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -17,7 +17,7 @@ and to select the type of media to use, for clusters that have several media typ
 
 ## Types of Volumes
 
-Kubernetes currently supports three types of Volumes, but more may be added in the future.
+Kubernetes currently supports multiple types of Volumes. The community welcomes additional contributions.
 
 ### EmptyDir
 
@@ -84,4 +84,8 @@ desiredState:
 id: testpd
 kind: Pod
 ```
+### NFS
 
+Kubernetes NFS volumes allow an existing NFS share to be made available to containers within a pod. 
+
+[The NFS Pod example](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/examples/nfs/test.yaml) demonstrates how to specify the usage of an NFS volume within a pod. In this example one can see that a volumeMount called "myshare" is being mounted onto /var/www/html/mount-test in the container "testpd". The volume "myshare" is defined as type nfs, with the NFS server serving from 172.17.0.2 and exporting directory /tmp as the share. The mount being created in this example is not read only. 

--- a/examples/nfs/test.yaml
+++ b/examples/nfs/test.yaml
@@ -6,12 +6,12 @@ desiredState:
         image: dockerfile/nginx
         volumeMounts:
             # name must match the volume name below
-            - name: nfs
+            - name: myshare
               mountPath: "/var/www/html/mount-test"
     id: nfspd
     version: v1beta1
     volumes:
-      - name: nfs
+      - name: myshare
         source:
           nfs:
             server: "172.17.0.2"


### PR DESCRIPTION
Now that we have the NFS Volume Plugin committed, we need to edit the Volumes doc page to describe  how to configure and use it. While the Plugin was committed with a pod file example,the example is minorly confusing in that it uses "nfs" as both the volume name and type. I've clarified this by renaming the name as "myshare" in the example, hence the inclusion of the example file in this PR.

Incidentally, the Volumes page is going to become an unnecessarily large if we include the pod example in-line with every plugin description. The NFS description links to the example file instead. I plan to follow this approach for the up-coming docs for Gluster File and Ceph Block.
