### PR TITLE
Change the cloud provider TCPLoadBalancerExists function to GetTCPLoadBalancer...

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -58,11 +58,10 @@ func GetLoadBalancerName(service *api.Service) string {
 
 // TCPLoadBalancer is an abstract, pluggable interface for TCP load balancers.
 type TCPLoadBalancer interface {
-	// TCPLoadBalancerExists returns whether the specified load balancer exists.
 	// TODO: Break this up into different interfaces (LB, etc) when we have more than one type of service
-	// TODO: This should really return the details of the load balancer so we can
-	// determine if it matches the needs of a service rather than if it exists.
-	TCPLoadBalancerExists(name, region string) (bool, error)
+	// GetTCPLoadBalancer returns whether the specified load balancer exists, and
+	// if so, what its IP address or hostname is.
+	GetTCPLoadBalancer(name, region string) (endpoint string, exists bool, err error)
 	// CreateTCPLoadBalancer creates a new tcp load balancer. Returns the IP address or hostname of the balancer
 	CreateTCPLoadBalancer(name, region string, externalIP net.IP, ports []int, hosts []string, affinityType api.AffinityType) (string, error)
 	// UpdateTCPLoadBalancer updates hosts under the specified load balancer.

--- a/pkg/cloudprovider/fake/fake.go
+++ b/pkg/cloudprovider/fake/fake.go
@@ -94,9 +94,9 @@ func (f *FakeCloud) Zones() (cloudprovider.Zones, bool) {
 	return f, true
 }
 
-// TCPLoadBalancerExists is a stub implementation of TCPLoadBalancer.TCPLoadBalancerExists.
-func (f *FakeCloud) TCPLoadBalancerExists(name, region string) (bool, error) {
-	return f.Exists, f.Err
+// GetTCPLoadBalancer is a stub implementation of TCPLoadBalancer.GetTCPLoadBalancer.
+func (f *FakeCloud) GetTCPLoadBalancer(name, region string) (endpoint string, exists bool, err error) {
+	return f.ExternalIP.String(), f.Exists, f.Err
 }
 
 // CreateTCPLoadBalancer is a test-spy implementation of TCPLoadBalancer.CreateTCPLoadBalancer.

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -239,16 +239,16 @@ func (gce *GCECloud) waitForRegionOp(op *compute.Operation, region string) error
 	return nil
 }
 
-// TCPLoadBalancerExists is an implementation of TCPLoadBalancer.TCPLoadBalancerExists.
-func (gce *GCECloud) TCPLoadBalancerExists(name, region string) (bool, error) {
-	_, err := gce.service.ForwardingRules.Get(gce.projectID, region, name).Do()
+// GetTCPLoadBalancer is an implementation of TCPLoadBalancer.GetTCPLoadBalancer
+func (gce *GCECloud) GetTCPLoadBalancer(name, region string) (endpoint string, exists bool, err error) {
+	fw, err := gce.service.ForwardingRules.Get(gce.projectID, region, name).Do()
 	if err == nil {
-		return true, nil
+		return fw.IPAddress, true, nil
 	}
 	if isHTTPErrorCode(err, http.StatusNotFound) {
-		return false, nil
+		return "", false, nil
 	}
-	return false, err
+	return "", false, err
 }
 
 func isHTTPErrorCode(err error, code int) bool {

--- a/pkg/cloudprovider/openstack/openstack.go
+++ b/pkg/cloudprovider/openstack/openstack.go
@@ -456,12 +456,15 @@ func getVipByName(client *gophercloud.ServiceClient, name string) (*vips.Virtual
 	return &vipList[0], nil
 }
 
-func (lb *LoadBalancer) TCPLoadBalancerExists(name, region string) (bool, error) {
+func (lb *LoadBalancer) GetTCPLoadBalancer(name, region string) (endpoint string, exists bool, err error) {
 	vip, err := getVipByName(lb.network, name)
 	if err == ErrNotFound {
-		return false, nil
+		return "", false, nil
 	}
-	return vip != nil, err
+	if vip == nil {
+		return "", false, err
+	}
+	return vip.Address, true, err
 }
 
 // TODO: This code currently ignores 'region' and always creates a

--- a/pkg/cloudprovider/openstack/openstack_test.go
+++ b/pkg/cloudprovider/openstack/openstack_test.go
@@ -173,12 +173,12 @@ func TestTCPLoadBalancer(t *testing.T) {
 		t.Fatalf("TCPLoadBalancer() returned false - perhaps your stack doesn't support Neutron?")
 	}
 
-	exists, err := lb.TCPLoadBalancerExists("noexist", "region")
+	_, exists, err := lb.GetTCPLoadBalancer("noexist", "region")
 	if err != nil {
-		t.Fatalf("TCPLoadBalancerExists(\"noexist\") returned error: %s", err)
+		t.Fatalf("GetTCPLoadBalancer(\"noexist\") returned error: %s", err)
 	}
 	if exists {
-		t.Fatalf("TCPLoadBalancerExists(\"noexist\") returned true")
+		t.Fatalf("GetTCPLoadBalancer(\"noexist\") returned exists")
 	}
 }
 


### PR DESCRIPTION
...which returns the IP/DNS address of the load balancer, enabling more intelligent reconciliation in the service controller.

@justinsb since this slightly modifies the interface that #5225 is implementing
