### PR TITLE
RFC: E2E test for GlusterFS

### DIFF
--- a/cluster/saltbase/salt/base.sls
+++ b/cluster/saltbase/salt/base.sls
@@ -5,7 +5,9 @@ pkg-core:
 {% if grains['os_family'] == 'RedHat' %}
       - python
       - git
+      - glusterfs-fuse
 {% else %}
       - apt-transport-https
       - python-apt
+      - glusterfs-client
 {% endif %}

--- a/test/e2e/nfs.go
+++ b/test/e2e/nfs.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * This test checks that NFS volume is working. It uses one pod exporting a
+ * directory and other pod consuming it, exporting its content through http.
+ *
+ * To export something via NFS, the pod must be privileged (it mounts
+ * /proc/fs/nfsd). The test reports 'success' on clusters with
+ * --allow_privileged=False (which is the default).
+ */
+
+package e2e
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NFS", func() {
+	clean := true // If 'false', the test won't clear its namespace (and pods and services) upon completion. Useful for debugging.
+
+	// filled in BeforeEach
+	var c *client.Client
+	var namespace string
+
+	BeforeEach(func() {
+		var err error
+		c, err = loadClient()
+		Expect(err).NotTo(HaveOccurred())
+		namespace = "e2e-ns-" + dateStamp() + "-0"
+	})
+
+	AfterEach(func() {
+		if !clean {
+			return
+		}
+		c.Namespaces().Delete(namespace)
+	})
+
+	It("should be able to mount NFS", func() {
+		podClient := c.Pods(namespace)
+		serviceClient := c.Services(namespace)
+
+		By("creating a NFS server pod")
+		nfs_pod := &api.Pod{
+			TypeMeta: api.TypeMeta{
+				Kind:       "Pod",
+				APIVersion: "v1beta3",
+			},
+			ObjectMeta: api.ObjectMeta{
+				Name: "nfs-server-" + string(util.NewUUID()),
+				Labels: map[string]string{
+					"role": "nfs-server",
+				},
+			},
+			Spec: api.PodSpec{
+				Containers: []api.Container{
+					{
+						Name:       "nfs-server",
+						Image:      "jsafrane/nfs-data",
+						Privileged: true,
+						Ports: []api.ContainerPort{
+							{
+								Name:          "nfs",
+								ContainerPort: 2049,
+								Protocol:      api.ProtocolTCP,
+							},
+						},
+					},
+				},
+			},
+		}
+		defer func() {
+			if !clean {
+				return
+			}
+			By("deleting the pod")
+			defer GinkgoRecover()
+			podClient.Delete(nfs_pod.Name)
+		}()
+		if _, err := podClient.Create(nfs_pod); err != nil {
+			// Skip the test when 'privileged' containers are not allowed
+			if strings.Contains(err.Error(), "spec.containers[0].privileged: forbidden 'true'") {
+				By("Skipping NFS test, which is supported only on on cluster with --allow_privileged=True")
+				return
+			}
+			// Report real error otherwise
+			Failf("Failed to create %s pod: %v", nfs_pod.Name, err)
+		}
+		expectNoError(waitForPodRunningInNamespace(c, nfs_pod.Name, namespace))
+
+		By("creating a NFS server service")
+		nfs_service := &api.Service{
+			TypeMeta: api.TypeMeta{
+				Kind:       "Service",
+				APIVersion: "v1beta3",
+			},
+			ObjectMeta: api.ObjectMeta{
+				Name: "nfs-server",
+			},
+			Spec: api.ServiceSpec{
+				Ports: []api.ServicePort{
+					{
+						Name:     "nfs",
+						Port:     2049,
+						Protocol: api.ProtocolTCP,
+					},
+				},
+				Selector: map[string]string{
+					"role": "nfs-server",
+				},
+			},
+		}
+
+		defer func() {
+			if !clean {
+				return
+			}
+			By("deleting the NFS service")
+			defer GinkgoRecover()
+			serviceClient.Delete(nfs_service.Name)
+		}()
+		if _, err := serviceClient.Create(nfs_service); err != nil {
+			Failf("Failed to create %s service: %v", nfs_service.Name, err)
+		}
+
+		By("locating the NFS server service")
+		srv, err := serviceClient.Get(nfs_service.Name)
+		expectNoError(err, "Cannot read IP address of service %v", nfs_service.Name)
+		serverIP := srv.Spec.PortalIP
+		Logf("NFS server IP address: %v", serverIP)
+
+		By("creating a NFS client pod")
+		web_pod := &api.Pod{
+			TypeMeta: api.TypeMeta{
+				Kind:       "Pod",
+				APIVersion: "v1beta3",
+			},
+			ObjectMeta: api.ObjectMeta{
+				Name: "nfs-web-" + string(util.NewUUID()),
+				Labels: map[string]string{
+					"role": "web-server",
+				},
+			},
+			Spec: api.PodSpec{
+				Containers: []api.Container{
+					{
+						Name:       "web",
+						Image:      "dockerfile/nginx",
+						Privileged: false,
+						Ports: []api.ContainerPort{
+							{
+								Name:          "web",
+								ContainerPort: 80,
+								Protocol:      api.ProtocolTCP,
+							},
+						},
+						VolumeMounts: []api.VolumeMount{
+							{
+								Name:      "nfs",
+								MountPath: "/var/www/html",
+							},
+						},
+					},
+				},
+				Volumes: []api.Volume{
+					{
+						Name: "nfs",
+						VolumeSource: api.VolumeSource{
+							NFS: &api.NFSVolumeSource{
+								Server:   serverIP,
+								Path:     "/",
+								ReadOnly: true,
+							},
+						},
+					},
+				},
+			},
+		}
+		defer func() {
+			if !clean {
+				return
+			}
+			By("deleting the pod")
+			defer GinkgoRecover()
+			podClient.Delete(web_pod.Name)
+		}()
+		if _, err := podClient.Create(web_pod); err != nil {
+			Failf("Failed to create %s pod: %v", web_pod.Name, err)
+		}
+		expectNoError(waitForPodRunningInNamespace(c, web_pod.Name, namespace))
+
+		By("reading a page from the web server")
+		body, err := c.Get().
+			Namespace(namespace).
+			Prefix("proxy").
+			Resource("pods").
+			Name(web_pod.Name).
+			DoRaw()
+		expectNoError(err, "Cannot read web page: %v", err)
+		Logf("body: %v", string(body))
+
+		By("checking the page content")
+		Expect(body).To(ContainSubstring("Hello world!"))
+	})
+})

