### PR TITLE
Select IPv4-only from host interfaces

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -397,6 +397,7 @@ func chooseHostInterfaceNativeGo() (net.IP, error) {
 		return nil, err
 	}
 	i := 0
+	var ip net.IP
 	for i = range intfs {
 		if flagsSet(intfs[i].Flags, net.FlagUp) && flagsClear(intfs[i].Flags, net.FlagLoopback|net.FlagPointToPoint) {
 			addrs, err := intfs[i].Addrs()
@@ -404,24 +405,25 @@ func chooseHostInterfaceNativeGo() (net.IP, error) {
 				return nil, err
 			}
 			if len(addrs) > 0 {
-				// This interface should suffice.
-				break
+				for _, addr := range addrs {
+					if addrIP, _, err := net.ParseCIDR(addr.String()); err == nil {
+						if addrIP.To4() != nil {
+							ip = addrIP.To4()
+							break
+						}
+					}
+				}
+				if ip != nil {
+					// This interface should suffice.
+					break
+				}
 			}
 		}
 	}
-	if i == len(intfs) {
-		return nil, err
+	if ip == nil {
+		return nil, fmt.Errorf("no acceptable interface from host")
 	}
 	glog.V(4).Infof("Choosing interface %s for from-host portals", intfs[i].Name)
-	addrs, err := intfs[i].Addrs()
-	if err != nil {
-		return nil, err
-	}
-	glog.V(4).Infof("Interface %s = %s", intfs[i].Name, addrs[0].String())
-	ip, _, err := net.ParseCIDR(addrs[0].String())
-	if err != nil {
-		return nil, err
-	}
 	return ip, nil
 }
 


### PR DESCRIPTION
On other platforms, ChooseHostInterfaces() is returning IPv6
addresses, which the master can't use (endpoints must be IPv4)

Fixes #7716
