### PR TITLE
logs for master components

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -614,7 +614,7 @@ function kube::release::create_docker_images_for_server() {
         rm -rf ${docker_build_path}
         mkdir -p ${docker_build_path}
         ln $1/${binary_name} ${docker_build_path}/${binary_name}
-        printf " FROM busybox \n ADD ${binary_name} /${binary_name} \n ENTRYPOINT [ \"/${binary_name}\" ]\n" > ${docker_file_path}
+        printf " FROM busybox \n ADD ${binary_name} /usr/local/bin/${binary_name}\n" > ${docker_file_path}
 
         local docker_image_tag=gcr.io/google_containers/$binary_name:$md5_sum
         docker build -q -t "${docker_image_tag}" ${docker_build_path} >/dev/null

--- a/cluster/saltbase/salt/kube-apiserver/init.sls
+++ b/cluster/saltbase/salt/kube-apiserver/init.sls
@@ -15,6 +15,12 @@
     - source: salt://kube-apiserver/basic_auth.csv
 {% endif %}
 
+/var/log/kube-apiserver.log:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 644
+
 # Copy kube-apiserver manifest to manifests folder for kubelet.
 /etc/kubernetes/manifests/kube-apiserver.manifest:
   file.managed:

--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
@@ -74,6 +74,10 @@
  {% set runtime_config = "--runtime_config=" + grains.runtime_config -%}
 {% endif -%}
 
+{% set params = address + " " + etcd_servers + " " + cloud_provider + " " + cloud_config + " " + runtime_config + " " + admission_control + " " + portal_net + " " + client_ca_file + " " + basic_auth_file -%}
+{% set params = params + " " + cluster_name + " " + cert_file + " " + key_file + " --secure_port=" + secure_port + " " + token_auth_file + " " + publicAddressOverride + " " + pillar['log_level'] -%}
+
+
 {
 "apiVersion": "v1beta3",
 "kind": "Pod",
@@ -85,24 +89,9 @@
     "name": "kube-apiserver",
     "image": "gcr.io/google_containers/kube-apiserver:{{pillar['kube-apiserver_docker_tag']}}",
     "command": [
-                 "/kube-apiserver",
-                 "{{address}}",
-                 "{{etcd_servers}}",
-                 "{{cloud_provider}}",
-                 "{{cloud_config}}",
-                 "{{runtime_config}}",
-                 "{{admission_control}}",
-                 "--allow_privileged={{pillar['allow_privileged']}}",
-                 "{{portal_net}}",
-                 "{{cluster_name}}",
-                 "{{cert_file}}",
-                 "{{key_file}}",
-                 "--secure_port={{secure_port}}",
-                 "{{token_auth_file}}",
-                 "{{client_ca_file}}",
-                 "{{basic_auth_file}}",
-                 "{{publicAddressOverride}}",
-                 "{{pillar['log_level']}}"
+                 "/bin/sh",
+                 "-c",
+                 "/usr/local/bin/kube-apiserver {{params}} --allow_privileged={{pillar['allow_privileged']}} 1>>/var/log/kube-apiserver.log 2>&1"
                ],
     "ports":[
       { "name": "https",
@@ -119,6 +108,9 @@
         { "name": "srvkube",
         "mountPath": "/srv/kubernetes",
         "readOnly": true},
+        { "name": "logfile",
+        "mountPath": "/var/log/kube-apiserver.log",
+        "readOnly": false},
         { "name": "etcssl",
         "mountPath": "/etc/ssl",
         "readOnly": true},
@@ -150,6 +142,10 @@
   { "name": "srvkube",
     "hostPath": {
         "path": "/srv/kubernetes"}
+  },
+  { "name": "logfile",
+    "hostPath": {
+        "path": "/var/log/kube-apiserver.log"}
   },
   { "name": "etcssl",
     "hostPath": {

--- a/cluster/saltbase/salt/kube-controller-manager/init.sls
+++ b/cluster/saltbase/salt/kube-controller-manager/init.sls
@@ -8,6 +8,12 @@
     - makedirs: true
     - dir_mode: 755
 
+/var/log/kube-controller-manager.log:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 644
+
 stop-legacy-kube_controller_manager:
   service.dead:
     - name: kube-controller-manager

--- a/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
+++ b/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
@@ -47,6 +47,8 @@
 {% endif -%}
 {% endif -%}
 
+{% set params = "--master=127.0.0.1:8080" + " " + machines + " " + cluster_name + " " + minion_regexp + " " + cloud_provider  + " " + sync_nodes + " " + cloud_config + " " + pillar['log_level'] -%}
+
 {
 "apiVersion": "v1beta3",
 "kind": "Pod",
@@ -58,20 +60,17 @@
     "name": "kube-controller-manager",
     "image": "gcr.io/google_containers/kube-controller-manager:{{pillar['kube-controller-manager_docker_tag']}}",
     "command": [
-                 "/kube-controller-manager",
-                 "--master=127.0.0.1:8080",
-                 "{{machines}}",
-                 "{{cluster_name}}",
-                 "{{minion_regexp}}",
-                 "{{cloud_provider}}",
-                 "{{sync_nodes}}",
-                 "{{cloud_config}}",
-                 "{{pillar['log_level']}}"
+                 "/bin/sh",
+                 "-c",
+                 "/usr/local/bin/kube-controller-manager {{params}} 1>>/var/log/kube-controller-manager.log 2>&1"
                ],
     "volumeMounts": [
         { "name": "srvkube",
         "mountPath": "/srv/kubernetes",
         "readOnly": true},
+        { "name": "logfile",
+        "mountPath": "/var/log/kube-controller-manager.log",
+        "readOnly": false},
         { "name": "etcssl",
         "mountPath": "/etc/ssl",
         "readOnly": true},
@@ -103,6 +102,10 @@
   { "name": "srvkube",
     "hostPath": {
         "path": "/srv/kubernetes"}
+  },
+  { "name": "logfile",
+    "hostPath": {
+        "path": "/var/log/kube-controller-manager.log"}
   },
   { "name": "etcssl",
     "hostPath": {

--- a/cluster/saltbase/salt/kube-scheduler/init.sls
+++ b/cluster/saltbase/salt/kube-scheduler/init.sls
@@ -9,6 +9,12 @@
     - makedirs: true
     - dir_mode: 755
 
+/var/log/kube-scheduler.log:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 644
+
 #stop legacy kube-scheduler service 
 stop_kube-scheduler:
   service.dead:

--- a/cluster/saltbase/salt/kube-scheduler/kube-scheduler.manifest
+++ b/cluster/saltbase/salt/kube-scheduler/kube-scheduler.manifest
@@ -9,10 +9,23 @@
     "name": "kube-scheduler",
     "image": "gcr.io/google_containers/kube-scheduler:{{pillar['kube-scheduler_docker_tag']}}",
     "command": [
-                 "/kube-scheduler",
-                 "--master=127.0.0.1:8080",
-                 "{{pillar['log_level']}}"
-               ]
+                 "/bin/sh",
+                 "-c",
+                 "/usr/local/bin/kube-scheduler --master=127.0.0.1:8080 {{pillar['log_level']}} 1>>/var/log/kube-scheduler.log 2>&1"
+               ],
+    "volumeMounts": [
+        {
+          "name": "logfile",
+          "mountPath": "/var/log/kube-scheduler.log",
+          "readOnly": false
+        }
+      ]
     }
+],
+"volumes":[
+  { "name": "logfile",
+    "hostPath": {
+        "path": "/var/log/kube-scheduler.log"}
+  }
 ]
 }}


### PR DESCRIPTION
Logs from kube-controller-manager, kube-apiserver and kube-scheduler pods are written to corresponding /var/log files
