### PR TITLE
Disable 'Timestamps' in Docker logs to prevent double-timestamps

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -220,7 +220,7 @@ func (dm *DockerManager) GetContainerLogs(pod *api.Pod, containerID, tail string
 		Stderr:       true,
 		OutputStream: stdout,
 		ErrorStream:  stderr,
-		Timestamps:   true,
+		Timestamps:   false,
 		RawTerminal:  false,
 		Follow:       follow,
 	}


### PR DESCRIPTION
Original Issue: https://github.com/openshift/origin/issues/2309

Having this option set to 'true' you will see double timestamps in the output of container logs:

``` console
2015-05-18T08:51:59.918042576Z 2015-05-18 04:51:59,912 - dock.plugins.squash - DEBUG - Archive generated
```

We can either 1. disable timestamps here and leave timestamps for Docker daemon or 2. make it optional similar to 'follow' (if it makes sense).
