### PR TITLE
Add latency metrics to REST client

### DIFF
--- a/pkg/client/metrics/metrics.go
+++ b/pkg/client/metrics/metrics.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const restClientSubsystem = "rest_client"
+
+var (
+	RequestLatency = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Subsystem: restClientSubsystem,
+			Name:      "request_latency_microseconds",
+			Help:      "Request latency in microseconds. Broken down by verb and URL",
+		},
+		[]string{"verb", "url"},
+	)
+)
+
+var registerMetrics sync.Once
+
+// Register all metrics.
+func Register() {
+	// Register the metrics.
+	registerMetrics.Do(func() {
+		prometheus.MustRegister(RequestLatency)
+	})
+}
+
+// Gets the time since the specified start in microseconds.
+func SinceInMicroseconds(start time.Time) float64 {
+	return float64(time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
+}


### PR DESCRIPTION
This fixes #6357

This generates metrics like:

rest_client_request_latency_microseconds{url="http://127.0.0.1:8080/api/v1beta1/bindings?namespace=default",verb="POST",quantile="0.5"} 215198
rest_client_request_latency_microseconds{url="http://127.0.0.1:8080/api/v1beta1/bindings?namespace=default",verb="POST",quantile="0.9"} 819610
rest_client_request_latency_microseconds{url="http://127.0.0.1:8080/api/v1beta1/bindings?namespace=default",verb="POST",quantile="0.99"} 1.636494e+06
rest_client_request_latency_microseconds_sum{url="http://127.0.0.1:8080/api/v1beta1/bindings?namespace=default",verb="POST"} 3.97255688e+08
rest_client_request_latency_microseconds_count{url="http://127.0.0.1:8080/api/v1beta1/bindings?namespace=default",verb="POST"} 1223
