### PR TITLE
Fixes #7416 - Fixed NFS example Dockerfile to include a valid Entrypoint.

### DIFF
--- a/examples/nfs/exporter/Dockerfile
+++ b/examples/nfs/exporter/Dockerfile
@@ -2,6 +2,10 @@ FROM fedora:21
 MAINTAINER Jan Safranek <jsafrane@redhat.com>
 EXPOSE 2049/tcp
 
-RUN yum -y install nfs-utils && yum clean all && run_nfs /usr/local/bin/run_nfs
+RUN yum -y install nfs-utils && yum clean all
+
+ADD run_nfs /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/run_nfs
 
 ENTRYPOINT ["/usr/local/bin/run_nfs"]


### PR DESCRIPTION
While running through this example the Dockerfile wouldn't build, upon closer inspection the entrypoint was not being copied into the container, and it was not executable.
