### PR TITLE
Stop using dockerfile/* images

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
@@ -2,7 +2,7 @@
 # to work with Kubernetes logging. Inspired by the Dockerfile
 # dockerfile/elasticsearch
 
-FROM dockerfile/java:openjdk-7-jre
+FROM java:openjdk-7-jre
 MAINTAINER Satnam Singh "satnam@google.com"
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/cluster/addons/fluentd-elasticsearch/logging-demo/README.md
+++ b/cluster/addons/fluentd-elasticsearch/logging-demo/README.md
@@ -59,19 +59,19 @@ synthetic-logger-0.25lps-pod           synth-lgr               ubuntu:14.04     
 synthetic-logger-10lps-pod             synth-lgr               ubuntu:14.04                       kubernetes-minion-1.c.kubernetes-elk.internal/146.148.42.44     name=synth-logging-source    Running
 influx-grafana                         influxdb                kubernetes/heapster_influxdb       kubernetes-minion-3.c.kubernetes-elk.internal/130.211.129.169   name=influxdb                Running
                                        grafana                 kubernetes/heapster_grafana                                                                                                     
-                                       elasticsearch           dockerfile/elasticsearch                                                                                                        
+                                       elasticsearch           elasticsearch                                                                                                                   
 heapster                               heapster                kubernetes/heapster                kubernetes-minion-2.c.kubernetes-elk.internal/146.148.41.87     name=heapster                Running
 67cfcb1f-9764-11e4-898c-42010af03582   etcd                    quay.io/coreos/etcd:latest         kubernetes-minion-3.c.kubernetes-elk.internal/130.211.129.169   k8s-app=skydns               Running
                                        kube2sky                kubernetes/kube2sky:1.0                                                                                                         
                                        skydns                  kubernetes/skydns:2014-12-23-001                                                                                                
-6ba20338-9764-11e4-898c-42010af03582   elasticsearch-logging   dockerfile/elasticsearch           kubernetes-minion-3.c.kubernetes-elk.internal/130.211.129.169   name=elasticsearch-logging   Running
+6ba20338-9764-11e4-898c-42010af03582   elasticsearch-logging   elasticsearch                      kubernetes-minion-3.c.kubernetes-elk.internal/130.211.129.169   name=elasticsearch-logging   Running
 ../../../cluster/kubectl.sh get replicationControllers
 Running: ../../../cluster/../cluster/gce/../../_output/dockerized/bin/linux/amd64/kubectl get replicationControllers
 CONTROLLER                         CONTAINER(S)            IMAGE(S)                           SELECTOR                     REPLICAS
 skydns                             etcd                    quay.io/coreos/etcd:latest         k8s-app=skydns               1
                                    kube2sky                kubernetes/kube2sky:1.0                                         
                                    skydns                  kubernetes/skydns:2014-12-23-001                                
-elasticsearch-logging-controller   elasticsearch-logging   dockerfile/elasticsearch           name=elasticsearch-logging   1
+elasticsearch-logging-controller   elasticsearch-logging   elasticsearch                      name=elasticsearch-logging   1
 kibana-logging-controller          kibana-logging          kubernetes/kibana                  name=kibana-logging          1
 ../../.../kubectl.sh get services
 Running: ../../../cluster/../cluster/gce/../../_output/dockerized/bin/linux/amd64/kubectl get services

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -1075,7 +1075,7 @@ const (
 			"containers": [
 				{
 					"name": "redis",
-					"image": "dockerfile/redis",
+					"image": "redis",
 					"volumeMounts": [{
 						"name": "redis-data",
 						"mountPath": "/data"
@@ -1103,7 +1103,7 @@ const (
 id: container-vm-guestbook-manifest
 containers:
   - name: redis
-    image: dockerfile/redis
+    image: redis
     volumeMounts:
       - name: redis-data
         mountPath: /data

--- a/cmd/integration/v1beta1-controller.json
+++ b/cmd/integration/v1beta1-controller.json
@@ -12,7 +12,7 @@
              "id": "nginx-controller",
              "containers": [{
                "name": "nginx",
-               "image": "dockerfile/nginx",
+               "image": "nginx",
                "ports": [{"containerPort": 80}]
              }]
            }

--- a/cmd/integration/v1beta3-controller.json
+++ b/cmd/integration/v1beta3-controller.json
@@ -15,7 +15,7 @@
        "spec": {
            "containers": [{
              "name": "nginx",
-             "image": "dockerfile/nginx",
+             "image": "nginx",
              "ports": [{"containerPort": 80}]
            }]
        }

--- a/docs/design/persistent-storage.md
+++ b/docs/design/persistent-storage.md
@@ -184,7 +184,7 @@ metadata:
   name: mypod
 spec:
   containers:
-    - image: dockerfile/nginx
+    - image: nginx
       name: myfrontend
       volumeMounts:
       - mountPath: "/var/www/html"

--- a/docs/devel/developer-guides/vagrant.md
+++ b/docs/devel/developer-guides/vagrant.md
@@ -181,7 +181,7 @@ NAME   IMAGE(S   SELECTOR   REPLICAS
 Start a container running nginx with a replication controller and three replicas
 
 ```
-$ cluster/kubectl.sh run-container my-nginx --image=dockerfile/nginx --replicas=3 --port=80
+$ cluster/kubectl.sh run-container my-nginx --image=nginx --replicas=3 --port=80
 ```
 
 When listing the pods, you will see that three containers have been started and are in Waiting state:
@@ -189,9 +189,9 @@ When listing the pods, you will see that three containers have been started and 
 ```
 $ cluster/kubectl.sh get pods
 NAME                                   IMAGE(S)            HOST                    LABELS         STATUS
-781191ff-3ffe-11e4-9036-0800279696e1   dockerfile/nginx    10.245.2.4/10.245.2.4   name=myNginx   Waiting
-7813c8bd-3ffe-11e4-9036-0800279696e1   dockerfile/nginx    10.245.2.2/10.245.2.2   name=myNginx   Waiting
-78140853-3ffe-11e4-9036-0800279696e1   dockerfile/nginx    10.245.2.3/10.245.2.3   name=myNginx   Waiting
+781191ff-3ffe-11e4-9036-0800279696e1   nginx               10.245.2.4/10.245.2.4   name=myNginx   Waiting
+7813c8bd-3ffe-11e4-9036-0800279696e1   nginx               10.245.2.2/10.245.2.2   name=myNginx   Waiting
+78140853-3ffe-11e4-9036-0800279696e1   nginx               10.245.2.3/10.245.2.3   name=myNginx   Waiting
 ```
 
 You need to wait for the provisioning to complete, you can monitor the minions by doing:
@@ -210,7 +210,7 @@ Once the docker image for nginx has been downloaded, the container will start an
 $ sudo salt '*minion-1' cmd.run 'docker ps'
 kubernetes-minion-1:
     CONTAINER ID        IMAGE                     COMMAND                CREATED             STATUS              PORTS                    NAMES
-    dbe79bf6e25b        dockerfile/nginx:latest   "nginx"                21 seconds ago      Up 19 seconds                                k8s--mynginx.8c5b8a3a--7813c8bd_-_3ffe_-_11e4_-_9036_-_0800279696e1.etcd--7813c8bd_-_3ffe_-_11e4_-_9036_-_0800279696e1--fcfa837f
+    dbe79bf6e25b        nginx:latest              "nginx"                21 seconds ago      Up 19 seconds                                k8s--mynginx.8c5b8a3a--7813c8bd_-_3ffe_-_11e4_-_9036_-_0800279696e1.etcd--7813c8bd_-_3ffe_-_11e4_-_9036_-_0800279696e1--fcfa837f
     fa0e29c94501        kubernetes/pause:latest   "/pause"               8 minutes ago       Up 8 minutes        0.0.0.0:8080->80/tcp     k8s--net.a90e7ce4--7813c8bd_-_3ffe_-_11e4_-_9036_-_0800279696e1.etcd--7813c8bd_-_3ffe_-_11e4_-_9036_-_0800279696e1--baf5b21b
 ```
 
@@ -219,16 +219,16 @@ Going back to listing the pods, services and replicationControllers, you now hav
 ```
 $ cluster/kubectl.sh get pods
 NAME                                   IMAGE(S)            HOST                    LABELS         STATUS
-781191ff-3ffe-11e4-9036-0800279696e1   dockerfile/nginx    10.245.2.4/10.245.2.4   name=myNginx   Running
-7813c8bd-3ffe-11e4-9036-0800279696e1   dockerfile/nginx    10.245.2.2/10.245.2.2   name=myNginx   Running
-78140853-3ffe-11e4-9036-0800279696e1   dockerfile/nginx    10.245.2.3/10.245.2.3   name=myNginx   Running
+781191ff-3ffe-11e4-9036-0800279696e1   nginx               10.245.2.4/10.245.2.4   name=myNginx   Running
+7813c8bd-3ffe-11e4-9036-0800279696e1   nginx               10.245.2.2/10.245.2.2   name=myNginx   Running
+78140853-3ffe-11e4-9036-0800279696e1   nginx               10.245.2.3/10.245.2.3   name=myNginx   Running
 
 $ cluster/kubectl.sh get services
 NAME   LABELS   SELECTOR   IP   PORT
 
 $ cluster/kubectl.sh get replicationControllers
 NAME      IMAGE(S            SELECTOR       REPLICAS
-myNginx   dockerfile/nginx   name=my-nginx   3
+myNginx   nginx              name=my-nginx   3
 ```
 
 We did not start any services, hence there are none listed. But we see three replicas displayed properly.
@@ -239,8 +239,8 @@ You can already play with resizing the replicas with:
 $ cluster/kubectl.sh resize rc my-nginx --replicas=2
 $ cluster/kubectl.sh get pods
 NAME                                   IMAGE(S)            HOST                    LABELS         STATUS
-7813c8bd-3ffe-11e4-9036-0800279696e1   dockerfile/nginx    10.245.2.2/10.245.2.2   name=myNginx   Running
-78140853-3ffe-11e4-9036-0800279696e1   dockerfile/nginx    10.245.2.3/10.245.2.3   name=myNginx   Running
+7813c8bd-3ffe-11e4-9036-0800279696e1   nginx               10.245.2.2/10.245.2.2   name=myNginx   Running
+78140853-3ffe-11e4-9036-0800279696e1   nginx               10.245.2.3/10.245.2.3   name=myNginx   Running
 ```
 
 Congratulations!

--- a/docs/getting-started-guides/aws.md
+++ b/docs/getting-started-guides/aws.md
@@ -47,7 +47,7 @@ The `kubectl.sh` line below spins up two containers running
 [Nginx](http://nginx.org/en/) running on port 80:
 
 ```bash
-cluster/kubectl.sh run-container my-nginx --image=dockerfile/nginx --replicas=2 --port=80
+cluster/kubectl.sh run-container my-nginx --image=nginx --replicas=2 --port=80
 ```
 
 To stop the containers:
@@ -82,7 +82,7 @@ Where pod.json contains something like:
       "id": "php",
       "containers": [{
         "name": "nginx",
-        "image": "dockerfile/nginx",
+        "image": "nginx",
         "ports": [{
           "containerPort": 80,
           "hostPort": 8081

--- a/docs/getting-started-guides/azure.md
+++ b/docs/getting-started-guides/azure.md
@@ -46,7 +46,7 @@ The `kubectl.sh` line below spins up two containers running
 [Nginx](http://nginx.org/en/) running on port 80:
 
 ```bash
-cluster/kubectl.sh run-container my-nginx --image=dockerfile/nginx --replicas=2 --port=80
+cluster/kubectl.sh run-container my-nginx --image=nginx --replicas=2 --port=80
 ```
 
 To stop the containers:
@@ -85,7 +85,7 @@ Where pod.json contains something like:
       "id": "php",
       "containers": [{
         "name": "nginx",
-        "image": "dockerfile/nginx",
+        "image": "nginx",
         "ports": [{
           "containerPort": 80,
           "hostPort": 8080

--- a/docs/getting-started-guides/coreos/azure/README.md
+++ b/docs/getting-started-guides/coreos/azure/README.md
@@ -80,7 +80,7 @@ POD                            IP             CONTAINER(S)    IMAGE(S)          
 frontend-controller-0133o      10.2.1.14      php-redis       kubernetes/example-guestbook-php-redis   kube-01/172.18.0.13   name=frontend,uses=redisslave,redis-master   Running
 frontend-controller-ls6k1      10.2.3.10      php-redis       kubernetes/example-guestbook-php-redis   <unassigned>          name=frontend,uses=redisslave,redis-master   Running
 frontend-controller-oh43e      10.2.2.15      php-redis       kubernetes/example-guestbook-php-redis   kube-02/172.18.0.14   name=frontend,uses=redisslave,redis-master   Running
-redis-master                   10.2.1.3       master          dockerfile/redis                         kube-01/172.18.0.13   name=redis-master                            Running
+redis-master                   10.2.1.3       master          redis                                    kube-01/172.18.0.13   name=redis-master                            Running
 redis-slave-controller-fplln   10.2.2.3       slave           brendanburns/redis-slave                 kube-02/172.18.0.14   name=redisslave,uses=redis-master            Running
 redis-slave-controller-gziey   10.2.1.4       slave           brendanburns/redis-slave                 kube-01/172.18.0.13   name=redisslave,uses=redis-master            Running
 

--- a/docs/getting-started-guides/coreos/bare_metal_offline.md
+++ b/docs/getting-started-guides/coreos/bare_metal_offline.md
@@ -606,7 +606,7 @@ On the Kubernetes Master node lets create a '''nginx.yml'''
         id: www
         containers:
           - name: nginx
-            image: dockerfile/nginx
+            image: nginx
     
 
 Now for the service: ```nginx-service.yml```

--- a/docs/getting-started-guides/gce.md
+++ b/docs/getting-started-guides/gce.md
@@ -52,7 +52,7 @@ The `kubectl.sh` line below spins up two containers running
 [Nginx](http://nginx.org/en/) running on port 80:
 
 ```bash
-cluster/kubectl.sh run-container my-nginx --image=dockerfile/nginx --replicas=2 --port=80
+cluster/kubectl.sh run-container my-nginx --image=nginx --replicas=2 --port=80
 ```
 
 To stop the containers:
@@ -87,7 +87,7 @@ Where pod.json contains something like:
       "id": "php",
       "containers": [{
         "name": "nginx",
-        "image": "dockerfile/nginx",
+        "image": "nginx",
         "ports": [{
           "containerPort": 80,
           "hostPort": 8081

--- a/docs/getting-started-guides/locally.md
+++ b/docs/getting-started-guides/locally.md
@@ -47,12 +47,12 @@ You can now use any of the cluster/kubectl.sh commands to interact with your loc
 cluster/kubectl.sh get pods
 cluster/kubectl.sh get services
 cluster/kubectl.sh get replicationControllers
-cluster/kubectl.sh run-container my-nginx --image=dockerfile/nginx --replicas=2 --port=80
+cluster/kubectl.sh run-container my-nginx --image=nginx --replicas=2 --port=80
 
 
 ## begin wait for provision to complete, you can monitor the docker pull by opening a new terminal
   sudo docker images
-  ## you should see it pulling the dockerfile/nginx image, once the above command returns it
+  ## you should see it pulling the nginx image, once the above command returns it
   sudo docker ps
   ## you should see your container running!
   exit

--- a/docs/getting-started-guides/mesos.md
+++ b/docs/getting-started-guides/mesos.md
@@ -141,7 +141,7 @@ $ cat <<EOPOD >nginx.json
     "version": "v1beta1",
     "containers": [{
       "name": "nginx-01",
-      "image": "dockerfile/nginx",
+      "image": "nginx",
       "ports": [{
         "containerPort": 80,
         "hostPort": 31000
@@ -177,7 +177,7 @@ We can use the `kubectl` interface to monitor the status of our pod:
 ```bash
 $ bin/kubectl get pods
 POD          IP           CONTAINER(S)  IMAGE(S)          HOST                       LABELS                STATUS
-nginx-id-01  172.17.5.27  nginx-01      dockerfile/nginx  10.72.72.178/10.72.72.178  cluster=gce,name=foo  Running
+nginx-id-01  172.17.5.27  nginx-01      nginx             10.72.72.178/10.72.72.178  cluster=gce,name=foo  Running
 ```
 
 Verify that the pod task is running in the Mesos web GUI. Click on the

--- a/docs/getting-started-guides/pod.json
+++ b/docs/getting-started-guides/pod.json
@@ -8,7 +8,7 @@
       "id": "php",
       "containers": [{
         "name": "nginx",
-        "image": "dockerfile/nginx",
+        "image": "nginx",
         "ports": [{
           "containerPort": 80,
           "hostPort": 8081

--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -187,7 +187,7 @@ NAME   IMAGE(S   SELECTOR   REPLICAS
 Start a container running nginx with a replication controller and three replicas
 
 ```
-$ cluster/kubectl.sh run-container my-nginx --image=dockerfile/nginx --replicas=3 --port=80
+$ cluster/kubectl.sh run-container my-nginx --image=nginx --replicas=3 --port=80
 ```
 
 When listing the pods, you will see that three containers have been started and are in Waiting state:
@@ -195,9 +195,9 @@ When listing the pods, you will see that three containers have been started and 
 ```
 $ cluster/kubectl.sh get pods
 NAME                                   IMAGE(S)            HOST                    LABELS         STATUS
-781191ff-3ffe-11e4-9036-0800279696e1   dockerfile/nginx    10.245.2.4/10.245.2.4   name=myNginx   Waiting
-7813c8bd-3ffe-11e4-9036-0800279696e1   dockerfile/nginx    10.245.2.2/10.245.2.2   name=myNginx   Waiting
-78140853-3ffe-11e4-9036-0800279696e1   dockerfile/nginx    10.245.2.3/10.245.2.3   name=myNginx   Waiting
+781191ff-3ffe-11e4-9036-0800279696e1   nginx               10.245.2.4/10.245.2.4   name=myNginx   Waiting
+7813c8bd-3ffe-11e4-9036-0800279696e1   nginx               10.245.2.2/10.245.2.2   name=myNginx   Waiting
+78140853-3ffe-11e4-9036-0800279696e1   nginx               10.245.2.3/10.245.2.3   name=myNginx   Waiting
 ```
 
 You need to wait for the provisioning to complete, you can monitor the minions by doing:
@@ -217,7 +217,7 @@ Once the docker image for nginx has been downloaded, the container will start an
 $ sudo salt '*minion-1' cmd.run 'docker ps'
 kubernetes-minion-1:
     CONTAINER ID        IMAGE                     COMMAND                CREATED             STATUS              PORTS                    NAMES
-    dbe79bf6e25b        dockerfile/nginx:latest   "nginx"                21 seconds ago      Up 19 seconds                                k8s--mynginx.8c5b8a3a--7813c8bd_-_3ffe_-_11e4_-_9036_-_0800279696e1.etcd--7813c8bd_-_3ffe_-_11e4_-_9036_-_0800279696e1--fcfa837f
+    dbe79bf6e25b        nginx:latest              "nginx"                21 seconds ago      Up 19 seconds                                k8s--mynginx.8c5b8a3a--7813c8bd_-_3ffe_-_11e4_-_9036_-_0800279696e1.etcd--7813c8bd_-_3ffe_-_11e4_-_9036_-_0800279696e1--fcfa837f
     fa0e29c94501        kubernetes/pause:latest   "/pause"               8 minutes ago       Up 8 minutes        0.0.0.0:8080->80/tcp     k8s--net.a90e7ce4--7813c8bd_-_3ffe_-_11e4_-_9036_-_0800279696e1.etcd--7813c8bd_-_3ffe_-_11e4_-_9036_-_0800279696e1--baf5b21b
     aa2ee3ed844a        google/cadvisor:latest    "/usr/bin/cadvisor -   38 minutes ago      Up 38 minutes                                k8s--cadvisor.9e90d182--cadvisor_-_agent.file--4626b3a2
     65a3a926f357        kubernetes/pause:latest   "/pause"               39 minutes ago      Up 39 minutes       0.0.0.0:4194->8080/tcp   k8s--net.c5ba7f0e--cadvisor_-_agent.file--342fd561
@@ -228,16 +228,16 @@ Going back to listing the pods, services and replicationControllers, you now hav
 ```
 $ cluster/kubectl.sh get pods
 NAME                                   IMAGE(S)            HOST                    LABELS         STATUS
-781191ff-3ffe-11e4-9036-0800279696e1   dockerfile/nginx    10.245.2.4/10.245.2.4   name=myNginx   Running
-7813c8bd-3ffe-11e4-9036-0800279696e1   dockerfile/nginx    10.245.2.2/10.245.2.2   name=myNginx   Running
-78140853-3ffe-11e4-9036-0800279696e1   dockerfile/nginx    10.245.2.3/10.245.2.3   name=myNginx   Running
+781191ff-3ffe-11e4-9036-0800279696e1   nginx               10.245.2.4/10.245.2.4   name=myNginx   Running
+7813c8bd-3ffe-11e4-9036-0800279696e1   nginx               10.245.2.2/10.245.2.2   name=myNginx   Running
+78140853-3ffe-11e4-9036-0800279696e1   nginx               10.245.2.3/10.245.2.3   name=myNginx   Running
 
 $ cluster/kubectl.sh get services
 NAME   LABELS   SELECTOR   IP   PORT
 
 $ cluster/kubectl.sh get replicationControllers
 NAME      IMAGE(S            SELECTOR       REPLICAS
-myNginx   dockerfile/nginx   name=my-nginx   3
+myNginx   nginx              name=my-nginx   3
 ```
 
 We did not start any services, hence there are none listed. But we see three replicas displayed properly.
@@ -248,8 +248,8 @@ You can already play with resizing the replicas with:
 $ cluster/kubectl.sh resize rc my-nginx --replicas=2
 $ cluster/kubectl.sh get pods
 NAME                                   IMAGE(S)            HOST                    LABELS         STATUS
-7813c8bd-3ffe-11e4-9036-0800279696e1   dockerfile/nginx    10.245.2.2/10.245.2.2   name=myNginx   Running
-78140853-3ffe-11e4-9036-0800279696e1   dockerfile/nginx    10.245.2.3/10.245.2.3   name=myNginx   Running
+7813c8bd-3ffe-11e4-9036-0800279696e1   nginx               10.245.2.2/10.245.2.2   name=myNginx   Running
+78140853-3ffe-11e4-9036-0800279696e1   nginx               10.245.2.3/10.245.2.3   name=myNginx   Running
 ```
 
 Congratulations!

--- a/docs/kubectl_run-container.md
+++ b/docs/kubectl_run-container.md
@@ -16,16 +16,16 @@ kubectl run-container NAME --image=image [--port=port] [--replicas=replicas] [--
 
 ```
 // Starts a single instance of nginx.
-$ kubectl run-container nginx --image=dockerfile/nginx
+$ kubectl run-container nginx --image=nginx
 
 // Starts a replicated instance of nginx.
-$ kubectl run-container nginx --image=dockerfile/nginx --replicas=5
+$ kubectl run-container nginx --image=nginx --replicas=5
 
 // Dry run. Print the corresponding API objects without creating them.
-$ kubectl run-container nginx --image=dockerfile/nginx --dry-run
+$ kubectl run-container nginx --image=nginx --dry-run
 
 // Start a single instance of nginx, but overload the desired state with a partial set of values parsed from JSON.
-$ kubectl run-container nginx --image=dockerfile/nginx --overrides='{ "apiVersion": "v1beta1", "desiredState": { ... } }'
+$ kubectl run-container nginx --image=nginx --overrides='{ "apiVersion": "v1beta1", "desiredState": { ... } }'
 ```
 
 ### Options

--- a/docs/man/man1/kubectl-run-container.1
+++ b/docs/man/man1/kubectl-run-container.1
@@ -176,16 +176,16 @@ Creates a replication controller to manage the created container(s).
 
 .nf
 // Starts a single instance of nginx.
-$ kubectl run\-container nginx \-\-image=dockerfile/nginx
+$ kubectl run\-container nginx \-\-image=nginx
 
 // Starts a replicated instance of nginx.
-$ kubectl run\-container nginx \-\-image=dockerfile/nginx \-\-replicas=5
+$ kubectl run\-container nginx \-\-image=nginx \-\-replicas=5
 
 // Dry run. Print the corresponding API objects without creating them.
-$ kubectl run\-container nginx \-\-image=dockerfile/nginx \-\-dry\-run
+$ kubectl run\-container nginx \-\-image=nginx \-\-dry\-run
 
 // Start a single instance of nginx, but overload the desired state with a partial set of values parsed from JSON.
-$ kubectl run\-container nginx \-\-image=dockerfile/nginx \-\-overrides='\{ "apiVersion": "v1beta1", "desiredState": \{ ... \} \}'
+$ kubectl run\-container nginx \-\-image=nginx \-\-overrides='\{ "apiVersion": "v1beta1", "desiredState": \{ ... \} \}'
 
 .fi
 .RE

--- a/examples/celery-rabbitmq/README.md
+++ b/examples/celery-rabbitmq/README.md
@@ -79,7 +79,7 @@ A RabbitMQ broker can be turned up using the file `examples/celery-rabbitmq/rabb
           "id": "rabbitmq",
           "containers": [{
             "name": "rabbitmq",
-            "image": "dockerfile/rabbitmq",
+            "image": "library/rabbitmq",
             "cpu": 100,
             "ports": [{"containerPort": 5672, "hostPort": 5672}]
           }]
@@ -144,7 +144,7 @@ There are several things to point out here...
 Like the RabbitMQ controller, this controller ensures that there is always a pod is running a Celery worker instance. The celery-app-add Docker image is an extension of the standard Celery image. This is the Dockerfile:
 
 ```
-FROM dockerfile/celery
+FROM library/celery
 
 ADD celery_conf.py /data/celery_conf.py
 ADD run_tasks.py /data/run_tasks.py
@@ -239,7 +239,7 @@ flower-controller-cegta     10.246.2.17         flower              endocode/flo
 kube-dns-fplln              10.246.1.3          etcd                quay.io/coreos/etcd:latest         10.245.1.3/10.245.1.3   k8s-app=kube-dns,kubernetes.io/cluster-service=true   Running
                                                 kube2sky            kubernetes/kube2sky:1.0                                                                                          
                                                 skydns              kubernetes/skydns:2014-12-23-001                                                                                 
-rabbitmq-controller-pjzb3   10.246.2.16         rabbitmq            dockerfile/rabbitmq                10.245.1.4/10.245.1.4   app=taskQueue,name=rabbitmq                           Running
+rabbitmq-controller-pjzb3   10.246.2.16         rabbitmq            library/rabbitmq                   10.245.1.4/10.245.1.4   app=taskQueue,name=rabbitmq                           Running
 
 ```
 

--- a/examples/celery-rabbitmq/celery-app-add/Dockerfile
+++ b/examples/celery-rabbitmq/celery-app-add/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockerfile/celery
+FROM library/celery
 
 ADD celery_conf.py /data/celery_conf.py
 ADD run_tasks.py /data/run_tasks.py

--- a/examples/celery-rabbitmq/rabbitmq-controller.json
+++ b/examples/celery-rabbitmq/rabbitmq-controller.json
@@ -12,7 +12,7 @@
           "id": "rabbitmq",
           "containers": [{
             "name": "rabbitmq",
-            "image": "dockerfile/rabbitmq",
+            "image": "library/rabbitmq",
             "cpu": 100,
             "ports": [{"containerPort": 5672, "hostPort": 5672}]
           }]

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -212,7 +212,23 @@ func TestExampleObjectSchemas(t *testing.T) {
 	}
 }
 
-var sampleRegexp = regexp.MustCompile("(?ms)^```(?:(?P<type>yaml)\\w*\\n(?P<content>.+?)|\\w*\\n(?P<content>\\{.+?\\}))\\w*\\n^```")
+// This regex is tricky, but it works.  For future me, here is the decode:
+//
+// Flags: (?ms) = multiline match, allow . to match \n
+// 1) Look for a line that starts with ``` (a markdown code block)
+// 2) (?: ... ) = non-capturing group
+// 3) (P<name>) = capture group as "name"
+// 4) Look for #1 followed by either:
+// 4a)    "yaml" followed by any word-characters followed by a newline (e.g. ```yamlfoo\n)
+// 4b)    "any word-characters followed by a newline (e.g. ```json\n)
+// 5) Look for either:
+// 5a)    #4a followed by one or more characters (non-greedy)
+// 5b)    #4b followed by { followed by one or more characters (non-greedy) followed by }
+// 6) Look for #5 followed by a newline followed by ``` (end of the code block)
+//
+// This could probably be simplified, but is already too delicate.  Before any
+// real changes, we should have a testscase that just tests this regex.
+var sampleRegexp = regexp.MustCompile("(?ms)^```(?:(?P<type>yaml)\\w*\\n(?P<content>.+?)|\\w*\\n(?P<content>\\{.+?\\}))\\n^```")
 var subsetRegexp = regexp.MustCompile("(?ms)\\.{3}")
 
 func TestReadme(t *testing.T) {

--- a/examples/guestbook/README.md
+++ b/examples/guestbook/README.md
@@ -39,7 +39,7 @@ Note that, although the redis server runs just with a single replica, we use rep
           "id": "redis-master",
           "containers": [{
             "name": "redis-master",
-            "image": "dockerfile/redis",
+            "image": "redis",
             "ports": [{
               "containerPort": 6379,   # containerPort: Where traffic to redis ultimately is routed to.
             }]
@@ -65,7 +65,7 @@ $ kubectl create -f examples/guestbook/redis-master-controller.json
 
 $ cluster/kubectl.sh get rc
 CONTROLLER                             CONTAINER(S)            IMAGE(S)                                 SELECTOR                     REPLICAS
-redis-master-controller                redis-master            dockerfile/redis                         name=redis-master            1
+redis-master-controller                redis-master            redis                                    name=redis-master            1
 ```
 
 Once that's up you can list the pods in the cluster, to verify that the master is running:
@@ -78,7 +78,7 @@ You'll see all kubernetes components, most importantly the redis master pod. It 
 
 ```shell
 POD                                          IP                  CONTAINER(S)            IMAGE(S)                                 HOST                                                              LABELS                                                     STATUS
-redis-master-controller-gb50a                10.244.3.7          redis-master            dockerfile/redis                         kubernetes-minion-7agi.c.hazel-mote-834.internal/104.154.54.203   app=redis,name=redis-master                                Running
+redis-master-controller-gb50a                10.244.3.7          redis-master            redis                                    kubernetes-minion-7agi.c.hazel-mote-834.internal/104.154.54.203   app=redis,name=redis-master                                Running
 ```
 
 If you ssh to that machine, you can run `docker ps` to see the actual pod:
@@ -88,7 +88,7 @@ me@workstation$ gcloud compute ssh kubernetes-minion-7agi
 
 me@kubernetes-minion-7agi:~$ sudo docker ps
 CONTAINER ID        IMAGE                                  COMMAND                CREATED              STATUS              PORTS                    NAMES
-0ffef9649265        dockerfile/redis:latest                "redis-server /etc/r   About a minute ago   Up About a minute                            k8s_redis-master.767aef46_redis-master-controller-gb50a.default.api_4530d7b3-ae5d-11e4-bf77-42010af0d719_579ee964
+0ffef9649265        redis:latest                           "redis-server /etc/r   About a minute ago   Up About a minute                            k8s_redis-master.767aef46_redis-master-controller-gb50a.default.api_4530d7b3-ae5d-11e4-bf77-42010af0d719_579ee964
 ```
 
 (Note that initial `docker pull` may take a few minutes, depending on network conditions.  You can monitor the status of this by running `journalctl -f -u docker` to check when the image is being downloaded.  Of course, you can also run `journalctl -f -u kubelet` to see what state the kubelet is in as well during this time.
@@ -182,7 +182,7 @@ redis-slave-controller
 
 $ kubectl get rc
 CONTROLLER                             CONTAINER(S)            IMAGE(S)                                 SELECTOR                     REPLICAS
-redis-master-controller                redis-master            dockerfile/redis                         name=redis-master            1
+redis-master-controller                redis-master            redis                                    name=redis-master            1
 redis-slave-controller                 redis-slave             kubernetes/redis-slave:v2                name=redis-slave             2
 ```
 
@@ -197,7 +197,7 @@ Once that's up you can list the pods in the cluster, to verify that the master a
 ```shell
 $ kubectl get pods
 POD                                          IP                  CONTAINER(S)            IMAGE(S)                                 HOST                                                              LABELS                                                     STATUS
-redis-master-controller-gb50a                10.244.3.7          redis-master            dockerfile/redis                         kubernetes-minion-7agi.c.hazel-mote-834.internal/104.154.54.203   app=redis,name=redis-master                                Running
+redis-master-controller-gb50a                10.244.3.7          redis-master            redis                                    kubernetes-minion-7agi.c.hazel-mote-834.internal/104.154.54.203   app=redis,name=redis-master                                Running
 redis-slave-controller-182tv                 10.244.3.6          redis-slave             kubernetes/redis-slave:v2                kubernetes-minion-7agi.c.hazel-mote-834.internal/104.154.54.203   app=redis,name=redis-slave,uses=redis-master               Running
 redis-slave-controller-zwk1b                 10.244.2.8          redis-slave             kubernetes/redis-slave:v2                kubernetes-minion-3vxa.c.hazel-mote-834.internal/104.154.54.6     app=redis,name=redis-slave,uses=redis-master               Running
 ```
@@ -287,7 +287,7 @@ frontend-controller
 $ kubectl get rc
 CONTROLLER                             CONTAINER(S)            IMAGE(S)                                   SELECTOR                     REPLICAS
 frontend-controller                    php-redis               kubernetes/example-guestbook-php-redis:v2  name=frontend                3
-redis-master-controller                redis-master            dockerfile/redis                           name=redis-master            1
+redis-master-controller                redis-master            redis                                      name=redis-master            1
 redis-slave-controller                 redis-slave             kubernetes/redis-slave:v2                  name=redis-slave             2
 ```
 
@@ -299,7 +299,7 @@ POD                                          IP                  CONTAINER(S)   
 frontend-controller-5m1zc                    10.244.1.131        php-redis               kubernetes/example-guestbook-php-redis:v2  kubernetes-minion-3vxa.c.hazel-mote-834.internal/146.148.71.71    app=frontend,name=frontend,uses=redis-slave,redis-master   Running
 frontend-controller-ckn42                    10.244.2.134        php-redis               kubernetes/example-guestbook-php-redis:v2  kubernetes-minion-by92.c.hazel-mote-834.internal/104.154.54.6     app=frontend,name=frontend,uses=redis-slave,redis-master   Running
 frontend-controller-v5drx                    10.244.0.128        php-redis               kubernetes/example-guestbook-php-redis:v2  kubernetes-minion-wilb.c.hazel-mote-834.internal/23.236.61.63     app=frontend,name=frontend,uses=redis-slave,redis-master   Running
-redis-master-controller-gb50a                10.244.3.7          redis-master            dockerfile/redis                           kubernetes-minion-7agi.c.hazel-mote-834.internal/104.154.54.203   app=redis,name=redis-master                                Running
+redis-master-controller-gb50a                10.244.3.7          redis-master            redis                                      kubernetes-minion-7agi.c.hazel-mote-834.internal/104.154.54.203   app=redis,name=redis-master                                Running
 redis-slave-controller-182tv                 10.244.3.6          redis-slave             kubernetes/redis-slave:v2                  kubernetes-minion-7agi.c.hazel-mote-834.internal/104.154.54.203   app=redis,name=redis-slave,uses=redis-master               Running
 redis-slave-controller-zwk1b                 10.244.2.8          redis-slave             kubernetes/redis-slave:v2                  kubernetes-minion-3vxa.c.hazel-mote-834.internal/104.154.54.6     app=redis,name=redis-slave,uses=redis-master               Running
 ```

--- a/examples/guestbook/redis-slave/Dockerfile
+++ b/examples/guestbook/redis-slave/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockerfile/redis
+FROM redis
 
 ADD run.sh /run.sh
 

--- a/examples/guestbook/v1beta3/redis-master.json
+++ b/examples/guestbook/v1beta3/redis-master.json
@@ -22,7 +22,7 @@
             "containers":[
                {
                   "name":"master",
-                  "image":"dockerfile/redis",
+                  "image":"redis",
                   "ports":[
                      {
                         "containerPort":6379,

--- a/examples/k8petstore/redis/Dockerfile
+++ b/examples/k8petstore/redis/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Pull base image.
-FROM dockerfile/ubuntu
+FROM ubuntu
 
 # Install Redis.
 RUN \

--- a/examples/nfs/nfs-web-pod.yaml
+++ b/examples/nfs/nfs-web-pod.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: web
-      image: dockerfile/nginx
+      image: nginx
       ports:
         - name: web
           containerPort: 80

--- a/examples/persistent-volumes/simpletest/pod.yaml
+++ b/examples/persistent-volumes/simpletest/pod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mypod
 spec:
   containers:
-    - image: dockerfile/nginx
+    - image: nginx
       name: myfrontend
       volumeMounts:
       - mountPath: "/var/www/html"

--- a/examples/walkthrough/README.md
+++ b/examples/walkthrough/README.md
@@ -19,7 +19,7 @@ desiredState:
     id: www
     containers:
       - name: nginx
-        image: dockerfile/nginx
+        image: nginx
 ```
 
 A pod definition is a declaration of a _desired state_.  Desired state is a very important concept in the Kubernetes model.  Many things present a desired state to the system, and it is Kubernetes' responsibility to make sure that the current state matches the desired state.  For example, when you create a Pod, you declare that you want the containers in it to be running.  If the containers happen to not be running (e.g. program failure, ...), Kubernetes will continue to (re-)create them for you in order to drive them to the desired state. This process continues until you delete the Pod.
@@ -40,7 +40,7 @@ desiredState:
     id: storage
     containers:
       - name: redis
-        image: dockerfile/redis
+        image: redis
         volumeMounts:
             # name must match the volume name below
           - name: redis-persistent-storage
@@ -55,23 +55,23 @@ desiredState:
 Ok, so what did we do?  We added a volume to our pod:
 
 ```yaml
-...
+    # ...
     volumes:
       - name: redis-persistent-storage
         source:
           emptyDir: {}
-...
+    # ...
 ```
 
 And we added a reference to that volume to our container:
 ```yaml
-...
+    # ...
         volumeMounts:
             # name must match the volume name below
           - name: redis-persistent-storage
             # mount path within the container
             mountPath: /data/redis
-...
+    # ...
 ```
 
 In Kubernetes, ```emptyDir``` Volumes live for the lifespan of the Pod, which is longer than the lifespan of any one container, so if the container fails and is restarted, our persistent storage will live on.
@@ -98,7 +98,7 @@ desiredState:
     id: www
     containers:
       - name: nginx
-        image: dockerfile/nginx
+        image: nginx
         volumeMounts:
           - name: www-data
             mountPath: /srv/www
@@ -114,7 +114,7 @@ desiredState:
     volumes:
       - name: www-data
         source:
-          emptyDir
+          emptyDir: {}
 ```
 
 Note that we have also added a volume here.  In this case, the volume is mounted into both containers.  It is marked ```readOnly``` in the web server's case, since it doesn't need to write to the directory.

--- a/examples/walkthrough/k8s201.md
+++ b/examples/walkthrough/k8s201.md
@@ -41,7 +41,7 @@ desiredState:
         id: nginx
         containers:
           - name: nginx
-            image: dockerfile/nginx
+            image: nginx
             ports:
               - containerPort: 80
     # Important: these labels need to match the selector above
@@ -135,7 +135,7 @@ desiredState:
     id: php
     containers:
       - name: nginx
-        image: dockerfile/nginx
+        image: nginx
         ports:
           - containerPort: 80
         # defines the health checking

--- a/examples/walkthrough/pod-with-http-healthcheck.yaml
+++ b/examples/walkthrough/pod-with-http-healthcheck.yaml
@@ -7,7 +7,7 @@ desiredState:
     id: php
     containers:
       - name: nginx
-        image: dockerfile/nginx
+        image: nginx
         ports:
           - containerPort: 80
         # defines the health checking

--- a/examples/walkthrough/pod1.yaml
+++ b/examples/walkthrough/pod1.yaml
@@ -7,4 +7,4 @@ desiredState:
     id: www
     containers:
       - name: nginx
-        image: dockerfile/nginx
+        image: nginx

--- a/examples/walkthrough/pod2.yaml
+++ b/examples/walkthrough/pod2.yaml
@@ -7,7 +7,7 @@ desiredState:
     id: storage
     containers:
       - name: redis
-        image: dockerfile/redis
+        image: redis
         volumeMounts:
             # name must match the volume name below
           - name: redis-persistent-storage

--- a/examples/walkthrough/replication-controller.yaml
+++ b/examples/walkthrough/replication-controller.yaml
@@ -16,7 +16,7 @@ desiredState:
         id: nginx
         containers:
           - name: nginx
-            image: dockerfile/nginx
+            image: nginx
             ports:
               - containerPort: 80
     # Important: these labels need to match the selector above

--- a/examples/walkthrough/v1beta3/README.md
+++ b/examples/walkthrough/v1beta3/README.md
@@ -40,7 +40,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: dockerfile/nginx
+    image: nginx
     volumeMounts:
     - mountPath: /srv/www
       name: www-data

--- a/examples/walkthrough/v1beta3/pod-with-http-healthcheck.yaml
+++ b/examples/walkthrough/v1beta3/pod-with-http-healthcheck.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: nginx
-      image: dockerfile/nginx
+      image: nginx
       # defines the health checking
       livenessProbe:
         # an http probe

--- a/examples/walkthrough/v1beta3/pod1.yaml
+++ b/examples/walkthrough/v1beta3/pod1.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   containers:
     - name: nginx
-      image: dockerfile/nginx
+      image: nginx

--- a/examples/walkthrough/v1beta3/pod2.yaml
+++ b/examples/walkthrough/v1beta3/pod2.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: redis
-      image: dockerfile/redis
+      image: redis
       volumeMounts:
           # name must match the volume name below
         - name: redis-persistent-storage

--- a/examples/walkthrough/v1beta3/replication-controller.yaml
+++ b/examples/walkthrough/v1beta3/replication-controller.yaml
@@ -19,6 +19,6 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: dockerfile/nginx
+          image: nginx
             ports:
             - containerPort: 80

--- a/pkg/api/validation/testdata/v1beta1/invalidPod.yaml
+++ b/pkg/api/validation/testdata/v1beta1/invalidPod.yaml
@@ -7,7 +7,7 @@ desiredState:
     id: redis-master
     containers:
       - name: "master"
-        image: "dockerfile/redis"
+        image: "redis"
         command: "this is a bad command"
 labels:
   name: "redis-master"

--- a/pkg/api/validation/testdata/v1beta1/invalidPod1.json
+++ b/pkg/api/validation/testdata/v1beta1/invalidPod1.json
@@ -8,7 +8,7 @@
       "id": "redis-master",
       "containers": [{
         "name": "master",
-        "image": "dockerfile/redis",
+        "image": "redis",
         "command": "this is a bad command"
       }]
     }

--- a/pkg/api/validation/testdata/v1beta1/validPod.yaml
+++ b/pkg/api/validation/testdata/v1beta1/validPod.yaml
@@ -7,7 +7,7 @@ desiredState:
     id: redis-master
     containers:
       - name: "master"
-        image: "dockerfile/redis"
+        image: "redis"
         command:
                 - this
                 - is

--- a/pkg/api/validation/testdata/v1beta3/invalidPod.yaml
+++ b/pkg/api/validation/testdata/v1beta3/invalidPod.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   containers:
   - args: "this is a bad command"
-    image: dockerfile/redis
+    image: redis
     name: master

--- a/pkg/api/validation/testdata/v1beta3/invalidPod1.json
+++ b/pkg/api/validation/testdata/v1beta3/invalidPod1.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "master",
-        "image": "dockerfile/redis",
+        "image": "redis",
         "args": "this is a bad command"
       }
     ]

--- a/pkg/api/validation/testdata/v1beta3/validPod.yaml
+++ b/pkg/api/validation/testdata/v1beta3/validPod.yaml
@@ -12,5 +12,5 @@ spec:
     - an
     - ok
     - command
-    image: dockerfile/redis
+    image: redis
     name: master

--- a/pkg/config/config_test.json
+++ b/pkg/config/config_test.json
@@ -42,7 +42,7 @@
         "version": "v1beta1",
         "containers": [{
           "name": "master",
-          "image": "dockerfile/redis",
+          "image": "redis",
           "env": [
             {
               "name": "REDIS_PASSWORD",

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -30,16 +30,16 @@ const (
 	run_long = `Create and run a particular image, possibly replicated.
 Creates a replication controller to manage the created container(s).`
 	run_example = `// Starts a single instance of nginx.
-$ kubectl run-container nginx --image=dockerfile/nginx
+$ kubectl run-container nginx --image=nginx
 
 // Starts a replicated instance of nginx.
-$ kubectl run-container nginx --image=dockerfile/nginx --replicas=5
+$ kubectl run-container nginx --image=nginx --replicas=5
 
 // Dry run. Print the corresponding API objects without creating them.
-$ kubectl run-container nginx --image=dockerfile/nginx --dry-run
+$ kubectl run-container nginx --image=nginx --dry-run
 
 // Start a single instance of nginx, but overload the desired state with a partial set of values parsed from JSON.
-$ kubectl run-container nginx --image=dockerfile/nginx --overrides='{ "apiVersion": "v1beta1", "desiredState": { ... } }'`
+$ kubectl run-container nginx --image=nginx --overrides='{ "apiVersion": "v1beta1", "desiredState": { ... } }'`
 )
 
 func NewCmdRunContainer(f *cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -483,7 +483,7 @@ var _ = Describe("Pods", func() {
 					Containers: []api.Container{
 						{
 							Name:  "nginx",
-							Image: "dockerfile/nginx",
+							Image: "nginx",
 						},
 					},
 				},
@@ -555,7 +555,7 @@ var _ = Describe("Pods", func() {
 					Containers: []api.Container{
 						{
 							Name:  "nginx",
-							Image: "dockerfile/nginx",
+							Image: "nginx",
 							Ports: []api.Port{{ContainerPort: 80}},
 						},
 					},


### PR DESCRIPTION
As per
http://blog.docker.com/2015/03/updates-available-to-popular-repos-update-your-images/
docker has stopped answering dockerfile/redis and dockerfile/nginx.  Fix all
users in our tree.  Sadly this means a lot of published examples are now broken.

I don't know why they didn't just make these aliases to their replacements.  Sigh.

Fixes #6914
