### PR TITLE
Listing existing algorithm providers in scheduler

### DIFF
--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -70,7 +70,7 @@ func NewSchedulerServer() *SchedulerServer {
 func (s *SchedulerServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.Port, "port", s.Port, "The port that the scheduler's http service runs on")
 	fs.Var(&s.Address, "address", "The IP address to serve on (set to 0.0.0.0 for all interfaces)")
-	fs.StringVar(&s.AlgorithmProvider, "algorithm_provider", s.AlgorithmProvider, "The scheduling algorithm provider to use")
+	fs.StringVar(&s.AlgorithmProvider, "algorithm_provider", s.AlgorithmProvider, "The scheduling algorithm provider to use, one of: "+factory.ListAlgorithmProviders())
 	fs.StringVar(&s.PolicyConfigFile, "policy_config_file", s.PolicyConfigFile, "File with scheduler policy configuration")
 	fs.BoolVar(&s.EnableProfiling, "profiling", true, "Enable profiling via web interface host:port/debug/pprof/")
 	fs.StringVar(&s.Master, "master", s.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")

--- a/plugin/pkg/scheduler/factory/plugins.go
+++ b/plugin/pkg/scheduler/factory/plugins.go
@@ -19,6 +19,7 @@ package factory
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"sync"
 
 	algorithm "github.com/GoogleCloudPlatform/kubernetes/pkg/scheduler"
@@ -299,4 +300,13 @@ func validatePriorityOrDie(priority schedulerapi.PriorityPolicy) {
 			glog.Fatalf("Exactly 1 priority argument is required")
 		}
 	}
+}
+
+// ListAlgorithmProviders is called when listing all available algortihm providers in `kube-scheduler --help`
+func ListAlgorithmProviders() string {
+	var availableAlgorithmProviders []string
+	for name := range algorithmProviderMap {
+		availableAlgorithmProviders = append(availableAlgorithmProviders, name)
+	}
+	return strings.Join(availableAlgorithmProviders, " | ")
 }


### PR DESCRIPTION
This PR implements issue #6612

Allow 'kube-scheduler --help' to show available algorithm providers under field '--algorithm_provider'. All available providers are listed and separated by ' | '.

If implemented a custom algorithm provider (MyProvider), --algorithm_provider would be like:

```
--algorithm_provider="DefaultProvider": The scheduling algorithm provider to use, one of: DefaultProvider | MyProvider
```
