### PR TITLE
kubelet/container: Update the runtime interface.

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -54,22 +54,24 @@ type Runtime interface {
 	KillContainerInPod(api.Container, *api.Pod) error
 	// GetPodStatus retrieves the status of the pod, including the information of
 	// all containers in the pod.
-	GetPodStatus(*Pod) (api.PodStatus, error)
+	GetPodStatus(*api.Pod) (api.PodStatus, error)
 	// GetContainers returns all containers on the node, including those are
 	// not managed by kubelet. If 'all' is false, then only running containers
 	// are returned.
 	GetContainers(all bool) ([]*Container, error)
 	// TODO(vmarmol): Merge RunInContainer and ExecInContainer.
 	// Runs the command in the container of the specified pod using nsinit.
-	RunInContainer(container api.Container, pod *api.Pod, cmd []string)
+	// TODO(yifan): Use strong type for containerID.
+	RunInContainer(containerID string, cmd []string) error
 	// Runs the command in the container of the specified pod using nsenter.
 	// Attaches the processes stdin, stdout, and stderr. Optionally uses a
 	// tty.
-	ExecInContainer(container api.Container, pod *api.Pod, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool)
+	// TODO(yifan): Use strong type for containerID.
+	ExecInContainer(containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error
 	// Forward the specified port from the specified pod to the stream.
-	PortForward(pod Pod, port uint16, stream io.ReadWriteCloser)
-	// Pull pulls an image from the network to local storage.
-	Pull(image string)
+	PortForward(pod Pod, port uint16, stream io.ReadWriteCloser) error
+	// PullImage pulls an image from the network to local storage.
+	PullImage(image string) error
 	// IsImagePresent checks whether the container image is already in the local storage.
 	IsImagePresent(image string) (bool, error)
 }


### PR DESCRIPTION
Make some of them (RunInContainer, ExecInContainer, etc) to have
same function signatures as current docker and rkt implementation.

Have discussed with @vmarmol last week. Think containerID is fine for now(though we want to have a strong type for the ID).
