### PR TITLE
Fix swagger spec

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -250,8 +250,8 @@
 		},
 		{
 			"ImportPath": "github.com/emicklei/go-restful",
-			"Comment": "v1.1.3-40-g4f30cbd",
-			"Rev": "4f30cbd5bd858a523d8fe9bd484f44513f50eeec"
+			"Comment": "v1.1.3-45-gd487287",
+			"Rev": "d4872876992d385f0e69b007f154e5633bdb40af"
 		},
 		{
 			"ImportPath": "github.com/evanphx/json-patch",

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/model_builder.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/model_builder.go
@@ -197,9 +197,13 @@ func (b modelBuilder) buildStructTypeProperty(field reflect.StructField, jsonNam
 			if required {
 				model.Required = append(model.Required, k)
 			}
-			// Add the model type to the global model list
-			if v.Ref != nil {
-				b.Models[*v.Ref] = sub.Models[*v.Ref]
+		}
+		// add all new referenced models
+		for key, sub := range sub.Models {
+			if key != subKey {
+				if _, ok := b.Models[key]; !ok {
+					b.Models[key] = sub
+				}
 			}
 		}
 		// empty name signals skip property
@@ -245,7 +249,12 @@ func (b modelBuilder) buildPointerTypeProperty(field reflect.StructField, jsonNa
 		b.addModel(fieldType.Elem().Elem(), elemName)
 	} else {
 		// non-array, pointer type
-		var pType = fieldType.String()[1:] // no star, include pkg path
+		var pType = b.jsonSchemaType(fieldType.String()[1:]) // no star, include pkg path
+		if b.isPrimitiveType(fieldType.String()[1:]) {
+			prop.Type = &pType
+			prop.Format = b.jsonSchemaFormat(fieldType.String()[1:])
+			return jsonName, prop
+		}
 		prop.Ref = &pType
 		elemName := ""
 		if fieldType.Elem().Name() == "" {
@@ -328,14 +337,15 @@ func (b modelBuilder) jsonSchemaType(modelName string) string {
 
 func (b modelBuilder) jsonSchemaFormat(modelName string) string {
 	schemaMap := map[string]string{
-		"int":       "int32",
-		"int32":     "int32",
-		"int64":     "int64",
-		"byte":      "byte",
-		"uint8":     "byte",
-		"float64":   "double",
-		"float32":   "float",
-		"time.Time": "date-time",
+		"int":        "int32",
+		"int32":      "int32",
+		"int64":      "int64",
+		"byte":       "byte",
+		"uint8":      "byte",
+		"float64":    "double",
+		"float32":    "float",
+		"time.Time":  "date-time",
+		"*time.Time": "date-time",
 	}
 	mapped, ok := schemaMap[modelName]
 	if !ok {

--- a/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/model_builder_test.go
+++ b/Godeps/_workspace/src/github.com/emicklei/go-restful/swagger/model_builder_test.go
@@ -84,6 +84,49 @@ func TestPrimitiveTypes(t *testing.T) {
  }`)
 }
 
+// clear && go test -v -test.run TestPrimitivePtrTypes ...swagger
+func TestPrimitivePtrTypes(t *testing.T) {
+	type Prims struct {
+		f *float64
+		t *time.Time
+		b *bool
+		s *string
+		i *int
+	}
+	testJsonFromStruct(t, Prims{}, `{
+  "swagger.Prims": {
+   "id": "swagger.Prims",
+   "required": [
+    "f",
+    "t",
+    "b",
+    "s",
+    "i"
+   ],
+   "properties": {
+    "b": {
+     "type": "boolean"
+    },
+    "f": {
+     "type": "number",
+     "format": "double"
+    },
+    "i": {
+     "type": "integer",
+     "format": "int32"
+    },
+    "s": {
+     "type": "string"
+    },
+    "t": {
+     "type": "string",
+     "format": "date-time"
+    }
+   }
+  }
+ }`)
+}
+
 // clear && go test -v -test.run TestS1 ...swagger
 func TestS1(t *testing.T) {
 	type S1 struct {
@@ -702,6 +745,52 @@ func TestEmbeddedStructA5(t *testing.T) {
  }`)
 }
 
+type D2 struct {
+	id int
+	D  []D
+}
+
+type A6 struct {
+	D2 "json:,inline"
+}
+
+// clear && go test -v -test.run TestStructA4 ...swagger
+func TestEmbeddedStructA6(t *testing.T) {
+	testJsonFromStruct(t, A6{}, `{
+  "swagger.A6": {
+   "id": "swagger.A6",
+   "required": [
+    "id",
+    "D"
+   ],
+   "properties": {
+    "D": {
+     "type": "array",
+     "items": {
+      "$ref": "swagger.D"
+     }
+    },
+    "id": {
+     "type": "integer",
+     "format": "int32"
+    }
+   }
+  },
+  "swagger.D": {
+   "id": "swagger.D",
+   "required": [
+    "Id"
+   ],
+   "properties": {
+    "Id": {
+     "type": "integer",
+     "format": "int32"
+    }
+   }
+  }
+ }`)
+}
+
 type ObjectId []byte
 
 type Region struct {
@@ -832,4 +921,60 @@ func TestSlices(t *testing.T) {
 		testJsonFromStruct(t, Customer{}, expected)
 	}
 
+}
+
+type Name struct {
+	Value string
+}
+
+func (n Name) PostBuildModel(m *Model) *Model {
+	m.Description = "titles must be upcase"
+	return m
+}
+
+type TOC struct {
+	Titles []Name
+}
+
+type Discography struct {
+	Title Name
+	TOC
+}
+
+// clear && go test -v -test.run TestEmbeddedStructPull204 ...swagger
+func TestEmbeddedStructPull204(t *testing.T) {
+	b := Discography{}
+	testJsonFromStruct(t, b, `
+{
+  "swagger.Discography": {
+   "id": "swagger.Discography",
+   "required": [
+    "Title",
+    "Titles"
+   ],
+   "properties": {
+    "Title": {
+     "$ref": "swagger.Name"
+    },
+    "Titles": {
+     "type": "array",
+     "items": {
+      "$ref": "swagger.Name"
+     }
+    }
+   }
+  },
+  "swagger.Name": {
+   "id": "swagger.Name",
+   "required": [
+    "Value"
+   ],
+   "properties": {
+    "Value": {
+     "type": "string"
+    }
+   }
+  }
+ }
+`)
 }

--- a/api/swagger-spec/v1beta1.json
+++ b/api/swagger-spec/v1beta1.json
@@ -6380,6 +6380,14 @@
         "description": "object name and auth scope, such as for teams and projects",
         "required": false,
         "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
        }
       ],
       "responseMessages": [
@@ -7226,10 +7234,6 @@
      }
     }
    },
-   "uint64": {
-    "id": "",
-    "properties": null
-   },
    "v1beta1.AWSElasticBlockStoreVolumeSource": {
     "id": "v1beta1.AWSElasticBlockStoreVolumeSource",
     "required": [
@@ -7307,8 +7311,8 @@
       "description": "name of the pod to bind"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -7415,8 +7419,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -7474,8 +7478,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -7618,6 +7622,10 @@
       "$ref": "v1beta1.RestartPolicy",
       "description": "restart policy for all containers within the pod; one of RestartPolicyAlways, RestartPolicyOnFailure, RestartPolicyNever"
      },
+     "terminationGracePeriodSeconds": {
+      "$ref": "int64",
+      "description": "optional duration in seconds the pod needs to terminate gracefully; may be decreased in delete request; value must be non-negative integer; the value zero indicates delete immediately; if this value is not set, the default grace period will be used instead; the grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal; set this value longer than the expected cleanup time for your process"
+     },
      "uuid": {
       "type": "string",
       "description": "manifest UUID, populated by the system, read-only"
@@ -7708,8 +7716,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -7752,40 +7760,17 @@
    "v1beta1.EndpointObjectReference": {
     "id": "v1beta1.EndpointObjectReference",
     "required": [
-     "endpoint"
+     "endpoint",
+     "targetRef"
     ],
     "properties": {
-     "apiVersion": {
-      "type": "string",
-      "description": "API version of the referent"
-     },
      "endpoint": {
       "type": "string",
       "description": "endpoint exposed by the referenced object"
      },
-     "fieldPath": {
-      "type": "string",
-      "description": "if referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]"
-     },
-     "kind": {
-      "type": "string",
-      "description": "kind of the referent"
-     },
-     "name": {
-      "type": "string",
-      "description": "id of the referent"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the referent"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "specific resourceVersion to which this reference is made, if any: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "uid": {
-      "type": "string",
-      "description": "uid of the referent"
+     "targetRef": {
+      "$ref": "v1beta1.ObjectReference",
+      "description": "reference to the object providing the entry point"
      }
     }
    },
@@ -7880,8 +7865,8 @@
       "description": "IP protocol for the first set of endpoint ports; must be UDP or TCP; TCP if unspecified"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -7953,8 +7938,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -7983,6 +7968,22 @@
      "value": {
       "type": "string",
       "description": "value of the environment variable; defaults to empty string"
+     },
+     "valueFrom": {
+      "$ref": "v1beta1.EnvVarSource",
+      "description": "source for the environment variable's value; cannot be used if value is not empty"
+     }
+    }
+   },
+   "v1beta1.EnvVarSource": {
+    "id": "v1beta1.EnvVarSource",
+    "required": [
+     "fieldRef"
+    ],
+    "properties": {
+     "fieldRef": {
+      "$ref": "v1beta1.ObjectFieldSelector",
+      "description": "selects a field of the pod; only name and namespace are supported"
      }
     }
    },
@@ -8051,8 +8052,8 @@
       "description": "short, machine understandable string that gives the reason for the transition into the object's current status"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -8122,8 +8123,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -8335,8 +8336,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -8419,8 +8420,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -8526,8 +8527,8 @@
       "description": "IP range assigned to the node"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "resources": {
       "$ref": "v1beta1.NodeResources",
@@ -8604,8 +8605,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -8678,8 +8679,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -8745,8 +8746,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -8875,13 +8876,9 @@
      "osImage",
      "containerRuntimeVersion",
      "kubeletVersion",
-     "KubeProxyVersion"
+     "kubeProxyVersion"
     ],
     "properties": {
-     "KubeProxyVersion": {
-      "type": "string",
-      "description": "Kube-proxy version reported by the node"
-     },
      "bootID": {
       "type": "string",
       "description": "boot id is the boot-id reported by the node"
@@ -8893,6 +8890,10 @@
      "kernelVersion": {
       "type": "string",
       "description": "Kernel version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64)"
+     },
+     "kubeProxyVersion": {
+      "type": "string",
+      "description": "Kube-proxy version reported by the node"
      },
      "kubeletVersion": {
       "type": "string",
@@ -8909,6 +8910,22 @@
      "systemUUID": {
       "type": "string",
       "description": "system uuid is the system-uuid reported by the node"
+     }
+    }
+   },
+   "v1beta1.ObjectFieldSelector": {
+    "id": "v1beta1.ObjectFieldSelector",
+    "required": [
+     "fieldPath"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema that fieldPath is written in terms of; defaults to v1beta1"
+     },
+     "fieldPath": {
+      "type": "string",
+      "description": "path of the field to select in the specified API version"
      }
     }
    },
@@ -8937,7 +8954,7 @@
      },
      "resourceVersion": {
       "type": "string",
-      "description": "specific resourceVersion to which this reference is made, if any: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "description": "specific resourceVersion to which this reference is made, if any: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "uid": {
       "type": "string",
@@ -8981,8 +8998,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9038,8 +9055,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9100,8 +9117,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9209,8 +9226,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9325,8 +9342,8 @@
       "description": "selector which must match a node's labels for the pod to be scheduled on that node"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9401,8 +9418,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9523,8 +9540,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9582,8 +9599,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9656,8 +9673,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9723,8 +9740,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9767,7 +9784,7 @@
      },
      "requests": {
       "type": "any",
-      "description": "Minimum amount of resources requested"
+      "description": "Minimum amount of resources requested; requests are honored only for persistent volumes as of now"
      }
     }
    },
@@ -9840,8 +9857,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9903,8 +9920,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -10017,8 +10034,8 @@
       "description": "externally visible IPs (e.g. load balancers) that should be proxied to this service"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selector": {
       "type": "any",
@@ -10084,8 +10101,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -10178,8 +10195,8 @@
       "description": "machine-readable description of why this operation is in the 'Failure' status; if this value is empty there is no information available; a reason clarifies an HTTP status code but does not override it"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",

--- a/api/swagger-spec/v1beta2.json
+++ b/api/swagger-spec/v1beta2.json
@@ -6380,6 +6380,14 @@
         "description": "object name and auth scope, such as for teams and projects",
         "required": false,
         "allowMultiple": false
+       },
+       {
+        "type": "v1beta2.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
        }
       ],
       "responseMessages": [
@@ -7226,10 +7234,6 @@
      }
     }
    },
