### PR TITLE
Build etcd image (version 2.0.9), and upgrade kubernetes cluster to the new version

### DIFF
--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -1,7 +1,7 @@
 .PHONY:	clean build push
 
 IMAGE = etcd
-TAG = 2.0.8
+TAG = 2.0.9
 OUTPUT_DIR = $(IMAGE)-v$(TAG)-linux-amd64
 
 clean:

--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -7,7 +7,7 @@
 "containers":[
     {
     "name": "etcd-container",
-    "image": "gcr.io/google_containers/etcd:2.0.8",
+    "image": "gcr.io/google_containers/etcd:2.0.9",
     "command": [
               "/usr/local/bin/etcd",
 	      "--addr",


### PR DESCRIPTION
After push.sh, the cluster is successfully running new version:

2752cfc55b8c        gcr.io/google_containers/etcd:2.0.9                  "/usr/local/bin/etcd   22 seconds ago      Up 21 seconds                           k8s_etcd-container.1e717455_etcd-server-kubernetes-master_default_5f35d49b23c06deb8fddf656fa1003b6_3dde77d4            

kubectl.sh get pods running fine. 

still run e2e tests. 
#6059 @wojtek-t
