### PR TITLE
fix kubeconfig serialization

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -274,7 +274,7 @@ function upload-server-tars() {
 function get-password {
   # go template to extract the auth-path of the current-context user
   # Note: we save dot ('.') to $dot because the 'with' action overrides dot
-  local template='{{$dot := .}}{{with $ctx := index $dot "current-context"}}{{$user := index $dot "contexts" $ctx "user"}}{{index $dot "users" $user "auth-path"}}{{end}}'
+  local template='{{$dot := .}}{{with $ctx := index $dot "current-context"}}{{range $element := (index $dot "contexts")}}{{ if eq .name $ctx }}{{ with $user := .context.user }}{{range $element := (index $dot "users")}}{{ if eq .name $user }}{{ index . "user" "auth-path" }}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}'
   local file=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o template --template="${template}")
   if [[ ! -z "$file" && -r "$file" ]]; then
     KUBE_USER=$(cat "$file" | python -c 'import json,sys;print json.load(sys.stdin)["User"]')

--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -91,8 +91,8 @@ function get-kubeconfig-basicauth() {
   # is missing.
   # Note: we save dot ('.') to $root because the 'with' action overrides it.
   # See http://golang.org/pkg/text/template/.
-  local username='{{$root := .}}{{with index $root "current-context"}}{{with index $root "contexts" .}}{{with index . "user"}}{{with index $root "users" .}}{{index . "username"}}{{end}}{{end}}{{end}}{{end}}'
-  local password='{{$root := .}}{{with index $root "current-context"}}{{with index $root "contexts" .}}{{with index . "user"}}{{with index $root "users" .}}{{index . "password"}}{{end}}{{end}}{{end}}{{end}}'
+  local username='{{$dot := .}}{{with $ctx := index $dot "current-context"}}{{range $element := (index $dot "contexts")}}{{ if eq .name $ctx }}{{ with $user := .context.user }}{{range $element := (index $dot "users")}}{{ if eq .name $user }}{{ index . "user" "username" }}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}'
+  local password='{{$dot := .}}{{with $ctx := index $dot "current-context"}}{{range $element := (index $dot "contexts")}}{{ if eq .name $ctx }}{{ with $user := .context.user }}{{range $element := (index $dot "users")}}{{ if eq .name $user }}{{ index . "user" "password" }}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}'
   KUBE_USER=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o template --template="${username}")
   KUBE_PASSWORD=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o template --template="${password}")
   # Handle empty/missing username|password

--- a/docs/kubectl-config-view.md
+++ b/docs/kubectl-config-view.md
@@ -23,7 +23,7 @@ $ kubectl config view
 $ kubectl config view --local
 
 // Get the password for the e2e user
