### PR TITLE
Check to prevent split brain api-servers/api-clients which can happen if...

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -49,6 +49,16 @@ API_CORS_ALLOWED_ORIGINS=${API_CORS_ALLOWED_ORIGINS:-"/127.0.0.1(:[0-9]+)?$,/loc
 KUBELET_PORT=${KUBELET_PORT:-10250}
 LOG_LEVEL=${LOG_LEVEL:-3}
 
+# For the common local scenario, fail fast if server is already running.
+# this can happen if you run local-up-cluster.sh twice and kill etcd in between.
+curl $API_HOST:$API_PORT
+if [ ! $? -eq 0 ]; then
+    echo "API SERVER port is free, proceeding..."
+else
+    echo "ERROR starting API SERVER, exiting.  Some host on $API_HOST is serving already on $API_PORT"
+    exit 1
+fi
+
 # Detect the OS name/arch so that we can find our binary
 case "$(uname -s)" in
   Darwin)


### PR DESCRIPTION
There are some different ways where local-up-cluster can mess you up when developing....

For example: 
1) etcd dies after local up cluster, and then
2) you restart
then:
3) You can get a server running which is different than the client version. scariest  of all, the server is more likely to be behind than the client, so it won't be immediately obvious.

To prevent this its super important to do a quick check that the API port isnt _ALREADY_ being served on.   This really messed me up today when I was trying to test some updates from head and i found that they weren't expressed in my local kube-apiserver , after a while, i realized, it was because kube-apiserver was indeed floating around already from a previous run of local-up-cluster.
