### PR TITLE
Fix issue of kube-scheduler returns "404" for "/healthz" request without disable pprof

### DIFF
--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master/ports"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler"
@@ -81,6 +82,7 @@ func (s *SchedulerServer) Run(_ []string) error {
 
 	go func() {
 		mux := http.NewServeMux()
+		healthz.InstallHandler(mux)
 		if s.EnableProfiling {
 			mux.HandleFunc("/debug/pprof/", pprof.Index)
 			mux.HandleFunc("/debug/pprof/profile", pprof.Profile)


### PR DESCRIPTION
Fixed #6644 and #6621

With this PR, /validate works as is:

```
curl 127.0.0.1:8080/validate
[
  {
    "component": "controller-manager",
    "health": "success",
    "msg": "ok",
    "err": "nil"
  },
  {
    "component": "scheduler",
    "health": "success",
    "msg": "ok",
    "err": "nil"
  },
  {
    "component": "etcd-0",
    "health": "success",
    "msg": "{\"action\":\"get\",\"node\":{\"dir\":true,\"nodes\":[{\"key\":\"/registry\",\"dir\":true,\"modifiedIndex\":3,\"createdIndex\":3}]}}\n",
    "err": "nil"
  },
  {
    "component": "node-0",
    "health": "success",
    "msg": "ok",
    "err": "nil"
  },
  {
    "component": "node-1",
    "health": "success",
    "msg": "ok",
    "err": "nil"
  },
  {
    "component": "node-2",
    "health": "success",
    "msg": "ok",
    "err": "nil"
  },
  {
    "component": "node-3",
    "health": "success",
    "msg": "ok",
    "err": "nil"
  }
```

Same with /debug/pprof/

```
# curl 127.0.0.1:10251/debug/pprof/
<html>
<head>
<title>/debug/pprof/</title>
</head>
/debug/pprof/<br>
<br>
<body>
profiles:<br>
<table>

<tr><td align=right>0<td><a href="/debug/pprof/block?debug=1">block</a>

<tr><td align=right>29<td><a href="/debug/pprof/goroutine?debug=1">goroutine</a>

<tr><td align=right>5<td><a href="/debug/pprof/heap?debug=1">heap</a>

<tr><td align=right>4<td><a href="/debug/pprof/threadcreate?debug=1">threadcreate</a>

</table>
<br>
<a href="/debug/pprof/goroutine?debug=2">full goroutine stack dump</a><br>
</body>
</html>

```
