### PR TITLE
Return a typed error for config validation, and make errors simple

### DIFF
--- a/pkg/api/errors/errors.go
+++ b/pkg/api/errors/errors.go
@@ -19,6 +19,7 @@ package errors
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
@@ -236,6 +237,72 @@ func NewTimeoutError(message string, retryAfterSeconds int) error {
 		Details: &api.StatusDetails{
 			RetryAfterSeconds: retryAfterSeconds,
 		},
+	}}
+}
+
+// NewGenericServerResponse returns a new error for server responses that are not in a recognizable form.
+func NewGenericServerResponse(code int, verb, kind, name, serverMessage string, retryAfterSeconds int) error {
+	reason := api.StatusReasonUnknown
+	message := fmt.Sprintf("the server responded with the status code %d but did not return more information", code)
+	switch code {
+	case http.StatusConflict:
+		if verb == "POST" {
+			reason = api.StatusReasonAlreadyExists
+		} else {
+			reason = api.StatusReasonConflict
+		}
+		message = "the server reported a conflict"
+	case http.StatusNotFound:
+		reason = api.StatusReasonNotFound
+		message = "the server could not find the requested resource"
+	case http.StatusBadRequest:
+		reason = api.StatusReasonBadRequest
+		message = "the server rejected our request for an unknown reason"
+	case http.StatusUnauthorized:
+		reason = api.StatusReasonUnauthorized
+		message = "the server has asked for the client to provide credentials"
+	case http.StatusForbidden:
+		reason = api.StatusReasonForbidden
+		message = "the server does not allow access to the requested resource"
+	case StatusUnprocessableEntity:
+		reason = api.StatusReasonInvalid
+		message = "the server rejected our request due to an error in our request"
+	case StatusServerTimeout:
+		reason = api.StatusReasonServerTimeout
+		message = "the server cannot complete the requested operation at this time, try again later"
+	case StatusTooManyRequests:
+		reason = api.StatusReasonTimeout
+		message = "the server has received too many requests and has asked us to try again later"
+	default:
+		if code >= 500 {
+			reason = api.StatusReasonInternalError
+			message = "an error on the server has prevented the request from succeeding"
+		}
+	}
+	switch {
+	case len(kind) > 0 && len(name) > 0:
+		message = fmt.Sprintf("%s (%s %s %s)", message, strings.ToLower(verb), kind, name)
+	case len(kind) > 0:
+		message = fmt.Sprintf("%s (%s %s)", message, strings.ToLower(verb), kind)
+	}
+	return &StatusError{api.Status{
+		Status: api.StatusFailure,
+		Code:   code,
+		Reason: reason,
+		Details: &api.StatusDetails{
+			Kind: kind,
+			ID:   name,
+
+			Causes: []api.StatusCause{
+				{
+					Type:    api.CauseTypeUnexpectedServerResponse,
+					Message: serverMessage,
+				},
+			},
+
+			RetryAfterSeconds: retryAfterSeconds,
+		},
+		Message: message,
 	}}
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1431,6 +1431,10 @@ const (
 	// CauseTypeFieldValueNotSupported is used to report valid (as per formatting rules)
 	// values that can not be handled (e.g. an enumerated string).
 	CauseTypeFieldValueNotSupported CauseType = "FieldValueNotSupported"
+	// CauseTypeUnexpectedServerResponse is used to report when the server responded to the client
+	// without the expected return type. The presence of this cause indicates the error may be
+	// due to an intervening proxy or the server software malfunctioning.
+	CauseTypeUnexpectedServerResponse CauseType = "UnexpectedServerResponse"
 )
 
 // ObjectReference contains enough information to let you inspect or modify the referred object.

--- a/pkg/client/clientcmd/client_config.go
+++ b/pkg/client/clientcmd/client_config.go
@@ -26,7 +26,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/clientauth"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
 )
 
 var (
@@ -261,7 +260,7 @@ func (config DirectClientConfig) ConfirmUsable() error {
 	validationErrors = append(validationErrors, validateAuthInfo(config.getAuthInfoName(), config.getAuthInfo())...)
 	validationErrors = append(validationErrors, validateClusterInfo(config.getClusterName(), config.getCluster())...)
 
-	return errors.NewAggregate(validationErrors)
+	return newErrConfigurationInvalid(validationErrors)
 }
 
 func (config DirectClientConfig) getContextName() string {

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -51,25 +51,6 @@ type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// UnexpectedStatusError is returned as an error if a response's body and HTTP code don't
-// make sense together.
-type UnexpectedStatusError struct {
-	Request  *http.Request
-	Response *http.Response
-	Body     string
-}
-
-// Error returns a textual description of 'u'.
-func (u *UnexpectedStatusError) Error() string {
-	return fmt.Sprintf("request [%+v] failed (%d) %s: %s", u.Request, u.Response.StatusCode, u.Response.Status, u.Body)
-}
-
-// IsUnexpectedStatusError determines if err is due to an unexpected status from the server.
-func IsUnexpectedStatusError(err error) bool {
-	_, ok := err.(*UnexpectedStatusError)
-	return ok
-}
-
 // RequestConstructionError is returned when there's an error assembling a request.
 type RequestConstructionError struct {
 	Err error
@@ -661,7 +642,6 @@ func (r *Request) transformResponse(resp *http.Response, req *http.Request, body
 //    initial contact, the presence of mismatched body contents from posted content types
 //    - Give these a separate distinct error type and capture as much as possible of the original message
 //
-// TODO: introduce further levels of refinement that allow a client to distinguish between 1 and 2-3.
 // TODO: introduce transformation of generic http.Client.Do() errors that separates 4.
 func (r *Request) transformUnstructuredResponseError(resp *http.Response, req *http.Request, body []byte) error {
 	if body == nil && resp.Body != nil {
@@ -669,43 +649,12 @@ func (r *Request) transformUnstructuredResponseError(resp *http.Response, req *h
 			body = data
 		}
 	}
-	var err error = &UnexpectedStatusError{
-		Request:  req,
-		Response: resp,
-		Body:     string(body),
-	}
 	message := "unknown"
 	if isTextResponse(resp) {
 		message = strings.TrimSpace(string(body))
 	}
-	// TODO: handle other error classes we know about
-	switch resp.StatusCode {
-	case http.StatusConflict:
-		if req.Method == "POST" {
-			err = errors.NewAlreadyExists(r.resource, r.resourceName)
-		} else {
-			err = errors.NewConflict(r.resource, r.resourceName, err)
-		}
-	case http.StatusNotFound:
-		err = errors.NewNotFound(r.resource, r.resourceName)
-	case http.StatusBadRequest:
-		err = errors.NewBadRequest(message)
-	case http.StatusUnauthorized:
-		err = errors.NewUnauthorized(message)
-	case http.StatusForbidden:
-		err = errors.NewForbidden(r.resource, r.resourceName, err)
-	case errors.StatusUnprocessableEntity:
-		err = errors.NewInvalid(r.resource, r.resourceName, nil)
-	case errors.StatusServerTimeout:
-		retryAfterSeconds, _ := retryAfterSeconds(resp)
-		err = errors.NewServerTimeout(r.resource, r.verb, retryAfterSeconds)
-	case errors.StatusTooManyRequests:
-		retryAfterSeconds, _ := retryAfterSeconds(resp)
-		err = errors.NewServerTimeout(r.resource, r.verb, retryAfterSeconds)
-	case http.StatusInternalServerError:
-		err = errors.NewInternalError(fmt.Errorf(message))
-	}
-	return err
+	retryAfter, _ := retryAfterSeconds(resp)
+	return errors.NewGenericServerResponse(resp.StatusCode, req.Method, r.resource, r.resourceName, message, retryAfter)
 }
 
 // isTextResponse returns true if the response appears to be a textual media type.

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -251,7 +251,7 @@ func TestTransformResponse(t *testing.T) {
 			},
 			Error: true,
 			ErrFn: func(err error) bool {
-				return err.Error() == "aaaaa" && apierrors.IsUnauthorized(err)
+				return strings.Contains(err.Error(), "server has asked for the client to provide") && apierrors.IsUnauthorized(err)
 			},
 		},
 		{Response: &http.Response{StatusCode: 403}, Error: true},

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -407,12 +407,12 @@ func chooseHostInterfaceNativeGo() (net.IP, error) {
 	if i == len(intfs) {
 		return nil, err
 	}
-	glog.V(2).Infof("Choosing interface %s for from-host portals", intfs[i].Name)
+	glog.V(4).Infof("Choosing interface %s for from-host portals", intfs[i].Name)
 	addrs, err := intfs[i].Addrs()
 	if err != nil {
 		return nil, err
 	}
-	glog.V(2).Infof("Interface %s = %s", intfs[i].Name, addrs[0].String())
+	glog.V(4).Infof("Interface %s = %s", intfs[i].Name, addrs[0].String())
 	ip, _, err := net.ParseCIDR(addrs[0].String())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Will allow clients to determine when the configuration is bad.

On v < 2, we write to os.Stderr and exit 1 instead of calling glog.Fatalf

Follow on to #5016 and #3894
