### PR TITLE
e2e: don't try to clean up after rolling-update test

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -94,15 +94,13 @@ var _ = Describe("kubectl", func() {
 		})
 
 		It("should do a rolling update of a replication controller", func() {
-			// Cleanup all resources in case we fail somewhere in the middle
-			defer cleanup(updateDemoRoot, ns, updateDemoSelector)
-
 			By("creating the initial replication controller")
 			runKubectl("create", "-f", nautilusPath, fmt.Sprintf("--namespace=%v", ns))
 			validateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
 			By("rolling-update to new replication controller")
 			runKubectl("rolling-update", "update-demo-nautilus", "--update-period=1s", "-f", kittenPath, fmt.Sprintf("--namespace=%v", ns))
 			validateController(c, kittenImage, 2, "update-demo", updateDemoSelector, getUDData("kitten.jpg", ns), ns)
+			// Everything will hopefully be cleaned up when the namespace is deleted.
 		})
 	})
 


### PR DESCRIPTION
Last fix for #8300.

As I commented there: the test creates update-demo-nautilus, then does a rolling update to update it to update-demo-kitten. We have the cleanup function try to delete both, in case something breaks in the middle of the test, but it's failing because update-demo-nautilus doesn't exist - as expected?

We can just remove the cleanup for this test case, since cleanup should be handled by the namespace deletion. I'm curious how this ever passed before, though.
