### PR TITLE
Rename salt minion_ip to hostname_override

### DIFF
--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -17,8 +17,8 @@
 
 {% set config = "--config=/etc/kubernetes/manifests" -%}
 {% set hostname_override = "" -%}
-{% if grains.minion_ip is defined -%}
-  {% set hostname_override = " --hostname_override=" + grains.minion_ip -%}
+{% if grains.hostname_override is defined -%}
+  {% set hostname_override = " --hostname_override=" + grains.hostname_override -%}
 {% endif -%}
 
 {% set cluster_dns = "" %}

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -72,7 +72,7 @@ grains:
   roles:
     - kubernetes-pool
   cbr-cidr: '$(echo "$CONTAINER_SUBNET" | sed -e "s/'/''/g")'
-  minion_ip: '$(echo "$MINION_IP" | sed -e "s/'/''/g")'
+  hostname_override: '$(echo "$MINION_IP" | sed -e "s/'/''/g")'
 EOF
 
 # we will run provision to update code each time we test, so we do not want to do salt install each time

--- a/cluster/vsphere/templates/salt-minion.sh
+++ b/cluster/vsphere/templates/salt-minion.sh
@@ -37,7 +37,7 @@ echo "master: $KUBE_MASTER" > /etc/salt/minion.d/master.conf
 #
 cat <<EOF >/etc/salt/minion.d/grains.conf
 grains:
-  minion_ip: $(ip route get 1.1.1.1 | awk '{print $7}')
+  hostname_override: $(ip route get 1.1.1.1 | awk '{print $7}')
   roles:
     - kubernetes-pool
     - kubernetes-pool-vsphere

--- a/docs/salt.md
+++ b/docs/salt.md
@@ -65,7 +65,7 @@ Key | Value
 `etcd_servers` | (Optional) Comma-delimited list of IP addresses the kube-apiserver and kubelet use to reach etcd.  Uses the IP of the first machine in the kubernetes_master role, or 127.0.0.1 on GCE.
 `hostnamef` | (Optional) The full host name of the machine, i.e. uname -n
 `node_ip` | (Optional) The IP address to use to address this node
-`minion_ip` | (Optional) Mapped to the kubelet hostname_override, K8S TODO - change this name
+`hostname_override` | (Optional) Mapped to the kubelet hostname_override
 `network_mode` | (Optional) Networking model to use among nodes: *openvswitch*
 `networkInterfaceName` | (Optional) Networking interface to use to bind addresses, default value *eth0*
 `publicAddressOverride` | (Optional) The IP address the kube-apiserver should use to bind against for external read-only access


### PR DESCRIPTION
Prep work for making AWS node identifier -> instance id
