### PR TITLE
Wait for docker to start cadvisor.

### DIFF
--- a/pkg/kubelet/cadvisor/cadvisor_fake.go
+++ b/pkg/kubelet/cadvisor/cadvisor_fake.go
@@ -28,6 +28,10 @@ type Fake struct {
 
 var _ Interface = new(Fake)
 
+func (c *Fake) Start() error {
+	return nil
+}
+
 func (c *Fake) ContainerInfo(name string, req *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error) {
 	return new(cadvisorApi.ContainerInfo), nil
 }

--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -57,10 +57,6 @@ func New(port uint) (Interface, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = m.Start()
-	if err != nil {
-		return nil, err
-	}
 
 	cadvisorClient := &cadvisorClient{
 		Manager: m,
@@ -73,8 +69,11 @@ func New(port uint) (Interface, error) {
 			return nil, err
 		}
 	}
-
 	return cadvisorClient, nil
+}
+
+func (cc *cadvisorClient) Start() error {
+	return cc.Manager.Start()
 }
 
 func (cc *cadvisorClient) exportHTTP(port uint) error {

--- a/pkg/kubelet/cadvisor/cadvisor_mock.go
+++ b/pkg/kubelet/cadvisor/cadvisor_mock.go
@@ -29,6 +29,11 @@ type Mock struct {
 
 var _ Interface = new(Mock)
 
+func (c *Mock) Start() error {
+	args := c.Called()
+	return args.Error(1)
+}
+
 // ContainerInfo is a mock implementation of Interface.ContainerInfo.
 func (c *Mock) ContainerInfo(name string, req *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error) {
 	args := c.Called(name, req)

--- a/pkg/kubelet/cadvisor/cadvisor_unsupported.go
+++ b/pkg/kubelet/cadvisor/cadvisor_unsupported.go
@@ -37,6 +37,10 @@ func New(port uint) (Interface, error) {
 
 var unsupportedErr = errors.New("cAdvisor is unsupported in this build")
 
+func (cu *cadvisorUnsupported) Start() error {
+	return unsupportedErr
+}
+
 func (cu *cadvisorUnsupported) DockerContainer(name string, req *cadvisorApi.ContainerInfoRequest) (cadvisorApi.ContainerInfo, error) {
 	return cadvisorApi.ContainerInfo{}, unsupportedErr
 }

--- a/pkg/kubelet/cadvisor/types.go
+++ b/pkg/kubelet/cadvisor/types.go
@@ -24,6 +24,7 @@ import (
 
 // Interface is an abstract interface for testability.  It abstracts the interface to cAdvisor.
 type Interface interface {
+	Start() error
 	DockerContainer(name string, req *cadvisorApi.ContainerInfoRequest) (cadvisorApi.ContainerInfo, error)
 	ContainerInfo(name string, req *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error)
 	SubcontainerInfo(name string, req *cadvisorApi.ContainerInfoRequest) (map[string]*cadvisorApi.ContainerInfo, error)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -656,6 +656,12 @@ func (kl *Kubelet) Run(updates <-chan PodUpdate) {
 		glog.Errorf("Failed to start ImageManager, images may not be garbage collected: %v", err)
 	}
 
+	err = kl.cadvisor.Start()
+	if err != nil {
+		kl.recorder.Eventf(kl.nodeRef, "kubeletSetupFailed", "Failed to start CAdvisor %v", err)
+		glog.Errorf("Failed to start CAdvisor, system may not be properly monitored: %v", err)
+	}
+
 	err = kl.containerManager.Start()
 	if err != nil {
 		kl.recorder.Eventf(kl.nodeRef, "kubeletSetupFailed", "Failed to start ContainerManager %v", err)


### PR DESCRIPTION
Together with #8324, this pr should fix #8291 for cadvisor breakage in rebooting case. 

cc/ @mbforbes @vmarmol 

How validate the fix, here are the steps I did:

1) Bring my test cluster
$ go run hack/e2e.go --v --build --up

2) Run monitoring tests
$ go run hack/e2e.go --v --test --test_args="--ginkgo.focus=._Monitor._"  

3) Restart nodes, and wait for both are in Ready state

4) Rerun monitoring tests. Without this PR, it should be failed
$ go run hack/e2e.go --v --test --test_args="--ginkgo.focus=._Monitor._"  

```
Monitoring
/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/monitoring.go:52
  verify monitoring pods and all cluster nodes are available on influxdb using heapster.
 /go/src/github.com/GoogleCloudPlatform/kubernetes/_output/dockerized/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/monitoring.go:51
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
Ran 1 of 48 Specs in 100.451 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 47 Skipped I0515 14:04:54.588358   15763 driver.go:96] All tests pass

```
