### PR TITLE
Add a new Chaos transport that can simulate network failure and add it to the kubelet

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -45,6 +45,7 @@ API_HOST=${API_HOST:-127.0.0.1}
 API_CORS_ALLOWED_ORIGINS=${API_CORS_ALLOWED_ORIGINS:-"/127.0.0.1(:[0-9]+)?$,/localhost(:[0-9]+)?$"}
 KUBELET_PORT=${KUBELET_PORT:-10250}
 LOG_LEVEL=${LOG_LEVEL:-3}
+CHAOS_CHANCE=${CHAOS_CHANCE:-0.0}
 
 # For the common local scenario, fail fast if server is already running.
 # this can happen if you run local-up-cluster.sh twice and kill etcd in between.
@@ -139,6 +140,7 @@ CTLRMGR_PID=$!
 KUBELET_LOG=/tmp/kubelet.log
 sudo -E "${GO_OUT}/kubelet" \
   --v=${LOG_LEVEL} \
+  --chaos_chance="${CHAOS_CHANCE}" \
   --hostname_override="127.0.0.1" \
   --address="127.0.0.1" \
   --api_servers="${API_HOST}:${API_PORT}" \

--- a/pkg/client/chaosclient/chaosclient.go
+++ b/pkg/client/chaosclient/chaosclient.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package chaosclient makes it easy to simulate network latency, misbehaving
+// servers, and random errors from servers. It is intended to stress test components
+// under failure conditions and expose weaknesses in the error handling logic
+// of the codebase.
+package chaosclient
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"math/rand"
+	"net/http"
+	"reflect"
+	"runtime"
+)
+
+// chaosrt provides the ability to perform simulations of HTTP client failures
+// under the Golang http.Transport interface.
+type chaosrt struct {
+	rt     http.RoundTripper
+	notify ChaosNotifier
+	c      []Chaos
+}
+
+// Chaos intercepts requests to a remote HTTP endpoint and can inject arbitrary
+// failures.
+type Chaos interface {
+	// Intercept should return true if the normal flow should be skipped, and the
+	// return response and error used instead. Modifications to the request will
+	// be ignored, but may be used to make decisions about types of failures.
+	Intercept(req *http.Request) (bool, *http.Response, error)
+}
+
+// ChaosNotifier notifies another component that the ChaosRoundTripper has simulated
+// a failure.
+type ChaosNotifier interface {
+	// OnChaos is invoked when a chaotic outcome was triggered. fn is the
+	// source of Chaos and req was the outgoing request
+	OnChaos(req *http.Request, c Chaos)
+}
+
+// ChaosFunc takes an http.Request and decides whether to alter the response. It
+// returns true if it wishes to mutate the response, with a http.Response or
+// error.
+type ChaosFunc func(req *http.Request) (bool, *http.Response, error)
+
+func (fn ChaosFunc) Intercept(req *http.Request) (bool, *http.Response, error) {
+	return fn.Intercept(req)
+}
+func (fn ChaosFunc) String() string {
+	return runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+}
+
+// NewChaosRoundTripper creates an http.RoundTripper that will intercept requests
+// based on the provided Chaos functions. The notifier is invoked when a Chaos
+// Intercept is fired.
+func NewChaosRoundTripper(rt http.RoundTripper, notify ChaosNotifier, c ...Chaos) http.RoundTripper {
+	return &chaosrt{rt, notify, c}
+}
+
+// RoundTrip gives each ChaosFunc an opportunity to intercept the request. The first
+// interceptor wins.
+func (rt *chaosrt) RoundTrip(req *http.Request) (*http.Response, error) {
+	for _, c := range rt.c {
+		if intercept, resp, err := c.Intercept(req); intercept {
+			rt.notify.OnChaos(req, c)
+			return resp, err
+		}
+	}
+	return rt.rt.RoundTrip(req)
+}
+
+// Seed represents a consistent stream of chaos.
+type Seed struct {
+	*rand.Rand
+}
+
+// NewSeed creates an object that assists in generating random chaotic events
+// based on a deterministic seed.
+func NewSeed(seed int64) Seed {
+	return Seed{rand.New(rand.NewSource(seed))}
+}
+
+type pIntercept struct {
+	Chaos
+	s Seed
+	p float64
+}
+
+// P returns a ChaosFunc that fires with a probabilty of p (p between 0.0
+// and 1.0 with 0.0 meaning never and 1.0 meaning always).
+func (s Seed) P(p float64, c Chaos) Chaos {
+	return pIntercept{c, s, p}
+}
+
+// Intercept intercepts requests with the provided probability p.
+func (c pIntercept) Intercept(req *http.Request) (bool, *http.Response, error) {
+	if c.s.Float64() < c.p {
+		return c.Chaos.Intercept(req)
+	}
+	return false, nil, nil
+}
+
+func (c pIntercept) String() string {
+	return fmt.Sprintf("P{%f %s}", c.p, c.Chaos)
+}
+
+// ErrSimulatedConnectionResetByPeer emulates the golang net error when a connection
+// is reset by a peer.
+// TODO: make this more accurate
+// TODO: add other error types
+// TODO: add a helper for returning multiple errors randomly.
+var ErrSimulatedConnectionResetByPeer = Error{errors.New("connection reset by peer")}
+
+// Error returns the nested error when C() is invoked.
+type Error struct {
+	error
+}
+
+// C returns the nested error
+func (e Error) Intercept(_ *http.Request) (bool, *http.Response, error) {
+	return true, nil, e.error
+}
+
+// LogChaos is the default ChaosNotifier and writes a message to the Golang log.
+var LogChaos = ChaosNotifier(logChaos{})
+
+type logChaos struct{}
+
+func (logChaos) OnChaos(req *http.Request, c Chaos) {
+	log.Printf("Triggered chaotic behavior for %s %s: %v", req.Method, req.URL.String(), c)
+}

