### PR TITLE
Remove node status from "componentstatuses" call.

### DIFF
--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -36,12 +36,23 @@ func TestGetServersToValidate(t *testing.T) {
 
 	master.nodeRegistry = registrytest.NewMinionRegistry([]string{"node1", "node2"}, api.NodeResources{})
 
-	servers := master.getServersToValidate(&config)
+	servers := master.getServersToValidate(&config, true)
 
 	if len(servers) != 7 {
 		t.Errorf("unexpected server list: %#v", servers)
 	}
 	for _, server := range []string{"scheduler", "controller-manager", "etcd-0", "etcd-1", "etcd-2", "node-0", "node-1"} {
+		if _, ok := servers[server]; !ok {
+			t.Errorf("server list missing: %s", server)
+		}
+	}
+
+	servers = master.getServersToValidate(&config, false)
+
+	if len(servers) != 5 {
+		t.Errorf("unexpected server list: %#v", servers)
+	}
+	for _, server := range []string{"scheduler", "controller-manager", "etcd-0", "etcd-1", "etcd-2"} {
 		if _, ok := servers[server]; !ok {
 			t.Errorf("server list missing: %s", server)
 		}


### PR DESCRIPTION
The legacy "/validate" behavior remains unchanged.

This should fix issue #7092.
