### PR TITLE
Remove /podInfo endpoint on kubelet

### DIFF
--- a/pkg/client/kubelet.go
+++ b/pkg/client/kubelet.go
@@ -18,27 +18,18 @@ package client
 
 import (
 	"errors"
-	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
 	"strconv"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/probe"
 	httprobe "github.com/GoogleCloudPlatform/kubernetes/pkg/probe/http"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
-
-// ErrPodInfoNotAvailable may be returned when the requested pod info is not available.
-var ErrPodInfoNotAvailable = errors.New("no pod info available")
 
 // KubeletClient is an interface for all kubelet functionality
 type KubeletClient interface {
 	KubeletHealthChecker
-	PodInfoGetter
 	ConnectionInfoGetter
 }
 
@@ -47,19 +38,11 @@ type KubeletHealthChecker interface {
 	HealthCheck(host string) (probe.Result, error)
 }
 
-// PodInfoGetter is an interface for things that can get information about a pod's containers.
-// Injectable for easy testing.
-type PodInfoGetter interface {
-	// GetPodStatus returns information about all containers which are part
-	// Returns an api.PodStatus, or an error if one occurs.
-	GetPodStatus(host, podNamespace, podID string) (api.PodStatusResult, error)
-}
-
 type ConnectionInfoGetter interface {
 	GetConnectionInfo(host string) (scheme string, port uint, transport http.RoundTripper, error error)
 }
 
-// HTTPKubeletClient is the default implementation of PodInfoGetter and KubeletHealthchecker, accesses the kubelet over HTTP.
+// HTTPKubeletClient is the default implementation of KubeletHealthchecker, accesses the kubelet over HTTP.
 type HTTPKubeletClient struct {
 	Client      *http.Client
 	Port        uint
@@ -120,39 +103,6 @@ func (c *HTTPKubeletClient) url(host, path, query string) string {
 	}).String()
 }
 
-// GetPodInfo gets information about the specified pod.
-func (c *HTTPKubeletClient) GetPodStatus(host, podNamespace, podID string) (api.PodStatusResult, error) {
-	status := api.PodStatusResult{}
-	query := url.Values{"podID": {podID}, "podNamespace": {podNamespace}}
-	response, err := c.getEntity(host, "/api/v1beta1/podInfo", query.Encode(), &status)
-	if response != nil && response.StatusCode == http.StatusNotFound {
-		return status, ErrPodInfoNotAvailable
-	}
-	return status, err
-}
-
-// getEntity might return a nil response.
-func (c *HTTPKubeletClient) getEntity(host, path, query string, entity runtime.Object) (*http.Response, error) {
-	request, err := http.NewRequest("GET", c.url(host, path, query), nil)
-	if err != nil {
-		return nil, err
-	}
-	response, err := c.Client.Do(request)
-	if err != nil {
-		return response, err
-	}
-	defer response.Body.Close()
-	if response.StatusCode >= 300 || response.StatusCode < 200 {
-		return response, fmt.Errorf("kubelet %q server responded with HTTP error code %d", host, response.StatusCode)
-	}
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return response, err
-	}
-	err = latest.Codec.DecodeInto(body, entity)
-	return response, err
-}
-
 func (c *HTTPKubeletClient) HealthCheck(host string) (probe.Result, error) {
 	return httprobe.DoHTTPProbe(c.url(host, "/healthz", ""), c.Client)
 }
