### PR TITLE
Use template to get first column in __kubectl_parse_get()

### DIFF
--- a/contrib/completions/bash/kubectl
+++ b/contrib/completions/bash/kubectl
@@ -157,14 +157,13 @@ __handle_word()
 }
 
 # call kubectl get $1,
-# use the first column in compgen
-# we could use templates, but then would need a template per resource
 __kubectl_parse_get()
 {
-    local kubectl_output out
-    if kubectl_output=$(kubectl get --no-headers "$1" 2>/dev/null); then
-        out=($(echo "${kubectl_output}" | awk '{print $1}'))
-        COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
+    local template
+    template="{{ range .items  }}{{ .metadata.name }} {{ end }}"
+    local kubectl_out
+    if kubectl_out=$(kubectl get -o template --template="${template}" "$1" 2>/dev/null); then
+        COMPREPLY=( $( compgen -W "${kubectl_out[*]}" -- "$cur" ) )
     fi
 }
 
@@ -180,7 +179,7 @@ __kubectl_get_resource()
 __kubectl_get_containers()
 {
     local template
-    template="{{ range .desiredState.manifest.containers  }}{{ .name }} {{ end }}"
+    template="{{ range .spec.containers  }}{{ .name }} {{ end }}"
     __debug "${FUNCNAME} nouns are ${nouns[*]}"
 
     local len="${#nouns[@]}"

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -28,14 +28,13 @@ import (
 
 const (
 	bash_completion_func = `# call kubectl get $1,
-# use the first column in compgen
-# we could use templates, but then would need a template per resource
 __kubectl_parse_get()
 {
-    local kubectl_output out
-    if kubectl_output=$(kubectl get --no-headers "$1" 2>/dev/null); then
-        out=($(echo "${kubectl_output}" | awk '{print $1}'))
-        COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
+    local template
+    template="{{ range .items  }}{{ .metadata.name }} {{ end }}"
+    local kubectl_out
+    if kubectl_out=$(kubectl get -o template --template="${template}" "$1" 2>/dev/null); then
+        COMPREPLY=( $( compgen -W "${kubectl_out[*]}" -- "$cur" ) )
     fi
 }
 
@@ -51,7 +50,7 @@ __kubectl_get_resource()
 __kubectl_get_containers()
 {
     local template
-    template="{{ range .desiredState.manifest.containers  }}{{ .name }} {{ end }}"
+    template="{{ range .spec.containers  }}{{ .name }} {{ end }}"
     __debug "${FUNCNAME} nouns are ${nouns[*]}"
 
     local len="${#nouns[@]}"


### PR DESCRIPTION
Output of `kubectl get pod` has been changed as below. This PR will delete lines that has an empty first column.

```
$ kubectl get pod
POD       IP           CONTAINER(S)   IMAGE(S)   HOST                  LABELS       STATUS    CREATED         MESSAGE
nginx     172.17.0.2                             127.0.0.1/127.0.0.1   name=nginx   Running   2 hours         
                       nginx          nginx                                         Running   About an hour
```
