### PR TITLE
Containers namespaces

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -86,7 +86,7 @@ func waitForPodCondition(c *client.Client, ns, podName, desc string, condition p
 	for start := time.Now(); time.Since(start) < podStartTimeout; time.Sleep(5 * time.Second) {
 		pod, err := c.Pods(ns).Get(podName)
 		if err != nil {
-			Logf("Get pod failed, ignoring for 5s: %v", err)
+			Logf("Get pod %v in ns %v failed, ignoring for 5s: %v", podName, ns, err)
 			continue
 		}
 		done, err := condition(pod)
@@ -367,7 +367,7 @@ func testContainerOutputInNamespace(ns, scenarioName string, c *client.Client, p
 	containerName := pod.Spec.Containers[0].Name
 
 	// Wait for client pod to complete.
-	expectNoError(waitForPodSuccess(c, pod.Name, containerName))
+	expectNoError(waitForPodSuccessInNamespace(c, pod.Name, containerName, ns))
 
 	// Grab its logs.  Get host first.
 	podStatus, err := c.Pods(ns).Get(pod.Name)


### PR DESCRIPTION
Here's a patch which (1) fixes a bug in  `testContainerOutputInNamespeace` so that it checks pods in the right namespaces, and also (2) an update to docker-containers E2E test to use namespaces properly.
