### PR TITLE
make .Stream handle error status codes

### DIFF
--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -531,6 +531,22 @@ func TestRequestStream(t *testing.T) {
 			},
 			Err: true,
 		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusUnauthorized,
+						Body: ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(testapi.Codec(), &api.Status{
+							Status: api.StatusFailure,
+							Reason: api.StatusReasonUnauthorized,
+						})))),
+					}, nil
+				}),
+				codec:   latest.Codec,
+				baseURL: &url.URL{},
+			},
+			Err: true,
+		},
 	}
 	for i, testCase := range testCases {
 		body, err := testCase.Request.Stream()


### PR DESCRIPTION
The implementation of .Stream() didn't handle non-2xx http status codes.  If the return code is non-2xx, .Stream now returns an error.  It attempts to convert the body contents into a status error to return, but if it is unsuccessful, the error indicates the http status code and the body content.

@smarterclayton This fixes what bit unauthorized build-logs.