-   "uint64": {
-    "id": "",
-    "properties": null
-   },
    "v1beta2.AWSElasticBlockStoreVolumeSource": {
     "id": "v1beta2.AWSElasticBlockStoreVolumeSource",
     "required": [
@@ -7307,8 +7311,8 @@
       "description": "name of the pod to bind"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -7415,8 +7419,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -7474,8 +7478,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -7618,6 +7622,10 @@
       "$ref": "v1beta2.RestartPolicy",
       "description": "restart policy for all containers within the pod; one of RestartPolicyAlways, RestartPolicyOnFailure, RestartPolicyNever"
      },
+     "terminationGracePeriodSeconds": {
+      "$ref": "int64",
+      "description": "optional duration in seconds the pod needs to terminate gracefully; may be decreased in delete request; value must be non-negative integer; the value zero indicates delete immediately; if this value is not set, the default grace period will be used instead; the grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal; set this value longer than the expected cleanup time for your process"
+     },
      "uuid": {
       "type": "string",
       "description": "manifest UUID; cannot be updated"
@@ -7708,8 +7716,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -7752,40 +7760,17 @@
    "v1beta2.EndpointObjectReference": {
     "id": "v1beta2.EndpointObjectReference",
     "required": [
-     "endpoint"
+     "endpoint",
+     "targetRef"
     ],
     "properties": {
-     "apiVersion": {
-      "type": "string",
-      "description": "API version of the referent"
-     },
      "endpoint": {
       "type": "string",
       "description": "endpoint exposed by the referenced object"
      },
-     "fieldPath": {
-      "type": "string",
-      "description": "if referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]"
-     },
-     "kind": {
-      "type": "string",
-      "description": "kind of the referent"
-     },
-     "name": {
-      "type": "string",
-      "description": "id of the referent"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the referent"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "specific resourceVersion to which this reference is made, if any: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "uid": {
-      "type": "string",
-      "description": "uid of the referent"
+     "targetRef": {
+      "$ref": "v1beta2.ObjectReference",
+      "description": "reference to the object providing the entry point"
      }
     }
    },
@@ -7880,8 +7865,8 @@
       "description": "IP protocol for the first set of endpoint ports; must be UDP or TCP; TCP if unspecified"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -7953,8 +7938,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -7979,6 +7964,22 @@
      "value": {
       "type": "string",
       "description": "value of the environment variable; defaults to empty string"
+     },
+     "valueFrom": {
+      "$ref": "v1beta2.EnvVarSource",
+      "description": "source for the environment variable's value; cannot be used if value is not empty"
+     }
+    }
+   },
+   "v1beta2.EnvVarSource": {
+    "id": "v1beta2.EnvVarSource",
+    "required": [
+     "fieldRef"
+    ],
+    "properties": {
+     "fieldRef": {
+      "$ref": "v1beta2.ObjectFieldSelector",
+      "description": "selects a field of the pod; only name and namespace are supported"
      }
     }
    },
@@ -8047,8 +8048,8 @@
       "description": "short, machine understandable string that gives the reason for the transition into the object's current status"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -8118,8 +8119,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -8331,8 +8332,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -8415,8 +8416,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -8522,8 +8523,8 @@
       "description": "IP range assigned to the node"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "resources": {
       "$ref": "v1beta2.NodeResources",
@@ -8593,8 +8594,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -8667,8 +8668,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -8734,8 +8735,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -8864,13 +8865,9 @@
      "osImage",
      "containerRuntimeVersion",
      "kubeletVersion",
-     "KubeProxyVersion"
+     "kubeProxyVersion"
     ],
     "properties": {
-     "KubeProxyVersion": {
-      "type": "string",
-      "description": "Kube-proxy version reported by the node"
-     },
      "bootID": {
       "type": "string",
       "description": "boot id is the boot-id reported by the node"
@@ -8882,6 +8879,10 @@
      "kernelVersion": {
       "type": "string",
       "description": "Kernel version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64)"
+     },
+     "kubeProxyVersion": {
+      "type": "string",
+      "description": "Kube-proxy version reported by the node"
      },
      "kubeletVersion": {
       "type": "string",
@@ -8898,6 +8899,22 @@
      "systemUUID": {
       "type": "string",
       "description": "system uuid is the system-uuid reported by the node"
+     }
+    }
+   },
+   "v1beta2.ObjectFieldSelector": {
+    "id": "v1beta2.ObjectFieldSelector",
+    "required": [
+     "fieldPath"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema that fieldPath is written in terms of; defaults to v1beta2"
+     },
+     "fieldPath": {
+      "type": "string",
+      "description": "path of the field to select in the specified API version"
      }
     }
    },
@@ -8926,7 +8943,7 @@
      },
      "resourceVersion": {
       "type": "string",
-      "description": "specific resourceVersion to which this reference is made, if any: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "description": "specific resourceVersion to which this reference is made, if any: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "uid": {
       "type": "string",
@@ -8970,8 +8987,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9027,8 +9044,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9089,8 +9106,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9198,8 +9215,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9214,10 +9231,10 @@
    "v1beta2.PersistentVolumeSpec": {
     "id": "v1beta2.PersistentVolumeSpec",
     "required": [
-     "hostPath",
      "glusterfs",
      "persistentDisk",
-     "awsElasticBlockStore"
+     "awsElasticBlockStore",
+     "hostPath"
     ],
     "properties": {
      "accessModes": {
@@ -9314,8 +9331,8 @@
       "description": "selector which must match a node's labels for the pod to be scheduled on that node"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9390,8 +9407,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9512,8 +9529,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9571,8 +9588,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9645,8 +9662,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9712,8 +9729,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9756,7 +9773,7 @@
      },
      "requests": {
       "type": "any",
-      "description": "Minimum amount of resources requested"
+      "description": "Minimum amount of resources requested; requests are honored only for persistent volumes as of now"
      }
     }
    },
@@ -9829,8 +9846,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -9892,8 +9909,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -10006,8 +10023,8 @@
       "description": "externally visible IPs (e.g. load balancers) that should be proxied to this service"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selector": {
       "type": "any",
@@ -10073,8 +10090,8 @@
       "description": "namespace to which the object belongs; must be a DNS_SUBDOMAIN; 'default' by default; cannot be updated"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",
@@ -10167,8 +10184,8 @@
       "description": "machine-readable description of why this operation is in the 'Failure' status; if this value is empty there is no information available; a reason clarifies an HTTP status code but does not override it"
      },
      "resourceVersion": {
-      "$ref": "uint64",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "type": "integer",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "selfLink": {
       "type": "string",

--- a/api/swagger-spec/v1beta3.json
+++ b/api/swagger-spec/v1beta3.json
@@ -7199,6 +7199,14 @@
         "description": "object name and auth scope, such as for teams and projects",
         "required": true,
         "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
        }
       ],
       "responseMessages": [
@@ -8316,57 +8324,21 @@
      "target"
     ],
     "properties": {
-     "annotations": {
-      "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
-     },
      "apiVersion": {
       "type": "string",
       "description": "version of the schema the object should have"
-     },
-     "creationTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
-     },
-     "deletionTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
-     },
-     "generateName": {
-      "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
      },
      "kind": {
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "labels": {
-      "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
-     },
-     "name": {
-      "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the object; cannot be updated"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
      "target": {
       "$ref": "v1beta3.ObjectReference",
       "description": "an object to bind to"
-     },
-     "uid": {
-      "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
    },
@@ -8421,10 +8393,6 @@
    "v1beta3.ComponentStatus": {
     "id": "v1beta3.ComponentStatus",
     "properties": {
-     "annotations": {
-      "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
-     },
      "apiVersion": {
       "type": "string",
       "description": "version of the schema the object should have"
@@ -8436,45 +8404,13 @@
       },
       "description": "list of component conditions observed"
      },
-     "creationTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
-     },
-     "deletionTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
-     },
-     "generateName": {
-      "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
-     },
      "kind": {
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "labels": {
-      "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
-     },
-     "name": {
-      "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the object; cannot be updated"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
-     },
-     "uid": {
-      "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only"
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      }
     }
    },
@@ -8499,13 +8435,9 @@
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ListMeta",
+      "description": "standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      }
     }
    },
