### PR TITLE
Add URL parameters to proxy redirect Location header

### DIFF
--- a/pkg/apiserver/proxy.go
+++ b/pkg/apiserver/proxy.go
@@ -195,7 +195,11 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// This is essentially a hack for https://github.com/GoogleCloudPlatform/kubernetes/issues/4958.
 	// Note: Keep this code after tryUpgrade to not break that flow.
 	if len(parts) == 2 && !strings.HasSuffix(req.URL.Path, "/") {
-		w.Header().Set("Location", req.URL.Path+"/")
+		var queryPart string
+		if len(req.URL.RawQuery) > 0 {
+			queryPart = "?" + req.URL.RawQuery
+		}
+		w.Header().Set("Location", req.URL.Path+"/"+queryPart)
 		w.WriteHeader(http.StatusMovedPermanently)
 		return
 	}

--- a/pkg/apiserver/proxy_test.go
+++ b/pkg/apiserver/proxy_test.go
@@ -374,19 +374,24 @@ func TestRedirectOnMissingTrailingSlash(t *testing.T) {
 		path string
 		// The path requested on the proxy server.
 		proxyServerPath string
+		// query string
+		query string
 	}{
-		{"/trailing/slash/", "/trailing/slash/"},
-		{"/", "/"},
+		{"/trailing/slash/", "/trailing/slash/", ""},
+		{"/", "/", "test1=value1&test2=value2"},
 		// "/" should be added at the end.
-		{"", "/"},
+		{"", "/", "test1=value1&test2=value2"},
 		// "/" should not be added at a non-root path.
-		{"/some/path", "/some/path"},
+		{"/some/path", "/some/path", ""},
 	}
 
 	for _, item := range table {
 		proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			if req.URL.Path != item.proxyServerPath {
 				t.Errorf("Unexpected request on path: %s, expected path: %s, item: %v", req.URL.Path, item.proxyServerPath, item)
+			}
+			if req.URL.RawQuery != item.query {
+				t.Errorf("Unexpected query on url: %s, expected: %s", req.URL.RawQuery, item.query)
 			}
 		}))
 		defer proxyServer.Close()
@@ -405,7 +410,7 @@ func TestRedirectOnMissingTrailingSlash(t *testing.T) {
 		proxyTestPattern := "/api/version2/proxy/namespaces/ns/foo/id" + item.path
 		req, err := http.NewRequest(
 			"GET",
-			server.URL+proxyTestPattern,
+			server.URL+proxyTestPattern+"?"+item.query,
 			strings.NewReader(""),
 		)
 		if err != nil {


### PR DESCRIPTION
When a URL that doesn't end in "/" is sent to the API proxy,
the proxy responds with a redirect to the URL with a "/" at the
end. The problem is that this redirect path does not include
query parameters that were passed in the original request. This
is a fix to that issue.
