### PR TITLE
Fix flakey port forward test

### DIFF
--- a/pkg/client/portforward/portforward_test.go
+++ b/pkg/client/portforward/portforward_test.go
@@ -138,7 +138,10 @@ func (c *fakeUpgradeConnection) CreateStream(headers http.Header) (httpstream.St
 
 	stream := &fakeUpgradeStream{}
 	c.streams[headers.Get(api.PortHeader)] = stream
-	stream.data = c.portData[headers.Get(api.PortHeader)]
+	// only simulate data on the data stream for now, not the error stream
+	if headers.Get(api.StreamType) == api.StreamTypeData {
+		stream.data = c.portData[headers.Get(api.PortHeader)]
+	}
 
 	return stream, nil
 }


### PR DESCRIPTION
Only simulate data for the data stream, not for the error stream too.

Fixes #6529
