### PR TITLE
Pod log subresource

### DIFF
--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -58,6 +58,7 @@ func init() {
 		&PersistentVolumeClaimList{},
 		&DeleteOptions{},
 		&ListOptions{},
+		&PodLogOptions{},
 	)
 	// Legacy names are supported
 	Scheme.AddKnownTypeWithName("", "Minion", &Node{})
@@ -97,3 +98,4 @@ func (*PersistentVolumeClaim) IsAnAPIObject()     {}
 func (*PersistentVolumeClaimList) IsAnAPIObject() {}
 func (*DeleteOptions) IsAnAPIObject()             {}
 func (*ListOptions) IsAnAPIObject()               {}
+func (*PodLogOptions) IsAnAPIObject()             {}

--- a/pkg/api/rest/rest.go
+++ b/pkg/api/rest/rest.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
-// RESTStorage is a generic interface for RESTful storage services.
+// Storage is a generic interface for RESTful storage services.
 // Resources which are exported to the RESTful API of apiserver need to implement this interface. It is expected
 // that objects may implement any of the below interfaces.
 type Storage interface {
@@ -52,6 +52,21 @@ type Getter interface {
 	// Although it can return an arbitrary error value, IsNotFound(err) is true for the
 	// returned error value err when the specified resource is not found.
 	Get(ctx api.Context, name string) (runtime.Object, error)
+}
+
+// GetterWithOptions is an object that retrieve a named RESTful resource and takes
+// additional options on the get request
+type GetterWithOptions interface {
+	// Get finds a resource in the storage by name and returns it.
+	// Although it can return an arbitrary error value, IsNotFound(err) is true for the
+	// returned error value err when the specified resource is not found.
+	// The options object passed to it is of the same type returned by the NewGetOptions
+	// method.
+	Get(ctx api.Context, name string, options runtime.Object) (runtime.Object, error)
+
+	// NewGetOptions returns an empty options object that will be used to pass
+	// options to the Get method.
+	NewGetOptions() runtime.Object
 }
 
 // Deleter is an object that can delete a named RESTful resource.
@@ -119,6 +134,7 @@ type CreaterUpdater interface {
 // CreaterUpdater must satisfy the Updater interface.
 var _ Updater = CreaterUpdater(nil)
 
+// Patcher is a storage object that supports both get and update.
 type Patcher interface {
 	Getter
 	Updater
@@ -153,11 +169,12 @@ type Redirector interface {
 // ResourceStreamer is an interface implemented by objects that prefer to be streamed from the server
 // instead of decoded directly.
 type ResourceStreamer interface {
-	// InputStream should return an io.Reader if the provided object supports streaming. The desired
+	// InputStream should return an io.ReadCloser if the provided object supports streaming. The desired
 	// api version and a accept header (may be empty) are passed to the call. If no error occurs,
-	// the caller may return a content type string with the reader that indicates the type of the
-	// stream.
-	InputStream(apiVersion, acceptHeader string) (io.ReadCloser, string, error)
+	// the caller may return a flag indicating whether the result should be flushed as writes occur
+	// and a content type string that indicates the type of the stream.
+	// If a null stream is returned, a StatusNoContent response wil be generated.
+	InputStream(apiVersion, acceptHeader string) (stream io.ReadCloser, flush bool, mimeType string, err error)
 }
 
 // StorageMetadata is an optional interface that callers can implement to provide additional

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1249,6 +1249,17 @@ type ListOptions struct {
 	ResourceVersion string
 }
 
+// PodLogOptions is the query options for a Pod's logs REST call
+type PodLogOptions struct {
+	TypeMeta
+
+	// Container for which to return logs
+	Container string
+
+	// If true, follow the logs for the pod
+	Follow bool
+}
+
 // Status is a return value for calls that don't return other objects.
 // TODO: this could go in apiserver, but I'm including it here so clients needn't
 // import both.

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -65,6 +65,7 @@ func init() {
 		&PersistentVolumeClaimList{},
 		&DeleteOptions{},
 		&ListOptions{},
+		&PodLogOptions{},
 	)
 	// Future names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta1", "Node", &Minion{})
@@ -104,3 +105,4 @@ func (*PersistentVolumeClaim) IsAnAPIObject()     {}
 func (*PersistentVolumeClaimList) IsAnAPIObject() {}
 func (*DeleteOptions) IsAnAPIObject()             {}
 func (*ListOptions) IsAnAPIObject()               {}
+func (*PodLogOptions) IsAnAPIObject()             {}

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -1104,6 +1104,17 @@ type ListOptions struct {
 	ResourceVersion string `json:"resourceVersion" description:"when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history"`
 }
 
+// PodLogOptions is the query options for a Pod's logs REST call
+type PodLogOptions struct {
+	TypeMeta `json:",inline"`
+
+	// Container for which to return logs
+	Container string `json:"container,omitempty" description:"the container for which to stream logs; defaults to only container if there is one container in the pod"`
+
+	// If true, follow the logs for the pod
+	Follow bool `json:"follow,omitempty" description:"follow the log stream of the pod; defaults to false"`
+}
+
 // Status is a return value for calls that don't return other objects.
 // TODO: this could go in apiserver, but I'm including it here so clients needn't
 // import both.

--- a/pkg/api/v1beta2/register.go
+++ b/pkg/api/v1beta2/register.go
@@ -65,6 +65,7 @@ func init() {
 		&PersistentVolumeClaimList{},
 		&DeleteOptions{},
 		&ListOptions{},
+		&PodLogOptions{},
 	)
 	// Future names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta2", "Node", &Minion{})
@@ -104,3 +105,4 @@ func (*PersistentVolumeClaim) IsAnAPIObject()     {}
 func (*PersistentVolumeClaimList) IsAnAPIObject() {}
 func (*DeleteOptions) IsAnAPIObject()             {}
 func (*ListOptions) IsAnAPIObject()               {}
+func (*PodLogOptions) IsAnAPIObject()             {}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -1118,6 +1118,17 @@ type ListOptions struct {
 	ResourceVersion string `json:"resourceVersion" description:"when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history"`
 }
 
+// PodLogOptions is the query options for a Pod's logs REST call
+type PodLogOptions struct {
+	TypeMeta `json:",inline"`
+
+	// Container for which to return logs
+	Container string `json:"container,omitempty" description:"the container for which to stream logs; defaults to only container if there is one container in the pod"`
+
+	// If true, follow the logs for the pod
+	Follow bool `json:"follow,omitempty" description:"follow the log stream of the pod; defaults to false"`
+}
+
 // Status is a return value for calls that don't return other objects.
 // TODO: this could go in apiserver, but I'm including it here so clients needn't
 // import both.

--- a/pkg/api/v1beta3/register.go
+++ b/pkg/api/v1beta3/register.go
@@ -59,6 +59,7 @@ func init() {
 		&PersistentVolumeClaimList{},
 		&DeleteOptions{},
 		&ListOptions{},
+		&PodLogOptions{},
 	)
 	// Legacy names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta3", "Minion", &Node{})
@@ -98,3 +99,4 @@ func (*PersistentVolumeClaim) IsAnAPIObject()     {}
 func (*PersistentVolumeClaimList) IsAnAPIObject() {}
 func (*DeleteOptions) IsAnAPIObject()             {}
 func (*ListOptions) IsAnAPIObject()               {}
+func (*PodLogOptions) IsAnAPIObject()             {}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -1236,6 +1236,17 @@ type ListOptions struct {
 	ResourceVersion string `json:"resourceVersion" description:"when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history"`
 }
 
+// PodLogOptions is the query options for a Pod's logs REST call
+type PodLogOptions struct {
+	TypeMeta `json:",inline"`
+
+	// Container for which to return logs
+	Container string `json:"container,omitempty" description:"the container for which to stream logs; defaults to only container if there is one container in the pod"`
+
+	// If true, follow the logs for the pod
+	Follow bool `json:"follow,omitempty" description:"follow the log stream of the pod; defaults to false"`
+}
+
 // Status is a return value for calls that don't return other objects.
 type Status struct {
 	TypeMeta `json:",inline"`

--- a/pkg/kubelet/handlers.go
+++ b/pkg/kubelet/handlers.go
@@ -18,9 +18,7 @@ package kubelet
 
 import (
 	"fmt"
-	"io"
 	"net"
-	"net/http"
 	"strconv"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -94,22 +92,4 @@ func (h *httpActionHandler) Run(podFullName string, uid types.UID, container *ap
 	url := fmt.Sprintf("http://%s/%s", net.JoinHostPort(host, strconv.Itoa(port)), handler.HTTPGet.Path)
 	_, err := h.client.Get(url)
 	return err
-}
-
-// FlushWriter provides wrapper for responseWriter with HTTP streaming capabilities
-type FlushWriter struct {
-	flusher http.Flusher
-	writer  io.Writer
-}
-
-// Write is a FlushWriter implementation of the io.Writer that sends any buffered data to the client.
-func (fw *FlushWriter) Write(p []byte) (n int, err error) {
-	n, err = fw.writer.Write(p)
-	if err != nil {
-		return
-	}
-	if fw.flusher != nil {
-		fw.flusher.Flush()
-	}
-	return
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -357,8 +357,8 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 
 // init initializes master.
 func (m *Master) init(c *Config) {
-	podStorage, bindingStorage, podStatusStorage := podetcd.NewStorage(c.EtcdHelper)
-	podRegistry := pod.NewRegistry(podStorage)
+	podStorage := podetcd.NewStorage(c.EtcdHelper)
+	podRegistry := pod.NewRegistry(podStorage.Pod)
 
 	eventRegistry := event.NewEtcdRegistry(c.EtcdHelper, uint64(c.EventTTL.Seconds()))
 	limitRangeRegistry := limitrange.NewEtcdRegistry(c.EtcdHelper)
@@ -385,10 +385,10 @@ func (m *Master) init(c *Config) {
 
 	// TODO: Factor out the core API registration
 	m.storage = map[string]rest.Storage{
-		"pods":         podStorage,
-		"pods/status":  podStatusStorage,
-		"pods/binding": bindingStorage,
-		"bindings":     bindingStorage,
+		"pods":         podStorage.Pod,
+		"pods/status":  podStorage.Status,
+		"pods/binding": podStorage.Binding,
+		"bindings":     podStorage.Binding,
 
 		"replicationControllers": controllerStorage,
 		"services":               service.NewStorage(m.serviceRegistry, c.Cloud, m.nodeRegistry, m.endpointRegistry, m.portalNet, c.ClusterName),

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -357,7 +357,7 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 
 // init initializes master.
 func (m *Master) init(c *Config) {
-	podStorage := podetcd.NewStorage(c.EtcdHelper)
+	podStorage := podetcd.NewStorage(c.EtcdHelper, c.KubeletClient)
 	podRegistry := pod.NewRegistry(podStorage.Pod)
 
 	eventRegistry := event.NewEtcdRegistry(c.EtcdHelper, uint64(c.EventTTL.Seconds()))
@@ -387,6 +387,7 @@ func (m *Master) init(c *Config) {
 	m.storage = map[string]rest.Storage{
 		"pods":         podStorage.Pod,
 		"pods/status":  podStorage.Status,
+		"pods/log":     podStorage.Log,
 		"pods/binding": podStorage.Binding,
 		"bindings":     podStorage.Binding,
 

--- a/pkg/registry/etcd/etcd_test.go
+++ b/pkg/registry/etcd/etcd_test.go
@@ -44,7 +44,7 @@ func NewTestEtcdRegistry(client tools.EtcdClient) *Registry {
 
 func NewTestEtcdRegistryWithPods(client tools.EtcdClient) *Registry {
 	helper := tools.NewEtcdHelper(client, latest.Codec)
-	podStorage := podetcd.NewStorage(helper)
+	podStorage := podetcd.NewStorage(helper, nil)
 	endpointStorage := endpointetcd.NewStorage(helper)
 	registry := NewRegistry(helper, pod.NewRegistry(podStorage.Pod), endpoint.NewRegistry(endpointStorage))
 	return registry

--- a/pkg/registry/etcd/etcd_test.go
+++ b/pkg/registry/etcd/etcd_test.go
@@ -44,9 +44,9 @@ func NewTestEtcdRegistry(client tools.EtcdClient) *Registry {
 
 func NewTestEtcdRegistryWithPods(client tools.EtcdClient) *Registry {
 	helper := tools.NewEtcdHelper(client, latest.Codec)
-	podStorage, _, _ := podetcd.NewStorage(helper)
+	podStorage := podetcd.NewStorage(helper)
 	endpointStorage := endpointetcd.NewStorage(helper)
-	registry := NewRegistry(helper, pod.NewRegistry(podStorage), endpoint.NewRegistry(endpointStorage))
+	registry := NewRegistry(helper, pod.NewRegistry(podStorage.Pod), endpoint.NewRegistry(endpointStorage))
 	return registry
 }
 

--- a/pkg/registry/generic/rest/doc.go
+++ b/pkg/registry/generic/rest/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rest has generic implementations of resources used for
+// REST responses
+package rest

--- a/pkg/registry/generic/rest/streamer.go
+++ b/pkg/registry/generic/rest/streamer.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
+)
+
+// LocationStreamer is a resource that streams the contents of a particular
+// location URL
+type LocationStreamer struct {
+	Location    *url.URL
+	Transport   http.RoundTripper
+	ContentType string
+	Flush       bool
+}
+
+// a LocationStreamer must implement a rest.ResourceStreamer
+var _ rest.ResourceStreamer = &LocationStreamer{}
+
+// IsAnAPIObject marks this object as a runtime.Object
+func (*LocationStreamer) IsAnAPIObject() {}
+
+// InputStream returns a stream with the contents of the URL location. If no location is provided,
+// a null stream is returned.
+func (s *LocationStreamer) InputStream(apiVersion, acceptHeader string) (stream io.ReadCloser, flush bool, contentType string, err error) {
+	if s.Location == nil {
+		// If no location was provided, return a null stream
+		return nil, false, "", nil
+	}
+	transport := s.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	client := &http.Client{Transport: transport}
+	resp, err := client.Get(s.Location.String())
+	if err != nil {
+		return
+	}
+	contentType = s.ContentType
+	if len(contentType) == 0 {
+		contentType = resp.Header.Get("Content-Type")
+		if len(contentType) > 0 {
+			contentType = strings.TrimSpace(strings.SplitN(contentType, ";", 2)[0])
+		}
+	}
+	flush = s.Flush
+	stream = resp.Body
+	return
+}

--- a/pkg/registry/generic/rest/streamer_test.go
+++ b/pkg/registry/generic/rest/streamer_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestInputStreamReader(t *testing.T) {
+	resultString := "Test output"
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(resultString))
+	}))
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Errorf("Error parsing server URL: %v", err)
+		return
+	}
+	streamer := &LocationStreamer{
+		Location: u,
+	}
+	readCloser, _, _, err := streamer.InputStream("v1beta1", "text/plain")
+	if err != nil {
+		t.Errorf("Unexpected error when getting stream: %v", err)
+		return
+	}
+	defer readCloser.Close()
+	result, err := ioutil.ReadAll(readCloser)
+	if string(result) != resultString {
+		t.Errorf("Stream content does not match. Got: %s. Expected: %s.", string(result), resultString)
+	}
+}
+
+func TestInputStreamNullLocation(t *testing.T) {
+	streamer := &LocationStreamer{
+		Location: nil,
+	}
+	readCloser, _, _, err := streamer.InputStream("v1beta1", "text/plain")
+	if err != nil {
+		t.Errorf("Unexpected error when getting stream with null location: %v", err)
+	}
+	if readCloser != nil {
+		t.Errorf("Expected stream to be nil. Got: %#v", readCloser)
+	}
+}
+
+type testTransport struct {
+	body string
+	err  error
+}
+
+func (tt *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	r := bufio.NewReader(bytes.NewBufferString(tt.body))
+	return http.ReadResponse(r, req)
+}
+
+func fakeTransport(mime, message string) http.RoundTripper {
+	content := fmt.Sprintf("HTTP/1.1 200 OK\nContent-Type: %s\n\n%s", mime, message)
+	return &testTransport{body: content}
+}
+
+func TestInputStreamContentType(t *testing.T) {
+	location, _ := url.Parse("http://www.example.com")
+	streamer := &LocationStreamer{
+		Location:  location,
+		Transport: fakeTransport("application/json", "hello world"),
+	}
+	readCloser, _, contentType, err := streamer.InputStream("v1beta1", "text/plain")
+	if err != nil {
+		t.Errorf("Unexpected error when getting stream: %v", err)
+		return
+	}
+	defer readCloser.Close()
+	if contentType != "application/json" {
+		t.Errorf("Unexpected content type. Got: %s. Expected: application/json", contentType)
+	}
+}
+
+func TestInputStreamTransport(t *testing.T) {
+	message := "hello world"
+	location, _ := url.Parse("http://www.example.com")
+	streamer := &LocationStreamer{
+		Location:  location,
+		Transport: fakeTransport("text/plain", message),
+	}
+	readCloser, _, _, err := streamer.InputStream("v1beta1", "text/plain")
+	if err != nil {
+		t.Errorf("Unexpected error when getting stream: %v", err)
+		return
+	}
+	defer readCloser.Close()
+	result, err := ioutil.ReadAll(readCloser)
+	if string(result) != message {
+		t.Errorf("Stream content does not match. Got: %s. Expected: %s.", string(result), message)
+	}
+}

--- a/pkg/registry/pod/etcd/etcd_test.go
+++ b/pkg/registry/pod/etcd/etcd_test.go
@@ -47,8 +47,8 @@ func newHelper(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper) {
 
 func newStorage(t *testing.T) (*REST, *BindingREST, *StatusREST, *tools.FakeEtcdClient, tools.EtcdHelper) {
 	fakeEtcdClient, h := newHelper(t)
-	storage, bindingStorage, statusStorage := NewStorage(h)
-	return storage, bindingStorage, statusStorage, fakeEtcdClient, h
+	storage := NewStorage(h)
+	return storage.Pod, storage.Binding, storage.Status, fakeEtcdClient, h
 }
 
 func validNewPod() *api.Pod {
@@ -89,7 +89,7 @@ func TestStorage(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
-	storage, _, _ := NewStorage(helper)
+	storage := NewStorage(helper).Pod
 	test := resttest.New(t, storage, fakeEtcdClient.SetError)
 	pod := validNewPod()
 	pod.ObjectMeta = api.ObjectMeta{}
@@ -107,7 +107,7 @@ func TestCreate(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
-	storage, _, _ := NewStorage(helper)
+	storage := NewStorage(helper).Pod
 	test := resttest.New(t, storage, fakeEtcdClient.SetError)
 
 	createFn := func() runtime.Object {
@@ -143,7 +143,7 @@ func expectPod(t *testing.T, out runtime.Object) (*api.Pod, bool) {
 func TestCreateRegistryError(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
 	fakeEtcdClient.Err = fmt.Errorf("test error")
-	storage, _, _ := NewStorage(helper)
+	storage := NewStorage(helper).Pod
 
 	pod := validNewPod()
 	_, err := storage.Create(api.NewDefaultContext(), pod)
@@ -154,7 +154,7 @@ func TestCreateRegistryError(t *testing.T) {
 
 func TestCreateSetsFields(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
-	storage, _, _ := NewStorage(helper)
+	storage := NewStorage(helper).Pod
 	pod := validNewPod()
 	_, err := storage.Create(api.NewDefaultContext(), pod)
 	if err != fakeEtcdClient.Err {
@@ -176,7 +176,7 @@ func TestCreateSetsFields(t *testing.T) {
 func TestListError(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
 	fakeEtcdClient.Err = fmt.Errorf("test error")
-	storage, _, _ := NewStorage(helper)
+	storage := NewStorage(helper).Pod
 	pods, err := storage.List(api.NewDefaultContext(), labels.Everything(), fields.Everything())
 	if err != fakeEtcdClient.Err {
 		t.Fatalf("Expected %#v, Got %#v", fakeEtcdClient.Err, err)
@@ -194,7 +194,7 @@ func TestListEmptyPodList(t *testing.T) {
 		E: fakeEtcdClient.NewError(tools.EtcdErrorCodeNotFound),
 	}
 
-	storage, _, _ := NewStorage(helper)
+	storage := NewStorage(helper).Pod
 	pods, err := storage.List(api.NewContext(), labels.Everything(), fields.Everything())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -231,7 +231,7 @@ func TestListPodList(t *testing.T) {
 			},
 		},
 	}
-	storage, _, _ := NewStorage(helper)
+	storage := NewStorage(helper).Pod
 
 	podsObj, err := storage.List(api.NewDefaultContext(), labels.Everything(), fields.Everything())
 	pods := podsObj.(*api.PodList)
@@ -280,7 +280,7 @@ func TestListPodListSelection(t *testing.T) {
 			},
 		},
 	}
-	storage, _, _ := NewStorage(helper)
+	storage := NewStorage(helper).Pod
 
 	ctx := api.NewDefaultContext()
 
@@ -345,7 +345,7 @@ func TestListPodListSelection(t *testing.T) {
 }
 
 func TestPodDecode(t *testing.T) {
-	storage, _, _ := NewStorage(tools.EtcdHelper{})
+	storage := NewStorage(tools.EtcdHelper{}).Pod
 	expected := validNewPod()
 	body, err := latest.Codec.Encode(expected)
 	if err != nil {
@@ -375,7 +375,7 @@ func TestGet(t *testing.T) {
 			},
 		},
 	}
-	storage, _, _ := NewStorage(helper)
+	storage := NewStorage(helper).Pod
 
 	obj, err := storage.Get(api.WithNamespace(api.NewContext(), "test"), "foo")
 	pod := obj.(*api.Pod)
@@ -392,7 +392,7 @@ func TestGet(t *testing.T) {
 func TestPodStorageValidatesCreate(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
 	fakeEtcdClient.Err = fmt.Errorf("test error")
-	storage, _, _ := NewStorage(helper)
+	storage := NewStorage(helper).Pod
 
 	pod := validNewPod()
 	pod.Labels = map[string]string{
@@ -410,7 +410,7 @@ func TestPodStorageValidatesCreate(t *testing.T) {
 // TODO: remove, this is covered by RESTTest.TestCreate
 func TestCreatePod(t *testing.T) {
 	_, helper := newHelper(t)
-	storage, _, _ := NewStorage(helper)
+	storage := NewStorage(helper).Pod
 
 	pod := validNewPod()
 	obj, err := storage.Create(api.NewDefaultContext(), pod)
@@ -432,7 +432,7 @@ func TestCreatePod(t *testing.T) {
 // TODO: remove, this is covered by RESTTest.TestCreate
 func TestCreateWithConflictingNamespace(t *testing.T) {
 	_, helper := newHelper(t)
-	storage, _, _ := NewStorage(helper)
+	storage := NewStorage(helper).Pod
 
 	pod := validNewPod()
 	pod.Namespace = "not-default"
@@ -461,7 +461,7 @@ func TestUpdateWithConflictingNamespace(t *testing.T) {
 			},
 		},
 	}
-	storage, _, _ := NewStorage(helper)
+	storage := NewStorage(helper).Pod
 
 	pod := validChangedPod()
 	pod.Namespace = "not-default"
@@ -578,7 +578,7 @@ func TestResourceLocation(t *testing.T) {
 				},
 			},
 		}
-		storage, _, _ := NewStorage(helper)
+		storage := NewStorage(helper).Pod
 
 		redirector := rest.Redirector(storage)
 		location, _, err := redirector.ResourceLocation(api.NewDefaultContext(), tc.query)
@@ -616,7 +616,7 @@ func TestDeletePod(t *testing.T) {
 			},
 		},
 	}
-	storage, _, _ := NewStorage(helper)
+	storage := NewStorage(helper).Pod
 
 	_, err := storage.Delete(api.NewDefaultContext(), "foo", nil)
 	if err != nil {

--- a/pkg/registry/pod/etcd/etcd_test.go
+++ b/pkg/registry/pod/etcd/etcd_test.go
@@ -47,7 +47,7 @@ func newHelper(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper) {
 
 func newStorage(t *testing.T) (*REST, *BindingREST, *StatusREST, *tools.FakeEtcdClient, tools.EtcdHelper) {
 	fakeEtcdClient, h := newHelper(t)
-	storage := NewStorage(h)
+	storage := NewStorage(h, nil)
 	return storage.Pod, storage.Binding, storage.Status, fakeEtcdClient, h
 }
 
@@ -89,7 +89,7 @@ func TestStorage(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
-	storage := NewStorage(helper).Pod
+	storage := NewStorage(helper, nil).Pod
 	test := resttest.New(t, storage, fakeEtcdClient.SetError)
 	pod := validNewPod()
 	pod.ObjectMeta = api.ObjectMeta{}
@@ -107,7 +107,7 @@ func TestCreate(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
-	storage := NewStorage(helper).Pod
+	storage := NewStorage(helper, nil).Pod
 	test := resttest.New(t, storage, fakeEtcdClient.SetError)
 
 	createFn := func() runtime.Object {
@@ -143,7 +143,7 @@ func expectPod(t *testing.T, out runtime.Object) (*api.Pod, bool) {
 func TestCreateRegistryError(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
 	fakeEtcdClient.Err = fmt.Errorf("test error")
-	storage := NewStorage(helper).Pod
+	storage := NewStorage(helper, nil).Pod
 
 	pod := validNewPod()
 	_, err := storage.Create(api.NewDefaultContext(), pod)
@@ -154,7 +154,7 @@ func TestCreateRegistryError(t *testing.T) {
 
 func TestCreateSetsFields(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
-	storage := NewStorage(helper).Pod
+	storage := NewStorage(helper, nil).Pod
 	pod := validNewPod()
 	_, err := storage.Create(api.NewDefaultContext(), pod)
 	if err != fakeEtcdClient.Err {
@@ -176,7 +176,7 @@ func TestCreateSetsFields(t *testing.T) {
 func TestListError(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
 	fakeEtcdClient.Err = fmt.Errorf("test error")
-	storage := NewStorage(helper).Pod
+	storage := NewStorage(helper, nil).Pod
 	pods, err := storage.List(api.NewDefaultContext(), labels.Everything(), fields.Everything())
 	if err != fakeEtcdClient.Err {
 		t.Fatalf("Expected %#v, Got %#v", fakeEtcdClient.Err, err)
@@ -194,7 +194,7 @@ func TestListEmptyPodList(t *testing.T) {
 		E: fakeEtcdClient.NewError(tools.EtcdErrorCodeNotFound),
 	}
 
-	storage := NewStorage(helper).Pod
+	storage := NewStorage(helper, nil).Pod
 	pods, err := storage.List(api.NewContext(), labels.Everything(), fields.Everything())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -231,7 +231,7 @@ func TestListPodList(t *testing.T) {
 			},
 		},
 	}
-	storage := NewStorage(helper).Pod
+	storage := NewStorage(helper, nil).Pod
 
 	podsObj, err := storage.List(api.NewDefaultContext(), labels.Everything(), fields.Everything())
 	pods := podsObj.(*api.PodList)
@@ -280,7 +280,7 @@ func TestListPodListSelection(t *testing.T) {
 			},
 		},
 	}
-	storage := NewStorage(helper).Pod
+	storage := NewStorage(helper, nil).Pod
 
 	ctx := api.NewDefaultContext()
 
@@ -345,7 +345,7 @@ func TestListPodListSelection(t *testing.T) {
 }
 
 func TestPodDecode(t *testing.T) {
-	storage := NewStorage(tools.EtcdHelper{}).Pod
+	storage := NewStorage(tools.EtcdHelper{}, nil).Pod
 	expected := validNewPod()
 	body, err := latest.Codec.Encode(expected)
 	if err != nil {
@@ -375,7 +375,7 @@ func TestGet(t *testing.T) {
 			},
 		},
 	}
-	storage := NewStorage(helper).Pod
+	storage := NewStorage(helper, nil).Pod
 
 	obj, err := storage.Get(api.WithNamespace(api.NewContext(), "test"), "foo")
 	pod := obj.(*api.Pod)
@@ -392,7 +392,7 @@ func TestGet(t *testing.T) {
 func TestPodStorageValidatesCreate(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
 	fakeEtcdClient.Err = fmt.Errorf("test error")
-	storage := NewStorage(helper).Pod
+	storage := NewStorage(helper, nil).Pod
 
 	pod := validNewPod()
 	pod.Labels = map[string]string{
@@ -410,7 +410,7 @@ func TestPodStorageValidatesCreate(t *testing.T) {
 // TODO: remove, this is covered by RESTTest.TestCreate
 func TestCreatePod(t *testing.T) {
 	_, helper := newHelper(t)
-	storage := NewStorage(helper).Pod
+	storage := NewStorage(helper, nil).Pod
 
 	pod := validNewPod()
 	obj, err := storage.Create(api.NewDefaultContext(), pod)
@@ -432,7 +432,7 @@ func TestCreatePod(t *testing.T) {
 // TODO: remove, this is covered by RESTTest.TestCreate
 func TestCreateWithConflictingNamespace(t *testing.T) {
 	_, helper := newHelper(t)
-	storage := NewStorage(helper).Pod
+	storage := NewStorage(helper, nil).Pod
 
 	pod := validNewPod()
 	pod.Namespace = "not-default"
@@ -461,7 +461,7 @@ func TestUpdateWithConflictingNamespace(t *testing.T) {
 			},
 		},
 	}
-	storage := NewStorage(helper).Pod
+	storage := NewStorage(helper, nil).Pod
 
 	pod := validChangedPod()
 	pod.Namespace = "not-default"
@@ -578,7 +578,7 @@ func TestResourceLocation(t *testing.T) {
 				},
 			},
 		}
-		storage := NewStorage(helper).Pod
+		storage := NewStorage(helper, nil).Pod
 
 		redirector := rest.Redirector(storage)
 		location, _, err := redirector.ResourceLocation(api.NewDefaultContext(), tc.query)
@@ -616,7 +616,7 @@ func TestDeletePod(t *testing.T) {
 			},
 		},
 	}
-	storage := NewStorage(helper).Pod
+	storage := NewStorage(helper, nil).Pod
 
 	_, err := storage.Delete(api.NewDefaultContext(), "foo", nil)
 	if err != nil {

--- a/pkg/util/flushwriter/doc.go
+++ b/pkg/util/flushwriter/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package flushwriter implements a wrapper for a writer that flushes on every
+// write if that writer implements the io.Flusher interface
+package flushwriter

--- a/pkg/util/flushwriter/writer.go
+++ b/pkg/util/flushwriter/writer.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flushwriter
+
+import (
+	"io"
+	"net/http"
+)
+
+// Wrap wraps an io.Writer into a writer that flushes after every write if
+// the writer implements the Flusher interface.
+func Wrap(w io.Writer) io.Writer {
+	fw := &flushWriter{
+		writer: w,
+	}
+	if flusher, ok := w.(http.Flusher); ok {
+		fw.flusher = flusher
+	}
+	return fw
+}
+
+// flushWriter provides wrapper for responseWriter with HTTP streaming capabilities
+type flushWriter struct {
+	flusher http.Flusher
+	writer  io.Writer
+}
+
+// Write is a FlushWriter implementation of the io.Writer that sends any buffered
+// data to the client.
+func (fw *flushWriter) Write(p []byte) (n int, err error) {
+	n, err = fw.writer.Write(p)
+	if err != nil {
+		return
+	}
+	if fw.flusher != nil {
+		fw.flusher.Flush()
+	}
+	return
+}

--- a/pkg/util/flushwriter/writer_test.go
+++ b/pkg/util/flushwriter/writer_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flushwriter
+
+import (
+	"fmt"
+	"testing"
+)
+
+type writerWithFlush struct {
+	writeCount, flushCount int
+	err                    error
+}
+
+func (w *writerWithFlush) Flush() {
+	w.flushCount++
+}
+
+func (w *writerWithFlush) Write(p []byte) (n int, err error) {
+	w.writeCount++
+	return len(p), w.err
+}
+
+type writerWithNoFlush struct {
+	writeCount int
+}
+
+func (w *writerWithNoFlush) Write(p []byte) (n int, err error) {
+	w.writeCount++
+	return len(p), nil
+}
+
+func TestWriteWithFlush(t *testing.T) {
+	w := &writerWithFlush{}
+	fw := Wrap(w)
+	for i := 0; i < 10; i++ {
+		_, err := fw.Write([]byte("Test write"))
+		if err != nil {
+			t.Errorf("Unexpected error while writing with flush writer: %v", err)
+		}
+	}
+	if w.flushCount != 10 {
+		t.Errorf("Flush not called the expected number of times. Actual: %d", w.flushCount)
+	}
+	if w.writeCount != 10 {
+		t.Errorf("Write not called the expected number of times. Actual: %d", w.writeCount)
+	}
+}
+
+func TestWriteWithoutFlush(t *testing.T) {
+	w := &writerWithNoFlush{}
+	fw := Wrap(w)
+	for i := 0; i < 10; i++ {
+		_, err := fw.Write([]byte("Test write"))
+		if err != nil {
+			t.Errorf("Unexpected error while writing with flush writer: %v", err)
+		}
+	}
+	if w.writeCount != 10 {
+		t.Errorf("Write not called the expected number of times. Actual: %d", w.writeCount)
+	}
+}
+
+func TestWriteError(t *testing.T) {
+	e := fmt.Errorf("Error")
+	w := &writerWithFlush{err: e}
+	fw := Wrap(w)
+	_, err := fw.Write([]byte("Test write"))
+	if err != e {
+		t.Errorf("Did not get expected error. Got: %#v", err)
+	}
+}


### PR DESCRIPTION
Creates a subresource for pods that responds with the log for that pod. This enables URLs such as:
/api/&lt;version&gt;/pods/&lt;podname&gt;/log
/api/&lt;version&gt;/namespace/&lt;ns&gt;/pods/&lt;podname&gt;/log

The following query parameter are accepted:
follow=[true/false] -- set to true if you want to follow the log
container=[container_name] -- specify the container for which to obtain the log. Must be specified if the pod has more than one container. If only one container exists, the parameter is not required.
