### PR TITLE
The versioned printer should be initialized with the mapping apiversion

### DIFF
--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -373,7 +373,7 @@ func (f *Factory) PrinterForMapping(cmd *cobra.Command, mapping *meta.RESTMappin
 		if len(version) == 0 {
 			return nil, fmt.Errorf("you must specify an output-version when using this output format")
 		}
-		printer = kubectl.NewVersionedPrinter(printer, mapping.ObjectConvertor, version)
+		printer = kubectl.NewVersionedPrinter(printer, mapping.ObjectConvertor, version, mapping.APIVersion)
 	} else {
 		printer, err = f.Printer(mapping, GetFlagBool(cmd, "no-headers"))
 		if err != nil {


### PR DESCRIPTION
VersionedPrinter handles fallback when multiple different APIVersions
are present if multiple arguments are passed (for instance, both Kube
resources at v1beta3 and a third party's API objects which are only
at v1). The cmd PrinterForMapping should always include the current
object's "mapping version" as a fallback in the event the preferred
API version does not map to the actual object.
