### PR TITLE
Modify Jenkins E2E to not fetch/unpack Kuberenetes, when deployment is disabled

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -97,99 +97,102 @@ export E2E_UP="${E2E_UP:-true}"
 export E2E_TEST="${E2E_TEST:-true}"
 export E2E_DOWN="${E2E_DOWN:-true}"
 
-if [[ ${KUBE_RUN_FROM_OUTPUT:-} =~ ^[yY]$ ]]; then
-    echo "Found KUBE_RUN_FROM_OUTPUT=y; will use binaries from _output"
-    cp _output/release-tars/kubernetes*.tar.gz .
-else
-    echo "Pulling binaries from GCS"
-    if [[ $(find . | wc -l) != 1 ]]; then
-        echo $PWD not empty, bailing!
-        exit 1
+if [[ "${E2E_UP,,}" == "true" ]]; then
+    if [[ ${KUBE_RUN_FROM_OUTPUT:-} =~ ^[yY]$ ]]; then
+        echo "Found KUBE_RUN_FROM_OUTPUT=y; will use binaries from _output"
+        cp _output/release-tars/kubernetes*.tar.gz .
+    else
+        echo "Pulling binaries from GCS"
+        if [[ $(find . | wc -l) != 1 ]]; then
+            echo $PWD not empty, bailing!
+            exit 1
+        fi
+    
+        # Tell kube-up.sh to skip the update, it doesn't lock. An internal
+        # gcloud bug can cause racing component updates to stomp on each
+        # other.
+        export KUBE_SKIP_UPDATE=y
+        sudo flock -x -n /var/run/lock/gcloud-components.lock -c "gcloud components update -q" || true
+
+        # The "ci" bucket is for builds like "v0.15.0-468-gfa648c1"
+        bucket="ci"
+        # The "latest" version picks the most recent "ci" or "release" build.
+        version_file="latest"
+        if [[ ${JENKINS_USE_RELEASE_TARS:-} =~ ^[yY]$ ]]; then
+            # The "release" bucket is for builds like "v0.15.0"
+            bucket="release"
+            if [[ ${JENKINS_USE_STABLE:-} =~ ^[yY]$ ]]; then
+                # The "stable" version picks the most recent "release" build.
+                version_file="stable"
+            fi
+        fi
+
+        githash=$(gsutil cat gs://kubernetes-release/${bucket}/${version_file}.txt)
+        gsutil -m cp gs://kubernetes-release/${bucket}/${githash}/kubernetes.tar.gz gs://kubernetes-release/${bucket}/${githash}/kubernetes-test.tar.gz .
     fi
 
-    # Tell kube-up.sh to skip the update, it doesn't lock. An internal
-    # gcloud bug can cause racing component updates to stomp on each
-    # other.
-    export KUBE_SKIP_UPDATE=y
-    sudo flock -x -n /var/run/lock/gcloud-components.lock -c "gcloud components update -q" || true
-
-    # The "ci" bucket is for builds like "v0.15.0-468-gfa648c1"
-    bucket="ci"
-    # The "latest" version picks the most recent "ci" or "release" build.
-    version_file="latest"
-    if [[ ${JENKINS_USE_RELEASE_TARS:-} =~ ^[yY]$ ]]; then
-        # The "release" bucket is for builds like "v0.15.0"
-        bucket="release"
-        if [[ ${JENKINS_USE_STABLE:-} =~ ^[yY]$ ]]; then
-            # The "stable" version picks the most recent "release" build.
-            version_file="stable"
+    if [[ ! "${CIRCLECI:-}" == "true" ]]; then
+        # Copy GCE keys so we don't keep cycling them.
+        # To set this up, you must know the <project>, <zone>, and <instance> that
+        # on which your jenkins jobs are running. Then do:
+        #
+        # # Get into the instance.
+        # $ gcloud compute ssh --project="<prj>" ssh --zone="<zone>" <instance>
+        #
+        # # Generate a key by ssh'ing into itself, then exit.
+        # $ gcloud compute ssh --project="<prj>" ssh --zone="<zone>" <instance>
+        # $ ^D
+        #
+        # # Copy the keys to the desired location, e.g. /var/lib/jenkins/gce_keys/
+        # $ sudo mkdir -p /var/lib/jenkins/gce_keys/
+        # $ sudo cp ~/.ssh/google_compute_engine /var/lib/jenkins/gce_keys/
+        # $ sudo cp ~/.ssh/google_compute_engine.pub /var/lib/jenkins/gce_keys/
+        #
+        # Move the permissions to jenkins.
+        # $ sudo chown -R jenkins /var/lib/jenkins/gce_keys/
+        # $ sudo chgrp -R jenkins /var/lib/jenkins/gce_keys/
+        if [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then
+            echo "Skipping SSH key copying for AWS"
+        else
+            mkdir -p ${WORKSPACE}/.ssh/
+            cp /var/lib/jenkins/gce_keys/google_compute_engine ${WORKSPACE}/.ssh/
+            cp /var/lib/jenkins/gce_keys/google_compute_engine.pub ${WORKSPACE}/.ssh/
         fi
     fi
 
-    githash=$(gsutil cat gs://kubernetes-release/${bucket}/${version_file}.txt)
-    gsutil -m cp gs://kubernetes-release/${bucket}/${githash}/kubernetes.tar.gz gs://kubernetes-release/${bucket}/${githash}/kubernetes-test.tar.gz .
+    md5sum kubernetes*.tar.gz
+    tar -xzf kubernetes.tar.gz
+    tar -xzf kubernetes-test.tar.gz
+
+    # Set by GKE-CI to change the CLUSTER_API_VERSION to the git version
+    if [[ ! -z ${E2E_SET_CLUSTER_API_VERSION:-} ]]; then
+        export CLUSTER_API_VERSION=$(echo ${githash} | cut -c 2-)
+    elif [[ ${JENKINS_USE_RELEASE_TARS:-} =~ ^[yY]$ ]]; then
+        release=$(gsutil cat gs://kubernetes-release/release/${version_file}.txt | cut -c 2-)
+        export CLUSTER_API_VERSION=${release}
+    fi
 fi
 
-if [[ ! "${CIRCLECI:-}" == "true" ]]; then
-  # Copy GCE keys so we don't keep cycling them.
-  # To set this up, you must know the <project>, <zone>, and <instance> that
-  # on which your jenkins jobs are running. Then do:
-  #
-  # # Get into the instance.
-  # $ gcloud compute ssh --project="<prj>" ssh --zone="<zone>" <instance>
-  #
-  # # Generate a key by ssh'ing into itself, then exit.
-  # $ gcloud compute ssh --project="<prj>" ssh --zone="<zone>" <instance>
-  # $ ^D
-  #
-  # # Copy the keys to the desired location, e.g. /var/lib/jenkins/gce_keys/
-  # $ sudo mkdir -p /var/lib/jenkins/gce_keys/
-  # $ sudo cp ~/.ssh/google_compute_engine /var/lib/jenkins/gce_keys/
-  # $ sudo cp ~/.ssh/google_compute_engine.pub /var/lib/jenkins/gce_keys/
-  #
-  # Move the permissions to jenkins.
-  # $ sudo chown -R jenkins /var/lib/jenkins/gce_keys/
-  # $ sudo chgrp -R jenkins /var/lib/jenkins/gce_keys/
-  if [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then
-    echo "Skipping SSH key copying for AWS"
-  else
-    mkdir -p ${WORKSPACE}/.ssh/
-    cp /var/lib/jenkins/gce_keys/google_compute_engine ${WORKSPACE}/.ssh/
-    cp /var/lib/jenkins/gce_keys/google_compute_engine.pub ${WORKSPACE}/.ssh/
-  fi
-fi
-
-md5sum kubernetes*.tar.gz
-tar -xzf kubernetes.tar.gz
-tar -xzf kubernetes-test.tar.gz
 cd kubernetes
-
-# Set by GKE-CI to change the CLUSTER_API_VERSION to the git version
-if [[ ! -z ${E2E_SET_CLUSTER_API_VERSION:-} ]]; then
-    export CLUSTER_API_VERSION=$(echo ${githash} | cut -c 2-)
-elif [[ ${JENKINS_USE_RELEASE_TARS:-} =~ ^[yY]$ ]]; then
-    release=$(gsutil cat gs://kubernetes-release/release/${version_file}.txt | cut -c 2-)
-    export CLUSTER_API_VERSION=${release}
-fi
 
 # Have cmd/e2e run by goe2e.sh generate JUnit report in ${WORKSPACE}/junit*.xml
 export E2E_REPORT_DIR=${WORKSPACE}
 
 ### Set up ###
 if [[ "${E2E_UP,,}" == "true" ]]; then
-	go run ./hack/e2e.go ${E2E_OPT} -v --down
-	go run ./hack/e2e.go ${E2E_OPT} -v --up
-	go run ./hack/e2e.go -v --ctl="version --match-server-version=false"
+    go run ./hack/e2e.go ${E2E_OPT} -v --down
+    go run ./hack/e2e.go ${E2E_OPT} -v --up
+    go run ./hack/e2e.go -v --ctl="version --match-server-version=false"
 fi
 
 ### Run tests ###
 # Jenkins will look at the junit*.xml files for test failures, so don't exit
 # with a nonzero error code if it was only tests that failed.
 if [[ "${E2E_TEST,,}" == "true" ]]; then
-	go run ./hack/e2e.go ${E2E_OPT} -v --test --test_args="${GINKGO_TEST_ARGS}--ginkgo.noColor" || true
+    go run ./hack/e2e.go ${E2E_OPT} -v --test --test_args="${GINKGO_TEST_ARGS}--ginkgo.noColor" || true
 fi
 
 ### Clean up ###
 if [[ "${E2E_DOWN,,}" == "true" ]]; then
-	go run ./hack/e2e.go ${E2E_OPT} -v --down
+    go run ./hack/e2e.go ${E2E_OPT} -v --down
 fi


### PR DESCRIPTION
Modify Jenkins E2E to not fetch/unpack Kuberenetes, when deployment is disabled. When running E2E tests only (no UP), the work space already contains all the correct files, and should not be overwritten.

This is actually the script that `kubernetes-soak-continuous-e2e` is currently running (via a public Git Gist). Once this is checked in I'll update the job to point to Kubernetes master HEAD.

CC @quinton-hoole 
