### PR TITLE
Controller Plugin framework

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/daemon"
 	"k8s.io/kubernetes/pkg/controller/endpoint"
 	"k8s.io/kubernetes/pkg/controller/namespace"
@@ -70,8 +71,10 @@ type CMServer struct {
 	ResourceQuotaSyncPeriod           time.Duration
 	NamespaceSyncPeriod               time.Duration
 	PVClaimBinderSyncPeriod           time.Duration
-	VolumeConfigFlags                 VolumeConfigFlags
 	HorizontalPodAutoscalerSyncPeriod time.Duration
+	VolumeConfigFlags                 VolumeConfigFlags
+	ControllerConfigFlags             ControllerConfigFlags
+	PluginMgr                         controller.PluginMgr
 	RegisterRetryCount                int
 	NodeMonitorGracePeriod            time.Duration
 	NodeStartupGracePeriod            time.Duration
@@ -115,6 +118,16 @@ func NewCMServer() *CMServer {
 			// default values here
 			PersistentVolumeRecyclerTimeoutNFS: 300,
 		},
+		ControllerConfigFlags: ControllerConfigFlags{
+			// default values here
+			ServiceSyncPeriod:                 5 * time.Minute,
+			NodeSyncPeriod:                    10 * time.Second,
+			ResourceQuotaSyncPeriod:           10 * time.Second,
+			NamespaceSyncPeriod:               5 * time.Minute,
+			PVClaimBinderSyncPeriod:           10 * time.Second,
+			HorizontalPodAutoscalerSyncPeriod: 1 * time.Minute,
+		},
+		PluginMgr: controller.NewPluginMgr(),
 	}
 	return &s
 }
@@ -125,6 +138,17 @@ func NewCMServer() *CMServer {
 // part of the code which knows what plugins are supported and which CLI flags correspond to each plugin.
 type VolumeConfigFlags struct {
 	PersistentVolumeRecyclerTimeoutNFS int
+}
+
+// ControllerConfigFlags is used to bind CLI flags to variables.  This struct's purpose is exactly the same as
+// VolumeConfigFlags above and all comments apply, but for controller plugins instead of volume plugins.
+type ControllerConfigFlags struct {
+	ServiceSyncPeriod                 time.Duration
+	NodeSyncPeriod                    time.Duration
+	ResourceQuotaSyncPeriod           time.Duration
+	NamespaceSyncPeriod               time.Duration
+	PVClaimBinderSyncPeriod           time.Duration
+	HorizontalPodAutoscalerSyncPeriod time.Duration
 }
 
 // AddFlags adds flags for a specific CMServer to the specified FlagSet
@@ -142,8 +166,6 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.ResourceQuotaSyncPeriod, "resource-quota-sync-period", s.ResourceQuotaSyncPeriod, "The period for syncing quota usage status in the system")
 	fs.DurationVar(&s.NamespaceSyncPeriod, "namespace-sync-period", s.NamespaceSyncPeriod, "The period for syncing namespace life-cycle updates")
 	fs.DurationVar(&s.PVClaimBinderSyncPeriod, "pvclaimbinder-sync-period", s.PVClaimBinderSyncPeriod, "The period for syncing persistent volumes and persistent volume claims")
-	// TODO markt -- make this example a working config item with Recycler Config PR.
-	//	fs.MyExample(&s.VolumeConfig.PersistentVolumeRecyclerTimeoutNFS, "pv-recycler-timeout-nfs", s.VolumeConfig.PersistentVolumeRecyclerTimeoutNFS, "The minimum timeout for an NFS PV recycling operation")
 	fs.DurationVar(&s.HorizontalPodAutoscalerSyncPeriod, "horizontal-pod-autoscaler-sync-period", s.HorizontalPodAutoscalerSyncPeriod, "The period for syncing the number of pods in horizontal pod autoscaler.")
 	fs.DurationVar(&s.PodEvictionTimeout, "pod-eviction-timeout", s.PodEvictionTimeout, "The grace period for deleting pods on failed nodes.")
 	fs.Float32Var(&s.DeletingPodsQps, "deleting-pods-qps", 0.1, "Number of nodes per second on which pods are deleted in case of node failure.")
