### PR TITLE
Eliminate grains.cloud_provider (in preference to grains.cloud) from SaltStack

### DIFF
--- a/cluster/saltbase/salt/kube-apiserver/default
+++ b/cluster/saltbase/salt/kube-apiserver/default
@@ -4,9 +4,16 @@
 {% endif -%}
 
 {% set cloud_provider = "" -%}
-{% if grains.cloud_provider is defined -%}
-  {% set cloud_provider = "--cloud_provider=" + grains.cloud_provider -%}
+{% set cloud_config = "" -%}
+
+{% if grains.cloud is defined -%}
+{% set cloud_provider = "--cloud_provider=" + grains.cloud -%}
+
+{% if grains.cloud == 'aws' -%}
+  {% set cloud_config = "--cloud_config=/etc/aws.conf" -%}
 {% endif -%}
+
+{% endif -%} # grains.cloud is defined
 
 {% set address = "--address=127.0.0.1" -%}
 
@@ -28,17 +35,6 @@
 {% else -%}
   {% set ips = salt['mine.get']('roles:kubernetes-master', 'network.ip_addrs', 'grain').values() -%}
   {% set etcd_servers = "--etcd_servers=http://" + ips[0][0] + ":4001" -%}
-{% endif -%}
-
-{% set cloud_config = "" -%}
-{% if grains.cloud is defined -%}
-{% if grains.cloud == 'gce' -%}
-  {% set cloud_provider = "--cloud_provider=gce" -%}
-{% endif -%}
-{% if grains.cloud == 'aws' -%}
-  {% set cloud_provider = "--cloud_provider=aws" -%}
-  {% set cloud_config = "--cloud_config=/etc/aws.conf" -%}
-{% endif -%}
 {% endif -%}
 
 {% if pillar['portal_net'] is defined -%}

--- a/cluster/saltbase/salt/kube-controller-manager/default
+++ b/cluster/saltbase/salt/kube-controller-manager/default
@@ -1,4 +1,3 @@
-{% set cloud_config = "" -%}
 {% set daemon_args = "$DAEMON_ARGS" -%}
 {% if grains['os_family'] == 'RedHat' -%}
 	{% set daemon_args = "" -%}
@@ -7,31 +6,28 @@
 {% set master="--master=127.0.0.1:8080" -%}
 
 {% set machines = ""-%}
-{% set cloud_provider = "" -%}
 {% set minion_regexp = "--minion_regexp=.*" -%}
 {% set sync_nodes = "--sync_nodes=true" -%}
-{% if grains.cloud_provider is defined -%}
-  {% set cloud_provider = "--cloud_provider=" + grains.cloud_provider -%}
-{% endif -%}
 
 {% if pillar['node_instance_prefix'] is defined -%}
   {% set minion_regexp = "--minion_regexp='" + pillar['node_instance_prefix'] + ".*'" -%}
 {% endif -%}
 
+{% set cloud_provider = "" -%}
+{% set cloud_config = "" -%}
+
 {% if grains.cloud is defined -%}
-{% if grains.cloud == 'gce' -%}
-  {% set cloud_provider = "--cloud_provider=gce" -%}
-{% endif -%}
+{% set cloud_provider = "--cloud_provider=" + grains.cloud -%}
+
 {% if grains.cloud == 'aws' -%}
-  {% set cloud_provider = "--cloud_provider=aws" -%}
   {% set cloud_config = "--cloud_config=/etc/aws.conf" -%}
   {% set machines = "--machines=" + ','.join(salt['mine.get']('roles:kubernetes-pool', 'network.ip_addrs', expr_form='grain').keys()) -%}
-{% endif -%}
-{% if grains.cloud == 'azure' -%}
+
+{% elif grains.cloud == 'azure' -%}
   MACHINES="{{ salt['mine.get']('roles:kubernetes-pool', 'grains.items', expr_form='grain').values()|join(',', attribute='hostnamef') }}"
   {% set machines = "--machines=$MACHINES" -%}
-{% endif -%}
-{% if grains.cloud == 'vsphere' -%}
+
+{% elif grains.cloud == 'vsphere' -%}
   # Collect IPs of minions as machines list.
   #
   # Use a bash array to build the value we need. Jinja 2.7 does support a 'map'
@@ -43,7 +39,9 @@
   {% endfor -%}
   {% set machines = "--machines=$(echo ${MACHINE_IPS[@]} | xargs -n1 echo | paste -sd,)" -%}
   {% set minion_regexp = "" -%}
-{% endif -%}
-{% endif -%}
+
+{% endif -%} # grains.cloud switch
+
+{% endif -%} # grains.cloud is defined
 
 DAEMON_ARGS="{{daemon_args}} {{master}} {{machines}} {{ minion_regexp }} {{ cloud_provider }} {{ sync_nodes }} {{ cloud_config }} {{pillar['log_level']}}"

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -81,7 +81,6 @@ grains:
   etcd_servers: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
   api_servers: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
   cloud: vagrant
-  cloud_provider: vagrant
   roles:
     - kubernetes-master
   runtime_config: '$(echo "$RUNTIME_CONFIG" | sed -e "s/'/''/g")'

--- a/docs/salt.md
+++ b/docs/salt.md
@@ -54,7 +54,6 @@ Key | Value
 `api_servers` | (Optional) The IP address / host name where a kubelet can get read-only access to kube-apiserver
 `cbr-cidr` | (Optional) The minion IP address range used for the docker container bridge.
 `cloud` | (Optional) Which IaaS platform is used to host kubernetes, *gce*, *azure*, *aws*, *vagrant*
-`cloud_provider` | (Optional) The cloud_provider used by apiserver: *gce*, *azure*, *vagrant*
 `etcd_servers` | (Optional) Comma-delimited list of IP addresses the kube-apiserver and kubelet use to reach etcd.  Uses the IP of the first machine in the kubernetes_master role.
 `hostnamef` | (Optional) The full host name of the machine, i.e. hostname -f
 `master_ip` | (Optional) The IP address that the kube-apiserver will bind against


### PR DESCRIPTION
This variable can be entirely derived from grains.cloud, and it
simplifies the configuration somewhat. (Or someone convince me I'm
wrong. I'm happy to be wrong here.)
