### PR TITLE
Fix quota status not updating with change in spec

### DIFF
--- a/pkg/resourcequota/resource_quota_controller.go
+++ b/pkg/resourcequota/resource_quota_controller.go
@@ -108,10 +108,13 @@ func FilterQuotaPods(pods []api.Pod) []api.Pod {
 // syncResourceQuota runs a complete sync of current status
 func (rm *ResourceQuotaManager) syncResourceQuota(quota api.ResourceQuota) (err error) {
 
+	// quota is dirty if any part of spec hard limits differs from the status hard limits
+	dirty := !api.Semantic.DeepEqual(quota.Spec.Hard, quota.Status.Hard)
+
 	// dirty tracks if the usage status differs from the previous sync,
 	// if so, we send a new usage with latest status
 	// if this is our first sync, it will be dirty by default, since we need track usage
-	dirty := quota.Status.Hard == nil || quota.Status.Used == nil
+	dirty = dirty || (quota.Status.Hard == nil || quota.Status.Used == nil)
 
 	// Create a usage object that is based on the quota resource version
 	usage := api.ResourceQuota{


### PR DESCRIPTION
Fix https://github.com/GoogleCloudPlatform/kubernetes/issues/6845

If there was no observed change in status.used, we were not updating the status.hard even if there was a change in spec.hard.  This made it that when a quota was increased or decreased, the actual enforced quota was not changing as expected.

This fixes the dirty flag to check that if the desired hard limits are different than the enforced limits that we always update the quota status to the desired limits.
