### PR TITLE
Remove useless bash conditional

### DIFF
--- a/contrib/completions/bash/kubectl
+++ b/contrib/completions/bash/kubectl
@@ -174,9 +174,6 @@ __kubectl_get_resource()
         return 1
     fi
     __kubectl_parse_get "${nouns[${#nouns[@]} -1]}"
-    if [[ $? -eq 0 ]]; then
-        return 0
-    fi
 }
 
 # $1 is the name of the pod we want to get the list of containers inside

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -45,9 +45,6 @@ __kubectl_get_resource()
         return 1
     fi
     __kubectl_parse_get "${nouns[${#nouns[@]} -1]}"
-    if [[ $? -eq 0 ]]; then
-        return 0
-    fi
 }
 
 # $1 is the name of the pod we want to get the list of containers inside


### PR DESCRIPTION
bash just returns the last return code, why are we testing and then
doing the same?
