### PR TITLE
WIP: kubelet: support backoff on container restarts

### DIFF
--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -48,13 +48,13 @@ func createPodWorkers() (*podWorkers, map[types.UID][]string) {
 
 	podWorkers := newPodWorkers(
 		fakeRuntimeCache,
-		func(pod *api.Pod, mirrorPod *api.Pod, runningPod kubecontainer.Pod) error {
+		func(pod *api.Pod, mirrorPod *api.Pod, runningPod kubecontainer.Pod) (*syncPodSummary, error) {
 			func() {
 				lock.Lock()
 				defer lock.Unlock()
 				processed[pod.UID] = append(processed[pod.UID], pod.Name)
 			}()
-			return nil
+			return &syncPodSummary{}, nil
 		},
 		fakeRecorder,
 	)

--- a/pkg/kubelet/runonce.go
+++ b/pkg/kubelet/runonce.go
@@ -103,7 +103,7 @@ func (kl *Kubelet) runPod(pod *api.Pod, retryDelay time.Duration) error {
 		glog.Infof("pod %q containers not running: syncing", pod.Name)
 		// We don't create mirror pods in this mode; pass a dummy boolean value
 		// to sycnPod.
-		if err = kl.syncPod(pod, nil, p); err != nil {
+		if _, err = kl.syncPod(pod, nil, p); err != nil {
 			return fmt.Errorf("error syncing pod: %v", err)
 		}
 		if retry >= RunOnceMaxRetries {


### PR DESCRIPTION
When a container is stuck in a crash loop, kubelet would waste resources trying
to restart it repeatedly. We want to reduce the impact of these unhealthy
containers.

This change instructs per-pod worker to back off on unexpected restarts, which
excludes user-made container changes.
- Upon an unexpected restart, a pod worker would double the current backoff
  interval, until it reaches the maximum interval.
- If no unexpected restart has occured in the past 5 minutes, the interval
  would be reset. This ensures that we do not carry over the effects of
  ancient restarts.

For containers with failure frequency lower than once per 5 minutes, the impact
of source usuage is minimal. There is no need to back off.
