### PR TITLE
Fix printing errors from failed binary runs

### DIFF
--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -42,7 +42,7 @@ func main() {
 	verflag.PrintAndExitIfRequested()
 
 	if err := s.Run(pflag.CommandLine.Args()); err != nil {
-		fmt.Fprint(os.Stderr, err.Error)
+		fmt.Fprint(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -49,7 +49,7 @@ func main() {
 	verflag.PrintAndExitIfRequested()
 
 	if err := s.Run(pflag.CommandLine.Args()); err != nil {
-		fmt.Fprint(os.Stderr, err.Error)
+		fmt.Fprint(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/kube-proxy/proxy.go
+++ b/cmd/kube-proxy/proxy.go
@@ -45,7 +45,7 @@ func main() {
 	verflag.PrintAndExitIfRequested()
 
 	if err := s.Run(pflag.CommandLine.Args()); err != nil {
-		fmt.Fprint(os.Stderr, err.Error)
+		fmt.Fprint(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -44,7 +44,7 @@ func main() {
 	verflag.PrintAndExitIfRequested()
 
 	if err := s.Run(pflag.CommandLine.Args()); err != nil {
-		fmt.Fprint(os.Stderr, err.Error)
+		fmt.Fprint(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
I had the kublet die on startup and the only error was "0x401da0"  Which
I assume is an address of the err.Error function.  The other way to fix
this, I think, would be to use err.Error(), however that could cause
fmt.Fprintf() problems, debuging on the error message people used.

Now I get a nice clean error I can understand:

"cAdvisor.New() err = mountpoint for cpu not found"
