### PR TITLE
AWS: make it possible to disable minion public ip assignment

### DIFF
--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -73,3 +73,7 @@ DNS_REPLICAS=1
 
 # Admission Controllers to invoke prior to persisting objects in cluster
 ADMISSION_CONTROL=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,SecurityContextDeny,ResourceQuota
+
+# Optional: Enable/disable public IP assignment for minions.
+# Important Note: disable only if you have setup a NAT instance for internet access and configured appropriate routes!
+ENABLE_MINION_PUBLIC_IP=${KUBE_ENABLE_MINION_PUBLIC_IP:-true}

--- a/cluster/aws/options.md
+++ b/cluster/aws/options.md
@@ -37,3 +37,15 @@ For production usage, we recommend bigger instances, for example:
 export MASTER_SIZE=c4.large
 export MINION_SIZE=r3.large
 ```
+
+**KUBE_ENABLE_MINION_PUBLIC_IP**
+
+Should a public IP automatically assigned to the minions? "true" or "false"  
+Defaults to: "true"
+
+Please note: Do not set this to "false" unless you...
+
+- ... already configured a NAT instance in the kubernetes VPC that will enable internet access for the new minions
+- ... already configured a route for "0.0.0.0/0" to this NAT instance
+- ... already configured a route for "YOUR_IP/32" to an AWS internet gateway (for the master instance to reach your
+  client directly during setup)

--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -107,7 +107,7 @@ function detect-minions () {
   KUBE_MINION_IP_ADDRESSES=()
   for (( i=0; i<${#MINION_NAMES[@]}; i++)); do
     local minion_ip
-    if [[ "ENABLE_MINION_PUBLIC_IP" == "true" ]]; then
+    if [[ "$ENABLE_MINION_PUBLIC_IP" == "true" ]]; then
       minion_ip=$(get_instance_public_ip ${MINION_NAMES[$i]})
     else
       minion_ip=$(get_instance_private_ip ${MINION_NAMES[$i]})

--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -107,7 +107,7 @@ function detect-minions () {
   KUBE_MINION_IP_ADDRESSES=()
   for (( i=0; i<${#MINION_NAMES[@]}; i++)); do
     local minion_ip
-    if [[ "$ENABLE_MINION_PUBLIC_IP" == "true" ]]; then
+    if [[ "${ENABLE_MINION_PUBLIC_IP}" == "true" ]]; then
       minion_ip=$(get_instance_public_ip ${MINION_NAMES[$i]})
     else
       minion_ip=$(get_instance_private_ip ${MINION_NAMES[$i]})
@@ -557,7 +557,7 @@ function kube-up {
     ) > "${KUBE_TEMP}/minion-start-${i}.sh"
 
     local public_ip_option
-    if [[ "ENABLE_MINION_PUBLIC_IP" == "true" ]]; then
+    if [[ "${ENABLE_MINION_PUBLIC_IP}" == "true" ]]; then
       public_ip_option="--associate-public-ip-address"
     else
       public_ip_option="--no-associate-public-ip-address"

--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -82,6 +82,14 @@ function get_instance_public_ip {
     --query Reservations[].Instances[].NetworkInterfaces[0].Association.PublicIp
 }
 
+function get_instance_private_ip {
+  local tagName=$1
+  $AWS_CMD --output text describe-instances \
+    --filters Name=tag:Name,Values=${tagName} \
+              Name=instance-state-name,Values=running \
+              Name=tag:KubernetesCluster,Values=${CLUSTER_ID} \
+    --query Reservations[].Instances[].NetworkInterfaces[0].PrivateIpAddress
+}
 
 function detect-master () {
   KUBE_MASTER=${MASTER_NAME}
@@ -98,7 +106,12 @@ function detect-master () {
 function detect-minions () {
   KUBE_MINION_IP_ADDRESSES=()
   for (( i=0; i<${#MINION_NAMES[@]}; i++)); do
-    local minion_ip=$(get_instance_public_ip ${MINION_NAMES[$i]})
+    local minion_ip
+    if [[ "ENABLE_MINION_PUBLIC_IP" == "true" ]]; then
+      minion_ip=$(get_instance_public_ip ${MINION_NAMES[$i]})
+    else
+      minion_ip=$(get_instance_private_ip ${MINION_NAMES[$i]})
+    fi
     echo "Found ${MINION_NAMES[$i]} at ${minion_ip}"
     KUBE_MINION_IP_ADDRESSES+=("${minion_ip}")
   done
@@ -542,6 +555,14 @@ function kube-up {
       grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/format-disks.sh"
       grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/salt-minion.sh"
     ) > "${KUBE_TEMP}/minion-start-${i}.sh"
+
+    local public_ip_option
+    if [[ "ENABLE_MINION_PUBLIC_IP" == "true" ]]; then
+      public_ip_option="--associate-public-ip-address"
+    else
+      public_ip_option="--no-associate-public-ip-address"
+    fi
+
     minion_id=$($AWS_CMD run-instances \
       --image-id $AWS_IMAGE \
       --iam-instance-profile Name=$IAM_PROFILE_MINION \
@@ -550,7 +571,7 @@ function kube-up {
       --private-ip-address $INTERNAL_IP_BASE.1${i} \
       --key-name kubernetes \
       --security-group-ids $SEC_GROUP_ID \
-      --associate-public-ip-address \
+      ${public_ip_option} \
       --user-data file://${KUBE_TEMP}/minion-start-${i}.sh | json_val '["Instances"][0]["InstanceId"]')
 
     add-tag $minion_id Name ${MINION_NAMES[$i]}


### PR DESCRIPTION
This patch makes it possible to disable the automatic assignment of a public IP when launching minions. The feature can be controlled by setting the env variable KUBE_ENABLE_MINION_PUBLIC_IP to "false" (instead of "true" - which is the default value).

Use case scenario:
- preconfigured VPC
- your local client is able to communicate with the VPC by means of a VPN connection
- internet access from the VPC is routed to the internet gateway by means of a NAT instance
- you do not want a public IP on your minions for security reasons
