### PR TITLE
Raise cAdvisor stats cache to 2m.

### DIFF
--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -42,8 +42,8 @@ type cadvisorClient struct {
 var _ Interface = new(cadvisorClient)
 
 // TODO(vmarmol): Make configurable.
-// The number of stats to keep in memory.
-const statsToCache = 60
+// The amount of time for which to keep stats in memory.
+const statsCacheDuration = 2 * time.Minute
 
 // Creates a cAdvisor and exports its API on the specified port if port > 0.
 func New(port uint) (Interface, error) {
@@ -53,7 +53,7 @@ func New(port uint) (Interface, error) {
 	}
 
 	// Create and start the cAdvisor container manager.
-	m, err := manager.New(memory.New(statsToCache, nil), sysFs)
+	m, err := manager.New(memory.New(statsCacheDuration, nil), sysFs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This used to be 60ns which was a bug from when we switched from number
of stats to duration. Seems like the type was silently
converted/ignored.
