### PR TITLE
Removes RunPod in the Runtime interface

### DIFF
--- a/pkg/kubelet/container/fake_runtime.go
+++ b/pkg/kubelet/container/fake_runtime.go
@@ -128,11 +128,11 @@ func (f *FakeRuntime) GetPods(all bool) ([]*Pod, error) {
 	return f.Podlist, f.Err
 }
 
-func (f *FakeRuntime) RunPod(pod *api.Pod, volumeMap map[string]volume.VolumePlugin) error {
+func (f *FakeRuntime) SyncPod(pod *api.Pod, _ Pod, _ api.PodStatus) error {
 	f.Lock()
 	defer f.Unlock()
 
-	f.CalledFunctions = append(f.CalledFunctions, "RunPod")
+	f.CalledFunctions = append(f.CalledFunctions, "SyncPod")
 	f.StartedPods = append(f.StartedPods, string(pod.UID))
 	for _, c := range pod.Spec.Containers {
 		f.StartedContainers = append(f.StartedContainers, c.Name)

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
 )
 
 type Version interface {
@@ -44,8 +43,6 @@ type Runtime interface {
 	// specifies whether the runtime returns all containers including those already
 	// exited and dead containers (used for garbage collection).
 	GetPods(all bool) ([]*Pod, error)
-	// RunPod starts all the containers of a pod within a namespace.
-	RunPod(*api.Pod, map[string]volume.Volume) error
 	// Syncs the running pod into the desired pod.
 	SyncPod(pod *api.Pod, runningPod Pod, podStatus api.PodStatus) error
 	// KillPod kills all the containers of a pod.

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -54,7 +54,8 @@ const (
 	maxReasonCacheEntries = 200
 )
 
-// TODO(yjhong): DockerManager should implement the Runtime interface.
+// DockerManager implements the Runtime interface.
+var _ kubecontainer.Runtime = &DockerManager{}
 
 type DockerManager struct {
 	client              DockerInterface


### PR DESCRIPTION
SyncPod subsumes RunPod, so the latter is no longer needed.
After this change, DockerManager implements the Runtime interface.
