### PR TITLE
Rename IsMountPoint to IsLikelyNotMountPoint

### DIFF
--- a/pkg/util/mount/fake.go
+++ b/pkg/util/mount/fake.go
@@ -62,11 +62,11 @@ func (f *FakeMounter) List() ([]MountPoint, error) {
 	return f.MountPoints, nil
 }
 
-func (f *FakeMounter) IsMountPoint(file string) (bool, error) {
+func (f *FakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	for _, mp := range f.MountPoints {
 		if mp.Path == file {
-			return true, nil
+			return false, nil
 		}
 	}
-	return false, nil
+	return true, nil
 }

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -30,8 +30,8 @@ type Interface interface {
 	// it could change between chunked reads). This is guaranteed to be
 	// consistent.
 	List() ([]MountPoint, error)
-	// IsMountPoint determines if a directory is a mountpoint.
-	IsMountPoint(file string) (bool, error)
+	// IsLikelyNotMountPoint determines if a directory is a mountpoint.
+	IsLikelyNotMountPoint(file string) (bool, error)
 }
 
 // This represents a single line in /proc/mounts or /etc/fstab.

--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -32,6 +32,6 @@ func (mounter *Mounter) List() ([]MountPoint, error) {
 	return []MountPoint{}, nil
 }
 
-func (mounter *Mounter) IsMountPoint(file string) (bool, error) {
-	return false, nil
+func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
+	return true, nil
 }

--- a/pkg/util/mount/nsenter_mount_unsupported.go
+++ b/pkg/util/mount/nsenter_mount_unsupported.go
@@ -38,6 +38,6 @@ func (*NsenterMounter) List() ([]MountPoint, error) {
 	return []MountPoint{}, nil
 }
 
-func (*NsenterMounter) IsMountPoint(file string) (bool, error) {
-	return false, nil
+func (*NsenterMounter) IsLikelyNotMountPoint(file string) (bool, error) {
+	return true, nil
 }

--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -189,12 +189,12 @@ func (b *awsElasticBlockStoreBuilder) SetUp() error {
 // SetUpAt attaches the disk and bind mounts to the volume path.
 func (b *awsElasticBlockStoreBuilder) SetUpAt(dir string) error {
 	// TODO: handle failed mounts here.
-	mountpoint, err := b.mounter.IsMountPoint(dir)
-	glog.V(4).Infof("PersistentDisk set up: %s %v %v", dir, mountpoint, err)
+	notMnt, err := b.mounter.IsLikelyNotMountPoint(dir)
+	glog.V(4).Infof("PersistentDisk set up: %s %v %v", dir, !notMnt, err)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	if mountpoint {
+	if !notMnt {
 		return nil
 	}
 
@@ -216,22 +216,22 @@ func (b *awsElasticBlockStoreBuilder) SetUpAt(dir string) error {
 	}
 	err = b.mounter.Mount(globalPDPath, dir, "", options)
 	if err != nil {
-		mountpoint, mntErr := b.mounter.IsMountPoint(dir)
+		notMnt, mntErr := b.mounter.IsLikelyNotMountPoint(dir)
 		if mntErr != nil {
-			glog.Errorf("isMountpoint check failed: %v", mntErr)
+			glog.Errorf("IsLikelyNotMountPoint check failed: %v", mntErr)
 			return err
 		}
-		if mountpoint {
+		if !notMnt {
 			if mntErr = b.mounter.Unmount(dir); mntErr != nil {
 				glog.Errorf("Failed to unmount: %v", mntErr)
 				return err
 			}
-			mountpoint, mntErr := b.mounter.IsMountPoint(dir)
+			notMnt, mntErr := b.mounter.IsLikelyNotMountPoint(dir)
 			if mntErr != nil {
-				glog.Errorf("isMountpoint check failed: %v", mntErr)
+				glog.Errorf("IsLikelyNotMountPoint check failed: %v", mntErr)
 				return err
 			}
-			if mountpoint {
+			if !notMnt {
 				// This is very odd, we don't expect it.  We'll try again next sync loop.
 				glog.Errorf("%s is still mounted, despite call to unmount().  Will try again next sync loop.", dir)
 				return err
@@ -295,12 +295,12 @@ func (c *awsElasticBlockStoreCleaner) TearDown() error {
 // Unmounts the bind mount, and detaches the disk only if the PD
 // resource was the last reference to that disk on the kubelet.
 func (c *awsElasticBlockStoreCleaner) TearDownAt(dir string) error {
-	mountpoint, err := c.mounter.IsMountPoint(dir)
+	notMnt, err := c.mounter.IsLikelyNotMountPoint(dir)
 	if err != nil {
 		glog.V(2).Info("Error checking if mountpoint ", dir, ": ", err)
 		return err
 	}
-	if !mountpoint {
+	if notMnt {
 		glog.V(2).Info("Not mountpoint, deleting")
 		return os.Remove(dir)
 	}
@@ -334,12 +334,12 @@ func (c *awsElasticBlockStoreCleaner) TearDownAt(dir string) error {
 	} else {
 		glog.V(2).Infof("Found multiple refs; won't detach EBS volume: %v", refs)
 	}
-	mountpoint, mntErr := c.mounter.IsMountPoint(dir)
+	notMnt, mntErr := c.mounter.IsLikelyNotMountPoint(dir)
 	if mntErr != nil {
-		glog.Errorf("isMountpoint check failed: %v", mntErr)
+		glog.Errorf("IsLikelyNotMountPoint check failed: %v", mntErr)
 		return err
 	}
-	if !mountpoint {
+	if notMnt {
 		if err := os.Remove(dir); err != nil {
 			glog.V(2).Info("Error removing mountpoint ", dir, ": ", err)
 			return err

--- a/pkg/volume/aws_ebs/aws_util.go
+++ b/pkg/volume/aws_ebs/aws_util.go
@@ -61,13 +61,13 @@ func (util *AWSDiskUtil) AttachAndMountDisk(b *awsElasticBlockStoreBuilder, glob
 	}
 
 	// Only mount the PD globally once.
-	mountpoint, err := b.mounter.IsMountPoint(globalPDPath)
+	notMnt, err := b.mounter.IsLikelyNotMountPoint(globalPDPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			if err := os.MkdirAll(globalPDPath, 0750); err != nil {
 				return err
 			}
-			mountpoint = false
+			notMnt = true
 		} else {
 			return err
 		}
@@ -76,7 +76,7 @@ func (util *AWSDiskUtil) AttachAndMountDisk(b *awsElasticBlockStoreBuilder, glob
 	if b.readOnly {
 		options = append(options, "ro")
 	}
-	if !mountpoint {
+	if notMnt {
 		err = b.diskMounter.Mount(devicePath, globalPDPath, b.fsType, options)
 		if err != nil {
 			os.Remove(globalPDPath)

--- a/pkg/volume/empty_dir/empty_dir.go
+++ b/pkg/volume/empty_dir/empty_dir.go
@@ -144,7 +144,7 @@ func (ed *emptyDir) SetUp() error {
 
 // SetUpAt creates new directory.
 func (ed *emptyDir) SetUpAt(dir string) error {
-	isMnt, err := ed.mounter.IsMountPoint(dir)
+	notMnt, err := ed.mounter.IsLikelyNotMountPoint(dir)
 	// Getting an os.IsNotExist err from is a contingency; the directory
 	// may not exist yet, in which case, setup should run.
 	if err != nil && !os.IsNotExist(err) {
@@ -156,7 +156,7 @@ func (ed *emptyDir) SetUpAt(dir string) error {
 	// medium is memory, and a mountpoint is present, then the volume is
 	// ready.
 	if volumeutil.IsReady(ed.getMetaDir()) {
-		if ed.medium == api.StorageMediumMemory && isMnt {
+		if ed.medium == api.StorageMediumMemory && !notMnt {
 			return nil
 		} else if ed.medium == api.StorageMediumDefault {
 			return nil

--- a/pkg/volume/empty_dir/empty_dir_linux.go
+++ b/pkg/volume/empty_dir/empty_dir_linux.go
@@ -37,9 +37,9 @@ type realMountDetector struct {
 
 func (m *realMountDetector) GetMountMedium(path string) (storageMedium, bool, error) {
 	glog.V(5).Infof("Determining mount medium of %v", path)
-	isMnt, err := m.mounter.IsMountPoint(path)
+	notMnt, err := m.mounter.IsLikelyNotMountPoint(path)
 	if err != nil {
-		return 0, false, fmt.Errorf("IsMountPoint(%q): %v", path, err)
+		return 0, false, fmt.Errorf("IsLikelyNotMountPoint(%q): %v", path, err)
 	}
 	buf := syscall.Statfs_t{}
 	if err := syscall.Statfs(path, &buf); err != nil {
@@ -48,9 +48,9 @@ func (m *realMountDetector) GetMountMedium(path string) (storageMedium, bool, er
 
 	glog.V(5).Info("Statfs_t of %v: %+v", path, buf)
 	if buf.Type == linuxTmpfsMagic {
-		return mediumMemory, isMnt, nil
+		return mediumMemory, !notMnt, nil
 	}
-	return mediumUnknown, isMnt, nil
+	return mediumUnknown, !notMnt, nil
 }
 
 // selinuxEnabled determines whether SELinux is enabled.

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -172,12 +172,12 @@ func (b *gcePersistentDiskBuilder) SetUp() error {
 // SetUpAt attaches the disk and bind mounts to the volume path.
 func (b *gcePersistentDiskBuilder) SetUpAt(dir string) error {
 	// TODO: handle failed mounts here.
-	mountpoint, err := b.mounter.IsMountPoint(dir)
-	glog.V(4).Infof("PersistentDisk set up: %s %v %v", dir, mountpoint, err)
+	notMnt, err := b.mounter.IsLikelyNotMountPoint(dir)
+	glog.V(4).Infof("PersistentDisk set up: %s %v %v", dir, !notMnt, err)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	if mountpoint {
+	if !notMnt {
 		return nil
 	}
 
@@ -199,22 +199,22 @@ func (b *gcePersistentDiskBuilder) SetUpAt(dir string) error {
 	}
 	err = b.mounter.Mount(globalPDPath, dir, "", options)
 	if err != nil {
-		mountpoint, mntErr := b.mounter.IsMountPoint(dir)
+		notMnt, mntErr := b.mounter.IsLikelyNotMountPoint(dir)
 		if mntErr != nil {
-			glog.Errorf("isMountpoint check failed: %v", mntErr)
+			glog.Errorf("IsLikelyNotMountPoint check failed: %v", mntErr)
 			return err
 		}
-		if mountpoint {
+		if !notMnt {
 			if mntErr = b.mounter.Unmount(dir); mntErr != nil {
 				glog.Errorf("Failed to unmount: %v", mntErr)
 				return err
 			}
-			mountpoint, mntErr := b.mounter.IsMountPoint(dir)
+			notMnt, mntErr := b.mounter.IsLikelyNotMountPoint(dir)
 			if mntErr != nil {
-				glog.Errorf("isMountpoint check failed: %v", mntErr)
+				glog.Errorf("IsLikelyNotMountPoint check failed: %v", mntErr)
 				return err
 			}
-			if mountpoint {
+			if !notMnt {
 				// This is very odd, we don't expect it.  We'll try again next sync loop.
 				glog.Errorf("%s is still mounted, despite call to unmount().  Will try again next sync loop.", dir)
 				return err
@@ -257,11 +257,11 @@ func (c *gcePersistentDiskCleaner) TearDown() error {
 // Unmounts the bind mount, and detaches the disk only if the PD
 // resource was the last reference to that disk on the kubelet.
 func (c *gcePersistentDiskCleaner) TearDownAt(dir string) error {
-	mountpoint, err := c.mounter.IsMountPoint(dir)
+	notMnt, err := c.mounter.IsLikelyNotMountPoint(dir)
 	if err != nil {
 		return err
 	}
-	if !mountpoint {
+	if notMnt {
 		return os.Remove(dir)
 	}
 
@@ -282,12 +282,12 @@ func (c *gcePersistentDiskCleaner) TearDownAt(dir string) error {
 			return err
 		}
 	}
-	mountpoint, mntErr := c.mounter.IsMountPoint(dir)
+	notMnt, mntErr := c.mounter.IsLikelyNotMountPoint(dir)
 	if mntErr != nil {
-		glog.Errorf("isMountpoint check failed: %v", mntErr)
+		glog.Errorf("IsLikelyNotMountPoint check failed: %v", mntErr)
 		return err
 	}
-	if !mountpoint {
+	if notMnt {
 		if err := os.Remove(dir); err != nil {
 			return err
 		}

--- a/pkg/volume/gce_pd/gce_util.go
+++ b/pkg/volume/gce_pd/gce_util.go
@@ -71,13 +71,13 @@ func (diskUtil *GCEDiskUtil) AttachAndMountDisk(b *gcePersistentDiskBuilder, glo
 	}
 
 	// Only mount the PD globally once.
-	mountpoint, err := b.mounter.IsMountPoint(globalPDPath)
+	notMnt, err := b.mounter.IsLikelyNotMountPoint(globalPDPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			if err := os.MkdirAll(globalPDPath, 0750); err != nil {
 				return err
 			}
-			mountpoint = false
+			notMnt = true
 		} else {
 			return err
 		}
@@ -86,7 +86,7 @@ func (diskUtil *GCEDiskUtil) AttachAndMountDisk(b *gcePersistentDiskBuilder, glo
 	if b.readOnly {
 		options = append(options, "ro")
 	}
-	if !mountpoint {
+	if notMnt {
 		err = b.diskMounter.Mount(devicePath, globalPDPath, b.fsType, options)
 		if err != nil {
 			os.Remove(globalPDPath)

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -140,12 +140,12 @@ func (b *glusterfsBuilder) SetUp() error {
 }
 
 func (b *glusterfsBuilder) SetUpAt(dir string) error {
-	mountpoint, err := b.mounter.IsMountPoint(dir)
-	glog.V(4).Infof("Glusterfs: mount set up: %s %v %v", dir, mountpoint, err)
+	notMnt, err := b.mounter.IsLikelyNotMountPoint(dir)
+	glog.V(4).Infof("Glusterfs: mount set up: %s %v %v", dir, !notMnt, err)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	if mountpoint {
+	if !notMnt {
 		return nil
 	}
 
@@ -185,12 +185,12 @@ func (c *glusterfsCleaner) TearDownAt(dir string) error {
 }
 
 func (c *glusterfsCleaner) cleanup(dir string) error {
-	mountpoint, err := c.mounter.IsMountPoint(dir)
+	notMnt, err := c.mounter.IsLikelyNotMountPoint(dir)
 	if err != nil {
-		glog.Errorf("Glusterfs: Error checking IsMountPoint: %v", err)
+		glog.Errorf("Glusterfs: Error checking IsLikelyNotMountPoint: %v", err)
 		return err
 	}
-	if !mountpoint {
+	if notMnt {
 		return os.RemoveAll(dir)
 	}
 
@@ -198,12 +198,12 @@ func (c *glusterfsCleaner) cleanup(dir string) error {
 		glog.Errorf("Glusterfs: Unmounting failed: %v", err)
 		return err
 	}
-	mountpoint, mntErr := c.mounter.IsMountPoint(dir)
+	notMnt, mntErr := c.mounter.IsLikelyNotMountPoint(dir)
 	if mntErr != nil {
-		glog.Errorf("Glusterfs: IsMountpoint check failed: %v", mntErr)
+		glog.Errorf("Glusterfs: IsLikelyNotMountPoint check failed: %v", mntErr)
 		return mntErr
 	}
-	if !mountpoint {
+	if notMnt {
 		if err := os.RemoveAll(dir); err != nil {
 			return err
 		}

--- a/pkg/volume/iscsi/disk_manager.go
+++ b/pkg/volume/iscsi/disk_manager.go
@@ -36,13 +36,13 @@ type diskManager interface {
 func diskSetUp(manager diskManager, b iscsiDiskBuilder, volPath string, mounter mount.Interface) error {
 	globalPDPath := manager.MakeGlobalPDName(*b.iscsiDisk)
 	// TODO: handle failed mounts here.
-	mountpoint, err := mounter.IsMountPoint(volPath)
+	notMnt, err := mounter.IsLikelyNotMountPoint(volPath)
 
 	if err != nil && !os.IsNotExist(err) {
 		glog.Errorf("cannot validate mountpoint: %s", volPath)
 		return err
 	}
-	if mountpoint {
+	if !notMnt {
 		return nil
 	}
 	if err := manager.AttachDisk(b); err != nil {
@@ -69,12 +69,12 @@ func diskSetUp(manager diskManager, b iscsiDiskBuilder, volPath string, mounter 
 
 // utility to tear down a disk based filesystem
 func diskTearDown(manager diskManager, c iscsiDiskCleaner, volPath string, mounter mount.Interface) error {
-	mountpoint, err := mounter.IsMountPoint(volPath)
+	notMnt, err := mounter.IsLikelyNotMountPoint(volPath)
 	if err != nil {
 		glog.Errorf("cannot validate mountpoint %s", volPath)
 		return err
 	}
-	if !mountpoint {
+	if notMnt {
 		return os.Remove(volPath)
 	}
 
@@ -97,12 +97,12 @@ func diskTearDown(manager diskManager, c iscsiDiskCleaner, volPath string, mount
 		}
 	}
 
-	mountpoint, mntErr := mounter.IsMountPoint(volPath)
+	notMnt, mntErr := mounter.IsLikelyNotMountPoint(volPath)
 	if mntErr != nil {
-		glog.Errorf("isMountpoint check failed: %v", mntErr)
+		glog.Errorf("IsLikelyNotMountPoint check failed: %v", mntErr)
 		return err
 	}
-	if !mountpoint {
+	if notMnt {
 		if err := os.Remove(volPath); err != nil {
 			return err
 		}

--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -101,8 +101,8 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskBuilder) error {
 	}
 	// mount it
 	globalPDPath := b.manager.MakeGlobalPDName(*b.iscsiDisk)
-	mountpoint, err := b.mounter.IsMountPoint(globalPDPath)
-	if mountpoint {
+	notMnt, err := b.mounter.IsLikelyNotMountPoint(globalPDPath)
+	if !notMnt {
 		glog.Infof("iscsi: %s already mounted", globalPDPath)
 		return nil
 	}

--- a/pkg/volume/rbd/disk_manager.go
+++ b/pkg/volume/rbd/disk_manager.go
@@ -42,13 +42,13 @@ type diskManager interface {
 func diskSetUp(manager diskManager, b rbdBuilder, volPath string, mounter mount.Interface) error {
 	globalPDPath := manager.MakeGlobalPDName(*b.rbd)
 	// TODO: handle failed mounts here.
-	mountpoint, err := mounter.IsMountPoint(volPath)
+	notMnt, err := mounter.IsLikelyNotMountPoint(volPath)
 
 	if err != nil && !os.IsNotExist(err) {
 		glog.Errorf("cannot validate mountpoint: %s", volPath)
 		return err
 	}
-	if mountpoint {
+	if !notMnt {
 		return nil
 	}
 	if err := manager.AttachDisk(b); err != nil {
@@ -75,12 +75,12 @@ func diskSetUp(manager diskManager, b rbdBuilder, volPath string, mounter mount.
 
 // utility to tear down a disk based filesystem
 func diskTearDown(manager diskManager, c rbdCleaner, volPath string, mounter mount.Interface) error {
-	mountpoint, err := mounter.IsMountPoint(volPath)
+	notMnt, err := mounter.IsLikelyNotMountPoint(volPath)
 	if err != nil {
 		glog.Errorf("cannot validate mountpoint %s", volPath)
 		return err
 	}
-	if !mountpoint {
+	if notMnt {
 		return os.Remove(volPath)
 	}
 
@@ -103,12 +103,12 @@ func diskTearDown(manager diskManager, c rbdCleaner, volPath string, mounter mou
 		}
 	}
 
-	mountpoint, mntErr := mounter.IsMountPoint(volPath)
+	notMnt, mntErr := mounter.IsLikelyNotMountPoint(volPath)
 	if mntErr != nil {
-		glog.Errorf("isMountpoint check failed: %v", mntErr)
+		glog.Errorf("IsLikelyNotMountPoint check failed: %v", mntErr)
 		return err
 	}
-	if !mountpoint {
+	if notMnt {
 		if err := os.Remove(volPath); err != nil {
 			return err
 		}

--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -215,12 +215,12 @@ func (util *RBDUtil) AttachDisk(b rbdBuilder) error {
 	}
 	// mount it
 	globalPDPath := b.manager.MakeGlobalPDName(*b.rbd)
-	mountpoint, err := b.mounter.IsMountPoint(globalPDPath)
-	// in the first time, the path shouldn't exist and IsMountPoint is expected to get NotExist
+	notMnt, err := b.mounter.IsLikelyNotMountPoint(globalPDPath)
+	// in the first time, the path shouldn't exist and IsLikelyNotMountPoint is expected to get NotExist
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("rbd: %s failed to check mountpoint", globalPDPath)
 	}
-	if mountpoint {
+	if !notMnt {
 		return nil
 	}
 

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -111,7 +111,7 @@ func (b *secretVolumeBuilder) getMetaDir() string {
 }
 
 func (b *secretVolumeBuilder) SetUpAt(dir string) error {
-	isMnt, err := b.mounter.IsMountPoint(dir)
+	notMnt, err := b.mounter.IsLikelyNotMountPoint(dir)
 	// Getting an os.IsNotExist err from is a contingency; the directory
 	// may not exist yet, in which case, setup should run.
 	if err != nil && !os.IsNotExist(err) {
@@ -120,7 +120,7 @@ func (b *secretVolumeBuilder) SetUpAt(dir string) error {
 
 	// If the plugin readiness file is present for this volume and
 	// the setup dir is a mountpoint, this volume is already ready.
-	if volumeutil.IsReady(b.getMetaDir()) && isMnt {
+	if volumeutil.IsReady(b.getMetaDir()) && !notMnt {
 		return nil
 	}
 


### PR DESCRIPTION
IsLikelyNotMountPoint determines if a directory is not a mountpoint.
It is fast but not necessarily ALWAYS correct. If the path is in fact
a bind mount from one part of a mount to another it will not be detected.
mkdir /tmp/a /tmp/b; mount --bin /tmp/a /tmp/b; IsLikelyNotMountPoint("/tmp/b")
will return true. When in fact /tmp/b is a mount point. So this patch
renames the function and switches it from a positive to a negative (I
could think of a good positive name). This should make future users of
this function aware that it isn't quite perfect, but probably good
enough.
