### PR TITLE
Ensure that e2e tests run on gce|gke and are appropriately skipped for other cloud providers.

### DIFF
--- a/test/e2e/certs.go
+++ b/test/e2e/certs.go
@@ -32,7 +32,7 @@ var _ = Describe("MasterCerts", func() {
 	})
 
 	It("should have all expected certs on the master", func() {
-		if testContext.Provider != "gce" && testContext.Provider != "gke" {
+		if !providerIs("gce", "gke") {
 			By(fmt.Sprintf("Skipping MasterCerts test for cloud provider %s (only supported for gce and gke)", testContext.Provider))
 			return
 		}

--- a/test/e2e/es_cluster_logging.go
+++ b/test/e2e/es_cluster_logging.go
@@ -57,11 +57,10 @@ func bodyToJSON(body []byte) (map[string]interface{}, error) {
 
 // ClusterLevelLoggingWithElasticsearch is an end to end test for cluster level logging.
 func ClusterLevelLoggingWithElasticsearch(c *client.Client) {
-
 	// TODO: For now assume we are only testing cluster logging with Elasticsearch
 	// on GCE. Once we are sure that Elasticsearch cluster level logging
 	// works for other providers we should widen this scope of this test.
-	if testContext.Provider != "gce" {
+	if !providerIs("gce") {
 		Logf("Skipping cluster level logging test for provider %s", testContext.Provider)
 		return
 	}

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -97,11 +97,12 @@ var _ = Describe("kubectl", func() {
 	Describe("guestbook", func() {
 		var guestbookPath = filepath.Join(testContext.RepoRoot, "examples/guestbook")
 
-		if testContext.Provider != "gce" && testContext.Provider != "gke" {
-			By(fmt.Sprintf("Skipping guestbook, uses createExternalLoadBalancer, a (gce|gke) feature"))
-		}
-
 		It("should create and stop a working application", func() {
+			if !providerIs("gce", "gke") {
+				By(fmt.Sprintf("Skipping guestbook, uses createExternalLoadBalancer, a (gce|gke) feature"))
+				return
+			}
+
 			defer cleanup(guestbookPath, frontendSelector, redisMasterSelector, redisSlaveSelector)
 
 			By("creating all guestbook components")

--- a/test/e2e/monitoring.go
+++ b/test/e2e/monitoring.go
@@ -42,7 +42,7 @@ var _ = Describe("Monitoring", func() {
 	})
 
 	It("verify monitoring pods and all cluster nodes are available on influxdb using heapster.", func() {
-		if testContext.Provider != "gce" {
+		if !providerIs("gce") {
 			By(fmt.Sprintf("Skipping Monitoring test, which is only supported for provider gce (not %s)",
 				testContext.Provider))
 			return

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -57,7 +57,7 @@ var _ = Describe("PD", func() {
 	})
 
 	It("should schedule a pod w/ a RW PD, remove it, then schedule it on another host", func() {
-		if testContext.Provider != "gce" && testContext.Provider != "aws" {
+		if !providerIs("gce", "aws") {
 			By(fmt.Sprintf("Skipping PD test, which is only supported for providers gce & aws (not %s)",
 				testContext.Provider))
 			return

--- a/test/e2e/rc.go
+++ b/test/e2e/rc.go
@@ -46,13 +46,12 @@ var _ = Describe("ReplicationController", func() {
 	})
 
 	It("should serve a basic image on each replica with a private image", func() {
-		switch testContext.Provider {
-		case "gce", "gke":
-			ServeImageOrFail(c, "private", "gcr.io/_b_k8s_authenticated_test/serve_hostname:1.1")
-		default:
+		if !providerIs("gce", "gke") {
 			By(fmt.Sprintf("Skipping private variant, which is only supported for providers gce and gke (not %s)",
 				testContext.Provider))
+			return
 		}
+		ServeImageOrFail(c, "private", "gcr.io/_b_k8s_authenticated_test/serve_hostname:1.1")
 	})
 })
 

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -47,7 +47,7 @@ var _ = Describe("Services", func() {
 	})
 
 	It("should provide DNS for the cluster", func() {
-		if testContext.Provider == "vagrant" {
+		if providerIs("vagrant") {
 			By("Skipping test which is broken for vagrant (See https://github.com/GoogleCloudPlatform/kubernetes/issues/3580)")
 			return
 		}

--- a/test/e2e/shell.go
+++ b/test/e2e/shell.go
@@ -35,14 +35,6 @@ var (
 var _ = Describe("Shell", func() {
 
 	defer GinkgoRecover()
-
-	// A number of scripts only work on gce
-	if testContext.Provider != "gce" && testContext.Provider != "gke" {
-		By(fmt.Sprintf("Skipping Shell test, which is only supported for provider gce and gke (not %s)",
-			testContext.Provider))
-		return
-	}
-
 	// Slurp up all the tests in hack/e2e-suite
 	bashE2ERoot := filepath.Join(root, "hack/e2e-suite")
 	files, err := ioutil.ReadDir(bashE2ERoot)
@@ -53,6 +45,12 @@ var _ = Describe("Shell", func() {
 	for _, file := range files {
 		fileName := file.Name() // Make a copy
 		It(fmt.Sprintf("tests that %v passes", fileName), func() {
+			// A number of scripts only work on gce
+			if !providerIs("gce", "gke") {
+				By(fmt.Sprintf("Skipping Shell test %s, which is only supported for provider gce and gke (not %s)",
+					fileName, testContext.Provider))
+				return
+			}
 			runCmdTest(filepath.Join(bashE2ERoot, fileName))
 		})
 	}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -62,6 +62,18 @@ func Failf(format string, a ...interface{}) {
 	Fail(fmt.Sprintf(format, a...), 1)
 }
 
+func providerIs(providers ...string) bool {
+	if testContext.Provider == "" {
+		Fail("testContext.Provider is not defined")
+	}
+	for _, provider := range providers {
+		if strings.ToLower(provider) == strings.ToLower(testContext.Provider) {
+			return true
+		}
+	}
+	return false
+}
+
 type podCondition func(pod *api.Pod) (bool, error)
 
 func waitForPodCondition(c *client.Client, ns, podName, desc string, condition podCondition) error {


### PR DESCRIPTION
Fixes #7008.

```
$ go run hack/e2e.go -v -test --test_args="--ginkgo.focus=Shell.*"
Random Seed: 1429397117 - Will randomize all specs
Will run 1 of 40 specs

SSSSSSSSSSSS
------------------------------
Shell
  tests that services.sh passes
  /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/shell.go:55
[It] tests that services.sh passes
  /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/shell.go:55
STEP: Running /Users/robertbailey/Work/go/src/github.com/roberthbailey/kubernetes/hack/e2e-suite/services.sh

• [SLOW TEST:180.331 seconds]
Shell
/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/shell.go:57
  tests that services.sh passes
  /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/shell.go:55
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSS
Ran 1 of 40 Specs in 180.332 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 39 Skipped I0418 15:48:18.165463   92339 driver.go:96] All tests pass

$ go run hack/e2e.go -v -test --test_args="--ginkgo.focus=kubectl.*guestbook.*"
Random Seed: 1429397326 - Will randomize all specs
Will run 1 of 40 specs

SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
kubectl guestbook
  should create and stop a working application
  /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/kubectl.go:112
[BeforeEach] kubectl
  /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/kubectl.go:53
>>> testContext.KubeConfig: /Users/robertbailey/.kube/config
[It] should create and stop a working application
  /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/kubectl.go:112
STEP: creating all guestbook components
INFO: Running '/Users/robertbailey/Work/go/src/github.com/roberthbailey/kubernetes/hack/../cluster/../_output/dockerized/bin/darwin/amd64/kubectl kubectl --kubeconfig=/U
sers/robertbailey/.kube/config create -f examples/guestbook'INFO: replicationControllers/frontend-controller
services/frontend
replicationControllers/redis-master-controller
services/redis-master
replicationControllers/redis-slave-controller
services/redis-slave

STEP: validating guestbook app
INFO: Waiting for frontend to serve content.INFO: Trying to add a new entry to the guestbook.
INFO: Verifying that added entry can be retrieved.
STEP: using stop to clean up resources
INFO: Running '/Users/robertbailey/Work/go/src/github.com/roberthbailey/kubernetes/hack/../cluster/../_output/dockerized/bin/darwin/amd64/kubectl kubectl --kubeconfig=/Users/robertbailey/.kube/config stop -f examples/guestbook'
INFO: replicationControllers/frontend-controller
services/frontend
replicationControllers/redis-master-controller
services/redis-master
replicationControllers/redis-slave-controller
services/redis-slave

INFO: Running '/Users/robertbailey/Work/go/src/github.com/roberthbailey/kubernetes/hack/../cluster/../_output/dockerized/bin/darwin/amd64/kubectl kubectl --kubeconfig=/Users/robertbailey/.kube/config get pods,rc,se -l name=frontend --no-headers'
INFO:
INFO: Running '/Users/robertbailey/Work/go/src/github.com/roberthbailey/kubernetes/hack/../cluster/../_output/dockerized/bin/darwin/amd64/kubectl kubectl --kubeconfig=/Users/robertbailey/.kube/config get pods,rc,se -l name=redis-master --no-headers'
INFO:
INFO: Running '/Users/robertbailey/Work/go/src/github.com/roberthbailey/kubernetes/hack/../cluster/../_output/dockerized/bin/darwin/amd64/kubectl kubectl --kubeconfig=/Users/robertbailey/.kube/config get pods,rc,se -l name=redis-slave --no-headers'
INFO:

• [SLOW TEST:62.806 seconds]
kubectl
/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/kubectl.go:115
  guestbook
  /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/kubectl.go:113
    should create and stop a working application
    /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/kubectl.go:112
------------------------------
SSSSSSSSS
Ran 1 of 40 Specs in 62.807 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 39 Skipped I0418 15:49:49.468811   94011 driver.go:96] All tests pass
```
