### PR TITLE
Allow resources to be updated

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -932,10 +932,19 @@ func ValidatePodUpdate(newPod, oldPod *api.Pod) errs.ValidationErrorList {
 		return allErrs
 	}
 	pod := *newPod
+	restartPolicyNever := oldPod.Spec.RestartPolicy == api.RestartPolicyNever
 	// Tricky, we need to copy the container list so that we don't overwrite the update
 	var newContainers []api.Container
 	for ix, container := range pod.Spec.Containers {
 		container.Image = oldPod.Spec.Containers[ix].Image
+		oldContainerResources := oldPod.Spec.Containers[ix].Resources
+		if restartPolicyNever {
+			if !api.Semantic.DeepEqual(newPod.Spec.Containers[ix].Resources, oldContainerResources) {
+				allErrs = append(allErrs, errs.NewFieldInvalid("spec.restartpolicy", newPod.Spec.RestartPolicy, "may not update resources of pods with restartPolicy: Never"))
+				return allErrs
+			}
+		}
+		container.Resources = oldContainerResources
 		newContainers = append(newContainers, container)
 	}
 	pod.Spec.Containers = newContainers

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -1301,8 +1301,40 @@ func TestValidatePodUpdate(t *testing.T) {
 					},
 				},
 			},
+			true,
+			"cpu change with default restartPolicy",
+		},
+		{
+			api.Pod{
+				ObjectMeta: api.ObjectMeta{Name: "foo"},
+				Spec: api.PodSpec{
+					RestartPolicy: api.RestartPolicyNever,
+					Containers: []api.Container{
+						{
+							Image: "foo:V1",
+							Resources: api.ResourceRequirements{
+								Limits: getResourceLimits("100m", "0"),
+							},
+						},
+					},
+				},
+			},
+			api.Pod{
+				ObjectMeta: api.ObjectMeta{Name: "foo"},
+				Spec: api.PodSpec{
+					RestartPolicy: api.RestartPolicyNever,
+					Containers: []api.Container{
+						{
+							Image: "foo:V2",
+							Resources: api.ResourceRequirements{
+								Limits: getResourceLimits("1000m", "0"),
+							},
+						},
+					},
+				},
+			},
 			false,
-			"cpu change",
+			"cpu change with restartPolicy: Never",
 		},
 		{
 			api.Pod{


### PR DESCRIPTION
As discussed in #5774, the patch loosen validation of pod update and allow resources to be updated.
