### PR TITLE
Fix data race in kubelet_test.go

### DIFF
--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -139,7 +139,7 @@ func (f *FakeDockerClient) ListContainers(options docker.ListContainersOptions) 
 	if options.All {
 		return append(f.ContainerList, f.ExitedContainerList...), err
 	}
-	return f.ContainerList, err
+	return append([]docker.APIContainers{}, f.ContainerList...), err
 }
 
 // InspectContainer is a test-spy implementation of DockerInterface.InspectContainer.


### PR DESCRIPTION
Ensure that FakeDockerClient make a copy of the internal list and return it.
