### PR TITLE
Use the standard podStartTimeout in services e2e test

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -330,7 +330,7 @@ var _ = Describe("Services", func() {
 
 		By("hitting the pod through the service's external load balancer")
 		var resp *http.Response
-		for t := time.Now(); time.Since(t) < time.Minute; time.Sleep(5 * time.Second) {
+		for t := time.Now(); time.Since(t) < podStartTimeout; time.Sleep(5 * time.Second) {
 			resp, err = http.Get(fmt.Sprintf("http://%s:%d", ip, port))
 			if err == nil {
 				break
@@ -409,7 +409,7 @@ func waitForPublicIPs(c *client.Client, serviceName, namespace string) (*api.Ser
 		}
 		Logf("Waiting for service %s in namespace %s to have a public IP (%v)", serviceName, namespace, time.Since(start))
 	}
-	return service, fmt.Errorf("service %s in namespace %s doesn't have a public IP after %.2f seconds", serviceName, namespace, podStartTimeout.Seconds())
+	return service, fmt.Errorf("service %s in namespace %s doesn't have a public IP after %.2f seconds", serviceName, namespace, timeout.Seconds())
 }
 
 func validateUniqueOrFail(s []string) {


### PR DESCRIPTION
...when waiting for a pod to be reachable behind an external load balancer.

I observed occasional timeouts when testing locally, and upon investigation
of one particular instance, found that it was just because the pod wasn't up
and running yet. I've changed the test to wait as long as all other tests do.

Also fix an unrelated error message.

This should reduce the chance of flakes of the form:

```
• Failure [110.286 seconds]
Services
/home/arob/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/service.go:395
  should be able to create a functioning external load balancer [It]
  /home/arob/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/service.go:350

  Expected error:
      <*url.Error | 0xc2080ca510>: {
          Op: "Get",
          URL: "http://108.59.85.194:80",
          Err: {
              Op: "dial",
              Net: "tcp",
              Addr: {
                  IP: "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xffl;U\xc2",
                  Port: 80,
                  Zone: "",
              },
              Err: {},
          },
      }
      Get http://108.59.85.194:80: dial tcp 108.59.85.194:80: i/o timeout
  not to have occurred
```

cc @quinton-hoole 
