### PR TITLE
Make argument order for testContainerOutputInNamespace consistent

### DIFF
--- a/test/e2e/docker_containers.go
+++ b/test/e2e/docker_containers.go
@@ -32,6 +32,7 @@ var _ = Describe("Docker Containers", func() {
 	BeforeEach(func() {
 		var err error
 		c, err = loadClient()
+		Expect(err).NotTo(HaveOccurred())
 		ns_, err := createTestingNS("containers", c)
 		ns = ns_.Name
 		Expect(err).NotTo(HaveOccurred())
@@ -44,18 +45,18 @@ var _ = Describe("Docker Containers", func() {
 	})
 
 	It("should use the image defaults if command and args are blank", func() {
-		testContainerOutputInNamespace(ns, "use defaults", c, entrypointTestPod(), []string{
+		testContainerOutputInNamespace("use defaults", c, entrypointTestPod(), []string{
 			"[/ep default arguments]",
-		})
+		}, ns)
 	})
 
 	It("should be able to override the image's default arguments (docker cmd)", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Args = []string{"override", "arguments"}
 
-		testContainerOutputInNamespace(ns, "override arguments", c, pod, []string{
+		testContainerOutputInNamespace("override arguments", c, pod, []string{
 			"[/ep override arguments]",
-		})
+		}, ns)
 	})
 
 	// Note: when you override the entrypoint, the image's arguments (docker cmd)
@@ -64,9 +65,9 @@ var _ = Describe("Docker Containers", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Command = []string{"/ep-2"}
 
-		testContainerOutputInNamespace(ns, "override command", c, pod, []string{
+		testContainerOutputInNamespace("override command", c, pod, []string{
 			"[/ep-2]",
-		})
+		}, ns)
 	})
 
 	It("should be able to override the image's default command and arguments", func() {
@@ -74,9 +75,9 @@ var _ = Describe("Docker Containers", func() {
 		pod.Spec.Containers[0].Command = []string{"/ep-2"}
 		pod.Spec.Containers[0].Args = []string{"override", "arguments"}
 
-		testContainerOutputInNamespace(ns, "override all", c, pod, []string{
+		testContainerOutputInNamespace("override all", c, pod, []string{
 			"[/ep-2 override arguments]",
-		})
+		}, ns)
 	})
 })
 

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -350,13 +350,13 @@ func runKubectl(args ...string) string {
 
 // testContainerOutput runs testContainerOutputInNamespace with the default namespace.
 func testContainerOutput(scenarioName string, c *client.Client, pod *api.Pod, expectedOutput []string) {
-	testContainerOutputInNamespace(api.NamespaceDefault, scenarioName, c, pod, expectedOutput)
+	testContainerOutputInNamespace(scenarioName, c, pod, expectedOutput, api.NamespaceDefault)
 }
 
 // testContainerOutputInNamespace runs the given pod in the given namespace and waits
 // for the first container in the podSpec to move into the 'Success' status.  It retrieves
 // the container log and searches for lines of expected output.
-func testContainerOutputInNamespace(ns, scenarioName string, c *client.Client, pod *api.Pod, expectedOutput []string) {
+func testContainerOutputInNamespace(scenarioName string, c *client.Client, pod *api.Pod, expectedOutput []string, ns string) {
 	By(fmt.Sprintf("Creating a pod to test %v", scenarioName))
 
 	defer c.Pods(ns).Delete(pod.Name)


### PR DESCRIPTION
The namespace arg to `testContainerOutputInNamespace` was inconsistent with the other `InNamespace` methods.