@@ -8840,49 +8772,17 @@
      "subsets"
     ],
     "properties": {
-     "annotations": {
-      "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
-     },
      "apiVersion": {
       "type": "string",
       "description": "version of the schema the object should have"
-     },
-     "creationTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
-     },
-     "deletionTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
-     },
-     "generateName": {
-      "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
      },
      "kind": {
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "labels": {
-      "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
-     },
-     "name": {
-      "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the object; cannot be updated"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
      "subsets": {
       "type": "array",
@@ -8890,10 +8790,6 @@
        "$ref": "v1beta3.EndpointSubset"
       },
       "description": "sets of addresses and ports that comprise a service"
-     },
-     "uid": {
-      "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
    },
@@ -8918,13 +8814,9 @@
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ListMeta",
+      "description": "standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      }
     }
    },
@@ -8941,16 +8833,31 @@
      "value": {
       "type": "string",
       "description": "value of the environment variable; defaults to empty string"
+     },
+     "valueFrom": {
+      "$ref": "v1beta3.EnvVarSource",
+      "description": "source for the environment variable's value; cannot be used if value is not empty"
+     }
+    }
+   },
+   "v1beta3.EnvVarSource": {
+    "id": "v1beta3.EnvVarSource",
+    "required": [
+     "fieldRef"
+    ],
+    "properties": {
+     "fieldRef": {
+      "$ref": "v1beta3.ObjectFieldSelector",
+      "description": "selects a field of the pod; only name and namespace are supported"
      }
     }
    },
    "v1beta3.Event": {
     "id": "v1beta3.Event",
+    "required": [
+     "metadata"
+    ],
     "properties": {
-     "annotations": {
-      "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
-     },
      "apiVersion": {
       "type": "string",
       "description": "version of the schema the object should have"
@@ -8960,21 +8867,9 @@
       "format": "int32",
       "description": "the number of times this event has occurred"
      },
-     "creationTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
-     },
-     "deletionTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
-     },
      "firstTimestamp": {
       "type": "string",
       "description": "the time at which the event was first recorded"
-     },
-     "generateName": {
-      "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
      },
      "involvedObject": {
       "$ref": "v1beta3.ObjectReference",
@@ -8984,10 +8879,6 @@
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "labels": {
-      "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
-     },
      "lastTimestamp": {
       "type": "string",
       "description": "the time at which the most recent occurance of this event was recorded"
@@ -8996,33 +8887,17 @@
       "type": "string",
       "description": "human-readable description of the status of this operation"
      },
-     "name": {
-      "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the object; cannot be updated"
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
      "reason": {
       "type": "string",
       "description": "short, machine understandable string that gives the reason for the transition into the object's current status"
      },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
-     },
      "source": {
       "$ref": "v1beta3.EventSource",
       "description": "component reporting this event"
-     },
-     "uid": {
-      "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
    },
@@ -9047,13 +8922,9 @@
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ListMeta",
+      "description": "standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      }
     }
    },
