### PR TITLE
Remove DockerPrefix references in Kubelet.

### DIFF
--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -17,6 +17,8 @@ limitations under the License.
 package container
 
 import (
+	"strings"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/probe"
 )
@@ -36,4 +38,15 @@ type Prober interface {
 // TODO(yifan): Remove netMode, ipcMode.
 type RunContainerOptionsGenerator interface {
 	GenerateRunContainerOptions(pod *api.Pod, container *api.Container, netMode, ipcMode string) (*RunContainerOptions, error)
+}
+
+// Trims runtime prefix from image name (e.g.: docker://busybox -> busybox).
+func TrimRuntimePrefixFromImage(img string) string {
+	const prefixSeparator = "://"
+
+	idx := strings.Index(img, prefixSeparator)
+	if idx < 0 {
+		return img
+	}
+	return img[idx+len(prefixSeparator):]
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -934,8 +934,7 @@ func shouldContainerBeRestarted(container *api.Container, pod *api.Pod, podStatu
 
 	// Set dead containers to unready state.
 	for _, c := range resultStatus {
-		// TODO(yifan): Unify the format of container ID. (i.e. including docker:// as prefix).
-		readinessManager.RemoveReadiness(strings.TrimPrefix(c.ContainerID, dockertools.DockerPrefix))
+		readinessManager.RemoveReadiness(kubecontainer.TrimRuntimePrefixFromImage(c.ContainerID))
 	}
 
 	// Check RestartPolicy for dead container.
@@ -1653,7 +1652,7 @@ func (kl *Kubelet) validateContainerStatus(podStatus *api.PodStatus, containerNa
 	if cStatus.State.Waiting != nil {
 		return "", fmt.Errorf("container %q is in waiting state.", containerName)
 	}
-	return strings.Replace(cStatus.ContainerID, dockertools.DockerPrefix, "", 1), nil
+	return kubecontainer.TrimRuntimePrefixFromImage(cStatus.ContainerID), nil
 }
 
 // GetKubeletContainerLogs returns logs from the container


### PR DESCRIPTION
Makes this usage generic and usable by other runtimes.

/cc @dchen1107 @yifan-gu 
