### PR TITLE
Change the RestartPolicy processing logic in ReplicationController and NodeController

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -878,10 +878,6 @@ func ValidateReplicationControllerSpec(spec *api.ReplicationControllerSpec) errs
 			allErrs = append(allErrs, errs.NewFieldInvalid("template.labels", spec.Template.Labels, "selector does not match template"))
 		}
 		allErrs = append(allErrs, ValidatePodTemplateSpec(spec.Template, spec.Replicas).Prefix("template")...)
-		// RestartPolicy has already been first-order validated as per ValidatePodTemplateSpec().
-		if spec.Template.Spec.RestartPolicy != api.RestartPolicyAlways {
-			allErrs = append(allErrs, errs.NewFieldNotSupported("template.restartPolicy", spec.Template.Spec.RestartPolicy))
-		}
 	}
 	return allErrs
 }

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -1751,44 +1751,6 @@ func TestValidateReplicationController(t *testing.T) {
 				Template: &invalidPodTemplate.Spec,
 			},
 		},
-		"invalid restart policy 1": {
-			ObjectMeta: api.ObjectMeta{
-				Name:      "abc-123",
-				Namespace: api.NamespaceDefault,
-			},
-			Spec: api.ReplicationControllerSpec{
-				Selector: validSelector,
-				Template: &api.PodTemplateSpec{
-					Spec: api.PodSpec{
-						RestartPolicy: api.RestartPolicyOnFailure,
-						DNSPolicy:     api.DNSClusterFirst,
-						Containers:    []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
-					},
-					ObjectMeta: api.ObjectMeta{
-						Labels: validSelector,
-					},
-				},
-			},
-		},
-		"invalid restart policy 2": {
-			ObjectMeta: api.ObjectMeta{
-				Name:      "abc-123",
-				Namespace: api.NamespaceDefault,
-			},
-			Spec: api.ReplicationControllerSpec{
-				Selector: validSelector,
-				Template: &api.PodTemplateSpec{
-					Spec: api.PodSpec{
-						RestartPolicy: api.RestartPolicyNever,
-						DNSPolicy:     api.DNSClusterFirst,
-						Containers:    []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
-					},
-					ObjectMeta: api.ObjectMeta{
-						Labels: validSelector,
-					},
-				},
-			},
-		},
 	}
 	for k, v := range errorCases {
 		errs := ValidateReplicationController(&v)

--- a/pkg/cloudprovider/controller/nodecontroller.go
+++ b/pkg/cloudprovider/controller/nodecontroller.go
@@ -597,6 +597,13 @@ func (nc *NodeController) deletePods(nodeID string) error {
 		if pod.Status.Host != nodeID {
 			continue
 		}
+		if api.RestartPolicyNever == pod.Spec.RestartPolicy {
+			continue
+		} else if api.RestartPolicyOnFailure == pod.Spec.RestartPolicy {
+			if api.PodSucceeded == pod.Status.Phase {
+				continue
+			}
+		}
 		glog.V(2).Infof("Delete pod %v", pod.Name)
 		if err := nc.kubeClient.Pods(pod.Namespace).Delete(pod.Name); err != nil {
 			glog.Errorf("Error deleting pod %v: %v", pod.Name, err)


### PR DESCRIPTION
We think ReplicationController should allow pod's RestartPolicy to be OnFailure and Never(it is just allowed to be Always now). We also think NodeController should consider the RestartPolicy when deleting pods.
