### PR TITLE
Don't always use aws.conf

### DIFF
--- a/cluster/aws/templates/salt-master.sh
+++ b/cluster/aws/templates/salt-master.sh
@@ -38,11 +38,6 @@ if [[ -n "${DOCKER_ROOT}" ]]; then
 EOF
 fi
 
-cat <<EOF > /etc/aws.conf
-[Global]
-Zone = ${ZONE}
-EOF
-
 # Auto accept all keys from minions that try to join
 mkdir -p /etc/salt/master.d
 cat <<EOF >/etc/salt/master.d/auto-accept.conf

--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
@@ -15,7 +15,9 @@
   {% endif -%}
 
 {% elif grains.cloud == 'aws' -%}
-  {% set cloud_config = "--cloud_config=/etc/aws.conf" -%}
+  {% if grains.cloud_config is defined -%}
+    {% set cloud_config = "--cloud_config=" + grains.cloud_config -%}
+  {% endif -%}
 {% endif -%}
 
 {% endif -%}

--- a/cluster/saltbase/salt/kube-controller-manager/default
+++ b/cluster/saltbase/salt/kube-controller-manager/default
@@ -25,7 +25,9 @@
   {% endif -%}
 
 {% elif grains.cloud == 'aws' -%}
-  {% set cloud_config = "--cloud_config=/etc/aws.conf" -%}
+  {% if grains.cloud_config is defined -%}
+    {% set cloud_config = "--cloud_config=" + grains.cloud_config -%}
+  {% endif -%}
   {% set machines = "--machines=" + ','.join(salt['mine.get']('roles:kubernetes-pool', 'network.ip_addrs', expr_form='grain').keys()) -%}
 
 {% elif grains.cloud == 'azure' -%}


### PR DESCRIPTION
We don't usually need it, and it makes it harder to put apiserver into a container.

This should fix aws after #6785
