### PR TITLE
Updating heapster to v0.12.1. 

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -16,17 +16,28 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec: 
       containers: 
-        - image: gcr.io/google_containers/heapster:v0.11.0
+        - image: gcr.io/google_containers/heapster:v0.12.1
           name: heapster
-          env: 
-            - name: FLAGS
-              value: "--poll_duration=2m --stats_resolution=1m --sink=gcm --sink=gcl"
+          command:
+            - /heapster
+            - --source=kubernetes:https://kubernetes
+            - --sink=gcm
+            - --sink=gcl
+            - --poll_duration=2m
+            - --stats_resolution=1m
           volumeMounts: 
             - name: ssl-certs
               mountPath: /etc/ssl/certs
               readOnly: true
+            - name: monitoring-token
+              mountPath: /etc/kubernetes/kubeconfig
+              readOnly: true
+
       volumes: 
         - name: ssl-certs
           hostPath: 
             path: /etc/ssl/certs
+        - name: monitoring-token
+          secret:
+            secretName: token-system-monitoring
 

--- a/cluster/addons/cluster-monitoring/influxdb/grafana-service.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/grafana-service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1beta3
 kind: Service
 metadata: 
   labels: 
-    name: influxGrafana
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Grafana"
   name: monitoring-grafana

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -16,17 +16,23 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec: 
       containers: 
-        - image: gcr.io/google_containers/heapster:v0.11.0
+        - image: gcr.io/google_containers/heapster:v0.12.1
           name: heapster
-          env: 
-            - name: FLAGS
-              value: "--poll_duration=2m --stats_resolution=1m --sink influxdb:http://monitoring-influxdb.default:8086"
+          command:
+            - /heapster
+            - --source=kubernetes:https://kubernetes
+            - --sink=influxdb:http://monitoring-influxdb:8086
           volumeMounts: 
             - name: ssl-certs
               mountPath: /etc/ssl/certs
+              readOnly: true
+            - name: monitoring-token
+              mountPath: /etc/kubernetes/kubeconfig
               readOnly: true
       volumes: 
         - name: ssl-certs
           hostPath: 
             path: "/etc/ssl/certs"
-
+        - name: monitoring-token
+          secret:
+            secretName: token-system-monitoring

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-service.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-service.yaml
@@ -3,8 +3,6 @@ kind: Service
 metadata: 
   labels: 
     name: influxGrafana
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "InfluxDB"
   name: monitoring-influxdb
 spec: 
   ports: 


### PR DESCRIPTION
This adds support for tokens and improves scalability in large clusters.

I tested both influxdb and gcm deployments manually.
