### PR TITLE
Add image-related methods to DockerManager

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -54,18 +54,18 @@ type Runtime interface {
 	KillContainerInPod(api.Container, *api.Pod) error
 	// GetPodStatus retrieves the status of the pod, including the information of
 	// all containers in the pod.
-	GetPodStatus(*api.Pod) (api.PodStatus, error)
+	GetPodStatus(*api.Pod) (*api.PodStatus, error)
 	// TODO(vmarmol): Merge RunInContainer and ExecInContainer.
 	// Runs the command in the container of the specified pod using nsinit.
 	// TODO(yifan): Use strong type for containerID.
-	RunInContainer(containerID string, cmd []string) error
+	RunInContainer(containerID string, cmd []string) ([]byte, error)
 	// Runs the command in the container of the specified pod using nsenter.
 	// Attaches the processes stdin, stdout, and stderr. Optionally uses a
 	// tty.
 	// TODO(yifan): Use strong type for containerID.
 	ExecInContainer(containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error
 	// Forward the specified port from the specified pod to the stream.
-	PortForward(pod Pod, port uint16, stream io.ReadWriteCloser) error
+	PortForward(pod *Pod, port uint16, stream io.ReadWriteCloser) error
 	// PullImage pulls an image from the network to local storage.
 	PullImage(image string) error
 	// IsImagePresent checks whether the container image is already in the local storage.

--- a/pkg/kubelet/dockertools/convert.go
+++ b/pkg/kubelet/dockertools/convert.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockertools
+
+import (
+	"fmt"
+
+	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+// This file contains helper functions to convert docker API types to runtime
+// (kubecontainer) types.
+
+// Converts docker.APIContainers to kubecontainer.Container.
+func toRuntimeContainer(c *docker.APIContainers) (*kubecontainer.Container, error) {
+	if c == nil {
+		return nil, fmt.Errorf("unable to convert a nil pointer to a runtime container")
+	}
+
+	dockerName, hash, err := getDockerContainerNameInfo(c)
+	if err != nil {
+		return nil, err
+	}
+	return &kubecontainer.Container{
+		ID:      types.UID(c.ID),
+		Name:    dockerName.ContainerName,
+		Image:   c.Image,
+		Hash:    hash,
+		Created: c.Created,
+	}, nil
+}
+
+// Converts docker.APIImages to kubecontainer.Image.
+func toRuntimeImage(image *docker.APIImages) (*kubecontainer.Image, error) {
+	if image == nil {
+		return nil, fmt.Errorf("unable to convert a nil pointer to a runtime image")
+	}
+
+	return &kubecontainer.Image{
+		ID:   image.ID,
+		Tags: image.RepoTags,
+		Size: image.Size,
+	}, nil
+}

--- a/pkg/kubelet/dockertools/convert_test.go
+++ b/pkg/kubelet/dockertools/convert_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockertools
+
+import (
+	"reflect"
+	"testing"
+
+	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+func TestToRuntimeContainer(t *testing.T) {
+	original := &docker.APIContainers{
+		ID:      "ab2cdf",
+		Image:   "bar_image",
+		Created: 12345,
+		Names:   []string{"/k8s_bar.5678_foo_ns_1234_42"},
+	}
+	expected := &kubecontainer.Container{
+		ID:      types.UID("ab2cdf"),
+		Name:    "bar",
+		Image:   "bar_image",
+		Hash:    0x5678,
+		Created: 12345,
+	}
+
+	actual, err := toRuntimeContainer(original)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected %#v, got %#v", expected, actual)
+	}
+}
+
+func TestToRuntimeImage(t *testing.T) {
+	original := &docker.APIImages{
+		ID:       "aeeea",
+		RepoTags: []string{"abc", "def"},
+		Size:     1234,
+	}
+	expected := &kubecontainer.Image{
+		ID:   "aeeea",
+		Tags: []string{"abc", "def"},
+		Size: 1234,
+	}
+
+	actual, err := toRuntimeImage(original)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected %#v, got %#v", expected, actual)
+	}
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -887,7 +887,7 @@ func (kl *Kubelet) pullImage(pod *api.Pod, container *api.Container) error {
 		return nil
 	}
 
-	err = kl.containerManager.Pull(container.Image)
+	err = kl.containerManager.PullImage(container.Image)
 	kl.runtimeHooks.ReportImagePull(pod, container, err)
 	return err
 }


### PR DESCRIPTION
This change is part of the efforts to make DockerManager implement the Runtime
interface.

The change also modifies the interface slightly to work with existing
code, and aggregates the type converting functions to convert.go.
