### PR TITLE
Enable 'Events' tests for all providers, we need it for local

### DIFF
--- a/test/e2e/events.go
+++ b/test/e2e/events.go
@@ -41,11 +41,6 @@ var _ = Describe("Events", func() {
 	})
 
 	It("should be sent by kubelets and the scheduler about pods scheduling and running", func() {
-		provider := testContext.Provider
-		if len(provider) > 0 && provider != "gce" && provider != "gke" && provider != "aws" {
-			By(fmt.Sprintf("skipping TestKubeletSendsEvent on cloud provider %s", provider))
-			return
-		}
 
 		podClient := c.Pods(api.NamespaceDefault)
 


### PR DESCRIPTION
It was disabled for non-cloud providers but I would like to enable for \* and I verified it works for 'local' 
