### PR TITLE
Update expiration timeout based on observed latencies

### DIFF
--- a/pkg/client/cache/expiration_cache.go
+++ b/pkg/client/cache/expiration_cache.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/golang/glog"
 	"time"
 )
 
@@ -81,6 +82,7 @@ func (c *ExpirationCache) getOrExpire(key string) (interface{}, bool) {
 		return nil, false
 	}
 	if c.expirationPolicy.IsExpired(timestampedItem) {
+		glog.V(4).Infof("Entry %v: %+v has expired", key, timestampedItem.obj)
 		// Since expiration happens lazily on read, don't hold up
 		// the reader trying to acquire a write lock for the delete.
 		// The next reader will retry the delete even if this one


### PR DESCRIPTION
Does https://github.com/GoogleCloudPlatform/kubernetes/pull/6866#issuecomment-97493339

To clarify, the latency of creating/watching a single pod isn't in minutes (and won't be even with 100 nodes), but creating 3000 pods at once and being notified of them all via watch is. The expiration timeout was set based on the rate limit qps, this PR bumps it up to the observed latency in a larger cluster. 

https://github.com/GoogleCloudPlatform/kubernetes/issues/7561
@davidopp @quinton-hoole @wojtek-t , whichever one of you is around today.
