### PR TITLE
Set the default namespace for events to be "default"

### DIFF
--- a/pkg/client/record/event.go
+++ b/pkg/client/record/event.go
@@ -253,10 +253,14 @@ func (recorder *recorderImpl) Eventf(object runtime.Object, reason, messageFmt s
 
 func makeEvent(ref *api.ObjectReference, reason, message string) *api.Event {
 	t := util.Now()
+	namespace := ref.Namespace
+	if namespace == "" {
+		namespace = api.NamespaceDefault
+	}
 	return &api.Event{
 		ObjectMeta: api.ObjectMeta{
 			Name:      fmt.Sprintf("%v.%x", ref.Name, t.UnixNano()),
-			Namespace: ref.Namespace,
+			Namespace: namespace,
 		},
 		InvolvedObject: *ref,
 		Reason:         reason,

--- a/pkg/client/record/event_test.go
+++ b/pkg/client/record/event_test.go
@@ -473,3 +473,92 @@ func TestLotsOfEvents(t *testing.T) {
 	sinkWatcher.Stop()
 	logWatcher.Stop()
 }
+
+func TestEventfNoNamespace(t *testing.T) {
+	testPod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			SelfLink: "/api/version/pods/foo",
+			Name:     "foo",
+			UID:      "bar",
+		},
+	}
+	testRef, err := api.GetPartialReference(testPod, "desiredState.manifest.containers[2]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	table := []struct {
+		obj          runtime.Object
+		reason       string
+		messageFmt   string
+		elements     []interface{}
+		expect       *api.Event
+		expectLog    string
+		expectUpdate bool
+	}{
+		{
+			obj:        testRef,
+			reason:     "Started",
+			messageFmt: "some verbose message: %v",
+			elements:   []interface{}{1},
+			expect: &api.Event{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:       "Pod",
+					Name:       "foo",
+					Namespace:  "",
+					UID:        "bar",
+					APIVersion: "version",
+					FieldPath:  "desiredState.manifest.containers[2]",
+				},
+				Reason:  "Started",
+				Message: "some verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
+				Count:   1,
+			},
+			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"desiredState.manifest.containers[2]"}): reason: 'Started' some verbose message: 1`,
+			expectUpdate: false,
+		},
+	}
+
+	for _, item := range table {
+		called := make(chan struct{})
+		testEvents := testEventSink{
+			OnCreate: func(event *api.Event) (*api.Event, error) {
+				returnEvent, _ := validateEvent(event, item.expect, t)
+				if item.expectUpdate {
+					t.Errorf("Expected event update(), got event create()")
+				}
+				called <- struct{}{}
+				return returnEvent, nil
+			},
+			OnUpdate: func(event *api.Event) (*api.Event, error) {
+				returnEvent, _ := validateEvent(event, item.expect, t)
+				if !item.expectUpdate {
+					t.Errorf("Expected event create(), got event update()")
+				}
+				called <- struct{}{}
+				return returnEvent, nil
+			},
+		}
+		eventBroadcaster := NewBroadcaster()
+		sinkWatcher := eventBroadcaster.StartRecordingToSink(&testEvents)
+		logWatcher1 := eventBroadcaster.StartLogging(t.Logf) // Prove that it is useful
+		logWatcher2 := eventBroadcaster.StartLogging(func(formatter string, args ...interface{}) {
+			if e, a := item.expectLog, fmt.Sprintf(formatter, args...); e != a {
+				t.Errorf("Expected '%v', got '%v'", e, a)
+			}
+			called <- struct{}{}
+		})
+		recorder := eventBroadcaster.NewRecorder(api.EventSource{Component: "eventTest"})
+		recorder.Eventf(item.obj, item.reason, item.messageFmt, item.elements...)
+
+		<-called
+		<-called
+		sinkWatcher.Stop()
+		logWatcher1.Stop()
+		logWatcher2.Stop()
+	}
+}


### PR DESCRIPTION
Fixes #7405 

Here is a snippet from `kubectl get events` showing node related events.

``` shell
$ kubectl.sh get events 2>&1 | grep Node
Mon, 27 Apr 2015 17:12:52 -0700   Mon, 27 Apr 2015 17:12:52 -0700   1         kubernetes-master                                 Node                                                 starting           {kubelet kubernetes-master}        Starting kubelet.
Mon, 27 Apr 2015 17:13:33 -0700   Mon, 27 Apr 2015 17:13:33 -0700   1         kubernetes-minion-wqm2                            Node                                                 starting           {kubelet kubernetes-minion-wqm2}   Starting kubelet.
Mon, 27 Apr 2015 17:13:34 -0700   Mon, 27 Apr 2015 17:13:34 -0700   1         kubernetes-minion-wqm2                            Node                                                 online             {kubelet kubernetes-minion-wqm2}   Node kubernetes-minion-wqm2 is now online
Mon, 27 Apr 2015 17:15:15 -0700   Mon, 27 Apr 2015 17:15:15 -0700   1         kubernetes-minion-vqwf                            Node                                                 online             {kubelet kubernetes-minion-vqwf}   Node kubernetes-minion-vqwf is now online
Mon, 27 Apr 2015 17:15:15 -0700   Mon, 27 Apr 2015 17:15:15 -0700   1         kubernetes-minion-vqwf                            Node                                                 starting           {kubelet kubernetes-minion-vqwf}   Starting kubelet.
```
