### PR TITLE
Update cAdvisor with moved docker root on AWS

### DIFF
--- a/cluster/aws/templates/format-disks.sh
+++ b/cluster/aws/templates/format-disks.sh
@@ -60,7 +60,12 @@ else
   mount -t btrfs ${block_devices[0]} /mnt
 
   # Move docker to /mnt if we have it
+  if [[ -d /var/lib/docker ]]; then
+    mv /var/lib/docker /mnt/
+  fi
   mkdir -p /mnt/docker
+  ln -s /mnt/docker /var/lib/docker
+  DOCKER_ROOT="/mnt/docker"
   DOCKER_OPTS="${DOCKER_OPTS} -g /mnt/docker"
 fi
 

--- a/cluster/aws/templates/salt-master.sh
+++ b/cluster/aws/templates/salt-master.sh
@@ -26,6 +26,18 @@ grains:
   cbr-cidr: "${MASTER_IP_RANGE}"
 EOF
 
+if [[ -n "${DOCKER_OPTS}" ]]; then
+  cat <<EOF >>/etc/salt/minion.d/grains.conf
+  docker_opts: '$(echo "$DOCKER_OPTS" | sed -e "s/'/''/g")'
+EOF
+fi
+
+if [[ -n "${DOCKER_ROOT}" ]]; then
+  cat <<EOF >>/etc/salt/minion.d/grains.conf
+  docker_root: '$(echo "$DOCKER_ROOT" | sed -e "s/'/''/g")'
+EOF
+fi
+
 cat <<EOF > /etc/aws.conf
 [Global]
 Zone = ${ZONE}

--- a/cluster/aws/templates/salt-minion.sh
+++ b/cluster/aws/templates/salt-minion.sh
@@ -31,11 +31,18 @@ grains:
 EOF
 
 
-if [[ -n "{DOCKER_OPTS}" ]]; then
+if [[ -n "${DOCKER_OPTS}" ]]; then
   cat <<EOF >>/etc/salt/minion.d/grains.conf
   docker_opts: '$(echo "$DOCKER_OPTS" | sed -e "s/'/''/g")'
 EOF
 fi
+
+if [[ -n "${DOCKER_ROOT}" ]]; then
+  cat <<EOF >>/etc/salt/minion.d/grains.conf
+  docker_root: '$(echo "$DOCKER_ROOT" | sed -e "s/'/''/g")'
+EOF
+fi
+
 
 # Install Salt
 #

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -28,4 +28,9 @@
   {% set cluster_domain = "--cluster_domain=" + pillar['dns_domain'] %}
 {% endif %}
 
-DAEMON_ARGS="{{daemon_args}} {{api_servers}} {{hostname_override}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}}"
+{% set docker_root = "" -%}
+{% if grains.docker_root is defined -%}
+  {% set docker_root = " --docker_root=" + grains.docker_root -%}
+{% endif -%}
+
+DAEMON_ARGS="{{daemon_args}} {{api_servers}} {{hostname_override}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}}"


### PR DESCRIPTION
We set up a symlink now, and we also pass docker_root into the kubelet.

The symlink is probably sufficient, but doing both feels safer.
