### PR TITLE
Don't exit abruptly if there aren't yet any minions right after the cluster is created.

### DIFF
--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -31,7 +31,7 @@ trap 'rm -rf "${MINIONS_FILE}"' EXIT
 attempt=0
 while true; do
   "${KUBE_ROOT}/cluster/kubectl.sh" get nodes -o template -t $'{{range.items}}{{.metadata.name}}\n{{end}}' --api-version=v1beta3 > "${MINIONS_FILE}"
-  found=$(grep -c . "${MINIONS_FILE}")
+  found=$(grep -c . "${MINIONS_FILE}") || true
   if [[ ${found} == "${NUM_MINIONS}" ]]; then
     break
   else


### PR DESCRIPTION
This just caused a gke-ci Jenkins run to fail (4548). 

/cc @ixdy @quinton-hoole 
