### PR TITLE
Fixed "componentstatuses" API object JSON descriptions.

### DIFF
--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -49,9 +49,9 @@ cat -n "${MINIONS_FILE}"
 
 attempt=0
 while true; do
-  kubectl_output=$("${KUBE_ROOT}/cluster/kubectl.sh" get componentstatus)
+  kubectl_output=$("${KUBE_ROOT}/cluster/kubectl.sh" get cs)
 
-  # The "kubectl validate" output is four columns like this:
+  # The "kubectl componentstatuses" output is four columns like this:
   #
   #     COMPONENT            HEALTH    MSG       ERR
   #     controller-manager   Healthy   ok        nil

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1837,10 +1837,10 @@ const (
 )
 
 type ComponentCondition struct {
-	Type    ComponentConditionType `json:"type" description:"the type of condition"`
-	Status  ConditionStatus        `json:"status" description:"the status of this condition"`
-	Message string                 `json:"message,omitempty" description:"health check message received from the component"`
-	Error   string                 `json:"error,omitempty" description:"error code from health check attempt (if any)"`
+	Type    ComponentConditionType `json:"type"`
+	Status  ConditionStatus        `json:"status"`
+	Message string                 `json:"message,omitempty"`
+	Error   string                 `json:"error,omitempty"`
 }
 
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.
@@ -1848,13 +1848,12 @@ type ComponentStatus struct {
 	TypeMeta   `json:",inline"`
 	ObjectMeta `json:"metadata,omitempty"`
 
-	Name       string               `json:"name,omitempty" description:"name of the component"`
-	Conditions []ComponentCondition `json:"conditions,omitempty" description:"list of component condition objects"`
+	Conditions []ComponentCondition `json:"conditions,omitempty"`
 }
 
 type ComponentStatusList struct {
 	TypeMeta `json:",inline"`
 	ListMeta `json:"metadata,omitempty"`
 
-	Items []ComponentStatus `json:"items" description:"items is a list of component status objects"`
+	Items []ComponentStatus `json:"items"`
 }

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -1602,8 +1602,8 @@ const (
 )
 
 type ComponentCondition struct {
-	Type    ComponentConditionType `json:"type"`
-	Status  ConditionStatus        `json:"status"`
+	Type    ComponentConditionType `json:"type" description:"type of component condition, currently only Healthy"`
+	Status  ConditionStatus        `json:"status" description:"current status of this component condition, one of True, False, Unknown"`
 	Message string                 `json:"message,omitempty" description:"health check message received from the component"`
 	Error   string                 `json:"error,omitempty" description:"error code from health check attempt (if any)"`
 }
@@ -1613,11 +1613,11 @@ type ComponentStatus struct {
 	TypeMeta `json:",inline"`
 
 	Name       string               `json:"name,omitempty" description:"name of the component"`
-	Conditions []ComponentCondition `json:"conditions,omitempty"`
+	Conditions []ComponentCondition `json:"conditions,omitempty" description:"list of component conditions observed"`
 }
 
 type ComponentStatusList struct {
 	TypeMeta `json:",inline"`
 
-	Items []ComponentStatus `json:"items" description:"items is a list of component status objects"`
+	Items []ComponentStatus `json:"items" description:"list of component status objects"`
 }

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -1665,8 +1665,8 @@ const (
 )
 
 type ComponentCondition struct {
-	Type    ComponentConditionType `json:"type"`
-	Status  ConditionStatus        `json:"status"`
+	Type    ComponentConditionType `json:"type" description:"type of component condition, currently only Healthy"`
+	Status  ConditionStatus        `json:"status" description:"current status of this component condition, one of True, False, Unknown"`
 	Message string                 `json:"message,omitempty" description:"health check message received from the component"`
 	Error   string                 `json:"error,omitempty" description:"error code from health check attempt (if any)"`
 }
