### PR TITLE
Install specific salt version on AWS, based on GCE

### DIFF
--- a/cluster/aws/templates/common.sh
+++ b/cluster/aws/templates/common.sh
@@ -27,3 +27,72 @@ download-or-bust() {
     md5sum "$file"
   done
 }
+
+
+
+# Install salt from GCS.  See README.md for instructions on how to update these
+# debs.
+install-salt() {
+  local salt_mode="$1"
+
+  if dpkg -s salt-minion &>/dev/null; then
+    echo "== SaltStack already installed, skipping install step =="
+    return
+  fi
+
+  echo "== Refreshing package database =="
+  until apt-get update; do
+    echo "== apt-get update failed, retrying =="
+    echo sleep 5
+  done
+
+  mkdir -p /var/cache/salt-install
+  cd /var/cache/salt-install
+
+  DEBS=(
+    libzmq3_3.2.3+dfsg-1~bpo70~dst+1_amd64.deb
+    python-zmq_13.1.0-1~bpo70~dst+1_amd64.deb
+    salt-common_2014.1.13+ds-1~bpo70+1_all.deb
+  )
+  if [[ "${salt_mode}" == "master" ]]; then
+    DEBS+=( salt-master_2014.1.13+ds-1~bpo70+1_all.deb )
+  fi
+  DEBS+=( salt-minion_2014.1.13+ds-1~bpo70+1_all.deb )
+  URL_BASE="https://storage.googleapis.com/kubernetes-release/salt"
+
+  for deb in "${DEBS[@]}"; do
+    if [ ! -e "${deb}" ]; then
+      download-or-bust "${URL_BASE}/${deb}"
+    fi
+  done
+
+  # Based on
+  # https://major.io/2014/06/26/install-debian-packages-without-starting-daemons/
+  # We do this to prevent Salt from starting the salt-minion
+  # daemon. The other packages don't have relevant daemons. (If you
+  # add a package that needs a daemon started, add it to a different
+  # list.)
+  cat > /usr/sbin/policy-rc.d <<EOF
+#!/bin/sh
+echo "Salt shall not start." >&2
+exit 101
+EOF
+  chmod 0755 /usr/sbin/policy-rc.d
+
+  for deb in "${DEBS[@]}"; do
+    echo "== Installing ${deb}, ignore dependency complaints (will fix later) =="
+    dpkg --skip-same-version --force-depends -i "${deb}"
+  done
+
+  # This will install any of the unmet dependencies from above.
+  echo "== Installing unmet dependencies =="
+  until apt-get install -f -y; do
+    echo "== apt-get install failed, retrying =="
+    echo sleep 5
+  done
+
+  rm /usr/sbin/policy-rc.d
+
+  # Log a timestamp
+  echo "== Finished installing Salt =="
+}

--- a/cluster/aws/templates/common.sh
+++ b/cluster/aws/templates/common.sh
@@ -66,19 +66,6 @@ install-salt() {
     fi
   done
 
-  # Based on
-  # https://major.io/2014/06/26/install-debian-packages-without-starting-daemons/
-  # We do this to prevent Salt from starting the salt-minion
-  # daemon. The other packages don't have relevant daemons. (If you
-  # add a package that needs a daemon started, add it to a different
-  # list.)
-  cat > /usr/sbin/policy-rc.d <<EOF
-#!/bin/sh
-echo "Salt shall not start." >&2
-exit 101
-EOF
-  chmod 0755 /usr/sbin/policy-rc.d
-
   for deb in "${DEBS[@]}"; do
     echo "== Installing ${deb}, ignore dependency complaints (will fix later) =="
     dpkg --skip-same-version --force-depends -i "${deb}"
@@ -90,8 +77,6 @@ EOF
     echo "== apt-get install failed, retrying =="
     echo sleep 5
   done
-
-  rm /usr/sbin/policy-rc.d
 
   # Log a timestamp
   echo "== Finished installing Salt =="

--- a/cluster/aws/templates/salt-master.sh
+++ b/cluster/aws/templates/salt-master.sh
@@ -51,12 +51,7 @@ reactor:
     - /srv/reactor/highstate-new.sls
 EOF
 
-# Install Salt
-#
-# We specify -X to avoid a race condition that can cause minion failure to
-# install.  See https://github.com/saltstack/salt-bootstrap/issues/270
-#
-# -M installs the master
-set +x
-curl -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -M -X
-set -x
+install-salt master
+
+service salt-master start
+service salt-minion start

--- a/cluster/aws/templates/salt-minion.sh
+++ b/cluster/aws/templates/salt-minion.sh
@@ -55,9 +55,6 @@ if [[ -n "${DOCKER_ROOT}" ]]; then
 EOF
 fi
 
+install-salt
 
-# Install Salt
-#
-# We specify -X to avoid a race condition that can cause minion failure to
-# install.  See https://github.com/saltstack/salt-bootstrap/issues/270
-curl -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -X
+service salt-minion start

--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -552,6 +552,7 @@ function kube-up {
       echo "SALT_MASTER='${MASTER_INTERNAL_IP}'"
       echo "MINION_IP_RANGE='${MINION_IP_RANGES[$i]}'"
       echo "DOCKER_OPTS='${EXTRA_DOCKER_OPTS:-}'"
+      grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/common.sh"
       grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/format-disks.sh"
       grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/salt-minion.sh"
     ) > "${KUBE_TEMP}/minion-start-${i}.sh"


### PR DESCRIPTION
The latest salt version breaks the container_bridge.py _state function

We can lock to the same version as GCE.  This is not a full fix,
because we can't update to the latest salt without breaking GCE,
but this at least unbreaks and sync AWS with GCE.

This isn't a straight copy from GCE, because we still use
the salt master on AWS (for now)

Fixes #8114
