### PR TITLE
Resolve #6812, limit length of load balancer names

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -18,6 +18,7 @@ package cloudprovider
 
 import (
 	"net"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 )
@@ -44,8 +45,15 @@ type Clusters interface {
 
 // TODO(#6812): Use a shorter name that's less likely to be longer than cloud
 // providers' name length limits.
-func GetLoadBalancerName(clusterName, serviceNamespace, serviceName string) string {
-	return clusterName + "-" + serviceNamespace + "-" + serviceName
+func GetLoadBalancerName(service *api.Service) string {
+	//GCE requires that the name of a load balancer starts with a lower case letter.
+	ret := "a" + string(service.UID)
+	ret = strings.Replace(ret, "-", "", -1)
+	//AWS requires that the name of a load balancer is shorter than 32 bytes.
+	if len(ret) > 32 {
+		ret = ret[:32]
+	}
+	return ret
 }
 
 // TCPLoadBalancer is an abstract, pluggable interface for TCP load balancers.

--- a/pkg/cloudprovider/nodecontroller/nodecontroller.go
+++ b/pkg/cloudprovider/nodecontroller/nodecontroller.go
@@ -266,7 +266,7 @@ func (nc *NodeController) reconcileExternalServices(nodes *api.NodeList) (should
 				glog.Errorf("External load balancers for non TCP services are not currently supported: %v.", service)
 				continue
 			}
-			name := cloudprovider.GetLoadBalancerName(nc.clusterName, service.Namespace, service.Name)
+			name := cloudprovider.GetLoadBalancerName(&service)
 			err := balancer.UpdateTCPLoadBalancer(name, zone.Region, hosts)
 			if err != nil {
 				glog.Errorf("External error while updating TCP load balancer: %v.", err)

--- a/pkg/cloudprovider/servicecontroller/servicecontroller.go
+++ b/pkg/cloudprovider/servicecontroller/servicecontroller.go
@@ -419,7 +419,7 @@ func needsUpdate(oldService *api.Service, newService *api.Service) bool {
 }
 
 func (s *ServiceController) loadBalancerName(service *api.Service) string {
-	return cloudprovider.GetLoadBalancerName(s.clusterName, service.Namespace, service.Name)
+	return cloudprovider.GetLoadBalancerName(service)
 }
 
 func getTCPPorts(service *api.Service) ([]int, error) {


### PR DESCRIPTION
Use the first 32 bytes of string ("a"+ service.UID) as ELB's name, thus the length of the name is shorter than the requirement of AWS. Adding a prefix "a" is to satisfy GCE's requiements on ELB's name.
