### PR TITLE
Revert "Set GOMAXPROCS for etcd"

### DIFF
--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -1,5 +1,3 @@
-{% set num_cpus = salt['grains.get']('num_cpus', '') %}
-
 {
 "apiVersion": "v1beta3",
 "kind": "Pod",
@@ -31,10 +29,6 @@
       { "name": "varetcd",
         "mountPath": "/var/etcd",
         "readOnly": false}
-        ],
-    "env": [
-      { "name": "GOMAXPROCS",
-        "value": "{{num_cpus}}"}
         ]
        }
 ],


### PR DESCRIPTION
@wojtek-t 

Apparently in many cases this causes that CPU in a large cluster is saturated and as a result more requests are longer than 1s.

Reverts GoogleCloudPlatform/kubernetes#7863
