### PR TITLE
Generic Config object and its REST implementation

### DIFF
--- a/pkg/apis/extensions/deep_copy_generated.go
+++ b/pkg/apis/extensions/deep_copy_generated.go
@@ -945,6 +945,44 @@ func deepCopy_extensions_ClusterAutoscalerSpec(in ClusterAutoscalerSpec, out *Cl
 	return nil
 }
 
+func deepCopy_extensions_ConfigMap(in ConfigMap, out *ConfigMap, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
+	if in.Data != nil {
+		out.Data = make(map[string]string)
+		for key, val := range in.Data {
+			out.Data[key] = val
+		}
+	} else {
+		out.Data = nil
+	}
+	return nil
+}
+
+func deepCopy_extensions_ConfigMapList(in ConfigMapList, out *ConfigMapList, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_unversioned_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]ConfigMap, len(in.Items))
+		for i := range in.Items {
+			if err := deepCopy_extensions_ConfigMap(in.Items[i], &out.Items[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
 func deepCopy_extensions_DaemonSet(in DaemonSet, out *DaemonSet, c *conversion.Cloner) error {
 	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -1633,6 +1671,8 @@ func init() {
 		deepCopy_extensions_ClusterAutoscaler,
 		deepCopy_extensions_ClusterAutoscalerList,
 		deepCopy_extensions_ClusterAutoscalerSpec,
+		deepCopy_extensions_ConfigMap,
+		deepCopy_extensions_ConfigMapList,
 		deepCopy_extensions_DaemonSet,
 		deepCopy_extensions_DaemonSetList,
 		deepCopy_extensions_DaemonSetSpec,

--- a/pkg/apis/extensions/register.go
+++ b/pkg/apis/extensions/register.go
@@ -65,6 +65,8 @@ func addKnownTypes() {
 		&Ingress{},
 		&IngressList{},
 		&api.ListOptions{},
+		&ConfigMap{},
+		&ConfigMapList{},
 	)
 }
 
@@ -86,3 +88,5 @@ func (obj *ThirdPartyResourceData) GetObjectKind() unversioned.ObjectKind      {
 func (obj *ThirdPartyResourceDataList) GetObjectKind() unversioned.ObjectKind  { return &obj.TypeMeta }
 func (obj *Ingress) GetObjectKind() unversioned.ObjectKind                     { return &obj.TypeMeta }
 func (obj *IngressList) GetObjectKind() unversioned.ObjectKind                 { return &obj.TypeMeta }
+func (obj *ConfigMap) GetObjectKind() unversioned.ObjectKind                   { return &obj.TypeMeta }
+func (obj *ConfigMapList) GetObjectKind() unversioned.ObjectKind               { return &obj.TypeMeta }

--- a/pkg/apis/extensions/types.generated.go
+++ b/pkg/apis/extensions/types.generated.go
@@ -13444,1167 +13444,685 @@ func (x *LabelSelectorOperator) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
+func (x *ConfigMap) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1121 := z.EncBinary()
+		_ = yym1121
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1122 := !z.EncBinary()
+			yy2arr1122 := z.EncBasicHandle().StructToArray
+			var yyq1122 [4]bool
+			_, _, _ = yysep1122, yyq1122, yy2arr1122
+			const yyr1122 bool = false
+			yyq1122[0] = x.Kind != ""
+			yyq1122[1] = x.APIVersion != ""
+			yyq1122[2] = true
+			yyq1122[3] = len(x.Data) != 0
+			var yynn1122 int
+			if yyr1122 || yy2arr1122 {
+				r.EncodeArrayStart(4)
+			} else {
+				yynn1122 = 0
+				for _, b := range yyq1122 {
+					if b {
+						yynn1122++
+					}
+				}
+				r.EncodeMapStart(yynn1122)
+				yynn1122 = 0
+			}
+			if yyr1122 || yy2arr1122 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1122[0] {
+					yym1124 := z.EncBinary()
+					_ = yym1124
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1122[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1125 := z.EncBinary()
+					_ = yym1125
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1122 || yy2arr1122 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1122[1] {
+					yym1127 := z.EncBinary()
+					_ = yym1127
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1122[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1128 := z.EncBinary()
+					_ = yym1128
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr1122 || yy2arr1122 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1122[2] {
+					yy1130 := &x.ObjectMeta
+					yy1130.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1122[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1131 := &x.ObjectMeta
+					yy1131.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1122 || yy2arr1122 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1122[3] {
+					if x.Data == nil {
+						r.EncodeNil()
+					} else {
+						yym1133 := z.EncBinary()
+						_ = yym1133
+						if false {
+						} else {
+							z.F.EncMapStringStringV(x.Data, false, e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1122[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("data"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.Data == nil {
+						r.EncodeNil()
+					} else {
+						yym1134 := z.EncBinary()
+						_ = yym1134
+						if false {
+						} else {
+							z.F.EncMapStringStringV(x.Data, false, e)
+						}
+					}
+				}
+			}
+			if yyr1122 || yy2arr1122 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *ConfigMap) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1135 := z.DecBinary()
+	_ = yym1135
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1136 := r.ContainerType()
+		if yyct1136 == codecSelferValueTypeMap1234 {
+			yyl1136 := r.ReadMapStart()
+			if yyl1136 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1136, d)
+			}
+		} else if yyct1136 == codecSelferValueTypeArray1234 {
+			yyl1136 := r.ReadArrayStart()
+			if yyl1136 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1136, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *ConfigMap) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1137Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1137Slc
+	var yyhl1137 bool = l >= 0
+	for yyj1137 := 0; ; yyj1137++ {
+		if yyhl1137 {
+			if yyj1137 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1137Slc = r.DecodeBytes(yys1137Slc, true, true)
+		yys1137 := string(yys1137Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1137 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv1140 := &x.ObjectMeta
+				yyv1140.CodecDecodeSelf(d)
+			}
+		case "data":
+			if r.TryDecodeAsNil() {
+				x.Data = nil
+			} else {
+				yyv1141 := &x.Data
+				yym1142 := z.DecBinary()
+				_ = yym1142
+				if false {
+				} else {
+					z.F.DecMapStringStringX(yyv1141, false, d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1137)
+		} // end switch yys1137
+	} // end for yyj1137
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *ConfigMap) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1143 int
+	var yyb1143 bool
+	var yyhl1143 bool = l >= 0
+	yyj1143++
+	if yyhl1143 {
+		yyb1143 = yyj1143 > l
+	} else {
+		yyb1143 = r.CheckBreak()
+	}
+	if yyb1143 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj1143++
+	if yyhl1143 {
+		yyb1143 = yyj1143 > l
+	} else {
+		yyb1143 = r.CheckBreak()
+	}
+	if yyb1143 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj1143++
+	if yyhl1143 {
+		yyb1143 = yyj1143 > l
+	} else {
+		yyb1143 = r.CheckBreak()
+	}
+	if yyb1143 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv1146 := &x.ObjectMeta
+		yyv1146.CodecDecodeSelf(d)
+	}
+	yyj1143++
+	if yyhl1143 {
+		yyb1143 = yyj1143 > l
+	} else {
+		yyb1143 = r.CheckBreak()
+	}
+	if yyb1143 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Data = nil
+	} else {
+		yyv1147 := &x.Data
+		yym1148 := z.DecBinary()
+		_ = yym1148
+		if false {
+		} else {
+			z.F.DecMapStringStringX(yyv1147, false, d)
+		}
+	}
+	for {
+		yyj1143++
+		if yyhl1143 {
+			yyb1143 = yyj1143 > l
+		} else {
+			yyb1143 = r.CheckBreak()
+		}
+		if yyb1143 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1143-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *ConfigMapList) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1149 := z.EncBinary()
+		_ = yym1149
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1150 := !z.EncBinary()
+			yy2arr1150 := z.EncBasicHandle().StructToArray
+			var yyq1150 [4]bool
+			_, _, _ = yysep1150, yyq1150, yy2arr1150
+			const yyr1150 bool = false
+			yyq1150[0] = x.Kind != ""
+			yyq1150[1] = x.APIVersion != ""
+			yyq1150[2] = true
+			yyq1150[3] = len(x.Items) != 0
+			var yynn1150 int
+			if yyr1150 || yy2arr1150 {
+				r.EncodeArrayStart(4)
+			} else {
+				yynn1150 = 0
+				for _, b := range yyq1150 {
+					if b {
+						yynn1150++
+					}
+				}
+				r.EncodeMapStart(yynn1150)
+				yynn1150 = 0
+			}
+			if yyr1150 || yy2arr1150 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1150[0] {
+					yym1152 := z.EncBinary()
+					_ = yym1152
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1150[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1153 := z.EncBinary()
+					_ = yym1153
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1150 || yy2arr1150 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1150[1] {
+					yym1155 := z.EncBinary()
+					_ = yym1155
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1150[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1156 := z.EncBinary()
+					_ = yym1156
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr1150 || yy2arr1150 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1150[2] {
+					yy1158 := &x.ListMeta
+					yym1159 := z.EncBinary()
+					_ = yym1159
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1158) {
+					} else {
+						z.EncFallback(yy1158)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1150[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1160 := &x.ListMeta
+					yym1161 := z.EncBinary()
+					_ = yym1161
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1160) {
+					} else {
+						z.EncFallback(yy1160)
+					}
+				}
+			}
+			if yyr1150 || yy2arr1150 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1150[3] {
+					if x.Items == nil {
+						r.EncodeNil()
+					} else {
+						yym1163 := z.EncBinary()
+						_ = yym1163
+						if false {
+						} else {
+							h.encSliceConfigMap(([]ConfigMap)(x.Items), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1150[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("items"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.Items == nil {
+						r.EncodeNil()
+					} else {
+						yym1164 := z.EncBinary()
+						_ = yym1164
+						if false {
+						} else {
+							h.encSliceConfigMap(([]ConfigMap)(x.Items), e)
+						}
+					}
+				}
+			}
+			if yyr1150 || yy2arr1150 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *ConfigMapList) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1165 := z.DecBinary()
+	_ = yym1165
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1166 := r.ContainerType()
+		if yyct1166 == codecSelferValueTypeMap1234 {
+			yyl1166 := r.ReadMapStart()
+			if yyl1166 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1166, d)
+			}
+		} else if yyct1166 == codecSelferValueTypeArray1234 {
+			yyl1166 := r.ReadArrayStart()
+			if yyl1166 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1166, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *ConfigMapList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1167Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1167Slc
+	var yyhl1167 bool = l >= 0
+	for yyj1167 := 0; ; yyj1167++ {
+		if yyhl1167 {
+			if yyj1167 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1167Slc = r.DecodeBytes(yys1167Slc, true, true)
+		yys1167 := string(yys1167Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1167 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv1170 := &x.ListMeta
+				yym1171 := z.DecBinary()
+				_ = yym1171
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1170) {
+				} else {
+					z.DecFallback(yyv1170, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv1172 := &x.Items
+				yym1173 := z.DecBinary()
+				_ = yym1173
+				if false {
+				} else {
+					h.decSliceConfigMap((*[]ConfigMap)(yyv1172), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1167)
+		} // end switch yys1167
+	} // end for yyj1167
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *ConfigMapList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1174 int
+	var yyb1174 bool
+	var yyhl1174 bool = l >= 0
+	yyj1174++
+	if yyhl1174 {
+		yyb1174 = yyj1174 > l
+	} else {
+		yyb1174 = r.CheckBreak()
+	}
+	if yyb1174 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj1174++
+	if yyhl1174 {
+		yyb1174 = yyj1174 > l
+	} else {
+		yyb1174 = r.CheckBreak()
+	}
+	if yyb1174 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj1174++
+	if yyhl1174 {
+		yyb1174 = yyj1174 > l
+	} else {
+		yyb1174 = r.CheckBreak()
+	}
+	if yyb1174 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv1177 := &x.ListMeta
+		yym1178 := z.DecBinary()
+		_ = yym1178
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1177) {
+		} else {
+			z.DecFallback(yyv1177, false)
+		}
+	}
+	yyj1174++
+	if yyhl1174 {
+		yyb1174 = yyj1174 > l
+	} else {
+		yyb1174 = r.CheckBreak()
+	}
+	if yyb1174 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv1179 := &x.Items
+		yym1180 := z.DecBinary()
+		_ = yym1180
+		if false {
+		} else {
+			h.decSliceConfigMap((*[]ConfigMap)(yyv1179), d)
+		}
+	}
+	for {
+		yyj1174++
+		if yyhl1174 {
+			yyb1174 = yyj1174 > l
+		} else {
+			yyb1174 = r.CheckBreak()
+		}
+		if yyb1174 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1174-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
 func (x codecSelfer1234) encSliceHorizontalPodAutoscaler(v []HorizontalPodAutoscaler, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1121 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1122 := &yyv1121
-		yy1122.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutoscaler, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1123 := *v
-	yyh1123, yyl1123 := z.DecSliceHelperStart()
-	var yyc1123 bool
-	if yyl1123 == 0 {
-		if yyv1123 == nil {
-			yyv1123 = []HorizontalPodAutoscaler{}
-			yyc1123 = true
-		} else if len(yyv1123) != 0 {
-			yyv1123 = yyv1123[:0]
-			yyc1123 = true
-		}
-	} else if yyl1123 > 0 {
-		var yyrr1123, yyrl1123 int
-		var yyrt1123 bool
-		if yyl1123 > cap(yyv1123) {
-
-			yyrg1123 := len(yyv1123) > 0
-			yyv21123 := yyv1123
-			yyrl1123, yyrt1123 = z.DecInferLen(yyl1123, z.DecBasicHandle().MaxInitLen, 320)
-			if yyrt1123 {
-				if yyrl1123 <= cap(yyv1123) {
-					yyv1123 = yyv1123[:yyrl1123]
-				} else {
-					yyv1123 = make([]HorizontalPodAutoscaler, yyrl1123)
-				}
-			} else {
-				yyv1123 = make([]HorizontalPodAutoscaler, yyrl1123)
-			}
-			yyc1123 = true
-			yyrr1123 = len(yyv1123)
-			if yyrg1123 {
-				copy(yyv1123, yyv21123)
-			}
-		} else if yyl1123 != len(yyv1123) {
-			yyv1123 = yyv1123[:yyl1123]
-			yyc1123 = true
-		}
-		yyj1123 := 0
-		for ; yyj1123 < yyrr1123; yyj1123++ {
-			yyh1123.ElemContainerState(yyj1123)
-			if r.TryDecodeAsNil() {
-				yyv1123[yyj1123] = HorizontalPodAutoscaler{}
-			} else {
-				yyv1124 := &yyv1123[yyj1123]
-				yyv1124.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1123 {
-			for ; yyj1123 < yyl1123; yyj1123++ {
-				yyv1123 = append(yyv1123, HorizontalPodAutoscaler{})
-				yyh1123.ElemContainerState(yyj1123)
-				if r.TryDecodeAsNil() {
-					yyv1123[yyj1123] = HorizontalPodAutoscaler{}
-				} else {
-					yyv1125 := &yyv1123[yyj1123]
-					yyv1125.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1123 := 0
-		for ; !r.CheckBreak(); yyj1123++ {
-
-			if yyj1123 >= len(yyv1123) {
-				yyv1123 = append(yyv1123, HorizontalPodAutoscaler{}) // var yyz1123 HorizontalPodAutoscaler
-				yyc1123 = true
-			}
-			yyh1123.ElemContainerState(yyj1123)
-			if yyj1123 < len(yyv1123) {
-				if r.TryDecodeAsNil() {
-					yyv1123[yyj1123] = HorizontalPodAutoscaler{}
-				} else {
-					yyv1126 := &yyv1123[yyj1123]
-					yyv1126.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1123 < len(yyv1123) {
-			yyv1123 = yyv1123[:yyj1123]
-			yyc1123 = true
-		} else if yyj1123 == 0 && yyv1123 == nil {
-			yyv1123 = []HorizontalPodAutoscaler{}
-			yyc1123 = true
-		}
-	}
-	yyh1123.End()
-	if yyc1123 {
-		*v = yyv1123
-	}
-}
-
-func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1127 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1128 := &yyv1127
-		yy1128.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1129 := *v
-	yyh1129, yyl1129 := z.DecSliceHelperStart()
-	var yyc1129 bool
-	if yyl1129 == 0 {
-		if yyv1129 == nil {
-			yyv1129 = []APIVersion{}
-			yyc1129 = true
-		} else if len(yyv1129) != 0 {
-			yyv1129 = yyv1129[:0]
-			yyc1129 = true
-		}
-	} else if yyl1129 > 0 {
-		var yyrr1129, yyrl1129 int
-		var yyrt1129 bool
-		if yyl1129 > cap(yyv1129) {
-
-			yyrg1129 := len(yyv1129) > 0
-			yyv21129 := yyv1129
-			yyrl1129, yyrt1129 = z.DecInferLen(yyl1129, z.DecBasicHandle().MaxInitLen, 32)
-			if yyrt1129 {
-				if yyrl1129 <= cap(yyv1129) {
-					yyv1129 = yyv1129[:yyrl1129]
-				} else {
-					yyv1129 = make([]APIVersion, yyrl1129)
-				}
-			} else {
-				yyv1129 = make([]APIVersion, yyrl1129)
-			}
-			yyc1129 = true
-			yyrr1129 = len(yyv1129)
-			if yyrg1129 {
-				copy(yyv1129, yyv21129)
-			}
-		} else if yyl1129 != len(yyv1129) {
-			yyv1129 = yyv1129[:yyl1129]
-			yyc1129 = true
-		}
-		yyj1129 := 0
-		for ; yyj1129 < yyrr1129; yyj1129++ {
-			yyh1129.ElemContainerState(yyj1129)
-			if r.TryDecodeAsNil() {
-				yyv1129[yyj1129] = APIVersion{}
-			} else {
-				yyv1130 := &yyv1129[yyj1129]
-				yyv1130.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1129 {
-			for ; yyj1129 < yyl1129; yyj1129++ {
-				yyv1129 = append(yyv1129, APIVersion{})
-				yyh1129.ElemContainerState(yyj1129)
-				if r.TryDecodeAsNil() {
-					yyv1129[yyj1129] = APIVersion{}
-				} else {
-					yyv1131 := &yyv1129[yyj1129]
-					yyv1131.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1129 := 0
-		for ; !r.CheckBreak(); yyj1129++ {
-
-			if yyj1129 >= len(yyv1129) {
-				yyv1129 = append(yyv1129, APIVersion{}) // var yyz1129 APIVersion
-				yyc1129 = true
-			}
-			yyh1129.ElemContainerState(yyj1129)
-			if yyj1129 < len(yyv1129) {
-				if r.TryDecodeAsNil() {
-					yyv1129[yyj1129] = APIVersion{}
-				} else {
-					yyv1132 := &yyv1129[yyj1129]
-					yyv1132.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1129 < len(yyv1129) {
-			yyv1129 = yyv1129[:yyj1129]
-			yyc1129 = true
-		} else if yyj1129 == 0 && yyv1129 == nil {
-			yyv1129 = []APIVersion{}
-			yyc1129 = true
-		}
-	}
-	yyh1129.End()
-	if yyc1129 {
-		*v = yyv1129
-	}
-}
-
-func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1133 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1134 := &yyv1133
-		yy1134.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1135 := *v
-	yyh1135, yyl1135 := z.DecSliceHelperStart()
-	var yyc1135 bool
-	if yyl1135 == 0 {
-		if yyv1135 == nil {
-			yyv1135 = []ThirdPartyResource{}
-			yyc1135 = true
-		} else if len(yyv1135) != 0 {
-			yyv1135 = yyv1135[:0]
-			yyc1135 = true
-		}
-	} else if yyl1135 > 0 {
-		var yyrr1135, yyrl1135 int
-		var yyrt1135 bool
-		if yyl1135 > cap(yyv1135) {
-
-			yyrg1135 := len(yyv1135) > 0
-			yyv21135 := yyv1135
-			yyrl1135, yyrt1135 = z.DecInferLen(yyl1135, z.DecBasicHandle().MaxInitLen, 232)
-			if yyrt1135 {
-				if yyrl1135 <= cap(yyv1135) {
-					yyv1135 = yyv1135[:yyrl1135]
-				} else {
-					yyv1135 = make([]ThirdPartyResource, yyrl1135)
-				}
-			} else {
-				yyv1135 = make([]ThirdPartyResource, yyrl1135)
-			}
-			yyc1135 = true
-			yyrr1135 = len(yyv1135)
-			if yyrg1135 {
-				copy(yyv1135, yyv21135)
-			}
-		} else if yyl1135 != len(yyv1135) {
-			yyv1135 = yyv1135[:yyl1135]
-			yyc1135 = true
-		}
-		yyj1135 := 0
-		for ; yyj1135 < yyrr1135; yyj1135++ {
-			yyh1135.ElemContainerState(yyj1135)
-			if r.TryDecodeAsNil() {
-				yyv1135[yyj1135] = ThirdPartyResource{}
-			} else {
-				yyv1136 := &yyv1135[yyj1135]
-				yyv1136.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1135 {
-			for ; yyj1135 < yyl1135; yyj1135++ {
-				yyv1135 = append(yyv1135, ThirdPartyResource{})
-				yyh1135.ElemContainerState(yyj1135)
-				if r.TryDecodeAsNil() {
-					yyv1135[yyj1135] = ThirdPartyResource{}
-				} else {
-					yyv1137 := &yyv1135[yyj1135]
-					yyv1137.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1135 := 0
-		for ; !r.CheckBreak(); yyj1135++ {
-
-			if yyj1135 >= len(yyv1135) {
-				yyv1135 = append(yyv1135, ThirdPartyResource{}) // var yyz1135 ThirdPartyResource
-				yyc1135 = true
-			}
-			yyh1135.ElemContainerState(yyj1135)
-			if yyj1135 < len(yyv1135) {
-				if r.TryDecodeAsNil() {
-					yyv1135[yyj1135] = ThirdPartyResource{}
-				} else {
-					yyv1138 := &yyv1135[yyj1135]
-					yyv1138.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1135 < len(yyv1135) {
-			yyv1135 = yyv1135[:yyj1135]
-			yyc1135 = true
-		} else if yyj1135 == 0 && yyv1135 == nil {
-			yyv1135 = []ThirdPartyResource{}
-			yyc1135 = true
-		}
-	}
-	yyh1135.End()
-	if yyc1135 {
-		*v = yyv1135
-	}
-}
-
-func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1139 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1140 := &yyv1139
-		yy1140.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1141 := *v
-	yyh1141, yyl1141 := z.DecSliceHelperStart()
-	var yyc1141 bool
-	if yyl1141 == 0 {
-		if yyv1141 == nil {
-			yyv1141 = []Deployment{}
-			yyc1141 = true
-		} else if len(yyv1141) != 0 {
-			yyv1141 = yyv1141[:0]
-			yyc1141 = true
-		}
-	} else if yyl1141 > 0 {
-		var yyrr1141, yyrl1141 int
-		var yyrt1141 bool
-		if yyl1141 > cap(yyv1141) {
-
-			yyrg1141 := len(yyv1141) > 0
-			yyv21141 := yyv1141
-			yyrl1141, yyrt1141 = z.DecInferLen(yyl1141, z.DecBasicHandle().MaxInitLen, 592)
-			if yyrt1141 {
-				if yyrl1141 <= cap(yyv1141) {
-					yyv1141 = yyv1141[:yyrl1141]
-				} else {
-					yyv1141 = make([]Deployment, yyrl1141)
-				}
-			} else {
-				yyv1141 = make([]Deployment, yyrl1141)
-			}
-			yyc1141 = true
-			yyrr1141 = len(yyv1141)
-			if yyrg1141 {
-				copy(yyv1141, yyv21141)
-			}
-		} else if yyl1141 != len(yyv1141) {
-			yyv1141 = yyv1141[:yyl1141]
-			yyc1141 = true
-		}
-		yyj1141 := 0
-		for ; yyj1141 < yyrr1141; yyj1141++ {
-			yyh1141.ElemContainerState(yyj1141)
-			if r.TryDecodeAsNil() {
-				yyv1141[yyj1141] = Deployment{}
-			} else {
-				yyv1142 := &yyv1141[yyj1141]
-				yyv1142.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1141 {
-			for ; yyj1141 < yyl1141; yyj1141++ {
-				yyv1141 = append(yyv1141, Deployment{})
-				yyh1141.ElemContainerState(yyj1141)
-				if r.TryDecodeAsNil() {
-					yyv1141[yyj1141] = Deployment{}
-				} else {
-					yyv1143 := &yyv1141[yyj1141]
-					yyv1143.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1141 := 0
-		for ; !r.CheckBreak(); yyj1141++ {
-
-			if yyj1141 >= len(yyv1141) {
-				yyv1141 = append(yyv1141, Deployment{}) // var yyz1141 Deployment
-				yyc1141 = true
-			}
-			yyh1141.ElemContainerState(yyj1141)
-			if yyj1141 < len(yyv1141) {
-				if r.TryDecodeAsNil() {
-					yyv1141[yyj1141] = Deployment{}
-				} else {
-					yyv1144 := &yyv1141[yyj1141]
-					yyv1144.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1141 < len(yyv1141) {
-			yyv1141 = yyv1141[:yyj1141]
-			yyc1141 = true
-		} else if yyj1141 == 0 && yyv1141 == nil {
-			yyv1141 = []Deployment{}
-			yyc1141 = true
-		}
-	}
-	yyh1141.End()
-	if yyc1141 {
-		*v = yyv1141
-	}
-}
-
-func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1145 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1146 := &yyv1145
-		yy1146.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1147 := *v
-	yyh1147, yyl1147 := z.DecSliceHelperStart()
-	var yyc1147 bool
-	if yyl1147 == 0 {
-		if yyv1147 == nil {
-			yyv1147 = []DaemonSet{}
-			yyc1147 = true
-		} else if len(yyv1147) != 0 {
-			yyv1147 = yyv1147[:0]
-			yyc1147 = true
-		}
-	} else if yyl1147 > 0 {
-		var yyrr1147, yyrl1147 int
-		var yyrt1147 bool
-		if yyl1147 > cap(yyv1147) {
-
-			yyrg1147 := len(yyv1147) > 0
-			yyv21147 := yyv1147
-			yyrl1147, yyrt1147 = z.DecInferLen(yyl1147, z.DecBasicHandle().MaxInitLen, 232)
-			if yyrt1147 {
-				if yyrl1147 <= cap(yyv1147) {
-					yyv1147 = yyv1147[:yyrl1147]
-				} else {
-					yyv1147 = make([]DaemonSet, yyrl1147)
-				}
-			} else {
-				yyv1147 = make([]DaemonSet, yyrl1147)
-			}
-			yyc1147 = true
-			yyrr1147 = len(yyv1147)
-			if yyrg1147 {
-				copy(yyv1147, yyv21147)
-			}
-		} else if yyl1147 != len(yyv1147) {
-			yyv1147 = yyv1147[:yyl1147]
-			yyc1147 = true
-		}
-		yyj1147 := 0
-		for ; yyj1147 < yyrr1147; yyj1147++ {
-			yyh1147.ElemContainerState(yyj1147)
-			if r.TryDecodeAsNil() {
-				yyv1147[yyj1147] = DaemonSet{}
-			} else {
-				yyv1148 := &yyv1147[yyj1147]
-				yyv1148.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1147 {
-			for ; yyj1147 < yyl1147; yyj1147++ {
-				yyv1147 = append(yyv1147, DaemonSet{})
-				yyh1147.ElemContainerState(yyj1147)
-				if r.TryDecodeAsNil() {
-					yyv1147[yyj1147] = DaemonSet{}
-				} else {
-					yyv1149 := &yyv1147[yyj1147]
-					yyv1149.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1147 := 0
-		for ; !r.CheckBreak(); yyj1147++ {
-
-			if yyj1147 >= len(yyv1147) {
-				yyv1147 = append(yyv1147, DaemonSet{}) // var yyz1147 DaemonSet
-				yyc1147 = true
-			}
-			yyh1147.ElemContainerState(yyj1147)
-			if yyj1147 < len(yyv1147) {
-				if r.TryDecodeAsNil() {
-					yyv1147[yyj1147] = DaemonSet{}
-				} else {
-					yyv1150 := &yyv1147[yyj1147]
-					yyv1150.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1147 < len(yyv1147) {
-			yyv1147 = yyv1147[:yyj1147]
-			yyc1147 = true
-		} else if yyj1147 == 0 && yyv1147 == nil {
-			yyv1147 = []DaemonSet{}
-			yyc1147 = true
-		}
-	}
-	yyh1147.End()
-	if yyc1147 {
-		*v = yyv1147
-	}
-}
-
-func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceData, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1151 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1152 := &yyv1151
-		yy1152.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceData, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1153 := *v
-	yyh1153, yyl1153 := z.DecSliceHelperStart()
-	var yyc1153 bool
-	if yyl1153 == 0 {
-		if yyv1153 == nil {
-			yyv1153 = []ThirdPartyResourceData{}
-			yyc1153 = true
-		} else if len(yyv1153) != 0 {
-			yyv1153 = yyv1153[:0]
-			yyc1153 = true
-		}
-	} else if yyl1153 > 0 {
-		var yyrr1153, yyrl1153 int
-		var yyrt1153 bool
-		if yyl1153 > cap(yyv1153) {
-
-			yyrg1153 := len(yyv1153) > 0
-			yyv21153 := yyv1153
-			yyrl1153, yyrt1153 = z.DecInferLen(yyl1153, z.DecBasicHandle().MaxInitLen, 216)
-			if yyrt1153 {
-				if yyrl1153 <= cap(yyv1153) {
-					yyv1153 = yyv1153[:yyrl1153]
-				} else {
-					yyv1153 = make([]ThirdPartyResourceData, yyrl1153)
-				}
-			} else {
-				yyv1153 = make([]ThirdPartyResourceData, yyrl1153)
-			}
-			yyc1153 = true
-			yyrr1153 = len(yyv1153)
-			if yyrg1153 {
-				copy(yyv1153, yyv21153)
-			}
-		} else if yyl1153 != len(yyv1153) {
-			yyv1153 = yyv1153[:yyl1153]
-			yyc1153 = true
-		}
-		yyj1153 := 0
-		for ; yyj1153 < yyrr1153; yyj1153++ {
-			yyh1153.ElemContainerState(yyj1153)
-			if r.TryDecodeAsNil() {
-				yyv1153[yyj1153] = ThirdPartyResourceData{}
-			} else {
-				yyv1154 := &yyv1153[yyj1153]
-				yyv1154.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1153 {
-			for ; yyj1153 < yyl1153; yyj1153++ {
-				yyv1153 = append(yyv1153, ThirdPartyResourceData{})
-				yyh1153.ElemContainerState(yyj1153)
-				if r.TryDecodeAsNil() {
-					yyv1153[yyj1153] = ThirdPartyResourceData{}
-				} else {
-					yyv1155 := &yyv1153[yyj1153]
-					yyv1155.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1153 := 0
-		for ; !r.CheckBreak(); yyj1153++ {
-
-			if yyj1153 >= len(yyv1153) {
-				yyv1153 = append(yyv1153, ThirdPartyResourceData{}) // var yyz1153 ThirdPartyResourceData
-				yyc1153 = true
-			}
-			yyh1153.ElemContainerState(yyj1153)
-			if yyj1153 < len(yyv1153) {
-				if r.TryDecodeAsNil() {
-					yyv1153[yyj1153] = ThirdPartyResourceData{}
-				} else {
-					yyv1156 := &yyv1153[yyj1153]
-					yyv1156.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1153 < len(yyv1153) {
-			yyv1153 = yyv1153[:yyj1153]
-			yyc1153 = true
-		} else if yyj1153 == 0 && yyv1153 == nil {
-			yyv1153 = []ThirdPartyResourceData{}
-			yyc1153 = true
-		}
-	}
-	yyh1153.End()
-	if yyc1153 {
-		*v = yyv1153
-	}
-}
-
-func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1157 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1158 := &yyv1157
-		yy1158.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1159 := *v
-	yyh1159, yyl1159 := z.DecSliceHelperStart()
-	var yyc1159 bool
-	if yyl1159 == 0 {
-		if yyv1159 == nil {
-			yyv1159 = []Job{}
-			yyc1159 = true
-		} else if len(yyv1159) != 0 {
-			yyv1159 = yyv1159[:0]
-			yyc1159 = true
-		}
-	} else if yyl1159 > 0 {
-		var yyrr1159, yyrl1159 int
-		var yyrt1159 bool
-		if yyl1159 > cap(yyv1159) {
-
-			yyrg1159 := len(yyv1159) > 0
-			yyv21159 := yyv1159
-			yyrl1159, yyrt1159 = z.DecInferLen(yyl1159, z.DecBasicHandle().MaxInitLen, 608)
-			if yyrt1159 {
-				if yyrl1159 <= cap(yyv1159) {
-					yyv1159 = yyv1159[:yyrl1159]
-				} else {
-					yyv1159 = make([]Job, yyrl1159)
-				}
-			} else {
-				yyv1159 = make([]Job, yyrl1159)
-			}
-			yyc1159 = true
-			yyrr1159 = len(yyv1159)
-			if yyrg1159 {
-				copy(yyv1159, yyv21159)
-			}
-		} else if yyl1159 != len(yyv1159) {
-			yyv1159 = yyv1159[:yyl1159]
-			yyc1159 = true
-		}
-		yyj1159 := 0
-		for ; yyj1159 < yyrr1159; yyj1159++ {
-			yyh1159.ElemContainerState(yyj1159)
-			if r.TryDecodeAsNil() {
-				yyv1159[yyj1159] = Job{}
-			} else {
-				yyv1160 := &yyv1159[yyj1159]
-				yyv1160.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1159 {
-			for ; yyj1159 < yyl1159; yyj1159++ {
-				yyv1159 = append(yyv1159, Job{})
-				yyh1159.ElemContainerState(yyj1159)
-				if r.TryDecodeAsNil() {
-					yyv1159[yyj1159] = Job{}
-				} else {
-					yyv1161 := &yyv1159[yyj1159]
-					yyv1161.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1159 := 0
-		for ; !r.CheckBreak(); yyj1159++ {
-
-			if yyj1159 >= len(yyv1159) {
-				yyv1159 = append(yyv1159, Job{}) // var yyz1159 Job
-				yyc1159 = true
-			}
-			yyh1159.ElemContainerState(yyj1159)
-			if yyj1159 < len(yyv1159) {
-				if r.TryDecodeAsNil() {
-					yyv1159[yyj1159] = Job{}
-				} else {
-					yyv1162 := &yyv1159[yyj1159]
-					yyv1162.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1159 < len(yyv1159) {
-			yyv1159 = yyv1159[:yyj1159]
-			yyc1159 = true
-		} else if yyj1159 == 0 && yyv1159 == nil {
-			yyv1159 = []Job{}
-			yyc1159 = true
-		}
-	}
-	yyh1159.End()
-	if yyc1159 {
-		*v = yyv1159
-	}
-}
-
-func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1163 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1164 := &yyv1163
-		yy1164.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1165 := *v
-	yyh1165, yyl1165 := z.DecSliceHelperStart()
-	var yyc1165 bool
-	if yyl1165 == 0 {
-		if yyv1165 == nil {
-			yyv1165 = []JobCondition{}
-			yyc1165 = true
-		} else if len(yyv1165) != 0 {
-			yyv1165 = yyv1165[:0]
-			yyc1165 = true
-		}
-	} else if yyl1165 > 0 {
-		var yyrr1165, yyrl1165 int
-		var yyrt1165 bool
-		if yyl1165 > cap(yyv1165) {
-
-			yyrg1165 := len(yyv1165) > 0
-			yyv21165 := yyv1165
-			yyrl1165, yyrt1165 = z.DecInferLen(yyl1165, z.DecBasicHandle().MaxInitLen, 112)
-			if yyrt1165 {
-				if yyrl1165 <= cap(yyv1165) {
-					yyv1165 = yyv1165[:yyrl1165]
-				} else {
-					yyv1165 = make([]JobCondition, yyrl1165)
-				}
-			} else {
-				yyv1165 = make([]JobCondition, yyrl1165)
-			}
-			yyc1165 = true
-			yyrr1165 = len(yyv1165)
-			if yyrg1165 {
-				copy(yyv1165, yyv21165)
-			}
-		} else if yyl1165 != len(yyv1165) {
-			yyv1165 = yyv1165[:yyl1165]
-			yyc1165 = true
-		}
-		yyj1165 := 0
-		for ; yyj1165 < yyrr1165; yyj1165++ {
-			yyh1165.ElemContainerState(yyj1165)
-			if r.TryDecodeAsNil() {
-				yyv1165[yyj1165] = JobCondition{}
-			} else {
-				yyv1166 := &yyv1165[yyj1165]
-				yyv1166.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1165 {
-			for ; yyj1165 < yyl1165; yyj1165++ {
-				yyv1165 = append(yyv1165, JobCondition{})
-				yyh1165.ElemContainerState(yyj1165)
-				if r.TryDecodeAsNil() {
-					yyv1165[yyj1165] = JobCondition{}
-				} else {
-					yyv1167 := &yyv1165[yyj1165]
-					yyv1167.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1165 := 0
-		for ; !r.CheckBreak(); yyj1165++ {
-
-			if yyj1165 >= len(yyv1165) {
-				yyv1165 = append(yyv1165, JobCondition{}) // var yyz1165 JobCondition
-				yyc1165 = true
-			}
-			yyh1165.ElemContainerState(yyj1165)
-			if yyj1165 < len(yyv1165) {
-				if r.TryDecodeAsNil() {
-					yyv1165[yyj1165] = JobCondition{}
-				} else {
-					yyv1168 := &yyv1165[yyj1165]
-					yyv1168.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1165 < len(yyv1165) {
-			yyv1165 = yyv1165[:yyj1165]
-			yyc1165 = true
-		} else if yyj1165 == 0 && yyv1165 == nil {
-			yyv1165 = []JobCondition{}
-			yyc1165 = true
-		}
-	}
-	yyh1165.End()
-	if yyc1165 {
-		*v = yyv1165
-	}
-}
-
-func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1169 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1170 := &yyv1169
-		yy1170.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1171 := *v
-	yyh1171, yyl1171 := z.DecSliceHelperStart()
-	var yyc1171 bool
-	if yyl1171 == 0 {
-		if yyv1171 == nil {
-			yyv1171 = []Ingress{}
-			yyc1171 = true
-		} else if len(yyv1171) != 0 {
-			yyv1171 = yyv1171[:0]
-			yyc1171 = true
-		}
-	} else if yyl1171 > 0 {
-		var yyrr1171, yyrl1171 int
-		var yyrt1171 bool
-		if yyl1171 > cap(yyv1171) {
-
-			yyrg1171 := len(yyv1171) > 0
-			yyv21171 := yyv1171
-			yyrl1171, yyrt1171 = z.DecInferLen(yyl1171, z.DecBasicHandle().MaxInitLen, 248)
-			if yyrt1171 {
-				if yyrl1171 <= cap(yyv1171) {
-					yyv1171 = yyv1171[:yyrl1171]
-				} else {
-					yyv1171 = make([]Ingress, yyrl1171)
-				}
-			} else {
-				yyv1171 = make([]Ingress, yyrl1171)
-			}
-			yyc1171 = true
-			yyrr1171 = len(yyv1171)
-			if yyrg1171 {
-				copy(yyv1171, yyv21171)
-			}
-		} else if yyl1171 != len(yyv1171) {
-			yyv1171 = yyv1171[:yyl1171]
-			yyc1171 = true
-		}
-		yyj1171 := 0
-		for ; yyj1171 < yyrr1171; yyj1171++ {
-			yyh1171.ElemContainerState(yyj1171)
-			if r.TryDecodeAsNil() {
-				yyv1171[yyj1171] = Ingress{}
-			} else {
-				yyv1172 := &yyv1171[yyj1171]
-				yyv1172.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1171 {
-			for ; yyj1171 < yyl1171; yyj1171++ {
-				yyv1171 = append(yyv1171, Ingress{})
-				yyh1171.ElemContainerState(yyj1171)
-				if r.TryDecodeAsNil() {
-					yyv1171[yyj1171] = Ingress{}
-				} else {
-					yyv1173 := &yyv1171[yyj1171]
-					yyv1173.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1171 := 0
-		for ; !r.CheckBreak(); yyj1171++ {
-
-			if yyj1171 >= len(yyv1171) {
-				yyv1171 = append(yyv1171, Ingress{}) // var yyz1171 Ingress
-				yyc1171 = true
-			}
-			yyh1171.ElemContainerState(yyj1171)
-			if yyj1171 < len(yyv1171) {
-				if r.TryDecodeAsNil() {
-					yyv1171[yyj1171] = Ingress{}
-				} else {
-					yyv1174 := &yyv1171[yyj1171]
-					yyv1174.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1171 < len(yyv1171) {
-			yyv1171 = yyv1171[:yyj1171]
-			yyc1171 = true
-		} else if yyj1171 == 0 && yyv1171 == nil {
-			yyv1171 = []Ingress{}
-			yyc1171 = true
-		}
-	}
-	yyh1171.End()
-	if yyc1171 {
-		*v = yyv1171
-	}
-}
-
-func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1175 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1176 := &yyv1175
-		yy1176.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1177 := *v
-	yyh1177, yyl1177 := z.DecSliceHelperStart()
-	var yyc1177 bool
-	if yyl1177 == 0 {
-		if yyv1177 == nil {
-			yyv1177 = []IngressRule{}
-			yyc1177 = true
-		} else if len(yyv1177) != 0 {
-			yyv1177 = yyv1177[:0]
-			yyc1177 = true
-		}
-	} else if yyl1177 > 0 {
-		var yyrr1177, yyrl1177 int
-		var yyrt1177 bool
-		if yyl1177 > cap(yyv1177) {
-
-			yyrg1177 := len(yyv1177) > 0
-			yyv21177 := yyv1177
-			yyrl1177, yyrt1177 = z.DecInferLen(yyl1177, z.DecBasicHandle().MaxInitLen, 24)
-			if yyrt1177 {
-				if yyrl1177 <= cap(yyv1177) {
-					yyv1177 = yyv1177[:yyrl1177]
-				} else {
-					yyv1177 = make([]IngressRule, yyrl1177)
-				}
-			} else {
-				yyv1177 = make([]IngressRule, yyrl1177)
-			}
-			yyc1177 = true
-			yyrr1177 = len(yyv1177)
-			if yyrg1177 {
-				copy(yyv1177, yyv21177)
-			}
-		} else if yyl1177 != len(yyv1177) {
-			yyv1177 = yyv1177[:yyl1177]
-			yyc1177 = true
-		}
-		yyj1177 := 0
-		for ; yyj1177 < yyrr1177; yyj1177++ {
-			yyh1177.ElemContainerState(yyj1177)
-			if r.TryDecodeAsNil() {
-				yyv1177[yyj1177] = IngressRule{}
-			} else {
-				yyv1178 := &yyv1177[yyj1177]
-				yyv1178.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1177 {
-			for ; yyj1177 < yyl1177; yyj1177++ {
-				yyv1177 = append(yyv1177, IngressRule{})
-				yyh1177.ElemContainerState(yyj1177)
-				if r.TryDecodeAsNil() {
-					yyv1177[yyj1177] = IngressRule{}
-				} else {
-					yyv1179 := &yyv1177[yyj1177]
-					yyv1179.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1177 := 0
-		for ; !r.CheckBreak(); yyj1177++ {
-
-			if yyj1177 >= len(yyv1177) {
-				yyv1177 = append(yyv1177, IngressRule{}) // var yyz1177 IngressRule
-				yyc1177 = true
-			}
-			yyh1177.ElemContainerState(yyj1177)
-			if yyj1177 < len(yyv1177) {
-				if r.TryDecodeAsNil() {
-					yyv1177[yyj1177] = IngressRule{}
-				} else {
-					yyv1180 := &yyv1177[yyj1177]
-					yyv1180.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1177 < len(yyv1177) {
-			yyv1177 = yyv1177[:yyj1177]
-			yyc1177 = true
-		} else if yyj1177 == 0 && yyv1177 == nil {
-			yyv1177 = []IngressRule{}
-			yyc1177 = true
-		}
-	}
-	yyh1177.End()
-	if yyc1177 {
-		*v = yyv1177
-	}
-}
-
-func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -14617,7 +14135,7 @@ func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec19
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
-func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1978.Decoder) {
+func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutoscaler, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -14627,7 +14145,7 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 	var yyc1183 bool
 	if yyl1183 == 0 {
 		if yyv1183 == nil {
-			yyv1183 = []HTTPIngressPath{}
+			yyv1183 = []HorizontalPodAutoscaler{}
 			yyc1183 = true
 		} else if len(yyv1183) != 0 {
 			yyv1183 = yyv1183[:0]
@@ -14640,15 +14158,15 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 
 			yyrg1183 := len(yyv1183) > 0
 			yyv21183 := yyv1183
-			yyrl1183, yyrt1183 = z.DecInferLen(yyl1183, z.DecBasicHandle().MaxInitLen, 64)
+			yyrl1183, yyrt1183 = z.DecInferLen(yyl1183, z.DecBasicHandle().MaxInitLen, 320)
 			if yyrt1183 {
 				if yyrl1183 <= cap(yyv1183) {
 					yyv1183 = yyv1183[:yyrl1183]
 				} else {
-					yyv1183 = make([]HTTPIngressPath, yyrl1183)
+					yyv1183 = make([]HorizontalPodAutoscaler, yyrl1183)
 				}
 			} else {
-				yyv1183 = make([]HTTPIngressPath, yyrl1183)
+				yyv1183 = make([]HorizontalPodAutoscaler, yyrl1183)
 			}
 			yyc1183 = true
 			yyrr1183 = len(yyv1183)
@@ -14663,7 +14181,7 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 		for ; yyj1183 < yyrr1183; yyj1183++ {
 			yyh1183.ElemContainerState(yyj1183)
 			if r.TryDecodeAsNil() {
-				yyv1183[yyj1183] = HTTPIngressPath{}
+				yyv1183[yyj1183] = HorizontalPodAutoscaler{}
 			} else {
 				yyv1184 := &yyv1183[yyj1183]
 				yyv1184.CodecDecodeSelf(d)
@@ -14672,10 +14190,10 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 		}
 		if yyrt1183 {
 			for ; yyj1183 < yyl1183; yyj1183++ {
-				yyv1183 = append(yyv1183, HTTPIngressPath{})
+				yyv1183 = append(yyv1183, HorizontalPodAutoscaler{})
 				yyh1183.ElemContainerState(yyj1183)
 				if r.TryDecodeAsNil() {
-					yyv1183[yyj1183] = HTTPIngressPath{}
+					yyv1183[yyj1183] = HorizontalPodAutoscaler{}
 				} else {
 					yyv1185 := &yyv1183[yyj1183]
 					yyv1185.CodecDecodeSelf(d)
@@ -14689,13 +14207,13 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 		for ; !r.CheckBreak(); yyj1183++ {
 
 			if yyj1183 >= len(yyv1183) {
-				yyv1183 = append(yyv1183, HTTPIngressPath{}) // var yyz1183 HTTPIngressPath
+				yyv1183 = append(yyv1183, HorizontalPodAutoscaler{}) // var yyz1183 HorizontalPodAutoscaler
 				yyc1183 = true
 			}
 			yyh1183.ElemContainerState(yyj1183)
 			if yyj1183 < len(yyv1183) {
 				if r.TryDecodeAsNil() {
-					yyv1183[yyj1183] = HTTPIngressPath{}
+					yyv1183[yyj1183] = HorizontalPodAutoscaler{}
 				} else {
 					yyv1186 := &yyv1183[yyj1183]
 					yyv1186.CodecDecodeSelf(d)
@@ -14710,7 +14228,7 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 			yyv1183 = yyv1183[:yyj1183]
 			yyc1183 = true
 		} else if yyj1183 == 0 && yyv1183 == nil {
-			yyv1183 = []HTTPIngressPath{}
+			yyv1183 = []HorizontalPodAutoscaler{}
 			yyc1183 = true
 		}
 	}
@@ -14720,7 +14238,7 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 	}
 }
 
-func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec1978.Encoder) {
+func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -14733,7 +14251,7 @@ func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec19
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
-func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1978.Decoder) {
+func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -14743,7 +14261,7 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 	var yyc1189 bool
 	if yyl1189 == 0 {
 		if yyv1189 == nil {
-			yyv1189 = []NodeUtilization{}
+			yyv1189 = []APIVersion{}
 			yyc1189 = true
 		} else if len(yyv1189) != 0 {
 			yyv1189 = yyv1189[:0]
@@ -14756,15 +14274,15 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 
 			yyrg1189 := len(yyv1189) > 0
 			yyv21189 := yyv1189
-			yyrl1189, yyrt1189 = z.DecInferLen(yyl1189, z.DecBasicHandle().MaxInitLen, 24)
+			yyrl1189, yyrt1189 = z.DecInferLen(yyl1189, z.DecBasicHandle().MaxInitLen, 32)
 			if yyrt1189 {
 				if yyrl1189 <= cap(yyv1189) {
 					yyv1189 = yyv1189[:yyrl1189]
 				} else {
-					yyv1189 = make([]NodeUtilization, yyrl1189)
+					yyv1189 = make([]APIVersion, yyrl1189)
 				}
 			} else {
-				yyv1189 = make([]NodeUtilization, yyrl1189)
+				yyv1189 = make([]APIVersion, yyrl1189)
 			}
 			yyc1189 = true
 			yyrr1189 = len(yyv1189)
@@ -14779,7 +14297,7 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 		for ; yyj1189 < yyrr1189; yyj1189++ {
 			yyh1189.ElemContainerState(yyj1189)
 			if r.TryDecodeAsNil() {
-				yyv1189[yyj1189] = NodeUtilization{}
+				yyv1189[yyj1189] = APIVersion{}
 			} else {
 				yyv1190 := &yyv1189[yyj1189]
 				yyv1190.CodecDecodeSelf(d)
@@ -14788,10 +14306,10 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 		}
 		if yyrt1189 {
 			for ; yyj1189 < yyl1189; yyj1189++ {
-				yyv1189 = append(yyv1189, NodeUtilization{})
+				yyv1189 = append(yyv1189, APIVersion{})
 				yyh1189.ElemContainerState(yyj1189)
 				if r.TryDecodeAsNil() {
-					yyv1189[yyj1189] = NodeUtilization{}
+					yyv1189[yyj1189] = APIVersion{}
 				} else {
 					yyv1191 := &yyv1189[yyj1189]
 					yyv1191.CodecDecodeSelf(d)
@@ -14805,13 +14323,13 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 		for ; !r.CheckBreak(); yyj1189++ {
 
 			if yyj1189 >= len(yyv1189) {
-				yyv1189 = append(yyv1189, NodeUtilization{}) // var yyz1189 NodeUtilization
+				yyv1189 = append(yyv1189, APIVersion{}) // var yyz1189 APIVersion
 				yyc1189 = true
 			}
 			yyh1189.ElemContainerState(yyj1189)
 			if yyj1189 < len(yyv1189) {
 				if r.TryDecodeAsNil() {
-					yyv1189[yyj1189] = NodeUtilization{}
+					yyv1189[yyj1189] = APIVersion{}
 				} else {
 					yyv1192 := &yyv1189[yyj1189]
 					yyv1192.CodecDecodeSelf(d)
@@ -14826,7 +14344,7 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 			yyv1189 = yyv1189[:yyj1189]
 			yyc1189 = true
 		} else if yyj1189 == 0 && yyv1189 == nil {
-			yyv1189 = []NodeUtilization{}
+			yyv1189 = []APIVersion{}
 			yyc1189 = true
 		}
 	}
@@ -14836,7 +14354,7 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 	}
 }
 
-func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *codec1978.Encoder) {
+func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -14849,7 +14367,7 @@ func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *cod
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
-func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *codec1978.Decoder) {
+func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -14859,7 +14377,7 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 	var yyc1195 bool
 	if yyl1195 == 0 {
 		if yyv1195 == nil {
-			yyv1195 = []ClusterAutoscaler{}
+			yyv1195 = []ThirdPartyResource{}
 			yyc1195 = true
 		} else if len(yyv1195) != 0 {
 			yyv1195 = yyv1195[:0]
@@ -14877,10 +14395,10 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 				if yyrl1195 <= cap(yyv1195) {
 					yyv1195 = yyv1195[:yyrl1195]
 				} else {
-					yyv1195 = make([]ClusterAutoscaler, yyrl1195)
+					yyv1195 = make([]ThirdPartyResource, yyrl1195)
 				}
 			} else {
-				yyv1195 = make([]ClusterAutoscaler, yyrl1195)
+				yyv1195 = make([]ThirdPartyResource, yyrl1195)
 			}
 			yyc1195 = true
 			yyrr1195 = len(yyv1195)
@@ -14895,7 +14413,7 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 		for ; yyj1195 < yyrr1195; yyj1195++ {
 			yyh1195.ElemContainerState(yyj1195)
 			if r.TryDecodeAsNil() {
-				yyv1195[yyj1195] = ClusterAutoscaler{}
+				yyv1195[yyj1195] = ThirdPartyResource{}
 			} else {
 				yyv1196 := &yyv1195[yyj1195]
 				yyv1196.CodecDecodeSelf(d)
@@ -14904,10 +14422,10 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 		}
 		if yyrt1195 {
 			for ; yyj1195 < yyl1195; yyj1195++ {
-				yyv1195 = append(yyv1195, ClusterAutoscaler{})
+				yyv1195 = append(yyv1195, ThirdPartyResource{})
 				yyh1195.ElemContainerState(yyj1195)
 				if r.TryDecodeAsNil() {
-					yyv1195[yyj1195] = ClusterAutoscaler{}
+					yyv1195[yyj1195] = ThirdPartyResource{}
 				} else {
 					yyv1197 := &yyv1195[yyj1195]
 					yyv1197.CodecDecodeSelf(d)
@@ -14921,13 +14439,13 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 		for ; !r.CheckBreak(); yyj1195++ {
 
 			if yyj1195 >= len(yyv1195) {
-				yyv1195 = append(yyv1195, ClusterAutoscaler{}) // var yyz1195 ClusterAutoscaler
+				yyv1195 = append(yyv1195, ThirdPartyResource{}) // var yyz1195 ThirdPartyResource
 				yyc1195 = true
 			}
 			yyh1195.ElemContainerState(yyj1195)
 			if yyj1195 < len(yyv1195) {
 				if r.TryDecodeAsNil() {
-					yyv1195[yyj1195] = ClusterAutoscaler{}
+					yyv1195[yyj1195] = ThirdPartyResource{}
 				} else {
 					yyv1198 := &yyv1195[yyj1195]
 					yyv1198.CodecDecodeSelf(d)
@@ -14942,7 +14460,7 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 			yyv1195 = yyv1195[:yyj1195]
 			yyc1195 = true
 		} else if yyj1195 == 0 && yyv1195 == nil {
-			yyv1195 = []ClusterAutoscaler{}
+			yyv1195 = []ThirdPartyResource{}
 			yyc1195 = true
 		}
 	}
@@ -14952,7 +14470,7 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 	}
 }
 
-func (x codecSelfer1234) encSliceLabelSelectorRequirement(v []LabelSelectorRequirement, e *codec1978.Encoder) {
+func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -14965,7 +14483,7 @@ func (x codecSelfer1234) encSliceLabelSelectorRequirement(v []LabelSelectorRequi
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
-func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequirement, d *codec1978.Decoder) {
+func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -14975,7 +14493,7 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 	var yyc1201 bool
 	if yyl1201 == 0 {
 		if yyv1201 == nil {
-			yyv1201 = []LabelSelectorRequirement{}
+			yyv1201 = []Deployment{}
 			yyc1201 = true
 		} else if len(yyv1201) != 0 {
 			yyv1201 = yyv1201[:0]
@@ -14988,15 +14506,15 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 
 			yyrg1201 := len(yyv1201) > 0
 			yyv21201 := yyv1201
-			yyrl1201, yyrt1201 = z.DecInferLen(yyl1201, z.DecBasicHandle().MaxInitLen, 56)
+			yyrl1201, yyrt1201 = z.DecInferLen(yyl1201, z.DecBasicHandle().MaxInitLen, 592)
 			if yyrt1201 {
 				if yyrl1201 <= cap(yyv1201) {
 					yyv1201 = yyv1201[:yyrl1201]
 				} else {
-					yyv1201 = make([]LabelSelectorRequirement, yyrl1201)
+					yyv1201 = make([]Deployment, yyrl1201)
 				}
 			} else {
-				yyv1201 = make([]LabelSelectorRequirement, yyrl1201)
+				yyv1201 = make([]Deployment, yyrl1201)
 			}
 			yyc1201 = true
 			yyrr1201 = len(yyv1201)
@@ -15011,7 +14529,7 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 		for ; yyj1201 < yyrr1201; yyj1201++ {
 			yyh1201.ElemContainerState(yyj1201)
 			if r.TryDecodeAsNil() {
-				yyv1201[yyj1201] = LabelSelectorRequirement{}
+				yyv1201[yyj1201] = Deployment{}
 			} else {
 				yyv1202 := &yyv1201[yyj1201]
 				yyv1202.CodecDecodeSelf(d)
@@ -15020,10 +14538,10 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 		}
 		if yyrt1201 {
 			for ; yyj1201 < yyl1201; yyj1201++ {
-				yyv1201 = append(yyv1201, LabelSelectorRequirement{})
+				yyv1201 = append(yyv1201, Deployment{})
 				yyh1201.ElemContainerState(yyj1201)
 				if r.TryDecodeAsNil() {
-					yyv1201[yyj1201] = LabelSelectorRequirement{}
+					yyv1201[yyj1201] = Deployment{}
 				} else {
 					yyv1203 := &yyv1201[yyj1201]
 					yyv1203.CodecDecodeSelf(d)
@@ -15037,13 +14555,13 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 		for ; !r.CheckBreak(); yyj1201++ {
 
 			if yyj1201 >= len(yyv1201) {
-				yyv1201 = append(yyv1201, LabelSelectorRequirement{}) // var yyz1201 LabelSelectorRequirement
+				yyv1201 = append(yyv1201, Deployment{}) // var yyz1201 Deployment
 				yyc1201 = true
 			}
 			yyh1201.ElemContainerState(yyj1201)
 			if yyj1201 < len(yyv1201) {
 				if r.TryDecodeAsNil() {
-					yyv1201[yyj1201] = LabelSelectorRequirement{}
+					yyv1201[yyj1201] = Deployment{}
 				} else {
 					yyv1204 := &yyv1201[yyj1201]
 					yyv1204.CodecDecodeSelf(d)
@@ -15058,12 +14576,1288 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 			yyv1201 = yyv1201[:yyj1201]
 			yyc1201 = true
 		} else if yyj1201 == 0 && yyv1201 == nil {
-			yyv1201 = []LabelSelectorRequirement{}
+			yyv1201 = []Deployment{}
 			yyc1201 = true
 		}
 	}
 	yyh1201.End()
 	if yyc1201 {
 		*v = yyv1201
+	}
+}
+
+func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1205 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1206 := &yyv1205
+		yy1206.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1207 := *v
+	yyh1207, yyl1207 := z.DecSliceHelperStart()
+	var yyc1207 bool
+	if yyl1207 == 0 {
+		if yyv1207 == nil {
+			yyv1207 = []DaemonSet{}
+			yyc1207 = true
+		} else if len(yyv1207) != 0 {
+			yyv1207 = yyv1207[:0]
+			yyc1207 = true
+		}
+	} else if yyl1207 > 0 {
+		var yyrr1207, yyrl1207 int
+		var yyrt1207 bool
+		if yyl1207 > cap(yyv1207) {
+
+			yyrg1207 := len(yyv1207) > 0
+			yyv21207 := yyv1207
+			yyrl1207, yyrt1207 = z.DecInferLen(yyl1207, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1207 {
+				if yyrl1207 <= cap(yyv1207) {
+					yyv1207 = yyv1207[:yyrl1207]
+				} else {
+					yyv1207 = make([]DaemonSet, yyrl1207)
+				}
+			} else {
+				yyv1207 = make([]DaemonSet, yyrl1207)
+			}
+			yyc1207 = true
+			yyrr1207 = len(yyv1207)
+			if yyrg1207 {
+				copy(yyv1207, yyv21207)
+			}
+		} else if yyl1207 != len(yyv1207) {
+			yyv1207 = yyv1207[:yyl1207]
+			yyc1207 = true
+		}
+		yyj1207 := 0
+		for ; yyj1207 < yyrr1207; yyj1207++ {
+			yyh1207.ElemContainerState(yyj1207)
+			if r.TryDecodeAsNil() {
+				yyv1207[yyj1207] = DaemonSet{}
+			} else {
+				yyv1208 := &yyv1207[yyj1207]
+				yyv1208.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1207 {
+			for ; yyj1207 < yyl1207; yyj1207++ {
+				yyv1207 = append(yyv1207, DaemonSet{})
+				yyh1207.ElemContainerState(yyj1207)
+				if r.TryDecodeAsNil() {
+					yyv1207[yyj1207] = DaemonSet{}
+				} else {
+					yyv1209 := &yyv1207[yyj1207]
+					yyv1209.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1207 := 0
+		for ; !r.CheckBreak(); yyj1207++ {
+
+			if yyj1207 >= len(yyv1207) {
+				yyv1207 = append(yyv1207, DaemonSet{}) // var yyz1207 DaemonSet
+				yyc1207 = true
+			}
+			yyh1207.ElemContainerState(yyj1207)
+			if yyj1207 < len(yyv1207) {
+				if r.TryDecodeAsNil() {
+					yyv1207[yyj1207] = DaemonSet{}
+				} else {
+					yyv1210 := &yyv1207[yyj1207]
+					yyv1210.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1207 < len(yyv1207) {
+			yyv1207 = yyv1207[:yyj1207]
+			yyc1207 = true
+		} else if yyj1207 == 0 && yyv1207 == nil {
+			yyv1207 = []DaemonSet{}
+			yyc1207 = true
+		}
+	}
+	yyh1207.End()
+	if yyc1207 {
+		*v = yyv1207
+	}
+}
+
+func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceData, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1211 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1212 := &yyv1211
+		yy1212.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceData, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1213 := *v
+	yyh1213, yyl1213 := z.DecSliceHelperStart()
+	var yyc1213 bool
+	if yyl1213 == 0 {
+		if yyv1213 == nil {
+			yyv1213 = []ThirdPartyResourceData{}
+			yyc1213 = true
+		} else if len(yyv1213) != 0 {
+			yyv1213 = yyv1213[:0]
+			yyc1213 = true
+		}
+	} else if yyl1213 > 0 {
+		var yyrr1213, yyrl1213 int
+		var yyrt1213 bool
+		if yyl1213 > cap(yyv1213) {
+
+			yyrg1213 := len(yyv1213) > 0
+			yyv21213 := yyv1213
+			yyrl1213, yyrt1213 = z.DecInferLen(yyl1213, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt1213 {
+				if yyrl1213 <= cap(yyv1213) {
+					yyv1213 = yyv1213[:yyrl1213]
+				} else {
+					yyv1213 = make([]ThirdPartyResourceData, yyrl1213)
+				}
+			} else {
+				yyv1213 = make([]ThirdPartyResourceData, yyrl1213)
+			}
+			yyc1213 = true
+			yyrr1213 = len(yyv1213)
+			if yyrg1213 {
+				copy(yyv1213, yyv21213)
+			}
+		} else if yyl1213 != len(yyv1213) {
+			yyv1213 = yyv1213[:yyl1213]
+			yyc1213 = true
+		}
+		yyj1213 := 0
+		for ; yyj1213 < yyrr1213; yyj1213++ {
+			yyh1213.ElemContainerState(yyj1213)
+			if r.TryDecodeAsNil() {
+				yyv1213[yyj1213] = ThirdPartyResourceData{}
+			} else {
+				yyv1214 := &yyv1213[yyj1213]
+				yyv1214.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1213 {
+			for ; yyj1213 < yyl1213; yyj1213++ {
+				yyv1213 = append(yyv1213, ThirdPartyResourceData{})
+				yyh1213.ElemContainerState(yyj1213)
+				if r.TryDecodeAsNil() {
+					yyv1213[yyj1213] = ThirdPartyResourceData{}
+				} else {
+					yyv1215 := &yyv1213[yyj1213]
+					yyv1215.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1213 := 0
+		for ; !r.CheckBreak(); yyj1213++ {
+
+			if yyj1213 >= len(yyv1213) {
+				yyv1213 = append(yyv1213, ThirdPartyResourceData{}) // var yyz1213 ThirdPartyResourceData
+				yyc1213 = true
+			}
+			yyh1213.ElemContainerState(yyj1213)
+			if yyj1213 < len(yyv1213) {
+				if r.TryDecodeAsNil() {
+					yyv1213[yyj1213] = ThirdPartyResourceData{}
+				} else {
+					yyv1216 := &yyv1213[yyj1213]
+					yyv1216.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1213 < len(yyv1213) {
+			yyv1213 = yyv1213[:yyj1213]
+			yyc1213 = true
+		} else if yyj1213 == 0 && yyv1213 == nil {
+			yyv1213 = []ThirdPartyResourceData{}
+			yyc1213 = true
+		}
+	}
+	yyh1213.End()
+	if yyc1213 {
+		*v = yyv1213
+	}
+}
+
+func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1217 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1218 := &yyv1217
+		yy1218.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1219 := *v
+	yyh1219, yyl1219 := z.DecSliceHelperStart()
+	var yyc1219 bool
+	if yyl1219 == 0 {
+		if yyv1219 == nil {
+			yyv1219 = []Job{}
+			yyc1219 = true
+		} else if len(yyv1219) != 0 {
+			yyv1219 = yyv1219[:0]
+			yyc1219 = true
+		}
+	} else if yyl1219 > 0 {
+		var yyrr1219, yyrl1219 int
+		var yyrt1219 bool
+		if yyl1219 > cap(yyv1219) {
+
+			yyrg1219 := len(yyv1219) > 0
+			yyv21219 := yyv1219
+			yyrl1219, yyrt1219 = z.DecInferLen(yyl1219, z.DecBasicHandle().MaxInitLen, 608)
+			if yyrt1219 {
+				if yyrl1219 <= cap(yyv1219) {
+					yyv1219 = yyv1219[:yyrl1219]
+				} else {
+					yyv1219 = make([]Job, yyrl1219)
+				}
+			} else {
+				yyv1219 = make([]Job, yyrl1219)
+			}
+			yyc1219 = true
+			yyrr1219 = len(yyv1219)
+			if yyrg1219 {
+				copy(yyv1219, yyv21219)
+			}
+		} else if yyl1219 != len(yyv1219) {
+			yyv1219 = yyv1219[:yyl1219]
+			yyc1219 = true
+		}
+		yyj1219 := 0
+		for ; yyj1219 < yyrr1219; yyj1219++ {
+			yyh1219.ElemContainerState(yyj1219)
+			if r.TryDecodeAsNil() {
+				yyv1219[yyj1219] = Job{}
+			} else {
+				yyv1220 := &yyv1219[yyj1219]
+				yyv1220.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1219 {
+			for ; yyj1219 < yyl1219; yyj1219++ {
+				yyv1219 = append(yyv1219, Job{})
+				yyh1219.ElemContainerState(yyj1219)
+				if r.TryDecodeAsNil() {
+					yyv1219[yyj1219] = Job{}
+				} else {
+					yyv1221 := &yyv1219[yyj1219]
+					yyv1221.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1219 := 0
+		for ; !r.CheckBreak(); yyj1219++ {
+
+			if yyj1219 >= len(yyv1219) {
+				yyv1219 = append(yyv1219, Job{}) // var yyz1219 Job
+				yyc1219 = true
+			}
+			yyh1219.ElemContainerState(yyj1219)
+			if yyj1219 < len(yyv1219) {
+				if r.TryDecodeAsNil() {
+					yyv1219[yyj1219] = Job{}
+				} else {
+					yyv1222 := &yyv1219[yyj1219]
+					yyv1222.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1219 < len(yyv1219) {
+			yyv1219 = yyv1219[:yyj1219]
+			yyc1219 = true
+		} else if yyj1219 == 0 && yyv1219 == nil {
+			yyv1219 = []Job{}
+			yyc1219 = true
+		}
+	}
+	yyh1219.End()
+	if yyc1219 {
+		*v = yyv1219
+	}
+}
+
+func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1223 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1224 := &yyv1223
+		yy1224.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1225 := *v
+	yyh1225, yyl1225 := z.DecSliceHelperStart()
+	var yyc1225 bool
+	if yyl1225 == 0 {
+		if yyv1225 == nil {
+			yyv1225 = []JobCondition{}
+			yyc1225 = true
+		} else if len(yyv1225) != 0 {
+			yyv1225 = yyv1225[:0]
+			yyc1225 = true
+		}
+	} else if yyl1225 > 0 {
+		var yyrr1225, yyrl1225 int
+		var yyrt1225 bool
+		if yyl1225 > cap(yyv1225) {
+
+			yyrg1225 := len(yyv1225) > 0
+			yyv21225 := yyv1225
+			yyrl1225, yyrt1225 = z.DecInferLen(yyl1225, z.DecBasicHandle().MaxInitLen, 112)
+			if yyrt1225 {
+				if yyrl1225 <= cap(yyv1225) {
+					yyv1225 = yyv1225[:yyrl1225]
+				} else {
+					yyv1225 = make([]JobCondition, yyrl1225)
+				}
+			} else {
+				yyv1225 = make([]JobCondition, yyrl1225)
+			}
+			yyc1225 = true
+			yyrr1225 = len(yyv1225)
+			if yyrg1225 {
+				copy(yyv1225, yyv21225)
+			}
+		} else if yyl1225 != len(yyv1225) {
+			yyv1225 = yyv1225[:yyl1225]
+			yyc1225 = true
+		}
+		yyj1225 := 0
+		for ; yyj1225 < yyrr1225; yyj1225++ {
+			yyh1225.ElemContainerState(yyj1225)
+			if r.TryDecodeAsNil() {
+				yyv1225[yyj1225] = JobCondition{}
+			} else {
+				yyv1226 := &yyv1225[yyj1225]
+				yyv1226.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1225 {
+			for ; yyj1225 < yyl1225; yyj1225++ {
+				yyv1225 = append(yyv1225, JobCondition{})
+				yyh1225.ElemContainerState(yyj1225)
+				if r.TryDecodeAsNil() {
+					yyv1225[yyj1225] = JobCondition{}
+				} else {
+					yyv1227 := &yyv1225[yyj1225]
+					yyv1227.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1225 := 0
+		for ; !r.CheckBreak(); yyj1225++ {
+
+			if yyj1225 >= len(yyv1225) {
+				yyv1225 = append(yyv1225, JobCondition{}) // var yyz1225 JobCondition
+				yyc1225 = true
+			}
+			yyh1225.ElemContainerState(yyj1225)
+			if yyj1225 < len(yyv1225) {
+				if r.TryDecodeAsNil() {
+					yyv1225[yyj1225] = JobCondition{}
+				} else {
+					yyv1228 := &yyv1225[yyj1225]
+					yyv1228.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1225 < len(yyv1225) {
+			yyv1225 = yyv1225[:yyj1225]
+			yyc1225 = true
+		} else if yyj1225 == 0 && yyv1225 == nil {
+			yyv1225 = []JobCondition{}
+			yyc1225 = true
+		}
+	}
+	yyh1225.End()
+	if yyc1225 {
+		*v = yyv1225
+	}
+}
+
+func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1229 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1230 := &yyv1229
+		yy1230.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1231 := *v
+	yyh1231, yyl1231 := z.DecSliceHelperStart()
+	var yyc1231 bool
+	if yyl1231 == 0 {
+		if yyv1231 == nil {
+			yyv1231 = []Ingress{}
+			yyc1231 = true
+		} else if len(yyv1231) != 0 {
+			yyv1231 = yyv1231[:0]
+			yyc1231 = true
+		}
+	} else if yyl1231 > 0 {
+		var yyrr1231, yyrl1231 int
+		var yyrt1231 bool
+		if yyl1231 > cap(yyv1231) {
+
+			yyrg1231 := len(yyv1231) > 0
+			yyv21231 := yyv1231
+			yyrl1231, yyrt1231 = z.DecInferLen(yyl1231, z.DecBasicHandle().MaxInitLen, 248)
+			if yyrt1231 {
+				if yyrl1231 <= cap(yyv1231) {
+					yyv1231 = yyv1231[:yyrl1231]
+				} else {
+					yyv1231 = make([]Ingress, yyrl1231)
+				}
+			} else {
+				yyv1231 = make([]Ingress, yyrl1231)
+			}
+			yyc1231 = true
+			yyrr1231 = len(yyv1231)
+			if yyrg1231 {
+				copy(yyv1231, yyv21231)
+			}
+		} else if yyl1231 != len(yyv1231) {
+			yyv1231 = yyv1231[:yyl1231]
+			yyc1231 = true
+		}
+		yyj1231 := 0
+		for ; yyj1231 < yyrr1231; yyj1231++ {
+			yyh1231.ElemContainerState(yyj1231)
+			if r.TryDecodeAsNil() {
+				yyv1231[yyj1231] = Ingress{}
+			} else {
+				yyv1232 := &yyv1231[yyj1231]
+				yyv1232.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1231 {
+			for ; yyj1231 < yyl1231; yyj1231++ {
+				yyv1231 = append(yyv1231, Ingress{})
+				yyh1231.ElemContainerState(yyj1231)
+				if r.TryDecodeAsNil() {
+					yyv1231[yyj1231] = Ingress{}
+				} else {
+					yyv1233 := &yyv1231[yyj1231]
+					yyv1233.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1231 := 0
+		for ; !r.CheckBreak(); yyj1231++ {
+
+			if yyj1231 >= len(yyv1231) {
+				yyv1231 = append(yyv1231, Ingress{}) // var yyz1231 Ingress
+				yyc1231 = true
+			}
+			yyh1231.ElemContainerState(yyj1231)
+			if yyj1231 < len(yyv1231) {
+				if r.TryDecodeAsNil() {
+					yyv1231[yyj1231] = Ingress{}
+				} else {
+					yyv1234 := &yyv1231[yyj1231]
+					yyv1234.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1231 < len(yyv1231) {
+			yyv1231 = yyv1231[:yyj1231]
+			yyc1231 = true
+		} else if yyj1231 == 0 && yyv1231 == nil {
+			yyv1231 = []Ingress{}
+			yyc1231 = true
+		}
+	}
+	yyh1231.End()
+	if yyc1231 {
+		*v = yyv1231
+	}
+}
+
+func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1235 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1236 := &yyv1235
+		yy1236.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1237 := *v
+	yyh1237, yyl1237 := z.DecSliceHelperStart()
+	var yyc1237 bool
+	if yyl1237 == 0 {
+		if yyv1237 == nil {
+			yyv1237 = []IngressRule{}
+			yyc1237 = true
+		} else if len(yyv1237) != 0 {
+			yyv1237 = yyv1237[:0]
+			yyc1237 = true
+		}
+	} else if yyl1237 > 0 {
+		var yyrr1237, yyrl1237 int
+		var yyrt1237 bool
+		if yyl1237 > cap(yyv1237) {
+
+			yyrg1237 := len(yyv1237) > 0
+			yyv21237 := yyv1237
+			yyrl1237, yyrt1237 = z.DecInferLen(yyl1237, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt1237 {
+				if yyrl1237 <= cap(yyv1237) {
+					yyv1237 = yyv1237[:yyrl1237]
+				} else {
+					yyv1237 = make([]IngressRule, yyrl1237)
+				}
+			} else {
+				yyv1237 = make([]IngressRule, yyrl1237)
+			}
+			yyc1237 = true
+			yyrr1237 = len(yyv1237)
+			if yyrg1237 {
+				copy(yyv1237, yyv21237)
+			}
+		} else if yyl1237 != len(yyv1237) {
+			yyv1237 = yyv1237[:yyl1237]
+			yyc1237 = true
+		}
+		yyj1237 := 0
+		for ; yyj1237 < yyrr1237; yyj1237++ {
+			yyh1237.ElemContainerState(yyj1237)
+			if r.TryDecodeAsNil() {
+				yyv1237[yyj1237] = IngressRule{}
+			} else {
+				yyv1238 := &yyv1237[yyj1237]
+				yyv1238.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1237 {
+			for ; yyj1237 < yyl1237; yyj1237++ {
+				yyv1237 = append(yyv1237, IngressRule{})
+				yyh1237.ElemContainerState(yyj1237)
+				if r.TryDecodeAsNil() {
+					yyv1237[yyj1237] = IngressRule{}
+				} else {
+					yyv1239 := &yyv1237[yyj1237]
+					yyv1239.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1237 := 0
+		for ; !r.CheckBreak(); yyj1237++ {
+
+			if yyj1237 >= len(yyv1237) {
+				yyv1237 = append(yyv1237, IngressRule{}) // var yyz1237 IngressRule
+				yyc1237 = true
+			}
+			yyh1237.ElemContainerState(yyj1237)
+			if yyj1237 < len(yyv1237) {
+				if r.TryDecodeAsNil() {
+					yyv1237[yyj1237] = IngressRule{}
+				} else {
+					yyv1240 := &yyv1237[yyj1237]
+					yyv1240.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1237 < len(yyv1237) {
+			yyv1237 = yyv1237[:yyj1237]
+			yyc1237 = true
+		} else if yyj1237 == 0 && yyv1237 == nil {
+			yyv1237 = []IngressRule{}
+			yyc1237 = true
+		}
+	}
+	yyh1237.End()
+	if yyc1237 {
+		*v = yyv1237
+	}
+}
+
+func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1241 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1242 := &yyv1241
+		yy1242.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1243 := *v
+	yyh1243, yyl1243 := z.DecSliceHelperStart()
+	var yyc1243 bool
+	if yyl1243 == 0 {
+		if yyv1243 == nil {
+			yyv1243 = []HTTPIngressPath{}
+			yyc1243 = true
+		} else if len(yyv1243) != 0 {
+			yyv1243 = yyv1243[:0]
+			yyc1243 = true
+		}
+	} else if yyl1243 > 0 {
+		var yyrr1243, yyrl1243 int
+		var yyrt1243 bool
+		if yyl1243 > cap(yyv1243) {
+
+			yyrg1243 := len(yyv1243) > 0
+			yyv21243 := yyv1243
+			yyrl1243, yyrt1243 = z.DecInferLen(yyl1243, z.DecBasicHandle().MaxInitLen, 64)
+			if yyrt1243 {
+				if yyrl1243 <= cap(yyv1243) {
+					yyv1243 = yyv1243[:yyrl1243]
+				} else {
+					yyv1243 = make([]HTTPIngressPath, yyrl1243)
+				}
+			} else {
+				yyv1243 = make([]HTTPIngressPath, yyrl1243)
+			}
+			yyc1243 = true
+			yyrr1243 = len(yyv1243)
+			if yyrg1243 {
+				copy(yyv1243, yyv21243)
+			}
+		} else if yyl1243 != len(yyv1243) {
+			yyv1243 = yyv1243[:yyl1243]
+			yyc1243 = true
+		}
+		yyj1243 := 0
+		for ; yyj1243 < yyrr1243; yyj1243++ {
+			yyh1243.ElemContainerState(yyj1243)
+			if r.TryDecodeAsNil() {
+				yyv1243[yyj1243] = HTTPIngressPath{}
+			} else {
+				yyv1244 := &yyv1243[yyj1243]
+				yyv1244.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1243 {
+			for ; yyj1243 < yyl1243; yyj1243++ {
+				yyv1243 = append(yyv1243, HTTPIngressPath{})
+				yyh1243.ElemContainerState(yyj1243)
+				if r.TryDecodeAsNil() {
+					yyv1243[yyj1243] = HTTPIngressPath{}
+				} else {
+					yyv1245 := &yyv1243[yyj1243]
+					yyv1245.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1243 := 0
+		for ; !r.CheckBreak(); yyj1243++ {
+
+			if yyj1243 >= len(yyv1243) {
+				yyv1243 = append(yyv1243, HTTPIngressPath{}) // var yyz1243 HTTPIngressPath
+				yyc1243 = true
+			}
+			yyh1243.ElemContainerState(yyj1243)
+			if yyj1243 < len(yyv1243) {
+				if r.TryDecodeAsNil() {
+					yyv1243[yyj1243] = HTTPIngressPath{}
+				} else {
+					yyv1246 := &yyv1243[yyj1243]
+					yyv1246.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1243 < len(yyv1243) {
+			yyv1243 = yyv1243[:yyj1243]
+			yyc1243 = true
+		} else if yyj1243 == 0 && yyv1243 == nil {
+			yyv1243 = []HTTPIngressPath{}
+			yyc1243 = true
+		}
+	}
+	yyh1243.End()
+	if yyc1243 {
+		*v = yyv1243
+	}
+}
+
+func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1247 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1248 := &yyv1247
+		yy1248.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1249 := *v
+	yyh1249, yyl1249 := z.DecSliceHelperStart()
+	var yyc1249 bool
+	if yyl1249 == 0 {
+		if yyv1249 == nil {
+			yyv1249 = []NodeUtilization{}
+			yyc1249 = true
+		} else if len(yyv1249) != 0 {
+			yyv1249 = yyv1249[:0]
+			yyc1249 = true
+		}
+	} else if yyl1249 > 0 {
+		var yyrr1249, yyrl1249 int
+		var yyrt1249 bool
+		if yyl1249 > cap(yyv1249) {
+
+			yyrg1249 := len(yyv1249) > 0
+			yyv21249 := yyv1249
+			yyrl1249, yyrt1249 = z.DecInferLen(yyl1249, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt1249 {
+				if yyrl1249 <= cap(yyv1249) {
+					yyv1249 = yyv1249[:yyrl1249]
+				} else {
+					yyv1249 = make([]NodeUtilization, yyrl1249)
+				}
+			} else {
+				yyv1249 = make([]NodeUtilization, yyrl1249)
+			}
+			yyc1249 = true
+			yyrr1249 = len(yyv1249)
+			if yyrg1249 {
+				copy(yyv1249, yyv21249)
+			}
+		} else if yyl1249 != len(yyv1249) {
+			yyv1249 = yyv1249[:yyl1249]
+			yyc1249 = true
+		}
+		yyj1249 := 0
+		for ; yyj1249 < yyrr1249; yyj1249++ {
+			yyh1249.ElemContainerState(yyj1249)
+			if r.TryDecodeAsNil() {
+				yyv1249[yyj1249] = NodeUtilization{}
+			} else {
+				yyv1250 := &yyv1249[yyj1249]
+				yyv1250.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1249 {
+			for ; yyj1249 < yyl1249; yyj1249++ {
+				yyv1249 = append(yyv1249, NodeUtilization{})
+				yyh1249.ElemContainerState(yyj1249)
+				if r.TryDecodeAsNil() {
+					yyv1249[yyj1249] = NodeUtilization{}
+				} else {
+					yyv1251 := &yyv1249[yyj1249]
+					yyv1251.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1249 := 0
+		for ; !r.CheckBreak(); yyj1249++ {
+
+			if yyj1249 >= len(yyv1249) {
+				yyv1249 = append(yyv1249, NodeUtilization{}) // var yyz1249 NodeUtilization
+				yyc1249 = true
+			}
+			yyh1249.ElemContainerState(yyj1249)
+			if yyj1249 < len(yyv1249) {
+				if r.TryDecodeAsNil() {
+					yyv1249[yyj1249] = NodeUtilization{}
+				} else {
+					yyv1252 := &yyv1249[yyj1249]
+					yyv1252.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1249 < len(yyv1249) {
+			yyv1249 = yyv1249[:yyj1249]
+			yyc1249 = true
+		} else if yyj1249 == 0 && yyv1249 == nil {
+			yyv1249 = []NodeUtilization{}
+			yyc1249 = true
+		}
+	}
+	yyh1249.End()
+	if yyc1249 {
+		*v = yyv1249
+	}
+}
+
+func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1253 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1254 := &yyv1253
+		yy1254.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1255 := *v
+	yyh1255, yyl1255 := z.DecSliceHelperStart()
+	var yyc1255 bool
+	if yyl1255 == 0 {
+		if yyv1255 == nil {
+			yyv1255 = []ClusterAutoscaler{}
+			yyc1255 = true
+		} else if len(yyv1255) != 0 {
+			yyv1255 = yyv1255[:0]
+			yyc1255 = true
+		}
+	} else if yyl1255 > 0 {
+		var yyrr1255, yyrl1255 int
+		var yyrt1255 bool
+		if yyl1255 > cap(yyv1255) {
+
+			yyrg1255 := len(yyv1255) > 0
+			yyv21255 := yyv1255
+			yyrl1255, yyrt1255 = z.DecInferLen(yyl1255, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1255 {
+				if yyrl1255 <= cap(yyv1255) {
+					yyv1255 = yyv1255[:yyrl1255]
+				} else {
+					yyv1255 = make([]ClusterAutoscaler, yyrl1255)
+				}
+			} else {
+				yyv1255 = make([]ClusterAutoscaler, yyrl1255)
+			}
+			yyc1255 = true
+			yyrr1255 = len(yyv1255)
+			if yyrg1255 {
+				copy(yyv1255, yyv21255)
+			}
+		} else if yyl1255 != len(yyv1255) {
+			yyv1255 = yyv1255[:yyl1255]
+			yyc1255 = true
+		}
+		yyj1255 := 0
+		for ; yyj1255 < yyrr1255; yyj1255++ {
+			yyh1255.ElemContainerState(yyj1255)
+			if r.TryDecodeAsNil() {
+				yyv1255[yyj1255] = ClusterAutoscaler{}
+			} else {
+				yyv1256 := &yyv1255[yyj1255]
+				yyv1256.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1255 {
+			for ; yyj1255 < yyl1255; yyj1255++ {
+				yyv1255 = append(yyv1255, ClusterAutoscaler{})
+				yyh1255.ElemContainerState(yyj1255)
+				if r.TryDecodeAsNil() {
+					yyv1255[yyj1255] = ClusterAutoscaler{}
+				} else {
+					yyv1257 := &yyv1255[yyj1255]
+					yyv1257.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1255 := 0
+		for ; !r.CheckBreak(); yyj1255++ {
+
+			if yyj1255 >= len(yyv1255) {
+				yyv1255 = append(yyv1255, ClusterAutoscaler{}) // var yyz1255 ClusterAutoscaler
+				yyc1255 = true
+			}
+			yyh1255.ElemContainerState(yyj1255)
+			if yyj1255 < len(yyv1255) {
+				if r.TryDecodeAsNil() {
+					yyv1255[yyj1255] = ClusterAutoscaler{}
+				} else {
+					yyv1258 := &yyv1255[yyj1255]
+					yyv1258.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1255 < len(yyv1255) {
+			yyv1255 = yyv1255[:yyj1255]
+			yyc1255 = true
+		} else if yyj1255 == 0 && yyv1255 == nil {
+			yyv1255 = []ClusterAutoscaler{}
+			yyc1255 = true
+		}
+	}
+	yyh1255.End()
+	if yyc1255 {
+		*v = yyv1255
+	}
+}
+
+func (x codecSelfer1234) encSliceLabelSelectorRequirement(v []LabelSelectorRequirement, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1259 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1260 := &yyv1259
+		yy1260.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequirement, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1261 := *v
+	yyh1261, yyl1261 := z.DecSliceHelperStart()
+	var yyc1261 bool
+	if yyl1261 == 0 {
+		if yyv1261 == nil {
+			yyv1261 = []LabelSelectorRequirement{}
+			yyc1261 = true
+		} else if len(yyv1261) != 0 {
+			yyv1261 = yyv1261[:0]
+			yyc1261 = true
+		}
+	} else if yyl1261 > 0 {
+		var yyrr1261, yyrl1261 int
+		var yyrt1261 bool
+		if yyl1261 > cap(yyv1261) {
+
+			yyrg1261 := len(yyv1261) > 0
+			yyv21261 := yyv1261
+			yyrl1261, yyrt1261 = z.DecInferLen(yyl1261, z.DecBasicHandle().MaxInitLen, 56)
+			if yyrt1261 {
+				if yyrl1261 <= cap(yyv1261) {
+					yyv1261 = yyv1261[:yyrl1261]
+				} else {
+					yyv1261 = make([]LabelSelectorRequirement, yyrl1261)
+				}
+			} else {
+				yyv1261 = make([]LabelSelectorRequirement, yyrl1261)
+			}
+			yyc1261 = true
+			yyrr1261 = len(yyv1261)
+			if yyrg1261 {
+				copy(yyv1261, yyv21261)
+			}
+		} else if yyl1261 != len(yyv1261) {
+			yyv1261 = yyv1261[:yyl1261]
+			yyc1261 = true
+		}
+		yyj1261 := 0
+		for ; yyj1261 < yyrr1261; yyj1261++ {
+			yyh1261.ElemContainerState(yyj1261)
+			if r.TryDecodeAsNil() {
+				yyv1261[yyj1261] = LabelSelectorRequirement{}
+			} else {
+				yyv1262 := &yyv1261[yyj1261]
+				yyv1262.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1261 {
+			for ; yyj1261 < yyl1261; yyj1261++ {
+				yyv1261 = append(yyv1261, LabelSelectorRequirement{})
+				yyh1261.ElemContainerState(yyj1261)
+				if r.TryDecodeAsNil() {
+					yyv1261[yyj1261] = LabelSelectorRequirement{}
+				} else {
+					yyv1263 := &yyv1261[yyj1261]
+					yyv1263.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1261 := 0
+		for ; !r.CheckBreak(); yyj1261++ {
+
+			if yyj1261 >= len(yyv1261) {
+				yyv1261 = append(yyv1261, LabelSelectorRequirement{}) // var yyz1261 LabelSelectorRequirement
+				yyc1261 = true
+			}
+			yyh1261.ElemContainerState(yyj1261)
+			if yyj1261 < len(yyv1261) {
+				if r.TryDecodeAsNil() {
+					yyv1261[yyj1261] = LabelSelectorRequirement{}
+				} else {
+					yyv1264 := &yyv1261[yyj1261]
+					yyv1264.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1261 < len(yyv1261) {
+			yyv1261 = yyv1261[:yyj1261]
+			yyc1261 = true
+		} else if yyj1261 == 0 && yyv1261 == nil {
+			yyv1261 = []LabelSelectorRequirement{}
+			yyc1261 = true
+		}
+	}
+	yyh1261.End()
+	if yyc1261 {
+		*v = yyv1261
+	}
+}
+
+func (x codecSelfer1234) encSliceConfigMap(v []ConfigMap, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1265 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1266 := &yyv1265
+		yy1266.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceConfigMap(v *[]ConfigMap, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1267 := *v
+	yyh1267, yyl1267 := z.DecSliceHelperStart()
+	var yyc1267 bool
+	if yyl1267 == 0 {
+		if yyv1267 == nil {
+			yyv1267 = []ConfigMap{}
+			yyc1267 = true
+		} else if len(yyv1267) != 0 {
+			yyv1267 = yyv1267[:0]
+			yyc1267 = true
+		}
+	} else if yyl1267 > 0 {
+		var yyrr1267, yyrl1267 int
+		var yyrt1267 bool
+		if yyl1267 > cap(yyv1267) {
+
+			yyrg1267 := len(yyv1267) > 0
+			yyv21267 := yyv1267
+			yyrl1267, yyrt1267 = z.DecInferLen(yyl1267, z.DecBasicHandle().MaxInitLen, 200)
+			if yyrt1267 {
+				if yyrl1267 <= cap(yyv1267) {
+					yyv1267 = yyv1267[:yyrl1267]
+				} else {
+					yyv1267 = make([]ConfigMap, yyrl1267)
+				}
+			} else {
+				yyv1267 = make([]ConfigMap, yyrl1267)
+			}
+			yyc1267 = true
+			yyrr1267 = len(yyv1267)
+			if yyrg1267 {
+				copy(yyv1267, yyv21267)
+			}
+		} else if yyl1267 != len(yyv1267) {
+			yyv1267 = yyv1267[:yyl1267]
+			yyc1267 = true
+		}
+		yyj1267 := 0
+		for ; yyj1267 < yyrr1267; yyj1267++ {
+			yyh1267.ElemContainerState(yyj1267)
+			if r.TryDecodeAsNil() {
+				yyv1267[yyj1267] = ConfigMap{}
+			} else {
+				yyv1268 := &yyv1267[yyj1267]
+				yyv1268.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1267 {
+			for ; yyj1267 < yyl1267; yyj1267++ {
+				yyv1267 = append(yyv1267, ConfigMap{})
+				yyh1267.ElemContainerState(yyj1267)
+				if r.TryDecodeAsNil() {
+					yyv1267[yyj1267] = ConfigMap{}
+				} else {
+					yyv1269 := &yyv1267[yyj1267]
+					yyv1269.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1267 := 0
+		for ; !r.CheckBreak(); yyj1267++ {
+
+			if yyj1267 >= len(yyv1267) {
+				yyv1267 = append(yyv1267, ConfigMap{}) // var yyz1267 ConfigMap
+				yyc1267 = true
+			}
+			yyh1267.ElemContainerState(yyj1267)
+			if yyj1267 < len(yyv1267) {
+				if r.TryDecodeAsNil() {
+					yyv1267[yyj1267] = ConfigMap{}
+				} else {
+					yyv1270 := &yyv1267[yyj1267]
+					yyv1270.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1267 < len(yyv1267) {
+			yyv1267 = yyv1267[:yyj1267]
+			yyc1267 = true
+		} else if yyj1267 == 0 && yyv1267 == nil {
+			yyv1267 = []ConfigMap{}
+			yyc1267 = true
+		}
+	}
+	yyh1267.End()
+	if yyc1267 {
+		*v = yyv1267
 	}
 }

--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -691,3 +691,26 @@ const (
 	LabelSelectorOpExists       LabelSelectorOperator = "Exists"
 	LabelSelectorOpDoesNotExist LabelSelectorOperator = "DoesNotExist"
 )
+
+// ConfigMap holds configuration data for components or applications to consume.
+type ConfigMap struct {
+	unversioned.TypeMeta `json:",inline"`
+
+	// Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata.
+	api.ObjectMeta `json:"metadata,omitempty"`
+
+	// Data contains the configuration data.
+	// Each key must be a valid DNS_SUBDOMAIN with an optional leading dot.
+	Data map[string]string `json:"data,omitempty"`
+}
+
+// ConfigMapList is a resource containing a list of ConfigMap objects.
+type ConfigMapList struct {
+	unversioned.TypeMeta `json:",inline"`
+
+	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
+	unversioned.ListMeta `json:"metadata,omitempty"`
+
+	// Items is the list of ConfigMaps.
+	Items []ConfigMap `json:"items,omitempty"`
+}

--- a/pkg/apis/extensions/v1beta1/conversion_generated.go
+++ b/pkg/apis/extensions/v1beta1/conversion_generated.go
@@ -2277,6 +2277,58 @@ func convert_extensions_ClusterAutoscalerSpec_To_v1beta1_ClusterAutoscalerSpec(i
 	return autoconvert_extensions_ClusterAutoscalerSpec_To_v1beta1_ClusterAutoscalerSpec(in, out, s)
 }
 
+func autoconvert_extensions_ConfigMap_To_v1beta1_ConfigMap(in *extensions.ConfigMap, out *ConfigMap, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*extensions.ConfigMap))(in)
+	}
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+		return err
+	}
+	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if in.Data != nil {
+		out.Data = make(map[string]string)
+		for key, val := range in.Data {
+			out.Data[key] = val
+		}
+	} else {
+		out.Data = nil
+	}
+	return nil
+}
+
+func convert_extensions_ConfigMap_To_v1beta1_ConfigMap(in *extensions.ConfigMap, out *ConfigMap, s conversion.Scope) error {
+	return autoconvert_extensions_ConfigMap_To_v1beta1_ConfigMap(in, out, s)
+}
+
+func autoconvert_extensions_ConfigMapList_To_v1beta1_ConfigMapList(in *extensions.ConfigMapList, out *ConfigMapList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*extensions.ConfigMapList))(in)
+	}
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]ConfigMap, len(in.Items))
+		for i := range in.Items {
+			if err := convert_extensions_ConfigMap_To_v1beta1_ConfigMap(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_extensions_ConfigMapList_To_v1beta1_ConfigMapList(in *extensions.ConfigMapList, out *ConfigMapList, s conversion.Scope) error {
+	return autoconvert_extensions_ConfigMapList_To_v1beta1_ConfigMapList(in, out, s)
+}
+
 func autoconvert_extensions_DaemonSet_To_v1beta1_DaemonSet(in *extensions.DaemonSet, out *DaemonSet, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.DaemonSet))(in)
@@ -3264,6 +3316,58 @@ func convert_v1beta1_ClusterAutoscalerSpec_To_extensions_ClusterAutoscalerSpec(i
 	return autoconvert_v1beta1_ClusterAutoscalerSpec_To_extensions_ClusterAutoscalerSpec(in, out, s)
 }
 
+func autoconvert_v1beta1_ConfigMap_To_extensions_ConfigMap(in *ConfigMap, out *extensions.ConfigMap, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*ConfigMap))(in)
+	}
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+		return err
+	}
+	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if in.Data != nil {
+		out.Data = make(map[string]string)
+		for key, val := range in.Data {
+			out.Data[key] = val
+		}
+	} else {
+		out.Data = nil
+	}
+	return nil
+}
+
+func convert_v1beta1_ConfigMap_To_extensions_ConfigMap(in *ConfigMap, out *extensions.ConfigMap, s conversion.Scope) error {
+	return autoconvert_v1beta1_ConfigMap_To_extensions_ConfigMap(in, out, s)
+}
+
+func autoconvert_v1beta1_ConfigMapList_To_extensions_ConfigMapList(in *ConfigMapList, out *extensions.ConfigMapList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*ConfigMapList))(in)
+	}
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]extensions.ConfigMap, len(in.Items))
+		for i := range in.Items {
+			if err := convert_v1beta1_ConfigMap_To_extensions_ConfigMap(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1beta1_ConfigMapList_To_extensions_ConfigMapList(in *ConfigMapList, out *extensions.ConfigMapList, s conversion.Scope) error {
+	return autoconvert_v1beta1_ConfigMapList_To_extensions_ConfigMapList(in, out, s)
+}
+
 func autoconvert_v1beta1_DaemonSet_To_extensions_DaemonSet(in *DaemonSet, out *extensions.DaemonSet, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DaemonSet))(in)
@@ -4209,6 +4313,8 @@ func init() {
 		autoconvert_extensions_ClusterAutoscalerList_To_v1beta1_ClusterAutoscalerList,
 		autoconvert_extensions_ClusterAutoscalerSpec_To_v1beta1_ClusterAutoscalerSpec,
 		autoconvert_extensions_ClusterAutoscaler_To_v1beta1_ClusterAutoscaler,
+		autoconvert_extensions_ConfigMapList_To_v1beta1_ConfigMapList,
+		autoconvert_extensions_ConfigMap_To_v1beta1_ConfigMap,
 		autoconvert_extensions_DaemonSetList_To_v1beta1_DaemonSetList,
 		autoconvert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec,
 		autoconvert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus,
@@ -4295,6 +4401,8 @@ func init() {
 		autoconvert_v1beta1_ClusterAutoscalerList_To_extensions_ClusterAutoscalerList,
 		autoconvert_v1beta1_ClusterAutoscalerSpec_To_extensions_ClusterAutoscalerSpec,
 		autoconvert_v1beta1_ClusterAutoscaler_To_extensions_ClusterAutoscaler,
+		autoconvert_v1beta1_ConfigMapList_To_extensions_ConfigMapList,
+		autoconvert_v1beta1_ConfigMap_To_extensions_ConfigMap,
 		autoconvert_v1beta1_DaemonSetList_To_extensions_DaemonSetList,
 		autoconvert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec,
 		autoconvert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus,

--- a/pkg/apis/extensions/v1beta1/deep_copy_generated.go
+++ b/pkg/apis/extensions/v1beta1/deep_copy_generated.go
@@ -947,6 +947,44 @@ func deepCopy_v1beta1_ClusterAutoscalerSpec(in ClusterAutoscalerSpec, out *Clust
 	return nil
 }
 
+func deepCopy_v1beta1_ConfigMap(in ConfigMap, out *ConfigMap, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
+	if in.Data != nil {
+		out.Data = make(map[string]string)
+		for key, val := range in.Data {
+			out.Data[key] = val
+		}
+	} else {
+		out.Data = nil
+	}
+	return nil
+}
+
+func deepCopy_v1beta1_ConfigMapList(in ConfigMapList, out *ConfigMapList, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_unversioned_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]ConfigMap, len(in.Items))
+		for i := range in.Items {
+			if err := deepCopy_v1beta1_ConfigMap(in.Items[i], &out.Items[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
 func deepCopy_v1beta1_DaemonSet(in DaemonSet, out *DaemonSet, c *conversion.Cloner) error {
 	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -1672,6 +1710,8 @@ func init() {
 		deepCopy_v1beta1_ClusterAutoscaler,
 		deepCopy_v1beta1_ClusterAutoscalerList,
 		deepCopy_v1beta1_ClusterAutoscalerSpec,
+		deepCopy_v1beta1_ConfigMap,
+		deepCopy_v1beta1_ConfigMapList,
 		deepCopy_v1beta1_DaemonSet,
 		deepCopy_v1beta1_DaemonSetList,
 		deepCopy_v1beta1_DaemonSetSpec,

--- a/pkg/apis/extensions/v1beta1/defaults.go
+++ b/pkg/apis/extensions/v1beta1/defaults.go
@@ -118,5 +118,10 @@ func addDefaultingFuncs() {
 				obj.Spec.CPUUtilization = &CPUTargetUtilization{TargetPercentage: 80}
 			}
 		},
+		func(obj *ConfigMap) {
+			if obj.Data == nil {
+				obj.Data = make(map[string]string)
+			}
+		},
 	)
 }

--- a/pkg/apis/extensions/v1beta1/register.go
+++ b/pkg/apis/extensions/v1beta1/register.go
@@ -58,6 +58,8 @@ func addKnownTypes() {
 		&Ingress{},
 		&IngressList{},
 		&ListOptions{},
+		&ConfigMap{},
+		&ConfigMapList{},
 	)
 }
 
@@ -80,3 +82,5 @@ func (obj *ThirdPartyResourceDataList) GetObjectKind() unversioned.ObjectKind  {
 func (obj *Ingress) GetObjectKind() unversioned.ObjectKind                     { return &obj.TypeMeta }
 func (obj *IngressList) GetObjectKind() unversioned.ObjectKind                 { return &obj.TypeMeta }
 func (obj *ListOptions) GetObjectKind() unversioned.ObjectKind                 { return &obj.TypeMeta }
+func (obj *ConfigMap) GetObjectKind() unversioned.ObjectKind                   { return &obj.TypeMeta }
+func (obj *ConfigMapList) GetObjectKind() unversioned.ObjectKind               { return &obj.TypeMeta }

--- a/pkg/apis/extensions/v1beta1/types.generated.go
+++ b/pkg/apis/extensions/v1beta1/types.generated.go
@@ -14019,1167 +14019,685 @@ func (x *LabelSelectorOperator) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
+func (x *ConfigMap) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1170 := z.EncBinary()
+		_ = yym1170
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1171 := !z.EncBinary()
+			yy2arr1171 := z.EncBasicHandle().StructToArray
+			var yyq1171 [4]bool
+			_, _, _ = yysep1171, yyq1171, yy2arr1171
+			const yyr1171 bool = false
+			yyq1171[0] = x.Kind != ""
+			yyq1171[1] = x.APIVersion != ""
+			yyq1171[2] = true
+			yyq1171[3] = len(x.Data) != 0
+			var yynn1171 int
+			if yyr1171 || yy2arr1171 {
+				r.EncodeArrayStart(4)
+			} else {
+				yynn1171 = 0
+				for _, b := range yyq1171 {
+					if b {
+						yynn1171++
+					}
+				}
+				r.EncodeMapStart(yynn1171)
+				yynn1171 = 0
+			}
+			if yyr1171 || yy2arr1171 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1171[0] {
+					yym1173 := z.EncBinary()
+					_ = yym1173
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1171[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1174 := z.EncBinary()
+					_ = yym1174
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1171 || yy2arr1171 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1171[1] {
+					yym1176 := z.EncBinary()
+					_ = yym1176
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1171[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1177 := z.EncBinary()
+					_ = yym1177
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr1171 || yy2arr1171 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1171[2] {
+					yy1179 := &x.ObjectMeta
+					yy1179.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1171[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1180 := &x.ObjectMeta
+					yy1180.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1171 || yy2arr1171 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1171[3] {
+					if x.Data == nil {
+						r.EncodeNil()
+					} else {
+						yym1182 := z.EncBinary()
+						_ = yym1182
+						if false {
+						} else {
+							z.F.EncMapStringStringV(x.Data, false, e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1171[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("data"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.Data == nil {
+						r.EncodeNil()
+					} else {
+						yym1183 := z.EncBinary()
+						_ = yym1183
+						if false {
+						} else {
+							z.F.EncMapStringStringV(x.Data, false, e)
+						}
+					}
+				}
+			}
+			if yyr1171 || yy2arr1171 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *ConfigMap) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1184 := z.DecBinary()
+	_ = yym1184
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1185 := r.ContainerType()
+		if yyct1185 == codecSelferValueTypeMap1234 {
+			yyl1185 := r.ReadMapStart()
+			if yyl1185 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1185, d)
+			}
+		} else if yyct1185 == codecSelferValueTypeArray1234 {
+			yyl1185 := r.ReadArrayStart()
+			if yyl1185 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1185, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *ConfigMap) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1186Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1186Slc
+	var yyhl1186 bool = l >= 0
+	for yyj1186 := 0; ; yyj1186++ {
+		if yyhl1186 {
+			if yyj1186 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1186Slc = r.DecodeBytes(yys1186Slc, true, true)
+		yys1186 := string(yys1186Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1186 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_v1.ObjectMeta{}
+			} else {
+				yyv1189 := &x.ObjectMeta
+				yyv1189.CodecDecodeSelf(d)
+			}
+		case "data":
+			if r.TryDecodeAsNil() {
+				x.Data = nil
+			} else {
+				yyv1190 := &x.Data
+				yym1191 := z.DecBinary()
+				_ = yym1191
+				if false {
+				} else {
+					z.F.DecMapStringStringX(yyv1190, false, d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1186)
+		} // end switch yys1186
+	} // end for yyj1186
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *ConfigMap) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1192 int
+	var yyb1192 bool
+	var yyhl1192 bool = l >= 0
+	yyj1192++
+	if yyhl1192 {
+		yyb1192 = yyj1192 > l
+	} else {
+		yyb1192 = r.CheckBreak()
+	}
+	if yyb1192 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj1192++
+	if yyhl1192 {
+		yyb1192 = yyj1192 > l
+	} else {
+		yyb1192 = r.CheckBreak()
+	}
+	if yyb1192 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj1192++
+	if yyhl1192 {
+		yyb1192 = yyj1192 > l
+	} else {
+		yyb1192 = r.CheckBreak()
+	}
+	if yyb1192 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_v1.ObjectMeta{}
+	} else {
+		yyv1195 := &x.ObjectMeta
+		yyv1195.CodecDecodeSelf(d)
+	}
+	yyj1192++
+	if yyhl1192 {
+		yyb1192 = yyj1192 > l
+	} else {
+		yyb1192 = r.CheckBreak()
+	}
+	if yyb1192 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Data = nil
+	} else {
+		yyv1196 := &x.Data
+		yym1197 := z.DecBinary()
+		_ = yym1197
+		if false {
+		} else {
+			z.F.DecMapStringStringX(yyv1196, false, d)
+		}
+	}
+	for {
+		yyj1192++
+		if yyhl1192 {
+			yyb1192 = yyj1192 > l
+		} else {
+			yyb1192 = r.CheckBreak()
+		}
+		if yyb1192 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1192-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *ConfigMapList) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1198 := z.EncBinary()
+		_ = yym1198
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1199 := !z.EncBinary()
+			yy2arr1199 := z.EncBasicHandle().StructToArray
+			var yyq1199 [4]bool
+			_, _, _ = yysep1199, yyq1199, yy2arr1199
+			const yyr1199 bool = false
+			yyq1199[0] = x.Kind != ""
+			yyq1199[1] = x.APIVersion != ""
+			yyq1199[2] = true
+			yyq1199[3] = len(x.Items) != 0
+			var yynn1199 int
+			if yyr1199 || yy2arr1199 {
+				r.EncodeArrayStart(4)
+			} else {
+				yynn1199 = 0
+				for _, b := range yyq1199 {
+					if b {
+						yynn1199++
+					}
+				}
+				r.EncodeMapStart(yynn1199)
+				yynn1199 = 0
+			}
+			if yyr1199 || yy2arr1199 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1199[0] {
+					yym1201 := z.EncBinary()
+					_ = yym1201
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1199[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1202 := z.EncBinary()
+					_ = yym1202
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1199 || yy2arr1199 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1199[1] {
+					yym1204 := z.EncBinary()
+					_ = yym1204
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1199[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1205 := z.EncBinary()
+					_ = yym1205
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr1199 || yy2arr1199 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1199[2] {
+					yy1207 := &x.ListMeta
+					yym1208 := z.EncBinary()
+					_ = yym1208
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1207) {
+					} else {
+						z.EncFallback(yy1207)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1199[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1209 := &x.ListMeta
+					yym1210 := z.EncBinary()
+					_ = yym1210
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1209) {
+					} else {
+						z.EncFallback(yy1209)
+					}
+				}
+			}
+			if yyr1199 || yy2arr1199 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1199[3] {
+					if x.Items == nil {
+						r.EncodeNil()
+					} else {
+						yym1212 := z.EncBinary()
+						_ = yym1212
+						if false {
+						} else {
+							h.encSliceConfigMap(([]ConfigMap)(x.Items), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1199[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("items"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.Items == nil {
+						r.EncodeNil()
+					} else {
+						yym1213 := z.EncBinary()
+						_ = yym1213
+						if false {
+						} else {
+							h.encSliceConfigMap(([]ConfigMap)(x.Items), e)
+						}
+					}
+				}
+			}
+			if yyr1199 || yy2arr1199 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *ConfigMapList) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1214 := z.DecBinary()
+	_ = yym1214
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1215 := r.ContainerType()
+		if yyct1215 == codecSelferValueTypeMap1234 {
+			yyl1215 := r.ReadMapStart()
+			if yyl1215 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1215, d)
+			}
+		} else if yyct1215 == codecSelferValueTypeArray1234 {
+			yyl1215 := r.ReadArrayStart()
+			if yyl1215 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1215, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *ConfigMapList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1216Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1216Slc
+	var yyhl1216 bool = l >= 0
+	for yyj1216 := 0; ; yyj1216++ {
+		if yyhl1216 {
+			if yyj1216 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1216Slc = r.DecodeBytes(yys1216Slc, true, true)
+		yys1216 := string(yys1216Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1216 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv1219 := &x.ListMeta
+				yym1220 := z.DecBinary()
+				_ = yym1220
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1219) {
+				} else {
+					z.DecFallback(yyv1219, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv1221 := &x.Items
+				yym1222 := z.DecBinary()
+				_ = yym1222
+				if false {
+				} else {
+					h.decSliceConfigMap((*[]ConfigMap)(yyv1221), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1216)
+		} // end switch yys1216
+	} // end for yyj1216
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *ConfigMapList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1223 int
+	var yyb1223 bool
+	var yyhl1223 bool = l >= 0
+	yyj1223++
+	if yyhl1223 {
+		yyb1223 = yyj1223 > l
+	} else {
+		yyb1223 = r.CheckBreak()
+	}
+	if yyb1223 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj1223++
+	if yyhl1223 {
+		yyb1223 = yyj1223 > l
+	} else {
+		yyb1223 = r.CheckBreak()
+	}
+	if yyb1223 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj1223++
+	if yyhl1223 {
+		yyb1223 = yyj1223 > l
+	} else {
+		yyb1223 = r.CheckBreak()
+	}
+	if yyb1223 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv1226 := &x.ListMeta
+		yym1227 := z.DecBinary()
+		_ = yym1227
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1226) {
+		} else {
+			z.DecFallback(yyv1226, false)
+		}
+	}
+	yyj1223++
+	if yyhl1223 {
+		yyb1223 = yyj1223 > l
+	} else {
+		yyb1223 = r.CheckBreak()
+	}
+	if yyb1223 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv1228 := &x.Items
+		yym1229 := z.DecBinary()
+		_ = yym1229
+		if false {
+		} else {
+			h.decSliceConfigMap((*[]ConfigMap)(yyv1228), d)
+		}
+	}
+	for {
+		yyj1223++
+		if yyhl1223 {
+			yyb1223 = yyj1223 > l
+		} else {
+			yyb1223 = r.CheckBreak()
+		}
+		if yyb1223 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1223-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
 func (x codecSelfer1234) encSliceHorizontalPodAutoscaler(v []HorizontalPodAutoscaler, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1170 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1171 := &yyv1170
-		yy1171.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutoscaler, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1172 := *v
-	yyh1172, yyl1172 := z.DecSliceHelperStart()
-	var yyc1172 bool
-	if yyl1172 == 0 {
-		if yyv1172 == nil {
-			yyv1172 = []HorizontalPodAutoscaler{}
-			yyc1172 = true
-		} else if len(yyv1172) != 0 {
-			yyv1172 = yyv1172[:0]
-			yyc1172 = true
-		}
-	} else if yyl1172 > 0 {
-		var yyrr1172, yyrl1172 int
-		var yyrt1172 bool
-		if yyl1172 > cap(yyv1172) {
-
-			yyrg1172 := len(yyv1172) > 0
-			yyv21172 := yyv1172
-			yyrl1172, yyrt1172 = z.DecInferLen(yyl1172, z.DecBasicHandle().MaxInitLen, 312)
-			if yyrt1172 {
-				if yyrl1172 <= cap(yyv1172) {
-					yyv1172 = yyv1172[:yyrl1172]
-				} else {
-					yyv1172 = make([]HorizontalPodAutoscaler, yyrl1172)
-				}
-			} else {
-				yyv1172 = make([]HorizontalPodAutoscaler, yyrl1172)
-			}
-			yyc1172 = true
-			yyrr1172 = len(yyv1172)
-			if yyrg1172 {
-				copy(yyv1172, yyv21172)
-			}
-		} else if yyl1172 != len(yyv1172) {
-			yyv1172 = yyv1172[:yyl1172]
-			yyc1172 = true
-		}
-		yyj1172 := 0
-		for ; yyj1172 < yyrr1172; yyj1172++ {
-			yyh1172.ElemContainerState(yyj1172)
-			if r.TryDecodeAsNil() {
-				yyv1172[yyj1172] = HorizontalPodAutoscaler{}
-			} else {
-				yyv1173 := &yyv1172[yyj1172]
-				yyv1173.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1172 {
-			for ; yyj1172 < yyl1172; yyj1172++ {
-				yyv1172 = append(yyv1172, HorizontalPodAutoscaler{})
-				yyh1172.ElemContainerState(yyj1172)
-				if r.TryDecodeAsNil() {
-					yyv1172[yyj1172] = HorizontalPodAutoscaler{}
-				} else {
-					yyv1174 := &yyv1172[yyj1172]
-					yyv1174.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1172 := 0
-		for ; !r.CheckBreak(); yyj1172++ {
-
-			if yyj1172 >= len(yyv1172) {
-				yyv1172 = append(yyv1172, HorizontalPodAutoscaler{}) // var yyz1172 HorizontalPodAutoscaler
-				yyc1172 = true
-			}
-			yyh1172.ElemContainerState(yyj1172)
-			if yyj1172 < len(yyv1172) {
-				if r.TryDecodeAsNil() {
-					yyv1172[yyj1172] = HorizontalPodAutoscaler{}
-				} else {
-					yyv1175 := &yyv1172[yyj1172]
-					yyv1175.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1172 < len(yyv1172) {
-			yyv1172 = yyv1172[:yyj1172]
-			yyc1172 = true
-		} else if yyj1172 == 0 && yyv1172 == nil {
-			yyv1172 = []HorizontalPodAutoscaler{}
-			yyc1172 = true
-		}
-	}
-	yyh1172.End()
-	if yyc1172 {
-		*v = yyv1172
-	}
-}
-
-func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1176 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1177 := &yyv1176
-		yy1177.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1178 := *v
-	yyh1178, yyl1178 := z.DecSliceHelperStart()
-	var yyc1178 bool
-	if yyl1178 == 0 {
-		if yyv1178 == nil {
-			yyv1178 = []APIVersion{}
-			yyc1178 = true
-		} else if len(yyv1178) != 0 {
-			yyv1178 = yyv1178[:0]
-			yyc1178 = true
-		}
-	} else if yyl1178 > 0 {
-		var yyrr1178, yyrl1178 int
-		var yyrt1178 bool
-		if yyl1178 > cap(yyv1178) {
-
-			yyrg1178 := len(yyv1178) > 0
-			yyv21178 := yyv1178
-			yyrl1178, yyrt1178 = z.DecInferLen(yyl1178, z.DecBasicHandle().MaxInitLen, 32)
-			if yyrt1178 {
-				if yyrl1178 <= cap(yyv1178) {
-					yyv1178 = yyv1178[:yyrl1178]
-				} else {
-					yyv1178 = make([]APIVersion, yyrl1178)
-				}
-			} else {
-				yyv1178 = make([]APIVersion, yyrl1178)
-			}
-			yyc1178 = true
-			yyrr1178 = len(yyv1178)
-			if yyrg1178 {
-				copy(yyv1178, yyv21178)
-			}
-		} else if yyl1178 != len(yyv1178) {
-			yyv1178 = yyv1178[:yyl1178]
-			yyc1178 = true
-		}
-		yyj1178 := 0
-		for ; yyj1178 < yyrr1178; yyj1178++ {
-			yyh1178.ElemContainerState(yyj1178)
-			if r.TryDecodeAsNil() {
-				yyv1178[yyj1178] = APIVersion{}
-			} else {
-				yyv1179 := &yyv1178[yyj1178]
-				yyv1179.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1178 {
-			for ; yyj1178 < yyl1178; yyj1178++ {
-				yyv1178 = append(yyv1178, APIVersion{})
-				yyh1178.ElemContainerState(yyj1178)
-				if r.TryDecodeAsNil() {
-					yyv1178[yyj1178] = APIVersion{}
-				} else {
-					yyv1180 := &yyv1178[yyj1178]
-					yyv1180.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1178 := 0
-		for ; !r.CheckBreak(); yyj1178++ {
-
-			if yyj1178 >= len(yyv1178) {
-				yyv1178 = append(yyv1178, APIVersion{}) // var yyz1178 APIVersion
-				yyc1178 = true
-			}
-			yyh1178.ElemContainerState(yyj1178)
-			if yyj1178 < len(yyv1178) {
-				if r.TryDecodeAsNil() {
-					yyv1178[yyj1178] = APIVersion{}
-				} else {
-					yyv1181 := &yyv1178[yyj1178]
-					yyv1181.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1178 < len(yyv1178) {
-			yyv1178 = yyv1178[:yyj1178]
-			yyc1178 = true
-		} else if yyj1178 == 0 && yyv1178 == nil {
-			yyv1178 = []APIVersion{}
-			yyc1178 = true
-		}
-	}
-	yyh1178.End()
-	if yyc1178 {
-		*v = yyv1178
-	}
-}
-
-func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1182 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1183 := &yyv1182
-		yy1183.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1184 := *v
-	yyh1184, yyl1184 := z.DecSliceHelperStart()
-	var yyc1184 bool
-	if yyl1184 == 0 {
-		if yyv1184 == nil {
-			yyv1184 = []ThirdPartyResource{}
-			yyc1184 = true
-		} else if len(yyv1184) != 0 {
-			yyv1184 = yyv1184[:0]
-			yyc1184 = true
-		}
-	} else if yyl1184 > 0 {
-		var yyrr1184, yyrl1184 int
-		var yyrt1184 bool
-		if yyl1184 > cap(yyv1184) {
-
-			yyrg1184 := len(yyv1184) > 0
-			yyv21184 := yyv1184
-			yyrl1184, yyrt1184 = z.DecInferLen(yyl1184, z.DecBasicHandle().MaxInitLen, 232)
-			if yyrt1184 {
-				if yyrl1184 <= cap(yyv1184) {
-					yyv1184 = yyv1184[:yyrl1184]
-				} else {
-					yyv1184 = make([]ThirdPartyResource, yyrl1184)
-				}
-			} else {
-				yyv1184 = make([]ThirdPartyResource, yyrl1184)
-			}
-			yyc1184 = true
-			yyrr1184 = len(yyv1184)
-			if yyrg1184 {
-				copy(yyv1184, yyv21184)
-			}
-		} else if yyl1184 != len(yyv1184) {
-			yyv1184 = yyv1184[:yyl1184]
-			yyc1184 = true
-		}
-		yyj1184 := 0
-		for ; yyj1184 < yyrr1184; yyj1184++ {
-			yyh1184.ElemContainerState(yyj1184)
-			if r.TryDecodeAsNil() {
-				yyv1184[yyj1184] = ThirdPartyResource{}
-			} else {
-				yyv1185 := &yyv1184[yyj1184]
-				yyv1185.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1184 {
-			for ; yyj1184 < yyl1184; yyj1184++ {
-				yyv1184 = append(yyv1184, ThirdPartyResource{})
-				yyh1184.ElemContainerState(yyj1184)
-				if r.TryDecodeAsNil() {
-					yyv1184[yyj1184] = ThirdPartyResource{}
-				} else {
-					yyv1186 := &yyv1184[yyj1184]
-					yyv1186.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1184 := 0
-		for ; !r.CheckBreak(); yyj1184++ {
-
-			if yyj1184 >= len(yyv1184) {
-				yyv1184 = append(yyv1184, ThirdPartyResource{}) // var yyz1184 ThirdPartyResource
-				yyc1184 = true
-			}
-			yyh1184.ElemContainerState(yyj1184)
-			if yyj1184 < len(yyv1184) {
-				if r.TryDecodeAsNil() {
-					yyv1184[yyj1184] = ThirdPartyResource{}
-				} else {
-					yyv1187 := &yyv1184[yyj1184]
-					yyv1187.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1184 < len(yyv1184) {
-			yyv1184 = yyv1184[:yyj1184]
-			yyc1184 = true
-		} else if yyj1184 == 0 && yyv1184 == nil {
-			yyv1184 = []ThirdPartyResource{}
-			yyc1184 = true
-		}
-	}
-	yyh1184.End()
-	if yyc1184 {
-		*v = yyv1184
-	}
-}
-
-func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1188 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1189 := &yyv1188
-		yy1189.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1190 := *v
-	yyh1190, yyl1190 := z.DecSliceHelperStart()
-	var yyc1190 bool
-	if yyl1190 == 0 {
-		if yyv1190 == nil {
-			yyv1190 = []Deployment{}
-			yyc1190 = true
-		} else if len(yyv1190) != 0 {
-			yyv1190 = yyv1190[:0]
-			yyc1190 = true
-		}
-	} else if yyl1190 > 0 {
-		var yyrr1190, yyrl1190 int
-		var yyrt1190 bool
-		if yyl1190 > cap(yyv1190) {
-
-			yyrg1190 := len(yyv1190) > 0
-			yyv21190 := yyv1190
-			yyrl1190, yyrt1190 = z.DecInferLen(yyl1190, z.DecBasicHandle().MaxInitLen, 600)
-			if yyrt1190 {
-				if yyrl1190 <= cap(yyv1190) {
-					yyv1190 = yyv1190[:yyrl1190]
-				} else {
-					yyv1190 = make([]Deployment, yyrl1190)
-				}
-			} else {
-				yyv1190 = make([]Deployment, yyrl1190)
-			}
-			yyc1190 = true
-			yyrr1190 = len(yyv1190)
-			if yyrg1190 {
-				copy(yyv1190, yyv21190)
-			}
-		} else if yyl1190 != len(yyv1190) {
-			yyv1190 = yyv1190[:yyl1190]
-			yyc1190 = true
-		}
-		yyj1190 := 0
-		for ; yyj1190 < yyrr1190; yyj1190++ {
-			yyh1190.ElemContainerState(yyj1190)
-			if r.TryDecodeAsNil() {
-				yyv1190[yyj1190] = Deployment{}
-			} else {
-				yyv1191 := &yyv1190[yyj1190]
-				yyv1191.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1190 {
-			for ; yyj1190 < yyl1190; yyj1190++ {
-				yyv1190 = append(yyv1190, Deployment{})
-				yyh1190.ElemContainerState(yyj1190)
-				if r.TryDecodeAsNil() {
-					yyv1190[yyj1190] = Deployment{}
-				} else {
-					yyv1192 := &yyv1190[yyj1190]
-					yyv1192.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1190 := 0
-		for ; !r.CheckBreak(); yyj1190++ {
-
-			if yyj1190 >= len(yyv1190) {
-				yyv1190 = append(yyv1190, Deployment{}) // var yyz1190 Deployment
-				yyc1190 = true
-			}
-			yyh1190.ElemContainerState(yyj1190)
-			if yyj1190 < len(yyv1190) {
-				if r.TryDecodeAsNil() {
-					yyv1190[yyj1190] = Deployment{}
-				} else {
-					yyv1193 := &yyv1190[yyj1190]
-					yyv1193.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1190 < len(yyv1190) {
-			yyv1190 = yyv1190[:yyj1190]
-			yyc1190 = true
-		} else if yyj1190 == 0 && yyv1190 == nil {
-			yyv1190 = []Deployment{}
-			yyc1190 = true
-		}
-	}
-	yyh1190.End()
-	if yyc1190 {
-		*v = yyv1190
-	}
-}
-
-func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1194 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1195 := &yyv1194
-		yy1195.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1196 := *v
-	yyh1196, yyl1196 := z.DecSliceHelperStart()
-	var yyc1196 bool
-	if yyl1196 == 0 {
-		if yyv1196 == nil {
-			yyv1196 = []DaemonSet{}
-			yyc1196 = true
-		} else if len(yyv1196) != 0 {
-			yyv1196 = yyv1196[:0]
-			yyc1196 = true
-		}
-	} else if yyl1196 > 0 {
-		var yyrr1196, yyrl1196 int
-		var yyrt1196 bool
-		if yyl1196 > cap(yyv1196) {
-
-			yyrg1196 := len(yyv1196) > 0
-			yyv21196 := yyv1196
-			yyrl1196, yyrt1196 = z.DecInferLen(yyl1196, z.DecBasicHandle().MaxInitLen, 224)
-			if yyrt1196 {
-				if yyrl1196 <= cap(yyv1196) {
-					yyv1196 = yyv1196[:yyrl1196]
-				} else {
-					yyv1196 = make([]DaemonSet, yyrl1196)
-				}
-			} else {
-				yyv1196 = make([]DaemonSet, yyrl1196)
-			}
-			yyc1196 = true
-			yyrr1196 = len(yyv1196)
-			if yyrg1196 {
-				copy(yyv1196, yyv21196)
-			}
-		} else if yyl1196 != len(yyv1196) {
-			yyv1196 = yyv1196[:yyl1196]
-			yyc1196 = true
-		}
-		yyj1196 := 0
-		for ; yyj1196 < yyrr1196; yyj1196++ {
-			yyh1196.ElemContainerState(yyj1196)
-			if r.TryDecodeAsNil() {
-				yyv1196[yyj1196] = DaemonSet{}
-			} else {
-				yyv1197 := &yyv1196[yyj1196]
-				yyv1197.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1196 {
-			for ; yyj1196 < yyl1196; yyj1196++ {
-				yyv1196 = append(yyv1196, DaemonSet{})
-				yyh1196.ElemContainerState(yyj1196)
-				if r.TryDecodeAsNil() {
-					yyv1196[yyj1196] = DaemonSet{}
-				} else {
-					yyv1198 := &yyv1196[yyj1196]
-					yyv1198.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1196 := 0
-		for ; !r.CheckBreak(); yyj1196++ {
-
-			if yyj1196 >= len(yyv1196) {
-				yyv1196 = append(yyv1196, DaemonSet{}) // var yyz1196 DaemonSet
-				yyc1196 = true
-			}
-			yyh1196.ElemContainerState(yyj1196)
-			if yyj1196 < len(yyv1196) {
-				if r.TryDecodeAsNil() {
-					yyv1196[yyj1196] = DaemonSet{}
-				} else {
-					yyv1199 := &yyv1196[yyj1196]
-					yyv1199.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1196 < len(yyv1196) {
-			yyv1196 = yyv1196[:yyj1196]
-			yyc1196 = true
-		} else if yyj1196 == 0 && yyv1196 == nil {
-			yyv1196 = []DaemonSet{}
-			yyc1196 = true
-		}
-	}
-	yyh1196.End()
-	if yyc1196 {
-		*v = yyv1196
-	}
-}
-
-func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceData, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1200 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1201 := &yyv1200
-		yy1201.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceData, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1202 := *v
-	yyh1202, yyl1202 := z.DecSliceHelperStart()
-	var yyc1202 bool
-	if yyl1202 == 0 {
-		if yyv1202 == nil {
-			yyv1202 = []ThirdPartyResourceData{}
-			yyc1202 = true
-		} else if len(yyv1202) != 0 {
-			yyv1202 = yyv1202[:0]
-			yyc1202 = true
-		}
-	} else if yyl1202 > 0 {
-		var yyrr1202, yyrl1202 int
-		var yyrt1202 bool
-		if yyl1202 > cap(yyv1202) {
-
-			yyrg1202 := len(yyv1202) > 0
-			yyv21202 := yyv1202
-			yyrl1202, yyrt1202 = z.DecInferLen(yyl1202, z.DecBasicHandle().MaxInitLen, 216)
-			if yyrt1202 {
-				if yyrl1202 <= cap(yyv1202) {
-					yyv1202 = yyv1202[:yyrl1202]
-				} else {
-					yyv1202 = make([]ThirdPartyResourceData, yyrl1202)
-				}
-			} else {
-				yyv1202 = make([]ThirdPartyResourceData, yyrl1202)
-			}
-			yyc1202 = true
-			yyrr1202 = len(yyv1202)
-			if yyrg1202 {
-				copy(yyv1202, yyv21202)
-			}
-		} else if yyl1202 != len(yyv1202) {
-			yyv1202 = yyv1202[:yyl1202]
-			yyc1202 = true
-		}
-		yyj1202 := 0
-		for ; yyj1202 < yyrr1202; yyj1202++ {
-			yyh1202.ElemContainerState(yyj1202)
-			if r.TryDecodeAsNil() {
-				yyv1202[yyj1202] = ThirdPartyResourceData{}
-			} else {
-				yyv1203 := &yyv1202[yyj1202]
-				yyv1203.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1202 {
-			for ; yyj1202 < yyl1202; yyj1202++ {
-				yyv1202 = append(yyv1202, ThirdPartyResourceData{})
-				yyh1202.ElemContainerState(yyj1202)
-				if r.TryDecodeAsNil() {
-					yyv1202[yyj1202] = ThirdPartyResourceData{}
-				} else {
-					yyv1204 := &yyv1202[yyj1202]
-					yyv1204.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1202 := 0
-		for ; !r.CheckBreak(); yyj1202++ {
-
-			if yyj1202 >= len(yyv1202) {
-				yyv1202 = append(yyv1202, ThirdPartyResourceData{}) // var yyz1202 ThirdPartyResourceData
-				yyc1202 = true
-			}
-			yyh1202.ElemContainerState(yyj1202)
-			if yyj1202 < len(yyv1202) {
-				if r.TryDecodeAsNil() {
-					yyv1202[yyj1202] = ThirdPartyResourceData{}
-				} else {
-					yyv1205 := &yyv1202[yyj1202]
-					yyv1205.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1202 < len(yyv1202) {
-			yyv1202 = yyv1202[:yyj1202]
-			yyc1202 = true
-		} else if yyj1202 == 0 && yyv1202 == nil {
-			yyv1202 = []ThirdPartyResourceData{}
-			yyc1202 = true
-		}
-	}
-	yyh1202.End()
-	if yyc1202 {
-		*v = yyv1202
-	}
-}
-
-func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1206 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1207 := &yyv1206
-		yy1207.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1208 := *v
-	yyh1208, yyl1208 := z.DecSliceHelperStart()
-	var yyc1208 bool
-	if yyl1208 == 0 {
-		if yyv1208 == nil {
-			yyv1208 = []Job{}
-			yyc1208 = true
-		} else if len(yyv1208) != 0 {
-			yyv1208 = yyv1208[:0]
-			yyc1208 = true
-		}
-	} else if yyl1208 > 0 {
-		var yyrr1208, yyrl1208 int
-		var yyrt1208 bool
-		if yyl1208 > cap(yyv1208) {
-
-			yyrg1208 := len(yyv1208) > 0
-			yyv21208 := yyv1208
-			yyrl1208, yyrt1208 = z.DecInferLen(yyl1208, z.DecBasicHandle().MaxInitLen, 624)
-			if yyrt1208 {
-				if yyrl1208 <= cap(yyv1208) {
-					yyv1208 = yyv1208[:yyrl1208]
-				} else {
-					yyv1208 = make([]Job, yyrl1208)
-				}
-			} else {
-				yyv1208 = make([]Job, yyrl1208)
-			}
-			yyc1208 = true
-			yyrr1208 = len(yyv1208)
-			if yyrg1208 {
-				copy(yyv1208, yyv21208)
-			}
-		} else if yyl1208 != len(yyv1208) {
-			yyv1208 = yyv1208[:yyl1208]
-			yyc1208 = true
-		}
-		yyj1208 := 0
-		for ; yyj1208 < yyrr1208; yyj1208++ {
-			yyh1208.ElemContainerState(yyj1208)
-			if r.TryDecodeAsNil() {
-				yyv1208[yyj1208] = Job{}
-			} else {
-				yyv1209 := &yyv1208[yyj1208]
-				yyv1209.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1208 {
-			for ; yyj1208 < yyl1208; yyj1208++ {
-				yyv1208 = append(yyv1208, Job{})
-				yyh1208.ElemContainerState(yyj1208)
-				if r.TryDecodeAsNil() {
-					yyv1208[yyj1208] = Job{}
-				} else {
-					yyv1210 := &yyv1208[yyj1208]
-					yyv1210.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1208 := 0
-		for ; !r.CheckBreak(); yyj1208++ {
-
-			if yyj1208 >= len(yyv1208) {
-				yyv1208 = append(yyv1208, Job{}) // var yyz1208 Job
-				yyc1208 = true
-			}
-			yyh1208.ElemContainerState(yyj1208)
-			if yyj1208 < len(yyv1208) {
-				if r.TryDecodeAsNil() {
-					yyv1208[yyj1208] = Job{}
-				} else {
-					yyv1211 := &yyv1208[yyj1208]
-					yyv1211.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1208 < len(yyv1208) {
-			yyv1208 = yyv1208[:yyj1208]
-			yyc1208 = true
-		} else if yyj1208 == 0 && yyv1208 == nil {
-			yyv1208 = []Job{}
-			yyc1208 = true
-		}
-	}
-	yyh1208.End()
-	if yyc1208 {
-		*v = yyv1208
-	}
-}
-
-func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1212 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1213 := &yyv1212
-		yy1213.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1214 := *v
-	yyh1214, yyl1214 := z.DecSliceHelperStart()
-	var yyc1214 bool
-	if yyl1214 == 0 {
-		if yyv1214 == nil {
-			yyv1214 = []JobCondition{}
-			yyc1214 = true
-		} else if len(yyv1214) != 0 {
-			yyv1214 = yyv1214[:0]
-			yyc1214 = true
-		}
-	} else if yyl1214 > 0 {
-		var yyrr1214, yyrl1214 int
-		var yyrt1214 bool
-		if yyl1214 > cap(yyv1214) {
-
-			yyrg1214 := len(yyv1214) > 0
-			yyv21214 := yyv1214
-			yyrl1214, yyrt1214 = z.DecInferLen(yyl1214, z.DecBasicHandle().MaxInitLen, 112)
-			if yyrt1214 {
-				if yyrl1214 <= cap(yyv1214) {
-					yyv1214 = yyv1214[:yyrl1214]
-				} else {
-					yyv1214 = make([]JobCondition, yyrl1214)
-				}
-			} else {
-				yyv1214 = make([]JobCondition, yyrl1214)
-			}
-			yyc1214 = true
-			yyrr1214 = len(yyv1214)
-			if yyrg1214 {
-				copy(yyv1214, yyv21214)
-			}
-		} else if yyl1214 != len(yyv1214) {
-			yyv1214 = yyv1214[:yyl1214]
-			yyc1214 = true
-		}
-		yyj1214 := 0
-		for ; yyj1214 < yyrr1214; yyj1214++ {
-			yyh1214.ElemContainerState(yyj1214)
-			if r.TryDecodeAsNil() {
-				yyv1214[yyj1214] = JobCondition{}
-			} else {
-				yyv1215 := &yyv1214[yyj1214]
-				yyv1215.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1214 {
-			for ; yyj1214 < yyl1214; yyj1214++ {
-				yyv1214 = append(yyv1214, JobCondition{})
-				yyh1214.ElemContainerState(yyj1214)
-				if r.TryDecodeAsNil() {
-					yyv1214[yyj1214] = JobCondition{}
-				} else {
-					yyv1216 := &yyv1214[yyj1214]
-					yyv1216.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1214 := 0
-		for ; !r.CheckBreak(); yyj1214++ {
-
-			if yyj1214 >= len(yyv1214) {
-				yyv1214 = append(yyv1214, JobCondition{}) // var yyz1214 JobCondition
-				yyc1214 = true
-			}
-			yyh1214.ElemContainerState(yyj1214)
-			if yyj1214 < len(yyv1214) {
-				if r.TryDecodeAsNil() {
-					yyv1214[yyj1214] = JobCondition{}
-				} else {
-					yyv1217 := &yyv1214[yyj1214]
-					yyv1217.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1214 < len(yyv1214) {
-			yyv1214 = yyv1214[:yyj1214]
-			yyc1214 = true
-		} else if yyj1214 == 0 && yyv1214 == nil {
-			yyv1214 = []JobCondition{}
-			yyc1214 = true
-		}
-	}
-	yyh1214.End()
-	if yyc1214 {
-		*v = yyv1214
-	}
-}
-
-func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1218 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1219 := &yyv1218
-		yy1219.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1220 := *v
-	yyh1220, yyl1220 := z.DecSliceHelperStart()
-	var yyc1220 bool
-	if yyl1220 == 0 {
-		if yyv1220 == nil {
-			yyv1220 = []Ingress{}
-			yyc1220 = true
-		} else if len(yyv1220) != 0 {
-			yyv1220 = yyv1220[:0]
-			yyc1220 = true
-		}
-	} else if yyl1220 > 0 {
-		var yyrr1220, yyrl1220 int
-		var yyrt1220 bool
-		if yyl1220 > cap(yyv1220) {
-
-			yyrg1220 := len(yyv1220) > 0
-			yyv21220 := yyv1220
-			yyrl1220, yyrt1220 = z.DecInferLen(yyl1220, z.DecBasicHandle().MaxInitLen, 248)
-			if yyrt1220 {
-				if yyrl1220 <= cap(yyv1220) {
-					yyv1220 = yyv1220[:yyrl1220]
-				} else {
-					yyv1220 = make([]Ingress, yyrl1220)
-				}
-			} else {
-				yyv1220 = make([]Ingress, yyrl1220)
-			}
-			yyc1220 = true
-			yyrr1220 = len(yyv1220)
-			if yyrg1220 {
-				copy(yyv1220, yyv21220)
-			}
-		} else if yyl1220 != len(yyv1220) {
-			yyv1220 = yyv1220[:yyl1220]
-			yyc1220 = true
-		}
-		yyj1220 := 0
-		for ; yyj1220 < yyrr1220; yyj1220++ {
-			yyh1220.ElemContainerState(yyj1220)
-			if r.TryDecodeAsNil() {
-				yyv1220[yyj1220] = Ingress{}
-			} else {
-				yyv1221 := &yyv1220[yyj1220]
-				yyv1221.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1220 {
-			for ; yyj1220 < yyl1220; yyj1220++ {
-				yyv1220 = append(yyv1220, Ingress{})
-				yyh1220.ElemContainerState(yyj1220)
-				if r.TryDecodeAsNil() {
-					yyv1220[yyj1220] = Ingress{}
-				} else {
-					yyv1222 := &yyv1220[yyj1220]
-					yyv1222.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1220 := 0
-		for ; !r.CheckBreak(); yyj1220++ {
-
-			if yyj1220 >= len(yyv1220) {
-				yyv1220 = append(yyv1220, Ingress{}) // var yyz1220 Ingress
-				yyc1220 = true
-			}
-			yyh1220.ElemContainerState(yyj1220)
-			if yyj1220 < len(yyv1220) {
-				if r.TryDecodeAsNil() {
-					yyv1220[yyj1220] = Ingress{}
-				} else {
-					yyv1223 := &yyv1220[yyj1220]
-					yyv1223.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1220 < len(yyv1220) {
-			yyv1220 = yyv1220[:yyj1220]
-			yyc1220 = true
-		} else if yyj1220 == 0 && yyv1220 == nil {
-			yyv1220 = []Ingress{}
-			yyc1220 = true
-		}
-	}
-	yyh1220.End()
-	if yyc1220 {
-		*v = yyv1220
-	}
-}
-
-func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv1224 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1225 := &yyv1224
-		yy1225.CodecEncodeSelf(e)
-	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv1226 := *v
-	yyh1226, yyl1226 := z.DecSliceHelperStart()
-	var yyc1226 bool
-	if yyl1226 == 0 {
-		if yyv1226 == nil {
-			yyv1226 = []IngressRule{}
-			yyc1226 = true
-		} else if len(yyv1226) != 0 {
-			yyv1226 = yyv1226[:0]
-			yyc1226 = true
-		}
-	} else if yyl1226 > 0 {
-		var yyrr1226, yyrl1226 int
-		var yyrt1226 bool
-		if yyl1226 > cap(yyv1226) {
-
-			yyrg1226 := len(yyv1226) > 0
-			yyv21226 := yyv1226
-			yyrl1226, yyrt1226 = z.DecInferLen(yyl1226, z.DecBasicHandle().MaxInitLen, 24)
-			if yyrt1226 {
-				if yyrl1226 <= cap(yyv1226) {
-					yyv1226 = yyv1226[:yyrl1226]
-				} else {
-					yyv1226 = make([]IngressRule, yyrl1226)
-				}
-			} else {
-				yyv1226 = make([]IngressRule, yyrl1226)
-			}
-			yyc1226 = true
-			yyrr1226 = len(yyv1226)
-			if yyrg1226 {
-				copy(yyv1226, yyv21226)
-			}
-		} else if yyl1226 != len(yyv1226) {
-			yyv1226 = yyv1226[:yyl1226]
-			yyc1226 = true
-		}
-		yyj1226 := 0
-		for ; yyj1226 < yyrr1226; yyj1226++ {
-			yyh1226.ElemContainerState(yyj1226)
-			if r.TryDecodeAsNil() {
-				yyv1226[yyj1226] = IngressRule{}
-			} else {
-				yyv1227 := &yyv1226[yyj1226]
-				yyv1227.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1226 {
-			for ; yyj1226 < yyl1226; yyj1226++ {
-				yyv1226 = append(yyv1226, IngressRule{})
-				yyh1226.ElemContainerState(yyj1226)
-				if r.TryDecodeAsNil() {
-					yyv1226[yyj1226] = IngressRule{}
-				} else {
-					yyv1228 := &yyv1226[yyj1226]
-					yyv1228.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1226 := 0
-		for ; !r.CheckBreak(); yyj1226++ {
-
-			if yyj1226 >= len(yyv1226) {
-				yyv1226 = append(yyv1226, IngressRule{}) // var yyz1226 IngressRule
-				yyc1226 = true
-			}
-			yyh1226.ElemContainerState(yyj1226)
-			if yyj1226 < len(yyv1226) {
-				if r.TryDecodeAsNil() {
-					yyv1226[yyj1226] = IngressRule{}
-				} else {
-					yyv1229 := &yyv1226[yyj1226]
-					yyv1229.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		if yyj1226 < len(yyv1226) {
-			yyv1226 = yyv1226[:yyj1226]
-			yyc1226 = true
-		} else if yyj1226 == 0 && yyv1226 == nil {
-			yyv1226 = []IngressRule{}
-			yyc1226 = true
-		}
-	}
-	yyh1226.End()
-	if yyc1226 {
-		*v = yyv1226
-	}
-}
-
-func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -15192,7 +14710,7 @@ func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec19
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
-func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1978.Decoder) {
+func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutoscaler, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -15202,7 +14720,7 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 	var yyc1232 bool
 	if yyl1232 == 0 {
 		if yyv1232 == nil {
-			yyv1232 = []HTTPIngressPath{}
+			yyv1232 = []HorizontalPodAutoscaler{}
 			yyc1232 = true
 		} else if len(yyv1232) != 0 {
 			yyv1232 = yyv1232[:0]
@@ -15215,15 +14733,15 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 
 			yyrg1232 := len(yyv1232) > 0
 			yyv21232 := yyv1232
-			yyrl1232, yyrt1232 = z.DecInferLen(yyl1232, z.DecBasicHandle().MaxInitLen, 64)
+			yyrl1232, yyrt1232 = z.DecInferLen(yyl1232, z.DecBasicHandle().MaxInitLen, 312)
 			if yyrt1232 {
 				if yyrl1232 <= cap(yyv1232) {
 					yyv1232 = yyv1232[:yyrl1232]
 				} else {
-					yyv1232 = make([]HTTPIngressPath, yyrl1232)
+					yyv1232 = make([]HorizontalPodAutoscaler, yyrl1232)
 				}
 			} else {
-				yyv1232 = make([]HTTPIngressPath, yyrl1232)
+				yyv1232 = make([]HorizontalPodAutoscaler, yyrl1232)
 			}
 			yyc1232 = true
 			yyrr1232 = len(yyv1232)
@@ -15238,7 +14756,7 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 		for ; yyj1232 < yyrr1232; yyj1232++ {
 			yyh1232.ElemContainerState(yyj1232)
 			if r.TryDecodeAsNil() {
-				yyv1232[yyj1232] = HTTPIngressPath{}
+				yyv1232[yyj1232] = HorizontalPodAutoscaler{}
 			} else {
 				yyv1233 := &yyv1232[yyj1232]
 				yyv1233.CodecDecodeSelf(d)
@@ -15247,10 +14765,10 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 		}
 		if yyrt1232 {
 			for ; yyj1232 < yyl1232; yyj1232++ {
-				yyv1232 = append(yyv1232, HTTPIngressPath{})
+				yyv1232 = append(yyv1232, HorizontalPodAutoscaler{})
 				yyh1232.ElemContainerState(yyj1232)
 				if r.TryDecodeAsNil() {
-					yyv1232[yyj1232] = HTTPIngressPath{}
+					yyv1232[yyj1232] = HorizontalPodAutoscaler{}
 				} else {
 					yyv1234 := &yyv1232[yyj1232]
 					yyv1234.CodecDecodeSelf(d)
@@ -15264,13 +14782,13 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 		for ; !r.CheckBreak(); yyj1232++ {
 
 			if yyj1232 >= len(yyv1232) {
-				yyv1232 = append(yyv1232, HTTPIngressPath{}) // var yyz1232 HTTPIngressPath
+				yyv1232 = append(yyv1232, HorizontalPodAutoscaler{}) // var yyz1232 HorizontalPodAutoscaler
 				yyc1232 = true
 			}
 			yyh1232.ElemContainerState(yyj1232)
 			if yyj1232 < len(yyv1232) {
 				if r.TryDecodeAsNil() {
-					yyv1232[yyj1232] = HTTPIngressPath{}
+					yyv1232[yyj1232] = HorizontalPodAutoscaler{}
 				} else {
 					yyv1235 := &yyv1232[yyj1232]
 					yyv1235.CodecDecodeSelf(d)
@@ -15285,7 +14803,7 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 			yyv1232 = yyv1232[:yyj1232]
 			yyc1232 = true
 		} else if yyj1232 == 0 && yyv1232 == nil {
-			yyv1232 = []HTTPIngressPath{}
+			yyv1232 = []HorizontalPodAutoscaler{}
 			yyc1232 = true
 		}
 	}
@@ -15295,7 +14813,7 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 	}
 }
 
-func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec1978.Encoder) {
+func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -15308,7 +14826,7 @@ func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec19
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
-func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1978.Decoder) {
+func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -15318,7 +14836,7 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 	var yyc1238 bool
 	if yyl1238 == 0 {
 		if yyv1238 == nil {
-			yyv1238 = []NodeUtilization{}
+			yyv1238 = []APIVersion{}
 			yyc1238 = true
 		} else if len(yyv1238) != 0 {
 			yyv1238 = yyv1238[:0]
@@ -15331,15 +14849,15 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 
 			yyrg1238 := len(yyv1238) > 0
 			yyv21238 := yyv1238
-			yyrl1238, yyrt1238 = z.DecInferLen(yyl1238, z.DecBasicHandle().MaxInitLen, 24)
+			yyrl1238, yyrt1238 = z.DecInferLen(yyl1238, z.DecBasicHandle().MaxInitLen, 32)
 			if yyrt1238 {
 				if yyrl1238 <= cap(yyv1238) {
 					yyv1238 = yyv1238[:yyrl1238]
 				} else {
-					yyv1238 = make([]NodeUtilization, yyrl1238)
+					yyv1238 = make([]APIVersion, yyrl1238)
 				}
 			} else {
-				yyv1238 = make([]NodeUtilization, yyrl1238)
+				yyv1238 = make([]APIVersion, yyrl1238)
 			}
 			yyc1238 = true
 			yyrr1238 = len(yyv1238)
@@ -15354,7 +14872,7 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 		for ; yyj1238 < yyrr1238; yyj1238++ {
 			yyh1238.ElemContainerState(yyj1238)
 			if r.TryDecodeAsNil() {
-				yyv1238[yyj1238] = NodeUtilization{}
+				yyv1238[yyj1238] = APIVersion{}
 			} else {
 				yyv1239 := &yyv1238[yyj1238]
 				yyv1239.CodecDecodeSelf(d)
@@ -15363,10 +14881,10 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 		}
 		if yyrt1238 {
 			for ; yyj1238 < yyl1238; yyj1238++ {
-				yyv1238 = append(yyv1238, NodeUtilization{})
+				yyv1238 = append(yyv1238, APIVersion{})
 				yyh1238.ElemContainerState(yyj1238)
 				if r.TryDecodeAsNil() {
-					yyv1238[yyj1238] = NodeUtilization{}
+					yyv1238[yyj1238] = APIVersion{}
 				} else {
 					yyv1240 := &yyv1238[yyj1238]
 					yyv1240.CodecDecodeSelf(d)
@@ -15380,13 +14898,13 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 		for ; !r.CheckBreak(); yyj1238++ {
 
 			if yyj1238 >= len(yyv1238) {
-				yyv1238 = append(yyv1238, NodeUtilization{}) // var yyz1238 NodeUtilization
+				yyv1238 = append(yyv1238, APIVersion{}) // var yyz1238 APIVersion
 				yyc1238 = true
 			}
 			yyh1238.ElemContainerState(yyj1238)
 			if yyj1238 < len(yyv1238) {
 				if r.TryDecodeAsNil() {
-					yyv1238[yyj1238] = NodeUtilization{}
+					yyv1238[yyj1238] = APIVersion{}
 				} else {
 					yyv1241 := &yyv1238[yyj1238]
 					yyv1241.CodecDecodeSelf(d)
@@ -15401,7 +14919,7 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 			yyv1238 = yyv1238[:yyj1238]
 			yyc1238 = true
 		} else if yyj1238 == 0 && yyv1238 == nil {
-			yyv1238 = []NodeUtilization{}
+			yyv1238 = []APIVersion{}
 			yyc1238 = true
 		}
 	}
@@ -15411,7 +14929,7 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 	}
 }
 
-func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *codec1978.Encoder) {
+func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -15424,7 +14942,7 @@ func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *cod
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
-func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *codec1978.Decoder) {
+func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -15434,7 +14952,7 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 	var yyc1244 bool
 	if yyl1244 == 0 {
 		if yyv1244 == nil {
-			yyv1244 = []ClusterAutoscaler{}
+			yyv1244 = []ThirdPartyResource{}
 			yyc1244 = true
 		} else if len(yyv1244) != 0 {
 			yyv1244 = yyv1244[:0]
@@ -15447,15 +14965,15 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 
 			yyrg1244 := len(yyv1244) > 0
 			yyv21244 := yyv1244
-			yyrl1244, yyrt1244 = z.DecInferLen(yyl1244, z.DecBasicHandle().MaxInitLen, 224)
+			yyrl1244, yyrt1244 = z.DecInferLen(yyl1244, z.DecBasicHandle().MaxInitLen, 232)
 			if yyrt1244 {
 				if yyrl1244 <= cap(yyv1244) {
 					yyv1244 = yyv1244[:yyrl1244]
 				} else {
-					yyv1244 = make([]ClusterAutoscaler, yyrl1244)
+					yyv1244 = make([]ThirdPartyResource, yyrl1244)
 				}
 			} else {
-				yyv1244 = make([]ClusterAutoscaler, yyrl1244)
+				yyv1244 = make([]ThirdPartyResource, yyrl1244)
 			}
 			yyc1244 = true
 			yyrr1244 = len(yyv1244)
@@ -15470,7 +14988,7 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 		for ; yyj1244 < yyrr1244; yyj1244++ {
 			yyh1244.ElemContainerState(yyj1244)
 			if r.TryDecodeAsNil() {
-				yyv1244[yyj1244] = ClusterAutoscaler{}
+				yyv1244[yyj1244] = ThirdPartyResource{}
 			} else {
 				yyv1245 := &yyv1244[yyj1244]
 				yyv1245.CodecDecodeSelf(d)
@@ -15479,10 +14997,10 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 		}
 		if yyrt1244 {
 			for ; yyj1244 < yyl1244; yyj1244++ {
-				yyv1244 = append(yyv1244, ClusterAutoscaler{})
+				yyv1244 = append(yyv1244, ThirdPartyResource{})
 				yyh1244.ElemContainerState(yyj1244)
 				if r.TryDecodeAsNil() {
-					yyv1244[yyj1244] = ClusterAutoscaler{}
+					yyv1244[yyj1244] = ThirdPartyResource{}
 				} else {
 					yyv1246 := &yyv1244[yyj1244]
 					yyv1246.CodecDecodeSelf(d)
@@ -15496,13 +15014,13 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 		for ; !r.CheckBreak(); yyj1244++ {
 
 			if yyj1244 >= len(yyv1244) {
-				yyv1244 = append(yyv1244, ClusterAutoscaler{}) // var yyz1244 ClusterAutoscaler
+				yyv1244 = append(yyv1244, ThirdPartyResource{}) // var yyz1244 ThirdPartyResource
 				yyc1244 = true
 			}
 			yyh1244.ElemContainerState(yyj1244)
 			if yyj1244 < len(yyv1244) {
 				if r.TryDecodeAsNil() {
-					yyv1244[yyj1244] = ClusterAutoscaler{}
+					yyv1244[yyj1244] = ThirdPartyResource{}
 				} else {
 					yyv1247 := &yyv1244[yyj1244]
 					yyv1247.CodecDecodeSelf(d)
@@ -15517,7 +15035,7 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 			yyv1244 = yyv1244[:yyj1244]
 			yyc1244 = true
 		} else if yyj1244 == 0 && yyv1244 == nil {
-			yyv1244 = []ClusterAutoscaler{}
+			yyv1244 = []ThirdPartyResource{}
 			yyc1244 = true
 		}
 	}
@@ -15527,7 +15045,7 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 	}
 }
 
-func (x codecSelfer1234) encSliceLabelSelectorRequirement(v []LabelSelectorRequirement, e *codec1978.Encoder) {
+func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -15540,7 +15058,7 @@ func (x codecSelfer1234) encSliceLabelSelectorRequirement(v []LabelSelectorRequi
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
-func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequirement, d *codec1978.Decoder) {
+func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -15550,7 +15068,7 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 	var yyc1250 bool
 	if yyl1250 == 0 {
 		if yyv1250 == nil {
-			yyv1250 = []LabelSelectorRequirement{}
+			yyv1250 = []Deployment{}
 			yyc1250 = true
 		} else if len(yyv1250) != 0 {
 			yyv1250 = yyv1250[:0]
@@ -15563,15 +15081,15 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 
 			yyrg1250 := len(yyv1250) > 0
 			yyv21250 := yyv1250
-			yyrl1250, yyrt1250 = z.DecInferLen(yyl1250, z.DecBasicHandle().MaxInitLen, 56)
+			yyrl1250, yyrt1250 = z.DecInferLen(yyl1250, z.DecBasicHandle().MaxInitLen, 600)
 			if yyrt1250 {
 				if yyrl1250 <= cap(yyv1250) {
 					yyv1250 = yyv1250[:yyrl1250]
 				} else {
-					yyv1250 = make([]LabelSelectorRequirement, yyrl1250)
+					yyv1250 = make([]Deployment, yyrl1250)
 				}
 			} else {
-				yyv1250 = make([]LabelSelectorRequirement, yyrl1250)
+				yyv1250 = make([]Deployment, yyrl1250)
 			}
 			yyc1250 = true
 			yyrr1250 = len(yyv1250)
@@ -15586,7 +15104,7 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 		for ; yyj1250 < yyrr1250; yyj1250++ {
 			yyh1250.ElemContainerState(yyj1250)
 			if r.TryDecodeAsNil() {
-				yyv1250[yyj1250] = LabelSelectorRequirement{}
+				yyv1250[yyj1250] = Deployment{}
 			} else {
 				yyv1251 := &yyv1250[yyj1250]
 				yyv1251.CodecDecodeSelf(d)
@@ -15595,10 +15113,10 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 		}
 		if yyrt1250 {
 			for ; yyj1250 < yyl1250; yyj1250++ {
-				yyv1250 = append(yyv1250, LabelSelectorRequirement{})
+				yyv1250 = append(yyv1250, Deployment{})
 				yyh1250.ElemContainerState(yyj1250)
 				if r.TryDecodeAsNil() {
-					yyv1250[yyj1250] = LabelSelectorRequirement{}
+					yyv1250[yyj1250] = Deployment{}
 				} else {
 					yyv1252 := &yyv1250[yyj1250]
 					yyv1252.CodecDecodeSelf(d)
@@ -15612,13 +15130,13 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 		for ; !r.CheckBreak(); yyj1250++ {
 
 			if yyj1250 >= len(yyv1250) {
-				yyv1250 = append(yyv1250, LabelSelectorRequirement{}) // var yyz1250 LabelSelectorRequirement
+				yyv1250 = append(yyv1250, Deployment{}) // var yyz1250 Deployment
 				yyc1250 = true
 			}
 			yyh1250.ElemContainerState(yyj1250)
 			if yyj1250 < len(yyv1250) {
 				if r.TryDecodeAsNil() {
-					yyv1250[yyj1250] = LabelSelectorRequirement{}
+					yyv1250[yyj1250] = Deployment{}
 				} else {
 					yyv1253 := &yyv1250[yyj1250]
 					yyv1253.CodecDecodeSelf(d)
@@ -15633,12 +15151,1288 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 			yyv1250 = yyv1250[:yyj1250]
 			yyc1250 = true
 		} else if yyj1250 == 0 && yyv1250 == nil {
-			yyv1250 = []LabelSelectorRequirement{}
+			yyv1250 = []Deployment{}
 			yyc1250 = true
 		}
 	}
 	yyh1250.End()
 	if yyc1250 {
 		*v = yyv1250
+	}
+}
+
+func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1254 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1255 := &yyv1254
+		yy1255.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1256 := *v
+	yyh1256, yyl1256 := z.DecSliceHelperStart()
+	var yyc1256 bool
+	if yyl1256 == 0 {
+		if yyv1256 == nil {
+			yyv1256 = []DaemonSet{}
+			yyc1256 = true
+		} else if len(yyv1256) != 0 {
+			yyv1256 = yyv1256[:0]
+			yyc1256 = true
+		}
+	} else if yyl1256 > 0 {
+		var yyrr1256, yyrl1256 int
+		var yyrt1256 bool
+		if yyl1256 > cap(yyv1256) {
+
+			yyrg1256 := len(yyv1256) > 0
+			yyv21256 := yyv1256
+			yyrl1256, yyrt1256 = z.DecInferLen(yyl1256, z.DecBasicHandle().MaxInitLen, 224)
+			if yyrt1256 {
+				if yyrl1256 <= cap(yyv1256) {
+					yyv1256 = yyv1256[:yyrl1256]
+				} else {
+					yyv1256 = make([]DaemonSet, yyrl1256)
+				}
+			} else {
+				yyv1256 = make([]DaemonSet, yyrl1256)
+			}
+			yyc1256 = true
+			yyrr1256 = len(yyv1256)
+			if yyrg1256 {
+				copy(yyv1256, yyv21256)
+			}
+		} else if yyl1256 != len(yyv1256) {
+			yyv1256 = yyv1256[:yyl1256]
+			yyc1256 = true
+		}
+		yyj1256 := 0
+		for ; yyj1256 < yyrr1256; yyj1256++ {
+			yyh1256.ElemContainerState(yyj1256)
+			if r.TryDecodeAsNil() {
+				yyv1256[yyj1256] = DaemonSet{}
+			} else {
+				yyv1257 := &yyv1256[yyj1256]
+				yyv1257.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1256 {
+			for ; yyj1256 < yyl1256; yyj1256++ {
+				yyv1256 = append(yyv1256, DaemonSet{})
+				yyh1256.ElemContainerState(yyj1256)
+				if r.TryDecodeAsNil() {
+					yyv1256[yyj1256] = DaemonSet{}
+				} else {
+					yyv1258 := &yyv1256[yyj1256]
+					yyv1258.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1256 := 0
+		for ; !r.CheckBreak(); yyj1256++ {
+
+			if yyj1256 >= len(yyv1256) {
+				yyv1256 = append(yyv1256, DaemonSet{}) // var yyz1256 DaemonSet
+				yyc1256 = true
+			}
+			yyh1256.ElemContainerState(yyj1256)
+			if yyj1256 < len(yyv1256) {
+				if r.TryDecodeAsNil() {
+					yyv1256[yyj1256] = DaemonSet{}
+				} else {
+					yyv1259 := &yyv1256[yyj1256]
+					yyv1259.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1256 < len(yyv1256) {
+			yyv1256 = yyv1256[:yyj1256]
+			yyc1256 = true
+		} else if yyj1256 == 0 && yyv1256 == nil {
+			yyv1256 = []DaemonSet{}
+			yyc1256 = true
+		}
+	}
+	yyh1256.End()
+	if yyc1256 {
+		*v = yyv1256
+	}
+}
+
+func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceData, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1260 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1261 := &yyv1260
+		yy1261.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceData, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1262 := *v
+	yyh1262, yyl1262 := z.DecSliceHelperStart()
+	var yyc1262 bool
+	if yyl1262 == 0 {
+		if yyv1262 == nil {
+			yyv1262 = []ThirdPartyResourceData{}
+			yyc1262 = true
+		} else if len(yyv1262) != 0 {
+			yyv1262 = yyv1262[:0]
+			yyc1262 = true
+		}
+	} else if yyl1262 > 0 {
+		var yyrr1262, yyrl1262 int
+		var yyrt1262 bool
+		if yyl1262 > cap(yyv1262) {
+
+			yyrg1262 := len(yyv1262) > 0
+			yyv21262 := yyv1262
+			yyrl1262, yyrt1262 = z.DecInferLen(yyl1262, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt1262 {
+				if yyrl1262 <= cap(yyv1262) {
+					yyv1262 = yyv1262[:yyrl1262]
+				} else {
+					yyv1262 = make([]ThirdPartyResourceData, yyrl1262)
+				}
+			} else {
+				yyv1262 = make([]ThirdPartyResourceData, yyrl1262)
+			}
+			yyc1262 = true
+			yyrr1262 = len(yyv1262)
+			if yyrg1262 {
+				copy(yyv1262, yyv21262)
+			}
+		} else if yyl1262 != len(yyv1262) {
+			yyv1262 = yyv1262[:yyl1262]
+			yyc1262 = true
+		}
+		yyj1262 := 0
+		for ; yyj1262 < yyrr1262; yyj1262++ {
+			yyh1262.ElemContainerState(yyj1262)
+			if r.TryDecodeAsNil() {
+				yyv1262[yyj1262] = ThirdPartyResourceData{}
+			} else {
+				yyv1263 := &yyv1262[yyj1262]
+				yyv1263.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1262 {
+			for ; yyj1262 < yyl1262; yyj1262++ {
+				yyv1262 = append(yyv1262, ThirdPartyResourceData{})
+				yyh1262.ElemContainerState(yyj1262)
+				if r.TryDecodeAsNil() {
+					yyv1262[yyj1262] = ThirdPartyResourceData{}
+				} else {
+					yyv1264 := &yyv1262[yyj1262]
+					yyv1264.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1262 := 0
+		for ; !r.CheckBreak(); yyj1262++ {
+
+			if yyj1262 >= len(yyv1262) {
+				yyv1262 = append(yyv1262, ThirdPartyResourceData{}) // var yyz1262 ThirdPartyResourceData
+				yyc1262 = true
+			}
+			yyh1262.ElemContainerState(yyj1262)
+			if yyj1262 < len(yyv1262) {
+				if r.TryDecodeAsNil() {
+					yyv1262[yyj1262] = ThirdPartyResourceData{}
+				} else {
+					yyv1265 := &yyv1262[yyj1262]
+					yyv1265.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1262 < len(yyv1262) {
+			yyv1262 = yyv1262[:yyj1262]
+			yyc1262 = true
+		} else if yyj1262 == 0 && yyv1262 == nil {
+			yyv1262 = []ThirdPartyResourceData{}
+			yyc1262 = true
+		}
+	}
+	yyh1262.End()
+	if yyc1262 {
+		*v = yyv1262
+	}
+}
+
+func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1266 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1267 := &yyv1266
+		yy1267.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1268 := *v
+	yyh1268, yyl1268 := z.DecSliceHelperStart()
+	var yyc1268 bool
+	if yyl1268 == 0 {
+		if yyv1268 == nil {
+			yyv1268 = []Job{}
+			yyc1268 = true
+		} else if len(yyv1268) != 0 {
+			yyv1268 = yyv1268[:0]
+			yyc1268 = true
+		}
+	} else if yyl1268 > 0 {
+		var yyrr1268, yyrl1268 int
+		var yyrt1268 bool
+		if yyl1268 > cap(yyv1268) {
+
+			yyrg1268 := len(yyv1268) > 0
+			yyv21268 := yyv1268
+			yyrl1268, yyrt1268 = z.DecInferLen(yyl1268, z.DecBasicHandle().MaxInitLen, 624)
+			if yyrt1268 {
+				if yyrl1268 <= cap(yyv1268) {
+					yyv1268 = yyv1268[:yyrl1268]
+				} else {
+					yyv1268 = make([]Job, yyrl1268)
+				}
+			} else {
+				yyv1268 = make([]Job, yyrl1268)
+			}
+			yyc1268 = true
+			yyrr1268 = len(yyv1268)
+			if yyrg1268 {
+				copy(yyv1268, yyv21268)
+			}
+		} else if yyl1268 != len(yyv1268) {
+			yyv1268 = yyv1268[:yyl1268]
+			yyc1268 = true
+		}
+		yyj1268 := 0
+		for ; yyj1268 < yyrr1268; yyj1268++ {
+			yyh1268.ElemContainerState(yyj1268)
+			if r.TryDecodeAsNil() {
+				yyv1268[yyj1268] = Job{}
+			} else {
+				yyv1269 := &yyv1268[yyj1268]
+				yyv1269.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1268 {
+			for ; yyj1268 < yyl1268; yyj1268++ {
+				yyv1268 = append(yyv1268, Job{})
+				yyh1268.ElemContainerState(yyj1268)
+				if r.TryDecodeAsNil() {
+					yyv1268[yyj1268] = Job{}
+				} else {
+					yyv1270 := &yyv1268[yyj1268]
+					yyv1270.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1268 := 0
+		for ; !r.CheckBreak(); yyj1268++ {
+
+			if yyj1268 >= len(yyv1268) {
+				yyv1268 = append(yyv1268, Job{}) // var yyz1268 Job
+				yyc1268 = true
+			}
+			yyh1268.ElemContainerState(yyj1268)
+			if yyj1268 < len(yyv1268) {
+				if r.TryDecodeAsNil() {
+					yyv1268[yyj1268] = Job{}
+				} else {
+					yyv1271 := &yyv1268[yyj1268]
+					yyv1271.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1268 < len(yyv1268) {
+			yyv1268 = yyv1268[:yyj1268]
+			yyc1268 = true
+		} else if yyj1268 == 0 && yyv1268 == nil {
+			yyv1268 = []Job{}
+			yyc1268 = true
+		}
+	}
+	yyh1268.End()
+	if yyc1268 {
+		*v = yyv1268
+	}
+}
+
+func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1272 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1273 := &yyv1272
+		yy1273.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1274 := *v
+	yyh1274, yyl1274 := z.DecSliceHelperStart()
+	var yyc1274 bool
+	if yyl1274 == 0 {
+		if yyv1274 == nil {
+			yyv1274 = []JobCondition{}
+			yyc1274 = true
+		} else if len(yyv1274) != 0 {
+			yyv1274 = yyv1274[:0]
+			yyc1274 = true
+		}
+	} else if yyl1274 > 0 {
+		var yyrr1274, yyrl1274 int
+		var yyrt1274 bool
+		if yyl1274 > cap(yyv1274) {
+
+			yyrg1274 := len(yyv1274) > 0
+			yyv21274 := yyv1274
+			yyrl1274, yyrt1274 = z.DecInferLen(yyl1274, z.DecBasicHandle().MaxInitLen, 112)
+			if yyrt1274 {
+				if yyrl1274 <= cap(yyv1274) {
+					yyv1274 = yyv1274[:yyrl1274]
+				} else {
+					yyv1274 = make([]JobCondition, yyrl1274)
+				}
+			} else {
+				yyv1274 = make([]JobCondition, yyrl1274)
+			}
+			yyc1274 = true
+			yyrr1274 = len(yyv1274)
+			if yyrg1274 {
+				copy(yyv1274, yyv21274)
+			}
+		} else if yyl1274 != len(yyv1274) {
+			yyv1274 = yyv1274[:yyl1274]
+			yyc1274 = true
+		}
+		yyj1274 := 0
+		for ; yyj1274 < yyrr1274; yyj1274++ {
+			yyh1274.ElemContainerState(yyj1274)
+			if r.TryDecodeAsNil() {
+				yyv1274[yyj1274] = JobCondition{}
+			} else {
+				yyv1275 := &yyv1274[yyj1274]
+				yyv1275.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1274 {
+			for ; yyj1274 < yyl1274; yyj1274++ {
+				yyv1274 = append(yyv1274, JobCondition{})
+				yyh1274.ElemContainerState(yyj1274)
+				if r.TryDecodeAsNil() {
+					yyv1274[yyj1274] = JobCondition{}
+				} else {
+					yyv1276 := &yyv1274[yyj1274]
+					yyv1276.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1274 := 0
+		for ; !r.CheckBreak(); yyj1274++ {
+
+			if yyj1274 >= len(yyv1274) {
+				yyv1274 = append(yyv1274, JobCondition{}) // var yyz1274 JobCondition
+				yyc1274 = true
+			}
+			yyh1274.ElemContainerState(yyj1274)
+			if yyj1274 < len(yyv1274) {
+				if r.TryDecodeAsNil() {
+					yyv1274[yyj1274] = JobCondition{}
+				} else {
+					yyv1277 := &yyv1274[yyj1274]
+					yyv1277.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1274 < len(yyv1274) {
+			yyv1274 = yyv1274[:yyj1274]
+			yyc1274 = true
+		} else if yyj1274 == 0 && yyv1274 == nil {
+			yyv1274 = []JobCondition{}
+			yyc1274 = true
+		}
+	}
+	yyh1274.End()
+	if yyc1274 {
+		*v = yyv1274
+	}
+}
+
+func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1278 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1279 := &yyv1278
+		yy1279.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1280 := *v
+	yyh1280, yyl1280 := z.DecSliceHelperStart()
+	var yyc1280 bool
+	if yyl1280 == 0 {
+		if yyv1280 == nil {
+			yyv1280 = []Ingress{}
+			yyc1280 = true
+		} else if len(yyv1280) != 0 {
+			yyv1280 = yyv1280[:0]
+			yyc1280 = true
+		}
+	} else if yyl1280 > 0 {
+		var yyrr1280, yyrl1280 int
+		var yyrt1280 bool
+		if yyl1280 > cap(yyv1280) {
+
+			yyrg1280 := len(yyv1280) > 0
+			yyv21280 := yyv1280
+			yyrl1280, yyrt1280 = z.DecInferLen(yyl1280, z.DecBasicHandle().MaxInitLen, 248)
+			if yyrt1280 {
+				if yyrl1280 <= cap(yyv1280) {
+					yyv1280 = yyv1280[:yyrl1280]
+				} else {
+					yyv1280 = make([]Ingress, yyrl1280)
+				}
+			} else {
+				yyv1280 = make([]Ingress, yyrl1280)
+			}
+			yyc1280 = true
+			yyrr1280 = len(yyv1280)
+			if yyrg1280 {
+				copy(yyv1280, yyv21280)
+			}
+		} else if yyl1280 != len(yyv1280) {
+			yyv1280 = yyv1280[:yyl1280]
+			yyc1280 = true
+		}
+		yyj1280 := 0
+		for ; yyj1280 < yyrr1280; yyj1280++ {
+			yyh1280.ElemContainerState(yyj1280)
+			if r.TryDecodeAsNil() {
+				yyv1280[yyj1280] = Ingress{}
+			} else {
+				yyv1281 := &yyv1280[yyj1280]
+				yyv1281.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1280 {
+			for ; yyj1280 < yyl1280; yyj1280++ {
+				yyv1280 = append(yyv1280, Ingress{})
+				yyh1280.ElemContainerState(yyj1280)
+				if r.TryDecodeAsNil() {
+					yyv1280[yyj1280] = Ingress{}
+				} else {
+					yyv1282 := &yyv1280[yyj1280]
+					yyv1282.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1280 := 0
+		for ; !r.CheckBreak(); yyj1280++ {
+
+			if yyj1280 >= len(yyv1280) {
+				yyv1280 = append(yyv1280, Ingress{}) // var yyz1280 Ingress
+				yyc1280 = true
+			}
+			yyh1280.ElemContainerState(yyj1280)
+			if yyj1280 < len(yyv1280) {
+				if r.TryDecodeAsNil() {
+					yyv1280[yyj1280] = Ingress{}
+				} else {
+					yyv1283 := &yyv1280[yyj1280]
+					yyv1283.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1280 < len(yyv1280) {
+			yyv1280 = yyv1280[:yyj1280]
+			yyc1280 = true
+		} else if yyj1280 == 0 && yyv1280 == nil {
+			yyv1280 = []Ingress{}
+			yyc1280 = true
+		}
+	}
+	yyh1280.End()
+	if yyc1280 {
+		*v = yyv1280
+	}
+}
+
+func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1284 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1285 := &yyv1284
+		yy1285.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1286 := *v
+	yyh1286, yyl1286 := z.DecSliceHelperStart()
+	var yyc1286 bool
+	if yyl1286 == 0 {
+		if yyv1286 == nil {
+			yyv1286 = []IngressRule{}
+			yyc1286 = true
+		} else if len(yyv1286) != 0 {
+			yyv1286 = yyv1286[:0]
+			yyc1286 = true
+		}
+	} else if yyl1286 > 0 {
+		var yyrr1286, yyrl1286 int
+		var yyrt1286 bool
+		if yyl1286 > cap(yyv1286) {
+
+			yyrg1286 := len(yyv1286) > 0
+			yyv21286 := yyv1286
+			yyrl1286, yyrt1286 = z.DecInferLen(yyl1286, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt1286 {
+				if yyrl1286 <= cap(yyv1286) {
+					yyv1286 = yyv1286[:yyrl1286]
+				} else {
+					yyv1286 = make([]IngressRule, yyrl1286)
+				}
+			} else {
+				yyv1286 = make([]IngressRule, yyrl1286)
+			}
+			yyc1286 = true
+			yyrr1286 = len(yyv1286)
+			if yyrg1286 {
+				copy(yyv1286, yyv21286)
+			}
+		} else if yyl1286 != len(yyv1286) {
+			yyv1286 = yyv1286[:yyl1286]
+			yyc1286 = true
+		}
+		yyj1286 := 0
+		for ; yyj1286 < yyrr1286; yyj1286++ {
+			yyh1286.ElemContainerState(yyj1286)
+			if r.TryDecodeAsNil() {
+				yyv1286[yyj1286] = IngressRule{}
+			} else {
+				yyv1287 := &yyv1286[yyj1286]
+				yyv1287.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1286 {
+			for ; yyj1286 < yyl1286; yyj1286++ {
+				yyv1286 = append(yyv1286, IngressRule{})
+				yyh1286.ElemContainerState(yyj1286)
+				if r.TryDecodeAsNil() {
+					yyv1286[yyj1286] = IngressRule{}
+				} else {
+					yyv1288 := &yyv1286[yyj1286]
+					yyv1288.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1286 := 0
+		for ; !r.CheckBreak(); yyj1286++ {
+
+			if yyj1286 >= len(yyv1286) {
+				yyv1286 = append(yyv1286, IngressRule{}) // var yyz1286 IngressRule
+				yyc1286 = true
+			}
+			yyh1286.ElemContainerState(yyj1286)
+			if yyj1286 < len(yyv1286) {
+				if r.TryDecodeAsNil() {
+					yyv1286[yyj1286] = IngressRule{}
+				} else {
+					yyv1289 := &yyv1286[yyj1286]
+					yyv1289.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1286 < len(yyv1286) {
+			yyv1286 = yyv1286[:yyj1286]
+			yyc1286 = true
+		} else if yyj1286 == 0 && yyv1286 == nil {
+			yyv1286 = []IngressRule{}
+			yyc1286 = true
+		}
+	}
+	yyh1286.End()
+	if yyc1286 {
+		*v = yyv1286
+	}
+}
+
+func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1290 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1291 := &yyv1290
+		yy1291.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1292 := *v
+	yyh1292, yyl1292 := z.DecSliceHelperStart()
+	var yyc1292 bool
+	if yyl1292 == 0 {
+		if yyv1292 == nil {
+			yyv1292 = []HTTPIngressPath{}
+			yyc1292 = true
+		} else if len(yyv1292) != 0 {
+			yyv1292 = yyv1292[:0]
+			yyc1292 = true
+		}
+	} else if yyl1292 > 0 {
+		var yyrr1292, yyrl1292 int
+		var yyrt1292 bool
+		if yyl1292 > cap(yyv1292) {
+
+			yyrg1292 := len(yyv1292) > 0
+			yyv21292 := yyv1292
+			yyrl1292, yyrt1292 = z.DecInferLen(yyl1292, z.DecBasicHandle().MaxInitLen, 64)
+			if yyrt1292 {
+				if yyrl1292 <= cap(yyv1292) {
+					yyv1292 = yyv1292[:yyrl1292]
+				} else {
+					yyv1292 = make([]HTTPIngressPath, yyrl1292)
+				}
+			} else {
+				yyv1292 = make([]HTTPIngressPath, yyrl1292)
+			}
+			yyc1292 = true
+			yyrr1292 = len(yyv1292)
+			if yyrg1292 {
+				copy(yyv1292, yyv21292)
+			}
+		} else if yyl1292 != len(yyv1292) {
+			yyv1292 = yyv1292[:yyl1292]
+			yyc1292 = true
+		}
+		yyj1292 := 0
+		for ; yyj1292 < yyrr1292; yyj1292++ {
+			yyh1292.ElemContainerState(yyj1292)
+			if r.TryDecodeAsNil() {
+				yyv1292[yyj1292] = HTTPIngressPath{}
+			} else {
+				yyv1293 := &yyv1292[yyj1292]
+				yyv1293.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1292 {
+			for ; yyj1292 < yyl1292; yyj1292++ {
+				yyv1292 = append(yyv1292, HTTPIngressPath{})
+				yyh1292.ElemContainerState(yyj1292)
+				if r.TryDecodeAsNil() {
+					yyv1292[yyj1292] = HTTPIngressPath{}
+				} else {
+					yyv1294 := &yyv1292[yyj1292]
+					yyv1294.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1292 := 0
+		for ; !r.CheckBreak(); yyj1292++ {
+
+			if yyj1292 >= len(yyv1292) {
+				yyv1292 = append(yyv1292, HTTPIngressPath{}) // var yyz1292 HTTPIngressPath
+				yyc1292 = true
+			}
+			yyh1292.ElemContainerState(yyj1292)
+			if yyj1292 < len(yyv1292) {
+				if r.TryDecodeAsNil() {
+					yyv1292[yyj1292] = HTTPIngressPath{}
+				} else {
+					yyv1295 := &yyv1292[yyj1292]
+					yyv1295.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1292 < len(yyv1292) {
+			yyv1292 = yyv1292[:yyj1292]
+			yyc1292 = true
+		} else if yyj1292 == 0 && yyv1292 == nil {
+			yyv1292 = []HTTPIngressPath{}
+			yyc1292 = true
+		}
+	}
+	yyh1292.End()
+	if yyc1292 {
+		*v = yyv1292
+	}
+}
+
+func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1296 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1297 := &yyv1296
+		yy1297.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1298 := *v
+	yyh1298, yyl1298 := z.DecSliceHelperStart()
+	var yyc1298 bool
+	if yyl1298 == 0 {
+		if yyv1298 == nil {
+			yyv1298 = []NodeUtilization{}
+			yyc1298 = true
+		} else if len(yyv1298) != 0 {
+			yyv1298 = yyv1298[:0]
+			yyc1298 = true
+		}
+	} else if yyl1298 > 0 {
+		var yyrr1298, yyrl1298 int
+		var yyrt1298 bool
+		if yyl1298 > cap(yyv1298) {
+
+			yyrg1298 := len(yyv1298) > 0
+			yyv21298 := yyv1298
+			yyrl1298, yyrt1298 = z.DecInferLen(yyl1298, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt1298 {
+				if yyrl1298 <= cap(yyv1298) {
+					yyv1298 = yyv1298[:yyrl1298]
+				} else {
+					yyv1298 = make([]NodeUtilization, yyrl1298)
+				}
+			} else {
+				yyv1298 = make([]NodeUtilization, yyrl1298)
+			}
+			yyc1298 = true
+			yyrr1298 = len(yyv1298)
+			if yyrg1298 {
+				copy(yyv1298, yyv21298)
+			}
+		} else if yyl1298 != len(yyv1298) {
+			yyv1298 = yyv1298[:yyl1298]
+			yyc1298 = true
+		}
+		yyj1298 := 0
+		for ; yyj1298 < yyrr1298; yyj1298++ {
+			yyh1298.ElemContainerState(yyj1298)
+			if r.TryDecodeAsNil() {
+				yyv1298[yyj1298] = NodeUtilization{}
+			} else {
+				yyv1299 := &yyv1298[yyj1298]
+				yyv1299.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1298 {
+			for ; yyj1298 < yyl1298; yyj1298++ {
+				yyv1298 = append(yyv1298, NodeUtilization{})
+				yyh1298.ElemContainerState(yyj1298)
+				if r.TryDecodeAsNil() {
+					yyv1298[yyj1298] = NodeUtilization{}
+				} else {
+					yyv1300 := &yyv1298[yyj1298]
+					yyv1300.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1298 := 0
+		for ; !r.CheckBreak(); yyj1298++ {
+
+			if yyj1298 >= len(yyv1298) {
+				yyv1298 = append(yyv1298, NodeUtilization{}) // var yyz1298 NodeUtilization
+				yyc1298 = true
+			}
+			yyh1298.ElemContainerState(yyj1298)
+			if yyj1298 < len(yyv1298) {
+				if r.TryDecodeAsNil() {
+					yyv1298[yyj1298] = NodeUtilization{}
+				} else {
+					yyv1301 := &yyv1298[yyj1298]
+					yyv1301.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1298 < len(yyv1298) {
+			yyv1298 = yyv1298[:yyj1298]
+			yyc1298 = true
+		} else if yyj1298 == 0 && yyv1298 == nil {
+			yyv1298 = []NodeUtilization{}
+			yyc1298 = true
+		}
+	}
+	yyh1298.End()
+	if yyc1298 {
+		*v = yyv1298
+	}
+}
+
+func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1302 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1303 := &yyv1302
+		yy1303.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1304 := *v
+	yyh1304, yyl1304 := z.DecSliceHelperStart()
+	var yyc1304 bool
+	if yyl1304 == 0 {
+		if yyv1304 == nil {
+			yyv1304 = []ClusterAutoscaler{}
+			yyc1304 = true
+		} else if len(yyv1304) != 0 {
+			yyv1304 = yyv1304[:0]
+			yyc1304 = true
+		}
+	} else if yyl1304 > 0 {
+		var yyrr1304, yyrl1304 int
+		var yyrt1304 bool
+		if yyl1304 > cap(yyv1304) {
+
+			yyrg1304 := len(yyv1304) > 0
+			yyv21304 := yyv1304
+			yyrl1304, yyrt1304 = z.DecInferLen(yyl1304, z.DecBasicHandle().MaxInitLen, 224)
+			if yyrt1304 {
+				if yyrl1304 <= cap(yyv1304) {
+					yyv1304 = yyv1304[:yyrl1304]
+				} else {
+					yyv1304 = make([]ClusterAutoscaler, yyrl1304)
+				}
+			} else {
+				yyv1304 = make([]ClusterAutoscaler, yyrl1304)
+			}
+			yyc1304 = true
+			yyrr1304 = len(yyv1304)
+			if yyrg1304 {
+				copy(yyv1304, yyv21304)
+			}
+		} else if yyl1304 != len(yyv1304) {
+			yyv1304 = yyv1304[:yyl1304]
+			yyc1304 = true
+		}
+		yyj1304 := 0
+		for ; yyj1304 < yyrr1304; yyj1304++ {
+			yyh1304.ElemContainerState(yyj1304)
+			if r.TryDecodeAsNil() {
+				yyv1304[yyj1304] = ClusterAutoscaler{}
+			} else {
+				yyv1305 := &yyv1304[yyj1304]
+				yyv1305.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1304 {
+			for ; yyj1304 < yyl1304; yyj1304++ {
+				yyv1304 = append(yyv1304, ClusterAutoscaler{})
+				yyh1304.ElemContainerState(yyj1304)
+				if r.TryDecodeAsNil() {
+					yyv1304[yyj1304] = ClusterAutoscaler{}
+				} else {
+					yyv1306 := &yyv1304[yyj1304]
+					yyv1306.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1304 := 0
+		for ; !r.CheckBreak(); yyj1304++ {
+
+			if yyj1304 >= len(yyv1304) {
+				yyv1304 = append(yyv1304, ClusterAutoscaler{}) // var yyz1304 ClusterAutoscaler
+				yyc1304 = true
+			}
+			yyh1304.ElemContainerState(yyj1304)
+			if yyj1304 < len(yyv1304) {
+				if r.TryDecodeAsNil() {
+					yyv1304[yyj1304] = ClusterAutoscaler{}
+				} else {
+					yyv1307 := &yyv1304[yyj1304]
+					yyv1307.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1304 < len(yyv1304) {
+			yyv1304 = yyv1304[:yyj1304]
+			yyc1304 = true
+		} else if yyj1304 == 0 && yyv1304 == nil {
+			yyv1304 = []ClusterAutoscaler{}
+			yyc1304 = true
+		}
+	}
+	yyh1304.End()
+	if yyc1304 {
+		*v = yyv1304
+	}
+}
+
+func (x codecSelfer1234) encSliceLabelSelectorRequirement(v []LabelSelectorRequirement, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1308 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1309 := &yyv1308
+		yy1309.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequirement, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1310 := *v
+	yyh1310, yyl1310 := z.DecSliceHelperStart()
+	var yyc1310 bool
+	if yyl1310 == 0 {
+		if yyv1310 == nil {
+			yyv1310 = []LabelSelectorRequirement{}
+			yyc1310 = true
+		} else if len(yyv1310) != 0 {
+			yyv1310 = yyv1310[:0]
+			yyc1310 = true
+		}
+	} else if yyl1310 > 0 {
+		var yyrr1310, yyrl1310 int
+		var yyrt1310 bool
+		if yyl1310 > cap(yyv1310) {
+
+			yyrg1310 := len(yyv1310) > 0
+			yyv21310 := yyv1310
+			yyrl1310, yyrt1310 = z.DecInferLen(yyl1310, z.DecBasicHandle().MaxInitLen, 56)
+			if yyrt1310 {
+				if yyrl1310 <= cap(yyv1310) {
+					yyv1310 = yyv1310[:yyrl1310]
+				} else {
+					yyv1310 = make([]LabelSelectorRequirement, yyrl1310)
+				}
+			} else {
+				yyv1310 = make([]LabelSelectorRequirement, yyrl1310)
+			}
+			yyc1310 = true
+			yyrr1310 = len(yyv1310)
+			if yyrg1310 {
+				copy(yyv1310, yyv21310)
+			}
+		} else if yyl1310 != len(yyv1310) {
+			yyv1310 = yyv1310[:yyl1310]
+			yyc1310 = true
+		}
+		yyj1310 := 0
+		for ; yyj1310 < yyrr1310; yyj1310++ {
+			yyh1310.ElemContainerState(yyj1310)
+			if r.TryDecodeAsNil() {
+				yyv1310[yyj1310] = LabelSelectorRequirement{}
+			} else {
+				yyv1311 := &yyv1310[yyj1310]
+				yyv1311.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1310 {
+			for ; yyj1310 < yyl1310; yyj1310++ {
+				yyv1310 = append(yyv1310, LabelSelectorRequirement{})
+				yyh1310.ElemContainerState(yyj1310)
+				if r.TryDecodeAsNil() {
+					yyv1310[yyj1310] = LabelSelectorRequirement{}
+				} else {
+					yyv1312 := &yyv1310[yyj1310]
+					yyv1312.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1310 := 0
+		for ; !r.CheckBreak(); yyj1310++ {
+
+			if yyj1310 >= len(yyv1310) {
+				yyv1310 = append(yyv1310, LabelSelectorRequirement{}) // var yyz1310 LabelSelectorRequirement
+				yyc1310 = true
+			}
+			yyh1310.ElemContainerState(yyj1310)
+			if yyj1310 < len(yyv1310) {
+				if r.TryDecodeAsNil() {
+					yyv1310[yyj1310] = LabelSelectorRequirement{}
+				} else {
+					yyv1313 := &yyv1310[yyj1310]
+					yyv1313.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1310 < len(yyv1310) {
+			yyv1310 = yyv1310[:yyj1310]
+			yyc1310 = true
+		} else if yyj1310 == 0 && yyv1310 == nil {
+			yyv1310 = []LabelSelectorRequirement{}
+			yyc1310 = true
+		}
+	}
+	yyh1310.End()
+	if yyc1310 {
+		*v = yyv1310
+	}
+}
+
+func (x codecSelfer1234) encSliceConfigMap(v []ConfigMap, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1314 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yy1315 := &yyv1314
+		yy1315.CodecEncodeSelf(e)
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decSliceConfigMap(v *[]ConfigMap, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1316 := *v
+	yyh1316, yyl1316 := z.DecSliceHelperStart()
+	var yyc1316 bool
+	if yyl1316 == 0 {
+		if yyv1316 == nil {
+			yyv1316 = []ConfigMap{}
+			yyc1316 = true
+		} else if len(yyv1316) != 0 {
+			yyv1316 = yyv1316[:0]
+			yyc1316 = true
+		}
+	} else if yyl1316 > 0 {
+		var yyrr1316, yyrl1316 int
+		var yyrt1316 bool
+		if yyl1316 > cap(yyv1316) {
+
+			yyrg1316 := len(yyv1316) > 0
+			yyv21316 := yyv1316
+			yyrl1316, yyrt1316 = z.DecInferLen(yyl1316, z.DecBasicHandle().MaxInitLen, 200)
+			if yyrt1316 {
+				if yyrl1316 <= cap(yyv1316) {
+					yyv1316 = yyv1316[:yyrl1316]
+				} else {
+					yyv1316 = make([]ConfigMap, yyrl1316)
+				}
+			} else {
+				yyv1316 = make([]ConfigMap, yyrl1316)
+			}
+			yyc1316 = true
+			yyrr1316 = len(yyv1316)
+			if yyrg1316 {
+				copy(yyv1316, yyv21316)
+			}
+		} else if yyl1316 != len(yyv1316) {
+			yyv1316 = yyv1316[:yyl1316]
+			yyc1316 = true
+		}
+		yyj1316 := 0
+		for ; yyj1316 < yyrr1316; yyj1316++ {
+			yyh1316.ElemContainerState(yyj1316)
+			if r.TryDecodeAsNil() {
+				yyv1316[yyj1316] = ConfigMap{}
+			} else {
+				yyv1317 := &yyv1316[yyj1316]
+				yyv1317.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt1316 {
+			for ; yyj1316 < yyl1316; yyj1316++ {
+				yyv1316 = append(yyv1316, ConfigMap{})
+				yyh1316.ElemContainerState(yyj1316)
+				if r.TryDecodeAsNil() {
+					yyv1316[yyj1316] = ConfigMap{}
+				} else {
+					yyv1318 := &yyv1316[yyj1316]
+					yyv1318.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		yyj1316 := 0
+		for ; !r.CheckBreak(); yyj1316++ {
+
+			if yyj1316 >= len(yyv1316) {
+				yyv1316 = append(yyv1316, ConfigMap{}) // var yyz1316 ConfigMap
+				yyc1316 = true
+			}
+			yyh1316.ElemContainerState(yyj1316)
+			if yyj1316 < len(yyv1316) {
+				if r.TryDecodeAsNil() {
+					yyv1316[yyj1316] = ConfigMap{}
+				} else {
+					yyv1319 := &yyv1316[yyj1316]
+					yyv1319.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1316 < len(yyv1316) {
+			yyv1316 = yyv1316[:yyj1316]
+			yyc1316 = true
+		} else if yyj1316 == 0 && yyv1316 == nil {
+			yyv1316 = []ConfigMap{}
+			yyc1316 = true
+		}
+	}
+	yyh1316.End()
+	if yyc1316 {
+		*v = yyv1316
 	}
 }

--- a/pkg/apis/extensions/v1beta1/types.go
+++ b/pkg/apis/extensions/v1beta1/types.go
@@ -719,3 +719,26 @@ const (
 	LabelSelectorOpExists       LabelSelectorOperator = "Exists"
 	LabelSelectorOpDoesNotExist LabelSelectorOperator = "DoesNotExist"
 )
+
+// ConfigMap holds configuration data for pods to consume.
+type ConfigMap struct {
+	unversioned.TypeMeta `json:",inline"`
+
+	// Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata.
+	v1.ObjectMeta `json:"metadata,omitempty"`
+
+	// Data contains the configuration data.
+	// Each key must be a valid DNS_SUBDOMAIN with an optional leading dot.
+	Data map[string]string `json:"data,omitempty"`
+}
+
+// ConfigMapList is a resource containing a list of ConfigMap objects.
+type ConfigMapList struct {
+	unversioned.TypeMeta `json:",inline"`
+
+	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
+	unversioned.ListMeta `json:"metadata,omitempty"`
+
+	// Items is the list of ConfigMaps.
+	Items []ConfigMap `json:"items,omitempty"`
+}

--- a/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
+++ b/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
@@ -74,6 +74,26 @@ func (ClusterAutoscalerSpec) SwaggerDoc() map[string]string {
 	return map_ClusterAutoscalerSpec
 }
 
+var map_ConfigMap = map[string]string{
+	"":         "ConfigMap holds configuration data for pods to consume.",
+	"metadata": "Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata.",
+	"data":     "Data contains the configuration data. Each key must be a valid DNS_SUBDOMAIN with an optional leading dot.",
+}
+
+func (ConfigMap) SwaggerDoc() map[string]string {
+	return map_ConfigMap
+}
+
+var map_ConfigMapList = map[string]string{
+	"":         "ConfigMapList is a resource containing a list of ConfigMap objects.",
+	"metadata": "More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+	"items":    "Items is the list of ConfigMaps.",
+}
+
+func (ConfigMapList) SwaggerDoc() map[string]string {
+	return map_ConfigMapList
+}
+
 var map_DaemonSet = map[string]string{
 	"":         "DaemonSet represents the configuration of a daemon set.",
 	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",

--- a/pkg/client/unversioned/configmap.go
+++ b/pkg/client/unversioned/configmap.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+const (
+	ConfigMapResourceName string = "configmaps"
+)
+
+type ConfigMapsNamespacer interface {
+	ConfigMaps(namespace string) ConfigMapsInterface
+}
+
+type ConfigMapsInterface interface {
+	Get(string) (*extensions.ConfigMap, error)
+	List(opts api.ListOptions) (*extensions.ConfigMapList, error)
+	Create(*extensions.ConfigMap) (*extensions.ConfigMap, error)
+	Delete(string) error
+	Update(*extensions.ConfigMap) (*extensions.ConfigMap, error)
+	Watch(api.ListOptions) (watch.Interface, error)
+}
+
+type ConfigMaps struct {
+	client    *ExtensionsClient
+	namespace string
+}
+
+// ConfigMaps should implement ConfigMapsInterface
+var _ ConfigMapsInterface = &ConfigMaps{}
+
+func newConfigMaps(c *ExtensionsClient, ns string) *ConfigMaps {
+	return &ConfigMaps{
+		client:    c,
+		namespace: ns,
+	}
+}
+
+func (c *ConfigMaps) Get(name string) (*extensions.ConfigMap, error) {
+	result := &extensions.ConfigMap{}
+	err := c.client.Get().
+		Namespace(c.namespace).
+		Resource(ConfigMapResourceName).
+		Name(name).
+		Do().
+		Into(result)
+
+	return result, err
+}
+
+func (c *ConfigMaps) List(opts api.ListOptions) (*extensions.ConfigMapList, error) {
+	result := &extensions.ConfigMapList{}
+	err := c.client.Get().
+		Namespace(c.namespace).
+		Resource(ConfigMapResourceName).
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+
+	return result, err
+}
+
+func (c *ConfigMaps) Create(cfg *extensions.ConfigMap) (*extensions.ConfigMap, error) {
+	result := &extensions.ConfigMap{}
+	err := c.client.Post().
+		Namespace(c.namespace).
+		Resource(ConfigMapResourceName).
+		Body(cfg).
+		Do().
+		Into(result)
+
+	return result, err
+}
+
+func (c *ConfigMaps) Delete(name string) error {
+	return c.client.Delete().
+		Namespace(c.namespace).
+		Resource(ConfigMapResourceName).
+		Name(name).
+		Do().
+		Error()
+}
+
+func (c *ConfigMaps) Update(cfg *extensions.ConfigMap) (*extensions.ConfigMap, error) {
+	result := &extensions.ConfigMap{}
+
+	err := c.client.Put().
+		Namespace(c.namespace).
+		Resource(ConfigMapResourceName).
+		Name(cfg.Name).
+		Body(cfg).
+		Do().
+		Into(result)
+
+	return result, err
+}
+
+func (c *ConfigMaps) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.namespace).
+		Resource(ConfigMapResourceName).
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/unversioned/extensions.go
+++ b/pkg/client/unversioned/extensions.go
@@ -39,6 +39,7 @@ type ExtensionsInterface interface {
 	JobsNamespacer
 	IngressNamespacer
 	ThirdPartyResourceNamespacer
+	ConfigMapsNamespacer
 }
 
 // ExtensionsClient is used to interact with experimental Kubernetes features.
@@ -99,6 +100,10 @@ func (c *ExtensionsClient) Jobs(namespace string) JobInterface {
 
 func (c *ExtensionsClient) Ingress(namespace string) IngressInterface {
 	return newIngress(c, namespace)
+}
+
+func (c *ExtensionsClient) ConfigMaps(namespace string) ConfigMapsInterface {
+	return newConfigMaps(c, namespace)
 }
 
 func (c *ExtensionsClient) ThirdPartyResources(namespace string) ThirdPartyResourceInterface {

--- a/pkg/client/unversioned/testclient/fake_configmaps.go
+++ b/pkg/client/unversioned/testclient/fake_configmaps.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+const (
+	configMapResourceName string = "configMaps"
+)
+
+// FakeConfigMaps implements ConfigMapInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeConfigMaps struct {
+	Fake      *FakeExperimental
+	Namespace string
+}
+
+func (c *FakeConfigMaps) Get(name string) (*extensions.ConfigMap, error) {
+	obj, err := c.Fake.Invokes(NewGetAction(configMapResourceName, c.Namespace, name), &extensions.ConfigMap{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*extensions.ConfigMap), err
+}
+
+func (c *FakeConfigMaps) List(opts api.ListOptions) (*extensions.ConfigMapList, error) {
+	obj, err := c.Fake.Invokes(NewListAction(configMapResourceName, c.Namespace, opts), &extensions.ConfigMapList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*extensions.ConfigMapList), err
+}
+
+func (c *FakeConfigMaps) Create(cfg *extensions.ConfigMap) (*extensions.ConfigMap, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction(configMapResourceName, c.Namespace, cfg), cfg)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*extensions.ConfigMap), err
+}
+
+func (c *FakeConfigMaps) Update(cfg *extensions.ConfigMap) (*extensions.ConfigMap, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction(configMapResourceName, c.Namespace, cfg), cfg)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*extensions.ConfigMap), err
+}
+
+func (c *FakeConfigMaps) Delete(name string) error {
+	_, err := c.Fake.Invokes(NewDeleteAction(configMapResourceName, c.Namespace, name), &extensions.ConfigMap{})
+	return err
+}
+
+func (c *FakeConfigMaps) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction(configMapResourceName, c.Namespace, opts))
+}

--- a/pkg/client/unversioned/testclient/testclient.go
+++ b/pkg/client/unversioned/testclient/testclient.go
@@ -353,6 +353,10 @@ func (c *FakeExperimental) Ingress(namespace string) client.IngressInterface {
 	return &FakeIngress{Fake: c, Namespace: namespace}
 }
 
+func (c *FakeExperimental) ConfigMaps(namespace string) client.ConfigMapsInterface {
+	return &FakeConfigMaps{Fake: c, Namespace: namespace}
+}
+
 func (c *FakeExperimental) ThirdPartyResources(namespace string) client.ThirdPartyResourceInterface {
 	return &FakeThirdPartyResources{Fake: c, Namespace: namespace}
 }

--- a/pkg/registry/configmap/doc.go
+++ b/pkg/registry/configmap/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package configmap provides Registry interface
+// and its REST implementation for storing
+// ConfigMap API objects.
+package configmap

--- a/pkg/registry/configmap/etcd/etcd.go
+++ b/pkg/registry/configmap/etcd/etcd.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/registry/configmap"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
+
+	etcdgeneric "k8s.io/kubernetes/pkg/registry/generic/etcd"
+)
+
+// REST implements a RESTStorage for ConfigMap against etcd
+type REST struct {
+	*etcdgeneric.Etcd
+}
+
+// NewREST returns a RESTStorage object that will work with ConfigMap objects.
+func NewREST(s storage.Interface, storageDecorator generic.StorageDecorator) *REST {
+	prefix := "/configmaps"
+
+	newListFunc := func() runtime.Object { return &extensions.ConfigMapList{} }
+	storageInterface := storageDecorator(
+		s, 100, &extensions.ConfigMap{}, prefix, false, newListFunc)
+
+	store := &etcdgeneric.Etcd{
+		NewFunc: func() runtime.Object {
+			return &extensions.ConfigMap{}
+		},
+
+		// NewListFunc returns an object to store results of an etcd list.
+		NewListFunc: newListFunc,
+
+		// Produces a path that etcd understands, to the root of the resource
+		// by combining the namespace in the context with the given prefix.
+		KeyRootFunc: func(ctx api.Context) string {
+			return etcdgeneric.NamespaceKeyRootFunc(ctx, prefix)
+		},
+
+		// Produces a path that etcd understands, to the resource by combining
+		// the namespace in the context with the given prefix
+		KeyFunc: func(ctx api.Context, name string) (string, error) {
+			return etcdgeneric.NamespaceKeyFunc(ctx, prefix, name)
+		},
+
+		// Retrieves the name field of a ConfigMap object.
+		ObjectNameFunc: func(obj runtime.Object) (string, error) {
+			return obj.(*extensions.ConfigMap).Name, nil
+		},
+
+		// Matches objects based on labels/fields for list and watch
+		PredicateFunc: configmap.MatchConfigMap,
+
+		EndpointName: "configmaps",
+
+		CreateStrategy: configmap.Strategy,
+		UpdateStrategy: configmap.Strategy,
+
+		Storage: storageInterface,
+	}
+	return &REST{store}
+}

--- a/pkg/registry/configmap/etcd/etcd_test.go
+++ b/pkg/registry/configmap/etcd/etcd_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	"k8s.io/kubernetes/pkg/registry/registrytest"
+	"k8s.io/kubernetes/pkg/runtime"
+	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
+)
+
+func newStorage(t *testing.T) (*REST, *etcdtesting.EtcdTestServer) {
+	etcdStorage, server := registrytest.NewEtcdStorage(t, "extensions")
+	return NewREST(etcdStorage, generic.UndecoratedStorage), server
+}
+
+func validNewConfigMap() *extensions.ConfigMap {
+	return &extensions.ConfigMap{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+			Labels: map[string]string{
+				"label-1": "value-1",
+				"label-2": "value-2",
+			},
+		},
+		Data: map[string]string{
+			"test": "data",
+		},
+	}
+}
+
+func TestCreate(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	test := registrytest.New(t, storage.Etcd)
+
+	validConfigMap := validNewConfigMap()
+	validConfigMap.ObjectMeta = api.ObjectMeta{
+		GenerateName: "foo-",
+	}
+
+	test.TestCreate(
+		validConfigMap,
+		&extensions.ConfigMap{
+			ObjectMeta: api.ObjectMeta{Name: "badName"},
+			Data: map[string]string{
+				"key": "value",
+			},
+		},
+		&extensions.ConfigMap{
+			ObjectMeta: api.ObjectMeta{Name: "name-2"},
+			Data: map[string]string{
+				"..dotfile": "do: nothing\n",
+			},
+		},
+	)
+}
+
+func TestUpdate(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	test := registrytest.New(t, storage.Etcd)
+	test.TestUpdate(
+		// valid
+		validNewConfigMap(),
+		// updateFunc
+		func(obj runtime.Object) runtime.Object {
+			cfg := obj.(*extensions.ConfigMap)
+			cfg.Data["update-test"] = "value"
+			return cfg
+		},
+		// invalid updateFunc
+		func(obj runtime.Object) runtime.Object {
+			cfg := obj.(*extensions.ConfigMap)
+			cfg.Data["badKey"] = "value"
+			return cfg
+		},
+	)
+}
+
+func TestDelete(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	test := registrytest.New(t, storage.Etcd)
+	test.TestDelete(validNewConfigMap())
+}
+
+func TestGet(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	test := registrytest.New(t, storage.Etcd)
+	test.TestGet(validNewConfigMap())
+}
+
+func TestList(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	test := registrytest.New(t, storage.Etcd)
+	test.TestList(validNewConfigMap())
+}
+
+func TestWatch(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	test := registrytest.New(t, storage.Etcd)
+	test.TestWatch(
+		validNewConfigMap(),
+		// matching labels
+		[]labels.Set{
+			{"label-1": "value-1"},
+			{"label-2": "value-2"},
+		},
+		// not matching labels
+		[]labels.Set{
+			{"foo": "bar"},
+		},
+		// matching fields
+		[]fields.Set{
+			{"metadata.namespace": "default"},
+			{"metadata.name": "foo"},
+		},
+		// not matching fields
+		[]fields.Set{
+			{"metadata.name": "bar"},
+			{"name": "foo"},
+		},
+	)
+}

--- a/pkg/registry/configmap/registry.go
+++ b/pkg/registry/configmap/registry.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/rest"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// Registry is an interface for things that know how to store ConfigMaps.
+type Registry interface {
+	ListConfigMaps(ctx api.Context, options *unversioned.ListOptions) (*extensions.ConfigMapList, error)
+	WatchConfigMaps(ctx api.Context, options *unversioned.ListOptions) (watch.Interface, error)
+	GetConfigMap(ctx api.Context, name string) (*extensions.ConfigMap, error)
+	CreateConfigMap(ctx api.Context, cfg *extensions.ConfigMap) (*extensions.ConfigMap, error)
+	UpdateConfigMap(ctx api.Context, cfg *extensions.ConfigMap) (*extensions.ConfigMap, error)
+	DeleteConfigMap(ctx api.Context, name string) error
+}
+
+// storage puts strong typing around storage calls
+type storage struct {
+	rest.StandardStorage
+}
+
+// NewRegistry returns a new Registry interface for the given Storage. Any mismatched
+// types will panic.
+func NewRegistry(s rest.StandardStorage) Registry {
+	return &storage{s}
+}
+
+func (s *storage) ListConfigMaps(ctx api.Context, options *unversioned.ListOptions) (*extensions.ConfigMapList, error) {
+	obj, err := s.List(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj.(*extensions.ConfigMapList), err
+}
+
+func (s *storage) WatchConfigMaps(ctx api.Context, options *unversioned.ListOptions) (watch.Interface, error) {
+	return s.Watch(ctx, options)
+}
+
+func (s *storage) GetConfigMap(ctx api.Context, name string) (*extensions.ConfigMap, error) {
+	obj, err := s.Get(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj.(*extensions.ConfigMap), nil
+}
+
+func (s *storage) CreateConfigMap(ctx api.Context, cfg *extensions.ConfigMap) (*extensions.ConfigMap, error) {
+	obj, err := s.Create(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj.(*extensions.ConfigMap), nil
+}
+
+func (s *storage) UpdateConfigMap(ctx api.Context, cfg *extensions.ConfigMap) (*extensions.ConfigMap, error) {
+	obj, _, err := s.Update(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj.(*extensions.ConfigMap), nil
+}
+
+func (s *storage) DeleteConfigMap(ctx api.Context, name string) error {
+	_, err := s.Delete(ctx, name, nil)
+
+	return err
+}

--- a/pkg/registry/configmap/strategy.go
+++ b/pkg/registry/configmap/strategy.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/rest"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/extensions/validation"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/validation/field"
+)
+
+// strategy implements behavior for ConfigMap objects
+type strategy struct {
+	runtime.ObjectTyper
+	api.NameGenerator
+}
+
+// Strategy is the default logic that applies when creating and updating ConfigMap
+// objects via the REST API.
+var Strategy = strategy{api.Scheme, api.SimpleNameGenerator}
+
+// Strategy should implement rest.RESTCreateStrategy
+var _ rest.RESTCreateStrategy = Strategy
+
+// Strategy should implement rest.RESTUpdateStrategy
+var _ rest.RESTUpdateStrategy = Strategy
+
+func (strategy) NamespaceScoped() bool {
+	return true
+}
+
+func (strategy) PrepareForCreate(obj runtime.Object) {
+	_ = obj.(*extensions.ConfigMap)
+}
+
+func (strategy) Validate(ctx api.Context, obj runtime.Object) field.ErrorList {
+	cfg := obj.(*extensions.ConfigMap)
+
+	return validation.ValidateConfigMap(cfg)
+}
+
+// Canonicalize normalizes the object after validation.
+func (strategy) Canonicalize(obj runtime.Object) {
+}
+
+func (strategy) AllowCreateOnUpdate() bool {
+	return false
+}
+
+func (strategy) PrepareForUpdate(newObj, oldObj runtime.Object) {
+	_ = oldObj.(*extensions.ConfigMap)
+	_ = newObj.(*extensions.ConfigMap)
+}
+
+func (strategy) AllowUnconditionalUpdate() bool {
+	return true
+}
+
+func (strategy) ValidateUpdate(ctx api.Context, newObj, oldObj runtime.Object) field.ErrorList {
+	oldCfg, newCfg := oldObj.(*extensions.ConfigMap), newObj.(*extensions.ConfigMap)
+
+	return validation.ValidateConfigMapUpdate(newCfg, oldCfg)
+}
+
+// ConfigMapToSelectableFields returns a field set that represents the object for matching purposes.
+func ConfigMapToSelectableFields(cfg *extensions.ConfigMap) fields.Set {
+	return generic.ObjectMetaFieldsSet(cfg.ObjectMeta, true)
+}
+
+// MatchConfigMap returns a generic matcher for a given label and field selector.
+func MatchConfigMap(label labels.Selector, field fields.Selector) generic.Matcher {
+	return &generic.SelectionPredicate{
+		Label: label,
+		Field: field,
+		GetAttrs: func(obj runtime.Object) (labels.Set, fields.Set, error) {
+			cfg, ok := obj.(*extensions.ConfigMap)
+			if !ok {
+				return nil, nil, fmt.Errorf("given object is not of type ConfigMap")
+			}
+
+			return labels.Set(cfg.ObjectMeta.Labels), ConfigMapToSelectableFields(cfg), nil
+		},
+	}
+}

--- a/pkg/registry/configmap/strategy_test.go
+++ b/pkg/registry/configmap/strategy_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+)
+
+func TestConfigMapStrategy(t *testing.T) {
+	ctx := api.NewDefaultContext()
+	if !Strategy.NamespaceScoped() {
+		t.Errorf("ConfigMap must be namespace scoped")
+	}
+	if Strategy.AllowCreateOnUpdate() {
+		t.Errorf("ConfigMap should not allow create on update")
+	}
+
+	cfg := &extensions.ConfigMap{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "valid-config-data",
+			Namespace: api.NamespaceDefault,
+		},
+		Data: map[string]string{
+			"foo": "bar",
+		},
+	}
+
+	Strategy.PrepareForCreate(cfg)
+
+	errs := Strategy.Validate(ctx, cfg)
+	if len(errs) != 0 {
+		t.Errorf("unexpected error validating %v", errs)
+	}
+
+	newCfg := &extensions.ConfigMap{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "valid-config-data-2",
+			Namespace:       api.NamespaceDefault,
+			ResourceVersion: "4",
+		},
+		Data: map[string]string{
+			"invalidKey": "updatedValue",
+		},
+	}
+
+	Strategy.PrepareForUpdate(newCfg, cfg)
+
+	errs = Strategy.ValidateUpdate(ctx, newCfg, cfg)
+	if len(errs) == 0 {
+		t.Errorf("Expected a validation error")
+	}
+}


### PR DESCRIPTION
Per #5582, generic `Config` object that will be stored in `etcd` and will be exposed through the `API` server instead of using flags.
