### PR TITLE
kubelet/container: Move prober.ContainerCommandRunner to container.

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -58,17 +58,6 @@ type Runtime interface {
 	// GetPodStatus retrieves the status of the pod, including the information of
 	// all containers in the pod.
 	GetPodStatus(*api.Pod) (*api.PodStatus, error)
-	// TODO(vmarmol): Merge RunInContainer and ExecInContainer.
-	// Runs the command in the container of the specified pod using nsinit.
-	// TODO(yifan): Use strong type for containerID.
-	RunInContainer(containerID string, cmd []string) ([]byte, error)
-	// Runs the command in the container of the specified pod using nsenter.
-	// Attaches the processes stdin, stdout, and stderr. Optionally uses a
-	// tty.
-	// TODO(yifan): Use strong type for containerID.
-	ExecInContainer(containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error
-	// Forward the specified port from the specified pod to the stream.
-	PortForward(pod *Pod, port uint16, stream io.ReadWriteCloser) error
 	// PullImage pulls an image from the network to local storage using the supplied
 	// secrets if necessary.
 	PullImage(image ImageSpec, secrets []api.Secret) error
@@ -84,6 +73,23 @@ type Runtime interface {
 	// stream the log. Set 'follow' to false and specify the number of lines (e.g.
 	// "100" or "all") to tail the log.
 	GetContainerLogs(pod *api.Pod, containerID, tail string, follow bool, stdout, stderr io.Writer) (err error)
+	// ContainerCommandRunner encapsulates the command runner interfaces for testability.
+	ContainerCommandRunner
+}
+
+// CommandRunner encapsulates the command runner interfaces for testability.
+type ContainerCommandRunner interface {
+	// TODO(vmarmol): Merge RunInContainer and ExecInContainer.
+	// Runs the command in the container of the specified pod using nsinit.
+	// TODO(yifan): Use strong type for containerID.
+	RunInContainer(containerID string, cmd []string) ([]byte, error)
+	// Runs the command in the container of the specified pod using nsenter.
+	// Attaches the processes stdin, stdout, and stderr. Optionally uses a
+	// tty.
+	// TODO(yifan): Use strong type for containerID.
+	ExecInContainer(containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error
+	// Forward the specified port from the specified pod to the stream.
+	PortForward(pod *Pod, port uint16, stream io.ReadWriteCloser) error
 }
 
 // Customizable hooks injected into container runtimes.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -44,7 +44,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/envvars"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/metrics"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/network"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/prober"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/rkt"
 	kubeletTypes "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
@@ -345,7 +344,7 @@ type Kubelet struct {
 	// Optional, defaults to /logs/ from /var/log
 	logServer http.Handler
 	// Optional, defaults to simple Docker implementation
-	runner prober.ContainerCommandRunner
+	runner kubecontainer.ContainerCommandRunner
 	// Optional, client for http requests, defaults to empty client
 	httpClient kubeletTypes.HttpGetter
 
@@ -1780,9 +1779,6 @@ func (kl *Kubelet) findContainer(podFullName string, podUID types.UID, container
 func (kl *Kubelet) RunInContainer(podFullName string, podUID types.UID, containerName string, cmd []string) ([]byte, error) {
 	podUID = kl.podManager.TranslatePodUID(podUID)
 
-	if kl.runner == nil {
-		return nil, fmt.Errorf("no runner specified.")
-	}
 	container, err := kl.findContainer(podFullName, podUID, containerName)
 	if err != nil {
 		return nil, err
@@ -1798,9 +1794,6 @@ func (kl *Kubelet) RunInContainer(podFullName string, podUID types.UID, containe
 func (kl *Kubelet) ExecInContainer(podFullName string, podUID types.UID, containerName string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error {
 	podUID = kl.podManager.TranslatePodUID(podUID)
 
-	if kl.runner == nil {
-		return fmt.Errorf("no runner specified.")
-	}
 	container, err := kl.findContainer(podFullName, podUID, containerName)
 	if err != nil {
 		return err
@@ -1815,10 +1808,6 @@ func (kl *Kubelet) ExecInContainer(podFullName string, podUID types.UID, contain
 // and the stream.
 func (kl *Kubelet) PortForward(podFullName string, podUID types.UID, port uint16, stream io.ReadWriteCloser) error {
 	podUID = kl.podManager.TranslatePodUID(podUID)
-
-	if kl.runner == nil {
-		return fmt.Errorf("no runner specified.")
-	}
 
 	pods, err := kl.containerRuntime.GetPods(false)
 	if err != nil {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1575,6 +1575,7 @@ func (f *fakeContainerCommandRunner) PortForward(pod *kubecontainer.Pod, port ui
 	f.Stream = stream
 	return nil
 }
+
 func TestRunInContainerNoSuchPod(t *testing.T) {
 	fakeCommandRunner := fakeContainerCommandRunner{}
 	testKubelet := newTestKubelet(t)

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/prober"
 	kubeletTypes "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
@@ -31,7 +30,7 @@ import (
 
 type HandlerRunner struct {
 	httpGetter       kubeletTypes.HttpGetter
-	commandRunner    prober.ContainerCommandRunner
+	commandRunner    kubecontainer.ContainerCommandRunner
 	containerManager podStatusProvider
 }
 
@@ -39,8 +38,7 @@ type podStatusProvider interface {
 	GetPodStatus(pod *api.Pod) (*api.PodStatus, error)
 }
 
-// TODO(yifan): Merge commandRunner and containerManager once containerManager implements the ContainerCommandRunner interface.
-func NewHandlerRunner(httpGetter kubeletTypes.HttpGetter, commandRunner prober.ContainerCommandRunner, containerManager podStatusProvider) kubecontainer.HandlerRunner {
+func NewHandlerRunner(httpGetter kubeletTypes.HttpGetter, commandRunner kubecontainer.ContainerCommandRunner, containerManager podStatusProvider) kubecontainer.HandlerRunner {
 	return &HandlerRunner{
 		httpGetter:       httpGetter,
 		commandRunner:    commandRunner,


### PR DESCRIPTION
Also include the ContainerCommandRunner in Runtime interface, but
still keep the ContainerCommandRunner interface for testability.

/cc @vmarmol @yujuhong  @dchen1107 
