### PR TITLE
fix verbs for exec, proxy, portforward

### DIFF
--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -42,6 +42,14 @@ var specialVerbs = map[string]bool{
 	"watch":    true,
 }
 
+// specialSubresources captures subresources that have semantic meaning.  For example, no matter what resource it is attached to
+// a "proxy" subresources is proving a "proxy" verb for some resource.  These should be permissioned based on their actual verbs.
+var specialSubresources = map[string]string{
+	"exec":        "exec",
+	"portforward": "proxy",
+	"proxy":       "proxy",
+}
+
 // Constant for the retry-after interval on rate limiting.
 // TODO: maybe make this dynamic? or user-adjustable?
 const RetryAfter = "1"
@@ -370,6 +378,11 @@ func (r *APIRequestInfoResolver) GetAPIRequestInfo(req *http.Request) (APIReques
 		fallthrough
 	case len(requestInfo.Parts) == 1:
 		requestInfo.Resource = requestInfo.Parts[0]
+	}
+
+	// check to see if the subresource is one with semantic meaning that affects the verb
+	if subresourceVerb, exists := specialSubresources[requestInfo.Subresource]; exists {
+		requestInfo.Verb = subresourceVerb
 	}
 
 	// if there's no name on the request and we thought it was a get before, then the actual verb is a list

--- a/pkg/apiserver/handlers_test.go
+++ b/pkg/apiserver/handlers_test.go
@@ -183,6 +183,9 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		{"GET", "/redirect/pods/foo", "redirect", "", api.NamespaceDefault, "pods", "", "Pod", "foo", []string{"pods", "foo"}},
 		{"GET", "/watch/pods", "watch", "", api.NamespaceAll, "pods", "", "Pod", "", []string{"pods"}},
 		{"GET", "/watch/namespaces/other/pods", "watch", "", "other", "pods", "", "Pod", "", []string{"pods"}},
+		{"GET", "/namespaces/other/pods/foo/exec", "exec", "", "other", "pods", "exec", "Pod", "foo", []string{"pods", "foo", "exec"}},
+		{"GET", "/namespaces/other/pods/foo/proxy", "proxy", "", "other", "pods", "proxy", "Pod", "foo", []string{"pods", "foo", "proxy"}},
+		{"GET", "/namespaces/other/pods/foo/portforward", "proxy", "", "other", "pods", "portforward", "Pod", "foo", []string{"pods", "foo", "portforward"}},
 
 		// fully-qualified paths
 		{"GET", pathWithNamespaceQuery("pods", "other", ""), "list", testapi.Version(), "other", "pods", "", "Pod", "", []string{"pods"}},


### PR DESCRIPTION
This fixes the verb for pod exec, proxy, and portforward.  Currently, they come back with a verb of "get", which confuses the authorizer into thinking that "pods/exec" is a "readonly" operation.

This pull says that some subresources have semantic meaning that changes the verb, regardless of what http verb was used.  Doing this makes policy reasonable again.

@erictune ptal
@smarterclayton This is important to describing bootstrap policy.
