### PR TITLE
Associate master instance with AWS Elastic IP

### DIFF
--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -43,7 +43,9 @@ MINION_SCOPES=""
 POLL_SLEEP_INTERVAL=3
 PORTAL_NET="10.0.0.0/16"
 MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
-
+# If set to Elastic IP, master instance will be associated with this IP.
+# Otherwise new Elastic IP will be aquired
+MASTER_RESERVED_IP="${MASTER_RESERVED_IP:-}"
 
 # When set to true, Docker Cache is enabled by default as part of the cluster bring up.
 ENABLE_DOCKER_REGISTRY_CACHE=true

--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -44,7 +44,8 @@ POLL_SLEEP_INTERVAL=3
 PORTAL_NET="10.0.0.0/16"
 MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
 # If set to Elastic IP, master instance will be associated with this IP.
-# Otherwise new Elastic IP will be aquired
+# If set to auto, a new Elastic IP will be aquired
+# Otherwise amazon-given public ip will be used (it'll change with reboot).
 MASTER_RESERVED_IP="${MASTER_RESERVED_IP:-}"
 
 # When set to true, Docker Cache is enabled by default as part of the cluster bring up.

--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -386,17 +386,21 @@ function assign-ip-to-instance {
   fi
 }
 
-# Assigns elastic ip to a Amazon EC2 instance. If assigned public IP is empty,
-# then will request new one.
+# If MASTER_RESERVED_IP looks like IP address, will try to assign it to master instance
+# If MASTER_RESERVED_IP is "auto", will allocate new elastic ip and assign that
+# If none of the above or something fails, will output originally assigne IP
 # Output: assigned IP address
 function assign-elastic-ip {
   local assigned_public_ip=$1
   local master_instance_id=$2
 
-  if [[ -n "${MASTER_RESERVED_IP}" ]]; then
+  # Check that MASTER_RESERVED_IP looks like an IPv4 address
+  if [[ "${MASTER_RESERVED_IP}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     assign-ip-to-instance "${MASTER_RESERVED_IP}" "${master_instance_id}" "${assigned_public_ip}"
-  else
+  elif [[ "${MASTER_RESERVED_IP}" = "auto" ]]; then
     assign-ip-to-instance $(allocate-elastic-ip) "${master_instance_id}" "${assigned_public_ip}"
+  else
+    echo "${assigned_public_ip}"
   fi
 }
 


### PR DESCRIPTION
When MASTER_RESERVED_IP is set to elastic IP from AWS, then aws/util.sh will
associate it with master instance and assign it to KUBE_MASTER_IP. If no MASTER_RESERVED_IP
is set, new elastic ip will be requested from amazon. This allows cluster certificates to
be generated for an IP that doesn't change between stopping & starting cluster instances.

The requested elastic ip is not released when kube-down.sh is run. I think it is good
because user could have created DNS records and it would be bad if the IP was removed.
He can reuse it next time through MASTER_RESERVED_IP when setting up cluster again.
