### PR TITLE
libvirt-coreos cluster: Fix etcd versions incompatibility issue

### DIFF
--- a/cluster/libvirt-coreos/.gitignore
+++ b/cluster/libvirt-coreos/.gitignore
@@ -1,2 +1,3 @@
 /libvirt_storage_pool/
 /coreos_production_qemu_image.img.bz2
+/etcd-v2.0.9-linux-amd64.tar.gz

--- a/cluster/libvirt-coreos/coreos.xml
+++ b/cluster/libvirt-coreos/coreos.xml
@@ -35,6 +35,11 @@
       <target dir='kubernetes'/>
       <readonly/>
     </filesystem>
+    <filesystem type='mount' accessmode='squash'>
+      <source dir='${etcd_dir}'/>
+      <target dir='etcd'/>
+      <readonly/>
+    </filesystem>
     <interface type='network'>
        <mac address='52:54:00:00:00:${i}'/>
        <source network='kubernetes_global'/>

--- a/cluster/libvirt-coreos/user_data.yml
+++ b/cluster/libvirt-coreos/user_data.yml
@@ -17,11 +17,22 @@ coreos:
   etcd:
     name: ${name}
     addr: ${public_ip}:4001
-    bind-addr: 0.0.0.0
+    # bind-addr: 0.0.0.0
     peer-addr: ${public_ip}:7001
     # peers: {etcd_peers}
     discovery: ${discovery}
   units:
+    - name: etcd.service
+      drop-ins:
+        - name: opt-etcd2.conf
+          content: |
+            [Unit]
+            After=opt-etcd.mount
+            Requires=opt-etcd.mount
+
+            [Service]
+            ExecStart=
+            ExecStart=/opt/etcd/bin/etcd
     - name: static.network
       command: start
       content: |
@@ -101,6 +112,17 @@ coreos:
         [Mount]
         What=kubernetes
         Where=/opt/kubernetes
+        Options=ro,trans=virtio,version=9p2000.L
+        Type=9p
+    - name: opt-etcd.mount
+      command: start
+      content: |
+        [Unit]
+        ConditionVirtualization=|vm
+
+        [Mount]
+        What=etcd
+        Where=/opt/etcd
         Options=ro,trans=virtio,version=9p2000.L
         Type=9p
   update:

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -25,6 +25,8 @@ export LIBVIRT_DEFAULT_URI=qemu:///system
 readonly POOL=kubernetes
 readonly POOL_PATH="$(cd $ROOT && pwd)/libvirt_storage_pool"
 
+ETCD_VERSION=${ETCD_VERSION:-v2.0.9}
+
 # join <delim> <list...>
 # Concatenates the list elements with the delimiter passed as first parameter
 #
@@ -93,6 +95,9 @@ function destroy-pool {
         virsh vol-delete $vol --pool $POOL
       done
 
+  rm -rf "$POOL_PATH"/etcd/*
+  virsh vol-delete etcd --pool $POOL || true
+
   [[ "$1" == 'keep_base_image' ]] && return
 
   set +e
@@ -138,6 +143,18 @@ function initialize-pool {
   if [[ "$ENABLE_CLUSTER_DNS" == "true" ]]; then
       render-template "$ROOT/skydns-svc.yaml" > "$POOL_PATH/kubernetes/addons/skydns-svc.yaml"
       render-template "$ROOT/skydns-rc.yaml"  > "$POOL_PATH/kubernetes/addons/skydns-rc.yaml"
+  fi
+
+  mkdir -p "$POOL_PATH/etcd"
+  if [[ ! -f "$ROOT/etcd-${ETCD_VERSION}-linux-amd64.tar.gz" ]]; then
+      wget -P "$ROOT" https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz
+  fi
+  if [[ "$ROOT/etcd-${ETCD_VERSION}-linux-amd64.tar.gz" -nt "$POOL_PATH/etcd/etcd" ]]; then
+      tar -x -C "$POOL_PATH/etcd" -f "$ROOT/etcd-${ETCD_VERSION}-linux-amd64.tar.gz" etcd-${ETCD_VERSION}-linux-amd64
+      rm -rf "$POOL_PATH/etcd/bin/*"
+      mkdir -p "$POOL_PATH/etcd/bin"
+      mv "$POOL_PATH"/etcd/etcd-${ETCD_VERSION}-linux-amd64/{etcd,etcdctl} "$POOL_PATH/etcd/bin"
+      rm -rf "$POOL_PATH/etcd/etcd-${ETCD_VERSION}-linux-amd64"
   fi
 
   virsh pool-refresh $POOL
@@ -187,6 +204,7 @@ function kube-up {
 
   readonly ssh_keys="$(cat ~/.ssh/id_*.pub | sed 's/^/  - /')"
   readonly kubernetes_dir="$POOL_PATH/kubernetes"
+  readonly etcd_dir="$POOL_PATH/etcd"
   readonly discovery=$(curl -s https://discovery.etcd.io/new)
 
   readonly machines=$(join , "${KUBE_MINION_IP_ADDRESSES[@]}")


### PR DESCRIPTION
Whereas CoreOS is still shipped with etcd 0.4.9, kubernetes has moved to etcd 2.0.4.

This version mismatch makes kubernetes unable to use etcd.
Kubernetes’ logs are full of “502:  (unhandled http status [Temporary Redirect] with body []) [0]”

This change makes libvirt-coreos cluster explicitly use etcd v2.0.9 instead of the one shipped within CoreOS.
This change aims at being reverted once CoreOS will migrate to etcd 2.
This migration is tracked at:
https://github.com/coreos/bugs/issues/317
