### PR TITLE
Enable profiling on kubelet healthz port

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	_ "net/http/pprof"
 	"path"
 	"strconv"
 	"strings"


### PR DESCRIPTION
This and scheduler are the last two kube-apps without an enable_profiling flag.
