### PR TITLE
Move pkg/scheduler to plugin/pkg/scheduler

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -48,7 +48,6 @@ import (
 	kubeletTypes "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/scheduler"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	utilErrors "github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
@@ -56,6 +55,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
 	"github.com/golang/glog"
 	cadvisorApi "github.com/google/cadvisor/info/v1"
 )
@@ -1315,7 +1315,7 @@ func (kl *Kubelet) checkCapacityExceeded(pods []*api.Pod) (fitting []*api.Pod, n
 	sort.Sort(podsByCreationTime(pods))
 
 	capacity := CapacityFromMachineInfo(info)
-	return scheduler.CheckPodsExceedingCapacity(pods, capacity)
+	return predicates.CheckPodsExceedingCapacity(pods, capacity)
 }
 
 // handleOutOfDisk detects if pods can't fit due to lack of disk space.
@@ -1364,7 +1364,7 @@ func (kl *Kubelet) checkNodeSelectorMatching(pods []*api.Pod) (fitting []*api.Po
 		return pods, nil
 	}
 	for _, pod := range pods {
-		if !scheduler.PodMatchesNodeLabels(pod, node) {
+		if !predicates.PodMatchesNodeLabels(pod, node) {
 			notFitting = append(notFitting, pod)
 			continue
 		}

--- a/pkg/registry/registrytest/scheduler.go
+++ b/pkg/registry/registrytest/scheduler.go
@@ -18,7 +18,7 @@ package registrytest
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/scheduler"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm"
 )
 
 type Scheduler struct {
@@ -27,7 +27,7 @@ type Scheduler struct {
 	Machine string
 }
 
-func (s *Scheduler) Schedule(pod *api.Pod, lister scheduler.MinionLister) (string, error) {
+func (s *Scheduler) Schedule(pod *api.Pod, lister algorithm.MinionLister) (string, error) {
 	s.Pod = pod
 	return s.Machine, s.Err
 }

--- a/plugin/pkg/scheduler/algorithm/doc.go
+++ b/plugin/pkg/scheduler/algorithm/doc.go
@@ -16,4 +16,4 @@ limitations under the License.
 
 // Package scheduler contains a generic Scheduler interface and several
 // implementations.
-package scheduler
+package algorithm

--- a/plugin/pkg/scheduler/algorithm/listers.go
+++ b/plugin/pkg/scheduler/algorithm/listers.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scheduler
+package algorithm
 
 import (
 	"fmt"

--- a/plugin/pkg/scheduler/algorithm/scheduler_interface.go
+++ b/plugin/pkg/scheduler/algorithm/scheduler_interface.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scheduler
+package algorithm
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -22,6 +22,6 @@ import (
 
 // Scheduler is an interface implemented by things that know how to schedule pods
 // onto machines.
-type Scheduler interface {
+type ScheduleAlgorithm interface {
 	Schedule(*api.Pod, MinionLister) (selectedMachine string, err error)
 }

--- a/plugin/pkg/scheduler/algorithm/scheduler_interface_test.go
+++ b/plugin/pkg/scheduler/algorithm/scheduler_interface_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scheduler
+package algorithm
 
 import (
 	"testing"
@@ -26,7 +26,7 @@ import (
 
 type schedulerTester struct {
 	t            *testing.T
-	scheduler    Scheduler
+	scheduler    ScheduleAlgorithm
 	minionLister MinionLister
 }
 
@@ -56,22 +56,5 @@ func (st *schedulerTester) expectFailure(pod *api.Pod) {
 	_, err := st.scheduler.Schedule(pod, st.minionLister)
 	if err == nil {
 		st.t.Error("Unexpected non-error")
-	}
-}
-
-func newPod(host string, hostPorts ...int) *api.Pod {
-	networkPorts := []api.ContainerPort{}
-	for _, port := range hostPorts {
-		networkPorts = append(networkPorts, api.ContainerPort{HostPort: port})
-	}
-	return &api.Pod{
-		Spec: api.PodSpec{
-			Host: host,
-			Containers: []api.Container{
-				{
-					Ports: networkPorts,
-				},
-			},
-		},
 	}
 }

--- a/plugin/pkg/scheduler/algorithm/types.go
+++ b/plugin/pkg/scheduler/algorithm/types.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scheduler
+package algorithm
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -25,8 +25,8 @@ type FitPredicate func(pod *api.Pod, existingPods []*api.Pod, node string) (bool
 
 // HostPriority represents the priority of scheduling to a particular host, lower priority is better.
 type HostPriority struct {
-	host  string
-	score int
+	Host  string
+	Score int
 }
 
 type HostPriorityList []HostPriority
@@ -36,10 +36,10 @@ func (h HostPriorityList) Len() int {
 }
 
 func (h HostPriorityList) Less(i, j int) bool {
-	if h[i].score == h[j].score {
-		return h[i].host < h[j].host
+	if h[i].Score == h[j].Score {
+		return h[i].Host < h[j].Host
 	}
-	return h[i].score < h[j].score
+	return h[i].Score < h[j].Score
 }
 
 func (h HostPriorityList) Swap(i, j int) {

--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -18,8 +18,11 @@ limitations under the License.
 package defaults
 
 import (
-	algorithm "github.com/GoogleCloudPlatform/kubernetes/pkg/scheduler"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm/priorities"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/factory"
 )
 
@@ -28,46 +31,46 @@ func init() {
 	// EqualPriority is a prioritizer function that gives an equal weight of one to all minions
 	// Register the priority function so that its available
 	// but do not include it as part of the default priorities
-	factory.RegisterPriorityFunction("EqualPriority", algorithm.EqualPriority, 1)
+	factory.RegisterPriorityFunction("EqualPriority", scheduler.EqualPriority, 1)
 }
 
 func defaultPredicates() util.StringSet {
 	return util.NewStringSet(
 		// Fit is defined based on the absence of port conflicts.
-		factory.RegisterFitPredicate("PodFitsPorts", algorithm.PodFitsPorts),
+		factory.RegisterFitPredicate("PodFitsPorts", predicates.PodFitsPorts),
 		// Fit is determined by resource availability.
 		factory.RegisterFitPredicateFactory(
 			"PodFitsResources",
 			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
-				return algorithm.NewResourceFitPredicate(args.NodeInfo)
+				return predicates.NewResourceFitPredicate(args.NodeInfo)
 			},
 		),
 		// Fit is determined by non-conflicting disk volumes.
-		factory.RegisterFitPredicate("NoDiskConflict", algorithm.NoDiskConflict),
+		factory.RegisterFitPredicate("NoDiskConflict", predicates.NoDiskConflict),
 		// Fit is determined by node selector query.
 		factory.RegisterFitPredicateFactory(
 			"MatchNodeSelector",
 			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
-				return algorithm.NewSelectorMatchPredicate(args.NodeInfo)
+				return predicates.NewSelectorMatchPredicate(args.NodeInfo)
 			},
 		),
 		// Fit is determined by the presence of the Host parameter and a string match
-		factory.RegisterFitPredicate("HostName", algorithm.PodFitsHost),
+		factory.RegisterFitPredicate("HostName", predicates.PodFitsHost),
 	)
 }
 
 func defaultPriorities() util.StringSet {
 	return util.NewStringSet(
 		// Prioritize nodes by least requested utilization.
-		factory.RegisterPriorityFunction("LeastRequestedPriority", algorithm.LeastRequestedPriority, 1),
+		factory.RegisterPriorityFunction("LeastRequestedPriority", priorities.LeastRequestedPriority, 1),
 		// Prioritizes nodes to help achieve balanced resource usage
-		factory.RegisterPriorityFunction("BalancedResourceAllocation", algorithm.BalancedResourceAllocation, 1),
+		factory.RegisterPriorityFunction("BalancedResourceAllocation", priorities.BalancedResourceAllocation, 1),
 		// spreads pods by minimizing the number of pods (belonging to the same service) on the same minion.
 		factory.RegisterPriorityConfigFactory(
 			"ServiceSpreadingPriority",
 			factory.PriorityConfigFactory{
 				Function: func(args factory.PluginFactoryArgs) algorithm.PriorityFunction {
-					return algorithm.NewServiceSpreadPriority(args.ServiceLister)
+					return priorities.NewServiceSpreadPriority(args.ServiceLister)
 				},
 				Weight: 1,
 			},

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -28,9 +28,9 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/controller/framework"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
-	algorithm "github.com/GoogleCloudPlatform/kubernetes/pkg/scheduler"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm"
 	schedulerapi "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/api"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/api/validation"
 
@@ -182,7 +182,7 @@ func (f *ConfigFactory) CreateFromKeys(predicateKeys, priorityKeys util.StringSe
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	algo := algorithm.NewGenericScheduler(predicateFuncs, priorityConfigs, f.PodLister, r)
+	algo := scheduler.NewGenericScheduler(predicateFuncs, priorityConfigs, f.PodLister, r)
 
 	podBackoff := podBackoff{
 		perPodBackoff: map[string]*backoffEntry{},

--- a/plugin/pkg/scheduler/factory/factory_test.go
+++ b/plugin/pkg/scheduler/factory/factory_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	algorithm "github.com/GoogleCloudPlatform/kubernetes/pkg/scheduler"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm"
 	schedulerapi "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/api"
 	latestschedulerapi "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/api/latest"
 )

--- a/plugin/pkg/scheduler/factory/plugins.go
+++ b/plugin/pkg/scheduler/factory/plugins.go
@@ -22,8 +22,10 @@ import (
 	"strings"
 	"sync"
 
-	algorithm "github.com/GoogleCloudPlatform/kubernetes/pkg/scheduler"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm/priorities"
 	schedulerapi "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/api"
 
 	"github.com/golang/glog"
@@ -34,7 +36,7 @@ type PluginFactoryArgs struct {
 	algorithm.PodLister
 	algorithm.ServiceLister
 	NodeLister algorithm.MinionLister
-	NodeInfo   algorithm.NodeInfo
+	NodeInfo   predicates.NodeInfo
 }
 
 // A FitPredicateFactory produces a FitPredicate from the given args.
@@ -95,7 +97,7 @@ func RegisterCustomFitPredicate(policy schedulerapi.PredicatePolicy) string {
 	if policy.Argument != nil {
 		if policy.Argument.ServiceAffinity != nil {
 			predicateFactory = func(args PluginFactoryArgs) algorithm.FitPredicate {
-				return algorithm.NewServiceAffinityPredicate(
+				return predicates.NewServiceAffinityPredicate(
 					args.PodLister,
 					args.ServiceLister,
 					args.NodeInfo,
@@ -104,7 +106,7 @@ func RegisterCustomFitPredicate(policy schedulerapi.PredicatePolicy) string {
 			}
 		} else if policy.Argument.LabelsPresence != nil {
 			predicateFactory = func(args PluginFactoryArgs) algorithm.FitPredicate {
-				return algorithm.NewNodeLabelPredicate(
+				return predicates.NewNodeLabelPredicate(
 					args.NodeInfo,
 					policy.Argument.LabelsPresence.Labels,
 					policy.Argument.LabelsPresence.Presence,
@@ -162,7 +164,7 @@ func RegisterCustomPriorityFunction(policy schedulerapi.PriorityPolicy) string {
 		if policy.Argument.ServiceAntiAffinity != nil {
 			pcf = &PriorityConfigFactory{
 				Function: func(args PluginFactoryArgs) algorithm.PriorityFunction {
-					return algorithm.NewServiceAntiAffinityPriority(
+					return priorities.NewServiceAntiAffinityPriority(
 						args.ServiceLister,
 						policy.Argument.ServiceAntiAffinity.Label,
 					)
@@ -172,7 +174,7 @@ func RegisterCustomPriorityFunction(policy schedulerapi.PriorityPolicy) string {
 		} else if policy.Argument.LabelPreference != nil {
 			pcf = &PriorityConfigFactory{
 				Function: func(args PluginFactoryArgs) algorithm.PriorityFunction {
-					return algorithm.NewNodeLabelPriority(
+					return priorities.NewNodeLabelPriority(
 						policy.Argument.LabelPreference.Label,
 						policy.Argument.LabelPreference.Presence,
 					)

--- a/plugin/pkg/scheduler/modeler.go
+++ b/plugin/pkg/scheduler/modeler.go
@@ -25,7 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	algorithm "github.com/GoogleCloudPlatform/kubernetes/pkg/scheduler"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm"
 
 	"github.com/golang/glog"
 )

--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -21,9 +21,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
-	// TODO: move everything from pkg/scheduler into this package. Remove references from registry.
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/scheduler"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/metrics"
 
 	"github.com/golang/glog"
@@ -70,8 +69,8 @@ type Config struct {
 	// It is expected that changes made via modeler will be observed
 	// by MinionLister and Algorithm.
 	Modeler      SystemModeler
-	MinionLister scheduler.MinionLister
-	Algorithm    scheduler.Scheduler
+	MinionLister algorithm.MinionLister
+	Algorithm    algorithm.ScheduleAlgorithm
 	Binder       Binder
 
 	// NextPod should be a function that blocks until the next pod


### PR DESCRIPTION
As the TODO in plugin/pkg/scheduler/scheduler.go described:

TODO: move everything from pkg/scheduler into this package. Remove
references from registry.
