### PR TITLE
Unbreak minion watch on kubelet

### DIFF
--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -1550,7 +1550,7 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "Minion",
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta1", "Node",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "name":

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -1475,7 +1475,7 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta2", "Minion",
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta2", "Node",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "name":

--- a/pkg/api/v1beta3/conversion.go
+++ b/pkg/api/v1beta3/conversion.go
@@ -39,7 +39,7 @@ func init() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta3", "Minion",
+	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta3", "Node",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "name":


### PR DESCRIPTION
Even though we watch against a minion/ endpoint, registering field selectors needs to happen against the `kind` of the resource, which is the name go reports for it's type (the type returned by the `New` function of its storage). In the case of minions, the storage is minion/etcd and the type is api.Node, so the kind is Node not Minion. 
