### PR TITLE
Set allocate_node_cidrs to be blank by default.

### DIFF
--- a/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
+++ b/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
@@ -1,6 +1,7 @@
 {% set machines = ""-%}
 {% set cluster_name = "" -%}
 {% set cluster_class_b = "" -%}
+{% set allocate_node_cidrs = "" -%}
 {% set minion_regexp = "--minion_regexp=.*" -%}
 {% set sync_nodes = "--sync_nodes=true" -%}
 


### PR DESCRIPTION
#7799 broke GKE-CI because `allocate_node_cidrs` isn't set.
