### PR TITLE
Cleanup some todos for gke + rip out dead code

### DIFF
--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -105,15 +105,6 @@ if [[ "$KUBERNETES_PROVIDER" == "gke" ]]; then
   config=(
     "--context=gke_${PROJECT}_${ZONE}_${CLUSTER_NAME}"
   )
-  # In gcloud versions prior to 0.9.59, GKE stores its kubeconfig
-  # in a separate location. If the file doesn't exist, then use
-  # the default kubeconfig file.
-  # TODO(roberthbailey): Remove this once gcloud 0.9.59 or above is released.
-  if [[ -e "${HOME}/.config/gcloud/kubernetes/kubeconfig" ]]; then
-    config+=(
-      "--kubeconfig=${HOME}/.config/gcloud/kubernetes/kubeconfig"
-    )
-  fi
 elif [[ "$KUBERNETES_PROVIDER" == "ubuntu" ]]; then
   detect-master > /dev/null
   config=(

--- a/cmd/e2e/e2e.go
+++ b/cmd/e2e/e2e.go
@@ -45,7 +45,6 @@ func init() {
 
 	flag.StringVar(&context.KubeConfig, clientcmd.RecommendedConfigPathFlag, "", "Path to kubeconfig containing embeded authinfo.")
 	flag.StringVar(&context.KubeContext, clientcmd.FlagContext, "", "kubeconfig context to use/override. If unset, will use value from 'current-context'")
-	flag.StringVar(&context.AuthConfig, "auth-config", "", "Path to the auth info file.")
 	flag.StringVar(&context.CertDir, "cert-dir", "", "Path to the directory containing the certs. Default is empty, which doesn't use certs.")
 	flag.StringVar(&context.Host, "host", "", "The host, or apiserver, to connect to")
 	flag.StringVar(&context.RepoRoot, "repo-root", "./", "Root directory of kubernetes repository, for finding test files. Default assumes working directory is repository root")

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -34,7 +34,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/clientauth"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
@@ -55,7 +54,6 @@ const (
 type TestContextType struct {
 	KubeConfig  string
 	KubeContext string
-	AuthConfig  string
 	CertDir     string
 	Host        string
 	RepoRoot    string
@@ -180,26 +178,8 @@ func loadConfig() (*client.Config, error) {
 			c.CurrentContext = testContext.KubeContext
 		}
 		return clientcmd.NewDefaultClientConfig(*c, &clientcmd.ConfigOverrides{}).ClientConfig()
-	case testContext.AuthConfig != "":
-		fmt.Printf(">>> testContext.AuthConfig: %s\n", testContext.AuthConfig)
-		config := &client.Config{
-			Host: testContext.Host,
-		}
-		info, err := clientauth.LoadFromFile(testContext.AuthConfig)
-		if err != nil {
-			return nil, fmt.Errorf("error loading AuthConfig: %v", err.Error())
-		}
-		// If the certificate directory is provided, set the cert paths to be there.
-		if testContext.CertDir != "" {
-			Logf("Expecting certs in %v.", testContext.CertDir)
-			info.CAFile = filepath.Join(testContext.CertDir, "ca.crt")
-			info.CertFile = filepath.Join(testContext.CertDir, "kubecfg.crt")
-			info.KeyFile = filepath.Join(testContext.CertDir, "kubecfg.key")
-		}
-		mergedConfig, err := info.MergeWithConfig(*config)
-		return &mergedConfig, err
 	default:
-		return nil, fmt.Errorf("either KubeConfig or AuthConfig must be specified to load client config")
+		return nil, fmt.Errorf("KubeConfig must be specified to load client config")
 	}
 }
 


### PR DESCRIPTION
Resolve todos blocked by gcloud 0.9.60 (it's out now). Also gets rid of AuthConfig uses in e2e driver that are not used anymore.

Don't merge yet, e2e in progress.
