### PR TITLE
AWS: Copy some new properties from config-default => config.test

### DIFF
--- a/cluster/aws/config-test.sh
+++ b/cluster/aws/config-test.sh
@@ -66,3 +66,10 @@ ENABLE_CLUSTER_DNS=true
 DNS_SERVER_IP="10.0.0.10"
 DNS_DOMAIN="kubernetes.local"
 DNS_REPLICAS=1
+
+# Admission Controllers to invoke prior to persisting objects in cluster
+ADMISSION_CONTROL=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,SecurityContextDeny,ResourceQuota
+
+# Optional: Enable/disable public IP assignment for minions.
+# Important Note: disable only if you have setup a NAT instance for internet access and configured appropriate routes!
+ENABLE_MINION_PUBLIC_IP=${KUBE_ENABLE_MINION_PUBLIC_IP:-true}


### PR DESCRIPTION
ENABLE_MINION_PUBLIC_IP was causing a failure because the variable wasn't declared.

ADMISSION_CONTROL should just be set the same for both test & default
