### PR TITLE
kube-proxy uses token to access port 443 of apiserver

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -473,6 +473,7 @@ DNS_SERVER_IP: $(yaml-quote ${DNS_SERVER_IP:-})
 DNS_DOMAIN: $(yaml-quote ${DNS_DOMAIN:-})
 KUBE_BEARER_TOKEN: $(yaml-quote ${KUBE_BEARER_TOKEN})
 KUBELET_TOKEN: $(yaml-quote ${KUBELET_TOKEN:-})
+KUBE_PROXY_TOKEN: $(yaml-quote ${KUBE_PROXY_TOKEN:-})
 ADMISSION_CONTROL: $(yaml-quote ${ADMISSION_CONTROL:-})
 MASTER_IP_RANGE: $(yaml-quote ${MASTER_IP_RANGE})
 EOF
@@ -587,6 +588,7 @@ function kube-up {
   # computer) can forget it later. This should disappear with
   # https://github.com/GoogleCloudPlatform/kubernetes/issues/3168
   KUBELET_TOKEN=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
+  KUBE_PROXY_TOKEN=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
 
   # Reserve the master's IP so that it can later be transferred to another VM
   # without disrupting the kubelets. IPs are associated with regions, not zones,
@@ -865,7 +867,7 @@ function kube-push {
   # node-kube-env. This isn't important until the node-ip-range issue
   # is solved (because that's blocking automatic dynamic nodes from
   # working). The node-kube-env has to be composed with the KUBELET_TOKEN
-  # Ideally we would have
+  # and KUBE_PROXY_TOKEN.  Ideally we would have
   # https://github.com/GoogleCloudPlatform/kubernetes/issues/3168
   # implemented before then, though, so avoiding this mess until then.
 

--- a/cluster/saltbase/salt/kube-proxy/default
+++ b/cluster/saltbase/salt/kube-proxy/default
@@ -2,11 +2,18 @@
 {% if grains['os_family'] == 'RedHat' -%}
 	{% set daemon_args = "" -%}
 {% endif -%}
-{% if grains.api_servers is defined -%}
-  {% set api_servers = "--master=http://" + grains.api_servers + ":7080" -%}
-{% else -%}
-  {% set ips = salt['mine.get']('roles:kubernetes-master', 'network.ip_addrs', 'grain').values() -%}
+{# TODO(azure-maintainer): add support for distributing kubeconfig with token to kube-proxy #}
+{# so it can use https #}
+{% if grains['cloud'] is defined and grains['cloud'] == 'azure' -%}
   {% set api_servers = "--master=http://" + ips[0][0] + ":7080" -%}
+  {% set kubeconfig = "" -%}
+{% else -%}
+  {% set kubeconfig = "--kubeconfig=/var/lib/kube-proxy/kubeconfig" -%}
+  {% if grains.api_servers is defined -%}
+    {% set api_servers = "--master=https://" + grains.api_servers -%}
+  {% else -%}
+    {% set ips = salt['mine.get']('roles:kubernetes-master', 'network.ip_addrs', 'grain').values() -%}
+    {% set api_servers = "--master=https://" + ips[0][0] -%}
+  {% endif -%}
 {% endif -%}
-
-DAEMON_ARGS="{{daemon_args}} {{api_servers}} {{pillar['log_level']}}"
+DAEMON_ARGS="{{daemon_args}} {{api_servers}} {{kubeconfig}} {{pillar['log_level']}}"

--- a/cluster/saltbase/salt/kube-proxy/init.sls
+++ b/cluster/saltbase/salt/kube-proxy/init.sls
@@ -55,3 +55,12 @@ kube-proxy:
 {% if grains['os_family'] != 'RedHat' %}
       - file: /etc/init.d/kube-proxy
 {% endif %}
+      - file: /var/lib/kube-proxy/kubeconfig
+
+/var/lib/kube-proxy/kubeconfig:
+  file.managed:
+    - source: salt://kube-proxy/kubeconfig
+    - user: root
+    - group: root
+    - mode: 400
+    - makedirs: true

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -137,14 +137,43 @@ EOF
 known_tokens_file="/srv/salt-overlay/salt/kube-apiserver/known_tokens.csv"
 if [[ ! -f "${known_tokens_file}" ]]; then
   kubelet_token=$(cat /dev/urandom | base64 | tr -d "=+/" | dd bs=32 count=1 2> /dev/null)
+  kube_proxy_token=$(cat /dev/urandom | base64 | tr -d "=+/" | dd bs=32 count=1 2> /dev/null)
 
   mkdir -p /srv/salt-overlay/salt/kube-apiserver
   known_tokens_file="/srv/salt-overlay/salt/kube-apiserver/known_tokens.csv"
-  (umask u=rw,go= ; echo "$kubelet_token,kubelet,kubelet" > $known_tokens_file)
+  (umask u=rw,go= ;
+   echo "$kubelet_token,kubelet,kubelet" > $known_tokens_file;
+   echo "$kube_proxy_token,kube_proxy,kube_proxy" >> $known_tokens_file)
 
   mkdir -p /srv/salt-overlay/salt/kubelet
   kubelet_auth_file="/srv/salt-overlay/salt/kubelet/kubernetes_auth"
   (umask u=rw,go= ; echo "{\"BearerToken\": \"$kubelet_token\", \"Insecure\": true }" > $kubelet_auth_file)
+
+  mkdir -p /srv/salt-overlay/salt/kube-proxy
+  kube_proxy_kubeconfig_file="/srv/salt-overlay/salt/kube_proxy/kubeconfig"
+  # Make a kubeconfig file with the token.
+  # TODO(etune): put apiserver certs into secret too, and reference from authfile,
+  # so that "Insecure" is not needed.
+  (umask 077;
+  cat > "${kube_proxy_kubeconfig_file}" <<EOF
+apiVersion: v1
+kind: Config
+users:
+- name: kube-proxy
+  user:
+    token: ${kube_proxy_token}
+clusters:
+- name: local
+  cluster:
+     insecure-skip-tls-verify: true
+contexts:
+- context:
+    cluster: local
+    user: kube-proxy
+  name: service-account-context
+current-context: service-account-context
+EOF
+)
 
   # Generate tokens for other "service accounts".  Append to known_tokens.
   #


### PR DESCRIPTION
Tested on GCE.
Includes untested modifications for AWS and Vagrant.
No changes for any other distros.
Probably will work on other up-to-date providers
but beware.  Symptom would be that service proxying
stops working.
1. Generates a token kube-proxy in AWS, GCE, and Vagrant setup scripts.
2. Distributes the token via salt-overlay, and salt to /var/lib/kube-proxy/kubeconfig
3. Changes kube-proxy args:
   - use the --kubeconfig argument
   - changes --master argument from http://MASTER:7080 to https://MASTER
     - http -> https
     - explicit port 7080 -> implied 443

Possible ways this might break other distros:

Mitigation: there is an default empty kubeconfig file.
If the distro does not populate the salt-overlay, then
it should get the empty, which parses to an empty
object, which, combined with the --master argument,
should still work.

Mitigation:
- azure: Special case to use 7080 in
- rackspace: way out of date, so don't care.
- vsphere: way out of date, so don't care.
- other distros: not using salt.
