### PR TITLE
Set vagrant test cluster default NUM_MINIONS=2

### DIFF
--- a/cluster/vagrant/config-test.sh
+++ b/cluster/vagrant/config-test.sh
@@ -15,5 +15,8 @@
 # limitations under the License.
 
 ## Contains configuration values for interacting with the Vagrant cluster in test mode
+#Set NUM_MINIONS to minimum required for testing.
+NUM_MINIONS=2
+
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${KUBE_ROOT}/cluster/vagrant/config-default.sh"


### PR DESCRIPTION
This lets e2e tests run smoothly on vagrants when spinning up a new cluster with default settings.
See: https://github.com/GoogleCloudPlatform/kubernetes/issues/7687
