### PR TITLE
abac policy file parsing bug

### DIFF
--- a/pkg/auth/authorizer/abac/abac.go
+++ b/pkg/auth/authorizer/abac/abac.go
@@ -78,9 +78,9 @@ func NewFromFile(path string) (policyList, error) {
 
 	scanner := bufio.NewScanner(file)
 	pl := make(policyList, 0)
-	var p policy
 
 	for scanner.Scan() {
+		var p policy
 		b := scanner.Bytes()
 		// TODO: skip comment lines.
 		err = json.Unmarshal(b, &p)


### PR DESCRIPTION
Re-using `p` results in corrupted results when reading incompletely specified lines.  For instance, with this file:

```
{"user":"bob", "readonly": true, "ns": "projectCaribou"}
{"readonly": true}
```

second rule actually has `ns` set.
