### PR TITLE
Add hack/parallel-e2e.sh to run hack/e2e.go on multiple clusters

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -63,7 +63,7 @@ function increment_ipv4 {
 }
 
 node_count="${NUM_MINIONS}"
-next_node="10.244.0.0"
+next_node="${KUBE_GCE_CLUSTER_CLASS_B:-10.244}.0.0"
 node_subnet_size=24
 node_subnet_count=$((2 ** (32-$node_subnet_size)))
 subnets=()
@@ -73,7 +73,7 @@ for ((node_num=0; node_num<node_count; node_num++)); do
   next_node=$(increment_ipv4 $next_node $node_subnet_count)
 done
 
-CLUSTER_IP_RANGE="10.244.0.0/16"
+CLUSTER_IP_RANGE="${KUBE_GCE_CLUSTER_CLASS_B:-10.244}.0.0/16"
 MINION_IP_RANGES=($(eval echo "${subnets[@]}"))
 
 MINION_SCOPES=("storage-ro" "compute-rw" "https://www.googleapis.com/auth/monitoring")

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -33,10 +33,9 @@ INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX:-e2e-test-${USER}}"
 MASTER_NAME="${INSTANCE_PREFIX}-master"
 MASTER_TAG="${INSTANCE_PREFIX}-master"
 MINION_TAG="${INSTANCE_PREFIX}-minion"
-CLUSTER_IP_RANGE="10.245.0.0/16"
-MINION_IP_RANGES=($(eval echo "10.245.{1..${NUM_MINIONS}}.0/24"))
+CLUSTER_IP_RANGE="${KUBE_GCE_CLUSTER_CLASS_B:-10.245}.0.0/16"
+MINION_IP_RANGES=($(eval echo "${KUBE_GCE_CLUSTER_CLASS_B:-10.245}.{1..${NUM_MINIONS}}.0/24"))
 MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
-
 MINION_SCOPES=("storage-ro" "compute-rw")
 # Increase the sleep interval value if concerned about API rate limits. 3, in seconds, is the default.
 POLL_SLEEP_INTERVAL=3

--- a/hack/parallel-e2e.sh
+++ b/hack/parallel-e2e.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+function down-clusters {
+  for count in $(seq 1 ${clusters}); do
+    export KUBE_GCE_INSTANCE_PREFIX=e2e-test-${USER}-${count}
+    local cluster_dir=${KUBE_ROOT}/_output/e2e/${KUBE_GCE_INSTANCE_PREFIX}
+    export KUBECONFIG=${cluster_dir}/.kubeconfig
+    go run ${KUBE_ROOT}/hack/e2e.go -down -v &
+  done
+
+  wait
+}
+
+function up-clusters {
+  for count in $(seq 1 ${clusters}); do
+    export KUBE_GCE_INSTANCE_PREFIX=e2e-test-${USER}-${count}
+    export KUBE_GCE_CLUSTER_CLASS_B="10.$((${count}*2-1))"
+    export MASTER_IP_RANGE="10.$((${count}*2)).0.0/24"
+
+    local cluster_dir=${KUBE_ROOT}/_output/e2e/${KUBE_GCE_INSTANCE_PREFIX}
+    mkdir -p ${cluster_dir}
+    export KUBECONFIG=${cluster_dir}/.kubeconfig
+    go run hack/e2e.go -up -v |& tee ${cluster_dir}/up.log &
+  done
+
+  fail=0
+  for job in $(jobs -p); do
+    wait "${job}" || fail=$((fail + 1))
+  done
+
+  if (( fail != 0 )); then
+    echo "${fail} cluster creation failures. Not continuing with tests."
+    exit 1
+  fi
+}
+
+function run-tests {
+  for count in $(seq 1 ${clusters}); do
+    export KUBE_GCE_INSTANCE_PREFIX=e2e-test-${USER}-${count}
+
+    local cluster_dir=${KUBE_ROOT}/_output/e2e/${KUBE_GCE_INSTANCE_PREFIX}
+    export KUBECONFIG=${cluster_dir}/.kubeconfig
+    export E2E_REPORT_DIR=${cluster_dir}
+    go run hack/e2e.go -test --test_args="--ginkgo.noColor" "${@:-}" -down |& tee ${cluster_dir}/e2e.log &
+  done
+
+  wait
+}
+
+# Outputs something like:
+# _output/e2e/e2e-test-zml-5/junit.xml
+#   FAIL: Shell tests that services.sh passes
+function post-process {
+  echo $1
+  cat $1 | python -c '
+import sys
+from xml.dom.minidom import parse
+
+failed = False
+for testcase in parse(sys.stdin).getElementsByTagName("testcase"):
+  if len(testcase.getElementsByTagName("failure")) != 0:
+    failed = True
+    print "  FAIL: {test}".format(test = testcase.getAttribute("name"))
+if not failed:
+  print "  SUCCESS!"
+'
+}
+
+function print-results {
+  for count in $(seq 1 ${clusters}); do
+    for junit in ${KUBE_ROOT}/_output/e2e/e2e-test-${USER}-${count}/junit*.xml; do
+      post-process ${junit}
+    done
+  done
+}
+
+if [[ ${KUBERNETES_PROVIDER:-gce} != "gce" ]]; then
+  echo "$0 not supported on ${KUBERNETES_PROVIDER} yet" >&2
+  exit 1
+fi
+
+readonly clusters=${1:-}
+
+if ! [[ "${clusters}" =~ ^[0-9]+$ ]]; then
+  echo "Usage: ${0} <number of clusters> [options to hack/e2e.go]" >&2
+  exit 1
+fi
+
+shift 1
+
+rm -rf _output/e2e
+down-clusters
+up-clusters
+run-tests "${@:-}"
+print-results


### PR DESCRIPTION
```
$ hack/parallel-e2e.sh
Usage: hack/parallel-e2e.sh <number of clusters> [options to hack/e2e.go]
```

Output is logged to `_output/e2e/<prefix>`. Test failures are aggregated by slurping the junit results from the parallelized output and summarized at the end of the run.

Fixes #4568. Also fixes #4596 along the way.
