### PR TITLE
Updating ServiceErrorHandler to list all paths that have the requested Path as a prefix

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -182,11 +183,31 @@ func InstallLogsSupport(mux Mux) {
 
 func InstallServiceErrorHandler(container *restful.Container, requestResolver *APIRequestInfoResolver, apiVersions []string) {
 	container.ServiceErrorHandler(func(serviceErr restful.ServiceError, request *restful.Request, response *restful.Response) {
-		serviceErrorHandler(requestResolver, apiVersions, serviceErr, request, response)
+		serviceErrorHandler(container, requestResolver, apiVersions, serviceErr, request, response)
 	})
 }
 
-func serviceErrorHandler(requestResolver *APIRequestInfoResolver, apiVersions []string, serviceErr restful.ServiceError, request *restful.Request, response *restful.Response) {
+func serviceErrorHandler(container *restful.Container, requestResolver *APIRequestInfoResolver, apiVersions []string, serviceErr restful.ServiceError, request *restful.Request, response *restful.Response) {
+	requestedPath := request.Request.URL.Path
+	// If there is any valid path with the requested path as prefix, then list all such paths.
+	for _, ws := range container.RegisteredWebServices() {
+		if strings.HasPrefix(requestedPath, ws.RootPath()) {
+			// List all valid paths which have the requested path as prefix.
+			var paths []string
+			for _, route := range ws.Routes() {
+				if strings.HasPrefix(route.Path, requestedPath) {
+					paths = append(paths, route.Path)
+				}
+			}
+			if len(paths) > 0 {
+				sort.Strings(paths)
+				writeRawJSON(http.StatusOK, api.RootPaths{Paths: paths}, response.ResponseWriter)
+				return
+			}
+		}
+	}
+
+	// There is no valid path with the requested path as prefix. Return a 404 with a JSON status object in this case.
 	requestInfo, err := requestResolver.GetAPIRequestInfo(request.Request)
 	codec := latest.Codec
 	if err == nil && requestInfo.APIVersion != "" {


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/2057

ServiceErrorHandler now outputs all paths that have the requested path as their prefix, if there is atleast one such.
Otherwise, it gives a 404.
This should help in API discovery.

Example output for:
/api/v1beta3/:
Before:
![vh1gdjtaobs](https://cloud.githubusercontent.com/assets/10199099/7509739/825a8ef2-f449-11e4-9609-9d13cc53e417.png)

After:
![f48gqf0vo0q](https://cloud.githubusercontent.com/assets/10199099/7509713/41a5af5e-f449-11e4-9d49-8b02eb9239a6.png)

Some more examples:
/api/v1beta3/watch:
![d1gtwrdyehl](https://cloud.githubusercontent.com/assets/10199099/7509769/de2a2af8-f449-11e4-9b8f-7a77b1d29457.png)

/api/v1beta3/dasdas
![a871h5k7ufb](https://cloud.githubusercontent.com/assets/10199099/7509779/f89588d8-f449-11e4-8418-b63a29fa94d8.png)
