### PR TITLE
lower log level on recovering from panic

### DIFF
--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -113,7 +113,7 @@ func RecoverPanics(handler http.Handler) http.Handler {
 		defer func() {
 			if x := recover(); x != nil {
 				http.Error(w, "apis panic. Look in log for details.", http.StatusInternalServerError)
-				glog.Infof("APIServer panic'd on %v %v: %v\n%s\n", req.Method, req.RequestURI, x, debug.Stack())
+				glog.Errorf("APIServer panic'd on %v %v: %v\n%s\n", req.Method, req.RequestURI, x, debug.Stack())
 			}
 		}()
 		defer httplog.NewLogged(req, &w).StacktraceWhen(

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -66,7 +66,7 @@ func logPanic(r interface{}) {
 		}
 		callers = callers + fmt.Sprintf("%v:%v\n", file, line)
 	}
-	glog.Infof("Recovered from panic: %#v (%v)\n%v", r, r, callers)
+	glog.Errorf("Recovered from panic: %#v (%v)\n%v", r, r, callers)
 }
 
 // ErrorHandlers is a list of functions which will be invoked when an unreturnable


### PR DESCRIPTION
Current log level on panic is high(Info). It is easy to miss it happens.
It should be at least error level.
