### PR TITLE
Add ServiceAccount admission plugin

### DIFF
--- a/cluster/aws/config-test.sh
+++ b/cluster/aws/config-test.sh
@@ -68,7 +68,7 @@ DNS_DOMAIN="kubernetes.local"
 DNS_REPLICAS=1
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,SecurityContextDeny,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
 
 # Optional: Enable/disable public IP assignment for minions.
 # Important Note: disable only if you have setup a NAT instance for internet access and configured appropriate routes!

--- a/cluster/ubuntu/config-default.sh
+++ b/cluster/ubuntu/config-default.sh
@@ -30,7 +30,7 @@ export PORTAL_NET=192.168.3.0/24
 export FLANNEL_NET=172.16.0.0/16
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,ServiceAccount,ResourceQuota
 
 # Optional: Install node monitoring.
 ENABLE_NODE_MONITORING=true

--- a/contrib/init/systemd/environ/apiserver
+++ b/contrib/init/systemd/environ/apiserver
@@ -20,7 +20,7 @@ KUBE_ETCD_SERVERS="--etcd_servers=http://127.0.0.1:4001"
 KUBE_SERVICE_ADDRESSES="--portal_net=10.254.0.0/16"
 
 # default admission control policies
-KUBE_ADMISSION_CONTROL="--admission_control=NamespaceAutoProvision,LimitRanger,SecurityContextDeny,ResourceQuota"
+KUBE_ADMISSION_CONTROL="--admission_control=NamespaceAutoProvision,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
 
 # Add your own!
 KUBE_API_ARGS=""


### PR DESCRIPTION
Missed a few places in #7101

Any pointers on testing these environments? I'm not positive the salt change to make the service account token controller use the server private key applies to all of these environments.
