### PR TITLE
update setup-network-environment 's download URL.

### DIFF
--- a/docs/getting-started-guides/coreos/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/master.yaml
@@ -26,7 +26,7 @@ coreos:
 
         [Service]
         ExecStartPre=-/usr/bin/mkdir -p /opt/bin
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/k8s/setup-network-environment 
+        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://github.com/kelseyhightower/setup-network-environment/releases/download/v1.0.0/setup-network-environment
         ExecStartPre=/usr/bin/chmod +x /opt/bin/setup-network-environment
         ExecStart=/opt/bin/setup-network-environment
         RemainAfterExit=yes

--- a/docs/getting-started-guides/coreos/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/node.yaml
@@ -49,7 +49,7 @@ coreos:
 
         [Service]
         ExecStartPre=-/usr/bin/mkdir -p /opt/bin
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/k8s/setup-network-environment 
+        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://github.com/kelseyhightower/setup-network-environment/releases/download/v1.0.0/setup-network-environment
         ExecStartPre=/usr/bin/chmod +x /opt/bin/setup-network-environment
         ExecStart=/opt/bin/setup-network-environment
         RemainAfterExit=yes


### PR DESCRIPTION
handles GoogleCloudPlatform/kubernetes#8405

please merge unless #8405 is/was a transient issue as right now CoreOS user-guides broken... 
