### PR TITLE
Kubelet: parallelize cleaning up containers in unwanted pods

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -375,7 +375,7 @@ func (dm *DockerManager) GetPodStatus(pod *api.Pod) (*api.PodStatus, error) {
 }
 
 func (dm *DockerManager) GetRunningContainers(ids []string) ([]*docker.Container, error) {
-	result := []*docker.Container{}
+	var result []*docker.Container
 	if dm.client == nil {
 		return nil, fmt.Errorf("unexpected nil docker client.")
 	}


### PR DESCRIPTION
Kubelet kills unwanted pods in SyncPods, which directly impact the latency of a
sync iteration. This change parallelizes the cleanup to lessen the effect.

Eventually, we should leverage per-pod workers for cleanup, with the exception
of truly orphaned pods.
