### PR TITLE
Increase ulimit -n for apiserver.

### DIFF
--- a/cluster/saltbase/salt/kube-apiserver/initd
+++ b/cluster/saltbase/salt/kube-apiserver/initd
@@ -38,6 +38,9 @@ DAEMON_USER=kube-apiserver
 #
 do_start()
 {
+        # Raise the file descriptor limit - we expect to open a lot of sockets!
+        ulimit -n 65536
+
         # Return
         #   0 if daemon has been started
         #   1 if daemon was already running


### PR DESCRIPTION
This fixes #6351 ("too many open files" error for large clusters)

@wojtek-t @satnam6502 
