### PR TITLE
Conversion tool was not able to build v1 conversions

### DIFF
--- a/cmd/kube-conversion/conversion.go
+++ b/cmd/kube-conversion/conversion.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta2"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"


### PR DESCRIPTION
No one is able to build conversion_generated.go files for v1 without this change.
