### PR TITLE
Docker log symlinks should use underscore separator

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -1222,7 +1222,7 @@ func (dm *DockerManager) runContainerInPod(pod *api.Pod, container *api.Containe
 	// labels for Cloud Logging.
 	podFullName := kubecontainer.GetPodFullName(pod)
 	containerLogFile := path.Join(dm.dockerRoot, "containers", id, fmt.Sprintf("%s-json.log", id))
-	symlinkFile := path.Join(dm.containerLogsDir, fmt.Sprintf("%s-%s-%s.log", podFullName, container.Name, id))
+	symlinkFile := path.Join(dm.containerLogsDir, fmt.Sprintf("%s_%s-%s.log", podFullName, container.Name, id))
 	if err = dm.os.Symlink(containerLogFile, symlinkFile); err != nil {
 		glog.Errorf("Failed to create symbolic link to the log file of pod %q container %q: %v", podFullName, container.Name, err)
 	}


### PR DESCRIPTION
From https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/kubelet/dockertools/manager.go#L1225, separator between namespace & pod container name is '-'. As this is a valid character in both namespace & container name, you can't tell where the split is. Changing this to '_' as is done between pod name & namespace makes this simple. One use case for this is the logging add-on to add richer kubernetes metadata simply by parsing file name - further metadata (e.g. labels) will be retrieved from the api server using the derived namespace & pod name.
