### PR TITLE
Delete expectations of a deleted rc instead of letting them expire

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -63,6 +63,7 @@ var expKeyFunc = func(obj interface{}) (string, error) {
 type RCExpectationsManager interface {
 	GetExpectations(rc *api.ReplicationController) (*PodExpectations, bool, error)
 	SatisfiedExpectations(rc *api.ReplicationController) bool
+	DeleteExpectations(rcKey string)
 	ExpectCreations(rc *api.ReplicationController, adds int) error
 	ExpectDeletions(rc *api.ReplicationController, dels int) error
 	CreationObserved(rc *api.ReplicationController)
@@ -84,6 +85,15 @@ func (r *RCExpectations) GetExpectations(rc *api.ReplicationController) (*PodExp
 		return podExp.(*PodExpectations), true, nil
 	} else {
 		return nil, false, err
+	}
+}
+
+// DeleteExpectations deletes the expectations of the given RC from the TTLStore.
+func (r *RCExpectations) DeleteExpectations(rcKey string) {
+	if podExp, exists, err := r.GetByKey(rcKey); err == nil && exists {
+		if err := r.Delete(podExp); err != nil {
+			glog.V(2).Infof("Error deleting expectations for rc %v: %v", rcKey, err)
+		}
 	}
 }
 

--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -351,6 +351,7 @@ func (rm *ReplicationManager) syncReplicationController(key string) error {
 	obj, exists, err := rm.controllerStore.Store.GetByKey(key)
 	if !exists {
 		glog.Infof("Replication Controller has been deleted %v", key)
+		rm.expectations.DeleteExpectations(key)
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
We currently let the expectations of an rc expire naturally. This PR deletes them explicitly when the rc is deleted. Also adds a unittest for rc deletion, which I apparently didn't have :\
