### PR TITLE
Use Pod.Spec.Host instead of Pod.Status.HostIP for pod subresources

### DIFF
--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -205,7 +205,7 @@ func LogLocation(getter ResourceGetter, connInfo client.ConnectionInfoGetter, ct
 			return nil, nil, errors.NewBadRequest(fmt.Sprintf("a container name must be specified for pod %s", name))
 		}
 	}
-	nodeHost := pod.Status.HostIP
+	nodeHost := pod.Spec.Host
 	if len(nodeHost) == 0 {
 		// If pod has not been assigned a host, return an empty location
 		return nil, nil, nil
@@ -245,7 +245,7 @@ func ExecLocation(getter ResourceGetter, connInfo client.ConnectionInfoGetter, c
 			return nil, nil, errors.NewBadRequest(fmt.Sprintf("a container name must be specified for pod %s", name))
 		}
 	}
-	nodeHost := pod.Status.HostIP
+	nodeHost := pod.Spec.Host
 	if len(nodeHost) == 0 {
 		// If pod has not been assigned a host, return an empty location
 		return nil, nil, fmt.Errorf("pod %s does not have a host assigned", name)
@@ -285,7 +285,7 @@ func PortForwardLocation(getter ResourceGetter, connInfo client.ConnectionInfoGe
 		return nil, nil, err
 	}
 
-	nodeHost := pod.Status.HostIP
+	nodeHost := pod.Spec.Host
 	if len(nodeHost) == 0 {
 		// If pod has not been assigned a host, return an empty location
 		return nil, nil, errors.NewBadRequest(fmt.Sprintf("pod %s does not have a host assigned", name))


### PR DESCRIPTION
The Spec.Host is set when binding a pod to a node and will contain the
canonical host name of the node. The Status.HostIP may not be included
in the node's server TLS certificate.
