### PR TITLE
WIP: kubelet/rkt: Support rkt for container runtime. (Splitted into other PRs)

### DIFF
--- a/pkg/kubelet/rkt/cap.go
+++ b/pkg/kubelet/rkt/cap.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rkt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+const (
+	CAP_CHOWN = iota
+	CAP_DAC_OVERRIDE
+	CAP_DAC_READ_SEARCH
+	CAP_FOWNER
+	CAP_FSETID
+	CAP_KILL
+	CAP_SETGID
+	CAP_SETUID
+	CAP_SETPCAP
+	CAP_LINUX_IMMUTABLE
+	CAP_NET_BIND_SERVICE
+	CAP_NET_BROADCAST
+	CAP_NET_ADMIN
+	CAP_NET_RAW
+	CAP_IPC_LOCK
+	CAP_IPC_OWNER
+	CAP_SYS_MODULE
+	CAP_SYS_RAWIO
+	CAP_SYS_CHROOT
+	CAP_SYS_PTRACE
+	CAP_SYS_PACCT
+	CAP_SYS_ADMIN
+	CAP_SYS_BOOT
+	CAP_SYS_NICE
+	CAP_SYS_RESOURCE
+	CAP_SYS_TIME
+	CAP_SYS_TTY_CONFIG
+	CAP_MKNOD
+	CAP_LEASE
+	CAP_AUDIT_WRITE
+	CAP_AUDIT_CONTROL
+	CAP_SETFCAP
+	CAP_MAC_OVERRIDE
+	CAP_MAC_ADMIN
+	CAP_SYSLOG
+	CAP_WAKE_ALARM
+	CAP_BLOCK_SUSPEND
+	CAP_AUDIT_READ
+)
+
+var capalibityList = map[int]string{
+	CAP_CHOWN:            "CAP_CHOWN",
+	CAP_DAC_OVERRIDE:     "CAP_DAC_OVERRIDE",
+	CAP_DAC_READ_SEARCH:  "CAP_DAC_READ_SEARCH",
+	CAP_FOWNER:           "CAP_FOWNER",
+	CAP_FSETID:           "CAP_FSETID",
+	CAP_KILL:             "CAP_KILL",
+	CAP_SETGID:           "CAP_SETGID",
+	CAP_SETUID:           "CAP_SETUID",
+	CAP_SETPCAP:          "CAP_SETPCAP",
+	CAP_LINUX_IMMUTABLE:  "CAP_LINUX_IMMUTABLE",
+	CAP_NET_BIND_SERVICE: "CAP_NET_BIND_SERVICE",
+	CAP_NET_BROADCAST:    "CAP_NET_BROADCAST",
+	CAP_NET_ADMIN:        "CAP_NET_ADMIN",
+	CAP_NET_RAW:          "CAP_NET_RAW",
+	CAP_IPC_LOCK:         "CAP_IPC_LOCK",
+	CAP_IPC_OWNER:        "CAP_IPC_OWNER",
+	CAP_SYS_MODULE:       "CAP_SYS_MODULE",
+	CAP_SYS_RAWIO:        "CAP_SYS_RAWIO",
+	CAP_SYS_CHROOT:       "CAP_SYS_CHROOT",
+	CAP_SYS_PTRACE:       "CAP_SYS_PTRACE",
+	CAP_SYS_PACCT:        "CAP_SYS_PACCT",
+	CAP_SYS_ADMIN:        "CAP_SYS_ADMIN",
+	CAP_SYS_BOOT:         "CAP_SYS_BOOT",
+	CAP_SYS_NICE:         "CAP_SYS_NICE",
+	CAP_SYS_RESOURCE:     "CAP_SYS_RESOURCE",
+	CAP_SYS_TIME:         "CAP_SYS_TIME",
+	CAP_SYS_TTY_CONFIG:   "CAP_SYS_TTY_CONFIG",
+	CAP_MKNOD:            "CAP_MKNOD",
+	CAP_LEASE:            "CAP_LEASE",
+	CAP_AUDIT_WRITE:      "CAP_AUDIT_WRITE",
+	CAP_AUDIT_CONTROL:    "CAP_AUDIT_CONTROL",
+	CAP_SETFCAP:          "CAP_SETFCAP",
+	CAP_MAC_OVERRIDE:     "CAP_MAC_OVERRIDE",
+	CAP_MAC_ADMIN:        "CAP_MAC_ADMIN",
+	CAP_SYSLOG:           "CAP_SYSLOG",
+	CAP_WAKE_ALARM:       "CAP_WAKE_ALARM",
+	CAP_BLOCK_SUSPEND:    "CAP_BLOCK_SUSPEND",
+	CAP_AUDIT_READ:       "CAP_AUDIT_READ",
+}
+
+func getAllCapabilities() string {
+	var capabilities []string
+	for _, cap := range capalibityList {
+		capabilities = append(capabilities, fmt.Sprintf("%q", cap))
+	}
+	return strings.Join(capabilities, ",")
+}
+
+func getCapabilities(caps []api.CapabilityType) string {
+	var capList []string
+	for _, cap := range caps {
+		capList = append(capList, fmt.Sprintf("%q", cap))
+	}
+	return strings.Join(capList, ",")
+}

--- a/pkg/kubelet/rkt/config.go
+++ b/pkg/kubelet/rkt/config.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rkt
+
+import "fmt"
+
+// Config stores the global configuration for the rkt runtime.
+// Run 'rkt' for more details.
+type Config struct {
+	// The debug flag for rkt.
+	Debug bool
+	// The rkt data directory.
+	Dir string
+	// This flag controls whether we skip image or key verification.
+	InsecureSkipVerify bool
+	// The local config directory.
+	LocalConfigDir string
+}
+
+// buildGlobalOptions returns an array of global command line options.
+func (c *Config) buildGlobalOptions() []string {
+	var result []string
+	if c == nil {
+		return result
+	}
+
+	result = append(result, fmt.Sprintf("--debug=%v", c.Debug))
+	result = append(result, fmt.Sprintf("--insecure-skip-verify=%v", c.InsecureSkipVerify))
+	if c.LocalConfigDir != "" {
+		result = append(result, fmt.Sprintf("--local-config=%s", c.LocalConfigDir))
+	}
+	if c.Dir != "" {
+		result = append(result, fmt.Sprintf("--dir=%s", c.Dir))
+	}
+	return result
+}

--- a/pkg/kubelet/rkt/log.go
+++ b/pkg/kubelet/rkt/log.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rkt
+
+import (
+	"io"
+	"os/exec"
+	"strconv"
+
+	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
+)
+
+// GetContainerLogs uses journalctl to get the logs of the container.
+// By default, it returns a snapshot of the container log. Set |follow| to true to
+// stream the log. Set |follow| to false and specify the number of lines (e.g.
+// "100" or "all") to tail the log.
+func (r *Runtime) GetContainerLogs(pod kubecontainer.Pod, tail string, follow bool, stdout, stderr io.Writer) error {
+	unitName := makePodServiceFileName(pod.Name, pod.Namespace, pod.ID)
+	cmd := exec.Command("journalctl", "-u", unitName)
+	if follow {
+		cmd.Args = append(cmd.Args, "-f")
+	}
+	if tail == "all" {
+		cmd.Args = append(cmd.Args, "-a")
+	} else {
+		_, err := strconv.Atoi(tail)
+		if err == nil {
+			cmd.Args = append(cmd.Args, "-n", tail)
+		}
+	}
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+	return cmd.Start()
+}

