### PR TITLE
Ignore latency metrics for events

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -158,7 +158,7 @@ var _ = Describe("Density", func() {
 			// Verify latency metrics
 			// TODO: Update threshold to 1s once we reach this goal
 			// TODO: We should reset metrics before the test. Currently previous tests influence latency metrics.
-			highLatencyRequests, err := HighLatencyRequests(c, 10*time.Second)
+			highLatencyRequests, err := HighLatencyRequests(c, 10*time.Second, util.NewStringSet("events"))
 			expectNoError(err)
 			Expect(highLatencyRequests).NotTo(BeNumerically(">", 0))
 		})

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -36,6 +36,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/clientauth"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/wait"
 
 	"golang.org/x/crypto/ssh"
@@ -761,14 +762,15 @@ func ReadLatencyMetrics(c *client.Client) ([]LatencyMetric, error) {
 
 // Prints summary metrics for request types with latency above threshold
 // and returns number of such request types.
-func HighLatencyRequests(c *client.Client, threshold time.Duration) (int, error) {
+func HighLatencyRequests(c *client.Client, threshold time.Duration, ignoredResources util.StringSet) (int, error) {
 	metrics, err := ReadLatencyMetrics(c)
 	if err != nil {
 		return 0, err
 	}
 	var badMetrics []LatencyMetric
 	for _, metric := range metrics {
-		if metric.verb != "WATCHLIST" &&
+		if !ignoredResources.Has(metric.resource) &&
+			metric.verb != "WATCHLIST" &&
 			// We are only interested in 99%tile, but for logging purposes
 			// it's useful to have all the offending percentiles.
 			metric.quantile <= 0.99 &&


### PR DESCRIPTION
This should fix some of the jenkins failure.

@wojtek-t @bprashanth @quinton-hoole 
