### PR TITLE
fix gendocs

### DIFF
--- a/cluster/addons/dns/kube2sky/RELEASES.md
+++ b/cluster/addons/dns/kube2sky/RELEASES.md
@@ -24,3 +24,6 @@ are ready, not on every PR.
 8. Verify it works.
 
 9. Allow the PR to be merged.
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/dns/kube2sky/RELEASES.md?pixel)]()

--- a/examples/limitrange/README.md
+++ b/examples/limitrange/README.md
@@ -1,1 +1,4 @@
 Please refer to this [doc](https://github.com/GoogleCloudPlatform/kubernetes/blob/620af168920b773ade28e27211ad684903a1db21/docs/design/admission_control_limit_range.md#kubectl).
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/examples/limitrange/README.md?pixel)]()


### PR DESCRIPTION
Noticed https://github.com/GoogleCloudPlatform/kubernetes/pull/8414 was failing on the verify-gendocs step which seemed to be unrelated to the changes.  Verified it was also broken in master, these are the changes from run-gendocs.sh.  Let me know if this is not the correct procedure.  

Will rebase https://github.com/GoogleCloudPlatform/kubernetes/pull/8414
