### PR TITLE
Fix Namespace Termination

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1121,21 +1121,13 @@ func validateFinalizerName(stringValue string) errs.ValidationErrorList {
 	return errs.ValidationErrorList{}
 }
 
-// ValidateNamespaceUpdate tests to make sure a namespace update can be applied.  Modifies oldNamespace.
-func ValidateNamespaceUpdate(oldNamespace *api.Namespace, namespace *api.Namespace) errs.ValidationErrorList {
+// ValidateNamespaceUpdate tests to make sure a namespace update can be applied.
+// newNamespace is updated with fields that cannot be changed
+func ValidateNamespaceUpdate(newNamespace *api.Namespace, oldNamespace *api.Namespace) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
-	allErrs = append(allErrs, ValidateObjectMetaUpdate(&oldNamespace.ObjectMeta, &namespace.ObjectMeta).Prefix("metadata")...)
-
-	// TODO: move reset function to its own location
-	// Ignore metadata changes now that they have been tested
-	oldNamespace.ObjectMeta = namespace.ObjectMeta
-	oldNamespace.Spec.Finalizers = namespace.Spec.Finalizers
-
-	// TODO: Add a 'real' ValidationError type for this error and provide print actual diffs.
-	if !api.Semantic.DeepEqual(oldNamespace, namespace) {
-		glog.V(4).Infof("Update failed validation %#v vs %#v", oldNamespace, namespace)
-		allErrs = append(allErrs, fmt.Errorf("update contains more than labels or annotation changes"))
-	}
+	allErrs = append(allErrs, ValidateObjectMetaUpdate(&oldNamespace.ObjectMeta, &newNamespace.ObjectMeta).Prefix("metadata")...)
+	newNamespace.Spec.Finalizers = oldNamespace.Spec.Finalizers
+	newNamespace.Status = oldNamespace.Status
 	return allErrs
 }
 
@@ -1148,15 +1140,14 @@ func ValidateNamespaceStatusUpdate(newNamespace, oldNamespace *api.Namespace) er
 	return allErrs
 }
 
-// ValidateNamespaceFinalizeUpdate tests to see if the update is legal for an end user to make. newNamespace is updated with fields
-// that cannot be changed.
+// ValidateNamespaceFinalizeUpdate tests to see if the update is legal for an end user to make.
+// newNamespace is updated with fields that cannot be changed.
 func ValidateNamespaceFinalizeUpdate(newNamespace, oldNamespace *api.Namespace) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
 	allErrs = append(allErrs, ValidateObjectMetaUpdate(&oldNamespace.ObjectMeta, &newNamespace.ObjectMeta).Prefix("metadata")...)
 	for i := range newNamespace.Spec.Finalizers {
 		allErrs = append(allErrs, validateFinalizerName(string(newNamespace.Spec.Finalizers[i]))...)
 	}
-	newNamespace.ObjectMeta = oldNamespace.ObjectMeta
 	newNamespace.Status = oldNamespace.Status
 	return allErrs
 }

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -2503,6 +2503,9 @@ func TestValidateNamespace(t *testing.T) {
 		},
 		{
 			ObjectMeta: api.ObjectMeta{Name: "abc-123"},
+			Spec: api.NamespaceSpec{
+				Finalizers: []api.FinalizerName{"example.com/something", "example.com/other"},
+			},
 		},
 	}
 	for _, successCase := range successCases {
@@ -2566,6 +2569,20 @@ func TestValidateNamespaceFinalizeUpdate(t *testing.T) {
 					Finalizers: []api.FinalizerName{"foo.com/bar", "what.com/bar"},
 				},
 			}, true},
