### PR TITLE
Collect and monitor concurrent request counts

### DIFF
--- a/pkg/apiserver/proxy.go
+++ b/pkg/apiserver/proxy.go
@@ -56,7 +56,8 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var apiResource string
 	var httpCode int
 	reqStart := time.Now()
-	defer monitor(&verb, &apiResource, util.GetClient(req), &httpCode, reqStart)
+	preRequestMonitor(&verb, &apiResource, util.GetClient(req))
+	defer postRequestMonitor(&verb, &apiResource, util.GetClient(req), &httpCode, reqStart)
 
 	requestInfo, err := r.apiRequestInfoResolver.GetAPIRequestInfo(req)
 	if err != nil {

--- a/pkg/apiserver/redirect.go
+++ b/pkg/apiserver/redirect.go
@@ -40,7 +40,8 @@ func (r *RedirectHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var apiResource string
 	var httpCode int
 	reqStart := time.Now()
-	defer monitor(&verb, &apiResource, util.GetClient(req), &httpCode, reqStart)
+	preRequestMonitor(&verb, &apiResource, util.GetClient(req))
+	defer postRequestMonitor(&verb, &apiResource, util.GetClient(req), &httpCode, reqStart)
 
 	requestInfo, err := r.apiRequestInfoResolver.GetAPIRequestInfo(req)
 	if err != nil {

--- a/pkg/apiserver/validator.go
+++ b/pkg/apiserver/validator.go
@@ -102,7 +102,8 @@ func (v *validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	apiResource := ""
 	var httpCode int
 	reqStart := time.Now()
-	defer monitor(&verb, &apiResource, util.GetClient(r), &httpCode, reqStart)
+	preRequestMonitor(&verb, &apiResource, util.GetClient(r))
+	defer postRequestMonitor(&verb, &apiResource, util.GetClient(r), &httpCode, reqStart)
 
 	reply := []ServerStatus{}
 	for name, server := range v.servers() {


### PR DESCRIPTION
This is easy enough to do and pretty useful in debugging density.

Example output:

```
INFO: WARNING: At 2015-05-13 21:58:43.269503692 -0700 PDT LIST Exceeded limit 78
INFO:   -- 0 concurrent nodes LIST from client kubectl/v0.17.0 (linux/amd64) kubernetes/939d950
INFO:   -- 0 concurrent services LIST from client kubectl/v0.17.0 (linux/amd64) kubernetes/939d950
INFO:   -- 73 concurrent pods LIST from client kubelet/v0.17.0 (linux/amd64) kubernetes/939d950
INFO:   -- 0 concurrent events LIST from client heapster/v0.15.0 (linux/amd64) kubernetes/unknown
```

@fgrzadkowski @wojtek-t 
@lavalamp fyi
