### PR TITLE
Revert "Kubelet: Add rkt as a runtime option"

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -210,7 +210,7 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.CloudConfigFile, "cloud-config", s.CloudConfigFile, "The path to the cloud provider configuration file.  Empty string for no configuration file.")
 	fs.StringVar(&s.ResourceContainer, "resource-container", s.ResourceContainer, "Absolute name of the resource-only container to create and run the Kubelet in (Default: /kubelet).")
 	fs.StringVar(&s.CgroupRoot, "cgroup_root", s.CgroupRoot, "Optional root cgroup to use for pods. This is handled by the container runtime on a best effort basis. Default: '', which means use the container runtime default.")
-	fs.StringVar(&s.ContainerRuntime, "container_runtime", s.ContainerRuntime, "The container runtime to use. Possible values: 'docker', 'rkt'. Default: 'docker'.")
+	fs.StringVar(&s.ContainerRuntime, "container_runtime", s.ContainerRuntime, "The container runtime to use. Possible values: 'docker'. Default: 'docker'.")
 
 	// Flags intended for testing, not recommended used in production environments.
 	fs.BoolVar(&s.ReallyCrashForTesting, "really-crash-for-testing", s.ReallyCrashForTesting, "If true, when panics occur crash. Intended for testing.")

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -44,7 +44,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/metrics"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/network"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/prober"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/rkt"
 	kubeletTypes "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
@@ -262,15 +261,6 @@ func NewMainKubelet(
 			klet,
 			klet.httpClient,
 			newKubeletRuntimeHooks(recorder))
-	case "rkt":
-		conf := &rkt.Config{
-			InsecureSkipVerify: true,
-		}
-		rktRuntime, err := rkt.New(conf, klet, recorder, containerRefManager, readinessManager)
-		if err != nil {
-			return nil, err
-		}
-		klet.containerRuntime = rktRuntime
 	default:
 		return nil, fmt.Errorf("unsupported container runtime %q specified", containerRuntime)
 	}

--- a/pkg/kubelet/rkt/gc.go
+++ b/pkg/kubelet/rkt/gc.go
@@ -18,10 +18,11 @@ package rkt
 
 // ImageManager manages and garbage collects the container images for rkt.
 type ImageManager struct {
+	runtime *runtime
 }
 
-func NewImageManager() *ImageManager {
-	return &ImageManager{}
+func NewImageManager(r *runtime) *ImageManager {
+	return &ImageManager{runtime: r}
 }
 
 // GarbageCollect collects the images. It is not implemented by rkt yet.

--- a/pkg/kubelet/rkt/rkt_linux.go
+++ b/pkg/kubelet/rkt/rkt_linux.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/capabilities"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/credentialprovider"
 	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/prober"
@@ -106,11 +105,7 @@ var _ kubecontainer.Runtime = &runtime{}
 // New creates the rkt container runtime which implements the container runtime interface.
 // It will test if the rkt binary is in the $PATH, and whether we can get the
 // version of it. If so, creates the rkt container runtime, otherwise returns an error.
-func New(config *Config,
-	generator kubecontainer.RunContainerOptionsGenerator,
-	recorder record.EventRecorder,
-	containerRefManager *kubecontainer.RefManager,
-	readinessManager *kubecontainer.ReadinessManager) (kubecontainer.Runtime, error) {
+func New(config *Config) (kubecontainer.Runtime, error) {
 	systemdVersion, err := getSystemdVersion()
 	if err != nil {
 		return nil, err
@@ -135,14 +130,11 @@ func New(config *Config,
 	}
 
 	rkt := &runtime{
-		generator:        generator,
-		readinessManager: readinessManager,
-		systemd:          systemd,
-		rktBinAbsPath:    rktBinAbsPath,
-		config:           config,
-		dockerKeyring:    credentialprovider.NewDockerKeyring(),
+		systemd:       systemd,
+		rktBinAbsPath: rktBinAbsPath,
+		config:        config,
+		dockerKeyring: credentialprovider.NewDockerKeyring(),
 	}
-	rkt.prober = prober.New(rkt, readinessManager, containerRefManager, recorder)
 
 	// Test the rkt version.
 	version, err := rkt.Version()

--- a/pkg/kubelet/rkt/rkt_unsupported.go
+++ b/pkg/kubelet/rkt/rkt_unsupported.go
@@ -23,7 +23,6 @@ import (
 	"io"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
 )
 
@@ -32,14 +31,6 @@ type unsupportedRuntime struct {
 }
 
 var _ kubecontainer.Runtime = &unsupportedRuntime{}
-
-func New(config *Config,
-	generator kubecontainer.RunContainerOptionsGenerator,
-	recorder record.EventRecorder,
-	containerRefManager *kubecontainer.RefManager,
-	readinessManager *kubecontainer.ReadinessManager) (kubecontainer.Runtime, error) {
-	return nil, unsupportedError
-}
 
 var unsupportedError = fmt.Errorf("rkt runtime is unsupported in this platform")
 


### PR DESCRIPTION
We're stuck creating clusters. On GCE-Debian, kubelet now has a dep on glibc 2.14, which ContainerVM doesn't have, so kubelet isn't coming up.

Reverts GoogleCloudPlatform/kubernetes#7743
