### PR TITLE
pkg/apiserver: use correct HTTP status code for bad method

### DIFF
--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -64,8 +64,8 @@ func ReadOnly(handler http.Handler) http.Handler {
 			handler.ServeHTTP(w, req)
 			return
 		}
-		w.WriteHeader(http.StatusForbidden)
-		fmt.Fprintf(w, "This is a read-only endpoint.")
+		w.Header().Set("Allow", "GET")
+		http.Error(w, "This is a read-only endpoint.", http.StatusMethodNotAllowed)
 	})
 }
 


### PR DESCRIPTION
405 is more accurate than 403 according to http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html.

But I am not sure if this breaks the existing API.
