### PR TITLE
Add kube::util::wait-for-jobs to report status, unlike builtin wait

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -508,11 +508,11 @@ function kube::release::package_tarballs() {
   kube::release::package_client_tarballs &
   kube::release::package_server_tarballs &
   kube::release::package_salt_tarball &
-  wait || { kube::log::error "previous tarball phase failed"; return 1; }
+  kube::util::wait-for-jobs || { kube::log::error "previous tarball phase failed"; return 1; }
 
   kube::release::package_full_tarball & # _full depends on all the previous phases
   kube::release::package_test_tarball & # _test doesn't depend on anything
-  wait || { kube::log::error "previous tarball phase failed"; return 1; }
+  kube::util::wait-for-jobs || { kube::log::error "previous tarball phase failed"; return 1; }
 }
 
 # Package up all of the cross compiled clients.  Over time this should grow into
@@ -549,7 +549,7 @@ function kube::release::package_client_tarballs() {
   done
 
   kube::log::status "Waiting on tarballs"
-  wait || { kube::log::error "client tarball creation failed"; exit 1; }
+  kube::util::wait-for-jobs || { kube::log::error "client tarball creation failed"; exit 1; }
 }
 
 # Package up all of the server binaries
@@ -619,7 +619,7 @@ function kube::release::create_docker_images_for_server() {
       ) &
     done
 
-    wait || { kube::log::error "previous Docker build failed"; return 1; }
+    kube::util::wait-for-jobs || { kube::log::error "previous Docker build failed"; return 1; }
     kube::log::status "Docker builds done"
   )
 }

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -95,3 +95,14 @@ kube::util::host_platform() {
   esac
   echo "${host_os}/${host_arch}"
 }
+
+# Wait for background jobs to finish. Return with
+# an error status if any of the jobs failed.
+kube::util::wait-for-jobs() {
+  local fail=0
+  local job
+  for job in $(jobs -p); do
+    wait "${job}" || fail=$((fail + 1))
+  done
+  return ${fail}
+}


### PR DESCRIPTION
*\* Sigh **

Fixes an additional complaint in #6463
