### PR TITLE
GCE CoreOS cluster - set master name based on variable

### DIFF
--- a/cluster/gce/coreos/node.yaml
+++ b/cluster/gce/coreos/node.yaml
@@ -123,7 +123,7 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/run/setup-auth.sh
         ExecStart=/opt/kubernetes/server/bin/kubelet \
-        --api_servers=https://kubernetes-master.c.${PROJECT_ID}.internal \
+        --api_servers=https://${KUBERNETES_MASTER_NAME}.c.${PROJECT_ID}.internal \
         --config=/etc/kubernetes/manifests \
         --allow_privileged=False \
         --v=2 \
@@ -146,7 +146,7 @@ coreos:
         EnvironmentFile=/etc/kube-env
         ExecStartPre=/run/config-kube-proxy.sh
         ExecStart=/opt/kubernetes/server/bin/kube-proxy \
-        --master=https://kubernetes-master.c.${PROJECT_ID}.internal \
+        --master=https://${KUBERNETES_MASTER_NAME}.c.${PROJECT_ID}.internal \
         --kubeconfig=/var/lib/kube-proxy/kubeconfig \
         --v=2 \
         --logtostderr=true


### PR DESCRIPTION
The name of the master changes based on environment. Was unable to run e2e until I made this change.
