### PR TITLE
Fix the ssh-to-node to actually fail on failures.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -967,11 +967,15 @@ function test-teardown {
 function ssh-to-node {
   local node="$1"
   local cmd="$2"
+  # Loop until we can successfully ssh into the box
   for try in $(seq 1 5); do
-    if gcloud compute ssh --ssh-flag="-o LogLevel=quiet" --project "${PROJECT}" --zone="${ZONE}" "${node}" --command "${cmd}"; then
+    if gcloud compute ssh --ssh-flag="-o LogLevel=quiet" --project "${PROJECT}" --zone="${ZONE}" "${node}" --command "echo test"; then
       break
     fi
+    sleep 5
   done
+  # Then actually try the command.
+  gcloud compute ssh --ssh-flag="-o LogLevel=quiet" --project "${PROJECT}" --zone="${ZONE}" "${node}" --command "${cmd}"
 }
 
 # Restart the kube-proxy on a node ($1)

--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -238,8 +238,15 @@ function ssh-to-node() {
 
   local node="$1"
   local cmd="$2"
-  "${GCLOUD}" compute ssh --ssh-flag="-o LogLevel=quiet" --project "${PROJECT}" \
-    --zone="${ZONE}" "${node}" --command "${cmd}"
+  # Loop until we can successfully ssh into the box
+  for try in $(seq 1 5); do
+    if gcloud compute ssh --ssh-flag="-o LogLevel=quiet" --project "${PROJECT}" --zone="${ZONE}" "${node}" --command "echo test"; then
+      break
+    fi
+    sleep 5
+  done
+  # Then actually try the command.
+  gcloud compute ssh --ssh-flag="-o LogLevel=quiet" --project "${PROJECT}" --zone="${ZONE}" "${node}" --command "${cmd}"
 }
 
 # Restart the kube-proxy on a node ($1)


### PR DESCRIPTION
@thockin since he wrote the original bug
@roberthbailey since he found it

Note that I had to guess about the intent of the loop.  I guessed that it was to ensure that the VM was ssh-able, not that it should retry the command.
