### PR TITLE
Fix downward API

### DIFF
--- a/examples/cassandra/cassandra-controller.yaml
+++ b/examples/cassandra/cassandra-controller.yaml
@@ -1,42 +1,39 @@
 apiVersion: v1beta3
 kind: ReplicationController
-metadata: 
-  labels: 
+metadata:
+  labels:
     name: cassandra
   name: cassandra
-spec: 
+spec:
   replicas: 1
-  selector: 
+  selector:
     name: cassandra
-  template: 
-    metadata: 
-      labels: 
+  template:
+    metadata:
+      labels:
         name: cassandra
-    spec: 
-      containers: 
-        - command: 
+    spec:
+      containers:
+        - command:
             - /run.sh
           resources:
             limits:
               cpu: 1
-          env: 
+          env:
             - name: MAX_HEAP_SIZE
-              key: MAX_HEAP_SIZE
               value: 512M
             - name: HEAP_NEWSIZE
-              key: HEAP_NEWSIZE
               value: 100M
           image: "kubernetes/cassandra:v2"
           name: cassandra
-          ports: 
+          ports:
             - containerPort: 9042
               name: cql
             - containerPort: 9160
               name: thrift
-          volumeMounts: 
+          volumeMounts:
             - mountPath: /cassandra_data
               name: data
-      volumes: 
+      volumes:
         - name: data
           emptyDir: {}
-

--- a/examples/cassandra/cassandra-service.yaml
+++ b/examples/cassandra/cassandra-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1beta3
 kind: Service
-metadata: 
-  labels: 
+metadata:
+  labels:
     name: cassandra
   name: cassandra
-spec: 
+spec:
   ports:
     - port: 9042
       targetPort: 9042
-  selector: 
+  selector:
     name: cassandra

--- a/examples/cassandra/cassandra.yaml
+++ b/examples/cassandra/cassandra.yaml
@@ -10,7 +10,7 @@ spec:
     - /run.sh
     resources:
       limits:
-        cpu: "1"      
+        cpu: "1"
     image: kubernetes/cassandra:v2
     name: cassandra
     ports:
@@ -31,5 +31,3 @@ spec:
   volumes:
     - name: data
       emptyDir: {}
-
-    

--- a/examples/downward-api/README.md
+++ b/examples/downward-api/README.md
@@ -14,7 +14,7 @@ started](../../docs/getting-started-guides) for installation instructions for yo
 Containers consume the downward API using environment variables.  The downward API allows
 containers to be injected with the name and namespace of the pod the container is in.
 
-Use the `examples/secrets/secret-pod.yaml` file to create a Pod with a container that consumes the
+Use the `examples/downward-api/dapi-pod.yaml` file to create a Pod with a container that consumes the
 downward API.
 
 ```shell


### PR DESCRIPTION
Also removes cassandra doc's env.key field.
@pmorie 

BTW, why the name downward API?  Pass metadata downward?
