### PR TITLE
Set the 'WWW-Authenticate' header on 401 responses when basic auth is enabled

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -297,6 +297,7 @@ func (s *APIServer) Run(_ []string) error {
 		ReadWritePort:          s.SecurePort,
 		PublicAddress:          net.IP(s.BindAddress),
 		Authenticator:          authenticator,
+		SupportsBasicAuth:      len(s.BasicAuthFile) > 0,
 		Authorizer:             authorizer,
 		AdmissionControl:       admissionController,
 		DisableV1Beta3:         disableV1beta3,

--- a/pkg/auth/handlers/handlers.go
+++ b/pkg/auth/handlers/handlers.go
@@ -49,7 +49,18 @@ func NewRequestAuthenticator(mapper api.RequestContextMapper, auth authenticator
 	)
 }
 
-var Unauthorized http.HandlerFunc = unauthorized
+func Unauthorized(supportsBasicAuth bool) http.HandlerFunc {
+	if supportsBasicAuth {
+		return unauthorizedBasicAuth
+	}
+	return unauthorized
+}
+
+// unauthorizedBasicAuth serves an unauthorized message to clients.
+func unauthorizedBasicAuth(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("WWW-Authenticate", `Basic realm="kubernetes-master"`)
+	http.Error(w, "Unauthorized", http.StatusUnauthorized)
+}
 
 // unauthorized serves an unauthorized message to clients.
 func unauthorized(w http.ResponseWriter, req *http.Request) {

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -89,11 +89,13 @@ type Config struct {
 	// allow v1beta3 to be conditionally disabled
 	DisableV1Beta3 bool
 	// allow downstream consumers to disable the index route
-	EnableIndex            bool
-	EnableProfiling        bool
-	APIPrefix              string
-	CorsAllowedOriginList  util.StringList
-	Authenticator          authenticator.Request
+	EnableIndex           bool
+	EnableProfiling       bool
+	APIPrefix             string
+	CorsAllowedOriginList util.StringList
+	Authenticator         authenticator.Request
+	// TODO(roberthbailey): Remove once the server no longer supports http basic auth.
+	SupportsBasicAuth      bool
 	Authorizer             authorizer.Authorizer
 	AdmissionControl       admission.Interface
 	MasterServiceNamespace string
@@ -500,7 +502,7 @@ func (m *Master) init(c *Config) {
 
 	// Install Authenticator
 	if c.Authenticator != nil {
-		authenticatedHandler, err := handlers.NewRequestAuthenticator(m.requestContextMapper, c.Authenticator, handlers.Unauthorized, handler)
+		authenticatedHandler, err := handlers.NewRequestAuthenticator(m.requestContextMapper, c.Authenticator, handlers.Unauthorized(c.SupportsBasicAuth), handler)
 		if err != nil {
 			glog.Fatalf("Could not initialize authenticator: %v", err)
 		}


### PR DESCRIPTION
This is required for basic auth to work with web browsers.

/cc @brendandburns 