@@ -161,11 +111,6 @@ func (c *HTTPKubeletClient) HealthCheck(host string) (probe.Result, error) {
 // when called.  It is useful to pass to the master in a test configuration with
 // no kubelets.
 type FakeKubeletClient struct{}
-
-// GetPodInfo is a fake implementation of PodInfoGetter.GetPodInfo.
-func (c FakeKubeletClient) GetPodStatus(host, podNamespace string, podID string) (api.PodStatusResult, error) {
-	return api.PodStatusResult{}, errors.New("Not Implemented")
-}
 
 func (c FakeKubeletClient) HealthCheck(host string) (probe.Result, error) {
 	return probe.Unknown, errors.New("Not Implemented")

--- a/pkg/client/kubelet_test.go
+++ b/pkg/client/kubelet_test.go
@@ -25,20 +25,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/probe"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 func TestHTTPKubeletClient(t *testing.T) {
-	expectObj := api.PodStatusResult{
-		Status: api.PodStatus{
-			ContainerStatuses: []api.ContainerStatus{
-				{Name: "myID1"},
-				{Name: "myID2"},
-			},
-		},
-	}
+	expectObj := probe.Success
 	body, err := json.Marshal(expectObj)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -63,76 +55,21 @@ func TestHTTPKubeletClient(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	podInfoGetter := &HTTPKubeletClient{
+	c := &HTTPKubeletClient{
 		Client: http.DefaultClient,
 		Port:   uint(port),
 	}
-	gotObj, err := podInfoGetter.GetPodStatus(parts[0], api.NamespaceDefault, "foo")
+	gotObj, err := c.HealthCheck(parts[0])
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-
-	// reflect.DeepEqual(expectObj, gotObj) doesn't handle blank times well
-	if len(gotObj.Status.ContainerStatuses) != len(expectObj.Status.ContainerStatuses) {
-		t.Errorf("Unexpected response.  Expected: %#v, received %#v", expectObj, gotObj)
-	}
-}
-
-func TestHTTPKubeletClientNotFound(t *testing.T) {
-	expectObj := api.PodContainerInfo{
-		ContainerInfo: []api.ContainerStatus{
-			{
-				Name: "myID",
-			},
-		},
-	}
-	_, err := json.Marshal(expectObj)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	fakeHandler := util.FakeHandler{
-		StatusCode:   404,
-		ResponseBody: "Pod not found",
-	}
-	testServer := httptest.NewServer(&fakeHandler)
-	defer testServer.Close()
-
-	hostURL, err := url.Parse(testServer.URL)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	parts := strings.Split(hostURL.Host, ":")
-
-	port, err := strconv.Atoi(parts[1])
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	podInfoGetter := &HTTPKubeletClient{
-		Client: http.DefaultClient,
-		Port:   uint(port),
-	}
-	_, err = podInfoGetter.GetPodStatus(parts[0], api.NamespaceDefault, "foo")
-	if err != ErrPodInfoNotAvailable {
-		t.Errorf("Expected %#v, Got %#v", ErrPodInfoNotAvailable, err)
+	if gotObj != expectObj {
+		t.Errorf("expected: %#v, got %#v", expectObj, gotObj)
 	}
 }
 
 func TestHTTPKubeletClientError(t *testing.T) {
-	expectObj := api.PodContainerInfo{
-		ContainerInfo: []api.ContainerStatus{
-			{
-				Name: "myID",
-			},
-		},
-	}
-	_, err := json.Marshal(expectObj)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
+	expectObj := probe.Failure
 	fakeHandler := util.FakeHandler{
 		StatusCode:   500,
 		ResponseBody: "Internal server error",
@@ -152,13 +89,13 @@ func TestHTTPKubeletClientError(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	podInfoGetter := &HTTPKubeletClient{
+	c := &HTTPKubeletClient{
 		Client: http.DefaultClient,
 		Port:   uint(port),
 	}
-	_, err = podInfoGetter.GetPodStatus(parts[0], api.NamespaceDefault, "foo")
-	if err == nil || !strings.Contains(err.Error(), "HTTP error code 500") {
-		t.Errorf("unexpected error: %v", err)
+	gotObj, err := c.HealthCheck(parts[0])
+	if gotObj != expectObj {
+		t.Errorf("expected: %#v, got %#v", expectObj, gotObj)
 	}
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1520,7 +1520,7 @@ func (kl *Kubelet) validateContainerStatus(podStatus *api.PodStatus, containerNa
 // or all of them.
 func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName, tail string, follow, previous bool, stdout, stderr io.Writer) error {
 	// TODO(vmarmol): Refactor to not need the pod status and verification.
-	podStatus, err := kl.GetPodStatus(podFullName)
+	podStatus, err := kl.getPodStatus(podFullName)
 	if err != nil {
 		return fmt.Errorf("failed to get status for pod %q - %v", podFullName, err)
 	}
@@ -1846,9 +1846,9 @@ func getPodReadyCondition(spec *api.PodSpec, statuses []api.ContainerStatus) []a
 	return ready
 }
 
-// GetPodStatus returns information of the containers in the pod from the
+// getPodStatus returns information of the containers in the pod from the
 // container runtime.
-func (kl *Kubelet) GetPodStatus(podFullName string) (api.PodStatus, error) {
+func (kl *Kubelet) getPodStatus(podFullName string) (api.PodStatus, error) {
 	// Check to see if we have a cached version of the status.
 	cachedPodStatus, found := kl.statusManager.GetPodStatus(podFullName)
 	if found {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -3010,7 +3010,7 @@ func TestHandlePortConflicts(t *testing.T) {
 
 	kl.handleNotFittingPods(pods)
 	// Check pod status stored in the status map.
-	status, err := kl.GetPodStatus(conflictedPodName)
+	status, err := kl.getPodStatus(conflictedPodName)
 	if err != nil {
 		t.Fatalf("status of pod %q is not found in the status map: %#v", conflictedPodName, err)
 	}
@@ -3020,7 +3020,7 @@ func TestHandlePortConflicts(t *testing.T) {
 
 	// Check if we can retrieve the pod status from GetPodStatus().
 	kl.podManager.SetPods(pods)
-	status, err = kl.GetPodStatus(conflictedPodName)
+	status, err = kl.getPodStatus(conflictedPodName)
 	if err != nil {
 		t.Fatalf("unable to retrieve pod status for pod %q: %#v.", conflictedPodName, err)
 	}
@@ -3062,7 +3062,7 @@ func TestHandleNodeSelector(t *testing.T) {
 
 	kl.handleNotFittingPods(pods)
 	// Check pod status stored in the status map.
-	status, err := kl.GetPodStatus(notfittingPodName)
+	status, err := kl.getPodStatus(notfittingPodName)
 	if err != nil {
 		t.Fatalf("status of pod %q is not found in the status map: %#v", notfittingPodName, err)
 	}
@@ -3072,7 +3072,7 @@ func TestHandleNodeSelector(t *testing.T) {
 
 	// Check if we can retrieve the pod status from GetPodStatus().
 	kl.podManager.SetPods(pods)
-	status, err = kl.GetPodStatus(notfittingPodName)
+	status, err = kl.getPodStatus(notfittingPodName)
 	if err != nil {
 		t.Fatalf("unable to retrieve pod status for pod %q: %#v.", notfittingPodName, err)
 	}
@@ -3120,7 +3120,7 @@ func TestHandleMemExceeded(t *testing.T) {
 
 	kl.handleNotFittingPods(pods)
 	// Check pod status stored in the status map.
-	status, err := kl.GetPodStatus(notfittingPodName)
+	status, err := kl.getPodStatus(notfittingPodName)
 	if err != nil {
 		t.Fatalf("status of pod %q is not found in the status map: %#v", notfittingPodName, err)
 	}
@@ -3130,7 +3130,7 @@ func TestHandleMemExceeded(t *testing.T) {
 
 	// Check if we can retrieve the pod status from GetPodStatus().
 	kl.podManager.SetPods(pods)
-	status, err = kl.GetPodStatus(notfittingPodName)
+	status, err = kl.getPodStatus(notfittingPodName)
 	if err != nil {
 		t.Fatalf("unable to retrieve pod status for pod %q: %#v.", notfittingPodName, err)
 	}
@@ -3153,12 +3153,12 @@ func TestPurgingObsoleteStatusMapEntries(t *testing.T) {
 	}
 	// Run once to populate the status map.
 	kl.handleNotFittingPods(pods)
-	if _, err := kl.GetPodStatus(kubecontainer.BuildPodFullName("pod2", "")); err != nil {
+	if _, err := kl.getPodStatus(kubecontainer.BuildPodFullName("pod2", "")); err != nil {
 		t.Fatalf("expected to have status cached for %q: %v", "pod2", err)
 	}
 	// Sync with empty pods so that the entry in status map will be removed.
 	kl.SyncPods([]*api.Pod{}, emptyPodUIDs, map[string]*api.Pod{}, time.Now())
-	if _, err := kl.GetPodStatus(kubecontainer.BuildPodFullName("pod2", "")); err == nil {
+	if _, err := kl.getPodStatus(kubecontainer.BuildPodFullName("pod2", "")); err == nil {
 		t.Fatalf("expected to not have status cached for %q: %v", "pod2", err)
 	}
 }
@@ -4167,7 +4167,7 @@ func TestGetPodStatusWithLastTermination(t *testing.T) {
 
 		// Check if we can retrieve the pod status from GetPodStatus().
 		podName := kubecontainer.GetPodFullName(pods[0])
-		status, err := kubelet.GetPodStatus(podName)
+		status, err := kubelet.getPodStatus(podName)
 		if err != nil {
 			t.Fatalf("unable to retrieve pod status for pod %q: %#v.", podName, err)
 		} else {
@@ -4240,7 +4240,7 @@ func TestGetPodCreationFailureReason(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	status, err := kubelet.GetPodStatus(kubecontainer.GetPodFullName(pod))
+	status, err := kubelet.getPodStatus(kubecontainer.GetPodFullName(pod))
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -4306,7 +4306,7 @@ func TestGetPodPullImageFailureReason(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	status, err := kubelet.GetPodStatus(kubecontainer.GetPodFullName(pod))
+	status, err := kubelet.getPodStatus(kubecontainer.GetPodFullName(pod))
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}


### PR DESCRIPTION
Kubelet sends pod status updates to the API server now. This endpoint is no
longer needed.

This fixes #8280.
