### PR TITLE
Using gcr.io/google_containers/etcd:2.0.8

### DIFF
--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -9,7 +9,7 @@
 "containers":[
     {
     "name": "etcd-container",
-    "image": "kubernetes/etcd:2.0.5.1",
+    "image": "gcr.io/google_containers/etcd:2.0.8",
     "command": [
               "/usr/local/bin/etcd",
 	      "--addr",


### PR DESCRIPTION
Upgrade to etcd 2.0.8, and also use image from gcr.io/google_containers/etcd:2.0.8

e2e test passed.

cc/ @ArtfulCoder 