@@ -1676,11 +1676,11 @@ type ComponentStatus struct {
 	TypeMeta `json:",inline"`
 
 	Name       string               `json:"name,omitempty" description:"name of the component"`
-	Conditions []ComponentCondition `json:"conditions,omitempty"`
+	Conditions []ComponentCondition `json:"conditions,omitempty" description:"list of component conditions observed"`
 }
 
 type ComponentStatusList struct {
 	TypeMeta `json:",inline"`
 
-	Items []ComponentStatus `json:"items" description:"items is a list of component status objects"`
+	Items []ComponentStatus `json:"items" description:"list of component status objects"`
 }

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -1683,7 +1683,7 @@ const (
 
 type ComponentCondition struct {
 	Type    ComponentConditionType `json:"type" description:"type of component condition, currently only Healthy"`
-	Status  ConditionStatus        `json:"status" description:"current status of this component condition"`
+	Status  ConditionStatus        `json:"status" description:"current status of this component condition, one of True, False, Unknown"`
 	Message string                 `json:"message,omitempty" description:"health check message received from the component"`
 	Error   string                 `json:"error,omitempty" description:"error code from health check attempt (if any)"`
 }
@@ -1691,15 +1691,14 @@ type ComponentCondition struct {
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.
 type ComponentStatus struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#metadata"`
 
-	Name       string               `json:"name,omitempty" description:"name of the component"`
-	Conditions []ComponentCondition `json:"conditions,omitempty" description:"Conditions is a list of ComponentCondition objects"`
+	Conditions []ComponentCondition `json:"conditions,omitempty" description:"list of component conditions observed" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 type ComponentStatusList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#metadata"`
 
-	Items []ComponentStatus `json:"items" description:"items is a list of ComponentStatus objects"`
+	Items []ComponentStatus `json:"items" description:"list of component status objects"`
 }

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -90,23 +90,25 @@ func testData() (*api.PodList, *api.ServiceList, *api.ReplicationControllerList)
 
 func testComponentStatusData() *api.ComponentStatusList {
 	good := &api.ComponentStatus{
-		Name: "servergood",
 		Conditions: []api.ComponentCondition{
 			{Type: api.ComponentHealthy, Status: api.ConditionTrue, Message: "ok", Error: "nil"},
 		},
 	}
+	good.Name = "servergood"
+
 	bad := &api.ComponentStatus{
-		Name: "serverbad",
 		Conditions: []api.ComponentCondition{
 			{Type: api.ComponentHealthy, Status: api.ConditionFalse, Message: "", Error: "bad status: 500"},
 		},
 	}
+	bad.Name = "serverbad"
+
 	unknown := &api.ComponentStatus{
-		Name: "serverunknown",
 		Conditions: []api.ComponentCondition{
 			{Type: api.ComponentHealthy, Status: api.ConditionUnknown, Message: "", Error: "fizzbuzz error"},
 		},
 	}
+	unknown.Name = "serverunknown"
 
 	return &api.ComponentStatusList{
 		Items: []api.ComponentStatus{*good, *bad, *unknown},

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -97,7 +97,7 @@ func (e ShortcutExpander) VersionAndKindForResource(resource string) (defaultVer
 func expandResourceShortcut(resource string) string {
 	shortForms := map[string]string{
 		// Please keep this alphabetized
-		"cs":     "componentstatus",
+		"cs":     "componentstatuses",
 		"ev":     "events",
 		"limits": "limitRanges",
 		"mi":     "minions",

--- a/pkg/registry/componentstatus/rest.go
+++ b/pkg/registry/componentstatus/rest.go
@@ -102,9 +102,9 @@ func (rs *REST) getComponentStatus(name string, server apiserver.Server) *api.Co
 	}
 
 	retVal := &api.ComponentStatus{
-		Name:       name,
 		Conditions: []api.ComponentCondition{*c},
 	}
+	retVal.Name = name
 
 	return retVal
 }

--- a/pkg/registry/componentstatus/rest_test.go
+++ b/pkg/registry/componentstatus/rest_test.go
@@ -67,12 +67,13 @@ func NewTestREST(resp testResponse) *REST {
 }
 
 func createTestStatus(name string, status api.ConditionStatus, msg string, err string) *api.ComponentStatus {
-	return &api.ComponentStatus{
-		Name: name,
+	retVal := &api.ComponentStatus{
 		Conditions: []api.ComponentCondition{
 			{Type: api.ComponentHealthy, Status: status, Message: msg, Error: err},
 		},
 	}
+	retVal.Name = name
+	return retVal
 }
 
 func TestList_NoError(t *testing.T) {


### PR DESCRIPTION
Also renamed "componentstatus" to "componentstatuses" in kubectl.
