### PR TITLE
Populate last terminated container information

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1987,6 +1987,7 @@ func (kl *Kubelet) generatePodStatus(pod *api.Pod) (api.PodStatus, error) {
 		}
 	}
 	podStatus.Conditions = append(podStatus.Conditions, getPodReadyCondition(spec, podStatus.ContainerStatuses)...)
+
 	hostIP, err := kl.GetHostIP()
 	if err != nil {
 		glog.Errorf("Cannot get host IP: %v", err)


### PR DESCRIPTION
With this PR, on node:

```
# docker ps -a | grep etcd-server-kubernete
be7e499dbc45        gcr.io/google_containers/etcd:2.0.9                  "/usr/local/bin/etcd   4 hours ago         Up 4 hours                                      k8s_etcd-container.1e717455_etcd-server-kubernetes-master_default_1e5f2c4ea3b621474a42261fac0c1a3d_950d2f78            
91d3df08509e        gcr.io/google_containers/etcd:2.0.9                  "/usr/local/bin/etcd   21 hours ago        Exited (137) 4 hours ago                        k8s_etcd-container.1e717455_etcd-server-kubernetes-master_default_1e5f2c4ea3b621474a42261fac0c1a3d_3d965d46            
7c6274cac6d9        gcr.io/google_containers/etcd:2.0.9                  "/usr/local/bin/etcd   22 hours ago        Exited (137) 21 hours ago                       k8s_etcd-container.1e717455_etcd-server-kubernetes-master_default_1e5f2c4ea3b621474a42261fac0c1a3d_51d1f8ce            
2ca37132942f        gcr.io/google_containers/etcd:2.0.9                  "/usr/local/bin/etcd   28 hours ago        Exited (137) 22 hours ago                       k8s_etcd-container.1e717455_etcd-server-kubernetes-master_default_1e5f2c4ea3b621474a42261fac0c1a3d_3a7ff2c0            
6da0ee59f2b1        gcr.io/google_containers/pause:0.8.0                 "/pause"               28 hours ago        Up 28 hours                                     k8s_POD.1a1fe303_etcd-server-kubernetes-master_default_1e5f2c4ea3b621474a42261fac0c1a3d_e268f17e                       
```

From client:

```
$ cluster/kubectl.sh get -o json pods etcd-server-kubernetes-master
...
    "status": {
        "phase": "Running",
        "Condition": [
            {
                "type": "Ready",
                "status": "True"
            }
        ],
        "containerStatuses": [
            {
                "name": "etcd-container",
                "state": {
                    "running": {
                        "startedAt": "2015-04-09T17:12:43Z"
                    }
                },
                "lastState": {
                    "termination": {
                        "exitCode": 137,
                        "startedAt": "2015-04-09T00:14:15Z",
                        "finishedAt": "2015-04-09T17:12:37Z",
                        "containerID": "docker://91d3df08509e8d31460c89806b5ab84938cb3a6dc0f7d93d435d549cc6fd9c14"
                    }
                },
                "ready": true,
                "restartCount": 3,
                "image": "gcr.io/google_containers/etcd:2.0.9",
                "imageID": "docker://b6b9a86dc06aa1361357ca1b105feba961f6a4145adca6c54e142c0be0fe87b0",
                "containerID": "docker://be7e499dbc456c52b4542a6017852a6bd32bab006160cc1f892e5a6896a18e1d"
            }
        ]
    }

```

Fix #4919
