### PR TITLE
Log which SSH key is used in e2e SSH test

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -695,6 +695,7 @@ func getSigner(provider string) (ssh.Signer, error) {
 		return nil, fmt.Errorf("getSigner(...) not implemented for %s", provider)
 	}
 	key := filepath.Join(keydir, keyfile)
+	Logf("Using SSH key: %s", key)
 
 	// Create an actual signer.
 	file, err := os.Open(key)


### PR DESCRIPTION
Log which SSH key is used in e2e SSH test to help debug #7714.
