### PR TITLE
Add old endpoint cleanup function

### DIFF
--- a/pkg/util/workqueue/queue.go
+++ b/pkg/util/workqueue/queue.go
@@ -85,6 +85,15 @@ func (q *Type) Add(item interface{}) {
 	q.cond.Signal()
 }
 
+// Len returns the current queue length, for informational purposes only. You
+// shouldn't e.g. gate a call to Add() or Get() on Len() being a particular
+// value, that can't be synchronized properly.
+func (q *Type) Len() int {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	return len(q.queue)
+}
+
 // Get blocks until it can return an item to be processed. If shutdown = true,
 // the caller should end their goroutine. You must call Done with item when you
 // have finished processing it.

--- a/pkg/util/workqueue/queue_test.go
+++ b/pkg/util/workqueue/queue_test.go
@@ -113,3 +113,19 @@ func TestAddWhileProcessing(t *testing.T) {
 	q.ShutDown()
 	consumerWG.Wait()
 }
+
+func TestLen(t *testing.T) {
+	q := workqueue.New()
+	q.Add("foo")
+	if e, a := 1, q.Len(); e != a {
+		t.Errorf("Expected %v, got %v", e, a)
+	}
+	q.Add("bar")
+	if e, a := 2, q.Len(); e != a {
+		t.Errorf("Expected %v, got %v", e, a)
+	}
+	q.Add("foo") // should not increase the queue length.
+	if e, a := 2, q.Len(); e != a {
+		t.Errorf("Expected %v, got %v", e, a)
+	}
+}


### PR DESCRIPTION
Fixes #6877

I have a nicer version that waits until the cache is full instead of 5 minutes, but it involves more changes and I didn't want to block this on that.

Anyway, it's not the end of the world if the cache isn't full, it'll just recreate the endpoint in the future.
