### PR TITLE
Revert "Continue after failed unit test"

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -151,7 +151,7 @@ runTests() {
   if [[ ! ${KUBE_COVER} =~ ^[yY]$ ]]; then
     kube::log::status "Running unit tests without code coverage"
     go test "${goflags[@]:+${goflags[@]}}" \
-      ${KUBE_RACE} ${KUBE_TIMEOUT} "${@+${@/#/${KUBE_GO_PACKAGE}/}}" || true
+      ${KUBE_RACE} ${KUBE_TIMEOUT} "${@+${@/#/${KUBE_GO_PACKAGE}/}}"
     return 0
   fi
 
@@ -173,7 +173,7 @@ runTests() {
           -cover -covermode="${KUBE_COVERMODE}" \
           -coverprofile="${cover_report_dir}/{}/${cover_profile}" \
           "${cover_params[@]+${cover_params[@]}}" \
-          "${KUBE_GO_PACKAGE}/{}" || true
+          "${KUBE_GO_PACKAGE}/{}"
 
   COMBINED_COVER_PROFILE="${cover_report_dir}/combined-coverage.out"
   {


### PR DESCRIPTION
This reverts commit f70752d9e1d1130f8bf083e744ac401e769fe49b (PR #6899).

This change caused Travis and Shippable to report success on all test
runs, even if any tests failed or timed out.

Fixes #7052

cc @lavalamp @quinton-hoole @erictune @nak3
