### PR TITLE
Fix vagrant setup broken by commit 7475efbcfb6a2e.

### DIFF
--- a/cluster/saltbase/pillar/privilege.sls
+++ b/cluster/saltbase/pillar/privilege.sls
@@ -1,2 +1,2 @@
 # If true, allow privileged containers to be created by API
-allow_privileged: false
+allow_privileged: true

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -151,10 +151,10 @@ if [[ ! -f "${known_tokens_file}" ]]; then
   # NB: If this list ever changes, this script actually has to
   # change to detect the existence of this file, kill any deleted
   # old tokens and add any new tokens (to handle the upgrade case).
-  local -r service_accounts=("system:scheduler" "system:controller_manager" "system:logging" "system:monitoring" "system:dns")
+  service_accounts=("system:scheduler" "system:controller_manager" "system:logging" "system:monitoring" "system:dns")
   for account in "${service_accounts[@]}"; do
     token=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
-    echo "${token},${account},${account}" >> "${KNOWN_TOKENS_FILE}"
+    echo "${token},${account},${account}" >> "${known_tokens_file}"
   done
 fi
 


### PR DESCRIPTION
- 'local' can be used only inside bash functions
- s/KNOWN_TOKENS_FILE/known_tokens_file
