### PR TITLE
Allow Secrets on Volumes and PersistentVolumes

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -172,6 +172,9 @@ type Volume struct {
 	// This is optional for now. If not specified, the Volume is implied to be an EmptyDir.
 	// This implied behavior is deprecated and will be removed in a future version.
 	VolumeSource `json:",inline,omitempty"`
+	// SecretName is the name of a Secret in the same namespace as the pod containing this volume
+	// used for volume authentication
+	SecretName string `json:"secretName,omitempty"`
 }
 
 // VolumeSource represents the source location of a volume to mount.
@@ -252,6 +255,9 @@ type PersistentVolumeSpec struct {
 	AccessModes []AccessModeType `json:"accessModes,omitempty"`
 	// holds the binding reference to a PersistentVolumeClaim
 	ClaimRef *ObjectReference `json:"claimRef,omitempty"`
+	// SecretRef is a reference to a Secret in the system.
+	// used for persistent volume authentication
+	SecretRef *ObjectReference `json:"secretRef,omitempty"`
 }
 
 type PersistentVolumeStatus struct {

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -1143,6 +1143,7 @@ func init() {
 				return err
 			}
 			out.Name = in.Name
+			out.SecretName = in.SecretName
 			return nil
 		},
 		func(in *Volume, out *newer.Volume, s conversion.Scope) error {
@@ -1150,6 +1151,7 @@ func init() {
 				return err
 			}
 			out.Name = in.Name
+			out.SecretName = in.SecretName
 			return nil
 		},
 

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -89,6 +89,9 @@ type Volume struct {
 	// This is optional for now. If not specified, the Volume is implied to be an EmptyDir.
 	// This implied behavior is deprecated and will be removed in a future version.
 	Source VolumeSource `json:"source,omitempty" description:"location and type of volume to mount; at most one of HostDir, EmptyDir, GCEPersistentDisk, AWSElasticBlockStore, or GitRepo; default is EmptyDir"`
+	// SecretName is the name of a Secret in the same namespace as the pod containing this volume
+	// used for volume authentication
+	SecretName string `json:"secretName,omitempty" description:"name of a Secret in the same namespace as the pod containing this volume"`
 }
 
 // VolumeSource represents the source location of a volume to mount.
