### PR TITLE
Including balanced resource allocation priority in the default set

### DIFF
--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -60,6 +60,8 @@ func defaultPriorities() util.StringSet {
 	return util.NewStringSet(
 		// Prioritize nodes by least requested utilization.
 		factory.RegisterPriorityFunction("LeastRequestedPriority", algorithm.LeastRequestedPriority, 1),
+		// Prioritizes nodes to help achieve balanced resource usage
+		factory.RegisterPriorityFunction("BalancedResourceAllocation", algorithm.BalancedResourceAllocation, 1),
 		// spreads pods by minimizing the number of pods (belonging to the same service) on the same minion.
 		factory.RegisterPriorityConfigFactory(
 			"ServiceSpreadingPriority",


### PR DESCRIPTION
This includes the priority function into the default configuration as well as make it available for inclusion within custom scheduler policies/configurations. 

If, for some reason, it should not be included in the default scheduler configuration, then I will modify the PR to at least register it (and make it available).
