### PR TITLE
Escape integration test codes from unit tests

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -35,6 +35,7 @@ kube::test::find_dirs() {
           -o -wholename '*/third_party/*' \
           -o -wholename '*/Godeps/*' \
           -o -wholename '*/contrib/podex/*' \
+          -o -wholename '*/test/integration/*' \
         \) -prune \
       \) -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./||' | sort -u
   )


### PR DESCRIPTION
When running `$ ./hack/test-go.sh`, we get following message.

```
?       github.com/GoogleCloudPlatform/kubernetes/test/integration  [no test files]
```

The cause is that There some `xxx_test.go` in `kubernetes/test/integration` (ex: auth_test.go), but they don't have xxx.go like `auth.go`.
