### PR TITLE
Update spew to support better map key sorting.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -89,7 +89,7 @@
 		},
 		{
 			"ImportPath": "github.com/davecgh/go-spew/spew",
-			"Rev": "1aaf839fb07e099361e445273993ccd9adc21b07"
+			"Rev": "3e6e67c4dcea3ac2f25fd4731abc0e1deaf36216"
 		},
 		{
 			"ImportPath": "github.com/daviddengcn/go-colortext",

--- a/Godeps/_workspace/src/github.com/davecgh/go-spew/spew/config.go
+++ b/Godeps/_workspace/src/github.com/davecgh/go-spew/spew/config.go
@@ -76,10 +76,16 @@ type ConfigState struct {
 
 	// SortKeys specifies map keys should be sorted before being printed. Use
 	// this to have a more deterministic, diffable output.  Note that only
-	// native types (bool, int, uint, floats, uintptr and string) are supported
-	// with other types sorted according to the reflect.Value.String() output
-	// which guarantees display stability.
+	// native types (bool, int, uint, floats, uintptr and string) and types
+	// that support the error or Stringer interfaces (if methods are
+	// enabled) are supported, with other types sorted according to the
+	// reflect.Value.String() output which guarantees display stability.
 	SortKeys bool
+
+	// SpewKeys specifies that, as a last resort attempt, map keys should
+	// be spewed to strings and sorted by those strings.  This is only
+	// considered if SortKeys is true.
+	SpewKeys bool
 }
 
 // Config is the active configuration of the top-level functions.

--- a/Godeps/_workspace/src/github.com/davecgh/go-spew/spew/doc.go
+++ b/Godeps/_workspace/src/github.com/davecgh/go-spew/spew/doc.go
@@ -99,9 +99,15 @@ The following configuration options are available:
 		Specifies map keys should be sorted before being printed. Use
 		this to have a more deterministic, diffable output.  Note that
 		only native types (bool, int, uint, floats, uintptr and string)
-		are supported with other types sorted according to the
-		reflect.Value.String() output which guarantees display stability.
-		Natural map order is used by default.
+		and types which implement error or Stringer interfaces are
+		supported with other types sorted according to the
+		reflect.Value.String() output which guarantees display
+		stability.  Natural map order is used by default.
+
+	* SpewKeys
+		Specifies that, as a last resort attempt, map keys should be
+		spewed to strings and sorted by those strings.  This is only
+		considered if SortKeys is true.
 
 Dump Usage
 

--- a/Godeps/_workspace/src/github.com/davecgh/go-spew/spew/dump.go
+++ b/Godeps/_workspace/src/github.com/davecgh/go-spew/spew/dump.go
@@ -382,7 +382,7 @@ func (d *dumpState) dump(v reflect.Value) {
 			numEntries := v.Len()
 			keys := v.MapKeys()
 			if d.cs.SortKeys {
-				sortValues(keys)
+				sortValues(keys, d.cs)
 			}
 			for i, key := range keys {
 				d.dump(d.unpackValue(key))

--- a/Godeps/_workspace/src/github.com/davecgh/go-spew/spew/dump_test.go
+++ b/Godeps/_workspace/src/github.com/davecgh/go-spew/spew/dump_test.go
@@ -64,9 +64,10 @@ package spew_test
 import (
 	"bytes"
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
 	"testing"
 	"unsafe"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 // dumpTest is used to describe a test to be perfomed against the Dump method.
@@ -983,4 +984,38 @@ func TestDumpSortedKeys(t *testing.T) {
 	if s != expected {
 		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
 	}
+
+	s = cfg.Sdump(map[stringer]int{"1": 1, "3": 3, "2": 2})
+	expected = `(map[spew_test.stringer]int) (len=3) {
+(spew_test.stringer) (len=1) stringer 1: (int) 1,
+(spew_test.stringer) (len=1) stringer 2: (int) 2,
+(spew_test.stringer) (len=1) stringer 3: (int) 3
+}
+`
+	if s != expected {
+		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
+	}
+
+	s = cfg.Sdump(map[pstringer]int{pstringer("1"): 1, pstringer("3"): 3, pstringer("2"): 2})
+	expected = `(map[spew_test.pstringer]int) (len=3) {
+(spew_test.pstringer) (len=1) stringer 1: (int) 1,
+(spew_test.pstringer) (len=1) stringer 2: (int) 2,
+(spew_test.pstringer) (len=1) stringer 3: (int) 3
+}
+`
+	if s != expected {
+		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
+	}
+
+	s = cfg.Sdump(map[customError]int{customError(1): 1, customError(3): 3, customError(2): 2})
+	expected = `(map[spew_test.customError]int) (len=3) {
+(spew_test.customError) error: 1: (int) 1,
+(spew_test.customError) error: 2: (int) 2,
+(spew_test.customError) error: 3: (int) 3
+}
+`
+	if s != expected {
+		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
+	}
+
 }

--- a/Godeps/_workspace/src/github.com/davecgh/go-spew/spew/format.go
+++ b/Godeps/_workspace/src/github.com/davecgh/go-spew/spew/format.go
@@ -309,7 +309,7 @@ func (f *formatState) format(v reflect.Value) {
 		} else {
 			keys := v.MapKeys()
 			if f.cs.SortKeys {
-				sortValues(keys)
+				sortValues(keys, f.cs)
 			}
 			for i, key := range keys {
 				if i > 0 {

--- a/Godeps/_workspace/src/github.com/davecgh/go-spew/spew/format_test.go
+++ b/Godeps/_workspace/src/github.com/davecgh/go-spew/spew/format_test.go
@@ -69,9 +69,10 @@ package spew_test
 import (
 	"bytes"
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
 	"testing"
 	"unsafe"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 // formatterTest is used to describe a test to be perfomed against NewFormatter.
@@ -1478,10 +1479,56 @@ func TestFormatter(t *testing.T) {
 	}
 }
 
+type testStruct struct {
+	x int
+}
+
+func (ts testStruct) String() string {
+	return fmt.Sprintf("ts.%d", ts.x)
+}
+
+type testStructP struct {
+	x int
+}
+
+func (ts *testStructP) String() string {
+	return fmt.Sprintf("ts.%d", ts.x)
+}
+
 func TestPrintSortedKeys(t *testing.T) {
 	cfg := spew.ConfigState{SortKeys: true}
 	s := cfg.Sprint(map[int]string{1: "1", 3: "3", 2: "2"})
 	expected := "map[1:1 2:2 3:3]"
+	if s != expected {
+		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
+	}
+
+	s = cfg.Sprint(map[stringer]int{"1": 1, "3": 3, "2": 2})
+	expected = "map[stringer 1:1 stringer 2:2 stringer 3:3]"
+	if s != expected {
+		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
+	}
+
+	s = cfg.Sprint(map[pstringer]int{pstringer("1"): 1, pstringer("3"): 3, pstringer("2"): 2})
+	expected = "map[stringer 1:1 stringer 2:2 stringer 3:3]"
+	if s != expected {
+		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
+	}
+
+	s = cfg.Sprint(map[testStruct]int{testStruct{1}: 1, testStruct{3}: 3, testStruct{2}: 2})
+	expected = "map[ts.1:1 ts.2:2 ts.3:3]"
+	if s != expected {
+		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
+	}
+
+	s = cfg.Sprint(map[testStructP]int{testStructP{1}: 1, testStructP{3}: 3, testStructP{2}: 2})
+	expected = "map[ts.1:1 ts.2:2 ts.3:3]"
+	if s != expected {
+		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
+	}
+
+	s = cfg.Sprint(map[customError]int{customError(1): 1, customError(3): 3, customError(2): 2})
+	expected = "map[error: 1:1 error: 2:2 error: 3:3]"
 	if s != expected {
 		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
 	}

--- a/Godeps/_workspace/src/github.com/davecgh/go-spew/spew/internal_test.go
+++ b/Godeps/_workspace/src/github.com/davecgh/go-spew/spew/internal_test.go
@@ -151,6 +151,6 @@ func TestAddedReflectValue(t *testing.T) {
 
 // SortValues makes the internal sortValues function available to the test
 // package.
-func SortValues(values []reflect.Value) {
-	sortValues(values)
+func SortValues(values []reflect.Value, cs *ConfigState) {
+	sortValues(values, cs)
 }


### PR DESCRIPTION
Next followup will use this.

@dchen1107 as the biggest need for this is in DeepHashObject which is used by kubelet mostly :)
