### PR TITLE
Fixing a lot of string formatting issues

### DIFF
--- a/pkg/api/helpers_test.go
+++ b/pkg/api/helpers_test.go
@@ -63,7 +63,7 @@ func TestSemantic(t *testing.T) {
 
 	for index, item := range table {
 		if e, a := item.shouldEqual, Semantic.DeepEqual(item.a, item.b); e != a {
-			t.Errorf("expected %v, got %v.", index, e, a)
+			t.Errorf("case[%d], expected %v, got %v.", index, e, a)
 		}
 	}
 }

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -653,7 +653,7 @@ func TestList(t *testing.T) {
 		if resp.StatusCode != http.StatusOK {
 			t.Errorf("%d: unexpected status: %d, Expected: %d, %#v", i, resp.StatusCode, http.StatusOK, resp)
 			body, _ := ioutil.ReadAll(resp.Body)
-			t.Logf("%d: body: %s", string(body))
+			t.Logf("%d: body: %s", i, string(body))
 			continue
 		}
 		// TODO: future, restore get links

--- a/pkg/auth/authorizer/abac/abac_test.go
+++ b/pkg/auth/authorizer/abac/abac_test.go
@@ -340,7 +340,7 @@ func TestPolicy(t *testing.T) {
 	for _, test := range tests {
 		matches := test.policy.matches(test.attr)
 		if test.matches != matches {
-			t.Errorf("unexpected value for %s, expected: %s, saw: %s", test.name, test.matches, matches)
+			t.Errorf("unexpected value for %s, expected: %t, saw: %t", test.name, test.matches, matches)
 		}
 	}
 }

--- a/pkg/client/helper_test.go
+++ b/pkg/client/helper_test.go
@@ -307,7 +307,7 @@ func TestSetKubernetesDefaults(t *testing.T) {
 func TestSetKubernetesDefaultsUserAgent(t *testing.T) {
 	config := &Config{}
 	if err := SetKubernetesDefaults(config); err != nil {
-		t.Errorf("unexpected error: %v")
+		t.Errorf("unexpected error: %v", err)
 	}
 	if !strings.Contains(config.UserAgent, "kubernetes/") {
 		t.Errorf("no user agent set: %#v", config)

--- a/pkg/client/portforward/portforward_test.go
+++ b/pkg/client/portforward/portforward_test.go
@@ -299,11 +299,11 @@ func TestForwardPorts(t *testing.T) {
 		// wait for r.ForwardPorts to actually return
 		err = <-doneChan
 		if err != nil {
-			t.Fatalf("%d: unexpected error: %s", err)
+			t.Fatalf("%d: unexpected error: %s", i, err)
 		}
 
 		if e, a := len(testCase.Send), len(conn.streams); e != a {
-			t.Fatalf("%d: expected %d streams to be created, got %d", e, a)
+			t.Fatalf("%d: expected %d streams to be created, got %d", i, e, a)
 		}
 
 		if !conn.closeCalled {

--- a/pkg/client/remotecommand/remotecommand_test.go
+++ b/pkg/client/remotecommand/remotecommand_test.go
@@ -282,7 +282,7 @@ func TestRequestExecuteRemoteCommand(t *testing.T) {
 		}
 
 		if !conn.closeCalled {
-			t.Fatalf("%d: expected upgraded connection to get closed")
+			t.Fatalf("%d: expected upgraded connection to get closed", i)
 		}
 	}
 }

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -644,11 +644,11 @@ func TestRequestUpgrade(t *testing.T) {
 		}
 
 		if testCase.AuthBasicHeader && !strings.Contains(rt.req.Header.Get("Authorization"), "Basic") {
-			t.Errorf("%d: expected basic auth header, got: %s", rt.req.Header.Get("Authorization"))
+			t.Errorf("%d: expected basic auth header, got: %s", i, rt.req.Header.Get("Authorization"))
 		}
 
 		if testCase.AuthBearerHeader && !strings.Contains(rt.req.Header.Get("Authorization"), "Bearer") {
-			t.Errorf("%d: expected bearer auth header, got: %s", rt.req.Header.Get("Authorization"))
+			t.Errorf("%d: expected bearer auth header, got: %s", i, rt.req.Header.Get("Authorization"))
 		}
 
 		if e, a := expectedConn, conn; e != a {

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -110,7 +110,7 @@ func parseLabels(spec []string) (map[string]string, []string, error) {
 		} else if strings.HasSuffix(labelSpec, "-") {
 			remove = append(remove, labelSpec[:len(labelSpec)-1])
 		} else {
-			return nil, nil, fmt.Errorf("unknown label spec: %v")
+			return nil, nil, fmt.Errorf("unknown label spec: %v", labelSpec)
 		}
 	}
 	for _, removeLabel := range remove {

--- a/pkg/kubectl/resize_test.go
+++ b/pkg/kubectl/resize_test.go
@@ -79,7 +79,7 @@ func TestReplicationControllerResize(t *testing.T) {
 		t.Errorf("unexpected action: %v, expected get-controller %s", fake.Actions[0], name)
 	}
 	if fake.Actions[1].Action != "update-controller" || fake.Actions[1].Value.(*api.ReplicationController).Spec.Replicas != int(count) {
-		t.Errorf("unexpected action %v, expected update-controller with replicas = %d", count)
+		t.Errorf("unexpected action %v, expected update-controller with replicas = %d", fake.Actions[1], count)
 	}
 }
 

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -173,7 +173,7 @@ func TestPathBuilder(t *testing.T) {
 
 	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
 	if err != nil || !singular || len(test.Infos) != 1 {
-		t.Fatalf("unexpected response: %v %f %#v", err, singular, test.Infos)
+		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
 	}
 
 	info := test.Infos[0]
@@ -225,7 +225,7 @@ func TestPathBuilderWithMultiple(t *testing.T) {
 
 	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
 	if err != nil || singular || len(test.Infos) != 2 {
-		t.Fatalf("unexpected response: %v %f %#v", err, singular, test.Infos)
+		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
 	}
 
 	info := test.Infos[1]
@@ -244,7 +244,7 @@ func TestDirectoryBuilder(t *testing.T) {
 
 	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
 	if err != nil || singular || len(test.Infos) < 4 {
-		t.Fatalf("unexpected response: %v %f %#v", err, singular, test.Infos)
+		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
 	}
 
 	found := false
@@ -274,7 +274,7 @@ func TestURLBuilder(t *testing.T) {
 
 	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
 	if err != nil || !singular || len(test.Infos) != 1 {
-		t.Fatalf("unexpected response: %v %f %#v", err, singular, test.Infos)
+		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
 	}
 	info := test.Infos[0]
 	if info.Name != "test" || info.Namespace != "foo" || info.Object == nil {
@@ -298,7 +298,7 @@ func TestURLBuilderRequireNamespace(t *testing.T) {
 
 	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
 	if err == nil || !singular || len(test.Infos) != 0 {
-		t.Fatalf("unexpected response: %v %f %#v", err, singular, test.Infos)
+		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
 	}
 }
 
@@ -320,7 +320,7 @@ func TestResourceByName(t *testing.T) {
 
 	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
 	if err != nil || !singular || len(test.Infos) != 1 {
-		t.Fatalf("unexpected response: %v %f %#v", err, singular, test.Infos)
+		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
 	}
 	if !reflect.DeepEqual(&pods.Items[0], test.Objects()[0]) {
 		t.Errorf("unexpected object: %#v", test.Objects())
@@ -347,7 +347,7 @@ func TestResourceByNameAndEmptySelector(t *testing.T) {
 	singular := false
 	infos, err := b.Do().IntoSingular(&singular).Infos()
 	if err != nil || !singular || len(infos) != 1 {
-		t.Fatalf("unexpected response: %v %f %#v", err, singular, infos)
+		t.Fatalf("unexpected response: %v %t %#v", err, singular, infos)
 	}
 	if !reflect.DeepEqual(&pods.Items[0], infos[0].Object) {
 		t.Errorf("unexpected object: %#v", infos[0])
@@ -383,7 +383,7 @@ func TestSelector(t *testing.T) {
 
 	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
 	if err != nil || singular || len(test.Infos) != 3 {
-		t.Fatalf("unexpected response: %v %f %#v", err, singular, test.Infos)
+		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
 	}
 	if !api.Semantic.DeepDerivative([]runtime.Object{&pods.Items[0], &pods.Items[1], &svc.Items[0]}, test.Objects()) {
 		t.Errorf("unexpected visited objects: %#v", test.Objects())
@@ -493,7 +493,7 @@ func TestResourceTuple(t *testing.T) {
 			continue
 		}
 		if len(info) != len(testCase.args) {
-			t.Errorf("%s: unexpected number of infos returned: %#v", info)
+			t.Errorf("%s: unexpected number of infos returned: %#v", k, info)
 		}
 	}
 }
@@ -508,7 +508,7 @@ func TestStream(t *testing.T) {
 
 	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
 	if err != nil || singular || len(test.Infos) != 3 {
-		t.Fatalf("unexpected response: %v %f %#v", err, singular, test.Infos)
+		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
 	}
 	if !api.Semantic.DeepDerivative([]runtime.Object{&pods.Items[0], &pods.Items[1], &rc.Items[0]}, test.Objects()) {
 		t.Errorf("unexpected visited objects: %#v", test.Objects())
@@ -525,7 +525,7 @@ func TestYAMLStream(t *testing.T) {
 
 	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
 	if err != nil || singular || len(test.Infos) != 3 {
-		t.Fatalf("unexpected response: %v %f %#v", err, singular, test.Infos)
+		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
 	}
 	if !api.Semantic.DeepDerivative([]runtime.Object{&pods.Items[0], &pods.Items[1], &rc.Items[0]}, test.Objects()) {
 		t.Errorf("unexpected visited objects: %#v", test.Objects())
@@ -653,7 +653,7 @@ func TestWatch(t *testing.T) {
 	select {
 	case obj := <-ch:
 		if obj.Type != watch.Added {
-			t.Fatalf("unexpected watch event", obj)
+			t.Fatalf("unexpected watch event %#v", obj)
 		}
 		service, ok := obj.Object.(*api.Service)
 		if !ok {
@@ -734,7 +734,7 @@ func TestIgnoreStreamErrors(t *testing.T) {
 
 	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
 	if err != nil || singular || len(test.Infos) != 2 {
-		t.Fatalf("unexpected response: %v %f %#v", err, singular, test.Infos)
+		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
 	}
 
 	if !api.Semantic.DeepDerivative([]runtime.Object{&pods.Items[0], &svc.Items[0]}, test.Objects()) {
@@ -768,7 +768,7 @@ func TestReceiveMultipleErrors(t *testing.T) {
 
 	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
 	if err == nil || singular || len(test.Infos) != 0 {
-		t.Fatalf("unexpected response: %v %f %#v", err, singular, test.Infos)
+		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
 	}
 
 	errs, ok := err.(errors.Aggregate)
@@ -776,6 +776,6 @@ func TestReceiveMultipleErrors(t *testing.T) {
 		t.Fatalf("unexpected error: %v", reflect.TypeOf(err))
 	}
 	if len(errs.Errors()) != 2 {
-		t.Errorf("unexpected errors", errs)
+		t.Errorf("unexpected errors %v", errs)
 	}
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1562,7 +1562,7 @@ func checkHostPortConflicts(pods []api.Pod) (fitting []api.Pod, notFitting []api
 func (kl *Kubelet) checkCapacityExceeded(pods []api.Pod) (fitting []api.Pod, notFitting []api.Pod) {
 	info, err := kl.GetCachedMachineInfo()
 	if err != nil {
-		glog.Error("error getting machine info: %v", err)
+		glog.Errorf("error getting machine info: %v", err)
 		return pods, []api.Pod{}
 	}
 
@@ -1780,7 +1780,7 @@ func (kl *Kubelet) tryUpdateNodeStatus() error {
 	// cAdvisor locally, e.g. for test-cmd.sh, and in integration test.
 	info, err := kl.GetCachedMachineInfo()
 	if err != nil {
-		glog.Error("error getting machine info: %v", err)
+		glog.Errorf("error getting machine info: %v", err)
 	} else {
 		node.Status.NodeInfo.MachineID = info.MachineID
 		node.Status.NodeInfo.SystemUUID = info.SystemUUID
@@ -1797,7 +1797,7 @@ func (kl *Kubelet) tryUpdateNodeStatus() error {
 
 	verinfo, err := kl.cadvisor.VersionInfo()
 	if err != nil {
-		glog.Error("error getting version info: %v", err)
+		glog.Errorf("error getting version info: %v", err)
 	} else {
 		node.Status.NodeInfo.KernelVersion = verinfo.KernelVersion
 		node.Status.NodeInfo.OsImage = verinfo.ContainerOsVersion

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2816,7 +2816,7 @@ func TestHandlePortConflicts(t *testing.T) {
 	// Check pod status stored in the status map.
 	status, err := kl.GetPodStatus(conflictedPodName)
 	if err != nil {
-		t.Fatalf("status of pod %q is not found in the status map: ", conflictedPodName, err)
+		t.Fatalf("status of pod %q is not found in the status map: %#v", conflictedPodName, err)
 	}
 	if status.Phase != api.PodFailed {
 		t.Fatalf("expected pod status %q. Got %q.", api.PodFailed, status.Phase)
@@ -2922,7 +2922,7 @@ func TestHandleMemExceeded(t *testing.T) {
 	// Check pod status stored in the status map.
 	status, err := kl.GetPodStatus(notfittingPodName)
 	if err != nil {
-		t.Fatalf("status of pod %q is not found in the status map: ", notfittingPodName, err)
+		t.Fatalf("status of pod %q is not found in the status map: %#v", notfittingPodName, err)
 	}
 	if status.Phase != api.PodFailed {
 		t.Fatalf("expected pod status %q. Got %q.", api.PodFailed, status.Phase)
@@ -2932,7 +2932,7 @@ func TestHandleMemExceeded(t *testing.T) {
 	kl.podManager.SetPods(pods)
 	status, err = kl.GetPodStatus(notfittingPodName)
 	if err != nil {
-		t.Fatalf("unable to retrieve pod status for pod %q: #v.", notfittingPodName, err)
+		t.Fatalf("unable to retrieve pod status for pod %q: %#v.", notfittingPodName, err)
 	}
 	if status.Phase != api.PodFailed {
 		t.Fatalf("expected pod status %q. Got %q.", api.PodFailed, status.Phase)
@@ -3227,7 +3227,7 @@ func TestUpdateNodeStatusError(t *testing.T) {
 	kubeClient.MinionsList = api.NodeList{Items: []api.Node{}}
 
 	if err := kubelet.updateNodeStatus(); err == nil {
-		t.Errorf("unexpected non error: %v")
+		t.Errorf("unexpected non error: %v", err)
 	}
 	if len(kubeClient.Actions) != nodeStatusUpdateRetry {
 		t.Errorf("unexpected actions: %v", kubeClient.Actions)

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -448,7 +448,7 @@ func TestPodsInfo(t *testing.T) {
 	}
 	result := string(body)
 	if !strings.Contains(result, "pod level status currently unimplemented") {
-		t.Errorf("expected body contains %s, got %d", "pod level status currently unimplemented", result)
+		t.Errorf("expected body contains pod level status currently unimplemented, got %s", result)
 	}
 }
 
@@ -477,7 +477,7 @@ func TestHealthCheck(t *testing.T) {
 	}
 	result := string(body)
 	if !strings.Contains(result, "ok") {
-		t.Errorf("expected body contains %s, got %d", "ok", result)
+		t.Errorf("expected body contains ok, got %s", result)
 	}
 
 	//Test with incorrect hostname
@@ -822,7 +822,7 @@ func TestServeExecInContainer(t *testing.T) {
 		}
 
 		if e, a := test.responseStatusCode, resp.StatusCode; e != a {
-			t.Fatalf("%d: response status: expected %v, got %v", e, a)
+			t.Fatalf("%d: response status: expected %v, got %v", i, e, a)
 		}
 
 		if test.responseStatusCode != http.StatusSwitchingProtocols {
@@ -987,7 +987,7 @@ func TestServePortForward(t *testing.T) {
 
 			p, err := strconv.ParseUint(test.port, 10, 16)
 			if err != nil {
-				t.Fatalf("%d: error parsing port string '%s': %v", i, port, err)
+				t.Fatalf("%d: error parsing port string '%s': %v", i, test.port, err)
 			}
 			if e, a := uint16(p), port; e != a {
 				t.Fatalf("%d: port: expected '%v', got '%v'", i, e, a)
@@ -1035,7 +1035,7 @@ func TestServePortForward(t *testing.T) {
 			t.Fatalf("Unexpected error creating streaming connection: %s", err)
 		}
 		if conn == nil {
-			t.Fatal("%d: Unexpected nil connection", i)
+			t.Fatalf("%d: Unexpected nil connection", i)
 		}
 		defer conn.Close()
 

--- a/pkg/kubelet/status_manager_test.go
+++ b/pkg/kubelet/status_manager_test.go
@@ -78,7 +78,7 @@ func verifyUpdates(t *testing.T, manager *statusManager, expectedUpdates int) {
 	}
 
 	if numUpdates != expectedUpdates {
-		t.Errorf("unexpected number of updates %d, expected %s", numUpdates, expectedUpdates)
+		t.Errorf("unexpected number of updates %d, expected %d", numUpdates, expectedUpdates)
 	}
 }
 

--- a/pkg/labels/selector.go
+++ b/pkg/labels/selector.go
@@ -445,7 +445,7 @@ func (p *Parser) parse() ([]Requirement, error) {
 		case IdentifierToken:
 			r, err := p.parseRequirement()
 			if err != nil {
-				return nil, fmt.Errorf("unable to parse requiremnt: ", err)
+				return nil, fmt.Errorf("unable to parse requiremnt: %v", err)
 			}
 			requirements = append(requirements, *r)
 			t, l := p.consume(Values)

--- a/pkg/labels/selector_test.go
+++ b/pkg/labels/selector_test.go
@@ -322,7 +322,7 @@ func TestToString(t *testing.T) {
 	}
 	for _, ts := range toStringTests {
 		if out := ts.In.String(); out == "" && ts.Valid {
-			t.Errorf("%+v.String() => '%v' expected no error", ts.In)
+			t.Errorf("%+v.String() => '%v' expected no error", ts.In, out)
 		} else if out != ts.Out {
 			t.Errorf("%+v.String() => '%v' want '%v'", ts.In, out, ts.Out)
 		}

--- a/pkg/registry/service/ip_allocator_test.go
+++ b/pkg/registry/service/ip_allocator_test.go
@@ -267,11 +267,11 @@ func TestGetIndexedIPSubnetTooSmall(t *testing.T) {
 		_, subnet, _ := net.ParseCIDR(testCase.subnet)
 		secondIP, err := GetIndexedIP(subnet, 2)
 		if err == nil {
-			t.Errorf("Expected error but no error occured for subnet: ", testCase.subnet)
+			t.Errorf("Expected error but no error occured for subnet: %s", testCase.subnet)
 		}
 		thirdIP, err := GetIndexedIP(subnet, 3)
 		if err == nil {
-			t.Errorf("Expected error but no error occured for subnet: ", testCase.subnet)
+			t.Errorf("Expected error but no error occured for subnet: %s", testCase.subnet)
 		}
 		if secondIP != nil {
 			t.Errorf("Unexpected second IP: Expected nil Actual <%q>", thirdIP.String())

--- a/pkg/registry/service/rest_test.go
+++ b/pkg/registry/service/rest_test.go
@@ -603,7 +603,7 @@ func TestServiceRegistryIPUpdate(t *testing.T) {
 
 	_, _, err := rest.Update(ctx, update)
 	if err == nil || !errors.IsInvalid(err) {
-		t.Error("Unexpected error type: %v", err)
+		t.Errorf("Unexpected error type: %v", err)
 	}
 }
 

--- a/pkg/scheduler/generic_scheduler_test.go
+++ b/pkg/scheduler/generic_scheduler_test.go
@@ -250,7 +250,7 @@ func TestFindFitAllError(t *testing.T) {
 	_, predicateMap, err := findNodesThatFit(api.Pod{}, FakePodLister([]api.Pod{}), predicates, makeNodeList(nodes))
 
 	if err != nil {
-		t.Errorf("unexpected error: %v")
+		t.Errorf("unexpected error: %v", err)
 	}
 
 	if len(predicateMap) != len(nodes) {
@@ -275,7 +275,7 @@ func TestFindFitSomeError(t *testing.T) {
 	_, predicateMap, err := findNodesThatFit(pod, FakePodLister([]api.Pod{}), predicates, makeNodeList(nodes))
 
 	if err != nil {
-		t.Errorf("unexpected error: %v")
+		t.Errorf("unexpected error: %v", err)
 	}
 
 	if len(predicateMap) != (len(nodes) - 1) {

--- a/pkg/volume/empty_dir/empty_dir_test.go
+++ b/pkg/volume/empty_dir/empty_dir_test.go
@@ -79,7 +79,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
 	if builder == nil {
-		t.Errorf("Got a nil Builder: %v")
+		t.Errorf("Got a nil Builder")
 	}
 
 	volPath := builder.GetPath()
@@ -107,7 +107,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}
 	if cleaner == nil {
-		t.Errorf("Got a nil Cleaner: %v")
+		t.Errorf("Got a nil Cleaner")
 	}
 
 	if err := cleaner.TearDown(); err != nil {
@@ -138,7 +138,7 @@ func TestPluginTmpfs(t *testing.T) {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
 	if builder == nil {
-		t.Errorf("Got a nil Builder: %v")
+		t.Errorf("Got a nil Builder")
 	}
 
 	volPath := builder.GetPath()
@@ -170,7 +170,7 @@ func TestPluginTmpfs(t *testing.T) {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}
 	if cleaner == nil {
-		t.Errorf("Got a nil Cleaner: %v")
+		t.Errorf("Got a nil Cleaner")
 	}
 
 	if err := cleaner.TearDown(); err != nil {
@@ -202,7 +202,7 @@ func TestPluginBackCompat(t *testing.T) {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
 	if builder == nil {
-		t.Errorf("Got a nil Builder: %v")
+		t.Errorf("Got a nil Builder")
 	}
 
 	volPath := builder.GetPath()
@@ -231,6 +231,6 @@ func TestPluginLegacy(t *testing.T) {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}
 	if cleaner == nil {
-		t.Errorf("Got a nil Cleaner: %v")
+		t.Errorf("Got a nil Cleaner")
 	}
 }

--- a/pkg/volume/gce_pd/gce_pd_test.go
+++ b/pkg/volume/gce_pd/gce_pd_test.go
@@ -108,7 +108,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
 	if builder == nil {
-		t.Errorf("Got a nil Builder: %v")
+		t.Errorf("Got a nil Builder")
 	}
 
 	path := builder.GetPath()
@@ -139,7 +139,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}
 	if cleaner == nil {
-		t.Errorf("Got a nil Cleaner: %v")
+		t.Errorf("Got a nil Cleaner")
 	}
 
 	if err := cleaner.TearDown(); err != nil {
@@ -176,6 +176,6 @@ func TestPluginLegacy(t *testing.T) {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}
 	if cleaner == nil {
-		t.Errorf("Got a nil Cleaner: %v")
+		t.Errorf("Got a nil Cleaner")
 	}
 }

--- a/pkg/volume/git_repo/git_repo_test.go
+++ b/pkg/volume/git_repo/git_repo_test.go
@@ -123,7 +123,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
 	if builder == nil {
-		t.Errorf("Got a nil Builder: %v")
+		t.Errorf("Got a nil Builder")
 	}
 
 	path := builder.GetPath()
@@ -145,7 +145,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}
 	if cleaner == nil {
-		t.Errorf("Got a nil Cleaner: %v")
+		t.Errorf("Got a nil Cleaner")
 	}
 
 	if err := cleaner.TearDown(); err != nil {
@@ -182,6 +182,6 @@ func TestPluginLegacy(t *testing.T) {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}
 	if cleaner == nil {
-		t.Errorf("Got a nil Cleaner: %v")
+		t.Errorf("Got a nil Cleaner")
 	}
 }

--- a/pkg/volume/host_path/host_path_test.go
+++ b/pkg/volume/host_path/host_path_test.go
@@ -73,7 +73,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
 	if builder == nil {
-		t.Errorf("Got a nil Builder: %v")
+		t.Errorf("Got a nil Builder")
 	}
 
 	path := builder.GetPath()
@@ -90,7 +90,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}
 	if cleaner == nil {
-		t.Errorf("Got a nil Cleaner: %v")
+		t.Errorf("Got a nil Cleaner")
 	}
 
 	if err := cleaner.TearDown(); err != nil {

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -114,7 +114,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
 	if builder == nil {
-		t.Errorf("Got a nil Builder: %v")
+		t.Errorf("Got a nil Builder")
 	}
 	path := builder.GetPath()
 	if path != "/tmp/fake/pods/poduid/volumes/kubernetes.io~nfs/vol1" {
@@ -147,7 +147,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}
 	if cleaner == nil {
-		t.Errorf("Got a nil Cleaner: %v")
+		t.Errorf("Got a nil Cleaner")
 	}
 	if err := cleaner.TearDown(); err != nil {
 		t.Errorf("Expected success, got: %v", err)

--- a/pkg/volume/secret/secret_test.go
+++ b/pkg/volume/secret/secret_test.go
@@ -103,7 +103,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
 	if builder == nil {
-		t.Errorf("Got a nil Builder: %v")
+		t.Errorf("Got a nil Builder")
 	}
 
 	volumePath := builder.GetPath()
@@ -145,7 +145,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}
 	if cleaner == nil {
-		t.Errorf("Got a nil Cleaner: %v")
+		t.Errorf("Got a nil Cleaner")
 	}
 
 	if err := cleaner.TearDown(); err != nil {

--- a/pkg/watch/mux_test.go
+++ b/pkg/watch/mux_test.go
@@ -147,7 +147,7 @@ func TestBroadcasterDropIfChannelFull(t *testing.T) {
 			defer wg.Done()
 			e1, ok := <-w.ResultChan()
 			if !ok {
-				t.Error("Watcher %v failed to retrieve first event.")
+				t.Errorf("Watcher %v failed to retrieve first event.", watcher)
 				return
 			}
 			if e, a := event1, e1; !reflect.DeepEqual(e, a) {
@@ -158,7 +158,7 @@ func TestBroadcasterDropIfChannelFull(t *testing.T) {
 			}
 			e2, ok := <-w.ResultChan()
 			if ok {
-				t.Error("Watcher %v received second event (%v, %#v) even though it shouldn't have.",
+				t.Errorf("Watcher %v received second event (%v, %#v) even though it shouldn't have.",
 					watcher, e2.Type, e2.Object)
 			}
 		}(i, watches[i])


### PR DESCRIPTION
- Improper format specifier (e.g. %s for bools or %s for ints)
- More or less parameters than format specifiers
- Not calling a formatting function when it should have (e.g. Error() instead of Errorf())

When there were too many parameters, I tried to add sensible format specifiers taking clues from the similar surrounding statements. When there were too few, I tried to find the intended thing to be put in the message.

If this is too big (like too many files), please let me know a sensible way to split it up.
