### PR TITLE
Update examples/meteor to use API v1beta3

### DIFF
--- a/examples/meteor/README.md
+++ b/examples/meteor/README.md
@@ -56,9 +56,9 @@ Wait until Mongo is started completely and then set up Meteor:
     kubectl create -f meteor-controller.json
     kubectl create -f meteor-service.json
 
-Note that meteor-service.json creates an external load balancer, so your app should be available through the IP of that load balancer once the Meteor pods are started. On gcloud you can find the IP of your load balancer by running:
+Note that meteor-service.json creates an external load balancer, so your app should be available through the IP of that load balancer once the Meteor pods are started. You can find the IP of your load balancer by running:
 
-    gcloud compute forwarding-rules list k8s-meteor-default-meteor | grep k8s-meteor-default-meteor | awk '{print $3}'
+    kubectl get services/meteor -o template -t "{{.spec.publicIPs}}"
 
 You might have to open up port 80 if it's not open yet in your project. For example:
 
@@ -68,5 +68,4 @@ You might have to open up port 80 if it's not open yet in your project. For exam
 
 
 TODO replace the mongo image with the official mongo? https://registry.hub.docker.com/_/mongo/
-TODO use Kubernetes v1beta3 syntax?
 

--- a/examples/meteor/meteor-controller.json
+++ b/examples/meteor/meteor-controller.json
@@ -1,26 +1,45 @@
 {
-  "id": "meteor-controller",
   "kind": "ReplicationController",
-  "apiVersion": "v1beta1",
-  "desiredState": {
-    "replicas": 2,
-    "replicaSelector": {"name": "meteor"},
-    "podTemplate": {
-      "desiredState": {
-        "manifest": {
-          "version": "v1beta1",
-          "id": "meteor-controller",
-          "containers": [{
-            "name": "meteor",
-            "image": "chees/meteor-gke-example:latest",
-            "cpu": 1000,
-            "memory": 500000000,
-            "ports": [{"name": "http-server", "containerPort": 8080, "hostPort": 80}]
-          }]
-        }
-      },
-      "labels": { "name": "meteor" }
+  "apiVersion": "v1beta3",
+  "metadata": {
+    "name": "meteor-controller",
+    "labels": {
+      "name": "meteor"
     }
   },
-  "labels": {"name": "meteor"}
+  "spec": {
+    "replicas": 2,
+    "selector": {
+      "name": "meteor"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "name": "meteor"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "meteor",
+            "image": "chees/meteor-gke-example:latest",
+            "ports": [
+              {
+                "name": "http-server",
+                "hostPort": 80,
+                "containerPort": 8080,
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "1",
+                "memory": "500000000"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
 }

--- a/examples/meteor/meteor-service.json
+++ b/examples/meteor/meteor-service.json
@@ -1,10 +1,21 @@
 {
-  "apiVersion": "v1beta1",
   "kind": "Service",
-  "id": "meteor",
-  "port": 80,
-  "containerPort": "http-server",
-  "selector": { "name": "meteor" },
-  "createExternalLoadBalancer": true,
-  "sessionAffinity": "ClientIP"
+  "apiVersion": "v1beta3",
+  "metadata": {
+    "name": "meteor"
+  },
+  "spec": {
+    "ports": [
+      {
+        "protocol": "TCP",
+        "port": 80,
+        "targetPort": "http-server"
+      }
+    ],
+    "selector": {
+      "name": "meteor"
+    },
+    "createExternalLoadBalancer": true,
+    "sessionAffinity": "ClientIP"
+  }
 }

--- a/examples/meteor/mongo-pod.json
+++ b/examples/meteor/mongo-pod.json
@@ -1,33 +1,46 @@
 {
-  "id": "mongo",
   "kind": "Pod",
-  "apiVersion": "v1beta1",
-  "desiredState": {
-    "manifest": {
-      "version": "v1beta1",
-      "id": "mongo",
-      "containers": [{
-        "name": "mongo",
-        "image": "mongo",
-        "cpu": 1000,
-        "ports": [{ "name": "mongo", "containerPort": 27017 }],
-        "volumeMounts": [{
-          "mountPath": "/data/db",
-          "name": "mongo-disk"
-        }]
-      }],
-      "volumes": [{
-        "name": "mongo-disk",
-        "source": {
-          "persistentDisk": {
-            "pdName": "mongo-disk",
-            "fsType": "ext4"
-          }
-        }
-      }]
+  "apiVersion": "v1beta3",
+  "metadata": {
+    "name": "mongo",
+    "labels": {
+      "name": "mongo",
+      "role": "mongo"
     }
   },
-  "labels": {
-    "name": "mongo", "role": "mongo"
+  "spec": {
+    "volumes": [
+      {
+        "name": "mongo-disk",
+        "gcePersistentDisk": {
+          "pdName": "mongo-disk",
+          "fsType": "ext4"
+        }
+      }
+    ],
+    "containers": [
+      {
+        "name": "mongo",
+        "image": "mongo",
+        "ports": [
+          {
+            "name": "mongo",
+            "containerPort": 27017,
+            "protocol": "TCP"
+          }
+        ],
+        "resources": {
+          "limits": {
+            "cpu": "1"
+          }
+        },
+        "volumeMounts": [
+          {
+            "name": "mongo-disk",
+            "mountPath": "/data/db"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/examples/meteor/mongo-service.json
+++ b/examples/meteor/mongo-service.json
@@ -1,13 +1,23 @@
 {
-  "id": "mongo",
   "kind": "Service",
-  "apiVersion": "v1beta1",
-  "port": 27017,
-  "containerPort": "mongo",
-  "selector": {
-    "name": "mongo", "role": "mongo"
+  "apiVersion": "v1beta3",
+  "metadata": {
+    "name": "mongo",
+    "labels": {
+      "name": "mongo"
+    }
   },
-  "labels": {
-    "name": "mongo"
+  "spec": {
+    "ports": [
+      {
+        "protocol": "TCP",
+        "port": 27017,
+        "targetPort": "mongo"
+      }
+    ],
+    "selector": {
+      "name": "mongo",
+      "role": "mongo"
+    }
   }
 }


### PR DESCRIPTION
@chees @nikhiljindal 
- I have updated the json files. I have verified that these json files can create service/pod/replicationcontroller correctly. But I don't know how to check if meteor is running correctly. Can some one verify?
- I change the way to get the external IP of the meteor service. Now it uses kubectl instead of the gcloud specific command.
