### PR TITLE
Validate Node IPs; clean up validation code

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -113,3 +113,20 @@ var standardFinalizers = util.NewStringSet(
 func IsStandardFinalizerName(str string) bool {
 	return standardFinalizers.Has(str)
 }
+
+// AddToNodeAddresses appends the NodeAddresses to the passed-by-pointer slice,
+// only if they do not already exist
+func AddToNodeAddresses(addresses *[]NodeAddress, addAddresses ...NodeAddress) {
+	for _, add := range addAddresses {
+		exists := false
+		for _, existing := range *addresses {
+			if existing.Address == add.Address && existing.Type == add.Type {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			*addresses = append(*addresses, add)
+		}
+	}
+}

--- a/pkg/api/helpers_test.go
+++ b/pkg/api/helpers_test.go
@@ -85,3 +85,60 @@ func TestIsStandardResource(t *testing.T) {
 		}
 	}
 }
+
+func TestAddToNodeAddresses(t *testing.T) {
+	testCases := []struct {
+		existing []NodeAddress
+		toAdd    []NodeAddress
+		expected []NodeAddress
+	}{
+		{
+			existing: []NodeAddress{},
+			toAdd:    []NodeAddress{},
+			expected: []NodeAddress{},
+		},
+		{
+			existing: []NodeAddress{},
+			toAdd: []NodeAddress{
+				{Type: NodeExternalIP, Address: "1.1.1.1"},
+				{Type: NodeHostName, Address: "localhost"},
+			},
+			expected: []NodeAddress{
+				{Type: NodeExternalIP, Address: "1.1.1.1"},
+				{Type: NodeHostName, Address: "localhost"},
+			},
+		},
+		{
+			existing: []NodeAddress{},
+			toAdd: []NodeAddress{
+				{Type: NodeExternalIP, Address: "1.1.1.1"},
+				{Type: NodeExternalIP, Address: "1.1.1.1"},
+			},
+			expected: []NodeAddress{
+				{Type: NodeExternalIP, Address: "1.1.1.1"},
+			},
+		},
+		{
+			existing: []NodeAddress{
+				{Type: NodeExternalIP, Address: "1.1.1.1"},
+				{Type: NodeInternalIP, Address: "10.1.1.1"},
+			},
+			toAdd: []NodeAddress{
+				{Type: NodeExternalIP, Address: "1.1.1.1"},
+				{Type: NodeHostName, Address: "localhost"},
+			},
+			expected: []NodeAddress{
+				{Type: NodeExternalIP, Address: "1.1.1.1"},
+				{Type: NodeInternalIP, Address: "10.1.1.1"},
+				{Type: NodeHostName, Address: "localhost"},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		AddToNodeAddresses(&tc.existing, tc.toAdd...)
+		if !Semantic.DeepEqual(tc.expected, tc.existing) {
+			t.Error("case[%d], expected: %v, got: %v", i, tc.expected, tc.existing)
+		}
+	}
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1166,7 +1166,6 @@ type NodeAddress struct {
 
 // NodeResources is an object for conveying resource information about a node.
 // see http://docs.k8s.io/resources.md for more details.
-// TODO: Use ResourceList instead?
 type NodeResources struct {
 	// Capacity represents the available resources of a node
 	Capacity ResourceList `json:"capacity,omitempty"`
@@ -1815,22 +1814,6 @@ const (
 	MergePatchType          PatchType = "application/merge-patch+json"
 	StrategicMergePatchType PatchType = "application/strategic-merge-patch+json"
 )
-
-// Appends the NodeAddresses to the passed-by-pointer slice, only if they do not already exist
-func AddToNodeAddresses(addresses *[]NodeAddress, addAddresses ...NodeAddress) {
-	for _, add := range addAddresses {
-		exists := false
-		for _, existing := range *addresses {
-			if existing.Address == add.Address && existing.Type == add.Type {
-				exists = true
-				break
-			}
-		}
-		if !exists {
-			*addresses = append(*addresses, add)
-		}
-	}
-}
 
 // Type and constants for component health validation.
 type ComponentConditionType string

--- a/pkg/registry/minion/rest.go
+++ b/pkg/registry/minion/rest.go
@@ -71,13 +71,13 @@ func (nodeStrategy) PrepareForUpdate(obj, old runtime.Object) {
 // Validate validates a new node.
 func (nodeStrategy) Validate(ctx api.Context, obj runtime.Object) fielderrors.ValidationErrorList {
 	node := obj.(*api.Node)
-	return validation.ValidateMinion(node)
+	return validation.ValidateNode(node)
 }
 
 // ValidateUpdate is the default update validation for an end user.
 func (nodeStrategy) ValidateUpdate(ctx api.Context, obj, old runtime.Object) fielderrors.ValidationErrorList {
-	errorList := validation.ValidateMinion(obj.(*api.Node))
-	return append(errorList, validation.ValidateMinionUpdate(old.(*api.Node), obj.(*api.Node))...)
+	errorList := validation.ValidateNode(obj.(*api.Node))
+	return append(errorList, validation.ValidateNodeUpdate(old.(*api.Node), obj.(*api.Node))...)
 }
 
 type nodeStatusStrategy struct {
@@ -98,7 +98,7 @@ func (nodeStatusStrategy) PrepareForUpdate(obj, old runtime.Object) {
 }
 
 func (nodeStatusStrategy) ValidateUpdate(ctx api.Context, obj, old runtime.Object) fielderrors.ValidationErrorList {
-	return validation.ValidateMinionUpdate(old.(*api.Node), obj.(*api.Node))
+	return validation.ValidateNodeUpdate(old.(*api.Node), obj.(*api.Node))
 }
 
 // ResourceGetter is an interface for retrieving resources by ResourceLocation.


### PR DESCRIPTION
Couple small fixes:
1. validate duplicate node ips #5188 
2. rename 'minion' -> 'node' in validation code
3. move AddToNodeAddresses from api.types to api.helpers, and add a test for it
4. remove some deprecated TODOs
