### PR TITLE
WIP: cluster-wide service ports

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -72,6 +72,7 @@ type APIServer struct {
 	CorsAllowedOriginList      util.StringList
 	AllowPrivileged            bool
 	PortalNet                  util.IPNet // TODO: make this a list
+	PortalServicePorts         util.PortRange
 	EnableLogsSupport          bool
 	MasterServiceNamespace     string
 	RuntimeConfig              util.ConfigurationMap
@@ -159,6 +160,7 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Var(&s.CorsAllowedOriginList, "cors_allowed_origins", "List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching.  If this list is empty CORS will not be enabled.")
 	fs.BoolVar(&s.AllowPrivileged, "allow_privileged", s.AllowPrivileged, "If true, allow privileged containers.")
 	fs.Var(&s.PortalNet, "portal_net", "A CIDR notation IP range from which to assign portal IPs. This must not overlap with any IP ranges assigned to nodes for pods.")
+	fs.Var(&s.PortalServicePorts, "portal_service_ports", "A port range from which to assign cluster-wide portal ports.")
 	fs.StringVar(&s.MasterServiceNamespace, "master_service_namespace", s.MasterServiceNamespace, "The namespace from which the kubernetes master services should be injected into pods")
 	fs.Var(&s.RuntimeConfig, "runtime_config", "A set of key=value pairs that describe runtime configuration that may be passed to the apiserver.")
 	client.BindKubeletClientConfigFlags(fs, &s.KubeletConfig)
@@ -277,6 +279,7 @@ func (s *APIServer) Run(_ []string) error {
 		EventTTL:               s.EventTTL,
 		KubeletClient:          kubeletClient,
 		PortalNet:              &n,
+		PortalServicePorts:     s.PortalServicePorts,
 		EnableLogsSupport:      s.EnableLogsSupport,
 		EnableUISupport:        true,
 		EnableSwaggerSupport:   true,

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -898,7 +898,10 @@ const (
 )
 
 // ServiceStatus represents the current status of a service
-type ServiceStatus struct{}
+type ServiceStatus struct {
+	// If the service is assigned a cluster-wide port, it is set here
+	ServicePort int `json:"servicePort,omitempty"`
+}
 
 // ServiceSpec describes the attributes that a user creates on a service
 type ServiceSpec struct {

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -53,6 +53,8 @@ type TCPLoadBalancer interface {
 	UpdateTCPLoadBalancer(name, region string, hosts []string) error
 	// DeleteTCPLoadBalancer deletes a specified load balancer.
 	DeleteTCPLoadBalancer(name, region string) error
+	// NeedsClusterServicePort returns whether we need a cluster-wide port allocation for load-balanced services
+	NeedsClusterServicePort() bool
 }
 
 // Instances is an abstract, pluggable interface for sets of instances.

--- a/pkg/cloudprovider/fake/fake.go
+++ b/pkg/cloudprovider/fake/fake.go
@@ -93,6 +93,11 @@ func (f *FakeCloud) TCPLoadBalancerExists(name, region string) (bool, error) {
 	return f.Exists, f.Err
 }
 
+// NeedsClusterServicePort is a stub implementation of TCPLoadBalancer.NeedsClusterServicePort.
+func (lb *FakeCloud) NeedsClusterServicePort() bool {
+	return false
+}
+
 // CreateTCPLoadBalancer is a test-spy implementation of TCPLoadBalancer.CreateTCPLoadBalancer.
 // It adds an entry "create" into the internal method call record.
 func (f *FakeCloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, ports []int, hosts []string, affinityType api.AffinityType) (string, error) {

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -233,6 +233,11 @@ func (gce *GCECloud) TCPLoadBalancerExists(name, region string) (bool, error) {
 	return false, err
 }
 
+// NeedsClusterServicePort is an implementation of TCPLoadBalancer.NeedsClusterServicePort.
+func (gce *GCECloud) NeedsClusterServicePort() bool {
+	return false
+}
+
 //translate from what K8s supports to what the cloud provider supports for session affinity.
 func translateAffinityType(affinityType api.AffinityType) GCEAffinityType {
 	switch affinityType {

--- a/pkg/cloudprovider/openstack/openstack.go
+++ b/pkg/cloudprovider/openstack/openstack.go
@@ -480,6 +480,11 @@ func (lb *LoadBalancer) TCPLoadBalancerExists(name, region string) (bool, error)
 	return vip != nil, err
 }
 
+// NeedsClusterServicePort is an implementation of TCPLoadBalancer.NeedsClusterServicePort.
+func (lb *LoadBalancer) NeedsClusterServicePort() bool {
+	return false
+}
+
 // TODO: This code currently ignores 'region' and always creates a
 // loadbalancer in only the current OpenStack region.  We should take
 // a list of regions (from config) and query/create loadbalancers in

--- a/pkg/registry/service/pool_allocator.go
+++ b/pkg/registry/service/pool_allocator.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"fmt"
+	math_rand "math/rand"
+	"sync"
+
+	"time"
+)
+
+type PoolAllocator struct {
+	driver PoolDriver
+
+	lock sync.Mutex // protects 'used'
+
+	used           map[string]bool
+	randomAttempts int
+
+	random *math_rand.Rand
+}
+
+type PoolDriver interface {
+	PickRandom(seed int) string
+	IterateStart() string
+	IterateNext(s string) string
+}
+
+// Init initializes a new PoolAllocator driver.
+func (a *PoolAllocator) Init(driver PoolDriver) {
+	seed := time.Now().UTC().UnixNano()
+	a.random = math_rand.New(math_rand.NewSource(seed))
+
+	a.randomAttempts = 1000
+	a.used = make(map[string]bool)
+
+	a.driver = driver
+}
+
+// Allocate allocates a specific entry.  This is useful when recovering saved state.
+func (a *PoolAllocator) Allocate(s string) error {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	inUse := a.used[s]
+	if inUse {
+		return fmt.Errorf("Entry %s is already allocated", s)
+	}
+	a.used[s] = true
+
+	return nil
+}
+
+// AllocateNext allocates and returns a new entry.
+func (a *PoolAllocator) AllocateNext() string {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	// Try randomly first
+	for i := 0; i < a.randomAttempts; i++ {
+		seed := a.random.Int()
+
+		s := a.driver.PickRandom(seed)
+
+		inUse := a.used[s]
+		if !inUse {
+			a.used[s] = true
+			return s
+		}
+	}
+
+	// If that doesn't work, try a linear search
+	s := a.driver.IterateStart()
+	for s != "" {
+		inUse := a.used[s]
+		if !inUse {
+			a.used[s] = true
+			return s
+		}
+
+		s = a.driver.IterateNext(s)
+	}
+	return ""
+}
+
+// Release de-allocates an entry.
+func (a *PoolAllocator) Release(s string) bool {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	inUse, found := a.used[s]
+	if !found {
+		return false
+	}
+	delete(a.used, s)
+	return inUse
+}

--- a/pkg/registry/service/pool_allocator_test.go
+++ b/pkg/registry/service/pool_allocator_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"net"
+	"testing"
+)
+
+type testPoolDriver struct {
+	items []string
+}
+
+func (d *testPoolDriver) PickRandom(seed int) string {
+	i := seed % len(d.items)
+	return d.items[i]
+}
+
+func (d *testPoolDriver) IterateStart() string {
+	return d.items[0]
+}
+
+func (d *testPoolDriver) IterateNext(last string) string {
+	// Note this won't do well with duplicates!
+	for i, s := range d.items {
+		if s == last {
+			next := i + 1
+			if next == len(d.items) {
+				return ""
+			} else {
+				return d.items[next]
+			}
+		}
+	}
+	return ""
+}
+
+func TestAllocate(t *testing.T) {
+	var pa PoolAllocator
+
+	driver := &testPoolDriver{items: {"1", "2", "3"}}
+	pa.Init(driver)
+
+	if err := pa.Allocate("0"); err != nil {
+		// TODO: Maybe it should?
+		t.Errorf("PoolAllocator does not know what items are valid for pool")
+	}
+
+	if err := ipa.Allocate("1"); err != nil {
+		t.Errorf("expected success, got %s", err)
+	}
+
+	if ipa.Allocate("1") == nil {
+		t.Errorf("expected failure")
+	}
+}
+
+func TestAllocateNext(t *testing.T) {
+	var pa PoolAllocator
+
+	driver := &testPoolDriver{items: {"a", "b", "c"}}
+	pa.Init(driver)
+
+	// Turn off random allocation attempts, so we just allocate in sequence
+	pa.randomAttempts = 0
+
+	v1, err := pa.AllocateNext()
+	if err != nil {
+		t.Error(err)
+	}
+	if v1 != "1" {
+		t.Errorf("expected 'a', got %s", v1)
+	}
+
+	v2, err := pa.AllocateNext()
+	if err != nil {
+		t.Error(err)
+	}
+	if v2 != "b" {
+		t.Errorf("expected 'b', got %s", v2)
+	}
+
+	v3, err := pa.AllocateNext()
+	if err != nil {
+		t.Error(err)
+	}
+	if v3 != "c" {
+		t.Errorf("expected 'c', got %s", v3)
+	}
+
+	_, err = pa.AllocateNext()
+	if err == nil {
+		t.Errorf("Expected nil - allocator is full")
+	}
+}
+
+func TestRelease(t *testing.T) {
+	var pa PoolAllocator
+
+	driver := &testPoolDriver{items: {"a", "b", "c"}}
+	pa.Init(driver)
+
+	ipa.randomAttempts = 0
+
+	err := ipa.Release("a")
+	if err == nil {
+		t.Errorf("Expected an error")
+	}
+
+	v1, err := ipa.AllocateNext()
+	if err != nil {
+		t.Error(err)
+	}
+	v2, err := ipa.AllocateNext()
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = ipa.AllocateNext()
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = ipa.Release(v2)
+	if err != nil {
+		t.Error(err)
+	}
+
+	v2_again, err := ipa.AllocateNext()
+	if v2_again != v2 {
+		t.Errorf("Expected %s, got %s", v2, v2_again)
+	}
+
+	_, err = pa.AllocateNext()
+	if err == nil {
+		t.Errorf("Expected nil - allocator is full")
+	}
+}

--- a/pkg/registry/service/port_allocator.go
+++ b/pkg/registry/service/port_allocator.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/golang/glog"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+// The smallest size of port range we accept.
+const minPortPoolSize = 8
+
+type portAllocator struct {
+	portRange util.PortRange
+	pool      PoolAllocator
+}
+
+// newPortAllocator creates and initializes a new portAllocator object.
+func newPortAllocator(portRange util.PortRange) *portAllocator {
+	rangeSize := portRange.Size()
+	if rangeSize < minPortPoolSize {
+		glog.Errorf("PortAllocator requires at least %d ports", minPortPoolSize)
+		return nil
+	}
+
+	a := &portAllocator{
+		portRange: portRange,
+	}
+	a.pool.Init(&portPoolDriver{portRange: portRange})
+
+	return a
+}
+
+// Allocate portAllocator a specific port.  This is useful when recovering saved state.
+func (a *portAllocator) Allocate(port int) error {
+	if !a.portRange.Contains(port) {
+		return fmt.Errorf("Port %v does not fall within port-range %v", port, a.portRange)
+	}
+
+	return a.pool.Allocate(portToString(port))
+}
+
+// Allocate allocates and returns a port.
+func (a *portAllocator) AllocateNext() (int, error) {
+	s := a.pool.AllocateNext()
+	if s == "" {
+		return 0, fmt.Errorf("can't find a free port in %s", a.portRange)
+	}
+	return stringToPort(s), nil
+}
+
+// Release de-allocates a port.
+func (a *portAllocator) Release(port int) error {
+	if !a.portRange.Contains(port) {
+		return fmt.Errorf("Port %v does not fall within port-range %v", port, a.portRange)
+	}
+
+	if !a.pool.Release(portToString(port)) {
+		glog.Warning("Released port that was not assigned: ", port)
+	}
+	return nil
+}
+
+type portPoolDriver struct {
+	portRange util.PortRange
+}
+
+func (d *portPoolDriver) PickRandom(seed int) string {
+	n := d.portRange.Size()
+	port := d.portRange.MinInclusive + (seed % n)
+	return portToString(port)
+}
+
+func (d *portPoolDriver) IterateStart() string {
+	port := d.portRange.MinInclusive
+	return portToString(port)
+}
+
+func (d *portPoolDriver) IterateNext(p string) string {
+	port := stringToPort(p)
+	port++
+	if port >= d.portRange.MaxExclusive {
+		return ""
+	}
+	return portToString(port)
+}
+
+func portToString(p int) string {
+	return strconv.Itoa(p)
+}
+
+func stringToPort(s string) int {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		panic("Invalid port-string: " + s)
+	}
+	return n
+}

--- a/pkg/registry/service/rest.go
+++ b/pkg/registry/service/rest.go
@@ -97,6 +97,15 @@ func (rs *REST) Create(ctx api.Context, obj runtime.Object) (runtime.Object, err
 		return nil, err
 	}
 
+	releaseServiceIp := false
+	defer func() {
+		if releaseServiceIp {
+			if api.IsServiceIPSet(service) {
+				rs.portalMgr.Release(net.ParseIP(service.Spec.PortalIP))
+			}
+		}
+	}()
+
 	if api.IsServiceIPRequested(service) {
 		// Allocate next available.
 		ip, err := rs.portalMgr.AllocateNext()
@@ -104,12 +113,14 @@ func (rs *REST) Create(ctx api.Context, obj runtime.Object) (runtime.Object, err
 			return nil, err
 		}
 		service.Spec.PortalIP = ip.String()
+		releaseServiceIp = true
 	} else if api.IsServiceIPSet(service) {
 		// Try to respect the requested IP.
 		if err := rs.portalMgr.Allocate(net.ParseIP(service.Spec.PortalIP)); err != nil {
 			el := fielderrors.ValidationErrorList{fielderrors.NewFieldInvalid("spec.portalIP", service.Spec.PortalIP, err.Error())}
 			return nil, errors.NewInvalid("Service", service.Name, el)
 		}
+		releaseServiceIp = true
 	}
 
 	// TODO: Move this to post-creation rectification loop, so that we make/remove external load balancers
@@ -117,20 +128,19 @@ func (rs *REST) Create(ctx api.Context, obj runtime.Object) (runtime.Object, err
 	if service.Spec.CreateExternalLoadBalancer {
 		err := rs.createExternalLoadBalancer(ctx, service)
 		if err != nil {
-			if api.IsServiceIPSet(service) {
-				rs.portalMgr.Release(net.ParseIP(service.Spec.PortalIP))
-			}
 			return nil, err
 		}
 	}
 
 	out, err := rs.registry.CreateService(ctx, service)
 	if err != nil {
-		if api.IsServiceIPSet(service) {
-			rs.portalMgr.Release(net.ParseIP(service.Spec.PortalIP))
-		}
 		err = rest.CheckGeneratedNameError(rest.Services, err, service)
 	}
+
+	if err == nil {
+		releaseServiceIp = false
+	}
+
 	return out, err
 }
 

--- a/pkg/util/port_range.go
+++ b/pkg/util/port_range.go
@@ -1,0 +1,59 @@
+package util
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type PortRange struct {
+	MinInclusive int
+	MaxExclusive int
+}
+
+func (pr *PortRange) Size() int {
+	return pr.MaxExclusive - pr.MinInclusive
+}
+
+func (pr *PortRange) Contains(p int) bool {
+	return (p >= pr.MinInclusive) && (p < pr.MaxExclusive)
+}
+
+func (pr PortRange) String() string {
+	// I'm guessing [a,b) is not user-friendly...
+	if pr.MinInclusive == pr.MaxExclusive {
+		return ""
+	}
+	return fmt.Sprintf("%d-%d", pr.MinInclusive, pr.MaxExclusive-1)
+}
+
+func (pr *PortRange) Set(value string) error {
+	if value == "" {
+		pr.MinInclusive = 0
+		pr.MaxExclusive = 0
+		return nil
+	}
+
+	hyphenIndex := strings.Index(value, "-")
+	if hyphenIndex == -1 {
+		return fmt.Errorf("Expected hyphen (-) in port range")
+	}
+
+	var err error
+	pr.MinInclusive, err = strconv.Atoi(value[:hyphenIndex])
+	if err == nil {
+		pr.MaxExclusive, err = strconv.Atoi(value[hyphenIndex+1:])
+	}
+	if err != nil {
+		return fmt.Errorf("Unable to parse port range: %s", value)
+	}
+
+	// Humans specify inclusive ranges
+	pr.MaxExclusive++
+
+	return nil
+}
+
+func (*PortRange) Type() string {
+	return "portRange"
+}


### PR DESCRIPTION
Uploading now for discussion wrt whether we merge this into #5225 

For AWS ELB load balancers, it looks like we will need to assign a port to externally load balanced services (more discussion in #5225).  This patch adds cluster-wide port assignments to the API server; there is more work to be done to have the kube-proxy respect this assignment and avoid the range when choosing random ports.

Comments welcome.  In particular, I'm not sure on the naming of the PortalServicePort parameter, or on whether we want a separate PoolAllocator (I think yes, because we will be moving this pool logic to etcd when we go multi-master).

Maybe I should split PoolAllocator into its own PR (and refactor the IP allocator to use it also)
