### PR TITLE
Kubelet watching only its own Node object

### DIFF
--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -1545,6 +1545,19 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "Minion",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "name":
+				return "name", value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
 	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "ReplicationController",
 		func(label, value string) (string, string, error) {
 			switch label {

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -1470,6 +1470,19 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta2", "Minion",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "name":
+				return "name", value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// if one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
 	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta2", "ReplicationController",
 		func(label, value string) (string, string, error) {
 			switch label {

--- a/pkg/api/v1beta3/conversion.go
+++ b/pkg/api/v1beta3/conversion.go
@@ -39,6 +39,19 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta3", "Minion",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "name":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
 	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta3", "ReplicationController",
 		func(label, value string) (string, string, error) {
 			switch label {

--- a/pkg/registry/minion/etcd/etcd.go
+++ b/pkg/registry/minion/etcd/etcd.go
@@ -49,6 +49,7 @@ func NewStorage(h tools.EtcdHelper, connection client.ConnectionInfoGetter) *RES
 		KeyFunc: func(ctx api.Context, name string) (string, error) {
 			return prefix + "/" + name, nil
 		},
+		WatchSingleFieldName: "name",
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*api.Node).Name, nil
 		},

--- a/pkg/registry/minion/rest.go
+++ b/pkg/registry/minion/rest.go
@@ -82,6 +82,13 @@ type ResourceGetter interface {
 	Get(api.Context, string) (runtime.Object, error)
 }
 
+// NodeToSelectableFields returns a label set that represents the object.
+func NodeToSelectableFields(node *api.Node) labels.Set {
+	return labels.Set{
+		"name": node.Name,
+	}
+}
+
 // MatchNode returns a generic matcher for a given label and field selector.
 func MatchNode(label labels.Selector, field fields.Selector) generic.Matcher {
 	return generic.MatcherFunc(func(obj runtime.Object) (bool, error) {
@@ -89,8 +96,8 @@ func MatchNode(label labels.Selector, field fields.Selector) generic.Matcher {
 		if !ok {
 			return false, fmt.Errorf("not a node")
 		}
-		// TODO: Add support for filtering based on field, once NodeStatus is defined.
-		return label.Matches(labels.Set(nodeObj.Labels)), nil
+		fields := NodeToSelectableFields(nodeObj)
+		return label.Matches(labels.Set(nodeObj.Labels)) && field.Matches(fields), nil
 	})
 }
 


### PR DESCRIPTION
This PR:
1. Adds an ability to watch fields of a minion (currently only "name" is supported)
2. Changes Kubelet so that it watches only its own "node" object (it reduces amount of "watch-related" http requests to etcd about nodes by ~#nodes times)

Related to #6059 and #6306 (although doesn't fix any of those).

cc @smarterclayton @bprashanth 
