### PR TITLE
proxy: lower udp timeout

### DIFF
--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -456,7 +456,7 @@ func (proxier *Proxier) addServiceOnPort(service ServicePortName, protocol api.P
 }
 
 // How long we leave idle UDP connections open.
-const udpIdleTimeout = 1 * time.Minute
+const udpIdleTimeout = 10 * time.Second
 
 // OnUpdate manages the active set of service proxies.
 // Active service proxies are reinitialized if found in the update set or


### PR DESCRIPTION
For https://github.com/GoogleCloudPlatform/kubernetes/issues/6738

change from 1 Minute -> 10 second

Or any suggested value? 
