### PR TITLE
Rolling node upgrade

### DIFF
--- a/cluster/gce/coreos/helper.sh
+++ b/cluster/gce/coreos/helper.sh
@@ -129,8 +129,15 @@ function create-master-instance {
 
 # TODO(dawnchen): Check $CONTAINER_RUNTIME to decide which
 # cloud_config yaml file should be passed
+# TODO(mbforbes): Make $1 required.
+# TODO(mbforbes): Document required vars (for this and call chain).
+# $1 version
 function create-node-instance-template {
-   create-node-template "${NODE_INSTANCE_PREFIX}-template" "${scope_flags[*]}" \
+  local suffix=""
+  if [[ -n ${1:-} ]]; then
+    suffix="-${1}"
+  fi
+   create-node-template "${NODE_INSTANCE_PREFIX}-template${suffix}" "${scope_flags[*]}" \
     "kube-env=${KUBE_TEMP}/node-kube-env.yaml" \
     "user-data=${KUBE_ROOT}/cluster/gce/coreos/node.yaml"
 }

--- a/cluster/gce/debian/helper.sh
+++ b/cluster/gce/debian/helper.sh
@@ -107,8 +107,15 @@ function create-master-instance {
     --disk name="${MASTER_NAME}-pd" device-name=master-pd mode=rw boot=no auto-delete=no
 }
 
+# TODO(mbforbes): Make $1 required.
+# TODO(mbforbes): Document required vars (for this and call chain).
+# $1 version
 function create-node-instance-template {
-  create-node-template "${NODE_INSTANCE_PREFIX}-template" "${scope_flags[*]}" \
+  local suffix=""
+  if [[ -n ${1:-} ]]; then
+    suffix="-${1}"
+  fi
+  create-node-template "${NODE_INSTANCE_PREFIX}-template${suffix}" "${scope_flags[*]}" \
     "startup-script=${KUBE_ROOT}/cluster/gce/configure-vm.sh" \
     "kube-env=${KUBE_TEMP}/node-kube-env.yaml"
 }


### PR DESCRIPTION
Fixes #6088

After doing this and waiting a bit, `kubectl get nodes` reports nodes as `Unknown` and then back to `Ready`. Also, `kubectl get pods` reports the pods on the minions as `Pending` and then eventually `Running`.

I have some confidence this might actually be the true state of the world, because I screwed up the kube/kube-proxy tokens in an earlier implementation, and neither of the above were true.

BTW, the validate cluster doesn't actually do what's intended right now, I think, because it returned successfully far before my cluster was working again.

Comments / feedback welcome. And yes, definitely want to bake this into a(n e2e) test ASAP.
