### PR TITLE
Revert "Change kube2sky to use token-system-dns secret, point at https e...

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -29,15 +29,10 @@ desiredState:
                     "-advertise-client-urls=http://127.0.0.1:4001",
             ]
           - name: kube2sky
-            image: gcr.io/google_containers/kube2sky:1.2
-            volumeMounts:
-              - name: dns-token
-                mountPath: /etc/dns_token
-                readOnly: true
+            image: gcr.io/google_containers/kube2sky:1.1
             command: [
                     # entrypoint = "/kube2sky",
                     "-domain={{ pillar['dns_domain'] }}",
-                    "-kubecfg_file=/etc/dns_token/kubeconfig",
             ]
           - name: skydns
             image: gcr.io/google_containers/skydns:2015-03-11-001
@@ -51,11 +46,3 @@ desiredState:
               - name: dns
                 containerPort: 53
                 protocol: UDP
-        volumes:
-          - name: dns-token
-            source:
-              secret:
-                target:
-                  kind: Secret
-                  namespace: default
-                  name: token-system-dns


### PR DESCRIPTION
Reverts GoogleCloudPlatform/kubernetes#7154. Seems to have caused the breaking of few e2e tests.
