### PR TITLE
AWS: master should download salt using SSL

### DIFF
--- a/cluster/aws/templates/salt-master.sh
+++ b/cluster/aws/templates/salt-master.sh
@@ -58,5 +58,5 @@ EOF
 #
 # -M installs the master
 set +x
-curl -L --connect-timeout 20 --retry 6 --retry-delay 10 http://bootstrap.saltstack.com | sh -s -- -M -X
+curl -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -M -X
 set -x


### PR DESCRIPTION
The minion already does, but the master was using plain http.

This is currently broken because of an expired cert (#7025), but the minion install fails anyway...
