### PR TITLE
Check if people copy, but do not update the boilerplate

### DIFF
--- a/hooks/boilerplate.go.txt
+++ b/hooks/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 The Kubernetes Authors All rights reserved.
+Copyright YEAR The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hooks/boilerplate.py
+++ b/hooks/boilerplate.py
@@ -47,11 +47,15 @@ def file_passes(filename, extension, ref, regexs):
     # trim our file to the same number of lines as the reference file
     data = data[:len(ref)]
 
-    # Replace all occurances of the regex "2015" with "2014"
+    p = regexs["year"]
+    for d in data:
+        if p.search(d):
+            return False
+
+    # Replace all occurances of the regex "2015|2014" with "YEAR"
     p = regexs["date"]
     for i, d in enumerate(data):
-
-        (data[i], found) = p.subn( '2014', d)
+        (data[i], found) = p.subn('YEAR', d)
         if found != 0:
             break
 
@@ -81,6 +85,8 @@ def main():
     ref = ref_file.read().splitlines()
 
     regexs = {}
+    # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
+    regexs["year"] = re.compile( 'YEAR' )
     # dates can be 2014 or 2015, company holder names can be anything
     regexs["date"] = re.compile( '(2014|2015)' )
     # strip // +build \n\n build constraints

--- a/hooks/boilerplate.py.txt
+++ b/hooks/boilerplate.py.txt
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2014 The Kubernetes Authors All rights reserved.
+# Copyright YEAR The Kubernetes Authors All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hooks/boilerplate.sh.txt
+++ b/hooks/boilerplate.sh.txt
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014 The Kubernetes Authors All rights reserved.
+# Copyright YEAR The Kubernetes Authors All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
We found in that someone just copied/pasted the boilerplate language into
their code. But the boilerplate contains 2014, not 2015. We have 2 ways
to fix this.

1) Update the boilerplate to 2015 so people would get the right one.
2) Update the boilerplate so it doesn't make sense and then warn when
people use it.

This PR takes the second option. While options #1 seems easier, it will
get wrong in 2016, 17, 18 and it's unlikely anyone remembers why they
need to update the boilerplate text and the regex rewrite. So just
make the humans do a tiny bit more work now.
