### PR TITLE
Continue after failed unit test

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -150,7 +150,7 @@ runTests() {
   if [[ ! ${KUBE_COVER} =~ ^[yY]$ ]]; then
     kube::log::status "Running unit tests without code coverage"
     go test "${goflags[@]:+${goflags[@]}}" \
-      ${KUBE_RACE} ${KUBE_TIMEOUT} "${@+${@/#/${KUBE_GO_PACKAGE}/}}"
+      ${KUBE_RACE} ${KUBE_TIMEOUT} "${@+${@/#/${KUBE_GO_PACKAGE}/}}" || true
     return 0
   fi
 
@@ -172,7 +172,7 @@ runTests() {
           -cover -covermode="${KUBE_COVERMODE}" \
           -coverprofile="${cover_report_dir}/{}/${cover_profile}" \
           "${cover_params[@]+${cover_params[@]}}" \
-          "${KUBE_GO_PACKAGE}/{}"
+          "${KUBE_GO_PACKAGE}/{}" || true
 
   COMBINED_COVER_PROFILE="${cover_report_dir}/combined-coverage.out"
   {


### PR DESCRIPTION
During the unit tests, if one of the test is failed, `test-go.sh` is stopped. This patch will make whole tests run.

FYI: Current output

```
$ ./hack/test-go.sh
....
ok      github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler  0.017s
ok      github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithmprovider    0.013s
ok      github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/api/validation   0.008s
ok      github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/factory  0.026s
?       github.com/GoogleCloudPlatform/kubernetes/test/integration  [no test files]
!!! Error in ./hack/test-go.sh:152
  'go test "${goflags[@]:+${goflags[@]}}" ${KUBE_RACE} ${KUBE_TIMEOUT} "${@+${@/#/${KUBE_GO_PACKAGE}/}}"' exited with status 1
```