--- a/pkg/kubelet/rkt/pod_info.go
+++ b/pkg/kubelet/rkt/pod_info.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rkt
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/golang/glog"
+)
+
+type podInfo struct {
+	state       string
+	networkInfo string
+	pid         int
+	// A map from image hashes to exit codes.
+	// TODO(yifan): Should be appName to exit code in the future.
+	exitCodes map[string]int
+}
+
+func newPodInfo() *podInfo {
+	return &podInfo{exitCodes: make(map[string]int)}
+}
+
+func (p *podInfo) parseStatus(status []string) error {
+	for _, line := range status {
+		tuples := strings.SplitN(line, "=", 2)
+		if len(tuples) != 2 {
+			glog.Warningf("Invalid status line: %q", line)
+			continue
+		}
+		switch tuples[0] {
+		case "state":
+			p.state = tuples[1]
+		case "networks":
+			p.networkInfo = tuples[1]
+		case "pid":
+			pid, err := strconv.Atoi(tuples[1])
+			if err != nil {
+				glog.Errorf("Cannot parse pid %q: %v", tuples[1], err)
+				continue
+			}
+			p.pid = pid
+		}
+		if strings.HasPrefix(tuples[0], "sha512") {
+			if p.exitCodes == nil {
+				p.exitCodes = make(map[string]int)
+			}
+			exitcode, err := strconv.Atoi(tuples[1])
+			if err != nil {
+				glog.Errorf("Cannot parse exit code %q: %v", tuples[1], err)
+			} else {
+				p.exitCodes[tuples[0]] = exitcode
+			}
+		}
+	}
+	return nil
+}
+
+// getIP returns the IP of a pod by parsing the network info.
+// The network info looks like this:
+//
+// default:ip4=172.16.28.3, database:ip4=172.16.28.42
+//
+func (p *podInfo) getIP() string {
+	parts := strings.Split(p.networkInfo, ",")
+
+	for _, part := range parts {
+		if strings.HasPrefix(part, "default:") {
+			return strings.Split(part, "=")[1]
+		}
+	}
+	return ""
+}
+
+// getContainerStatus converts the rkt pod state to the api.containerStatus.
+// TODO(yifan): Get more detailed info such as Image, ImageID, etc.
+func (p *podInfo) getContainerStatus(container *kubecontainer.Container) api.ContainerStatus {
+	var status api.ContainerStatus
+	status.Name = container.Name
+	status.Image = container.Image
+
+	containerID, _ := parseContainerID(string(container.ID))
+	status.ImageID = containerID.imageID
+
+	switch p.state {
+	case Running:
+		// TODO(yifan): Get StartedAt.
+		status.State = api.ContainerState{
+			Running: &api.ContainerStateRunning{
+				StartedAt: util.Unix(container.Created, 0),
+			},
+		}
+	case Embryo, Preparing, Prepared:
+		status.State = api.ContainerState{Waiting: &api.ContainerStateWaiting{}}
+	case AbortedPrepare, Deleting, Exited, Garbage:
+		status.State = api.ContainerState{
+			Termination: &api.ContainerStateTerminated{
+				ExitCode:  p.exitCodes[status.ImageID],
+				StartedAt: util.Unix(container.Created, 0),
+			},
+		}
+	default:
+		glog.Warningf("Unknown pod state: %q", p.state)
+	}
+	return status
+}
+
+func (p *podInfo) toPodStatus(pod *kubecontainer.Pod) api.PodStatus {
+	var status api.PodStatus
+	status.PodIP = p.getIP()
+	// For now just make every container's state as same as the pod.
+	for _, container := range pod.Containers {
+		status.ContainerStatuses = append(status.ContainerStatuses, p.getContainerStatus(container))
+	}
+	return status
+}

--- a/pkg/kubelet/rkt/pod_info.go
+++ b/pkg/kubelet/rkt/pod_info.go
@@ -36,7 +36,7 @@ type podInfo struct {
 }
 
 func newPodInfo() *podInfo {
-	return &podInfo{exitCodes: make(map[string]int)}
+	return &podInfo{pid: -1, exitCodes: make(map[string]int)}
 }
 
 func (p *podInfo) parseStatus(status []string) error {

--- a/pkg/kubelet/rkt/pull.go
+++ b/pkg/kubelet/rkt/pull.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rkt
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/docker/docker/pkg/parsers"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/golang/glog"
+)
+
+func (r *Runtime) writeDockerAuthConfig(image string, creds docker.AuthConfiguration) error {
+	registry := "index.docker.io"
+	// Image spec: [<registry>/]<repository>/<image>[:<version]
+	explicitRegistry := (strings.Count(image, "/") == 2)
+	if explicitRegistry {
+		registry = strings.Split(image, "/")[0]
+	}
+
+	localConfigDir := rktLocalConfigDir
+	if r.config.LocalConfigDir != "" {
+		localConfigDir = r.config.LocalConfigDir
+	}
+	authDir := path.Join(localConfigDir, "auth.d")
+	if _, err := os.Stat(authDir); os.IsNotExist(err) {
+		if err := os.Mkdir(authDir, 0600); err != nil {
+			glog.Errorf("Cannot create auth dir: %v", err)
+			return err
+		}
+	}
+	f, err := os.Create(path.Join(localConfigDir, "auth.d", registry+".json"))
+	if err != nil {
+		glog.Errorf("Cannot create docker auth config file: %v", err)
+		return err
+	}
+	defer f.Close()
+	config := fmt.Sprintf(dockerAuthTemplate, registry, creds.Username, creds.Password)
+	if _, err := f.Write([]byte(config)); err != nil {
+		glog.Errorf("Cannot write docker auth config file: %v", err)
+		return err
+	}
+	return nil
+}
+
+// PullImage invokes 'rkt fetch' to download an aci.
+func (r *Runtime) PullImage(img string) error {
+	if strings.HasPrefix(img, dockerPrefix) {
+		repoToPull, tag := parsers.ParseRepositoryTag(img)
+		// If no tag was specified, use the default "latest".
+		if len(tag) == 0 {
+			tag = "latest"
+		}
+
+		creds, ok := r.dockerKeyring.Lookup(repoToPull)
+		if !ok {
+			glog.V(1).Infof("Pulling image %s without credentials", img)
+		}
+
+		// Let's update a json.
+		// TODO(yifan): Find a way to feed this to rkt.
+		if err := r.writeDockerAuthConfig(img, creds); err != nil {
+			return err
+		}
+	}
+
+	output, err := r.RunCommand("fetch", img)
+	if err != nil {
+		return fmt.Errorf("failed to fetch image: %v:", output)
+	}
+	return nil
+}
+
+// IsImagePresent returns true if the image is available on the machine.
+// TODO(yifan): This is hack, which uses 'rkt prepare --local' to test whether
+// the image is present.
+func (r *Runtime) IsImagePresent(img string) (bool, error) {
+	if _, err := r.RunCommand("prepare", "--local=true", img); err != nil {
+		return false, nil
+	}
+	return true, nil
+}

