### PR TITLE
add client for podTemplate resource

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -31,6 +31,7 @@ import (
 // an interface to allow mock testing.
 type Interface interface {
 	PodsNamespacer
+	PodTemplatesNamespacer
 	ReplicationControllersNamespacer
 	ServicesNamespacer
 	EndpointsNamespacer
@@ -65,6 +66,10 @@ func (c *Client) Endpoints(namespace string) EndpointsInterface {
 
 func (c *Client) Pods(namespace string) PodInterface {
 	return newPods(c, namespace)
+}
+
+func (c *Client) PodTemplates(namespace string) PodTemplateInterface {
+	return newPodTemplates(c, namespace)
 }
 
 func (c *Client) Services(namespace string) ServiceInterface {

--- a/pkg/client/pod_templates.go
+++ b/pkg/client/pod_templates.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// PodTemplatesNamespacer has methods to work with PodTemplate resources in a namespace
+type PodTemplatesNamespacer interface {
+	PodTemplates(namespace string) PodTemplateInterface
+}
+
+// PodTemplateInterface has methods to work with PodTemplate resources.
+type PodTemplateInterface interface {
+	List(label labels.Selector, field fields.Selector) (*api.PodTemplateList, error)
+	Get(name string) (*api.PodTemplate, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Create(podTemplate *api.PodTemplate) (*api.PodTemplate, error)
+	Update(podTemplate *api.PodTemplate) (*api.PodTemplate, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// podTemplates implements PodTemplatesNamespacer interface
+type podTemplates struct {
+	r  *Client
+	ns string
+}
+
+// newPodTemplates returns a podTemplates
+func newPodTemplates(c *Client, namespace string) *podTemplates {
+	return &podTemplates{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+// List takes label and field selectors, and returns the list of podTemplates that match those selectors.
+func (c *podTemplates) List(label labels.Selector, field fields.Selector) (result *api.PodTemplateList, err error) {
+	result = &api.PodTemplateList{}
+	err = c.r.Get().Namespace(c.ns).Resource("podTemplates").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	return
+}
+
+// Get takes the name of the podTemplate, and returns the corresponding PodTemplate object, and an error if it occurs
+func (c *podTemplates) Get(name string) (result *api.PodTemplate, err error) {
+	result = &api.PodTemplate{}
+	err = c.r.Get().Namespace(c.ns).Resource("podTemplates").Name(name).Do().Into(result)
+	return
+}
+
+// Delete takes the name of the podTemplate, and returns an error if one occurs
+func (c *podTemplates) Delete(name string, options *api.DeleteOptions) error {
+	// TODO: to make this reusable in other client libraries
+	if options == nil {
+		return c.r.Delete().Namespace(c.ns).Resource("podTemplates").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.r.APIVersion())
+	if err != nil {
+		return err
+	}
+	return c.r.Delete().Namespace(c.ns).Resource("podTemplates").Name(name).Body(body).Do().Error()
+}
+
+// Create takes the representation of a podTemplate.  Returns the server's representation of the podTemplate, and an error, if it occurs.
+func (c *podTemplates) Create(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
+	result = &api.PodTemplate{}
+	err = c.r.Post().Namespace(c.ns).Resource("podTemplates").Body(podTemplate).Do().Into(result)
+	return
+}
+
+// Update takes the representation of a podTemplate to update.  Returns the server's representation of the podTemplate, and an error, if it occurs.
+func (c *podTemplates) Update(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
+	result = &api.PodTemplate{}
+	err = c.r.Put().Namespace(c.ns).Resource("podTemplates").Name(podTemplate.Name).Body(podTemplate).Do().Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested podTemplates.
+func (c *podTemplates) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("podTemplates").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}

--- a/pkg/client/pod_templates_test.go
+++ b/pkg/client/pod_templates_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+)
+
+func getPodTemplatesResoureName() string {
+	return "podtemplates"
+}
+
+func TestPodTemplateCreate(t *testing.T) {
+	if api.PreV1Beta3(testapi.Version()) {
+		return
+	}
+
+	ns := api.NamespaceDefault
+	podTemplate := api.PodTemplate{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: ns,
+		},
+		Template: api.PodTemplateSpec{},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.ResourcePath(getPodTemplatesResoureName(), ns, ""),
+			Query:  buildQueryValues(ns, nil),
+			Body:   &podTemplate,
+		},
+		Response: Response{StatusCode: 200, Body: &podTemplate},
+	}
+
+	response, err := c.Setup().PodTemplates(ns).Create(&podTemplate)
+	c.Validate(t, response, err)
+}
+
+func TestPodTemplateGet(t *testing.T) {
+	if api.PreV1Beta3(testapi.Version()) {
+		return
+	}
+
+	ns := api.NamespaceDefault
+	podTemplate := &api.PodTemplate{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: ns,
+		},
+		Template: api.PodTemplateSpec{},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.ResourcePath(getPodTemplatesResoureName(), ns, "abc"),
+			Query:  buildQueryValues(ns, nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: podTemplate},
+	}
+
+	response, err := c.Setup().PodTemplates(ns).Get("abc")
+	c.Validate(t, response, err)
+}
+
+func TestPodTemplateList(t *testing.T) {
+	if api.PreV1Beta3(testapi.Version()) {
+		return
+	}
+
+	ns := api.NamespaceDefault
+	podTemplateList := &api.PodTemplateList{
+		Items: []api.PodTemplate{
+			{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: ns,
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.ResourcePath(getPodTemplatesResoureName(), ns, ""),
+			Query:  buildQueryValues(ns, nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: podTemplateList},
+	}
+	response, err := c.Setup().PodTemplates(ns).List(labels.Everything(), fields.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestPodTemplateUpdate(t *testing.T) {
+	if api.PreV1Beta3(testapi.Version()) {
+		return
+	}
+
+	ns := api.NamespaceDefault
+	podTemplate := &api.PodTemplate{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			Namespace:       ns,
+			ResourceVersion: "1",
+		},
+		Template: api.PodTemplateSpec{},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.ResourcePath(getPodTemplatesResoureName(), ns, "abc"), Query: buildQueryValues(ns, nil)},
+		Response: Response{StatusCode: 200, Body: podTemplate},
+	}
+	response, err := c.Setup().PodTemplates(ns).Update(podTemplate)
+	c.Validate(t, response, err)
+}
+
+func TestPodTemplateDelete(t *testing.T) {
+	if api.PreV1Beta3(testapi.Version()) {
+		return
+	}
+
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.ResourcePath(getPodTemplatesResoureName(), ns, "foo"), Query: buildQueryValues(ns, nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup().PodTemplates(ns).Delete("foo", nil)
+	c.Validate(t, nil, err)
+}
+
+func TestPodTemplateWatch(t *testing.T) {
+	if api.PreV1Beta3(testapi.Version()) {
+		return
+	}
+
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   "/api/" + testapi.Version() + "/watch/" + getPodTemplatesResoureName(),
+			Query:  url.Values{"resourceVersion": []string{}}},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup().PodTemplates(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/pkg/client/testclient/fake_pod_templates.go
+++ b/pkg/client/testclient/fake_pod_templates.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// FakePodTemplates implements PodTemplatesInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakePodTemplates struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakePodTemplates) List(label labels.Selector, field fields.Selector) (*api.PodTemplateList, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "list-podTemplates"}, &api.PodTemplateList{})
+	return obj.(*api.PodTemplateList), err
+}
+
+func (c *FakePodTemplates) Get(name string) (*api.PodTemplate, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "get-podTemplate", Value: name}, &api.PodTemplate{})
+	return obj.(*api.PodTemplate), err
+}
+
+func (c *FakePodTemplates) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.Invokes(FakeAction{Action: "delete-podTemplate", Value: name}, &api.PodTemplate{})
+	return err
+}
+
+func (c *FakePodTemplates) Create(pod *api.PodTemplate) (*api.PodTemplate, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "create-podTemplate"}, &api.PodTemplate{})
+	return obj.(*api.PodTemplate), err
+}
+
+func (c *FakePodTemplates) Update(pod *api.PodTemplate) (*api.PodTemplate, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "update-podTemplate", Value: pod.Name}, &api.PodTemplate{})
+	return obj.(*api.PodTemplate), err
+}
+
+func (c *FakePodTemplates) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-podTemplates", Value: resourceVersion})
+	return c.Fake.Watch, c.Fake.Err
+}

--- a/pkg/client/testclient/testclient.go
+++ b/pkg/client/testclient/testclient.go
@@ -103,6 +103,10 @@ func (c *Fake) Pods(namespace string) client.PodInterface {
 	return &FakePods{Fake: c, Namespace: namespace}
 }
 
+func (c *Fake) PodTemplates(namespace string) client.PodTemplateInterface {
+	return &FakePodTemplates{Fake: c, Namespace: namespace}
+}
+
 func (c *Fake) Services(namespace string) client.ServiceInterface {
 	return &FakeServices{Fake: c, Namespace: namespace}
 }


### PR DESCRIPTION
I use kubeclient for my tool and need interface for podTemplate. It is not yet used inside but would be used somewhere soon.
NOTE: The tests skip v1beta1 API because it seems to be disabled for v1beta1/v1beta2 explicitly.
