### PR TITLE
Ensure root scope types have no namespace set

### DIFF
--- a/pkg/api/context.go
+++ b/pkg/api/context.go
@@ -61,6 +61,11 @@ func WithNamespace(parent Context, namespace string) Context {
 	return WithValue(parent, namespaceKey, namespace)
 }
 
+// WithoutNamespace returns a copy of parent in which the namespace value is set to NamespaceNone
+func WithoutNamespace(parent Context) Context {
+	return WithValue(parent, namespaceKey, NamespaceNone)
+}
+
 // NamespaceFrom returns the value of the namespace key on the ctx
 func NamespaceFrom(ctx Context) (string, bool) {
 	namespace, ok := ctx.Value(namespaceKey).(string)

--- a/pkg/api/rest/create.go
+++ b/pkg/api/rest/create.go
@@ -57,7 +57,14 @@ func BeforeCreate(strategy RESTCreateStrategy, ctx api.Context, obj runtime.Obje
 			return errors.NewBadRequest("the namespace of the provided object does not match the namespace sent on the request")
 		}
 	} else {
-		objectMeta.Namespace = api.NamespaceNone
+		if ns, ok := api.NamespaceFrom(ctx); ok && ns != api.NamespaceNone {
+			return errors.NewBadRequest("namespace is not allowed on this type")
+		}
+		if objectMeta.Namespace != api.NamespaceNone {
+			return errors.NewInvalid(kind, objectMeta.Name, fielderrors.ValidationErrorList{
+				fielderrors.NewFieldInvalid("metadata.namespace", objectMeta.Namespace, "namespace is not allowed on this type"),
+			})
+		}
 	}
 	strategy.PrepareForCreate(obj)
 	api.FillObjectMetaSystemFields(ctx, objectMeta)

--- a/pkg/api/rest/resttest/resttest.go
+++ b/pkg/api/rest/resttest/resttest.go
@@ -36,6 +36,8 @@ type Tester struct {
 	clusterScope bool
 }
 
