### PR TITLE
kubelet: Refactor GetDockerVersion().

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -25,11 +25,20 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
 )
 
+type Version interface {
+	// Compare compares two versions of the runtime. On success it returns -1
+	// if the version is less than the other, 1 if it is greater than the other,
+	// or 0 if they are equal.
+	Compare(other string) (int, error)
+	// String returns a string that represents the version.
+	String() string
+}
+
 // Runtime interface defines the interfaces that should be implemented
 // by a container runtime.
 type Runtime interface {
-	// Version returns a map of version information of the container runtime.
-	Version() (map[string]string, error)
+	// Version returns the version information of the container runtime.
+	Version() (Version, error)
 	// GetPods returns a list containers group by pods. The boolean parameter
 	// specifies whether the runtime returns all containers including those already
 	// exited and dead containers (used for garbage collection).

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -120,7 +120,8 @@ type dockerContainerCommandRunner struct {
 var dockerAPIVersionWithExec, _ = docker.NewAPIVersion("1.15")
 
 // Returns the major and minor version numbers of docker server.
-func (d *dockerContainerCommandRunner) GetDockerServerVersion() (docker.APIVersion, error) {
+// TODO(yifan): Remove this once the ContainerCommandRunner is implemented by dockerManager.
+func (d *dockerContainerCommandRunner) getDockerServerVersion() (docker.APIVersion, error) {
 	env, err := d.client.Version()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get docker server version - %v", err)
@@ -136,7 +137,7 @@ func (d *dockerContainerCommandRunner) GetDockerServerVersion() (docker.APIVersi
 }
 
 func (d *dockerContainerCommandRunner) nativeExecSupportExists() (bool, error) {
-	version, err := d.GetDockerServerVersion()
+	version, err := d.getDockerServerVersion()
 	if err != nil {
 		return false, err
 	}
@@ -479,7 +480,6 @@ func ConnectToDockerOrDie(dockerEndpoint string) DockerInterface {
 // TODO(yifan): Move this to container.Runtime.
 type ContainerCommandRunner interface {
 	RunInContainer(containerID string, cmd []string) ([]byte, error)
-	GetDockerServerVersion() (docker.APIVersion, error)
 	ExecInContainer(containerID string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool) error
 	PortForward(pod *kubecontainer.Pod, port uint16, stream io.ReadWriteCloser) error
 }

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -129,10 +129,10 @@ func TestContainerManifestNaming(t *testing.T) {
 	}
 }
 
-func TestGetDockerServerVersion(t *testing.T) {
+func TestVersion(t *testing.T) {
 	fakeDocker := &FakeDockerClient{VersionInfo: docker.Env{"Version=1.1.3", "ApiVersion=1.15"}}
-	runner := dockerContainerCommandRunner{fakeDocker}
-	version, err := runner.GetDockerServerVersion()
+	manager := &DockerManager{client: fakeDocker}
+	version, err := manager.Version()
 	if err != nil {
 		t.Errorf("got error while getting docker server version - %s", err)
 	}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1658,13 +1658,12 @@ func (kl *Kubelet) syncLoop(updates <-chan PodUpdate, handler SyncHandler) {
 	}
 }
 
-// Returns Docker version for this Kubelet.
-func (kl *Kubelet) GetDockerVersion() (docker.APIVersion, error) {
-	if kl.dockerClient == nil {
-		return nil, fmt.Errorf("no Docker client")
+// Returns the container runtime version for this Kubelet.
+func (kl *Kubelet) GetContainerRuntimeVersion() (kubecontainer.Version, error) {
+	if kl.containerManager == nil {
+		return nil, fmt.Errorf("no container runtime")
 	}
-	dockerRunner := dockertools.NewDockerContainerCommandRunner(kl.dockerClient)
-	return dockerRunner.GetDockerServerVersion()
+	return kl.containerManager.Version()
 }
 
 func (kl *Kubelet) validatePodPhase(podStatus *api.PodStatus) error {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1597,10 +1597,6 @@ func (f *fakeContainerCommandRunner) RunInContainer(id string, cmd []string) ([]
 	return []byte{}, f.E
 }
 
-func (f *fakeContainerCommandRunner) GetDockerServerVersion() (docker.APIVersion, error) {
-	return nil, nil
-}
-
 func (f *fakeContainerCommandRunner) ExecInContainer(id string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool) error {
 	f.Cmd = cmd
 	f.ID = id


### PR DESCRIPTION
Remove GetDockerServerVersion from DockerContainerCommandRunner interface,
and make it more generic.

Depends on #7133, will rebase when that is merged.
