### PR TITLE
Kubelet configure cbr0 instead of configure-vm.sh

### DIFF
--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -64,14 +64,6 @@ for k,v in yaml.load(sys.stdin).iteritems():
   else
     KUBERNETES_MASTER="true"
   fi
-
-  if [[ "${KUBERNETES_MASTER}" != "true" ]] && [[ -z "${MINION_IP_RANGE:-}" ]]; then
-    # This block of code should go away once the master can allocate CIDRs
-    until MINION_IP_RANGE=$(curl-metadata node-ip-range); do
-      echo 'Waiting for metadata MINION_IP_RANGE...'
-      sleep 3
-    done
-  fi
 }
 
 function remove-docker-artifacts() {
@@ -393,7 +385,7 @@ function salt-node-role() {
 grains:
   roles:
     - kubernetes-pool
-  cbr-cidr: '$(echo "$MINION_IP_RANGE" | sed -e "s/'/''/g")'
+  cbr-cidr: 10.123.45.0/30
   cloud: gce
 EOF
 }

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -40,4 +40,9 @@
   {% set docker_root = " --docker_root=" + grains.docker_root -%}
 {% endif -%}
 
-DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{hostname_override}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}}"
+{% set configure_cbr0 = "" -%}
+{% if pillar['allocate_node_cidrs'] is defined -%}
+  {% set configure_cbr0 = "--configure-cbr0=" + pillar['allocate_node_cidrs'] -%}
+{% endif -%}
+
+DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{hostname_override}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{configure_cbr0}}"

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -104,6 +104,7 @@ type KubeletServer struct {
 	CgroupRoot                     string
 	ContainerRuntime               string
 	DockerDaemonContainer          string
+	ConfigureCBR0                  bool
 
 	// Flags intended for testing
 
@@ -162,6 +163,7 @@ func NewKubeletServer() *KubeletServer {
 		CgroupRoot:                  "/",
 		ContainerRuntime:            "docker",
 		DockerDaemonContainer:       "/docker-daemon",
+		ConfigureCBR0:               false,
 	}
 }
 
@@ -218,6 +220,7 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.CgroupRoot, "cgroup_root", s.CgroupRoot, "Optional root cgroup to use for pods. This is handled by the container runtime on a best effort basis. Default: '/', which means top-level.")
 	fs.StringVar(&s.ContainerRuntime, "container_runtime", s.ContainerRuntime, "The container runtime to use. Possible values: 'docker', 'rkt'. Default: 'docker'.")
 	fs.StringVar(&s.DockerDaemonContainer, "docker-daemon-container", s.DockerDaemonContainer, "Optional resource-only container in which to place the Docker Daemon. Empty for no container (Default: /docker-daemon).")
+	fs.BoolVar(&s.ConfigureCBR0, "configure-cbr0", s.ConfigureCBR0, "If true, kubelet will configure cbr0 based on Node.Spec.PodCIDR.")
 
 	// Flags intended for testing, not recommended used in production environments.
 	fs.BoolVar(&s.ReallyCrashForTesting, "really-crash-for-testing", s.ReallyCrashForTesting, "If true, when panics occur crash. Intended for testing.")
@@ -333,6 +336,7 @@ func (s *KubeletServer) Run(_ []string) error {
 		ContainerRuntime:          s.ContainerRuntime,
 		Mounter:                   mounter,
 		DockerDaemonContainer:     s.DockerDaemonContainer,
+		ConfigureCBR0:             s.ConfigureCBR0,
 	}
 
 	RunKubelet(&kcfg, nil)
@@ -582,6 +586,7 @@ type KubeletConfig struct {
 	ContainerRuntime               string
 	Mounter                        mount.Interface
 	DockerDaemonContainer          string
+	ConfigureCBR0                  bool
 }
 
 func createAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.PodConfig, err error) {
@@ -631,7 +636,8 @@ func createAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.Pod
 		kc.CgroupRoot,
 		kc.ContainerRuntime,
 		kc.Mounter,
-		kc.DockerDaemonContainer)
+		kc.DockerDaemonContainer,
+		kc.ConfigureCBR0)
 
 	if err != nil {
 		return nil, nil, err

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -17,7 +17,6 @@ limitations under the License.
 package gce_cloud
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -42,10 +41,6 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/cloud/compute/metadata"
 )
