### PR TITLE
List output with differing types should be more resilient

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -157,11 +157,7 @@ func TestExampleObjectSchemas(t *testing.T) {
 			"service":                   &api.Service{},
 			"replication-controller":    &api.ReplicationController{},
 		},
-		"../examples/update-demo/v1beta1": {
-			"kitten-rc":   &api.ReplicationController{},
-			"nautilus-rc": &api.ReplicationController{},
-		},
-		"../examples/update-demo/v1beta3": {
+		"../examples/update-demo": {
 			"kitten-rc":   &api.ReplicationController{},
 			"nautilus-rc": &api.ReplicationController{},
 		},

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -162,6 +162,7 @@ for version in "${kube_api_versions[@]}"; do
   # Command
   kubectl create "${kube_flags[@]}" -f examples/limitrange/valid-pod.json
   # Post-condition: valid-pod POD is running
+  kubectl get "${kube_flags[@]}" pods -o json
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'valid-pod:'
   kube::test::get_object_assert 'pod valid-pod' "{{$id_field}}" 'valid-pod'
   kube::test::get_object_assert 'pod/valid-pod' "{{$id_field}}" 'valid-pod'

--- a/pkg/api/meta/restmapper.go
+++ b/pkg/api/meta/restmapper.go
@@ -251,3 +251,42 @@ func (m *DefaultRESTMapper) AliasesForResource(alias string) ([]string, bool) {
 	}
 	return nil, false
 }
+
+// MultiRESTMapper is a wrapper for multiple RESTMappers.
+type MultiRESTMapper []RESTMapper
+
+// VersionAndKindForResource provides the Version and Kind  mappings for the
+// REST resources. This implementation supports multiple REST schemas and return
+// the first match.
+func (m MultiRESTMapper) VersionAndKindForResource(resource string) (defaultVersion, kind string, err error) {
+	for _, t := range m {
+		defaultVersion, kind, err = t.VersionAndKindForResource(resource)
+		if err == nil {
+			return
+		}
+	}
+	return
+}
+
+// RESTMapping provides the REST mapping for the resource based on the resource
+// kind and version. This implementation supports multiple REST schemas and
+// return the first match.
+func (m MultiRESTMapper) RESTMapping(kind string, versions ...string) (mapping *RESTMapping, err error) {
+	for _, t := range m {
+		mapping, err = t.RESTMapping(kind, versions...)
+		if err == nil {
+			return
+		}
+	}
+	return
+}
+
+// AliasesForResource finds the first alias response for the provided mappers.
+func (m MultiRESTMapper) AliasesForResource(alias string) (aliases []string, ok bool) {
+	for _, t := range m {
+		if aliases, ok = t.AliasesForResource(alias); ok {
+			return
+		}
+	}
+	return nil, false
+}

--- a/pkg/conversion/encode.go
+++ b/pkg/conversion/encode.go
@@ -53,7 +53,7 @@ func (s *Scheme) EncodeToVersion(obj interface{}, destVersion string) (data []by
 	obj = maybeCopy(obj)
 	v, _ := EnforcePtr(obj) // maybeCopy guarantees a pointer
 	if _, registered := s.typeToVersion[v.Type()]; !registered {
-		return nil, fmt.Errorf("type %v is not registered and it will be impossible to Decode it, therefore Encode will refuse to encode it.", v.Type())
+		return nil, fmt.Errorf("type %v is not registered for %q and it will be impossible to Decode it, therefore Encode will refuse to encode it.", v.Type(), destVersion)
 	}
 
 	objVersion, objKind, err := s.ObjectVersionAndKind(obj)

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
 	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource"
@@ -162,28 +160,20 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 		}
 		defaultVersion := clientConfig.Version
 
-		// the outermost object will be converted to the output-version
-		version := cmdutil.OutputVersion(cmd, defaultVersion)
-
+		singular := false
 		r := b.Flatten().Do()
