### PR TITLE
Fix exec/portforward minions->nodes

### DIFF
--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -134,7 +134,7 @@ func RunExec(f *Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cobra.C
 
 	req := client.RESTClient.Get().
 		Prefix("proxy").
-		Resource("minions").
+		Resource("nodes").
 		Name(pod.Spec.Host).
 		Suffix("exec", namespace, podName, containerName)
 

--- a/pkg/kubectl/cmd/portforward.go
+++ b/pkg/kubectl/cmd/portforward.go
@@ -104,7 +104,7 @@ func RunPortForward(f *Factory, cmd *cobra.Command, args []string) error {
 
 	req := client.RESTClient.Get().
 		Prefix("proxy").
-		Resource("minions").
+		Resource("nodes").
 		Name(pod.Spec.Host).
 		Suffix("portForward", namespace, podName)
 


### PR DESCRIPTION
Exec and port forward weren't working with v1beta3 because they were
proxying minions. Change minions to nodes. This appears to work with
v1beta1 and v1beta2 as well.
