### PR TITLE
Use the $NOTIFY_SOCKET convention for kube-apiserver startup

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -217,6 +217,22 @@ func newEtcd(etcdConfigFile string, etcdServerList util.StringList, storageVersi
 	return master.NewEtcdHelper(client, storageVersion, pathPrefix)
 }
 
+// Tells the service manager like systemd about startup. For further docs:
+// http://www.freedesktop.org/software/systemd/man/sd_notify.html
+func notifyReady() {
+	path := os.Getenv("NOTIFY_SOCKET")
+	if path != "" {
+		conn, err := net.DialUnix("unixgram", nil, &net.UnixAddr{Name: path, Net: "unix"})
+		if err == nil {
+			defer conn.Close()
+			_, err = conn.Write([]byte("READY=1\n"))
+		}
+		if err != nil {
+			glog.Warningf("unable to notify systemd about service ready state: %v", err)
+		}
+	}
+}
+
 // Run runs the specified APIServer.  This should never exit.
 func (s *APIServer) Run(_ []string) error {
 	s.verifyPortalFlags()
@@ -447,6 +463,9 @@ func (s *APIServer) Run(_ []string) error {
 						glog.Infof("Using self-signed cert (%s, %s)", s.TLSCertFile, s.TLSPrivateKeyFile)
 					}
 				}
+
+				notifyReady()
+
 				if err := secureServer.ListenAndServeTLS(s.TLSCertFile, s.TLSPrivateKeyFile); err != nil {
 					glog.Errorf("Unable to listen for secure (%v); will try again.", err)
 				}
@@ -463,6 +482,11 @@ func (s *APIServer) Run(_ []string) error {
 		MaxHeaderBytes: 1 << 20,
 	}
 	glog.Infof("Serving insecurely on %s", insecureLocation)
+
+	if secureLocation == "" {
+		notifyReady()
+	}
+
 	glog.Fatal(http.ListenAndServe())
 	return nil
 }

--- a/contrib/init/systemd/kube-apiserver.service
+++ b/contrib/init/systemd/kube-apiserver.service
@@ -18,6 +18,7 @@ ExecStart=/usr/bin/kube-apiserver \
 	    $KUBE_ADMISSION_CONTROL \
 	    $KUBE_API_ARGS
 Restart=on-failure
+Type=notify
 LimitNOFILE=65536
 
 [Install]


### PR DESCRIPTION
Use the systemd $NOTIFY_SOCKET convention for kube-apiserver
startup. This allows it to be part of dependency trees and for
consumers to wait until it is listening on its ports.

The $NOTIFY_SOCKET protocol is described here:

http://www.freedesktop.org/software/systemd/man/sd_notify.html

Currently this is limited to the kube-apiserver process. Other
kube processes are internal kubernetes moving points. The API
server is the entry point relied on by callers.
