### PR TITLE
Improve test case to ensure finalize does desired behavior

### DIFF
--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -47,6 +47,7 @@ type Fake struct {
 	ResourceQuotaStatus       api.ResourceQuota
 	ResourceQuotasList        api.ResourceQuotaList
 	NamespacesList            api.NamespaceList
+	Namespace                 api.Namespace
 	SecretList                api.SecretList
 	Secret                    api.Secret
 	Err                       error

--- a/pkg/client/fake_namespaces.go
+++ b/pkg/client/fake_namespaces.go
@@ -61,7 +61,8 @@ func (c *FakeNamespaces) Watch(label labels.Selector, field fields.Selector, res
 
 func (c *FakeNamespaces) Finalize(namespace *api.Namespace) (*api.Namespace, error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "finalize-namespace", Value: namespace.Name})
-	return &api.Namespace{}, nil
+	c.Fake.Namespace = *namespace
+	return namespace, nil
 }
 
 func (c *FakeNamespaces) Status(namespace *api.Namespace) (*api.Namespace, error) {

--- a/pkg/namespace/namespace_controller_test.go
+++ b/pkg/namespace/namespace_controller_test.go
@@ -58,6 +58,13 @@ func TestFinalize(t *testing.T) {
 	if mockClient.Actions[0].Action != "finalize-namespace" {
 		t.Errorf("Expected finalize-namespace action %v", mockClient.Actions[0].Action)
 	}
+	finalizers := mockClient.Namespace.Spec.Finalizers
+	if len(finalizers) != 1 {
+		t.Errorf("There should be a single finalizer remaining")
+	}
+	if "other" != string(finalizers[0]) {
+		t.Errorf("Unexpected finalizer value, %v", finalizers[0])
+	}
 }
 
 func TestSyncNamespaceThatIsTerminating(t *testing.T) {


### PR DESCRIPTION
Ensure finalize operation in namespace controller only removes "kubernetes" and not other named finalizer tokens by improving our test case.
