### PR TITLE
AWS: don't try to create undefined config_dir

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -615,7 +615,6 @@ function kube-up {
   # TODO: generate ADMIN (and KUBELET) tokens and put those in the master's
   # config file.  Distribute the same way the htpasswd is done.
   (
-    mkdir -p "${config_dir}"
     umask 077
     ssh -oStrictHostKeyChecking=no -i "${AWS_SSH_KEY}" "ubuntu@${KUBE_MASTER_IP}" sudo cat /srv/kubernetes/kubecfg.crt >"${KUBE_CERT}" 2>"$LOG"
     ssh -oStrictHostKeyChecking=no -i "${AWS_SSH_KEY}" "ubuntu@${KUBE_MASTER_IP}" sudo cat /srv/kubernetes/kubecfg.key >"${KUBE_KEY}" 2>"$LOG"


### PR DESCRIPTION
This variable is not defined, and is causing AWS builds to fail.

e.g. 
http://kubernetes-dashboard.meteor.com/testresult/aws:ubuntu__bf45a623829abaf06eee42a8a5882f87528eea56
