### PR TITLE
removed elasticsearch and fluentd-gcp pods from master

### DIFF
--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -58,14 +58,6 @@ base:
     - kubelet
 {% endif %}
 
-{% if pillar.get('enable_node_logging', '').lower() == 'true' and pillar['logging_destination'] is defined %}
-  {% if pillar['logging_destination'] == 'elasticsearch' %}
-    - fluentd-es
-  {% elif pillar['logging_destination'] == 'gcp' %}
-    - fluentd-gcp
-  {% endif %}
-{% endif %}
-
   'roles:kubernetes-pool-vsphere':
     - match: grain
     - static-routes


### PR DESCRIPTION
I had added the elasticsearch and fluentd-gcp pods to master about 3 weeks ago in preparation to extract logs from master component pods.

But a decision has yet to be made on how we are doing to do log extraction from master pods.
Also, these logging pods need kube-proxy to work.

Till a final decision is made on log extraction from master component pods, I am removing elasticsearch and fluentd-gcp pods from master.
