### PR TITLE
Fixup event object reference generation to allow downstream objects

### DIFF
--- a/pkg/api/ref_test.go
+++ b/pkg/api/ref_test.go
@@ -27,6 +27,13 @@ type FakeAPIObject struct{}
 
 func (*FakeAPIObject) IsAnAPIObject() {}
 
+type ExtensionAPIObject struct {
+	TypeMeta
+	ObjectMeta
+}
+
+func (*ExtensionAPIObject) IsAnAPIObject() {}
+
 func TestGetReference(t *testing.T) {
 	table := map[string]struct {
 		obj       runtime.Object
@@ -66,6 +73,26 @@ func TestGetReference(t *testing.T) {
 				ResourceVersion: "42",
 			},
 		},
+		"extensionAPIObject": {
+			obj: &ExtensionAPIObject{
+				TypeMeta: TypeMeta{
+					Kind: "ExtensionAPIObject",
+				},
+				ObjectMeta: ObjectMeta{
+					Name:            "foo",
+					UID:             "bar",
+					ResourceVersion: "42",
+					SelfLink:        "/custom_prefix/version1/extensions/foo",
+				},
+			},
+			ref: &ObjectReference{
+				Kind:            "ExtensionAPIObject",
+				APIVersion:      "version1",
+				Name:            "foo",
+				UID:             "bar",
+				ResourceVersion: "42",
+			},
+		},
 		"badSelfLink": {
 			obj: &ServiceList{
 				ListMeta: ListMeta{
@@ -90,7 +117,7 @@ func TestGetReference(t *testing.T) {
 	for name, item := range table {
 		ref, err := GetPartialReference(item.obj, item.fieldPath)
 		if e, a := item.shouldErr, (err != nil); e != a {
-			t.Errorf("%v: expected %v, got %v", name, e, a)
+			t.Errorf("%v: expected %v, got %v, err %v", name, e, a, err)
 			continue
 		}
 		if e, a := item.ref, ref; !reflect.DeepEqual(e, a) {

--- a/pkg/kubelet/container/ref_test.go
+++ b/pkg/kubelet/container/ref_test.go
@@ -86,6 +86,8 @@ func TestGenerateContainerRef(t *testing.T) {
 		noSelfLinkPod        = okPod
 		defaultedSelfLinkPod = okPod
 	)
+	noSelfLinkPod.Kind = ""
+	noSelfLinkPod.APIVersion = ""
 	noSelfLinkPod.ObjectMeta.SelfLink = ""
 	defaultedSelfLinkPod.ObjectMeta.SelfLink = "/api/v1beta1/pods/ok"
 


### PR DESCRIPTION
OpenShift introduces new objects that are not in core Kubernetes, and we want to be able to reference those objects when building Events.  

This code fixes up the GetReference code to not make certain assumptions:
1. it allows for the api to be served on alternate root prefixes
2. it respects the meta.Kind and meta.Version on an object before delegating to scheme.  this is preferred because in our use cases, we are building involvedObject references to resources that were already persisted, and therefore, meta.Kind and meta.Version have the proper values.

@smarterclayton this is part of the quota work I am doing to ensure we get events around objects that create pods... in particular builds and deployments.
