### PR TITLE
Fix vagrant regression from 6691

### DIFF
--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -22,6 +22,7 @@ export NUM_MINIONS
 
 # The IP of the master
 export MASTER_IP="10.245.1.2"
+export KUBE_MASTER_IP="10.245.1.2"
 
 export INSTANCE_PREFIX="kubernetes"
 export MASTER_NAME="${INSTANCE_PREFIX}-master"


### PR DESCRIPTION
cluster/common.sh started requiring KUBE_MASTER_IP across all providers.
