### PR TITLE
Convert node level logging to Cloud Logging to use token-system-logging

### DIFF
--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -14,8 +14,8 @@ spec:
       mountPath: /varlog
     - name: containers
       mountPath: /var/lib/docker/containers
-    - name: token-admin
-      mountPath: /etc/token-admin
+    - name: token-system-logging
+      mountPath: /etc/token-system-logging
       readOnly: true
   volumes:
   - name: varlog
@@ -24,6 +24,6 @@ spec:
   - name: containers
     hostPath:
       path: /var/lib/docker/containers
-  - name: token-admin
+  - name: token-system-logging
     secret:
-    secretName: token-admin
+      secretName: token-system-logging


### PR DESCRIPTION
As per the request of @erictune convert the node level to Cloud Logging agent to use `token-system-admin` @a-robinson 

Verified on an instance of this pod.

```
root@fluentd-cloud-logging:/etc/token-system-logging# cat kubeconfig 
apiVersion: v1
kind: Config
users:
- name: system:logging
  user:
    token: <REMOVED>
clusters:
- name: local
  cluster:
     server: "https://kubernetes:443"
     insecure-skip-tls-verify: true
contexts:
- context:
    cluster: local
    user: system:logging
  name: service-account-context
current-context: service-account-context
```
