### PR TITLE
Set Weave To 0.9.0 And Update Etcd Configuration For Azure

### DIFF
--- a/docs/getting-started-guides/coreos/azure/cloud_config_templates/kubernetes-cluster-etcd-node-template.yml
+++ b/docs/getting-started-guides/coreos/azure/cloud_config_templates/kubernetes-cluster-etcd-node-template.yml
@@ -37,6 +37,7 @@ coreos:
         Environment=ETCD_INITIAL_ADVERTISE_PEER_URLS=http://%host%:2380
         Environment=ETCD_LISTEN_PEER_URLS=http://%host%:2380
         Environment=ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379,http://0.0.0.0:4001
+        Environment=ETCD_ADVERTISE_CLIENT_URLS=http://%host%:2379,http://%host%:4001
         Environment=ETCD_INITIAL_CLUSTER=%cluster%
         Environment=ETCD_INITIAL_CLUSTER_STATE=new
         ExecStart=/opt/bin/etcd2

--- a/docs/getting-started-guides/coreos/azure/cloud_config_templates/kubernetes-cluster-main-nodes-template.yml
+++ b/docs/getting-started-guides/coreos/azure/cloud_config_templates/kubernetes-cluster-main-nodes-template.yml
@@ -129,7 +129,7 @@ coreos:
         ExecStartPre=/usr/bin/curl \
           --silent \
           --location \
-          https://github.com/zettio/weave/releases/download/latest_release/weave \
+          https://github.com/weaveworks/weave/releases/download/v0.9.0/weave \
           --output /opt/bin/weave
         ExecStartPre=/usr/bin/curl \
           --silent \


### PR DESCRIPTION
Weave 0.10.0 has just been released and after testing, it doesn't work with the current Azure scripts.
