### PR TITLE
kubelet/container: Remove ipcMode and netMode from  RunContainerOptions.

### DIFF
--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -30,9 +30,8 @@ type HandlerRunner interface {
 
 // RunContainerOptionsGenerator generates the options that necessary for
 // container runtime to run a container.
-// TODO(yifan): Remove netMode, ipcMode.
 type RunContainerOptionsGenerator interface {
-	GenerateRunContainerOptions(pod *api.Pod, container *api.Container, netMode, ipcMode string) (*RunContainerOptions, error)
+	GenerateRunContainerOptions(pod *api.Pod, container *api.Container) (*RunContainerOptions, error)
 }
 
 // Trims runtime prefix from ID or image name (e.g.: docker://busybox -> busybox).

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -201,13 +201,6 @@ type RunContainerOptions struct {
 	DNS []string
 	// The list of DNS search domains.
 	DNSSearch []string
-	// Docker namespace identifiers(currently we have 'NetMode' and 'IpcMode'.
-	// These are for docker to attach a container in a pod to the pod infra
-	// container's namespace.
-	// TODO(yifan): Remove these after we pushed the pod infra container logic
-	// into docker's container runtime.
-	NetMode string
-	IpcMode string
 	// The parent cgroup to pass to Docker
 	CgroupParent string
 }

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -472,7 +472,14 @@ func (dm *DockerManager) GetPodInfraContainer(pod kubecontainer.Pod) (kubecontai
 	return kubecontainer.Container{}, fmt.Errorf("unable to find pod infra container for pod %v", pod.ID)
 }
 
-func (dm *DockerManager) runContainer(pod *api.Pod, container *api.Container, opts *kubecontainer.RunContainerOptions, ref *api.ObjectReference) (string, error) {
+func (dm *DockerManager) runContainer(
+	pod *api.Pod,
+	container *api.Container,
+	opts *kubecontainer.RunContainerOptions,
+	ref *api.ObjectReference,
+	netMode string,
+	ipcMode string) (string, error) {
+
 	dockerName := KubeletContainerName{
 		PodFullName:   kubecontainer.GetPodFullName(pod),
 		PodUID:        pod.UID,
@@ -544,8 +551,8 @@ func (dm *DockerManager) runContainer(pod *api.Pod, container *api.Container, op
 	hc := &docker.HostConfig{
 		PortBindings: portBindings,
 		Binds:        opts.Binds,
-		NetworkMode:  opts.NetMode,
-		IpcMode:      opts.IpcMode,
+		NetworkMode:  netMode,
+		IpcMode:      ipcMode,
 	}
 	if len(opts.DNS) > 0 {
 		hc.DNS = opts.DNS
@@ -1074,12 +1081,12 @@ func (dm *DockerManager) runContainerInPod(pod *api.Pod, container *api.Containe
 		glog.Errorf("Couldn't make a ref to pod %v, container %v: '%v'", pod.Name, container.Name, err)
 	}
 
-	opts, err := dm.generator.GenerateRunContainerOptions(pod, container, netMode, ipcMode)
+	opts, err := dm.generator.GenerateRunContainerOptions(pod, container)
 	if err != nil {
 		return "", err
 	}
 
-	id, err := dm.runContainer(pod, container, opts, ref)
+	id, err := dm.runContainer(pod, container, opts, ref, netMode, ipcMode)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -686,13 +686,9 @@ func makeBinds(container *api.Container, podVolumes kubecontainer.VolumeMap) (bi
 
 // GenerateRunContainerOptions generates the RunContainerOptions, which can be used by
 // the container runtime to set parameters for launching a container.
-func (kl *Kubelet) GenerateRunContainerOptions(pod *api.Pod, container *api.Container, netMode, ipcMode string) (*kubecontainer.RunContainerOptions, error) {
+func (kl *Kubelet) GenerateRunContainerOptions(pod *api.Pod, container *api.Container) (*kubecontainer.RunContainerOptions, error) {
 	var err error
-	opts := &kubecontainer.RunContainerOptions{
-		NetMode:      netMode,
-		IpcMode:      ipcMode,
-		CgroupParent: kl.cgroupRoot,
-	}
+	opts := &kubecontainer.RunContainerOptions{CgroupParent: kl.cgroupRoot}
 
 	vol, ok := kl.volumeManager.GetVolumes(pod.UID)
 	if !ok {


### PR DESCRIPTION
Since createPodInfraContainer() is moved into dockertools. There is no
need to pass the ipcMode or netMode via RunContainerOptions.

/cc @dchen1107 @vmarmol @yujuhong 
