### PR TITLE
Remove 'auth-path' in the arguments for kubelet.

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -178,7 +178,6 @@ if [[ -z "${DOCKERIZE_KUBELET}" ]]; then
     --hostname_override="127.0.0.1" \
     --address="127.0.0.1" \
     --api_servers="${API_HOST}:${API_PORT}" \
-    --auth_path="${KUBE_ROOT}/hack/.test-cmd-auth" \
     --port="$KUBELET_PORT" >"${KUBELET_LOG}" 2>&1 &
   KUBELET_PID=$!
 else


### PR DESCRIPTION
Otherwise kubelet will fail to create the client because it can't
find the nonexisting auth file.
