### PR TITLE
Makefile for build pause image and push to gcr.io

### DIFF
--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -1,0 +1,13 @@
+.PHONY:	build push
+
+IMAGE = pause
+TAG = 0.8.0
+
+build:
+	./prepare.sh
+	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .
+
+push:	build
+	gcloud preview docker push gcr.io/google_containers/$(IMAGE):$(TAG)
+
+all:	push


### PR DESCRIPTION
cc/ @vmarmol 

Successfully build and push the pause image to gcr.io

```
$ make build
docker build -t gcr.io/google_containers/pause:0.8.0 .
Sending build context to Docker daemon 248.8 kB
Sending build context to Docker daemon 
Step 0 : FROM scratch
 ---> 511136ea3c5a
Step 1 : ADD pause /
 ---> 1b312fdf350f
Removing intermediate container bf3592f94f83
Step 2 : ENTRYPOINT /pause
 ---> Running in cfbb167d3117
 ---> 3814339874c7
Removing intermediate container cfbb167d3117
Successfully built 3814339874c7
```

```
$ make push
gcloud preview docker push gcr.io/google_containers/pause:0.8.0
The push refers to a repository [gcr.io/google_containers/pause] (len: 1)
Sending image list
Pushing repository gcr.io/google_containers/pause (1 tags)
Image 511136ea3c5a already pushed, skipping
9a957de6fa3f: Image successfully pushed 
d3853ddbda1d: Image successfully pushed 
Pushing tag for rev [d3853ddbda1d] on {https://gcr.io/v1/repositories/google_containers/pause/tags/0.8.0}
```

Fixed #6231

Next step is I am going to make sure cached one in ContainerVM image point to the one with gcr.io tag.