@@ -9237,57 +9108,21 @@
    "v1beta3.LimitRange": {
     "id": "v1beta3.LimitRange",
     "properties": {
-     "annotations": {
-      "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
-     },
      "apiVersion": {
       "type": "string",
       "description": "version of the schema the object should have"
-     },
-     "creationTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
-     },
-     "deletionTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
-     },
-     "generateName": {
-      "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
      },
      "kind": {
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "labels": {
-      "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
-     },
-     "name": {
-      "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the object; cannot be updated"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.LimitRangeSpec",
-      "description": "spec defines the limits enforced; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
-     },
-     "uid": {
-      "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only"
+      "description": "spec defines the limits enforced; http://docs.k8s.io/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -9333,13 +9168,9 @@
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ListMeta",
+      "description": "standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      }
     }
    },
@@ -9355,6 +9186,19 @@
        "$ref": "v1beta3.LimitRangeItem"
       },
       "description": "limits is the list of LimitRangeItem objects that are enforced"
+     }
+    }
+   },
+   "v1beta3.ListMeta": {
+    "id": "v1beta3.ListMeta",
+    "properties": {
+     "resourceVersion": {
+      "type": "string",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object; populated by the system, read-only"
      }
     }
    },
@@ -9382,61 +9226,25 @@
    "v1beta3.Namespace": {
     "id": "v1beta3.Namespace",
     "properties": {
-     "annotations": {
-      "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
-     },
      "apiVersion": {
       "type": "string",
       "description": "version of the schema the object should have"
-     },
-     "creationTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
-     },
-     "deletionTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
-     },
-     "generateName": {
-      "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
      },
      "kind": {
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "labels": {
-      "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
-     },
-     "name": {
-      "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the object; cannot be updated"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.NamespaceSpec",
-      "description": "spec defines the behavior of the Namespace; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
+      "description": "spec defines the behavior of the Namespace; http://docs.k8s.io/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta3.NamespaceStatus",
-      "description": "status describes the current status of a Namespace; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
-     },
-     "uid": {
-      "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only"
+      "description": "status describes the current status of a Namespace; http://docs.k8s.io/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -9461,13 +9269,9 @@
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ListMeta",
+      "description": "standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      }
     }
    },
