### PR TITLE
Configure the kubelet to use HTTPS (take 2)

### DIFF
--- a/cluster/addons/cluster-monitoring/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/heapster-controller.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1beta1
 id: monitoring-heapster-controller
 kind: ReplicationController
-desiredState: 
+desiredState:
   replicas: 1
-  replicaSelector:    
+  replicaSelector:
     name: heapster
   podTemplate:
     desiredState:
@@ -13,11 +13,13 @@ desiredState:
         containers:
           - name: heapster
             image: gcr.io/google_containers/heapster:v0.10.0
-            env: 
+            env:
               - name: "INFLUXDB_HOST"
                 value: "monitoring-influxdb"
               - name: "SINK"
                 value: "influxdb"
+              - name: "FLAGS"
+                value: "--kubelet_port=10255"
             volumeMounts:
               - name: ssl-certs
                 mountPath: /etc/ssl/certs
@@ -27,10 +29,10 @@ desiredState:
             source:
               hostDir:
                 path: /etc/ssl/certs
-    labels: 
+    labels:
       name: heapster
       uses: monitoring-influxdb
       kubernetes.io/cluster-service: "true"
-labels: 
+labels:
   name: heapster
   kubernetes.io/cluster-service: "true"

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -100,7 +100,7 @@ func NewAPIServer() *APIServer {
 		RuntimeConfig: make(util.ConfigurationMap),
 		KubeletConfig: client.KubeletConfig{
 			Port:        10250,
-			EnableHttps: false,
+			EnableHttps: true,
 			HTTPTimeout: time.Duration(5) * time.Second,
 		},
 	}

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -83,7 +83,7 @@ func NewCMServer() *CMServer {
 		SyncNodeStatus:          false,
 		KubeletConfig: client.KubeletConfig{
 			Port:        ports.KubeletPort,
-			EnableHttps: false,
+			EnableHttps: true,
 			HTTPTimeout: time.Duration(5) * time.Second,
 		},
 	}

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -18,10 +18,12 @@ limitations under the License.
 package app
 
 import (
+	"crypto/tls"
 	"fmt"
 	"math/rand"
 	"net"
 	"net/http"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -88,6 +90,9 @@ type KubeletServer struct {
 	NetworkPluginName              string
 	CloudProvider                  string
 	CloudConfigFile                string
+	TLSCertFile                    string
+	TLSPrivateKeyFile              string
+	CertDirectory                  string
 }
 
 // NewKubeletServer will create a new KubeletServer with default values.
@@ -116,6 +121,7 @@ func NewKubeletServer() *KubeletServer {
 		ImageGCLowThresholdPercent:  80,
 		NetworkPluginName:           "",
 		HostNetworkSources:          kubelet.FileSource,
+		CertDirectory:               "/var/run/kubernetes",
 	}
 }
 
@@ -129,6 +135,12 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.EnableServer, "enable_server", s.EnableServer, "Enable the info server")
 	fs.Var(&s.Address, "address", "The IP address for the info server to serve on (set to 0.0.0.0 for all interfaces)")
 	fs.UintVar(&s.Port, "port", s.Port, "The port for the info server to serve on")
+	fs.StringVar(&s.TLSCertFile, "tls_cert_file", s.TLSCertFile, ""+
+		"File containing x509 Certificate for HTTPS.  (CA cert, if any, concatenated after server cert). "+
+		"If --tls_cert_file and --tls_private_key_file are not provided, a self-signed certificate and key "+
+		"are generated for the public address and saved to the directory passed to --cert_dir.")
+	fs.StringVar(&s.TLSPrivateKeyFile, "tls_private_key_file", s.TLSPrivateKeyFile, "File containing x509 private key matching --tls_cert_file.")
+	fs.StringVar(&s.CertDirectory, "cert_dir", s.CertDirectory, "The directory where the TLS certs are located (by default /var/run/kubernetes)")
 	fs.StringVar(&s.HostnameOverride, "hostname_override", s.HostnameOverride, "If non-empty, will use this string as identification instead of the actual hostname.")
 	fs.StringVar(&s.PodInfraContainerImage, "pod_infra_container_image", s.PodInfraContainerImage, "The image whose network/ipc namespaces containers in each pod will use.")
 	fs.StringVar(&s.DockerEndpoint, "docker_endpoint", s.DockerEndpoint, "If non-empty, use this for the docker endpoint to communicate with")
