### PR TITLE
Support glob wildcards for gcr.io credentials

### DIFF
--- a/pkg/credentialprovider/gcp/metadata.go
+++ b/pkg/credentialprovider/gcp/metadata.go
@@ -37,7 +37,9 @@ const (
 	storageScopePrefix = "https://www.googleapis.com/auth/devstorage"
 )
 
-var containerRegistryUrls = []string{"container.cloud.google.com", "gcr.io"}
+// For these urls, the parts of the host name can be glob, for example '*.gcr.io" will match
+// "foo.gcr.io" and "bar.gcr.io".
+var containerRegistryUrls = []string{"container.cloud.google.com", "gcr.io", "*.gcr.io"}
 
 var metadataHeader = &http.Header{
 	"Metadata-Flavor": []string{"Google"},

--- a/pkg/credentialprovider/keyring_test.go
+++ b/pkg/credentialprovider/keyring_test.go
@@ -22,71 +22,246 @@ import (
 	"testing"
 )
 
-func TestDockerKeyringFromBytes(t *testing.T) {
-	url := "hello.kubernetes.io"
-	email := "foo@bar.baz"
-	username := "foo"
-	password := "bar"
-	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
-	sampleDockerConfig := fmt.Sprintf(`{
+func TestUrlsMatch(t *testing.T) {
+	tests := []struct {
+		globUrl       string
+		targetUrl     string
+		matchExpected bool
+	}{
+		// match when there is no path component
+		{
+			globUrl:       "*.kubernetes.io",
+			targetUrl:     "prefix.kubernetes.io",
+			matchExpected: true,
+		},
+		{
+			globUrl:       "prefix.*.io",
+			targetUrl:     "prefix.kubernetes.io",
+			matchExpected: true,
+		},
+		{
+			globUrl:       "prefix.kubernetes.*",
+			targetUrl:     "prefix.kubernetes.io",
+			matchExpected: true,
+		},
+		{
+			globUrl:       "*-good.kubernetes.io",
+			targetUrl:     "prefix-good.kubernetes.io",
+			matchExpected: true,
+		},
+		// match with path components
+		{
+			globUrl:       "*.kubernetes.io/blah",
+			targetUrl:     "prefix.kubernetes.io/blah",
+			matchExpected: true,
+		},
+		{
+			globUrl:       "prefix.*.io/foo",
+			targetUrl:     "prefix.kubernetes.io/foo/bar",
+			matchExpected: true,
+		},
+		// match with path components and ports
+		{
+			globUrl:       "*.kubernetes.io:1111/blah",
+			targetUrl:     "prefix.kubernetes.io:1111/blah",
+			matchExpected: true,
+		},
+		{
+			globUrl:       "prefix.*.io:1111/foo",
+			targetUrl:     "prefix.kubernetes.io:1111/foo/bar",
+			matchExpected: true,
+		},
+		// no match when number of parts mismatch
+		{
+			globUrl:       "*.kubernetes.io",
+			targetUrl:     "kubernetes.io",
+			matchExpected: false,
+		},
+		{
+			globUrl:       "*.*.kubernetes.io",
+			targetUrl:     "prefix.kubernetes.io",
+			matchExpected: false,
+		},
+		{
+			globUrl:       "*.*.kubernetes.io",
+			targetUrl:     "kubernetes.io",
+			matchExpected: false,
+		},
+		// no match when some parts mismatch
+		{
+			globUrl:       "kubernetes.io",
+			targetUrl:     "kubernetes.com",
+			matchExpected: false,
+		},
+		{
+			globUrl:       "k*.io",
+			targetUrl:     "quay.io",
+			matchExpected: false,
+		},
+		// no match when ports mismatch
+		{
+			globUrl:       "*.kubernetes.io:1234/blah",
+			targetUrl:     "prefix.kubernetes.io:1111/blah",
+			matchExpected: false,
+		},
+		{
+			globUrl:       "prefix.*.io/foo",
+			targetUrl:     "prefix.kubernetes.io:1111/foo/bar",
+			matchExpected: false,
+		},
+	}
+	for _, test := range tests {
+		matched, _ := urlsMatchStr(test.globUrl, test.targetUrl)
+		if matched != test.matchExpected {
+			t.Errorf("Expected match result of %s and %s to be %t, but was %t",
+				test.globUrl, test.targetUrl, test.matchExpected, matched)
+		}
+	}
+}
+
+func TestDockerKeyringForGlob(t *testing.T) {
+	tests := []struct {
+		globUrl   string
+		targetUrl string
+	}{
+		{
+			globUrl:   "hello.kubernetes.io",
+			targetUrl: "hello.kubernetes.io",
+		},
+		{
+			globUrl:   "*.docker.io",
+			targetUrl: "prefix.docker.io",
+		},
+		{
+			globUrl:   "prefix.*.io",
+			targetUrl: "prefix.docker.io",
+		},
+		{
+			globUrl:   "prefix.docker.*",
+			targetUrl: "prefix.docker.io",
+		},
+		{
+			globUrl:   "*.docker.io/path",
+			targetUrl: "prefix.docker.io/path",
+		},
+		{
+			globUrl:   "prefix.*.io/path",
+			targetUrl: "prefix.docker.io/path/subpath",
+		},
+		{
+			globUrl:   "prefix.docker.*/path",
+			targetUrl: "prefix.docker.io/path",
+		},
+		{
+			globUrl:   "*.docker.io:8888",
+			targetUrl: "prefix.docker.io:8888",
+		},
+		{
+			globUrl:   "prefix.*.io:8888",
+			targetUrl: "prefix.docker.io:8888",
+		},
+		{
+			globUrl:   "prefix.docker.*:8888",
+			targetUrl: "prefix.docker.io:8888",
+		},
+		{
+			globUrl:   "*.docker.io/path:1111",
+			targetUrl: "prefix.docker.io/path:1111",
+		},
+		{
+			globUrl:   "prefix.*.io/path:1111",
+			targetUrl: "prefix.docker.io/path/subpath:1111",
+		},
+		{
+			globUrl:   "prefix.docker.*/path:1111",
+			targetUrl: "prefix.docker.io/path:1111",
+		},
+	}
+	for _, test := range tests {
+		email := "foo@bar.baz"
+		username := "foo"
+		password := "bar"
+		auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
+		sampleDockerConfig := fmt.Sprintf(`{
    "https://%s": {
      "email": %q,
      "auth": %q
    }
-}`, url, email, auth)
+}`, test.globUrl, email, auth)
 
-	keyring := &BasicDockerKeyring{}
-	if cfg, err := readDockerConfigFileFromBytes([]byte(sampleDockerConfig)); err != nil {
-		t.Errorf("Error processing json blob %q, %v", sampleDockerConfig, err)
-	} else {
-		keyring.Add(cfg)
-	}
+		keyring := &BasicDockerKeyring{}
+		if cfg, err := readDockerConfigFileFromBytes([]byte(sampleDockerConfig)); err != nil {
+			t.Errorf("Error processing json blob %q, %v", sampleDockerConfig, err)
+		} else {
+			keyring.Add(cfg)
+		}
 
-	creds, ok := keyring.Lookup(url + "/foo/bar")
-	if !ok {
-		t.Errorf("Didn't find expected URL: %s", url)
-		return
-	}
-	if len(creds) > 1 {
-		t.Errorf("Got more hits than expected: %s", creds)
-	}
-	val := creds[0]
+		creds, ok := keyring.Lookup(test.targetUrl + "/foo/bar")
+		if !ok {
+			t.Errorf("Didn't find expected URL: %s", test.targetUrl)
+			return
+		}
+		val := creds[0]
 
-	if username != val.Username {
-		t.Errorf("Unexpected username value, want: %s, got: %s", username, val.Username)
-	}
-	if password != val.Password {
-		t.Errorf("Unexpected password value, want: %s, got: %s", password, val.Password)
-	}
-	if email != val.Email {
-		t.Errorf("Unexpected email value, want: %s, got: %s", email, val.Email)
+		if username != val.Username {
+			t.Errorf("Unexpected username value, want: %s, got: %s", username, val.Username)
+		}
+		if password != val.Password {
+			t.Errorf("Unexpected password value, want: %s, got: %s", password, val.Password)
+		}
+		if email != val.Email {
+			t.Errorf("Unexpected email value, want: %s, got: %s", email, val.Email)
+		}
 	}
 }
 
 func TestKeyringMiss(t *testing.T) {
-	url := "hello.kubernetes.io"
-	email := "foo@bar.baz"
-	username := "foo"
-	password := "bar"
-	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
-	sampleDockerConfig := fmt.Sprintf(`{
+	tests := []struct {
+		globUrl   string
+		lookupUrl string
+	}{
+		{
+			globUrl:   "hello.kubernetes.io",
+			lookupUrl: "world.mesos.org/foo/bar",
+		},
+		{
+			globUrl:   "*.docker.com",
+			lookupUrl: "prefix.docker.io",
+		},
+		{
+			globUrl:   "suffix.*.io",
+			lookupUrl: "prefix.docker.io",
+		},
+		{
+			globUrl:   "prefix.docker.c*",
+			lookupUrl: "prefix.docker.io",
+		},
+	}
+	for _, test := range tests {
+		email := "foo@bar.baz"
+		username := "foo"
+		password := "bar"
+		auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
+		sampleDockerConfig := fmt.Sprintf(`{
    "https://%s": {
      "email": %q,
      "auth": %q
    }
-}`, url, email, auth)
+}`, test.globUrl, email, auth)
 
-	keyring := &BasicDockerKeyring{}
-	if cfg, err := readDockerConfigFileFromBytes([]byte(sampleDockerConfig)); err != nil {
-		t.Errorf("Error processing json blob %q, %v", sampleDockerConfig, err)
-	} else {
-		keyring.Add(cfg)
+		keyring := &BasicDockerKeyring{}
+		if cfg, err := readDockerConfigFileFromBytes([]byte(sampleDockerConfig)); err != nil {
+			t.Errorf("Error processing json blob %q, %v", sampleDockerConfig, err)
+		} else {
+			keyring.Add(cfg)
+		}
+
+		_, ok := keyring.Lookup(test.lookupUrl + "/foo/bar")
+		if ok {
+			t.Errorf("Expected not to find URL %s, but found", test.lookupUrl)
+		}
 	}
 
-	val, ok := keyring.Lookup("world.mesos.org/foo/bar")
-	if ok {
-		t.Errorf("Found unexpected credential: %+v", val)
-	}
 }
 
 func TestKeyringMissWithDockerHubCredentials(t *testing.T) {


### PR DESCRIPTION
Adding glob wildcards to URLs for GCR.IO credentials.

Globs were chosen instead of regular expression because we prefer clarity and globs would serve most of our use cases well already.
