### PR TITLE
Use kubeconfig in several components

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -22,13 +22,13 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof"
-	"os"
 	"strconv"
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
+	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/proxy"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/proxy/config"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -46,7 +46,7 @@ type ProxyServer struct {
 	HealthzBindAddress util.IP
 	OOMScoreAdj        int
 	ResourceContainer  string
-	Host               string
+	Master             string
 	Kubeconfig         string
 }
 
@@ -64,7 +64,7 @@ func NewProxyServer() *ProxyServer {
 // AddFlags adds flags for a specific ProxyServer to the specified FlagSet
 func (s *ProxyServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Var(&s.BindAddress, "bind_address", "The IP address for the proxy server to serve on (set to 0.0.0.0 for all interfaces)")
-	fs.StringVar(&s.Host, "master", s.Host, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
+	fs.StringVar(&s.Master, "master", s.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
 	fs.IntVar(&s.HealthzPort, "healthz_port", s.HealthzPort, "The port to bind the health check server. Use 0 to disable.")
 	fs.Var(&s.HealthzBindAddress, "healthz_bind_address", "The IP address for the health check server to serve on, defaulting to 127.0.0.1 (set to 0.0.0.0 for all interfaces)")
 	fs.IntVar(&s.OOMScoreAdj, "oom_score_adj", s.OOMScoreAdj, "The oom_score_adj value for kube-proxy process. Values must be within the range [-1000, 1000]")
@@ -109,36 +109,31 @@ func (s *ProxyServer) Run(_ []string) error {
 	// are registered yet.
 
 	// define api config source
-	if s.Host != "" || s.Kubeconfig != "" {
-		var kubeconfig *client.Config
-		if s.Kubeconfig != "" {
-			var err error
-			loader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-				&clientcmd.ClientConfigLoadingRules{ExplicitPath: s.Kubeconfig},
-				&clientcmd.ConfigOverrides{})
-			kubeconfig, err = loader.ClientConfig()
-			if os.IsNotExist(err) {
-				glog.Fatalf("Could not find kubeconfig file at %s", s.Kubeconfig)
-			}
-			if err != nil {
-				glog.Fatalf("Error loading kubeconfig file \"%s\": %v", s.Kubeconfig, err)
-			}
-		}
-		if s.Host != "" {
-			kubeconfig.Host = s.Host
-		}
-		client, err := client.New(kubeconfig)
-		if err != nil {
-			glog.Fatalf("Invalid API configuration: %v", err)
-		}
-		config.NewSourceAPI(
-			client.Services(api.NamespaceAll),
-			client.Endpoints(api.NamespaceAll),
-			30*time.Second,
-			serviceConfig.Channel("api"),
-			endpointsConfig.Channel("api"),
-		)
+	if s.Kubeconfig == "" && s.Master == "" {
+		glog.Warningf("Neither --kubeconfig nor --master was specified.  Using default API client.  This might not work.")
 	}
+
+	// This creates a client, first loading any specified kubeconfig
+	// file, and then overriding the Master flag, if non-empty.
+	kubeconfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: s.Kubeconfig},
+		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: s.Master}}).ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	client, err := client.New(kubeconfig)
+	if err != nil {
+		glog.Fatalf("Invalid API configuration: %v", err)
+	}
+
+	config.NewSourceAPI(
+		client.Services(api.NamespaceAll),
+		client.Endpoints(api.NamespaceAll),
+		30*time.Second,
+		serviceConfig.Channel("api"),
+		endpointsConfig.Channel("api"),
+	)
 
 	if s.HealthzPort > 0 {
 		go util.Forever(func() {

--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
+	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master/ports"
@@ -47,10 +49,11 @@ import (
 type SchedulerServer struct {
 	Port              int
 	Address           util.IP
-	ClientConfig      client.Config
 	AlgorithmProvider string
 	PolicyConfigFile  string
 	EnableProfiling   bool
+	Master            string
+	Kubeconfig        string
 }
 
 // NewSchedulerServer creates a new SchedulerServer with default parameters
@@ -67,17 +70,31 @@ func NewSchedulerServer() *SchedulerServer {
 func (s *SchedulerServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.Port, "port", s.Port, "The port that the scheduler's http service runs on")
 	fs.Var(&s.Address, "address", "The IP address to serve on (set to 0.0.0.0 for all interfaces)")
-	s.ClientConfig.QPS = 20.0
-	s.ClientConfig.Burst = 100
-	client.BindClientConfigFlags(fs, &s.ClientConfig)
 	fs.StringVar(&s.AlgorithmProvider, "algorithm_provider", s.AlgorithmProvider, "The scheduling algorithm provider to use")
 	fs.StringVar(&s.PolicyConfigFile, "policy_config_file", s.PolicyConfigFile, "File with scheduler policy configuration")
 	fs.BoolVar(&s.EnableProfiling, "profiling", true, "Enable profiling via web interface host:port/debug/pprof/")
+	fs.StringVar(&s.Master, "master", s.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
+	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
 }
 
 // Run runs the specified SchedulerServer.  This should never exit.
 func (s *SchedulerServer) Run(_ []string) error {
-	kubeClient, err := client.New(&s.ClientConfig)
+	if s.Kubeconfig == "" && s.Master == "" {
+		glog.Warningf("Neither --kubeconfig nor --master was specified.  Using default API client.  This might not work.")
+	}
+
+	// This creates a client, first loading any specified kubeconfig
+	// file, and then overriding the Master flag, if non-empty.
+	kubeconfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: s.Kubeconfig},
+		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: s.Master}}).ClientConfig()
+	if err != nil {
+		return err
+	}
+	kubeconfig.QPS = 20.0
+	kubeconfig.Burst = 100
+
+	kubeClient, err := client.New(kubeconfig)
 	if err != nil {
 		glog.Fatalf("Invalid API configuration: %v", err)
 	}


### PR DESCRIPTION
kube-proxy, kube-controller-manager, and kube-scheduler learn how to
read a kubeconfig file, via the `--kubeconfig` flag

They continue to support the `--master flag`, which is used by all distros.

They forget these flags: `--api_version, --insecure_skip_tls_verify, --client_certificate, --client_key, --certificate_authority, --max_outgoing_qps, --max_outgoing_burst`, but there was no config in the repo using those flags, and we can set them in the kubeconfig if we need to.

I've manually tested that the binaries can read kubeconfigs, but I'll modify their config to actually use the kubeconfigs in a subsequent PR.

My cluster passes validation with this PR. 
