### PR TITLE
Make the API server deal with HEAD requests via the service proxy

### DIFF
--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -514,6 +514,8 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			addProxyRoute(ws, "PUT", a.prefix, action.Path, proxyHandler, kind, resource, action.Params)
 			addProxyRoute(ws, "POST", a.prefix, action.Path, proxyHandler, kind, resource, action.Params)
 			addProxyRoute(ws, "DELETE", a.prefix, action.Path, proxyHandler, kind, resource, action.Params)
+			addProxyRoute(ws, "HEAD", a.prefix, action.Path, proxyHandler, kind, resource, action.Params)
+			addProxyRoute(ws, "TRACE", a.prefix, action.Path, proxyHandler, kind, resource, action.Params)
 		case "CONNECT":
 			for _, method := range connecter.ConnectMethods() {
 				route := ws.Method(method).Path(action.Path).


### PR DESCRIPTION
This addresses issue  #7517 and I tested this out on the Elasticsearch and Kibana logging setup. I observed the new Kibana 4 (running with a back-end server) correctly issuing a HEAD request to Elasticsearch.

```
NFO: 2015-05-08T06:27:51Z
  Adding connection to https://104.197.16.133/api/v1beta3/proxy/namespaces/default/services/kibana-logging/elasticsearch


index.js?_b=6004:45725 bootstrap
index.js?_b=6004:45725 es check
index.js?_b=6004:45725 config init
index.js?_b=6004:45721 complete in 135.86ms
index.js?_b=6004:45725 checkEsVersion
index.js?_b=6004:45721 complete in 127.33ms
index.js?_b=6004:45725 kibana index check
index.js?_b=6004:17838 HEAD https://104.197.16.133/api/v1beta3/proxy/namespaces/default/services/kibana-logging/elasticsearch/.kibana 404 (Not Found)(anonymous function) @ index.js?_b=6004:17838sendReq @ index.js?_b=6004:17632$get.serverRequest @ index.js?_b=6004:17352deferred.promise.then.wrappedCallback @ index.js?_b=6004:20888deferred.promise.then.wrappedCallback @ index.js?_b=6004:20888(anonymous function) @ index.js?_b=6004:20974$get.Scope.$eval @ index.js?_b=6004:22017$get.Scope.$digest @ index.js?_b=6004:21829(anonymous function) @ index.js?_b=6004:22055completeOutstandingRequest @ index.js?_b=6004:13617(anonymous function) @ index.js?_b=6004:13931
index.js?_b=6004:45721 complete in 66.83ms
index.js?_b=6004:45725 kibana index creation
index.js?_b=6004:45721 complete in 200.15ms
index.js?_b=6004:45721 complete in 532.59ms
index.js?_b=6004:45721 complete in 825.34ms
index.js?_b=6004:19332 Error: Please specify a default index pattern
    at index.js?_b=6004:44810
    at deferred.promise.then.wrappedCallback (index.js?_b=6004:20888)
    at index.js?_b=6004:20974
    at Scope.$get.Scope.$eval (index.js?_b=6004:22017)
    at Scope.$get.Scope.$digest (index.js?_b=6004:21829)
    at Scope.$get.Scope.$apply (index.js?_b=6004:22121)
    at done (index.js?_b=6004:17656)
    at completeRequest (index.js?_b=6004:17870)
    at XMLHttpRequest.xhr.onreadystatechange (index.js?_b=6004:17809)(anonymous function) @ index.js?_b=6004:19332$get @ index.js?_b=6004:16604deferred.promise.then.wrappedCallback @ index.js?_b=6004:20891(anonymous function) @ index.js?_b=6004:20974$get.Scope.$eval @ index.js?_b=6004:22017$get.Scope.$digest @ index.js?_b=6004:21829$get.Scope.$apply @ index.js?_b=6004:22121done @ index.js?_b=6004:17656completeRequest @ index.js?_b=6004:17870xhr.onreadystatechange @ index.js?_b=6004:17809
index.js?_b=6004:45725 loading default index pattern
index.js?_b=6004:45423 Root Search Source: index pattern set to null
index.js?_b=6004:45721 complete in 0.82ms
index.js?_b=6004:45423 config change: defaultIndex: undefined -> logstash-*
index.js?_b=6004:45725 loading default index pattern
index.js?_b=6004:45423 Root Search Source: index pattern set to logstash-*
index.js?_b=6004:45721 complete in 86.99ms
index.js?_b=6004:45725 loading default index pattern
index.js?_b=6004:45423 Root Search Source: index pattern set to logstash-*
index.js?_b=6004:45721 complete in 1.04ms
index.js?_b=6004:45725 loading default index pattern
```

@lavalamp @brendandburns @ArtfulCoder 
