### PR TITLE
Go build cleanup

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -303,7 +303,7 @@ kube::golang::build_binaries_for_platform() {
       fi
 
       if kube::golang::is_statically_linked_library "${binary}"; then
-        CGO_ENABLED=0 go build -installsuffix cgo -o "${output_path}/${bin}" \
+        CGO_ENABLED=0 go build -o "${output_path}/${bin}" \
           "${goflags[@]:+${goflags[@]}}" \
           -ldflags "${version_ldflags}" \
           "${binary}"

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -295,6 +295,7 @@ kube::golang::build_binaries_for_platform() {
       output_path="${output_path}/${platform//\//_}"
     fi
 
+    kube::log::progress "    "
     for binary in "${binaries[@]}"; do
       local bin=$(basename "${binary}")
       if [[ ${GOOS} == "windows" ]]; then
@@ -312,7 +313,9 @@ kube::golang::build_binaries_for_platform() {
           -ldflags "${version_ldflags}" \
           "${binary}"
       fi
+      kube::log::progress "*"
     done
+    kube::log::progress "\n"
   else
     # Use go install.
     if [[ "${#nonstatics[@]}" != 0 ]]; then

--- a/hack/lib/logging.sh
+++ b/hack/lib/logging.sh
@@ -119,6 +119,13 @@ kube::log::info() {
   done
 }
 
+# Just like kube::log::info, but no \n, so you can make a progress bar
+kube::log::progress() {
+  for message; do
+    echo -e -n "$message"
+  done
+}
+
 kube::log::info_from_stdin() {
   local messages=()
   while read -r line; do


### PR DESCRIPTION
Two small changes.
- Remove the useless -installsuffix cgo option to go build (it is a go install option)
- Print little \* on the screen for every binary built with go build. So it doesn't look like it locked up.
