### PR TITLE
Fix environment variable error in Vagrant docs

### DIFF
--- a/docs/devel/developer-guides/vagrant.md
+++ b/docs/devel/developer-guides/vagrant.md
@@ -328,7 +328,7 @@ If you need more granular control, you can set the amount of memory for the mast
 
 ```sh
 export KUBERNETES_MASTER_MEMORY=1536
-export KUBERNETES_MASTER_MINION=2048
+export KUBERNETES_MINION_MEMORY=2048
 ```
 
 #### I ran vagrant suspend and nothing works!

--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -294,7 +294,7 @@ If you need more granular control, you can set the amount of memory for the mast
 
 ```sh
 export KUBERNETES_MASTER_MEMORY=1536
-export KUBERNETES_MASTER_MINION=2048
+export KUBERNETES_MINION_MEMORY=2048
 ```
 
 #### I ran vagrant suspend and nothing works!


### PR DESCRIPTION
Fixing my own mistake:

`KUBERNETES_MASTER_MINION` :disappointed: -> [`KUBERNETES_MINION_MEMORY`](https://github.com/GoogleCloudPlatform/kubernetes/blob/627586f69eaa0d52b4233bb37953e6ae5da66079/Vagrantfile#L90) :relieved:
