### PR TITLE
Fixing and updating broken persistent volume nfs example

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -151,6 +151,7 @@ func TestExampleObjectSchemas(t *testing.T) {
 			"local-01": &api.PersistentVolume{},
 			"local-02": &api.PersistentVolume{},
 			"gce":      &api.PersistentVolume{},
+			"nfs":      &api.PersistentVolume{},
 		},
 		"../examples/persistent-volumes/claims": {
 			"claim-01": &api.PersistentVolumeClaim{},

--- a/examples/persistent-volumes/volumes/nfs.yaml
+++ b/examples/persistent-volumes/volumes/nfs.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1beta3
+kind: PersistentVolume
+metadata:
+  name: pv0003
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  nfs:
+    path: /tmp
+    server: 172.17.0.2

--- a/examples/storage/persistentvolume-nfs-example.yaml
+++ b/examples/storage/persistentvolume-nfs-example.yaml
@@ -1,9 +1,0 @@
-id: pv0003
-kind: PersistentVolume
-apiVersion: v1beta1
-spec:
-  source:
-    nfsMount:
-      server: "172.17.0.2"
-      path: "/tmp"
-      readOnly: false


### PR DESCRIPTION
Fixed the broken v1beta1 example for persistent volume nfs example and upgraded it to v1beta3.
Have also added a test to make sure it does not break again.

Ref https://github.com/GoogleCloudPlatform/kubernetes/issues/6584
