### PR TITLE
Use pod namespace when looking for its GlusterFS endpoints.

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -67,7 +67,7 @@ func (plugin *glusterfsPlugin) GetAccessModes() []api.AccessModeType {
 
 func (plugin *glusterfsPlugin) NewBuilder(spec *volume.Spec, podRef *api.ObjectReference, _ volume.VolumeOptions) (volume.Builder, error) {
 	ep_name := spec.VolumeSource.Glusterfs.EndpointsName
-	ns := api.NamespaceDefault
+	ns := podRef.Namespace
 	ep, err := plugin.host.GetKubeClient().Endpoints(ns).Get(ep_name)
 	if err != nil {
 		glog.Errorf("Glusterfs: failed to get endpoints %s[%v]", ep_name, err)


### PR DESCRIPTION
When writing e2e tests for GlusterFS I noticed that the endpoints specified in GlusterfsVolumeSource.Endpoints are always looked up in 'default' namespace, while my GlusterFS is in e2e-ns-<timestamp> namespace and also the client pod with GlusterfsVolumeSource should be created there.

IMO Kubernetes should look for the endpoints in the namespace where the pod is being created.
