### PR TITLE
make the httpGet port the match the containerPort in the walkthrough example

### DIFF
--- a/examples/walkthrough/k8s201.md
+++ b/examples/walkthrough/k8s201.md
@@ -138,7 +138,7 @@ spec:
         # an http probe
         httpGet:
           path: /_status/healthz
-          port: 8080
+          port: 80
         # length of time to wait for a pod to initialize
         # after pod startup, before applying health checking
         initialDelaySeconds: 30

--- a/examples/walkthrough/pod-with-http-healthcheck.yaml
+++ b/examples/walkthrough/pod-with-http-healthcheck.yaml
@@ -11,7 +11,7 @@ spec:
         # an http probe
         httpGet:
           path: /_status/healthz
-          port: 8080
+          port: 80
         # length of time to wait for a pod to initialize
         # after pod startup, before applying health checking
         initialDelaySeconds: 30


### PR DESCRIPTION
Per @bgrant0607 's comments in #7940, make the httpGet port the match the containerPort in the walkthrough example. @nikhiljindal 
