### PR TITLE
Override the host header when health checking the kubelet

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -581,7 +581,8 @@ func (m *Master) getServersToValidate(c *Config) map[string]apiserver.Server {
 		glog.Errorf("Failed to list minions: %v", err)
 	}
 	for ix, node := range nodes.Items {
-		serversToValidate[fmt.Sprintf("node-%d", ix)] = apiserver.Server{Addr: node.Name, Port: ports.KubeletPort, Path: "/healthz", EnableHTTPS: true}
+		nodeAddr := node.Name
+		serversToValidate[fmt.Sprintf("node-%d", ix)] = apiserver.Server{Addr: nodeAddr, HostHeader: node.Name, Port: ports.KubeletPort, Path: "/healthz", EnableHTTPS: true}
 	}
 	return serversToValidate
 }


### PR DESCRIPTION
The kubelet checks the host header, to make sure the master has the
right name for the minion.

This lets us separate the network-address from the node name.
