### PR TITLE
(minor) Add pgrep debugging to etcd error

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -27,7 +27,8 @@ kube::etcd::start() {
   }
 
   if pgrep etcd >/dev/null 2>&1; then
-    kube::log::usage "etcd appears to already be running on this machine. Please kill and restart the test."
+    kube::log::usage "etcd appears to already be running on this machine (`pgrep -l etcd`) (or its a zombie and you need to kill its parent)."
+    kube::log::usage "retry after you resolve this etcd error."
     exit 1
   fi
 


### PR DESCRIPTION
 having this error printout w/ the etcd proc number (and zombie reminder)  might have made my morning a lil more fun :).  IF you develop on  a cluster w/ lots of restarts of hack/local-up or else sometimes use the cluster for  running a real kube server - etcd collations can happen pretty easily.
