### PR TITLE
Add kubectl log --previous support to view last terminated container log

### DIFF
--- a/contrib/completions/bash/kubectl
+++ b/contrib/completions/bash/kubectl
@@ -404,6 +404,8 @@ _kubectl_log()
     flags+=("--help")
     flags+=("-h")
     flags+=("--interactive")
+    flags+=("--previous")
+    flags+=("-p")
 
     must_have_one_flag=()
     must_have_one_noun=()

--- a/docs/kubectl_log.md
+++ b/docs/kubectl_log.md
@@ -8,7 +8,7 @@ Print the logs for a container in a pod.
 Print the logs for a container in a pod. If the pod has only one container, the container name is optional.
 
 ```
-kubectl log [-f] POD [CONTAINER]
+kubectl log [-f] [-p] POD [CONTAINER]
 ```
 
 ### Examples
@@ -16,6 +16,9 @@ kubectl log [-f] POD [CONTAINER]
 ```
 // Returns snapshot of ruby-container logs from pod 123456-7890.
 $ kubectl log 123456-7890 ruby-container
+
+// Returns snapshot of previous terminated ruby-container logs from pod 123456-7890.
+$ kubectl log -p 123456-7890 ruby-container
 
 // Starts streaming of ruby-container logs from pod 123456-7890.
 $ kubectl log -f 123456-7890 ruby-container
@@ -27,6 +30,7 @@ $ kubectl log -f 123456-7890 ruby-container
   -f, --follow=false: Specify if the logs should be streamed.
   -h, --help=false: help for log
       --interactive=true: If true, prompt the user for input when required. Default true.
+  -p, --previous=false: If true, print the logs for the previous instance of the container in a pod if it exists.
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/kubectl-log.1
+++ b/docs/man/man1/kubectl-log.1
@@ -29,6 +29,10 @@ Print the logs for a container in a pod. If the pod has only one container, the 
 \fB\-\-interactive\fP=true
     If true, prompt the user for input when required. Default true.
 
+.PP
+\fB\-p\fP, \fB\-\-previous\fP=false
+    If true, print the logs for the previous instance of the container in a pod if it exists.
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
@@ -139,6 +143,9 @@ Print the logs for a container in a pod. If the pod has only one container, the 
 .nf
 // Returns snapshot of ruby\-container logs from pod 123456\-7890.
 $ kubectl log 123456\-7890 ruby\-container
+
+// Returns snapshot of previous terminated ruby\-container logs from pod 123456\-7890.
+$ kubectl log \-p 123456\-7890 ruby\-container
 
 // Starts streaming of ruby\-container logs from pod 123456\-7890.
 $ kubectl log \-f 123456\-7890 ruby\-container

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1330,6 +1330,9 @@ type PodLogOptions struct {
 
 	// If true, follow the logs for the pod
 	Follow bool
+
+	// If true, return previous terminated container logs
+	Previous bool
 }
 
 // PodExecOptions is the query options to a Pod's remote exec call

--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -1802,6 +1802,7 @@ func init() {
 			}
 			out.Container = in.Container
 			out.Follow = in.Follow
+			out.Previous = in.Previous
 			return nil
 		},
 		func(in *newer.PodLogOptions, out *PodLogOptions, s conversion.Scope) error {
@@ -1810,6 +1811,7 @@ func init() {
 			}
 			out.Container = in.Container
 			out.Follow = in.Follow
+			out.Previous = in.Previous
 			return nil
 		},
 		func(in *PodProxyOptions, out *newer.PodProxyOptions, s conversion.Scope) error {

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1320,6 +1320,9 @@ type PodLogOptions struct {
 
 	// If true, follow the logs for the pod
 	Follow bool `json:"follow,omitempty" description:"follow the log stream of the pod; defaults to false"`
+
+	//  If true, return previous terminated container logs
+	Previous bool `json:"previous,omitempty" description:"return previous terminated container logs; defaults to false"`
 }
 
 // PodExecOptions is the query options to a Pod's remote exec call

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -1188,6 +1188,9 @@ type PodLogOptions struct {
 
 	// If true, follow the logs for the pod
 	Follow bool `json:"follow,omitempty" description:"follow the log stream of the pod; defaults to false"`
+
+	//  If true, return previous terminated container logs
+	Previous bool `json:"previous,omitempty" description:"return previous terminated container logs; defaults to false"`
 }
 
 // PodExecOptions is the query options to a Pod's remote exec call

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -1208,6 +1208,9 @@ type PodLogOptions struct {
 
 	// If true, follow the logs for the pod
 	Follow bool `json:"follow,omitempty" description:"follow the log stream of the pod; defaults to false"`
+
+	//  If true, return previous terminated container logs
+	Previous bool `json:"previous,omitempty" description:"return previous terminated container logs; defaults to false"`
 }
 
 // PodExecOptions is the query options to a Pod's remote exec call

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -2544,6 +2544,7 @@ func convert_v1beta3_PodLogOptions_To_api_PodLogOptions(in *PodLogOptions, out *
 	}
 	out.Container = in.Container
 	out.Follow = in.Follow
+	out.Previous = in.Previous
 	return nil
 }
 
@@ -2556,6 +2557,7 @@ func convert_api_PodLogOptions_To_v1beta3_PodLogOptions(in *newer.PodLogOptions,
 	}
 	out.Container = in.Container
 	out.Follow = in.Follow
+	out.Previous = in.Previous
 	return nil
 }
 

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -1320,6 +1320,9 @@ type PodLogOptions struct {
 
 	// If true, follow the logs for the pod
 	Follow bool `json:"follow,omitempty" description:"follow the log stream of the pod; defaults to false"`
+
+	//  If true, return previous terminated container logs
+	Previous bool `json:"previous,omitempty" description:"return previous terminated container logs; defaults to false"`
 }
 
 // PodExecOptions is the query options to a Pod's remote exec call

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1373,21 +1373,31 @@ func (kl *Kubelet) validatePodPhase(podStatus *api.PodStatus) error {
 	return fmt.Errorf("pod is not in 'Running', 'Succeeded' or 'Failed' state - State: %q", podStatus.Phase)
 }
 
-func (kl *Kubelet) validateContainerStatus(podStatus *api.PodStatus, containerName string) (containerID string, err error) {
+func (kl *Kubelet) validateContainerStatus(podStatus *api.PodStatus, containerName string, previous bool) (containerID string, err error) {
+	var cID string
+
 	cStatus, found := api.GetContainerStatus(podStatus.ContainerStatuses, containerName)
 	if !found {
 		return "", fmt.Errorf("container %q not found in pod", containerName)
 	}
-	if cStatus.State.Waiting != nil {
-		return "", fmt.Errorf("container %q is in waiting state.", containerName)
+	if previous {
+		if cStatus.LastTerminationState.Termination == nil {
+			return "", fmt.Errorf("previous terminated container %q not found in pod", containerName)
+		}
+		cID = cStatus.LastTerminationState.Termination.ContainerID
+	} else {
+		if cStatus.State.Waiting != nil {
+			return "", fmt.Errorf("container %q is in waiting state.", containerName)
+		}
+		cID = cStatus.ContainerID
 	}
-	return kubecontainer.TrimRuntimePrefix(cStatus.ContainerID), nil
+	return kubecontainer.TrimRuntimePrefix(cID), nil
 }
 
 // GetKubeletContainerLogs returns logs from the container
 // TODO: this method is returning logs of random container attempts, when it should be returning the most recent attempt
 // or all of them.
-func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName, tail string, follow bool, stdout, stderr io.Writer) error {
+func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName, tail string, follow, previous bool, stdout, stderr io.Writer) error {
 	// TODO(vmarmol): Refactor to not need the pod status and verification.
 	podStatus, err := kl.GetPodStatus(podFullName)
 	if err != nil {
@@ -1397,7 +1407,7 @@ func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName, tail stri
 		// No log is available if pod is not in a "known" phase (e.g. Unknown).
 		return err
 	}
-	containerID, err := kl.validateContainerStatus(&podStatus, containerName)
+	containerID, err := kl.validateContainerStatus(&podStatus, containerName, previous)
 	if err != nil {
 		// No log is available if the container status is missing or is in the
 		// waiting state.

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -53,7 +53,7 @@ type fakeKubelet struct {
 	containerVersionFunc               func() (kubecontainer.Version, error)
 	execFunc                           func(pod string, uid types.UID, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool) error
 	portForwardFunc                    func(name string, uid types.UID, port uint16, stream io.ReadWriteCloser) error
-	containerLogsFunc                  func(podFullName, containerName, tail string, follow bool, stdout, stderr io.Writer) error
+	containerLogsFunc                  func(podFullName, containerName, tail string, follow, pervious bool, stdout, stderr io.Writer) error
 	streamingConnectionIdleTimeoutFunc func() time.Duration
 	hostnameFunc                       func() string
 }
@@ -90,8 +90,8 @@ func (fk *fakeKubelet) ServeLogs(w http.ResponseWriter, req *http.Request) {
 	fk.logFunc(w, req)
 }
 
-func (fk *fakeKubelet) GetKubeletContainerLogs(podFullName, containerName, tail string, follow bool, stdout, stderr io.Writer) error {
-	return fk.containerLogsFunc(podFullName, containerName, tail, follow, stdout, stderr)
+func (fk *fakeKubelet) GetKubeletContainerLogs(podFullName, containerName, tail string, follow, previous bool, stdout, stderr io.Writer) error {
+	return fk.containerLogsFunc(podFullName, containerName, tail, follow, previous, stdout, stderr)
 }
 
 func (fk *fakeKubelet) GetHostname() string {
@@ -553,8 +553,8 @@ func setPodByNameFunc(fw *serverTestFramework, namespace, pod, container string)
 	}
 }
 
-func setGetContainerLogsFunc(fw *serverTestFramework, t *testing.T, expectedPodName, expectedContainerName, expectedTail string, expectedFollow bool, output string) {
-	fw.fakeKubelet.containerLogsFunc = func(podFullName, containerName, tail string, follow bool, stdout, stderr io.Writer) error {
+func setGetContainerLogsFunc(fw *serverTestFramework, t *testing.T, expectedPodName, expectedContainerName, expectedTail string, expectedFollow, expectedPrevious bool, output string) {
+	fw.fakeKubelet.containerLogsFunc = func(podFullName, containerName, tail string, follow, previous bool, stdout, stderr io.Writer) error {
 		if podFullName != expectedPodName {
 			t.Errorf("expected %s, got %s", expectedPodName, podFullName)
 		}
@@ -567,6 +567,10 @@ func setGetContainerLogsFunc(fw *serverTestFramework, t *testing.T, expectedPodN
 		if follow != expectedFollow {
 			t.Errorf("expected %t, got %t", expectedFollow, follow)
 		}
+		if previous != expectedPrevious {
+			t.Errorf("expected %t, got %t", expectedPrevious, previous)
+		}
+
 		io.WriteString(stdout, output)
 		return nil
 	}
@@ -581,8 +585,9 @@ func TestContainerLogs(t *testing.T) {
 	expectedContainerName := "baz"
 	expectedTail := ""
 	expectedFollow := false
+	expectedPrevious := false
 	setPodByNameFunc(fw, podNamespace, podName, expectedContainerName)
-	setGetContainerLogsFunc(fw, t, expectedPodName, expectedContainerName, expectedTail, expectedFollow, output)
+	setGetContainerLogsFunc(fw, t, expectedPodName, expectedContainerName, expectedTail, expectedFollow, expectedPrevious, output)
 	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogs/" + podNamespace + "/" + podName + "/" + expectedContainerName)
 	if err != nil {
 		t.Errorf("Got error GETing: %v", err)
@@ -608,8 +613,9 @@ func TestContainerLogsWithTail(t *testing.T) {
 	expectedContainerName := "baz"
 	expectedTail := "5"
 	expectedFollow := false
+	expectedPrevious := false
 	setPodByNameFunc(fw, podNamespace, podName, expectedContainerName)
-	setGetContainerLogsFunc(fw, t, expectedPodName, expectedContainerName, expectedTail, expectedFollow, output)
+	setGetContainerLogsFunc(fw, t, expectedPodName, expectedContainerName, expectedTail, expectedFollow, expectedPrevious, output)
 	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogs/" + podNamespace + "/" + podName + "/" + expectedContainerName + "?tail=5")
 	if err != nil {
 		t.Errorf("Got error GETing: %v", err)
@@ -635,8 +641,9 @@ func TestContainerLogsWithFollow(t *testing.T) {
 	expectedContainerName := "baz"
 	expectedTail := ""
 	expectedFollow := true
+	expectedPrevious := false
 	setPodByNameFunc(fw, podNamespace, podName, expectedContainerName)
-	setGetContainerLogsFunc(fw, t, expectedPodName, expectedContainerName, expectedTail, expectedFollow, output)
+	setGetContainerLogsFunc(fw, t, expectedPodName, expectedContainerName, expectedTail, expectedFollow, expectedPrevious, output)
 	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogs/" + podNamespace + "/" + podName + "/" + expectedContainerName + "?follow=1")
 	if err != nil {
 		t.Errorf("Got error GETing: %v", err)

--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -212,6 +212,9 @@ func LogLocation(getter ResourceGetter, connInfo client.ConnectionInfoGetter, ct
 	if opts.Follow {
 		params.Add("follow", "true")
 	}
+	if opts.Previous {
+		params.Add("previous", "true")
+	}
 	loc := &url.URL{
 		Scheme:   nodeScheme,
 		Host:     fmt.Sprintf("%s:%d", nodeHost, nodePort),


### PR DESCRIPTION
Fixed #4640. 

View current running container:

```
$ cluster/kubectl.sh log kube-dns-u6iwr etcd
Starting cluster using os distro: debian
current-context: "golden-system-455_kubernetes"
Running: cluster/../cluster/gce/../../cluster/../_output/dockerized/bin/linux/amd64/kubectl log kube-dns-u6iwr etcd
2015-05-08T17:19:52.082453389Z 2015/05/08 17:19:52 etcd: no data-dir provided, using default data-dir ./default.etcd
2015-05-08T17:19:52.082507932Z 2015/05/08 17:19:52 etcd: listening for peers on http://localhost:2380
2015-05-08T17:19:52.082513303Z 2015/05/08 17:19:52 etcd: listening for peers on http://localhost:7001
2015-05-08T17:19:52.082516618Z 2015/05/08 17:19:52 etcd: listening for client requests on http://127.0.0.1:2379
2015-05-08T17:19:52.082519759Z 2015/05/08 17:19:52 etcd: listening for client requests on http://127.0.0.1:4001
2015-05-08T17:19:52.082523120Z 2015/05/08 17:19:52 etcdserver: datadir is valid for the 2.0.1 format
2015-05-08T17:19:52.082526742Z 2015/05/08 17:19:52 etcdserver: name = default
2015-05-08T17:19:52.082530076Z 2015/05/08 17:19:52 etcdserver: data dir = default.etcd
2015-05-08T17:19:52.082533163Z 2015/05/08 17:19:52 etcdserver: member dir = default.etcd/member
2015-05-08T17:19:52.082536440Z 2015/05/08 17:19:52 etcdserver: heartbeat = 100ms
2015-05-08T17:19:52.082539361Z 2015/05/08 17:19:52 etcdserver: election = 1000ms
2015-05-08T17:19:52.082542194Z 2015/05/08 17:19:52 etcdserver: snapshot count = 10000
2015-05-08T17:19:52.082545096Z 2015/05/08 17:19:52 etcdserver: advertise client URLs = http://127.0.0.1:2379,http://127.0.0.1:4001
2015-05-08T17:19:52.082553872Z 2015/05/08 17:19:52 etcdserver: initial advertise peer URLs = http://localhost:2380,http://localhost:7001
2015-05-08T17:19:52.082557335Z 2015/05/08 17:19:52 etcdserver: initial cluster = default=http://localhost:2380,default=http://localhost:7001
2015-05-08T17:19:52.082561674Z 2015/05/08 17:19:52 etcdserver: start member 6a5871dbdd12c17c in cluster f68652439e3f8f2a
2015-05-08T17:19:52.082565037Z 2015/05/08 17:19:52 raft: 6a5871dbdd12c17c became follower at term 0
2015-05-08T17:19:52.082568494Z 2015/05/08 17:19:52 raft: newRaft 6a5871dbdd12c17c [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastterm: 0]
2015-05-08T17:19:52.082571870Z 2015/05/08 17:19:52 raft: 6a5871dbdd12c17c became follower at term 1
2015-05-08T17:19:52.135010625Z 2015/05/08 17:19:52 etcdserver: added local member 6a5871dbdd12c17c [http://localhost:2380 http://localhost:7001] to cluster f68652439e3f8f2a
2015-05-08T17:19:53.778680605Z 2015/05/08 17:19:53 raft: 6a5871dbdd12c17c is starting a new election at term 1
2015-05-08T17:19:53.782947933Z 2015/05/08 17:19:53 raft: 6a5871dbdd12c17c became candidate at term 2
2015-05-08T17:19:53.782958531Z 2015/05/08 17:19:53 raft: 6a5871dbdd12c17c received vote from 6a5871dbdd12c17c at term 2
2015-05-08T17:19:53.782962231Z 2015/05/08 17:19:53 raft: 6a5871dbdd12c17c became leader at term 2
2015-05-08T17:19:53.782965857Z 2015/05/08 17:19:53 raft.node: 6a5871dbdd12c17c elected leader 6a5871dbdd12c17c at term 2
2015-05-08T17:19:53.784006311Z 2015/05/08 17:19:53 etcdserver: published {Name:default ClientURLs:[http://127.0.0.1:2379 http://127.0.0.1:4001]} to cluster f68652439e3f8f2a
```

View last terminated container:

```
$ cluster/kubectl.sh log --previous kube-dns-u6iwr etcd
Starting cluster using os distro: debian
current-context: "golden-system-455_kubernetes"
Running: cluster/../cluster/gce/../../cluster/../_output/dockerized/bin/linux/amd64/kubectl log --previous kube-dns-u6iwr etcd
2015-05-08T01:04:04.531822712Z 2015/05/08 01:04:04 etcdserver: start to snapshot (applied: 30003, lastsnap: 20002)
2015-05-08T01:04:04.539799516Z 2015/05/08 01:04:04 etcdserver: compacted log at index 30003
2015-05-08T01:04:04.567473474Z 2015/05/08 01:04:04 etcdserver: saved snapshot at index 30003
2015-05-08T02:26:45.031556653Z 2015/05/08 02:26:45 etcdserver: start to snapshot (applied: 40004, lastsnap: 30003)
2015-05-08T02:26:45.034289317Z 2015/05/08 02:26:45 etcdserver: compacted log at index 40004
2015-05-08T02:26:45.063427077Z 2015/05/08 02:26:45 etcdserver: saved snapshot at index 40004
2015-05-08T03:49:23.031419059Z 2015/05/08 03:49:23 etcdserver: start to snapshot (applied: 50005, lastsnap: 40004)
2015-05-08T03:49:23.034633854Z 2015/05/08 03:49:23 etcdserver: compacted log at index 50005
2015-05-08T03:49:23.063567111Z 2015/05/08 03:49:23 etcdserver: saved snapshot at index 50005
2015-05-08T03:49:41.240453029Z 2015/05/08 03:49:41 filePurge: successfully removed file default.etcd/member/wal/0000000000000000-0000000000000000.wal
2015-05-08T05:12:01.031479334Z 2015/05/08 05:12:01 etcdserver: start to snapshot (applied: 60006, lastsnap: 50005)
2015-05-08T05:12:01.035340614Z 2015/05/08 05:12:01 etcdserver: compacted log at index 60006
2015-05-08T05:12:01.063295479Z 2015/05/08 05:12:01 etcdserver: saved snapshot at index 60006
2015-05-08T05:12:11.283689186Z 2015/05/08 05:12:11 filePurge: successfully removed file default.etcd/member/snap/0000000000000002-0000000000002711.snap
2015-05-08T05:12:11.283939737Z 2015/05/08 05:12:11 filePurge: successfully removed file default.etcd/member/wal/0000000000000001-0000000000002712.wal
2015-05-08T06:34:41.531536560Z 2015/05/08 06:34:41 etcdserver: start to snapshot (applied: 70007, lastsnap: 60006)
2015-05-08T06:34:41.535609973Z 2015/05/08 06:34:41 etcdserver: compacted log at index 70007
2015-05-08T06:34:41.563516650Z 2015/05/08 06:34:41 etcdserver: saved snapshot at index 70007
2015-05-08T06:35:11.327789880Z 2015/05/08 06:35:11 filePurge: successfully removed file default.etcd/member/snap/0000000000000002-0000000000004e22.snap
2015-05-08T06:35:11.328059550Z 2015/05/08 06:35:11 filePurge: successfully removed file default.etcd/member/wal/0000000000000002-0000000000004e23.wal
2015-05-08T07:57:19.531724879Z 2015/05/08 07:57:19 etcdserver: start to snapshot (applied: 80008, lastsnap: 70007)
2015-05-08T07:57:19.536553856Z 2015/05/08 07:57:19 etcdserver: compacted log at index 80008
2015-05-08T07:57:19.563253209Z 2015/05/08 07:57:19 etcdserver: saved snapshot at index 80008
2015-05-08T07:57:41.373356734Z 2015/05/08 07:57:41 filePurge: successfully removed file default.etcd/member/snap/0000000000000002-0000000000007533.snap
2015-05-08T07:57:41.373606942Z 2015/05/08 07:57:41 filePurge: successfully removed file default.etcd/member/wal/0000000000000003-0000000000007534.wal
2015-05-08T09:20:00.031505826Z 2015/05/08 09:20:00 etcdserver: start to snapshot (applied: 90009, lastsnap: 80008)
2015-05-08T09:20:00.036393165Z 2015/05/08 09:20:00 etcdserver: compacted log at index 90009
2015-05-08T09:20:00.063395366Z 2015/05/08 09:20:00 etcdserver: saved snapshot at index 90009
2015-05-08T09:20:11.428310827Z 2015/05/08 09:20:11 filePurge: successfully removed file default.etcd/member/snap/0000000000000002-0000000000009c44.snap
2015-05-08T09:20:11.428828475Z 2015/05/08 09:20:11 filePurge: successfully removed file default.etcd/member/wal/0000000000000004-0000000000009c45.wal
2015-05-08T10:42:38.031654974Z 2015/05/08 10:42:38 etcdserver: start to snapshot (applied: 100010, lastsnap: 90009)
```

If the last terminated container is not exist:

```
$ cluster/kubectl.sh log --previous etcd-server-kubernetes-master
current-context: "golden-system-455_kubernetes"
Running: cluster/../cluster/gce/../../cluster/../_output/dockerized/bin/linux/amd64/kubectl log --previous etcd-server-kubernetes-master
Internal Error: previous terminated container "etcd-container" not found in pod
```

cc/ @vishh
