### PR TITLE
Make SyncPodSync as the default SyncPodType.

### DIFF
--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -77,9 +77,9 @@ func Register(containerCache kubecontainer.RuntimeCache) {
 type SyncPodType int
 
 const (
-	SyncPodCreate SyncPodType = iota
+	SyncPodSync SyncPodType = iota
 	SyncPodUpdate
-	SyncPodSync
+	SyncPodCreate
 )
 
 func (sp SyncPodType) String() string {


### PR DESCRIPTION
We would like the default to be sync instead of create to easily differentiate
create operations in empty metrics map.
