### PR TITLE
Fix https://github.com/GoogleCloudPlatform/kubernetes/issues/8147

### DIFF
--- a/docs/getting-started-guides/ubuntu.md
+++ b/docs/getting-started-guides/ubuntu.md
@@ -19,7 +19,7 @@ This document describes how to deploy kubernetes on ubuntu nodes, including 1 ma
 ### **Main Steps**
 #### I. Make *kubernetes* , *etcd* and *flanneld* binaries
 
-First clone the kubernetes github repo, `$ git clone git@github.com:GoogleCloudPlatform/kubernetes.git`
+First clone the kubernetes github repo, `$ git clone https://github.com/GoogleCloudPlatform/kubernetes.git`
 then `$ cd kubernetes/cluster/ubuntu`.
 
 Then run `$ ./build.sh`, this will download all the needed binaries into `./binaries`.


### PR DESCRIPTION
In ubuntu getting started guide change:
`$ git clone git@github.com:GoogleCloudPlatform/kubernetes.git`
to:
 `$ git clone https://github.com/GoogleCloudPlatform/kubernetes.git`
so that those without ssh setup for github can follow the guide and clone kubernetes.
