### PR TITLE
Make gofmt message precise  (-s option)

### DIFF
--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -44,9 +44,10 @@ find_files() {
     \) -name '*.go'
 }
 
-bad_files=$(find_files | xargs gofmt -s -l)
+GOFMT="gofmt -s"
+bad_files=$(find_files | xargs $GOFMT -l)
 if [[ -n "${bad_files}" ]]; then
-  echo "!!! gofmt needs to be run on the following files: "
+  echo "!!! '$GOFMT' needs to be run on the following files: "
   echo "${bad_files}"
   exit 1
 fi


### PR DESCRIPTION
Quickie to make jenkins 'go-fmt' error message a little clear.  It requires that you run gofmt w/ the **-s** option, but right now only sais **run gofmt**. 

Parameter here makes it so that its more precise....
