### PR TITLE
The redis-master-controller should be stopped

### DIFF
--- a/examples/guestbook/README.md
+++ b/examples/guestbook/README.md
@@ -430,11 +430,11 @@ If you are in a live kubernetes cluster, you can just kill the pods, using a scr
 
 ```shell
 ### First, kill services and controllers.
+kubectl stop -f examples/guestbook/redis-master-controller.json
 kubectl stop -f examples/guestbook/redis-slave-controller.json
 kubectl stop -f examples/guestbook/frontend-controller.json
 kubectl delete -f examples/guestbook/redis-master-service.json
 kubectl delete -f examples/guestbook/redis-slave-service.json
-kubectl delete pod redis-master # This is the only pod that requires manual removal.
 ```
 
 ### Troubleshooting


### PR DESCRIPTION
The redis-master-controller should be stopped, and the redis-master will be deleted automatically.