@@ -9495,61 +9299,25 @@
    "v1beta3.Node": {
     "id": "v1beta3.Node",
     "properties": {
-     "annotations": {
-      "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
-     },
      "apiVersion": {
       "type": "string",
       "description": "version of the schema the object should have"
-     },
-     "creationTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
-     },
-     "deletionTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
-     },
-     "generateName": {
-      "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
      },
      "kind": {
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "labels": {
-      "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
-     },
-     "name": {
-      "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the object; cannot be updated"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.NodeSpec",
-      "description": "specification of a node; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
+      "description": "specification of a node; http://docs.k8s.io/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta3.NodeStatus",
-      "description": "most recently observed status of the node; populated by the system, read-only; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
-     },
-     "uid": {
-      "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only"
+      "description": "most recently observed status of the node; populated by the system, read-only; http://docs.k8s.io/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -9561,10 +9329,12 @@
     ],
     "properties": {
      "address": {
-      "type": "string"
+      "type": "string",
+      "description": "the node address"
      },
      "type": {
-      "type": "string"
+      "type": "string",
+      "description": "node address type, one of Hostname, ExternalIP or InternalIP"
      }
     }
    },
@@ -9622,13 +9392,9 @@
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ListMeta",
+      "description": "standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      }
     }
    },
