### PR TITLE
Support absence of source RC in RollingUpdater

### DIFF
--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"time"
 
@@ -201,7 +202,7 @@ func RunRollingUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, arg
 			filename, oldName)
 	}
 
-	updater := kubectl.NewRollingUpdater(newRc.Namespace, kubectl.NewRollingUpdaterClient(client))
+	updater := kubectl.NewRollingUpdater(newRc.Namespace, kubectl.NewRollingUpdaterClient(client), ioutil.Discard)
 
 	var hasLabel bool
 	for key, oldValue := range oldRc.Spec.Selector {


### PR DESCRIPTION
This is some POC work to show what's involved in changing RollingUpdater to support the absence of an "old" ReplicationController. These changes would also allow OpenShift to make use of RollingUpdater by pre-processing our RCs to include the annotations RollingUpdater expects.

I'm not crazy about having to set annotations, but I'd rather do that downstream than change the fundamental operating principals of this code. I'm also not entirely pleased with how this refactored code reads (feels modal), but at least there's something to talk about. 

cc @smarterclayton @bgrant0607 
