### PR TITLE
Skip fetching from server when deleting a named resource

### DIFF
--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -87,7 +87,7 @@ func RunDelete(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 		FilenameParam(filenames...).
 		SelectorParam(cmdutil.GetFlagString(cmd, "selector")).
 		SelectAllParam(cmdutil.GetFlagBool(cmd, "all")).
-		ResourceTypeOrNameArgs(false, args...).
+		ResourceTypeOrNameArgs(false, args...).RequireObject(false).
 		Flatten().
 		Do()
 	err = r.Err()


### PR DESCRIPTION
Added a test to ensure `kubectl delete $TYPE $NAME` doesn't first GET the resource