@@ -9661,7 +9427,7 @@
      },
      "capacity": {
       "type": "any",
-      "description": "compute resource capacity of the node; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/resources.md"
+      "description": "compute resource capacity of the node; http://docs.k8s.io/resources.md"
      },
      "conditions": {
       "type": "array",
@@ -9671,7 +9437,8 @@
       "description": "list of node conditions observed"
      },
      "nodeInfo": {
-      "$ref": "v1beta3.NodeSystemInfo"
+      "$ref": "v1beta3.NodeSystemInfo",
+      "description": "set of ids/uuids to uniquely identify the node"
      },
      "phase": {
       "type": "string",
@@ -9689,13 +9456,9 @@
      "osImage",
      "containerRuntimeVersion",
      "kubeletVersion",
-     "KubeProxyVersion"
+     "kubeProxyVersion"
     ],
     "properties": {
-     "KubeProxyVersion": {
-      "type": "string",
-      "description": "Kube-proxy version reported by the node"
-     },
      "bootID": {
       "type": "string",
       "description": "boot id is the boot-id reported by the node"
@@ -9708,19 +9471,86 @@
       "type": "string",
       "description": "Kernel version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64)"
      },
+     "kubeProxyVersion": {
+      "type": "string",
+      "description": "Kube-proxy version reported by the node"
+     },
      "kubeletVersion": {
       "type": "string",
       "description": "Kubelet version reported by the node"
      },
      "machineID": {
-      "type": "string"
+      "type": "string",
+      "description": "machine-id reported by the node"
      },
      "osImage": {
       "type": "string",
       "description": "OS image used reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy))"
      },
      "systemUUID": {
-      "type": "string"
+      "type": "string",
+      "description": "system-uuid reported by the node"
+     }
+    }
+   },
+   "v1beta3.ObjectFieldSelector": {
+    "id": "v1beta3.ObjectFieldSelector",
+    "required": [
+     "fieldPath"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema that fieldPath is written in terms of; defaults to v1beta3"
+     },
+     "fieldPath": {
+      "type": "string",
+      "description": "path of the field to select in the specified API version"
+     }
+    }
+   },
+   "v1beta3.ObjectMeta": {
+    "id": "v1beta3.ObjectMeta",
+    "properties": {
+     "annotations": {
+      "type": "any",
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
+     },
+     "creationTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
+     },
+     "deletionTimestamp": {
+      "type": "string",
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
+     },
+     "generateName": {
+      "type": "string",
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
+     },
+     "labels": {
+      "type": "any",
+      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
+     },
+     "name": {
+      "type": "string",
+      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace of the object; cannot be updated"
+     },
+     "resourceVersion": {
+      "type": "string",
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
+     },
+     "selfLink": {
+      "type": "string",
+      "description": "URL for the object; populated by the system, read-only"
+     },
+     "uid": {
+      "type": "string",
+      "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
    },
@@ -9749,7 +9579,7 @@
      },
      "resourceVersion": {
       "type": "string",
-      "description": "specific resourceVersion to which this reference is made, if any: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
+      "description": "specific resourceVersion to which this reference is made, if any: http://docs.k8s.io/api-conventions.md#concurrency-control-and-consistency"
      },
      "uid": {
       "type": "string",
@@ -9760,49 +9590,17 @@
    "v1beta3.PersistentVolume": {
     "id": "v1beta3.PersistentVolume",
     "properties": {
-     "annotations": {
-      "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
-     },
      "apiVersion": {
       "type": "string",
       "description": "version of the schema the object should have"
-     },
-     "creationTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
-     },
-     "deletionTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
-     },
-     "generateName": {
-      "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
      },
      "kind": {
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "labels": {
-      "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
-     },
-     "name": {
-      "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the object; cannot be updated"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.PersistentVolumeSpec",
@@ -9811,59 +9609,23 @@
      "status": {
       "$ref": "v1beta3.PersistentVolumeStatus",
       "description": "current status of a persistent volume; populated by the system, read-only"
-     },
-     "uid": {
-      "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
    },
    "v1beta3.PersistentVolumeClaim": {
     "id": "v1beta3.PersistentVolumeClaim",
     "properties": {
-     "annotations": {
-      "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
-     },
      "apiVersion": {
       "type": "string",
       "description": "version of the schema the object should have"
-     },
-     "creationTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
-     },
-     "deletionTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
-     },
-     "generateName": {
-      "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
      },
      "kind": {
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "labels": {
-      "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
-     },
-     "name": {
-      "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the object; cannot be updated"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.PersistentVolumeClaimSpec"
@@ -9871,10 +9633,6 @@
      "status": {
       "$ref": "v1beta3.PersistentVolumeClaimStatus",
       "description": "the current status of a persistent volume claim; read-only"
-     },
-     "uid": {
-      "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
    },
@@ -9895,13 +9653,8 @@
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ListMeta"
      }
     }
    },
@@ -9976,13 +9729,8 @@
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ListMeta"
      }
     }
    },
