### PR TITLE
*: Default ReplicationController replicas count to 1

### DIFF
--- a/pkg/api/conversion.go
+++ b/pkg/api/conversion.go
@@ -150,5 +150,17 @@ func init() {
 			out.DNSPolicy = in.DNSPolicy
 			return nil
 		},
+		func(input *int, out **int, s conversion.Scope) error {
+			*out = input
+			return nil
+		},
+		func(input **int, out *int, s conversion.Scope) error {
+			if *input == nil {
+				*out = 1
+				return nil
+			}
+			*out = **input
+			return nil
+		},
 	)
 }

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -71,6 +71,16 @@ var Semantic = conversion.EqualitiesOrDie(
 	func(a, b fields.Selector) bool {
 		return a.String() == b.String()
 	},
+	// HACK: for default value intp value of json.
+	func(a, b *int) bool {
+		if a == nil {
+			return b == nil || *b == 1
+		}
+		if b == nil {
+			return a == nil || *a == 1
+		}
+		return *a == *b
+	},
 )
 
 var standardResources = util.NewStringSet(

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -18,10 +18,10 @@ package api_test
 
 import (
 	"encoding/json"
+	"testing"
 
 	"math/rand"
 	"reflect"
-	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -855,7 +855,8 @@ type PodTemplateList struct {
 // a TemplateRef or a Template set.
 type ReplicationControllerSpec struct {
 	// Replicas is the number of desired replicas.
-	Replicas int `json:"replicas"`
+	// A nil Replicas is the default value 1.
+	Replicas *int `json:"replicas"`
 
 	// Selector is a label query over pods that should match the Replicas count.
 	Selector map[string]string `json:"selector"`
@@ -870,6 +871,13 @@ type ReplicationControllerSpec struct {
 	// TemplateRef.
 	// Must be set before converting to a v1beta1 or v1beta2 API object.
 	Template *PodTemplateSpec `json:"template,omitempty"`
+}
+
+func (rcSpec ReplicationControllerSpec) DesiredReplicas() int {
+	if rcSpec.Replicas != nil {
+		return *rcSpec.Replicas
+	}
+	return 1
 }
 
 // ReplicationControllerStatus represents the current status of a replication
@@ -1785,4 +1793,8 @@ func AddToNodeAddresses(addresses *[]NodeAddress, addAddresses ...NodeAddress) {
 			*addresses = append(*addresses, add)
 		}
 	}
+}
+
+func Intp(i int) *int {
+	return &i
 }

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -458,7 +458,7 @@ func init() {
 		},
 
 		func(in *newer.ReplicationControllerSpec, out *ReplicationControllerState, s conversion.Scope) error {
-			out.Replicas = in.Replicas
+			out.Replicas = in.DesiredReplicas()
 			if err := s.Convert(&in.Selector, &out.ReplicaSelector, 0); err != nil {
 				return err
 			}
@@ -477,7 +477,7 @@ func init() {
 			return nil
 		},
 		func(in *ReplicationControllerState, out *newer.ReplicationControllerSpec, s conversion.Scope) error {
-			out.Replicas = in.Replicas
+			out.Replicas = &in.Replicas
 			if err := s.Convert(&in.ReplicaSelector, &out.Selector, 0); err != nil {
 				return err
 			}

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -246,7 +246,7 @@ func init() {
 		},
 
 		func(in *newer.ReplicationControllerSpec, out *ReplicationControllerState, s conversion.Scope) error {
-			out.Replicas = in.Replicas
+			out.Replicas = in.DesiredReplicas()
 			if err := s.Convert(&in.Selector, &out.ReplicaSelector, 0); err != nil {
 				return err
 			}
@@ -265,7 +265,7 @@ func init() {
 			return nil
 		},
 		func(in *ReplicationControllerState, out *newer.ReplicationControllerSpec, s conversion.Scope) error {
-			out.Replicas = in.Replicas
+			out.Replicas = &in.Replicas
 			if err := s.Convert(&in.ReplicaSelector, &out.Selector, 0); err != nil {
 				return err
 			}

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1003,7 +1003,7 @@ func ValidateReplicationControllerSpec(spec *api.ReplicationControllerSpec) errs
 	if selector.Empty() {
 		allErrs = append(allErrs, errs.NewFieldRequired("selector"))
 	}
-	if spec.Replicas < 0 {
+	if spec.DesiredReplicas() < 0 {
 		allErrs = append(allErrs, errs.NewFieldInvalid("replicas", spec.Replicas, isNegativeErrorMsg))
 	}
 
@@ -1014,7 +1014,7 @@ func ValidateReplicationControllerSpec(spec *api.ReplicationControllerSpec) errs
 		if !selector.Matches(labels) {
 			allErrs = append(allErrs, errs.NewFieldInvalid("template.labels", spec.Template.Labels, "selector does not match template"))
 		}
-		allErrs = append(allErrs, ValidatePodTemplateSpec(spec.Template, spec.Replicas).Prefix("template")...)
+		allErrs = append(allErrs, ValidatePodTemplateSpec(spec.Template, spec.DesiredReplicas()).Prefix("template")...)
 		// RestartPolicy has already been first-order validated as per ValidatePodTemplateSpec().
 		if spec.Template.Spec.RestartPolicy != api.RestartPolicyAlways {
 			allErrs = append(allErrs, errs.NewFieldNotSupported("template.restartPolicy", spec.Template.Spec.RestartPolicy))

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -1687,7 +1687,7 @@ func TestValidateReplicationControllerUpdate(t *testing.T) {
 			update: api.ReplicationController{
 				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 3,
+					Replicas: api.Intp(3),
 					Selector: validSelector,
 					Template: &validPodTemplate.Spec,
 				},
@@ -1704,7 +1704,7 @@ func TestValidateReplicationControllerUpdate(t *testing.T) {
 			update: api.ReplicationController{
 				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 1,
+					Replicas: api.Intp(1),
 					Selector: validSelector,
 					Template: &readWriteVolumePodTemplate.Spec,
 				},
@@ -1730,7 +1730,7 @@ func TestValidateReplicationControllerUpdate(t *testing.T) {
 			update: api.ReplicationController{
 				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 2,
+					Replicas: api.Intp(2),
 					Selector: validSelector,
 					Template: &readWriteVolumePodTemplate.Spec,
 				},
@@ -1747,7 +1747,7 @@ func TestValidateReplicationControllerUpdate(t *testing.T) {
 			update: api.ReplicationController{
 				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 2,
+					Replicas: api.Intp(2),
 					Selector: invalidSelector,
 					Template: &validPodTemplate.Spec,
 				},
@@ -1764,7 +1764,7 @@ func TestValidateReplicationControllerUpdate(t *testing.T) {
 			update: api.ReplicationController{
 				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 2,
+					Replicas: api.Intp(2),
 					Selector: validSelector,
 					Template: &invalidPodTemplate.Spec,
 				},
@@ -1781,7 +1781,7 @@ func TestValidateReplicationControllerUpdate(t *testing.T) {
 			update: api.ReplicationController{
 				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: -1,
+					Replicas: api.Intp(-1),
 					Selector: validSelector,
 					Template: &validPodTemplate.Spec,
 				},
@@ -1853,7 +1853,7 @@ func TestValidateReplicationController(t *testing.T) {
 		{
 			ObjectMeta: api.ObjectMeta{Name: "abc-123", Namespace: api.NamespaceDefault},
 			Spec: api.ReplicationControllerSpec{
-				Replicas: 1,
+				Replicas: api.Intp(1),
 				Selector: validSelector,
 				Template: &readWriteVolumePodTemplate.Spec,
 			},
@@ -1902,7 +1902,7 @@ func TestValidateReplicationController(t *testing.T) {
 		"read-write persistent disk with > 1 pod": {
 			ObjectMeta: api.ObjectMeta{Name: "abc"},
 			Spec: api.ReplicationControllerSpec{
-				Replicas: 2,
+				Replicas: api.Intp(2),
 				Selector: validSelector,
 				Template: &readWriteVolumePodTemplate.Spec,
 			},
@@ -1910,7 +1910,7 @@ func TestValidateReplicationController(t *testing.T) {
 		"negative_replicas": {
 			ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
 			Spec: api.ReplicationControllerSpec{
-				Replicas: -1,
+				Replicas: api.Intp(-1),
 				Selector: validSelector,
 			},
 		},

--- a/pkg/client/conditions.go
+++ b/pkg/client/conditions.go
@@ -29,6 +29,6 @@ func ControllerHasDesiredReplicas(c Interface, controller *api.ReplicationContro
 		if err != nil {
 			return false, err
 		}
-		return ctrl.Status.Replicas == ctrl.Spec.Replicas, nil
+		return ctrl.Status.Replicas == ctrl.Spec.DesiredReplicas(), nil
 	}
 }

--- a/pkg/client/replication_controllers_test.go
+++ b/pkg/client/replication_controllers_test.go
@@ -50,7 +50,7 @@ func TestListControllers(t *testing.T) {
 							},
 						},
 						Spec: api.ReplicationControllerSpec{
-							Replicas: 2,
+							Replicas: api.Intp(2),
 							Template: &api.PodTemplateSpec{},
 						},
 					},
@@ -78,7 +78,7 @@ func TestGetController(t *testing.T) {
 					},
 				},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 2,
+					Replicas: api.Intp(2),
 					Template: &api.PodTemplateSpec{},
 				},
 			},
@@ -117,7 +117,7 @@ func TestUpdateController(t *testing.T) {
 					},
 				},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 2,
+					Replicas: api.Intp(2),
 					Template: &api.PodTemplateSpec{},
 				},
 			},
@@ -155,7 +155,7 @@ func TestCreateController(t *testing.T) {
 					},
 				},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 2,
+					Replicas: api.Intp(2),
 					Template: &api.PodTemplateSpec{},
 				},
 			},

--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -198,7 +198,7 @@ func (rm *ReplicationManager) syncReplicationController(controller api.Replicati
 	}
 	filteredList := FilterActivePods(podList.Items)
 	activePods := len(filteredList)
-	diff := activePods - controller.Spec.Replicas
+	diff := activePods - controller.Spec.DesiredReplicas()
 	if diff < 0 {
 		diff *= -1
 		wait := sync.WaitGroup{}

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -58,7 +58,7 @@ func newReplicationController(replicas int) api.ReplicationController {
 		TypeMeta:   api.TypeMeta{APIVersion: testapi.Version()},
 		ObjectMeta: api.ObjectMeta{Name: "foobar", Namespace: api.NamespaceDefault, ResourceVersion: "18"},
 		Spec: api.ReplicationControllerSpec{
-			Replicas: replicas,
+			Replicas: &replicas,
 			Template: &api.PodTemplateSpec{
 				ObjectMeta: api.ObjectMeta{
 					Labels: map[string]string{

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -217,7 +217,7 @@ func ExamplePrintReplicationController() {
 			Labels: map[string]string{"foo": "bar"},
 		},
 		Spec: api.ReplicationControllerSpec{
-			Replicas: 1,
+			Replicas: api.Intp(1),
 			Selector: map[string]string{"foo": "bar"},
 			Template: &api.PodTemplateSpec{
 				ObjectMeta: api.ObjectMeta{

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -79,7 +79,7 @@ func testData() (*api.PodList, *api.ServiceList, *api.ReplicationControllerList)
 			{
 				ObjectMeta: api.ObjectMeta{Name: "rc1", Namespace: "test", ResourceVersion: "18"},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 1,
+					Replicas: api.Intp(1),
 				},
 			},
 		},

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -131,8 +131,8 @@ func RunRollingUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, arg
 			filename, oldName)
 	}
 	// TODO: handle resizes during rolling update
-	if newRc.Spec.Replicas == 0 {
-		newRc.Spec.Replicas = oldRc.Spec.Replicas
+	if newRc.Spec.DesiredReplicas() == 0 {
+		newRc.Spec.Replicas = api.Intp(oldRc.Spec.DesiredReplicas())
 	}
 	err = updater.Update(out, oldRc, newRc, period, interval, timeout)
 	if err != nil {

--- a/pkg/kubectl/resize.go
+++ b/pkg/kubectl/resize.go
@@ -70,8 +70,8 @@ func (c ControllerResizeError) Error() string {
 
 // Validate ensures that the preconditions match.  Returns nil if they are valid, an error otherwise
 func (precondition *ResizePrecondition) Validate(controller *api.ReplicationController) error {
-	if precondition.Size != -1 && controller.Spec.Replicas != precondition.Size {
-		return PreconditionError{"replicas", strconv.Itoa(precondition.Size), strconv.Itoa(controller.Spec.Replicas)}
+	if precondition.Size != -1 && controller.Spec.DesiredReplicas() != precondition.Size {
+		return PreconditionError{"replicas", strconv.Itoa(precondition.Size), strconv.Itoa(controller.Spec.DesiredReplicas())}
 	}
 	if precondition.ResourceVersion != "" && controller.ResourceVersion != precondition.ResourceVersion {
 		return PreconditionError{"resource version", precondition.ResourceVersion, controller.ResourceVersion}
@@ -132,7 +132,7 @@ func (resizer *ReplicationControllerResizer) ResizeSimple(namespace, name string
 			return "", err
 		}
 	}
-	controller.Spec.Replicas = int(newSize)
+	controller.Spec.Replicas = api.Intp(int(newSize))
 	// TODO: do retry on 409 errors here?
 	if _, err := rc.Update(controller); err != nil {
 		return "", ControllerResizeError{ControllerResizeUpdateFailure, controller.ResourceVersion, err}

--- a/pkg/kubectl/resize_test.go
+++ b/pkg/kubectl/resize_test.go
@@ -79,7 +79,7 @@ func TestReplicationControllerResize(t *testing.T) {
 	if fake.Actions[0].Action != "get-replicationController" || fake.Actions[0].Value != name {
 		t.Errorf("unexpected action: %v, expected get-replicationController %s", fake.Actions[0], name)
 	}
-	if fake.Actions[1].Action != "update-replicationController" || fake.Actions[1].Value.(*api.ReplicationController).Spec.Replicas != int(count) {
+	if fake.Actions[1].Action != "update-replicationController" || fake.Actions[1].Value.(*api.ReplicationController).Spec.DesiredReplicas() != int(count) {
 		t.Errorf("unexpected action %v, expected update-replicationController with replicas = %d", fake.Actions[1], count)
 	}
 }
@@ -87,7 +87,7 @@ func TestReplicationControllerResize(t *testing.T) {
 func TestReplicationControllerResizeFailsPreconditions(t *testing.T) {
 	fake := testclient.NewSimpleFake(&api.ReplicationController{
 		Spec: api.ReplicationControllerSpec{
-			Replicas: 10,
+			Replicas: api.Intp(10),
 		},
 	})
 	resizer := ReplicationControllerResizer{fake}
@@ -123,7 +123,7 @@ func TestPreconditionValidate(t *testing.T) {
 					ResourceVersion: "foo",
 				},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 10,
+					Replicas: api.Intp(10),
 				},
 			},
 			expectError: false,
@@ -136,7 +136,7 @@ func TestPreconditionValidate(t *testing.T) {
 					ResourceVersion: "foo",
 				},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 0,
+					Replicas: api.Intp(0),
 				},
 			},
 			expectError: false,
@@ -149,7 +149,7 @@ func TestPreconditionValidate(t *testing.T) {
 					ResourceVersion: "foo",
 				},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 10,
+					Replicas: api.Intp(10),
 				},
 			},
 			expectError: false,
@@ -162,7 +162,7 @@ func TestPreconditionValidate(t *testing.T) {
 					ResourceVersion: "foo",
 				},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 10,
+					Replicas: api.Intp(10),
 				},
 			},
 			expectError: false,
@@ -175,7 +175,7 @@ func TestPreconditionValidate(t *testing.T) {
 					ResourceVersion: "foo",
 				},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 20,
+					Replicas: api.Intp(20),
 				},
 			},
 			expectError: true,
@@ -188,7 +188,7 @@ func TestPreconditionValidate(t *testing.T) {
 					ResourceVersion: "bar",
 				},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 10,
+					Replicas: api.Intp(10),
 				},
 			},
 			expectError: true,
@@ -201,7 +201,7 @@ func TestPreconditionValidate(t *testing.T) {
 					ResourceVersion: "bar",
 				},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 20,
+					Replicas: api.Intp(20),
 				},
 			},
 			expectError: true,

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -373,7 +373,7 @@ func printReplicationController(controller *api.ReplicationController, w io.Writ
 		firstContainer.Name,
 		firstContainer.Image,
 		formatLabels(controller.Spec.Selector),
-		controller.Spec.Replicas)
+		controller.Spec.DesiredReplicas())
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/rolling_updater_test.go
+++ b/pkg/kubectl/rolling_updater_test.go
@@ -88,7 +88,7 @@ func oldRc(replicas int) *api.ReplicationController {
 			UID:  "7764ae47-9092-11e4-8393-42010af018ff",
 		},
 		Spec: api.ReplicationControllerSpec{
-			Replicas: replicas,
+			Replicas: api.Intp(replicas),
 			Selector: map[string]string{"version": "v1"},
 			Template: &api.PodTemplateSpec{
 				ObjectMeta: api.ObjectMeta{

--- a/pkg/kubectl/run.go
+++ b/pkg/kubectl/run.go
@@ -56,7 +56,7 @@ func (BasicReplicationController) Generate(params map[string]string) (runtime.Ob
 			Labels: labels,
 		},
 		Spec: api.ReplicationControllerSpec{
-			Replicas: count,
+			Replicas: api.Intp(count),
 			Selector: labels,
 			Template: &api.PodTemplateSpec{
 				ObjectMeta: api.ObjectMeta{

--- a/pkg/kubectl/run_test.go
+++ b/pkg/kubectl/run_test.go
@@ -42,7 +42,7 @@ func TestGenerate(t *testing.T) {
 					Labels: map[string]string{"run-container": "foo"},
 				},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 1,
+					Replicas: api.Intp(1),
 					Selector: map[string]string{"run-container": "foo"},
 					Template: &api.PodTemplateSpec{
 						ObjectMeta: api.ObjectMeta{
@@ -73,7 +73,7 @@ func TestGenerate(t *testing.T) {
 					Labels: map[string]string{"run-container": "foo"},
 				},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 1,
+					Replicas: api.Intp(1),
 					Selector: map[string]string{"run-container": "foo"},
 					Template: &api.PodTemplateSpec{
 						ObjectMeta: api.ObjectMeta{
@@ -109,7 +109,7 @@ func TestGenerate(t *testing.T) {
 					Labels: map[string]string{"foo": "bar", "baz": "blah"},
 				},
 				Spec: api.ReplicationControllerSpec{
-					Replicas: 1,
+					Replicas: api.Intp(1),
 					Selector: map[string]string{"foo": "bar", "baz": "blah"},
 					Template: &api.PodTemplateSpec{
 						ObjectMeta: api.ObjectMeta{

--- a/pkg/kubectl/stop_test.go
+++ b/pkg/kubectl/stop_test.go
@@ -29,7 +29,7 @@ import (
 func TestReplicationControllerStop(t *testing.T) {
 	fake := testclient.NewSimpleFake(&api.ReplicationController{
 		Spec: api.ReplicationControllerSpec{
-			Replicas: 0,
+			Replicas: api.Intp(0),
 		},
 	})
 	reaper := ReplicationControllerReaper{fake, time.Millisecond, time.Millisecond}

--- a/pkg/registry/controller/etcd/etcd_test.go
+++ b/pkg/registry/controller/etcd/etcd_test.go
@@ -159,7 +159,7 @@ func TestCreateControllerWithGeneratedName(t *testing.T) {
 			GenerateName: "rc-",
 		},
 		Spec: api.ReplicationControllerSpec{
-			Replicas: 2,
+			Replicas: api.Intp(2),
 			Selector: map[string]string{"a": "b"},
 			Template: &validPodTemplate.Spec,
 		},
@@ -341,7 +341,7 @@ func TestEtcdUpdateController(t *testing.T) {
 	resp, _ := fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &validController), 0)
 	update := validController
 	update.ResourceVersion = strconv.FormatUint(resp.Node.ModifiedIndex, 10)
-	update.Spec.Replicas = validController.Spec.Replicas + 1
+	update.Spec.Replicas = api.Intp(validController.Spec.DesiredReplicas() + 1)
 	_, created, err := storage.Update(ctx, &update)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -351,7 +351,7 @@ func TestEtcdUpdateController(t *testing.T) {
 	}
 	ctrl, err := storage.Get(ctx, validController.Name)
 	updatedController, _ := ctrl.(*api.ReplicationController)
-	if updatedController.Spec.Replicas != validController.Spec.Replicas+1 {
+	if updatedController.Spec.DesiredReplicas() != validController.Spec.DesiredReplicas()+1 {
 		t.Errorf("Unexpected controller: %#v", ctrl)
 	}
 }
@@ -661,7 +661,7 @@ func TestCreate(t *testing.T) {
 		// valid
 		&api.ReplicationController{
 			Spec: api.ReplicationControllerSpec{
-				Replicas: 2,
+				Replicas: api.Intp(2),
 				Selector: map[string]string{"a": "b"},
 				Template: &validPodTemplate.Spec,
 			},
@@ -669,7 +669,7 @@ func TestCreate(t *testing.T) {
 		// invalid
 		&api.ReplicationController{
 			Spec: api.ReplicationControllerSpec{
-				Replicas: 2,
+				Replicas: api.Intp(2),
 				Selector: map[string]string{},
 				Template: &validPodTemplate.Spec,
 			},

--- a/pkg/registry/etcd/etcd_test.go
+++ b/pkg/registry/etcd/etcd_test.go
@@ -267,7 +267,7 @@ func TestEtcdUpdateController(t *testing.T) {
 	_, err := registry.UpdateController(ctx, &api.ReplicationController{
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: strconv.FormatUint(resp.Node.ModifiedIndex, 10)},
 		Spec: api.ReplicationControllerSpec{
-			Replicas: 2,
+			Replicas: api.Intp(2),
 		},
 	})
 	if err != nil {
@@ -275,7 +275,7 @@ func TestEtcdUpdateController(t *testing.T) {
 	}
 
 	ctrl, err := registry.GetController(ctx, "foo")
-	if ctrl.Spec.Replicas != 2 {
+	if ctrl.Spec.DesiredReplicas() != 2 {
 		t.Errorf("Unexpected controller: %#v", ctrl)
 	}
 }

--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -41,7 +41,7 @@ func DeleteRC(c *client.Client, ns, name string) error {
 		return fmt.Errorf("Failed to find replication controller %s in namespace %s: %v", name, ns, err)
 	}
 
-	rc.Spec.Replicas = 0
+	rc.Spec.Replicas = api.Intp(0)
 
 	if _, err := c.ReplicationControllers(ns).Update(rc); err != nil {
 		return fmt.Errorf("Failed to resize replication controller %s to zero: %v", name, err)
@@ -79,7 +79,7 @@ func RunRC(c *client.Client, name string, ns, image string, replicas int) {
 			Name: name,
 		},
 		Spec: api.ReplicationControllerSpec{
-			Replicas: replicas,
+			Replicas: api.Intp(replicas),
 			Selector: map[string]string{
 				"name": name,
 			},
@@ -203,7 +203,7 @@ var _ = Describe("Density", func() {
 		// isn't 0.  This means the controller wasn't cleaned up
 		// during the test so clean it up here
 		rc, err := c.ReplicationControllers(ns).Get(RCName)
-		if err == nil && rc.Spec.Replicas != 0 {
+		if err == nil && rc.Spec.DesiredReplicas() != 0 {
 			DeleteRC(c, ns, RCName)
 		}
 	})

--- a/test/e2e/rc.go
+++ b/test/e2e/rc.go
@@ -72,7 +72,7 @@ func ServeImageOrFail(c *client.Client, test string, image string) {
 			Name: name,
 		},
 		Spec: api.ReplicationControllerSpec{
-			Replicas: replicas,
+			Replicas: api.Intp(replicas),
 			Selector: map[string]string{
 				"name": name,
 			},


### PR DESCRIPTION
/cc @bgrant0607  @dchen1107 @rjnagal @brendandburns

Fix https://github.com/GoogleCloudPlatform/kubernetes/issues/6700

Well... I was thinking this is an easy one to play with, just changing int to *int. However, it involves tons of things including printing, getting values, conversion and comparison. 

I am not sure if this is what we want to do. If it is, I would like to explore more and try to simplify the setting and getting pointer values from the `Spec`.

A safer way may be creating another user-faced json and translate that to the `Spec`?
