### PR TITLE
Make serviceaccount/token lookup more flexible

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -300,7 +300,7 @@ func (s *APIServer) Run(_ []string) error {
 	if s.ServiceAccountKeyFile == "" && s.TLSPrivateKeyFile != "" {
 		s.ServiceAccountKeyFile = s.TLSPrivateKeyFile
 	}
-	authenticator, err := apiserver.NewAuthenticator(s.BasicAuthFile, s.ClientCAFile, s.TokenAuthFile, s.ServiceAccountKeyFile, s.ServiceAccountLookup, client)
+	authenticator, err := apiserver.NewAuthenticator(s.BasicAuthFile, s.ClientCAFile, s.TokenAuthFile, s.ServiceAccountKeyFile, s.ServiceAccountLookup, helper)
 	if err != nil {
 		glog.Fatalf("Invalid Authentication Config: %v", err)
 	}

--- a/pkg/serviceaccount/jwt_test.go
+++ b/pkg/serviceaccount/jwt_test.go
@@ -214,7 +214,8 @@ func TestTokenGenerateAndValidate(t *testing.T) {
 	}
 
 	for k, tc := range testCases {
-		authenticator := JWTTokenAuthenticator(tc.Keys, tc.Client != nil, tc.Client)
+		getter := NewGetterFromClient(tc.Client)
+		authenticator := JWTTokenAuthenticator(tc.Keys, tc.Client != nil, getter)
 
 		user, ok, err := authenticator.AuthenticateToken(token)
 		if (err != nil) != tc.ExpectedErr {

--- a/pkg/serviceaccount/tokengetter.go
+++ b/pkg/serviceaccount/tokengetter.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccount
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/secret"
+	secretetcd "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/secret/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/serviceaccount"
+	serviceaccountetcd "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/serviceaccount/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+)
+
+// ServiceAccountTokenGetter defines functions to retrieve a named service account and secret
+type ServiceAccountTokenGetter interface {
+	GetServiceAccount(namespace, name string) (*api.ServiceAccount, error)
+	GetSecret(namespace, name string) (*api.Secret, error)
+}
+
+// clientGetter implements ServiceAccountTokenGetter using a client.Interface
+type clientGetter struct {
+	client client.Interface
+}
+
+// NewGetterFromClient returns a ServiceAccountTokenGetter that
+// uses the specified client to retrieve service accounts and secrets.
+// The client should NOT authenticate using a service account token
+// the returned getter will be used to retrieve, or recursion will result.
+func NewGetterFromClient(c client.Interface) ServiceAccountTokenGetter {
+	return clientGetter{c}
+}
+func (c clientGetter) GetServiceAccount(namespace, name string) (*api.ServiceAccount, error) {
+	return c.client.ServiceAccounts(namespace).Get(name)
+}
+func (c clientGetter) GetSecret(namespace, name string) (*api.Secret, error) {
+	return c.client.Secrets(namespace).Get(name)
+}
+
+// registryGetter implements ServiceAccountTokenGetter using a service account and secret registry
+type registryGetter struct {
+	serviceAccounts serviceaccount.Registry
+	secrets         secret.Registry
+}
+
+// NewGetterFromRegistries returns a ServiceAccountTokenGetter that
+// uses the specified registries to retrieve service accounts and secrets.
+func NewGetterFromRegistries(serviceAccounts serviceaccount.Registry, secrets secret.Registry) ServiceAccountTokenGetter {
+	return &registryGetter{serviceAccounts, secrets}
+}
+func (r *registryGetter) GetServiceAccount(namespace, name string) (*api.ServiceAccount, error) {
+	ctx := api.WithNamespace(api.NewContext(), namespace)
+	return r.serviceAccounts.GetServiceAccount(ctx, name)
+}
+func (r *registryGetter) GetSecret(namespace, name string) (*api.Secret, error) {
+	ctx := api.WithNamespace(api.NewContext(), namespace)
+	return r.secrets.GetSecret(ctx, name)
+}
+
+// NewGetterFromEtcdHelper returns a ServiceAccountTokenGetter that
+// uses the specified helper to retrieve service accounts and secrets.
+func NewGetterFromEtcdHelper(helper tools.EtcdHelper) ServiceAccountTokenGetter {
+	return NewGetterFromRegistries(
+		serviceaccount.NewRegistry(serviceaccountetcd.NewStorage(helper)),
+		secret.NewRegistry(secretetcd.NewStorage(helper)),
+	)
+}

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -366,7 +366,8 @@ func startServiceAccountTestServer(t *testing.T) (*client.Client, client.Config,
 		return nil, false, nil
 	})
 	serviceAccountKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	serviceAccountTokenAuth := serviceaccount.JWTTokenAuthenticator([]*rsa.PublicKey{&serviceAccountKey.PublicKey}, true, rootClient)
+	serviceAccountTokenGetter := serviceaccount.NewGetterFromClient(rootClient)
+	serviceAccountTokenAuth := serviceaccount.JWTTokenAuthenticator([]*rsa.PublicKey{&serviceAccountKey.PublicKey}, true, serviceAccountTokenGetter)
 	authenticator := union.New(
 		bearertoken.New(rootTokenAuth),
 		bearertoken.New(serviceAccountTokenAuth),


### PR DESCRIPTION
If the service account JWT token authenticator is configured to look up the service account and secret to validate they still exist, it previously did so using a client. If that client's authentication happened to use a service account token, recursion could result.

This PR:
- [x] makes the JWT token authenticator take a much more narrowly defined interface to look up the service accounts and tokens
- [x] provides an implementation of that interface backed by a client
- [x] provides an implementation of that interface backed by a etcd registries
