### PR TITLE
Add summary metrics to apiserver for easier debugging and future use in performance tests

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -65,11 +65,19 @@ var (
 		},
 		[]string{"verb", "resource", "client"},
 	)
+	requestLatenciesSummary = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "apiserver_request_latencies_summary",
+			Help: "Response latency summary in microseconds for each verb and resource.",
+		},
+		[]string{"verb", "resource"},
+	)
 )
 
 func init() {
 	prometheus.MustRegister(requestCounter)
 	prometheus.MustRegister(requestLatencies)
+	prometheus.MustRegister(requestLatenciesSummary)
 }
 
 // monitor is a helper function for each HTTP request handler to use for
@@ -77,6 +85,7 @@ func init() {
 func monitor(verb, resource *string, client string, httpCode *int, reqStart time.Time) {
 	requestCounter.WithLabelValues(*verb, *resource, client, strconv.Itoa(*httpCode)).Inc()
 	requestLatencies.WithLabelValues(*verb, *resource, client).Observe(float64((time.Since(reqStart)) / time.Microsecond))
+	requestLatenciesSummary.WithLabelValues(*verb, *resource).Observe(float64((time.Since(reqStart)) / time.Microsecond))
 }
 
 // monitorFilter creates a filter that reports the metrics for a given resource and action.


### PR DESCRIPTION
Example metrics:

apiserver_request_latencies_summary{resource="componentstatuses",verb="LIST",quantile="0.99"} 1.4990218e+07
apiserver_request_latencies_summary{resource="endpoints",verb="GET",quantile="0.99"} 1.552383e+06
apiserver_request_latencies_summary{resource="endpoints",verb="PUT",quantile="0.99"} 1.980128e+06
apiserver_request_latencies_summary{resource="events",verb="POST",quantile="0.99"} 1.467722e+06
apiserver_request_latencies_summary{resource="limitranges",verb="LIST",quantile="0.99"} 997
apiserver_request_latencies_summary{resource="namespaces",verb="LIST",quantile="0.99"} 5433
apiserver_request_latencies_summary{resource="namespaces",verb="POST",quantile="0.99"} 3.685993e+06
