### PR TITLE
API Server - pass path name in context of create request for subresource

### DIFF
--- a/pkg/api/rest/rest.go
+++ b/pkg/api/rest/rest.go
@@ -28,6 +28,25 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
+//TODO:
+// Storage interfaces need to be separated into two groups; those that operate
+// on collections and those that operate on individually named items.
+// Collection interfaces:
+// (Method: Current -> Proposed)
+//    GET: Lister -> CollectionGetter
+//    WATCH: Watcher -> CollectionWatcher
+//    CREATE: Creater -> CollectionCreater
+//    DELETE: (n/a) -> CollectionDeleter
+//    UPDATE: (n/a) -> CollectionUpdater
+//
+// Single item interfaces:
+// (Method: Current -> Proposed)
+//    GET: Getter -> NamedGetter
+//    WATCH: (n/a) -> NamedWatcher
+//    CREATE: (n/a) -> NamedCreater
+//    DELETE: Deleter -> NamedDeleter
+//    UPDATE: Update -> NamedUpdater
+
 // Storage is a generic interface for RESTful storage services.
 // Resources which are exported to the RESTful API of apiserver need to implement this interface. It is expected
 // that objects may implement any of the below interfaces.
@@ -115,6 +134,18 @@ type Creater interface {
 
 	// Create creates a new version of a resource.
 	Create(ctx api.Context, obj runtime.Object) (runtime.Object, error)
+}
+
+// NamedCreater is an object that can create an instance of a RESTful object using a name parameter.
+type NamedCreater interface {
+	// New returns an empty object that can be used with Create after request data has been put into it.
+	// This object must be a pointer type for use with Codec.DecodeInto([]byte, runtime.Object)
+	New() runtime.Object
+
+	// Create creates a new version of a resource. It expects a name parameter from the path.
+	// This is needed for create operations on subresources which include the name of the parent
+	// resource in the path.
+	Create(ctx api.Context, name string, obj runtime.Object) (runtime.Object, error)
 }
 
 // Updater is an object that can update an instance of a RESTful object.

--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -130,6 +130,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 
 	// what verbs are supported by the storage, used to know what verbs we support per path
 	creater, isCreater := storage.(rest.Creater)
+	namedCreater, isNamedCreater := storage.(rest.NamedCreater)
 	lister, isLister := storage.(rest.Lister)
 	getter, isGetter := storage.(rest.Getter)
 	getterWithOptions, isGetterWithOptions := storage.(rest.GetterWithOptions)
@@ -143,6 +144,10 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 	storageMeta, isMetadata := storage.(rest.StorageMetadata)
 	if !isMetadata {
 		storageMeta = defaultStorageMetadata{}
+	}
+
+	if isNamedCreater {
+		isCreater = true
 	}
 
 	var versionedList interface{}
@@ -436,7 +441,13 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			addParams(route, action.Params)
 			ws.Route(route)
 		case "POST": // Create a resource.
-			route := ws.POST(action.Path).To(CreateResource(creater, reqScope, a.group.Typer, admit)).
+			var handler restful.RouteFunction
+			if isNamedCreater {
+				handler = CreateNamedResource(namedCreater, reqScope, a.group.Typer, admit)
+			} else {
+				handler = CreateResource(creater, reqScope, a.group.Typer, admit)
+			}
+			route := ws.POST(action.Path).To(handler).
 				Filter(m).
 				Doc("create a "+kind).
 				Operation("create"+kind).


### PR DESCRIPTION
Allows a REST storage for a subresource to obtain name in path from
request.
