### PR TITLE
skydns: use the etcd-2.x native syntax, enable IANA attributed ports.

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -22,11 +22,12 @@ spec:
         image: gcr.io/google_containers/etcd:2.0.9
         command:
         - /usr/local/bin/etcd
-        - --addr
-        - 127.0.0.1:4001
-        - --bind-addr
-        - 127.0.0.1:4001
-        - -initial-cluster-token=skydns-etcd
+        - -listen-client-urls
+        - http://127.0.0.1:2379,http://127.0.0.1:4001
+        - -advertise-client-urls
+        - http://127.0.0.1:2379,http://127.0.0.1:4001
+        - -initial-cluster-token
+        - skydns-etcd
       - name: kube2sky
         image: gcr.io/google_containers/kube2sky:1.4
         args:


### PR DESCRIPTION
per https://github.com/coreos/etcd/blob/master/Documentation/backward_compatibility.md
(there are no functional changes, we just stop using the legacy flags, for
consistency.)
