### PR TITLE
Prioritize deleting the non-running pods when reducing replicas

### DIFF
--- a/pkg/api/resource_helpers.go
+++ b/pkg/api/resource_helpers.go
@@ -58,3 +58,13 @@ func GetExistingContainerStatus(statuses []ContainerStatus, name string) Contain
 	}
 	return ContainerStatus{}
 }
+
+// IsPodReady retruns true if a pod is ready; false otherwise.
+func IsPodReady(pod *Pod) bool {
+	for _, c := range pod.Status.Conditions {
+		if c.Type == PodReady && c.Status == ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/service/endpoints_controller.go
+++ b/pkg/service/endpoints_controller.go
@@ -315,14 +315,7 @@ func (e *EndpointController) syncService(key string) {
 				continue
 			}
 
-			inService := false
-			for _, c := range pod.Status.Conditions {
-				if c.Type == api.PodReady && c.Status == api.ConditionTrue {
-					inService = true
-					break
-				}
-			}
-			if !inService {
+			if !api.IsPodReady(pod) {
 				glog.V(5).Infof("Pod is out of service: %v/%v", pod.Namespace, pod.Name)
 				continue
 			}


### PR DESCRIPTION
This changes instructs the replication controller to delete replicas in the
order of "unscheduled (pending)", "scheduled (pending)", and "scheduled
(running)" pods. This is less disruptive than deleting random pods.

This fixes #3948.
