### PR TITLE
Fedora Guide: Missing yum installation of etcd

### DIFF
--- a/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -23,6 +23,11 @@ fed-node = 192.168.121.65
 ```
 yum -y install --enablerepo=updates-testing kubernetes
 ```
+* Install etcd
+
+```
+yum -y install etcd
+```
 
 * Add master and node to /etc/hosts on all machines (not needed if hostnames already in DNS). Make sure that communication works between fed-master and fed-node by using a utility such as ping.
 


### PR DESCRIPTION
The Fedora installation requires a yum install of etcd. The guide is missing this so I added a step to install it.
