### PR TITLE
Make minion disk size in GCE kube-up customizable

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -22,7 +22,7 @@ MASTER_SIZE=${MASTER_SIZE:-n1-standard-1}
 MINION_SIZE=${MINION_SIZE:-n1-standard-1}
 NUM_MINIONS=${NUM_MINIONS:-4}
 MINION_DISK_TYPE=pd-standard
-MINION_DISK_SIZE=100GB
+MINION_DISK_SIZE=${MINION_DISK_SIZE:-100GB}
 # TODO(dchen1107): Filed an internal issue to create an alias
 # for containervm image, so that gcloud will expand this
 # to the latest supported image.


### PR DESCRIPTION
I needed this when I wanted to test a large number of nodes and was hitting quotas.
