### PR TITLE
use Watch for single object instead of WatchList

### DIFF
--- a/pkg/registry/etcd/etcd.go
+++ b/pkg/registry/etcd/etcd.go
@@ -271,7 +271,8 @@ func (r *Registry) WatchServices(ctx api.Context, label labels.Selector, field f
 		if err != nil {
 			return nil, err
 		}
-		return r.Watch(key, version), nil
+		// TODO: use generic.SelectionPredicate
+		return r.Watch(key, version, tools.Everything)
 	}
 	if field.Empty() {
 		return r.WatchList(makeServiceListKey(ctx), version, tools.Everything)

--- a/pkg/registry/generic/etcd/etcd_test.go
+++ b/pkg/registry/generic/etcd/etcd_test.go
@@ -690,11 +690,16 @@ func TestEtcdWatch(t *testing.T) {
 
 	for name, m := range table {
 		podA := &api.Pod{
-			ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
-			Spec:       api.PodSpec{Host: "machine"},
+			ObjectMeta: api.ObjectMeta{
+				Name:            "foo",
+				Namespace:       api.NamespaceDefault,
+				ResourceVersion: "1",
+			},
+			Spec: api.PodSpec{Host: "machine"},
 		}
 		respWithPodA := &etcd.Response{
 			Node: &etcd.Node{
+				Key:           "/registry/pods/default/foo",
 				Value:         runtime.EncodeOrDie(testapi.Codec(), podA),
 				ModifiedIndex: 1,
 				CreatedIndex:  1,

--- a/pkg/tools/etcd_helper_watch.go
+++ b/pkg/tools/etcd_helper_watch.go
@@ -79,8 +79,10 @@ func (h *EtcdHelper) WatchList(key string, resourceVersion uint64, filter Filter
 // Watch begins watching the specified key. Events are decoded into
 // API objects and sent down the returned watch.Interface.
 // Errors will be sent down the channel.
-func (h *EtcdHelper) Watch(key string, resourceVersion uint64) watch.Interface {
-	return h.WatchAndTransform(key, resourceVersion, nil)
+func (h *EtcdHelper) Watch(key string, resourceVersion uint64, filter FilterFunc) (watch.Interface, error) {
+	w := newEtcdWatcher(false, nil, filter, h.Codec, h.Versioner, nil)
+	go w.etcdWatch(h.Client, key, resourceVersion)
+	return w, nil
 }
 
 // WatchAndTransform begins watching the specified key. Events are decoded into

--- a/test/integration/etcd_tools_test.go
+++ b/test/integration/etcd_tools_test.go
@@ -101,7 +101,11 @@ func TestWatch(t *testing.T) {
 		expectedVersion := resp.Node.ModifiedIndex
 
 		// watch should load the object at the current index
-		w := helper.Watch(key, 0)
+		w, err := helper.Watch(key, 0, tools.Everything)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
 		event := <-w.ResultChan()
 		if event.Type != watch.Added || event.Object == nil {
 			t.Fatalf("expected first value to be set to ADDED, got %#v", event)


### PR DESCRIPTION
Related to #6986 
EtcdHelper WatchList is ignoring root key in [exceptKey](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/tools/etcd_helper_watch.go#L115). As it is used for single object the key itself is ignored, so watching such as query with field-selector is totally not working.
