### PR TITLE
Verify request latency in e2e performance tests.

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -154,6 +154,13 @@ var _ = Describe("Density", func() {
 			// Tune the threshold for allowed failures.
 			badEvents := BadEvents(events)
 			Expect(badEvents).NotTo(BeNumerically(">", int(math.Floor(0.01*float64(totalPods)))))
+
+			// Verify latency metrics
+			// TODO: Update threshold to 1s once we reach this goal
+			// TODO: We should reset metrics before the test. Currently previous tests influence latency metrics.
+			highLatencyRequests, err := HighLatencyRequests(c, 10*time.Second)
+			expectNoError(err)
+			Expect(highLatencyRequests).NotTo(BeNumerically(">", 0))
 		})
 	}
 })

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -713,3 +713,70 @@ func getSigner(provider string) (ssh.Signer, error) {
 	}
 	return signer, nil
 }
+
+// LatencyMetrics stores data about request latency at a given quantile
+// broken down by verb (e.g. GET, PUT, LIST) and resource (e.g. pods, services).
+type LatencyMetric struct {
+	verb     string
+	resource string
+	// 0 <= quantile <=1, e.g. 0.95 is 95%tile, 0.5 is median.
+	quantile float64
+	latency  time.Duration
+}
+
+func ReadLatencyMetrics(c *client.Client) ([]LatencyMetric, error) {
+	body, err := c.Get().AbsPath("/metrics").DoRaw()
+	if err != nil {
+		return nil, err
+	}
+	metrics := make([]LatencyMetric, 0)
+	for _, line := range strings.Split(string(body), "\n") {
+		if strings.HasPrefix(line, "apiserver_request_latencies_summary{") {
+			// Example line:
+			// apiserver_request_latencies_summary{resource="namespaces",verb="LIST",quantile="0.99"} 908
+			// TODO: This parsing code is long and not readable. We should improve it.
+			keyVal := strings.Split(line, " ")
+			if len(keyVal) != 2 {
+				return nil, fmt.Errorf("Error parsing metric %q", line)
+			}
+			keyElems := strings.Split(line, "\"")
+			if len(keyElems) != 7 {
+				return nil, fmt.Errorf("Error parsing metric %q", line)
+			}
+			resource := keyElems[1]
+			verb := keyElems[3]
+			quantile, err := strconv.ParseFloat(keyElems[5], 64)
+			if err != nil {
+				return nil, fmt.Errorf("Error parsing metric %q", line)
+			}
+			latency, err := strconv.ParseFloat(keyVal[1], 64)
+			if err != nil {
+				return nil, fmt.Errorf("Error parsing metric %q", line)
+			}
+			metrics = append(metrics, LatencyMetric{verb, resource, quantile, time.Duration(int64(latency)) * time.Microsecond})
+		}
+	}
+	return metrics, nil
+}
+
+// Prints summary metrics for request types with latency above threshold
+// and returns number of such request types.
+func HighLatencyRequests(c *client.Client, threshold time.Duration) (int, error) {
+	metrics, err := ReadLatencyMetrics(c)
+	if err != nil {
+		return 0, err
+	}
+	var badMetrics []LatencyMetric
+	for _, metric := range metrics {
+		if metric.verb != "WATCHLIST" &&
+			// We are only interested in 99%tile, but for logging purposes
+			// it's useful to have all the offending percentiles.
+			metric.quantile <= 0.99 &&
+			metric.latency > threshold {
+			Logf("WARNING - requests with too high latency: %+v", metric)
+			badMetrics = append(badMetrics, metric)
+		}
+	}
+
+	return len(badMetrics), nil
+}


### PR DESCRIPTION
This is a first step to verify whether we meet goal in #4521

@wojtek-t @lavalamp @davidopp 

Test output:

INFO: WARNING - requests with too high latency: {verb:LIST resource:events quantile:0.99 latency:223985000}
INFO: WARNING - requests with too high latency: {verb:DELETE resource:pods quantile:0.9 latency:212482000}
INFO: WARNING - requests with too high latency: {verb:DELETE resource:pods quantile:0.99 latency:225625000}
[AfterEach] Density
  /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/density.go:79
STEP: Cleaning up the replication controller
STEP: Destroying namespace for this suite e2e-tests-density-d3d7a48f-de14-41ce-b449-8f250dd7e889

• Failure [70.520 seconds]
Density
/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/density.go:216
  [Performance suite] should allow starting 30 pods per node [It]
  /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/density.go:164

  Expected
      <int>: 3
  not to be >
      <int>: 0
