### PR TITLE
Fixed kubelet deleting data from volumes on stop (#7317).

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1466,12 +1466,6 @@ func (kl *Kubelet) killUnwantedPods(desiredPods map[types.UID]empty,
 				glog.Errorf("Failed killing the pod %q: %v", pod.Name, err)
 				return
 			}
-			// Remove the pod directory.
-			err = os.RemoveAll(kl.getPodDir(pod.ID))
-			if err != nil {
-				glog.Errorf("Failed removing pod directory for %q", pod.Name)
-				return
-			}
 		}(pod, ch)
 	}
 


### PR DESCRIPTION
We must not clear the pod directory in killUnwantedPods(), volumes are still
mounted there at this time. There already is cleanupOrphanedPodDirs(),
called later in the SyncPods() sequence, which should remove these pod
directories.
