### PR TITLE
Fixes #7886 - Used network-environment to get ip, swap wget for curl

### DIFF
--- a/docs/getting-started-guides/coreos/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/master.yaml
@@ -70,6 +70,24 @@ coreos:
             -e MIRROR_TAGS_CACHE_TTL=1800 \
             quay.io/devops/docker-registry:latest
     - name: docker.service
+      content: |
+        [Unit]
+        Description=Docker Application Container Engine
+        Documentation=http://docs.docker.com
+        After=docker.socket early-docker.target network.target
+        Requires=docker.socket early-docker.target
+
+        [Service]
+        Environment=TMPDIR=/var/tmp
+        EnvironmentFile=-/run/flannel_docker_opts.env
+        EnvironmentFile=/etc/network-environment
+        MountFlags=slave
+        LimitNOFILE=1048576
+        LimitNPROC=1048576
+        ExecStart=/usr/lib/coreos/dockerd --daemon --host=fd:// --registry-mirror=http://${DEFAULT_IPV4}:5000 $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
+
+        [Install]
+        WantedBy=multi-user.target
       drop-ins:
         - name: 51-docker-mirror.conf
           content: |
@@ -78,18 +96,17 @@ coreos:
             # startup, otherwise containers won't land in flannel's network...
             Requires=docker-cache.service flanneld.service
             After=docker-cache.service flanneld.service
-            [Service]
-            Environment=DOCKER_OPTS='--registry-mirror=http://$private_ipv4:5000'
     - name: kube-apiserver.service
       command: start
       content: |
         [Unit]
         Description=Kubernetes API Server
         Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-        Requires=etcd2.service
-        After=etcd2.service
+        Requires=etcd2.service setup-network-environment.service
+        After=etcd2.service setup-network-environment.service
 
         [Service]
+        EnvironmentFile=/etc/network-environment
         ExecStartPre=-/usr/bin/mkdir -p /opt/bin
         ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.15.0/bin/linux/amd64/kube-apiserver
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-apiserver
@@ -101,7 +118,7 @@ coreos:
         --secure_port=6443 \
         --portal_net=10.100.0.0/16 \
         --etcd_servers=http://127.0.0.1:4001 \
-        --public_address_override=$private_ipv4 \
+        --public_address_override=${DEFAULT_IPV4} \
         --logtostderr=true
         Restart=always
         RestartSec=10
@@ -150,7 +167,7 @@ coreos:
 
         [Service]
         # ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/k8s/kube-register
-        ExecStartPre=/usr/bin/wget -N -O /opt/bin/kube-register https://github.com/kelseyhightower/kube-register/releases/download/v0.0.3/kube-register-0.0.3-linux-amd64
+        ExecStartPre=/usr/bin/curl -L -o /opt/bin/kube-register -z /opt/bin/kube-register https://github.com/kelseyhightower/kube-register/releases/download/v0.0.3/kube-register-0.0.3-linux-amd64
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-register
         ExecStart=/opt/bin/kube-register \
         --metadata=role=node \

--- a/docs/getting-started-guides/coreos/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/node.yaml
@@ -91,7 +91,7 @@ coreos:
         ExecStart=/opt/bin/kubelet \
         --address=0.0.0.0 \
         --port=10250 \
-        --hostname_override=$private_ipv4 \
+        --hostname_override=${DEFAULT_IPV4} \
         --api_servers=<master-private-ip>:8080 \
         --allow_privileged=true \
         --logtostderr=true \


### PR DESCRIPTION
I re-used setup-network-environment instead of $private_ipv4, this
does meant overwriting the docker.service with a custom service.

Also, the wget command was always getting kube-register, curl
works more reliabily for this.
