### PR TITLE
Validating against negative weights for priority functions

### DIFF
--- a/plugin/pkg/scheduler/api/validation/validation.go
+++ b/plugin/pkg/scheduler/api/validation/validation.go
@@ -29,8 +29,8 @@ func ValidatePolicy(policy schedulerapi.Policy) error {
 	validationErrors := make([]error, 0)
 
 	for _, priority := range policy.Priorities {
-		if priority.Weight == 0 {
-			validationErrors = append(validationErrors, fmt.Errorf("Priority %s should have a non-zero weight applied to it", priority.Name))
+		if priority.Weight <= 0 {
+			validationErrors = append(validationErrors, fmt.Errorf("Priority %s should have a positive weight applied to it", priority.Name))
 		}
 	}
 

--- a/plugin/pkg/scheduler/api/validation/validation_test.go
+++ b/plugin/pkg/scheduler/api/validation/validation_test.go
@@ -25,29 +25,28 @@ import (
 func TestValidatePriorityWithNoWeight(t *testing.T) {
 	policy := api.Policy{Priorities: []api.PriorityPolicy{{Name: "NoWeightPriority"}}}
 	if ValidatePolicy(policy) == nil {
-		t.Errorf("Expected error about priority weight being zero")
+		t.Errorf("Expected error about priority weight not being positive")
 	}
 }
 
 func TestValidatePriorityWithZeroWeight(t *testing.T) {
 	policy := api.Policy{Priorities: []api.PriorityPolicy{{Name: "NoWeightPriority", Weight: 0}}}
 	if ValidatePolicy(policy) == nil {
-		t.Errorf("Expected error about priority weight being zero")
+		t.Errorf("Expected error about priority weight not being positive")
 	}
 }
 
 func TestValidatePriorityWithNonZeroWeight(t *testing.T) {
 	policy := api.Policy{Priorities: []api.PriorityPolicy{{Name: "WeightPriority", Weight: 2}}}
 	errs := ValidatePolicy(policy)
-	if ValidatePolicy(policy) != nil {
+	if errs != nil {
 		t.Errorf("Unexpected errors %v", errs)
 	}
 }
 
 func TestValidatePriorityWithNegativeWeight(t *testing.T) {
 	policy := api.Policy{Priorities: []api.PriorityPolicy{{Name: "WeightPriority", Weight: -2}}}
-	errs := ValidatePolicy(policy)
-	if ValidatePolicy(policy) != nil {
-		t.Errorf("Unexpected errors %v", errs)
+	if ValidatePolicy(policy) == nil {
+		t.Errorf("Expected error about priority weight not being positive")
 	}
 }


### PR DESCRIPTION
Refer discussion on another PR for some context for this change.
https://github.com/GoogleCloudPlatform/kubernetes/pull/6202#discussion_r27620641
