### PR TITLE
Fix representation of v1beta3 pod in secrets doc

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -32,7 +32,7 @@ The values are arbitrary data, encoded using base64.
 This is an example of a pod that uses a secret, in json format:
 ```json
 {
-  "apiVersion":"v1beta3",
+  "apiVersion": "v1beta3",
   "name": "mypod",
   "kind": "Pod",
   "spec": {
@@ -48,10 +48,8 @@ This is an example of a pod that uses a secret, in json format:
       }],
       "volumes": [{
         "name": "foo",
-        "source": {
-          "secret": {
-            "secretName": "mysecret"
-          }
+        "secret": {
+          "secretName": "mysecret"
         }
       }]
     }


### PR DESCRIPTION
Thanks to @asautins for finding this.
