### PR TITLE
WIP: Group unidentified containers into list of pods

### DIFF
--- a/pkg/kubelet/dockertools/convert.go
+++ b/pkg/kubelet/dockertools/convert.go
@@ -46,6 +46,23 @@ func toRuntimeContainer(c *docker.APIContainers) (*kubecontainer.Container, erro
 	}, nil
 }
 
+// unknownToRuntimeContainer converts a docker container with insufficient
+// kubelet-related information to a runtime container. Example usage of this
+// function would be to convert an alien (not managed by kubelet) container or
+// to convert a kubelet-managed container with old, incompatible naming
+// convention.
+func unknownToRuntimeContainer(c *docker.APIContainers) (*kubecontainer.Container, error) {
+	if c == nil {
+		return nil, fmt.Errorf("unable to convert a nil pointer to a runtime container")
+	}
+
+	return &kubecontainer.Container{
+		ID:      types.UID(c.ID),
+		Image:   c.Image,
+		Created: c.Created,
+	}, nil
+}
+
 // Converts docker.APIImages to kubecontainer.Image.
 func toRuntimeImage(image *docker.APIImages) (*kubecontainer.Image, error) {
 	if image == nil {

--- a/pkg/kubelet/dockertools/convert.go
+++ b/pkg/kubelet/dockertools/convert.go
@@ -72,6 +72,6 @@ func toRuntimeImage(image *docker.APIImages) (*kubecontainer.Image, error) {
 	return &kubecontainer.Image{
 		ID:   image.ID,
 		Tags: image.RepoTags,
-		Size: image.Size,
+		Size: image.VirtualSize,
 	}, nil
 }

--- a/pkg/kubelet/dockertools/convert_test.go
+++ b/pkg/kubelet/dockertools/convert_test.go
@@ -72,9 +72,9 @@ func TestUnknownToRuntimeContainer(t *testing.T) {
 
 func TestToRuntimeImage(t *testing.T) {
 	original := &docker.APIImages{
-		ID:       "aeeea",
-		RepoTags: []string{"abc", "def"},
-		Size:     1234,
+		ID:          "aeeea",
+		RepoTags:    []string{"abc", "def"},
+		VirtualSize: 1234,
 	}
 	expected := &kubecontainer.Image{
 		ID:   "aeeea",

--- a/pkg/kubelet/dockertools/convert_test.go
+++ b/pkg/kubelet/dockertools/convert_test.go
@@ -49,6 +49,27 @@ func TestToRuntimeContainer(t *testing.T) {
 	}
 }
 
+func TestUnknownToRuntimeContainer(t *testing.T) {
+	original := &docker.APIContainers{
+		ID:      "ab2cdf",
+		Image:   "bar_image",
+		Created: 12345,
+	}
+	expected := &kubecontainer.Container{
+		ID:      types.UID("ab2cdf"),
+		Image:   "bar_image",
+		Created: 12345,
+	}
+
+	actual, err := unknownToRuntimeContainer(original)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected %#v, got %#v", expected, actual)
+	}
+}
+
 func TestToRuntimeImage(t *testing.T) {
 	original := &docker.APIImages{
 		ID:       "aeeea",

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -90,6 +90,36 @@ func TestGetContainerID(t *testing.T) {
 	}
 }
 
+func TestGetDockerContainerLists(t *testing.T) {
+	fakeDocker := &FakeDockerClient{}
+	k8sContainers := []docker.APIContainers{
+		{
+			ID:    "foobar",
+			Names: []string{"/k8s_foo_qux_ns_1234_42"},
+		},
+		{
+			ID:    "barbar",
+			Names: []string{"/k8s_bar_qux_ns_2565_42"},
+		},
+	}
+	alienContainers := []docker.APIContainers{
+		{
+			ID: "alien",
+		},
+	}
+	fakeDocker.ContainerList = append(k8sContainers, alienContainers...)
+	actualK8s, actualAliens, err := getContainerLists(fakeDocker, false)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if reflect.DeepEqual(k8sContainers, actualK8s) {
+		t.Error("expected %#v, got %#v", k8sContainers, actualK8s)
+	}
+	if reflect.DeepEqual(alienContainers, actualAliens) {
+		t.Error("expected %#v, got %#v", alienContainers, actualAliens)
+	}
+}
+
 func verifyPackUnpack(t *testing.T, podNamespace, podUID, podName, containerName string) {
 	container := &api.Container{Name: containerName}
 	hasher := adler32.New()

--- a/pkg/kubelet/dockertools/fake_manager.go
+++ b/pkg/kubelet/dockertools/fake_manager.go
@@ -22,6 +22,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/network"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/prober"
 	kubeletTypes "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/types"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 func NewFakeDockerManager(
@@ -44,4 +45,26 @@ func NewFakeDockerManager(
 	dm.Puller = &FakeDockerPuller{}
 	dm.prober = prober.New(nil, readinessManager, containerRefManager, recorder)
 	return dm
+}
+
+func NewSimpleFakeDockerManager() (*DockerManager, *FakeDockerClient) {
+	fakeDocker := &FakeDockerClient{Errors: make(map[string]error), RemovedImages: util.StringSet{}}
+	fakeRecorder := &record.FakeRecorder{}
+	readinessManager := kubecontainer.NewReadinessManager()
+	containerRefManager := kubecontainer.NewRefManager()
+	networkPlugin, _ := network.InitNetworkPlugin([]network.NetworkPlugin{}, "", network.NewFakeHost(nil))
+	dockerManager := NewFakeDockerManager(
+		fakeDocker,
+		fakeRecorder,
+		readinessManager,
+		containerRefManager,
+		PodInfraContainerImage,
+		0, 0, "",
+		kubecontainer.FakeOS{},
+		networkPlugin,
+		nil,
+		nil,
+		nil)
+
+	return dockerManager, fakeDocker
 }

--- a/pkg/kubelet/dockertools/manager_test.go
+++ b/pkg/kubelet/dockertools/manager_test.go
@@ -36,28 +36,6 @@ import (
 	"github.com/fsouza/go-dockerclient"
 )
 
-func newTestDockerManager() (*DockerManager, *FakeDockerClient) {
-	fakeDocker := &FakeDockerClient{Errors: make(map[string]error), RemovedImages: util.StringSet{}}
-	fakeRecorder := &record.FakeRecorder{}
-	readinessManager := kubecontainer.NewReadinessManager()
-	containerRefManager := kubecontainer.NewRefManager()
-	networkPlugin, _ := network.InitNetworkPlugin([]network.NetworkPlugin{}, "", network.NewFakeHost(nil))
-	dockerManager := NewFakeDockerManager(
-		fakeDocker,
-		fakeRecorder,
-		readinessManager,
-		containerRefManager,
-		PodInfraContainerImage,
-		0, 0, "",
-		kubecontainer.FakeOS{},
-		networkPlugin,
-		nil,
-		nil,
-		nil)
-
-	return dockerManager, fakeDocker
-}
-
 func TestSetEntrypointAndCommand(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -145,7 +123,7 @@ func verifyPods(a, b []*kubecontainer.Pod) bool {
 }
 
 func TestGetPods(t *testing.T) {
-	manager, fakeDocker := newTestDockerManager()
+	manager, fakeDocker := NewSimpleFakeDockerManager()
 	dockerContainers := []docker.APIContainers{
 		{
 			ID:    "1111",
@@ -252,7 +230,7 @@ func TestGetUnknownPods(t *testing.T) {
 }
 
 func TestListImages(t *testing.T) {
-	manager, fakeDocker := newTestDockerManager()
+	manager, fakeDocker := NewSimpleFakeDockerManager()
 	dockerImages := []docker.APIImages{{ID: "1111"}, {ID: "2222"}, {ID: "3333"}}
 	expected := util.NewStringSet([]string{"1111", "2222", "3333"}...)
 
@@ -307,7 +285,7 @@ func dockerContainersToPod(containers DockerContainers) kubecontainer.Pod {
 }
 
 func TestKillContainerInPod(t *testing.T) {
-	manager, fakeDocker := newTestDockerManager()
+	manager, fakeDocker := NewSimpleFakeDockerManager()
 
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
@@ -353,7 +331,7 @@ func TestKillContainerInPod(t *testing.T) {
 }
 
 func TestKillContainerInPodWithError(t *testing.T) {
-	manager, fakeDocker := newTestDockerManager()
+	manager, fakeDocker := NewSimpleFakeDockerManager()
 
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
@@ -428,7 +406,7 @@ func replaceProber(dm *DockerManager, result probe.Result, err error) {
 // Unknown or error.
 //
 func TestProbeContainer(t *testing.T) {
-	manager, _ := newTestDockerManager()
+	manager, _ := NewSimpleFakeDockerManager()
 	dc := &docker.APIContainers{
 		ID:      "foobar",
 		Created: time.Now().Unix(),

--- a/pkg/kubelet/image_manager_test.go
+++ b/pkg/kubelet/image_manager_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/cadvisor"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	docker "github.com/fsouza/go-dockerclient"
 	cadvisorApiV2 "github.com/google/cadvisor/info/v2"
 	"github.com/stretchr/testify/assert"
@@ -34,12 +33,10 @@ import (
 var zero time.Time
 
 func newRealImageManager(policy ImageGCPolicy) (*realImageManager, *dockertools.FakeDockerClient, *cadvisor.Mock) {
-	fakeDocker := &dockertools.FakeDockerClient{
-		RemovedImages: util.NewStringSet(),
-	}
+	dockerManager, fakeDocker := dockertools.NewSimpleFakeDockerManager()
 	mockCadvisor := new(cadvisor.Mock)
 	return &realImageManager{
-		dockerClient: fakeDocker,
+		runtime:      dockerManager,
 		policy:       policy,
 		imageRecords: make(map[string]*imageRecord),
 		cadvisor:     mockCadvisor,

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -193,10 +193,6 @@ func NewMainKubelet(
 	if err != nil {
 		return nil, err
 	}
-	imageManager, err := newImageManager(dockerClient, cadvisorInterface, recorder, nodeRef, imageGCPolicy)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize image manager: %v", err)
-	}
 	statusManager := newStatusManager(kubeClient)
 	readinessManager := kubecontainer.NewReadinessManager()
 	containerRefManager := kubecontainer.NewRefManager()
@@ -227,7 +223,6 @@ func NewMainKubelet(
 		recorder:                       recorder,
 		cadvisor:                       cadvisorInterface,
 		containerGC:                    containerGC,
-		imageManager:                   imageManager,
 		statusManager:                  statusManager,
 		volumeManager:                  volumeManager,
 		cloud:                          cloud,
@@ -286,6 +281,12 @@ func NewMainKubelet(
 		return nil, fmt.Errorf("timed out waiting for %q to come up: %v", containerRuntime, err)
 	}
 	klet.lastTimestampRuntimeUp = time.Now()
+
+	imageManager, err := newImageManager(klet.containerRuntime, cadvisorInterface, recorder, nodeRef, imageGCPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize image manager: %v", err)
+	}
+	klet.imageManager = imageManager
 
 	klet.runner = klet.containerRuntime
 	klet.podManager = newBasicPodManager(klet.kubeClient)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1209,6 +1209,10 @@ func (kl *Kubelet) killUnwantedPods(desiredPods map[types.UID]empty,
 	defer close(ch)
 	numWorkers := 0
 	for _, pod := range runningPods {
+		if pod.Name == kubeletTypes.DefaultK8sPodName || pod.Name == kubeletTypes.DefaultAlienPodName {
+			// Filter out unknown pods.
+			continue
+		}
 		if _, found := desiredPods[pod.ID]; found {
 			// Per-pod workers will handle the desired pods.
 			continue

--- a/pkg/kubelet/types/types.go
+++ b/pkg/kubelet/types/types.go
@@ -18,6 +18,13 @@ package types
 
 import "net/http"
 
+const (
+	// Name of the pod grouping unidentified kubelet-managed containers.
+	DefaultK8sPodName = "/unknown-kubernetes"
+	// Name of the pod grouping unidentified non-kubelet-managed containers.
+	DefaultAlienPodName = "/unknown-containers"
+)
+
 // DockerID is an ID of docker container. It is a type to make it clear when we're working with docker container Ids
 type DockerID string
 


### PR DESCRIPTION
This PR groups unidentified docker containers into pods and return them through
`GetPods` in the Runtime interface to facilitate image management to be
container runtime-agnostic.
- All kubelet-managed, unidentified containers are grouped into one pod.
- All non-kubelet-managed containers are grouped into one pod. 

This partially addresses #7807.
