### PR TITLE
Make it easier to reuse kubelet server code

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -240,7 +240,7 @@ func (s *KubeletServer) Run(_ []string) error {
 
 	// TODO(vmarmol): Do this through container config.
 	if err := util.ApplyOomScoreAdj(0, s.OOMScoreAdj); err != nil {
-		glog.Info(err)
+		glog.Warning(err)
 	}
 
 	client, err := s.createAPIServerClient()
@@ -248,7 +248,7 @@ func (s *KubeletServer) Run(_ []string) error {
 		glog.Warningf("No API client: %v", err)
 	}
 
-	glog.Infof("Using root directory: %v", s.RootDirectory)
+	glog.V(2).Infof("Using root directory: %v", s.RootDirectory)
 
 	credentialprovider.SetPreferredDockercfgPath(s.RootDirectory)
 
@@ -267,7 +267,7 @@ func (s *KubeletServer) Run(_ []string) error {
 		RootFreeDiskMB:   s.LowDiskSpaceThresholdMB,
 	}
 	cloud := cloudprovider.InitCloudProvider(s.CloudProvider, s.CloudConfigFile)
-	glog.Infof("Successfully initialized cloud provider: %q from the config file: %q\n", s.CloudProvider, s.CloudConfigFile)
+	glog.V(2).Infof("Successfully initialized cloud provider: %q from the config file: %q\n", s.CloudProvider, s.CloudConfigFile)
 
 	hostNetworkSources, err := kubelet.GetValidatedSources(strings.Split(s.HostNetworkSources, ","))
 	if err != nil {
@@ -278,9 +278,9 @@ func (s *KubeletServer) Run(_ []string) error {
 		s.TLSCertFile = path.Join(s.CertDirectory, "kubelet.crt")
 		s.TLSPrivateKeyFile = path.Join(s.CertDirectory, "kubelet.key")
 		if err := util.GenerateSelfSignedCert(util.GetHostname(s.HostnameOverride), s.TLSCertFile, s.TLSPrivateKeyFile); err != nil {
-			glog.Fatalf("Unable to generate self signed cert: %v", err)
+			return fmt.Errorf("unable to generate self signed cert: %v", err)
 		}
-		glog.Infof("Using self-signed cert (%s, %s)", s.TLSCertFile, s.TLSPrivateKeyFile)
+		glog.V(4).Infof("Using self-signed cert (%s, %s)", s.TLSCertFile, s.TLSPrivateKeyFile)
 	}
 	tlsOptions := &kubelet.TLSOptions{
 		Config: &tls.Config{
@@ -295,7 +295,7 @@ func (s *KubeletServer) Run(_ []string) error {
 
 	mounter := mount.New()
 	if s.Containerized {
-		glog.Info("Running kubelet in containerized mode (experimental)")
+		glog.V(2).Info("Running kubelet in containerized mode (experimental)")
 		mounter = &mount.NsenterMounter{}
 	}
 
@@ -344,7 +344,9 @@ func (s *KubeletServer) Run(_ []string) error {
 		ConfigureCBR0:             s.ConfigureCBR0,
 	}
 
-	RunKubelet(&kcfg, nil)
+	if err := RunKubelet(&kcfg, nil); err != nil {
+		return err
+	}
 
 	if s.HealthzPort > 0 {
 		healthz.DefaultHealthz()
@@ -356,9 +358,12 @@ func (s *KubeletServer) Run(_ []string) error {
 		}, 5*time.Second)
 	}
 
-	// runs forever
-	select {}
+	if s.RunOnce {
+		return nil
+	}
 
+	// run forever
+	select {}
 }
 
 func (s *KubeletServer) authPathClientConfig(useDefaults bool) (*client.Config, error) {
@@ -509,16 +514,16 @@ func SimpleKubelet(client *client.Client,
 //   2 Kubelet binary
 //   3 Standalone 'kubernetes' binary
 // Eventually, #2 will be replaced with instances of #3
-func RunKubelet(kcfg *KubeletConfig, builder KubeletBuilder) {
+func RunKubelet(kcfg *KubeletConfig, builder KubeletBuilder) error {
 	kcfg.Hostname = util.GetHostname(kcfg.HostnameOverride)
 	eventBroadcaster := record.NewBroadcaster()
 	kcfg.Recorder = eventBroadcaster.NewRecorder(api.EventSource{Component: "kubelet", Host: kcfg.Hostname})
 	eventBroadcaster.StartLogging(glog.Infof)
 	if kcfg.KubeClient != nil {
-		glog.Infof("Sending events to api server.")
+		glog.V(4).Infof("Sending events to api server.")
 		eventBroadcaster.StartRecordingToSink(kcfg.KubeClient.Events(""))
 	} else {
-		glog.Infof("No api server defined - no events will be sent to API server.")
+		glog.Warning("No api server defined - no events will be sent to API server.")
 	}
 	capabilities.Setup(kcfg.AllowPrivileged, kcfg.HostNetworkSources)
 
@@ -532,18 +537,19 @@ func RunKubelet(kcfg *KubeletConfig, builder KubeletBuilder) {
 	}
 	k, podCfg, err := builder(kcfg)
 	if err != nil {
-		glog.Errorf("Failed to create kubelet: %s", err)
-		return
+		return fmt.Errorf("failed to create kubelet: %v", err)
 	}
 	// process pods and exit.
 	if kcfg.Runonce {
 		if _, err := k.RunOnce(podCfg.Updates()); err != nil {
-			glog.Errorf("--runonce failed: %v", err)
+			return fmt.Errorf("runonce failed: %v", err)
 		}
+		glog.Infof("Started kubelet as runonce")
 	} else {
 		startKubelet(k, podCfg, kcfg)
+		glog.Infof("Started kubelet")
 	}
-	glog.Infof("Started kubelet")
+	return nil
 }
 
 func startKubelet(k KubeletBootstrap, podCfg *config.PodConfig, kc *KubeletConfig) {

--- a/pkg/healthz/healthz.go
+++ b/pkg/healthz/healthz.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"sync"
 )
 
 // HealthzChecker is a named healthz check.
@@ -28,9 +29,13 @@ type HealthzChecker interface {
 	Check(req *http.Request) error
 }
 
+var defaultHealthz = sync.Once{}
+
 // DefaultHealthz installs the default healthz check to the http.DefaultServeMux.
 func DefaultHealthz(checks ...HealthzChecker) {
-	InstallHandler(http.DefaultServeMux, checks...)
+	defaultHealthz.Do(func() {
+		InstallHandler(http.DefaultServeMux, checks...)
+	})
 }
 
 // PingHealthz returns true automatically when checked

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -277,7 +277,7 @@ func getDockerEndpoint(dockerEndpoint string) string {
 func ConnectToDockerOrDie(dockerEndpoint string) DockerInterface {
 	if dockerEndpoint == "fake://" {
 		return &FakeDockerClient{
-			VersionInfo: docker.Env{"ApiVersion=1.16"},
+			VersionInfo: docker.Env{"ApiVersion=1.18"},
 		}
 	}
 	client, err := docker.NewClient(getDockerEndpoint(dockerEndpoint))


### PR DESCRIPTION
Ensure that RunKubelet() returns errors consistently, and make info output
match Kube conventions.

Allows OpenShift to more easily reuse the Kubelet.

Also sets FakeDocker to emulate Docker 1.6, and ensures DefaultHealthz can't
stomp on itself.
