### PR TITLE
allow selective removal of kubeconfig override flags

### DIFF
--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -323,8 +323,8 @@ func DefaultClientConfig(flags *pflag.FlagSet) clientcmd.ClientConfig {
 	overrides := &clientcmd.ConfigOverrides{}
 	flagNames := clientcmd.RecommendedConfigOverrideFlags("")
 	// short flagnames are disabled by default.  These are here for compatibility with existing scripts
-	flagNames.AuthOverrideFlags.AuthPathShort = "a"
-	flagNames.ClusterOverrideFlags.APIServerShort = "s"
+	flagNames.AuthOverrideFlags.AuthPath.ShortName = "a"
+	flagNames.ClusterOverrideFlags.APIServer.ShortName = "s"
 
 	clientcmd.BindOverrideFlags(overrides, flags, flagNames)
 	clientConfig := clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, overrides, os.Stdin)


### PR DESCRIPTION
The recommended bind methods are really useful, but don't allow callers to turn off certain flags.  Adding the ability to disable a flag by removing it's `LongName`.

@smarterclayton we'd like this or something like it to resolve: https://github.com/openshift/origin/issues/1704
