### PR TITLE
Suggest running make clean on verify-gendocs failure

### DIFF
--- a/hack/verify-gendocs.sh
+++ b/hack/verify-gendocs.sh
@@ -80,6 +80,8 @@ then
 	echo "${COMPROOT} up to date."
 else
 	echo "${COMPROOT} is out of date. Please run hack/run-gendocs.sh"
+	echo "If you did not make a change to kubectl or its dependencies,"
+	echo "run 'make clean' and retry this command."
 	exit 1
 fi
 


### PR DESCRIPTION
I've had 5 or so people ping/send prs for gendocs failing after an update to cobra or pflags that changed the output of kubectl. Our incremental build isn't smart about picking up godep changes, so this puts a friendly reminder in hack/verify-gendocs.sh to avoid wasting people's time when `make clean` will fix.
