### PR TITLE
kubelet/fake_docker_client: Use self's PID instead of 42 in testing.

### DIFF
--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -18,6 +18,7 @@ package dockertools
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
 	"sync"
@@ -180,7 +181,7 @@ func (f *FakeDockerClient) StartContainer(id string, hostConfig *docker.HostConf
 		HostConfig: hostConfig,
 		State: docker.State{
 			Running: true,
-			Pid:     42,
+			Pid:     os.Getpid(),
 		},
 		NetworkSettings: &docker.NetworkSettings{IPAddress: "1.2.3.4"},
 	}


### PR DESCRIPTION
This is safer to use self's PID than some arbitrary PID (say 42),
since the kubelet will set the oom_score_adj for real in `kubelet.createPodInfraContainer`.
https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/kubelet/kubelet.go#L929

We can get rid of this in the future once we make the docker runtime to create pod infra container (thus we can add a stub in the fake docker)

Thanks!
@vmarmol @yujuhong 
