### PR TITLE
Build hyperkube into a static binary

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -88,6 +88,7 @@ readonly KUBE_STATIC_LIBRARIES=(
   kube-apiserver
   kube-controller-manager
   kube-scheduler
+  hyperkube
 )
 
 kube::golang::is_statically_linked_library() {


### PR DESCRIPTION
As requested in https://groups.google.com/forum/#!topic/google-containers/nP3vTRlJSfU

As first verified by @eparis in that thread, this both doesn't break the build and does make the hyperkube binary static:

```
$ ldd _output/local/go/bin/hyperkube 
    not a dynamic executable
```

And for comparison:

```
$ ldd _output/local/go/bin/kubelet 
    linux-vdso.so.1 =>  (0x00007ffff73fc000)
    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f98ecbe2000)
    libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f98ec856000)
    /lib64/ld-linux-x86-64.so.2 (0x00007f98ece04000)
```
