### PR TITLE
Updating components to use v1beta3

### DIFF
--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -165,7 +165,7 @@ function wait-cluster-readiness {
 
   local timeout=50
   while [[ $timeout -ne 0 ]]; do
-    nb_ready_minions=$("${kubectl}" get minions -o template -t "{{range.items}}{{range.status.conditions}}{{.kind}}{{end}}:{{end}}" 2>/dev/null | tr ':' '\n' | grep -c Ready || true)
+    nb_ready_minions=$("${kubectl}" get minions -o template -t "{{range.items}}{{range.status.conditions}}{{.kind}}{{end}}:{{end}}" --api-version=v1beta1 2>/dev/null | tr ':' '\n' | grep -c Ready || true)
     echo "Nb ready minions: $nb_ready_minions / $NUM_MINIONS"
     if [[ "$nb_ready_minions" -eq "$NUM_MINIONS" ]]; then
         return 0

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -165,7 +165,7 @@ function verify-cluster {
     local count="0"
     until [[ "$count" == "1" ]]; do
       local minions
-      minions=$("${KUBE_ROOT}/cluster/kubectl.sh" get minions -o template -t '{{range.items}}{{.id}}:{{end}}')
+      minions=$("${KUBE_ROOT}/cluster/kubectl.sh" get minions -o template -t '{{range.items}}{{.id}}:{{end}}' --api-version=v1beta1)
       count=$(echo $minions | grep -c "${MINION_IPS[i]}") || {
         printf "."
         sleep 2
@@ -179,7 +179,7 @@ function verify-cluster {
   vagrant ssh master --command "kubectl get pods" || {
     echo "WARNING: kubectl to localhost failed.  This could mean localhost is not bound to an IP"
   }
-  
+
   (
     echo
     echo "Kubernetes cluster is running.  The master is running at:"

--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -37,7 +37,7 @@ trap 'rm -rf "${MINIONS_FILE}"' EXIT
 # Make several attempts to deal with slow cluster birth.
 attempt=0
 while true; do
-  "${KUBE_ROOT}/cluster/kubectl.sh" get minions -o template -t $'{{range.items}}{{.id}}\n{{end}}' > "${MINIONS_FILE}"
+  "${KUBE_ROOT}/cluster/kubectl.sh" get nodes -o template -t $'{{range.items}}{{.metadata.name}}\n{{end}}' --api-version=v1beta3 > "${MINIONS_FILE}"
   found=$(grep -c . "${MINIONS_FILE}")
   if [[ ${found} == "${NUM_MINIONS}" ]]; then
     break

--- a/docs/kubectl-get.md
+++ b/docs/kubectl-get.md
@@ -30,7 +30,7 @@ $ kubectl get replicationController web
 $ kubectl get -o json pod web-pod-13je7
 
 // Return only the status value of the specified pod.
-$ kubectl get -o template web-pod-13je7 --template={{.currentState.status}}
+$ kubectl get -o template web-pod-13je7 --template={{.currentState.status}} --api-version=v1beta1
 
 // List all replication controllers and services together in ps output format.
 $ kubectl get rc,services

--- a/docs/man/man1/kubectl-get.1
+++ b/docs/man/man1/kubectl-get.1
@@ -176,7 +176,7 @@ $ kubectl get replicationController web
 $ kubectl get \-o json pod web\-pod\-13je7
 
 // Return only the status value of the specified pod.
-$ kubectl get \-o template web\-pod\-13je7 \-\-template=\{\{.currentState.status\}\}
+$ kubectl get \-o template web\-pod\-13je7 \-\-template=\{\{.currentState.status\}\} \-\-api\-version=v1beta1
 
 // List all replication controllers and services together in ps output format.
 $ kubectl get rc,services

--- a/hack/e2e-internal/e2e-status.sh
+++ b/hack/e2e-internal/e2e-status.sh
@@ -58,7 +58,7 @@ until [[ ${all_running} == 1 ]]; do
     echo "All pods never 'Running' in time." >&2
     exit 1
   fi
-  statuses=($(${KUBECTL} get pods --template='{{range.items}}{{.currentState.status}} {{end}}'))
+  statuses=($(${KUBECTL} get pods --template='{{range.items}}{{.currentState.status}} {{end}}' --api-version=v1beta1))
 
   # Ensure that we have enough pods.
   echo "Found ${#statuses[@]} pods with statuses: ${statuses[@]}" >&2

--- a/hack/e2e-suite/services.sh
+++ b/hack/e2e-suite/services.sh
@@ -152,6 +152,7 @@ function query_pods() {
   for i in $(seq 1 10); do
     pods_unsorted=($(${KUBECTL} get pods -o template \
         '--template={{range.items}}{{.id}} {{end}}' \
+        '--api-version=v1beta1' \
         -l name="$1"))
     found="${#pods_unsorted[*]}"
     if [[ "${found}" == "$2" ]]; then
@@ -185,7 +186,7 @@ function wait_for_pods() {
     echo "Waiting for ${pods_needed} pods to become 'running'"
     pods_needed="$2"
     for id in ${pods_sorted}; do
-      status=$(${KUBECTL} get pods "${id}" -o template --template='{{.currentState.status}}')
+      status=$(${KUBECTL} get pods "${id}" -o template --template='{{.currentState.status}}' --api-version=v1beta1)
       if [[ "${status}" == "Running" ]]; then
         pods_needed=$((pods_needed-1))
       fi
@@ -311,9 +312,9 @@ svc1_pods=$(query_pods "${svc1_name}" "${svc1_count}")
 svc2_pods=$(query_pods "${svc2_name}" "${svc2_count}")
 
 # Get the portal IPs.
-svc1_ip=$(${KUBECTL} get services -o template '--template={{.portalIP}}' "${svc1_name}")
+svc1_ip=$(${KUBECTL} get services -o template '--template={{.portalIP}}' "${svc1_name}" --api-version=v1beta1)
 test -n "${svc1_ip}" || error "Service1 IP is blank"
-svc2_ip=$(${KUBECTL} get services -o template '--template={{.portalIP}}' "${svc2_name}")
+svc2_ip=$(${KUBECTL} get services -o template '--template={{.portalIP}}' "${svc2_name}" --api-version=v1beta1)
 test -n "${svc2_ip}" || error "Service2 IP is blank"
 if [[ "${svc1_ip}" == "${svc2_ip}" ]]; then
   error "Portal IPs conflict: ${svc1_ip}"
@@ -383,7 +384,7 @@ wait_for_pods "${svc3_name}" "${svc3_count}"
 svc3_pods=$(query_pods "${svc3_name}" "${svc3_count}")
 
 # Get the portal IP.
-svc3_ip=$(${KUBECTL} get services -o template '--template={{.portalIP}}' "${svc3_name}")
+svc3_ip=$(${KUBECTL} get services -o template '--template={{.portalIP}}' "${svc3_name}" --api-version=v1beta1)
 test -n "${svc3_ip}" || error "Service3 IP is blank"
 
 echo "Verifying the portals from the host"
@@ -439,7 +440,7 @@ wait_for_pods "${svc4_name}" "${svc4_count}"
 svc4_pods=$(query_pods "${svc4_name}" "${svc4_count}")
 
 # Get the portal IP.
-svc4_ip=$(${KUBECTL} get services -o template '--template={{.portalIP}}' "${svc4_name}")
+svc4_ip=$(${KUBECTL} get services -o template '--template={{.portalIP}}' "${svc4_name}" --api-version=v1beta1)
 test -n "${svc4_ip}" || error "Service4 IP is blank"
 if [[ "${svc4_ip}" == "${svc2_ip}" || "${svc4_ip}" == "${svc3_ip}" ]]; then
   error "Portal IPs conflict: ${svc4_ip}"

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -125,7 +125,7 @@ for version in "${kube_api_versions[@]}"; do
       -s "http://127.0.0.1:${API_PORT}"
       --match-server-version
     )
-    [ "$(kubectl get minions -t $'{{ .apiVersion }}' "${kube_flags[@]}")" == "v1beta1" ]
+    [ "$(kubectl get minions -t $'{{ .apiVersion }}' "${kube_flags[@]}")" == "v1beta3" ]
   else
     kube_flags=(
       -s "http://127.0.0.1:${API_PORT}"
@@ -134,17 +134,17 @@ for version in "${kube_api_versions[@]}"; do
     )
     [ "$(kubectl get minions -t $'{{ .apiVersion }}' "${kube_flags[@]}")" == "${version}" ]
   fi
-  id_field=".id"
-  labels_field=".labels"
-  service_selector_field=".selector"
-  rc_replicas_field=".desiredState.replicas"
-  port_field=".port"
-  if [ "$version" = "v1beta3" ]; then
-    id_field=".metadata.name"
-    labels_field=".metadata.labels"
-    service_selector_field=".spec.selector"
-    rc_replicas_field=".spec.replicas"
-    port_field="(index .spec.ports 0).port"
+  id_field=".metadata.name"
+  labels_field=".metadata.labels"
+  service_selector_field=".spec.selector"
+  rc_replicas_field=".spec.replicas"
+  port_field="(index .spec.ports 0).port"
+  if [ "${version}" = "v1beta1" ] || [ "${version}" = "v1beta2" ]; then
+    id_field=".id"
+    labels_field=".labels"
+    service_selector_field=".selector"
+    rc_replicas_field=".desiredState.replicas"
+    port_field=".port"
   fi
 
   # Passing no arguments to create is an error

--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Version is the string that represents the current external default version.
-const Version = "v1beta1"
+const Version = "v1beta3"
 
 // OldestVersion is the string that represents the oldest server version supported,
 // for client code that wants to hardcode the lowest common denominator.
@@ -46,7 +46,7 @@ var Versions = []string{"v1beta1", "v1beta2", "v1beta3"}
 // the latest supported version.  Use this Codec when writing to
 // disk, a data store that is not dynamically versioned, or in tests.
 // This codec can decode any object that Kubernetes is aware of.
-var Codec = v1beta1.Codec
+var Codec = v1beta3.Codec
 
 // accessor is the shared static metadata accessor for the API.
 var accessor = meta.NewAccessor()

--- a/pkg/api/latest/latest_test.go
+++ b/pkg/api/latest/latest_test.go
@@ -72,10 +72,11 @@ func TestInterfacesFor(t *testing.T) {
 }
 
 func TestRESTMapper(t *testing.T) {
-	if v, k, err := RESTMapper.VersionAndKindForResource("replicationControllers"); err != nil || v != Version || k != "ReplicationController" {
+	// TODO: This test does not seem right. The version returned here depends on the order in which API versions were registered. This will just return the API version that was registered first. Fix this.
+	if v, k, err := RESTMapper.VersionAndKindForResource("replicationControllers"); err != nil || v != "v1beta1" || k != "ReplicationController" {
 		t.Errorf("unexpected version mapping: %s %s %v", v, k, err)
 	}
-	if v, k, err := RESTMapper.VersionAndKindForResource("replicationcontrollers"); err != nil || v != Version || k != "ReplicationController" {
+	if v, k, err := RESTMapper.VersionAndKindForResource("replicationcontrollers"); err != nil || v != "v1beta1" || k != "ReplicationController" {
 		t.Errorf("unexpected version mapping: %s %s %v", v, k, err)
 	}
 

--- a/pkg/client/restclient_test.go
+++ b/pkg/client/restclient_test.go
@@ -39,7 +39,7 @@ func TestSetsCodec(t *testing.T) {
 		Codec  runtime.Codec
 	}{
 		"v1beta1": {false, "/api/v1beta1/", v1beta1.Codec},
-		"":        {false, "/api/v1beta1/", v1beta1.Codec},
+		"":        {false, "/api/" + latest.Version + "/", latest.Codec},
 		"v1beta2": {false, "/api/v1beta2/", v1beta2.Codec},
 		"v1beta3": {false, "/api/v1beta3/", v1beta3.Codec},
 		"v1beta4": {true, "", nil},

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -48,7 +48,7 @@ $ kubectl get replicationController web
 $ kubectl get -o json pod web-pod-13je7
 
 // Return only the status value of the specified pod.
-$ kubectl get -o template web-pod-13je7 --template={{.currentState.status}}
+$ kubectl get -o template web-pod-13je7 --template={{.currentState.status}} --api-version=v1beta1
 
 // List all replication controllers and services together in ps output format.
 $ kubectl get rc,services

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 
 	. "github.com/onsi/ginkgo"
@@ -140,6 +141,7 @@ func waitForGuestbookResponse(c *client.Client, cmd, arg, expectedResponse strin
 func makeRequestToGuestbook(c *client.Client, cmd, value string) (string, error) {
 	result, err := c.Get().
 		Prefix("proxy").
+		Namespace(api.NamespaceDefault).
 		Resource("services").
 		Name("frontend").
 		Suffix("/index.php").
@@ -165,6 +167,7 @@ func getUDData(jpgExpected string) func(*client.Client, string) error {
 		Logf("validating pod %s", podID)
 		body, err := c.Get().
 			Prefix("proxy").
+			Namespace(api.NamespaceDefault).
 			Resource("pods").
 			Name(podID).
 			Suffix("data.json").

--- a/test/e2e/rc.go
+++ b/test/e2e/rc.go
@@ -165,6 +165,7 @@ func ServeImageOrFail(c *client.Client, test string, image string) {
 	for i, pod := range pods.Items {
 		body, err := c.Get().
 			Prefix("proxy").
+			Namespace(api.NamespaceDefault).
 			Resource("pods").
 			Name(string(pod.Name)).
 			Do().

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -166,7 +166,6 @@ var _ = Describe("Services", func() {
 	It("should provide RW and RO services", func() {
 		svc := api.ServiceList{}
 		err := c.Get().
-			Namespace(api.NamespaceDefault).
 			AbsPath("/api/v1beta1/proxy/services/kubernetes-ro/api/v1beta1/services").
 			Do().
 			Into(&svc)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -231,7 +231,7 @@ func validateController(c *client.Client, containerImage string, replicas int, c
 
 	By(fmt.Sprintf("waiting for all containers in %s pods to come up.", testname)) //testname should be selector
 	for start := time.Now(); time.Since(start) < podStartTimeout; time.Sleep(5 * time.Second) {
-		getPodsOutput := runKubectl("get", "pods", "-o", "template", getPodsTemplate, "-l", testname)
+		getPodsOutput := runKubectl("get", "pods", "-o", "template", getPodsTemplate, "--api-version=v1beta1", "-l", testname)
 		pods := strings.Fields(getPodsOutput)
 		if numPods := len(pods); numPods != replicas {
 			By(fmt.Sprintf("Replicas for %s: expected=%d actual=%d", testname, replicas, numPods))
@@ -239,13 +239,13 @@ func validateController(c *client.Client, containerImage string, replicas int, c
 		}
 		var runningPods []string
 		for _, podID := range pods {
-			running := runKubectl("get", "pods", podID, "-o", "template", getContainerStateTemplate)
+			running := runKubectl("get", "pods", podID, "-o", "template", getContainerStateTemplate, "--api-version=v1beta1")
 			if running == "false" {
 				Logf("%s is created but not running", podID)
 				continue
 			}
 
-			currentImage := runKubectl("get", "pods", podID, "-o", "template", getImageTemplate)
+			currentImage := runKubectl("get", "pods", podID, "-o", "template", getImageTemplate, "--api-version=v1beta1")
 			if currentImage != containerImage {
 				Logf("%s is created but running wrong image; expected: %s, actual: %s", podID, containerImage, currentImage)
 				continue
@@ -345,7 +345,7 @@ func testContainerOutputInNamespace(ns, scenarioName string, c *client.Client, p
 	for time.Now().Sub(start) < (60 * time.Second) {
 		logs, err = c.Get().
 			Prefix("proxy").
-			Resource("minions").
+			Resource("nodes").
 			Name(podStatus.Spec.Host).
 			Suffix("containerLogs", ns, podStatus.Name, containerName).
 			Do().


### PR DESCRIPTION
For https://github.com/GoogleCloudPlatform/kubernetes/issues/5475
- Setting the default version in clientcmds to v1beta3
- Updating api.Latest to point to v1beta3 instead of v1beta1
