### PR TITLE
refresh aws getting-started pages and templates

### DIFF
--- a/docs/getting-started-guides/README.md
+++ b/docs/getting-started-guides/README.md
@@ -20,7 +20,7 @@ Bare-metal     | custom       | Fedora | flannel   | [docs](../../docs/getting-s
 libvirt        | custom       | Fedora | flannel   | [docs](../../docs/getting-started-guides/fedora/flannel_multi_node_cluster.md) | Community ([@aveshagarwal](https://github.com/aveshagarwal))| Tested with 0.15.0
 KVM            | custom       | Fedora | flannel   | [docs](../../docs/getting-started-guides/fedora/flannel_multi_node_cluster.md) | Community ([@aveshagarwal](https://github.com/aveshagarwal))| Tested with 0.15.0
 Mesos/GCE      |              |        |             | [docs](../../docs/getting-started-guides/mesos.md)     | [Community](https://github.com/mesosphere/kubernetes-mesos) ([@jdef](https://github.com/jdef)) | Uses K8s v0.11.2
-AWS            | CoreOS       | CoreOS | flannel     | [docs](../../docs/getting-started-guides/coreos.md)    | Community                    | Uses K8s version 0.16.1
+AWS            | CoreOS       | CoreOS | flannel     | [docs](../../docs/getting-started-guides/coreos.md)    | Community                    | Uses K8s version 0.17.0
 GCE            | CoreOS       | CoreOS | flannel     | [docs](../../docs/getting-started-guides/coreos.md)    | Community (@kelseyhightower) | Uses K8s version 0.15.0
 Vagrant        | CoreOS       | CoreOS | flannel     | [docs](../../docs/getting-started-guides/coreos.md)    | Community ( [@pires](https://github.com/pires), [@AntonioMeireles](https://github.com/AntonioMeireles) )           | Uses K8s version 0.15.0
 Bare-metal (Offline) | CoreOS       | CoreOS | flannel      | [docs](../../docs/getting-started-guides/coreos/bare_metal_offline.md) | Community([@jeffbean](https://github.com/jeffbean))    | Uses K8s version 0.15.0

--- a/docs/getting-started-guides/aws.md
+++ b/docs/getting-started-guides/aws.md
@@ -1,38 +1,52 @@
-## Getting started on AWS
+# Getting started on AWS EC2
 
-### Prerequisites
+## Prerequisites
 
 1. You need an AWS account. Visit [http://aws.amazon.com](http://aws.amazon.com) to get started
 2. Install and configure [AWS Command Line Interface](http://aws.amazon.com/cli)
 3. You need an AWS [instance profile and role](http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html) with EC2 full access.
 
-### Cluster turnup
-
-Using ```wget```
-```sh
+## Cluster turnup
+### Supported procedure: `get-kube`
+```bash
+#Using wget
 export KUBERNETES_PROVIDER=aws; wget -q -O - https://get.k8s.io | bash
-```
 
-or if you prefer ```curl```
-
-```sh
+#Using cURL
 export KUBERNETES_PROVIDER=aws; curl -sS https://get.k8s.io | bash
 ```
 
 NOTE: This script calls [cluster/kube-up.sh](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/cluster/kube-up.sh)
 which in turn calls [cluster/aws/util.sh](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/cluster/aws/util.sh)
 using [cluster/aws/config-default.sh](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/cluster/aws/config-default.sh).
-By default, the script will provision a new VPC and a 4 node k8s cluster in us-west-2 (Oregon). It'll also try to create or reuse
-a keypair called "kubernetes", and IAM profiles called "kubernetes-master" and "kubernetes-minion".  If these already exist, make
-sure you want them to be used here. You can override the variables defined in config-default.sh to change this behavior.
 
-Once the cluster is up, it will print the ip address of your cluster, this process takes about 5 to 10 minutes.
+This process takes about 5 to 10 minutes. Once the cluster is up, the IP addresses of your master and node(s) will be printed,
+as well as information about the default services running in the cluster (monitoring, logging, dns). User credentials and security
+tokens are written in `~/.kube/kubeconfig`, they will be necessary to use the CLI or the HTTP Basic Auth.
 
+By default, the script will provision a new VPC and a 4 node k8s cluster in us-west-2a (Oregon) with `t2.micro` instances running on Ubuntu.
+You can override the variables defined in [config-default.sh](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/cluster/aws/config-default.sh) to change this behavior as follows:
+
+```bash
+export KUBE_AWS_ZONE=eu-west-1c
+export NUM_MINIONS=2
+export MINION_SIZE=m3.medium
+export AWS_S3_REGION=eu-west-1
+export AWS_S3_BUCKET=mycompany-kubernetes-artifacts
+export INSTANCE_PREFIX=k8s
+...
 ```
-export KUBERNETES_MASTER=https://<ip-address>
-```
 
-Copy the appropriate ```kubectl``` binary to somewhere in your ```PATH```, for example:
+It will also try to create or reuse a keypair called "kubernetes", and IAM profiles called "kubernetes-master" and "kubernetes-minion".
+If these already exist, make sure you want them to be used here.
+
+### Alternatives
+A contributed [example](aws-coreos.md) allows you to setup a Kubernetes cluster based on [CoreOS](http://www.coreos.com), either using
+AWS CloudFormation or EC2 with user data (cloud-config).
+
+## Getting started with your cluster
+### Command line administration tool: `kubectl`
+Copy the appropriate `kubectl` binary to any location defined in your `PATH` environment variable, for example:
 
 ```bash
 # OS X
@@ -42,24 +56,26 @@ sudo cp kubernetes/platforms/darwin/amd64/kubectl /usr/local/bin/kubectl
 sudo cp kubernetes/platforms/linux/amd64/kubectl /usr/local/bin/kubectl
 ```
 
+An up-to-date documentation page for this tool is available here: [kubectl manual](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/kubectl.md)
 
-### Getting started with your cluster
-See [a simple nginx example](../../examples/simple-nginx.md) to try out your new cluster.
+By default, `kubectl` will use the `kubeconfig` file generated during the cluster startup for authenticating against the API.
+For more information, please read [kubeconfig files](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/kubeconfig-file.md)
 
-For more complete applications, please look in the [examples directory](../../examples)
+### Examples
+See [a simple nginx example](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/examples/simple-nginx.md) to try out your new cluster.
 
-### Tearing down the cluster
+The "Guestbook" application is another popular example to get started with Kubernetes: [guestbook example](https://github.com/GoogleCloudPlatform/kubernetes/tree/master/examples/guestbook)
+
+For more complete applications, please look in the [examples directory](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/examples)
+
+## Tearing down the cluster
+Make sure the environment variables you used to provision your cluster are still exported, then call the following script inside the
+`kubernetes` directory:
+
 ```bash
-cd kubernetes
 cluster/kube-down.sh
 ```
 
-### Running examples
-
-Take a look at [next steps](https://github.com/GoogleCloudPlatform/kubernetes/tree/master/examples/guestbook)
-
-### Cloud Formation [optional]
-There is a contributed [example](aws-coreos.md) from [CoreOS](http://www.coreos.com) using Cloud Formation.
-
-### Further reading
-Please see the [Kubernetes docs](https://github.com/GoogleCloudPlatform/kubernetes/tree/master/docs) for more details on administering and using a Kubernetes cluster.
+## Further reading
+Please see the [Kubernetes docs](https://github.com/GoogleCloudPlatform/kubernetes/tree/master/docs) for more details on administering
+and using a Kubernetes cluster.

--- a/docs/getting-started-guides/aws/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/aws/cloud-configs/master.yaml
@@ -100,7 +100,7 @@ coreos:
         After=network-online.target
 
         [Service]
-        ExecStart=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.16.1/bin/linux/amd64/kubectl
+        ExecStart=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kubectl
         ExecStart=/usr/bin/chmod +x /opt/bin/kubectl
         Type=oneshot
         RemainAfterExit=true
@@ -114,7 +114,7 @@ coreos:
         After=etcd2-waiter.service
 
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.16.1/bin/linux/amd64/kube-apiserver
+        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kube-apiserver
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-apiserver
         ExecStart=/opt/bin/kube-apiserver \
         --insecure-bind-address=0.0.0.0 \
@@ -132,7 +132,7 @@ coreos:
         After=kube-apiserver.service
 
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.16.1/bin/linux/amd64/kube-controller-manager
+        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kube-controller-manager
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-controller-manager
         ExecStart=/opt/bin/kube-controller-manager \
         --master=127.0.0.1:8080
@@ -148,7 +148,7 @@ coreos:
         After=kube-apiserver.service
 
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.16.1/bin/linux/amd64/kube-scheduler
+        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kube-scheduler
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-scheduler
         ExecStart=/opt/bin/kube-scheduler \
         --master=127.0.0.1:8080

--- a/docs/getting-started-guides/aws/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/aws/cloud-configs/node.yaml
@@ -48,7 +48,7 @@ coreos:
         After=network-online.target
 
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.16.1/bin/linux/amd64/kubelet
+        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kubelet
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kubelet
         # wait for kubernetes master to be up and ready
         ExecStartPre=/opt/bin/wupiao <master-private-ip> 8080
@@ -67,7 +67,7 @@ coreos:
         After=network-online.target
 
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.16.1/bin/linux/amd64/kube-proxy
+        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kube-proxy
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
         # wait for kubernetes master to be up and ready
         ExecStartPre=/opt/bin/wupiao <master-private-ip> 8080

--- a/docs/getting-started-guides/aws/cloudformation-template.json
+++ b/docs/getting-started-guides/aws/cloudformation-template.json
@@ -1,37 +1,37 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "Kubernetes 0.16.1 on EC2 powered by CoreOS 668.2.0 (alpha)",
+  "Description": "Kubernetes 0.17.0 on EC2 powered by CoreOS 681.0.0 (alpha)",
   "Mappings": {
       "RegionMap": {
           "eu-central-1" : {
-              "AMI" : "ami-5a330c47"
+              "AMI" : "ami-4c4f7151"
           },
           "ap-northeast-1" : {
-              "AMI" : "ami-905c9f90"
+              "AMI" : "ami-3a35fd3a"
           },
           "us-gov-west-1" : {
-              "AMI" : "ami-d1debff2"
+              "AMI" : "ami-57117174"
           },
           "sa-east-1" : {
-              "AMI" : "ami-d365e1ce"
+              "AMI" : "ami-fbcc4ae6"
           },
           "ap-southeast-2" : {
-              "AMI" : "ami-7db5c947"
+              "AMI" : "ami-593c4263"
           },
           "ap-southeast-1" : {
-              "AMI" : "ami-06c8f454"
+              "AMI" : "ami-3a083668"
           },
           "us-east-1" : {
-              "AMI" : "ami-2cd3dc44"
+              "AMI" : "ami-40322028"
           },
           "us-west-2" : {
-              "AMI" : "ami-69447259"
+              "AMI" : "ami-23b58613"
           },
           "us-west-1" : {
-              "AMI" : "ami-d524c891"
+              "AMI" : "ami-15618f51"
           },
           "eu-west-1" : {
-              "AMI" : "ami-c5b7d8b2"
+              "AMI" : "ami-8d1164fa"
           }
       }
   },
@@ -243,7 +243,7 @@
           "        Requires=network-online.target\n",
           "        After=network-online.target\n\n",
           "        [Service]\n",
-          "        ExecStart=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.16.1/bin/linux/amd64/kubectl\n",
+          "        ExecStart=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kubectl\n",
           "        ExecStart=/usr/bin/chmod +x /opt/bin/kubectl\n",
           "        Type=oneshot\n",
           "        RemainAfterExit=true\n",
@@ -256,7 +256,7 @@
           "        Requires=etcd2-waiter.service\n",
           "        After=etcd2-waiter.service\n\n",
           "        [Service]\n",
-          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.16.1/bin/linux/amd64/kube-apiserver\n",
+          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kube-apiserver\n",
           "        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-apiserver\n",
           "        ExecStart=/opt/bin/kube-apiserver \\\n",
           "        --insecure-bind-address=0.0.0.0 \\\n",
@@ -273,7 +273,7 @@
           "        Requires=kube-apiserver.service\n",
           "        After=kube-apiserver.service\n\n",
           "        [Service]\n",
-          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.16.1/bin/linux/amd64/kube-controller-manager\n",
+          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kube-controller-manager\n",
           "        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-controller-manager\n",
           "        ExecStart=/opt/bin/kube-controller-manager \\\n",
           "        --master=127.0.0.1:8080\n",
@@ -288,7 +288,7 @@
           "        Requires=kube-apiserver.service\n",
           "        After=kube-apiserver.service\n\n",
           "        [Service]\n",
-          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.16.1/bin/linux/amd64/kube-scheduler\n",
+          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kube-scheduler\n",
           "        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-scheduler\n",
           "        ExecStart=/opt/bin/kube-scheduler \\\n",
           "        --master=127.0.0.1:8080\n",
@@ -367,7 +367,7 @@
           "        Requires=network-online.target\n",
           "        After=network-online.target\n\n",
           "        [Service]\n",
-          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.16.1/bin/linux/amd64/kubelet\n",
+          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kubelet\n",
           "        ExecStartPre=/usr/bin/chmod +x /opt/bin/kubelet\n",
           "        ExecStart=/opt/bin/kubelet \\\n",
           "        --api-servers=", {"Fn::GetAtt" :["KubernetesMasterInstance" , "PrivateIp"]}, ":8080 \\\n",
@@ -383,7 +383,7 @@
           "        Requires=network-online.target\n",
           "        After=network-online.target\n\n",
           "        [Service]\n",
-          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.16.1/bin/linux/amd64/kube-proxy\n",
+          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kube-proxy\n",
           "        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy\n",
           "        ExecStart=/opt/bin/kube-proxy \\\n",
           "        --master=http://", {"Fn::GetAtt" :["KubernetesMasterInstance" , "PrivateIp"]}, ":8080\n",

--- a/docs/getting-started-guides/aws/kubectl.md
+++ b/docs/getting-started-guides/aws/kubectl.md
@@ -1,28 +1,21 @@
 # Install and configure kubectl
 
 ## Download the kubectl CLI tool
-
+```bash
 ### Darwin
-
-```
-wget https://storage.googleapis.com/kubernetes-release/release/v0.10.1/bin/darwin/amd64/kubectl
-```
+wget https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/darwin/amd64/kubectl
 
 ### Linux
-
-```
-wget https://storage.googleapis.com/kubernetes-release/release/v0.10.1/bin/linux/amd64/kubectl
+wget https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kubectl
 ```
 
 ### Copy kubectl to your path
-
-```
+```bash
 chmod +x kubectl
 mv kubectl /usr/local/bin/
 ```
 
 ### Create a secure tunnel for API communication
-
-```
+```bash
 ssh -f -nNT -L 8080:127.0.0.1:8080 core@<master-public-ip>
 ```


### PR DESCRIPTION
"Getting started" guides for AWS were still mentioning k8s v0.10.1 in some places. On top of that I did a bit of reorganization and bumped the versions of k8s and CoreOS respectively to v0.17.0 and 681.0.0  in cloud-configs.
