### PR TITLE
Call kube-down in test-teardown for vagrant.

### DIFF
--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -295,7 +295,7 @@ function test-setup {
 
 # Execute after running tests to perform any required clean-up
 function test-teardown {
-  echo "Vagrant ignores tear-down" 1>&2
+  kube-down
 }
 
 # Set the {user} and {password} environment values required to interact with provider


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/7978
