### PR TITLE
Enable logging.write scope for minions. 

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -76,7 +76,7 @@ done
 CLUSTER_IP_RANGE="${KUBE_GCE_CLUSTER_CLASS_B:-10.244}.0.0/16"
 MINION_IP_RANGES=($(eval echo "${subnets[@]}"))
 
-MINION_SCOPES=("storage-ro" "compute-rw" "https://www.googleapis.com/auth/monitoring")
+MINION_SCOPES=("storage-ro" "compute-rw" "https://www.googleapis.com/auth/monitoring" "https://www.googleapis.com/auth/logging-write")
 # Increase the sleep interval value if concerned about API rate limits. 3, in seconds, is the default.
 POLL_SLEEP_INTERVAL=3
 PORTAL_NET="10.0.0.0/16"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -36,7 +36,7 @@ MINION_TAG="${INSTANCE_PREFIX}-minion"
 CLUSTER_IP_RANGE="${KUBE_GCE_CLUSTER_CLASS_B:-10.245}.0.0/16"
 MINION_IP_RANGES=($(eval echo "${KUBE_GCE_CLUSTER_CLASS_B:-10.245}.{1..${NUM_MINIONS}}.0/24"))
 MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
-MINION_SCOPES=("storage-ro" "compute-rw")
+MINION_SCOPES=("storage-ro" "compute-rw" "https://www.googleapis.com/auth/logging-write" "https://www.googleapis.com/auth/monitoring")
 # Increase the sleep interval value if concerned about API rate limits. 3, in seconds, is the default.
 POLL_SLEEP_INTERVAL=3
 PORTAL_NET="10.0.0.0/16"

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -605,10 +605,6 @@ function kube-up {
   # Report logging choice (if any).
   if [[ "${ENABLE_NODE_LOGGING-}" == "true" ]]; then
     echo "+++ Logging using Fluentd to ${LOGGING_DESTINATION:-unknown}"
-    # For logging to GCP we need to enable some minion scopes.
-    if [[ "${LOGGING_DESTINATION-}" == "gcp" ]]; then
-      MINION_SCOPES+=('https://www.googleapis.com/auth/logging.write')
-    fi
   fi
 
   # Wait for last batch of jobs


### PR DESCRIPTION
This is required for storing events in Google Cloud Logging via heapster.
