### PR TITLE
defaults_tests: verify defaults when converting to an API object

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1507,7 +1507,8 @@ type ContainerManifest struct {
 	Containers    []Container   `json:"containers"`
 	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty"`
 	// Required: Set DNS policy.
-	DNSPolicy DNSPolicy `json:"dnsPolicy"`
+	DNSPolicy   DNSPolicy `json:"dnsPolicy"`
+	HostNetwork bool      `json:"hostNetwork,omitempty"`
 }
 
 // ContainerManifestList is used to communicate container manifests to kubelet.

--- a/pkg/api/v1beta1/defaults_test.go
+++ b/pkg/api/v1beta1/defaults_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	newer "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	current "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
@@ -30,13 +31,18 @@ func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
 		t.Errorf("%v\n %#v", err, obj)
 		return nil
 	}
-	obj2 := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(runtime.Object)
-	err = current.Codec.DecodeInto(data, obj2)
+	obj2, err := newer.Codec.Decode(data)
 	if err != nil {
 		t.Errorf("%v\nData: %s\nSource: %#v", err, string(data), obj)
 		return nil
 	}
-	return obj2
+	obj3 := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(runtime.Object)
+	err = newer.Scheme.Convert(obj2, obj3)
+	if err != nil {
+		t.Errorf("%v\nSource: %#v", err, obj2)
+		return nil
+	}
+	return obj3
 }
 
 func TestSetDefaultService(t *testing.T) {

--- a/pkg/api/v1beta2/defaults_test.go
+++ b/pkg/api/v1beta2/defaults_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	newer "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	current "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta2"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
@@ -30,13 +31,18 @@ func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
 		t.Errorf("%v\n %#v", err, obj)
 		return nil
 	}
-	obj2 := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(runtime.Object)
-	err = current.Codec.DecodeInto(data, obj2)
+	obj2, err := newer.Codec.Decode(data)
 	if err != nil {
 		t.Errorf("%v\nData: %s\nSource: %#v", err, string(data), obj)
 		return nil
 	}
-	return obj2
+	obj3 := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(runtime.Object)
+	err = newer.Scheme.Convert(obj2, obj3)
+	if err != nil {
+		t.Errorf("%v\nSource: %#v", err, obj2)
+		return nil
+	}
+	return obj3
 }
 
 func TestSetDefaultService(t *testing.T) {

--- a/pkg/api/v1beta3/defaults_test.go
+++ b/pkg/api/v1beta3/defaults_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	newer "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	current "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -31,13 +32,18 @@ func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
 		t.Errorf("%v\n %#v", err, obj)
 		return nil
 	}
-	obj2 := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(runtime.Object)
-	err = current.Codec.DecodeInto(data, obj2)
+	obj2, err := newer.Codec.Decode(data)
 	if err != nil {
 		t.Errorf("%v\nData: %s\nSource: %#v", err, string(data), obj)
 		return nil
 	}
-	return obj2
+	obj3 := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(runtime.Object)
+	err = newer.Scheme.Convert(obj2, obj3)
+	if err != nil {
+		t.Errorf("%v\nSource: %#v", err, obj2)
+		return nil
+	}
+	return obj3
 }
 
 func TestSetDefaultService(t *testing.T) {


### PR DESCRIPTION
This change verifies that defaults are applied after decoding an versioned
object into an API object.

This addresses the test issues in #6210