--- a/pkg/kubelet/rkt/rkt-metadata.service
+++ b/pkg/kubelet/rkt/rkt-metadata.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=rkt metadata service
+Documentation=http://github.com/coreos/rkt
+After=network.target rkt-metadata.socket
+Requires=rkt-metadata.socket
+
+[Service]
+ExecStart=/usr/bin/rkt metadata-service
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/kubelet/rkt/rkt-metadata.socket
+++ b/pkg/kubelet/rkt/rkt-metadata.socket
@@ -1,0 +1,13 @@
+[Unit]
+Description=rkt metadata service socket
+PartOf=rkt-metadata.service
+
+[Socket]
+ListenStream=/run/rkt/metadata-svc.sock
+SocketMode=0660
+SocketUser=root
+SocketGroup=root
+RemoveOnStop=true
+
+[Install]
+WantedBy=sockets.target

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -210,46 +210,14 @@ func New(config *Config) (*Runtime, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, found := result[rktBinName]; !found {
-		return nil, fmt.Errorf("rkt: cannot get the version of rkt")
-	}
-	glog.V(4).Infof("Rkt version: %v.", result)
+	glog.V(4).Infof("Rkt version: %v", result)
 	return rkt, nil
-}
-
-// Version invokes 'rkt version' to get the version information of the rkt
-// runtime on the machine.
-// The return values are a map of component:version.
-//
-// Example:
-// rkt:0.3.2+git
-// appc:0.3.0+git
-//p
-func (r *Runtime) Version() (map[string]string, error) {
-	output, err := r.RunCommand("version")
-	if err != nil {
-		return nil, err
-	}
-
-	// Example output for 'rkt version':
-	// rkt version 0.3.2+git
-	// appc version 0.3.0+git
-	result := make(map[string]string)
-	for _, line := range output {
-		tuples := strings.Split(strings.TrimSpace(line), " ")
-		if len(tuples) != 3 {
-			glog.Warningf("Cannot parse the output: %q.", line)
-			continue
-		}
-		result[tuples[0]] = tuples[2]
-	}
-	return result, nil
 }
 
 // GetPods runs 'systemctl list-unit' and 'rkt list' to get the list of all the appcs.
 // Then it will use the result to contruct list of pods.
 func (r *Runtime) GetPods(all bool) ([]*kubecontainer.Pod, error) {
-	glog.V(4).Infof("Rkt getting pods.")
+	glog.V(4).Infof("Rkt getting pods")
 
 	units, err := r.systemd.ListUnits()
 	if err != nil {

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -777,7 +777,7 @@ func (r *Runtime) preparePod(pod *api.Pod, volumeMap map[string]volume.Volume) (
 		return "", false, err
 	}
 
-	runPrepared := fmt.Sprintf("%s run-prepared --private-net=true %s", r.absPath, uuid)
+	runPrepared := fmt.Sprintf("%s run-prepared --private-net=%v %s", r.absPath, pod.Spec.HostNetwork, uuid)
 	units := []*unit.UnitOption{
 		newUnitOption(unitKubernetesSection, unitRktID, uuid),
 		newUnitOption(unitKubernetesSection, unitPodName, string(b)),

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1,0 +1,733 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rkt
+
+import (
+	"encoding/json"
+	"fmt"
+	"hash/adler32"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
+	schema "github.com/appc/spec/schema"
+	appctypes "github.com/appc/spec/schema/types"
+	"github.com/coreos/go-systemd/dbus"
+	"github.com/coreos/go-systemd/unit"
+	"github.com/coreos/rkt/store"
+	"github.com/golang/glog"
+)
+
+const (
+	acversion            = "0.5.1"
+	kubernetesUnitPrefix = "k8s"
+	systemdServiceDir    = "/run/systemd/system"
+	tmpPodManifestDir    = "/tmp"
+
+	unitKubernetesSection = "X-Kubernetes"
+	unitPodName           = "POD"
+	unitRktID             = "RktID"
+
+	// TODO(yifan): Export in rkt?
+	defaultDataDir = "/var/lib/rkt"
+)
+
+const (
+	rktBinName = "rkt"
+
+	Embryo         = "embryo"
+	Preparing      = "preparing"
+	AbortedPrepare = "aborted prepare"
+	Prepared       = "prepared"
+	Running        = "running"
+	Deleting       = "deleting" // This covers pod.isExitedDeleting and pod.isDeleting.
+	Exited         = "exited"   // This covers pod.isExited and pod.isExitedGarbage.
+	Garbage        = "garbage"
+)
+
+// Runtime implements the ContainerRuntime for rkt. The implementation
+// uses systemd, so in order to run this runtime, systemd must be installed
+// on the machine.
+type Runtime struct {
+	systemd *dbus.Conn
+	absPath string
+	config  *Config
+}
+
+// Config stores the global configuration for the rkt runtime.
+// Run 'rkt' for more details.
+type Config struct {
+	// The debug flag for rkt.
+	Debug bool
+	// The rkt data directory
+	Dir string
+	// This flag controls whether we skip image or key verification.
+	InsecureSkipVerify bool
+}
+
+// buildGlobalOptions returns an array of global command line options.
+func (c *Config) buildGlobalOptions() []string {
+	var result []string
+	if c == nil {
+		return result
+	}
+
+	result = append(result, fmt.Sprintf("--debug=%v", c.Debug))
+	result = append(result, fmt.Sprintf("--insecure-skip-verify=%v", c.InsecureSkipVerify))
+	if c.Dir != "" {
+		result = append(result, fmt.Sprintf("--dir=%s", c.Dir))
+	}
+	return result
+}
+
+// New creates the rkt container runtime which implements the container runtime interface.
+// It will test if the rkt binary is in the $PATH, and whether we can get the
+// version of it. If so, creates the rkt container runtime, otherwise returns an error.
+func New(config *Config) (*Runtime, error) {
+	systemd, err := dbus.New()
+	if err != nil {
+		return nil, err
+	}
+	// Test if rkt binary is in $PATH.
+	absPath, err := exec.LookPath(rktBinName)
+	if err != nil {
+		return nil, err
+	}
+	rkt := &Runtime{
+		systemd: systemd,
+		absPath: absPath,
+		config:  config,
+	}
+
+	// Simply verify the binary by trying 'rkt version'.
+	result, err := rkt.Version()
+	if err != nil {
+		return nil, err
+	}
+	if _, found := result[rktBinName]; !found {
+		return nil, fmt.Errorf("rkt: cannot get the version of rkt")
+	}
+	glog.V(4).Infof("Rkt version: %v.", result)
+	return rkt, nil
+}
+
+// Version invokes 'rkt version' to get the version information of the rkt
+// runtime on the machine.
+// The return values are a map of component:version.
+//
+// Example:
+// rkt:0.3.2+git
+// appc:0.3.0+git
+//p
+func (r *Runtime) Version() (map[string]string, error) {
+	output, err := r.RunCommand("version")
+	if err != nil {
+		return nil, err
+	}
+
+	// Example output for 'rkt version':
+	// rkt version 0.3.2+git
+	// appc version 0.3.0+git
+	result := make(map[string]string)
+	for _, line := range output {
+		tuples := strings.Split(strings.TrimSpace(line), " ")
+		if len(tuples) != 3 {
+			glog.Warningf("Cannot parse the output: %q.", line)
+			continue
+		}
+		result[tuples[0]] = tuples[2]
+	}
+	return result, nil
+}
+
+// GetPods runs 'systemctl list-unit' and 'rkt list' to get the list of all the appcs.
+// Then it will use the result to contruct list of pods.
+func (r *Runtime) GetPods(all bool) ([]*kubecontainer.Pod, error) {
+	glog.V(4).Infof("Rkt getting pods.")
+
+	units, err := r.systemd.ListUnits()
+	if err != nil {
+		return nil, err
+	}
+
+	podInfos, err := r.getPodInfos()
+	if err != nil {
+		return nil, err
+	}
+
+	var pods []*kubecontainer.Pod
+	for _, u := range units {
+		if strings.HasPrefix(u.Name, kubernetesUnitPrefix) {
+			pod, err := r.makePod(u.Name, podInfos)
+			if err != nil {
+				glog.Warningf("Cannot construct pod from unit file: %v.", err)
+				continue
+			}
+			pods = append(pods, pod)
+		}
+	}
+	return pods, nil
+}
+
+// RunPod first creates the unit file for a pod, and then calls
+// StartUnit over d-bus.
+func (r *Runtime) RunPod(pod *api.Pod, volumeMap map[string]volume.Volume) error {
+	glog.V(4).Infof("Rkt starts to run pod: name %q.", pod.Name)
+
+	name, needReload, err := r.preparePod(pod, volumeMap)
+	if err != nil {
+		return err
+	}
+	if needReload {
+		if err := r.systemd.Reload(); err != nil {
+			return err
+		}
+	}
+
+	// TODO(yifan): This is the old version of go-systemd. Should update when libcontainer updates
+	// its version of go-systemd.
+	_, err = r.systemd.StartUnit(name, "replace")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// KillPod invokes 'systemctl kill' to kill the unit that runs the pod.
+func (r *Runtime) KillPod(pod *api.Pod) error {
+	glog.V(4).Infof("Rkt is killing pod: name %q.", pod.Name)
+
+	serviceName := makePodServiceFileName(pod.Name, pod.Namespace)
+
+	// TODO(yifan): More graceful stop. Replace with StopUnit and wait for a timeout.
+	r.systemd.KillUnit(serviceName, int32(syscall.SIGKILL))
+	return r.systemd.Reload()
+}
+
+func (r *Runtime) RestartPod(pod *api.Pod, volumeMap map[string]volume.Volume) error {
+	if err := r.KillPod(pod); err != nil {
+		return err
+	}
+	return r.RunPod(pod, volumeMap)
+}
+
+// GetPodStatus currently invokes GetPods() to return the status. TODO(yifan): This is a hack,
+// should try to split the status and the pod list.
+func (r *Runtime) GetPodStatus(pod *api.Pod) (*api.PodStatus, error) {
+	pods, err := r.GetPods(true)
+	if err != nil {
+		return nil, err
+	}
+	p := kubecontainer.Pods(pods).FindPodByID(pod.UID)
+	// TODO(yifan): Refactor this, use nil.
+	if len(p.Containers) == 0 {
+		return nil, fmt.Errorf("cannot find status for pod: %q", kubecontainer.BuildPodFullName(pod.Name, pod.Namespace))
+	}
+	return &p.Status, nil
+}
+
+// RunCommand invokes rkt binary with arguments and returns the result
+// from stdout in a list of strings.
+// TODO(yifan): Do not export this.
+func (r *Runtime) RunCommand(args ...string) ([]string, error) {
+	glog.V(4).Info("Run rkt command:", args)
+
+	cmd := exec.Command(rktBinName)
+	cmd.Args = append(cmd.Args, r.config.buildGlobalOptions()...)
+	cmd.Args = append(cmd.Args, args...)
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(strings.TrimSpace(string(output)), "\n"), nil
+}
+
+type podInfo struct {
+	state       string
+	networkInfo string
+}
+
+// getIP returns the IP of a pod by parsing the network info.
+// The network info looks like this:
+//
+// default:ip4=172.16.28.3, database:ip4=172.16.28.42
+//
+func (p *podInfo) getIP() string {
+	parts := strings.Split(p.networkInfo, ",")
+
+	for _, part := range parts {
+		if strings.HasPrefix(part, "default:") {
+			return strings.Split(part, "=")[1]
+		}
+	}
+	return ""
+}
+
+// getContainerStatus converts the rkt pod state to the api.containerStatus.
+// TODO(yifan): Get more detailed info such as Image, ImageID, etc.
+func (p *podInfo) getContainerStatus(container *kubecontainer.Container) api.ContainerStatus {
+	var status api.ContainerStatus
+	status.Name = container.Name
+	status.Image = container.Image
+	switch p.state {
+	case Running:
+		// TODO(yifan): Get StartedAt.
+		status.State = api.ContainerState{
+			Running: &api.ContainerStateRunning{
+				StartedAt: util.Unix(container.Created, 0),
+			},
+		}
+	case Embryo, Preparing, Prepared:
+		status.State = api.ContainerState{Waiting: &api.ContainerStateWaiting{}}
+	case AbortedPrepare, Deleting, Exited, Garbage:
+		status.State = api.ContainerState{
+			Termination: &api.ContainerStateTerminated{
+				StartedAt: util.Unix(container.Created, 0),
+			},
+		}
+	default:
+		glog.Warningf("Unknown pod state: %q", p.state)
+	}
+	return status
+}
+
+func (p *podInfo) toPodStatus(pod *kubecontainer.Pod) api.PodStatus {
+	var status api.PodStatus
+	status.PodIP = p.getIP()
+	// For now just make every container's state as same as the pod.
+	for _, container := range pod.Containers {
+		status.ContainerStatuses = append(status.ContainerStatuses, p.getContainerStatus(container))
+	}
+	return status
+}
+
+// splitLine breaks a line by tabs, and trims the leading and tailing spaces.
+func splitLine(line string) []string {
+	var result []string
+	start := 0
+
+	line = strings.TrimSpace(line)
+	for i := 0; i < len(line); i++ {
+		if line[i] == '\t' {
+			result = append(result, line[start:i])
+			for line[i] == '\t' {
+				i++
+			}
+			start = i
+		}
+	}
+	result = append(result, line[start:])
+	return result
+}
+
+// getPodInfos returns a map of [pod-uuid]:*podInfo
+func (r *Runtime) getPodInfos() (map[string]*podInfo, error) {
+	output, err := r.RunCommand("list", "--no-legend", "--full")
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output) == 0 {
+		// No pods is running.
+		return nil, nil
+	}
+
+	// Example output of current 'rkt list --full' (version == 0.4.2):
+	// UUID                                 ACI     STATE      NETWORKS
+	// 2372bc17-47cb-43fb-8d78-20b31729feda	foo     running    default:ip4=172.16.28.3
+	//                                      bar
+	// 40e2813b-9d5d-4146-a817-0de92646da96 foo     exited
+	// 40e2813b-9d5d-4146-a817-0de92646da96 bar     exited
+	//
+	// With '--no-legend', the first line is eliminated.
+
+	result := make(map[string]*podInfo)
+	for _, line := range output {
+		tuples := splitLine(line)
+		if len(tuples) < 3 { // At least it should have 3 entries.
+			continue
+		}
+		info := &podInfo{
+			state: tuples[2],
+		}
+		if len(tuples) == 4 {
+			info.networkInfo = tuples[3]
+		}
+		result[tuples[0]] = info
+	}
+	return result, nil
+}
+
+// makePod constructs the pod by reading information from the given unit file
+// and from the pod infos.
+func (r *Runtime) makePod(unitName string, podInfos map[string]*podInfo) (*kubecontainer.Pod, error) {
+	f, err := os.Open(path.Join(systemdServiceDir, unitName))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var pod kubecontainer.Pod
+	opts, err := unit.Deserialize(f)
+	if err != nil {
+		return nil, err
+	}
+
+	var rktID string
+	for _, opt := range opts {
+		if opt.Section != unitKubernetesSection {
+			continue
+		}
+		switch opt.Name {
+		case unitPodName:
+			// NOTE: In fact we unmarshal from a serialized
+			// api.BoundPod type here.
+			err = json.Unmarshal([]byte(opt.Value), &pod)
+			if err != nil {
+				return nil, err
+			}
+		case unitRktID:
+			rktID = opt.Value
+		default:
+			glog.Warningf("unexpected key: %q", opt.Name)
+		}
+	}
+
+	if len(rktID) == 0 {
+		return nil, fmt.Errorf("rkt: cannot find rkt ID of pod %v, unit file is broken", pod)
+	}
+	info, found := podInfos[rktID]
+	if !found {
+		glog.Warningf("Cannot find info for pod %q, rkt uuid: %q", pod.Name, rktID)
+		return &pod, nil
+	}
+	pod.Status = info.toPodStatus(&pod)
+	return &pod, nil
+}
+
+// makePodServiceFileName constructs the unit file name for the given pod.
+// TODO(yifan), when BoundPod and Pod are combined, we can change the input to
+// take just a pod.
+func makePodServiceFileName(podName, podNamespace string) string {
+	// TODO(yifan): Revisit this later, decide whether we want to use UID.
+	return fmt.Sprintf("%s_%s_%s.service", kubernetesUnitPrefix, podName, podNamespace)
+}
+
+func newUnitOption(section, name, value string) *unit.UnitOption {
+	return &unit.UnitOption{Section: section, Name: name, Value: value}
+}
+
+// setApp overrides the app's fields if any of them are specified in the
+// container's spec.
+func setApp(app *appctypes.App, c *api.Container) error {
+	// Override the exec.
+	// TOOD(yifan): Revisit this for the overriding rule.
+	if len(c.Command) > 0 || len(c.Args) > 0 {
+		app.Exec = append(c.Command, c.Args...)
+	}
+
+	// TODO(yifan): Use non-root user in the future?
+	// Currently it's a bug as reported https://github.com/coreos/rkt/issues/539.
+	// However since we cannot get the user/group information from the container
+	// spec, maybe we use the file path to set the user/group?
+	app.User, app.Group = "0", "0"
+
+	// Override the working directory.
+	if len(c.WorkingDir) > 0 {
+		app.WorkingDirectory = c.WorkingDir
+	}
+
+	// Override the environment.
+	if len(c.Env) > 0 {
+		app.Environment = []appctypes.EnvironmentVariable{}
+	}
+	for _, env := range c.Env {
+		app.Environment = append(app.Environment, appctypes.EnvironmentVariable{
+			Name:  env.Name,
+			Value: env.Value,
+		})
+	}
+
+	// Override the mount points.
+	if len(c.VolumeMounts) > 0 {
+		app.MountPoints = []appctypes.MountPoint{}
+	}
+	for _, m := range c.VolumeMounts {
+		mountPointName, err := appctypes.NewACName(m.Name)
+		if err != nil {
+			glog.Errorf("Cannot use the volume mount's name %q as ACName: %v", m.Name, err)
+			return err
+		}
+		app.MountPoints = append(app.MountPoints, appctypes.MountPoint{
+			Name:     *mountPointName,
+			Path:     m.MountPath,
+			ReadOnly: m.ReadOnly,
+		})
+	}
+
+	// Override the ports.
+	if len(c.Ports) > 0 {
+		app.Ports = []appctypes.Port{}
+	}
+	for _, p := range c.Ports {
+		portName, err := appctypes.NewACName(p.Name)
+		if err != nil {
+			glog.Errorf("Cannot use the port's name %q as ACName: %v", p.Name, err)
+			return err
+		}
+		app.Ports = append(app.Ports, appctypes.Port{
+			Name:     *portName,
+			Protocol: string(p.Protocol),
+			Port:     uint(p.ContainerPort),
+		})
+	}
+	// TODO(yifan): Isolators.
+	return nil
+}
+
+// makePodManifest transforms a kubelet pod spec to the rkt pod manifest.
+func makePodManifest(pod *api.Pod, volumeMap map[string]volume.Volume) (*schema.PodManifest, error) {
+	manifest := schema.BlankPodManifest()
+
+	// Get the image manifests, assume they are already in the cas,
+	// and extract the app field from the image and to be the 'base app'.
+	//
+	// We do this is because we will fully replace the image manifest's app
+	// with the pod manifest's app in rkt runtime. See below:
+	//
+	// https://github.com/coreos/rkt/issues/723.
+	//
+	ds, err := store.NewStore(defaultDataDir)
+	if err != nil {
+		glog.Errorf("Cannot open store: %v", err)
+		return nil, err
+	}
+	for _, c := range pod.Spec.Containers {
+		fullKey, err := ds.ResolveKey(c.Image)
+		if err != nil {
+			return nil, fmt.Errorf("cannot resolve key: %v", err)
+		}
+		hash, err := appctypes.NewHash(fullKey)
+		if err != nil {
+			glog.Errorf("impossible: cannot create hash from full key: %v", err)
+			return nil, err
+		}
+		im, err := ds.GetImageManifest((*hash).String())
+		if err != nil {
+			glog.Errorf("Cannot get image manifest: %v", err)
+			return nil, err
+		}
+
+		// Override the image manifest's app and store it in the pod manifest.
+		app := im.App
+		if err := setApp(app, &c); err != nil {
+			return nil, err
+		}
+
+		appName, err := appctypes.NewACName(c.Name)
+		if err != nil {
+			glog.Errorf("Cannot use the container's name %q as ACName: %v", c.Name, err)
+			return nil, err
+		}
+
+		manifest.Apps = append(manifest.Apps, schema.RuntimeApp{
+			Name:  *appName,
+			Image: schema.RuntimeImage{ID: *hash},
+			App:   app,
+		})
+	}
+
+	// Set global volumes.
+	for name, volume := range volumeMap {
+		volName, err := appctypes.NewACName(name)
+		if err != nil {
+			glog.Errorf("Cannot use the volume's name %q as ACName: %v", name, err)
+			return nil, err
+		}
+		manifest.Volumes = append(manifest.Volumes, appctypes.Volume{
+			Name:   *volName,
+			Kind:   "host",
+			Source: volume.GetPath(),
+		})
+	}
+
+	// Set global ports.
+	for _, c := range pod.Spec.Containers {
+		for _, port := range c.Ports {
+			portName, err := appctypes.NewACName(port.Name)
+			if err != nil {
+				glog.Errorf("Cannot use the volume's name %q as ACName: %v", port.Name, err)
+				return nil, err
+			}
+			manifest.Ports = append(manifest.Ports, appctypes.ExposedPort{
+				Name:     *portName,
+				HostPort: uint(port.HostPort),
+			})
+		}
+	}
+	// TODO(yifan): Set pod-level isolators once it's supported in kubernetes.
+	return manifest, nil
+}
+
+func apiPodToRuntimePod(uuid string, pod *api.Pod) *kubecontainer.Pod {
+	p := &kubecontainer.Pod{
+		ID:        pod.UID,
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+	}
+	for i := range pod.Spec.Containers {
+		c := &pod.Spec.Containers[i]
+		p.Containers = append(p.Containers, &kubecontainer.Container{
+			ID:      buildContainerID(&containerID{uuid, c.Name}),
+			Name:    c.Name,
+			Image:   c.Image,
+			Hash:    HashContainer(c),
+			Created: time.Now().Unix(),
+		})
+	}
+	return p
+}
+
+type containerID struct {
+	uuid    string // uuid of the pod.
+	appName string // name of the app in that pod.
+}
+
+// buildContainerID constructs the containers's ID using containerID,
+// which containers the pod uuid and the container name.
+// The result can be used to globally identify a container.
+func buildContainerID(c *containerID) types.UID {
+	return types.UID(fmt.Sprintf("%s:%s", c.uuid, c.appName))
+}
+
+// parseContainerID parses the containerID into pod uuid and the container name. The
+// results can be used to get more information of the container.
+func parseContainerID(id types.UID) (*containerID, error) {
+	tuples := strings.Split(string(id), ":")
+	if len(tuples) != 2 {
+		return nil, fmt.Errorf("rkt: cannot parse container ID for: %v", id)
+	}
+	return &containerID{
+		uuid:    tuples[0],
+		appName: tuples[1],
+	}, nil
+}
+
+// preparePod creates the unit file and save it under systemdUnitDir.
+// On success, it will return a string that represents name of the unit file
+// and a boolean that indicates if the unit file needs reload.
+func (r *Runtime) preparePod(pod *api.Pod, volumeMap map[string]volume.Volume) (string, bool, error) {
+	cmds := []string{"prepare", "--quiet"}
+
+	// Construct the '--volume' cmd line.
+	for name, mount := range volumeMap {
+		cmds = append(cmds, "--volume")
+		cmds = append(cmds, fmt.Sprintf("%s,kind=host,source=%s", name, mount.GetPath()))
+	}
+
+	// Append ACIs.
+	for _, c := range pod.Spec.Containers {
+		cmds = append(cmds, c.Image)
+	}
+
+	output, err := r.RunCommand(cmds...)
+	if err != nil {
+		return "", false, err
+	}
+	if len(output) != 1 {
+		return "", false, fmt.Errorf("rkt: cannot get uuid from 'rkt prepare'")
+	}
+	uuid := output[0]
+	glog.V(4).Infof("'rkt prepare' returns %q.", uuid)
+
+	p := apiPodToRuntimePod(uuid, pod)
+	b, err := json.Marshal(p)
+	if err != nil {
+		glog.Errorf("rkt: cannot marshal pod `%s_%s`: %v", p.Name, p.Namespace, err)
+		return "", false, err
+	}
+
+	runPrepared := fmt.Sprintf("%s run-prepared --private-net=true %s", r.absPath, uuid)
+	units := []*unit.UnitOption{
+		newUnitOption(unitKubernetesSection, unitRktID, uuid),
+		newUnitOption(unitKubernetesSection, unitPodName, string(b)),
+		newUnitOption("Service", "ExecStart", runPrepared),
+	}
+
+	// Save the unit file under systemd's service directory.
+	// TODO(yifan) Garbage collect 'dead' serivce files.
+	needReload := false
+	unitName := makePodServiceFileName(pod.Name, pod.Namespace)
+	if _, err := os.Stat(path.Join(systemdServiceDir, unitName)); err == nil {
+		needReload = true
+	}
+	unitFile, err := os.Create(path.Join(systemdServiceDir, unitName))
+	if err != nil {
+		return "", false, err
+	}
+	defer unitFile.Close()
+
+	_, err = io.Copy(unitFile, unit.Serialize(units))
+	if err != nil {
+		return "", false, err
+	}
+	return unitName, needReload, nil
+}
+
+// Note: In rkt, the container ID is in the form of "UUID_ImageID".
+func (r *Runtime) RunInContainer(containerID string, cmd []string) ([]byte, error) {
+	id, err := parseContainerID(types.UID(containerID))
+	if err != nil {
+		return nil, err
+	}
+	// TODO(yifan): Currently, store image ID in appName.
+	// This will change in the future, see https://github.com/coreos/rkt/pull/640
+	args := append([]string{}, "enter", "--imageid", id.appName, id.uuid)
+	args = append(args, cmd...)
+	result, err := r.RunCommand(args...)
+	return []byte(strings.Join(result, "\n")), err
+}
+
+// PullImage invokes 'rkt fetch' to download an aci.
+func (r *Runtime) PullImage(img string) error {
+	_, err := r.RunCommand("fetch", img)
+	return err
+}
+
+// IsImagePresent returns true if the image is available on the machine.
+// TODO(yifan): Not implemented yet.
+func (r *Runtime) IsImagePresent(img string) (bool, error) {
+	return false, nil
+}
+
+// TODO(yifan): Move this duplicated function to container runtime.
+// HashContainer computes the hash of one api.Container.
+func HashContainer(container *api.Container) uint64 {
+	hash := adler32.New()
+	util.DeepHashObject(hash, *container)
+	return uint64(hash.Sum32())
+}

--- a/pkg/kubelet/rkt/rkt_gc.go
+++ b/pkg/kubelet/rkt/rkt_gc.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rkt
+
+import (
+	"os/exec"
+
+	"github.com/golang/glog"
+)
+
+const (
+	// Duration to wait before discarding inactive pods from garbage
+	defaultGracePeriod = "1m"
+	// Duration to wait before expiring prepared pods.
+	defaultExpirePrepared = "1m"
+)
+
+// GarbageCollect collects the pods/containers. TODO(yifan): Enforce the gc policy.
+func (r *Runtime) GarbageCollect() error {
+	if err := exec.Command("systemctl", "reset-failed").Run(); err != nil {
+		glog.Errorf("Failed to reset failed systemd services: %v", err)
+	}
+	if _, err := r.RunCommand("gc", "--grace-period="+defaultGracePeriod, "--expire-prepared="+defaultExpirePrepared); err != nil {
+		glog.Errorf("Failed to gc: %v", err)
+		return err
+	}
+	return nil
+}
+
+type ImageManager struct {
+	runtime *Runtime
+}
+
+func NewImageManager(r *Runtime) *ImageManager {
+	return &ImageManager{runtime: r}
+}
+
+// GarbageCollect collects the images. It is not implemented by rkt yet.
+func (im *ImageManager) GarbageCollect() error {
+	return nil
+}

--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -1,0 +1,412 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rkt
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"path"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
+)
+
+var enableTests bool
+
+func init() {
+	// Disabled by default since these tests require root privilege.
+	rand.Seed(time.Now().UnixNano())
+	flag.BoolVar(&enableTests, "enable-rkt-tests", false, "Whether the rkt tests should be enabled")
+}
+
+const (
+	testACI1     = "http://users.developer.core-os.net/k8s_tests/test1.aci"
+	testACI2     = "http://users.developer.core-os.net/k8s_tests/test2.aci"
+	mountTestACI = "http://users.developer.core-os.net/k8s_tests/mount_test.aci"
+)
+
+var (
+	defaultTestTimeout = time.Second * 5
+)
+
+func newRktOrFail(t *testing.T) *Runtime {
+	rkt, err := New(&Config{
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		t.Fatalf("Cannot create rkt: %v", err)
+	}
+	return rkt
+}
+
+func TestVersion(t *testing.T) {
+	rkt := newRktOrFail(t)
+	_, err := rkt.Version()
+	if err != nil {
+		t.Errorf("Cannot get rkt version: %v", err)
+	}
+}
+
+func TestParseLine(t *testing.T) {
+	tests := []struct {
+		input  string
+		output []string
+	}{
+		{
+			input:  "foo",
+			output: []string{"foo"},
+		},
+		{
+			input:  "\tfoo",
+			output: []string{"foo"},
+		},
+		{
+			input:  "\tfoo\t",
+			output: []string{"foo"},
+		},
+		{
+			input:  "\tfoo\tbar\t",
+			output: []string{"foo", "bar"},
+		},
+		{
+			input:  "\tfoo\t\n",
+			output: []string{"foo"},
+		},
+		{
+			input:  "uuid\taci\tstate\tnetwork",
+			output: []string{"uuid", "aci", "state", "network"},
+		},
+		{
+			input:  "uuid\t\t\t\t\taci\t\tstate\tnetwork",
+			output: []string{"uuid", "aci", "state", "network"},
+		},
+	}
+
+	for i, tt := range tests {
+		if !reflect.DeepEqual(splitLine(tt.input), tt.output) {
+			t.Errorf("test %d fail, expect: %v, saw: %v", i, tt.output, tt.input)
+		}
+	}
+}
+
+// verifyContainer returns true if container a's info is correct according to
+// container b.
+func verifyContainer(a *kubecontainer.Container, b *api.Container) bool {
+	return a.Name == b.Name &&
+		a.Image == b.Image &&
+		a.Hash == HashContainer(b)
+}
+
+// verifyContainers returns true if the containers are correct according to the
+// expectedContainers. It returns false if not.
+func verifyContainers(containers []*kubecontainer.Container, expectedContainers []api.Container) bool {
+	if len(containers) != len(expectedContainers) {
+		return false
+	}
+
+	ok := 0
+	for i := range containers {
+		for j := range expectedContainers {
+			if verifyContainer(containers[i], &expectedContainers[j]) {
+				ok += 1
+			}
+		}
+	}
+	return ok == len(containers)
+}
+
+// checkAllContainerStates returns true if all containers have
+// the expected state, false otherwise.
+func checkAllContainerStates(p *kubecontainer.Pod, expectedState string) bool {
+	for _, status := range p.Status.ContainerStatuses {
+		switch expectedState {
+		case "running":
+			if status.State.Running == nil {
+				return false
+			}
+		case "termination":
+			if status.State.Termination == nil {
+				return false
+			}
+		case "waiting":
+			if status.State.Waiting == nil {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// tryFindPod tries to find a pod which has the expected information and containers.
+func tryFindPod(expectedPod *api.Pod, pods []*kubecontainer.Pod) *kubecontainer.Pod {
+	for _, p := range pods {
+		if p.ID == expectedPod.ObjectMeta.UID &&
+			p.Name == expectedPod.ObjectMeta.Name &&
+			p.Namespace == expectedPod.ObjectMeta.Namespace &&
+			verifyContainers(p.Containers, expectedPod.Spec.Containers) {
+			return p
+		}
+	}
+	return nil
+}
+
+// verifyPod tests if the expected pod with expected state exists.
+func verifyPod(rkt *Runtime, expectedPod *api.Pod, expectedState string, t *testing.T) {
+	pods, err := rkt.GetPods()
+	if err != nil {
+		t.Errorf("Cannot list pods: %v", err)
+	}
+	foundPod := tryFindPod(expectedPod, pods)
+	if foundPod == nil {
+		t.Errorf("Cannot find the pod: %v", expectedPod.Name)
+	}
+
+	timeout := time.Now().Add(defaultTestTimeout)
+	for !checkAllContainerStates(foundPod, expectedState) {
+		if time.Now().After(timeout) {
+			t.Errorf("Timeout Waiting expected state: %q", expectedState)
+			return
+		}
+
+		time.Sleep(time.Second)
+		pods, err = rkt.GetPods()
+		if err != nil {
+			t.Errorf("Cannot list pods: %v", err)
+		}
+		foundPod = tryFindPod(expectedPod, pods)
+		if foundPod == nil {
+			t.Errorf("Cannot find pod: %v", expectedPod.Name)
+		}
+	}
+}
+
+// TestRunListKillListPod runs and kills a pod, and verify the pod is
+// being correctly run and killed.
+func TestRunListKillListPod(t *testing.T) {
+	if !enableTests {
+		return
+	}
+	rkt := newRktOrFail(t)
+
+	pod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			UID:       types.UID(fmt.Sprintf("testRkt_%d", rand.Int())),
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name:  "testImage1",
+					Image: testACI1,
+				},
+				{
+					Name:  "testImage2",
+					Image: testACI2,
+				},
+			},
+		},
+	}
+
+	if err := rkt.RunPod(pod, nil); err != nil {
+		t.Errorf("Cannot run pod: %v", err)
+	}
+
+	verifyPod(rkt, pod, "running", t)
+	if err := rkt.KillPod(pod); err != nil {
+		t.Errorf("Cannot kill pod %v", err)
+	}
+
+	verifyPod(rkt, pod, "termination", t)
+}
+
+// TestKillAndRunContainerInPod runs a pod, and kill/restart a container
+// in that pod.
+func TestKillAndRunContainerInPod(t *testing.T) {
+	if !enableTests {
+		return
+	}
+	rkt := newRktOrFail(t)
+
+	containers := []api.Container{
+		{
+			Name:  "testImage1",
+			Image: testACI1,
+		},
+		{
+			Name:  "testImage2",
+			Image: testACI2,
+		},
+	}
+
+	pod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			UID:         types.UID(fmt.Sprintf("testRkt_%d", rand.Int())),
+			Name:        "foo",
+			Namespace:   "default",
+			Annotations: make(map[string]string),
+		},
+		Spec: api.PodSpec{
+			Containers: containers,
+		},
+	}
+
+	if err := rkt.RunPod(pod, nil); err != nil {
+		t.Errorf("Cannot run pod: %v", err)
+	}
+
+	verifyPod(rkt, pod, "running", t)
+
+	if err := rkt.KillContainerInPod(containers[1], pod); err != nil {
+		t.Errorf("Cannot kill container: %v", err)
+	}
+
+	pod.Spec.Containers = []api.Container{containers[0]}
+	verifyPod(rkt, pod, "running", t)
+
+	if err := rkt.RunContainerInPod(containers[1], pod, nil); err != nil {
+		t.Errorf("Cannot run container: %v", err)
+	}
+
+	pod.Spec.Containers = containers
+	verifyPod(rkt, pod, "running", t)
+
+	// Tear down the pod
+	if err := rkt.KillPod(pod); err != nil {
+		t.Errorf("Cannot kill pod: %v", err)
+	}
+}
+
+type stubVolume struct {
+	path string
+}
+
+func (f *stubVolume) GetPath() string {
+	return f.path
+}
+
+// TestRunPodWithMountVolumes starts a pod that will mount volumes and
+// generate files on the host file system.
+func TestRunPodWithMountVolumes(t *testing.T) {
+	if !enableTests {
+		return
+	}
+	// The output file name is hardcoded.
+	tmpDirPath := "/tmp"
+	outputFiles := []string{
+		"outputFoo.txt",
+		"outputBar.txt",
+	}
+
+	rkt := newRktOrFail(t)
+
+	pod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			UID:         types.UID(fmt.Sprintf("testRkt_%d", rand.Int())),
+			Name:        "foo",
+			Namespace:   "default",
+			Annotations: make(map[string]string),
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name:  "mountTest",
+					Image: mountTestACI,
+					VolumeMounts: []api.VolumeMount{
+						{
+							Name:      "foo",
+							ReadOnly:  false,
+							MountPath: "/foo",
+						},
+						{
+							Name:      "bar",
+							ReadOnly:  false,
+							MountPath: "/bar",
+						},
+					},
+				},
+			},
+			Volumes: []api.Volume{
+				{
+					Name: "foo",
+					VolumeSource: api.VolumeSource{
+						HostPath: &api.HostPathVolumeSource{"/tmp"},
+					},
+				},
+				{
+					Name: "bar",
+					VolumeSource: api.VolumeSource{
+						HostPath: &api.HostPathVolumeSource{"/tmp"},
+					},
+				},
+			},
+		},
+	}
+
+	volumeMap := map[string]volume.Volume{
+		"foo": &stubVolume{"/tmp"},
+		"bar": &stubVolume{"/tmp"},
+	}
+
+	// Clean the dir.
+	if err := os.Remove(path.Join(tmpDirPath, outputFiles[0])); err != nil {
+		if !os.IsNotExist(err) {
+			t.Error("Cannot remove output file: %v", err)
+		}
+	}
+
+	if err := os.Remove(path.Join(tmpDirPath, outputFiles[1])); err != nil {
+		if !os.IsNotExist(err) {
+			t.Error("Cannot remove output file: %v", err)
+		}
+	}
+
+	if err := rkt.RunPod(pod, volumeMap); err != nil {
+		t.Errorf("Cannot run pod: %v", err)
+	}
+
+	verifyPod(rkt, pod, "running", t)
+
+	// Wait for the execution of the pod.
+	due := time.Now().Add(defaultTestTimeout)
+	for {
+		time.Sleep(time.Second)
+		if time.Now().After(due) {
+			t.Errorf("Timeout waiting the output files")
+			break
+		}
+		if _, err := os.Stat(path.Join(tmpDirPath, outputFiles[0])); err != nil {
+			continue
+		}
+		if _, err := os.Stat(path.Join(tmpDirPath, outputFiles[1])); err != nil {
+			continue
+		}
+		break
+	}
+	if err := rkt.KillPod(pod); err != nil {
+		t.Errorf("Cannot kill pod: %v", err)
+	}
+}

