### PR TITLE
Do not automatically decode runtime.RawExtension

### DIFF
--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -115,12 +115,14 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 		},
 		func(j *api.List, c fuzz.Continue) {
 			c.FuzzNoCustom(j) // fuzz self without calling this function again
-			if j.Items == nil {
+			// TODO: uncomment when round trip starts from a versioned object
+			if false { //j.Items == nil {
 				j.Items = []runtime.Object{}
 			}
 		},
 		func(j *runtime.Object, c fuzz.Continue) {
-			if c.RandBool() {
+			// TODO: uncomment when round trip starts from a versioned object
+			if true { //c.RandBool() {
 				*j = &runtime.Unknown{
 					TypeMeta: runtime.TypeMeta{Kind: "Something", APIVersion: "unknown"},
 					RawJSON:  []byte(`{"apiVersion":"unknown","kind":"Something","someKey":"someValue"}`),

--- a/pkg/client/testclient/testclient.go
+++ b/pkg/client/testclient/testclient.go
@@ -27,7 +27,7 @@ import (
 
 // NewSimpleFake returns a client that will respond with the provided objects
 func NewSimpleFake(objects ...runtime.Object) *Fake {
-	o := NewObjects(api.Scheme)
+	o := NewObjects(api.Scheme, api.Scheme)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)

--- a/pkg/client/testclient/testclient_test.go
+++ b/pkg/client/testclient/testclient_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	o := NewObjects(api.Scheme)
-	if err := AddObjectsFromPath("../../../examples/guestbook/frontend-service.json", o); err != nil {
+	o := NewObjects(api.Scheme, api.Scheme)
+	if err := AddObjectsFromPath("../../../examples/guestbook/frontend-service.json", o, api.Scheme); err != nil {
 		t.Fatal(err)
 	}
 	client := &Fake{ReactFn: ObjectReaction(o, latest.RESTMapper)}
@@ -52,7 +52,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestErrors(t *testing.T) {
-	o := NewObjects(api.Scheme)
+	o := NewObjects(api.Scheme, api.Scheme)
 	o.Add(&api.List{
 		Items: []runtime.Object{
 			// This first call to List will return this error

--- a/pkg/conversion/error.go
+++ b/pkg/conversion/error.go
@@ -54,6 +54,10 @@ type missingKindErr struct {
 	data string
 }
 
+func NewMissingKindErr(data string) error {
+	return &missingKindErr{data}
+}
+
 func (k *missingKindErr) Error() string {
 	return fmt.Sprintf("Object 'Kind' is missing in '%s'", k.data)
 }
@@ -68,6 +72,10 @@ func IsMissingKind(err error) bool {
 
 type missingVersionErr struct {
 	data string
+}
+
+func NewMissingVersionErr(data string) error {
+	return &missingVersionErr{data}
 }
 
 func (k *missingVersionErr) Error() string {

--- a/pkg/conversion/scheme.go
+++ b/pkg/conversion/scheme.go
@@ -238,6 +238,17 @@ func (s *Scheme) AddDefaultingFuncs(defaultingFuncs ...interface{}) error {
 	return nil
 }
 
+// Recognizes returns true if the scheme is able to handle the provided version and kind
+// of an object.
+func (s *Scheme) Recognizes(version, kind string) bool {
+	m, ok := s.versionMap[version]
+	if !ok {
+		return false
+	}
+	_, ok = m[kind]
+	return ok
+}
+
 // RegisterInputDefaults sets the provided field mapping function and field matching
 // as the defaults for the provided input type.  The fn may be nil, in which case no
 // mapping will happen by default. Use this method to register a mechanism for handling

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -393,6 +393,17 @@ func TestGetMultipleTypeObjectsAsList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	list, err := runtime.ExtractList(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if errs := runtime.DecodeList(list, api.Scheme); len(errs) > 0 {
+		t.Fatalf("unexpected error: %v", errs)
+	}
+	if err := runtime.SetList(out, list); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
 	expected := &api.List{
 		Items: []runtime.Object{
 			&pods.Items[0],

--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -347,6 +347,12 @@ func (v FlattenListVisitor) Visit(fn VisitorFunc) error {
 		if err != nil {
 			return fn(info)
 		}
+		if errs := runtime.DecodeList(items, struct {
+			runtime.ObjectTyper
+			runtime.Decoder
+		}{v.Mapper, info.Mapping.Codec}); len(errs) > 0 {
+			return errors.NewAggregate(errs)
+		}
 		for i := range items {
 			item, err := v.InfoForObject(items[i])
 			if err != nil {

--- a/pkg/namespace/namespace_controller_test.go
+++ b/pkg/namespace/namespace_controller_test.go
@@ -135,7 +135,7 @@ func TestSyncNamespaceThatIsActive(t *testing.T) {
 }
 
 func TestRunStop(t *testing.T) {
-	o := testclient.NewObjects(api.Scheme)
+	o := testclient.NewObjects(api.Scheme, api.Scheme)
 	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}
 	nsMgr := NewNamespaceManager(client, 1*time.Second)
 

--- a/pkg/runtime/codec.go
+++ b/pkg/runtime/codec.go
@@ -21,8 +21,8 @@ import (
 )
 
 // CodecFor returns a Codec that invokes Encode with the provided version.
-func CodecFor(scheme *Scheme, version string) Codec {
-	return &codecWrapper{scheme, version}
+func CodecFor(codec ObjectCodec, version string) Codec {
+	return &codecWrapper{codec, version}
 }
 
 // yamlCodec converts YAML passed to the Decoder methods to JSON.
@@ -69,11 +69,11 @@ func EncodeOrDie(codec Codec, obj Object) string {
 // codecWrapper implements encoding to an alternative
 // default version for a scheme.
 type codecWrapper struct {
-	*Scheme
+	ObjectCodec
 	version string
 }
 
 // Encode implements Codec
 func (c *codecWrapper) Encode(obj Object) ([]byte, error) {
-	return c.Scheme.EncodeToVersion(obj, c.version)
+	return c.EncodeToVersion(obj, c.version)
 }

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -16,6 +16,24 @@ limitations under the License.
 
 package runtime
 
+// ObjectScheme represents common conversions between formal external API versions
+// and the internal Go structs. ObjectScheme is typically used with ObjectCodec to
+// transform internal Go structs into serialized versions. There may be many valid
+// ObjectCodecs for each ObjectScheme.
+type ObjectScheme interface {
+	ObjectConvertor
+	ObjectTyper
+	ObjectCreater
+	ObjectCopier
+}
+
+// ObjectCodec represents the common mechanisms for converting to and from a particular
+// binary representation of an object.
+type ObjectCodec interface {
+	ObjectEncoder
+	Decoder
+}
+
 // Decoder defines methods for deserializing API objects into a given type
 type Decoder interface {
 	Decode(data []byte) (Object, error)
@@ -33,6 +51,22 @@ type Codec interface {
 	Encoder
 }
 
+// ObjectCopier duplicates an object.
+type ObjectCopier interface {
+	// Copy returns an exact copy of the provided Object, or an error if the
+	// copy could not be completed.
+	Copy(Object) (Object, error)
+}
+
+// ObjectEncoder turns an object into a byte array. This interface is a
+// general form of the Encoder interface
+type ObjectEncoder interface {
+	// EncodeToVersion convert and serializes an object in the internal format
+	// to a specified output version. An error is returned if the object
+	// cannot be converted for any reason.
+	EncodeToVersion(obj Object, outVersion string) ([]byte, error)
+}
+
 // ObjectConvertor converts an object to a different version.
 type ObjectConvertor interface {
 	Convert(in, out interface{}) error
@@ -43,13 +77,36 @@ type ObjectConvertor interface {
 // ObjectTyper contains methods for extracting the APIVersion and Kind
 // of objects.
 type ObjectTyper interface {
+	// DataVersionAndKind returns the version and kind of the provided data, or an error
+	// if another problem is detected. In many cases this method can be as expensive to
+	// invoke as the Decode method.
 	DataVersionAndKind([]byte) (version, kind string, err error)
+	// ObjectVersionAndKind returns the version and kind of the provided object, or an
+	// error if the object is not recognized (IsNotRegisteredError will return true).
 	ObjectVersionAndKind(Object) (version, kind string, err error)
+	// Recognizes returns true if the scheme is able to handle the provided version and kind,
+	// or more precisely that the provided version is a possible conversion or decoding
+	// target.
+	Recognizes(version, kind string) bool
 }
 
 // ObjectCreater contains methods for instantiating an object by kind and version.
 type ObjectCreater interface {
 	New(version, kind string) (out Object, err error)
+}
+
+// ObjectDecoder is a convenience interface for identifying serialized versions of objects
+// and transforming them into Objects. It intentionally overlaps with ObjectTyper and
+// Decoder for use in decode only paths.
+type ObjectDecoder interface {
+	Decoder
+	// DataVersionAndKind returns the version and kind of the provided data, or an error
+	// if another problem is detected. In many cases this method can be as expensive to
+	// invoke as the Decode method.
+	DataVersionAndKind([]byte) (version, kind string, err error)
+	// Recognizes returns true if the scheme is able to handle the provided version and kind
+	// of an object.
+	Recognizes(version, kind string) bool
 }
 
 // ResourceVersioner provides methods for setting and retrieving

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -116,3 +116,17 @@ type Unknown struct {
 }
 
 func (*Unknown) IsAnAPIObject() {}
+
+// Unstructured allows objects that do not have Golang structs registered to be manipulated
+// generically. This can be used to deal with the API objects from a plug-in. Unstructured
+// objects still have functioning TypeMeta features-- kind, version, etc.
+// TODO: Make this object have easy access to field based accessors and settors for
+// metadata and field mutatation.
+type Unstructured struct {
+	TypeMeta `json:",inline"`
+	// Object is a JSON compatible map with string, float, int, []interface{}, or map[string]interface{}
+	// children.
+	Object map[string]interface{}
+}
+
+func (*Unstructured) IsAnAPIObject() {}

--- a/pkg/runtime/unstructured.go
+++ b/pkg/runtime/unstructured.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
+)
+
+// UnstructuredJSONScheme is capable of converting JSON data into the Unstructured
+// type, which can be used for generic access to objects without a predefined scheme.
+var UnstructuredJSONScheme ObjectDecoder = unstructuredJSONScheme{}
+
+type unstructuredJSONScheme struct{}
+
+// Recognizes returns true for any version or kind that is specified (internal
+// versions are specifically excluded).
+func (unstructuredJSONScheme) Recognizes(version, kind string) bool {
+	return len(version) > 0 && len(kind) > 0
+}
+
+func (s unstructuredJSONScheme) Decode(data []byte) (Object, error) {
+	unstruct := &Unstructured{}
+	if err := s.DecodeInto(data, unstruct); err != nil {
+		return nil, err
+	}
+	return unstruct, nil
+}
+
+func (unstructuredJSONScheme) DecodeInto(data []byte, obj Object) error {
+	unstruct, ok := obj.(*Unstructured)
+	if !ok {
+		return fmt.Errorf("the unstructured JSON scheme does not recognize %v", reflect.TypeOf(obj))
+	}
+
+	m := make(map[string]interface{})
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	if v, ok := m["kind"]; ok {
+		if s, ok := v.(string); ok {
+			unstruct.Kind = s
+		}
+	}
+	if v, ok := m["apiVersion"]; ok {
+		if s, ok := v.(string); ok {
+			unstruct.APIVersion = s
+		}
+	}
+	if len(unstruct.APIVersion) == 0 {
+		return conversion.NewMissingVersionErr(string(data))
+	}
+	if len(unstruct.Kind) == 0 {
+		return conversion.NewMissingKindErr(string(data))
+	}
+	unstruct.Object = m
+	return nil
+}
+
+func (unstructuredJSONScheme) DataVersionAndKind(data []byte) (version, kind string, err error) {
+	obj := TypeMeta{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return "", "", err
+	}
+	if len(obj.APIVersion) == 0 {
+		return "", "", conversion.NewMissingVersionErr(string(data))
+	}
+	if len(obj.Kind) == 0 {
+		return "", "", conversion.NewMissingKindErr(string(data))
+	}
+	return obj.APIVersion, obj.Kind, nil
+}

--- a/pkg/runtime/unstructured_test.go
+++ b/pkg/runtime/unstructured_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime_test
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+)
+
+func TestDecodeUnstructured(t *testing.T) {
+	pl := &api.List{
+		Items: []runtime.Object{
+			&api.Pod{ObjectMeta: api.ObjectMeta{Name: "1"}},
+			&runtime.Unknown{TypeMeta: runtime.TypeMeta{Kind: "Pod", APIVersion: "v1beta3"}, RawJSON: []byte(`{"kind":"Pod","apiVersion":"v1beta3","metadata":{"name":"test"}}`)},
+			&runtime.Unknown{TypeMeta: runtime.TypeMeta{Kind: "", APIVersion: "v1beta3"}, RawJSON: []byte(`{"kind":"Pod","apiVersion":"v1beta3","metadata":{"name":"test"}}`)},
+			&runtime.Unstructured{TypeMeta: runtime.TypeMeta{Kind: "Foo", APIVersion: "Bar"}, Object: map[string]interface{}{"test": "value"}},
+		},
+	}
+	if errs := runtime.DecodeList(pl.Items, runtime.UnstructuredJSONScheme); len(errs) == 1 {
+		t.Fatalf("unexpected error %v", errs)
+	}
+	if pod, ok := pl.Items[1].(*runtime.Unstructured); !ok || pod.Object["kind"] != "Pod" || pod.Object["metadata"].(map[string]interface{})["name"] != "test" {
+		t.Errorf("object not converted: %#v", pl.Items[1])
+	}
+	if _, ok := pl.Items[2].(*runtime.Unknown); !ok {
+		t.Errorf("object should not have been converted: %#v", pl.Items[2])
+	}
+}

--- a/pkg/volume/persistent_claim/persistent_claim_test.go
+++ b/pkg/volume/persistent_claim/persistent_claim_test.go
@@ -153,7 +153,7 @@ func TestNewBuilder(t *testing.T) {
 	}
 
 	for _, item := range tests {
-		o := testclient.NewObjects(api.Scheme)
+		o := testclient.NewObjects(api.Scheme, api.Scheme)
 		o.Add(item.pv)
 		o.Add(item.claim)
 		client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}
@@ -213,7 +213,7 @@ func TestNewBuilderClaimNotBound(t *testing.T) {
 			ClaimName: "claimC",
 		},
 	}
-	o := testclient.NewObjects(api.Scheme)
+	o := testclient.NewObjects(api.Scheme, api.Scheme)
 	o.Add(pv)
 	o.Add(claim)
 	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}

--- a/pkg/volumeclaimbinder/persistent_volume_claim_binder_test.go
+++ b/pkg/volumeclaimbinder/persistent_volume_claim_binder_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestRunStop(t *testing.T) {
-	o := testclient.NewObjects(api.Scheme)
+	o := testclient.NewObjects(api.Scheme, api.Scheme)
 	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}
 	binder := NewPersistentVolumeClaimBinder(client, 1*time.Second)
 
@@ -111,8 +111,8 @@ func TestExampleObjects(t *testing.T) {
 	}
 
 	for name, scenario := range scenarios {
-		o := testclient.NewObjects(api.Scheme)
-		if err := testclient.AddObjectsFromPath("../../examples/persistent-volumes/"+name, o); err != nil {
+		o := testclient.NewObjects(api.Scheme, api.Scheme)
+		if err := testclient.AddObjectsFromPath("../../examples/persistent-volumes/"+name, o, api.Scheme); err != nil {
 			t.Fatal(err)
 		}
 
@@ -168,11 +168,11 @@ func TestExampleObjects(t *testing.T) {
 
 func TestBindingWithExamples(t *testing.T) {
 	api.ForTesting_ReferencesAllowBlankSelfLinks = true
-	o := testclient.NewObjects(api.Scheme)
-	if err := testclient.AddObjectsFromPath("../../examples/persistent-volumes/claims/claim-01.yaml", o); err != nil {
+	o := testclient.NewObjects(api.Scheme, api.Scheme)
+	if err := testclient.AddObjectsFromPath("../../examples/persistent-volumes/claims/claim-01.yaml", o, api.Scheme); err != nil {
 		t.Fatal(err)
 	}
-	if err := testclient.AddObjectsFromPath("../../examples/persistent-volumes/volumes/local-01.yaml", o); err != nil {
+	if err := testclient.AddObjectsFromPath("../../examples/persistent-volumes/volumes/local-01.yaml", o, api.Scheme); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Make clients opt in to decoding objects that are stored in the generic api.List object by invoking runtime.DecodeList() with a set of schemes. Makes it easier to handle unknown schema objects because decoding is in the control of the code.  
### Change

A caller who is aware of the api.List type (or any object that has a runtime.RawExtension -> runtime.Object conversion) must also be aware that the runtime.Objects they receive may be unprocessed.  

The type they get is `*runtime.Unknown` (as before for a type not in the schema), but even objects in the schema are left unprocessed.

To make this easier, I added `runtime.DecodeList` which walks a []runtime.Object and looks for unrecognized objects.  Hypothetical call pattern is:

```
obj, _ := codec.Decode(data)
list, _ := runtime.ExtractList(obj)
runtime.Decode(list, <scheme1>, <otherschemes>)
```

The new "unstructured type" is itself a scheme, so you could do:

```
runtime.Decode(list, api.Scheme, config.Scheme, UnstructuredJSONScheme)
```

which would result in all `*runtime.Unknown` being converted to objects in api.Scheme, config.Scheme, or turned into `*runtime.Unstructured` which is map[string]interface{}

Also added a number of interfaces to runtime/interfaces which starts to tease apart conversion and decoding (and cleaned up a few places where that code was missing).

Fixes #7070
