### PR TITLE
This commit fixes "kubectl get nodes" output and makes it more sane. It also fixes related test case resource_printer_test.

### DIFF
--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -503,12 +503,6 @@ func printNode(node *api.Node, w io.Writer) error {
 		cond := node.Status.Conditions[i]
 		conditionMap[cond.Type] = &cond
 	}
-	var schedulable string
-	if node.Spec.Unschedulable {
-		schedulable = "Unschedulable"
-	} else {
-		schedulable = "Schedulable"
-	}
 	var status []string
 	for _, validCondition := range NodeAllConditions {
 		if condition, ok := conditionMap[validCondition]; ok {
@@ -522,7 +516,10 @@ func printNode(node *api.Node, w io.Writer) error {
 	if len(status) == 0 {
 		status = append(status, "Unknown")
 	}
-	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", node.Name, schedulable, formatLabels(node.Labels), strings.Join(status, ","))
+	if node.Spec.Unschedulable {
+		status = append(status, "SchedulingDisabled")
+	}
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\n", node.Name, formatLabels(node.Labels), strings.Join(status, ","))
 	return err
 }
 

--- a/pkg/kubectl/resource_printer_test.go
+++ b/pkg/kubectl/resource_printer_test.go
@@ -557,6 +557,14 @@ func TestPrintMinionStatus(t *testing.T) {
 		},
 		{
 			minion: api.Node{
+				ObjectMeta: api.ObjectMeta{Name: "foo2"},
+				Spec:       api.NodeSpec{Unschedulable: true},
+				Status:     api.NodeStatus{Conditions: []api.NodeCondition{{Type: api.NodeReady, Status: api.ConditionTrue}}},
+			},
+			status: "Ready,SchedulingDisabled",
+		},
+		{
+			minion: api.Node{
 				ObjectMeta: api.ObjectMeta{Name: "foo3"},
 				Status: api.NodeStatus{Conditions: []api.NodeCondition{
 					{Type: api.NodeReady, Status: api.ConditionTrue},
@@ -574,16 +582,40 @@ func TestPrintMinionStatus(t *testing.T) {
 		{
 			minion: api.Node{
 				ObjectMeta: api.ObjectMeta{Name: "foo5"},
+				Spec:       api.NodeSpec{Unschedulable: true},
+				Status:     api.NodeStatus{Conditions: []api.NodeCondition{{Type: api.NodeReady, Status: api.ConditionFalse}}},
+			},
+			status: "NotReady,SchedulingDisabled",
+		},
+		{
+			minion: api.Node{
+				ObjectMeta: api.ObjectMeta{Name: "foo6"},
 				Status:     api.NodeStatus{Conditions: []api.NodeCondition{{Type: "InvalidValue", Status: api.ConditionTrue}}},
 			},
 			status: "Unknown",
 		},
 		{
 			minion: api.Node{
-				ObjectMeta: api.ObjectMeta{Name: "foo6"},
+				ObjectMeta: api.ObjectMeta{Name: "foo7"},
 				Status:     api.NodeStatus{Conditions: []api.NodeCondition{{}}},
 			},
 			status: "Unknown",
+		},
+		{
+			minion: api.Node{
+				ObjectMeta: api.ObjectMeta{Name: "foo8"},
+				Spec:       api.NodeSpec{Unschedulable: true},
+				Status:     api.NodeStatus{Conditions: []api.NodeCondition{{Type: "InvalidValue", Status: api.ConditionTrue}}},
+			},
+			status: "Unknown,SchedulingDisabled",
+		},
+		{
+			minion: api.Node{
+				ObjectMeta: api.ObjectMeta{Name: "foo9"},
+				Spec:       api.NodeSpec{Unschedulable: true},
+				Status:     api.NodeStatus{Conditions: []api.NodeCondition{{}}},
+			},
+			status: "Unknown,SchedulingDisabled",
 		},
 	}
 


### PR DESCRIPTION
In its current form, "kubectl get nodes" output seems misaligned and sometimes incorrect too as it shows for example:
# kubectl get nodes

NAME                LABELS              STATUS
fed-node   Schedulable   name=fed-node-label  NotReady

This patch combines Schedulable/Unschedubale with Ready/NotReady/Unknown in STATUS field. So if unschedulable bit is true, the output will be:

NAME       LABELS                      STATUS
fed-node    name=fed-node-label   Ready,Unschedubale    

or STATUS will be (NotReady,Unschedulable) or (Unknown, Unschedulable).

If unschedulable bit is false (by default), it will show:
fed-node    name=fed-node-label   Ready,Schedubale 

If Node is in Ready state. But if Node is in NotReady or Unkown state, it will show:
fed-node    name=fed-node-label   NotReady,UnSchedubale  or  (Unknown,Unschedulable)

Currently it shows Schedulable  even with  NotReady or Unknown, which seems incorrect as it does not make any sense to output a Node as Schedulable when in NotReady/Unknown state. As soon as a Node becomes Ready, it will show STATUS as Ready,Schedulable. 
