### PR TITLE
Add resource shortcut "no" for nodes

### DIFF
--- a/docs/getting-started-guides/locally.md
+++ b/docs/getting-started-guides/locally.md
@@ -31,7 +31,7 @@ hack/local-up-cluster.sh
 ```
 
 This will build and start a lightweight local cluster, consisting of a master
-and a single minion. Type Control-C to shut it down.
+and a single node. Type Control-C to shut it down.
 
 You can use the cluster/kubectl.sh script to interact with the local cluster. hack/local-up-cluster.sh will
 print the commands to run to point kubectl at the local cluster.
@@ -94,7 +94,7 @@ change the portal_net flag to something else.
 
 #### I cannot create a replication controller with replica size greater than 1!  What gives?
 
-You are running a single minion setup.  This has the limitation of only supporting a single replica of a given pod.  If you are interested in running with larger replica sizes, we encourage you to try the local vagrant setup or one of the cloud providers.
+You are running a single node setup.  This has the limitation of only supporting a single replica of a given pod.  If you are interested in running with larger replica sizes, we encourage you to try the local vagrant setup or one of the cloud providers.
 
 #### I changed Kubernetes code, how do I run it?
 

--- a/docs/kubectl_get.md
+++ b/docs/kubectl_get.md
@@ -8,7 +8,7 @@ Display one or many resources
 Display one or many resources.
 
 Possible resources include pods (po), replication controllers (rc), services
-(svc), minions (mi), events (ev), or component statuses (cs).
+(svc), nodes (no), events (ev), or component statuses (cs).
 
 By specifying the output as 'template' and providing a Go template as the value
 of the --template flag, you can filter the attributes of the fetched resource(s).

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -101,6 +101,7 @@ func expandResourceShortcut(resource string) string {
 		"ev":     "events",
 		"limits": "limitRanges",
 		"mi":     "minions",
+		"no":     "nodes",
 		"po":     "pods",
 		"pv":     "persistentVolumes",
 		"pvc":    "persistentVolumeClaims",


### PR DESCRIPTION
- add resource shortcut "no" for nodes
- replace mention of "minions (mi)" in kubectl_get docs with "nodes (no)"
