### PR TITLE
External ip mapping services

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+	"os"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
@@ -83,7 +84,8 @@ func (s *ProxyServer) Run(_ []string) error {
 		protocol = iptables.ProtocolIpv6
 	}
 	loadBalancer := proxy.NewLoadBalancerRR()
-	proxier := proxy.NewProxier(loadBalancer, net.IP(s.BindAddress), iptables.New(exec.New(), protocol), s.extIf, s.intIf, "")
+	hostname, _ := os.Hostname()
+	proxier := proxy.NewProxier(loadBalancer, net.IP(s.BindAddress), iptables.New(exec.New(), protocol), s.extIf, s.intIf, hostname, &s.ClientConfig)
 	if proxier == nil {
 		glog.Fatalf("failed to create proxier, aborting")
 	}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -880,6 +880,11 @@ type ServiceSpec struct {
 	// None can be specified for headless services when proxying is not required
 	PortalIP string `json:"portalIP,omitempty"`
 
+	// ExternalMapping indicates that this isn't an internal service, but rather just a mapping of an external 
+	// address to a pod. If this is set to true, then PortalIP will contain a single string, filled in 
+	// by the claiming kube-proxy daemon, and the destination pod must be specified in the Selector map
+	ExternalMapping bool `json:"externalMapping,omitempty"`
+
 	// CreateExternalLoadBalancer indicates whether a load balancer should be created for this service.
 	CreateExternalLoadBalancer bool `json:"createExternalLoadBalancer,omitempty"`
 	// PublicIPs are used by external load balancers, or can be set by

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -733,6 +733,7 @@ func init() {
 			out.CreateExternalLoadBalancer = in.Spec.CreateExternalLoadBalancer
 			out.PublicIPs = in.Spec.PublicIPs
 			out.PortalIP = in.Spec.PortalIP
+			out.ExternalMapping = in.Spec.ExternalMapping
 			if err := s.Convert(&in.Spec.SessionAffinity, &out.SessionAffinity, 0); err != nil {
 				return err
 			}
@@ -776,6 +777,7 @@ func init() {
 			out.Spec.CreateExternalLoadBalancer = in.CreateExternalLoadBalancer
 			out.Spec.PublicIPs = in.PublicIPs
 			out.Spec.PortalIP = in.PortalIP
+			out.Spec.ExternalMapping = in.ExternalMapping
 			if err := s.Convert(&in.SessionAffinity, &out.Spec.SessionAffinity, 0); err != nil {
 				return err
 			}

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -734,6 +734,10 @@ type Service struct {
 
 	// This service will route traffic to pods having labels matching this selector. If null, no endpoints will be automatically created. If empty, all pods will be selected.
 	Selector map[string]string `json:"selector" description:"label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified"`
+	// ExternalMapping indicates that this isn't an internal service, but rather just a mapping of an external
+	// address to a pod. If this is set to true, then PortalIP will contain a single string, filled in
+	// by the claiming kube-proxy daemon, and the destination pod must be specified in the Selector map
+	ExternalMapping bool `json:"externalMapping,omitempty"`
 
 	// An external load balancer should be set up via the cloud-provider
 	CreateExternalLoadBalancer bool `json:"createExternalLoadBalancer,omitempty" description:"set up a cloud-provider-specific load balancer on an external IP"`

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -664,6 +664,7 @@ func init() {
 			out.CreateExternalLoadBalancer = in.Spec.CreateExternalLoadBalancer
 			out.PublicIPs = in.Spec.PublicIPs
 			out.PortalIP = in.Spec.PortalIP
+			out.ExternalMapping = in.Spec.ExternalMapping
 			if err := s.Convert(&in.Spec.SessionAffinity, &out.SessionAffinity, 0); err != nil {
 				return err
 			}
@@ -707,6 +708,7 @@ func init() {
 			out.Spec.CreateExternalLoadBalancer = in.CreateExternalLoadBalancer
 			out.Spec.PublicIPs = in.PublicIPs
 			out.Spec.PortalIP = in.PortalIP
+			out.Spec.ExternalMapping = in.ExternalMapping
 			if err := s.Convert(&in.SessionAffinity, &out.Spec.SessionAffinity, 0); err != nil {
 				return err
 			}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -736,6 +736,11 @@ type Service struct {
 	// This service will route traffic to pods having labels matching this selector. If null, no endpoints will be automatically created. If empty, all pods will be selected.
 	Selector map[string]string `json:"selector" description:"label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified"`
 
+	// ExternalMapping indicates that this isn't an internal service, but rather just a mapping of an external
+	// address to a pod. If this is set to true, then PortalIP will contain a single string, filled in
+	// by the claiming kube-proxy daemon, and the destination pod must be specified in the Selector map
+	ExternalMapping bool `json:"externalMapping,omitempty"`
+
 	// An external load balancer should be set up via the cloud-provider
 	CreateExternalLoadBalancer bool `json:"createExternalLoadBalancer,omitempty" description:"set up a cloud-provider-specific load balancer on an external IP"`
 

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -868,6 +868,11 @@ type ServiceSpec struct {
 	// None can be specified for headless services when proxying is not required
 	PortalIP string `json:"portalIP,omitempty description: IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused, and creation of the service will fail otherwise; cannot be updated; 'None' can be specified for a headless service when proxying is not required"`
 
+	// ExternalMapping indicates that this isn't an internal service, but rather just a mapping of an external 
+	// address to a pod. If this is set to true, then PublicIPs will contain a single string, filled in 
+	// by the claiming kube-proxy daemon, and the destination pod must be specified in the Selector map
+	ExternalMapping bool `json:"externalMapping,omitempty"`
+
 	// CreateExternalLoadBalancer indicates whether a load balancer should be created for this service.
 	CreateExternalLoadBalancer bool `json:"createExternalLoadBalancer,omitempty" description:"set up a cloud-provider-specific load balancer on an external IP"`
 

--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -308,12 +308,15 @@ type Proxier struct {
 	listenIP      net.IP
 	iptables      iptables.Interface
 	hostIP        net.IP
+	extIf        string
+	intIf	     string
+	extName	     string
 }
 
 // NewProxier returns a new Proxier given a LoadBalancer and an address on
 // which to listen.  Because of the iptables logic, It is assumed that there
 // is only a single Proxier active on a machine.
-func NewProxier(loadBalancer LoadBalancer, listenIP net.IP, iptables iptables.Interface) *Proxier {
+func NewProxier(loadBalancer LoadBalancer, listenIP net.IP, iptables iptables.Interface, extIf string, intIf string, extName string) *Proxier {
 	if listenIP.Equal(localhostIPv4) || listenIP.Equal(localhostIPv6) {
 		glog.Errorf("Can't proxy only on localhost - iptables can't do it")
 		return nil
@@ -325,10 +328,10 @@ func NewProxier(loadBalancer LoadBalancer, listenIP net.IP, iptables iptables.In
 		return nil
 	}
 	glog.Infof("Setting Proxy IP to %v", hostIP)
-	return CreateProxier(loadBalancer, listenIP, iptables, hostIP)
+	return CreateProxier(loadBalancer, listenIP, iptables, hostIP, extIf, intIf, extName)
 }
 
-func CreateProxier(loadBalancer LoadBalancer, listenIP net.IP, iptables iptables.Interface, hostIP net.IP) *Proxier {
+func CreateProxier(loadBalancer LoadBalancer, listenIP net.IP, iptables iptables.Interface, hostIP net.IP, extIf string, intIf string, extName string) *Proxier {
 	glog.Infof("Initializing iptables")
 	// Clean up old messes.  Ignore erors.
 	iptablesDeleteOld(iptables)
@@ -349,6 +352,9 @@ func CreateProxier(loadBalancer LoadBalancer, listenIP net.IP, iptables iptables
 		listenIP:     listenIP,
 		iptables:     iptables,
 		hostIP:       hostIP,
+		extIf:	      extIf,
+		intIf:	      intIf,
+		extName:      extName,
 	}
 }
 


### PR DESCRIPTION
Using feedback from my earlier pull request here:
https://github.com/GoogleCloudPlatform/kubernetes/pull/3435

I've rewritten the onramp router to be merged with the kube-proxy service to provide external ip mapping services:
# Overview

One of the features thats missing in Kubernetes is the ability to assign external ip addresses to pods in a kube cloud. This patch series is the start of my work to enable that access. It allows this access via the following:
- Augemtation of the Service specifcation to include an External Mapping boolean
- Augmentation of kube-proxy so that when ExternalMapping is true:
  - PortalIP is taken to be the external ip address to assign for use in external proxying
  - The Selector key "pod" is used to find the pod to forward requests to
  - The Selector key "node" is used to identify the specific host to preform the forwarding
# Operation

External IP services operate via iptables.  When a given kube-proxy instance detects that it has been requested to forward external requests to internal hosts, it sets up two sets of iptables rules, an internal DNAT rule to translate the specified external PortalIP adress to the internal Pod IP address and a Masquerade Rule that translates outgoing traffic to use the PortalIP address instead of its Pod Address
# Limitations

Currently kube-proxy assumes that the PortalIP address specified in the service json is already assigned to the selected node.
