### PR TITLE
Fix incorrect reference to name in v1beta3 API.

### DIFF
--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -1534,7 +1534,7 @@ func init() {
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "name":
-				return "name", value, nil
+				return "metadata.name", value, nil
 			case "DesiredState.Host":
 				return "spec.host", value, nil
 			case "DesiredState.Status":
@@ -1554,7 +1554,7 @@ func init() {
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "name":
-				return "name", value, nil
+				return "metadata.name", value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)
 			}
@@ -1567,7 +1567,7 @@ func init() {
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "name":
-				return "name", value, nil
+				return "metadata.name", value, nil
 			case "currentState.replicas":
 				return "status.replicas", value, nil
 			default:

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -1459,7 +1459,7 @@ func init() {
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "name":
-				return "name", value, nil
+				return "metadata.name", value, nil
 			case "DesiredState.Host":
 				return "spec.host", value, nil
 			case "DesiredState.Status":
@@ -1479,7 +1479,7 @@ func init() {
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "name":
-				return "name", value, nil
+				return "metadata.name", value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)
 			}
@@ -1492,7 +1492,7 @@ func init() {
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "name":
-				return "name", value, nil
+				return "metadata.name", value, nil
 			case "currentState.replicas":
 				return "status.replicas", value, nil
 			default:

--- a/pkg/api/v1beta3/conversion.go
+++ b/pkg/api/v1beta3/conversion.go
@@ -27,7 +27,7 @@ func init() {
 	err := newer.Scheme.AddFieldLabelConversionFunc("v1beta3", "Pod",
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "name",
+			case "metadata.name",
 				"status.phase",
 				"spec.host":
 				return label, value, nil
@@ -42,7 +42,7 @@ func init() {
 	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta3", "Node",
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "name":
+			case "metadata.name":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)
@@ -55,10 +55,9 @@ func init() {
 	err = newer.Scheme.AddFieldLabelConversionFunc("v1beta3", "ReplicationController",
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "name":
-				return "name", value, nil
-			case "status.replicas":
-				return "status.replicas", value, nil
+			case "metadata.name",
+				"status.replicas":
+				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)
 			}

--- a/pkg/client/cache/store.go
+++ b/pkg/client/cache/store.go
@@ -63,7 +63,8 @@ func (k KeyError) Error() string {
 
 // MetaNamespaceKeyFunc is a convenient default KeyFunc which knows how to make
 // keys for API objects which implement meta.Interface.
-// The key uses the format: <namespace>/<name>
+// The key uses the format <namespace>/<name> unless <namespace> is empty, then
+// it's just <name>.
 func MetaNamespaceKeyFunc(obj interface{}) (string, error) {
 	meta, err := meta.Accessor(obj)
 	if err != nil {

--- a/pkg/registry/controller/etcd/etcd_test.go
+++ b/pkg/registry/controller/etcd/etcd_test.go
@@ -544,14 +544,15 @@ func TestEtcdWatchControllersFields(t *testing.T) {
 	testFieldMap := map[int][]fields.Set{
 		PASS: {
 			{"status.replicas": "0"},
-			{"name": "foo"},
-			{"status.replicas": "0", "name": "foo"},
+			{"metadata.name": "foo"},
+			{"status.replicas": "0", "metadata.name": "foo"},
 		},
 		FAIL: {
 			{"status.replicas": "10"},
-			{"name": "bar"},
-			{"status.replicas": "10", "name": "foo"},
-			{"status.replicas": "0", "name": "bar"},
+			{"metadata.name": "bar"},
+			{"name": "foo"},
+			{"status.replicas": "10", "metadata.name": "foo"},
+			{"status.replicas": "0", "metadata.name": "bar"},
 		},
 	}
 	testEtcdActions := []string{

--- a/pkg/registry/generic/registry.go
+++ b/pkg/registry/generic/registry.go
@@ -53,7 +53,7 @@ func (s *SelectionPredicate) Matches(obj runtime.Object) (bool, error) {
 // name.
 func (s *SelectionPredicate) MatchesSingle() (string, bool) {
 	// TODO: should be namespace.name
-	if name, ok := s.Field.RequiresExactMatch("name"); ok {
+	if name, ok := s.Field.RequiresExactMatch("metadata.name"); ok {
 		return name, true
 	}
 	return "", false

--- a/pkg/registry/generic/registry.go
+++ b/pkg/registry/generic/registry.go
@@ -49,14 +49,37 @@ func (s *SelectionPredicate) Matches(obj runtime.Object) (bool, error) {
 	return s.Label.Matches(labels) && s.Field.Matches(fields), nil
 }
 
+// MatchesSingle will return (name, true) iff s.Field matches on the object's
+// name.
+func (s *SelectionPredicate) MatchesSingle() (string, bool) {
+	// TODO: should be namespace.name
+	if name, ok := s.Field.RequiresExactMatch("name"); ok {
+		return name, true
+	}
+	return "", false
+}
+
 // Matcher can return true if an object matches the Matcher's selection
-// criteria.
+// criteria. If it is known that the matcher will match only a single object
+// then MatchesSingle should return the key of that object and true. This is an
+// optimization only--Matches() should continue to work.
 type Matcher interface {
-	Matches(obj runtime.Object) (bool, error)
+	// Matches should return true if obj matches this matcher's requirements.
+	Matches(obj runtime.Object) (matchesThisObject bool, err error)
+
+	// If this matcher matches a single object, return the key for that
+	// object and true here. This will greatly increase efficiency. You
+	// must still implement Matches(). Note that key does NOT need to
+	// include the object's namespace.
+	MatchesSingle() (key string, matchesSingleObject bool)
+
+	// TODO: when we start indexing objects, add something like the below:
+	//         MatchesIndices() (indexName []string, indexValue []string)
+	//       where indexName/indexValue are the same length.
 }
 
 // MatcherFunc makes a matcher from the provided function. For easy definition
-// of matchers for testing.
+// of matchers for testing. Note: use SelectionPredicate above for real code!
 func MatcherFunc(f func(obj runtime.Object) (bool, error)) Matcher {
 	return matcherFunc(f)
 }
@@ -67,6 +90,36 @@ type matcherFunc func(obj runtime.Object) (bool, error)
 func (m matcherFunc) Matches(obj runtime.Object) (bool, error) {
 	return m(obj)
 }
+
+// MatchesSingle always returns "", false-- because this is a predicate
+// implementation of Matcher.
+func (m matcherFunc) MatchesSingle() (string, bool) {
+	return "", false
+}
+
+// MatchOnKey returns a matcher that will send only the object matching key
+// through the matching function f. For testing!
+// Note: use SelectionPredicate above for real code!
+func MatchOnKey(key string, f func(obj runtime.Object) (bool, error)) Matcher {
+	return matchKey{key, f}
+}
+
+type matchKey struct {
+	key string
+	matcherFunc
+}
+
+// MatchesSingle always returns its key, true.
+func (m matchKey) MatchesSingle() (string, bool) {
+	return m.key, true
+}
+
+var (
+	// Assert implementations match the interface.
+	_ = Matcher(matchKey{})
+	_ = Matcher(&SelectionPredicate{})
+	_ = Matcher(matcherFunc(nil))
+)
 
 // DecoratorFunc can mutate the provided object prior to being returned.
 type DecoratorFunc func(obj runtime.Object) error

--- a/pkg/registry/generic/registry_test.go
+++ b/pkg/registry/generic/registry_test.go
@@ -68,9 +68,9 @@ func TestSelectionPredicate(t *testing.T) {
 			shouldMatch:   false,
 		},
 		"D": {
-			fieldSelector:  "name=12345",
+			fieldSelector:  "metadata.name=12345",
 			labels:         labels.Set{},
-			fields:         fields.Set{"name": "12345"},
+			fields:         fields.Set{"metadata.name": "12345"},
 			shouldMatch:    true,
 			matchSingleKey: "12345",
 		},

--- a/pkg/registry/generic/registry_test.go
+++ b/pkg/registry/generic/registry_test.go
@@ -44,6 +44,7 @@ func TestSelectionPredicate(t *testing.T) {
 		fields                       fields.Set
 		err                          error
 		shouldMatch                  bool
+		matchSingleKey               string
 	}{
 		"A": {
 			labelSelector: "name=foo",
@@ -65,6 +66,13 @@ func TestSelectionPredicate(t *testing.T) {
 			labels:        labels.Set{},
 			fields:        fields.Set{"uid": "12345"},
 			shouldMatch:   false,
+		},
+		"D": {
+			fieldSelector:  "name=12345",
+			labels:         labels.Set{},
+			fields:         fields.Set{"name": "12345"},
+			shouldMatch:    true,
+			matchSingleKey: "12345",
 		},
 		"error": {
 			labelSelector: "name=foo",
@@ -98,6 +106,15 @@ func TestSelectionPredicate(t *testing.T) {
 		if e, a := item.shouldMatch, got; e != a {
 			t.Errorf("%v: expected %v, got %v", name, e, a)
 		}
+		if key := item.matchSingleKey; key != "" {
+			got, ok := sp.MatchesSingle()
+			if !ok {
+				t.Errorf("%v: expected single match", name)
+			}
+			if e, a := key, got; e != a {
+				t.Errorf("%v: expected %v, got %v", name, e, a)
+			}
+		}
 	}
 }
 
@@ -118,21 +135,34 @@ func TestFilterList(t *testing.T) {
 		},
 	}
 
-	got, err := FilterList(try,
-		MatcherFunc(func(obj runtime.Object) (bool, error) {
-			i, ok := obj.(*Ignored)
-			if !ok {
-				return false, errors.New("wrong type")
-			}
-			return i.ID[0] == 'b', nil
-		}),
-		nil,
-	)
+	m := MatcherFunc(func(obj runtime.Object) (bool, error) {
+		i, ok := obj.(*Ignored)
+		if !ok {
+			return false, errors.New("wrong type")
+		}
+		return i.ID[0] == 'b', nil
+	})
+	if _, matchesSingleObject := m.MatchesSingle(); matchesSingleObject {
+		t.Errorf("matcher unexpectedly matches only a single object.")
+	}
+
+	got, err := FilterList(try, m, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
 
 	if e, a := expect, got; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+}
+
+func TestSingleMatch(t *testing.T) {
+	m := MatchOnKey("pod-name-here", func(obj runtime.Object) (bool, error) { return true, nil })
+	got, ok := m.MatchesSingle()
+	if !ok {
+		t.Errorf("Expected MatchesSingle to return true")
+	}
+	if e, a := "pod-name-here", got; e != a {
 		t.Errorf("Expected %#v, got %#v", e, a)
 	}
 }

--- a/pkg/registry/minion/etcd/etcd.go
+++ b/pkg/registry/minion/etcd/etcd.go
@@ -23,9 +23,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
 	etcdgeneric "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/minion"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
@@ -49,14 +46,11 @@ func NewStorage(h tools.EtcdHelper, connection client.ConnectionInfoGetter) *RES
 		KeyFunc: func(ctx api.Context, name string) (string, error) {
 			return prefix + "/" + name, nil
 		},
-		WatchSingleFieldName: "name",
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*api.Node).Name, nil
 		},
-		PredicateFunc: func(label labels.Selector, field fields.Selector) generic.Matcher {
-			return minion.MatchNode(label, field)
-		},
-		EndpointName: "minion",
+		PredicateFunc: minion.MatchNode,
+		EndpointName:  "minion",
 
 		CreateStrategy: minion.Strategy,
 		UpdateStrategy: minion.Strategy,

--- a/pkg/registry/minion/etcd/etcd_test.go
+++ b/pkg/registry/minion/etcd/etcd_test.go
@@ -347,59 +347,6 @@ func TestEtcdWatchNodesMatch(t *testing.T) {
 	watching.Stop()
 }
 
-func TestEtcdWatchNodesFields(t *testing.T) {
-	ctx := api.NewDefaultContext()
-	storage, fakeClient := newStorage(t)
-	node := validNewNode()
-	nodeBytes, _ := latest.Codec.Encode(node)
-
-	testFieldMap := map[int][]fields.Set{
-		PASS: {
-			{"name": "foo"},
-		},
-		FAIL: {
-			{"name": "bar"},
-		},
-	}
-
-	for _, singleWatchField := range []string{"", "name"} {
-		storage.WatchSingleFieldName = singleWatchField
-		for expectedResult, fieldSet := range testFieldMap {
-			for _, field := range fieldSet {
-				watching, err := storage.Watch(ctx,
-					labels.Everything(),
-					field.AsSelector(),
-					"1",
-				)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				fakeClient.WaitForWatchCompletion()
-				fakeClient.WatchResponse <- &etcd.Response{
-					Action: "create",
-					Node: &etcd.Node{
-						Value: string(nodeBytes),
-					},
-				}
-				select {
-				case r, ok := <-watching.ResultChan():
-					if expectedResult == FAIL {
-						t.Errorf("unexpected result from channel %#v", r)
-					}
-					if !ok {
-						t.Errorf("watching channel should be open")
-					}
-				case <-time.After(time.Millisecond * 100):
-					if expectedResult == PASS {
-						t.Errorf("unexpected timeout from result channel")
-					}
-				}
-				watching.Stop()
-			}
-		}
-	}
-}
-
 func TestEtcdWatchNodesNotMatch(t *testing.T) {
 	ctx := api.NewDefaultContext()
 	storage, fakeClient := newStorage(t)

--- a/pkg/registry/minion/rest.go
+++ b/pkg/registry/minion/rest.go
@@ -85,7 +85,7 @@ type ResourceGetter interface {
 // NodeToSelectableFields returns a label set that represents the object.
 func NodeToSelectableFields(node *api.Node) fields.Set {
 	return fields.Set{
-		"name": node.Name,
+		"metadata.name": node.Name,
 	}
 }
 

--- a/pkg/registry/minion/rest.go
+++ b/pkg/registry/minion/rest.go
@@ -83,22 +83,25 @@ type ResourceGetter interface {
 }
 
 // NodeToSelectableFields returns a label set that represents the object.
-func NodeToSelectableFields(node *api.Node) labels.Set {
-	return labels.Set{
+func NodeToSelectableFields(node *api.Node) fields.Set {
+	return fields.Set{
 		"name": node.Name,
 	}
 }
 
 // MatchNode returns a generic matcher for a given label and field selector.
 func MatchNode(label labels.Selector, field fields.Selector) generic.Matcher {
-	return generic.MatcherFunc(func(obj runtime.Object) (bool, error) {
-		nodeObj, ok := obj.(*api.Node)
-		if !ok {
-			return false, fmt.Errorf("not a node")
-		}
-		fields := NodeToSelectableFields(nodeObj)
-		return label.Matches(labels.Set(nodeObj.Labels)) && field.Matches(fields), nil
-	})
+	return &generic.SelectionPredicate{
+		Label: label,
+		Field: field,
+		GetAttrs: func(obj runtime.Object) (labels.Set, fields.Set, error) {
+			nodeObj, ok := obj.(*api.Node)
+			if !ok {
+				return nil, nil, fmt.Errorf("not a node")
+			}
+			return labels.Set(nodeObj.ObjectMeta.Labels), NodeToSelectableFields(nodeObj), nil
+		},
+	}
 }
 
 // ResourceLocation returns a URL to which one can send traffic for the specified node.

--- a/pkg/registry/minion/rest_test.go
+++ b/pkg/registry/minion/rest_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package minion
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+)
+
+func TestMatchNode(t *testing.T) {
+	testFieldMap := map[bool][]fields.Set{
+		true: {
+			{"name": "foo"},
+		},
+		false: {
+			{"foo": "bar"},
+		},
+	}
+
+	for expectedResult, fieldSet := range testFieldMap {
+		for _, field := range fieldSet {
+			m := MatchNode(labels.Everything(), field.AsSelector())
+			_, matchesSingle := m.MatchesSingle()
+			if e, a := expectedResult, matchesSingle; e != a {
+				t.Errorf("%+v: expected %v, got %v", e, a)
+			}
+		}
+	}
+}

--- a/pkg/registry/minion/rest_test.go
+++ b/pkg/registry/minion/rest_test.go
@@ -26,7 +26,7 @@ import (
 func TestMatchNode(t *testing.T) {
 	testFieldMap := map[bool][]fields.Set{
 		true: {
-			{"name": "foo"},
+			{"metadata.name": "foo"},
 		},
 		false: {
 			{"foo": "bar"},

--- a/pkg/registry/pod/etcd/etcd_test.go
+++ b/pkg/registry/pod/etcd/etcd_test.go
@@ -291,7 +291,7 @@ func TestListPodListSelection(t *testing.T) {
 		{
 			expectedIDs: util.NewStringSet("foo", "bar", "baz", "qux", "zot"),
 		}, {
-			field:       "name=zot",
+			field:       "metadata.name=zot",
 			expectedIDs: util.NewStringSet("zot"),
 		}, {
 			label:       "label=qux",


### PR DESCRIPTION
Only look at the second commit, the first is in #6373.

@bgrant0607 Unfortunately, we wrote "name" instead of "metadata.name" in our field selector for v1beta3. This PR rectifies that, but of course is a breaking change. I'm not sure if anyone uses this yet. It's up to you how to proceed.
