### PR TITLE
Endpoints controller is logging too much

### DIFF
--- a/pkg/service/endpoints_controller.go
+++ b/pkg/service/endpoints_controller.go
@@ -312,11 +312,11 @@ func (e *EndpointController) syncService(key string) {
 			portProto := servicePort.Protocol
 			portNum, err := findPort(pod, servicePort)
 			if err != nil {
-				glog.Errorf("Failed to find port for service %s/%s: %v", service.Namespace, service.Name, err)
+				glog.V(4).Infof("Failed to find port for service %s/%s: %v", service.Namespace, service.Name, err)
 				continue
 			}
 			if len(pod.Status.PodIP) == 0 {
-				glog.Errorf("Failed to find an IP for pod %s/%s", pod.Namespace, pod.Name)
+				glog.V(4).Infof("Failed to find an IP for pod %s/%s", pod.Namespace, pod.Name)
 				continue
 			}
 

--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -36,6 +36,8 @@ type FitError struct {
 	FailedPredicates FailedPredicateMap
 }
 
+var ErrNoNodesAvailable = fmt.Errorf("no nodes available to schedule pods")
+
 // implementation of the error interface
 func (f *FitError) Error() string {
 	output := fmt.Sprintf("failed to find fit for pod: %v", f.Pod)
@@ -59,7 +61,7 @@ func (g *genericScheduler) Schedule(pod *api.Pod, minionLister algorithm.MinionL
 		return "", err
 	}
 	if len(minions.Items) == 0 {
-		return "", fmt.Errorf("no minions available to schedule pods")
+		return "", ErrNoNodesAvailable
 	}
 
 	filteredNodes, failedPredicateMap, err := findNodesThatFit(pod, g.pods, g.predicates, minions)


### PR DESCRIPTION
Pods not having an IP yet or pods that don't have a port aren't v(0)
log items, since the former is usually temporary and the latter has
nothing actionable for an admit.

Make both V(4) as per our guidelines
