### PR TITLE
[DO NOT MERGE] make verify-boilerplate.sh year aware

### DIFF
--- a/hooks/boilerplate.go.txt
+++ b/hooks/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Google Inc. All rights reserved.
+Copyright 2013 Google Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hooks/boilerplate.sh
+++ b/hooks/boilerplate.sh
@@ -25,12 +25,14 @@ if [ ! -e $REF_FILE ]; then
   exit 0
 fi
 
+YEAR=$(git log --diff-filter=A -- ${FILE} | grep Date | awk '{print $6}' | sort | head -n 1)
+
 LINES=$(cat "${REF_FILE}" | wc -l | tr -d ' ')
 if [[ "${EXT}" == "go" ]]; then
   # remove build tags from the top of Go file
-  DIFFER=$(cat "${FILE}" | sed '/\/\*/,$!d' | sed 's/2015/2014/g' | head "-${LINES}" | diff -q - "${REF_FILE}")
+  DIFFER=$(cat "${FILE}" | sed '/\/\*/,$!d' | sed "s/${YEAR}/2013/g" | head "-${LINES}" | diff -q - "${REF_FILE}")
 else
-  DIFFER=$(head "-${LINES}" "${FILE}" | sed 's/2015/2014/g' | diff -q - "${REF_FILE}")
+  DIFFER=$(head "-${LINES}" "${FILE}" | sed "s/${YEAR}/2013/g" | diff -q - "${REF_FILE}")
 fi
 
 if [[ -z "${DIFFER}" ]]; then

--- a/hooks/boilerplate.sh.txt
+++ b/hooks/boilerplate.sh.txt
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2013 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
@jlowdermilk This makes the command run really slow (checks the git log of every file), but I think it is finding bad years. 

```
[deads@deads-dev-01 kubernetes]$ hack/verify-boilerplate.sh  | wc -l
249
```

Not sure if you want to chase those down using this update.  The few hits I checked looked valid.
