### PR TITLE
kubelet/container: Move ShouldContainerBeRestarted() to runtime.

### DIFF
--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/golang/glog"
 )
 
 // HandlerRunner runs a lifecycle handler for a container.
@@ -43,4 +44,40 @@ func TrimRuntimePrefix(fullString string) string {
 		return fullString
 	}
 	return fullString[idx+len(prefixSeparator):]
+}
+
+// ShouldContainerBeRestarted checks whether a container needs to be restarted.
+// TODO(yifan): Think about how to refactor this.
+func ShouldContainerBeRestarted(container *api.Container, pod *api.Pod, podStatus *api.PodStatus, readinessManager *ReadinessManager) bool {
+	podFullName := GetPodFullName(pod)
+
+	// Get all dead container status.
+	var resultStatus []*api.ContainerStatus
+	for i, containerStatus := range podStatus.ContainerStatuses {
+		if containerStatus.Name == container.Name && containerStatus.State.Termination != nil {
+			resultStatus = append(resultStatus, &podStatus.ContainerStatuses[i])
+		}
+	}
+
+	// Set dead containers to unready state.
+	for _, c := range resultStatus {
+		readinessManager.RemoveReadiness(TrimRuntimePrefix(c.ContainerID))
+	}
+
+	// Check RestartPolicy for dead container.
+	if len(resultStatus) > 0 {
+		if pod.Spec.RestartPolicy == api.RestartPolicyNever {
+			glog.V(4).Infof("Already ran container %q of pod %q, do nothing", container.Name, podFullName)
+			return false
+		}
+		if pod.Spec.RestartPolicy == api.RestartPolicyOnFailure {
+			// Check the exit code of last run. Note: This assumes the result is sorted
+			// by the created time in reverse order.
+			if resultStatus[0].State.Termination.ExitCode == 0 {
+				glog.V(4).Infof("Already successfully ran container %q of pod %q, do nothing", container.Name, podFullName)
+				return false
+			}
+		}
+	}
+	return true
 }


### PR DESCRIPTION
This moves ShouldContainerBeRestarted to runtime, so it can be reused by rkt.

But I hate the function name, and the function input is ad hoc. Add a TODO to remind us to refactor this later.

@vmarmol @dchen1107 @yujuhong @jonboulle 
