### PR TITLE
cluster/gce/coreos: Add metadata-service in node.yaml

### DIFF
--- a/cluster/gce/coreos/node.yaml
+++ b/cluster/gce/coreos/node.yaml
@@ -76,8 +76,7 @@ coreos:
         ExecStartPre=/usr/bin/wget \
         -O /opt/rkt/rkt-v0.5.4.tar.gz \
         https://github.com/coreos/rkt/releases/download/v0.5.4/rkt-v0.5.4.tar.gz
-        ExecStartPre=/usr/bin/tar xzvf /opt/rkt/rkt-v0.5.4.tar.gz -C /opt --overwrite
-        ExecStart=/bin/systemd-run rkt metadata-service
+        ExecStart=/usr/bin/tar xzvf /opt/rkt/rkt-v0.5.4.tar.gz -C /opt --overwrite
 
     - name: kubernetes-install-minion.service
       command: start
@@ -154,3 +153,31 @@ coreos:
         Restart=always
         RestartSec=10
 
+    - name: rkt-metadata.socket
+      command: start
+      content: |
+        [Unit]
+        Description=rkt metadata service socket
+        PartOf=rkt-metadata.service
+        Requires=kubernetes-install-rkt.service
+        After=kubernetes-install-rkt.service
+        [Socket]
+        ListenStream=/run/rkt/metadata-svc.sock
+        SocketMode=0660
+        SocketUser=root
+        SocketGroup=root
+        RemoveOnStop=true
+
+    - name: rkt-metadata.service
+      command: start
+      content: |
+        [Unit]
+        Description=rkt metadata service
+        Documentation=http://github.com/coreos/rkt
+        Requires=rkt-metadata.socket
+        After=network.target rkt-metadata.socket
+        Requires=kubernetes-install-rkt.service
+        After=kubernetes-install-rkt.service
+        [Service]
+        # TODO(yifan): Make version configuable.
+        ExecStart=/opt/rkt-v0.5.4/rkt metadata-service


### PR DESCRIPTION
/cc @dchen1107 @vmarmol @jonboulle @bakins

Actually I found the metadata service is already started in old node.yaml, just updated with more specific service/socket files.
This saves us from start `metadata service` manually in #7465
