### PR TITLE
publish node components version information

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -407,6 +407,14 @@ func describeNode(node *api.Node, pods []api.Pod, events *api.EventList) (string
 				fmt.Fprintf(out, " %s:\t%s\n", resource, value.String())
 			}
 		}
+
+		fmt.Fprintf(out, "Version:\n")
+		fmt.Fprintf(out, " Kernel Version:\t%s\n", node.Status.NodeInfo.KernelVersion)
+		fmt.Fprintf(out, " OS Image:\t%s\n", node.Status.NodeInfo.OsImage)
+		fmt.Fprintf(out, " Container Runtime Version:\t%s\n", node.Status.NodeInfo.ContainerRuntimeVersion)
+		fmt.Fprintf(out, " Kubelet Version:\t%s\n", node.Status.NodeInfo.KubeletVersion)
+		fmt.Fprintf(out, " Kube-Proxy Version:\t%s\n", node.Status.NodeInfo.KubeProxyVersion)
+
 		if len(node.Spec.PodCIDR) > 0 {
 			fmt.Fprintf(out, "PodCIDR:\t%s\n", node.Spec.PodCIDR)
 		}

--- a/pkg/kubelet/cadvisor/cadvisor_fake.go
+++ b/pkg/kubelet/cadvisor/cadvisor_fake.go
@@ -39,6 +39,10 @@ func (c *Fake) MachineInfo() (*cadvisorApi.MachineInfo, error) {
 	return new(cadvisorApi.MachineInfo), nil
 }
 
+func (c *Fake) VersionInfo() (*cadvisorApi.VersionInfo, error) {
+	return new(cadvisorApi.VersionInfo), nil
+}
+
 func (c *Fake) DockerImagesFsInfo() (cadvisorApiV2.FsInfo, error) {
 	return cadvisorApiV2.FsInfo{}, nil
 }

--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -109,6 +109,10 @@ func (self *cadvisorClient) ContainerInfo(name string, req *cadvisorApi.Containe
 	return self.GetContainerInfo(name, req)
 }
 
+func (self *cadvisorClient) VersionInfo() (*cadvisorApi.VersionInfo, error) {
+	return self.GetVersionInfo()
+}
+
 func (self *cadvisorClient) MachineInfo() (*cadvisorApi.MachineInfo, error) {
 	return self.GetMachineInfo()
 }

--- a/pkg/kubelet/cadvisor/cadvisor_mock.go
+++ b/pkg/kubelet/cadvisor/cadvisor_mock.go
@@ -46,6 +46,11 @@ func (c *Mock) MachineInfo() (*cadvisorApi.MachineInfo, error) {
 	return args.Get(0).(*cadvisorApi.MachineInfo), args.Error(1)
 }
 
+func (c *Mock) VersionInfo() (*cadvisorApi.VersionInfo, error) {
+	args := c.Called()
+	return args.Get(0).(*cadvisorApi.VersionInfo), args.Error(1)
+}
+
 func (c *Mock) DockerImagesFsInfo() (cadvisorApiV2.FsInfo, error) {
 	args := c.Called()
 	return args.Get(0).(cadvisorApiV2.FsInfo), args.Error(1)

--- a/pkg/kubelet/cadvisor/cadvisor_unsupported.go
+++ b/pkg/kubelet/cadvisor/cadvisor_unsupported.go
@@ -48,6 +48,10 @@ func (self *cadvisorUnsupported) MachineInfo() (*cadvisorApi.MachineInfo, error)
 	return nil, unsupportedErr
 }
 
+func (self *cadvisorUnsupported) VersionInfo() (*cadvisorApi.VersionInfo, error) {
+	return nil, unsupportedErr
+}
+
 func (self *cadvisorUnsupported) DockerImagesFsInfo() (cadvisorApiV2.FsInfo, error) {
 	return cadvisorApiV2.FsInfo{}, unsupportedErr
 }

--- a/pkg/kubelet/cadvisor/types.go
+++ b/pkg/kubelet/cadvisor/types.go
@@ -27,6 +27,8 @@ type Interface interface {
 	ContainerInfo(name string, req *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error)
 	MachineInfo() (*cadvisorApi.MachineInfo, error)
 
+	VersionInfo() (*cadvisorApi.VersionInfo, error)
+
 	// Returns usage information about the filesystem holding Docker images.
 	DockerImagesFsInfo() (cadvisorApiV2.FsInfo, error)
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -51,6 +51,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	utilErrors "github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/fsouza/go-dockerclient"
@@ -1767,6 +1768,19 @@ func (kl *Kubelet) tryUpdateNodeStatus() error {
 				"Node %s has been rebooted, boot id: %s", kl.hostname, info.BootID)
 		}
 		node.Status.NodeInfo.BootID = info.BootID
