### PR TITLE
Break request metrics in apiserver by client.

### DIFF
--- a/pkg/apiserver/proxy.go
+++ b/pkg/apiserver/proxy.go
@@ -33,6 +33,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream"
 	proxyutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util/proxy"
 
@@ -55,7 +56,7 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var apiResource string
 	var httpCode int
 	reqStart := time.Now()
-	defer monitor("proxy", &verb, &apiResource, &httpCode, reqStart)
+	defer monitor(&verb, &apiResource, util.GetClient(req), &httpCode, reqStart)
 
 	requestInfo, err := r.apiRequestInfoResolver.GetAPIRequestInfo(req)
 	if err != nil {

--- a/pkg/apiserver/redirect.go
+++ b/pkg/apiserver/redirect.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/httplog"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 type RedirectHandler struct {
@@ -39,7 +40,7 @@ func (r *RedirectHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var apiResource string
 	var httpCode int
 	reqStart := time.Now()
-	defer monitor("redirect", &verb, &apiResource, &httpCode, reqStart)
+	defer monitor(&verb, &apiResource, util.GetClient(req), &httpCode, reqStart)
 
 	requestInfo, err := r.apiRequestInfoResolver.GetAPIRequestInfo(req)
 	if err != nil {

--- a/pkg/apiserver/validator.go
+++ b/pkg/apiserver/validator.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/probe"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 // TODO: this basic interface is duplicated in N places.  consolidate?
@@ -101,7 +102,7 @@ func (v *validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	apiResource := ""
 	var httpCode int
 	reqStart := time.Now()
-	defer monitor("validate", &verb, &apiResource, &httpCode, reqStart)
+	defer monitor(&verb, &apiResource, util.GetClient(r), &httpCode, reqStart)
 
 	reply := []ServerStatus{}
 	for name, server := range v.servers() {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"os"
 	"path"
 	"reflect"
@@ -490,4 +491,13 @@ func chooseHostInterfaceFromRoute(inFile io.Reader, nw networkInterfacer) (net.I
 		return nil, fmt.Errorf("Unable to select an IP.")
 	}
 	return nil, nil
+}
+
+func GetClient(req *http.Request) string {
+	if userAgent, ok := req.Header["User-Agent"]; ok {
+		if len(userAgent) > 0 {
+			return userAgent[0]
+		}
+	}
+	return "unknown"
 }


### PR DESCRIPTION
Example metrics:

apiserver_request_count{client="kubelet/v0.15.0 (linux/amd64) kubernetes/21788d8",code="200",resource="pods",verb="DELETE"} 3
apiserver_request_count{client="kubelet/v0.15.0 (linux/amd64) kubernetes/21788d8",code="200",resource="pods",verb="GET"} 7112
apiserver_request_count{client="kubelet/v0.15.0 (linux/amd64) kubernetes/21788d8",code="200",resource="pods",verb="LIST"} 2678
apiserver_request_count{client="kubelet/v0.15.0 (linux/amd64) kubernetes/21788d8",code="200",resource="pods",verb="POST"} 86
apiserver_request_count{client="kubelet/v0.15.0 (linux/amd64) kubernetes/21788d8",code="200",resource="pods",verb="PUT"} 7088
apiserver_request_count{client="kubelet/v0.15.0 (linux/amd64) kubernetes/21788d8",code="200",resource="pods",verb="WATCHLIST"} 4198

This fixes #7069

@alex-mohr @a-robinson 