-$ kubectl config view -o template --template='{{ index . "users" "e2e" "password" }}'
+$ kubectl config view -o template --template='{{range .users}}{{ if eq .name "e2e" }}{{ index .user.password }}{{end}}{{end}}'
 ```
 
 ### Options

--- a/docs/man/man1/kubectl-config-view.1
+++ b/docs/man/man1/kubectl-config-view.1
@@ -172,7 +172,7 @@ $ kubectl config view
 $ kubectl config view \-\-local
 
 // Get the password for the e2e user
-$ kubectl config view \-o template \-\-template='\{\{ index . "users" "e2e" "password" \}\}'
+$ kubectl config view \-o template \-\-template='\{\{range .users\}\}\{\{ if eq .name "e2e" \}\}\{\{ index .user.password \}\}\{\{end\}\}\{\{end\}\}'
 
 .fi
 .RE

--- a/examples/openshift-origin/resource-generator.sh
+++ b/examples/openshift-origin/resource-generator.sh
@@ -41,19 +41,19 @@ fi
 TEMPLATE="--template=\"{{ index . \"current-context\" }}\""
 CURRENT_CONTEXT=$( "${kubectl}" "${config[@]:+${config[@]}}" config view -o template "${TEMPLATE}" )
 
-TEMPLATE="--template=\"{{ index . \"contexts\" ${CURRENT_CONTEXT} \"cluster\" }}\""
+TEMPLATE="--template=\"{{range .contexts}}{{ if eq .name ${CURRENT_CONTEXT} }}{{ .context.cluster }}{{end}}{{end}}\""
 CURRENT_CLUSTER=$( "${kubectl}" "${config[@]:+${config[@]}}" config view -o template "${TEMPLATE}" )
 
-TEMPLATE="--template=\"{{ index . \"contexts\" ${CURRENT_CONTEXT} \"user\" }}\""
+TEMPLATE="--template=\"{{range .contexts}}{{ if eq .name ${CURRENT_CONTEXT} }}{{ .context.user }}{{end}}{{end}}\""
 CURRENT_USER=$( "${kubectl}" "${config[@]:+${config[@]}}" config view -o template "${TEMPLATE}" )
 
-TEMPLATE="--template={{ index . \"clusters\" ${CURRENT_CLUSTER} \"certificate-authority\" }}"
+TEMPLATE="--template=\"{{range .clusters}}{{ if eq .name ${CURRENT_CLUSTER} }}{{ index . \"cluster\" \"certificate-authority\" }}{{end}}{{end}}\""
 CERTIFICATE_AUTHORITY=$( "${kubectl}" "${config[@]:+${config[@]}}" config view -o template "${TEMPLATE}" )
 
-TEMPLATE="--template={{ index . \"clusters\" ${CURRENT_CLUSTER} \"server\" }}"
+TEMPLATE="--template=\"{{range .clusters}}{{ if eq .name ${CURRENT_CLUSTER} }}{{ .cluster.server }}{{end}}{{end}}\""
 KUBE_MASTER=$( "${kubectl}" "${config[@]:+${config[@]}}" config view -o template "${TEMPLATE}" )
 
-TEMPLATE="--template={{ index . \"users\" ${CURRENT_USER} \"auth-path\" }}"
+TEMPLATE="--template=\"{{range .users}}{{ if eq .name ${CURRENT_USER} }}{{ index . \"user\" \"auth-path\" }}{{end}}{{end}}\""
 AUTH_PATH=$( "${kubectl}" "${config[@]:+${config[@]}}" config view -o template "${TEMPLATE}" )
 
 # Build an auth_path file to embed as a secret

--- a/pkg/kubectl/cmd/config/config_test.go
+++ b/pkg/kubectl/cmd/config/config_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -45,6 +46,36 @@ type configCommandTest struct {
 	startingConfig  clientcmdapi.Config
 	expectedConfig  clientcmdapi.Config
 	expectedOutputs []string
+}
+
+func ExampleView() {
+	expectedConfig := newRedFederalCowHammerConfig()
+	test := configCommandTest{
+		args:           []string{"view"},
+		startingConfig: newRedFederalCowHammerConfig(),
+		expectedConfig: expectedConfig,
+	}
+
+	output := test.run(nil)
+	fmt.Printf("%v", output)
+	// Output:
+	// apiVersion: v1
+	// clusters:
+	// - cluster:
+	//     server: http://cow.org:8080
+	//   name: cow-cluster
+	// contexts:
+	// - context:
+	//     cluster: cow-cluster
+	//     user: red-user
+	//   name: federal-context
+	// current-context: ""
+	// kind: Config
+	// preferences: {}
+	// users:
+	// - name: red-user
+	//   user:
+	//     token: red-token
 }
 
 func TestSetCurrentContext(t *testing.T) {
@@ -629,7 +660,7 @@ func testConfigCommand(args []string, startingConfig clientcmdapi.Config) (strin
 	return buf.String(), *config
 }
 
-func (test configCommandTest) run(t *testing.T) {
+func (test configCommandTest) run(t *testing.T) string {
 	out, actualConfig := testConfigCommand(test.args, test.startingConfig)
 
 	testSetNilMapsToEmpties(reflect.ValueOf(&test.expectedConfig))
@@ -645,6 +676,8 @@ func (test configCommandTest) run(t *testing.T) {
 			t.Errorf("expected '%s' in output, got '%s'", expectedOutput, out)
 		}
 	}
+
+	return out
 }
 func testSetNilMapsToEmpties(curr reflect.Value) {
 	actualCurrValue := curr


### PR DESCRIPTION
Partially addresses https://github.com/GoogleCloudPlatform/kubernetes/issues/5625.

This updates `kubectl config view` to produce the output based on the serialization format instead of the in memory copy.

I attempted to do this before, but I failed to handle the different templates that already existed and that resulted in e2e failures.  This time I've update the templates in the scripts (see the `update scripts with correct templates` commit).  I'm running e2e now, but the individual formats were equivalent when I tested them.  See https://gist.github.com/deads2k/c294a882c9358ea7679f for how I located them and what the equivalence was.
