### PR TITLE
fix typo in gce.yaml: ensure 'accessModes' value is a list

### DIFF
--- a/examples/persistent-volumes/volumes/gce.yaml
+++ b/examples/persistent-volumes/volumes/gce.yaml
@@ -7,7 +7,7 @@ spec:
     storage: 10Gi
   accessModes:
     - ReadWriteOnce
-      ReadOnlyMany
+    - ReadOnlyMany
   gcePersistentDisk:
     pdName: "abc123"
     fsType: "ext4"


### PR DESCRIPTION
Leaving out the initial hyphen means that the value of 'accessModes' field is a string of two words with an internal space.  This change (adding the initial hyphen) means that the value of 'accessModes' field is a list of two elements, each of which is a normal string.
