### PR TITLE
Make secrets client honor namespace

### DIFF
--- a/pkg/client/secrets.go
+++ b/pkg/client/secrets.go
@@ -53,7 +53,7 @@ func newSecrets(c *Client, ns string) *secrets {
 func (s *secrets) Create(secret *api.Secret) (*api.Secret, error) {
 	result := &api.Secret{}
 	err := s.client.Post().
-		Namespace(secret.Namespace).
+		Namespace(s.namespace).
 		Resource("secrets").
 		Body(secret).
 		Do().


### PR DESCRIPTION
All other clients take the namespace from the constructed client, not the passed object.
