### PR TITLE
Revert "Revert "Kubelet: Add rkt as a runtime option""

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -210,7 +210,7 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.CloudConfigFile, "cloud-config", s.CloudConfigFile, "The path to the cloud provider configuration file.  Empty string for no configuration file.")
 	fs.StringVar(&s.ResourceContainer, "resource-container", s.ResourceContainer, "Absolute name of the resource-only container to create and run the Kubelet in (Default: /kubelet).")
 	fs.StringVar(&s.CgroupRoot, "cgroup_root", s.CgroupRoot, "Optional root cgroup to use for pods. This is handled by the container runtime on a best effort basis. Default: '', which means use the container runtime default.")
-	fs.StringVar(&s.ContainerRuntime, "container_runtime", s.ContainerRuntime, "The container runtime to use. Possible values: 'docker'. Default: 'docker'.")
+	fs.StringVar(&s.ContainerRuntime, "container_runtime", s.ContainerRuntime, "The container runtime to use. Possible values: 'docker', 'rkt'. Default: 'docker'.")
 
 	// Flags intended for testing, not recommended used in production environments.
 	fs.BoolVar(&s.ReallyCrashForTesting, "really-crash-for-testing", s.ReallyCrashForTesting, "If true, when panics occur crash. Intended for testing.")

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -44,6 +44,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/metrics"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/network"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/prober"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/rkt"
 	kubeletTypes "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
@@ -261,6 +262,15 @@ func NewMainKubelet(
 			klet,
 			klet.httpClient,
 			newKubeletRuntimeHooks(recorder))
+	case "rkt":
+		conf := &rkt.Config{
+			InsecureSkipVerify: true,
+		}
+		rktRuntime, err := rkt.New(conf, klet, recorder, containerRefManager, readinessManager)
+		if err != nil {
+			return nil, err
+		}
+		klet.containerRuntime = rktRuntime
 	default:
 		return nil, fmt.Errorf("unsupported container runtime %q specified", containerRuntime)
 	}

--- a/pkg/kubelet/rkt/gc.go
+++ b/pkg/kubelet/rkt/gc.go
@@ -18,11 +18,10 @@ package rkt
 
 // ImageManager manages and garbage collects the container images for rkt.
 type ImageManager struct {
-	runtime *runtime
 }
 
-func NewImageManager(r *runtime) *ImageManager {
-	return &ImageManager{runtime: r}
+func NewImageManager() *ImageManager {
+	return &ImageManager{}
 }
 
 // GarbageCollect collects the images. It is not implemented by rkt yet.

--- a/pkg/kubelet/rkt/rkt_unsupported.go
+++ b/pkg/kubelet/rkt/rkt_unsupported.go
@@ -23,6 +23,7 @@ import (
 	"io"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
 )
 
@@ -31,6 +32,14 @@ type unsupportedRuntime struct {
 }
 
 var _ kubecontainer.Runtime = &unsupportedRuntime{}
+
+func New(config *Config,
+	generator kubecontainer.RunContainerOptionsGenerator,
+	recorder record.EventRecorder,
+	containerRefManager *kubecontainer.RefManager,
+	readinessManager *kubecontainer.ReadinessManager) (kubecontainer.Runtime, error) {
+	return nil, unsupportedError
+}
 
 var unsupportedError = fmt.Errorf("rkt runtime is unsupported in this platform")
 


### PR DESCRIPTION
Unrevert #7743 

I was able to tell from a `make release` that this wasn't the culprit I was seeing.

Reverts GoogleCloudPlatform/kubernetes#7806
