### PR TITLE
Check Pod privileged container

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -30,7 +30,6 @@ import (
 	"sync"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/capabilities"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/lifecycle"
@@ -540,10 +539,6 @@ func (dm *DockerManager) runContainer(pod *api.Pod, container *api.Container, op
 			b := fmt.Sprintf("%s:%s", containerLogPath, container.TerminationMessagePath)
 			opts.Binds = append(opts.Binds, b)
 		}
-	}
-
-	if !capabilities.Get().AllowPrivileged && securitycontext.HasPrivilegedRequest(container) {
-		return "", fmt.Errorf("container requested privileged mode, but it is disallowed globally.")
 	}
 
 	hc := &docker.HostConfig{

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/capabilities"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/credentialprovider"
 	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
@@ -213,13 +212,10 @@ func setIsolators(app *appctypes.App, c *api.Container) error {
 
 	// Retained capabilities/privileged.
 	privileged := false
-	if !capabilities.Get().AllowPrivileged && securitycontext.HasPrivilegedRequest(c) {
-		return fmt.Errorf("container requested privileged mode, but it is disallowed globally.")
-	} else {
-		if c.SecurityContext != nil && c.SecurityContext.Privileged != nil {
-			privileged = *c.SecurityContext.Privileged
-		}
+	if c.SecurityContext != nil && c.SecurityContext.Privileged != nil {
+		privileged = *c.SecurityContext.Privileged
 	}
+
 	var addCaps string
 	if privileged {
 		addCaps = getAllCapabilities()


### PR DESCRIPTION
Check privileged container in kubelet before running/syncing a Pod.  We currently check it in container runtime, but it seems to be a little late?  @vmarmol 
