### PR TITLE
Updated instance name for standalone CoreOS guide.

### DIFF
--- a/docs/getting-started-guides/coreos/coreos_single_node_cluster.md
+++ b/docs/getting-started-guides/coreos/coreos_single_node_cluster.md
@@ -40,9 +40,9 @@ gcloud compute instances create standalone \
 --metadata-from-file user-data=standalone.yaml 
 ```
 
-Next, setup an ssh tunnel to the master so you can run kubectl from your local host.
-In one terminal, run `gcloud compute ssh master --ssh-flag="-L 8080:127.0.0.1:8080"` and in a second
-run `gcloud compute ssh master --ssh-flag="-R 8080:127.0.0.1:8080"`.
+Next, setup an ssh tunnel to the instance so you can run kubectl from your local host.
+In one terminal, run `gcloud compute ssh standalone --ssh-flag="-L 8080:127.0.0.1:8080"` and in a second
+run `gcloud compute ssh standalone --ssh-flag="-R 8080:127.0.0.1:8080"`.
 
 
 ### VMware Fusion


### PR DESCRIPTION
Updated the instance name in the guide from "master" to "standalone" to match the instance name used when the image is created.