--- a/test/e2e/nfs.go
+++ b/test/e2e/nfs.go
@@ -50,10 +50,9 @@ var _ = Describe("NFS", func() {
 	})
 
 	AfterEach(func() {
-		if !clean {
-			return
+		if clean {
+			c.Namespaces().Delete(namespace)
 		}
-		c.Namespaces().Delete(namespace)
 	})
 
 	It("should be able to mount NFS", func() {
@@ -90,12 +89,11 @@ var _ = Describe("NFS", func() {
 			},
 		}
 		defer func() {
-			if !clean {
-				return
+			if clean {
+				By("deleting the pod")
+				defer GinkgoRecover()
+				podClient.Delete(nfs_pod.Name)
 			}
-			By("deleting the pod")
-			defer GinkgoRecover()
-			podClient.Delete(nfs_pod.Name)
 		}()
 		if _, err := podClient.Create(nfs_pod); err != nil {
 			// Skip the test when 'privileged' containers are not allowed
@@ -132,12 +130,11 @@ var _ = Describe("NFS", func() {
 		}
 
 		defer func() {
-			if !clean {
-				return
+			if clean {
+				By("deleting the NFS service")
+				defer GinkgoRecover()
+				serviceClient.Delete(nfs_service.Name)
 			}
-			By("deleting the NFS service")
-			defer GinkgoRecover()
-			serviceClient.Delete(nfs_service.Name)
 		}()
 		if _, err := serviceClient.Create(nfs_service); err != nil {
 			Failf("Failed to create %s service: %v", nfs_service.Name, err)
@@ -197,12 +194,11 @@ var _ = Describe("NFS", func() {
 			},
 		}
 		defer func() {
-			if !clean {
-				return
+			if clean {
+				By("deleting the pod")
+				defer GinkgoRecover()
+				podClient.Delete(web_pod.Name)
 			}
-			By("deleting the pod")
-			defer GinkgoRecover()
-			podClient.Delete(web_pod.Name)
 		}()
 		if _, err := podClient.Create(web_pod); err != nil {
 			Failf("Failed to create %s pod: %v", web_pod.Name, err)

--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -134,6 +134,9 @@ func startVolumeServer(client *client.Client, config VolumeTestConfig) *api.Serv
 	By("locating the NFS server service")
 	srv, err := serviceClient.Get(serverService.Name)
 	expectNoError(err, "Cannot read IP address of service %v: %v", serverService.Name, err)
+
+	By("sleeping a bit to give the server time to start")
+	time.Sleep(1 * time.Second)
 	return srv
 }
 

--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * This test checks that various VolumeSources are working. For each volume
+ * type it creates a server pod + service, exporing simple 'index.html' file.
+ * Then it uses appropriate VolumeSource to import this file into a client pod
+ * and tests, that the pod can see the file. It does so by importing the file
+ * into web server root and loadind the index.html from it.
+ *
+ * These tests work only when privileged containers are allowed, exporting
+ * various filesystems (NFS, GlusterFS, ...) usually needs some mounting or
+ * other privileged magic in the server pod.
+ */
+
+package e2e
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"strings"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// Configuration of one tests. The test consist of:
+// - server pod - runs serverImage, exports ports[
+// - server service - exports ports[] from the server pod
+// - client service - does not need any special configuration
+type VolumeTestConfig struct {
+	namespace string
+	// Prefix of all pods and services. Typically the test name.
+	prefix string
+	// Name of container image for the server pod.
+	serverImage string
+	// Ports to export from the server pod via the server service. TCP only.
+	serverPorts []int
+}
+
+// Starts a container specified by config.containerImage and exports all
+// configured ports from it as a service. The returned service should be used to
+// get the server IP address and create appropriate VolumeSource.
+// The function may return nil - the test should be skipped in this case.
+func startVolumeServer(client *client.Client, config VolumeTestConfig) *api.Service {
+	podClient := client.Pods(config.namespace)
+	serviceClient := client.Services(config.namespace)
+
+	portCount := len(config.serverPorts)
+	serverPodPorts := make([]api.ContainerPort, portCount)
+	serverServicePorts := make([]api.ServicePort, portCount)
+
+	for i := 0; i < portCount; i++ {
+		portName := fmt.Sprintf("%s-%d", config.prefix, i)
+
+		serverPodPorts[i] = api.ContainerPort{
+			Name:          portName,
+			ContainerPort: config.serverPorts[i],
+			Protocol:      api.ProtocolTCP,
+		}
+
+		serverServicePorts[i] = api.ServicePort{
+			Name:     portName,
+			Port:     config.serverPorts[i],
+			Protocol: api.ProtocolTCP,
+		}
+	}
+
+	By(fmt.Sprint("creating ", config.prefix, " server pod"))
+	serverPod := &api.Pod{
+		TypeMeta: api.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1beta3",
+		},
+		ObjectMeta: api.ObjectMeta{
+			Name: config.prefix + "-server",
+			Labels: map[string]string{
+				"role": config.prefix + "-server",
+			},
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name:       config.prefix + "-server",
+					Image:      config.serverImage,
+					Privileged: true,
+					Ports: serverPodPorts,
+				},
+			},
+		},
+	}
+	if _, err := podClient.Create(serverPod); err != nil {
+		// Skip the test when 'privileged' containers are not allowed
+		if strings.Contains(err.Error(), "spec.containers[0].privileged: forbidden 'true'") {
+			By(fmt.Sprint("Skipping ", config.prefix, " test, which is supported only on on cluster with --allow_privileged=True"))
+			return nil
+		}
+		// Report real error otherwise
+		Failf("Failed to create %s pod: %v", serverPod.Name, err)
+	}
+
+	expectNoError(waitForPodRunningInNamespace(client, serverPod.Name, config.namespace))
+	By(fmt.Sprint("creating ", config.prefix, " server service"))
+	serverService := &api.Service{
+		TypeMeta: api.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1beta3",
+		},
+		ObjectMeta: api.ObjectMeta{
+			Name: config.prefix + "-server",
+		},
+		Spec: api.ServiceSpec{
+			Ports: serverServicePorts,
+			Selector: map[string]string{
+				"role": config.prefix + "-server",
+			},
+		},
+	}
+	if _, err := serviceClient.Create(serverService); err != nil {
+		Failf("Failed to create %s service: %v", serverService.Name, err)
+	}
+
+	By("locating the NFS server service")
+	srv, err := serviceClient.Get(serverService.Name)
+	expectNoError(err, "Cannot read IP address of service %v: %v", serverService.Name, err)
+	return srv
+}
+
+// Clean both server pod+service and client pod.
+func volumeTestCleanup(client *client.Client, config VolumeTestConfig) {
+	By(fmt.Sprint("cleaning the environment after ", config.prefix))
+
+	defer GinkgoRecover()
+
+	podClient := client.Pods(config.namespace)
+	serviceClient := client.Services(config.namespace)
+
+ 	// ignore all errors, the pods/services may not be even created
+	podClient.Delete(config.prefix + "-client")
+	serviceClient.Delete(config.prefix + "-server")
+	podClient.Delete(config.prefix + "-server")
+
+	if config.namespace != "default" {
+		client.Namespaces().Delete(config.namespace)
+	}
+}
+
+// Start a client pod using given VolumeSource (exported by startVolumeServer())
+// and check that the pod sees the data from the server pod+service.
+func testVolumeClient(client *client.Client, config VolumeTestConfig, volume api.VolumeSource, expectedContent string) {
+	By(fmt.Sprint("starting ", config.prefix, " client"))
+	podClient := client.Pods(config.namespace)
+
+	clientPod := &api.Pod{
+		TypeMeta: api.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1beta3",
+		},
+		ObjectMeta: api.ObjectMeta{
+			Name: config.prefix + "-client",
+			Labels: map[string]string{
+				"role": config.prefix + "-client",
+			},
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name:       config.prefix + "-client",
+					Image:      "dockerfile/nginx",
+					Privileged: false,
+					Ports: []api.ContainerPort{
+						{
+							Name:          "web",
+							ContainerPort: 80,
+							Protocol:      api.ProtocolTCP,
+						},
+					},
+					VolumeMounts: []api.VolumeMount{
+						{
+							Name:      config.prefix + "-volume",
+							MountPath: "/var/www/html",
+						},
+					},
+				},
+			},
+			Volumes: []api.Volume{
+				{
+					Name: config.prefix + "-volume",
+					VolumeSource: volume,
+				},
+			},
+		},
+	}
+	if _, err := podClient.Create(clientPod); err != nil {
+		Failf("Failed to create %s pod: %v", clientPod.Name, err)
+	}
+	expectNoError(waitForPodRunningInNamespace(client, clientPod.Name, config.namespace))
+
+	By("reading a web page from the client")
+	body, err := client.Get().
+		Namespace(config.namespace).
+		Prefix("proxy").
+		Resource("pods").
+		Name(clientPod.Name).
+		DoRaw()
+	expectNoError(err, "Cannot read web page: %v", err)
+	Logf("body: %v", string(body))
+
+	By("checking the page content")
+	Expect(body).To(ContainSubstring(expectedContent))
+}
+
+var _ = Describe("Volumes", func() {
+	clean := true // If 'false', the test won't clear its namespace (and pods and services) upon completion. Useful for debugging.
+
+	// filled in BeforeEach
+	var c *client.Client
+	var namespace string
+
+	BeforeEach(func() {
+		var err error
+		c, err = loadClient()
+		Expect(err).NotTo(HaveOccurred())
+		namespace = "e2e-ns-" + dateStamp() + "-0"
+	})
+
+	It("should be able to mount NFS", func() {
+		config := VolumeTestConfig{
+			namespace: namespace,
+			prefix: "nfs",
+			serverImage: "jsafrane/nfs-data",
+			serverPorts: []int { 2049 },
+		}
+
+		defer func() {
+			if clean {
+				volumeTestCleanup(c, config)
+			}
+		}()
+
+		srv := startVolumeServer(c, config)
+		if srv == nil {
+			// Skip the test, message has been already logged.
+			return
+		}
+
+		serverIP := srv.Spec.PortalIP
+		Logf("NFS server IP address: %v", serverIP)
+
+		volume := api.VolumeSource{
+			NFS: &api.NFSVolumeSource{
+				Server:   serverIP,
+				Path:     "/",
+				ReadOnly: true,
+			},
+		}
+		testVolumeClient(c, config, volume, "Hello world!")
+	})
+})

--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -177,7 +177,7 @@ func testVolumeClient(client *client.Client, config VolumeTestConfig, volume api
 			Containers: []api.Container{
 				{
 					Name:       config.prefix + "-client",
-					Image:      "dockerfile/nginx",
+					Image:      "nginx",
 					Privileged: false,
 					Ports: []api.ContainerPort{
 						{
@@ -189,7 +189,7 @@ func testVolumeClient(client *client.Client, config VolumeTestConfig, volume api
 					VolumeMounts: []api.VolumeMount{
 						{
 							Name:      config.prefix + "-volume",
-							MountPath: "/var/www/html",
+							MountPath: "/usr/share/nginx/html",
 						},
 					},
 				},

--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -306,7 +306,7 @@ var _ = Describe("Volumes", func() {
 				ReadOnly:      true,
 			},
 		}
-		testVolumeClient(c, config, volume, "Hello from Glustr!")
+		testVolumeClient(c, config, volume, "Hello from Gluster!")
 	})
 
 })

--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2015 Google Inc. All rights reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
Based on my NFS test in PR #6755.  It has the same problems as the  NFS test - it needs "random" container which exports a file over GlusterFS. Based on Fedora, ~400MB.

I'd really like to see some policy about these test containers...
