### PR TITLE
Fix namespace example

### DIFF
--- a/examples/kubernetes-namespaces/namespace-dev.json
+++ b/examples/kubernetes-namespaces/namespace-dev.json
@@ -1,10 +1,10 @@
 {
   "kind": "Namespace",
-  "apiVersion":"v1beta1",  
+  "apiVersion":"v1beta1",
   "id": "development",
   "spec": {},
   "status": {},
   "labels": {
     "name": "development"
-  }  
+  }
 }

--- a/examples/kubernetes-namespaces/namespace-prod.json
+++ b/examples/kubernetes-namespaces/namespace-prod.json
@@ -1,10 +1,10 @@
 {
   "kind": "Namespace",
-  "apiVersion":"v1beta1",  
+  "apiVersion":"v1beta1",
   "id": "production",
   "spec": {},
   "status": {},
   "labels": {
     "name": "production"
-  }  
+  }
 }

--- a/examples/kubernetes-namespaces/v1beta3/README.md
+++ b/examples/kubernetes-namespaces/v1beta3/README.md
@@ -52,13 +52,15 @@ Use the file `examples/kubernetes-namespaces/v1beta3/namespace-dev.json` which d
 
 ```js
 {
-  "kind": "Namespace",
   "apiVersion":"v1beta3",
-  "name": "development",
+  "kind": "Namespace",
+  "metadata": {
+    "name": "development"
+  },
   "spec": {},
   "labels": {
     "name": "development"
-  },
+  }
 }
 ```
 
@@ -95,8 +97,8 @@ To demonstrate this, let's spin up a simple replication controller and pod in th
 The first step is to define a context for the kubectl client to work in each namespace.
 
 ```shell
-$ cluster/kubectl.sh config set-context dev --namespace=development
-$ cluster/kubectl.sh config set-context prod --namespace=production
+$ cluster/kubectl.sh config set-context dev --namespace=development --cluster=${CLUSTER_NAME} --user=${USER_NAME}
+$ cluster/kubectl.sh config set-context prod --namespace=production --cluster=${CLUSTER_NAME} --user=${USER_NAME}
 ```
 
 The above commands provided two request contexts you can alternate against depending on what namespace you
@@ -115,13 +117,13 @@ $ cluster/kubectl.sh config view
 clusters: {}
 contexts:
   dev:
-    cluster: ""
+    cluster: ${CLUSTER_NAME}
     namespace: development
-    user: ""
+    user: ${USER_NAME}
   prod:
-    cluster: ""
+    cluster: ${CLUSTER_NAME}
     namespace: production
-    user: ""
+    user: ${USER_NAME}
 current-context: dev
 preferences: {}
 users: {}

--- a/examples/kubernetes-namespaces/v1beta3/namespace-dev.json
+++ b/examples/kubernetes-namespaces/v1beta3/namespace-dev.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion":"v1beta3",  
+  "apiVersion":"v1beta3",
   "kind": "Namespace",
   "metadata": {
     "name": "development"
@@ -7,5 +7,5 @@
   "spec": {},
   "labels": {
     "name": "development"
-  }  
+  }
 }

--- a/examples/kubernetes-namespaces/v1beta3/namespace-prod.json
+++ b/examples/kubernetes-namespaces/v1beta3/namespace-prod.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion":"v1beta3",  
+  "apiVersion":"v1beta3",
   "kind": "Namespace",
   "metadata": {
     "name": "production"
@@ -7,5 +7,5 @@
   "spec": {},
   "labels": {
     "name": "production"
-  }  
+  }
 }


### PR DESCRIPTION
The json section is not converted in v1beta3, although the version is set to v1beta3.

More importantly `cluster/kubectl.sh config set-context dev --namespace=development` won't work  as we introduced cluster name, and user.  We'll have to set the two context var as well in kubectl, which is a little cubersome, do we have a better default than emtpy string?
