### PR TITLE
Pass KUBELET_TOKEN in kube-env metadata.

### DIFF
--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -73,19 +73,6 @@ for k,v in yaml.load(sys.stdin).iteritems():
   fi
 }
 
-function ensure-kube-token() {
-  # We bake the KUBELET_TOKEN in separately to avoid auth information
-  # having to be re-communicated on kube-push. (Otherwise the client
-  # has to keep the bearer token around to handle generating a valid
-  # kube-env.)
-  if [[ -z "${KUBELET_TOKEN:-}" ]] && [[ ! -e "${KNOWN_TOKENS_FILE}" ]]; then
-    until KUBELET_TOKEN=$(curl-metadata kube-token); do
-      echo 'Waiting for metadata KUBELET_TOKEN...'
-      sleep 3
-    done
-  fi
-}
-
 function remove-docker-artifacts() {
   echo "== Deleting docker0 =="
   # Forcibly install bridge-utils (options borrowed from Salt logs).
@@ -416,7 +403,6 @@ if [[ -z "${is_push}" ]]; then
   ensure-install-dir
   set-kube-env
   [[ "${KUBERNETES_MASTER}" == "true" ]] && mount-master-pd
-  ensure-kube-token
   create-salt-pillar
   create-salt-auth
   download-release


### PR DESCRIPTION
ensure-kube-token is not needed anymore because
the token passed in kube-env.

In the up case it is set, in the push case it is an empty string
but not used.

Allow unset KUBELET_TOKEN (for push case).

Fix comment.

Passes e2e.
