### PR TITLE
Fixes atomic update logic in kubectl rolling-update

### DIFF
--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -292,11 +292,10 @@ func addDeploymentKeyToReplicationController(oldRc *api.ReplicationController, c
 	}
 	oldRc.Spec.Template.Labels[deploymentKey] = oldHash
 
-	rc, err := client.ReplicationControllers(namespace).Update(oldRc)
+	oldRc, err = client.ReplicationControllers(namespace).Update(oldRc)
 	if err != nil {
 		return err
 	}
-	oldRc.ResourceVersion = rc.ResourceVersion
 
 	// Update all labels to include the new hash, so they are correctly adopted
 	// TODO: extract the code from the label command and re-use it here.

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -291,9 +291,12 @@ func addDeploymentKeyToReplicationController(oldRc *api.ReplicationController, c
 		oldRc.Spec.Template.Labels = map[string]string{}
 	}
 	oldRc.Spec.Template.Labels[deploymentKey] = oldHash
-	if _, err := client.ReplicationControllers(namespace).Update(oldRc); err != nil {
+
+	rc, err := client.ReplicationControllers(namespace).Update(oldRc)
+	if err != nil {
 		return err
 	}
+	oldRc.ResourceVersion = rc.ResourceVersion
 
 	// Update all labels to include the new hash, so they are correctly adopted
 	// TODO: extract the code from the label command and re-use it here.

--- a/pkg/registry/generic/etcd/etcd.go
+++ b/pkg/registry/generic/etcd/etcd.go
@@ -296,7 +296,7 @@ func (e *Etcd) Update(ctx api.Context, obj runtime.Object) (runtime.Object, bool
 		}
 		if newVersion != version {
 			// TODO: return the most recent version to a client?
-			return nil, 0, kubeerr.NewConflict(e.EndpointName, name, fmt.Errorf("the resource was updated to %d", version))
+			return nil, 0, kubeerr.NewConflict(e.EndpointName, name, fmt.Errorf("version is %v, does not match %v specified in the update request", newVersion, version))
 		}
 		if err := rest.BeforeUpdate(e.UpdateStrategy, ctx, obj, existing); err != nil {
 			return nil, 0, err


### PR DESCRIPTION
The addDeploymentKeyToReplicationController function attempts two updates with the same object, but didn't bump `ResourceVersion` after the first update. This causes the second update to fail with a conflict.