@@ -167,6 +170,9 @@ type PersistentVolumeSpec struct {
 	AccessModes []AccessModeType `json:"accessModes,omitempty" description:"all ways the volume can be mounted"`
 	// holds the binding reference to a PersistentVolumeClaim
 	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"the binding reference to a persistent volume claim"`
+	// SecretRef is a reference to a Secret in the system.
+	// used for persistent volume authentication
+	SecretRef *ObjectReference `json:"secretRef,omitempty" description:"a reference to a secret in the system"`
 }
 
 type PersistentVolumeStatus struct {

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -1074,6 +1074,7 @@ func init() {
 				return err
 			}
 			out.Name = in.Name
+			out.SecretName = in.SecretName
 			return nil
 		},
 		func(in *Volume, out *newer.Volume, s conversion.Scope) error {
@@ -1081,6 +1082,7 @@ func init() {
 				return err
 			}
 			out.Name = in.Name
+			out.SecretName = in.SecretName
 			return nil
 		},
 

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -56,6 +56,9 @@ type Volume struct {
 	// This is optional for now. If not specified, the Volume is implied to be an EmptyDir.
 	// This implied behavior is deprecated and will be removed in a future version.
 	Source VolumeSource `json:"source,omitempty" description:"location and type of volume to mount; at most one of HostDir, EmptyDir, GCEPersistentDisk, AWSElasticBlockStore, or GitRepo; default is EmptyDir"`
+	// SecretName is the name of a Secret in the same namespace as the pod containing this volume
+	// used for volume authentication
+	SecretName string `json:"secretName,omitempty" description:"name of a Secret in the same namespace as the pod containing this volume"`
 }
 
 // VolumeSource represents the source location of a volume to mount.
@@ -136,6 +139,9 @@ type PersistentVolumeSpec struct {
 	AccessModes []AccessModeType `json:"accessModes,omitempty" description:"all ways the volume can be mounted"`
 	// holds the binding reference to a PersistentVolumeClaim
 	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"the binding reference to a persistent volume claim"`
+	// SecretRef is a reference to a Secret in the system.
+	// used for persistent volume authentication
+	SecretRef *ObjectReference `json:"secretRef,omitempty" description:"a reference to a secret in the system"`
 }
 
 type PersistentVolumeStatus struct {

--- a/pkg/api/v1beta3/conversion.go
+++ b/pkg/api/v1beta3/conversion.go
@@ -1104,6 +1104,7 @@ func init() {
 		},
 		func(in *Volume, out *newer.Volume, s conversion.Scope) error {
 			out.Name = in.Name
+			out.SecretName = in.SecretName
 			if err := s.Convert(&in.VolumeSource, &out.VolumeSource, 0); err != nil {
 				return err
 			}
@@ -1111,6 +1112,7 @@ func init() {
 		},
 		func(in *newer.Volume, out *Volume, s conversion.Scope) error {
 			out.Name = in.Name
+			out.SecretName = in.SecretName
 			if err := s.Convert(&in.VolumeSource, &out.VolumeSource, 0); err != nil {
 				return err
 			}
@@ -2161,6 +2163,11 @@ func init() {
 			return nil
 		},
 		func(in *PersistentVolumeSpec, out *newer.PersistentVolumeSpec, s conversion.Scope) error {
+			if in.SecretRef != nil {
+				if err := s.Convert(&in.SecretRef, &out.SecretRef, 0); err != nil {
+					return err
+				}
+			}
 			if in.Capacity != nil {
 				out.Capacity = make(map[newer.ResourceName]resource.Quantity)
 				for key, val := range in.Capacity {
@@ -2188,6 +2195,11 @@ func init() {
 			return nil
 		},
 		func(in *newer.PersistentVolumeSpec, out *PersistentVolumeSpec, s conversion.Scope) error {
+			if in.SecretRef != nil {
+				if err := s.Convert(&in.SecretRef, &out.SecretRef, 0); err != nil {
+					return err
+				}
+			}
 			if in.Capacity != nil {
 				out.Capacity = make(map[ResourceName]resource.Quantity)
 				for key, val := range in.Capacity {

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -189,6 +189,9 @@ type Volume struct {
 	// This is optional for now. If not specified, the Volume is implied to be an EmptyDir.
 	// This implied behavior is deprecated and will be removed in a future version.
 	VolumeSource `json:",inline,omitempty"`
+	// SecretName is the name of a Secret in the same namespace as the pod containing this volume
+	// used for volume authentication
+	SecretName string `json:"secretName,omitempty" description:"name of a Secret in the same namespace as the pod containing this volume"`
 }
 
 // VolumeSource represents the source location of a volume to mount.
@@ -269,6 +272,9 @@ type PersistentVolumeSpec struct {
 	AccessModes []AccessModeType `json:"accessModes,omitempty" description:"all ways the volume can be mounted"`
 	// holds the binding reference to a PersistentVolumeClaim
 	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"the binding reference to a persistent volume claim"`
+	// SecretRef is a reference to a Secret in the system.
+	// used for persistent volume authentication
+	SecretRef *ObjectReference `json:"secretRef,omitempty" description:"a reference to a secret in the system"`
 }
 
 type PersistentVolumeStatus struct {

--- a/pkg/kubelet/volumes.go
+++ b/pkg/kubelet/volumes.go
@@ -106,7 +106,10 @@ func (kl *Kubelet) newVolumeBuilderFromPlugins(spec *volume.Spec, podRef *api.Ob
 			return nil, fmt.Errorf("Failed to find secret %s in namespace %s", spec.SecretName, podRef.Namespace)
 		}
 	}
-	builder.SetSecret(secret)
+	err = builder.SetSecret(secret)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to set secret on builder: %v", err)
+	}
 
 	glog.V(3).Infof("Used volume plugin %q for %s", plugin.Name(), spew.Sprintf("%#v", *spec))
 	return builder, nil

--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -266,7 +266,9 @@ func (pd *awsElasticBlockStore) GetPath() string {
 	return pd.plugin.host.GetPodVolumeDir(pd.podUID, util.EscapeQualifiedNameForDisk(name), pd.volName)
 }
 
-func (pd *awsElasticBlockStore) SetSecret(secret *api.Secret) {
+func (pd *awsElasticBlockStore) SetSecret(secret *api.Secret) error {
+	// validate secret and return an error if invalid
+	return nil
 }
 
 // Unmounts the bind mount, and detaches the disk only if the PD

--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -266,6 +266,9 @@ func (pd *awsElasticBlockStore) GetPath() string {
 	return pd.plugin.host.GetPodVolumeDir(pd.podUID, util.EscapeQualifiedNameForDisk(name), pd.volName)
 }
 
+func (pd *awsElasticBlockStore) SetSecret(secret *api.Secret) {
+}
+
 // Unmounts the bind mount, and detaches the disk only if the PD
 // resource was the last reference to that disk on the kubelet.
 func (pd *awsElasticBlockStore) TearDown() error {

--- a/pkg/volume/empty_dir/empty_dir.go
+++ b/pkg/volume/empty_dir/empty_dir.go
@@ -225,6 +225,9 @@ func (ed *emptyDir) GetPath() string {
 	return ed.plugin.host.GetPodVolumeDir(ed.podUID, util.EscapeQualifiedNameForDisk(name), ed.volName)
 }
 
+func (pd *emptyDir) SetSecret(secret *api.Secret) {
+}
+
 // TearDown simply discards everything in the directory.
 func (ed *emptyDir) TearDown() error {
 	return ed.TearDownAt(ed.GetPath())

--- a/pkg/volume/empty_dir/empty_dir.go
+++ b/pkg/volume/empty_dir/empty_dir.go
@@ -225,7 +225,9 @@ func (ed *emptyDir) GetPath() string {
 	return ed.plugin.host.GetPodVolumeDir(ed.podUID, util.EscapeQualifiedNameForDisk(name), ed.volName)
 }
 
-func (pd *emptyDir) SetSecret(secret *api.Secret) {
+func (pd *emptyDir) SetSecret(secret *api.Secret) error {
+	// validate secret and return an error if invalid
+	return nil
 }
 
 // TearDown simply discards everything in the directory.

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -257,7 +257,9 @@ func (pd *gcePersistentDisk) GetPath() string {
 	return pd.plugin.host.GetPodVolumeDir(pd.podUID, util.EscapeQualifiedNameForDisk(name), pd.volName)
 }
 
-func (pd *gcePersistentDisk) SetSecret(secret *api.Secret) {
+func (pd *gcePersistentDisk) SetSecret(secret *api.Secret) error {
+	// validate secret and return an error if invalid
+	return nil
 }
 
 // Unmounts the bind mount, and detaches the disk only if the PD

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -257,6 +257,9 @@ func (pd *gcePersistentDisk) GetPath() string {
 	return pd.plugin.host.GetPodVolumeDir(pd.podUID, util.EscapeQualifiedNameForDisk(name), pd.volName)
 }
 
+func (pd *gcePersistentDisk) SetSecret(secret *api.Secret) {
+}
+
 // Unmounts the bind mount, and detaches the disk only if the PD
 // resource was the last reference to that disk on the kubelet.
 func (pd *gcePersistentDisk) TearDown() error {

--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -185,6 +185,9 @@ func (gr *gitRepo) GetPath() string {
 	return gr.plugin.host.GetPodVolumeDir(gr.podRef.UID, util.EscapeQualifiedNameForDisk(name), gr.volName)
 }
 
+func (pd *gitRepo) SetSecret(secret *api.Secret) {
+}
+
 // TearDown simply deletes everything in the directory.
 func (gr *gitRepo) TearDown() error {
 	return gr.TearDownAt(gr.GetPath())

--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -185,7 +185,9 @@ func (gr *gitRepo) GetPath() string {
 	return gr.plugin.host.GetPodVolumeDir(gr.podRef.UID, util.EscapeQualifiedNameForDisk(name), gr.volName)
 }
 
-func (pd *gitRepo) SetSecret(secret *api.Secret) {
+func (pd *gitRepo) SetSecret(secret *api.Secret) error {
+	// validate secret and return an error if invalid
+	return nil
 }
 
 // TearDown simply deletes everything in the directory.

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -148,8 +148,10 @@ func (glusterfsVolume *glusterfs) GetPath() string {
 	return glusterfsVolume.plugin.host.GetPodVolumeDir(glusterfsVolume.podRef.UID, util.EscapeQualifiedNameForDisk(name), glusterfsVolume.volName)
 }
 
-func (glusterfsVolume *glusterfs) SetSecret(secret *api.Secret) {
+func (glusterfsVolume *glusterfs) SetSecret(secret *api.Secret) error {
+	// validate secret and return an error if invalid
 	glusterfsVolume.secret = secret
+	return nil
 }
 
 func (glusterfsVolume *glusterfs) TearDown() error {

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -108,6 +108,7 @@ type glusterfs struct {
 	volName  string
 	podRef   *api.ObjectReference
 	hosts    *api.Endpoints
+	secret   *api.Secret
 	path     string
 	readonly bool
 	mounter  mount.Interface
@@ -145,6 +146,10 @@ func (glusterfsVolume *glusterfs) SetUpAt(dir string) error {
 func (glusterfsVolume *glusterfs) GetPath() string {
 	name := glusterfsPluginName
 	return glusterfsVolume.plugin.host.GetPodVolumeDir(glusterfsVolume.podRef.UID, util.EscapeQualifiedNameForDisk(name), glusterfsVolume.volName)
+}
+
+func (glusterfsVolume *glusterfs) SetSecret(secret *api.Secret) {
+	glusterfsVolume.secret = secret
 }
 
 func (glusterfsVolume *glusterfs) TearDown() error {

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -89,6 +89,9 @@ func (hp *hostPath) GetPath() string {
 	return hp.path
 }
 
+func (pd *hostPath) SetSecret(secret *api.Secret) {
+}
+
 // TearDown does nothing.
 func (hp *hostPath) TearDown() error {
 	return nil

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -89,7 +89,9 @@ func (hp *hostPath) GetPath() string {
 	return hp.path
 }
 
-func (pd *hostPath) SetSecret(secret *api.Secret) {
+func (pd *hostPath) SetSecret(secret *api.Secret) error {
+	// validate secret and return an error if invalid
+	return nil
 }
 
 // TearDown does nothing.

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -130,7 +130,9 @@ func (iscsi *iscsiDisk) GetPath() string {
 	return iscsi.plugin.host.GetPodVolumeDir(iscsi.podUID, util.EscapeQualifiedNameForDisk(name), iscsi.volName)
 }
 
-func (pd *iscsiDisk) SetSecret(secret *api.Secret) {
+func (pd *iscsiDisk) SetSecret(secret *api.Secret) error {
+	// validate secret and return an error if invalid
+	return nil
 }
 
 func (iscsi *iscsiDisk) SetUp() error {

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -130,6 +130,9 @@ func (iscsi *iscsiDisk) GetPath() string {
 	return iscsi.plugin.host.GetPodVolumeDir(iscsi.podUID, util.EscapeQualifiedNameForDisk(name), iscsi.volName)
 }
 
+func (pd *iscsiDisk) SetSecret(secret *api.Secret) {
+}
+
 func (iscsi *iscsiDisk) SetUp() error {
 	return iscsi.SetUpAt(iscsi.GetPath())
 }

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -155,6 +155,9 @@ func (nfsVolume *nfs) GetPath() string {
 	return nfsVolume.plugin.host.GetPodVolumeDir(nfsVolume.podRef.UID, util.EscapeQualifiedNameForDisk(name), nfsVolume.volName)
 }
 
+func (pd *nfs) SetSecret(secret *api.Secret) {
+}
+
 func (nfsVolume *nfs) TearDown() error {
 	return nfsVolume.TearDownAt(nfsVolume.GetPath())
 }

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -155,7 +155,9 @@ func (nfsVolume *nfs) GetPath() string {
 	return nfsVolume.plugin.host.GetPodVolumeDir(nfsVolume.podRef.UID, util.EscapeQualifiedNameForDisk(name), nfsVolume.volName)
 }
 
-func (pd *nfs) SetSecret(secret *api.Secret) {
+func (pd *nfs) SetSecret(secret *api.Secret) error {
+	// validate secret and return an error if invalid
+	return nil
 }
 
 func (nfsVolume *nfs) TearDown() error {

--- a/pkg/volume/persistent_claim/persistent_claim_test.go
+++ b/pkg/volume/persistent_claim/persistent_claim_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/gce_pd"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/glusterfs"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/host_path"
 )
 

--- a/pkg/volume/persistent_claim/persistent_claim_test.go
+++ b/pkg/volume/persistent_claim/persistent_claim_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/gce_pd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/glusterfs"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/host_path"
 )
 

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -146,17 +146,22 @@ func NewSpecFromPersistentVolume(pv *api.PersistentVolume) *Spec {
 	}
 }
 
+// SecretClient decouples resolution of the secret from the Kube client.
+// The interface is narrowed and testing is simpler.
 type SecretClient interface {
 	Get(namespace, name string) (*api.Secret, error)
 }
 
-type realSecretClient struct {
-	client    client.Interface
-	namespace string
+func NewSecretClient(client client.Interface) SecretClient {
+	return &realSecretClient{client}
 }
 
-func (resolver *realSecretClient) Get(name string) (*api.Secret, error) {
-	return resolver.client.Secrets(resolver.namespace).Get(name)
+type realSecretClient struct {
+	client client.Interface
+}
+
+func (rsc *realSecretClient) Get(namespace, name string) (*api.Secret, error) {
+	return rsc.client.Secrets(namespace).Get(name)
 }
 
 // InitPlugins initializes each plugin.  All plugins must have unique names.

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -124,6 +124,8 @@ type Spec struct {
 	Name                   string
 	VolumeSource           api.VolumeSource
 	PersistentVolumeSource api.PersistentVolumeSource
+	SecretName             string
+	SecretRef              *api.ObjectReference
 }
 
 // NewSpecFromVolume creates an Spec from an api.Volume
@@ -131,6 +133,7 @@ func NewSpecFromVolume(vs *api.Volume) *Spec {
 	return &Spec{
 		Name:         vs.Name,
 		VolumeSource: vs.VolumeSource,
+		SecretName:   vs.SecretName,
 	}
 }
 
@@ -139,7 +142,21 @@ func NewSpecFromPersistentVolume(pv *api.PersistentVolume) *Spec {
 	return &Spec{
 		Name: pv.Name,
 		PersistentVolumeSource: pv.Spec.PersistentVolumeSource,
+		SecretRef:              pv.Spec.SecretRef,
 	}
+}
+
+type SecretClient interface {
+	Get(namespace, name string) (*api.Secret, error)
+}
+
+type realSecretClient struct {
+	client    client.Interface
+	namespace string
+}
+
+func (resolver *realSecretClient) Get(name string) (*api.Secret, error) {
+	return resolver.client.Secrets(resolver.namespace).Get(name)
 }
 
 // InitPlugins initializes each plugin.  All plugins must have unique names.

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -153,7 +153,9 @@ func (sv *secretVolume) GetPath() string {
 	return sv.plugin.host.GetPodVolumeDir(sv.podRef.UID, util.EscapeQualifiedNameForDisk(secretPluginName), sv.volName)
 }
 
-func (pd *secretVolume) SetSecret(secret *api.Secret) {
+func (pd *secretVolume) SetSecret(secret *api.Secret) error {
+	// validate secret and return an error if invalid
+	return nil
 }
 
 func (sv *secretVolume) TearDown() error {

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -153,6 +153,9 @@ func (sv *secretVolume) GetPath() string {
 	return sv.plugin.host.GetPodVolumeDir(sv.podRef.UID, util.EscapeQualifiedNameForDisk(secretPluginName), sv.volName)
 }
 
+func (pd *secretVolume) SetSecret(secret *api.Secret) {
+}
+
 func (sv *secretVolume) TearDown() error {
 	return sv.TearDownAt(sv.GetPath())
 }

--- a/pkg/volume/testing.go
+++ b/pkg/volume/testing.go
@@ -96,11 +96,11 @@ func (plugin *FakeVolumePlugin) CanSupport(spec *Spec) bool {
 }
 
 func (plugin *FakeVolumePlugin) NewBuilder(spec *Spec, podRef *api.ObjectReference, opts VolumeOptions) (Builder, error) {
-	return &FakeVolume{podRef.UID, spec.Name, plugin}, nil
+	return &FakeVolume{podRef.UID, spec.Name, plugin, nil}, nil
 }
 
 func (plugin *FakeVolumePlugin) NewCleaner(volName string, podUID types.UID) (Cleaner, error) {
-	return &FakeVolume{podUID, volName, plugin}, nil
+	return &FakeVolume{podUID, volName, plugin, nil}, nil
 }
 
 func (plugin *FakeVolumePlugin) GetAccessModes() []api.AccessModeType {
@@ -111,6 +111,7 @@ type FakeVolume struct {
 	PodUID  types.UID
 	VolName string
 	Plugin  *FakeVolumePlugin
+	Secret  *api.Secret
 }
 
 func (fv *FakeVolume) SetUp() error {
@@ -126,6 +127,7 @@ func (fv *FakeVolume) GetPath() string {
 }
 
 func (pd *FakeVolume) SetSecret(secret *api.Secret) {
+	pd.Secret = secret
 }
 
 func (fv *FakeVolume) TearDown() error {

--- a/pkg/volume/testing.go
+++ b/pkg/volume/testing.go
@@ -125,6 +125,9 @@ func (fv *FakeVolume) GetPath() string {
 	return path.Join(fv.Plugin.Host.GetPodVolumeDir(fv.PodUID, util.EscapeQualifiedNameForDisk(fv.Plugin.PluginName), fv.VolName))
 }
 
+func (pd *FakeVolume) SetSecret(secret *api.Secret) {
+}
+
 func (fv *FakeVolume) TearDown() error {
 	return fv.TearDownAt(fv.GetPath())
 }

--- a/pkg/volume/testing.go
+++ b/pkg/volume/testing.go
@@ -126,8 +126,9 @@ func (fv *FakeVolume) GetPath() string {
 	return path.Join(fv.Plugin.Host.GetPodVolumeDir(fv.PodUID, util.EscapeQualifiedNameForDisk(fv.Plugin.PluginName), fv.VolName))
 }
 
-func (pd *FakeVolume) SetSecret(secret *api.Secret) {
+func (pd *FakeVolume) SetSecret(secret *api.Secret) error {
 	pd.Secret = secret
+	return nil
 }
 
 func (fv *FakeVolume) TearDown() error {

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -42,8 +42,9 @@ type Builder interface {
 	// directory path, which may or may not exist yet.  This may be called
 	// more than once, so implementations must be idempotent.
 	SetUpAt(dir string) error
-	// SetSecret allows secure injection of a secret into the volume by the kubelet for volumes which require authentication
-	SetSecret(secret *api.Secret)
+	// SetSecret allows secure injection of a secret into the volume by the kubelet for volumes which require authentication.
+	// A secret should be validated before being accepted, returning an error for an invalid secret.
+	SetSecret(secret *api.Secret) error
 }
 
 // Cleaner interface provides method to cleanup/unmount the volumes.

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -17,6 +17,7 @@ limitations under the License.
 package volume
 
 import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"io/ioutil"
 	"os"
 	"path"
@@ -41,6 +42,8 @@ type Builder interface {
 	// directory path, which may or may not exist yet.  This may be called
 	// more than once, so implementations must be idempotent.
 	SetUpAt(dir string) error
+	// SetSecret allows secure injection of a secret into the volume by the kubelet for volumes which require authentication
+	SetSecret(secret *api.Secret)
 }
 
 // Cleaner interface provides method to cleanup/unmount the volumes.


### PR DESCRIPTION
Some volumes currently need secrets (ceph, gluster).  Most other volumes can be enhanced to support authentication (securing HostPath, auth to gitrepo, NFS, etc.).
- Volumes have named secrets which are found in the pod's namespace
- Persistent Volumes have ObjectRefs to any Secret in the system
- Secrets are looked up by Kubelet and injected into the volume builder before SetUp() is called

@thockin @smarterclayton @pmorie 

As suggested in #6578.
