### PR TITLE
Allow users not address the portalIp explicitly in the template

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -859,6 +859,11 @@ func ValidateServiceUpdate(oldService, service *api.Service) errs.ValidationErro
 	allErrs := errs.ValidationErrorList{}
 	allErrs = append(allErrs, ValidateObjectMetaUpdate(&oldService.ObjectMeta, &service.ObjectMeta).Prefix("metadata")...)
 
+	// if portalIP is not given when updating, consider it uses the exsiting one.
+	if service.Spec.PortalIP == "" {
+		service.Spec.PortalIP = oldService.Spec.PortalIP
+	}
+
 	// TODO: PortalIP should be a Status field, since the system can set a value != to the user's value
 	// once PortalIP is set, it cannot be unset.
 	if api.IsServiceIPSet(oldService) && service.Spec.PortalIP != oldService.Spec.PortalIP {

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -2227,10 +2227,18 @@ func TestValidateServiceUpdate(t *testing.T) {
 			numErrs: 1,
 		},
 		{
-			name: "remove portal IP",
+			name: "portal IP not given",
 			tweakSvc: func(oldSvc, newSvc *api.Service) {
 				oldSvc.Spec.PortalIP = "1.2.3.4"
 				newSvc.Spec.PortalIP = ""
+			},
+			numErrs: 0,
+		},
+		{
+			name: "remove portal IP",
+			tweakSvc: func(oldSvc, newSvc *api.Service) {
+				oldSvc.Spec.PortalIP = "1.2.3.4"
+				newSvc.Spec.PortalIP = "None"
 			},
 			numErrs: 1,
 		},


### PR DESCRIPTION
When portalIp is not given while updating, use old one instead. Closes #5907
