### PR TITLE
Fix typo in e2e

### DIFF
--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -181,7 +181,7 @@ func Up() bool {
 
 // Ensure that the cluster is large engough to run the e2e tests.
 func ValidateClusterSize() {
-	// Check that there are at least 3 minions running
+	// Check that there are at least minMinionCount minions running
 	cmd := exec.Command(path.Join(*root, "hack/e2e-internal/e2e-cluster-size.sh"))
 	if *verbose {
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
Correct comment in e2e.go ’…at least 3 minions running’ -> ‘…at least 2
minions running’.
