### PR TITLE
Build etcd image (version: 2.0.8) and push it to gcr.io

### DIFF
--- a/cluster/images/etcd/Dockerfile
+++ b/cluster/images/etcd/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+MAINTAINER  Dawn Chen <dawnchen@google.com>
+
+ADD ./etcd /usr/local/bin/etcd
+ADD ./etcdctl /usr/local/bin/etcdctl

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -1,0 +1,20 @@
+.PHONY:	clean build push
+
+IMAGE = etcd
+TAG = 2.0.8
+OUTPUT_DIR = $(IMAGE)-v$(TAG)-linux-amd64
+
+clean:
+	rm -rf $(OUTPUT_DIR) $(IMAGE)-v$(TAG)-linux-amd64.tar.gz etcd etcdctl
+
+build: clean
+	curl -L -O https://github.com/coreos/etcd/releases/download/v$(TAG)/$(IMAGE)-v$(TAG)-linux-amd64.tar.gz
+	tar xzvf $(IMAGE)-v$(TAG)-linux-amd64.tar.gz
+	cp $(OUTPUT_DIR)/etcd .
+	cp $(OUTPUT_DIR)/etcdctl .
+	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .
+
+push:	build
+	gcloud preview docker push gcr.io/google_containers/$(IMAGE):$(TAG)
+
+all:	push


### PR DESCRIPTION
cc/ @brendandburns @erictune @ArtfulCoder 

```
/images/etcd$ make push
rm -rf etcd-v2.0.8-linux-amd64 etcd-v2.0.8-linux-amd64.tar.gz etcd etcdctl
curl -L -O https://github.com/coreos/etcd/releases/download/v2.0.8/etcd-v2.0.8-linux-amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   409    0   409    0     0    730      0 --:--:-- --:--:-- --:--:--   730
100 3707k  100 3707k    0     0  1208k      0  0:00:03  0:00:03 --:--:-- 2204k
tar xzvf etcd-v2.0.8-linux-amd64.tar.gz
etcd-v2.0.8-linux-amd64/
etcd-v2.0.8-linux-amd64/Documentation/
etcd-v2.0.8-linux-amd64/etcd
etcd-v2.0.8-linux-amd64/etcdctl
etcd-v2.0.8-linux-amd64/README-etcdctl.md
etcd-v2.0.8-linux-amd64/README.md
etcd-v2.0.8-linux-amd64/Documentation/admin_guide.md
etcd-v2.0.8-linux-amd64/Documentation/api.md
etcd-v2.0.8-linux-amd64/Documentation/backward_compatibility.md
etcd-v2.0.8-linux-amd64/Documentation/clustering.md
etcd-v2.0.8-linux-amd64/Documentation/configuration.md
etcd-v2.0.8-linux-amd64/Documentation/docker_guide.md
etcd-v2.0.8-linux-amd64/Documentation/errorcode.md
etcd-v2.0.8-linux-amd64/Documentation/glossary.md
etcd-v2.0.8-linux-amd64/Documentation/internal-protocol-versioning.md
etcd-v2.0.8-linux-amd64/Documentation/libraries-and-tools.md
etcd-v2.0.8-linux-amd64/Documentation/other_apis.md
etcd-v2.0.8-linux-amd64/Documentation/platforms/
etcd-v2.0.8-linux-amd64/Documentation/production-ready.md
etcd-v2.0.8-linux-amd64/Documentation/proxy.md
etcd-v2.0.8-linux-amd64/Documentation/rfc/
etcd-v2.0.8-linux-amd64/Documentation/runtime-configuration.md
etcd-v2.0.8-linux-amd64/Documentation/security.md
etcd-v2.0.8-linux-amd64/Documentation/tuning.md
etcd-v2.0.8-linux-amd64/Documentation/rfc/api_security.md
etcd-v2.0.8-linux-amd64/Documentation/platforms/freebsd.md
cp etcd-v2.0.8-linux-amd64/etcd .
cp etcd-v2.0.8-linux-amd64/etcdctl .
docker build -t gcr.io/google_containers/etcd:2.0.8 .
Sending build context to Docker daemon 29.57 MB
Sending build context to Docker daemon 
Step 0 : FROM scratch
 ---> 511136ea3c5a
Step 1 : MAINTAINER Dawn Chen <dawnchen@google.com>
 ---> Using cache
 ---> 4ec7f790b564
Step 2 : ADD ./etcd /usr/local/bin/etcd
 ---> 1555d7ff268c
Removing intermediate container 2c3a5d7da961
Step 3 : ADD ./etcdctl /usr/local/bin/etcdctl
 ---> 7459fa04a08c
Removing intermediate container b1ca9b69d64a
Successfully built 7459fa04a08c
gcloud preview docker push gcr.io/google_containers/etcd:2.0.8
The push refers to a repository [gcr.io/google_containers/etcd] (len: 1)
Sending image list
Pushing repository gcr.io/google_containers/etcd (1 tags)
Image 511136ea3c5a already pushed, skipping
Image 4ec7f790b564 already pushed, skipping
1555d7ff268c: Image successfully pushed 
7459fa04a08c: Image successfully pushed 
Pushing tag for rev [7459fa04a08c] on {https://gcr.io/v1/repositories/google_containers/etcd/tags/2.0.8}
```

Next step is convert existing usage of etcd 2.0.5 to 2.0.8. I did manually test against this image on my cluster, everything is fine. I didn't include this into current PR because it requires a e2e tests. 

```
root@kubernetes-master:/var/log# docker ps
CONTAINER ID        IMAGE                                  COMMAND                CREATED              STATUS              PORTS               NAMES
5dc0012630d4        gcr.io/google_containers/etcd:2.0.8    "/usr/local/bin/etcd   About a minute ago   Up About a minute                       k8s_etcd-container.2d50745a_etcd-server-kubernetes-master_default_e9bbb4ee353cd2f832609c427382e2ac_7473fb36   
2e34c262b138        gcr.io/google_containers/pause:0.8.0   "/pause"               2 minutes ago        Up 2 minutes                            k8s_POD.1a1fe303_etcd-server-kubernetes-master_default_e9bbb4ee353cd2f832609c427382e2ac_1e3d4a63              
```
