### PR TITLE
Admission control to prevent exec on privileged pods

### DIFF
--- a/cmd/kube-apiserver/app/plugins.go
+++ b/cmd/kube-apiserver/app/plugins.go
@@ -32,6 +32,7 @@ import (
 	// Admission policies
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/admit"
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/deny"
+	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/exec/denyprivileged"
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/limitranger"
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/namespace/autoprovision"
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/namespace/exists"

--- a/pkg/admission/attributes.go
+++ b/pkg/admission/attributes.go
@@ -25,12 +25,12 @@ type attributesRecord struct {
 	kind      string
 	namespace string
 	resource  string
-	operation string
+	operation Operation
 	object    runtime.Object
 	userInfo  user.Info
 }
 
-func NewAttributesRecord(object runtime.Object, kind, namespace, resource, operation string, userInfo user.Info) Attributes {
+func NewAttributesRecord(object runtime.Object, kind, namespace, resource string, operation Operation, userInfo user.Info) Attributes {
 	return &attributesRecord{
 		kind:      kind,
 		namespace: namespace,
@@ -53,7 +53,7 @@ func (record *attributesRecord) GetResource() string {
 	return record.resource
 }
 
-func (record *attributesRecord) GetOperation() string {
+func (record *attributesRecord) GetOperation() Operation {
 	return record.operation
 }
 

--- a/pkg/admission/chain_test.go
+++ b/pkg/admission/chain_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"fmt"
+	"testing"
+)
+
+type FakeHandler struct {
+	*Handler
+	name        string
+	admit       bool
+	admitCalled bool
+}
+
+func (h *FakeHandler) Admit(a Attributes) (err error) {
+	h.admitCalled = true
+	if h.admit {
+		return nil
+	}
+	return fmt.Errorf("Don't admit")
+}
+
+func makeHandler(name string, admit bool, ops ...Operation) Interface {
+	return &FakeHandler{
+		name:    name,
+		admit:   admit,
+		Handler: NewHandler(ops...),
+	}
+}
+
+func TestAdmit(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation Operation
+		chain     chainAdmissionHandler
+		accept    bool
+		calls     map[string]bool
+	}{
+		{
+			name:      "all accept",
+			operation: Create,
+			chain: []Interface{
+				makeHandler("a", true, Update, Delete, Create),
+				makeHandler("b", true, Delete, Create),
+				makeHandler("c", true, Create),
+			},
+			calls:  map[string]bool{"a": true, "b": true, "c": true},
+			accept: true,
+		},
+		{
+			name:      "ignore handler",
+			operation: Create,
+			chain: []Interface{
+				makeHandler("a", true, Update, Delete, Create),
+				makeHandler("b", false, Delete),
+				makeHandler("c", true, Create),
+			},
+			calls:  map[string]bool{"a": true, "c": true},
+			accept: true,
+		},
+		{
+			name:      "ignore all",
+			operation: Connect,
+			chain: []Interface{
+				makeHandler("a", true, Update, Delete, Create),
+				makeHandler("b", false, Delete),
+				makeHandler("c", true, Create),
+			},
+			calls:  map[string]bool{},
+			accept: true,
+		},
+		{
+			name:      "reject one",
+			operation: Delete,
+			chain: []Interface{
+				makeHandler("a", true, Update, Delete, Create),
+				makeHandler("b", false, Delete),
+				makeHandler("c", true, Create),
+			},
+			calls:  map[string]bool{"a": true, "b": true},
+			accept: false,
+		},
+	}
+	for _, test := range tests {
+		err := test.chain.Admit(NewAttributesRecord(nil, "", "", "", test.operation, nil))
+		accepted := (err == nil)
+		if accepted != test.accept {
+			t.Errorf("%s: unexpected result of admit call: %v\n", test.name, accepted)
+		}
+		for _, h := range test.chain {
+			fake := h.(*FakeHandler)
+			_, shouldBeCalled := test.calls[fake.name]
+			if shouldBeCalled != fake.admitCalled {
+				t.Errorf("%s: handler %s not called as expected: %v", test.name, fake.name, fake.admitCalled)
+				continue
+			}
+		}
+	}
+}
+
+func TestHandles(t *testing.T) {
+	chain := chainAdmissionHandler{
+		makeHandler("a", true, Update, Delete, Create),
+		makeHandler("b", true, Delete, Create),
+		makeHandler("c", true, Create),
+	}
+
+	tests := []struct {
+		name      string
+		operation Operation
+		chain     chainAdmissionHandler
+		expected  bool
+	}{
+		{
+			name:      "all handle",
+			operation: Create,
+			expected:  true,
+		},
+		{
+			name:      "none handle",
+			operation: Connect,
+			expected:  false,
+		},
+		{
+			name:      "some handle",
+			operation: Delete,
+			expected:  true,
+		},
+	}
+	for _, test := range tests {
+		handles := chain.Handles(test.operation)
+		if handles != test.expected {
+			t.Errorf("Unexpected handles result. Expected: %v. Actual: %v", test.expected, handles)
+		}
+	}
+}

--- a/pkg/admission/handler.go
+++ b/pkg/admission/handler.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+// Handler is a base for admission control handlers that
+// support a predefined set of operations
+type Handler struct {
+	operations util.StringSet
+}
+
+// Handles returns true for methods that this handler supports
+func (h *Handler) Handles(operation Operation) bool {
+	return h.operations.Has(string(operation))
+}
+
+// NewHandler creates a new base handler that handles the passed
+// in operations
+func NewHandler(ops ...Operation) *Handler {
+	operations := util.NewStringSet()
+	for _, op := range ops {
+		operations.Insert(string(op))
+	}
+	return &Handler{
+		operations: operations,
+	}
+}

--- a/pkg/admission/interfaces.go
+++ b/pkg/admission/interfaces.go
@@ -26,7 +26,7 @@ import (
 type Attributes interface {
 	GetNamespace() string
 	GetResource() string
-	GetOperation() string
+	GetOperation() Operation
 	GetObject() runtime.Object
 	GetKind() string
 	GetUserInfo() user.Info
@@ -36,4 +36,19 @@ type Attributes interface {
 type Interface interface {
 	// Admit makes an admission decision based on the request attributes
 	Admit(a Attributes) (err error)
+
+	// Handles returns true if this admission controller can handle the given operation
+	// where operation can be one of CREATE, UPDATE, DELETE, or CONNECT
+	Handles(operation Operation) bool
 }
+
+// Operation is the type of resource operation being checked for admission control
+type Operation string
+
+// Operation constants
+const (
+	Create  Operation = "CREATE"
+	Update  Operation = "UPDATE"
+	Delete  Operation = "DELETE"
+	Connect Operation = "CONNECT"
+)

--- a/pkg/api/rest/rest.go
+++ b/pkg/api/rest/rest.go
@@ -246,3 +246,18 @@ type StorageMetadata interface {
 	// PATCH) can respond with.
 	ProducesMIMETypes(verb string) []string
 }
+
+// ConnectRequest is an object passed to admission control for Connect operations
+type ConnectRequest struct {
+	// Name is the name of the object on which the connect request was made
+	Name string
+
+	// Options is the options object passed to the connect request. See the NewConnectOptions method on Connecter
+	Options runtime.Object
+
+	// ResourcePath is the path for the resource in the REST server (ie. "pods/proxy")
+	ResourcePath string
+}
+
+// IsAnAPIObject makes ConnectRequest a runtime.Object
+func (*ConnectRequest) IsAnAPIObject() {}

--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -539,7 +539,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		case "CONNECT":
 			for _, method := range connecter.ConnectMethods() {
 				route := ws.Method(method).Path(action.Path).
-					To(ConnectResource(connecter, reqScope, connectOptionsKind, connectSubpath, connectSubpathKey)).
+					To(ConnectResource(connecter, reqScope, admit, connectOptionsKind, path, connectSubpath, connectSubpathKey)).
 					Filter(m).
 					Doc("connect " + method + " requests to " + kind).
 					Operation("connect" + method + kind).

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -293,11 +293,13 @@ func createHandler(r rest.NamedCreater, scope RequestScope, typer runtime.Object
 			return
 		}
 
-		userInfo, _ := api.UserFrom(ctx)
-		err = admit.Admit(admission.NewAttributesRecord(obj, scope.Kind, namespace, scope.Resource, "CREATE", userInfo))
-		if err != nil {
-			errorJSON(err, scope.Codec, w)
-			return
+		if admit.Handles(admission.Create) {
+			userInfo, _ := api.UserFrom(ctx)
+			err = admit.Admit(admission.NewAttributesRecord(obj, scope.Kind, namespace, scope.Resource, admission.Create, userInfo))
+			if err != nil {
+				errorJSON(err, scope.Codec, w)
+				return
+			}
 		}
 
 		result, err := finishRequest(timeout, func() (runtime.Object, error) {
@@ -361,11 +363,13 @@ func PatchResource(r rest.Patcher, scope RequestScope, typer runtime.ObjectTyper
 		ctx = api.WithNamespace(ctx, namespace)
 
 		// PATCH requires same permission as UPDATE
-		userInfo, _ := api.UserFrom(ctx)
-		err = admit.Admit(admission.NewAttributesRecord(obj, scope.Kind, namespace, scope.Resource, "UPDATE", userInfo))
-		if err != nil {
-			errorJSON(err, scope.Codec, w)
-			return
+		if admit.Handles(admission.Update) {
+			userInfo, _ := api.UserFrom(ctx)
+			err = admit.Admit(admission.NewAttributesRecord(obj, scope.Kind, namespace, scope.Resource, admission.Update, userInfo))
+			if err != nil {
+				errorJSON(err, scope.Codec, w)
+				return
+			}
 		}
 
 		versionedObj, err := converter.ConvertToVersion(obj, scope.APIVersion)
@@ -459,11 +463,13 @@ func UpdateResource(r rest.Updater, scope RequestScope, typer runtime.ObjectType
 			return
 		}
 
-		userInfo, _ := api.UserFrom(ctx)
-		err = admit.Admit(admission.NewAttributesRecord(obj, scope.Kind, namespace, scope.Resource, "UPDATE", userInfo))
-		if err != nil {
-			errorJSON(err, scope.Codec, w)
-			return
+		if admit.Handles(admission.Update) {
+			userInfo, _ := api.UserFrom(ctx)
+			err = admit.Admit(admission.NewAttributesRecord(obj, scope.Kind, namespace, scope.Resource, admission.Update, userInfo))
+			if err != nil {
+				errorJSON(err, scope.Codec, w)
+				return
+			}
 		}
 
 		wasCreated := false
@@ -521,11 +527,13 @@ func DeleteResource(r rest.GracefulDeleter, checkBody bool, scope RequestScope, 
 			}
 		}
 
-		userInfo, _ := api.UserFrom(ctx)
-		err = admit.Admit(admission.NewAttributesRecord(nil, scope.Kind, namespace, scope.Resource, "DELETE", userInfo))
-		if err != nil {
-			errorJSON(err, scope.Codec, w)
-			return
+		if admit.Handles(admission.Delete) {
+			userInfo, _ := api.UserFrom(ctx)
+			err = admit.Admit(admission.NewAttributesRecord(nil, scope.Kind, namespace, scope.Resource, admission.Delete, userInfo))
+			if err != nil {
+				errorJSON(err, scope.Codec, w)
+				return
+			}
 		}
 
 		result, err := finishRequest(timeout, func() (runtime.Object, error) {

--- a/plugin/pkg/admission/admit/admission.go
+++ b/plugin/pkg/admission/admit/admission.go
@@ -37,6 +37,11 @@ func (alwaysAdmit) Admit(a admission.Attributes) (err error) {
 	return nil
 }
 
+func (alwaysAdmit) Handles(operation admission.Operation) bool {
+	return true
+}
+
+// NewAlwaysAdmit creates a new always admit admission handler
 func NewAlwaysAdmit() admission.Interface {
 	return new(alwaysAdmit)
 }

--- a/plugin/pkg/admission/deny/admission.go
+++ b/plugin/pkg/admission/deny/admission.go
@@ -38,6 +38,11 @@ func (alwaysDeny) Admit(a admission.Attributes) (err error) {
 	return admission.NewForbidden(a, errors.New("Admission control is denying all modifications"))
 }
 
+func (alwaysDeny) Handles(operation admission.Operation) bool {
+	return true
+}
+
+// NewAlwaysDeny creates an always deny admission handler
 func NewAlwaysDeny() admission.Interface {
 	return new(alwaysDeny)
 }

--- a/plugin/pkg/admission/exec/denyprivileged/admission.go
+++ b/plugin/pkg/admission/exec/denyprivileged/admission.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package denyprivileged
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+)
+
+func init() {
+	admission.RegisterPlugin("DenyExecOnPrivileged", func(client client.Interface, config io.Reader) (admission.Interface, error) {
+		return NewDenyExecOnPrivileged(client), nil
+	})
+}
+
+// denyExecOnPrivileged is an implementation of admission.Interface which says no to a pod/exec on
+// a privileged pod
+type denyExecOnPrivileged struct {
+	*admission.Handler
+	client client.Interface
+}
+
+func (d *denyExecOnPrivileged) Admit(a admission.Attributes) (err error) {
+	connectRequest, ok := a.GetObject().(*rest.ConnectRequest)
+	if !ok {
+		return errors.NewBadRequest("a connect request was received, but could not convert the request object.")
+	}
+	// Only handle exec requests on pods
+	if connectRequest.ResourcePath != "pods/exec" {
+		return nil
+	}
+	pod, err := d.client.Pods(a.GetNamespace()).Get(connectRequest.Name)
+	if err != nil {
+		return admission.NewForbidden(a, err)
+	}
+	if isPrivileged(pod) {
+		return admission.NewForbidden(a, fmt.Errorf("Cannot exec into a privileged container"))
+	}
+	return nil
+}
+
+// isPrivileged will return true a pod has any privileged containers
+func isPrivileged(pod *api.Pod) bool {
+	for _, c := range pod.Spec.Containers {
+		if c.SecurityContext == nil {
+			continue
+		}
+		if *c.SecurityContext.Privileged {
+			return true
+		}
+	}
+	return false
+}
+
+// NewDenyExecOnPrivileged creates a new admission controller that denies an exec operation on a privileged pod
+func NewDenyExecOnPrivileged(client client.Interface) admission.Interface {
+	return &denyExecOnPrivileged{
+		Handler: admission.NewHandler(admission.Connect),
+		client:  client,
+	}
+}

--- a/plugin/pkg/admission/exec/denyprivileged/admission_test.go
+++ b/plugin/pkg/admission/exec/denyprivileged/admission_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package denyprivileged
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+)
+
+// TestAdmission verifies a namespace is created on create requests for namespace managed resources
+func TestAdmissionAccept(t *testing.T) {
+	testAdmission(t, acceptPod("podname"), true)
+}
+
+func TestAdmissionDeny(t *testing.T) {
+	testAdmission(t, denyPod("podname"), false)
+}
+
+func testAdmission(t *testing.T, pod *api.Pod, shouldAccept bool) {
+	mockClient := &testclient.Fake{
+		ReactFn: func(action testclient.FakeAction) (runtime.Object, error) {
+			if action.Action == "get-pod" && action.Value.(string) == pod.Name {
+				return pod, nil
+			}
+			t.Errorf("Unexpected API call: %#v", action)
+			return nil, nil
+		},
+	}
+	handler := &denyExecOnPrivileged{
+		client: mockClient,
+	}
+	req := &rest.ConnectRequest{Name: pod.Name, ResourcePath: "pods/exec"}
+	err := handler.Admit(admission.NewAttributesRecord(req, "Pod", "test", "pods", admission.Connect, nil))
+	if shouldAccept && err != nil {
+		t.Errorf("Unexpected error returned from admission handler: %v", err)
+	}
+	if !shouldAccept && err == nil {
+		t.Errorf("An error was expected from the admission handler. Received nil")
+	}
+
+}
+
+func acceptPod(name string) *api.Pod {
+	return &api.Pod{
+		ObjectMeta: api.ObjectMeta{Name: name, Namespace: "test"},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{Name: "ctr1", Image: "image"},
+				{Name: "ctr2", Image: "image2"},
+			},
+		},
+	}
+}
+
+func denyPod(name string) *api.Pod {
+	privileged := true
+	return &api.Pod{
+		ObjectMeta: api.ObjectMeta{Name: name, Namespace: "test"},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{Name: "ctr1", Image: "image"},
+				{
+					Name:  "ctr2",
+					Image: "image2",
+					SecurityContext: &api.SecurityContext{
+						Privileged: &privileged,
+					},
+				},
+			},
+		},
+	}
+}

--- a/plugin/pkg/admission/namespace/autoprovision/admission_test.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission_test.go
@@ -41,7 +41,7 @@ func TestAdmission(t *testing.T) {
 			Containers: []api.Container{{Name: "ctr", Image: "image"}},
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(&pod, "Pod", namespace, "pods", "CREATE", nil))
+	err := handler.Admit(admission.NewAttributesRecord(&pod, "Pod", namespace, "pods", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler")
 	}
@@ -72,7 +72,7 @@ func TestAdmissionNamespaceExists(t *testing.T) {
 			Containers: []api.Container{{Name: "ctr", Image: "image"}},
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(&pod, "Pod", namespace, "pods", "CREATE", nil))
+	err := handler.Admit(admission.NewAttributesRecord(&pod, "Pod", namespace, "pods", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler")
 	}
@@ -85,10 +85,7 @@ func TestAdmissionNamespaceExists(t *testing.T) {
 func TestIgnoreAdmission(t *testing.T) {
 	namespace := "test"
 	mockClient := &testclient.Fake{}
-	handler := &provision{
-		client: mockClient,
-		store:  cache.NewStore(cache.MetaNamespaceKeyFunc),
-	}
+	handler := admission.NewChainHandler(createProvision(mockClient, nil))
 	pod := api.Pod{
 		ObjectMeta: api.ObjectMeta{Name: "123", Namespace: namespace},
 		Spec: api.PodSpec{
@@ -96,7 +93,7 @@ func TestIgnoreAdmission(t *testing.T) {
 			Containers: []api.Container{{Name: "ctr", Image: "image"}},
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(&pod, "Pod", namespace, "pods", "UPDATE", nil))
+	err := handler.Admit(admission.NewAttributesRecord(&pod, "Pod", namespace, "pods", admission.Update, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler")
 	}
@@ -123,7 +120,7 @@ func TestAdmissionNamespaceExistsUnknownToHandler(t *testing.T) {
 			Containers: []api.Container{{Name: "ctr", Image: "image"}},
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(&pod, "Pod", namespace, "pods", "CREATE", nil))
+	err := handler.Admit(admission.NewAttributesRecord(&pod, "Pod", namespace, "pods", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler")
 	}

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -42,6 +42,7 @@ func init() {
 // It rejects all incoming requests in a namespace context if the namespace does not exist.
 // It is useful in deployments that want to enforce pre-declaration of a Namespace resource.
 type exists struct {
+	*admission.Handler
 	client client.Interface
 	store  cache.Store
 }
@@ -75,6 +76,7 @@ func (e *exists) Admit(a admission.Attributes) (err error) {
 	return admission.NewForbidden(a, fmt.Errorf("Namespace %s does not exist", a.GetNamespace()))
 }
 
+// NewExists creates a new namespace exists admission control handler
 func NewExists(c client.Interface) admission.Interface {
 	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
 	reflector := cache.NewReflector(
@@ -92,7 +94,8 @@ func NewExists(c client.Interface) admission.Interface {
 	)
 	reflector.Run()
 	return &exists{
-		client: c,
-		store:  store,
+		client:  c,
+		store:   store,
+		Handler: admission.NewHandler(admission.Create, admission.Update, admission.Delete),
 	}
 }

--- a/plugin/pkg/admission/securitycontext/scdeny/admission.go
+++ b/plugin/pkg/admission/securitycontext/scdeny/admission.go
@@ -34,20 +34,21 @@ func init() {
 
 // plugin contains the client used by the SecurityContextDeny admission controller
 type plugin struct {
+	*admission.Handler
 	client client.Interface
 }
 
 // NewSecurityContextDeny creates a new instance of the SecurityContextDeny admission controller
 func NewSecurityContextDeny(client client.Interface) admission.Interface {
-	return &plugin{client}
+	return &plugin{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+		client:  client,
+	}
 }
 
 // Admit will deny any SecurityContext that defines options that were not previously available in the api.Container
 // struct (Capabilities and Privileged)
 func (p *plugin) Admit(a admission.Attributes) (err error) {
-	if a.GetOperation() == "DELETE" {
-		return nil
-	}
 	if a.GetResource() != string(api.ResourcePods) {
 		return nil
 	}

--- a/plugin/pkg/admission/securitycontext/scdeny/admission_test.go
+++ b/plugin/pkg/admission/securitycontext/scdeny/admission_test.go
@@ -63,3 +63,19 @@ func TestAdmission(t *testing.T) {
 		}
 	}
 }
+
+func TestHandles(t *testing.T) {
+	handler := NewSecurityContextDeny(nil)
+	tests := map[admission.Operation]bool{
+		admission.Update:  true,
+		admission.Create:  true,
+		admission.Delete:  false,
+		admission.Connect: false,
+	}
+	for op, expected := range tests {
+		result := handler.Handles(op)
+		if result != expected {
+			t.Errorf("Unexpected result for operation %s: %v\n", op, result)
+		}
+	}
+}

--- a/plugin/pkg/admission/serviceaccount/admission_test.go
+++ b/plugin/pkg/admission/serviceaccount/admission_test.go
@@ -29,9 +29,10 @@ import (
 
 func TestIgnoresNonCreate(t *testing.T) {
 	pod := &api.Pod{}
-	for _, op := range []string{"UPDATE", "DELETE", "CUSTOM"} {
+	for _, op := range []admission.Operation{admission.Update, admission.Delete, admission.Connect} {
 		attrs := admission.NewAttributesRecord(pod, "Pod", "myns", string(api.ResourcePods), op, nil)
-		err := NewServiceAccount(nil).Admit(attrs)
+		handler := admission.NewChainHandler(NewServiceAccount(nil))
+		err := handler.Admit(attrs)
 		if err != nil {
 			t.Errorf("Expected %s operation allowed, got err: %v", op, err)
 		}
@@ -40,7 +41,7 @@ func TestIgnoresNonCreate(t *testing.T) {
 
 func TestIgnoresNonPodResource(t *testing.T) {
 	pod := &api.Pod{}
-	attrs := admission.NewAttributesRecord(pod, "Pod", "myns", "CustomResource", "CREATE", nil)
+	attrs := admission.NewAttributesRecord(pod, "Pod", "myns", "CustomResource", admission.Create, nil)
 	err := NewServiceAccount(nil).Admit(attrs)
 	if err != nil {
 		t.Errorf("Expected non-pod resource allowed, got err: %v", err)
@@ -48,7 +49,7 @@ func TestIgnoresNonPodResource(t *testing.T) {
 }
 
 func TestIgnoresNilObject(t *testing.T) {
-	attrs := admission.NewAttributesRecord(nil, "Pod", "myns", string(api.ResourcePods), "CREATE", nil)
+	attrs := admission.NewAttributesRecord(nil, "Pod", "myns", string(api.ResourcePods), admission.Create, nil)
 	err := NewServiceAccount(nil).Admit(attrs)
 	if err != nil {
 		t.Errorf("Expected nil object allowed allowed, got err: %v", err)
@@ -57,7 +58,7 @@ func TestIgnoresNilObject(t *testing.T) {
 
 func TestIgnoresNonPodObject(t *testing.T) {
 	obj := &api.Namespace{}
-	attrs := admission.NewAttributesRecord(obj, "Pod", "myns", string(api.ResourcePods), "CREATE", nil)
+	attrs := admission.NewAttributesRecord(obj, "Pod", "myns", string(api.ResourcePods), admission.Create, nil)
 	err := NewServiceAccount(nil).Admit(attrs)
 	if err != nil {
 		t.Errorf("Expected non pod object allowed, got err: %v", err)
@@ -77,7 +78,7 @@ func TestIgnoresMirrorPod(t *testing.T) {
 			},
 		},
 	}
-	attrs := admission.NewAttributesRecord(pod, "Pod", "myns", string(api.ResourcePods), "CREATE", nil)
+	attrs := admission.NewAttributesRecord(pod, "Pod", "myns", string(api.ResourcePods), admission.Create, nil)
 	err := NewServiceAccount(nil).Admit(attrs)
 	if err != nil {
 		t.Errorf("Expected mirror pod without service account or secrets allowed, got err: %v", err)
@@ -95,7 +96,7 @@ func TestRejectsMirrorPodWithServiceAccount(t *testing.T) {
 			ServiceAccount: "default",
 		},
 	}
-	attrs := admission.NewAttributesRecord(pod, "Pod", "myns", string(api.ResourcePods), "CREATE", nil)
+	attrs := admission.NewAttributesRecord(pod, "Pod", "myns", string(api.ResourcePods), admission.Create, nil)
 	err := NewServiceAccount(nil).Admit(attrs)
 	if err == nil {
 		t.Errorf("Expected a mirror pod to be prevented from referencing a service account")
@@ -115,7 +116,7 @@ func TestRejectsMirrorPodWithSecretVolumes(t *testing.T) {
 			},
 		},
 	}
-	attrs := admission.NewAttributesRecord(pod, "Pod", "myns", string(api.ResourcePods), "CREATE", nil)
+	attrs := admission.NewAttributesRecord(pod, "Pod", "myns", string(api.ResourcePods), admission.Create, nil)
 	err := NewServiceAccount(nil).Admit(attrs)
 	if err == nil {
 		t.Errorf("Expected a mirror pod to be prevented from referencing a secret volume")
@@ -137,7 +138,7 @@ func TestAssignsDefaultServiceAccountAndToleratesMissingAPIToken(t *testing.T) {
 	})
 
 	pod := &api.Pod{}
-	attrs := admission.NewAttributesRecord(pod, "Pod", ns, string(api.ResourcePods), "CREATE", nil)
+	attrs := admission.NewAttributesRecord(pod, "Pod", ns, string(api.ResourcePods), admission.Create, nil)
 	err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -161,7 +162,7 @@ func TestFetchesUncachedServiceAccount(t *testing.T) {
 	admit := NewServiceAccount(client)
 
 	pod := &api.Pod{}
-	attrs := admission.NewAttributesRecord(pod, "Pod", ns, string(api.ResourcePods), "CREATE", nil)
+	attrs := admission.NewAttributesRecord(pod, "Pod", ns, string(api.ResourcePods), admission.Create, nil)
 	err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -180,7 +181,7 @@ func TestDeniesInvalidServiceAccount(t *testing.T) {
 	admit := NewServiceAccount(client)
 
 	pod := &api.Pod{}
-	attrs := admission.NewAttributesRecord(pod, "Pod", ns, string(api.ResourcePods), "CREATE", nil)
+	attrs := admission.NewAttributesRecord(pod, "Pod", ns, string(api.ResourcePods), admission.Create, nil)
 	err := admit.Admit(attrs)
 	if err == nil {
 		t.Errorf("Expected error for missing service account, got none")
@@ -242,7 +243,7 @@ func TestAutomountsAPIToken(t *testing.T) {
 			},
 		},
 	}
-	attrs := admission.NewAttributesRecord(pod, "Pod", ns, string(api.ResourcePods), "CREATE", nil)
+	attrs := admission.NewAttributesRecord(pod, "Pod", ns, string(api.ResourcePods), admission.Create, nil)
 	err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -391,7 +392,7 @@ func TestRejectsUnreferencedSecretVolumes(t *testing.T) {
 			},
 		},
 	}
-	attrs := admission.NewAttributesRecord(pod, "Pod", ns, string(api.ResourcePods), "CREATE", nil)
+	attrs := admission.NewAttributesRecord(pod, "Pod", ns, string(api.ResourcePods), admission.Create, nil)
 	err := admit.Admit(attrs)
 	if err == nil {
 		t.Errorf("Expected rejection for using a secret the service account does not reference")


### PR DESCRIPTION
Add admission control to the CONNECT action in the API server and create an admission controller that will deny pod/exec to pods with privileged containers.
