### PR TITLE
Fix TestServeExecInContainerIdleTimeout flake

### DIFF
--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -655,15 +655,6 @@ func TestServeExecInContainerIdleTimeout(t *testing.T) {
 	if conn == nil {
 		t.Fatal("Unexpected nil connection")
 	}
-	defer conn.Close()
-
-	h := http.Header{}
-	h.Set(api.StreamType, api.StreamTypeError)
-	stream, err := conn.CreateStream(h)
-	if err != nil {
-		t.Fatalf("error creating input stream: %v", err)
-	}
-	defer stream.Reset()
 
 	<-conn.CloseChan()
 }

--- a/pkg/util/httpstream/spdy/connection.go
+++ b/pkg/util/httpstream/spdy/connection.go
@@ -71,7 +71,7 @@ func newConnection(conn *spdystream.Connection, newStreamHandler httpstream.NewS
 
 // createStreamResponseTimeout indicates how long to wait for the other side to
 // acknowledge the new stream before timing out.
-const createStreamResponseTimeout = 2 * time.Second
+const createStreamResponseTimeout = 30 * time.Second
 
 // Close first sends a reset for all of the connection's streams, and then
 // closes the underlying spdystream.Connection.


### PR DESCRIPTION
Remove creation of stream from TestServeExecInContainerIdleTimeout as
it's not necessary to very idle timeout.

Increase stream creation and ack timeouts to 30 seconds.

Fixes #5628
