### PR TITLE
FIX: Issue #7750 - Hyperkube docker image needs certificates to connect to cloud-providers

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -1,7 +1,7 @@
 FROM google/debian:wheezy
 
 RUN apt-get update
-RUN apt-get -yy -q install iptables
+RUN apt-get -yy -q install iptables ca-certificates
 COPY hyperkube /hyperkube
 RUN chmod a+rx /hyperkube
 


### PR DESCRIPTION
This PR addresses a bug found with hyperkube and controller-manager service. Logs from controller-manager shows errors connecting to AWS during cloud sync. Resolved by adding ca-certificates package to base hyperkube docker image (editing dockerfile).
