### PR TITLE
Fixes an issue with hosts having an IPv6 address on localhost

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -295,7 +295,11 @@ func (d *dockerContainerCommandRunner) PortForward(pod *kubecontainer.Pod, port 
 	}
 
 	containerPid := container.State.Pid
-	// TODO use exec.LookPath for socat / what if the host doesn't have it???
+	// TODO what if the host doesn't have it???
+	_, lookupErr := exec.LookPath("socat")
+	if lookupErr != nil {
+		return fmt.Errorf("Unable to do port forwarding: socat not found.")
+	}
 	args := []string{"-t", fmt.Sprintf("%d", containerPid), "-n", "socat", "-", fmt.Sprintf("TCP4:localhost:%d", port)}
 	// TODO use exec.LookPath
 	command := exec.Command("nsenter", args...)


### PR DESCRIPTION
- When 'getent hosts localhost' returns '::1' the creation of the listener fails because of the port parsing which uses ":" as a separator
- Use of net.SplitHostPort() to do the job
- Adding unit tests to ensure that the creation succeeds
- On docker.go: adds a test on the presence the socat command which was failing silenty if not installed
