### PR TITLE
Add PodSpec.NodeFailurePolicy = {Reschedule, Delete, Ignore}

### DIFF
--- a/pkg/api/v1beta3/defaults.go
+++ b/pkg/api/v1beta3/defaults.go
@@ -70,6 +70,9 @@ func init() {
 			if obj.DNSPolicy == "" {
 				obj.DNSPolicy = DNSClusterFirst
 			}
+			if obj.NodeFailurePolicy == "" {
+				obj.NodeFailurePolicy = NodeFailurePolicyReschedule
+			}
 			if obj.RestartPolicy == "" {
 				obj.RestartPolicy = RestartPolicyAlways
 			}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -667,6 +667,19 @@ type PodCondition struct {
 	Status ConditionStatus `json:"status" description:"status of the condition, one of Full, None, Unknown"`
 }
 
+// NodeFailurePolicy describes what should happen when when the pod is
+// unable to run on its bound node, such as when that node is marked
+// as failed or removed from the cluster.  Only one of the following
+// policies may be specified.  If none are specified, the default is
+// NodeFailurePolicyReschedule.
+type NodeFailurePolicy string
+
+const (
+	NodeFailurePolicyReschedule NodeFailurePolicy = "Reschedule"
+	NodeFailurePolicyDelete     NodeFailurePolicy = "Delete"
+	NodeFailurePolicyIgnore     NodeFailurePolicy = "Ignore"
+)
+
 // RestartPolicy describes how the container should be restarted.
 // Only one of the following restart policies may be specified.
 // If none of the following policies is specified, the default one
@@ -697,8 +710,13 @@ const (
 type PodSpec struct {
 	Volumes []Volume `json:"volumes" description:"list of volumes that can be mounted by containers belonging to the pod"`
 	// Required: there must be at least one container in a pod.
-	Containers    []Container   `json:"containers" description:"list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod"`
-	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty" description:"restart policy for all containers within the pod; one of RestartPolicyAlways, RestartPolicyOnFailure, RestartPolicyNever"`
+	Containers []Container `json:"containers" description:"list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod"`
+	// Optional: Set NodeFailurePolicy for when the pod is unable
+	// to run on its bound node, such as when that node is marked
+	// as failed or removed from the cluster.  Defaults to
+	// "Reschedule"
+	NodeFailurePolicy NodeFailurePolicy `json:"nodeFailurePolicy,omitempty" description:"node failure policy when the pod is unable to run on its bound node; one of NodeFailurePolicyReschedule, NodeFailurePolicyDelete, NodeFailurePolicyIgnore"`
+	RestartPolicy     RestartPolicy     `json:"restartPolicy,omitempty" description:"restart policy for all containers within the pod; one of RestartPolicyAlways, RestartPolicyOnFailure, RestartPolicyNever"`
 	// Optional: Set DNS policy.  Defaults to "ClusterFirst"
 	DNSPolicy DNSPolicy `json:"dnsPolicy,omitempty" description:"DNS policy for containers within the pod; one of 'ClusterFirst' or 'Default'"`
 	// NodeSelector is a selector which must be true for the pod to fit on a node


### PR DESCRIPTION
A start to updating PodSpec to include NodeFailurePolicy, which
describes what the user would like the system to do when the pod is
unable to run on its bound node, such as when that node is marked as
failed or removed from the cluster.

NodeFailurePolicy may be Reschedule, Delete, or Ignore, with a
default policy of Reschedule.

Default behavior will change such that pods reschedule in the presence
of node failures by restarting on working nodes instead of being
deleted.  And if users do not want the default behavior, they're able
to opt for deletion -- or completely disable those automatics by
setting the policy to Ignore and using some other mechanism to react.

This PR is only a sketch of the API and discusses the rationale and
proposed plan.  After general consensus on the overall structure, I'll
implement it.  Plan: update the rest of pkg/api to support this field,
add inter-version conversion logic, update the existing pod eviction
code in cloudprovider/controller/nodecontroller.go to reschedule or
delete based on policy, add tests, and update docs to reflect new
usage.

I realize we've discussed similar topics before (most recently #5353,
but also #5334, #5335, and #260) with alternate approaches based on
philosophical perspectives as to what pods should be, but on further
reflection, I think we can do better by our users by meeting them
where they are and being pragmatic about allowing pods to survive
failures by rescheduling onto other nodes.

In particular, pod lifetime becomes bound to cluster lifetime rather
than the lifetime of a given node.  That change furthers our goal of
helping users to think about pods and containers rather than specific
nodes.  Consider two specific use cases: (1) moving from node to
cluster and (2) resizing a cluster.

(1) If someone is using Kubelet (or docker or monit or supervisord) on
a particular node to keep its containers running, when they transition
to Kubernetes, they receive a container cluster equivalent and
their created pods benefit from the new environment.

(2) With our current behavior, on static clusters composed of robust
VMs, pods run for a long time.  But if the cluster is resized smaller,
pods on deleted nodes unexpectedly disappear.  With reschedulable
pods, they'll keep existing and running.

Other benefits:
- Names (IDs) remain unchanged as a pod moves around the cluster, which helps debugging and introspection.
- Users can more-incrementally adopt Kubernetes concepts: they need only use pods and not replication controllers at first.
- Replication controllers potentially become simpler: their config describes a factory that is able to create pods with specified properties, but the handling of specific names and ids is reflected in the pod.
  - E.g. consider the difference between "an EBS volume of 100GB" and "specific EBS volume Foo".
  - ... and we no longer need to create replication controllers of size 1.
  - ... and it becomes feasible to have N reschedulable pods via 1 RC instead of N RCs.  (Or write a RCRC to replicate RCs of size 1.)

Yes, there will be costs to this change.  I rather-obviously think the
benefits outweigh those.  We won't be able to delete pods when it
might be convenient to do so.  And with some of the current overlay
networks, in the short term a pod will change IP addresses because pod
IPs are drawn from ranges bound to a particular host (though
presumably we'll eventually remove that constraint).  It's important
that Kubernetes provide a great Container Cluster Construction Set --
but it's even more important that the out-of-the-box experience for
vanilla Kubernetes be a great experience too.

@smarterclayton, @erictune, @brendandburns because they've at various
times seemed seemed to think it might be reasonable to reschedule
pods.  And @bgrant0607 for obvious reasons.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/kubernetes/6393)

<!-- Reviewable:end -->
