### PR TITLE
Changing the implementation of DeepCopy to use reflection

### DIFF
--- a/pkg/api/copy_test.go
+++ b/pkg/api/copy_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api_test
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
+	apitesting "github.com/GoogleCloudPlatform/kubernetes/pkg/api/testing"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
+)
+
+func TestDeepCopyApiObjects(t *testing.T) {
+	for i := 0; i < *fuzzIters; i++ {
+		for _, version := range []string{"", testapi.Version()} {
+			f := apitesting.FuzzerFor(t, version, rand.NewSource(rand.Int63()))
+			for kind := range api.Scheme.KnownTypes(version) {
+				item, err := api.Scheme.New(version, kind)
+				if err != nil {
+					t.Fatalf("Could not create a %s: %s", kind, err)
+				}
+				f.Fuzz(item)
+				itemCopy, err := conversion.DeepCopy(item)
+				if err != nil {
+					t.Errorf("Could not deep copy a %s: %s", kind, err)
+					continue
+				}
+
+				if !reflect.DeepEqual(item, itemCopy) {
+					t.Errorf("expected %#v\ngot %#v", item, itemCopy)
+				}
+			}
+		}
+	}
+}

--- a/pkg/conversion/deep_copy_test.go
+++ b/pkg/conversion/deep_copy_test.go
@@ -108,6 +108,24 @@ func TestDeepCopyPointerSeparate(t *testing.T) {
 	}
 }
 
+func TestDeepCopyStruct(t *testing.T) {
+	type Foo struct {
+		A int
+	}
+	type Bar struct {
+		Foo
+		F *Foo
+	}
+	a := &Bar{Foo{1}, &Foo{2}}
+	b := copyOrDie(t, a).(*Bar)
+	a.A = 3
+	a.F.A = 4
+
+	if b.A != 1 || b.F.A != 2 {
+		t.Errorf("deep copy wasn't deep: %#v, %#v", a, b)
+	}
+}
+
 var result interface{}
 
 func BenchmarkDeepCopy(b *testing.B) {


### PR DESCRIPTION
The Gob encode/decode method did not properly handle pointers to primitive types as discussed in #8054.