@@ -10040,61 +9788,25 @@
    "v1beta3.Pod": {
     "id": "v1beta3.Pod",
     "properties": {
-     "annotations": {
-      "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
-     },
      "apiVersion": {
       "type": "string",
       "description": "version of the schema the object should have"
-     },
-     "creationTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
-     },
-     "deletionTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
-     },
-     "generateName": {
-      "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
      },
      "kind": {
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "labels": {
-      "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
-     },
-     "name": {
-      "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the object; cannot be updated"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.PodSpec",
-      "description": "specification of the desired behavior of the pod; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
+      "description": "specification of the desired behavior of the pod; http://docs.k8s.io/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta3.PodStatus",
-      "description": "most recently observed status of the pod; populated by the system, read-only; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
-     },
-     "uid": {
-      "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only"
+      "description": "most recently observed status of the pod; populated by the system, read-only; http://docs.k8s.io/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -10136,13 +9848,8 @@
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ListMeta"
      }
     }
    },
@@ -10179,6 +9886,10 @@
      "restartPolicy": {
       "type": "string",
       "description": "restart policy for all containers within the pod; one of RestartPolicyAlways, RestartPolicyOnFailure, RestartPolicyNever"
+     },
+     "terminationGracePeriodSeconds": {
+      "$ref": "int64",
+      "description": "optional duration in seconds the pod needs to terminate gracefully; may be decreased in delete request; value must be non-negative integer; the value zero indicates delete immediately; if this value is not set, the default grace period will be used instead; the grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal; set this value longer than the expected cleanup time for your process"
      },
      "volumes": {
       "type": "array",
@@ -10227,57 +9938,21 @@
    "v1beta3.PodTemplate": {
     "id": "v1beta3.PodTemplate",
     "properties": {
-     "annotations": {
-      "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
-     },
      "apiVersion": {
       "type": "string",
       "description": "version of the schema the object should have"
-     },
-     "creationTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
-     },
-     "deletionTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
-     },
-     "generateName": {
-      "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
      },
      "kind": {
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "labels": {
-      "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
-     },
-     "name": {
-      "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the object; cannot be updated"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
      "template": {
       "$ref": "v1beta3.PodTemplateSpec",
-      "description": "the template of the desired behavior of the pod; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
-     },
-     "uid": {
-      "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only"
+      "description": "the template of the desired behavior of the pod; http://docs.k8s.io/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -10302,62 +9977,22 @@
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ListMeta",
+      "description": "standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      }
     }
    },
    "v1beta3.PodTemplateSpec": {
     "id": "v1beta3.PodTemplateSpec",
     "properties": {
-     "annotations": {
-      "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
-     },
-     "creationTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
-     },
-     "deletionTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
-     },
-     "generateName": {
-      "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
-     },
-     "labels": {
-      "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
-     },
-     "name": {
-      "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the object; cannot be updated"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.PodSpec",
-      "description": "specification of the desired behavior of the pod; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
-     },
-     "uid": {
-      "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only"
+      "description": "specification of the desired behavior of the pod; http://docs.k8s.io/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -10391,61 +10026,25 @@
    "v1beta3.ReplicationController": {
     "id": "v1beta3.ReplicationController",
     "properties": {
-     "annotations": {
-      "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
-     },
      "apiVersion": {
       "type": "string",
       "description": "version of the schema the object should have"
-     },
-     "creationTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
-     },
-     "deletionTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
-     },
-     "generateName": {
-      "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
      },
      "kind": {
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "labels": {
-      "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
-     },
-     "name": {
-      "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the object; cannot be updated"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.ReplicationControllerSpec",
-      "description": "specification of the desired behavior of the replication controller; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
+      "description": "specification of the desired behavior of the replication controller; http://docs.k8s.io/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta3.ReplicationControllerStatus",
-      "description": "most recently observed status of the replication controller; populated by the system, read-only; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
-     },
-     "uid": {
-      "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only"
+      "description": "most recently observed status of the replication controller; populated by the system, read-only; http://docs.k8s.io/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -10470,13 +10069,9 @@
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ListMeta",
+      "description": "standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      }
     }
    },
@@ -10521,61 +10116,25 @@
    "v1beta3.ResourceQuota": {
     "id": "v1beta3.ResourceQuota",
     "properties": {
-     "annotations": {
-      "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
-     },
      "apiVersion": {
       "type": "string",
       "description": "version of the schema the object should have"
-     },
-     "creationTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
-     },
-     "deletionTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
-     },
-     "generateName": {
-      "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
      },
      "kind": {
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "labels": {
-      "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
-     },
-     "name": {
-      "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the object; cannot be updated"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.ResourceQuotaSpec",
-      "description": "spec defines the desired quota; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
+      "description": "spec defines the desired quota; http://docs.k8s.io/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta3.ResourceQuotaStatus",
-      "description": "status defines the actual enforced quota and current usage; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
-     },
-     "uid": {
-      "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only"
+      "description": "status defines the actual enforced quota and current usage; http://docs.k8s.io/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -10600,13 +10159,9 @@
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ListMeta",
+      "description": "standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      }
     }
    },
@@ -10641,68 +10196,32 @@
      },
      "requests": {
       "type": "any",
-      "description": "Minimum amount of resources requested"
+      "description": "Minimum amount of resources requested; requests are honored only for persistent volumes as of now"
      }
     }
    },
    "v1beta3.Secret": {
     "id": "v1beta3.Secret",
     "properties": {
-     "annotations": {
-      "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
-     },
      "apiVersion": {
       "type": "string",
       "description": "version of the schema the object should have"
-     },
-     "creationTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
      },
      "data": {
       "type": "any",
       "description": "data contains the secret data.  Each key must be a valid DNS_SUBDOMAIN.  Each value must be a base64 encoded string"
      },
-     "deletionTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
-     },
-     "generateName": {
-      "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
-     },
      "kind": {
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "labels": {
-      "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
-     },
-     "name": {
-      "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the object; cannot be updated"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
      "type": {
       "type": "string",
       "description": "type facilitates programmatic handling of secret data"
-     },
-     "uid": {
-      "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only"
      }
     }
    },