+		{api.Namespace{
+			ObjectMeta: api.ObjectMeta{
+				Name: "fooemptyfinalizer"},
+			Spec: api.NamespaceSpec{
+				Finalizers: []api.FinalizerName{"foo.com/bar"},
+			},
+		},
+			api.Namespace{
+				ObjectMeta: api.ObjectMeta{
+					Name: "fooemptyfinalizer"},
+				Spec: api.NamespaceSpec{
+					Finalizers: []api.FinalizerName{"", "foo.com/bar", "what.com/bar"},
+				},
+			}, false},
 	}
 	for i, test := range tests {
 		test.namespace.ObjectMeta.ResourceVersion = "1"
@@ -2632,59 +2649,76 @@ func TestValidateNamespaceUpdate(t *testing.T) {
 		{api.Namespace{}, api.Namespace{}, true},
 		{api.Namespace{
 			ObjectMeta: api.ObjectMeta{
-				Name: "foo"}},
+				Name: "foo1"}},
 			api.Namespace{
 				ObjectMeta: api.ObjectMeta{
-					Name: "bar"},
+					Name: "bar1"},
 			}, false},
 		{api.Namespace{
 			ObjectMeta: api.ObjectMeta{
-				Name:   "foo",
+				Name:   "foo2",
 				Labels: map[string]string{"foo": "bar"},
 			},
 		}, api.Namespace{
 			ObjectMeta: api.ObjectMeta{
-				Name:   "foo",
+				Name:   "foo2",
 				Labels: map[string]string{"foo": "baz"},
 			},
 		}, true},
 		{api.Namespace{
 			ObjectMeta: api.ObjectMeta{
-				Name: "foo",
+				Name: "foo3",
 			},
 		}, api.Namespace{
 			ObjectMeta: api.ObjectMeta{
-				Name:   "foo",
+				Name:   "foo3",
 				Labels: map[string]string{"foo": "baz"},
 			},
 		}, true},
 		{api.Namespace{
 			ObjectMeta: api.ObjectMeta{
-				Name:   "foo",
+				Name:   "foo4",
 				Labels: map[string]string{"bar": "foo"},
 			},
 		}, api.Namespace{
 			ObjectMeta: api.ObjectMeta{
-				Name:   "foo",
+				Name:   "foo4",
 				Labels: map[string]string{"foo": "baz"},
 			},
 		}, true},
 		{api.Namespace{
 			ObjectMeta: api.ObjectMeta{
-				Name:   "foo",
+				Name:   "foo5",
 				Labels: map[string]string{"foo": "baz"},
 			},
 		}, api.Namespace{
 			ObjectMeta: api.ObjectMeta{
-				Name:   "foo",
+				Name:   "foo5",
 				Labels: map[string]string{"Foo": "baz"},
+			},
+		}, true},
+		{api.Namespace{
+			ObjectMeta: api.ObjectMeta{
+				Name:   "foo6",
+				Labels: map[string]string{"foo": "baz"},
+			},
+		}, api.Namespace{
+			ObjectMeta: api.ObjectMeta{
+				Name:   "foo6",
+				Labels: map[string]string{"Foo": "baz"},
+			},
+			Spec: api.NamespaceSpec{
+				Finalizers: []api.FinalizerName{"kubernetes"},
+			},
+			Status: api.NamespaceStatus{
+				Phase: api.NamespaceTerminating,
 			},
 		}, true},
 	}
 	for i, test := range tests {
 		test.namespace.ObjectMeta.ResourceVersion = "1"
 		test.oldNamespace.ObjectMeta.ResourceVersion = "1"
-		errs := ValidateNamespaceUpdate(&test.oldNamespace, &test.namespace)
+		errs := ValidateNamespaceUpdate(&test.namespace, &test.oldNamespace)
 		if test.valid && len(errs) > 0 {
 			t.Errorf("%d: Unexpected error: %v", i, errs)
 			t.Logf("%#v vs %#v", test.oldNamespace.ObjectMeta, test.namespace.ObjectMeta)

--- a/pkg/namespace/namespace_controller.go
+++ b/pkg/namespace/namespace_controller.go
@@ -99,20 +99,16 @@ func finalized(namespace api.Namespace) bool {
 
 // finalize will finalize the namespace for kubernetes
 func finalize(kubeClient client.Interface, namespace api.Namespace) (*api.Namespace, error) {
-	namespaceFinalize := api.Namespace{
-		ObjectMeta: api.ObjectMeta{
-			Name:            namespace.Name,
-			ResourceVersion: namespace.ResourceVersion,
-		},
-		Spec: api.NamespaceSpec{},
-	}
+	namespaceFinalize := api.Namespace{}
+	namespaceFinalize.ObjectMeta = namespace.ObjectMeta
+	namespaceFinalize.Spec = namespace.Spec
 	finalizerSet := util.NewStringSet()
 	for i := range namespace.Spec.Finalizers {
 		if namespace.Spec.Finalizers[i] != api.FinalizerKubernetes {
 			finalizerSet.Insert(string(namespace.Spec.Finalizers[i]))
 		}
 	}
-	namespaceFinalize.Spec.Finalizers = make([]api.FinalizerName, len(finalizerSet), len(finalizerSet))
+	namespaceFinalize.Spec.Finalizers = make([]api.FinalizerName, 0, len(finalizerSet))
 	for _, value := range finalizerSet.List() {
 		namespaceFinalize.Spec.Finalizers = append(namespaceFinalize.Spec.Finalizers, api.FinalizerName(value))
 	}

--- a/pkg/registry/namespace/rest.go
+++ b/pkg/registry/namespace/rest.go
@@ -118,6 +118,13 @@ func (namespaceFinalizeStrategy) ValidateUpdate(ctx api.Context, obj, old runtim
 	return validation.ValidateNamespaceFinalizeUpdate(obj.(*api.Namespace), old.(*api.Namespace))
 }
 
+// PrepareForUpdate clears fields that are not allowed to be set by end users on update.
+func (namespaceFinalizeStrategy) PrepareForUpdate(obj, old runtime.Object) {
+	newNamespace := obj.(*api.Namespace)
+	oldNamespace := old.(*api.Namespace)
+	newNamespace.Status = oldNamespace.Status
+}
+
 // MatchNamespace returns a generic matcher for a given label and field selector.
 func MatchNamespace(label labels.Selector, field fields.Selector) generic.Matcher {
 	return generic.MatcherFunc(func(obj runtime.Object) (bool, error) {


### PR DESCRIPTION
There was a regression as part of the PrepareForUpdate changes that prevented deletion of a namespace because the list of finalizers was never being reduced because we were always taking the input from the client and overriding it with the old value from the server.

This change fixes the following:
1. Fixes issue where we copied old objectMeta to new object which made client specified resource versions ignored for idempotent calls.  This caused race conditions between multiple finalizers.
2. Add prepare for update strategy for namespace finalize strategy to do the right thing

/cc @smarterclayton 
