### PR TITLE
Add support for HTTP basic auth to the kube-apiserver.

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -61,6 +61,7 @@ type APIServer struct {
 	CloudProvider              string
 	CloudConfigFile            string
 	EventTTL                   time.Duration
+	BasicAuthFile              string
 	ClientCAFile               string
 	TokenAuthFile              string
 	AuthorizationMode          string
@@ -143,6 +144,7 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.CloudProvider, "cloud_provider", s.CloudProvider, "The provider for cloud services.  Empty string for no provider.")
 	fs.StringVar(&s.CloudConfigFile, "cloud_config", s.CloudConfigFile, "The path to the cloud provider configuration file.  Empty string for no configuration file.")
 	fs.DurationVar(&s.EventTTL, "event_ttl", s.EventTTL, "Amount of time to retain events. Default 1 hour.")
+	fs.StringVar(&s.BasicAuthFile, "basic_auth_file", s.BasicAuthFile, "If set, the file that will be used to secure the secure port of the API server via http basic authentication.")
 	fs.StringVar(&s.ClientCAFile, "client_ca_file", s.ClientCAFile, "If set, any request presenting a client certificate signed by one of the authorities in the client_ca_file is authenticated with an identity corresponding to the CommonName of the client certificate.")
 	fs.StringVar(&s.TokenAuthFile, "token_auth_file", s.TokenAuthFile, "If set, the file that will be used to secure the secure port of the API server via token authentication.")
 	fs.StringVar(&s.AuthorizationMode, "authorization_mode", s.AuthorizationMode, "Selects how to do authorization on the secure port.  One of: "+strings.Join(apiserver.AuthorizationModeChoices, ","))
@@ -229,7 +231,7 @@ func (s *APIServer) Run(_ []string) error {
 
 	n := net.IPNet(s.PortalNet)
 
-	authenticator, err := apiserver.NewAuthenticator(s.ClientCAFile, s.TokenAuthFile)
+	authenticator, err := apiserver.NewAuthenticator(s.BasicAuthFile, s.ClientCAFile, s.TokenAuthFile)
 	if err != nil {
 		glog.Fatalf("Invalid Authentication Config: %v", err)
 	}

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,6 +1,13 @@
 # Authentication Plugins
 
-Kubernetes uses tokens or client certificates to authenticate users for API calls.
+Kubernetes uses http basic auth, tokens, or client certificates to authenticate users for API calls.
+
+Basic authentication is enabled by passing the `--basic_auth_file=SOMEFILE`
+option to apiserver. Currently, the basic auth credentials last indefinitely,
+and the password cannot be changed without restarting apiserver.
+
+The basic auth file format is implemented in `plugin/pkg/auth/authenticator/password/passwordfile/...`
+and is a csv file with 3 columns: password, user name, user id.
 
 Client certificate authentication is enabled by passing the `--client_ca_file=SOMEFILE`
 option to apiserver. The referenced file must contain one or more certificates authorities

--- a/plugin/pkg/auth/authenticator/password/passwordfile/passwordfile.go
+++ b/plugin/pkg/auth/authenticator/password/passwordfile/passwordfile.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package passwordfile
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
+)
+
+type PasswordAuthenticator struct {
+	passwords map[string]*user.DefaultInfo
+}
+
+// NewCSV returns a PasswordAuthenticator, populated from a CSV file.
+// The CSV file must contain records in the format "password,username,useruid"
+func NewCSV(path string) (*PasswordAuthenticator, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	passwords := make(map[string]*user.DefaultInfo)
+	reader := csv.NewReader(file)
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if len(record) < 3 {
+			return nil, fmt.Errorf("password file '%s' must have at least 3 columns (password, user name, user uid), found %d", path, len(record))
+		}
+		obj := &user.DefaultInfo{
+			Name: record[1],
+			UID:  record[2],
+		}
+		passwords[record[0]] = obj
+	}
+
+	return &PasswordAuthenticator{passwords}, nil
+}
+
+func (a *PasswordAuthenticator) AuthenticatePassword(username, password string) (user.Info, bool, error) {
+	user, ok := a.passwords[password]
+	if !ok {
+		return nil, false, nil
+	}
+	if user.Name != username {
+		return nil, false, nil
+	}
+	return user, true, nil
+}

--- a/plugin/pkg/auth/authenticator/password/passwordfile/passwordfile_test.go
+++ b/plugin/pkg/auth/authenticator/password/passwordfile/passwordfile_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package passwordfile
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
+)
+
+func TestPasswordFile(t *testing.T) {
+	auth, err := newWithContents(t, `
+password1,user1,uid1
+password2,user2,uid2
+`)
+	if err != nil {
+		t.Fatalf("unable to read passwordfile: %v", err)
+	}
+
+	testCases := []struct {
+		Username string
+		Password string
+		User     *user.DefaultInfo
+		Ok       bool
+		Err      bool
+	}{
+		{
+			Username: "user1",
+			Password: "password1",
+			User:     &user.DefaultInfo{Name: "user1", UID: "uid1"},
+			Ok:       true,
+		},
+		{
+			Username: "user2",
+			Password: "password2",
+			User:     &user.DefaultInfo{Name: "user2", UID: "uid2"},
+			Ok:       true,
+		},
+		{
+			Username: "user1",
+			Password: "password2",
+		},
+		{
+			Username: "user2",
+			Password: "password1",
+		},
+		{
+			Username: "user3",
+			Password: "password3",
+		},
+		{
+			Username: "user4",
+			Password: "password4",
+		},
+	}
+	for i, testCase := range testCases {
+		user, ok, err := auth.AuthenticatePassword(testCase.Username, testCase.Password)
+		if err != nil {
+			t.Errorf("%d: unexpected error: %v", i, err)
+		}
+		if testCase.User == nil {
+			if user != nil {
+				t.Errorf("%d: unexpected non-nil user %#v", i, user)
+			}
+		} else if !reflect.DeepEqual(testCase.User, user) {
+			t.Errorf("%d: expected user %#v, got %#v", i, testCase.User, user)
+		}
+		if testCase.Ok != ok {
+			t.Errorf("%d: expected auth %v, got %v", i, testCase.Ok, ok)
+		}
+	}
+}
+
+func TestBadPasswordFile(t *testing.T) {
+	if _, err := newWithContents(t, `
+password1,user1,uid1
+password2,user2,uid2
+password3,user3
+password4
+`); err == nil {
+		t.Fatalf("unexpected non error")
+	}
+}
+
+func TestInsufficientColumnsPasswordFile(t *testing.T) {
+	if _, err := newWithContents(t, "password4\n"); err == nil {
+		t.Fatalf("unexpected non error")
+	}
+}
+
+func newWithContents(t *testing.T, contents string) (auth *PasswordAuthenticator, err error) {
+	f, err := ioutil.TempFile("", "passwordfile_test")
+	if err != nil {
+		t.Fatalf("unexpected error creating passwordfile: %v", err)
+	}
+	f.Close()
+	defer os.Remove(f.Name())
+
+	if err := ioutil.WriteFile(f.Name(), []byte(contents), 0700); err != nil {
+		t.Fatalf("unexpected error writing passwordfile: %v", err)
+	}
+
+	return NewCSV(f.Name())
+}


### PR DESCRIPTION
Part 1 of getting rid of nginx. 
