### PR TITLE
fix kube-down for provider gke

### DIFF
--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -303,5 +303,5 @@ function kube-down() {
   echo "... in kube-down()" >&2
   detect-project >&2
   "${GCLOUD}" alpha container clusters delete --project="${PROJECT}" \
-    --zone="${ZONE}" "${CLUSTER_NAME}"
+    --zone="${ZONE}" "${CLUSTER_NAME} --quiet"
 }


### PR DESCRIPTION
gcloud clusters delete now prompts for confirmation by default. add `--quiet` flag to skip.

cc @zmerlynn 
