### PR TITLE
Fix vagrant cpu count on linux.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,7 +79,13 @@ host = RbConfig::CONFIG['host_os']
 if host =~ /darwin/
   $vm_cpus = `sysctl -n hw.physicalcpu`.to_i
 elsif host =~ /linux/
-  $vm_cpus = `cat /proc/cpuinfo | grep 'core id' | wc -l`.to_i
+  #This should work on most processors, however it will fail on ones without the core id field.
+  #So far i have only seen this on a raspberry pi. which you probably don't want to run vagrant on anyhow...
+  #But just in case we'll default to the result of nproc if we get 0 just to be safe.
+  $vm_cpus = `cat /proc/cpuinfo | grep 'core id' | uniq | wc -l`.to_i
+  if $vm_cpus < 1
+      $vm_cpus = `nproc`.to_i
+  end
 else # sorry Windows folks, I can't help you
   $vm_cpus = 2
 end


### PR DESCRIPTION
Corrects error in https://github.com/GoogleCloudPlatform/kubernetes/commit/19224deb04ea0f7b5003c9d29e9c841d7b1b6152 on linux cpus with hyperthreading (we need to pass the results of `cat /proc/cpuinfo | grep 'core id'` through uniq before counting the lines).
Also checks that we found more than 0 lines (cores) and defaults to the result of nproc in case we didn't (necessary for processors without the core id field, so far only observed on a raspberry pi).
