### PR TITLE
Use go-dockerclient's APIVersion

### DIFF
--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -130,26 +130,20 @@ func TestContainerManifestNaming(t *testing.T) {
 }
 
 func TestGetDockerServerVersion(t *testing.T) {
-	fakeDocker := &FakeDockerClient{VersionInfo: docker.Env{"Client version=1.2", "Server version=1.1.3", "Server API version=1.15"}}
+	fakeDocker := &FakeDockerClient{VersionInfo: docker.Env{"Version=1.1.3", "ApiVersion=1.15"}}
 	runner := dockerContainerCommandRunner{fakeDocker}
 	version, err := runner.GetDockerServerVersion()
 	if err != nil {
 		t.Errorf("got error while getting docker server version - %s", err)
 	}
-	expectedVersion := []uint{1, 15}
-	if len(expectedVersion) != len(version) {
-		t.Errorf("invalid docker server version. expected: %v, got: %v", expectedVersion, version)
-	} else {
-		for idx, val := range expectedVersion {
-			if version[idx] != val {
-				t.Errorf("invalid docker server version. expected: %v, got: %v", expectedVersion, version)
-			}
-		}
+	expectedVersion, _ := docker.NewAPIVersion("1.15")
+	if e, a := expectedVersion.String(), version.String(); e != a {
+		t.Errorf("invalid docker server version. expected: %v, got: %v", e, a)
 	}
 }
 
 func TestExecSupportExists(t *testing.T) {
-	fakeDocker := &FakeDockerClient{VersionInfo: docker.Env{"Client version=1.2", "Server version=1.3.0", "Server API version=1.15"}}
+	fakeDocker := &FakeDockerClient{VersionInfo: docker.Env{"Version=1.3.0", "ApiVersion=1.15"}}
 	runner := dockerContainerCommandRunner{fakeDocker}
 	useNativeExec, err := runner.nativeExecSupportExists()
 	if err != nil {
@@ -161,7 +155,7 @@ func TestExecSupportExists(t *testing.T) {
 }
 
 func TestExecSupportNotExists(t *testing.T) {
-	fakeDocker := &FakeDockerClient{VersionInfo: docker.Env{"Client version=1.2", "Server version=1.1.2", "Server API version=1.14"}}
+	fakeDocker := &FakeDockerClient{VersionInfo: docker.Env{"Version=1.1.2", "ApiVersion=1.14"}}
 	runner := dockerContainerCommandRunner{fakeDocker}
 	useNativeExec, _ := runner.nativeExecSupportExists()
 	if useNativeExec {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1636,7 +1636,7 @@ func (kl *Kubelet) syncLoop(updates <-chan PodUpdate, handler SyncHandler) {
 }
 
 // Returns Docker version for this Kubelet.
-func (kl *Kubelet) GetDockerVersion() ([]uint, error) {
+func (kl *Kubelet) GetDockerVersion() (docker.APIVersion, error) {
 	if kl.dockerClient == nil {
 		return nil, fmt.Errorf("no Docker client")
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1593,7 +1593,7 @@ func (f *fakeContainerCommandRunner) RunInContainer(id string, cmd []string) ([]
 	return []byte{}, f.E
 }
 
-func (f *fakeContainerCommandRunner) GetDockerServerVersion() ([]uint, error) {
+func (f *fakeContainerCommandRunner) GetDockerServerVersion() (docker.APIVersion, error) {
 	return nil, nil
 }
 

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream/spdy"
+	"github.com/fsouza/go-dockerclient"
 	cadvisorApi "github.com/google/cadvisor/info/v1"
 )
 
@@ -47,7 +48,7 @@ type fakeKubelet struct {
 	podsFunc                           func() []*api.Pod
 	logFunc                            func(w http.ResponseWriter, req *http.Request)
 	runFunc                            func(podFullName string, uid types.UID, containerName string, cmd []string) ([]byte, error)
-	dockerVersionFunc                  func() ([]uint, error)
+	dockerVersionFunc                  func() (docker.APIVersion, error)
 	execFunc                           func(pod string, uid types.UID, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool) error
 	portForwardFunc                    func(name string, uid types.UID, port uint16, stream io.ReadWriteCloser) error
 	containerLogsFunc                  func(podFullName, containerName, tail string, follow bool, stdout, stderr io.Writer) error
@@ -71,7 +72,7 @@ func (fk *fakeKubelet) GetRootInfo(req *cadvisorApi.ContainerInfoRequest) (*cadv
 	return fk.rootInfoFunc(req)
 }
 
-func (fk *fakeKubelet) GetDockerVersion() ([]uint, error) {
+func (fk *fakeKubelet) GetDockerVersion() (docker.APIVersion, error) {
 	return fk.dockerVersionFunc()
 }
 
@@ -449,8 +450,8 @@ func TestPodsInfo(t *testing.T) {
 
 func TestHealthCheck(t *testing.T) {
 	fw := newServerTest()
-	fw.fakeKubelet.dockerVersionFunc = func() ([]uint, error) {
-		return []uint{1, 15}, nil
+	fw.fakeKubelet.dockerVersionFunc = func() (docker.APIVersion, error) {
+		return docker.NewAPIVersion("1.15")
 	}
 	fw.fakeKubelet.hostnameFunc = func() string {
 		return "127.0.0.1"
@@ -489,8 +490,8 @@ func TestHealthCheck(t *testing.T) {
 	}
 
 	//Test with old docker version
-	fw.fakeKubelet.dockerVersionFunc = func() ([]uint, error) {
-		return []uint{1, 1}, nil
+	fw.fakeKubelet.dockerVersionFunc = func() (docker.APIVersion, error) {
+		return docker.NewAPIVersion("1.1")
 	}
 
 	resp, err = http.Get(fw.testHTTPServer.URL + "/healthz")


### PR DESCRIPTION
Use go-dockerclient's APIVersion to check the minimum required Docker
version, as it contains methods for parsing the ApiVersion response from
the Docker daemon and for comparing 2 APIVersion objects.
