### PR TITLE
Use KUBE_SKIP_UPDATE in Jenkins

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -102,6 +102,10 @@ else
         exit 1
     fi
 
+    # Tell kube-up.sh to skip the update, it doesn't lock. An internal
+    # gcloud bug can cause racing component updates to stomp on each
+    # other.
+    export KUBE_SKIP_UPDATE=y
     sudo flock -x -n /var/run/lock/gcloud-components.lock -c "gcloud components update -q" || true
 
     # The "ci" bucket is for builds like "v0.15.0-468-gfa648c1"


### PR DESCRIPTION
After #7146, we need to protect Jenkins from the internal gcloud bug (again).
