### PR TITLE
Allow more retries on errors in density test

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -257,7 +257,6 @@ func writeJSON(statusCode int, codec runtime.Codec, object runtime.Object, w htt
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	glog.Infof("Writting status code: %d", statusCode)
 	w.WriteHeader(statusCode)
 	w.Write(formatted.Bytes())
 }

--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -36,7 +36,7 @@ import (
 
 // Convenient wrapper around listing pods supporting retries.
 func listPods(c *client.Client, namespace string, label labels.Selector) (*api.PodList, error) {
-	maxRetries := 2
+	maxRetries := 4
 	pods, err := c.Pods(namespace).List(label)
 	for i := 0; i < maxRetries; i++ {
 		if err == nil {


### PR DESCRIPTION
Such failures are happening frequently while running performance tests on Jenkins.
