### PR TITLE
Remove nodeinfo endpoint from kubelet

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -103,10 +103,6 @@ func (fakeKubeletClient) GetPodStatus(host, podNamespace, podName string) (api.P
 	return r, nil
 }
 
-func (fakeKubeletClient) GetNodeInfo(host string) (api.NodeInfo, error) {
-	return api.NodeInfo{}, nil
-}
-
 func (fakeKubeletClient) GetConnectionInfo(host string) (string, uint, http.RoundTripper, error) {
 	return "", 0, nil, errors.New("Not Implemented")
 }

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -34,7 +34,6 @@ func init() {
 		&Service{},
 		&NodeList{},
 		&Node{},
-		&NodeInfo{},
 		&Status{},
 		&Endpoints{},
 		&EndpointsList{},
@@ -75,7 +74,6 @@ func (*ServiceList) IsAnAPIObject()               {}
 func (*Endpoints) IsAnAPIObject()                 {}
 func (*EndpointsList) IsAnAPIObject()             {}
 func (*Node) IsAnAPIObject()                      {}
-func (*NodeInfo) IsAnAPIObject()                  {}
 func (*NodeList) IsAnAPIObject()                  {}
 func (*Binding) IsAnAPIObject()                   {}
 func (*Status) IsAnAPIObject()                    {}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1079,15 +1079,6 @@ type NodeStatus struct {
 	NodeInfo NodeSystemInfo `json:"nodeInfo,omitempty"`
 }
 
-// NodeInfo is the information collected on the node.
-type NodeInfo struct {
-	TypeMeta `json:",inline"`
-	// Capacity represents the available resources of a node
-	Capacity ResourceList `json:"capacity,omitempty"`
-	// NodeSystemInfo is a set of ids/uuids to uniquely identify the node
-	NodeSystemInfo `json:",inline,omitempty"`
-}
-
 type NodePhase string
 
 // These are the valid phases of node.

--- a/pkg/api/v1beta3/register.go
+++ b/pkg/api/v1beta3/register.go
@@ -38,7 +38,6 @@ func init() {
 		&Endpoints{},
 		&EndpointsList{},
 		&Node{},
-		&NodeInfo{},
 		&NodeList{},
 		&Binding{},
 		&Status{},
@@ -78,7 +77,6 @@ func (*ServiceList) IsAnAPIObject()               {}
 func (*Endpoints) IsAnAPIObject()                 {}
 func (*EndpointsList) IsAnAPIObject()             {}
 func (*Node) IsAnAPIObject()                      {}
-func (*NodeInfo) IsAnAPIObject()                  {}
 func (*NodeList) IsAnAPIObject()                  {}
 func (*Binding) IsAnAPIObject()                   {}
 func (*Status) IsAnAPIObject()                    {}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -1073,15 +1073,6 @@ type NodeStatus struct {
 	NodeInfo NodeSystemInfo `json:"nodeInfo,omitempty"`
 }
 
-// NodeInfo is the information collected on the node.
-type NodeInfo struct {
-	TypeMeta `json:",inline"`
-	// Capacity represents the available resources of a node
-	Capacity ResourceList `json:"capacity,omitempty"`
-	// NodeSystemInfo is a set of ids/uuids to uniquely identify the node
-	NodeSystemInfo `json:",inline,omitempty"`
-}
-
 type NodePhase string
 
 // These are the valid phases of node.

--- a/pkg/client/kubelet.go
+++ b/pkg/client/kubelet.go
@@ -39,7 +39,6 @@ var ErrPodInfoNotAvailable = errors.New("no pod info available")
 type KubeletClient interface {
 	KubeletHealthChecker
 	PodInfoGetter
-	NodeInfoGetter
 	ConnectionInfoGetter
 }
 
@@ -54,10 +53,6 @@ type PodInfoGetter interface {
 	// GetPodStatus returns information about all containers which are part
 	// Returns an api.PodStatus, or an error if one occurs.
 	GetPodStatus(host, podNamespace, podID string) (api.PodStatusResult, error)
-}
-
-type NodeInfoGetter interface {
-	GetNodeInfo(host string) (api.NodeInfo, error)
 }
 
 type ConnectionInfoGetter interface {
@@ -136,13 +131,6 @@ func (c *HTTPKubeletClient) GetPodStatus(host, podNamespace, podID string) (api.
 	return status, err
 }
 
-// GetNodeInfo gets information about the specified node.
-func (c *HTTPKubeletClient) GetNodeInfo(host string) (api.NodeInfo, error) {
-	info := api.NodeInfo{}
-	_, err := c.getEntity(host, "/api/v1beta1/nodeInfo", "", &info)
-	return info, err
-}
-
 // getEntity might return a nil response.
 func (c *HTTPKubeletClient) getEntity(host, path, query string, entity runtime.Object) (*http.Response, error) {
 	request, err := http.NewRequest("GET", c.url(host, path, query), nil)
@@ -177,11 +165,6 @@ type FakeKubeletClient struct{}
 // GetPodInfo is a fake implementation of PodInfoGetter.GetPodInfo.
 func (c FakeKubeletClient) GetPodStatus(host, podNamespace string, podID string) (api.PodStatusResult, error) {
 	return api.PodStatusResult{}, errors.New("Not Implemented")
-}
-
-// GetNodeInfo is a fake implementation of PodInfoGetter.GetNodeInfo
-func (c FakeKubeletClient) GetNodeInfo(host string) (api.NodeInfo, error) {
-	return api.NodeInfo{}, errors.New("Not Implemented")
 }
 
 func (c FakeKubeletClient) HealthCheck(host string) (probe.Result, error) {

--- a/pkg/cloudprovider/controller/nodecontroller_test.go
+++ b/pkg/cloudprovider/controller/nodecontroller_test.go
@@ -146,10 +146,6 @@ func (c *FakeKubeletClient) GetPodStatus(host, podNamespace, podID string) (api.
 	return api.PodStatusResult{}, errors.New("Not Implemented")
 }
 
-func (c *FakeKubeletClient) GetNodeInfo(host string) (api.NodeInfo, error) {
-	return api.NodeInfo{}, errors.New("Not Implemented")
-}
-
 func (c *FakeKubeletClient) GetConnectionInfo(host string) (string, uint, http.RoundTripper, error) {
 	return "", 0, nil, errors.New("Not Implemented")
 }

--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -136,7 +136,6 @@ func (s *Server) InstallDefaultHandlers() {
 	)
 	s.mux.HandleFunc("/podInfo", s.handlePodInfoOld)
 	s.mux.HandleFunc("/api/v1beta1/podInfo", s.handlePodInfoVersioned)
-	s.mux.HandleFunc("/api/v1beta1/nodeInfo", s.handleNodeInfoVersioned)
 	s.mux.HandleFunc("/pods", s.handlePods)
 	s.mux.HandleFunc("/stats/", s.handleStats)
 	s.mux.HandleFunc("/spec/", s.handleSpec)
@@ -344,31 +343,6 @@ func (s *Server) handleStats(w http.ResponseWriter, req *http.Request) {
 // handleLogs handles logs requests against the Kubelet.
 func (s *Server) handleLogs(w http.ResponseWriter, req *http.Request) {
 	s.host.ServeLogs(w, req)
-}
-
-// handleNodeInfoVersioned handles node info requests against the Kubelet.
-func (s *Server) handleNodeInfoVersioned(w http.ResponseWriter, req *http.Request) {
-	info, err := s.host.GetCachedMachineInfo()
-	if err != nil {
-		s.error(w, err)
-		return
-	}
-	capacity := CapacityFromMachineInfo(info)
-	data, err := json.Marshal(api.NodeInfo{
-		Capacity: capacity,
-		NodeSystemInfo: api.NodeSystemInfo{
-			MachineID:  info.MachineID,
-			SystemUUID: info.SystemUUID,
-			BootID:     info.BootID,
-		},
-	})
-
-	if err != nil {
-		s.error(w, err)
-		return
-	}
-	w.Header().Add("Content-type", "application/json")
-	w.Write(data)
 }
 
 // handleSpec handles spec requests against the Kubelet.


### PR DESCRIPTION
I've removed the NodeInfo structure from v1beta3 (but not v1beta1, v1bet2).  Let me know if this works.

Personally, I think removing the structure won't break things as it's not an externally visible: it's used only to exchange nodeinfo from master (node controller) and kubelet.

e2e passed