@@ -195,6 +207,26 @@ func (s *KubeletServer) Run(_ []string) error {
 	if err != nil {
 		return err
 	}
+
+	if s.TLSCertFile == "" && s.TLSPrivateKeyFile == "" {
+		s.TLSCertFile = path.Join(s.CertDirectory, "kubelet.crt")
+		s.TLSPrivateKeyFile = path.Join(s.CertDirectory, "kubelet.key")
+		if err := util.GenerateSelfSignedCert(util.GetHostname(s.HostnameOverride), s.TLSCertFile, s.TLSPrivateKeyFile); err != nil {
+			glog.Fatalf("Unable to generate self signed cert: %v", err)
+		}
+		glog.Infof("Using self-signed cert (%s, %s)", s.TLSCertFile, s.TLSPrivateKeyFile)
+	}
+	tlsOptions := &kubelet.TLSOptions{
+		Config: &tls.Config{
+			// Change default from SSLv3 to TLSv1.0 (because of POODLE vulnerability).
+			MinVersion: tls.VersionTLS10,
+			// Populate PeerCertificates in requests, but don't yet reject connections without certificates.
+			ClientAuth: tls.RequestClientCert,
+		},
+		CertFile: s.TLSCertFile,
+		KeyFile:  s.TLSPrivateKeyFile,
+	}
+
 	kcfg := KubeletConfig{
 		Address:                        s.Address,
 		AllowPrivileged:                s.AllowPrivileged,
@@ -226,6 +258,7 @@ func (s *KubeletServer) Run(_ []string) error {
 		NetworkPlugins:                 ProbeNetworkPlugins(),
 		NetworkPluginName:              s.NetworkPluginName,
 		StreamingConnectionIdleTimeout: s.StreamingConnectionIdleTimeout,
+		TLSOptions:                     tlsOptions,
 		ImageGCPolicy:                  imageGCPolicy,
 		Cloud:                          cloud,
 	}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -48,6 +48,7 @@ ETCD_PORT=${ETCD_PORT:-4001}
 API_PORT=${API_PORT:-8080}
 API_HOST=${API_HOST:-127.0.0.1}
 KUBELET_PORT=${KUBELET_PORT:-10250}
+KUBELET_HEALTHZ_PORT=${KUBELET_HEALTHZ_PORT:-10248}
 CTLRMGR_PORT=${CTLRMGR_PORT:-10252}
 
 # Check kubectl
@@ -58,27 +59,31 @@ kube::log::status "Starting kubelet in masterless mode"
 "${KUBE_OUTPUT_HOSTBIN}/kubelet" \
   --really_crash_for_testing=true \
   --root_dir=/tmp/kubelet.$$ \
+  --cert_dir="${TMPDIR:-/tmp/}" \
   --docker_endpoint="fake://" \
   --hostname_override="127.0.0.1" \
   --address="127.0.0.1" \
-  --port="$KUBELET_PORT" 1>&2 &
+  --port="$KUBELET_PORT" \
+  --healthz_port="${KUBELET_HEALTHZ_PORT}" 1>&2 &
 KUBELET_PID=$!
-kube::util::wait_for_url "http://127.0.0.1:${KUBELET_PORT}/healthz" "kubelet: " 0.2 25
+kube::util::wait_for_url "http://127.0.0.1:${KUBELET_HEALTHZ_PORT}/healthz" "kubelet: " 0.2 25
 kill ${KUBELET_PID} 1>&2 2>/dev/null
 
 kube::log::status "Starting kubelet in masterful mode"
 "${KUBE_OUTPUT_HOSTBIN}/kubelet" \
   --really_crash_for_testing=true \
   --root_dir=/tmp/kubelet.$$ \
+  --cert_dir="${TMPDIR:-/tmp/}" \
   --docker_endpoint="fake://" \
   --hostname_override="127.0.0.1" \
   --address="127.0.0.1" \
   --api_servers="${API_HOST}:${API_PORT}" \
   --auth_path="${KUBE_ROOT}/hack/.test-cmd-auth" \
-  --port="$KUBELET_PORT" 1>&2 &
+  --port="$KUBELET_PORT" \
+  --healthz_port="${KUBELET_HEALTHZ_PORT}" 1>&2 &
 KUBELET_PID=$!
 
-kube::util::wait_for_url "http://127.0.0.1:${KUBELET_PORT}/healthz" "kubelet: " 0.2 25
+kube::util::wait_for_url "http://127.0.0.1:${KUBELET_HEALTHZ_PORT}/healthz" "kubelet: " 0.2 25
 
 # Start kube-apiserver
 kube::log::status "Starting kube-apiserver"

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -139,14 +139,7 @@ func (g *APIGroupVersion) InstallREST(container *restful.Container) error {
 
 // TODO: Convert to go-restful
 func InstallValidator(mux Mux, servers func() map[string]Server) {
-	validator, err := NewValidator(servers)
-	if err != nil {
-		glog.Errorf("failed to set up validator: %v", err)
-		return
-	}
-	if validator != nil {
-		mux.Handle("/validate", validator)
-	}
+	mux.Handle("/validate", NewValidator(servers))
 }
 
 // TODO: document all handlers

--- a/pkg/apiserver/validator_test.go
+++ b/pkg/apiserver/validator_test.go
@@ -21,33 +21,25 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/probe"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
-type fakeHttpGet struct {
+type fakeRoundTripper struct {
 	err  error
 	resp *http.Response
 	url  string
 }
 
-func (f *fakeHttpGet) Get(url string) (*http.Response, error) {
-	f.url = url
+func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.url = req.URL.String()
 	return f.resp, f.err
-}
-
-func makeFake(data string, statusCode int, err error) *fakeHttpGet {
-	return &fakeHttpGet{
-		err: err,
-		resp: &http.Response{
-			Body:       ioutil.NopCloser(bytes.NewBufferString(data)),
-			StatusCode: statusCode,
-		},
-	}
 }
 
 func TestValidate(t *testing.T) {
@@ -66,11 +58,18 @@ func TestValidate(t *testing.T) {
 	s := Server{Addr: "foo.com", Port: 8080, Path: "/healthz"}
 
 	for _, test := range tests {
-		fake := makeFake(test.data, test.code, test.err)
+		fakeRT := &fakeRoundTripper{
+			err: test.err,
+			resp: &http.Response{
+				Body:       ioutil.NopCloser(bytes.NewBufferString(test.data)),
+				StatusCode: test.code,
+			},
+		}
+		fake := &http.Client{Transport: fakeRT}
 		status, data, err := s.check(fake)
 		expect := fmt.Sprintf("http://%s:%d/healthz", s.Addr, s.Port)
-		if fake.url != expect {
-			t.Errorf("expected %s, got %s", expect, fake.url)
+		if fakeRT.url != expect {
+			t.Errorf("expected %s, got %s", expect, fakeRT.url)
 		}
 		if test.expectErr && err == nil {
 			t.Errorf("unexpected non-error")
@@ -87,8 +86,30 @@ func TestValidate(t *testing.T) {
 	}
 }
 
+func makeTestValidator(servers map[string]string, rt http.RoundTripper) (http.Handler, error) {
+	result := map[string]Server{}
+	for name, value := range servers {
+		host, port, err := net.SplitHostPort(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid server spec: %s (%v)", value, err)
+		}
+		val, err := strconv.Atoi(port)
+		if err != nil {
+			return nil, fmt.Errorf("invalid server spec: %s (%v)", port, err)
+		}
+		result[name] = Server{Addr: host, Port: val, Path: "/healthz"}
+	}
+
+	return &validator{servers: func() map[string]Server { return result }, rt: rt}, nil
+}
+
 func TestValidator(t *testing.T) {
-	fake := makeFake("foo", 200, nil)
+	fake := &fakeRoundTripper{
+		resp: &http.Response{
+			Body:       ioutil.NopCloser(bytes.NewBufferString("foo")),
+			StatusCode: 200,
+		},
+	}
 	validator, err := makeTestValidator(map[string]string{
 		"foo": "foo.com:80",
 		"bar": "bar.com:8080",
@@ -101,7 +122,6 @@ func TestValidator(t *testing.T) {
 	defer testServer.Close()
 
 	resp, err := http.Get(testServer.URL + "/validatez")
-
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -113,13 +133,15 @@ func TestValidator(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	status := []ServerStatus{}
-	err = json.Unmarshal(data, &status)
-	if err != nil {
+	var status []ServerStatus
+	if err := json.Unmarshal(data, &status); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	components := util.StringSet{}
 	for _, s := range status {
+		if s.Err != "nil" {
+			t.Errorf("Component %v is unhealthy: %v", s.Component, s.Err)
+		}
 		components.Insert(s.Component)
 	}
 	if len(status) != 2 || !components.Has("foo") || !components.Has("bar") {

--- a/pkg/client/kubelet.go
+++ b/pkg/client/kubelet.go
@@ -75,9 +75,14 @@ type HTTPKubeletClient struct {
 func NewKubeletClient(config *KubeletConfig) (KubeletClient, error) {
 	transport := http.DefaultTransport
 
-	tlsConfig, err := TLSConfigFor(&Config{
-		TLSClientConfig: config.TLSClientConfig,
-	})
+	cfg := &Config{TLSClientConfig: config.TLSClientConfig}
+	if config.EnableHttps {
+		hasCA := len(config.CAFile) > 0 || len(config.CAData) > 0
+		if !hasCA {
+			cfg.Insecure = true
+		}
+	}
+	tlsConfig, err := TLSConfigFor(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -561,7 +561,7 @@ func (m *Master) getServersToValidate(c *Config) map[string]apiserver.Server {
 		glog.Errorf("Failed to list minions: %v", err)
 	}
 	for ix, node := range nodes.Items {
-		serversToValidate[fmt.Sprintf("node-%d", ix)] = apiserver.Server{Addr: node.Name, Port: ports.KubeletPort, Path: "/healthz"}
+		serversToValidate[fmt.Sprintf("node-%d", ix)] = apiserver.Server{Addr: node.Name, Port: ports.KubeletPort, Path: "/healthz", EnableHTTPS: true}
 	}
 	return serversToValidate
 }

--- a/pkg/master/ports/ports.go
+++ b/pkg/master/ports/ports.go
@@ -32,4 +32,10 @@ const (
 	// ControllerManagerPort is the default port for the controller manager status server.
 	// May be overridden by a flag at startup.
 	ControllerManagerPort = 10252
+	// KubeletReadOnlyPort exposes basic read-only services from the kubelet.
+	// May be overridden by a flag at startup.
+	// This is necessary for heapster to collect monitoring stats from the kubelet
+	// until heapster can transition to using the SSL endpoint.
+	// TODO(roberthbailey): Remove this once we have a better solution for heapster.
+	KubeletReadOnlyPort = 10255
 )


### PR DESCRIPTION
I've added a new read-only HTTP port on the Kubelet specifically for use by Heapster until we reconfigure Heapster to connect to the TLS port. I ran the "Monitoring verify monitoring pods and all cluster nodes are available on influxdb using heapster" e2e test 10 times in a row with no failures. 

I left this as two commits so it would be simple to see what was different from #6243 but I'm happy to squish them before this is merged. 

/cc @vishh 
