### PR TITLE
Fix kube2sky flakes. Fix tools.GetEtcdVersion to work with etcd > 2.0.7

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -21,15 +21,17 @@ desiredState:
         dnsPolicy: "Default"  # Don't use cluster DNS.
         containers:
           - name: etcd
-            image: quay.io/coreos/etcd:v2.0.3
+            image: gcr.io/google_containers/etcd:2.0.9
             command: [
-                    # entrypoint = "/etcd",
-                    "-listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001",
+                    "/usr/local/bin/etcd",
+                    "--addr",
+                    "127.0.0.1:4001",
+                    "--bind-addr",
+                    "127.0.0.1:4001",
                     "-initial-cluster-token=skydns-etcd",
-                    "-advertise-client-urls=http://127.0.0.1:4001",
             ]
           - name: kube2sky
-            image: gcr.io/google_containers/kube2sky:1.2
+            image: gcr.io/google_containers/kube2sky:1.3
             volumeMounts:
                - name: dns-token
                  mountPath: /etc/dns_token

--- a/pkg/tools/etcd_helper.go
+++ b/pkg/tools/etcd_helper.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tools
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -475,35 +474,22 @@ func (h *EtcdHelper) PrefixEtcdKey(key string) string {
 	return path.Join("/", h.PathPrefix, key)
 }
 
-// GetEtcdVersion performs a version check against the provided Etcd server, returning a triplet
-// of the release version, internal version, and error (if any).
-func GetEtcdVersion(host string) (releaseVersion, internalVersion string, err error) {
+// GetEtcdVersion performs a version check against the provided Etcd server,
+// returning the string response, and error (if any).
+func GetEtcdVersion(host string) (string, error) {
 	response, err := http.Get(host + "/version")
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 	defer response.Body.Close()
-
-	body, err := ioutil.ReadAll(response.Body)
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Unsuccessful response from server: %v", err)
+	}
+	versionBytes, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
-
-	var dat map[string]interface{}
-	if err := json.Unmarshal(body, &dat); err != nil {
-		return "", "", fmt.Errorf("unknown server: %s", string(body))
-	}
-	if obj := dat["releaseVersion"]; obj != nil {
-		if s, ok := obj.(string); ok {
-			releaseVersion = s
-		}
-	}
-	if obj := dat["internalVersion"]; obj != nil {
-		if s, ok := obj.(string); ok {
-			internalVersion = s
-		}
-	}
-	return
+	return string(versionBytes), nil
 }
 
 func startEtcd() (*exec.Cmd, error) {
@@ -516,7 +502,7 @@ func startEtcd() (*exec.Cmd, error) {
 }
 
 func NewEtcdClientStartServerIfNecessary(server string) (EtcdClient, error) {
-	_, _, err := GetEtcdVersion(server)
+	_, err := GetEtcdVersion(server)
 	if err != nil {
 		glog.Infof("Failed to find etcd, attempting to start.")
 		_, err := startEtcd()

--- a/pkg/tools/etcd_helper_test.go
+++ b/pkg/tools/etcd_helper_test.go
@@ -685,35 +685,16 @@ func TestGuaranteedUpdate_CreateCollision(t *testing.T) {
 
 func TestGetEtcdVersion_ValidVersion(t *testing.T) {
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, "{\"releaseVersion\":\"2.0.3\",\"internalVersion\":\"2\"}")
+		fmt.Fprint(w, "etcd 2.0.9")
 	}))
 	defer testServer.Close()
 
-	var relVersion string
-	var intVersion string
+	var version string
 	var err error
-	if relVersion, intVersion, err = GetEtcdVersion(testServer.URL); err != nil {
+	if version, err = GetEtcdVersion(testServer.URL); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	assert.Equal(t, "2.0.3", relVersion, "Unexpected external version")
-	assert.Equal(t, "2", intVersion, "Unexpected internal version")
-	assert.Nil(t, err)
-}
-
-func TestGetEtcdVersion_UnknownVersion(t *testing.T) {
-	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, "{\"unknownAttribute\":\"foobar\",\"internalVersion\":\"2\"}")
-	}))
-	defer testServer.Close()
-
-	var relVersion string
-	var intVersion string
-	var err error
-	if relVersion, intVersion, err = GetEtcdVersion(testServer.URL); err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-	assert.Equal(t, "", relVersion, "Unexpected external version")
-	assert.Equal(t, "2", intVersion, "Unexpected internal version")
+	assert.Equal(t, "etcd 2.0.9", version, "Unexpected version")
 	assert.Nil(t, err)
 }
 
@@ -723,8 +704,12 @@ func TestGetEtcdVersion_ErrorStatus(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	var err error
-	_, _, err = GetEtcdVersion(testServer.URL)
+	_, err := GetEtcdVersion(testServer.URL)
+	assert.NotNil(t, err)
+}
+
+func TestGetEtcdVersion_NotListening(t *testing.T) {
+	_, err := GetEtcdVersion("http://127.0.0.1:4001")
 	assert.NotNil(t, err)
 }
 


### PR DESCRIPTION
Etcd has a race where <url>/v2/members returns an empty list of client IDs, and the go-etcd client library interprets this as a single machine with url "". This causes requests to fail, and retry forever (https://github.com/coreos/go-etcd/issues/210).

This updates kube2sky to initialize the client until it has an actual url for a machine.

In the process of debugging this, I also upgraded the etcd in the kube-dns pod to 2.0.9. This failed (https://github.com/GoogleCloudPlatform/kubernetes/issues/6852) until I updated the GetEtcdVersion() function to handle etcd > 2.0.7 (string version instead of JSON).

Once this gets an LGTM, I'll push a 1.3 of kube2sky to google_containers and change the skydns rc spec to point at it.
