### PR TITLE
Update Ginkgo to latest HEAD release with one-character fix

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -328,8 +328,8 @@
 		},
 		{
 			"ImportPath": "github.com/onsi/ginkgo",
-			"Comment": "v1.1.0-42-gdbb5c6c",
-			"Rev": "dbb5c6caf33238b57facc1d975b1aaca6b90288c"
+			"Comment": "v1.1.0-44-gae043a2",
+			"Rev": "ae043a2b2a91d6441adedc96d2c01958a78ee516"
 		},
 		{
 			"ImportPath": "github.com/onsi/gomega",

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testrunner/test_runner.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testrunner/test_runner.go
@@ -291,7 +291,7 @@ func (t *TestRunner) runParallelGinkgoSuite() RunResult {
 }
 
 func (t *TestRunner) cmd(ginkgoArgs []string, stream io.Writer, node int) *exec.Cmd {
-	args := []string{"-test.timeout=24h"}
+	args := []string{"--test.timeout=24h"}
 	if t.cover {
 		coverprofile := "--test.coverprofile=" + t.Suite.PackageName + ".coverprofile"
 		if t.numCPU > 1 {


### PR DESCRIPTION
The Ginkgo native test runner needed a small fix to work with pflag; this fix is included in this update.
