### PR TITLE
e2e: pass namespace when calling kubectl stop

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -72,7 +72,7 @@ var _ = Describe("kubectl", func() {
 		)
 
 		It("should create and stop a replication controller", func() {
-			defer cleanup(nautilusPath, updateDemoSelector)
+			defer cleanup(nautilusPath, ns, updateDemoSelector)
 
 			By("creating a replication controller")
 			runKubectl("create", "-f", nautilusPath, fmt.Sprintf("--namespace=%v", ns))
@@ -80,7 +80,7 @@ var _ = Describe("kubectl", func() {
 		})
 
 		It("should scale a replication controller", func() {
-			defer cleanup(nautilusPath, updateDemoSelector)
+			defer cleanup(nautilusPath, ns, updateDemoSelector)
 
 			By("creating a replication controller")
 			runKubectl("create", "-f", nautilusPath, fmt.Sprintf("--namespace=%v", ns))
@@ -94,15 +94,13 @@ var _ = Describe("kubectl", func() {
 		})
 
 		It("should do a rolling update of a replication controller", func() {
-			// Cleanup all resources in case we fail somewhere in the middle
-			defer cleanup(updateDemoRoot, updateDemoSelector)
-
 			By("creating the initial replication controller")
 			runKubectl("create", "-f", nautilusPath, fmt.Sprintf("--namespace=%v", ns))
 			validateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
 			By("rolling-update to new replication controller")
 			runKubectl("rolling-update", "update-demo-nautilus", "--update-period=1s", "-f", kittenPath, fmt.Sprintf("--namespace=%v", ns))
 			validateController(c, kittenImage, 2, "update-demo", updateDemoSelector, getUDData("kitten.jpg", ns), ns)
+			// Everything will hopefully be cleaned up when the namespace is deleted.
 		})
 	})
 
@@ -115,7 +113,7 @@ var _ = Describe("kubectl", func() {
 				return
 			}
 
-			defer cleanup(guestbookPath, frontendSelector, redisMasterSelector, redisSlaveSelector)
+			defer cleanup(guestbookPath, ns, frontendSelector, redisMasterSelector, redisSlaveSelector)
 
 			By("creating all guestbook components")
 			runKubectl("create", "-f", guestbookPath, fmt.Sprintf("--namespace=%v", ns))

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -212,9 +212,9 @@ func expectNoError(err error, explain ...interface{}) {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), explain...)
 }
 
-func cleanup(filePath string, selectors ...string) {
-	By("using stop to clean up resources")
-	runKubectl("stop", "-f", filePath)
+func cleanup(filePath, namespace string, selectors ...string) {
+	By(fmt.Sprintf("using stop to clean up resources in namespace %v", namespace))
+	runKubectl("stop", "-f", filePath, fmt.Sprintf("--namespace=%v", namespace))
 
 	for _, selector := range selectors {
 		resources := runKubectl("get", "pods,rc,se", "-l", selector, "--no-headers")


### PR DESCRIPTION
After #7544, resources in the kubectl e2e test were being created in their own namespaces, but due to a bug introduced by #6194, `kubectl stop` was not failing, even though these resources did not exist in the default namespace, since the error was being ignored. This was not apparent until #8249 was merged, at which point it caused the `kubectl stop` calls in cleanup to fail.

This is now resolved by passing the namespace to kubectl in most of the test cases; in one case, I just removed the cleanup call entirely, as (I think) it's expected that one of the resources shouldn't exist, but I wasn't sure how best to handle that. Cleanup should still be handled adequately by the namespace being deleted, anyway.

Fixes #8300.
