### PR TITLE
Bump kube2sky to 1.2. Point it at https endpoint (3rd try).

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -29,7 +29,7 @@ desiredState:
                     "-advertise-client-urls=http://127.0.0.1:4001",
             ]
           - name: kube2sky
-            image: gcr.io/google_containers/kube2sky:1.1
+            image: gcr.io/google_containers/kube2sky:1.2
             volumeMounts:
                - name: dns-token
                  mountPath: /etc/dns_token
@@ -37,6 +37,7 @@ desiredState:
             command: [
                     # entrypoint = "/kube2sky",
                     "-domain={{ pillar['dns_domain'] }}",
+                    "-kubecfg_file=/etc/dns_token/kubeconfig",
             ]
           - name: skydns
             image: gcr.io/google_containers/skydns:2015-03-11-001


### PR DESCRIPTION
Reverts the revert (#7461) of the re-merged (#7275) revert (#7207) of #7154.

I've run {up, DNS-test, down}  ~15 times locally without a flake. From @quinton-hoole's investigation on https://github.com/GoogleCloudPlatform/kubernetes/issues/7453#issuecomment-97279300, it appears that #7353 has fixed the apiserver-watch race kube2sky was running into.