@@ -299,6 +321,22 @@ func (s *CMServer) Run(_ []string) error {
 		kubeClient,
 		serviceaccount.DefaultServiceAccountsControllerOptions(),
 	).Run()
+
+	ctrlHost := controller.NewHost(kubeClient)
+
+	err = s.PluginMgr.InitPlugins(ProbeControllerPlugins(s.ControllerConfigFlags), ctrlHost)
+	if err != nil {
+		glog.Fatalf("Failed to start controller PluginManager: %v", err)
+	}
+
+	s.PluginMgr.RunAll()
+	for _, plugin := range s.PluginMgr.Status() {
+		errMsg := ""
+		if plugin.Err != nil {
+			errMsg = fmt.Sprintf("  error: %v", plugin.Err)
+		}
+		glog.V(5).Infof("Plugin %s running: %s %s", plugin.Name, plugin.Running, errMsg)
+	}
 
 	select {}
 }

--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -25,6 +25,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
 
 	// Volume plugins
+	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/host_path"
 	"k8s.io/kubernetes/pkg/volume/nfs"
@@ -51,5 +52,18 @@ func ProbeRecyclableVolumePlugins(flags VolumeConfigFlags) []volume.VolumePlugin
 
 	allPlugins = append(allPlugins, host_path.ProbeVolumePlugins(hostPathConfig)...)
 	allPlugins = append(allPlugins, nfs.ProbeVolumePlugins(nfsConfig)...)
