### PR TITLE
Add flag to control rate of client requests. Increase limits for scheduler, controllers and apiserver.

### DIFF
--- a/cluster/saltbase/salt/kube-apiserver/default
+++ b/cluster/saltbase/salt/kube-apiserver/default
@@ -60,4 +60,4 @@
  {% set runtime_config = "--runtime_config=" + grains.runtime_config -%}
 {% endif -%}
 
-DAEMON_ARGS="{{daemon_args}} {{address}} {{etcd_servers}} {{ cloud_provider }} {{ cloud_config }} {{ runtime_config }} {{admission_control}} --allow_privileged={{pillar['allow_privileged']}} {{portal_net}}  {{cluster_name}} {{cert_file}} {{key_file}} {{secure_port}} {{token_auth_file}} {{publicAddressOverride}} {{pillar['log_level']}}"
+DAEMON_ARGS="{{daemon_args}} {{address}} {{etcd_servers}} {{ cloud_provider }} {{ cloud_config }} {{ runtime_config }} {{admission_control}} --allow_privileged={{pillar['allow_privileged']}} {{portal_net}}  {{cluster_name}} {{cert_file}} {{key_file}} {{secure_port}} {{token_auth_file}} {{publicAddressOverride}} {{pillar['log_level']}} --max_requests_inflight=80"

--- a/cluster/saltbase/salt/kube-controller-manager/default
+++ b/cluster/saltbase/salt/kube-controller-manager/default
@@ -49,4 +49,4 @@
 
 {% endif -%} # grains.cloud is defined
 
-DAEMON_ARGS="{{daemon_args}} {{master}} {{machines}} {{ minion_regexp }} {{ cloud_provider }} {{ sync_nodes }} {{ cloud_config }} {{pillar['log_level']}}"
+DAEMON_ARGS="{{daemon_args}} {{master}} {{machines}} {{ minion_regexp }} {{ cloud_provider }} {{ sync_nodes }} {{ cloud_config }} {{pillar['log_level']}} --max_qps=20"

--- a/cluster/saltbase/salt/kube-scheduler/default
+++ b/cluster/saltbase/salt/kube-scheduler/default
@@ -4,4 +4,4 @@
 {% endif -%}
 {% set master="--master=127.0.0.1:8080" -%}
 
-DAEMON_ARGS="{{daemon_args}} {{master}} {{pillar['log_level']}}"
+DAEMON_ARGS="{{daemon_args}} {{master}} {{pillar['log_level']}} --max_qps=20"

--- a/pkg/client/flags.go
+++ b/pkg/client/flags.go
@@ -27,6 +27,7 @@ type FlagSet interface {
 	BoolVar(p *bool, name string, value bool, usage string)
 	UintVar(p *uint, name string, value uint, usage string)
 	DurationVar(p *time.Duration, name string, value time.Duration, usage string)
+	Float32Var(p *float32, name string, value float32, usage string)
 }
 
 // BindClientConfigFlags registers a standard set of CLI flags for connecting to a Kubernetes API server.
@@ -38,6 +39,7 @@ func BindClientConfigFlags(flags FlagSet, config *Config) {
 	flags.StringVar(&config.CertFile, "client_certificate", config.CertFile, "Path to a client key file for TLS.")
 	flags.StringVar(&config.KeyFile, "client_key", config.KeyFile, "Path to a client key file for TLS.")
 	flags.StringVar(&config.CAFile, "certificate_authority", config.CAFile, "Path to a cert. file for the certificate authority.")
+	flags.Float32Var(&config.QPS, "max_qps", config.QPS, "Maximum number of queries per second that could be issued by this client.")
 }
 
 func BindKubeletClientConfigFlags(flags FlagSet, config *KubeletConfig) {

--- a/pkg/client/flags_test.go
+++ b/pkg/client/flags_test.go
@@ -68,11 +68,21 @@ func (f *fakeFlagSet) DurationVar(p *time.Duration, name string, value time.Dura
 	f.set.Insert(name)
 }
 
+func (f *fakeFlagSet) Float32Var(p *float32, name string, value float32, usage string) {
+	if p == nil {
+		f.t.Errorf("unexpected nil pointer")
+	}
+	if usage == "" {
+		f.t.Errorf("unexpected empty usage")
+	}
+	f.set.Insert(name)
+}
+
 func TestBindClientConfigFlags(t *testing.T) {
 	flags := &fakeFlagSet{t, util.StringSet{}}
 	config := &Config{}
 	BindClientConfigFlags(flags, config)
-	if len(flags.set) != 6 {
+	if len(flags.set) != 7 {
 		t.Errorf("unexpected flag set: %#v", flags)
 	}
 }


### PR DESCRIPTION
This change is needed for density test to run reasonably fast for 50 node cluster.

@wojtek-t @brendanburns 
