### PR TITLE
Throw an API error when deleting namespace in termination

### DIFF
--- a/pkg/registry/namespace/etcd/etcd.go
+++ b/pkg/registry/namespace/etcd/etcd.go
@@ -21,6 +21,7 @@ import (
 	"path"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	apierrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
@@ -101,7 +102,7 @@ func (r *REST) Delete(ctx api.Context, name string, options *api.DeleteOptions) 
 
 	// prior to final deletion, we must ensure that finalizers is empty
 	if len(namespace.Spec.Finalizers) != 0 {
-		err = fmt.Errorf("Namespace %v termination is in progress, waiting for %v", namespace.Name, namespace.Spec.Finalizers)
+		err = apierrors.NewConflict("Namespace", namespace.Name, fmt.Errorf("Termination is in progress, waiting for %v", namespace.Spec.Finalizers))
 		return nil, err
 	}
 	return r.Etcd.Delete(ctx, name, nil)


### PR DESCRIPTION
Errors from API server should be from the api/errors package in order to get a proper Status response.

Fixing a bug in namespace registry where this rule was not respected.

/cc @smarterclayton 
