### PR TITLE
Improve container resource requirements validation

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -740,7 +740,7 @@ func validateContainers(containers []api.Container, volumes util.StringSet) errs
 		cErrs = append(cErrs, validateEnv(ctr.Env).Prefix("env")...)
 		cErrs = append(cErrs, validateVolumeMounts(ctr.VolumeMounts, volumes).Prefix("volumeMounts")...)
 		cErrs = append(cErrs, validatePullPolicy(&ctr).Prefix("pullPolicy")...)
-		cErrs = append(cErrs, validateResourceRequirements(&ctr).Prefix("resources")...)
+		cErrs = append(cErrs, ValidateResourceRequirements(&ctr.Resources).Prefix("resources")...)
 		allErrs = append(allErrs, cErrs.PrefixIndex(i)...)
 	}
 	// Check for colliding ports across all containers.
@@ -1167,9 +1167,9 @@ func validateBasicResource(quantity resource.Quantity) errs.ValidationErrorList 
 }
 
 // Validates resource requirement spec.
-func validateResourceRequirements(container *api.Container) errs.ValidationErrorList {
+func ValidateResourceRequirements(requirements *api.ResourceRequirements) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
-	for resourceName, quantity := range container.Resources.Limits {
+	for resourceName, quantity := range requirements.Limits {
 		// Validate resource name.
 		errs := validateResourceName(resourceName.String(), fmt.Sprintf("resources.limits[%s]", resourceName))
 		if api.IsStandardResourceName(resourceName.String()) {
@@ -1177,7 +1177,14 @@ func validateResourceRequirements(container *api.Container) errs.ValidationError
 		}
 		allErrs = append(allErrs, errs...)
 	}
-
+	for resourceName, quantity := range requirements.Requests {
+		// Validate resource name.
+		errs := validateResourceName(resourceName.String(), fmt.Sprintf("resources.requests[%s]", resourceName))
+		if api.IsStandardResourceName(resourceName.String()) {
+			errs = append(errs, validateBasicResource(quantity).Prefix(fmt.Sprintf("Resource %s: ", resourceName))...)
+		}
+		allErrs = append(allErrs, errs...)
+	}
 	return allErrs
 }
 

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -954,6 +954,16 @@ func TestValidateContainers(t *testing.T) {
 				ImagePullPolicy: "IfNotPresent",
 			},
 		},
+		"Resource Requests CPU invalid": {
+			{
+				Name:  "abc-123",
+				Image: "image",
+				Resources: api.ResourceRequirements{
+					Requests: getResourceLimits("-10", "0"),
+				},
+				ImagePullPolicy: "IfNotPresent",
+			},
+		},
 		"Resource Memory invalid": {
 			{
 				Name:  "abc-123",


### PR DESCRIPTION
Container validation was not covering requests, but only limits.
1. Added coverage for requests.
2. Made ValidateResourceRequirements public so it can be used downstream.
