### PR TITLE
Revert "Added ISCSI to PV structs"

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -220,9 +220,6 @@ type PersistentVolumeSource struct {
 	// This is useful for development and testing only.
 	// on-host storage is not supported in any way
 	HostPath *HostPathVolumeSource `json:"hostPath"`
-	// ISCSIVolumeSource represents an ISCSI resource that is attached to a
-	// kubelet's host machine and then exposed to the pod.
-	ISCSI *ISCSIVolumeSource `json:"iscsi"`
 	// Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod
 	Glusterfs *GlusterfsVolumeSource `json:"glusterfs"`
 	// NFS represents an NFS mount on the host that shares a pod's lifetime

--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -1606,9 +1606,6 @@ func init() {
 			if err := s.Convert(&in.HostPath, &out.HostPath, 0); err != nil {
 				return err
 			}
-			if err := s.Convert(&in.ISCSI, &out.ISCSI, 0); err != nil {
-				return err
-			}
 			if err := s.Convert(&in.Glusterfs, &out.Glusterfs, 0); err != nil {
 				return err
 			}
@@ -1625,9 +1622,6 @@ func init() {
 				return err
 			}
 			if err := s.Convert(&in.HostPath, &out.HostPath, 0); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ISCSI, &out.ISCSI, 0); err != nil {
 				return err
 			}
 			if err := s.Convert(&in.Glusterfs, &out.Glusterfs, 0); err != nil {

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -245,9 +245,6 @@ type PersistentVolumeSource struct {
 	// This is useful for development and testing only.
 	// on-host storage is not supported in any way.
 	HostPath *HostPathVolumeSource `json:"hostPath" description:"a HostPath provisioned by a developer or tester; for develment use only"`
-	// ISCSI represents an ISCSI Disk resource that is attached to a
-	// kubelet's host machine and then exposed to the pod.
-	ISCSI *ISCSIVolumeSource `json:"iscsi" description:"an iSCSI disk resource provisioned by an admin"`
 	// Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod
 	Glusterfs *GlusterfsVolumeSource `json:"glusterfs" description:"Glusterfs volume resource provisioned by an admin"`
 	// NFS represents an NFS mount on the host

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -143,9 +143,6 @@ type PersistentVolumeSource struct {
 	// This is useful for development and testing only.
 	// on-host storage is not supported in any way.
 	HostPath *HostPathVolumeSource `json:"hostPath" description:"a HostPath provisioned by a developer or tester; for develment use only"`
-	// ISCSI represents an ISCSI Disk resource that is attached to a
-	// kubelet's host machine and then exposed to the pod.
-	ISCSI *ISCSIVolumeSource `json:"iscsi" description:"an iSCSI disk resource provisioned by an admin"`
 	// Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod
 	Glusterfs *GlusterfsVolumeSource `json:"glusterfs" description:"Glusterfs volume resource provisioned by an admin"`
 	// NFS represents an NFS mount on the host

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -105,9 +105,6 @@ type PersistentVolumeSource struct {
 	// This is useful for development and testing only.
 	// on-host storage is not supported in any way.
 	HostPath *HostPathVolumeSource `json:"hostPath" description:"a HostPath provisioned by a developer or tester; for develment use only"`
-	// ISCSI represents an ISCSI Disk resource that is attached to a
-	// kubelet's host machine and then exposed to the pod.
-	ISCSI *ISCSIVolumeSource `json:"iscsi" description:"an iSCSI disk resource provisioned by an admin"`
 	// Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod
 	Glusterfs *GlusterfsVolumeSource `json:"glusterfs" description:"Glusterfs volume resource provisioned by an admin"`
 	// NFS represents an NFS mount on the host

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -2245,14 +2245,6 @@ func convert_v1beta3_PersistentVolumeSource_To_api_PersistentVolumeSource(in *Pe
 	} else {
 		out.HostPath = nil
 	}
-	if in.ISCSI != nil {
-		out.ISCSI = new(newer.ISCSIVolumeSource)
-		if err := convert_v1beta3_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
-			return err
-		}
-	} else {
-		out.ISCSI = nil
-	}
 	if in.Glusterfs != nil {
 		out.Glusterfs = new(newer.GlusterfsVolumeSource)
 		if err := convert_v1beta3_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
@@ -2299,14 +2291,6 @@ func convert_api_PersistentVolumeSource_To_v1beta3_PersistentVolumeSource(in *ne
 		}
 	} else {
 		out.HostPath = nil
-	}
-	if in.ISCSI != nil {
-		out.ISCSI = new(ISCSIVolumeSource)
-		if err := convert_api_ISCSIVolumeSource_To_v1beta3_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
-			return err
-		}
-	} else {
-		out.ISCSI = nil
 	}
 	if in.Glusterfs != nil {
 		out.Glusterfs = new(GlusterfsVolumeSource)

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -245,9 +245,6 @@ type PersistentVolumeSource struct {
 	// This is useful for development and testing only.
 	// on-host storage is not supported in any way.
 	HostPath *HostPathVolumeSource `json:"hostPath" description:"a HostPath provisioned by a developer or tester; for develment use only"`
-	// ISCSI represents an ISCSI Disk resource that is attached to a
-	// kubelet's host machine and then exposed to the pod.
-	ISCSI *ISCSIVolumeSource `json:"iscsi" description:"an iSCSI disk resource provisioned by an admin"`
 	// Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod
 	Glusterfs *GlusterfsVolumeSource `json:"glusterfs" description:"Glusterfs volume resource provisioned by an admin"`
 	// NFS represents an NFS mount on the host

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -461,10 +461,6 @@ func ValidatePersistentVolume(pv *api.PersistentVolume) errs.ValidationErrorList
 		numVolumes++
 		allErrs = append(allErrs, validateAWSElasticBlockStoreVolumeSource(pv.Spec.AWSElasticBlockStore).Prefix("awsElasticBlockStore")...)
 	}
-	if pv.Spec.ISCSI != nil {
-		numVolumes++
-		allErrs = append(allErrs, validateISCSIVolumeSource(pv.Spec.ISCSI).Prefix("iscsi")...)
-	}
 	if pv.Spec.Glusterfs != nil {
 		numVolumes++
 		allErrs = append(allErrs, validateGlusterfs(pv.Spec.Glusterfs).Prefix("glusterfs")...)

--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -39,28 +39,6 @@ func TestCanSupport(t *testing.T) {
 	}
 }
 
-func TestGetAccessModes(t *testing.T) {
-	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
-
-	plug, err := plugMgr.FindPersistentPluginByName("kubernetes.io/iscsi")
-	if err != nil {
-		t.Errorf("Can't find the plugin by name")
-	}
-	if !contains(plug.GetAccessModes(), api.ReadWriteOnce) || !contains(plug.GetAccessModes(), api.ReadOnlyMany) {
-		t.Errorf("Expected two AccessModeTypes:  %s and %s", api.ReadWriteOnce, api.ReadOnlyMany)
-	}
-}
-
-func contains(modes []api.AccessModeType, mode api.AccessModeType) bool {
-	for _, m := range modes {
-		if m == mode {
-			return true
-		}
-	}
-	return false
-}
-
 type fakeDiskManager struct {
 	attachCalled bool
 	detachCalled bool


### PR DESCRIPTION
Reverts GoogleCloudPlatform/kubernetes#7734

go 1.3 - v1beta3 shippable tests are consistently failing
https://app.shippable.com/builds/554cf8d5ff724e0c00e4fe49
