### PR TITLE
Shorten up the AWS getting started guide to point to get.k8s.io.

### DIFF
--- a/docs/getting-started-guides/aws.md
+++ b/docs/getting-started-guides/aws.md
@@ -8,26 +8,19 @@
 
 ### Cluster turnup
 
-#### Download Kubernetes
-##### a) Preferred Option: Install from [0.10.0 release](https://github.com/GoogleCloudPlatform/kubernetes/releases/tag/v0.10.0)
-1. ```wget https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v0.10.0/kubernetes.tar.gz```
-2. ```tar -xzf kubernetes.tar.gz; cd kubernetes```
-3. ```export PATH=$PATH:$PWD/platforms/<os>/<platform>```
-
-##### b) Alternate Option: Install from source at head
-1. ```git clone https://github.com/GoogleCloudPlatform/kubernetes.git```
-2. ```cd kubernetes; make release```
-3. ```export PATH=$PATH:$PWD/_output/local/bin/<os>/<platform>```
-
-#### Turn up the cluster
-```
-export KUBERNETES_PROVIDER=aws
-cluster/kube-up.sh
+Using ```wget```
+```sh
+export KUBERNETES_PROVIDER=aws; wget -q -O - https://get.k8s.io | bash
 ```
 
-The script above relies on AWS S3 to deploy the software to instances running in EC2.
+or if you prefer ```curl```
 
-NOTE: The script will provision a new VPC and a 5 node k8s cluster in us-west-2 (Oregon). It'll also try to create or
+```sh
+export KUBERNETES_PROVIDER=aws; curl -sS https://get.k8s.io | bash
+```
+
+
+NOTE: The script will provision a new VPC and a 4 node k8s cluster in us-west-2 (Oregon). It'll also try to create or
 reuse a keypair called "kubernetes", and IAM profiles called "kubernetes-master" and "kubernetes-minion".  If these
 already exist, make sure you want them to be used here.
 
@@ -39,18 +32,105 @@ export KUBERNETES_MASTER=https://<ip-address>
 
 Also setup your path to point to the released binaries:
 ```
-export PATH=$PATH:$PWD:/cluster
+export PATH=$PATH:$PWD:/kubernetes/cluster
+```
+
+If you run into trouble come ask questions on IRC at #google-containers on freenode.
+
+
+### Running a container (simple version)
+
+Once you have your cluster created you can use ```${SOME_DIR}/kubernetes/cluster/kubectl.sh``` to access
+the kubernetes api.
+
+The `kubectl.sh` line below spins up two containers running
+[Nginx](http://nginx.org/en/) running on port 80:
+
+```bash
+cluster/kubectl.sh run-container my-nginx --image=dockerfile/nginx --replicas=2 --port=80
+```
+
+To stop the containers:
+
+```bash
+cluster/kubectl.sh stop rc my-nginx
+```
+
+To delete the containers:
+
+```bash
+cluster/kubectl.sh delete rc my-nginx
+```
+
+### Running a container (more complete version)
+
+```bash
+cd kubernetes
+cluster/kubectl.sh create -f docs/getting-started-guides/pod.json
+```
+
+Where pod.json contains something like:
+
+```json
+{
+  "id": "php",
+  "kind": "Pod",
+  "apiVersion": "v1beta1",
+  "desiredState": {
+    "manifest": {
+      "version": "v1beta1",
+      "id": "php",
+      "containers": [{
+        "name": "nginx",
+        "image": "dockerfile/nginx",
+        "ports": [{
+          "containerPort": 80,
+          "hostPort": 8081
+        }],
+        "livenessProbe": {
+          "enabled": true,
+          "type": "http",
+          "initialDelaySeconds": 30,
+          "httpGet": {
+            "path": "/index.html",
+            "port": 8081
+          }
+        }
+      }]
+    }
+  },
+  "labels": {
+    "name": "foo"
+  }
+}
+```
+
+You can see your cluster's pods:
+
+```bash
+cluster/kubectl.sh get pods
+```
+
+and delete the pod you just created:
+
+```bash
+cluster/kubectl.sh delete pods php
+```
+
+Since this pod is scheduled on a minion running in AWS, you will have to enable incoming tcp traffic via the port specified in the
+pod manifest before you see the nginx welcome page. After doing so, it should be visible at http://<external ip of minion running nginx>:<port from manifest>.
+
+Look in `examples/` for more examples
+
+### Tearing down the cluster
+```bash
+cd kubernetes
+cluster/kube-down.sh
 ```
 
 ### Running examples
 
-Take a look at [next steps](https://github.com/GoogleCloudPlatform/kubernetes#where-to-go-next)
-
-### Tearing down the cluster
-```
-cd kubernetes
-cluster/kube-down.sh
-```
+Take a look at [next steps](https://github.com/GoogleCloudPlatform/kubernetes/tree/master/examples/guestbook)
 
 ### Cloud Formation [optional]
 There is a contributed [example](aws-coreos.md) from [CoreOS](http://www.coreos.com) using Cloud Formation.


### PR DESCRIPTION
Stop pointing at an obsolete release.
