### PR TITLE
Use the full hostname for mirror pod name.

### DIFF
--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -21,7 +21,6 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"strings"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
@@ -37,13 +36,8 @@ import (
 )
 
 // Generate a pod name that is unique among nodes by appending the hostname.
-func generatePodName(name, hostname string) (string, error) {
-	// Hostname can be a fully-qualified domain name. To increase readability,
-	// only append the first chunk. Note that this assumes that no two nodes in
-	// the cluster should have the same host-specific label; this is true if
-	// all nodes have the same domain name.
-	chunks := strings.Split(hostname, ".")
-	return fmt.Sprintf("%s-%s", name, chunks[0]), nil
+func generatePodName(name, hostname string) string {
+	return fmt.Sprintf("%s-%s", name, hostname)
 }
 
 func applyDefaults(pod *api.Pod, source string, isFile bool, hostname string) error {
@@ -62,13 +56,10 @@ func applyDefaults(pod *api.Pod, source string, isFile bool, hostname string) er
 
 	// This is required for backward compatibility, and should be removed once we
 	// completely deprecate ContainerManifest.
-	var err error
 	if len(pod.Name) == 0 {
 		pod.Name = string(pod.UID)
 	}
-	if pod.Name, err = generatePodName(pod.Name, hostname); err != nil {
-		return err
-	}
+	pod.Name = generatePodName(pod.Name, hostname)
 	glog.V(5).Infof("Generated Name %q for UID %q from URL %s", pod.Name, pod.UID, source)
 
 	if pod.Namespace == "" {

--- a/pkg/util/node.go
+++ b/pkg/util/node.go
@@ -24,13 +24,16 @@ import (
 )
 
 func GetHostname(hostnameOverride string) string {
-	hostname := []byte(hostnameOverride)
+	hostname := hostnameOverride
 	if string(hostname) == "" {
-		fqdn, err := exec.Command("uname", "-n").Output()
+		nodename, err := exec.Command("uname", "-n").Output()
 		if err != nil {
 			glog.Fatalf("Couldn't determine hostname: %v", err)
 		}
-		hostname = fqdn
+		chunks := strings.Split(string(nodename), ".")
+		// nodename could be a fully-qualified domain name or not. Take the first
+		// word of nodename as the hostname for consistency.
+		hostname = chunks[0]
 	}
-	return strings.ToLower(strings.TrimSpace(string(hostname)))
+	return strings.ToLower(strings.TrimSpace(hostname))
 }


### PR DESCRIPTION
This change appends the full hostname to the mirror pod name (instead of taking
the first token) so that if the hostname is overriden, we'd not be creating
unncessary name conflicts. An example would be that a user overrides the
hostnames to be "127.0.0.1" and "127.0.0.2", and both of them were resolved to
"127" for the mirror pod name suffix.

Also, because `uname -n` could return a FQDN or not, this change takes only
the first token of it as the hostname for consistency.
