### PR TITLE
pkg/kubelet: move the capabilities related code to util.go

### DIFF
--- a/pkg/kubelet/util.go
+++ b/pkg/kubelet/util.go
@@ -17,6 +17,8 @@ limitations under the License.
 package kubelet
 
 import (
+	"fmt"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/capabilities"
@@ -41,4 +43,33 @@ func CapacityFromMachineInfo(info *cadvisorApi.MachineInfo) api.ResourceList {
 			resource.BinarySI),
 	}
 	return c
+}
+
+// Check whether we have the capabilities to run the specified pod.
+func canRunPod(pod *api.Pod) error {
+	if pod.Spec.HostNetwork {
+		allowed, err := allowHostNetwork(pod)
+		if err != nil {
+			return err
+		}
+		if !allowed {
+			return fmt.Errorf("pod with UID %q specified host networking, but is disallowed", pod.UID)
+		}
+	}
+	// TODO(vmarmol): Check Privileged too.
+	return nil
+}
+
+// Determined whether the specified pod is allowed to use host networking
+func allowHostNetwork(pod *api.Pod) (bool, error) {
+	podSource, err := getPodSource(pod)
+	if err != nil {
+		return false, err
+	}
+	for _, source := range capabilities.Get().HostNetworkSources {
+		if source == podSource {
+			return true, nil
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION
/cc @ArtfulCoder
1. Moved the capabilities related code to util.go. Other code is there.
2. dropped the kubelet receiver from canRunPod method.
