### PR TITLE
Prepare for running scalability test on Jenkins

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -37,6 +37,21 @@ else
     export HOME=${WORKSPACE} # Nothing should want Jenkins $HOME
 fi
 
+# Additional parameters that are passed to ginkgo runner.
+GINKGO_TEST_ARGS=""
+
+if [[ "${SCALABILITY:-}" == "true" ]]; then
+    export MASTER_SIZE="n1-standard-4"
+    # TODO(wojtek-t): Once we have enough quota for the project, increase
+    # NUM_MINIONS to 100 (which is our v1.0 goal).
+    export NUM_MINIONS="10"
+    GINKGO_TEST_ARGS="--ginkgo.focus=Density "
+else
+    export MASTER_SIZE="g1-small"
+    export NUM_MINIONS="2"
+fi
+
+
 # Unlike the kubernetes-build script, we expect some environment
 # variables to be set. We echo these immediately and presume "set -o
 # nounset" will force the caller to set them: (The first several are
@@ -111,7 +126,7 @@ go run ./hack/e2e.go -v --ctl="version --match-server-version=false"
 ### Run tests ###
 # Jenkins will look at the junit*.xml files for test failures, so don't exit
 # with a nonzero error code if it was only tests that failed.
-go run ./hack/e2e.go ${E2E_OPT} -v --test --test_args="--ginkgo.noColor" || true
+go run ./hack/e2e.go ${E2E_OPT} -v --test --test_args="${GINKGO_TEST_ARGS}--ginkgo.noColor" || true
 
 ### Clean up ###
 go run ./hack/e2e.go ${E2E_OPT} -v --down


### PR DESCRIPTION
Change hack/jenkins/e2e.sh so that it support one additional env variable as its input.
Based on its (SCALABILITY) value it will set:
- the size of the cluster (# nodes)
- the size of the master
- pass additional flag to ginkgo runner, which will result in running a different suite of tests

@ixdy @zmerlynn @quinton-hoole 
