### PR TITLE
Disable shell test for non-gce providers

### DIFF
--- a/test/e2e/shell.go
+++ b/test/e2e/shell.go
@@ -35,6 +35,14 @@ var (
 var _ = Describe("Shell", func() {
 
 	defer GinkgoRecover()
+
+	// A number of scripts only work on gce
+	if testContext.Provider != "gce" && testContext.Provider != "gke" {
+		By(fmt.Sprintf("Skipping Shell test, which is only supported for provider gce and gke (not %s)",
+			testContext.Provider))
+		return
+	}
+
 	// Slurp up all the tests in hack/e2e-suite
 	bashE2ERoot := filepath.Join(root, "hack/e2e-suite")
 	files, err := ioutil.ReadDir(bashE2ERoot)


### PR DESCRIPTION
A bunch of the scripts require gce utils, just disable for non-gce providers until we can sort through them. 
