### PR TITLE
add StringSet.HasAny

### DIFF
--- a/pkg/util/set.go
+++ b/pkg/util/set.go
@@ -75,6 +75,16 @@ func (s StringSet) HasAll(items ...string) bool {
 	return true
 }
 
+// HasAny returns true if any items are contained in the set.
+func (s StringSet) HasAny(items ...string) bool {
+	for _, item := range items {
+		if s.Has(item) {
+			return true
+		}
+	}
+	return false
+}
+
 // Difference returns a set of objects that are not in s2
 // For example:
 // s1 = {1, 2, 3}

--- a/pkg/util/set_test.go
+++ b/pkg/util/set_test.go
@@ -117,3 +117,15 @@ func TestStringSetDifference(t *testing.T) {
 		t.Errorf("Unexpected contents: %#v", d.List())
 	}
 }
+
+func TestStringSetHasAny(t *testing.T) {
+	a := NewStringSet("1", "2", "3")
+
+	if !a.HasAny("1", "4") {
+		t.Errorf("expected true, got false")
+	}
+
+	if a.HasAny("0", "4") {
+		t.Errorf("expected false, got true")
+	}
+}


### PR DESCRIPTION
`HasAny` is useful shorthand.  We use it for determining whether any change is necessary: https://github.com/deads2k/origin/blob/deads-make-remove-user-predictable/pkg/cmd/experimental/policy/remove_user_from_project.go#L74 

@derekwaynecarr Any objection to creating this in the base library?