--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"os/exec"
 	"path"
 	"reflect"
 	"testing"
@@ -532,5 +533,37 @@ func TestExecInContainer(t *testing.T) {
 
 	if err := rkt.KillPod(pod); err != nil {
 		t.Errorf("Cannot kill pod %v", err)
+	}
+}
+
+func TestIsImagePresentAndPullImage(t *testing.T) {
+	testImage := "nginx"
+	rkt := newRktOrFail(t)
+
+	if err := exec.Command("rkt", "gc", "--expire-prepared=0", "--grace-period=0").Run(); err != nil {
+		t.Errorf("Failed to rkt gc: %v", err)
+	}
+	if err := os.RemoveAll("/var/lib/rkt"); err != nil {
+		t.Errorf("Failed to remove rkt dir: %v", err)
+	}
+
+	ok, err := rkt.IsImagePresent(testImage)
+	if err != nil {
+		t.Errorf("IsImagePresent failed: %v", err)
+	}
+	if ok {
+		t.Errorf("Should not find the image present!")
+	}
+
+	if err := rkt.PullImage(testImage); err != nil {
+		t.Errorf("Failed to pull image: %v", err)
+	}
+
+	ok, err = rkt.IsImagePresent(testImage)
+	if err != nil {
+		t.Errorf("IsImagePresent failed: %v", err)
+	}
+	if !ok {
+		t.Errorf("Should find the image present!")
 	}
 }

