### PR TITLE
Remove fqdn dependency for node name

### DIFF
--- a/cluster/azure/templates/salt-minion.sh
+++ b/cluster/azure/templates/salt-minion.sh
@@ -31,7 +31,7 @@ log_level: debug
 log_level_logfile: debug
 EOF
 
-hostnamef=$(hostname -f)
+hostnamef=$(uname -n)
 apt-get install -y ipcalc
 netmask=$(ipcalc $MINION_IP_RANGE | grep Netmask | awk '{ print $2 }')
 network=$(ipcalc $MINION_IP_RANGE | grep Address | awk '{ print $2 }')

--- a/cluster/saltbase/salt/generate-cert/make-ca-cert.sh
+++ b/cluster/saltbase/salt/generate-cert/make-ca-cert.sh
@@ -36,7 +36,7 @@ if [ "$cert_ip" == "_use_aws_external_ip_" ]; then
 fi
 
 if [ "$cert_ip" == "_use_azure_dns_name_" ]; then
-  cert_ip=$(hostname -f | awk -F. '{ print $2 }').cloudapp.net
+  cert_ip=$(uname -n | awk -F. '{ print $2 }').cloudapp.net
   use_cn=true
 fi
 

--- a/docs/getting-started-guides/mesos.md
+++ b/docs/getting-started-guides/mesos.md
@@ -47,7 +47,7 @@ $ export KUBERNETES_MASTER=http://${servicehost}:8888
 Start etcd and verify that it is running:
 
 ```bash
-$ sudo docker run -d --hostname $(hostname -f) --name etcd -p 4001:4001 -p 7001:7001 coreos/etcd
+$ sudo docker run -d --hostname $(uname -n) --name etcd -p 4001:4001 -p 7001:7001 coreos/etcd
 ```
 
 ```bash

--- a/docs/man/kubelet.1.md
+++ b/docs/man/kubelet.1.md
@@ -15,7 +15,7 @@ There are 4 ways that a container manifest can be provided to the Kubelet:
 
     File Path passed as a flag on the command line. This file is rechecked every 20 seconds (configurable with a flag).
     HTTP endpoint HTTP endpoint passed as a parameter on the command line. This endpoint is checked every 20 seconds (also configurable with a flag).
-    etcd server The Kubelet will reach out and do a watch on an etcd server. The etcd path that is watched is /registry/hosts/$(hostname -f). As this is a watch, changes are noticed and acted upon very quickly.
+    etcd server The Kubelet will reach out and do a watch on an etcd server. The etcd path that is watched is /registry/hosts/$(uname -n). As this is a watch, changes are noticed and acted upon very quickly.
     HTTP server The kubelet can also listen for HTTP and respond to a simple API (underspec'd currently) to submit a new manifest.
  
 

--- a/docs/man/man1/kubelet.1
+++ b/docs/man/man1/kubelet.1
@@ -21,7 +21,7 @@ There are 4 ways that a container manifest can be provided to the Kubelet:
 .nf
 File Path passed as a flag on the command line. This file is rechecked every 20 seconds (configurable with a flag).
 HTTP endpoint HTTP endpoint passed as a parameter on the command line. This endpoint is checked every 20 seconds (also configurable with a flag).
-etcd server The Kubelet will reach out and do a watch on an etcd server. The etcd path that is watched is /registry/hosts/\$(hostname \-f). As this is a watch, changes are noticed and acted upon very quickly.
+etcd server The Kubelet will reach out and do a watch on an etcd server. The etcd path that is watched is /registry/hosts/\$(uname \-n). As this is a watch, changes are noticed and acted upon very quickly.
 HTTP server The kubelet can also listen for HTTP and respond to a simple API (underspec'd currently) to submit a new manifest.
 
 .fi

--- a/docs/salt.md
+++ b/docs/salt.md
@@ -63,7 +63,7 @@ Key | Value
 `cbr-cidr` | (Optional) The minion IP address range used for the docker container bridge.
 `cloud` | (Optional) Which IaaS platform is used to host kubernetes, *gce*, *azure*, *aws*, *vagrant*
 `etcd_servers` | (Optional) Comma-delimited list of IP addresses the kube-apiserver and kubelet use to reach etcd.  Uses the IP of the first machine in the kubernetes_master role, or 127.0.0.1 on GCE.
-`hostnamef` | (Optional) The full host name of the machine, i.e. hostname -f (only used on Azure)
+`hostnamef` | (Optional) The full host name of the machine, i.e. uname -n
 `node_ip` | (Optional) The IP address to use to address this node
 `minion_ip` | (Optional) Mapped to the kubelet hostname_override, K8S TODO - change this name
 `network_mode` | (Optional) Networking model to use among nodes: *openvswitch*

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"os/exec"
 	"path"
 	"strconv"
 	"strings"
@@ -446,26 +445,8 @@ func (gce *GCECloud) ExternalID(instance string) (string, error) {
 	return strconv.FormatUint(inst.Id, 10), nil
 }
 
-// fqdnSuffix is hacky function to compute the delta between hostame and hostname -f.
-func fqdnSuffix() (string, error) {
-	fullHostname, err := exec.Command("hostname", "-f").Output()
-	if err != nil {
-		return "", err
-	}
-	hostname := strings.Split(string(fullHostname), ".")[0]
-	return strings.TrimSpace(string(fullHostname)[len(string(hostname)):]), nil
-}
-
 // List is an implementation of Instances.List.
 func (gce *GCECloud) List(filter string) ([]string, error) {
-	// GCE gives names without their fqdn suffix, so get that here for appending.
-	// This is needed because the kubelet looks for its jobs in /registry/hosts/<fqdn>/pods
-	// We should really just replace this convention, with a negotiated naming protocol for kubelet's
-	// to register with the master.
-	suffix, err := fqdnSuffix()
-	if err != nil {
-		return []string{}, err
-	}
 	listCall := gce.service.Instances.List(gce.projectID, gce.zone)
 	if len(filter) > 0 {
 		listCall = listCall.Filter("name eq " + filter)
@@ -476,7 +457,7 @@ func (gce *GCECloud) List(filter string) ([]string, error) {
 	}
 	var instances []string
 	for _, instance := range res.Items {
-		instances = append(instances, instance.Name+suffix)
+		instances = append(instances, instance.Name)
 	}
 	return instances, nil
 }

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -452,10 +452,7 @@ func fqdnSuffix() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	hostname, err := exec.Command("hostname").Output()
-	if err != nil {
-		return "", err
-	}
+	hostname := strings.Split(string(fullHostname), ".")[0]
 	return strings.TrimSpace(string(fullHostname)[len(string(hostname)):]), nil
 }
 
@@ -468,9 +465,6 @@ func (gce *GCECloud) List(filter string) ([]string, error) {
 	suffix, err := fqdnSuffix()
 	if err != nil {
 		return []string{}, err
-	}
-	if len(suffix) > 0 {
-		suffix = "." + suffix
 	}
 	listCall := gce.service.Instances.List(gce.projectID, gce.zone)
 	if len(filter) > 0 {

--- a/pkg/util/node.go
+++ b/pkg/util/node.go
@@ -26,8 +26,6 @@ import (
 func GetHostname(hostnameOverride string) string {
 	hostname := []byte(hostnameOverride)
 	if string(hostname) == "" {
-		// Note: We use exec here instead of os.Hostname() because we
-		// want the FQDN, and this is the easiest way to get it.
 		fqdn, err := exec.Command("uname", "-n").Output()
 		if err != nil {
 			glog.Fatalf("Couldn't determine hostname: %v", err)

--- a/pkg/util/node.go
+++ b/pkg/util/node.go
@@ -28,7 +28,7 @@ func GetHostname(hostnameOverride string) string {
 	if string(hostname) == "" {
 		// Note: We use exec here instead of os.Hostname() because we
 		// want the FQDN, and this is the easiest way to get it.
-		fqdn, err := exec.Command("hostname", "-f").Output()
+		fqdn, err := exec.Command("uname", "-n").Output()
 		if err != nil {
 			glog.Fatalf("Couldn't determine hostname: %v", err)
 		}


### PR DESCRIPTION
Based on @nak3's commit: Replace hostname -f with uname -n (PR #6466)

Fixed #7071 

Ran e2e tests, and all passed:

Ran 34 of 39 Specs in 869.489 seconds
SUCCESS! -- 34 Passed | 0 Failed | 1 Pending | 4 Skipped I0420 13:52:02.795357   13155 driver.go:117] All tests pass

cc/ @cjcullen @nak3
