### PR TITLE
Convert nodel level logging to ES to use token-system-logging

### DIFF
--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
@@ -14,8 +14,8 @@ spec:
       mountPath: /varlog
     - name: containers
       mountPath: /var/lib/docker/containers
-    - name: token-admin
-      mountPath: /etc/token-admin
+    - name: token-system-logging
+      mountPath: /etc/token-system-logging
       readOnly: true
   volumes:
   - name: varlog
@@ -24,6 +24,6 @@ spec:
   - name: containers
     hostPath:
       path: /var/lib/docker/containers
-  - name: token-admin
+  - name: token-system-logging
     secret:
-    secretName: token-admin
+      secretName: token-system-logging


### PR DESCRIPTION
As per @erictune 's request, switched to using `token-system-logging` secret. @a-robinson 

Checked on a running instance a pod:

```
root@fluentd-elasticsearch:/etc/token-system-logging# cat kubeconfig 
apiVersion: v1
kind: Config
users:
- name: system:logging
  user:
    token: <REMOVED>
clusters:
- name: local
  cluster:
     server: "https://kubernetes:443"
     insecure-skip-tls-verify: true
contexts:
- context:
    cluster: local
    user: system:logging
  name: service-account-context
current-context: service-account-context
```
