### PR TITLE
Remove unused code in kubelet/server_test.go

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -433,32 +433,6 @@ func TestKillContainer(t *testing.T) {
 	}
 }
 
-type channelReader struct {
-	list [][]api.Pod
-	wg   sync.WaitGroup
-}
-
-func startReading(channel <-chan interface{}) *channelReader {
-	cr := &channelReader{}
-	cr.wg.Add(1)
-	go func() {
-		for {
-			update, ok := <-channel
-			if !ok {
-				break
-			}
-			cr.list = append(cr.list, update.(PodUpdate).Pods)
-		}
-		cr.wg.Done()
-	}()
-	return cr
-}
-
-func (cr *channelReader) GetList() [][]api.Pod {
-	cr.wg.Wait()
-	return cr.list
-}
-
 var emptyPodUIDs map[types.UID]metrics.SyncPodType
 
 func TestSyncPodsDoesNothing(t *testing.T) {

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -112,18 +112,13 @@ func (fk *fakeKubelet) StreamingConnectionIdleTimeout() time.Duration {
 }
 
 type serverTestFramework struct {
-	updateChan      chan interface{}
-	updateReader    *channelReader
 	serverUnderTest *Server
 	fakeKubelet     *fakeKubelet
 	testHTTPServer  *httptest.Server
 }
 
 func newServerTest() *serverTestFramework {
-	fw := &serverTestFramework{
-		updateChan: make(chan interface{}),
-	}
-	fw.updateReader = startReading(fw.updateChan)
+	fw := &serverTestFramework{}
 	fw.fakeKubelet = &fakeKubelet{
 		podByNameFunc: func(namespace, name string) (*api.Pod, bool) {
 			return &api.Pod{


### PR DESCRIPTION
The code creates a channel and a go routine waiting for update, which is never
used by any test. Remove the unused code.