-
-var ErrMetadataConflict = errors.New("Metadata already set at the same key")
-
-const podCIDRMetadataKey string = "node-ip-range"
 
 // GCECloud is an implementation of Interface, TCPLoadBalancer and Instances for Google Compute Engine.
 type GCECloud struct {
@@ -562,44 +557,23 @@ func getMetadataValue(metadata *compute.Metadata, key string) (string, bool) {
 
 func (gce *GCECloud) Configure(name string, spec *api.NodeSpec) error {
 	instanceName := canonicalizeInstanceName(name)
-	instance, err := gce.service.Instances.Get(gce.projectID, gce.zone, instanceName).Do()
-	if err != nil {
-		return err
-	}
-	if currentValue, ok := getMetadataValue(instance.Metadata, podCIDRMetadataKey); ok {
-		if currentValue == spec.PodCIDR {
-			// IP range already set to proper value.
-			return nil
-		}
-		return ErrMetadataConflict
-	}
-	// We are setting the metadata, so they can be picked-up by the configure-vm.sh script to start docker with the given CIDR for Pods.
-	instance.Metadata.Items = append(instance.Metadata.Items,
-		&compute.MetadataItems{
-			Key:   podCIDRMetadataKey,
-			Value: spec.PodCIDR,
-		})
-	setMetadataCall := gce.service.Instances.SetMetadata(gce.projectID, gce.zone, instanceName, instance.Metadata)
-	setMetadataOp, err := setMetadataCall.Do()
-	if err != nil {
-		return err
-	}
-	err = gce.waitForZoneOp(setMetadataOp)
-	if err != nil {
-		return err
-	}
-	insertCall := gce.service.Routes.Insert(gce.projectID, &compute.Route{
+	insertOp, err := gce.service.Routes.Insert(gce.projectID, &compute.Route{
 		Name:            instanceName,
 		DestRange:       spec.PodCIDR,
 		NextHopInstance: fmt.Sprintf("zones/%s/instances/%s", gce.zone, instanceName),
 		Network:         fmt.Sprintf("global/networks/%s", gce.networkName),
 		Priority:        1000,
-	})
-	insertOp, err := insertCall.Do()
+	}).Do()
 	if err != nil {
 		return err
 	}
-	return gce.waitForGlobalOp(insertOp)
+	if err := gce.waitForGlobalOp(insertOp); err != nil {
+		if gapiErr, ok := err.(*googleapi.Error); ok && gapiErr.Code == http.StatusConflict {
+			// TODO (cjcullen): Make this actually check the route is correct.
+			return nil
+		}
+	}
+	return err
 }
 
 func (gce *GCECloud) Release(name string) error {

--- a/pkg/kubelet/container_bridge.go
+++ b/pkg/kubelet/container_bridge.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"bytes"
+	"net"
+	"os/exec"
+	"regexp"
+
+	"github.com/golang/glog"
+)
+
+var cidrRegexp = regexp.MustCompile(`inet ([0-9a-fA-F.:]*/[0-9]*)`)
+
+func ensureCbr0(wantCIDR *net.IPNet) error {
+	if !cbr0CidrCorrect(wantCIDR) {
+		glog.V(5).Infof("Attempting to recreate cbr0 with address range: %s", wantCIDR)
+
+		// delete cbr0
+		if err := exec.Command("ip", "link", "set", "dev", "cbr0", "down").Run(); err != nil {
+			glog.Error(err)
+			return err
+		}
+		if err := exec.Command("brctl", "delbr", "cbr0").Run(); err != nil {
+			glog.Error(err)
+			return err
+		}
+		// recreate cbr0 with wantCIDR
+		if err := exec.Command("brctl", "addbr", "cbr0").Run(); err != nil {
+			glog.Error(err)
+			return err
+		}
+		if err := exec.Command("ip", "addr", "add", wantCIDR.String(), "dev", "cbr0").Run(); err != nil {
+			glog.Error(err)
+			return err
+		}
+		if err := exec.Command("ip", "link", "set", "dev", "cbr0", "up").Run(); err != nil {
+			glog.Error(err)
+			return err
+		}
+		// restart docker
+		if err := exec.Command("service", "docker", "restart").Run(); err != nil {
+			glog.Error(err)
+			return err
+		}
+		glog.V(5).Info("Recreated cbr0 and restarted docker")
+	}
+	return nil
+}
+
+func cbr0CidrCorrect(wantCIDR *net.IPNet) bool {
+	output, err := exec.Command("ip", "addr", "show", "cbr0").Output()
+	if err != nil {
+		return false
+	}
+	match := cidrRegexp.FindSubmatch(output)
+	if len(match) < 2 {
+		return false
+	}
+	cbr0IP, cbr0CIDR, err := net.ParseCIDR(string(match[1]))
+	cbr0CIDR.IP = cbr0IP
+	if err != nil {
+		glog.Errorf("Couldn't parse CIDR: %q", match[1])
+		return false
+	}
+	glog.V(5).Infof("Want cbr0 CIDR: %s, have cbr0 CIDR: %s", wantCIDR, cbr0CIDR)
+	return wantCIDR.IP.Equal(cbr0IP) && bytes.Equal(wantCIDR.Mask, cbr0CIDR.Mask)
+}


### PR DESCRIPTION
We need this to get #6949 to work, now that the master assigns CIDRs to nodes.

Currently, we have:

Kubelet:
1. Configure-vm.sh spins until node-ip-range entry can be read from metadata.
2. Salt creates cbr0 w/ node-ip-range.
3. Kubelet starts up, asks for itself from apiserver.

NodeController:
1. Query GCE instances to get list of (new) nodes.
2. For each node:
- Choose an unused CIDR for that node.
- Add node to registry
- Create a route for that CIDR to the node.
- Set the node-ip-range value in that node's metadata to the CIDR.

If we want kubelet to reach out to the master to register (#6949), we have a bootstrapping problem:
- NodeController is not relying on cloudProvider for a list of nodes, so starts with no known nodes.
- Kubelet never starts because configure-vm.sh is waiting for NodeController to write node-ip-range to metadata.

What this PR would do is:

Kubelet:
1. Salt creates cbr0 w/ some garbage CIDR range.
2. Kubelet starts up, asks for itself from apiserver.
3. If the NodeSpec has a PodCIDR set that does not match the existing cbr0, reconfigure cbr0 and restart docker.

NodeController:
1. Query GCE instances to get list of (new) nodes.
2. For each node:
- Choose an unused CIDR for that node.
- Add node to registry
- Create a route for that CIDR to the node.

This will allow #6949 to look like:

Kubelet:
1. Salt creates cbr0 w/ some garbage CIDR range.
2. Kubelet starts up, posts registration to apiserver.
3. Kubelet asks for itself from apiserver.
4. If the NodeSpec has a PodCIDR set that does not match the existing cbr0, reconfigure cbr0 and restart docker.

NodeController:
1. When a node posts its registration:
- Choose an unused CIDR for that node.
- Add node to registry
- Create a route for that CIDR to the node.
