### PR TITLE
Don't print debugging things on every run of kubectl.sh

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -23,11 +23,10 @@ source "${KUBE_ROOT}/cluster/gce/${KUBE_CONFIG_FILE-"config-default.sh"}"
 source "${KUBE_ROOT}/cluster/common.sh"
 
 if [[ "${OS_DISTRIBUTION}" == "debian" || "${OS_DISTRIBUTION}" == "coreos" ]]; then
-  echo "Starting cluster using os distro: ${OS_DISTRIBUTION}" >&2
   source "${KUBE_ROOT}/cluster/gce/${OS_DISTRIBUTION}/helper.sh"
 else
-  echo "Cannot start cluster using os distro: ${OS_DISTRIBUTION}" >&2
-  return
+  echo "Cannot operate on cluster using os distro: ${OS_DISTRIBUTION}" >&2
+  exit 1
 fi
 
 NODE_INSTANCE_PREFIX="${INSTANCE_PREFIX}-minion"

--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -114,7 +114,11 @@ elif [[ "$KUBERNETES_PROVIDER" == "ubuntu" ]]; then
   )
 fi
 
-echo "current-context: \"$(${kubectl} "${config[@]:+${config[@]}}" config view -o template --template='{{index . "current-context"}}')\"" >&2
 
-echo "Running:" "${kubectl}" "${config[@]:+${config[@]}}" "${@+$@}" >&2
+if false; then
+  # disable these debugging messages by default
+  echo "current-context: \"$(${kubectl} "${config[@]:+${config[@]}}" config view -o template --template='{{index . "current-context"}}')\"" >&2
+  echo "Running:" "${kubectl}" "${config[@]:+${config[@]}}" "${@+$@}" >&2
+fi
+
 "${kubectl}" "${config[@]:+${config[@]}}" "${@+$@}"


### PR DESCRIPTION
It's intensely weird to see kubectl.sh tell me it's starting a cluster every time I run it.
