### PR TITLE
annotate required flags for bash_completions

### DIFF
--- a/contrib/completions/bash/kubectl
+++ b/contrib/completions/bash/kubectl
@@ -304,6 +304,8 @@ _kubectl_create()
     flags+=("-h")
 
     must_have_one_flag=()
+    must_have_one_flag+=("--filename=")
+    must_have_one_flag+=("-f")
     must_have_one_noun=()
 }
 
@@ -328,6 +330,9 @@ _kubectl_update()
     flags+=("--patch=")
 
     must_have_one_flag=()
+    must_have_one_flag+=("--filename=")
+    must_have_one_flag+=("-f")
+    must_have_one_flag+=("--patch=")
     must_have_one_noun=()
 }
 
@@ -433,6 +438,7 @@ _kubectl_resize()
     flags+=("--resource-version=")
 
     must_have_one_flag=()
+    must_have_one_flag+=("--replicas=")
     must_have_one_noun=()
 }
 
@@ -458,6 +464,10 @@ _kubectl_exec()
     flags+=("-t")
 
     must_have_one_flag=()
+    must_have_one_flag+=("--container=")
+    must_have_one_flag+=("-c")
+    must_have_one_flag+=("--pod=")
+    must_have_one_flag+=("-p")
     must_have_one_noun=()
 }
 
@@ -477,6 +487,8 @@ _kubectl_port-forward()
     two_word_flags+=("-p")
 
     must_have_one_flag=()
+    must_have_one_flag+=("--pod=")
+    must_have_one_flag+=("-p")
     must_have_one_noun=()
 }
 
@@ -533,6 +545,7 @@ _kubectl_run-container()
     two_word_flags+=("-t")
 
     must_have_one_flag=()
+    must_have_one_flag+=("--image=")
     must_have_one_noun=()
 }
 
@@ -595,6 +608,7 @@ _kubectl_expose()
     two_word_flags+=("-t")
 
     must_have_one_flag=()
+    must_have_one_flag+=("--port=")
     must_have_one_noun=()
 }
 

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -54,6 +54,7 @@ func NewCmdCreate(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 
 	usage := "Filename, directory, or URL to file to use to create the resource"
 	kubectl.AddJsonFilenameFlag(cmd, &filenames, usage)
+	cmd.MarkFlagRequired("filename")
 
 	return cmd
 }

--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -50,8 +50,10 @@ func NewCmdExec(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *
 		},
 	}
 	cmd.Flags().StringP("pod", "p", "", "Pod name")
+	cmd.MarkFlagRequired("pod")
 	// TODO support UID
 	cmd.Flags().StringP("container", "c", "", "Container name")
+	cmd.MarkFlagRequired("container")
 	cmd.Flags().BoolP("stdin", "i", false, "Pass stdin to the container")
 	cmd.Flags().BoolP("tty", "t", false, "Stdin is a TTY")
 	return cmd

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -57,6 +57,7 @@ func NewCmdExposeService(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().String("generator", "service/v1", "The name of the API generator to use.  Default is 'service/v1'.")
 	cmd.Flags().String("protocol", "TCP", "The network protocol for the service to be created. Default is 'tcp'.")
 	cmd.Flags().Int("port", -1, "The port that the service should serve on. Required.")
+	cmd.MarkFlagRequired("port")
 	cmd.Flags().Bool("create-external-load-balancer", false, "If true, create an external load balancer for this service. Implementation is cloud provider dependent. Default is 'false'.")
 	cmd.Flags().String("selector", "", "A label selector to use for this service. If empty (the default) infer the selector from the replication controller.")
 	cmd.Flags().StringP("labels", "l", "", "Labels to apply to the service created by this call.")

--- a/pkg/kubectl/cmd/portforward.go
+++ b/pkg/kubectl/cmd/portforward.go
@@ -54,6 +54,7 @@ func NewCmdPortForward(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringP("pod", "p", "", "Pod name")
+	cmd.MarkFlagRequired("pod")
 	// TODO support UID
 	return cmd
 }

--- a/pkg/kubectl/cmd/resize.go
+++ b/pkg/kubectl/cmd/resize.go
@@ -61,6 +61,7 @@ func NewCmdResize(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().String("resource-version", "", "Precondition for resource version. Requires that the current resource version match this value in order to resize.")
 	cmd.Flags().Int("current-replicas", -1, "Precondition for current size. Requires that the current size of the replication controller match this value in order to resize.")
 	cmd.Flags().Int("replicas", -1, "The new desired number of replicas. Required.")
+	cmd.MarkFlagRequired("replicas")
 	return cmd
 }
 

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -56,6 +56,7 @@ func NewCmdRunContainer(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmdutil.AddPrinterFlags(cmd)
 	cmd.Flags().String("generator", "run-container/v1", "The name of the API generator to use.  Default is 'run-container-controller/v1'.")
 	cmd.Flags().String("image", "", "The image for the container to run.")
+	cmd.MarkFlagRequired("image")
 	cmd.Flags().IntP("replicas", "r", 1, "Number of replicas to create for this container. Default is 1.")
 	cmd.Flags().Bool("dry-run", false, "If true, only print the object that would be sent, without sending it.")
 	cmd.Flags().String("overrides", "", "An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field.")

--- a/pkg/kubectl/cmd/update.go
+++ b/pkg/kubectl/cmd/update.go
@@ -56,7 +56,9 @@ func NewCmdUpdate(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	}
 	usage := "Filename, directory, or URL to file to use to update the resource."
 	kubectl.AddJsonFilenameFlag(cmd, &filenames, usage)
+	cmd.MarkFlagRequired("filename")
 	cmd.Flags().String("patch", "", "A JSON document to override the existing resource. The resource is downloaded, patched with the JSON, then updated.")
+	cmd.MarkFlagRequired("patch")
 	return cmd
 }
 


### PR DESCRIPTION
some commands require that certain flags be set in order to function.
Annotate those flags so the bash completions will suggest to the user
that they be set.
