### PR TITLE
[do not merge]:  Allow reclamation of PersistentVolumes

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -236,7 +236,7 @@ func (s *CMServer) Run(_ []string) error {
 	pvclaimBinder.Run()
 	pvRecycler, err := volumeclaimbinder.NewPersistentVolumeRecycler(kubeClient, s.PVClaimBinderSyncPeriod, ProbeRecyclableVolumePlugins())
 	if err != nil {
-		glog.Errorf("Failed to start persistent volume recycler: %+v", err)
+		glog.Fatalf("Failed to start persistent volume recycler: %+v", err)
 	}
 	pvRecycler.Run()
 

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -234,6 +234,11 @@ func (s *CMServer) Run(_ []string) error {
 
 	pvclaimBinder := volumeclaimbinder.NewPersistentVolumeClaimBinder(kubeClient, s.PVClaimBinderSyncPeriod)
 	pvclaimBinder.Run()
+	pvRecycler, err := volumeclaimbinder.NewPersistentVolumeRecycler(kubeClient, s.PVClaimBinderSyncPeriod, ProbePersistentVolumePlugins())
+	if err != nil {
+		glog.Errorf("Failed to start persistent volume recycler: %+v", err)
+	}
+	pvRecycler.Run()
 
 	if len(s.ServiceAccountKeyFile) > 0 {
 		privateKey, err := serviceaccount.ReadPrivateKey(s.ServiceAccountKeyFile)

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -234,7 +234,7 @@ func (s *CMServer) Run(_ []string) error {
 
 	pvclaimBinder := volumeclaimbinder.NewPersistentVolumeClaimBinder(kubeClient, s.PVClaimBinderSyncPeriod)
 	pvclaimBinder.Run()
-	pvRecycler, err := volumeclaimbinder.NewPersistentVolumeRecycler(kubeClient, s.PVClaimBinderSyncPeriod, ProbePersistentVolumePlugins())
+	pvRecycler, err := volumeclaimbinder.NewPersistentVolumeRecycler(kubeClient, s.PVClaimBinderSyncPeriod, ProbeRecyclableVolumePlugins())
 	if err != nil {
 		glog.Errorf("Failed to start persistent volume recycler: %+v", err)
 	}

--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -32,27 +32,18 @@ import (
 
 	// Volume plugins
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/aws_ebs"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/gce_pd"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/glusterfs"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/host_path"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/iscsi"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/nfs"
 )
 
-// ProbeVolumePlugins collects all persistent volume plugins into an easy to use list.
-func ProbePersistentVolumePlugins() []volume.VolumePlugin {
+// ProbeRecyclableVolumePlugins collects all persistent volume plugins into an easy to use list.
+func ProbeRecyclableVolumePlugins() []volume.VolumePlugin {
 	allPlugins := []volume.VolumePlugin{}
 
 	// The list of plugins to probe is decided by the kubelet binary, not
 	// by dynamic linking or other "magic".  Plugins will be analyzed and
 	// initialized later.
-	allPlugins = append(allPlugins, aws_ebs.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, gce_pd.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, host_path.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, nfs.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, iscsi.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, glusterfs.ProbeVolumePlugins()...)
-
 	return allPlugins
 }

--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -20,6 +20,8 @@ import (
 	// This file exists to force the desired plugin implementations to be linked.
 	// This should probably be part of some configuration fed into the build for a
 	// given binary target.
+
+	//Cloud providers
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/aws"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/gce"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/mesos"
@@ -27,4 +29,30 @@ import (
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/ovirt"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/rackspace"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/vagrant"
+
+	// Volume plugins
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/aws_ebs"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/gce_pd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/glusterfs"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/host_path"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/iscsi"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/nfs"
 )
+
+// ProbeVolumePlugins collects all persistent volume plugins into an easy to use list.
+func ProbePersistentVolumePlugins() []volume.VolumePlugin {
+	allPlugins := []volume.VolumePlugin{}
+
+	// The list of plugins to probe is decided by the kubelet binary, not
+	// by dynamic linking or other "magic".  Plugins will be analyzed and
+	// initialized later.
+	allPlugins = append(allPlugins, aws_ebs.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, gce_pd.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, host_path.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, nfs.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, iscsi.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, glusterfs.ProbeVolumePlugins()...)
+
+	return allPlugins
+}

--- a/contrib/for-tests/volumes-tester/nfs/run_nfs.sh
+++ b/contrib/for-tests/volumes-tester/nfs/run_nfs.sh
@@ -20,7 +20,7 @@ function start()
     # prepare /etc/exports
     for i in "$@"; do
         # fsid=0: needed for NFSv4
-        echo "$i *(rw,fsid=0)" >> /etc/exports
+        echo "$i *(rw,fsid=0,no_root_squash)" >> /etc/exports
         echo "Serving $i"
     done
 

--- a/examples/persistent-volumes/volumes/local-02.yaml
+++ b/examples/persistent-volumes/volumes/local-02.yaml
@@ -11,4 +11,4 @@ spec:
     - ReadWriteOnce
   hostPath:
     path: "/tmp/data02"
-  reclamationPolicy: Recycle
+  persistentVolumeReclaimPolicy: Recycle

--- a/examples/persistent-volumes/volumes/local-02.yaml
+++ b/examples/persistent-volumes/volumes/local-02.yaml
@@ -6,8 +6,9 @@ metadata:
     type: local
 spec:
   capacity:
-    storage: 5Gi
+    storage: 8Gi
   accessModes:
     - ReadWriteOnce
   hostPath:
     path: "/tmp/data02"
+  reclamationPolicy: Recycle

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1243,6 +1243,7 @@ func deepCopy_api_PersistentVolumeSpec(in PersistentVolumeSpec, out *PersistentV
 	} else {
 		out.ClaimRef = nil
 	}
+	out.PersistentVolumeReclaimPolicy = in.PersistentVolumeReclaimPolicy
 	return nil
 }
 

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -236,8 +236,8 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			c.FuzzNoCustom(pv) // fuzz self without calling this function again
 			types := []api.PersistentVolumePhase{api.VolumePending, api.VolumeBound, api.VolumeReleased, api.VolumeAvailable}
 			pv.Status.Phase = types[c.Rand.Intn(len(types))]
-			reclamationPolicies := []api.ReclamationPolicy{api.DeleteOnRelease, api.RecycleOnRelease, api.RetainOnRelease}
-			pv.Spec.ReclamationPolicy = reclamationPolicies[c.Rand.Intn(len(reclamationPolicies))]
+			reclamationPolicies := []api.PersistentVolumeReclaimPolicy{api.PersistentVolumeReclaimDelete, api.PersistentVolumeReclaimRecycle, api.PersistentVolumeReclaimRetain}
+			pv.Spec.PersistentVolumeReclaimPolicy = reclamationPolicies[c.Rand.Intn(len(reclamationPolicies))]
 		},
 		func(pvc *api.PersistentVolumeClaim, c fuzz.Continue) {
 			c.FuzzNoCustom(pvc) // fuzz self without calling this function again

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -236,6 +236,8 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			c.FuzzNoCustom(pv) // fuzz self without calling this function again
 			types := []api.PersistentVolumePhase{api.VolumePending, api.VolumeBound, api.VolumeReleased, api.VolumeAvailable}
 			pv.Status.Phase = types[c.Rand.Intn(len(types))]
+			reclamationPolicies := []api.ReclamationPolicy{api.DeleteOnRelease, api.RecycleOnRelease, api.RetainOnRelease}
+			pv.Spec.ReclamationPolicy = reclamationPolicies[c.Rand.Intn(len(reclamationPolicies))]
 		},
 		func(pvc *api.PersistentVolumeClaim, c fuzz.Continue) {
 			c.FuzzNoCustom(pvc) // fuzz self without calling this function again

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -264,7 +264,7 @@ type PersistentVolumeSpec struct {
 	// claim.VolumeName is the authoritative bind between PV and PVC.
 	ClaimRef *ObjectReference `json:"claimRef,omitempty"`
 	// PersistentVolumeReclaimPolicy represents what happens to a persistent volume when released from its claim.
-	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"reclamationPolicy,omitempty"`
+	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"persistentVolumeReclaimPolicy,omitempty"`
 }
 
 // PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -263,23 +263,23 @@ type PersistentVolumeSpec struct {
 	// ClaimRef is expected to be non-nil when bound.
 	// claim.VolumeName is the authoritative bind between PV and PVC.
 	ClaimRef *ObjectReference `json:"claimRef,omitempty"`
-	// ReclamationPolicy represents what happens to a persistent volume when released from its claim.
-	ReclamationPolicy ReclamationPolicy `json:"reclamationPolicy,omitempty"`
+	// PersistentVolumeReclaimPolicy represents what happens to a persistent volume when released from its claim.
+	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"reclamationPolicy,omitempty"`
 }
 
-// ReclamationPolicy describes a policy for end-of-life maintenance of persistent volumes
-type ReclamationPolicy string
+// PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes
+type PersistentVolumeReclaimPolicy string
 
 const (
-	// RecycleOnRelease means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim.
+	// PersistentVolumeReclaimRecycle means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim.
 	// The volume plugin must support Recycling.
-	RecycleOnRelease ReclamationPolicy = "Recycle"
-	// DeleteOnRelease means the volume will be deleted from Kubernetes on release from its claim.
+	PersistentVolumeReclaimRecycle PersistentVolumeReclaimPolicy = "Recycle"
+	// PersistentVolumeReclaimDelete means the volume will be deleted from Kubernetes on release from its claim.
 	// The volume plugin must support Deletion.
-	DeleteOnRelease ReclamationPolicy = "Delete"
-	// RetainOnRelease means the volume will left in its current phase (Released) for manual reclamation by the administrator.
+	PersistentVolumeReclaimDelete PersistentVolumeReclaimPolicy = "Delete"
+	// PersistentVolumeReclaimRetain means the volume will left in its current phase (Released) for manual reclamation by the administrator.
 	// The default policy is Retain.
-	RetainOnRelease ReclamationPolicy = "Retain"
+	PersistentVolumeReclaimRetain PersistentVolumeReclaimPolicy = "Retain"
 )
 
 type PersistentVolumeStatus struct {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -359,6 +359,8 @@ const (
 	VolumeRecycled PersistentVolumePhase = "Recycled"
 	// used for PersistentVolumes that have been removed from the infrastructure
 	VolumeDeleted PersistentVolumePhase = "Deleted"
+	// used for PersistentVolumes that failed to be correctly recycled or deleted after being released from a claim
+	VolumeFailed PersistentVolumePhase = "Failed"
 )
 
 type PersistentVolumeClaimPhase string

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -263,7 +263,24 @@ type PersistentVolumeSpec struct {
 	// ClaimRef is expected to be non-nil when bound.
 	// claim.VolumeName is the authoritative bind between PV and PVC.
 	ClaimRef *ObjectReference `json:"claimRef,omitempty"`
+	// ReclamationPolicy represents what happens to a persistent volume when released from its claim.
+	ReclamationPolicy ReclamationPolicy `json:"reclamationPolicy,omitempty"`
 }
+
+// ReclamationPolicy describes a policy for end-of-life maintenance of persistent volumes
+type ReclamationPolicy string
+
+const (
+	// RecycleOnRelease means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim.
+	// The volume plugin must support Recycling.
+	RecycleOnRelease ReclamationPolicy = "Recycle"
+	// DeleteOnRelease means the volume will be deleted from Kubernetes on release from its claim.
+	// The volume plugin must support Deletion.
+	DeleteOnRelease ReclamationPolicy = "Delete"
+	// RetainOnRelease means the volume will left in its current phase (Released) for manual reclamation by the administrator.
+	// The default policy is Retain.
+	RetainOnRelease ReclamationPolicy = "Retain"
+)
 
 type PersistentVolumeStatus struct {
 	// Phase indicates if a volume is available, bound to a claim, or released by a claim
@@ -337,6 +354,11 @@ const (
 	// used for PersistentVolumes where the bound PersistentVolumeClaim was deleted
 	// released volumes must be recycled before becoming available again
 	VolumeReleased PersistentVolumePhase = "Released"
+	// used for PersistentVolumes that have been recycled and can be made available
+	// again to new PersistentVolumeClaims
+	VolumeRecycled PersistentVolumePhase = "Recycled"
+	// used for PersistentVolumes that have been removed from the infrastructure
+	VolumeDeleted PersistentVolumePhase = "Deleted"
 )
 
 type PersistentVolumeClaimPhase string

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -1358,7 +1358,7 @@ func convert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(in *api.Persist
 	} else {
 		out.ClaimRef = nil
 	}
-	out.ReclamationPolicy = ReclamationPolicy(in.ReclamationPolicy)
+	out.PersistentVolumeReclaimPolicy = PersistentVolumeReclaimPolicy(in.PersistentVolumeReclaimPolicy)
 	return nil
 }
 
@@ -3634,7 +3634,7 @@ func convert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in *PersistentV
 	} else {
 		out.ClaimRef = nil
 	}
-	out.ReclamationPolicy = api.ReclamationPolicy(in.ReclamationPolicy)
+	out.PersistentVolumeReclaimPolicy = api.PersistentVolumeReclaimPolicy(in.PersistentVolumeReclaimPolicy)
 	return nil
 }
 

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -1358,6 +1358,7 @@ func convert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(in *api.Persist
 	} else {
 		out.ClaimRef = nil
 	}
+	out.ReclamationPolicy = ReclamationPolicy(in.ReclamationPolicy)
 	return nil
 }
 
@@ -2297,6 +2298,7 @@ func convert_api_VolumeSource_To_v1_VolumeSource(in *api.VolumeSource, out *Volu
 	} else {
 		out.RBD = nil
 	}
+	out.ReclamationPolicy = api.ReclamationPolicy(in.ReclamationPolicy)
 	return nil
 }
 

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -2298,7 +2298,6 @@ func convert_api_VolumeSource_To_v1_VolumeSource(in *api.VolumeSource, out *Volu
 	} else {
 		out.RBD = nil
 	}
-	out.ReclamationPolicy = api.ReclamationPolicy(in.ReclamationPolicy)
 	return nil
 }
 
@@ -3635,6 +3634,7 @@ func convert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in *PersistentV
 	} else {
 		out.ClaimRef = nil
 	}
+	out.ReclamationPolicy = api.ReclamationPolicy(in.ReclamationPolicy)
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1174,6 +1174,7 @@ func deepCopy_v1_PersistentVolumeSpec(in PersistentVolumeSpec, out *PersistentVo
 	} else {
 		out.ClaimRef = nil
 	}
+	out.PersistentVolumeReclaimPolicy = in.PersistentVolumeReclaimPolicy
 	return nil
 }
 

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -113,8 +113,8 @@ func addDefaultingFuncs() {
 			if obj.Status.Phase == "" {
 				obj.Status.Phase = VolumePending
 			}
-			if obj.Spec.ReclamationPolicy == "" {
-				obj.Spec.ReclamationPolicy = RetainOnRelease
+			if obj.Spec.PersistentVolumeReclaimPolicy == "" {
+				obj.Spec.PersistentVolumeReclaimPolicy = PersistentVolumeReclaimRetain
 			}
 		},
 		func(obj *PersistentVolumeClaim) {

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -113,6 +113,9 @@ func addDefaultingFuncs() {
 			if obj.Status.Phase == "" {
 				obj.Status.Phase = VolumePending
 			}
+			if obj.Spec.ReclamationPolicy == "" {
+				obj.Spec.ReclamationPolicy = RetainOnRelease
+			}
 		},
 		func(obj *PersistentVolumeClaim) {
 			if obj.Status.Phase == "" {

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -258,6 +258,9 @@ func TestSetDefaultPersistentVolume(t *testing.T) {
 	if pv2.Status.Phase != versioned.VolumePending {
 		t.Errorf("Expected volume phase %v, got %v", versioned.VolumePending, pv2.Status.Phase)
 	}
+	if pv2.Spec.PersistentVolumeReclaimPolicy != versioned.PersistentVolumeReclaimRetain {
+		t.Errorf("Expected pv reclaim policy %v, got %v", versioned.PersistentVolumeReclaimRetain, pv2.Spec.PersistentVolumeReclaimPolicy)
+	}
 }
 
 func TestSetDefaultPersistentVolumeClaim(t *testing.T) {

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -280,7 +280,24 @@ type PersistentVolumeSpec struct {
 	// ClaimRef is expected to be non-nil when bound.
 	// claim.VolumeName is the authoritative bind between PV and PVC.
 	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim"`
+	// ReclamationPolicy represents what happens to a persistent volume when released from its claim.
+	ReclamationPolicy ReclamationPolicy `json:"reclamationPolicy,omitempty" description:"reclamationPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
 }
+
+// ReclamationPolicy describes a policy for end-of-life maintenance of persistent volumes
+type ReclamationPolicy string
+
+const (
+	// RecycleOnRelease means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim.
+	// The volume plugin must support Recycling.
+	RecycleOnRelease ReclamationPolicy = "Recycle"
+	// DeleteOnRelease means the volume will be deleted from Kubernetes on release from its claim.
+	// The volume plugin must support Deletion.
+	DeleteOnRelease ReclamationPolicy = "Delete"
+	// RetainOnRelease means the volume will left in its current phase (Released) for manual reclamation by the administrator.
+	// The default policy is Retain.
+	RetainOnRelease ReclamationPolicy = "Retain"
+)
 
 type PersistentVolumeStatus struct {
 	// Phase indicates if a volume is available, bound to a claim, or released by a claim
@@ -354,6 +371,11 @@ const (
 	// used for PersistentVolumes where the bound PersistentVolumeClaim was deleted
 	// released volumes must be recycled before becoming available again
 	VolumeReleased PersistentVolumePhase = "Released"
+	// used for PersistentVolumes that have been recycled and can be made available
+	// again to new PersistentVolumeClaims
+	VolumeRecycled PersistentVolumePhase = "Recycled"
+	// used for PersistentVolumes that have been removed from the infrastructure
+	VolumeDeleted PersistentVolumePhase = "Deleted"
 )
 
 type PersistentVolumeClaimPhase string

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -280,23 +280,23 @@ type PersistentVolumeSpec struct {
 	// ClaimRef is expected to be non-nil when bound.
 	// claim.VolumeName is the authoritative bind between PV and PVC.
 	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim"`
-	// ReclamationPolicy represents what happens to a persistent volume when released from its claim.
-	ReclamationPolicy ReclamationPolicy `json:"reclamationPolicy,omitempty" description:"reclamationPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
+	// PersistentVolumeReclaimPolicy represents what happens to a persistent volume when released from its claim.
+	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"reclamationPolicy,omitempty" description:"reclamationPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
 }
 
-// ReclamationPolicy describes a policy for end-of-life maintenance of persistent volumes
-type ReclamationPolicy string
+// PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes
+type PersistentVolumeReclaimPolicy string
 
 const (
-	// RecycleOnRelease means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim.
+	// PersistentVolumeReclaimRecycle means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim.
 	// The volume plugin must support Recycling.
-	RecycleOnRelease ReclamationPolicy = "Recycle"
-	// DeleteOnRelease means the volume will be deleted from Kubernetes on release from its claim.
+	PersistentVolumeReclaimRecycle PersistentVolumeReclaimPolicy = "Recycle"
+	// PersistentVolumeReclaimDelete means the volume will be deleted from Kubernetes on release from its claim.
 	// The volume plugin must support Deletion.
-	DeleteOnRelease ReclamationPolicy = "Delete"
-	// RetainOnRelease means the volume will left in its current phase (Released) for manual reclamation by the administrator.
+	PersistentVolumeReclaimDelete PersistentVolumeReclaimPolicy = "Delete"
+	// PersistentVolumeReclaimRetain means the volume will left in its current phase (Released) for manual reclamation by the administrator.
 	// The default policy is Retain.
-	RetainOnRelease ReclamationPolicy = "Retain"
+	PersistentVolumeReclaimRetain PersistentVolumeReclaimPolicy = "Retain"
 )
 
 type PersistentVolumeStatus struct {

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -281,7 +281,7 @@ type PersistentVolumeSpec struct {
 	// claim.VolumeName is the authoritative bind between PV and PVC.
 	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim"`
 	// PersistentVolumeReclaimPolicy represents what happens to a persistent volume when released from its claim.
-	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"reclamationPolicy,omitempty" description:"reclamationPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
+	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"persistentVolumeReclaimPolicy,omitempty" description:"persistentVolumeReclaimPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
 }
 
 // PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -376,6 +376,8 @@ const (
 	VolumeRecycled PersistentVolumePhase = "Recycled"
 	// used for PersistentVolumes that have been removed from the infrastructure
 	VolumeDeleted PersistentVolumePhase = "Deleted"
+	// used for PersistentVolumes that failed to be correctly recycled or deleted after being released from a claim
+	VolumeFailed PersistentVolumePhase = "Failed"
 )
 
 type PersistentVolumeClaimPhase string

--- a/pkg/api/v1beta1/defaults.go
+++ b/pkg/api/v1beta1/defaults.go
@@ -125,6 +125,9 @@ func addDefaultingFuncs() {
 			if obj.Status.Phase == "" {
 				obj.Status.Phase = VolumePending
 			}
+			if obj.Spec.ReclamationPolicy == "" {
+				obj.Spec.ReclamationPolicy = RetainOnRelease
+			}
 		},
 		func(obj *PersistentVolumeClaim) {
 			if obj.Status.Phase == "" {

--- a/pkg/api/v1beta1/defaults.go
+++ b/pkg/api/v1beta1/defaults.go
@@ -125,8 +125,8 @@ func addDefaultingFuncs() {
 			if obj.Status.Phase == "" {
 				obj.Status.Phase = VolumePending
 			}
-			if obj.Spec.ReclamationPolicy == "" {
-				obj.Spec.ReclamationPolicy = RetainOnRelease
+			if obj.Spec.PersistentVolumeReclaimPolicy == "" {
+				obj.Spec.PersistentVolumeReclaimPolicy = PersistentVolumeReclaimRetain
 			}
 		},
 		func(obj *PersistentVolumeClaim) {

--- a/pkg/api/v1beta1/defaults_test.go
+++ b/pkg/api/v1beta1/defaults_test.go
@@ -185,6 +185,9 @@ func TestSetDefaultPersistentVolume(t *testing.T) {
 	if pv2.Status.Phase != versioned.VolumePending {
 		t.Errorf("Expected volume phase %v, got %v", versioned.VolumePending, pv2.Status.Phase)
 	}
+	if pv2.Spec.PersistentVolumeReclaimPolicy != versioned.PersistentVolumeReclaimRetain {
+		t.Errorf("Expected pv reclaim policy %v, got %v", versioned.PersistentVolumeReclaimRetain, pv2.Spec.PersistentVolumeReclaimPolicy)
+	}
 }
 
 func TestSetDefaultPersistentVolumeClaim(t *testing.T) {

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -189,7 +189,7 @@ type PersistentVolumeSpec struct {
 	// ClaimRef is a non-binding reference to the claim bound to this volume
 	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim"`
 	// PersistentVolumeReclaimPolicy represents what happens to a persistent volume when released from its claim.
-	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"reclamationPolicy,omitempty" description:"reclamationPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
+	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"persistentVolumeReclaimPolicy,omitempty" description:"persistentVolumeReclaimPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
 }
 
 // PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -188,23 +188,23 @@ type PersistentVolumeSpec struct {
 	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"all ways the volume can be mounted"`
 	// ClaimRef is a non-binding reference to the claim bound to this volume
 	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim"`
-	// ReclamationPolicy represents what happens to a persistent volume when released from its claim.
-	ReclamationPolicy ReclamationPolicy `json:"reclamationPolicy,omitempty" description:"reclamationPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
+	// PersistentVolumeReclaimPolicy represents what happens to a persistent volume when released from its claim.
+	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"reclamationPolicy,omitempty" description:"reclamationPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
 }
 
-// ReclamationPolicy describes a policy for end-of-life maintenance of persistent volumes
-type ReclamationPolicy string
+// PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes
+type PersistentVolumeReclaimPolicy string
 
 const (
-	// RecycleOnRelease means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim.
+	// PersistentVolumeReclaimRecycle means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim.
 	// The volume plugin must support Recycling.
-	RecycleOnRelease ReclamationPolicy = "Recycle"
-	// DeleteOnRelease means the volume will be deleted from Kubernetes on release from its claim.
+	PersistentVolumeReclaimRecycle PersistentVolumeReclaimPolicy = "Recycle"
+	// PersistentVolumeReclaimDelete means the volume will be deleted from Kubernetes on release from its claim.
 	// The volume plugin must support Deletion.
-	DeleteOnRelease ReclamationPolicy = "Delete"
-	// RetainOnRelease means the volume will left in its current phase (Released) for manual reclamation by the administrator.
+	PersistentVolumeReclaimDelete PersistentVolumeReclaimPolicy = "Delete"
+	// PersistentVolumeReclaimRetain means the volume will left in its current phase (Released) for manual reclamation by the administrator.
 	// The default policy is Retain.
-	RetainOnRelease ReclamationPolicy = "Retain"
+	PersistentVolumeReclaimRetain PersistentVolumeReclaimPolicy = "Retain"
 )
 
 type PersistentVolumeStatus struct {

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -188,7 +188,24 @@ type PersistentVolumeSpec struct {
 	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"all ways the volume can be mounted"`
 	// ClaimRef is a non-binding reference to the claim bound to this volume
 	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim"`
+	// ReclamationPolicy represents what happens to a persistent volume when released from its claim.
+	ReclamationPolicy ReclamationPolicy `json:"reclamationPolicy,omitempty" description:"reclamationPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
 }
+
+// ReclamationPolicy describes a policy for end-of-life maintenance of persistent volumes
+type ReclamationPolicy string
+
+const (
+	// RecycleOnRelease means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim.
+	// The volume plugin must support Recycling.
+	RecycleOnRelease ReclamationPolicy = "Recycle"
+	// DeleteOnRelease means the volume will be deleted from Kubernetes on release from its claim.
+	// The volume plugin must support Deletion.
+	DeleteOnRelease ReclamationPolicy = "Delete"
+	// RetainOnRelease means the volume will left in its current phase (Released) for manual reclamation by the administrator.
+	// The default policy is Retain.
+	RetainOnRelease ReclamationPolicy = "Retain"
+)
 
 type PersistentVolumeStatus struct {
 	// Phase indicates if a volume is available, bound to a claim, or released by a claim
@@ -259,6 +276,11 @@ const (
 	// used for PersistentVolumes where the bound PersistentVolumeClaim was deleted
 	// released volumes must be recycled before becoming available again
 	VolumeReleased PersistentVolumePhase = "Released"
+	// used for PersistentVolumes that have been recycled and can be made available
+	// again to new PersistentVolumeClaims
+	VolumeRecycled PersistentVolumePhase = "Recycled"
+	// used for PersistentVolumes that have been removed from the infrastructure
+	VolumeDeleted PersistentVolumePhase = "Deleted"
 )
 
 type PersistentVolumeClaimPhase string

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -281,6 +281,8 @@ const (
 	VolumeRecycled PersistentVolumePhase = "Recycled"
 	// used for PersistentVolumes that have been removed from the infrastructure
 	VolumeDeleted PersistentVolumePhase = "Deleted"
+	// used for PersistentVolumes that failed to be correctly recycled or deleted after being released from a claim
+	VolumeFailed PersistentVolumePhase = "Failed"
 )
 
 type PersistentVolumeClaimPhase string

--- a/pkg/api/v1beta2/defaults.go
+++ b/pkg/api/v1beta2/defaults.go
@@ -126,6 +126,9 @@ func addDefaultingFuncs() {
 			if obj.Status.Phase == "" {
 				obj.Status.Phase = VolumePending
 			}
+			if obj.Spec.ReclamationPolicy == "" {
+				obj.Spec.ReclamationPolicy = RetainOnRelease
+			}
 		},
 		func(obj *PersistentVolumeClaim) {
 			if obj.Status.Phase == "" {

--- a/pkg/api/v1beta2/defaults.go
+++ b/pkg/api/v1beta2/defaults.go
@@ -126,8 +126,8 @@ func addDefaultingFuncs() {
 			if obj.Status.Phase == "" {
 				obj.Status.Phase = VolumePending
 			}
-			if obj.Spec.ReclamationPolicy == "" {
-				obj.Spec.ReclamationPolicy = RetainOnRelease
+			if obj.Spec.PersistentVolumeReclaimPolicy == "" {
+				obj.Spec.PersistentVolumeReclaimPolicy = PersistentVolumeReclaimRetain
 			}
 		},
 		func(obj *PersistentVolumeClaim) {

--- a/pkg/api/v1beta2/defaults_test.go
+++ b/pkg/api/v1beta2/defaults_test.go
@@ -175,6 +175,9 @@ func TestSetDefaultPersistentVolume(t *testing.T) {
 	if pv2.Status.Phase != versioned.VolumePending {
 		t.Errorf("Expected volume phase %v, got %v", versioned.VolumePending, pv2.Status.Phase)
 	}
+	if pv2.Spec.PersistentVolumeReclaimPolicy != versioned.PersistentVolumeReclaimRetain {
+		t.Errorf("Expected pv reclaim policy %v, got %v", versioned.PersistentVolumeReclaimRetain, pv2.Spec.PersistentVolumeReclaimPolicy)
+	}
 }
 
 func TestSetDefaultPersistentVolumeClaim(t *testing.T) {

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -146,7 +146,7 @@ type PersistentVolumeSpec struct {
 	// claim.VolumeName is the authoritative bind between PV and PVC.
 	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim"`
 	// PersistentVolumeReclaimPolicy represents what happens to a persistent volume when released from its claim.
-	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"reclamationPolicy,omitempty" description:"reclamationPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
+	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"persistentVolumeReclaimPolicy,omitempty" description:"persistentVolumeReclaimPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
 }
 
 // PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -145,7 +145,24 @@ type PersistentVolumeSpec struct {
 	// ClaimRef is expected to be non-nil when bound.
 	// claim.VolumeName is the authoritative bind between PV and PVC.
 	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim"`
+	// ReclamationPolicy represents what happens to a persistent volume when released from its claim.
+	ReclamationPolicy ReclamationPolicy `json:"reclamationPolicy,omitempty" description:"reclamationPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
 }
+
+// ReclamationPolicy describes a policy for end-of-life maintenance of persistent volumes
+type ReclamationPolicy string
+
+const (
+	// RecycleOnRelease means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim.
+	// The volume plugin must support Recycling.
+	RecycleOnRelease ReclamationPolicy = "Recycle"
+	// DeleteOnRelease means the volume will be deleted from Kubernetes on release from its claim.
+	// The volume plugin must support Deletion.
+	DeleteOnRelease ReclamationPolicy = "Delete"
+	// RetainOnRelease means the volume will left in its current phase (Released) for manual reclamation by the administrator.
+	// The default policy is Retain.
+	RetainOnRelease ReclamationPolicy = "Retain"
+)
 
 type PersistentVolumeStatus struct {
 	// Phase indicates if a volume is available, bound to a claim, or released by a claim
@@ -216,6 +233,11 @@ const (
 	// used for PersistentVolumes where the bound PersistentVolumeClaim was deleted
 	// released volumes must be recycled before becoming available again
 	VolumeReleased PersistentVolumePhase = "Released"
+	// used for PersistentVolumes that have been recycled and can be made available
+	// again to new PersistentVolumeClaims
+	VolumeRecycled PersistentVolumePhase = "Recycled"
+	// used for PersistentVolumes that have been removed from the infrastructure
+	VolumeDeleted PersistentVolumePhase = "Deleted"
 )
 
 type PersistentVolumeClaimPhase string

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -145,23 +145,23 @@ type PersistentVolumeSpec struct {
 	// ClaimRef is expected to be non-nil when bound.
 	// claim.VolumeName is the authoritative bind between PV and PVC.
 	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim"`
-	// ReclamationPolicy represents what happens to a persistent volume when released from its claim.
-	ReclamationPolicy ReclamationPolicy `json:"reclamationPolicy,omitempty" description:"reclamationPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
+	// PersistentVolumeReclaimPolicy represents what happens to a persistent volume when released from its claim.
+	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"reclamationPolicy,omitempty" description:"reclamationPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
 }
 
-// ReclamationPolicy describes a policy for end-of-life maintenance of persistent volumes
-type ReclamationPolicy string
+// PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes
+type PersistentVolumeReclaimPolicy string
 
 const (
-	// RecycleOnRelease means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim.
+	// PersistentVolumeReclaimRecycle means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim.
 	// The volume plugin must support Recycling.
-	RecycleOnRelease ReclamationPolicy = "Recycle"
-	// DeleteOnRelease means the volume will be deleted from Kubernetes on release from its claim.
+	PersistentVolumeReclaimRecycle PersistentVolumeReclaimPolicy = "Recycle"
+	// PersistentVolumeReclaimDelete means the volume will be deleted from Kubernetes on release from its claim.
 	// The volume plugin must support Deletion.
-	DeleteOnRelease ReclamationPolicy = "Delete"
-	// RetainOnRelease means the volume will left in its current phase (Released) for manual reclamation by the administrator.
+	PersistentVolumeReclaimDelete PersistentVolumeReclaimPolicy = "Delete"
+	// PersistentVolumeReclaimRetain means the volume will left in its current phase (Released) for manual reclamation by the administrator.
 	// The default policy is Retain.
-	RetainOnRelease ReclamationPolicy = "Retain"
+	PersistentVolumeReclaimRetain PersistentVolumeReclaimPolicy = "Retain"
 )
 
 type PersistentVolumeStatus struct {

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -238,6 +238,8 @@ const (
 	VolumeRecycled PersistentVolumePhase = "Recycled"
 	// used for PersistentVolumes that have been removed from the infrastructure
 	VolumeDeleted PersistentVolumePhase = "Deleted"
+	// used for PersistentVolumes that failed to be correctly recycled or deleted after being released from a claim
+	VolumeFailed PersistentVolumePhase = "Failed"
 )
 
 type PersistentVolumeClaimPhase string

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -1265,6 +1265,7 @@ func convert_api_PersistentVolumeSpec_To_v1beta3_PersistentVolumeSpec(in *api.Pe
 	} else {
 		out.ClaimRef = nil
 	}
+	out.ReclamationPolicy = ReclamationPolicy(in.ReclamationPolicy)
 	return nil
 }
 
@@ -2168,6 +2169,7 @@ func convert_api_VolumeSource_To_v1beta3_VolumeSource(in *api.VolumeSource, out 
 	} else {
 		out.RBD = nil
 	}
+	out.ReclamationPolicy = api.ReclamationPolicy(in.ReclamationPolicy)
 	return nil
 }
 

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -1265,7 +1265,7 @@ func convert_api_PersistentVolumeSpec_To_v1beta3_PersistentVolumeSpec(in *api.Pe
 	} else {
 		out.ClaimRef = nil
 	}
-	out.ReclamationPolicy = ReclamationPolicy(in.ReclamationPolicy)
+	out.PersistentVolumeReclaimPolicy = PersistentVolumeReclaimPolicy(in.PersistentVolumeReclaimPolicy)
 	return nil
 }
 
@@ -3412,7 +3412,7 @@ func convert_v1beta3_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in *Persis
 	} else {
 		out.ClaimRef = nil
 	}
-	out.ReclamationPolicy = api.ReclamationPolicy(in.ReclamationPolicy)
+	out.PersistentVolumeReclaimPolicy = api.PersistentVolumeReclaimPolicy(in.PersistentVolumeReclaimPolicy)
 	return nil
 }
 

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -2169,7 +2169,6 @@ func convert_api_VolumeSource_To_v1beta3_VolumeSource(in *api.VolumeSource, out 
 	} else {
 		out.RBD = nil
 	}
-	out.ReclamationPolicy = api.ReclamationPolicy(in.ReclamationPolicy)
 	return nil
 }
 
@@ -3413,6 +3412,7 @@ func convert_v1beta3_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in *Persis
 	} else {
 		out.ClaimRef = nil
 	}
+	out.ReclamationPolicy = api.ReclamationPolicy(in.ReclamationPolicy)
 	return nil
 }
 

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1178,6 +1178,7 @@ func deepCopy_v1beta3_PersistentVolumeSpec(in PersistentVolumeSpec, out *Persist
 	} else {
 		out.ClaimRef = nil
 	}
+	out.PersistentVolumeReclaimPolicy = in.PersistentVolumeReclaimPolicy
 	return nil
 }
 

--- a/pkg/api/v1beta3/defaults.go
+++ b/pkg/api/v1beta3/defaults.go
@@ -117,8 +117,8 @@ func addDefaultingFuncs() {
 			if obj.Status.Phase == "" {
 				obj.Status.Phase = VolumePending
 			}
-			if obj.Spec.ReclamationPolicy == "" {
-				obj.Spec.ReclamationPolicy = RetainOnRelease
+			if obj.Spec.PersistentVolumeReclaimPolicy == "" {
+				obj.Spec.PersistentVolumeReclaimPolicy = PersistentVolumeReclaimRetain
 			}
 		},
 		func(obj *PersistentVolumeClaim) {

--- a/pkg/api/v1beta3/defaults.go
+++ b/pkg/api/v1beta3/defaults.go
@@ -117,6 +117,9 @@ func addDefaultingFuncs() {
 			if obj.Status.Phase == "" {
 				obj.Status.Phase = VolumePending
 			}
+			if obj.Spec.ReclamationPolicy == "" {
+				obj.Spec.ReclamationPolicy = RetainOnRelease
+			}
 		},
 		func(obj *PersistentVolumeClaim) {
 			if obj.Status.Phase == "" {

--- a/pkg/api/v1beta3/defaults_test.go
+++ b/pkg/api/v1beta3/defaults_test.go
@@ -195,6 +195,9 @@ func TestSetDefaultPersistentVolume(t *testing.T) {
 	if pv2.Status.Phase != versioned.VolumePending {
 		t.Errorf("Expected volume phase %v, got %v", versioned.VolumePending, pv2.Status.Phase)
 	}
+	if pv2.Spec.PersistentVolumeReclaimPolicy != versioned.PersistentVolumeReclaimRetain {
+		t.Errorf("Expected pv reclaim policy %v, got %v", versioned.PersistentVolumeReclaimRetain, pv2.Spec.PersistentVolumeReclaimPolicy)
+	}
 }
 
 func TestSetDefaultPersistentVolumeClaim(t *testing.T) {

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -280,7 +280,24 @@ type PersistentVolumeSpec struct {
 	// ClaimRef is expected to be non-nil when bound.
 	// claim.VolumeName is the authoritative bind between PV and PVC.
 	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim"`
+	// ReclamationPolicy represents what happens to a persistent volume when released from its claim.
+	ReclamationPolicy ReclamationPolicy `json:"reclamationPolicy,omitempty" description:"reclamationPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
 }
+
+// ReclamationPolicy describes a policy for end-of-life maintenance of persistent volumes
+type ReclamationPolicy string
+
+const (
+	// RecycleOnRelease means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim.
+	// The volume plugin must support Recycling.
+	RecycleOnRelease ReclamationPolicy = "Recycle"
+	// DeleteOnRelease means the volume will be deleted from Kubernetes on release from its claim.
+	// The volume plugin must support Deletion.
+	DeleteOnRelease ReclamationPolicy = "Delete"
+	// RetainOnRelease means the volume will left in its current phase (Released) for manual reclamation by the administrator.
+	// The default policy is Retain.
+	RetainOnRelease ReclamationPolicy = "Retain"
+)
 
 type PersistentVolumeStatus struct {
 	// Phase indicates if a volume is available, bound to a claim, or released by a claim
@@ -354,6 +371,11 @@ const (
 	// used for PersistentVolumes where the bound PersistentVolumeClaim was deleted
 	// released volumes must be recycled before becoming available again
 	VolumeReleased PersistentVolumePhase = "Released"
+	// used for PersistentVolumes that have been recycled and can be made available
+	// again to new PersistentVolumeClaims
+	VolumeRecycled PersistentVolumePhase = "Recycled"
+	// used for PersistentVolumes that have been removed from the infrastructure
+	VolumeDeleted PersistentVolumePhase = "Deleted"
 )
 
 type PersistentVolumeClaimPhase string

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -280,23 +280,23 @@ type PersistentVolumeSpec struct {
 	// ClaimRef is expected to be non-nil when bound.
 	// claim.VolumeName is the authoritative bind between PV and PVC.
 	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim"`
-	// ReclamationPolicy represents what happens to a persistent volume when released from its claim.
-	ReclamationPolicy ReclamationPolicy `json:"reclamationPolicy,omitempty" description:"reclamationPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
+	// PersistentVolumeReclaimPolicy represents what happens to a persistent volume when released from its claim.
+	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"reclamationPolicy,omitempty" description:"reclamationPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
 }
 
-// ReclamationPolicy describes a policy for end-of-life maintenance of persistent volumes
-type ReclamationPolicy string
+// PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes
+type PersistentVolumeReclaimPolicy string
 
 const (
-	// RecycleOnRelease means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim.
+	// PersistentVolumeReclaimRecycle means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim.
 	// The volume plugin must support Recycling.
-	RecycleOnRelease ReclamationPolicy = "Recycle"
-	// DeleteOnRelease means the volume will be deleted from Kubernetes on release from its claim.
+	PersistentVolumeReclaimRecycle PersistentVolumeReclaimPolicy = "Recycle"
+	// PersistentVolumeReclaimDelete means the volume will be deleted from Kubernetes on release from its claim.
 	// The volume plugin must support Deletion.
-	DeleteOnRelease ReclamationPolicy = "Delete"
-	// RetainOnRelease means the volume will left in its current phase (Released) for manual reclamation by the administrator.
+	PersistentVolumeReclaimDelete PersistentVolumeReclaimPolicy = "Delete"
+	// PersistentVolumeReclaimRetain means the volume will left in its current phase (Released) for manual reclamation by the administrator.
 	// The default policy is Retain.
-	RetainOnRelease ReclamationPolicy = "Retain"
+	PersistentVolumeReclaimRetain PersistentVolumeReclaimPolicy = "Retain"
 )
 
 type PersistentVolumeStatus struct {

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -281,7 +281,7 @@ type PersistentVolumeSpec struct {
 	// claim.VolumeName is the authoritative bind between PV and PVC.
 	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim"`
 	// PersistentVolumeReclaimPolicy represents what happens to a persistent volume when released from its claim.
-	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"reclamationPolicy,omitempty" description:"reclamationPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
+	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"persistentVolumeReclaimPolicy,omitempty" description:"persistentVolumeReclaimPolicy is what happens to a volume when released from its claim; one of Recycle, Delete, Retain.  Default is Retain."`
 }
 
 // PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -376,6 +376,8 @@ const (
 	VolumeRecycled PersistentVolumePhase = "Recycled"
 	// used for PersistentVolumes that have been removed from the infrastructure
 	VolumeDeleted PersistentVolumePhase = "Deleted"
+	// used for PersistentVolumes that failed to be correctly recycled or deleted after being released from a claim
+	VolumeFailed PersistentVolumePhase = "Failed"
 )
 
 type PersistentVolumeClaimPhase string

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -311,7 +311,7 @@ func (d *PersistentVolumeDescriber) Describe(namespace, name string) (string, er
 		} else {
 			fmt.Fprintf(out, "Claim:\t%s\n", "")
 		}
-		fmt.Fprintf(out, "Reclamation Policy:\t%d\n", pv.Spec.ReclamationPolicy)
+		fmt.Fprintf(out, "Reclamation Policy:\t%d\n", pv.Spec.PersistentVolumeReclaimPolicy)
 		return nil
 	})
 }

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -311,6 +311,7 @@ func (d *PersistentVolumeDescriber) Describe(namespace, name string) (string, er
 		} else {
 			fmt.Fprintf(out, "Claim:\t%s\n", "")
 		}
+		fmt.Fprintf(out, "Reclamation Policy:\t%d\n", pv.Spec.ReclamationPolicy)
 		return nil
 	})
 }

--- a/pkg/registry/persistentvolume/etcd/etcd_test.go
+++ b/pkg/registry/persistentvolume/etcd/etcd_test.go
@@ -59,7 +59,7 @@ func validNewPersistentVolume(name string) *api.PersistentVolume {
 			PersistentVolumeSource: api.PersistentVolumeSource{
 				HostPath: &api.HostPathVolumeSource{Path: "/foo"},
 			},
-			ReclamationPolicy: api.RetainOnRelease,
+			PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimRetain,
 		},
 		Status: api.PersistentVolumeStatus{
 			Phase: api.VolumePending,

--- a/pkg/registry/persistentvolume/etcd/etcd_test.go
+++ b/pkg/registry/persistentvolume/etcd/etcd_test.go
@@ -59,6 +59,7 @@ func validNewPersistentVolume(name string) *api.PersistentVolume {
 			PersistentVolumeSource: api.PersistentVolumeSource{
 				HostPath: &api.HostPathVolumeSource{Path: "/foo"},
 			},
+			ReclamationPolicy: api.RetainOnRelease,
 		},
 		Status: api.PersistentVolumeStatus{
 			Phase: api.VolumePending,

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -160,8 +160,8 @@ func (r *hostPathRecycler) Recycle() error {
 			Containers: []api.Container{
 				{
 					Name: "scrubber-" + uuid,
-					Image: "busybox",
-					Command: []string{"ls -la"},
+					Image: "gcr.io/google_containers/busybox",
+					Command: []string{"sh", "-c", "rm -rf"},
 					WorkingDir: "/scrub",
 					VolumeMounts: []api.VolumeMount{
 						{

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -33,6 +33,10 @@ func ProbeVolumePlugins() []volume.VolumePlugin {
 	return []volume.VolumePlugin{&hostPathPlugin{nil, newRecycler}}
 }
 
+func ProbeRecyclableVolumePlugins(recyclerFunc func(spec *volume.Spec, host volume.VolumeHost) (volume.Recycler, error)) []volume.VolumePlugin {
+	return []volume.VolumePlugin{&hostPathPlugin{nil, recyclerFunc}}
+}
+
 type hostPathPlugin struct {
 	host volume.VolumeHost
 	// decouple creating recyclers by deferring to a function.  Allows for easier testing.

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -149,6 +149,7 @@ func (r *hostPathRecycler) Recycle() error {
 			},
 		},
 		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicyNever,
 			Volumes: []api.Volume{
 				{
 					Name: uuid,
@@ -160,9 +161,9 @@ func (r *hostPathRecycler) Recycle() error {
 			Containers: []api.Container{
 				{
 					Name: "scrubber-" + uuid,
-					Image: "gcr.io/google_containers/busybox",
-					Command: []string{"sh", "-c", "rm -rf"},
-					WorkingDir: "/scrub",
+					Image: "centos",
+					// delete the contents of the volume, but not the directory itself
+					Command: []string{"/bin/rm", "-rfv", "/scrub/*"},
 					VolumeMounts: []api.VolumeMount{
 						{
 							Name: uuid,

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/mount"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/mount"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
 )
 
@@ -138,11 +138,11 @@ func (r *hostPathRecycler) GetPath() string {
 // Recycler provides methods to reclaim the volume resource.
 func (r *hostPathRecycler) Recycle() error {
 	uuid := string(util.NewUUID())
-	timeout := int64(30)
+	timeout := int64(60)
 
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
-			Name: "scrubber-" + r.name,
+			Name:      "scrubber-" + r.name,
 			Namespace: api.NamespaceDefault,
 			Labels: map[string]string{
 				"scrubber": uuid,
@@ -154,19 +154,20 @@ func (r *hostPathRecycler) Recycle() error {
 				{
 					Name: uuid,
 					VolumeSource: api.VolumeSource{
-						HostPath: &api.HostPathVolumeSource{ r.path },
+						HostPath: &api.HostPathVolumeSource{r.path},
 					},
 				},
 			},
 			Containers: []api.Container{
 				{
-					Name: "scrubber-" + uuid,
-					Image: "centos",
+					Name:  "scrubber-" + uuid,
+					Image: "busybox",
 					// delete the contents of the volume, but not the directory itself
-					Command: []string{"/bin/rm", "-rfv", "/scrub/*"},
+					Command: []string{"/bin/sh"},
+					Args:    []string{"-c", "rm -rf /scrub/*"},
 					VolumeMounts: []api.VolumeMount{
 						{
-							Name: uuid,
+							Name:      uuid,
 							MountPath: "/scrub",
 						},
 					},

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -80,7 +80,7 @@ func (plugin *hostPathPlugin) NewRecycler(spec *volume.Spec) (volume.Recycler, e
 	return plugin.newRecyclerFunc(spec, plugin.host)
 }
 
-func newRecycler(spec *volume.Spec, host volume.VolumeHost)(volume.Recycler, error){
+func newRecycler(spec *volume.Spec, host volume.VolumeHost) (volume.Recycler, error) {
 	if spec.VolumeSource.HostPath != nil {
 		return &hostPathRecycler{spec.VolumeSource.HostPath.Path, host}, nil
 	} else {
@@ -139,7 +139,7 @@ func (hp *hostPathRecycler) Recycle() error {
 		2. use host.client to save to API and watch it
 		3. if pod errors or times out, return error
 		   if pod exits, return nil for success
-	 */
+	*/
 
 	return nil
 }

--- a/pkg/volume/host_path/host_path_test.go
+++ b/pkg/volume/host_path/host_path_test.go
@@ -63,7 +63,7 @@ func TestRecycler(t *testing.T) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins([]volume.VolumePlugin{&hostPathPlugin{nil, newMockRecycler}}, volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
 
-	spec := &volume.Spec{PersistentVolumeSource:api.PersistentVolumeSource{HostPath: &api.HostPathVolumeSource{Path: "/foo"}}}
+	spec := &volume.Spec{PersistentVolumeSource: api.PersistentVolumeSource{HostPath: &api.HostPathVolumeSource{Path: "/foo"}}}
 	plug, err := plugMgr.FindRecyclablePluginBySpec(spec)
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
@@ -75,7 +75,7 @@ func TestRecycler(t *testing.T) {
 	if recycler.GetPath() != spec.PersistentVolumeSource.HostPath.Path {
 		t.Errorf("Expected %s but got %s", spec.PersistentVolumeSource.HostPath.Path, recycler.GetPath())
 	}
-	if err := recycler.Recycle() ; err != nil {
+	if err := recycler.Recycle(); err != nil {
 		t.Errorf("Mock Recycler expected to return nil but got %s", err)
 	}
 }

--- a/pkg/volume/host_path/host_path_test.go
+++ b/pkg/volume/host_path/host_path_test.go
@@ -59,6 +59,47 @@ func TestGetAccessModes(t *testing.T) {
 	}
 }
 
+func TestRecycler(t *testing.T) {
+	plugMgr := volume.VolumePluginMgr{}
+	plugMgr.InitPlugins([]volume.VolumePlugin{&hostPathPlugin{nil, newMockRecycler}}, volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
+
+	spec := &volume.Spec{PersistentVolumeSource:api.PersistentVolumeSource{HostPath: &api.HostPathVolumeSource{Path: "/foo"}}}
+	plug, err := plugMgr.FindRecyclablePluginBySpec(spec)
+	if err != nil {
+		t.Errorf("Can't find the plugin by name")
+	}
+	recycler, err := plug.NewRecycler(spec)
+	if err != nil {
+		t.Error("Failed to make a new Recyler: %v", err)
+	}
+	if recycler.GetPath() != spec.PersistentVolumeSource.HostPath.Path {
+		t.Errorf("Expected %s but got %s", spec.PersistentVolumeSource.HostPath.Path, recycler.GetPath())
+	}
+	if err := recycler.Recycle() ; err != nil {
+		t.Errorf("Mock Recycler expected to return nil but got %s", err)
+	}
+}
+
+func newMockRecycler(spec *volume.Spec, host volume.VolumeHost) (volume.Recycler, error) {
+	return &mockRecycler{
+		path: spec.PersistentVolumeSource.HostPath.Path,
+	}, nil
+}
+
+type mockRecycler struct {
+	path string
+	host volume.VolumeHost
+}
+
+func (r *mockRecycler) GetPath() string {
+	return r.path
+}
+
+func (r *mockRecycler) Recycle() error {
+	// return nil means recycle passed
+	return nil
+}
+
 func TestPlugin(t *testing.T) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("fake", nil, nil))

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -38,6 +38,8 @@ type nfsPlugin struct {
 }
 
 var _ volume.VolumePlugin = &nfsPlugin{}
+var _ volume.PersistentVolumePlugin = &nfsPlugin{}
+var _ volume.RecyclableVolumePlugin = &nfsPlugin{}
 
 const (
 	nfsPluginName = "kubernetes.io/nfs"
@@ -93,6 +95,10 @@ func (plugin *nfsPlugin) newCleanerInternal(volName string, podUID types.UID, mo
 		pod:        &api.Pod{ObjectMeta: api.ObjectMeta{UID: podUID}},
 		plugin:     plugin,
 	}, nil
+}
+
+func (plugin *nfsPlugin) NewRecycler(spec *volume.Spec) (volume.Recycler, error) {
+	return &nfs{}, nil
 }
 
 // NFS volumes represent a bare host file or directory mount of an NFS export.
@@ -189,5 +195,10 @@ func (nfsVolume *nfs) TearDownAt(dir string) error {
 		}
 	}
 
+	return nil
+}
+
+func (nfsVolume *nfs) Recycle() error {
+	// TODO implement "basic scrub" recycler -- busybox w/ "rm -rf" for volume
 	return nil
 }

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -105,7 +105,7 @@ func (plugin *nfsPlugin) NewRecycler(spec *volume.Spec) (volume.Recycler, error)
 	return plugin.newRecyclerFunc(spec, plugin.host)
 }
 
-func newRecycler(spec *volume.Spec, host volume.VolumeHost)(volume.Recycler, error){
+func newRecycler(spec *volume.Spec, host volume.VolumeHost) (volume.Recycler, error) {
 	if spec.VolumeSource.HostPath != nil {
 		return &nfsRecycler{
 			volName:    spec.Name,
@@ -225,7 +225,7 @@ type nfsRecycler struct {
 	volName    string
 	server     string
 	exportPath string
-	host volume.VolumeHost
+	host       volume.VolumeHost
 }
 
 func (r *nfsRecycler) GetPath() string {
@@ -242,7 +242,7 @@ func (r *nfsRecycler) Recycle() error {
 		2. use host.client to save to API and watch it
 		3. if pod errors or times out, return error
 		   if pod exits, return nil for success
-	 */
+	*/
 
 	return nil
 }

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -111,12 +111,14 @@ func newRecycler(spec *volume.Spec, host volume.VolumeHost) (volume.Recycler, er
 			name:   spec.Name,
 			server: spec.VolumeSource.NFS.Server,
 			path:   spec.VolumeSource.NFS.Path,
+			host:   host,
 		}, nil
 	} else {
 		return &nfsRecycler{
 			name:   spec.Name,
 			server: spec.PersistentVolumeSource.NFS.Server,
 			path:   spec.PersistentVolumeSource.NFS.Path,
+			host:   host,
 		}, nil
 	}
 }

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -60,12 +60,11 @@ func TestGetAccessModes(t *testing.T) {
 	}
 }
 
-
 func TestRecycler(t *testing.T) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins([]volume.VolumePlugin{&nfsPlugin{newRecyclerFunc: newMockRecycler}}, volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
 
-	spec := &volume.Spec{PersistentVolumeSource:api.PersistentVolumeSource{NFS: &api.NFSVolumeSource{Path: "/foo"}}}
+	spec := &volume.Spec{PersistentVolumeSource: api.PersistentVolumeSource{NFS: &api.NFSVolumeSource{Path: "/foo"}}}
 	plug, err := plugMgr.FindRecyclablePluginBySpec(spec)
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
@@ -77,7 +76,7 @@ func TestRecycler(t *testing.T) {
 	if recycler.GetPath() != spec.PersistentVolumeSource.NFS.Path {
 		t.Errorf("Expected %s but got %s", spec.PersistentVolumeSource.NFS.Path, recycler.GetPath())
 	}
-	if err := recycler.Recycle() ; err != nil {
+	if err := recycler.Recycle(); err != nil {
 		t.Errorf("Mock Recycler expected to return nil but got %s", err)
 	}
 }
@@ -101,7 +100,6 @@ func (r *mockRecycler) Recycle() error {
 	// return nil means recycle passed
 	return nil
 }
-
 
 func contains(modes []api.PersistentVolumeAccessMode, mode api.PersistentVolumeAccessMode) bool {
 	for _, m := range modes {

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -60,6 +60,49 @@ func TestGetAccessModes(t *testing.T) {
 	}
 }
 
+
+func TestRecycler(t *testing.T) {
+	plugMgr := volume.VolumePluginMgr{}
+	plugMgr.InitPlugins([]volume.VolumePlugin{&nfsPlugin{newRecyclerFunc: newMockRecycler}}, volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
+
+	spec := &volume.Spec{PersistentVolumeSource:api.PersistentVolumeSource{NFS: &api.NFSVolumeSource{Path: "/foo"}}}
+	plug, err := plugMgr.FindRecyclablePluginBySpec(spec)
+	if err != nil {
+		t.Errorf("Can't find the plugin by name")
+	}
+	recycler, err := plug.NewRecycler(spec)
+	if err != nil {
+		t.Error("Failed to make a new Recyler: %v", err)
+	}
+	if recycler.GetPath() != spec.PersistentVolumeSource.NFS.Path {
+		t.Errorf("Expected %s but got %s", spec.PersistentVolumeSource.NFS.Path, recycler.GetPath())
+	}
+	if err := recycler.Recycle() ; err != nil {
+		t.Errorf("Mock Recycler expected to return nil but got %s", err)
+	}
+}
+
+func newMockRecycler(spec *volume.Spec, host volume.VolumeHost) (volume.Recycler, error) {
+	return &mockRecycler{
+		path: spec.PersistentVolumeSource.NFS.Path,
+	}, nil
+}
+
+type mockRecycler struct {
+	path string
+	host volume.VolumeHost
+}
+
+func (r *mockRecycler) GetPath() string {
+	return r.path
+}
+
+func (r *mockRecycler) Recycle() error {
+	// return nil means recycle passed
+	return nil
+}
+
+
 func contains(modes []api.PersistentVolumeAccessMode, mode api.PersistentVolumeAccessMode) bool {
 	for _, m := range modes {
 		if m == mode {

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -79,6 +79,15 @@ type PersistentVolumePlugin interface {
 	GetAccessModes() []api.PersistentVolumeAccessMode
 }
 
+// RecyclableVolumePlugin is an extended interface of VolumePlugin and is used
+// by persistent volumes that want to be recycled before being made available again to new claims
+type RecyclableVolumePlugin interface {
+	VolumePlugin
+	// NewRecycler creates a new volume.Recycler which knows how to reclaim this resource
+	// after the volume's release from a PersistentVolumeClaim
+	NewRecycler(spec *Spec) (Recycler, error)
+}
+
 // VolumeHost is an interface that plugins can use to access the kubelet.
 type VolumeHost interface {
 	// GetPluginDir returns the absolute path to a directory under which
@@ -217,7 +226,21 @@ func (pm *VolumePluginMgr) FindPluginByName(name string) (VolumePlugin, error) {
 	return pm.plugins[matches[0]], nil
 }
 
-// FindPluginByName fetches a plugin by name or by legacy name.  If no plugin
+// FindPersistentPluginBySpec looks for a persistent volume plugin that can support a given volume
+// specification.  If no plugin is found, return an error
+func (pm *VolumePluginMgr) FindPersistentPluginBySpec(spec *Spec) (PersistentVolumePlugin, error) {
+	plugin, err := pm.FindPluginBySpec(spec)
+	if err != nil {
+		return nil, fmt.Errorf("Could not find volume plugin for spec: %+v", spec)
+	}
+	pvPlugin, err := pm.FindPersistentPluginByName(plugin.Name())
+	if err != nil {
+		return nil, fmt.Errorf("Could not find persistent volume plugin for spec: %+v", plugin.Name())
+	}
+	return pvPlugin, nil
+}
+
+// FindPersistentPluginByName fetches a persistent volume plugin by name.  If no plugin
 // is found, returns error.
 func (pm *VolumePluginMgr) FindPersistentPluginByName(name string) (PersistentVolumePlugin, error) {
 	volumePlugin, err := pm.FindPluginByName(name)
@@ -227,5 +250,18 @@ func (pm *VolumePluginMgr) FindPersistentPluginByName(name string) (PersistentVo
 	if persistentVolumePlugin, ok := volumePlugin.(PersistentVolumePlugin); ok {
 		return persistentVolumePlugin, nil
 	}
-	return nil, fmt.Errorf("no persistent volume plugin matched")
+	return nil, fmt.Errorf("no persistent volume plugin matched: %+v")
+}
+
+// FindRecyclablePluginByName fetches a persistent volume plugin by name.  If no plugin
+// is found, returns error.
+func (pm *VolumePluginMgr) FindRecyclablePluginBySpec(spec *Spec) (RecyclableVolumePlugin, error) {
+	volumePlugin, err := pm.FindPluginBySpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	if recyclableVolumePlugin, ok := volumePlugin.(RecyclableVolumePlugin); ok {
+		return recyclableVolumePlugin, nil
+	}
+	return nil, fmt.Errorf("no recyclable volume plugin matched")
 }

--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -68,7 +68,7 @@ func ScrubPodVolumeAndWatchUntilCompletion(pod *api.Pod, client client.Interface
 	}
 
 	// the binder will eventually catch up and set status on Claims
-	watch := newPodWatch(client, pod.Namespace, pod.Name, 5)
+	watch := newPodWatch(client, pod.Namespace, pod.Name, 5 * time.Second)
 	defer watch.Stop()
 
 	success := false
@@ -82,10 +82,7 @@ func ScrubPodVolumeAndWatchUntilCompletion(pod *api.Pod, client client.Interface
 			success = true
 			break
 		} else {
-
-			// TODO how to handle pods that were killed by ActiveDeadlineSeconds
-
-			glog.V(5).Infof("Pod event %+v\n", pod)
+			glog.V(5).Infof("Pod event %+v\n", pod.Name + " " + string(pod.Status.Phase))
 		}
 	}
 

--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -68,7 +68,7 @@ func ScrubPodVolumeAndWatchUntilCompletion(pod *api.Pod, client client.Interface
 	}
 
 	// the binder will eventually catch up and set status on Claims
-	watch := newPodWatch(client, pod.Namespace, pod.Name, 5 * time.Second)
+	watch := newPodWatch(client, pod.Namespace, pod.Name, 5*time.Second)
 	defer watch.Stop()
 
 	success := false
@@ -83,7 +83,7 @@ func ScrubPodVolumeAndWatchUntilCompletion(pod *api.Pod, client client.Interface
 			success = true
 			break
 		} else {
-			glog.V(5).Infof("Pod event %+v\n", pod.Name + " " + string(pod.Status.Phase))
+			glog.V(5).Infof("Pod event %+v\n", pod.Name+" "+string(pod.Status.Phase))
 		}
 	}
 

--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -59,7 +59,6 @@ func contains(modes []api.PersistentVolumeAccessMode, mode api.PersistentVolumeA
 
 // basicVolumeScrubber is an implementation of volume.Recycler
 type basicVolumeScrubber struct {
-
 }
 
 // podWatch provides watch semantics for a pod backed by a poller, since

--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -79,11 +79,17 @@ func ScrubPodVolumeAndWatchUntilCompletion(pod *api.Pod, client client.Interface
 		glog.V(5).Infof("Handling %s event for pod %+v\n", event.Type, pod)
 
 		if pod.Status.Phase == api.PodSucceeded {
+			glog.V(5).Infof("Success!  Scrub pod %s is phase %s\n", pod.Name, pod.Status.Phase)
 			success = true
 			break
 		} else {
 			glog.V(5).Infof("Pod event %+v\n", pod.Name + " " + string(pod.Status.Phase))
 		}
+	}
+
+	err = client.Pods(api.NamespaceDefault).Delete(pod.Name, nil)
+	if err != nil {
+		return fmt.Errorf("Error deleting scrubber pod: %s\n", pod.Name)
 	}
 
 	if success {

--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -57,6 +57,11 @@ func contains(modes []api.PersistentVolumeAccessMode, mode api.PersistentVolumeA
 	return false
 }
 
+// basicVolumeScrubber is an implementation of volume.Recycler
+type basicVolumeScrubber struct {
+
+}
+
 // podWatch provides watch semantics for a pod backed by a poller, since
 // events aren't generated for pod status updates.
 type podWatch struct {

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -29,7 +29,7 @@ type Volume interface {
 	GetPath() string
 }
 
-// Builder interface provides method to set up/mount the volume.
+// Builder interface provides methods to set up/mount the volume.
 type Builder interface {
 	// Uses Interface to provide the path for Docker binds.
 	Volume
@@ -43,7 +43,7 @@ type Builder interface {
 	SetUpAt(dir string) error
 }
 
-// Cleaner interface provides method to cleanup/unmount the volumes.
+// Cleaner interface provides methods to cleanup/unmount the volumes.
 type Cleaner interface {
 	Volume
 	// TearDown unmounts the volume from a self-determined directory and
@@ -52,6 +52,14 @@ type Cleaner interface {
 	// TearDown unmounts the volume from the specified directory and
 	// removes traces of the SetUp procedure.
 	TearDownAt(dir string) error
+}
+
+// Recycler provides methods to reclaim the volume resource.
+type Recycler interface {
+	Volume
+	// Recycle reclaims the resource.  Calls to this method should block until the recycling task is complete.
+	// Any error returned indicates the volume has failed to be reclaimed.  A nil return indicates success.
+	Recycle() error
 }
 
 func RenameDirectory(oldPath, newName string) (string, error) {

--- a/pkg/volumeclaimbinder/persistent_volume_claim_binder.go
+++ b/pkg/volumeclaimbinder/persistent_volume_claim_binder.go
@@ -202,7 +202,7 @@ func syncVolume(volumeIndex *persistentVolumeOrderedIndex, binderClient binderCl
 			return fmt.Errorf("PersistentVolume[%s] expected to be bound but found nil claimRef: %+v", volume.Name, volume)
 		} else {
 			// another process is watching for released volumes.
-			// ReclamationPolicy is set per PersistentVolume
+			// PersistentVolumeReclaimPolicy is set per PersistentVolume
 		}
 
 	// recycled volumes can be made available again to new claims

--- a/pkg/volumeclaimbinder/persistent_volume_claim_binder.go
+++ b/pkg/volumeclaimbinder/persistent_volume_claim_binder.go
@@ -99,7 +99,10 @@ func (binder *PersistentVolumeClaimBinder) addVolume(obj interface{}) {
 	binder.lock.Lock()
 	defer binder.lock.Unlock()
 	volume := obj.(*api.PersistentVolume)
-	syncVolume(binder.volumeIndex, binder.client, volume)
+	err := syncVolume(binder.volumeIndex, binder.client, volume)
+	if err != nil {
+		glog.Errorf("PVClaimBinder could not add volume %s: %+v", volume.Name, err)
+	}
 }
 
 func (binder *PersistentVolumeClaimBinder) updateVolume(oldObj, newObj interface{}) {
@@ -107,7 +110,10 @@ func (binder *PersistentVolumeClaimBinder) updateVolume(oldObj, newObj interface
 	defer binder.lock.Unlock()
 	newVolume := newObj.(*api.PersistentVolume)
 	binder.volumeIndex.Update(newVolume)
-	syncVolume(binder.volumeIndex, binder.client, newVolume)
+	err := syncVolume(binder.volumeIndex, binder.client, newVolume)
+	if err != nil {
+		glog.Errorf("PVClaimBinder could not update volume %s: %+v", newVolume.Name, err)
+	}
 }
 
 func (binder *PersistentVolumeClaimBinder) deleteVolume(obj interface{}) {
@@ -121,18 +127,24 @@ func (binder *PersistentVolumeClaimBinder) addClaim(obj interface{}) {
 	binder.lock.Lock()
 	defer binder.lock.Unlock()
 	claim := obj.(*api.PersistentVolumeClaim)
-	syncClaim(binder.volumeIndex, binder.client, claim)
+	err := syncClaim(binder.volumeIndex, binder.client, claim)
+	if err != nil {
+		glog.Errorf("PVClaimBinder could not add claim %s: %+v", claim.Name, err)
+	}
 }
 
 func (binder *PersistentVolumeClaimBinder) updateClaim(oldObj, newObj interface{}) {
 	binder.lock.Lock()
 	defer binder.lock.Unlock()
 	newClaim := newObj.(*api.PersistentVolumeClaim)
-	syncClaim(binder.volumeIndex, binder.client, newClaim)
+	err := syncClaim(binder.volumeIndex, binder.client, newClaim)
+	if err != nil {
+		glog.Errorf("PVClaimBinder could not update claim %s: %+v", newClaim.Name, err)
+	}
 }
 
 func syncVolume(volumeIndex *persistentVolumeOrderedIndex, binderClient binderClient, volume *api.PersistentVolume) (err error) {
-	glog.V(5).Infof("Synchronizing PersistentVolume[%s]\n", volume.Name)
+	glog.V(5).Infof("Synchronizing PersistentVolume[%s], current phase: %s\n", volume.Name, volume.Status.Phase)
 
 	// volumes can be in one of the following states:
 	//
@@ -173,7 +185,7 @@ func syncVolume(volumeIndex *persistentVolumeOrderedIndex, binderClient binderCl
 	//bound volumes require verification of their bound claims
 	case api.VolumeBound:
 		if volume.Spec.ClaimRef == nil {
-			return fmt.Errorf("PersistentVolume[%s] expected to be bound but found nil claimRef: %+v", volume)
+			return fmt.Errorf("PersistentVolume[%s] expected to be bound but found nil claimRef: %+v", volume.Name, volume)
 		} else {
 			_, err := binderClient.GetPersistentVolumeClaim(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name)
 			if err != nil {
@@ -187,9 +199,41 @@ func syncVolume(volumeIndex *persistentVolumeOrderedIndex, binderClient binderCl
 	// released volumes require recycling
 	case api.VolumeReleased:
 		if volume.Spec.ClaimRef == nil {
+			return fmt.Errorf("PersistentVolume[%s] expected to be bound but found nil claimRef: %+v", volume.Name, volume)
+		} else {
+			// another process is watching for released volumes.
+			// ReclamationPolicy is set per PersistentVolume
+		}
+
+	// recycled volumes can be made available again to new claims
+	case api.VolumeRecycled:
+		if volume.Spec.ClaimRef == nil {
+			return fmt.Errorf("PersistentVolume[%s] expected to be bound but found nil claimRef: %+v", volume.Name, volume)
+		} else {
+			// this is the last bind between persistent volume and claim.
+			// The claim has already been deleted by the user at this point
+			oldClaimRef := volume.Spec.ClaimRef
+			volume.Spec.ClaimRef = nil
+			_, err = binderClient.UpdatePersistentVolume(volume)
+			if err != nil {
+				// rollback on error, keep the ClaimRef until we can successfully update the volume
+				volume.Spec.ClaimRef = oldClaimRef
+				return fmt.Errorf("Unexpected error saving PersistentVolume: %+v", err)
+			}
+			// send the newly recycled volume back through the top of the processing loop
+			nextPhase = api.VolumePending
+		}
+
+		// recycled volumes can be made available again to new claims
+	case api.VolumeDeleted:
+		if volume.Spec.ClaimRef == nil {
 			return fmt.Errorf("PersistentVolume[%s] expected to be bound but found nil claimRef: %+v", volume)
 		} else {
-			// TODO: implement Recycle method on plugins
+			err = binderClient.DeletePersistentVolume(volume)
+			if err != nil {
+				return fmt.Errorf("Unexpected error deleting PersistentVolume: %+v", err)
+			}
+			volumeIndex.Delete(volume)
 		}
 	}
 
@@ -254,6 +298,7 @@ func syncClaim(volumeIndex *persistentVolumeOrderedIndex, binderClient binderCli
 		}
 
 		if volume.Spec.ClaimRef == nil {
+			glog.V(5).Infof("Rebuilding bind on pv.Spec.ClaimRef\n")
 			claimRef, err := api.GetReference(claim)
 			if err != nil {
 				return fmt.Errorf("Unexpected error getting claim reference: %v\n", err)
@@ -318,6 +363,7 @@ func (controller *PersistentVolumeClaimBinder) Stop() {
 type binderClient interface {
 	GetPersistentVolume(name string) (*api.PersistentVolume, error)
 	UpdatePersistentVolume(volume *api.PersistentVolume) (*api.PersistentVolume, error)
+	DeletePersistentVolume(volume *api.PersistentVolume) error
 	UpdatePersistentVolumeStatus(volume *api.PersistentVolume) (*api.PersistentVolume, error)
 	GetPersistentVolumeClaim(namespace, name string) (*api.PersistentVolumeClaim, error)
 	UpdatePersistentVolumeClaim(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error)
@@ -338,6 +384,10 @@ func (c *realBinderClient) GetPersistentVolume(name string) (*api.PersistentVolu
 
 func (c *realBinderClient) UpdatePersistentVolume(volume *api.PersistentVolume) (*api.PersistentVolume, error) {
 	return c.client.PersistentVolumes().Update(volume)
+}
+
+func (c *realBinderClient) DeletePersistentVolume(volume *api.PersistentVolume) error {
+	return c.client.PersistentVolumes().Delete(volume.Name)
 }
 
 func (c *realBinderClient) UpdatePersistentVolumeStatus(volume *api.PersistentVolume) (*api.PersistentVolume, error) {

--- a/pkg/volumeclaimbinder/persistent_volume_claim_binder_test.go
+++ b/pkg/volumeclaimbinder/persistent_volume_claim_binder_test.go
@@ -249,6 +249,8 @@ func TestBindingWithExamples(t *testing.T) {
 		t.Errorf("Expected non-nil ClaimRef: %+v", pv.Spec)
 	}
 
+	mockClient.volume = pv
+
 	// released volumes with a PersistentVolumeReclaimPolicy (recycle/delete) can have further processing
 	err = recycler.reclaimVolume(pv)
 	if err != nil {

--- a/pkg/volumeclaimbinder/persistent_volume_claim_binder_test.go
+++ b/pkg/volumeclaimbinder/persistent_volume_claim_binder_test.go
@@ -199,7 +199,7 @@ func TestBindingWithExamples(t *testing.T) {
 	}
 
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(host_path.ProbeVolumePlugins(), volume.NewFakeVolumeHost("fake", nil, nil))
+	plugMgr.InitPlugins(host_path.ProbeRecyclableVolumePlugins(newMockRecycler), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
 
 	recycler := &PersistentVolumeRecycler{
 		kubeClient: client,
@@ -307,4 +307,25 @@ func (c *mockBinderClient) UpdatePersistentVolumeClaim(claim *api.PersistentVolu
 
 func (c *mockBinderClient) UpdatePersistentVolumeClaimStatus(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error) {
 	return claim, nil
+}
+
+
+func newMockRecycler(spec *volume.Spec, host volume.VolumeHost) (volume.Recycler, error) {
+	return &mockRecycler{
+		path: spec.PersistentVolumeSource.HostPath.Path,
+	}, nil
+}
+
+type mockRecycler struct {
+	path string
+	host volume.VolumeHost
+}
+
+func (r *mockRecycler) GetPath() string {
+	return r.path
+}
+
+func (r *mockRecycler) Recycle() error {
+	// return nil means recycle passed
+	return nil
 }

--- a/pkg/volumeclaimbinder/persistent_volume_claim_binder_test.go
+++ b/pkg/volumeclaimbinder/persistent_volume_claim_binder_test.go
@@ -309,7 +309,6 @@ func (c *mockBinderClient) UpdatePersistentVolumeClaimStatus(claim *api.Persiste
 	return claim, nil
 }
 
-
 func newMockRecycler(spec *volume.Spec, host volume.VolumeHost) (volume.Recycler, error) {
 	return &mockRecycler{
 		path: spec.PersistentVolumeSource.HostPath.Path,

--- a/pkg/volumeclaimbinder/persistent_volume_claim_binder_test.go
+++ b/pkg/volumeclaimbinder/persistent_volume_claim_binder_test.go
@@ -260,6 +260,8 @@ func TestBindingWithExamples(t *testing.T) {
 
 	// after the status change above, the binder picks up again
 	syncVolume(volumeIndex, mockClient, pv)
+	// the first change of the volume in the binder triggers another change
+	syncVolume(volumeIndex, mockClient, pv)
 
 	if pv.Status.Phase != api.VolumePending {
 		t.Errorf("Expected phase %s but got %s", api.VolumePending, pv.Status.Phase)

--- a/pkg/volumeclaimbinder/persistent_volume_claim_binder_test.go
+++ b/pkg/volumeclaimbinder/persistent_volume_claim_binder_test.go
@@ -107,7 +107,7 @@ func TestExampleObjects(t *testing.T) {
 							Path: "/tmp/data02",
 						},
 					},
-					ReclamationPolicy: api.RecycleOnRelease,
+					PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimRecycle,
 				},
 			},
 		},
@@ -182,7 +182,7 @@ func TestBindingWithExamples(t *testing.T) {
 	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}
 
 	pv, err := client.PersistentVolumes().Get("any")
-	pv.Spec.ReclamationPolicy = api.RecycleOnRelease
+	pv.Spec.PersistentVolumeReclaimPolicy = api.PersistentVolumeReclaimRecycle
 	if err != nil {
 		t.Error("Unexpected error getting PV from client: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestBindingWithExamples(t *testing.T) {
 		t.Errorf("Expected non-nil ClaimRef: %+v", pv.Spec)
 	}
 
-	// released volumes with a ReclamationPolicy (recycle/delete) can have further processing
+	// released volumes with a PersistentVolumeReclaimPolicy (recycle/delete) can have further processing
 	err = recycler.reclaimVolume(pv)
 	if err != nil {
 		t.Errorf("Unexpected error reclaiming volume: %+v", err)

--- a/pkg/volumeclaimbinder/persistent_volume_recycler.go
+++ b/pkg/volumeclaimbinder/persistent_volume_recycler.go
@@ -91,15 +91,15 @@ func (recycler *PersistentVolumeRecycler) reclaimVolume(pv *api.PersistentVolume
 		// TODO: allow parallel recycling operations to increase throughput
 
 		var err error
-		switch pv.Spec.ReclamationPolicy {
-		case api.RecycleOnRelease:
+		switch pv.Spec.PersistentVolumeReclaimPolicy {
+		case api.PersistentVolumeReclaimRecycle:
 			err = recycler.handleRecycle(pv)
-		case api.DeleteOnRelease:
+		case api.PersistentVolumeReclaimDelete:
 			// TODO implement handleDelete in a separate PR w/ cloud volumes
-		case api.RetainOnRelease:
+		case api.PersistentVolumeReclaimRetain:
 			glog.V(5).Infof("Volume %s is set to retain after release.  Skipping.\n", pv.Name)
 		default:
-			err = fmt.Errorf("No ReclamationPolicy defined for spec: %+v", pv)
+			err = fmt.Errorf("No PersistentVolumeReclaimPolicy defined for spec: %+v", pv)
 		}
 		if err != nil {
 			errMsg := fmt.Sprintf("Could not recycle volume spec: %+v", err)

--- a/pkg/volumeclaimbinder/persistent_volume_recycler.go
+++ b/pkg/volumeclaimbinder/persistent_volume_recycler.go
@@ -98,7 +98,7 @@ func (recycler *PersistentVolumeRecycler) reclaimVolume(pv *api.PersistentVolume
 		// both handleRecycle and handleDelete block until completion
 		// TODO: allow parallel recycling operations to increase throughput
 
-//		var err error
+		//		var err error
 		switch pv.Spec.PersistentVolumeReclaimPolicy {
 		case api.PersistentVolumeReclaimRecycle:
 			err = recycler.handleRecycle(pv)

--- a/pkg/volumeclaimbinder/persistent_volume_recycler.go
+++ b/pkg/volumeclaimbinder/persistent_volume_recycler.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volumeclaimbinder
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/controller/framework"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/mount"
+	"github.com/golang/glog"
+)
+
+// PersistentVolumeRecycler is a controller that synchronizes recycles PersistentVolume that have been released from their claims.
+type PersistentVolumeRecycler struct {
+	volumeController *framework.Controller
+	stopChannel      chan struct{}
+	client           recyclerClient
+	kubeClient       client.Interface
+	pluginMgr        volume.VolumePluginMgr
+}
+
+// PersistentVolumeRecycler creates a new PersistentVolumeRecycler
+func NewPersistentVolumeRecycler(kubeClient client.Interface, syncPeriod time.Duration, plugins []volume.VolumePlugin) (*PersistentVolumeRecycler, error) {
+	recyclerClient := NewRecyclerClient(kubeClient)
+	recycler := &PersistentVolumeRecycler{
+		client:     recyclerClient,
+		kubeClient: kubeClient,
+	}
+
+	if err := recycler.pluginMgr.InitPlugins(plugins, recycler); err != nil {
+		return nil, fmt.Errorf("Could not initialize volume plugins for PVClaimBinder: %+v", err)
+	}
+
+	_, volumeController := framework.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func() (runtime.Object, error) {
+				return kubeClient.PersistentVolumes().List(labels.Everything(), fields.Everything())
+			},
+			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+				return kubeClient.PersistentVolumes().Watch(labels.Everything(), fields.Everything(), resourceVersion)
+			},
+		},
+		&api.PersistentVolume{},
+		syncPeriod,
+		framework.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				pv := obj.(*api.PersistentVolume)
+				recycler.reclaimVolume(pv)
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				pv := newObj.(*api.PersistentVolume)
+				recycler.reclaimVolume(pv)
+			},
+		},
+	)
+
+	recycler.volumeController = volumeController
+	return recycler, nil
+}
+
+func (recycler *PersistentVolumeRecycler) reclaimVolume(pv *api.PersistentVolume) error {
+	if pv.Status.Phase == api.VolumeReleased && pv.Spec.ClaimRef != nil {
+		glog.V(5).Infof("Reclaiming PersistentVolume[%s]\n", pv.Name)
+
+		// both handleRecycle and handleDelete block until completion
+		// TODO: allow parallel recycling operations to increase throughput
+
+		var err error
+		switch pv.Spec.ReclamationPolicy {
+		case api.RecycleOnRelease:
+			err = recycler.handleRecycle(pv)
+		case api.DeleteOnRelease:
+			// TODO implement handleDelete in a separate PR w/ cloud volumes
+		case api.RetainOnRelease:
+			glog.V(5).Infof("Volume %s is set to retain after release.  Skipping.\n", pv.Name)
+		default:
+			err = fmt.Errorf("No ReclamationPolicy defined for spec: %+v", pv)
+		}
+		if err != nil {
+			errMsg := fmt.Sprintf("Could not recycle volume spec: %+v", err)
+			glog.Errorf(errMsg)
+			return fmt.Errorf(errMsg)
+		}
+	}
+	return nil
+}
+
+func (recycler *PersistentVolumeRecycler) handleRecycle(pv *api.PersistentVolume) error {
+	glog.V(5).Infof("Recycling PersistentVolume[%s]\n", pv.Name)
+	spec := volume.NewSpecFromPersistentVolume(pv)
+	plugin, err := recycler.pluginMgr.FindRecyclablePluginBySpec(spec)
+	if err != nil {
+		return fmt.Errorf("Could not find recyclable volume plugin for spec: %+v", err)
+	}
+	volRecycler, err := plugin.NewRecycler(spec)
+	if err != nil {
+		return fmt.Errorf("Could not obtain Recycler for spec: %+v", err)
+	}
+	// blocks until completion
+	err = volRecycler.Recycle()
+	if err != nil {
+		return fmt.Errorf("Could not recycle volume spec: %+v", err)
+	} else {
+		glog.V(5).Infof("PersistentVolume[%s] successfully recycled\n", pv.Name)
+		pv.Status.Phase = api.VolumeRecycled
+		_, err := recycler.client.UpdatePersistentVolumeStatus(pv)
+		if err != nil {
+			glog.Errorf("Error updating pv.Status: %+v", err)
+		}
+	}
+	glog.V(5).Infof("Successfully recycled PersistentVolume[%s]\n", pv.Name)
+	return nil
+}
+
+// Run starts this recycler's control loops
+func (recycler *PersistentVolumeRecycler) Run() {
+	glog.V(5).Infof("Starting PersistentVolumeRecycler\n")
+	if recycler.stopChannel == nil {
+		recycler.stopChannel = make(chan struct{})
+		go recycler.volumeController.Run(recycler.stopChannel)
+	}
+}
+
+// Stop gracefully shuts down this binder
+func (recycler *PersistentVolumeRecycler) Stop() {
+	glog.V(5).Infof("Stopping PersistentVolumeRecycler\n")
+	if recycler.stopChannel != nil {
+		close(recycler.stopChannel)
+		recycler.stopChannel = nil
+	}
+}
+
+// recyclerClient abstracts access to PVs
+type recyclerClient interface {
+	GetPersistentVolume(name string) (*api.PersistentVolume, error)
+	UpdatePersistentVolume(volume *api.PersistentVolume) (*api.PersistentVolume, error)
+	UpdatePersistentVolumeStatus(volume *api.PersistentVolume) (*api.PersistentVolume, error)
+}
+
+func NewRecyclerClient(c client.Interface) recyclerClient {
+	return &realRecyclerClient{c}
+}
+
+type realRecyclerClient struct {
+	client client.Interface
+}
+
+func (c *realRecyclerClient) GetPersistentVolume(name string) (*api.PersistentVolume, error) {
+	return c.client.PersistentVolumes().Get(name)
+}
+
+func (c *realRecyclerClient) UpdatePersistentVolume(volume *api.PersistentVolume) (*api.PersistentVolume, error) {
+	return c.client.PersistentVolumes().Update(volume)
+}
+
+func (c *realRecyclerClient) UpdatePersistentVolumeStatus(volume *api.PersistentVolume) (*api.PersistentVolume, error) {
+	return c.client.PersistentVolumes().UpdateStatus(volume)
+}
+
+// PersistentVolumeRecycler is host to the volume plugins, but does not actually mount any volumes.
+// Because no mounting is performed, most of the VolumeHost methods are not implemented.
+func (f *PersistentVolumeRecycler) GetPluginDir(podUID string) string {
+	return ""
+}
+
+func (f *PersistentVolumeRecycler) GetPodVolumeDir(podUID types.UID, pluginName, volumeName string) string {
+	return ""
+}
+
+func (f *PersistentVolumeRecycler) GetPodPluginDir(podUID types.UID, pluginName string) string {
+	return ""
+}
+
+func (f *PersistentVolumeRecycler) GetKubeClient() client.Interface {
+	return f.kubeClient
+}
+
+func (f *PersistentVolumeRecycler) NewWrapperBuilder(spec *volume.Spec, pod *api.Pod, opts volume.VolumeOptions, mounter mount.Interface) (volume.Builder, error) {
+	return nil, fmt.Errorf("NewWrapperBuilder not supported by PVClaimBinder's VolumeHost implementation")
+}
+
+func (f *PersistentVolumeRecycler) NewWrapperCleaner(spec *volume.Spec, podUID types.UID, mounter mount.Interface) (volume.Cleaner, error) {
+	return nil, fmt.Errorf("NewWrapperCleaner not supported by PVClaimBinder's VolumeHost implementation")
+}

--- a/test/e2e/persistent_volumes.go
+++ b/test/e2e/persistent_volumes.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"time"
+)
+
+var _ = Describe("persistentVolumes", func() {
+	//		f := NewFramework("pv")
+
+	var c *client.Client
+	var ns string
+
+	BeforeEach(func() {
+		var err error
+		c, err = loadClient()
+		Expect(err).NotTo(HaveOccurred())
+		ns_, err := createTestingNS("pv", c)
+		ns = ns_.Name
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
+		if err := c.Namespaces().Delete(ns); err != nil {
+			Failf("Couldn't delete ns %s", err)
+		}
+	})
+
+	It("PersistentVolume", func() {
+		config := VolumeTestConfig{
+			namespace:   ns,
+			prefix:      "nfs",
+			serverImage: "gcr.io/google_containers/volume-nfs",
+			serverPorts: []int{2049},
+		}
+
+		defer func() {
+			volumeTestCleanup(c, config)
+		}()
+
+		pod := startVolumeServer(c, config)
+		serverIP := pod.Status.PodIP
+		Logf("NFS server IP address: %v", serverIP)
+
+		pv := makePersistentVolume(serverIP)
+		pvc := makePersistentVolumeClaim(ns)
+
+		Logf("Creating PersistentVolume using NFS")
+		pv, err := c.PersistentVolumes().Create(pv)
+		Expect(err).NotTo(HaveOccurred())
+
+		Logf("Creating PersistentVolumeClaim")
+		pvc, err = c.PersistentVolumeClaims(ns).Create(pvc)
+		Expect(err).NotTo(HaveOccurred())
+
+		// allow the binder a chance to catch up
+		time.Sleep(20 * time.Second)
+
+		pv, err = c.PersistentVolumes().Get(pv.Name)
+		Expect(err).NotTo(HaveOccurred())
+		if pv.Spec.ClaimRef == nil {
+			Failf("Expected PersistentVolume to be bound, but got nil ClaimRef: %+v", pv)
+		}
+
+		Logf("Deleting PersistentVolumeClaim to trigger PV Recycling")
+		err = c.PersistentVolumeClaims(ns).Delete(pvc.Name)
+		Expect(err).NotTo(HaveOccurred())
+
+		// allow the recycler a chance to catch up
+		time.Sleep(20 * time.Second)
+
+		pv, err = c.PersistentVolumes().Get(pv.Name)
+		Expect(err).NotTo(HaveOccurred())
+		if pv.Spec.ClaimRef != nil {
+			Failf("Expected PersistentVolume to be unbound, but found non-nil ClaimRef: %+v", pv)
+		}
+
+		// TODO: run a pod to get the contents of the NFS volume to confirm it is scrubbed clean
+
+	})
+})
+
+func makePersistentVolume(serverIP string) *api.PersistentVolume {
+	return &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			Name: "nfs-" + string(util.NewUUID()),
+		},
+		Spec: api.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimRecycle,
+			Capacity: api.ResourceList{
+				api.ResourceName(api.ResourceStorage): resource.MustParse("2Gi"),
+			},
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				NFS: &api.NFSVolumeSource{
+					Server:   serverIP,
+					Path:     "/",
+					ReadOnly: false,
+				},
+			},
+			AccessModes: []api.PersistentVolumeAccessMode{
+				api.ReadWriteOnce,
+				api.ReadOnlyMany,
+				api.ReadWriteMany,
+			},
+		},
+	}
+}
+
+func makePersistentVolumeClaim(ns string) *api.PersistentVolumeClaim {
+	return &api.PersistentVolumeClaim{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "pvc-" + string(util.NewUUID()),
+			Namespace: ns,
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			AccessModes: []api.PersistentVolumeAccessMode{
+				api.ReadWriteOnce,
+				api.ReadOnlyMany,
+				api.ReadWriteMany,
+			},
+			Resources: api.ResourceRequirements{
+				Requests: api.ResourceList{
+					api.ResourceName(api.ResourceStorage): resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+}

--- a/test/e2e/persistent_volumes.go
+++ b/test/e2e/persistent_volumes.go
@@ -102,7 +102,7 @@ var _ = Describe("persistentVolumes", func() {
 
 		// Now check that index.html from the NFS server was really removed
 		checkpod := makeCheckPod(ns, serverIP)
-		testContainerOutputInNamespace("the volume was scrubbed", c, checkpod, []string{"index.html does not exist",}, ns)
+		testContainerOutputInNamespace("the volume was scrubbed", c, checkpod, []string{"index.html does not exist"}, ns)
 
 	})
 })


### PR DESCRIPTION
- New pv.Spec.ReclamationPolicy
  - Allows Recycle/Delete on release.  Retain by default.
- New volume plugin interfaces
  - RecyclableVolumePlugin -- allows recycling of PVs
  - DeletableVolumePlugin -- allows deletion of PVs from the infrastructure
- New PersistentVolumeRecycler controller loop
  - single threaded initially for correctness
  - separate from PersistentVolumeClaimBinder because we don't want the binder to block on reclamation tasks
  - works with the binder to remove or re-add reclaimed volumes to/from the pool of available volumes

Needs implementations:
- Basic scrub impl:  run a pod w/ busybox "rm -rf" on the volume
  - develop/test with HostPath, use for NFS, potentially other volumes
- Cloud volumes:  delete via API

PVs deleted from cloud providers as policy will be reprovisioned by #6773

Edit:   The purpose of this PR is to dynamically reclaim used and released resources.  As PersistentVolumeClaims are deleted, their backing PersistentVolumes are released, but they are not yet reusable.  Either they need to be scrubbed of their data before become Available again or the volumes should be deleted from the infrastructure.

The scrubbing use case is a build server using NFS as scratch space.  No need for an admin to reprovision the cluster after the volumes are used up.  Basic scrub is sufficient to put them back into the pool.  Don't use basic scrub at The Fed or the NSA.
