### PR TITLE
Retry kube-addons creation if kube-addons creation fails.

### DIFF
--- a/cluster/saltbase/salt/kube-addons/initd
+++ b/cluster/saltbase/salt/kube-addons/initd
@@ -26,14 +26,32 @@ KUBECTL=/usr/local/bin/kubectl
 # and status_of_proc is working.
 . /lib/lsb/init-functions
 
+# $1 addon to start.
+# $2 count of tries to start the addon.
+# $3 delay in seconds between two consecutive tries
+function start_addon() {
+  addon=$1;
+  tries=$2;
+  delay=$3;
+  while [ ${tries} -gt 0 ]; do
+    ${KUBECTL} create -f ${addon} && \
+        echo "== Successfully started ${addon} at $(date -Is)" && \
+        return 0;
+    let tries=tries-1;
+    echo "== Failed to start ${addon} at $(date -Is). ${tries} tries remaining. =="
+    sleep ${delay};
+  done
+  return 1;
+}
+
 function addon_manager_async() {
     # The business logic for whether a given object should be created
     # was already enforced by salt, and /etc/kubernetes/addons is the
     # managed result is of that. Start everything below that directory.
     echo "== Kubernetes addon manager started at $(date -Is) =="
     for obj in $(find /etc/kubernetes/addons -name \*.yaml); do
-	    ${KUBECTL} create -f ${obj} &
-	    echo "++ addon ${obj} started in pid $! ++"
+        start_addon ${obj} 100 10 &
+        echo "++ addon ${obj} starting in pid $! ++"
     done
     noerrors="true"
     for pid in $(jobs -p); do
@@ -51,6 +69,7 @@ function addon_manager_async() {
     # is simple.)
     sleep infinity
 }
+
 
 #
 # Function that starts the daemon/service


### PR DESCRIPTION
etcd/kube-apiserver might not be up when kube-addons are being created.
added retry logic for kube-addons creation to give time for kube-apiserver & etcd to come up.
