### PR TITLE
Add an alternative TokenSource to the GCE CloudProvider.

### DIFF
--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -300,6 +300,16 @@ grains:
   cbr-cidr: ${MASTER_IP_RANGE}
   cloud: gce
 EOF
+  if ! [[ -z "${PROJECT_ID:-}" ]] && ! [[ -z "${TOKEN_URL:-}" ]]; then
+    cat <<EOF >/etc/gce.conf
+[global]
+token-url = ${TOKEN_URL}
+project-id = ${PROJECT_ID}
+EOF
+    cat <<EOF >>/etc/salt/minion.d/grains.conf
+  cloud_config: /etc/gce.conf
+EOF
+  fi
 }
 
 function salt-node-role() {

--- a/cluster/saltbase/salt/kube-apiserver/default
+++ b/cluster/saltbase/salt/kube-apiserver/default
@@ -9,7 +9,12 @@
 {% if grains.cloud is defined -%}
 {% set cloud_provider = "--cloud_provider=" + grains.cloud -%}
 
-{% if grains.cloud == 'aws' -%}
+{% if grains.cloud == 'gce' -%}
+  {% if grains.cloud_config is defined -%}
+    {% set cloud_config = "--cloud_config=" + grains.cloud_config -%}
+  {% endif -%}
+
+{% elif grains.cloud == 'aws' -%}
   {% set cloud_config = "--cloud_config=/etc/aws.conf" -%}
 {% endif -%}
 
@@ -25,7 +30,6 @@
 {% if grains.publicAddressOverride is defined -%}
   {% set publicAddressOverride = "--public_address_override=" + grains.publicAddressOverride -%}
 {% endif -%}
-
 
 {% if grains.etcd_servers is defined -%}
   {% set etcd_servers = "--etcd_servers=http://" + grains.etcd_servers + ":4001" -%}

--- a/cluster/saltbase/salt/kube-controller-manager/default
+++ b/cluster/saltbase/salt/kube-controller-manager/default
@@ -19,7 +19,12 @@
 {% if grains.cloud is defined -%}
 {% set cloud_provider = "--cloud_provider=" + grains.cloud -%}
 
-{% if grains.cloud == 'aws' -%}
+{% if grains.cloud == 'gce' -%}
+  {% if grains.cloud_config is defined -%}
+    {% set cloud_config = "--cloud_config=" + grains.cloud_config -%}
+  {% endif -%}
+
+{% elif grains.cloud == 'aws' -%}
   {% set cloud_config = "--cloud_config=/etc/aws.conf" -%}
   {% set machines = "--machines=" + ','.join(salt['mine.get']('roles:kubernetes-pool', 'network.ip_addrs', expr_form='grain').keys()) -%}
 

--- a/pkg/cloudprovider/gce/token_source.go
+++ b/pkg/cloudprovider/gce/token_source.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce_cloud
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"code.google.com/p/google-api-go-client/googleapi"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+type altTokenSource struct {
+	oauthClient *http.Client
+	tokenURL    string
+}
+
+func (a *altTokenSource) Token() (*oauth2.Token, error) {
+	req, err := http.NewRequest("GET", a.tokenURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	res, err := a.oauthClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var tok struct {
+		AccessToken       string `json:"accessToken"`
+		ExpiryTimeSeconds int64  `json:"expiryTimeSeconds,string"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&tok); err != nil {
+		return nil, err
+	}
+	return &oauth2.Token{
+		AccessToken: tok.AccessToken,
+		Expiry:      time.Unix(tok.ExpiryTimeSeconds, 0),
+	}, nil
+}
+
+func newAltTokenSource(tokenURL string) oauth2.TokenSource {
+	client := oauth2.NewClient(oauth2.NoContext, google.ComputeTokenSource(""))
+	a := &altTokenSource{
+		oauthClient: client,
+		tokenURL:    tokenURL,
+	}
+	return oauth2.ReuseTokenSource(nil, a)
+}


### PR DESCRIPTION
This provides more flexible options for obtaining OAuth tokens.

Also, don't barf if we can't find a LegacyHostIP (changes in GCECloud.NodeAddresses()). Just return the ExternalIP.
