### PR TITLE
Fix readiness probe

### DIFF
--- a/pkg/kubelet/probe.go
+++ b/pkg/kubelet/probe.go
@@ -66,10 +66,14 @@ func (kl *Kubelet) probeContainer(pod *api.Pod, status api.PodStatus, container 
 	ref, ok := kl.containerRefManager.GetRef(containerID)
 	if !ok {
 		glog.Warningf("No ref for pod '%v' - '%v'", containerID, container.Name)
-	} else {
-		kl.recorder.Eventf(ref, "unhealthy", "Liveness Probe Failed %v - %v", containerID, container.Name)
+		return probe.Success, err
 	}
-	return ready, err
+
+	if ready != probe.Success {
+		kl.recorder.Eventf(ref, "unhealthy", "Readiness Probe Failed %v - %v", containerID, container.Name)
+	}
+
+	return probe.Success, nil
 }
 
 // probeContainerLiveness probes the liveness of a container.

--- a/pkg/kubelet/probe_test.go
+++ b/pkg/kubelet/probe_test.go
@@ -256,26 +256,14 @@ func TestProbeContainer(t *testing.T) {
 			testContainer: api.Container{
 				ReadinessProbe: &api.Probe{InitialDelaySeconds: 100},
 			},
-			expectedResult:    probe.Failure,
+			expectedResult:    probe.Success,
 			expectedReadiness: false,
 		},
 		{
 			testContainer: api.Container{
 				ReadinessProbe: &api.Probe{InitialDelaySeconds: -100},
 			},
-			expectedResult:    probe.Unknown,
-			expectedReadiness: false,
-		},
-		{
-			testContainer: api.Container{
-				ReadinessProbe: &api.Probe{
-					InitialDelaySeconds: -100,
-					Handler: api.Handler{
-						Exec: &api.ExecAction{},
-					},
-				},
-			},
-			expectedResult:    probe.Failure,
+			expectedResult:    probe.Success,
 			expectedReadiness: false,
 		},
 		{
@@ -299,8 +287,8 @@ func TestProbeContainer(t *testing.T) {
 					},
 				},
 			},
-			expectedResult:    probe.Unknown,
-			expectedReadiness: false,
+			expectedResult:    probe.Success,
+			expectedReadiness: true,
 		},
 		{
 			testContainer: api.Container{
@@ -311,9 +299,21 @@ func TestProbeContainer(t *testing.T) {
 					},
 				},
 			},
-			expectError:       true,
-			expectedResult:    probe.Unknown,
-			expectedReadiness: false,
+			expectedResult:    probe.Success,
+			expectedReadiness: true,
+		},
+		{
+			testContainer: api.Container{
+				ReadinessProbe: &api.Probe{
+					InitialDelaySeconds: -100,
+					Handler: api.Handler{
+						Exec: &api.ExecAction{},
+					},
+				},
+			},
+			expectError:       false,
+			expectedResult:    probe.Success,
+			expectedReadiness: true,
 		},
 		// Both LivenessProbe and ReadinessProbe.
 		{
@@ -321,7 +321,7 @@ func TestProbeContainer(t *testing.T) {
 				LivenessProbe:  &api.Probe{InitialDelaySeconds: 100},
 				ReadinessProbe: &api.Probe{InitialDelaySeconds: 100},
 			},
-			expectedResult:    probe.Failure,
+			expectedResult:    probe.Success,
 			expectedReadiness: false,
 		},
 		{
@@ -329,7 +329,7 @@ func TestProbeContainer(t *testing.T) {
 				LivenessProbe:  &api.Probe{InitialDelaySeconds: 100},
 				ReadinessProbe: &api.Probe{InitialDelaySeconds: -100},
 			},
-			expectedResult:    probe.Unknown,
+			expectedResult:    probe.Success,
 			expectedReadiness: false,
 		},
 		{


### PR DESCRIPTION
Any pod with a readiness probe with an initial delay will be killed immediately.

If a pod has a readiness probe with an initial delay, the probeContainer() method will return probe.Failure immediately (since failure is the default state of the readiness probe before the initial delay, as opposed to liveness probe which defaults to healthy before the initial delay). This bug was introduced in #5148.

I dislike that liveness and readiness are lumped together in a single method as the action taken in response to each are pretty much unrelated. I think that readiness probe could be independent of the success or failure of liveness probe, which seems like the only reason the are collocated into a single method.  As it's currently implemented probeContainer() should only return results from the liveness probe, and never return any results from the readiness probe, as the result of probeContainer() feeds the decision on whether or not to kill the container.
