### PR TITLE
Fix getting services in expose cmd

### DIFF
--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -150,23 +150,23 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 				}
 				return kubectl.MakeLabels(rc.Spec.Selector), nil
 			case "Pod":
-				rc, err := client.Pods(namespace).Get(name)
+				pod, err := client.Pods(namespace).Get(name)
 				if err != nil {
 					return "", err
 				}
-				if len(rc.Labels) == 0 {
+				if len(pod.Labels) == 0 {
 					return "", fmt.Errorf("the pod has no labels and cannot be exposed")
 				}
-				return kubectl.MakeLabels(rc.Labels), nil
+				return kubectl.MakeLabels(pod.Labels), nil
 			case "Service":
-				rc, err := client.ReplicationControllers(namespace).Get(name)
+				svc, err := client.Services(namespace).Get(name)
 				if err != nil {
 					return "", err
 				}
-				if rc.Spec.Selector == nil {
+				if svc.Spec.Selector == nil {
 					return "", fmt.Errorf("the service has no pod selector set")
 				}
-				return kubectl.MakeLabels(rc.Spec.Selector), nil
+				return kubectl.MakeLabels(svc.Spec.Selector), nil
 			default:
 				return "", fmt.Errorf("it is not possible to get a pod selector from %s", mapping.Kind)
 			}


### PR DESCRIPTION
Prior to this PR:

```
[vagrant@openshiftdev sample-app]$ osc get svc
NAME              LABELS                                    SELECTOR                            IP              PORT(S)
docker-registry   docker-registry=default                   docker-registry=default             172.30.43.3     5000/TCP
kubernetes        component=apiserver,provider=kubernetes   <none>                              172.30.0.2      443/TCP
kubernetes-ro     component=apiserver,provider=kubernetes   <none>                              172.30.0.1      80/TCP
mysql             name=hello                                deploymentconfig=mysql,name=hello   172.30.217.57   3306/TCP
[vagrant@openshiftdev sample-app]$ openshift kubectl expose service mysql --port=41 --target-port=8000
Error from server: replicationControllers "mysql" not found
```

Now:

```
[vagrant@openshiftdev sample-app]$ openshift kubectl expose service mysql --port=41 --target-port=800
Error from server: service "mysql" already exists
[vagrant@openshiftdev sample-app]$ openshift kubectl expose service mysql --port=41 --target-port=800 --service-name=mysql2
NAME      LABELS    SELECTOR                            IP               PORT(S)
mysql2    <none>    deploymentconfig=mysql,name=hello   172.30.228.100   41/TCP
```

cc: @smarterclayton 
