### PR TITLE
Updates to etcd.manifest

### DIFF
--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -19,7 +19,7 @@
     "command": [
               "/bin/sh",
               "-c",
-              "/usr/local/bin/etcd --addr 127.0.0.1:4001 --bind-addr 127.0.0.1:4001 --data-dir /var/etcd/data 1>>/var/log/etcd.log 2>&1"
+              "/usr/local/bin/etcd --advertise-client-urls http://127.0.0.1:4001 --listen-client-urls http://127.0.0.1:4001 --data-dir /var/etcd/data 1>>/var/log/etcd.log 2>&1"
             ],
     "livenessProbe": {
       "httpGet": {


### PR DESCRIPTION
etcd.manifest seems to be using old CLI parameters -addr and --bind-addr which have replaced with --advertise-client-urls, and --listen-client-urls. Ports 4001,7001 have been replaced with 2379, 2380. Also added --initial-advertise-peer-urls and --listen-peer-urls options to listen on port 2380.
