### PR TITLE
AWS: Change apiserver to listen on 443 directly, not through nginx

### DIFF
--- a/cluster/aws/templates/create-dynamic-salt-files.sh
+++ b/cluster/aws/templates/create-dynamic-salt-files.sh
@@ -36,8 +36,12 @@ dns_domain: '$(echo "$DNS_DOMAIN" | sed -e "s/'/''/g")'
 admission_control: '$(echo "$ADMISSION_CONTROL" | sed -e "s/'/''/g")'
 EOF
 
-mkdir -p /srv/salt-overlay/salt/nginx
-echo $MASTER_HTPASSWD > /srv/salt-overlay/salt/nginx/htpasswd
+readonly BASIC_AUTH_FILE="/srv/salt-overlay/salt/kube-apiserver/basic_auth.csv"
+if [ ! -e "${BASIC_AUTH_FILE}" ]; then
+  mkdir -p /srv/salt-overlay/salt/kube-apiserver
+  (umask 077;
+    echo "${KUBE_PASSWORD},${KUBE_USER},admin" > "${BASIC_AUTH_FILE}")
+fi
 
 # Generate and distribute a shared secret (bearer token) to
 # apiserver and the nodes so that kubelet and kube-proxy can

--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -361,10 +361,6 @@ function kube-up {
   ensure-iam-profiles
 
   get-password
-  python "${KUBE_ROOT}/third_party/htpasswd/htpasswd.py" \
-    -b -c "${KUBE_TEMP}/htpasswd" "$KUBE_USER" "$KUBE_PASSWORD"
-  local htpasswd
-  htpasswd=$(cat "${KUBE_TEMP}/htpasswd")
 
   if [[ ! -f "$AWS_SSH_KEY" ]]; then
     ssh-keygen -f "$AWS_SSH_KEY" -N ''
@@ -442,7 +438,8 @@ function kube-up {
     echo "readonly SERVER_BINARY_TAR_URL='${SERVER_BINARY_TAR_URL}'"
     echo "readonly SALT_TAR_URL='${SALT_TAR_URL}'"
     echo "readonly ZONE='${ZONE}'"
-    echo "readonly MASTER_HTPASSWD='${htpasswd}'"
+    echo "readonly KUBE_USER='${KUBE_USER}'"
+    echo "readonly KUBE_PASSWORD='${KUBE_PASSWORD}'"
     echo "readonly PORTAL_NET='${PORTAL_NET}'"
     echo "readonly ENABLE_CLUSTER_MONITORING='${ENABLE_CLUSTER_MONITORING:-false}'"
     echo "readonly ENABLE_NODE_MONITORING='${ENABLE_NODE_MONITORING:-false}'"

--- a/cluster/saltbase/salt/kube-apiserver/init.sls
+++ b/cluster/saltbase/salt/kube-apiserver/init.sls
@@ -9,7 +9,7 @@
 {% endif %}
 {% endif %}
 
-{% if grains['cloud'] is defined and grains['cloud'] == 'gce' %}
+{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce' ]  %}
 /srv/kubernetes/basic_auth.csv:
   file.managed:
     - source: salt://kube-apiserver/basic_auth.csv

--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
@@ -46,7 +46,7 @@
 {% set client_ca_file = "" -%}
 
 {% set secure_port = "6443" -%}
-{% if grains['cloud'] is defined and grains['cloud'] == 'gce' %}
+{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce' ]    %}
   {% set secure_port = "443" -%}
   {% set client_ca_file = "--client_ca_file=/srv/kubernetes/ca.crt" -%}
 {% endif -%}
@@ -60,7 +60,7 @@
 {% endif -%}
 {% endif -%}
 
-{% if grains['cloud'] is defined and grains['cloud'] == 'gce' %}
+{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce' ]  %}
   {% set basic_auth_file = "--basic_auth_file=/srv/kubernetes/basic_auth.csv" -%}
 {% endif -%}
 

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -16,7 +16,7 @@
 {% endif -%}
 
 # TODO: remove nginx for other cloud providers.
-{% if grains['cloud'] is defined and grains['cloud'] == 'gce' -%}
+{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce' ]  %}
   {% set api_servers_with_port = api_servers -%}
 {% else -%}
   {% set api_servers_with_port = api_servers + ":6443" -%}

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -33,7 +33,7 @@ base:
     - kube-controller-manager
     - kube-scheduler
     - monit
-{% if grains['cloud'] is defined and grains['cloud'] != 'gce' %}
+{% if grains['cloud'] is defined and not grains.cloud in [ 'aws', 'gce' ] %}
     - nginx
 {% endif %}
     - cadvisor


### PR DESCRIPTION
Mirrors changes in GCE.  I think the same changes will be needed for vagrant.

I think this fixes the problem described in #7622, but only for AWS (not for vagrant).  @derekwaynecarr: the changes aren't too bad (trivial, except that you have to make sure you have ca.crt & basic_auth.csv).  A simpler (but shorter-term) fix would be just to change the master port for kube-proxy to 6443, just like we currently do for kubelet.
