### PR TITLE
Update Gingko to latest HEAD release and revert hack to handle SIGTERM in e2e tests

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -338,8 +338,8 @@
 		},
 		{
 			"ImportPath": "github.com/onsi/ginkgo",
-			"Comment": "v1.1.0-33-g17ea479729ee",
-			"Rev": "17ea479729ee427265ac1e913443018350946ddf"
+			"Comment": "v1.1.0-42-gdbb5c6c",
+			"Rev": "dbb5c6caf33238b57facc1d975b1aaca6b90288c"
 		},
 		{
 			"ImportPath": "github.com/onsi/gomega",

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/CHANGELOG.md
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/CHANGELOG.md
@@ -32,7 +32,8 @@ Bug Fixes:
 - If --skipPackages is used and all packages are skipped, Ginkgo should exit 0.
 - Fix tempfile leak when running in parallel
 - Fix incorrect failure message when a panic occurs during a parallel test run
-
+- Fixed an issue where a pending test within a focused context (or a focused test within a pending context) would skip all other tests.
+- Be more consistent about handling SIGTERM as well as SIGINT
 
 ## 1.1.0 (8/2/2014)
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/bootstrap_command.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/bootstrap_command.go
@@ -54,7 +54,7 @@ var agoutiBootstrapText = `package {{.Package}}_test
 import (
 	{{.GinkgoImport}}
 	{{.GomegaImport}}
-	. "github.com/sclevine/agouti/core"
+	"github.com/sclevine/agouti"
 
 	"testing"
 )
@@ -64,23 +64,20 @@ func Test{{.FormattedName}}(t *testing.T) {
 	RunSpecs(t, "{{.FormattedName}} Suite")
 }
 
-var agoutiDriver WebDriver
+var agoutiDriver *agouti.WebDriver
 
 var _ = BeforeSuite(func() {
-	var err error
-
 	// Choose a WebDriver:
 
-	agoutiDriver, err = PhantomJS()
-	// agoutiDriver, err = Selenium()
-	// agoutiDriver, err = Chrome()
+	agoutiDriver = agouti.PhantomJS()
+	// agoutiDriver = agouti.Selenium()
+	// agoutiDriver = agouti.ChromeDriver()
 
-	Expect(err).NotTo(HaveOccurred())
 	Expect(agoutiDriver.Start()).To(Succeed())
 })
 
 var _ = AfterSuite(func() {
-	agoutiDriver.Stop()
+	Expect(agoutiDriver.Stop()).To(Succeed())
 })
 `
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/generate_command.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/generate_command.go
@@ -51,21 +51,21 @@ import (
 
 	{{if .IncludeImports}}. "github.com/onsi/ginkgo"{{end}}
 	{{if .IncludeImports}}. "github.com/onsi/gomega"{{end}}
-	. "github.com/sclevine/agouti/core"
 	. "github.com/sclevine/agouti/matchers"
+	"github.com/sclevine/agouti"
 )
 
 var _ = Describe("{{.Subject}}", func() {
-	var page Page
+	var page *agouti.Page
 
 	BeforeEach(func() {
 		var err error
-		page, err = agoutiDriver.Page()
+		page, err = agoutiDriver.NewPage()
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		page.Destroy()
+		Expect(page.Destroy()).To(Succeed())
 	})
 })
 `

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/help_command.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/help_command.go
@@ -23,7 +23,7 @@ func printHelp(args []string, additionalArgs []string) {
 	} else {
 		command, found := commandMatching(args[0])
 		if !found {
-			complainAndQuit(fmt.Sprintf("Unkown command: %s", args[0]))
+			complainAndQuit(fmt.Sprintf("Unknown command: %s", args[0]))
 		}
 
 		usageForCommand(command, true)

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/interrupthandler/interrupt_handler.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/interrupthandler/interrupt_handler.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"syscall"
 )
 
 type InterruptHandler struct {
@@ -33,7 +34,7 @@ func (h *InterruptHandler) WasInterrupted() bool {
 
 func (h *InterruptHandler) handleInterrupt() {
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 
 	<-c
 	signal.Stop(c)

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/watch/delta_tracker.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/watch/delta_tracker.go
@@ -64,7 +64,7 @@ func (d *DeltaTracker) Delta(suites []testsuite.TestSuite) (delta Delta, errors 
 func (d *DeltaTracker) WillRun(suite testsuite.TestSuite) error {
 	s, ok := d.suites[suite.Path]
 	if !ok {
-		return fmt.Errorf("unkown suite %s", suite.Path)
+		return fmt.Errorf("unknown suite %s", suite.Path)
 	}
 
 	return s.MarkAsRunAndRecomputedDependencies(d.maxDepth)

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/subcommand_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/subcommand_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Subcommand", func() {
 
 			Ω(content).Should(ContainSubstring("\t" + `. "github.com/onsi/ginkgo"`))
 			Ω(content).Should(ContainSubstring("\t" + `. "github.com/onsi/gomega"`))
-			Ω(content).Should(ContainSubstring("\t" + `. "github.com/sclevine/agouti/core"`))
+			Ω(content).Should(ContainSubstring("\t" + `"github.com/sclevine/agouti"`))
 		})
 	})
 
@@ -256,9 +256,9 @@ var _ = Describe("Subcommand", func() {
 				Ω(content).Should(ContainSubstring("package foo_bar_test"))
 				Ω(content).Should(ContainSubstring("\t" + `. "github.com/onsi/ginkgo"`))
 				Ω(content).Should(ContainSubstring("\t" + `. "github.com/onsi/gomega"`))
-				Ω(content).Should(ContainSubstring("\t" + `. "github.com/sclevine/agouti/core"`))
 				Ω(content).Should(ContainSubstring("\t" + `. "github.com/sclevine/agouti/matchers"`))
-				Ω(content).Should(ContainSubstring("page, err = agoutiDriver.Page()"))
+				Ω(content).Should(ContainSubstring("\t" + `"github.com/sclevine/agouti"`))
+				Ω(content).Should(ContainSubstring("page, err = agoutiDriver.NewPage()"))
 			})
 		})
 	})

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation/code_location_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation/code_location_test.go
@@ -1,11 +1,11 @@
 package codelocation_test
 
 import (
-	"runtime"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/internal/codelocation"
 	"github.com/onsi/ginkgo/types"
 	. "github.com/onsi/gomega"
+	"runtime"
 )
 
 var _ = Describe("CodeLocation", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/containernode/container_node_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/containernode/container_node_test.go
@@ -1,8 +1,8 @@
 package containernode_test
 
 import (
-	"math/rand"
 	"github.com/onsi/ginkgo/internal/leafnodes"
+	"math/rand"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/measure_node_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/measure_node_test.go
@@ -5,10 +5,10 @@ import (
 	. "github.com/onsi/ginkgo/internal/leafnodes"
 	. "github.com/onsi/gomega"
 
-	"time"
 	"github.com/onsi/ginkgo/internal/codelocation"
 	Failer "github.com/onsi/ginkgo/internal/failer"
 	"github.com/onsi/ginkgo/types"
+	"time"
 )
 
 var _ = Describe("Measure Nodes", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/aggregator_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/aggregator_test.go
@@ -4,11 +4,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"time"
 	"github.com/onsi/ginkgo/config"
 	. "github.com/onsi/ginkgo/internal/remote"
 	st "github.com/onsi/ginkgo/reporters/stenographer"
 	"github.com/onsi/ginkgo/types"
+	"time"
 )
 
 var _ = Describe("Aggregator", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec/specs.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec/specs.go
@@ -52,7 +52,7 @@ func (e *Specs) ApplyFocus(description string, focusString string, skipString st
 func (e *Specs) applyProgrammaticFocus() {
 	e.hasProgrammaticFocus = false
 	for _, spec := range e.specs {
-		if spec.Focused() {
+		if spec.Focused() && !spec.Pending() {
 			e.hasProgrammaticFocus = true
 			break
 		}

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec/specs_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec/specs_test.go
@@ -231,6 +231,36 @@ var _ = Describe("Specs", func() {
 		})
 	})
 
+	Describe("With a focused spec within a pending context and a pending spec within a focused context", func() {
+		BeforeEach(func() {
+			pendingInFocused := New(
+				leafnodes.NewItNode("PendingInFocused", func() {}, pendingFlag, codelocation.New(0), 0, nil, 0),
+				[]*containernode.ContainerNode{
+					containernode.New("", focusedFlag, codelocation.New(0)),
+				}, false)
+
+			focusedInPending := New(
+				leafnodes.NewItNode("FocusedInPending", func() {}, focusedFlag, codelocation.New(0), 0, nil, 0),
+				[]*containernode.ContainerNode{
+					containernode.New("", pendingFlag, codelocation.New(0)),
+				}, false)
+
+			specs = NewSpecs([]*Spec{
+				newSpec("A", noneFlag),
+				newSpec("B", noneFlag),
+				pendingInFocused,
+				focusedInPending,
+			})
+			specs.ApplyFocus("", "", "")
+		})
+
+		It("should not have a programmatic focus and should run all tests", func() {
+			Ω(willRunTexts(specs)).Should(Equal([]string{"A", "B"}))
+			Ω(skippedTexts(specs)).Should(BeEmpty())
+			Ω(pendingTexts(specs)).Should(ConsistOf(ContainSubstring("PendingInFocused"), ContainSubstring("FocusedInPending")))
+		})
+	})
+
 	Describe("skipping measurements", func() {
 		BeforeEach(func() {
 			specs = NewSpecs([]*Spec{

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go
@@ -170,7 +170,7 @@ func (runner *SpecRunner) CurrentSpecSummary() (*types.SpecSummary, bool) {
 
 func (runner *SpecRunner) registerForInterrupts() {
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 
 	<-c
 	signal.Stop(c)


### PR DESCRIPTION
Changes to Ginkgo this pulls in:
- Fixed an issue where a pending test within a focused context (or a focused test within a pending context) would skip all other tests.
- Be more consistent about handling SIGTERM as well as SIGINT
- maybe a few other minor bugfixes?
