### PR TITLE
Fix GCE kube-down incorrect MIG delete OpID

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -653,14 +653,14 @@ function kube-down {
     "${NODE_INSTANCE_PREFIX}-group")
   if [[ "$deleteCmdOutput" != ""  ]]; then
     # Managed instance group deletion is done asyncronously, we must wait for it to complete, or subsequent steps fail
-    deleteCmdOperationId=$(echo $deleteCmdOutput | grep "Operation:" | sed "s/.*Operation:\s//" | sed "s/\s.*//" | sed "s/ //g")
+    deleteCmdOperationId=$(echo $deleteCmdOutput | grep "Operation:" | sed "s/.*Operation:[[:space:]]*\([^[:space:]]*\).*/\1/g")
     if [[ "$deleteCmdOperationId" != ""  ]]; then
       deleteCmdStatus="PENDING"
       while [[ "$deleteCmdStatus" != "DONE" ]]
       do
-	sleep 5
+        sleep 5
         deleteCmdOperationOutput=$(gcloud preview managed-instance-groups --zone "${ZONE}" get-operation $deleteCmdOperationId)
-        deleteCmdStatus=$(echo $deleteCmdOperationOutput | grep -i "status:" | sed "s/.*status:\s//" | sed "s/\s.*//" | sed "s/ //g")
+        deleteCmdStatus=$(echo $deleteCmdOperationOutput | grep -i "status:" | sed "s/.*status:[[:space:]]*\([^[:space:]]*\).*/\1/g")
         echo "Waiting for MIG deletion to complete. Current status: " $deleteCmdStatus
       done
     fi


### PR DESCRIPTION
Fixes #8193

PR #8096 was relying on GNU `sed` behavior to work correctly, so it would break when run from OS X. Fix is to limit ourselves to POSIX `sed` features

Tested on Ubuntu with `sed`, `sed --posix` and on OS X.

CC @quinton-hoole and @roberthbailey 
