### PR TITLE
kubelet_test: Fix copy bug.

### DIFF
--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -71,7 +71,8 @@ func (f *FakeDockerClient) AssertUnorderedCalls(calls []string) (err error) {
 	f.Lock()
 	defer f.Unlock()
 
-	var actual, expected []string
+	actual := make([]string, len(calls))
+	expected := make([]string, len(f.called))
 	copy(actual, calls)
 	copy(expected, f.called)
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -144,7 +144,8 @@ func verifyStringArrayEquals(t *testing.T, actual, expected []string) {
 }
 
 func verifyStringArrayEqualsAnyOrder(t *testing.T, actual, expected []string) {
-	var act, exp []string
+	act := make([]string, len(actual))
+	exp := make([]string, len(expected))
 	copy(act, actual)
 	copy(exp, expected)
 


### PR DESCRIPTION
Initialize the slice before copying in verifyUnorderedCalls()
and verifyStringArrayEqualsAnyOrder().

Oops, found a bug caused by https://github.com/GoogleCloudPlatform/kubernetes/pull/6022 during updating tests :P

@vmarmol 
