### PR TITLE
Added NFS to PV structs

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -222,6 +222,8 @@ type PersistentVolumeSource struct {
 	HostPath *HostPathVolumeSource `json:"hostPath"`
 	// Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod
 	Glusterfs *GlusterfsVolumeSource `json:"glusterfs"`
+	// NFS represents an NFS mount on the host that shares a pod's lifetime
+	NFS *NFSVolumeSource `json:"nfs"`
 }
 
 type PersistentVolumeClaimVolumeSource struct {

--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -1609,6 +1609,9 @@ func init() {
 			if err := s.Convert(&in.Glusterfs, &out.Glusterfs, 0); err != nil {
 				return err
 			}
+			if err := s.Convert(&in.NFS, &out.NFS, 0); err != nil {
+				return err
+			}
 			return nil
 		},
 		func(in *newer.PersistentVolumeSource, out *PersistentVolumeSource, s conversion.Scope) error {
@@ -1622,6 +1625,9 @@ func init() {
 				return err
 			}
 			if err := s.Convert(&in.Glusterfs, &out.Glusterfs, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.NFS, &out.NFS, 0); err != nil {
 				return err
 			}
 			return nil

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -247,6 +247,8 @@ type PersistentVolumeSource struct {
 	HostPath *HostPathVolumeSource `json:"hostPath" description:"a HostPath provisioned by a developer or tester; for develment use only"`
 	// Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod
 	Glusterfs *GlusterfsVolumeSource `json:"glusterfs" description:"Glusterfs volume resource provisioned by an admin"`
+	// NFS represents an NFS mount on the host
+	NFS *NFSVolumeSource `json:"nfs" description:"NFS volume resource provisioned by an admin"`
 }
 
 type PersistentVolume struct {

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -145,6 +145,8 @@ type PersistentVolumeSource struct {
 	HostPath *HostPathVolumeSource `json:"hostPath" description:"a HostPath provisioned by a developer or tester; for develment use only"`
 	// Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod
 	Glusterfs *GlusterfsVolumeSource `json:"glusterfs" description:"Glusterfs volume resource provisioned by an admin"`
+	// NFS represents an NFS mount on the host
+	NFS *NFSVolumeSource `json:"nfs" description:"NFS volume resource provisioned by an admin"`
 }
 
 type PersistentVolumeClaimVolumeSource struct {

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -107,6 +107,8 @@ type PersistentVolumeSource struct {
 	HostPath *HostPathVolumeSource `json:"hostPath" description:"a HostPath provisioned by a developer or tester; for develment use only"`
 	// Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod
 	Glusterfs *GlusterfsVolumeSource `json:"glusterfs" description:"Glusterfs volume resource provisioned by an admin"`
+	// NFS represents an NFS mount on the host
+	NFS *NFSVolumeSource `json:"nfs" description:"NFS volume resource provisioned by an admin"`
 }
 
 type PersistentVolumeClaimVolumeSource struct {

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -2253,6 +2253,14 @@ func convert_v1beta3_PersistentVolumeSource_To_api_PersistentVolumeSource(in *Pe
 	} else {
 		out.Glusterfs = nil
 	}
+	if in.NFS != nil {
+		out.NFS = new(newer.NFSVolumeSource)
+		if err := convert_v1beta3_NFSVolumeSource_To_api_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
+			return err
+		}
+	} else {
+		out.NFS = nil
+	}
 	return nil
 }
 
@@ -2291,6 +2299,14 @@ func convert_api_PersistentVolumeSource_To_v1beta3_PersistentVolumeSource(in *ne
 		}
 	} else {
 		out.Glusterfs = nil
+	}
+	if in.NFS != nil {
+		out.NFS = new(NFSVolumeSource)
+		if err := convert_api_NFSVolumeSource_To_v1beta3_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
+			return err
+		}
+	} else {
+		out.NFS = nil
 	}
 	return nil
 }

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -247,6 +247,8 @@ type PersistentVolumeSource struct {
 	HostPath *HostPathVolumeSource `json:"hostPath" description:"a HostPath provisioned by a developer or tester; for develment use only"`
 	// Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod
 	Glusterfs *GlusterfsVolumeSource `json:"glusterfs" description:"Glusterfs volume resource provisioned by an admin"`
+	// NFS represents an NFS mount on the host
+	NFS *NFSVolumeSource `json:"nfs" description:"NFS volume resource provisioned by an admin"`
 }
 
 type PersistentVolume struct {

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -465,6 +465,10 @@ func ValidatePersistentVolume(pv *api.PersistentVolume) errs.ValidationErrorList
 		numVolumes++
 		allErrs = append(allErrs, validateGlusterfs(pv.Spec.Glusterfs).Prefix("glusterfs")...)
 	}
+	if pv.Spec.NFS != nil {
+		numVolumes++
+		allErrs = append(allErrs, validateNFS(pv.Spec.NFS).Prefix("nfs")...)
+	}
 	if numVolumes != 1 {
 		allErrs = append(allErrs, errs.NewFieldInvalid("", pv.Spec.PersistentVolumeSource, "exactly 1 volume type is required"))
 	}


### PR DESCRIPTION
@thockin We removed NFS from these structs in previous PRs and said we'd add NFS in a separate request.  Here it is.

The NFS plugin already supported PV and the unit tests correctly test it.  Only had to add it to the API.
