### PR TITLE
E2E: Add Api Server option to kubectl

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -54,7 +54,7 @@ var _ = Describe("kubectl", func() {
 
 	Describe("update-demo", func() {
 		var (
-			updateDemoRoot = filepath.Join(testContext.RepoRoot, "examples/update-demo/v1beta3")
+			updateDemoRoot = filepath.Join(testContext.RepoRoot, "examples/update-demo")
 			nautilusPath   = filepath.Join(updateDemoRoot, "nautilus-rc.yaml")
 			kittenPath     = filepath.Join(updateDemoRoot, "kitten-rc.yaml")
 		)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -274,8 +274,15 @@ func kubectlCmd(args ...string) *exec.Cmd {
 	defaultArgs := []string{}
 	if testContext.KubeConfig != "" {
 		defaultArgs = append(defaultArgs, "--"+clientcmd.RecommendedConfigPathFlag+"="+testContext.KubeConfig)
+
+		// Reference the KubeContext
 		if testContext.KubeContext != "" {
 			defaultArgs = append(defaultArgs, "--"+clientcmd.FlagContext+"="+testContext.KubeContext)
+		}
+
+		// Reference a --server option so tests can run anywhere.
+		if testContext.Host != "" {
+			defaultArgs = append(defaultArgs, "--"+clientcmd.FlagAPIServer+"="+testContext.Host)
 		}
 	} else {
 		defaultArgs = append(defaultArgs, "--"+clientcmd.FlagAuthPath+"="+testContext.AuthConfig)


### PR DESCRIPTION
simple improvements to kubectl.go which will allow it to reference API Server at different IP Addresses.   works for my local tests for the base kubectl functionality (i.e. test guestbook and so on).
