### PR TITLE
Remove the use of secrets from node level logging agents

### DIFF
--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
@@ -14,9 +14,6 @@ spec:
       mountPath: /varlog
     - name: containers
       mountPath: /var/lib/docker/containers
-    - name: token-system-logging
-      mountPath: /etc/token-system-logging
-      readOnly: true
   volumes:
   - name: varlog
     hostPath:
@@ -24,6 +21,4 @@ spec:
   - name: containers
     hostPath:
       path: /var/lib/docker/containers
-  - name: token-system-logging
-    secret:
-      secretName: token-system-logging
+

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -14,9 +14,6 @@ spec:
       mountPath: /varlog
     - name: containers
       mountPath: /var/lib/docker/containers
-    - name: token-system-logging
-      mountPath: /etc/token-system-logging
-      readOnly: true
   volumes:
   - name: varlog
     hostPath:
@@ -24,6 +21,4 @@ spec:
   - name: containers
     hostPath:
       path: /var/lib/docker/containers
-  - name: token-system-logging
-    secret:
-      secretName: token-system-logging
+


### PR DESCRIPTION
To temporarily cure the issue #8180 while we get to the bottom of what is going on.
This removes the use of the secret `token-system-logging` from the Fluentd to Elastiscsearch and Fluentd to Cloud Logging agents because these mirror pods are no longer allowed to access secrets.
This is a safe removal because I have not yet added the refinements to these pods that would have used the secrets to make apiserver calls to get label metadata.
