### PR TITLE
kubelet/container: Introduce RunContainerOptionsGenerator.

### DIFF
--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -30,3 +30,10 @@ type HandlerRunner interface {
 type Prober interface {
 	Probe(pod *api.Pod, status api.PodStatus, container api.Container, containerID string, createdAt int64) (probe.Result, error)
 }
+
+// RunContainerOptionsGenerator generates the options that necessary for
+// container runtime to run a container.
+// TODO(yifan): Remove netMode, ipcMode.
+type RunContainerOptionsGenerator interface {
+	GenerateRunContainerOptions(pod *api.Pod, container *api.Container, netMode, ipcMode string) (*RunContainerOptions, error)
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -682,9 +682,9 @@ func makeBinds(container *api.Container, podVolumes volumeMap) (binds []string) 
 	return
 }
 
-// generateRunContainerOptions generates the RunContainerOptions, which can be used by
+// GenerateRunContainerOptions generates the RunContainerOptions, which can be used by
 // the container runtime to set parameters for launching a container.
-func (kl *Kubelet) generateRunContainerOptions(pod *api.Pod, container *api.Container, netMode, ipcMode string) (*kubecontainer.RunContainerOptions, error) {
+func (kl *Kubelet) GenerateRunContainerOptions(pod *api.Pod, container *api.Container, netMode, ipcMode string) (*kubecontainer.RunContainerOptions, error) {
 	var err error
 	opts := &kubecontainer.RunContainerOptions{
 		NetMode: netMode,
@@ -725,7 +725,7 @@ func (kl *Kubelet) runContainer(pod *api.Pod, container *api.Container, netMode,
 		glog.Errorf("Couldn't make a ref to pod %v, container %v: '%v'", pod.Name, container.Name, err)
 	}
 
-	opts, err := kl.generateRunContainerOptions(pod, container, netMode, ipcMode)
+	opts, err := kl.GenerateRunContainerOptions(pod, container, netMode, ipcMode)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This interface wraps the kubelet to provide the options for
container runtime to run a container.

@vmarmol @dchen1107 @bakins