-		obj, err := r.Object()
+		infos, err := r.IntoSingular(&singular).Infos()
 		if err != nil {
 			return err
 		}
 
-		// try conversion to all the possible versions
-		// TODO: simplify by adding a ResourceBuilder mode
-		versions := []string{version, latest.Version}
-		infos, _ := r.Infos()
-		for _, info := range infos {
-			versions = append(versions, info.Mapping.APIVersion)
+		// the outermost object will be converted to the output-version, but inner
+		// objects can use their mappings
+		version := cmdutil.OutputVersion(cmd, defaultVersion)
+		obj, err := resource.AsVersionedObject(infos, !singular, version)
+		if err != nil {
+			return err
 		}
-
-		// TODO: add a new ResourceBuilder mode for Object() that attempts to ensure the objects
-		// are in the appropriate version if one exists (and if not, use the best effort).
-		// TODO: ensure api-version is set with the default preferred api version by the client
-		// builder on initialization
-		printer := kubectl.NewVersionedPrinter(printer, api.Scheme, versions...)
 
 		return printer.PrintObj(obj, out)
 	}

--- a/pkg/runtime/helper.go
+++ b/pkg/runtime/helper.go
@@ -149,3 +149,25 @@ func FieldPtr(v reflect.Value, fieldName string, dest interface{}) error {
 	}
 	return fmt.Errorf("couldn't assign/convert %v to %v", field.Type(), v.Type())
 }
+
+// MultiObjectTyper returns the types of objects across multiple schemes in order.
+type MultiObjectTyper []ObjectTyper
+
+func (m MultiObjectTyper) DataVersionAndKind(data []byte) (version, kind string, err error) {
+	for _, t := range m {
+		version, kind, err = t.DataVersionAndKind(data)
+		if err == nil {
+			return
+		}
+	}
+	return
+}
+func (m MultiObjectTyper) ObjectVersionAndKind(obj Object) (version, kind string, err error) {
+	for _, t := range m {
+		version, kind, err = t.ObjectVersionAndKind(obj)
+		if err == nil {
+			return
+		}
+	}
+	return
+}

--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -18,9 +18,10 @@ package runtime
 
 import (
 	"fmt"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
 	"net/url"
 	"reflect"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
 )
 
 // Scheme defines methods for serializing and deserializing API objects. It
@@ -147,8 +148,9 @@ func (self *Scheme) rawExtensionToEmbeddedObject(in *RawExtension, out *Embedded
 }
 
 // runtimeObjectToRawExtensionArray takes a list of objects and encodes them as RawExtension in the output version
-// defined by the conversion.Scope. If objects must be encoded to different schema versions you should set them as
-// runtime.Unknown in the internal version instead.
+// defined by the conversion.Scope. If objects must be encoded to different schema versions than the default, you
+// should encode them yourself with runtime.Unknown, or convert the object prior to invoking conversion. Objects
+// outside of the current scheme must be added as runtime.Unknown.
 func (self *Scheme) runtimeObjectToRawExtensionArray(in *[]Object, out *[]RawExtension, s conversion.Scope) error {
 	src := *in
 	dest := make([]RawExtension, len(src))
@@ -160,7 +162,12 @@ func (self *Scheme) runtimeObjectToRawExtensionArray(in *[]Object, out *[]RawExt
 		case *Unknown:
 			dest[i].RawJSON = t.RawJSON
 		default:
-			data, err := scheme.EncodeToVersion(src[i], outVersion)
+			version := outVersion
+			// if the object exists
+			if inVersion, _, err := scheme.ObjectVersionAndKind(src[i]); err == nil && len(inVersion) != 0 {
+				version = inVersion
+			}
+			data, err := scheme.EncodeToVersion(src[i], version)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
kubectl get can output a series of objects as a List in versioned
form, but not all API objects are available in the same schema.
Make the act of converting a []runtime.Object to api.List more
robust and add a test to verify its behavior in Get.

Makes it easier for client code to output unified objects.
