### PR TITLE
Make AWS configuration file optional (fall-back to metadata service)

### DIFF
--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -119,14 +119,14 @@ func getAuth() (auth aws.Auth, err error) {
 
 // readAWSCloudConfig reads an instance of AWSCloudConfig from config reader.
 func readAWSCloudConfig(config io.Reader, metadata AWSMetadata) (*AWSCloudConfig, error) {
-	if config == nil {
-		return nil, fmt.Errorf("no AWS cloud provider config file given")
-	}
-
 	var cfg AWSCloudConfig
-	err := gcfg.ReadInto(&cfg, config)
-	if err != nil {
-		return nil, err
+	var err error
+
+	if config != nil {
+		err = gcfg.ReadInto(&cfg, config)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if cfg.Global.Zone == "" {


### PR DESCRIPTION
The AWS configuration file currently only has the current AZ.  It is easy to get that from the metadata service.

This brings AWS closer to GCE, and also avoids the need to create an aws.conf file for kubelet on the minions when we do EBS volumes.
