### PR TITLE
Added client header info for authentication doc.

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -16,6 +16,9 @@ be short-lived, and to be generated as needed rather than stored in a file.
 The token file format is implemented in `plugin/pkg/auth/authenticator/token/tokenfile/...`
 and is a csv file with 3 columns: token, user name, user uid.
 
+When using token authentication from an http client the apiserver expects an `Authorization`
+header with a value of `Bearer SOMETOKEN`.
+
 Basic authentication is enabled by passing the `--basic_auth_file=SOMEFILE`
 option to apiserver. Currently, the basic auth credentials last indefinitely,
 and the password cannot be changed without restarting apiserver. Note that basic
@@ -25,6 +28,8 @@ more secure modes described above easier to use.
 The basic auth file format is implemented in `plugin/pkg/auth/authenticator/password/passwordfile/...`
 and is a csv file with 3 columns: password, user name, user id.
 
+When using basic authentication from an http client the apiserver expects an `Authorization` header
+with a value of `Basic BASE64ENCODEDUSER:PASSWORD`.
 
 ## Plugin Development
 


### PR DESCRIPTION
This morning I was asked what the format for sending "tokens" from a client and realized I couldn't find a good kubernetes doc to pass over as a reference. This adds simple information on what client header to use and what the value should consist of for those who may not familiar with bearer tokens or basic auth formats.
