### PR TITLE
readinessProbe calls livenessProbe.Exec.Command which cause "invalid memory address or nil pointer dereference".

### DIFF
--- a/pkg/kubelet/probe.go
+++ b/pkg/kubelet/probe.go
@@ -173,7 +173,7 @@ func (pb *prober) runProbe(p *api.Probe, pod *api.Pod, status api.PodStatus, con
 		glog.V(4).Infof("TCP-Probe PodIP: %v, Port: %v, Timeout: %v", status.PodIP, port, timeout)
 		return pb.tcp.Probe(status.PodIP, port, timeout)
 	}
-	glog.Warningf("Failed to find probe builder for %s %+v", container.Name, container.LivenessProbe)
+	glog.Warningf("Failed to find probe builder for container: %v", container)
 	return probe.Unknown, nil
 }
 

--- a/pkg/kubelet/probe.go
+++ b/pkg/kubelet/probe.go
@@ -154,7 +154,7 @@ func (pb *prober) runProbe(p *api.Probe, pod *api.Pod, status api.PodStatus, con
 	timeout := time.Duration(p.TimeoutSeconds) * time.Second
 	if p.Exec != nil {
 		glog.V(4).Infof("Exec-Probe Pod: %v, Container: %v", pod, container)
-		return pb.exec.Probe(pb.newExecInContainer(pod, container, containerID))
+		return pb.exec.Probe(pb.newExecInContainer(pod, container, containerID, p.Exec.Command))
 	}
 	if p.HTTPGet != nil {
 		port, err := extractPort(p.HTTPGet.Port, container)
@@ -227,9 +227,9 @@ type execInContainer struct {
 	run func() ([]byte, error)
 }
 
-func (p *prober) newExecInContainer(pod *api.Pod, container api.Container, containerID string) exec.Cmd {
+func (p *prober) newExecInContainer(pod *api.Pod, container api.Container, containerID string, cmd []string) exec.Cmd {
 	return execInContainer{func() ([]byte, error) {
-		return p.runner.RunInContainer(containerID, container.LivenessProbe.Exec.Command)
+		return p.runner.RunInContainer(containerID, cmd)
 	}}
 }
 

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -180,8 +180,8 @@ func (pb *prober) runProbeWithRetries(p *api.Probe, pod *api.Pod, status api.Pod
 func (pb *prober) runProbe(p *api.Probe, pod *api.Pod, status api.PodStatus, container api.Container, containerID string) (probe.Result, error) {
 	timeout := time.Duration(p.TimeoutSeconds) * time.Second
 	if p.Exec != nil {
-		glog.V(4).Infof("Exec-Probe Pod: %v, Container: %v", pod, container)
-		return pb.exec.Probe(pb.newExecInContainer(pod, container, containerID))
+		glog.V(4).Infof("Exec-Probe Pod: %v, Container: %v, Command: %v", pod, container, p.Exec.Command)
+		return pb.exec.Probe(pb.newExecInContainer(pod, container, containerID, p.Exec.Command))
 	}
 	if p.HTTPGet != nil {
 		port, err := extractPort(p.HTTPGet.Port, container)
@@ -200,7 +200,7 @@ func (pb *prober) runProbe(p *api.Probe, pod *api.Pod, status api.PodStatus, con
 		glog.V(4).Infof("TCP-Probe PodIP: %v, Port: %v, Timeout: %v", status.PodIP, port, timeout)
 		return pb.tcp.Probe(status.PodIP, port, timeout)
 	}
-	glog.Warningf("Failed to find probe builder for %s %+v", container.Name, container.LivenessProbe)
+	glog.Warningf("Failed to find probe builder for container: %v", container)
 	return probe.Unknown, nil
 }
 
@@ -254,9 +254,9 @@ type execInContainer struct {
 	run func() ([]byte, error)
 }
 
-func (p *prober) newExecInContainer(pod *api.Pod, container api.Container, containerID string) exec.Cmd {
+func (p *prober) newExecInContainer(pod *api.Pod, container api.Container, containerID string, cmd []string) exec.Cmd {
 	return execInContainer{func() ([]byte, error) {
-		return p.Runner.RunInContainer(containerID, container.LivenessProbe.Exec.Command)
+		return p.runner.RunInContainer(containerID, cmd)
 	}}
 }
 

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -256,7 +256,7 @@ type execInContainer struct {
 
 func (p *prober) newExecInContainer(pod *api.Pod, container api.Container, containerID string, cmd []string) exec.Cmd {
 	return execInContainer{func() ([]byte, error) {
-		return p.runner.RunInContainer(containerID, cmd)
+		return p.Runner.RunInContainer(containerID, cmd)
 	}}
 }
 


### PR DESCRIPTION
readinessProbe calls livenessProbe.Exec.Command which cause
"invalid memory address or nil pointer dereference".
