### PR TITLE
Fix crash in kubelet when persistent volume claim is not bound.

### DIFF
--- a/pkg/volume/persistent_claim/persistent_claim.go
+++ b/pkg/volume/persistent_claim/persistent_claim.go
@@ -57,6 +57,10 @@ func (plugin *persistentClaimPlugin) NewBuilder(spec *volume.Spec, podRef *api.O
 		return nil, err
 	}
 
+	if claim.Status.VolumeRef == nil {
+		return nil, fmt.Errorf("The claim %+v is not yet bound to a volume", claim.Name)
+	}
+
 	pv, err := plugin.host.GetKubeClient().PersistentVolumes().Get(claim.Status.VolumeRef.Name)
 	if err != nil {
 		glog.Errorf("Error finding persistent volume for claim: %+v\n", claim.Name)


### PR DESCRIPTION
While testing #6105 ran into this issue, kubelet crashed because
controller had not yet bound the claim to a volume.
