### PR TITLE
Remove unmatched double-quotes in CoreOS's standalone.yaml

### DIFF
--- a/docs/getting-started-guides/coreos/cloud-configs/standalone.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/standalone.yaml
@@ -10,7 +10,7 @@ coreos:
     initial-cluster-token: k8s_etcd
     listen-peer-urls: http://0.0.0.0:2380,http://0.0.0.0:7001
     initial-advertise-peer-urls: http://0.0.0.0:2380
-    initial-cluster: master=http://0.0.0.0:2380"
+    initial-cluster: master=http://0.0.0.0:2380
     initial-cluster-state: new
   units:
     - name: etcd.service


### PR DESCRIPTION
This is a simple fix but it was a blocker for me following the CoreOS guide to bring up Kubernetes on a standalone host.  I noticed that etcd wouldn't start and CoreOS was spewing an error about invalid etcd configuration, which led me back to this unmatched double quote.  After removing this, I was able to get the node fired up!
