### PR TITLE
kubelet: Refactor RunInContainer/ExecInContainer/PortForward.

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -124,9 +124,8 @@ type RunContainerOptions struct {
 
 type Pods []*Pod
 
-// FindPodByID returns a pod in the pod list by UID. It will return an empty pod
+// FindPodByID finds and returns a pod in the pod list by UID. It will return an empty pod
 // if not found.
-// TODO(yifan): Use a map?
 func (p Pods) FindPodByID(podUID types.UID) Pod {
 	for i := range p {
 		if p[i].ID == podUID {
@@ -134,6 +133,27 @@ func (p Pods) FindPodByID(podUID types.UID) Pod {
 		}
 	}
 	return Pod{}
+}
+
+// FindPodByFullName finds and returns a pod in the pod list by the full name.
+// It will return an empty pod if not found.
+func (p Pods) FindPodByFullName(podFullName string) Pod {
+	for i := range p {
+		if BuildPodFullName(p[i].Name, p[i].Namespace) == podFullName {
+			return *p[i]
+		}
+	}
+	return Pod{}
+}
+
+// FindPod combines FindPodByID and FindPodByFullName, it finds and returns a pod in the
+// pod list either by the full name or the pod ID. It will return an empty pod
+// if not found.
+func (p Pods) FindPod(podFullName string, podUID types.UID) Pod {
+	if len(podFullName) > 0 {
+		return p.FindPodByFullName(podFullName)
+	}
+	return p.FindPodByID(podUID)
 }
 
 // FindContainerByName returns a container in the pod with the given name.

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1425,8 +1425,12 @@ func (f *fakeContainerCommandRunner) ExecInContainer(id string, cmd []string, in
 	return f.E
 }
 
-func (f *fakeContainerCommandRunner) PortForward(podInfraContainerID string, port uint16, stream io.ReadWriteCloser) error {
-	f.ID = podInfraContainerID
+func (f *fakeContainerCommandRunner) PortForward(pod *kubecontainer.Pod, port uint16, stream io.ReadWriteCloser) error {
+	podInfraContainer := pod.FindContainerByName(dockertools.PodInfraContainerName)
+	if podInfraContainer == nil {
+		return fmt.Errorf("cannot find pod infra container in pod %q", kubecontainer.BuildPodFullName(pod.Name, pod.Namespace))
+	}
+	f.ID = string(podInfraContainer.ID)
 	f.Port = port
 	f.Stream = stream
 	return nil


### PR DESCRIPTION
Replace GetKubeletDockerContainers() with GetPods().

This removes the docker specific code in further. (Now we only have one GetKubeletDockerContainers!)

I remember @dchen1107 said now each pod has its UID, so I think we can remove the podFullName part in the kubelet's interface.(correct me if I am wrong, thank you!).

@vmarmol @yujuhong 
