### PR TITLE
Replication controller gives failedCreate events

### DIFF
--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -55,6 +56,7 @@ type PodControlInterface interface {
 // RealPodControl is the default implementation of PodControllerInterface.
 type RealPodControl struct {
 	kubeClient client.Interface
+	recorder   record.EventRecorder
 }
 
 // Time period of main replication controller sync loop
@@ -92,6 +94,7 @@ func (r RealPodControl) createReplica(namespace string, controller api.Replicati
 		return
 	}
 	if _, err := r.kubeClient.Pods(namespace).Create(pod); err != nil {
+		r.recorder.Eventf(&controller, "failedCreate", "Error creating: %v", err)
 		util.HandleError(fmt.Errorf("unable to create pod replica: %v", err))
 	}
 }
@@ -102,12 +105,17 @@ func (r RealPodControl) deletePod(namespace, podID string) error {
 
 // NewReplicationManager creates a new ReplicationManager.
 func NewReplicationManager(kubeClient client.Interface) *ReplicationManager {
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(kubeClient.Events(""))
+
 	rm := &ReplicationManager{
 		kubeClient: kubeClient,
 		podControl: RealPodControl{
 			kubeClient: kubeClient,
+			recorder:   eventBroadcaster.NewRecorder(api.EventSource{Component: "replication-controller"}),
 		},
 	}
+
 	rm.syncHandler = rm.syncReplicationController
 	return rm
 }


### PR DESCRIPTION
A replication controller may fail to create a pod for a number of reasons based on any quota constraints that are imposed in the namespace (max number of pods, max cpu, memory, etc.)

This PR lets the end-user see via the CLI why a replication controller is failing to meet the desired state when it fails to create a pod by creating an event.

The end-user sees the following:

``` shell
cluster/kubectl.sh describe rc demo --namespace=test
current-context: "vagrant"
Running: cluster/../cluster/vagrant/../../_output/dockerized/bin/linux/amd64/kubectl --kubeconfig=/home/decarr/.kubernetes_vagrant_kubeconfig describe rc demo --namespace=test
W0414 15:42:01.624142   17925 request.go:288] field selector: v1beta1 - events - involvedObject.namespace - test: need to check if this is versioned correctly.
W0414 15:42:01.624213   17925 request.go:288] field selector: v1beta1 - events - involvedObject.kind - ReplicationController: need to check if this is versioned correctly.
W0414 15:42:01.624222   17925 request.go:288] field selector: v1beta1 - events - involvedObject.uid - 1c5df4dd-e2de-11e4-83b7-0800279696e1: need to check if this is versioned correctly.
W0414 15:42:01.624229   17925 request.go:288] field selector: v1beta1 - events - involvedObject.id - demo: need to check if this is versioned correctly.
Name:       demo
Image(s):   openshift/hello-openshift
Selector:   run-container=demo
Labels:     run-container=demo
Replicas:   10 current / 20 desired
Pods Status:    10 Running / 0 Waiting / 0 Succeeded / 0 Failed
Events:
  FirstSeen             LastSeen            Count   From                SubobjectPath   Reason      Message
  Tue, 14 Apr 2015 15:40:31 -0400   Tue, 14 Apr 2015 15:41:01 -0400 145 {replication-controller }           failedCreate    Error creating: pods "" is forbidden: Unable to CREATE pods at this time because there was an error enforcing quota
  Tue, 14 Apr 2015 15:41:06 -0400   Tue, 14 Apr 2015 15:41:57 -0400 140 {replication-controller }           failedCreate    Error creating: pods "" is forbidden: Limited to 10 pods

```

/cc @jwforres @liggitt 
