### PR TITLE
Add vagrant-libvirt support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,7 +60,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   def customize_vm(config)
     config.vm.box = $kube_box[$kube_os]["name"]
     config.vm.box_url = $kube_box[$kube_os]["box_url"]
-
+    if ENV['KUBERNETES_USE_NFS'] == "true" then
+      config.vm.synced_folder ".", "/vagrant", type: "nfs", nfs_udp: false, nfs_export: (ENV['KUBERNETES_NFS_EXPORT'] == "true")
+    end
     config.vm.provider :virtualbox do |v|
       v.customize ["modifyvm", :id, "--memory", $vm_mem]
       v.customize ["modifyvm", :id, "--cpus", $vm_cpus]

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -155,6 +155,11 @@ if [[ ! -f /srv/salt-overlay/salt/nginx/htpasswd ]]; then
     "$MASTER_USER" "$MASTER_PASSWD"
 fi
 
+# Install docker, needed by "release install script" below.
+yum install -y docker-io
+systemctl enable docker
+systemctl start docker
+
 echo "Running release install script"
 rm -rf /kube-install
 mkdir -p /kube-install

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -33,12 +33,18 @@ function detect-minions {
 # Verify prereqs on host machine  Also sets exports USING_KUBE_SCRIPTS=true so
 # that our Vagrantfile doesn't error out.
 function verify-prereqs {
-  for x in vagrant VBoxManage; do
-    if ! which "$x" >/dev/null; then
-      echo "Can't find $x in PATH, please fix and retry."
+  if ! which "vagrant" >/dev/null; then
+    echo "Can't find vagrant in PATH, please fix and retry."
+    exit 1
+  fi
+
+  # Check for VirtualBox or vagrant-libvirt
+  if ! which "VirtualBox" >/dev/null 2>/dev/null; then
+    if ! vagrant plugin list | grep vagrant-libvirt >/dev/null; then
+      echo "Can't find VirtualBox in PATH or vagrant-libvirt plugin, please fix and retry."
       exit 1
     fi
-  done
+  fi
 
   # Set VAGRANT_CWD to KUBE_ROOT so that we find the right Vagrantfile no
   # matter what directory the tools are called from.

--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -76,6 +76,13 @@ vagrant ssh minion-1
 [vagrant@kubernetes-minion-1] $ sudo journalctl -r -u kubelet
 ```
 
+For some vagrant operations, environment variables form config-default.sh must be set up:
+```
+export NUM_MINIONS=3
+source cluster/vagrant/config-default.sh
+vagrant status
+```
+
 ### Customization
 Following environment variables can be used to tun up your vagrant setup.
 

--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -4,7 +4,17 @@ Running kubernetes with Vagrant (and VirtualBox) is an easy way to run/test/deve
 
 ### Prerequisites
 1. Install latest version >= 1.6.2 of vagrant from http://www.vagrantup.com/downloads.html
-2. Install latest version of Virtual Box from https://www.virtualbox.org/wiki/Downloads
+2. Install one of vagrant virtualization providers:
+  1. Install latest version of Virtual Box from https://www.virtualbox.org/wiki/Downloads (easier to use).
+  2. Alternatively, install libvirt and vagrant-libvirt and vagrant-mutate plugins. On Fedora 21, these commands can be used:
+          $ yum install vagrant vagrant-libvirt
+          $ vagrant plugin install vagrant-mutate
+
+      The base virtual machine image must be converted from VirtualBox format to libvirt format, e.g. by using these commands:
+          $ vagrant box add fedora20 http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-20_chef-provisionerless.box
+          $ vagrant mutate fedora20 libvirt
+          $ vagrant box remove fedora20 --provider=virtualbox
+
 
 ### Setup
 
@@ -65,6 +75,17 @@ vagrant ssh minion-1
 [vagrant@kubernetes-minion-1] $ sudo systemctl status kubelet
 [vagrant@kubernetes-minion-1] $ sudo journalctl -r -u kubelet
 ```
+
+### Customization
+Following environment variables can be used to tun up your vagrant setup.
+
+Variable | Docs
+-------- | ----
+NUM_MINIONS | Number of minion nodes to create (default=`1`).
+KUBERNETES_MEMORY | Memory (in MB) available to each virtual machine (default=`1024`).
+KUBERNETES_BOX_URL | URL to base virtual image. If not set and the image is not already present the image will be downloaded automatically (default=/empty/).
+KUBERNETES_USE_NFS | If `true`, vagrant will use NFS to share files, such as Kubernetes binaries, between the host and the virtual machines. Otherwise default vagrant sharing will be used, which may be (slow) rsync under libvirt (default=`false`).
+KUBERNETES_NFS_EXPORT | Used only when KUBERNETES_USE_NFS is `true`. If set to `true`, vagrant will automatically modify your `/etc/exports` to export the right directory via NFS. Set to `false`, if you want to manage `/etc/exports` by yourselves (default=`true`).
 
 ### Interacting with your Kubernetes cluster with Vagrant.
 

--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -76,7 +76,7 @@ vagrant ssh minion-1
 [vagrant@kubernetes-minion-1] $ sudo journalctl -r -u kubelet
 ```
 
-For some vagrant operations, environment variables form config-default.sh must be set up:
+For some vagrant operations, environment variables from config-default.sh must be set up:
 ```
 export NUM_MINIONS=3
 source cluster/vagrant/config-default.sh
@@ -84,7 +84,7 @@ vagrant status
 ```
 
 ### Customization
-Following environment variables can be used to tun up your vagrant setup.
+Following environment variables can be used to tune up your vagrant setup.
 
 Variable | Docs
 -------- | ----


### PR DESCRIPTION
I use libvirt instead of VirtualBox and these patches helped me to run kube-up.sh on Fedora 21. Detailed steps are in the third patch.
