### PR TITLE
Fix boilerplate check crash if .go file has no comments

### DIFF
--- a/examples/k8petstore/web-server/PetStoreBook.go
+++ b/examples/k8petstore/web-server/PetStoreBook.go
@@ -1,5 +1,3 @@
-package main
-
 /*
 Copyright 2014 The Kubernetes Authors All rights reserved.
 
@@ -15,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+package main
 
 import (
 	"encoding/json"

--- a/hooks/boilerplate.py
+++ b/hooks/boilerplate.py
@@ -25,18 +25,20 @@ import sys
 def PrintError(*err):
   print(*err, file=sys.stderr)
 
-def file_passes(filename, extention, ref, regex):
+def file_passes(filename, extention, ref, regexs):
     try:
         f = open(filename, 'r')
     except:
         return False
 
-    data = f.readlines()
+    data = f.read()
 
     # remove build tags from the top of Go file
     if extention == "go":
-        while data[0] != "/*\n":
-            data = data[1:]
+        p = regexs["go_build_constraints"]
+        (data, found) = p.subn("", data, 1)
+
+    data = data.splitlines()
 
     # if our test file is smaller than the reference it surely fails!
     if len(ref) > len(data):
@@ -46,8 +48,10 @@ def file_passes(filename, extention, ref, regex):
     data = data[:len(ref)]
 
     # Replace all occurances of the regex "2015" with "2014"
+    p = regexs["date"]
     for i, d in enumerate(data):
-        (data[i], found) = regex.subn( '2014', d)
+
+        (data[i], found) = p.subn( '2014', d)
         if found != 0:
             break
 
@@ -74,13 +78,16 @@ def main():
     except:
         # No boilerplate template is success
         return True
-    ref = ref_file.readlines()
+    ref = ref_file.read().splitlines()
 
+    regexs = {}
     # dates can be 2014 or 2015, company holder names can be anything
-    p = re.compile( '(2014|2015)' )
+    regexs["date"] = re.compile( '(2014|2015)' )
+    # strip // +build \n\n build constraints
+    regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
 
     for filename in filenames:
-        if not file_passes(filename, extention, ref, p):
+        if not file_passes(filename, extention, ref, regexs):
             print(filename, file=sys.stdout)
 
 if __name__ == "__main__":

--- a/hooks/boilerplate.py
+++ b/hooks/boilerplate.py
@@ -25,7 +25,7 @@ import sys
 def PrintError(*err):
   print(*err, file=sys.stderr)
 
-def file_passes(filename, extention, ref, regexs):
+def file_passes(filename, extension, ref, regexs):
     try:
         f = open(filename, 'r')
     except:
@@ -34,7 +34,7 @@ def file_passes(filename, extention, ref, regexs):
     data = f.read()
 
     # remove build tags from the top of Go file
-    if extention == "go":
+    if extension == "go":
         p = regexs["go_build_constraints"]
         (data, found) = p.subn("", data, 1)
 
@@ -68,11 +68,11 @@ def main():
 
     basedir = os.path.dirname(os.path.abspath(__file__))
 
-    extention = sys.argv[1]
+    extension = sys.argv[1]
     # argv[0] is the binary, argv[1] is the extension (go, sh, py, whatever)
     filenames = sys.argv[2:]
 
-    ref_filename = basedir + "/boilerplate." + extention + ".txt"
+    ref_filename = basedir + "/boilerplate." + extension + ".txt"
     try:
         ref_file = open(ref_filename, 'r')
     except:
@@ -87,7 +87,7 @@ def main():
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
 
     for filename in filenames:
-        if not file_passes(filename, extention, ref, regexs):
+        if not file_passes(filename, extension, ref, regexs):
             print(filename, file=sys.stdout)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Clayton pointed out that if he created a file with no /\* in it anywhere
the boilerplate logic would crash like:

```
$ hack/verify-boilerplate.sh
Traceback (most recent call last):
  File "hack/../hooks/boilerplate.py", line 87, in <module>
    sys.exit(main())
  File "hack/../hooks/boilerplate.py", line 83, in main
    if not file_passes(filename, extention, ref, p):
  File "hack/../hooks/boilerplate.py", line 38, in file_passes
    while data[0] != "/*\n":
IndexError: list index out of range
```

That is because we were just stripping everything before the first line
that contained exacly "/*".  If no such line existed it got to the end
and just kept going.

This does something smarter. We use a regex to look for one or more
lines which start // +build followed by a single newline and remove only
those.  This obviously found one place where the package name was above
the license and was being missed by both the old and the new checker.

It also fixed the python spew and just tells you your file fails.
