### PR TITLE
Monit watch kubelet and kube-proxy on master node too.

### DIFF
--- a/cluster/saltbase/salt/monit/init.sls
+++ b/cluster/saltbase/salt/monit/init.sls
@@ -12,7 +12,6 @@ monit:
     - group: root
     - mode: 644
 
-{% if "kubernetes-pool" in grains.get('roles', []) %}
 /etc/monit/conf.d/kubelet:
   file:
     - managed
@@ -28,7 +27,6 @@ monit:
     - user: root
     - group: root
     - mode: 644
-{% endif %}
 
 monit-service:
   service:


### PR DESCRIPTION
I manually tested it against a running cluster by killing kubelet. After kube push, kubelet is restarted by monit.

cc @zmerlynn 
#8171
