### PR TITLE
Updating serviceErrorHandler to use apiVersion specific codec

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -155,8 +155,8 @@
 		},
 		{
 			"ImportPath": "github.com/emicklei/go-restful",
-			"Comment": "v1.1.3-34-g5e1952e",
-			"Rev": "5e1952ed0806503c059e4463c2654200660f484b"
+			"Comment": "v1.1.3-40-g4f30cbd",
+			"Rev": "4f30cbd5bd858a523d8fe9bd484f44513f50eeec"
 		},
 		{
 			"ImportPath": "github.com/evanphx/json-patch",

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/container.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/container.go
@@ -54,8 +54,9 @@ func (c *Container) RecoverHandler(handler RecoverHandleFunction) {
 }
 
 // ServiceErrorHandleFunction declares functions that can be used to handle a service error situation.
-// The first argument is the service error. The second must be used to communicate an error response.
-type ServiceErrorHandleFunction func(ServiceError, *Response)
+// The first argument is the service error, the second is the request that resulted in the error and
+// the third must be used to communicate an error response.
+type ServiceErrorHandleFunction func(ServiceError, *Request, *Response)
 
 // ServiceErrorHandler changes the default function (writeServiceError) to be called
 // when a ServiceError is detected.
@@ -143,7 +144,7 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 // writeServiceError is the default ServiceErrorHandleFunction and is called
 // when a ServiceError is returned during route selection. Default implementation
 // calls resp.WriteErrorString(err.Code, err.Message)
-func writeServiceError(err ServiceError, resp *Response) {
+func writeServiceError(err ServiceError, req *Request, resp *Response) {
 	resp.WriteErrorString(err.Code, err.Message)
 }
 
@@ -194,7 +195,7 @@ func (c *Container) dispatch(httpWriter http.ResponseWriter, httpRequest *http.R
 			switch err.(type) {
 			case ServiceError:
 				ser := err.(ServiceError)
-				c.serviceErrorHandleFunc(ser, resp)
+				c.serviceErrorHandleFunc(ser, req, resp)
 			}
 			// TODO
 		}}

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/CHANGES.md
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/CHANGES.md
@@ -1,5 +1,8 @@
 Change history of swagger
 =
+2015-04-09
+- add ModelBuildable interface for customization of Model
+
 2015-03-17
 - preserve order of Routes per WebService in Swagger listing
 - fix use of $ref and type in Swagger models

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/model_builder_test.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/model_builder_test.go
@@ -647,6 +647,61 @@ func TestStructA3(t *testing.T) {
  }`)
 }
 
+type A4 struct {
+	D "json:,inline"
+}
+
+// clear && go test -v -test.run TestStructA4 ...swagger
+func TestEmbeddedStructA4(t *testing.T) {
+	testJsonFromStruct(t, A4{}, `{
+  "swagger.A4": {
+   "id": "swagger.A4",
+   "required": [
+    "Id"
+   ],
+   "properties": {
+    "Id": {
+     "type": "integer",
+     "format": "int32"
+    }
+   }
+  }
+ }`)
+}
+
+type A5 struct {
+	D `json:"d"`
+}
+
+// clear && go test -v -test.run TestStructA5 ...swagger
+func TestEmbeddedStructA5(t *testing.T) {
+	testJsonFromStruct(t, A5{}, `{
+  "swagger.A5": {
+   "id": "swagger.A5",
+   "required": [
+    "d"
+   ],
+   "properties": {
+    "d": {
+     "$ref": "swagger.D"
+    }
+   }
+  },
+  "swagger.D": {
+   "id": "swagger.D",
+   "required": [
+    "Id"
+   ],
+   "properties": {
+    "Id": {
+     "type": "integer",
+     "format": "int32"
+    }
+   }
+  }
+ }`)
+}
+
 type ObjectId []byte
 
 type Region struct {

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/postbuild_model_test.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/postbuild_model_test.go
@@ -1,0 +1,42 @@
+package swagger
+
+import "testing"
+
+type Boat struct {
+	Length int `json:"-"` // on default, this makes the fields not required
+	Weight int `json:"-"`
+}
+
+// PostBuildModel is from swagger.ModelBuildable
+func (b Boat) PostBuildModel(m *Model) *Model {
+	// override required
+	m.Required = []string{"Length", "Weight"}
+
+	// add model property (just to test is can be added; is this a real usecase?)
+	extraType := "string"
+	m.Properties["extra"] = ModelProperty{
+		Description: "extra description",
+		DataTypeFields: DataTypeFields{
+			Type: &extraType,
+		},
+	}
+	return m
+}
+
+func TestCustomPostModelBuilde(t *testing.T) {
+	testJsonFromStruct(t, Boat{}, `{
+  "swagger.Boat": {
+   "id": "swagger.Boat",
+   "required": [
+    "Length",
+    "Weight"
+   ],
+   "properties": {
+    "extra": {
+     "type": "string",
+     "description": "extra description"
+    }
+   }
+  }
+}`)
+}

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/swagger_webservice.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/swagger_webservice.go
@@ -299,7 +299,7 @@ func (sws SwaggerService) addModelFromSampleTo(operation *Operation, isResponse 
 		}
 		operation.Type = modelName
 	}
-	modelBuilder{models}.addModel(reflect.TypeOf(sample), "")
+	modelBuilder{models}.addModelFrom(sample)
 }
 
 func asSwaggerParameter(param restful.ParameterData) Parameter {

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/utils_test.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/utils_test.go
@@ -18,7 +18,7 @@ func testJsonFromStruct(t *testing.T, sample interface{}, expectedJson string) b
 func modelsFromStruct(sample interface{}) map[string]Model {
 	models := map[string]Model{}
 	builder := modelBuilder{models}
-	builder.addModel(reflect.TypeOf(sample), "")
+	builder.addModelFrom(sample)
 	return models
 }
 

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -449,7 +449,9 @@ func (m *Master) init(c *Config) {
 
 	apiserver.InstallSupport(m.muxHelper, m.rootWebService)
 	apiserver.AddApiWebService(m.handlerContainer, c.APIPrefix, apiVersions)
-	apiserver.InstallServiceErrorHandler(m.handlerContainer)
+	defaultVersion := m.defaultAPIGroupVersion()
+	requestInfoResolver := &apiserver.APIRequestInfoResolver{util.NewStringSet(strings.TrimPrefix(defaultVersion.Root, "/")), defaultVersion.Mapper}
+	apiserver.InstallServiceErrorHandler(m.handlerContainer, requestInfoResolver, apiVersions)
 
 	// Register root handler.
 	// We do not register this using restful Webservice since we do not want to surface this in api docs.


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/6999

```
$ curl -X PUT -i http://localhost:8080/api/v1beta3/redirect/namespaces/default/services/kubernetes
HTTP/1.1 405 Method Not Allowed
Content-Type: application/json
Date: Thu, 23 Apr 2015 07:12:57 GMT
Content-Length: 234

{
  "kind": "Status",
  "apiVersion": "v1beta3",
  "metadata": {},
  "status": "Failure",
  "message": "the server does not allow this method on the requested resource",
  "reason": "MethodNotAllowed",
  "details": {},
  "code": 405
}
```

```
curl -X PUT -i http://localhost:8080/api/v1beta2/redirect/services/kubernetes
HTTP/1.1 405 Method Not Allowed
Content-Type: application/json
Date: Thu, 23 Apr 2015 07:04:49 GMT
Content-Length: 245

{
  "kind": "Status",
  "creationTimestamp": null,
  "apiVersion": "v1beta2",
  "status": "Failure",
  "message": "the server does not allow this method on the requested resource",
  "reason": "MethodNotAllowed",
  "details": {},
  "code": 405
}
```

```
$ curl -X PUT -i http://localhost:8080/api/dsadas
HTTP/1.1 404 Not Found
Content-Type: application/json
Date: Thu, 23 Apr 2015 07:04:34 GMT
Content-Length: 211

{
  "kind": "Status",
  "apiVersion": "v1beta3",
  "metadata": {},
  "status": "Failure",
  "message": "the server could not find the requested resource",
  "reason": "NotFound",
  "details": {},
  "code": 404
}
```