@@ -10727,13 +10246,9 @@
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ListMeta",
+      "description": "standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      }
     }
    },
@@ -10752,61 +10267,25 @@
    "v1beta3.Service": {
     "id": "v1beta3.Service",
     "properties": {
-     "annotations": {
-      "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects"
-     },
      "apiVersion": {
       "type": "string",
       "description": "version of the schema the object should have"
-     },
-     "creationTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists"
-     },
-     "deletionTimestamp": {
-      "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested"
-     },
-     "generateName": {
-      "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified"
      },
      "kind": {
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "labels": {
-      "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services"
-     },
-     "name": {
-      "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated"
-     },
-     "namespace": {
-      "type": "string",
-      "description": "namespace of the object; cannot be updated"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.ServiceSpec",
-      "description": "specification of the desired behavior of the service; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
+      "description": "specification of the desired behavior of the service; http://docs.k8s.io/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta3.ServiceStatus",
-      "description": "most recently observed status of the service; populated by the system, read-only; https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#spec-and-status"
-     },
-     "uid": {
-      "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only"
+      "description": "most recently observed status of the service; populated by the system, read-only; http://docs.k8s.io/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -10831,13 +10310,9 @@
       "type": "string",
       "description": "kind of object, in CamelCase; cannot be updated"
      },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
+     "metadata": {
+      "$ref": "v1beta3.ListMeta",
+      "description": "standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      }
     }
    },
@@ -10936,17 +10411,13 @@
       "type": "string",
       "description": "human-readable description of the status of this operation"
      },
+     "metadata": {
+      "$ref": "v1beta3.ListMeta",
+      "description": "standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"
+     },
      "reason": {
       "type": "string",
       "description": "machine-readable description of why this operation is in the 'Failure' status; if this value is empty there is no information available; a reason clarifies an HTTP status code but does not override it"
-     },
-     "resourceVersion": {
-      "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/api-conventions.md#concurrency-control-and-consistency"
-     },
-     "selfLink": {
-      "type": "string",
-      "description": "URL for the object; populated by the system, read-only"
      },
      "status": {
       "type": "string",
@@ -11009,15 +10480,15 @@
     "id": "v1beta3.Volume",
     "required": [
      "name",
-     "gcePersistentDisk",
-     "iscsi",
-     "glusterfs",
-     "hostPath",
-     "emptyDir",
      "awsElasticBlockStore",
      "gitRepo",
      "secret",
-     "nfs"
+     "nfs",
+     "glusterfs",
+     "hostPath",
+     "emptyDir",
+     "gcePersistentDisk",
+     "iscsi"
     ],
     "properties": {
      "awsElasticBlockStore": {

--- a/pkg/api/validation/schema.go
+++ b/pkg/api/validation/schema.go
@@ -165,6 +165,7 @@ func (s *SwaggerSchema) validateField(value interface{}, apiVersion, fieldName, 
 			}
 		}
 	case "uint64":
+	case "int64":
 	case "integer":
 		_, isNumber := value.(float64)
 		_, isInteger := value.(int)


### PR DESCRIPTION
We found while working on #7592 that updating the swagger spec results in validation failures around int64 fields.  This PR updates the godep for go-restful, allows int64 fields in the API, and updates the swagger spec.

PTAL @bgrant0607 @smarterclayton 
