### PR TITLE
Release 0.16.2

### DIFF
--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -31,7 +31,7 @@ trap 'rm -rf "${MINIONS_FILE}"' EXIT
 attempt=0
 while true; do
   "${KUBE_ROOT}/cluster/kubectl.sh" get nodes -o template -t $'{{range.items}}{{.metadata.name}}\n{{end}}' --api-version=v1beta3 > "${MINIONS_FILE}"
-  found=$(grep -c . "${MINIONS_FILE}")
+  found=$(grep -c . "${MINIONS_FILE}") || true
   if [[ ${found} == "${NUM_MINIONS}" ]]; then
     break
   else

--- a/pkg/kubelet/config/common_test.go
+++ b/pkg/kubelet/config/common_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
+
+	"github.com/ghodss/yaml"
+)
+
+func noDefault(*api.Pod) error { return nil }
+
+func TestDecodeSinglePod(t *testing.T) {
+	pod := &api.Pod{
+		TypeMeta: api.TypeMeta{
+			APIVersion: "",
+		},
+		ObjectMeta: api.ObjectMeta{
+			Name:      "test",
+			UID:       "12345",
+			Namespace: "mynamespace",
+		},
+		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicyAlways,
+			DNSPolicy:     api.DNSClusterFirst,
+			Containers: []api.Container{{
+				Name:                   "image",
+				Image:                  "test/image",
+				ImagePullPolicy:        "IfNotPresent",
+				TerminationMessagePath: "/dev/termination-log",
+			}},
+		},
+	}
+	json, err := testapi.Codec().Encode(pod)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	parsed, podOut, err := tryDecodeSinglePod(json, noDefault)
+	if testapi.Version() == "v1beta1" {
+		// v1beta1 conversion leaves empty lists that should be nil
+		podOut.Spec.Containers[0].Resources.Limits = nil
+		podOut.Spec.Containers[0].Resources.Requests = nil
+	}
+	if !parsed {
+		t.Errorf("expected to have parsed file: (%s)", string(json))
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %v (%s)", err, string(json))
+	}
+	if !reflect.DeepEqual(pod, podOut) {
+		t.Errorf("expected:\n%#v\ngot:\n%#v\n%s", pod, podOut, string(json))
+	}
+
+	externalPod, err := testapi.Converter().ConvertToVersion(pod, "v1beta3")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	yaml, err := yaml.Marshal(externalPod)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	parsed, podOut, err = tryDecodeSinglePod(yaml, noDefault)
+	if !parsed {
+		t.Errorf("expected to have parsed file: (%s)", string(yaml))
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %v (%s)", err, string(yaml))
+	}
+	if !reflect.DeepEqual(pod, podOut) {
+		t.Errorf("expected:\n%#v\ngot:\n%#v\n%s", pod, podOut, string(yaml))
+	}
+}
+
+func TestDecodePodList(t *testing.T) {
+	pod := &api.Pod{
+		TypeMeta: api.TypeMeta{
+			APIVersion: "",
+		},
+		ObjectMeta: api.ObjectMeta{
+			Name:      "test",
+			UID:       "12345",
+			Namespace: "mynamespace",
+		},
+		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicyAlways,
+			DNSPolicy:     api.DNSClusterFirst,
+			Containers: []api.Container{{
+				Name:                   "image",
+				Image:                  "test/image",
+				ImagePullPolicy:        "IfNotPresent",
+				TerminationMessagePath: "/dev/termination-log",
+			}},
+		},
+	}
+	podList := &api.PodList{
+		Items: []api.Pod{*pod},
+	}
+	json, err := testapi.Codec().Encode(podList)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	parsed, podListOut, err := tryDecodePodList(json, noDefault)
+	if testapi.Version() == "v1beta1" {
+		// v1beta1 conversion leaves empty lists that should be nil
+		podListOut.Items[0].Spec.Containers[0].Resources.Limits = nil
+		podListOut.Items[0].Spec.Containers[0].Resources.Requests = nil
+	}
+	if !parsed {
+		t.Errorf("expected to have parsed file: (%s)", string(json))
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %v (%s)", err, string(json))
+	}
+	if !reflect.DeepEqual(podList, &podListOut) {
+		t.Errorf("expected:\n%#v\ngot:\n%#v\n%s", podList, &podListOut, string(json))
+	}
+
+	externalPodList, err := testapi.Converter().ConvertToVersion(podList, "v1beta3")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	yaml, err := yaml.Marshal(externalPodList)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	parsed, podListOut, err = tryDecodePodList(yaml, noDefault)
+	if !parsed {
+		t.Errorf("expected to have parsed file: (%s)", string(yaml))
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %v (%s)", err, string(yaml))
+	}
+	if !reflect.DeepEqual(podList, &podListOut) {
+		t.Errorf("expected:\n%#v\ngot:\n%#v\n%s", pod, &podListOut, string(yaml))
+	}
+}

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -36,8 +36,8 @@ package version
 var (
 	// TODO: Deprecate gitMajor and gitMinor, use only gitVersion instead.
 	gitMajor     string = "0"              // major version, always numeric
-	gitMinor     string = "16.1+"          // minor version, numeric possibly followed by "+"
-	gitVersion   string = "v0.16.1-dev"    // version from git, output of $(git describe)
+	gitMinor     string = "16.2"           // minor version, numeric possibly followed by "+"
+	gitVersion   string = "v0.16.2"        // version from git, output of $(git describe)
 	gitCommit    string = ""               // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 )

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -36,8 +36,8 @@ package version
 var (
 	// TODO: Deprecate gitMajor and gitMinor, use only gitVersion instead.
 	gitMajor     string = "0"              // major version, always numeric
-	gitMinor     string = "16.2"           // minor version, numeric possibly followed by "+"
-	gitVersion   string = "v0.16.2"        // version from git, output of $(git describe)
+	gitMinor     string = "16.2+"          // minor version, numeric possibly followed by "+"
+	gitVersion   string = "v0.16.2-dev"    // version from git, output of $(git describe)
 	gitCommit    string = ""               // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 )


### PR DESCRIPTION
- #7515: Fix YAML parsing for v1beta3 objects in the kubelet for file/http
- #7650: Don't exit abruptly if there aren't yet any minions right after the cluster is created.
