### PR TITLE
Use --host option even if kubecontext is not provided.

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -272,6 +272,11 @@ func validateController(c *client.Client, containerImage string, replicas int, c
 // kubectlCmd runs the kubectl executable.
 func kubectlCmd(args ...string) *exec.Cmd {
 	defaultArgs := []string{}
+
+	// Reference a --server option so tests can run anywhere.
+	if testContext.Host != "" {
+		defaultArgs = append(defaultArgs, "--"+clientcmd.FlagAPIServer+"="+testContext.Host)
+	}
 	if testContext.KubeConfig != "" {
 		defaultArgs = append(defaultArgs, "--"+clientcmd.RecommendedConfigPathFlag+"="+testContext.KubeConfig)
 
@@ -280,10 +285,6 @@ func kubectlCmd(args ...string) *exec.Cmd {
 			defaultArgs = append(defaultArgs, "--"+clientcmd.FlagContext+"="+testContext.KubeContext)
 		}
 
-		// Reference a --server option so tests can run anywhere.
-		if testContext.Host != "" {
-			defaultArgs = append(defaultArgs, "--"+clientcmd.FlagAPIServer+"="+testContext.Host)
-		}
 	} else {
 		defaultArgs = append(defaultArgs, "--"+clientcmd.FlagAuthPath+"="+testContext.AuthConfig)
 		if testContext.CertDir != "" {


### PR DESCRIPTION
Kubecontext may or may not be provided, in either case, host option still is valid if provided by testContext.
