### PR TITLE
coreos/azure: Kubernetes version bump to 0.17, various other fixes

### DIFF
--- a/docs/getting-started-guides/README.md
+++ b/docs/getting-started-guides/README.md
@@ -11,7 +11,7 @@ IaaS Provider  | Config. Mgmt | OS     | Networking  | Docs                     
 GKE            |              |        | GCE         | [docs](https://cloud.google.com/container-engine)      | Commercial                   | Uses K8s version 0.15.0
 Vagrant        | Saltstack    | Fedora | OVS         | [docs](../../docs/getting-started-guides/vagrant.md)   | Project                      | Uses latest via https://get.k8s.io/
 GCE            | Saltstack    | Debian | GCE         | [docs](../../docs/getting-started-guides/gce.md)       | Project                      | Tested with 0.15.0 by @robertbailey
-Azure          | CoreOS       | CoreOS | Weave       | [docs](../../docs/getting-started-guides/coreos/azure/README.md)         | Community ([@errordeveloper](https://github.com/errordeveloper), [@squillace](https://github.com/squillace), [@chanezon](https://github.com/chanezon), [@crossorigin](https://github.com/crossorigin)) | Uses K8s version 0.15.0
+Azure          | CoreOS       | CoreOS | Weave       | [docs](../../docs/getting-started-guides/coreos/azure/README.md)         | Community ([@errordeveloper](https://github.com/errordeveloper), [@squillace](https://github.com/squillace), [@chanezon](https://github.com/chanezon), [@crossorigin](https://github.com/crossorigin)) | Uses K8s version 0.17.0
 Docker Single Node | custom       | N/A    | local       | [docs](docker.md) | Project (@brendandburns) | Tested @ 0.14.1 |
 Docker Multi Node  | Flannel | N/A    | local       | [docs](docker-multinode.md) | Project (@brendandburns) | Tested @ 0.14.1 |
 Bare-metal     | Ansible      | Fedora | flannel     | [docs](../../docs/getting-started-guides/fedora/fedora_ansible_config.md)       | Project    | Uses K8s v0.13.2

--- a/docs/getting-started-guides/coreos/azure/cloud_config_templates/kubernetes-cluster-etcd-node-template.yml
+++ b/docs/getting-started-guides/coreos/azure/cloud_config_templates/kubernetes-cluster-etcd-node-template.yml
@@ -1,6 +1,16 @@
 ## This file is used as input to deployment script, which ammends it as needed.
 ## More specifically, we need to add peer hosts for each but the elected peer.
 
+write_files:
+  - path: /opt/bin/curl-retry.sh
+    permissions: '0755'
+    owner: root
+    content: |
+      #!/bin/sh -x
+      until curl $@
+      do sleep 1
+      done
+
 coreos:
   units:
     - name: download-etcd2.service
@@ -16,7 +26,8 @@ coreos:
         [Service]
         Environment=ETCD2_RELEASE_TARBALL=https://github.com/coreos/etcd/releases/download/v2.0.9/etcd-v2.0.9-linux-amd64.tar.gz
         ExecStartPre=/bin/mkdir -p /opt/bin
-        ExecStart=/bin/bash -c "curl --silent --location $ETCD2_RELEASE_TARBALL | tar xzv -C /opt"
+        ExecStart=/opt/bin/curl-retry.sh --silent --location $ETCD2_RELEASE_TARBALL --output /tmp/etcd2.tgz
+        ExecStart=/bin/tar xzvf /tmp/etcd2.tgz -C /opt
         ExecStartPost=/bin/ln -s /opt/etcd-v2.0.9-linux-amd64/etcd /opt/bin/etcd2
         ExecStartPost=/bin/ln -s /opt/etcd-v2.0.9-linux-amd64/etcdctl /opt/bin/etcdctl2
         RemainAfterExit=yes

--- a/docs/getting-started-guides/coreos/azure/cloud_config_templates/kubernetes-cluster-main-nodes-template.yml
+++ b/docs/getting-started-guides/coreos/azure/cloud_config_templates/kubernetes-cluster-main-nodes-template.yml
@@ -3,6 +3,15 @@
 ## are going to deploy.
 
 write_files:
+  - path: /opt/bin/curl-retry.sh
+    permissions: '0755'
+    owner: root
+    content: |
+      #!/bin/sh -x
+      until curl $@
+      do sleep 1
+      done
+
   - path: /opt/bin/register_minion.sh
     permissions: '0755'
     owner: root
@@ -134,18 +143,18 @@ coreos:
         Before=weave-helper.service
         Before=docker.service
         Description=Install Weave
-        Documentation=http://weaveworks.github.io/weave/
+        Documentation=http://docs.weave.works/
         Requires=network-online.target
         [Service]
         Type=oneshot
         RemainAfterExit=yes
         ExecStartPre=/bin/mkdir -p /opt/bin/
-        ExecStartPre=/usr/bin/curl \
+        ExecStartPre=/opt/bin/curl-retry.sh \
           --silent \
           --location \
           https://github.com/weaveworks/weave/releases/download/latest_release/weave \
           --output /opt/bin/weave
-        ExecStartPre=/usr/bin/curl \
+        ExecStartPre=/opt/bin/curl-retry.sh \
           --silent \
           --location \
           https://raw.github.com/errordeveloper/weave-demos/master/poseidon/weave-helper \
@@ -164,11 +173,12 @@ coreos:
         After=install-weave.service
         After=docker.service
         Description=Weave Network Router
-        Documentation=http://weaveworks.github.io/weave/
+        Documentation=http://docs.weave.works/
         Requires=docker.service
         Requires=install-weave.service
         [Service]
         ExecStart=/opt/bin/weave-helper
+        Restart=always
         [Install]
         WantedBy=weave-network.target
 
@@ -179,7 +189,7 @@ coreos:
         After=install-weave.service
         After=docker.service
         Description=Weave Network Router
-        Documentation=http://weaveworks.github.io/weave/
+        Documentation=http://docs.weave.works/
         Requires=docker.service
         Requires=install-weave.service
         [Service]
@@ -189,6 +199,7 @@ coreos:
         ExecStartPre=/opt/bin/weave launch $WEAVE_PEERS
         ExecStart=/usr/bin/docker attach weave
         Restart=on-failure
+        Restart=always
         ExecStop=/opt/bin/weave stop
         [Install]
         WantedBy=weave-network.target
@@ -201,8 +212,6 @@ coreos:
         After=install-weave.service
         Before=weave.service
         Before=docker.service
-        Description=Docker Application Container Engine
-        Documentation=http://docs.docker.io
         Requires=network.target
         Requires=install-weave.service
         [Service]
@@ -226,15 +235,18 @@ coreos:
         Before=kubelet.service
         Before=proxy.service
         Description=Download Kubernetes Binaries
-        Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+        Documentation=http://kubernetes.io/
         Requires=network-online.target
         [Service]
-        Environment=KUBE_RELEASE_TARBALL=https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v0.15.0/kubernetes.tar.gz
+        Environment=KUBE_RELEASE_TARBALL=https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v0.17.0/kubernetes.tar.gz
         ExecStartPre=/bin/mkdir -p /opt/
-        ExecStart=/bin/bash -c "curl --silent --location $KUBE_RELEASE_TARBALL | tar xzv -C /tmp/"
+        ExecStart=/opt/bin/curl-retry.sh --silent --location $KUBE_RELEASE_TARBALL --output /tmp/kubernetes.tgz
+        ExecStart=/bin/tar xzvf /tmp/kubernetes.tgz -C /tmp/
         ExecStart=/bin/tar xzvf /tmp/kubernetes/server/kubernetes-server-linux-amd64.tar.gz -C /opt
+        ExecStartPost=/bin/chmod o+rx -R /opt/kubernetes
         ExecStartPost=/bin/ln -s /opt/kubernetes/server/bin/kubectl /opt/bin/
         ExecStartPost=/bin/mv /tmp/kubernetes/examples/guestbook /home/core/guestbook-example
+        ExecStartPost=/bin/chown core. -R /home/core/guestbook-example
         ExecStartPost=/bin/rm -rf /tmp/kubernetes
         ExecStartPost=/bin/sed 's/\("createExternalLoadBalancer":\) true/\1 false/' -i /home/core/guestbook-example/frontend-service.json
         RemainAfterExit=yes
@@ -252,7 +264,7 @@ coreos:
         Before=scheduler.service
         ConditionFileIsExecutable=/opt/kubernetes/server/bin/kube-apiserver
         Description=Kubernetes API Server
-        Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+        Documentation=http://kubernetes.io/
         Wants=download-kubernetes.service
         ConditionHost=kube-00
         [Service]
@@ -276,7 +288,7 @@ coreos:
         After=download-kubernetes.service
         ConditionFileIsExecutable=/opt/kubernetes/server/bin/kube-scheduler
         Description=Kubernetes Scheduler
-        Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+        Documentation=http://kubernetes.io/
         Wants=apiserver.service
         ConditionHost=kube-00
         [Service]
@@ -296,7 +308,7 @@ coreos:
         After=apiserver.service
         ConditionFileIsExecutable=/opt/kubernetes/server/bin/kube-controller-manager
         Description=Kubernetes Controller Manager
-        Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+        Documentation=http://kubernetes.io/
         Wants=apiserver.service
         Wants=download-kubernetes.service
         ConditionHost=kube-00
@@ -317,7 +329,7 @@ coreos:
         After=download-kubernetes.service
         ConditionFileIsExecutable=/opt/kubernetes/server/bin/kubelet
         Description=Kubernetes Kubelet
-        Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+        Documentation=http://kubernetes.io/
         Wants=download-kubernetes.service
         ConditionHost=!kube-00
         [Service]
@@ -343,7 +355,7 @@ coreos:
         After=download-kubernetes.service
         ConditionFileIsExecutable=/opt/kubernetes/server/bin/kube-proxy
         Description=Kubernetes Proxy
-        Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+        Documentation=http://kubernetes.io/
         Wants=download-kubernetes.service
         ConditionHost=!kube-00
         [Service]
@@ -365,7 +377,7 @@ coreos:
         ConditionFileIsExecutable=/opt/kubernetes/server/bin/kubectl
         ConditionFileIsExecutable=/opt/bin/register_minion.sh
         Description=Kubernetes Create Minion
-        Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+        Documentation=http://kubernetes.io/
         Wants=download-kubernetes.service
         ConditionHost=!kube-00
         [Service]

--- a/docs/getting-started-guides/coreos/azure/lib/azure_wrapper.js
+++ b/docs/getting-started-guides/coreos/azure/lib/azure_wrapper.js
@@ -13,9 +13,9 @@ var inspect = require('util').inspect;
 var util = require('./util.js');
 
 var coreos_image_ids = {
-  'stable': '2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-633.1.0',
-  'beta': '2b171e93f07c4903bcad35bda10acf22__CoreOS-Beta-647.0.0', // untested
-  'alpha': '2b171e93f07c4903bcad35bda10acf22__CoreOS-Alpha-647.0.0' // untested
+  'stable': '2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-647.0.0',
+  'beta': '2b171e93f07c4903bcad35bda10acf22__CoreOS-Beta-668.3.0', // untested
+  'alpha': '2b171e93f07c4903bcad35bda10acf22__CoreOS-Alpha-681.0.0' // untested
 };
 
 var conf = {};
@@ -170,6 +170,7 @@ exports.queue_storage_if_needed = function() {
     conf.resources['storage_account'] = util.rand_suffix;
     task_queue.push([
       'storage', 'account', 'create',
+      '--type=LRS',
       get_location(),
       conf.resources['storage_account'],
     ]);

--- a/docs/getting-started-guides/coreos/azure/package.json
+++ b/docs/getting-started-guides/coreos/azure/package.json
@@ -9,7 +9,7 @@
   "author": "Ilya Dmitrichenko <errordeveloper@gmail.com>",
   "license": "Apache 2.0",
   "dependencies": {
-    "azure-cli": "^0.8.17",
+    "azure-cli": "^0.9.2",
     "colors": "^1.0.3",
     "js-yaml": "^3.2.5",
     "openssl-wrapper": "^0.2.1",


### PR DESCRIPTION
- Bump CLI tools version to 0.9.2
- Add curl wrapper as Azure DNS seems flaky
- Bump to 0.17
- Bump CoreOS image IDs
- Update docs URL
- Fix permissions
- Always restart Weave services (coreos/bugs#334)
