### PR TITLE
Service port names are required for multi-port

### DIFF
--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -1601,6 +1601,14 @@ func TestValidateService(t *testing.T) {
 			numErrs: 1,
 		},
 		{
+			name: "empty multi-port port[0] name",
+			tweakSvc: func(s *api.Service) {
+				s.Spec.Ports[0].Name = ""
+				s.Spec.Ports = append(s.Spec.Ports, api.ServicePort{Name: "p", Protocol: "TCP", Port: 12345})
+			},
+			numErrs: 1,
+		},
+		{
 			name: "invalid port name",
 			tweakSvc: func(s *api.Service) {
 				s.Spec.Ports[0].Name = "INVALID"


### PR DESCRIPTION
There is no provision for the first port to be unnamed.  I think I
initially allowed that, but then the Subset struct became a sorted
struct, so the first-ness of the port got lost.  If you have a Service
with one named and one unnamed port, what happens is that the
EndpointController fails to create Endpoints (validation error).
