### PR TITLE
`kubectl get rc,pods` should invoke in that order

### DIFF
--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -587,8 +587,16 @@ func (b *Builder) Do() *Result {
 	return r
 }
 
+// SplitResourceArgument splits the argument with commas and returns unique
+// strings in the original order.
 func SplitResourceArgument(arg string) []string {
+	out := []string{}
 	set := util.NewStringSet()
-	set.Insert(strings.Split(arg, ",")...)
-	return set.List()
+	for _, s := range strings.Split(arg, ",") {
+		if set.Has(s) {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
 }


### PR DESCRIPTION
SplitResourceArguments should not use a golang map