--- a/pkg/client/chaosclient/chaosclient_test.go
+++ b/pkg/client/chaosclient/chaosclient_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chaosclient
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+type TestLogChaos struct {
+	*testing.T
+}
+
+func (t TestLogChaos) OnChaos(req *http.Request, c Chaos) {
+	t.Logf("CHAOS: chaotic behavior for %s %s: %v", req.Method, req.URL.String(), c)
+}
+
+func unwrapURLError(err error) error {
+	if urlErr, ok := err.(*url.Error); ok && urlErr != nil {
+		return urlErr.Err
+	}
+	return err
+}
+
+func TestChaos(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	client := http.Client{
+		Transport: NewChaosRoundTripper(http.DefaultTransport, TestLogChaos{t}, ErrSimulatedConnectionResetByPeer),
+	}
+	resp, err := client.Get(server.URL)
+	if unwrapURLError(err) != ErrSimulatedConnectionResetByPeer.error {
+		t.Fatalf("expected reset by peer: %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("expected no response object: %#v", resp)
+	}
+}
+
+func TestPartialChaos(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	seed := NewSeed(1)
+	client := http.Client{
+		Transport: NewChaosRoundTripper(
+			http.DefaultTransport, TestLogChaos{t},
+			seed.P(0.5, ErrSimulatedConnectionResetByPeer),
+		),
+	}
+	success, fail := 0, 0
+	for {
+		_, err := client.Get(server.URL)
+		if err != nil {
+			fail++
+		} else {
+			success++
+		}
+		if success > 1 && fail > 1 {
+			break
+		}
+	}
+}

--- a/pkg/kubectl/cmd/update.go
+++ b/pkg/kubectl/cmd/update.go
@@ -114,7 +114,6 @@ func RunUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 		fmt.Fprintf(out, "%s/%s\n", info.Mapping.Resource, info.Name)
 		return nil
 	})
-
 }
 
 func updateWithPatch(cmd *cobra.Command, args []string, f *cmdutil.Factory, patch string) (string, error) {


### PR DESCRIPTION
A new package `pkg/client/chaosclient` has a framework for simulating random HTTP
client failures as well as returning arbitrary responses. The client.Config is
extended to support the ability to wrap the transport to inject those errors, and
the kubelet now takes an argument `--chaos_chance=<p>` which reflects the probability
a request to the master will be rejected with a "connection reset by peer" error.

To try this locally, pass --chaos_chance=0.1 to the kubelet on start, or try this
with the local cluster:

```
$ CHAOS_CHANCE=0.1 hack/local-up-cluster.sh
```

The Chaos transport will log when it replaces a request - since the default error
is a fairly generic one, most parts of the code should immediately log that to
glog at at least V(2).  

Future enhancements will be including more error scenarios, the ability to 
simulate network latency, and possibly panics.
