### PR TITLE
Update Kibana to v1.2 which paramaterizes location of Elasticsearch

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
@@ -12,7 +12,7 @@ desiredState:
         id: kibana-viewer
         containers:
           - name: kibana-logging
-            image: gcr.io/google_containers/kibana:1.1
+            image: gcr.io/google_containers/kibana:1.2
             env: 
               - name: "ES_SCHEME"
                 value: "https"

--- a/cluster/addons/fluentd-elasticsearch/kibana-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/kibana-image/Makefile
@@ -1,6 +1,6 @@
 .PHONY:	build push
 
-TAG = 1.1
+TAG = 1.2
 
 build:
 	docker build -t gcr.io/google_containers/kibana:$(TAG) .


### PR DESCRIPTION
Following on from #5776 this updates the image for Kibana to use the kind work done by @jonlangemak
