### PR TITLE
Reject unbounded cpu and memory pods if quota is restricting it

### DIFF
--- a/pkg/resourcequota/resource_quota_controller.go
+++ b/pkg/resourcequota/resource_quota_controller.go
@@ -226,6 +226,28 @@ func PodCPU(pod *api.Pod) *resource.Quantity {
 	return resource.NewMilliQuantity(int64(val), resource.DecimalSI)
 }
 
+// IsPodCPUUnbounded returns true if the cpu use is unbounded for any container in pod
+func IsPodCPUUnbounded(pod *api.Pod) bool {
+	for j := range pod.Spec.Containers {
+		container := pod.Spec.Containers[j]
+		if container.Resources.Limits.Cpu().MilliValue() == int64(0) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsPodMemoryUnbounded returns true if the memory use is unbounded for any container in pod
+func IsPodMemoryUnbounded(pod *api.Pod) bool {
+	for j := range pod.Spec.Containers {
+		container := pod.Spec.Containers[j]
+		if container.Resources.Limits.Memory().Value() == int64(0) {
+			return true
+		}
+	}
+	return false
+}
+
 // PodMemory computes the memory usage of a pod
 func PodMemory(pod *api.Pod) *resource.Quantity {
 	val := int64(0)

--- a/plugin/pkg/admission/resourcequota/admission.go
+++ b/plugin/pkg/admission/resourcequota/admission.go
@@ -169,6 +169,9 @@ func IncrementUsage(a admission.Attributes, status *api.ResourceQuotaStatus, cli
 
 		hardMem, hardMemFound := status.Hard[api.ResourceMemory]
 		if hardMemFound {
+			if set[api.ResourceMemory] && resourcequota.IsPodMemoryUnbounded(pod) {
+				return false, fmt.Errorf("Limited to %s memory, but pod has no specified memory limit", hardMem.String())
+			}
 			used, usedFound := status.Used[api.ResourceMemory]
 			if !usedFound {
 				return false, fmt.Errorf("Quota usage stats are not yet known, unable to admit resource until an accurate count is completed.")
@@ -182,6 +185,9 @@ func IncrementUsage(a admission.Attributes, status *api.ResourceQuotaStatus, cli
 		}
 		hardCPU, hardCPUFound := status.Hard[api.ResourceCPU]
 		if hardCPUFound {
+			if set[api.ResourceCPU] && resourcequota.IsPodCPUUnbounded(pod) {
+				return false, fmt.Errorf("Limited to %s CPU, but pod has no specified cpu limit", hardCPU.String())
+			}
 			used, usedFound := status.Used[api.ResourceCPU]
 			if !usedFound {
 				return false, fmt.Errorf("Quota usage stats are not yet known, unable to admit resource until an accurate count is completed.")


### PR DESCRIPTION
If a quota is enforcing a hard usage limit on cpu or memory in a Namespace, then we reject any pod whose container is requesting unbounded cpu or memory on a Node.

If a user wants to apply a default cpu or memory usage for each container that has unspecified limits, they can create a LimitRange resource that sets a default.

https://github.com/GoogleCloudPlatform/kubernetes/blob/master/examples/limitrange/v1beta3/limit-range.json#L32
