### PR TITLE
Add cleanup policy to RollingUpdater

### DIFF
--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -134,7 +134,15 @@ func RunRollingUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, arg
 	if newRc.Spec.Replicas == 0 {
 		newRc.Spec.Replicas = oldRc.Spec.Replicas
 	}
-	err = updater.Update(out, oldRc, newRc, period, interval, timeout)
+	err = updater.Update(&kubectl.RollingUpdaterConfig{
+		Out:           out,
+		OldRc:         oldRc,
+		NewRc:         newRc,
+		UpdatePeriod:  period,
+		Interval:      interval,
+		Timeout:       timeout,
+		CleanupPolicy: kubectl.DeleteRollingUpdateCleanupPolicy,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Support configurable cleanup policies in RollingUpdater. Downstream
  library consumers don't necessarily have the same rules for post
  deployment cleanup; making the behavior policy driven is more flexible.
- Refactor RollingUpdater to accept a config object during Update instead
  of a long argument list.
- Add test coverage for cleanup policy.
