### PR TITLE
Allow ServiceAccountsController to manage multiple named service accounts

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -263,7 +263,7 @@ func (s *CMServer) Run(_ []string) error {
 
 	serviceaccount.NewServiceAccountsController(
 		kubeClient,
-		serviceaccount.DefaultServiceAccountControllerOptions(),
+		serviceaccount.DefaultServiceAccountsControllerOptions(),
 	).Run()
 
 	select {}

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -423,7 +423,7 @@ func startServiceAccountTestServer(t *testing.T) (*client.Client, client.Config,
 	// Start the service account and service account token controllers
 	tokenController := serviceaccount.NewTokensController(rootClient, serviceaccount.DefaultTokenControllerOptions(serviceaccount.JWTTokenGenerator(serviceAccountKey)))
 	tokenController.Run()
-	serviceAccountController := serviceaccount.NewServiceAccountsController(rootClient, serviceaccount.DefaultServiceAccountControllerOptions())
+	serviceAccountController := serviceaccount.NewServiceAccountsController(rootClient, serviceaccount.DefaultServiceAccountsControllerOptions())
 	serviceAccountController.Run()
 	// Start the admission plugin reflectors
 	serviceAccountAdmission.Run()


### PR DESCRIPTION
Doesn't change default behavior (single managed service account named "default"), but allows the controller to manage multiple named service accounts per namespace