--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -402,8 +402,6 @@ func TestRunInContainer(t *testing.T) {
 		t.Errorf("Cannot run pod: %v", err)
 	}
 
-	// TODO(yifan): Sleep here because there is race between "running" and pid file is ready.
-	time.Sleep(time.Second)
 	verifyPod(rkt, pod, "running", t)
 
 	pods, err := rkt.GetPods(true)
@@ -422,10 +420,10 @@ func TestRunInContainer(t *testing.T) {
 	for i, tt := range tests {
 		output, err := rkt.RunInContainer(string(runningContainer.ID), tt.cmds)
 		if err != tt.expectedErr {
-			t.Errorf("%d: Expected: %#v, saw: %#v", i, tt.expectedErr, err)
+			t.Errorf("%d: Expected: %v, saw: %v", i, tt.expectedErr, err)
 		}
 		if !reflect.DeepEqual(tt.expectedOutput, output) {
-			t.Errorf("%d: Expected: %#v, saw: %#v", i, tt.expectedOutput, output)
+			t.Errorf("%d: Expected: %v, saw: %v", i, tt.expectedOutput, output)
 		}
 	}
 
@@ -485,8 +483,6 @@ func TestExecInContainer(t *testing.T) {
 		t.Errorf("Cannot run pod: %v", err)
 	}
 
-	// TODO(yifan): Sleep here because there is race between "running" and pid file is ready.
-	time.Sleep(time.Second)
 	verifyPod(rkt, pod, "running", t)
 
 	pods, err := rkt.GetPods(true)

--- a/pkg/kubelet/rkt/runner.go
+++ b/pkg/kubelet/rkt/runner.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rkt
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
+	"github.com/coreos/go-systemd/unit"
+	"github.com/golang/glog"
+	"github.com/kr/pty"
+)
+
+// Note: In rkt, the container ID is in the form of "UUID:appName:ImageID", where
+// appName is the container name.
+func (r *Runtime) RunInContainer(containerID string, cmd []string) ([]byte, error) {
+	glog.V(4).Infof("Rkt running in container.")
+
+	id, err := parseContainerID(containerID)
+	if err != nil {
+		return nil, err
+	}
+	// TODO(yifan): Use appName instead of imageID.
+	// see https://github.com/coreos/rkt/pull/640
+	args := append([]string{}, "enter", "--imageid", id.imageID, id.uuid)
+	args = append(args, cmd...)
+
+	result, err := r.RunCommand(args...)
+	return []byte(strings.Join(result, "\n")), err
+}
+
+// Pty unsupported yet.
+func startPty(c *exec.Cmd) (*os.File, error) {
+	return pty.Start(c)
+}
+
+// Note: In rkt, the container ID is in the form of "UUID:appName:ImageID", where
+// appName is the container name.
+func (r *Runtime) ExecInContainer(containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error {
+	glog.V(4).Infof("Rkt execing in container.")
+
+	id, err := parseContainerID(containerID)
+	if err != nil {
+		return err
+	}
+	// TODO(yifan): Use appName instead of imageID.
+	// see https://github.com/coreos/rkt/pull/640
+	args := append([]string{}, "enter", "--imageid", id.imageID, id.uuid)
+	args = append(args, cmd...)
+	command := r.buildCommand(args...)
+
+	if tty {
+		p, err := startPty(command)
+		if err != nil {
+			return err
+		}
+		defer p.Close()
+
+		// make sure to close the stdout stream
+		defer stdout.Close()
+
+		if stdin != nil {
+			go io.Copy(p, stdin)
+		}
+		if stdout != nil {
+			go io.Copy(stdout, p)
+		}
+		return command.Wait()
+	}
+	if stdin != nil {
+		// Use an os.Pipe here as it returns true *os.File objects.
+		// This way, if you run 'kubectl exec -p <pod> -i bash' (no tty) and type 'exit',
+		// the call below to command.Run() can unblock because its Stdin is the read half
+		// of the pipe.
+		r, w, err := os.Pipe()
+		if err != nil {
+			return err
+		}
+		go io.Copy(w, stdin)
+
+		command.Stdin = r
+	}
+	if stdout != nil {
+		command.Stdout = stdout
+	}
+	if stderr != nil {
+		command.Stderr = stderr
+	}
+	return command.Run()
+}
+
+func (r *Runtime) findRktID(pod kubecontainer.Pod) (string, error) {
+	units, err := r.systemd.ListUnits()
+	if err != nil {
+		return "", err
+	}
+
+	for _, u := range units {
+		if strings.HasPrefix(u.Name, makePodServiceFileName(pod.Name, pod.Namespace, pod.ID)) {
+			f, err := os.Open(path.Join(systemdServiceDir, u.Name))
+			if err != nil {
+				return "", err
+			}
+			defer f.Close()
+			opts, err := unit.Deserialize(f)
+			if err != nil {
+				return "", err
+			}
+
+			for _, opt := range opts {
+				if opt.Section == unitKubernetesSection && opt.Name == unitRktID {
+					return opt.Value, nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("rkt uuid not found for pod %v", pod)
+}
+
+// PortForward executes socat in the pod's network namespace and copies
+// data between stream (representing the user's local connection on their
+// computer) and the specified port in the container.
+//
+// TODO:
+//  - match cgroups of container
+//  - should we support nsenter + socat on the host? (current impl)
+//  - should we support nsenter + socat in a container, running with elevated privs and --pid=host?
+func (r *Runtime) PortForward(pod kubecontainer.Pod, port uint16, stream io.ReadWriteCloser) error {
+	glog.V(4).Infof("Rkt port forwarding in container.")
+
+	podInfos, err := r.getPodInfos()
+	if err != nil {
+		return err
+	}
+
+	rktID, err := r.findRktID(pod)
+	if err != nil {
+		return err
+	}
+
+	info, ok := podInfos[rktID]
+	if !ok {
+		return fmt.Errorf("cannot find the pod info for pod %v", pod)
+	}
+	if info.pid < 0 {
+		return fmt.Errorf("cannot get the pid for pod %v", pod)
+	}
+
+	// TODO what if the host doesn't have it???
+	_, lookupErr := exec.LookPath("socat")
+	if lookupErr != nil {
+		return fmt.Errorf("unable to do port forwarding: socat not found.")
+	}
+	args := []string{"-t", fmt.Sprintf("%d", info.pid), "-n", "socat", "-", fmt.Sprintf("TCP4:localhost:%d", port)}
+	// TODO use exec.LookPath
+	command := exec.Command("nsenter", args...)
+	command.Stdin = stream
+	command.Stdout = stream
+	return command.Run()
+}

--- a/pkg/kubelet/rkt/version.go
+++ b/pkg/kubelet/rkt/version.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rkt
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
+	"github.com/golang/glog"
+)
+
+type rktVersion []int
+
+func parseVersion(input string) (rktVersion, error) {
+	tail := strings.Index(input, "+")
+	if tail > 0 {
+		input = input[:tail]
+	}
+	var result rktVersion
+	tuples := strings.Split(input, ".")
+	for _, t := range tuples {
+		n, err := strconv.Atoi(t)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, n)
+	}
+	return result, nil
+}
+
+func (r rktVersion) Compare(other string) (int, error) {
+	v, err := parseVersion(other)
+	if err != nil {
+		return -1, err
+	}
+
+	for i := range r {
+		if i > len(v)-1 {
+			return 1, nil
+		}
+		if r[i] < v[i] {
+			return -1, nil
+		}
+		if r[i] > v[i] {
+			return 1, nil
+		}
+	}
+
+	// When loop ends, len(r) is <= len(v).
+	if len(r) < len(v) {
+		return -1, nil
+	}
+	return 0, nil
+}
+
+func (r rktVersion) String() string {
+	var version []string
+	for _, v := range r {
+		version = append(version, fmt.Sprintf("%d", v))
+	}
+	return strings.Join(version, ".")
+}
+
+// Version invokes 'rkt version' to get the version information of the rkt
+// runtime on the machine.
+// The return values are an int array containers the version number.
+//
+// Example:
+// rkt:0.3.2+git --> []int{0, 3, 2}.
+//
+func (r *Runtime) Version() (kubecontainer.Version, error) {
+	output, err := r.RunCommand("version")
+	if err != nil {
+		return nil, err
+	}
+
+	// Example output for 'rkt version':
+	// rkt version 0.3.2+git
+	// appc version 0.3.0+git
+	for _, line := range output {
+		tuples := strings.Split(strings.TrimSpace(line), " ")
+		if len(tuples) != 3 {
+			glog.Warningf("Cannot parse the output: %q.", line)
+			continue
+		}
+		if tuples[0] == "rkt" {
+			return parseVersion(tuples[2])
+		}
+	}
+	return nil, fmt.Errorf("rkt: cannot determine the version")
+}


### PR DESCRIPTION
Let's use this PR to track the missing functions for experimental rkt support in k8s:
(Expected version of rkt: 0.5.4)
- [x] Privilege container (though for now, containers by default have CAP_SYS_ADMIN in rkt, see (https://github.com/coreos/rkt/issues/576)
- [x] Exec/RunInContainer
- [x] Get Container Logs (Only pod level logs for now)
- [x] Image pull with credentials
- [x] Garbage collection
- [x] Host network
- [x] More status, including PID (Now we have PID, exitcode)
- [x] <del> Unify the container image format, let's assume it's docker images for now. </del>I decided to abort this for now, let's just do `docker://` for now until we get a solution for #7208 
- [x] Portforwarding

What I am missing? @vmarmol @dchen1107 @jonboulle 

Update:
- [ ] Get container info
