### PR TITLE
Fix a broken fmt.Errorf in the services e2e test

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -409,7 +409,7 @@ func waitForPublicIPs(c *client.Client, serviceName, namespace string) (*api.Ser
 		}
 		Logf("Waiting for service %s in namespace %s to have a public IP (%v)", serviceName, namespace, time.Since(start))
 	}
-	return service, fmt.Errorf("service %s in namespace %s to have a public IP after %.2f seconds", nil, serviceName, namespace, podStartTimeout.Seconds())
+	return service, fmt.Errorf("service %s in namespace %s doesn't have a public IP after %.2f seconds", serviceName, namespace, podStartTimeout.Seconds())
 }
 
 func validateUniqueOrFail(s []string) {


### PR DESCRIPTION
It had an extraneous nil parameter that was breaking the formatting.

cc @quinton-hoole 
