### PR TITLE
Requeue rc if a single get/put retry on status.Replicas fails

### DIFF
--- a/pkg/client/testclient/fake_replication_controllers.go
+++ b/pkg/client/testclient/fake_replication_controllers.go
@@ -30,32 +30,41 @@ type FakeReplicationControllers struct {
 	Namespace string
 }
 
+const (
+	GetControllerAction    = "get-replicationController"
+	UpdateControllerAction = "update-replicationController"
+	WatchControllerAction  = "watch-replicationController"
+	DeleteControllerAction = "delete-replicationController"
+	ListControllerAction   = "list-replicationControllers"
+	CreateControllerAction = "create-replicationController"
+)
+
 func (c *FakeReplicationControllers) List(selector labels.Selector) (*api.ReplicationControllerList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-replicationControllers"}, &api.ReplicationControllerList{})
+	obj, err := c.Fake.Invokes(FakeAction{Action: ListControllerAction}, &api.ReplicationControllerList{})
 	return obj.(*api.ReplicationControllerList), err
 }
 
 func (c *FakeReplicationControllers) Get(name string) (*api.ReplicationController, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-replicationController", Value: name}, &api.ReplicationController{})
+	obj, err := c.Fake.Invokes(FakeAction{Action: GetControllerAction, Value: name}, &api.ReplicationController{})
 	return obj.(*api.ReplicationController), err
 }
 
 func (c *FakeReplicationControllers) Create(controller *api.ReplicationController) (*api.ReplicationController, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-replicationController", Value: controller}, &api.ReplicationController{})
+	obj, err := c.Fake.Invokes(FakeAction{Action: CreateControllerAction, Value: controller}, &api.ReplicationController{})
 	return obj.(*api.ReplicationController), err
 }
 
 func (c *FakeReplicationControllers) Update(controller *api.ReplicationController) (*api.ReplicationController, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "update-replicationController", Value: controller}, &api.ReplicationController{})
+	obj, err := c.Fake.Invokes(FakeAction{Action: UpdateControllerAction, Value: controller}, &api.ReplicationController{})
 	return obj.(*api.ReplicationController), err
 }
 
 func (c *FakeReplicationControllers) Delete(name string) error {
-	_, err := c.Fake.Invokes(FakeAction{Action: "delete-replicationController", Value: name}, &api.ReplicationController{})
+	_, err := c.Fake.Invokes(FakeAction{Action: DeleteControllerAction, Value: name}, &api.ReplicationController{})
 	return err
 }
 
 func (c *FakeReplicationControllers) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-replicationController", Value: resourceVersion})
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: WatchControllerAction, Value: resourceVersion})
 	return c.Fake.Watch, nil
 }

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
@@ -27,12 +26,14 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/wait"
 	"github.com/golang/glog"
 	"sync/atomic"
 )
 
-const CreatedByAnnotation = "kubernetes.io/created-by"
+const (
+	CreatedByAnnotation = "kubernetes.io/created-by"
+	updateRetries       = 1
+)
 
 // Expectations are a way for replication controllers to tell the rc manager what they expect. eg:
 //	RCExpectations: {
@@ -276,21 +277,28 @@ func filterActivePods(pods []api.Pod) []*api.Pod {
 	return result
 }
 
-// updateReplicaCount attempts to update the Status.Replicas of the given controller, with retries.
-// Note that the controller pointer might contain a more recent version of the same controller passed into the function.
-func updateReplicaCount(rcClient client.ReplicationControllerInterface, controller *api.ReplicationController, numReplicas int) error {
-	return wait.Poll(10*time.Millisecond, 100*time.Millisecond, func() (bool, error) {
-		if controller.Status.Replicas != numReplicas {
-			glog.V(4).Infof("Updating replica count for rc: %v, %d->%d", controller.Name, controller.Status.Replicas, numReplicas)
-			controller.Status.Replicas = numReplicas
-			_, err := rcClient.Update(controller)
-			if err != nil {
-				glog.V(2).Infof("Controller %v failed to update replica count: %v", controller.Name, err)
-				// Update the controller with the latest resource version for the next poll
-				controller, _ = rcClient.Get(controller.Name)
-				return false, err
-			}
+// updateReplicaCount attempts to update the Status.Replicas of the given controller, with a single GET/PUT retry.
+func updateReplicaCount(rcClient client.ReplicationControllerInterface, controller api.ReplicationController, numReplicas int) (updateErr error) {
+	// This is the steady state. It happens when the rc doesn't have any expectations, since
+	// we do a periodic relist every 30s.
+	if controller.Status.Replicas == numReplicas {
+		return nil
+	}
+	var getErr error
+	glog.V(4).Infof("Updating replica count for rc: %v, %d->%d", controller.Name, controller.Status.Replicas, numReplicas)
+	for i, rc := 0, &controller; ; i++ {
+		rc.Status.Replicas = numReplicas
+		_, updateErr = rcClient.Update(rc)
+		if updateErr == nil || i >= updateRetries {
+			return updateErr
 		}
-		return true, nil
-	})
+		// Update the controller with the latest resource version for the next poll
+		if rc, getErr = rcClient.Get(controller.Name); getErr != nil {
+			// If the GET fails we can't trust status.Replicas anymore. This error
+			// is bound to be more interesting than the update failure.
+			return getErr
+		}
+	}
+	// Failed 2 updates one of which was with the latest controller, return the update error
+	return
 }

--- a/pkg/namespace/namespace_controller_test.go
+++ b/pkg/namespace/namespace_controller_test.go
@@ -88,11 +88,12 @@ func TestSyncNamespaceThatIsTerminating(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error when synching namespace %v", err)
 	}
+	// TODO: Reuse the constants for all these strings from testclient
 	expectedActionSet := util.NewStringSet(
+		testclient.ListControllerAction,
 		"list-services",
 		"list-pods",
 		"list-resourceQuotas",
-		"list-replicationControllers",
 		"list-secrets",
 		"list-limitRanges",
 		"list-events",


### PR DESCRIPTION
Does https://github.com/GoogleCloudPlatform/kubernetes/pull/6866#issuecomment-97271867. 

Essentially we try once with the rc we have, if that fails (which can happen for all pods that show up via watch in the window mentioned in the above comment), we do a single get and try the update again. If the second udpate fails, requeue the rc.
