### PR TITLE
specify port 6443 for the kube proxy on Vagrant

### DIFF
--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -67,7 +67,7 @@ grains:
   cloud: vagrant
   network_mode: openvswitch
   node_ip: '$(echo "$MINION_IP" | sed -e "s/'/''/g")'
-  api_servers: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
+  api_servers: '$(echo "$MASTER_IP" | sed -e "s/'/''/g"):6443'
   networkInterfaceName: eth1
   roles:
     - kubernetes-pool


### PR DESCRIPTION
This patch explicitly sets the TCP port for the kube-proxy to use when contacting the master api-server.

Apparently the api-server port has moved to 6443, at least in the Vagrant cluster but the kube-proxy process does not yet default to the new port.

This patch makes the Vagrant cluster functional, insuring that the kube-proxy is configured properly when the cluster is formed.  However this is really a temporary patch.

The correct final change would be to modify the kube-proxy to use port 6443 by default.
