### PR TITLE
Remove /Validate endpoint

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -157,12 +157,6 @@ func (g *APIGroupVersion) InstallREST(container *restful.Container) error {
 	return errors.NewAggregate(registrationErrors)
 }
 
-// TODO: This endpoint is deprecated and should be removed at some point.
-// Use "componentstatus" API instead.
-func InstallValidator(mux Mux, servers func() map[string]Server) {
-	mux.Handle("/validate", NewValidator(servers))
-}
-
 // TODO: document all handlers
 // InstallSupport registers the APIServer support functions
 func InstallSupport(mux Mux, ws *restful.WebService) {

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -36,18 +36,7 @@ func TestGetServersToValidate(t *testing.T) {
 
 	master.nodeRegistry = registrytest.NewMinionRegistry([]string{"node1", "node2"}, api.NodeResources{})
 
-	servers := master.getServersToValidate(&config, true)
-
-	if len(servers) != 7 {
-		t.Errorf("unexpected server list: %#v", servers)
-	}
-	for _, server := range []string{"scheduler", "controller-manager", "etcd-0", "etcd-1", "etcd-2", "node-0", "node-1"} {
-		if _, ok := servers[server]; !ok {
-			t.Errorf("server list missing: %s", server)
-		}
-	}
-
-	servers = master.getServersToValidate(&config, false)
+	servers := master.getServersToValidate(&config)
 
 	if len(servers) != 5 {
 		t.Errorf("unexpected server list: %#v", servers)


### PR DESCRIPTION
This is one step towards fixing #2462. GKE no longer uses the validate endpoint, and its been deprecated for a couple weeks now, so I want to chop it off.
