### PR TITLE
Fix heapster config to talk to the right kubelet port.

### DIFF
--- a/cluster/addons/cluster-monitoring/v1beta3/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/v1beta3/heapster-controller.yaml
@@ -23,6 +23,8 @@ spec:
               value: "monitoring-influxdb"
             - name: "SINK"
               value: "influxdb"
+            - name: "FLAGS"
+              value: "--kubelet_port=10255"
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs


### PR DESCRIPTION
The config was updated for v1bet1, but the tests are using v1beta3.
