### PR TITLE
Fix S3 location handling for US classic

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -238,8 +238,8 @@ function upload-server-tars() {
 
   local s3_bucket_location=$(aws --output text s3api get-bucket-location --bucket ${AWS_S3_BUCKET})
   local s3_url_base=https://s3-${s3_bucket_location}.amazonaws.com
-  if [[ "${s3_bucket_location}" == "us-east-1" ]]; then
-    # us-east-1 does not follow the pattern
+  if [[ "${s3_bucket_location}" == "None" ]]; then
+    # "US Classic" does not follow the pattern
     s3_url_base=https://s3.amazonaws.com
   fi
 


### PR DESCRIPTION
I got the return value for US-classic S3 buckets wrong; it returns "None", not "us-east-1"
