### PR TITLE
Expose pod name as a label on containers.

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -504,6 +504,10 @@ func (dm *DockerManager) runContainer(pod *api.Pod, container *api.Container, op
 	if len(containerHostname) > hostnameMaxLen {
 		containerHostname = containerHostname[:hostnameMaxLen]
 	}
+	namespacedName := types.NamespacedName{pod.Namespace, pod.Name}
+	labels := map[string]string{
+		"io.kubernetes.pod.name": namespacedName.String(),
+	}
 	dockerOpts := docker.CreateContainerOptions{
 		Name: BuildDockerName(dockerName, container),
 		Config: &docker.Config{
@@ -514,6 +518,7 @@ func (dm *DockerManager) runContainer(pod *api.Pod, container *api.Container, op
 			Memory:       container.Resources.Limits.Memory().Value(),
 			CPUShares:    milliCPUToShares(container.Resources.Limits.Cpu().MilliValue()),
 			WorkingDir:   container.WorkingDir,
+			Labels:       labels,
 		},
 	}
 


### PR DESCRIPTION
Full pod name is exposed under key 'kubernetes.io/pod'.
It helps in introspection by looking at all containers in a pod through
'docker ps -a -f label=kubernetes.io/pod=podXXX'

We also plan to visualize this in cAdvisor.
