### PR TITLE
Vagrant should not block on daemons that moved to pods

### DIFF
--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -124,7 +124,7 @@ function verify-cluster {
   # verify master has all required daemons
   echo "Validating master"
   local machine="master"
-  local -a required_daemon=("salt-master" "salt-minion" "kube-apiserver" "nginx" "kube-controller-manager" "kube-scheduler" "kubelet")
+  local -a required_daemon=("salt-master" "salt-minion" "nginx" "kube-controller-manager" "kubelet")
   local validated="1"
   until [[ "$validated" == "0" ]]; do
     validated="0"


### PR DESCRIPTION
kube-apiserver and kube-scheduler are now running in pods.

This let's kube-up.sh work for vagrant provider and not get stuck in a validating loop.

/cc @dchen1107 @ArtfulCoder 
