### PR TITLE
s/apiservers/api_servers/ in Salt

### DIFF
--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -343,7 +343,6 @@ function salt-set-apiserver() {
 
   cat <<EOF >>/etc/salt/minion.d/grains.conf
   api_servers: '${kube_master_fqdn}'
-  apiservers: '${kube_master_fqdn}'
 EOF
 }
 

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -3,14 +3,16 @@
   {% set daemon_args = "" -%}
 {% endif -%}
 
-{% if grains.apiservers is defined -%}
-  {% set apiservers = "--api_servers=https://" + grains.apiservers + ":6443" -%}
+{% if grains.api_servers is defined -%}
+  {% set api_servers = "--api_servers=https://" + grains.api_servers + ":6443" -%}
+{% elif grains.apiservers is defined -%} # TODO(remove after 0.16.0): Deprecated form
+  {% set api_servers = "--api_servers=https://" + grains.apiservers + ":6443" -%}
 {% elif grains['roles'][0] == 'kubernetes-master' -%}
   {% set master_ipv4 = salt['grains.get']('fqdn_ip4')[0] -%}
-  {% set apiservers = "--api_servers=https://" + master_ipv4 + ":6443" -%}
+  {% set api_servers = "--api_servers=https://" + master_ipv4 + ":6443" -%}
 {% else -%}
   {% set ips = salt['mine.get']('roles:kubernetes-master', 'network.ip_addrs', 'grain').values() -%}
-  {% set apiservers = "--api_servers=https://" + ips[0][0] + ":6443" -%}
+  {% set api_servers = "--api_servers=https://" + ips[0][0] + ":6443" -%}
 {% endif -%}
 
 {% set address = "--address=0.0.0.0" -%}
@@ -31,4 +33,4 @@
   {% set cluster_domain = "--cluster_domain=" + pillar['dns_domain'] %}
 {% endif %}
 
-DAEMON_ARGS="{{daemon_args}} {{apiservers}} {{auth_path}} {{hostname_override}} {{address}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}}"
+DAEMON_ARGS="{{daemon_args}} {{api_servers}} {{auth_path}} {{hostname_override}} {{address}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}}"

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -70,7 +70,6 @@ grains:
   etcd_servers: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
   api_servers: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
   networkInterfaceName: eth1
-  apiservers: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
   roles:
     - kubernetes-pool
   cbr-cidr: '$(echo "$CONTAINER_SUBNET" | sed -e "s/'/''/g")'

--- a/docs/salt.md
+++ b/docs/salt.md
@@ -51,7 +51,7 @@ The following enumerates the set of defined key/value pairs that are supported t
 
 Key | Value
 ------------- | -------------
-`apiservers` | (Optional) The IP address / host name where a kubelet can get read-only access to kube-apiserver
+`api_servers` | (Optional) The IP address / host name where a kubelet can get read-only access to kube-apiserver
 `cbr-cidr` | (Optional) The minion IP address range used for the docker container bridge.
 `cloud` | (Optional) Which IaaS platform is used to host kubernetes, *gce*, *azure*, *aws*, *vagrant*
 `cloud_provider` | (Optional) The cloud_provider used by apiserver: *gce*, *azure*, *vagrant*


### PR DESCRIPTION
It looks like api_servers finally won this battle. Kill off the
last remaining places passing it, but allow the kubelet Salt to
accept apiservers for a period of time.

(This was bothering my OCD.)