+	}
+
+	verinfo, err := kl.cadvisor.VersionInfo()
+	if err != nil {
+		glog.Error("error getting version info: %v", err)
+	} else {
+		node.Status.NodeInfo.KernelVersion = verinfo.KernelVersion
+		node.Status.NodeInfo.OsImage = verinfo.ContainerOsVersion
+		// TODO: Determine the runtime is docker or rocket
+		node.Status.NodeInfo.ContainerRuntimeVersion = "docker://" + verinfo.DockerVersion
+		node.Status.NodeInfo.KubeletVersion = version.Get().String()
+		// TODO: kube-proxy might be different version from kubelet in the future
+		node.Status.NodeInfo.KubeProxyVersion = version.Get().String()
 	}
 
 	currentTime := util.Now()

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/network"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/volume/host_path"
 	"github.com/fsouza/go-dockerclient"
@@ -3062,6 +3063,12 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 		MemoryCapacity: 1024,
 	}
 	mockCadvisor.On("MachineInfo").Return(machineInfo, nil)
+	versionInfo := &cadvisorApi.VersionInfo{
+		KernelVersion:      "3.16.0-0.bpo.4-amd64",
+		ContainerOsVersion: "Debian GNU/Linux 7 (wheezy)",
+		DockerVersion:      "1.5.0",
+	}
+	mockCadvisor.On("VersionInfo").Return(versionInfo, nil)
 	expectedNode := &api.Node{
 		ObjectMeta: api.ObjectMeta{Name: "testnode"},
 		Spec:       api.NodeSpec{},
@@ -3076,9 +3083,14 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 				},
 			},
 			NodeInfo: api.NodeSystemInfo{
-				MachineID:  "123",
-				SystemUUID: "abc",
-				BootID:     "1b3",
+				MachineID:               "123",
+				SystemUUID:              "abc",
+				BootID:                  "1b3",
+				KernelVersion:           "3.16.0-0.bpo.4-amd64",
+				OsImage:                 "Debian GNU/Linux 7 (wheezy)",
+				ContainerRuntimeVersion: "docker://1.5.0",
+				KubeletVersion:          version.Get().String(),
+				KubeProxyVersion:        version.Get().String(),
 			},
 			Capacity: api.ResourceList{
 				api.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
@@ -3144,6 +3156,12 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 		MemoryCapacity: 1024,
 	}
 	mockCadvisor.On("MachineInfo").Return(machineInfo, nil)
+	versionInfo := &cadvisorApi.VersionInfo{
+		KernelVersion:      "3.16.0-0.bpo.4-amd64",
+		ContainerOsVersion: "Debian GNU/Linux 7 (wheezy)",
+		DockerVersion:      "1.5.0",
+	}
+	mockCadvisor.On("VersionInfo").Return(versionInfo, nil)
 	expectedNode := &api.Node{
 		ObjectMeta: api.ObjectMeta{Name: "testnode"},
 		Spec:       api.NodeSpec{},
@@ -3158,9 +3176,14 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 				},
 			},
 			NodeInfo: api.NodeSystemInfo{
-				MachineID:  "123",
-				SystemUUID: "abc",
-				BootID:     "1b3",
+				MachineID:               "123",
+				SystemUUID:              "abc",
+				BootID:                  "1b3",
+				KernelVersion:           "3.16.0-0.bpo.4-amd64",
+				OsImage:                 "Debian GNU/Linux 7 (wheezy)",
+				ContainerRuntimeVersion: "docker://1.5.0",
+				KubeletVersion:          version.Get().String(),
+				KubeProxyVersion:        version.Get().String(),
 			},
 			Capacity: api.ResourceList{
 				api.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),


### PR DESCRIPTION
With this PR, kubectl describe nodes id includes related version info.

Running: cluster/../cluster/gce/../../cluster/../_output/dockerized/bin/linux/amd64/kubectl describe nodes kubernetes-minion-4vox.c.golden-system-455.internal
Name:           kubernetes-minion-4vox.c.golden-system-455.internal
Labels:         <none>
CreationTimestamp:  Mon, 30 Mar 2015 16:20:29 -0700
Conditions:
  Type      Status  LastProbeTime               LastTransitionTime          Reason                  Message
  Ready     True    Tue, 31 Mar 2015 00:35:37 -0700     Mon, 30 Mar 2015 16:20:59 -0700     kubelet is posting ready status  
Addresses:  130.211.182.208,104.197.28.200
Capacity:
 cpu:       1
 memory:    3800824Ki
Version:
 Kernel Version:        3.16.0-0.bpo.4-amd64
 OS Image:          Debian GNU/Linux 7 (wheezy)
 Container Runtime Version: docker://1.5.0
 Kubelet Version:       v0.14.0-10-g3e0cdff97c2e77-dirty
 Kube-Proxy Version:        v0.14.0-10-g3e0cdff97c2e77-dirty
ExternalID:         9471772650125516840
Pods:               (2 in total)
  fluentd-to-elasticsearch-kubernetes-minion-4vox
  monitoring-influx-grafana-controller-240nz
Events:
  FirstSeen             LastSeen            Count   From                                SubobjectPath   Reason      Message
  Tue, 31 Mar 2015 00:17:25 -0700   Tue, 31 Mar 2015 00:17:25 -0700 1   {kubelet kubernetes-minion-4vox.c.golden-system-455.internal}           starting    Starting kubelet.

Fix #5948
