### PR TITLE
Disable nginx service

### DIFF
--- a/cluster/saltbase/salt/nginx/init.sls
+++ b/cluster/saltbase/salt/nginx/init.sls
@@ -48,8 +48,6 @@ stop_nginx-service:
   service.dead:
     - name: nginx
     - enable: None
-    - watch:
-      - file: /etc/kubernetes/manifests/nginx.json
 
 {% else %}
 nginx-service:


### PR DESCRIPTION
Without this change, a noticed that existing nginx service did not seem to die, till i re-ran salt scripts on master.
We need to absolutely disable nginx service if we are running nginx in a pod.

Noone has noticed this yet because, we atleast have one nginx process running (either in or outside the pod) listening on the right port.

@brendanburns 
