### PR TITLE
Fixing the number of times our unit tests are run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,13 @@ language: go
 matrix:
   include:
     - go: 1.4
-      env: KUBE_TEST_API_VERSIONS="v1beta1"
+      env:
+        - KUBE_TEST_API_VERSIONS="v1beta1"
+          KUBE_TEST_ETCD_PREFIXES="registry"
     - go: 1.3
-      env: KUBE_TEST_API_VERSIONS="v1beta3"
+      env:
+        - KUBE_TEST_API_VERSIONS="v1beta3"
+          KUBE_TEST_ETCD_PREFIXES="kubernetes.io/registry"
 
 install:
   - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
@@ -25,10 +29,10 @@ before_script:
   - npm install karma karma-junit-reporter karma-phantomjs-launcher karma-jasmine
 
 script:
-  - KUBE_RACE="-race" KUBE_COVER="y" KUBE_GOVERALLS_BIN="$HOME/gopath/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_API_VERSIONS=$KUBE_TEST_API_VERSIONS ./hack/test-go.sh -- -p=2
+  - KUBE_RACE="-race" KUBE_COVER="y" KUBE_GOVERALLS_BIN="$HOME/gopath/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES}" ./hack/test-go.sh -- -p=2
   - node_modules/karma/bin/karma start www/master/karma.conf.js --single-run --browsers PhantomJS
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/test-cmd.sh
-  - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH KUBE_TEST_API_VERSIONS=$KUBE_TEST_API_VERSIONS KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4 LOG_LEVEL=4 ./hack/test-integration.sh
+  - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4 LOG_LEVEL=4 ./hack/test-integration.sh
 
 notifications:
   irc: "chat.freenode.net#google-containers"

--- a/shippable.yml
+++ b/shippable.yml
@@ -7,9 +7,11 @@ build_image: shipimg/ubuntu1204_go:latest
 matrix:
   include:
     - go: 1.4
-      env: KUBE_TEST_API_VERSIONS="v1beta1"
+      env:
+        - KUBE_TEST_API_VERSIONS=v1beta1 KUBE_TEST_ETCD_PREFIXES=registry
     - go: 1.3
-      env: KUBE_TEST_API_VERSIONS="v1beta3"
+      env:
+        - KUBE_TEST_API_VERSIONS=v1beta3 KUBE_TEST_ETCD_PREFIXES=kubernetes.io/registry
 
 before_install:
   - source $HOME/.gvm/scripts/gvm;
@@ -31,9 +33,9 @@ install:
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/verify-gendocs.sh
 
 script:
-  - KUBE_RACE="-race" KUBE_COVER="y" KUBE_GOVERALLS_BIN="$HOME/gopath/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_API_VERSIONS=$KUBE_TEST_API_VERSIONS ./hack/test-go.sh -- -p=2
+  - KUBE_RACE="-race" KUBE_COVER="y" KUBE_GOVERALLS_BIN="$HOME/gopath/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES}" KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" ./hack/test-go.sh -- -p=2
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/test-cmd.sh
-  - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH KUBE_TEST_API_VERSIONS=$KUBE_TEST_API_VERSIONS KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4 LOG_LEVEL=4 ./hack/test-integration.sh
+  - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4 LOG_LEVEL=4 ./hack/test-integration.sh
 
 notifications:
   irc: "chat.freenode.net#google-containers"


### PR DESCRIPTION
Fix as per discussion in https://github.com/GoogleCloudPlatform/kubernetes/pull/5707#discussion_r30097801.
Right now our unit tests are running 3 times when run locally and 4 times when run on shippable or travis.
This fix brings back that number to 2 everywhere.
