### PR TITLE
Introduce a `svc` segment/level for DNS names for pods

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -865,7 +865,8 @@ func (kl *Kubelet) getClusterDNS(pod *api.Pod) ([]string, []string, error) {
 	}
 	if kl.clusterDomain != "" {
 		nsDomain := fmt.Sprintf("%s.%s", pod.Namespace, kl.clusterDomain)
-		dnsSearch = append([]string{nsDomain, kl.clusterDomain}, hostSearch...)
+		newNsDomain := fmt.Sprintf("%s.svc.%s", pod.Namespace, kl.clusterDomain)
+		dnsSearch = append([]string{newNsDomain, nsDomain, kl.clusterDomain}, hostSearch...)
 	}
 	return dns, dnsSearch, nil
 }


### PR DESCRIPTION
Our DNS implementation will start generating dns names for services with this new segment.

Full Format: <service_name>:<service_namespace>.svc.kubernetes.local

For #7472
