### PR TITLE
Node upgrade daemon.

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -65,10 +65,7 @@ function usage() {
 
 function upgrade-master() {
   echo "== Upgrading master to '${SERVER_BINARY_TAR_URL}'. Do not interrupt, deleting master instance. =="
-
   detect-master
-  get-password
-  set-master-htpasswd
 
   # Delete the master instance. Note that the master-pd is created
   # with auto-delete=no, so it should not be deleted.
@@ -102,6 +99,7 @@ function wait-for-master() {
 function prepare-upgrade() {
   ensure-temp-dir
   detect-project
+  get-bearer-token
 
   if [[ "${local_binaries}" == "true" ]]; then
     find-release-tars
@@ -113,11 +111,8 @@ function prepare-upgrade() {
 
 function upgrade-nodes() {
   echo "== Upgrading nodes to ${SERVER_BINARY_TAR_URL}. =="
-
   detect-minion-names
-  get-password
-  set-master-htpasswd
-  kube-update-nodes upgrade
+  kube-update-nodes
   echo "== Done =="
 }
 

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -255,23 +255,6 @@ function detect-master () {
   echo "Using master: $KUBE_MASTER (external IP: $KUBE_MASTER_IP)"
 }
 
-# Ensure that we have a password created for validating to the master.  Will
-# read from kubeconfig for the current context if available.
-#
-# Assumed vars
-#   KUBE_ROOT
-#
-# Vars set:
-#   KUBE_USER
-#   KUBE_PASSWORD
-function get-password {
-  get-kubeconfig-basicauth
-  if [[ -z "${KUBE_USER}" || -z "${KUBE_PASSWORD}" ]]; then
-    KUBE_USER=admin
-    KUBE_PASSWORD=$(python -c 'import string,random; print "".join(random.SystemRandom().choice(string.ascii_letters + string.digits) for _ in range(16))')
-  fi
-}
-
 # Ensure that we have a bearer token created for validating to the master.
 # Will read from kubeconfig for the current context if available.
 #
@@ -415,6 +398,12 @@ function add-instance-metadata {
 }
 
 # Robustly try to add metadata on an instance, from a file.
+#
+# Assumed vars:
+#   PROJECT
+#   ZONE
+#
+# Args:
 # $1: The name of the instance.
 # $2...$n: The metadata key=file pairs to add.
 function add-instance-metadata-from-file {
@@ -862,7 +851,7 @@ function kube-push {
   echo "Pushing to master (log at ${OUTPUT}/kube-push-${KUBE_MASTER}.log) ..."
   cat ${KUBE_ROOT}/cluster/gce/configure-vm.sh | gcloud compute ssh --ssh-flag="-o LogLevel=quiet" --project "${PROJECT}" --zone "${ZONE}" "${KUBE_MASTER}" --command "sudo bash -s -- --push" &> ${OUTPUT}/kube-push-"${KUBE_MASTER}".log
 
-  kube-update-nodes push
+  kube-update-nodes
 
   # TODO(zmerlynn): Re-create instance-template with the new
   # node-kube-env. This isn't important until the node-ip-range issue
@@ -889,31 +878,17 @@ function kube-push {
 # the configure-vm from our version instead.
 #
 # Assumed vars:
-#  KUBE_ROOT
-#  MINION_NAMES
-#  KUBE_TEMP
-#  PROJECT
-#  ZONE
+#   KUBE_ROOT     (uses)
+#   MINION_NAMES  (uses)
+#   KUBE_TEMP     (uses)
+#   PROJECT       (for add-instance-medata-from-file)
+#   ZONE          (for add-instance-medata-from-file)
 function kube-update-nodes() {
-  action=${1}
-
-  OUTPUT=${KUBE_ROOT}/_output/logs
-  mkdir -p ${OUTPUT}
-
   echo "Updating node metadata... "
   write-node-env
   for (( i=0; i<${#MINION_NAMES[@]}; i++)); do
     add-instance-metadata-from-file "${MINION_NAMES[$i]}" "kube-env=${KUBE_TEMP}/node-kube-env.yaml" "startup-script=${KUBE_ROOT}/cluster/gce/configure-vm.sh" &
   done
-  wait-for-jobs
-  echo "Done"
-
-  for (( i=0; i<${#MINION_NAMES[@]}; i++)); do
-    echo "Starting ${action} on node (log at ${OUTPUT}/kube-${action}-${MINION_NAMES[$i]}.log) ..."
-    cat ${KUBE_ROOT}/cluster/gce/configure-vm.sh | gcloud compute ssh --ssh-flag="-o LogLevel=quiet" --project "${PROJECT}" --zone "${ZONE}" "${MINION_NAMES[$i]}" --command "sudo bash -s -- --push" &> ${OUTPUT}/kube-${action}-"${MINION_NAMES[$i]}".log &
-  done
-
-  echo -n "Waiting..."
   wait-for-jobs
   echo "Done"
 }

--- a/cluster/saltbase/salt/node-upgrade-gcp/init.sls
+++ b/cluster/saltbase/salt/node-upgrade-gcp/init.sls
@@ -1,0 +1,26 @@
+{% if grains['cloud'] is defined and grains['cloud'] == 'gce' %}
+/etc/kubernetes/node-upgrade-gcp.sh:
+  file.managed:
+    - source: salt://node-upgrade-gcp/node-upgrade-gcp.sh
+    - user: root
+    - group: root
+    - mode: 755
+  {% if grains['os_family'] == 'RedHat' %}
+/usr/lib/systemd/system/node-upgrade-gcp.service:
+  file.managed:
+    - source: salt://node-upgrade-gcp/node-upgrade-gcp.service
+    - user: root
+    - group: root
+  {% else %}
+/etc/init.d/node-upgrade-gcp:
+  file.managed:
+    - source: salt://node-upgrade-gcp/initd
+    - user: root
+    - group: root
+    - mode: 755
+  {% endif %}
+{% endif %}
+
+node-upgrade-gcp:
+  service.running
+    - enable: True

--- a/cluster/saltbase/salt/node-upgrade-gcp/initd
+++ b/cluster/saltbase/salt/node-upgrade-gcp/initd
@@ -1,28 +1,25 @@
 #!/bin/bash
 #
 ### BEGIN INIT INFO
-# Provides:   kube-addons
-# Required-Start:    $local_fs $network $syslog kube-apiserver
+# Provides:   node-upgrade-gcp
+# Required-Start:    $local_fs $network $syslog
 # Required-Stop:
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: Kubernetes Addon Object Manager
+# Short-Description: Node Upgrade Manager for GCP
 # Description:
-#   Enforces installation of Kubernetes Addon Objects
+#   Responsible for automatically upgrading Kuberentes software
 ### END INIT INFO
 
 
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
-DESC="Kubernetes Addon Object Manager"
-NAME=kube-addons
+DESC="Node Upgrade Manager for GCP"
+NAME=node-upgrade-gcp
 DAEMON_LOG_FILE=/var/log/$NAME.log
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
-KUBE_ADDONS_SH=/etc/kubernetes/kube-addons.sh
-
-# Read configuration variable file if it is present
-[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+NODE_UPGRADE_GCP_SH=/etc/kubernetes/node-upgrade-gcp.sh
 
 # Define LSB log_* functions.
 # Depend on lsb-base (>= 3.2-14) to ensure that this file is present
@@ -37,7 +34,7 @@ KUBE_ADDONS_SH=/etc/kubernetes/kube-addons.sh
 #
 do_start()
 {
-    ${KUBE_ADDONS_SH} </dev/null >>${DAEMON_LOG_FILE} 2>&1 &
+    ${NODE_UPGRADE_GCP_SH} </dev/null >>${DAEMON_LOG_FILE} 2>&1 &
     echo $! > ${PIDFILE}
     disown
 }

--- a/cluster/saltbase/salt/node-upgrade-gcp/node-upgrade-gcp.service
+++ b/cluster/saltbase/salt/node-upgrade-gcp/node-upgrade-gcp.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Node Upgrade Manager for GCP
+Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+
+[Service]
+ExecStart=/etc/kubernetes/node-upgrade-gcp.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/cluster/saltbase/salt/node-upgrade-gcp/node-upgrade-gcp.sh
+++ b/cluster/saltbase/salt/node-upgrade-gcp/node-upgrade-gcp.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Monitors node configuration data from the metadata server and runs node
+# upgrades when they change.
+
+# Settings
+# CACHE_DIR is where metadata files are saved once they've been curled.
+readonly CACHE_DIR="metadata-cache"
+# *_EXT denote the role of a saved metadata file.
+readonly CACHE_EXT="cache"
+readonly LATEST_EXT="latest"
+# WATCH_KEYS are the metadata keys for which, if any of their values change, a
+# node upgrade is performed.
+readonly WATCH_KEYS=("kube-env" "startup-script")
+
+# log prints to stdout all arguments received, prepending a prefix (such as the
+# date) for more readable logs.
+#
+# Args:
+#   $@ -- echos all arguments received
+function log() {
+  echo "$(date): ${@}"
+}
+
+# get-metadata curls all keys in WATCH_KEYS from the metadata server, retrying
+# until success, and saves them in CACHE_DIR named by the key and the provided
+# extension.
+#
+# Assumed vars:
+#   WATCH_KEYS
+#   CACHE_DIR
+#
+# Args:
+#  $1 -- extension to use for files (e.g. CACHE_EXT or LATEST_EXT)
+function get-metadata() {
+  local ext="${1}"
+  log "Attempting to get metadata."
+  for k in "${WATCH_KEYS[@]}"; do
+    log "Attempting to get metadata with key '${k}'."
+    local cache_file="${CACHE_DIR}/${k}.${ext}"
+    # We use --retry for some exponential backoff, but this curls until success.
+    until curl -f -s --retry 5 -o "${cache_file}" -H "Metadata-Flavor: Google" \
+      "http://metadata/computeMetadata/v1/instance/attributes/${k}"; do :; done
+    log "Successfully saved metadata with key '${k}' in '${cache_file}'."
+  done
+}
+
+# monitor-upgradability runs until any metadata on the server changes, or until
+# the request to the metadata server fails. If the request succeeds and we get
+# a metadata change, it will kick off a node upgrade if any of the values
+# retrieved by a key in WATCH_KEYS changes. This process exits if a node upgrade
+# is kicked off. Note that for any case other than performing an upgrade, it
+# returns, and thus must be called repeatedly to continue checking for upgrades.
+#
+# Assumed vars:
+#   WATCH_KEYS
+#   CACHE_DIR
+#   CACHE_EXT
+#   LATEST_EXT
+function monitor-upgradability() {
+  # Wait for _any_ metadata to change.
+  log "Waiting for metadata changes."
+  curl -s "http://metadata/computeMetadata/v1/instance/attributes/?recursive=true&wait_for_change=true" -H "Metadata-Flavor: Google"
+  result=$?
+  if [[ ${result} -ne 0 ]]; then
+    log "Metadata request failed; returned ${result}"
+    return
+  fi
+
+  # Get latest metadata.
+  log "Metadata changed; getting latest versions."
+  get-metadata "${LATEST_EXT}"
+
+  # Diff cache vs latest.
+  log "Diffing cached versus latest metadata."
+  local do_upgrade=0
+  for k in "${WATCH_KEYS[@]}"; do
+    diff "${CACHE_DIR}/${k}.${CACHE_EXT}" "${CACHE_DIR}/${k}.${LATEST_EXT}" > /dev/null
+    if [[ $? -ne 0 ]]; then
+      log "Metadata with key '${k}' differ."
+      do_upgrade=1
+      break
+    fi
+  done
+
+  # Don't upgrade if no metadata changed.
+  if [[ ${do_upgrade} -eq 0 ]]; then
+    log "No metadata differences found; will not upgrade."
+    return
+  fi
+
+  # Kick off a node upgrade.
+  log "Relevant metadata differ; performing node upgrade."
+  upgrade-node
+}
+
+# upgrade-node launches a node upgrade, assuming that the script to do so is
+# found in ${CACHE_DIR}/startup-script.${LATEST_EXT}, then exits.
+#
+# Assumed vars:
+#   CACHE_DIR
+#   LATEST_EXT
+function upgrade-node() {
+  log "Running ${CACHE_DIR}/startup-script.${LATEST_EXT}"
+  # Wait 1 second (generous) for this upgrader to exit.
+  sudo /bin/bash -c "sleep 1; /bin/bash '${CACHE_DIR}/startup-script.${LATEST_EXT}' --push" &
+  # The upgrade must start this process again.
+  log "Exiting"
+  exit 0
+}
+
+# Execution begins here.
+
+# This is running in a root-owned directory, so we do two sudo calls to create
+# a nonprivileged one.
+log "Creating cache directory '${CACHE_DIR}/'"
+sudo mkdir -p "${CACHE_DIR}"
+sudo chown $(whoami) "${CACHE_DIR}"
+
+# If we just did an upgrade, use the upgraded-to values as the current cache.
+# Otherwise, grab the current metadata as the cache (before the first upgrade,
+# any metadata changes that happens before this runs won't be caught).
+log "Checking for cached 'latest' configuration metadata."
+latest_exists=1
+for k in "${WATCH_KEYS[@]}"; do
+  if [[ ! -s "${CACHE_DIR}/${k}.${LATEST_EXT}" ]]; then
+    latest_exists=0
+  fi
+done
+if [[ latest_exists -eq 1 ]]; then
+  log "Found 'latest' versions of all required metadata. Using as current config."
+  for k in "${WATCH_KEYS[@]}"; do
+    mv "${CACHE_DIR}/${k}.${LATEST_EXT}" "${CACHE_DIR}/${k}.${CACHE_EXT}"
+  done
+else
+  log "One or more 'latest' metadata files not found locally. Getting from server."
+  get-metadata "${CACHE_EXT}"
+fi
+
+# Wait indefinitely for upgrades.
+while true; do
+  monitor-upgradability
+done

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -24,6 +24,9 @@ base:
 {% endif %}
     - logrotate
     - monit
+{% if grains['cloud'] is defined and grains['cloud'] == 'gce' %}
+    - node-upgrade-gcp
+{% endif %}
 
   'roles:kubernetes-master':
     - match: grain


### PR DESCRIPTION
Give a node upgrade must make changes to the node's system, including the kubernetes binaries, it must happen outside of the kubelet itself. Thus, there seem to be two options for doing this:
1. SSH into the node and run commands that way (affectionately known as _"blasting bash"_). This is what we have currently. 
2. Have a daemon running on the node that looks for a trigger to upgrade from some authority. This is what this PR implements, but only for GCE and using the metadata server.

In the long term, this should:
- be version-aware (don't try to upgrade across unsupported config changes, like Docker or OS)
- be a Go program
- have a versioned API (both incoming [e.g. upgrade policy] and outgoing [upgrade status])
- be able to upgrade itself
- be provider agnostic

Please be careful merging this; I suspect this will be controversial as it's a nontrivial change to node behavior, so my hope was to send this PR out so we could begin throwing chairs around the room.

This implements #6099, a basic node upgrade mechanism without any nice-to-haves.
