### PR TITLE
Install atop on test nodes

### DIFF
--- a/cluster/saltbase/salt/atop/init.sls
+++ b/cluster/saltbase/salt/atop/init.sls
@@ -1,0 +1,15 @@
+{% if grains['os_family'] != 'RedHat' %}
+
+atop:
+  pkg:
+    - installed
+
+atop-service:
+  service:
+    - running
+    - name: atop
+    - watch:
+      - pkg: atop
+      - file: /etc/init.d/atop
+
+{% endif %}

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -13,6 +13,7 @@ base:
 {% endif %}
     - helpers
     - cadvisor
+    - atop
     - kubelet
     - kube-proxy
 {% if pillar.get('enable_node_logging', '').lower() == 'true' and pillar['logging_destination'] is defined %}
@@ -37,6 +38,7 @@ base:
     - nginx
 {% endif %}
     - cadvisor
+    - atop
     - kube-client-tools
     - kube-master-addons
 {% if grains['cloud'] is defined and grains['cloud'] != 'vagrant' %}


### PR DESCRIPTION
I guess I need some way to differentiate test nodes (a grain?), and I guess I can use that to control log levels too. Looking for someone with opinions. @wojtek-t (how do you install htop on 100 nodes?) @zmerlynn (thoughts?) 
ref https://github.com/GoogleCloudPlatform/kubernetes/issues/7815. 
