### PR TITLE
Revert kube2sky to use kubernetes-ro service 

### DIFF
--- a/cluster/addons/dns/kube2sky/Makefile
+++ b/cluster/addons/dns/kube2sky/Makefile
@@ -4,7 +4,7 @@
 
 .PHONY: all kube2sky container push clean
 
-TAG = 1.4
+TAG = 1.5
 PREFIX = gcr.io/google_containers
 
 all: container

--- a/cluster/addons/dns/kube2sky/kube2sky.go
+++ b/cluster/addons/dns/kube2sky/kube2sky.go
@@ -195,7 +195,7 @@ func newKubeClient() (*kclient.Client, error) {
 		var err error
 		if config, err = kclientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 			&kclientcmd.ClientConfigLoadingRules{ExplicitPath: *argKubecfgFile},
-			&kclientcmd.ConfigOverrides{ClusterInfo: kclientcmdapi.Cluster{Server: masterUrl}}).ClientConfig(); err != nil {
+			&kclientcmd.ConfigOverrides{ClusterInfo: kclientcmdapi.Cluster{Server: masterUrl, InsecureSkipTLSVerify: true}}).ClientConfig(); err != nil {
 			return nil, err
 		}
 	}

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -28,7 +28,7 @@ spec:
         - -initial-cluster-token
         - skydns-etcd
       - name: kube2sky
-        image: gcr.io/google_containers/kube2sky:1.4
+        image: gcr.io/google_containers/kube2sky:1.5
         args:
         # command = "/kube2sky"
         - -domain={{ pillar['dns_domain'] }}


### PR DESCRIPTION
This is required until the master cert is updated to support kubernetes service VIP.
