### PR TITLE
Retry on bad Elasticsearch cluster status in e2e

### DIFF
--- a/test/e2e/es_cluster_logging.go
+++ b/test/e2e/es_cluster_logging.go
@@ -123,7 +123,10 @@ func ClusterLevelLoggingWithElasticsearch(c *client.Client) {
 			Logf("After %v expected status to be a float64 but got %v of type %T", time.Since(start), statusIntf, statusIntf)
 			continue
 		}
-		break
+		if int(statusCode) == 200 {
+			break
+		}
+		Logf("Got status code %v from Elasticsearch service.", statusCode)
 	}
 	Expect(err).NotTo(HaveOccurred())
 	if int(statusCode) != 200 {


### PR DESCRIPTION
A change to using two Elasticsearch pods seems to make the service come up slower so we should check for a 200 status and retry if we don't get one in the grace period.