+	return allPlugins
+}
+
+// ProbeControllerPlugins collects all compiled-in plugins into an easy to use list.
+func ProbeControllerPlugins(flags ControllerConfigFlags) []controller.Plugin {
+	allPlugins := []controller.Plugin{}
+
+	_ = controller.ControllerConfig{
+		SyncPeriod: flags.ResourceQuotaSyncPeriod,
+	}
+
+	// allPlugins = append(allPlugins, resourcequota.ProbeControllerPlugins(config)...)
+
 	return allPlugins
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+// Controller represents a long-lived process that watches objects in the system and responds to events.
+// All start/start complexity (managing stop channels, etc.) is deliberately left to the plugin.
+type Controller interface {
+	// Run starts a controller.  This function must be idempotent.
+	Run() error
+	// Stop stops a controller.  This function must be idempotent.
+	Stop() error
+	// Status returns runtime status of the controller and any potential error that may have stopped it
+	Status() (bool, error)
+}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPluginMgrInit(t *testing.T) {
+	tests := map[string]struct {
+		expectedFailure bool
+		errorContains   string
+		plugins         []Plugin
+	}{
+		"invalid-name": {
+			expectedFailure: true,
+			errorContains:   "invalid name",
+			plugins: []Plugin{
+				&FakeControllerPlugin{"invalid!@#!#$%-name", nil},
+			},
+		},
+		"duplicate-plugins": {
+			expectedFailure: true,
+			errorContains:   "registered more than once",
+			plugins: []Plugin{
+				&FakeControllerPlugin{"valid-but-dupe-name", nil},
+				&FakeControllerPlugin{"valid-but-dupe-name", nil},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		mgr := NewPluginMgr()
+		err := mgr.InitPlugins(test.plugins, NewFakeHost(nil))
+
+		switch {
+
+		case err != nil && test.expectedFailure:
+			if !strings.Contains(err.Error(), test.errorContains) {
+				t.Errorf("Plugin test %s failed.  Expected '%s' to be part of '%s'", name, test.errorContains, err)
+			}
+		case err != nil && !test.expectedFailure:
+			t.Errorf("Unexpected failure for plugin test '%s': %v", name, err)
+		case err == nil && test.expectedFailure:
+			t.Errorf("Expected failure for '%s' but did not get an error", name)
+		}
+	}
+}
+
+func TestPluginMgrStartStop(t *testing.T) {
+	tests := map[string]struct {
+		expectedRunning int
+		plugins         []Plugin
+	}{
+		"both-running": {
+			expectedRunning: 2,
+			plugins: []Plugin{
+				&FakeControllerPlugin{"foo", nil},
+				&FakeControllerPlugin{"bar", nil},
+			},
+		},
+		"one-running": {
+			expectedRunning: 1,
+			plugins: []Plugin{
+				&FakeControllerPlugin{"valid-but-dupe-name", nil},
+				&FakeControllerPlugin{"valid-but-dupe-name", nil},
+			},
+		},
+		"none-running": {
+			expectedRunning: 0,
+			plugins: []Plugin{
+				&FakeControllerPlugin{"!@#$-invalid-name", nil},
+				&FakeControllerPlugin{"@#$%-invalid-name", nil},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		mgr := NewPluginMgr()
+		_ = mgr.InitPlugins(test.plugins, NewFakeHost(nil))
+
+		mgr.RunAll()
+		running := 0
+		for _, status := range mgr.Status() {
+			if status.Running {
+				running++
+			}
+		}
+		if running != test.expectedRunning {
+			t.Errorf("Unexpected %i running but found %i in test '%s'", test.expectedRunning, running, name)
+		}
+
+		mgr.StopAll()
+		running = 0
+		for _, status := range mgr.Status() {
+			if status.Running {
+				running++
+			}
+		}
+		if running != 0 {
+			t.Errorf("Unexpected 0 running but found %i in test '%s'", test.expectedRunning, running, name)
+		}
+
+	}
+
+}

--- a/pkg/controller/plugins.go
+++ b/pkg/controller/plugins.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/errors"
+
+	"github.com/golang/glog"
+)
+
+// Plugin is an interface to controller plugins that can be run
+// in kube-controller-manager.  A PluginMgr handles instantiating
+// and managing the lifecycle of controllers.
+type Plugin interface {
+	// Init initializes the plugin.  This will be called once before Run.
+	Init(host Host)
+
+	// Name returns the plugin's name.  Plugins should use namespaced names
+	// such as "example.com/replication-controller".  The "kubernetes.io" namespace is
+	// reserved for plugins which are bundled with kubernetes.
+	Name() string
+
+	// NewController returns an instance of this plugin's controller.
+	NewController() (Controller, error)
+}
+
+// Host is an interface that plugins can use to access the kube-controller-manager
+type Host interface {
+	// GetKubeClient returns a client interface
+	GetKubeClient() client.Interface
+}
+
+// PluginMgr is an interface to a component that manages the lifecycle of controller plugins.
+type PluginMgr interface {
+	InitPlugins(plugins []Plugin, host Host) error
+	RunAll()
+	StopAll()
+	Status() []PluginStatus
+	FindPluginByName(name string) (Plugin, error)
+}
+
+// pluginMgr is a private implementation of PluginMgr creatable through its factory func NewPluginMgr
+type pluginMgr struct {
+	mutex   sync.Mutex
+	plugins map[string]*managedPlugin
+}
+
+// NewPluginMgr returns a new instance of pluginMgr
+func NewPluginMgr() *pluginMgr {
+	return &pluginMgr{
+		plugins: make(map[string]*managedPlugin),
+	}
+}
+
+// managedPlugin is a wrapper around Plugin that adds runtime information
+type managedPlugin struct {
+	// plugin is the actual plugin being run by the plugin manager
+	plugin Plugin
+	// controller is the instance of a controller started by the plugin manager
+	controller Controller
+	// running is the runtime status of the plugin.
+	// True means the plugin is running correctly.
+	// False means either the controller has not yet been run or an error has occurred
+	running bool
+	// err is any error caught during InitPlugins or RunAll.
+	// Only plugins without errors after Init will be run
+	err error
+}
+
+// PluginStatus is a value object that describes a plugin's current status
+type PluginStatus struct {
+	// Name is the name of the plugin
+	Name string
+	// Running is the runtime status of the plugin.  See managedPlugin.running
+	Running bool
+	// Err is any error caught for this plugin.  See managedPlugin.err
+	Err error
+}
+
+// ControllerConfig is how controller plugins receive configuration.  An instance of ControllerConfig specific to
+// the plugin will be passed to the plugin's ProbeControllerPlugins(config) func.  Only the binary hosting the
+// plugins knows what plugins are included.  This requires specific configuration to happen in the binary which
+// is passed downward generically via ControllerConfig.
+//
+// Volumes in ControllerConfig are intended to be relevant to several plugins, but not necessarily all plugins.
+// The preference is to leverage strong typing in this struct.  All config items must have a descriptive but
+// non-specific name (e.g, SyncPeriod is OK but SyncPeriodForNodeController is !OK).
+//
+// OtherAttributes is a map of string values intended for one-off configuration relevant to a single plugin. All
+// values are passed by string and require interpretation by the plugin.  Passing config strings is the least
+// desirable option.  The preference is for common attributes and strong typing for config.
+type ControllerConfig struct {
+	SyncPeriod      time.Duration
+	OtherAttributes map[string]string
+}
+
+// InitPlugins initializes each plugin.
+// This must be called exactly once before any New* methods are called on any plugins.
+func (mgr *pluginMgr) InitPlugins(plugins []Plugin, host Host) error {
+	mgr.mutex.Lock()
+	defer mgr.mutex.Unlock()
+
+	allErrs := []error{}
+	for _, plugin := range plugins {
+		name := plugin.Name()
+		if !util.IsQualifiedName(name) {
+			allErrs = append(allErrs, fmt.Errorf("controller plugin has invalid name: %#v", plugin))
+			continue
+		}
+
+		if _, found := mgr.plugins[name]; found {
+			allErrs = append(allErrs, fmt.Errorf("controller plugin %q was registered more than once", name))
+			continue
+		}
+
+		plugin.Init(host)
+		mgr.plugins[name] = &managedPlugin{plugin: plugin}
+		glog.V(1).Infof("Loaded controller plugin %q", name)
+	}
+	return errors.NewAggregate(allErrs)
+}
+
+// FindPluginByName fetches a plugin by name.  If no plugin is found, returns error.
+func (mgr *pluginMgr) FindPluginByName(name string) (Plugin, error) {
+	mgr.mutex.Lock()
+	defer mgr.mutex.Unlock()
+	if managedPlugin, ok := mgr.plugins[name]; ok {
+		return managedPlugin.plugin, nil
+	}
+	return nil, fmt.Errorf("no controller plugin found matching %s", name)
+}
+
+// RunAll attempts to create Controller instances for each plugin and run them.  This method will not fail
+// for any particular plugin.  Runtime Status is kept for all plugins.  Callers should use pluginMgr.Status
+func (mgr *pluginMgr) RunAll() {
+	mgr.mutex.Lock()
+	defer mgr.mutex.Unlock()
+	for name, managedPlugin := range mgr.plugins {
+		// do not attempt to run a plugin that had previous errors or is already running.
+		// this check makes RunAll idempotent.
+		if managedPlugin.err != nil || managedPlugin.running {
+			continue
+		}
+		managedPlugin.controller, managedPlugin.err = managedPlugin.plugin.NewController()
+		if managedPlugin.err != nil {
+			glog.V(1).Infof("Unexpected error creating controller %s: %v", name, managedPlugin.err)
+			continue
+		}
+
+		managedPlugin.err = managedPlugin.controller.Run()
+		if managedPlugin.err != nil {
+			glog.V(1).Infof("Unexpected error running controller %s: %v", name, managedPlugin.err)
+			continue
+		}
+
+		glog.V(3).Infof("Controller plugin %s is running", name)
+		managedPlugin.running = true
+	}
+}
+
+// StopAll stops all Controllers by closing their stop channels
+func (mgr *pluginMgr) StopAll() {
+	mgr.mutex.Lock()
+	defer mgr.mutex.Unlock()
+
+	for name, managedPlugin := range mgr.plugins {
+		// do not attempt to stop a plugin that isn't running or that has previous errors
+		// this checks makes StopAll idempotent
+		if managedPlugin.err != nil || !managedPlugin.running {
+			continue
+		}
+		managedPlugin.err = managedPlugin.controller.Stop()
+		if managedPlugin.err != nil {
+			glog.V(1).Infof("Unexpected error stopping controller %s: %v", name, managedPlugin.err)
+			continue
+		}
+
+		glog.V(3).Infof("Controller plugin %s is stopped", name)
+		managedPlugin.running = false
+	}
+}
+
+// Status returns the runtime status of all plugins under management
+func (mgr *pluginMgr) Status() []PluginStatus {
+	statuses := []PluginStatus{}
+	for name, managedPlugin := range mgr.plugins {
+		status := PluginStatus{
+			Name:    name,
+			Running: managedPlugin.running,
+			Err:     managedPlugin.err,
+		}
+		statuses = append(statuses, status)
+	}
+	return statuses
+}
+
+// controllerHost is a basic implementation of Host
+type ControllerHost struct {
+	client client.Interface
+}
+
+func (host *ControllerHost) GetKubeClient() client.Interface {
+	return host.client
+}
+
+func NewHost(client client.Interface) Host {
+	return &ControllerHost{client}
+}

--- a/pkg/controller/testing.go
+++ b/pkg/controller/testing.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+type fakeHost struct {
+	kubeClient client.Interface
+}
+
+func NewFakeHost(kubeClient client.Interface) *fakeHost {
+	return &fakeHost{kubeClient}
+}
+
+func (h *fakeHost) GetKubeClient() client.Interface {
+	return h.kubeClient
+}
+
+var _ Plugin = &FakeControllerPlugin{}
+
+type FakeControllerPlugin struct {
+	PluginName string
+	Host       Host
+}
+
+func (p *FakeControllerPlugin) Init(host Host) {
+	p.Host = host
+}
+
+func (p *FakeControllerPlugin) Name() string {
+	return p.PluginName
+}
+
+func (p *FakeControllerPlugin) NewController() (Controller, error) {
+	return &FakeController{}, nil
+}
+
+type FakeController struct {
+	Error   error
+	Running bool
+}
+
+func (c *FakeController) Run() error {
+	if c.Error != nil {
+		return c.Error
+	}
+	c.Running = true
+	return nil
+}
+
+func (c *FakeController) Stop() error {
+	if c.Error != nil {
+		return c.Error
+	}
+	c.Running = false
+	return nil
+}
+
+func (c *FakeController) Status() (bool, error) {
+	return c.Running, c.Error
+}


### PR DESCRIPTION
This is a sketch for discussion.  I'm curious to know if this is a desirable direction for kube-controller-manager.

Goals:
1.  Change controllers into plugins.  Each is similar in implementation.  Make a framework to run many plugins in kube-controller-manager.  Plugin arch copied from VolumePlugin and NetworkPlugin.
2.  Be ready to support @lavalamp's Controller Framework (#5270)
3.  Port 1 controller (i used EndpointsController) as an example.
4.  Future enhancements:
   1. Potentially change kube-controller-manager into a server to allow queries into its status.  The manager can query each of its controllers and report back on each of them.
   2. Allow graceful shutdown of all controllers via stop channels (Smith's Controller Framework has a similar stop mechanism)
   3. Allow set/override default sync values (defaults set by plugins, override by CLI flags)
   4. Refactor CLI sync flags to allow plugin to add these somehow, as opposed to explicitly adding each.

Optional:  Potentially rename all controllers to something akin to "_Manager" or "_Synchronizer" to differentiate a process from a kind.  Example:  PersistentVolumeManager is the sync loop.  PersistentVolumeController is a proposed Kind in the API that makes new PVs.

Genesis: I wrote a controller in which I thought I needed to reconcile 2 objects and didn't like the duplication required.  It wasn't hard to genericize, after which I thought I'd take a shot at making all controllers work similarly.  Porting endpoints_controller was very easy to do.  

@thockin @bgrant0607 