+const testNamespace = "test"
+
 type injectErrorFunc func(err error)
 
 func New(t *testing.T, storage rest.Storage, storageError injectErrorFunc) *Tester {
@@ -61,7 +63,7 @@ func (t *Tester) newContext() api.Context {
 	if t.clusterScope {
 		return api.NewContext()
 	}
-	return api.NewDefaultContext()
+	return api.WithNamespace(api.NewContext(), testNamespace)
 }
 
 func copyOrDie(obj runtime.Object) runtime.Object {
@@ -113,7 +115,7 @@ func (t *Tester) TestCreateHasMetadata(valid runtime.Object) {
 	}
 
 	objectMeta.Name = "test"
-	objectMeta.Namespace = api.NamespaceDefault
+	objectMeta.Namespace = testNamespace
 	if t.clusterScope {
 		objectMeta.Namespace = api.NamespaceNone
 	}

--- a/pkg/api/rest/resttest/resttest.go
+++ b/pkg/api/rest/resttest/resttest.go
@@ -57,6 +57,13 @@ func (t *Tester) ClusterScope() *Tester {
 	return t
 }
 
+func (t *Tester) newContext() api.Context {
+	if t.clusterScope {
+		return api.NewContext()
+	}
+	return api.NewDefaultContext()
+}
+
 func copyOrDie(obj runtime.Object) runtime.Object {
 	out, err := api.Scheme.Copy(obj)
 	if err != nil {
@@ -87,7 +94,7 @@ func (t *Tester) TestCreateResetsUserData(valid runtime.Object) {
 	objectMeta.UID = "bad-uid"
 	objectMeta.CreationTimestamp = now
 
-	obj, err := t.storage.(rest.Creater).Create(api.NewDefaultContext(), valid)
+	obj, err := t.storage.(rest.Creater).Create(t.newContext(), valid)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -107,13 +114,11 @@ func (t *Tester) TestCreateHasMetadata(valid runtime.Object) {
 
 	objectMeta.Name = "test"
 	objectMeta.Namespace = api.NamespaceDefault
-	context := api.NewDefaultContext()
 	if t.clusterScope {
 		objectMeta.Namespace = api.NamespaceNone
-		context = api.NewContext()
 	}
 
-	obj, err := t.storage.(rest.Creater).Create(context, valid)
+	obj, err := t.storage.(rest.Creater).Create(t.newContext(), valid)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -133,7 +138,7 @@ func (t *Tester) TestCreateGeneratesName(valid runtime.Object) {
 
 	objectMeta.GenerateName = "test-"
 
-	_, err = t.storage.(rest.Creater).Create(api.NewDefaultContext(), valid)
+	_, err = t.storage.(rest.Creater).Create(t.newContext(), valid)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -150,7 +155,7 @@ func (t *Tester) TestCreateGeneratesNameReturnsServerTimeout(valid runtime.Objec
 
 	objectMeta.GenerateName = "test-"
 	t.withStorageError(errors.NewAlreadyExists("kind", "thing"), func() {
-		_, err := t.storage.(rest.Creater).Create(api.NewDefaultContext(), valid)
+		_, err := t.storage.(rest.Creater).Create(t.newContext(), valid)
 		if err == nil || !errors.IsServerTimeout(err) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -159,7 +164,7 @@ func (t *Tester) TestCreateGeneratesNameReturnsServerTimeout(valid runtime.Objec
 
 func (t *Tester) TestCreateInvokesValidation(invalid ...runtime.Object) {
 	for i, obj := range invalid {
-		ctx := api.NewDefaultContext()
+		ctx := t.newContext()
 		_, err := t.storage.(rest.Creater).Create(ctx, obj)
 		if !errors.IsInvalid(err) {
 			t.Errorf("%d: Expected to get an invalid resource error, got %v", i, err)
@@ -175,11 +180,11 @@ func (t *Tester) TestCreateRejectsMismatchedNamespace(valid runtime.Object) {
 
 	objectMeta.Namespace = "not-default"
 
-	_, err = t.storage.(rest.Creater).Create(api.NewDefaultContext(), valid)
+	_, err = t.storage.(rest.Creater).Create(t.newContext(), valid)
 	if err == nil {
 		t.Errorf("Expected an error, but we didn't get one")
-	} else if strings.Contains(err.Error(), "Controller.Namespace does not match the provided context") {
-		t.Errorf("Expected 'Controller.Namespace does not match the provided context' error, got '%v'", err.Error())
+	} else if !strings.Contains(err.Error(), "does not match the namespace sent on the request") {
+		t.Errorf("Expected 'does not match the namespace sent on the request' error, got '%v'", err.Error())
 	}
 }
 
@@ -189,13 +194,32 @@ func (t *Tester) TestCreateRejectsNamespace(valid runtime.Object) {
 		t.Fatalf("object does not have ObjectMeta: %v\n%#v", err, valid)
 	}
 
+	// Reject on non-empty namespace in object meta
 	objectMeta.Namespace = "not-default"
 
-	_, err = t.storage.(rest.Creater).Create(api.NewDefaultContext(), valid)
+	_, err = t.storage.(rest.Creater).Create(t.newContext(), copyOrDie(valid))
 	if err == nil {
 		t.Errorf("Expected an error, but we didn't get one")
-	} else if strings.Contains(err.Error(), "Controller.Namespace does not match the provided context") {
-		t.Errorf("Expected 'Controller.Namespace does not match the provided context' error, got '%v'", err.Error())
+	} else if !strings.Contains(err.Error(), "namespace is not allowed on this type") {
+		t.Errorf("Expected 'namespace is not allowed on this type' error, got '%v'", err.Error())
+	}
+
+	// Reject on mismatched non-empty namespace in context
+	objectMeta.Namespace = ""
+	_, err = t.storage.(rest.Creater).Create(api.NewDefaultContext(), copyOrDie(valid))
+	if err == nil {
+		t.Errorf("Expected an error, but we didn't get one")
+	} else if !strings.Contains(err.Error(), "namespace is not allowed on this type") {
+		t.Errorf("Expected 'namespace is not allowed on this type' error, got '%v'", err.Error())
+	}
+
+	// Reject on matching non-empty namespace in context
+	objectMeta.Namespace = "default"
+	_, err = t.storage.(rest.Creater).Create(api.NewDefaultContext(), copyOrDie(valid))
+	if err == nil {
+		t.Errorf("Expected an error, but we didn't get one")
+	} else if !strings.Contains(err.Error(), "namespace is not allowed on this type") {
+		t.Errorf("Expected 'namespace is not allowed on this type' error, got '%v'", err.Error())
 	}
 }
 
@@ -205,7 +229,7 @@ func (t *Tester) TestDeleteInvokesValidation(invalid ...runtime.Object) {
 		if err != nil {
 			t.Fatalf("object does not have ObjectMeta: %v\n%#v", err, obj)
 		}
-		ctx := api.NewDefaultContext()
+		ctx := t.newContext()
 		_, err = t.storage.(rest.GracefulDeleter).Delete(ctx, objectMeta.Name, nil)
 		if !errors.IsInvalid(err) {
 			t.Errorf("%d: Expected to get an invalid resource error, got %v", i, err)
@@ -227,7 +251,7 @@ func (t *Tester) TestDeleteNonExist(createFn func() runtime.Object) {
 	if err != nil {
 		t.Fatalf("object does not have ObjectMeta: %v\n%#v", err, existing)
 	}
-	context := api.NewDefaultContext()
+	context := t.newContext()
 
 	t.withStorageError(&etcd.EtcdError{ErrorCode: tools.EtcdErrorCodeNotFound}, func() {
 		_, err := t.storage.(rest.GracefulDeleter).Delete(context, objectMeta.Name, nil)
@@ -249,7 +273,7 @@ func (t *Tester) TestDeleteNoGraceful(createFn func() runtime.Object, wasGracefu
 		t.Fatalf("object does not have ObjectMeta: %v\n%#v", err, existing)
 	}
 
-	ctx := api.WithNamespace(api.NewContext(), objectMeta.Namespace)
+	ctx := api.WithNamespace(t.newContext(), objectMeta.Namespace)
 	_, err = t.storage.(rest.GracefulDeleter).Delete(ctx, objectMeta.Name, api.NewDeleteOptions(10))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -268,7 +292,7 @@ func (t *Tester) TestDeleteGracefulHasDefault(existing runtime.Object, expectedG
 		t.Fatalf("object does not have ObjectMeta: %v\n%#v", err, existing)
 	}
 
-	ctx := api.WithNamespace(api.NewContext(), objectMeta.Namespace)
+	ctx := api.WithNamespace(t.newContext(), objectMeta.Namespace)
 	_, err = t.storage.(rest.GracefulDeleter).Delete(ctx, objectMeta.Name, &api.DeleteOptions{})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -287,7 +311,7 @@ func (t *Tester) TestDeleteGracefulUsesZeroOnNil(existing runtime.Object, expect
 		t.Fatalf("object does not have ObjectMeta: %v\n%#v", err, existing)
 	}
 
-	ctx := api.WithNamespace(api.NewContext(), objectMeta.Namespace)
+	ctx := api.WithNamespace(t.newContext(), objectMeta.Namespace)
 	_, err = t.storage.(rest.GracefulDeleter).Delete(ctx, objectMeta.Name, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/pkg/api/rest/update.go
+++ b/pkg/api/rest/update.go
@@ -55,7 +55,14 @@ func BeforeUpdate(strategy RESTUpdateStrategy, ctx api.Context, obj, old runtime
 			return errors.NewBadRequest("the namespace of the provided object does not match the namespace sent on the request")
 		}
 	} else {
-		objectMeta.Namespace = api.NamespaceNone
+		if ns, ok := api.NamespaceFrom(ctx); ok && ns != api.NamespaceNone {
+			return errors.NewBadRequest("namespace is not allowed on this type")
+		}
+		if objectMeta.Namespace != api.NamespaceNone {
+			return errors.NewInvalid(kind, objectMeta.Name, fielderrors.ValidationErrorList{
+				fielderrors.NewFieldInvalid("metadata.namespace", objectMeta.Namespace, "namespace is not allowed on this type"),
+			})
+		}
 	}
 	strategy.PrepareForUpdate(obj, old)
 	if errs := strategy.ValidateUpdate(ctx, obj, old); len(errs) > 0 {

--- a/pkg/apiserver/handlers_test.go
+++ b/pkg/apiserver/handlers_test.go
@@ -151,6 +151,15 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		{"GET", "/namespaces", "list", "", "", "namespaces", "", "Namespace", "", []string{"namespaces"}},
 		{"GET", "/namespaces/other", "get", "", "other", "namespaces", "", "Namespace", "other", []string{"namespaces", "other"}},
 
+		// root scope type paths
+		{"GET", "/minions", "list", "", "", "minions", "", "Minion", "", []string{"minions"}},
+		{"GET", "/minions/foo", "get", "", "", "minions", "", "Minion", "foo", []string{"minions", "foo"}},
+		{"PUT", "/minions/foo", "update", "", "", "minions", "", "Minion", "foo", []string{"minions", "foo"}},
+		{"POST", "/minions", "create", "", "", "minions", "", "Minion", "", []string{"minions"}},
+		{"DELETE", "/minions/foo", "delete", "", "", "minions", "", "Minion", "foo", []string{"minions", "foo"}},
+		{"GET", "/proxy/minions/foo", "proxy", "", "", "minions", "", "Minion", "foo", []string{"minions", "foo"}},
+		{"GET", "/redirect/minions/foo", "redirect", "", "", "minions", "", "Minion", "foo", []string{"minions", "foo"}},
+
 		{"GET", "/namespaces/other/pods", "list", "", "other", "pods", "", "Pod", "", []string{"pods"}},
 		{"GET", "/namespaces/other/pods/foo", "get", "", "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
 		{"GET", "/pods", "list", "", api.NamespaceAll, "pods", "", "Pod", "", []string{"pods"}},
@@ -179,6 +188,15 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		{"GET", "/api/v1beta1/redirect/pods/foo", "redirect", "v1beta1", api.NamespaceDefault, "pods", "", "Pod", "foo", []string{"pods", "foo"}},
 		{"GET", "/api/v1beta1/watch/pods", "watch", "v1beta1", api.NamespaceAll, "pods", "", "Pod", "", []string{"pods"}},
 		{"GET", "/api/v1beta1/watch/namespaces/other/pods", "watch", "v1beta1", "other", "pods", "", "Pod", "", []string{"pods"}},
+
+		// fully-qualified root scope type paths
+		{"GET", "/api/v1beta1/minions", "list", "v1beta1", "", "minions", "", "Minion", "", []string{"minions"}},
+		{"GET", "/api/v1beta1/minions/foo", "get", "v1beta1", "", "minions", "", "Minion", "foo", []string{"minions", "foo"}},
+		{"PUT", "/api/v1beta1/minions/foo", "update", "v1beta1", "", "minions", "", "Minion", "foo", []string{"minions", "foo"}},
+		{"POST", "/api/v1beta1/minions", "create", "v1beta1", "", "minions", "", "Minion", "", []string{"minions"}},
+		{"DELETE", "/api/v1beta1/minions/foo", "delete", "v1beta1", "", "minions", "", "Minion", "foo", []string{"minions", "foo"}},
+		{"GET", "/api/v1beta1/proxy/minions/foo", "proxy", "v1beta1", "", "minions", "", "Minion", "foo", []string{"minions", "foo"}},
+		{"GET", "/api/v1beta1/redirect/minions/foo", "redirect", "v1beta1", "", "minions", "", "Minion", "foo", []string{"minions", "foo"}},
 
 		// subresource identification
 		{"GET", "/namespaces/other/pods/foo/status", "get", "", "other", "pods", "status", "Pod", "foo", []string{"pods", "foo", "status"}},

--- a/pkg/apiserver/handlers_test.go
+++ b/pkg/apiserver/handlers_test.go
@@ -147,9 +147,14 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		expectedParts       []string
 	}{
 
-		// resource paths
+		// namespace paths
 		{"GET", "/namespaces", "list", "", "", "namespaces", "", "Namespace", "", []string{"namespaces"}},
 		{"GET", "/namespaces/other", "get", "", "other", "namespaces", "", "Namespace", "other", []string{"namespaces", "other"}},
+		{"PUT", "/namespaces/other", "update", "", "other", "namespaces", "", "Namespace", "other", []string{"namespaces", "other"}},
+		{"POST", "/namespaces", "create", "", "", "namespaces", "", "Namespace", "", []string{"namespaces"}},
+		{"DELETE", "/namespaces/other", "delete", "", "other", "namespaces", "", "Namespace", "other", []string{"namespaces", "other"}},
+		{"GET", "/proxy/namespaces/other", "proxy", "", "other", "namespaces", "", "Namespace", "other", []string{"namespaces", "other"}},
+		{"GET", "/redirect/namespaces/other", "redirect", "", "other", "namespaces", "", "Namespace", "other", []string{"namespaces", "other"}},
 
 		// root scope type paths
 		{"GET", "/minions", "list", "", "", "minions", "", "Minion", "", []string{"minions"}},
@@ -160,6 +165,7 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		{"GET", "/proxy/minions/foo", "proxy", "", "", "minions", "", "Minion", "foo", []string{"minions", "foo"}},
 		{"GET", "/redirect/minions/foo", "redirect", "", "", "minions", "", "Minion", "foo", []string{"minions", "foo"}},
 
+		// resource paths
 		{"GET", "/namespaces/other/pods", "list", "", "other", "pods", "", "Pod", "", []string{"pods"}},
 		{"GET", "/namespaces/other/pods/foo", "get", "", "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
 		{"GET", "/pods", "list", "", api.NamespaceAll, "pods", "", "Pod", "", []string{"pods"}},
@@ -200,6 +206,7 @@ func TestGetAPIRequestInfo(t *testing.T) {
 
 		// subresource identification
 		{"GET", "/namespaces/other/pods/foo/status", "get", "", "other", "pods", "status", "Pod", "foo", []string{"pods", "foo", "status"}},
+		{"PUT", "/namespaces/other/status", "update", "", "other", "status", "", "", "", []string{"status"}},
 		{"PUT", "/namespaces/other/finalize", "update", "", "other", "finalize", "", "", "", []string{"finalize"}},
 	}
 

--- a/pkg/registry/controller/etcd/etcd.go
+++ b/pkg/registry/controller/etcd/etcd.go
@@ -45,7 +45,7 @@ func NewREST(h tools.EtcdHelper) *REST {
 		NewListFunc: func() runtime.Object { return &api.ReplicationControllerList{} },
 		// Produces a path that etcd understands, to the root of the resource
 		// by combining the namespace in the context with the given prefix
-		KeyRootFunc: func(ctx api.Context) string {
+		KeyRootFunc: func(ctx api.Context) (string, error) {
 			return etcdgeneric.NamespaceKeyRootFunc(ctx, controllerPrefix)
 		},
 		// Produces a path that etcd understands, to the resource by combining

--- a/pkg/registry/controller/etcd/etcd_test.go
+++ b/pkg/registry/controller/etcd/etcd_test.go
@@ -95,7 +95,7 @@ func makeControllerKey(ctx api.Context, id string) (string, error) {
 
 // makeControllerListKey constructs etcd paths to the root of the resource,
 // not a specific controller resource
-func makeControllerListKey(ctx api.Context) string {
+func makeControllerListKey(ctx api.Context) (string, error) {
 	return etcdgeneric.NamespaceKeyRootFunc(ctx, controllerPrefix)
 }
 
@@ -381,7 +381,10 @@ func TestEtcdDeleteController(t *testing.T) {
 func TestEtcdListControllers(t *testing.T) {
 	storage, fakeClient := newStorage(t)
 	ctx := api.NewDefaultContext()
-	key := makeControllerListKey(ctx)
+	key, err := makeControllerListKey(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	controller := validController
 	controller.Name = "bar"
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
@@ -412,7 +415,10 @@ func TestEtcdListControllers(t *testing.T) {
 func TestEtcdListControllersNotFound(t *testing.T) {
 	storage, fakeClient := newStorage(t)
 	ctx := api.NewDefaultContext()
-	key := makeControllerListKey(ctx)
+	key, err := makeControllerListKey(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
 		E: tools.EtcdErrorNotFound,
@@ -430,7 +436,10 @@ func TestEtcdListControllersNotFound(t *testing.T) {
 func TestEtcdListControllersLabelsMatch(t *testing.T) {
 	storage, fakeClient := newStorage(t)
 	ctx := api.NewDefaultContext()
-	key := makeControllerListKey(ctx)
+	key, err := makeControllerListKey(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	controller := validController
 	controller.Labels = map[string]string{"k": "v"}
@@ -494,7 +503,11 @@ func TestEtcdWatchController(t *testing.T) {
 func TestEtcdWatchControllersMatch(t *testing.T) {
 	ctx := api.WithNamespace(api.NewDefaultContext(), validController.Namespace)
 	storage, fakeClient := newStorage(t)
-	fakeClient.ExpectNotFoundGet(etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/pods"))
+	key, err := etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/pods")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fakeClient.ExpectNotFoundGet(key)
 
 	watching, err := storage.Watch(ctx,
 		labels.SelectorFromSet(validController.Spec.Selector),
@@ -537,7 +550,11 @@ func TestEtcdWatchControllersMatch(t *testing.T) {
 func TestEtcdWatchControllersFields(t *testing.T) {
 	ctx := api.WithNamespace(api.NewDefaultContext(), validController.Namespace)
 	storage, fakeClient := newStorage(t)
-	fakeClient.ExpectNotFoundGet(etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/pods"))
+	key, err := etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/pods")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fakeClient.ExpectNotFoundGet(key)
 
 	testFieldMap := map[int][]fields.Set{
 		PASS: {
@@ -618,7 +635,11 @@ func TestEtcdWatchControllersFields(t *testing.T) {
 func TestEtcdWatchControllersNotMatch(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	storage, fakeClient := newStorage(t)
-	fakeClient.ExpectNotFoundGet(etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/pods"))
+	key, err := etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/pods")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fakeClient.ExpectNotFoundGet(key)
 
 	watching, err := storage.Watch(ctx,
 		labels.SelectorFromSet(labels.Set{"name": "foo"}),

--- a/pkg/registry/endpoint/etcd/etcd.go
+++ b/pkg/registry/endpoint/etcd/etcd.go
@@ -39,7 +39,7 @@ func NewStorage(h tools.EtcdHelper) *REST {
 		&etcdgeneric.Etcd{
 			NewFunc:     func() runtime.Object { return &api.Endpoints{} },
 			NewListFunc: func() runtime.Object { return &api.EndpointsList{} },
-			KeyRootFunc: func(ctx api.Context) string {
+			KeyRootFunc: func(ctx api.Context) (string, error) {
 				return etcdgeneric.NamespaceKeyRootFunc(ctx, prefix)
 			},
 			KeyFunc: func(ctx api.Context, name string) (string, error) {

--- a/pkg/registry/endpoint/etcd/etcd_test.go
+++ b/pkg/registry/endpoint/etcd/etcd_test.go
@@ -112,7 +112,10 @@ func TestDelete(t *testing.T) {
 func TestEtcdListEndpoints(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	storage, fakeClient := newStorage(t)
-	key := storage.KeyRootFunc(ctx)
+	key, err := storage.KeyRootFunc(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
@@ -182,7 +185,10 @@ func TestListEmptyEndpointsList(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	storage, fakeClient := newStorage(t)
 	fakeClient.ChangeIndex = 1
-	key := storage.KeyRootFunc(ctx)
+	key, err := storage.KeyRootFunc(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
 		E: fakeClient.NewError(tools.EtcdErrorCodeNotFound),
@@ -205,7 +211,10 @@ func TestListEndpointsList(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	storage, fakeClient := newStorage(t)
 	fakeClient.ChangeIndex = 1
-	key := storage.KeyRootFunc(ctx)
+	key, err := storage.KeyRootFunc(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{

--- a/pkg/registry/etcd/etcd_test.go
+++ b/pkg/registry/etcd/etcd_test.go
@@ -311,7 +311,11 @@ func TestEtcdWatchController(t *testing.T) {
 func TestEtcdWatchControllersMatch(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.ExpectNotFoundGet(etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/pods"))
+	key, err := etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/pods")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fakeClient.ExpectNotFoundGet(key)
 	registry := NewTestEtcdRegistryWithPods(fakeClient)
 	watching, err := registry.WatchControllers(ctx,
 		labels.SelectorFromSet(labels.Set{"name": "foo"}),
@@ -352,7 +356,11 @@ func TestEtcdWatchControllersMatch(t *testing.T) {
 func TestEtcdWatchControllersNotMatch(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	fakeClient := tools.NewFakeEtcdClient(t)
-	fakeClient.ExpectNotFoundGet(etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/pods"))
+	key, err := etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/pods")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fakeClient.ExpectNotFoundGet(key)
 	registry := NewTestEtcdRegistryWithPods(fakeClient)
 	watching, err := registry.WatchControllers(ctx,
 		labels.SelectorFromSet(labels.Set{"name": "foo"}),

--- a/pkg/registry/event/registry.go
+++ b/pkg/registry/event/registry.go
@@ -37,7 +37,7 @@ func NewEtcdRegistry(h tools.EtcdHelper, ttl uint64) generic.Registry {
 			NewFunc:      func() runtime.Object { return &api.Event{} },
 			NewListFunc:  func() runtime.Object { return &api.EventList{} },
 			EndpointName: "events",
-			KeyRootFunc: func(ctx api.Context) string {
+			KeyRootFunc: func(ctx api.Context) (string, error) {
 				return etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/events")
 			},
 			KeyFunc: func(ctx api.Context, id string) (string, error) {

--- a/pkg/registry/generic/etcd/etcd_test.go
+++ b/pkg/registry/generic/etcd/etcd_test.go
@@ -74,7 +74,7 @@ func NewTestGenericEtcdRegistry(t *testing.T) (*tools.FakeEtcdClient, *Etcd) {
 		EndpointName:   "pods",
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,
-		KeyRootFunc:    func(ctx api.Context) string { return "/registry/pods" },
+		KeyRootFunc:    func(ctx api.Context) (string, error) { return "/registry/pods", nil },
 		KeyFunc: func(ctx api.Context, id string) (string, error) {
 			return path.Join("/registry/pods", id), nil
 		},
@@ -207,7 +207,12 @@ func TestEtcdList(t *testing.T) {
 			}
 			fakeClient.Data[key] = item.in
 		} else {
-			fakeClient.Data[registry.KeyRootFunc(api.NewContext())] = item.in
+			key, err := registry.KeyRootFunc(api.NewContext())
+			if err != nil {
+				t.Errorf("%v: unexpected error: %v", name, err)
+				continue
+			}
+			fakeClient.Data[key] = item.in
 		}
 		list, err := registry.ListPredicate(api.NewContext(), item.m)
 		if e, a := item.succeed, err == nil; e != a {

--- a/pkg/registry/limitrange/registry.go
+++ b/pkg/registry/limitrange/registry.go
@@ -36,7 +36,7 @@ func NewEtcdRegistry(h tools.EtcdHelper) generic.Registry {
 			NewFunc:      func() runtime.Object { return &api.LimitRange{} },
 			NewListFunc:  func() runtime.Object { return &api.LimitRangeList{} },
 			EndpointName: "limitranges",
-			KeyRootFunc: func(ctx api.Context) string {
+			KeyRootFunc: func(ctx api.Context) (string, error) {
 				return etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/limitranges")
 			},
 			KeyFunc: func(ctx api.Context, id string) (string, error) {

--- a/pkg/registry/minion/etcd/etcd.go
+++ b/pkg/registry/minion/etcd/etcd.go
@@ -54,11 +54,11 @@ func NewStorage(h tools.EtcdHelper, connection client.ConnectionInfoGetter) (*RE
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.Node{} },
 		NewListFunc: func() runtime.Object { return &api.NodeList{} },
-		KeyRootFunc: func(ctx api.Context) string {
-			return prefix
+		KeyRootFunc: func(ctx api.Context) (string, error) {
+			return etcdgeneric.NoNamespaceKeyRootFunc(ctx, prefix)
 		},
 		KeyFunc: func(ctx api.Context, name string) (string, error) {
-			return prefix + "/" + name, nil
+			return etcdgeneric.NoNamespaceKeyFunc(ctx, prefix, name)
 		},
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*api.Node).Name, nil

--- a/pkg/registry/namespace/etcd/etcd.go
+++ b/pkg/registry/namespace/etcd/etcd.go
@@ -48,14 +48,15 @@ type FinalizeREST struct {
 
 // NewStorage returns a RESTStorage object that will work against namespaces
 func NewStorage(h tools.EtcdHelper) (*REST, *StatusREST, *FinalizeREST) {
+	prefix := "/registry/namespaces"
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.Namespace{} },
 		NewListFunc: func() runtime.Object { return &api.NamespaceList{} },
-		KeyRootFunc: func(ctx api.Context) string {
-			return "/registry/namespaces"
+		KeyRootFunc: func(ctx api.Context) (string, error) {
+			return etcdgeneric.NoNamespaceKeyRootFunc(ctx, prefix)
 		},
 		KeyFunc: func(ctx api.Context, name string) (string, error) {
-			return "/registry/namespaces/" + name, nil
+			return etcdgeneric.NoNamespaceKeyFunc(ctx, prefix, name)
 		},
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*api.Namespace).Name, nil

--- a/pkg/registry/namespace/etcd/etcd.go
+++ b/pkg/registry/namespace/etcd/etcd.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
@@ -80,6 +81,35 @@ func NewStorage(h tools.EtcdHelper) (*REST, *StatusREST, *FinalizeREST) {
 	return &REST{Etcd: store, status: &statusStore}, &StatusREST{store: &statusStore}, &FinalizeREST{store: &finalizeStore}
 }
 
+// validateContext checks for either of these conditions
+// - ctx has no namespace set (valid since Namespace is a root-scoped type)
+// - ctx has a namespace equal to the given name (valid since getting/updating/deleting a Namespace is considered scoped to that namespace)
+func validateContext(ctx api.Context, name string) error {
+	ns := api.NamespaceValue(ctx)
+	if ns != api.NamespaceNone && ns != name {
+		return errors.NewBadRequest("Namespace in context does not match namespace name")
+	}
+	return nil
+}
+
+// Get overrides the default implementation to validate the namespace in the context,
+// then call the generic etcd registry without a namespace in the context
+func (r *REST) Get(ctx api.Context, name string) (runtime.Object, error) {
+	if err := validateContext(ctx, name); err != nil {
+		return nil, err
+	}
+	return r.Etcd.Get(api.WithoutNamespace(ctx), name)
+}
+
+// Update overrides the default implementation to validate the namespace in the context,
+// then call the generic etcd registry without a namespace in the context
+func (r *REST) Update(ctx api.Context, obj runtime.Object) (runtime.Object, bool, error) {
+	if err := validateContext(ctx, obj.(*api.Namespace).Name); err != nil {
+		return nil, false, err
+	}
+	return r.Etcd.Update(api.WithoutNamespace(ctx), obj)
+}
+
 // Delete enforces life-cycle rules for namespace termination
 func (r *REST) Delete(ctx api.Context, name string, options *api.DeleteOptions) (runtime.Object, error) {
 	nsObj, err := r.Get(ctx, name)
@@ -88,6 +118,7 @@ func (r *REST) Delete(ctx api.Context, name string, options *api.DeleteOptions) 
 	}
 
 	namespace := nsObj.(*api.Namespace)
+	ctx = api.WithoutNamespace(ctx)
 
 	// upon first request to delete, we switch the phase to start namespace termination
 	if namespace.DeletionTimestamp.IsZero() {
@@ -111,8 +142,13 @@ func (r *StatusREST) New() runtime.Object {
 }
 
 // Update alters the status subset of an object.
+// This function validates the namespace in the context,
+// then calls the generic etcd registry without a namespace in the context
 func (r *StatusREST) Update(ctx api.Context, obj runtime.Object) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, obj)
+	if err := validateContext(ctx, obj.(*api.Namespace).Name); err != nil {
+		return nil, false, err
+	}
+	return r.store.Update(api.WithoutNamespace(ctx), obj)
 }
 
 func (r *FinalizeREST) New() runtime.Object {
@@ -120,6 +156,11 @@ func (r *FinalizeREST) New() runtime.Object {
 }
 
 // Update alters the status finalizers subset of an object.
+// This function validates the namespace in the context,
+// then calls the generic etcd registry without a namespace in the context
 func (r *FinalizeREST) Update(ctx api.Context, obj runtime.Object) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, obj)
+	if err := validateContext(ctx, obj.(*api.Namespace).Name); err != nil {
+		return nil, false, err
+	}
+	return r.store.Update(api.WithoutNamespace(ctx), obj)
 }

--- a/pkg/registry/namespace/etcd/etcd_test.go
+++ b/pkg/registry/namespace/etcd/etcd_test.go
@@ -70,9 +70,10 @@ func TestStorage(t *testing.T) {
 func TestCreate(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
 	storage, _, _ := NewStorage(helper)
-	test := resttest.New(t, storage, fakeEtcdClient.SetError)
+	test := resttest.New(t, storage, fakeEtcdClient.SetError).ClusterScope()
 	namespace := validNewNamespace()
-	namespace.ObjectMeta = api.ObjectMeta{}
+	namespace.Name = ""
+	namespace.GenerateName = "foo"
 	test.TestCreate(
 		// valid
 		namespace,
@@ -96,7 +97,7 @@ func TestCreateSetsFields(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
 	storage, _, _ := NewStorage(helper)
 	namespace := validNewNamespace()
-	_, err := storage.Create(api.NewDefaultContext(), namespace)
+	_, err := storage.Create(api.NewContext(), namespace)
 	if err != fakeEtcdClient.Err {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -158,7 +159,7 @@ func TestListNamespaceList(t *testing.T) {
 		},
 	}
 	storage, _, _ := NewStorage(helper)
-	namespacesObj, err := storage.List(api.NewDefaultContext(), labels.Everything(), fields.Everything())
+	namespacesObj, err := storage.List(api.NewContext(), labels.Everything(), fields.Everything())
 	namespaces := namespacesObj.(*api.NamespaceList)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -205,7 +206,7 @@ func TestListNamespaceListSelection(t *testing.T) {
 		},
 	}
 	storage, _, _ := NewStorage(helper)
-	ctx := api.NewDefaultContext()
+	ctx := api.NewContext()
 	table := []struct {
 		label, field string
 		expectedIDs  util.StringSet
@@ -314,7 +315,7 @@ func TestDeleteNamespace(t *testing.T) {
 		},
 	}
 	storage, _, _ := NewStorage(helper)
-	_, err := storage.Delete(api.NewDefaultContext(), "foo", nil)
+	_, err := storage.Delete(api.NewContext(), "foo", nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -344,7 +345,7 @@ func TestDeleteNamespaceWithIncompleteFinalizers(t *testing.T) {
 		},
 	}
 	storage, _, _ := NewStorage(helper)
-	_, err := storage.Delete(api.NewDefaultContext(), "foo", nil)
+	_, err := storage.Delete(api.NewContext(), "foo", nil)
 	if err == nil {
 		t.Fatalf("expected error: %v", err)
 	}
@@ -373,7 +374,7 @@ func TestDeleteNamespaceWithCompleteFinalizers(t *testing.T) {
 		},
 	}
 	storage, _, _ := NewStorage(helper)
-	_, err := storage.Delete(api.NewDefaultContext(), "foo", nil)
+	_, err := storage.Delete(api.NewContext(), "foo", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/registry/persistentvolume/etcd/etcd.go
+++ b/pkg/registry/persistentvolume/etcd/etcd.go
@@ -38,11 +38,11 @@ func NewStorage(h tools.EtcdHelper) (*REST, *StatusREST) {
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.PersistentVolume{} },
 		NewListFunc: func() runtime.Object { return &api.PersistentVolumeList{} },
-		KeyRootFunc: func(ctx api.Context) string {
-			return prefix
+		KeyRootFunc: func(ctx api.Context) (string, error) {
+			return etcdgeneric.NoNamespaceKeyRootFunc(ctx, prefix)
 		},
 		KeyFunc: func(ctx api.Context, name string) (string, error) {
-			return prefix + "/" + name, nil
+			return etcdgeneric.NoNamespaceKeyFunc(ctx, prefix, name)
 		},
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*api.PersistentVolume).Name, nil

--- a/pkg/registry/persistentvolumeclaim/etcd/etcd.go
+++ b/pkg/registry/persistentvolumeclaim/etcd/etcd.go
@@ -38,7 +38,7 @@ func NewStorage(h tools.EtcdHelper) (*REST, *StatusREST) {
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.PersistentVolumeClaim{} },
 		NewListFunc: func() runtime.Object { return &api.PersistentVolumeClaimList{} },
-		KeyRootFunc: func(ctx api.Context) string {
+		KeyRootFunc: func(ctx api.Context) (string, error) {
 			return etcdgeneric.NamespaceKeyRootFunc(ctx, prefix)
 		},
 		KeyFunc: func(ctx api.Context, name string) (string, error) {

--- a/pkg/registry/persistentvolumeclaim/etcd/etcd_test.go
+++ b/pkg/registry/persistentvolumeclaim/etcd/etcd_test.go
@@ -115,7 +115,10 @@ func TestDelete(t *testing.T) {
 func TestEtcdListPersistentVolumeClaims(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	registry, _, fakeClient, _ := newStorage(t)
-	key := registry.KeyRootFunc(ctx)
+	key, err := registry.KeyRootFunc(ctx)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
@@ -177,7 +180,10 @@ func TestListEmptyPersistentVolumeClaimsList(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	registry, _, fakeClient, _ := newStorage(t)
 	fakeClient.ChangeIndex = 1
-	key := registry.KeyRootFunc(ctx)
+	key, err := registry.KeyRootFunc(ctx)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
 		E: fakeClient.NewError(tools.EtcdErrorCodeNotFound),
@@ -200,7 +206,10 @@ func TestListPersistentVolumeClaimsList(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	registry, _, fakeClient, _ := newStorage(t)
 	fakeClient.ChangeIndex = 1
-	key := registry.KeyRootFunc(ctx)
+	key, err := registry.KeyRootFunc(ctx)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{

--- a/pkg/registry/pod/etcd/etcd.go
+++ b/pkg/registry/pod/etcd/etcd.go
@@ -60,7 +60,7 @@ func NewStorage(h tools.EtcdHelper, k client.ConnectionInfoGetter) PodStorage {
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.Pod{} },
 		NewListFunc: func() runtime.Object { return &api.PodList{} },
-		KeyRootFunc: func(ctx api.Context) string {
+		KeyRootFunc: func(ctx api.Context) (string, error) {
 			return etcdgeneric.NamespaceKeyRootFunc(ctx, prefix)
 		},
 		KeyFunc: func(ctx api.Context, name string) (string, error) {

--- a/pkg/registry/pod/etcd/etcd_test.go
+++ b/pkg/registry/pod/etcd/etcd_test.go
@@ -1232,7 +1232,10 @@ func TestEtcdDeletePodMultipleContainers(t *testing.T) {
 func TestEtcdEmptyList(t *testing.T) {
 	registry, _, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
-	key := registry.KeyRootFunc(ctx)
+	key, err := registry.KeyRootFunc(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
@@ -1255,7 +1258,10 @@ func TestEtcdEmptyList(t *testing.T) {
 func TestEtcdListNotFound(t *testing.T) {
 	registry, _, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
-	key := registry.KeyRootFunc(ctx)
+	key, err := registry.KeyRootFunc(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
 		E: tools.EtcdErrorNotFound,
@@ -1273,7 +1279,10 @@ func TestEtcdListNotFound(t *testing.T) {
 func TestEtcdList(t *testing.T) {
 	registry, _, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
-	key := registry.KeyRootFunc(ctx)
+	key, err := registry.KeyRootFunc(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{

--- a/pkg/registry/resourcequota/etcd/etcd.go
+++ b/pkg/registry/resourcequota/etcd/etcd.go
@@ -38,7 +38,7 @@ func NewStorage(h tools.EtcdHelper) (*REST, *StatusREST) {
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.ResourceQuota{} },
 		NewListFunc: func() runtime.Object { return &api.ResourceQuotaList{} },
-		KeyRootFunc: func(ctx api.Context) string {
+		KeyRootFunc: func(ctx api.Context) (string, error) {
 			return etcdgeneric.NamespaceKeyRootFunc(ctx, prefix)
 		},
 		KeyFunc: func(ctx api.Context, name string) (string, error) {

--- a/pkg/registry/resourcequota/etcd/etcd_test.go
+++ b/pkg/registry/resourcequota/etcd/etcd_test.go
@@ -502,7 +502,10 @@ func TestEtcdUpdateStatus(t *testing.T) {
 func TestEtcdEmptyList(t *testing.T) {
 	registry, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
-	key := registry.KeyRootFunc(ctx)
+	key, err := registry.KeyRootFunc(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
@@ -525,7 +528,10 @@ func TestEtcdEmptyList(t *testing.T) {
 func TestEtcdListNotFound(t *testing.T) {
 	registry, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
-	key := registry.KeyRootFunc(ctx)
+	key, err := registry.KeyRootFunc(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{},
 		E: tools.EtcdErrorNotFound,
@@ -543,7 +549,10 @@ func TestEtcdListNotFound(t *testing.T) {
 func TestEtcdList(t *testing.T) {
 	registry, _, fakeClient, _ := newStorage(t)
 	ctx := api.NewDefaultContext()
-	key := registry.KeyRootFunc(ctx)
+	key, err := registry.KeyRootFunc(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	fakeClient.Data[key] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{

--- a/pkg/registry/secret/registry.go
+++ b/pkg/registry/secret/registry.go
@@ -36,7 +36,7 @@ func NewEtcdRegistry(h tools.EtcdHelper) generic.Registry {
 			NewFunc:      func() runtime.Object { return &api.Secret{} },
 			NewListFunc:  func() runtime.Object { return &api.SecretList{} },
 			EndpointName: "secrets",
-			KeyRootFunc: func(ctx api.Context) string {
+			KeyRootFunc: func(ctx api.Context) (string, error) {
 				return etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/secrets")
 			},
 			KeyFunc: func(ctx api.Context, id string) (string, error) {

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -411,8 +411,6 @@ func TestAuthModeAlwaysAllow(t *testing.T) {
 				if resVersion := previousResourceVersion[getPreviousResourceVersionKey(r.URL, "")]; resVersion != 0 {
 					sub += fmt.Sprintf(",\r\n\"resourceVersion\": \"%v\"", resVersion)
 				}
-				namespace := "default"
-				sub += fmt.Sprintf(",\r\n\"namespace\": %q", namespace)
 			}
 			bodyStr = fmt.Sprintf(r.body, sub)
 		}
@@ -620,8 +618,6 @@ func TestAliceNotForbiddenOrUnauthorized(t *testing.T) {
 				if resVersion := previousResourceVersion[getPreviousResourceVersionKey(r.URL, "")]; resVersion != 0 {
 					sub += fmt.Sprintf(",\r\n\"resourceVersion\": \"%v\"", resVersion)
 				}
-				namespace := "default"
-				sub += fmt.Sprintf(",\r\n\"namespace\": %q", namespace)
 			}
 			bodyStr = fmt.Sprintf(r.body, sub)
 		}


### PR DESCRIPTION
We need to be stricter in ensuring that no namespace is set for root-scoped types. Otherwise, someone could make it through policy checks under a namespace at one layer, then get escalated when another layer ignores the namespace.

These three places were mishandling root-scoped objects:
1. GetAPIRequestInfo sets the request namespace to "default"
2. BeforeCreate/BeforeUpdate sets ObjectMeta.Namespace to "" but ignores a namespace set in the context
3. The etcd key-building functions for root-scoped objects ignore any namespace in the passed context rather than erroring

This PR:
- [x] Adds error return value to root key function to allow indicating errors when the context has an invalid namespace for the type
- [x] Returns errors early in BeforeCreate/BeforeUpdate when an invalid namespace is set in the context or in the object for an unnamespaced type
- [x] Fixes rest tests to use generated names in minion and namespace tests (were getting AlreadyExists errors which was preventing testing the namespace validation conditions)
- [x] Fixes rest test error checking
- [x] Makes minion and node tests use `ClusterScope()`
- [x] Changes GetAPIRequestInfo to stop defaulting `requestInfo.Namespace` to `default` for root-scoped types
