### PR TITLE
Do not log "event already exists" errors

### DIFF
--- a/pkg/client/record/event.go
+++ b/pkg/client/record/event.go
@@ -176,7 +176,11 @@ func recordEvent(sink EventSink, event *api.Event, updateExistingEvent bool) boo
 		glog.Errorf("Unable to construct event '%#v': '%v' (will not retry!)", event, err)
 		return true
 	case *errors.StatusError:
-		glog.Errorf("Server rejected event '%#v': '%v' (will not retry!)", event, err)
+		if errors.IsAlreadyExists(err) {
+			glog.V(5).Infof("Server rejected event '%#v': '%v' (will not retry!)", event, err)
+		} else {
+			glog.Errorf("Server rejected event '%#v': '%v' (will not retry!)", event, err)
+		}
 		return true
 	case *errors.UnexpectedObjectError:
 		// We don't expect this; it implies the server's response didn't match a


### PR DESCRIPTION
When the server rejects an event because it has already been created, log it
at a very high level (debug) instead of the default level. Duplicate events
typically only occur due to programmer error or failure conditions, so they
can safely be ignored in production environments.

@lavalamp I believe this is sane, correct me if not.
