### PR TITLE
Added optional step to fedora getting started.

### DIFF
--- a/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -77,6 +77,15 @@ KUBE_SERVICE_ADDRESSES="--portal_net=10.254.0.0/16"
 KUBE_API_ARGS=""
 ```
 
+* *Optional* Edit /etc/kubernetes/controller-manager and remove --machines=127.0.0.1 from the KUBELET_ADDRESSES. Leaving this in won't hurt anything but it will cause the output to note that the 127.0.0.1 node is NotReady because we will not be configuring one in this guide.
+
+```
+KUBELET_ADDRESSES=""
+
+KUBE_CONTROLLER_MANAGER_ARGS=""
+```
+
+
 * Edit /etc/etcd/etcd.conf,let the etcd to listen all the ip instead of 127.0.0.1,if not ,you will get the error like "connection refused"
 ```
 ETCD_LISTEN_CLIENT_URLS="http://0.0.0.0:4001"


### PR DESCRIPTION
If the --machines flag is left in the output differs slightly from the guide as such:

```
# kubectl get nodes
NAME        LABELS        STATUS
127.0.0.1   Schedulable   <none>                NotReady
fed-node    Schedulable   name=fed-node-label   Unknown
```
