### PR TITLE
GlusterFS Critical Bug Resolved - Removing warning in README

### DIFF
--- a/examples/glusterfs/README.md
+++ b/examples/glusterfs/README.md
@@ -1,5 +1,3 @@
-### Warning: Only use this plugin  in Read Only mode. There is currently [a critical bug](https://github.com/GoogleCloudPlatform/kubernetes/issues/7317) that deletes your data when used in Read/Write mode.
-
 ## Glusterfs
 
 [Glusterfs](http://www.gluster.org) is an open source scale-out filesystem. These examples provide information about how to allow containers use Glusterfs volumes.


### PR DESCRIPTION
Now that we've resolved the data deletion bug  (https://github.com/GoogleCloudPlatform/kubernetes/issues/7317) we can remove the warning at the top of the GlusterFS Volume Plugin README 
