### PR TITLE
Inconsistency in api terminology of pod conditions

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -828,7 +828,7 @@ type PodSpec struct {
 // state of a system.
 type PodStatus struct {
 	Phase      PodPhase       `json:"phase,omitempty"`
-	Conditions []PodCondition `json:"Condition,omitempty"`
+	Conditions []PodCondition `json:"conditions,omitempty"`
 	// A human readable message indicating details about why the pod is in this state.
 	Message string `json:"message,omitempty"`
 

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -830,7 +830,7 @@ type PodSpec struct {
 // state of a system.
 type PodStatus struct {
 	Phase      PodPhase       `json:"phase,omitempty" description:"current condition of the pod."`
-	Conditions []PodCondition `json:"Condition,omitempty" description:"current service state of pod" patchStrategy:"merge" patchMergeKey:"type"`
+	Conditions []PodCondition `json:"conditions,omitempty" description:"current service state of pod" patchStrategy:"merge" patchMergeKey:"type"`
 	// A human readable message indicating details about why the pod is in this state.
 	Message string `json:"message,omitempty" description:"human readable message indicating details about why the pod is in this condition"`
 


### PR DESCRIPTION
While nodes returns the "conditions" key in api requests, pods returns
"Condition". Also, from pods states docs it seems that the right
terminology should be "conditions".

Fixes #8038
