### PR TITLE
make go-oracle happy

### DIFF
--- a/test/e2e/empty_dir.go
+++ b/test/e2e/empty_dir.go
@@ -30,16 +30,13 @@ import (
 
 var _ = Describe("emptyDir", func() {
 	var (
-		c         *client.Client
-		podClient client.PodInterface
+		c *client.Client
 	)
 
 	BeforeEach(func() {
 		var err error
 		c, err = loadClient()
 		expectNoError(err)
-
-		podClient = c.Pods(api.NamespaceDefault)
 	})
 
 	It("volume on tmpfs should have the correct mode", func() {


### PR DESCRIPTION
gooracle was complaining about an unused variable.  I like being able to use gooracle against everything, including tests.
