### PR TITLE
Registering a serviceErrorHandler with go-restful to always return JSON responses

### DIFF
--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -785,7 +785,7 @@ func (r *Request) transformUnstructuredResponseError(resp *http.Response, req *h
 		message = strings.TrimSpace(string(body))
 	}
 	retryAfter, _ := retryAfterSeconds(resp)
-	return errors.NewGenericServerResponse(resp.StatusCode, req.Method, r.resource, r.resourceName, message, retryAfter)
+	return errors.NewGenericServerResponse(resp.StatusCode, req.Method, r.resource, r.resourceName, message, retryAfter, true)
 }
 
 // isTextResponse returns true if the response appears to be a textual media type.

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -431,6 +431,7 @@ func (m *Master) init(c *Config) {
 
 	apiserver.InstallSupport(m.muxHelper, m.rootWebService)
 	apiserver.AddApiWebService(m.handlerContainer, c.APIPrefix, apiVersions)
+	apiserver.InstallServiceErrorHandler(m.handlerContainer)
 
 	// Register root handler.
 	// We do not register this using restful Webservice since we do not want to surface this in api docs.


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/4347, https://github.com/GoogleCloudPlatform/kubernetes/issues/1990 and https://github.com/GoogleCloudPlatform/kubernetes/issues/6153

This is required to return Json errors instead of plain text.

Running 
`$curl -X PUT -i http://localhost:8085/api/v1beta3/redirect/namespaces/default/services/kubernetes` with this change gives the following output:

```
HTTP/1.1 405 Method Not Allowed
Content-Type: application/json
Content-Length: 234

{
  "kind": "Status",
  "apiVersion": "v1beta3",
  "metadata": {},
  "status": "Failure",
  "message": "the server does not allow this method on the requested resource",
  "reason": "MethodNotAllowed",
  "details": {},
  "code": 405
}
```

instead of the previous response:

```
HTTP/1.1 405 Method Not Allowed
Content-Length: 23
Content-Type: text/plain; charset=utf-8

405: Method Not Allowed
```
