### PR TITLE
Print container statuses in `kubectl get pods`

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -336,6 +336,8 @@ func (dm *DockerManager) GetPodStatus(pod *api.Pod) (*api.PodStatus, error) {
 			continue
 		}
 		var containerStatus api.ContainerStatus
+		containerStatus.Name = container.Name
+		containerStatus.Image = container.Image
 		if oldStatus, found := oldStatuses[container.Name]; found {
 			// Some states may be lost due to GC; apply the last observed
 			// values if possible.


### PR DESCRIPTION
`kubectl get pod` already prints one container per line. This change fills in
the status for each container listed. This aims to help users quickly identify
unhealthy pods (e.g. in a crash loop) at a glance.
- The first row of every pod would display the pod information and status
- Each row of the subsequent rows corresponds to a container in that pod:
  - STATUS refers to the container status (Running, Waiting, Terminated).
  - CREATED refers to the elapsed time since the last start time of the
    container.
  - MESSAGE is a string which explains the last termination reason, and/or
    the reason behind the waiting status.
