### PR TITLE
kubelet/container: Add Pull() and IsImagePresent() to runtime interface.

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -66,7 +66,10 @@ type Runtime interface {
 	// Attaches the processes stdin, stdout, and stderr. Optionally uses a
 	// tty.
 	ExecInContainer(container api.Container, pod *api.Pod, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool)
-	// TODO(yifan): Pull/Remove images
+	// Pull pulls an image from the network to local storage.
+	Pull(image string)
+	// IsImagePresent checks whether the container image is already in the local storage.
+	IsImagePresent(image string) (bool, error)
 }
 
 // Container runner is a narrow interface to consume in the Kubelet


### PR DESCRIPTION
@vmarmol @dchen1107 

This adds the image puller interfaces.

Here is some discussion around the docker credentials for rkt:
I was looking at `pkg/credentialprovider`, seems some of the credentials are provided dynamically via http(https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/credentialprovider/gcp/metadata.go#L120). I infer that this means the credential can actually change? Right?

Now in rkt 0.5.4, we can save the docker credential in config files on the host. But if the credentials are changing, I guess I need to update the rkt config files before each pull operation.

/cc @jonboulle 
