### PR TITLE
Create system secrets in kubeconfig format

### DIFF
--- a/cluster/saltbase/salt/kube-addons/default
+++ b/cluster/saltbase/salt/kube-addons/default
@@ -1,0 +1,14 @@
+#TODO(erictune): once we make DNS a hard requirement for clusters, then this can be removed,
+# and APISERVER_URL="https://kubernetes:443"
+{% if grains.api_servers is defined -%}
+  {% set api_server = "https://" + grains.api_servers + ":6443" -%}
+{% elif grains.apiservers is defined -%} # TODO(remove after 0.16.0): Deprecated form
+  {% set api_server = "https://" + grains.apiservers + ":6443" -%}
+{% elif grains['roles'][0] == 'kubernetes-master' -%}
+  {% set master_ipv4 = salt['grains.get']('fqdn_ip4')[0] -%}
+  {% set api_server = "https://" + master_ipv4 + ":6443" -%}
+{% else -%}
+  {% set ips = salt['mine.get']('roles:kubernetes-master', 'network.ip_addrs', 'grain').values() -%}
+  {% set api_server = "https://" + ips[0][0] + ":6443" -%}
+{% endif -%}
+export APISERVER_URL={{ api_server }}

--- a/cluster/saltbase/salt/kube-addons/init.sls
+++ b/cluster/saltbase/salt/kube-addons/init.sls
@@ -48,6 +48,20 @@
     - makedirs: True
 {% endif %}
 
+{% if grains['os_family'] == 'RedHat' %}
+{% set environment_file = '/etc/sysconfig/kube-addons' %}
+{% else %}
+{% set environment_file = '/etc/default/kube-addons' %}
+{% endif %}
+
+{{ environment_file }}:
+  file.managed:
+    - source: salt://kube-addons/default
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 644
+
 /etc/kubernetes/kube-addons.sh:
   file.managed:
     - source: salt://kube-addons/kube-addons.sh

--- a/cluster/saltbase/salt/kube-addons/initd
+++ b/cluster/saltbase/salt/kube-addons/initd
@@ -21,6 +21,9 @@ PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 KUBE_ADDONS_SH=/etc/kubernetes/kube-addons.sh
 
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
 # Define LSB log_* functions.
 # Depend on lsb-base (>= 3.2-14) to ensure that this file is present
 # and status_of_proc is working.

--- a/cluster/saltbase/salt/kube-addons/kube-addons.service
+++ b/cluster/saltbase/salt/kube-addons/kube-addons.service
@@ -3,6 +3,7 @@ Description=Kubernetes Addon Object Manager
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 
 [Service]
+EnvironmentFile=/etc/sysconfig/kube-addons
 ExecStart=/etc/kubernetes/kube-addons.sh
 
 [Install]

--- a/cluster/saltbase/salt/kube-addons/kube-addons.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addons.sh
@@ -19,23 +19,47 @@
 # managed result is of that. Start everything below that directory.
 KUBECTL=/usr/local/bin/kubectl
 
-function create-kubernetesauth-secret() {
+if [ -z "$APISERVER_URL" ] ; then
+  echo "Must set APISERVER_URL"
+  exit 1
+fi
+
+function create-kubeconfig-secret() {
   local -r token=$1
   local -r username=$2
   local -r safe_username=$(tr -s ':_' '--' <<< "${username}")
 
-  # Make secret with a kubernetes_auth file with a token.
+  # Make a kubeconfig file with the token.
   # TODO(etune): put apiserver certs into secret too, and reference from authfile,
   # so that "Insecure" is not needed.
-  kafile=$(echo "{\"BearerToken\": \"${token}\", \"Insecure\": true }" | base64 -w0)
-  read -r -d '' secretjson <<EOF
+  read -r -d '' kubeconfig <<EOF
+apiVersion: v1
+kind: Config
+users:
+- name: ${username}
+  user:
+    token: ${token}
+clusters:
+- name: local
+  cluster:
+     server: ${APISERVER_URL}
+     insecure-skip-tls-verify: true
+contexts:
+- context:
+    cluster: local
+    user: ${username}
+  name: service-account-context
+current-context: service-account-context
+EOF
+  local -r kubeconfig_base64=$(echo "${kubeconfig}" | base64 -w0)
+  read -r -d '' secretyaml <<EOF
 apiVersion: v1beta1
 kind: Secret 
 id: token-${safe_username}
 data:
-  kubernetes-auth: ${kafile}
+  kubeconfig: ${kubeconfig_base64}
 EOF
-  create-resource-from-string "${secretjson}" 100 10 "Secret-for-token-for-user-${username}" &
+  create-resource-from-string "${secretyaml}" 100 10 "Secret-for-token-for-user-${username}" &
 # TODO: label the secrets with special label so kubectl does not show these?
 }
 
@@ -86,7 +110,7 @@ while read line; do
   IFS=',' read -a parts <<< "${line}"
   token=${parts[0]}
   username=${parts[1]}
-  create-kubernetesauth-secret "${token}" "${username}"
+  create-kubeconfig-secret "${token}" "${username}"
 done < /srv/kubernetes/known_tokens.csv
 
 for obj in $(find /etc/kubernetes/addons -name \*.yaml); do


### PR DESCRIPTION
Was previously kubernetes_auth format.

Made kube-addons.sh be a jinja template so I can set the apiserver
URL.  I hope this can go away soon so once DNS is a required
cluster feature.
