### PR TITLE
Fix vagrant regression due to #7326

### DIFF
--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
@@ -43,7 +43,7 @@
 
 {% set cert_file = "--tls_cert_file=/srv/kubernetes/server.cert" -%}
 {% set key_file = "--tls_private_key_file=/srv/kubernetes/server.key" -%}
-{% set client_ca_file = "--client_ca_file=/dev/null" -%}
+{% set client_ca_file = "" -%}
 
 {% set secure_port = "6443" -%}
 {% if grains['cloud'] is defined and grains['cloud'] == 'gce' %}


### PR DESCRIPTION
Change made here: https://github.com/GoogleCloudPlatform/kubernetes/pull/7326

Affected all non-GCE salt based providers.

The kube-apiserver errors when getting /dev/null as input.

Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/7385
