### PR TITLE
Tighten label parsing

### DIFF
--- a/pkg/kubectl/generate.go
+++ b/pkg/kubectl/generate.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 )
 
@@ -81,19 +80,18 @@ func MakeLabels(labels map[string]string) string {
 }
 
 // ParseLabels turns a string representation of a label set into a map[string]string
-func ParseLabels(labelString string) map[string]string {
+func ParseLabels(labelString string) (map[string]string, error) {
 	if len(labelString) == 0 {
-		return nil
+		return nil, fmt.Errorf("no label spec passed")
 	}
 	labels := map[string]string{}
 	labelSpecs := strings.Split(labelString, ",")
 	for ix := range labelSpecs {
 		labelSpec := strings.Split(labelSpecs[ix], "=")
 		if len(labelSpec) != 2 {
-			glog.Errorf("unexpected label spec: %s", labelSpecs[ix])
-			continue
+			return nil, fmt.Errorf("unexpected label spec: %s", labelSpecs[ix])
 		}
 		labels[labelSpec[0]] = labelSpec[1]
 	}
-	return labels
+	return labels, nil
 }

--- a/pkg/kubectl/run.go
+++ b/pkg/kubectl/run.go
@@ -39,8 +39,12 @@ func (BasicReplicationController) Generate(params map[string]string) (runtime.Ob
 	// TODO: extract this flag to a central location.
 	labelString, found := params["labels"]
 	var labels map[string]string
+	var err error
 	if found && len(labelString) > 0 {
-		labels = ParseLabels(labelString)
+		labels, err = ParseLabels(labelString)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		labels = map[string]string{
 			"run-container": params["name"],

--- a/pkg/kubectl/service.go
+++ b/pkg/kubectl/service.go
@@ -45,12 +45,18 @@ func (ServiceGenerator) Generate(params map[string]string) (runtime.Object, erro
 	if !found || len(selectorString) == 0 {
 		return nil, fmt.Errorf("'selector' is a required parameter.")
 	}
-	selector := ParseLabels(selectorString)
+	selector, err := ParseLabels(selectorString)
+	if err != nil {
+		return nil, err
+	}
 
 	labelsString, found := params["labels"]
 	var labels map[string]string
 	if found && len(labelsString) > 0 {
-		labels = ParseLabels(labelsString)
+		labels, err = ParseLabels(labelsString)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	name, found := params["name"]


### PR DESCRIPTION
I was wondering if there is any reason `ParseLabels` deliberately doesn't error on invalid label specs. Is there any?
