### PR TITLE
Trim cluster log tags to pod name and container name

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
@@ -33,6 +33,9 @@ RUN sed -i -e "s/USER=td-agent/USER=root/" -e "s/GROUP=td-agent/GROUP=root/" /et
 # Install the Elasticsearch Fluentd plug-in.
 RUN /usr/sbin/td-agent-gem install fluent-plugin-elasticsearch
 
+# Install the record reformer plugin.
+RUN /usr/sbin/td-agent-gem install fluent-plugin-record-reformer
+
 # Copy the Fluentd configuration file.
 COPY td-agent.conf /etc/td-agent/td-agent.conf
 

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
@@ -1,7 +1,7 @@
 .PHONY:	build push
 
 IMAGE = fluentd-elasticsearch
-TAG = 1.4
+TAG = 1.5
 
 build:	
 	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
@@ -40,9 +40,15 @@
   path /varlog/containers/*.log
   pos_file /varlog/es-containers.log.pos
   time_format %Y-%m-%dT%H:%M:%S
-  tag kubernetes.*
+  tag reform.*
   read_from_head true
 </source>
+
+<match reform.**>
+  type record_reformer
+  enable_ruby true
+  tag kubernetes.${tag_suffix[3].split('-')[0..-2].join('-')}
+</match>
 
 <match kubernetes.**>
    type elasticsearch

--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.json
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.json
@@ -5,7 +5,7 @@
  "spec": {
    "containers": [
      { "name": "fluentd-elasticsearch",
-       "image": "gcr.io/google_containers/fluentd-elasticsearch:1.4",
+       "image": "gcr.io/google_containers/fluentd-elasticsearch:1.5",
        "env": [
          { "name": "FLUENTD_ARGS",
            "value": "-qq"}


### PR DESCRIPTION
This changes updates the Fluentd to Elasticsearch collector to use a tag which has the format `kubernetes.<pod-name>-<container-name>` and it strips out the Docker image name and some of the previous prefix which was not useful. Once this is in I will update the corresponding collector for Cloud Logging which should result in nicer tag for searching the logs of a pod even after container restarts.
