### PR TITLE
Remove unused env variable from the fluentd dockerfiles

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
@@ -14,6 +14,9 @@ MAINTAINER Satnam Singh "satnam@google.com"
 # Ensure there are enough file descriptors for running Fluentd.
 RUN ulimit -n 65536
 
+# Disable prompts from apt.
+ENV DEBIAN_FRONTEND noninteractive
+
 # Install prerequisites.
 RUN apt-get update && \
     apt-get install -y curl && \

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
@@ -11,10 +11,9 @@ MAINTAINER Satnam Singh "satnam@google.com"
 
 # Disable prompts from apt.
 ENV DEBIAN_FRONTEND noninteractive
-ENV OPTS_APT -y --force-yes --no-install-recommends
 
 RUN apt-get -q update && \
-    apt-get -y install curl && \
+    apt-get install -y curl && \
     apt-get clean && \
     curl -s https://storage.googleapis.com/signals-agents/logging/google-fluentd-install.sh | sudo bash
 

--- a/contrib/logging/fluentd-sidecar-es/Dockerfile
+++ b/contrib/logging/fluentd-sidecar-es/Dockerfile
@@ -10,14 +10,16 @@
 FROM ubuntu:14.04
 MAINTAINER Alex Robinson "arob@google.com"
 
+# Ensure there are enough file descriptors for running Fluentd.
+RUN ulimit -n 65536
+
 # Disable prompts from apt.
 ENV DEBIAN_FRONTEND noninteractive
-ENV OPTS_APT -y --force-yes --no-install-recommends
 
 # Install the standard, official Fluentd agent (called td-agent, for the
 # project's parent company, Treasure Data).
 RUN apt-get -q update && \
-    apt-get -y install curl && \
+    apt-get install -y curl && \
     apt-get install -y -q libcurl4-openssl-dev make && \
     apt-get clean
 RUN /usr/bin/curl -L http://toolbelt.treasuredata.com/sh/install-ubuntu-trusty-td-agent2.sh | sh

--- a/contrib/logging/fluentd-sidecar-gcp/Dockerfile
+++ b/contrib/logging/fluentd-sidecar-gcp/Dockerfile
@@ -13,11 +13,10 @@ MAINTAINER Alex Robinson "arob@google.com"
 
 # Disable prompts from apt.
 ENV DEBIAN_FRONTEND noninteractive
-ENV OPTS_APT -y --force-yes --no-install-recommends
 
 # Install the Fluentd agent that knows how to send logs to Google Cloud Logging.
 RUN apt-get -q update && \
-    apt-get -y install curl && \
+    apt-get install -y curl && \
     apt-get clean && \
     curl -s https://storage.googleapis.com/signals-agents/logging/google-fluentd-install.sh | sudo bash
 


### PR DESCRIPTION
... and make their apt-get arguments consistent.

As pointed out by @rimey in the [PR adding the fluentd-sidecar-es image](https://github.com/GoogleCloudPlatform/kubernetes/commit/5bf64e9fa335484dacabcc615b3e722fcdc5095e#commitcomment-10902443).

cc @rimey @satnam6502 
