### PR TITLE
*: update go-etcd dependency

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -74,8 +74,8 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/go-etcd/etcd",
-			"Comment": "v0.4.6-8-g60e12ca",
-			"Rev": "60e12cac3db8ffce00b576b4af0e7b0a968f1003"
+			"Comment": "v2.0.0-3-g0424b5f",
+			"Rev": "0424b5f86ef0ca57a5309c599f74bbb3e97ecd9d"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-systemd/dbus",

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/client_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/client_test.go
@@ -94,3 +94,15 @@ func TestPersistence(t *testing.T) {
 		t.Fatalf("The two configs should be equal!")
 	}
 }
+
+func TestClientRetry(t *testing.T) {
+	c := NewClient([]string{"http://strange", "http://127.0.0.1:4001"})
+	// use first endpoint as the picked url
+	c.cluster.picked = 0
+	if _, err := c.Set("foo", "bar", 5); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Delete("foo", true); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/cluster.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/cluster.go
@@ -30,5 +30,8 @@ func (cl *Cluster) pick() string { return cl.Machines[cl.picked] }
 
 func (cl *Cluster) updateFromStr(machines string) {
 	cl.Machines = strings.Split(machines, ",")
+	for i := range cl.Machines {
+		cl.Machines[i] = strings.TrimSpace(cl.Machines[i])
+	}
 	cl.picked = rand.Intn(len(cl.Machines))
 }

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/member.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/member.go
@@ -1,0 +1,30 @@
+package etcd
+
+import "encoding/json"
+
+type Member struct {
+	ID         string   `json:"id"`
+	Name       string   `json:"name"`
+	PeerURLs   []string `json:"peerURLs"`
+	ClientURLs []string `json:"clientURLs"`
+}
+
+type memberCollection []Member
+
+func (c *memberCollection) UnmarshalJSON(data []byte) error {
+	d := struct {
+		Members []Member
+	}{}
+
+	if err := json.Unmarshal(data, &d); err != nil {
+		return err
+	}
+
+	if d.Members == nil {
+		*c = make([]Member, 0)
+		return nil
+	}
+
+	*c = d.Members
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/member_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/member_test.go
@@ -1,0 +1,71 @@
+package etcd
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestMemberCollectionUnmarshal(t *testing.T) {
+	tests := []struct {
+		body []byte
+		want memberCollection
+	}{
+		{
+			body: []byte(`{"members":[]}`),
+			want: memberCollection([]Member{}),
+		},
+		{
+			body: []byte(`{"members":[{"id":"2745e2525fce8fe","peerURLs":["http://127.0.0.1:7003"],"name":"node3","clientURLs":["http://127.0.0.1:4003"]},{"id":"42134f434382925","peerURLs":["http://127.0.0.1:2380","http://127.0.0.1:7001"],"name":"node1","clientURLs":["http://127.0.0.1:2379","http://127.0.0.1:4001"]},{"id":"94088180e21eb87b","peerURLs":["http://127.0.0.1:7002"],"name":"node2","clientURLs":["http://127.0.0.1:4002"]}]}`),
+			want: memberCollection(
+				[]Member{
+					{
+						ID:   "2745e2525fce8fe",
+						Name: "node3",
+						PeerURLs: []string{
+							"http://127.0.0.1:7003",
+						},
+						ClientURLs: []string{
+							"http://127.0.0.1:4003",
+						},
+					},
+					{
+						ID:   "42134f434382925",
+						Name: "node1",
+						PeerURLs: []string{
+							"http://127.0.0.1:2380",
+							"http://127.0.0.1:7001",
+						},
+						ClientURLs: []string{
+							"http://127.0.0.1:2379",
+							"http://127.0.0.1:4001",
+						},
+					},
+					{
+						ID:   "94088180e21eb87b",
+						Name: "node2",
+						PeerURLs: []string{
+							"http://127.0.0.1:7002",
+						},
+						ClientURLs: []string{
+							"http://127.0.0.1:4002",
+						},
+					},
+				},
+			),
+		},
+	}
+
+	for i, tt := range tests {
+		var got memberCollection
+		err := json.Unmarshal(tt.body, &got)
+		if err != nil {
+			t.Errorf("#%d: unexpected error: %v", i, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(tt.want, got) {
+			t.Errorf("#%d: incorrect output: want=%#v, got=%#v", i, tt.want, got)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/requests.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/requests.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -189,13 +188,19 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 
 		logger.Debug("Connecting to etcd: attempt ", attempt+1, " for ", rr.RelativePath)
 
-		httpPath = c.getHttpPath(rr.RelativePath)
+		// get httpPath if not set
+		if httpPath == "" {
+			httpPath = c.getHttpPath(rr.RelativePath)
+		}
 
 		// Return a cURL command if curlChan is set
 		if c.cURLch != nil {
 			command := fmt.Sprintf("curl -X %s %s", rr.Method, httpPath)
 			for key, value := range rr.Values {
 				command += fmt.Sprintf(" -d %s=%s", key, value[0])
+			}
+			if c.credentials != nil {
+				command += fmt.Sprintf(" -u %s", c.credentials.username)
 			}
 			c.sendCURL(command)
 		}
@@ -226,7 +231,13 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 			return nil, err
 		}
 
+		if c.credentials != nil {
+			req.SetBasicAuth(c.credentials.username, c.credentials.password)
+		}
+
 		resp, err = c.httpClient.Do(req)
+		// clear previous httpPath
+		httpPath = ""
 		defer func() {
 			if resp != nil {
 				resp.Body.Close()
@@ -281,6 +292,19 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 			}
 		}
 
+		if resp.StatusCode == http.StatusTemporaryRedirect {
+			u, err := resp.Location()
+
+			if err != nil {
+				logger.Warning(err)
+			} else {
+				// set httpPath for following redirection
+				httpPath = u.String()
+			}
+			resp.Body.Close()
+			continue
+		}
+
 		if checkErr := checkRetry(c.cluster, numReqs, *resp,
 			errors.New("Unexpected HTTP status code")); checkErr != nil {
 			return nil, checkErr
@@ -304,9 +328,8 @@ func DefaultCheckRetry(cluster *Cluster, numReqs int, lastResp http.Response,
 	err error) error {
 
 	if isEmptyResponse(lastResp) {
-		if !isConnectionError(err) {
-			return err
-		}
+		// always retry if it failed to get response from one machine
+		return nil
 	} else if !shouldRetry(lastResp) {
 		body := []byte("nil")
 		if lastResp.Body != nil {
@@ -332,11 +355,6 @@ func DefaultCheckRetry(cluster *Cluster, numReqs int, lastResp http.Response,
 }
 
 func isEmptyResponse(r http.Response) bool { return r.StatusCode == 0 }
-
-func isConnectionError(err error) bool {
-	_, ok := err.(*net.OpError)
-	return ok
-}
 
 // shouldRetry returns whether the reponse deserves retry.
 func shouldRetry(r http.Response) bool {

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/requests_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/requests_test.go
@@ -1,0 +1,22 @@
+package etcd
+
+import "testing"
+
+func TestKeyToPath(t *testing.T) {
+	tests := []struct {
+		key   string
+		wpath string
+	}{
+		{"", "keys/"},
+		{"foo", "keys/foo"},
+		{"foo/bar", "keys/foo/bar"},
+		{"%z", "keys/%25z"},
+		{"/", "keys/"},
+	}
+	for i, tt := range tests {
+		path := keyToPath(tt.key)
+		if path != tt.wpath {
+			t.Errorf("#%d: path = %s, want %s", i, path, tt.wpath)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/version.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/version.go
@@ -1,3 +1,6 @@
 package etcd
 
-const version = "v2"
+const (
+	version        = "v2"
+	packageVersion = "v2.0.0+git"
+)


### PR DESCRIPTION
We recently updated the go-etcd. It solves the following issues:
1. support both 0.4.x and 2.x cluster
2. support redirection
3. always switch to another etcd member in case of a network failure
4. fix a bug in sync cluster

This solves #6734 because it can support both etcd version now.
This should fix #6748 

/cc @xiang90 @barakmich @kelseyhightower 
