### PR TITLE
Make PodTemplate an API objects

### DIFF
--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -28,6 +28,8 @@ func init() {
 		&Pod{},
 		&PodList{},
 		&PodStatusResult{},
+		&PodTemplate{},
+		&PodTemplateList{},
 		&ReplicationControllerList{},
 		&ReplicationController{},
 		&ServiceList{},
@@ -67,6 +69,8 @@ func init() {
 func (*Pod) IsAnAPIObject()                       {}
 func (*PodList) IsAnAPIObject()                   {}
 func (*PodStatusResult) IsAnAPIObject()           {}
+func (*PodTemplate) IsAnAPIObject()               {}
+func (*PodTemplateList) IsAnAPIObject()           {}
 func (*ReplicationController) IsAnAPIObject()     {}
 func (*ReplicationControllerList) IsAnAPIObject() {}
 func (*Service) IsAnAPIObject()                   {}


### PR DESCRIPTION
I think this is a bug - PodTemplate is an API object in v1beta1, v1beta2 and v1beta3.

cc @lavalamp @bgrant0607 
