### PR TITLE
AWS: Set hostname_override for minions, back to fully-qualified name

### DIFF
--- a/cluster/aws/templates/salt-minion.sh
+++ b/cluster/aws/templates/salt-minion.sh
@@ -30,6 +30,18 @@ grains:
   cloud: aws
 EOF
 
+# We set the hostname_override to the full EC2 private dns name
+# we'd like to use EC2 instance-id, but currently the kubelet health-check assumes the name
+# is resolvable, although that check should be going away entirely (#7092)
+if [[ -z "${HOSTNAME_OVERRIDE}" ]]; then
+  HOSTNAME_OVERRIDE=`curl --silent curl http://169.254.169.254/2007-01-19/meta-data/local-hostname`
+fi
+
+if [[ -n "${HOSTNAME_OVERRIDE}" ]]; then
+  cat <<EOF >>/etc/salt/minion.d/grains.conf
+  hostname_override: "${HOSTNAME_OVERRIDE}"
+EOF
+fi
 
 if [[ -n "${DOCKER_OPTS}" ]]; then
   cat <<EOF >>/etc/salt/minion.d/grains.conf


### PR DESCRIPTION
This is a stop-gap fix; we'd really like to use EC2 instance ids,
but that is blocked by #7092 or changing that health-check to not
assume that the node name is resolvable.

This stop-gap essentially reverts #7072 for AWS
