### PR TITLE
Fix a small regression on api server proxy after switch to v1beta3.

### DIFF
--- a/pkg/kubectl/cmd/log.go
+++ b/pkg/kubectl/cmd/log.go
@@ -115,7 +115,7 @@ func RunLog(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 
 	readCloser, err := client.RESTClient.Get().
 		Prefix("proxy").
-		Resource("minions").
+		Resource("nodes").
 		Name(pod.Spec.Host).
 		Suffix("containerLogs", namespace, podID, container).
 		Param("follow", strconv.FormatBool(follow)).


### PR DESCRIPTION
Fix #6696

With this PR, the docker container log is returned instead of 404 error. 

```
$ cluster/kubectl.sh log monitoring-heapster-controller-fi7yi
current-context: "golden-system-455_kubernetes"
Running: cluster/../cluster/gce/../../cluster/../_output/dockerized/bin/linux/amd64/kubectl log monitoring-heapster-controller-fi7yi
2015-04-10T10:42:42.076249991Z E0410 10:42:42.076061       7 reflector.go:149] watch of *api.Pod ended with error: very short watch
2015-04-10T20:26:36.800914918Z E0410 20:26:36.800874       7 reflector.go:149] watch of *api.Pod ended with error: very short watch
2015-04-10T20:26:36.803854539Z E0410 20:26:36.803838       7 reflector.go:149] watch of *api.Node ended with error: very short watch
2015-04-10T20:26:37.804776426Z E0410 20:26:37.804526       7 reflector.go:115] Failed to list *api.Pod: Get http://10.0.0.1:80/api/v1beta1/pods?fields=DesiredState.Host%21%3D&namespace=: read tcp 10.0.0.1:80: connection reset by peer
2015-04-10T20:26:37.807796136Z E0410 20:26:37.807776       7 reflector.go:115] Failed to list *api.Node: Get http://10.0.0.1:80/api/v1beta1/minions?namespace=: read tcp 10.0.0.1:80: connection reset by peer

```

cc/ @nikhiljindal 
