### PR TITLE
aws: make it possible to have multiple k8s clusters in one vpc

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -43,7 +43,6 @@ function json_val {
 function get_vpc_id {
   $AWS_CMD --output text describe-vpcs \
            --filters Name=tag:Name,Values=kubernetes-vpc \
-                     Name=tag:KubernetesCluster,Values=${CLUSTER_ID} \
            --query Vpcs[].VpcId
 }
 


### PR DESCRIPTION
I think it should be possible to have multiple k8s clusters in one VPC.
Example scenario:
- VPC "kubernetes-vpc" CIDR 172.20.0.0/16
- cluster "kube-frontend-1a" in availability zone "1a" with CIDR 172.20.1.0/24
- cluster "kube-frontend-1b" in availability zone "1b" with CIDR 172.20.2.0/24
- cluster "kube-frontend-1c" in availability zone "1c" with CIDR 172.20.3.0/24

Therefore there should be no filter for "KubernetesCluster" when looking for an existing vpc during setup.
