### PR TITLE
Rename a few API types (non-breaking change)

### DIFF
--- a/api/swagger-spec/v1beta1.json
+++ b/api/swagger-spec/v1beta1.json
@@ -8165,8 +8165,8 @@
      }
     }
    },
-   "v1beta1.AccessModeType": {
-    "id": "v1beta1.AccessModeType",
+   "v1beta1.PersistentVolumeAccessMode": {
+    "id": "v1beta1.PersistentVolumeAccessMode",
     "properties": {}
    },
    "v1beta1.Binding": {
@@ -10054,7 +10054,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta1.AccessModeType"
+       "$ref": "v1beta1.PersistentVolumeAccessMode"
       },
       "description": "the desired access modes the volume should have"
      },
@@ -10074,7 +10074,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta1.AccessModeType"
+       "$ref": "v1beta1.PersistentVolumeAccessMode"
       },
       "description": "the actual access modes the volume has"
      },
@@ -10170,7 +10170,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta1.AccessModeType"
+       "$ref": "v1beta1.PersistentVolumeAccessMode"
       },
       "description": "all ways the volume can be mounted"
      },

--- a/api/swagger-spec/v1beta1.json
+++ b/api/swagger-spec/v1beta1.json
@@ -8236,21 +8236,21 @@
      "add": {
       "type": "array",
       "items": {
-       "$ref": "v1beta1.CapabilityType"
+       "$ref": "v1beta1.Capability"
       },
       "description": "added capabilities"
      },
      "drop": {
       "type": "array",
       "items": {
-       "$ref": "v1beta1.CapabilityType"
+       "$ref": "v1beta1.Capability"
       },
       "description": "droped capabilities"
      }
     }
    },
-   "v1beta1.CapabilityType": {
-    "id": "v1beta1.CapabilityType",
+   "v1beta1.Capability": {
+    "id": "v1beta1.Capability",
     "properties": {}
    },
    "v1beta1.ComponentCondition": {

--- a/api/swagger-spec/v1beta1.json
+++ b/api/swagger-spec/v1beta1.json
@@ -8165,8 +8165,8 @@
      }
     }
    },
-   "v1beta1.PersistentVolumeAccessMode": {
-    "id": "v1beta1.PersistentVolumeAccessMode",
+   "v1beta1.AccessModeType": {
+    "id": "v1beta1.AccessModeType",
     "properties": {}
    },
    "v1beta1.Binding": {
@@ -8236,21 +8236,21 @@
      "add": {
       "type": "array",
       "items": {
-       "$ref": "v1beta1.Capability"
+       "$ref": "v1beta1.CapabilityType"
       },
       "description": "added capabilities"
      },
      "drop": {
       "type": "array",
       "items": {
-       "$ref": "v1beta1.Capability"
+       "$ref": "v1beta1.CapabilityType"
       },
       "description": "droped capabilities"
      }
     }
    },
-   "v1beta1.Capability": {
-    "id": "v1beta1.Capability",
+   "v1beta1.CapabilityType": {
+    "id": "v1beta1.CapabilityType",
     "properties": {}
    },
    "v1beta1.ComponentCondition": {
@@ -10054,7 +10054,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta1.PersistentVolumeAccessMode"
+       "$ref": "v1beta1.AccessModeType"
       },
       "description": "the desired access modes the volume should have"
      },
@@ -10074,7 +10074,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta1.PersistentVolumeAccessMode"
+       "$ref": "v1beta1.AccessModeType"
       },
       "description": "the actual access modes the volume has"
      },
@@ -10160,17 +10160,17 @@
    "v1beta1.PersistentVolumeSpec": {
     "id": "v1beta1.PersistentVolumeSpec",
     "required": [
-     "glusterfs",
-     "nfs",
      "persistentDisk",
      "awsElasticBlockStore",
-     "hostPath"
+     "hostPath",
+     "glusterfs",
+     "nfs"
     ],
     "properties": {
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta1.PersistentVolumeAccessMode"
+       "$ref": "v1beta1.AccessModeType"
       },
       "description": "all ways the volume can be mounted"
      },

--- a/api/swagger-spec/v1beta2.json
+++ b/api/swagger-spec/v1beta2.json
@@ -8236,21 +8236,21 @@
      "add": {
       "type": "array",
       "items": {
-       "$ref": "v1beta2.CapabilityType"
+       "$ref": "v1beta2.Capability"
       },
       "description": "added capabilities"
      },
      "drop": {
       "type": "array",
       "items": {
-       "$ref": "v1beta2.CapabilityType"
+       "$ref": "v1beta2.Capability"
       },
       "description": "droped capabilities"
      }
     }
    },
-   "v1beta2.CapabilityType": {
-    "id": "v1beta2.CapabilityType",
+   "v1beta2.Capability": {
+    "id": "v1beta2.Capability",
     "properties": {}
    },
    "v1beta2.ComponentCondition": {

--- a/api/swagger-spec/v1beta2.json
+++ b/api/swagger-spec/v1beta2.json
@@ -8165,8 +8165,8 @@
      }
     }
    },
-   "v1beta2.AccessModeType": {
-    "id": "v1beta2.AccessModeType",
+   "v1beta2.PersistentVolumeAccessMode": {
+    "id": "v1beta2.PersistentVolumeAccessMode",
     "properties": {}
    },
    "v1beta2.Binding": {
@@ -10043,7 +10043,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta2.AccessModeType"
+       "$ref": "v1beta2.PersistentVolumeAccessMode"
       },
       "description": "the desired access modes the volume should have"
      },
@@ -10063,7 +10063,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta2.AccessModeType"
+       "$ref": "v1beta2.PersistentVolumeAccessMode"
       },
       "description": "the actual access modes the volume has"
      },
@@ -10159,7 +10159,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta2.AccessModeType"
+       "$ref": "v1beta2.PersistentVolumeAccessMode"
       },
       "description": "all ways the volume can be mounted"
      },

--- a/api/swagger-spec/v1beta2.json
+++ b/api/swagger-spec/v1beta2.json
@@ -8165,8 +8165,8 @@
      }
     }
    },
-   "v1beta2.PersistentVolumeAccessMode": {
-    "id": "v1beta2.PersistentVolumeAccessMode",
+   "v1beta2.AccessModeType": {
+    "id": "v1beta2.AccessModeType",
     "properties": {}
    },
    "v1beta2.Binding": {
@@ -8236,21 +8236,21 @@
      "add": {
       "type": "array",
       "items": {
-       "$ref": "v1beta2.Capability"
+       "$ref": "v1beta2.CapabilityType"
       },
       "description": "added capabilities"
      },
      "drop": {
       "type": "array",
       "items": {
-       "$ref": "v1beta2.Capability"
+       "$ref": "v1beta2.CapabilityType"
       },
       "description": "droped capabilities"
      }
     }
    },
-   "v1beta2.Capability": {
-    "id": "v1beta2.Capability",
+   "v1beta2.CapabilityType": {
+    "id": "v1beta2.CapabilityType",
     "properties": {}
    },
    "v1beta2.ComponentCondition": {
@@ -10043,7 +10043,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta2.PersistentVolumeAccessMode"
+       "$ref": "v1beta2.AccessModeType"
       },
       "description": "the desired access modes the volume should have"
      },
@@ -10063,7 +10063,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta2.PersistentVolumeAccessMode"
+       "$ref": "v1beta2.AccessModeType"
       },
       "description": "the actual access modes the volume has"
      },
@@ -10149,17 +10149,17 @@
    "v1beta2.PersistentVolumeSpec": {
     "id": "v1beta2.PersistentVolumeSpec",
     "required": [
+     "glusterfs",
      "nfs",
      "persistentDisk",
      "awsElasticBlockStore",
-     "hostPath",
-     "glusterfs"
+     "hostPath"
     ],
     "properties": {
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta2.PersistentVolumeAccessMode"
+       "$ref": "v1beta2.AccessModeType"
       },
       "description": "all ways the volume can be mounted"
      },

--- a/api/swagger-spec/v1beta3.json
+++ b/api/swagger-spec/v1beta3.json
@@ -9575,8 +9575,8 @@
      }
     }
    },
-   "v1beta3.AccessModeType": {
-    "id": "v1beta3.AccessModeType",
+   "v1beta3.PersistentVolumeAccessMode": {
+    "id": "v1beta3.PersistentVolumeAccessMode",
     "properties": {}
    },
    "v1beta3.Binding": {
@@ -10936,7 +10936,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta3.AccessModeType"
+       "$ref": "v1beta3.PersistentVolumeAccessMode"
       },
       "description": "the desired access modes the volume should have"
      },
@@ -10956,7 +10956,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta3.AccessModeType"
+       "$ref": "v1beta3.PersistentVolumeAccessMode"
       },
       "description": "the actual access modes the volume has"
      },
@@ -11013,7 +11013,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta3.AccessModeType"
+       "$ref": "v1beta3.PersistentVolumeAccessMode"
       },
       "description": "all ways the volume can be mounted"
      },

--- a/api/swagger-spec/v1beta3.json
+++ b/api/swagger-spec/v1beta3.json
@@ -9609,21 +9609,21 @@
      "add": {
       "type": "array",
       "items": {
-       "$ref": "v1beta3.CapabilityType"
+       "$ref": "v1beta3.Capability"
       },
       "description": "added capabilities"
      },
      "drop": {
       "type": "array",
       "items": {
-       "$ref": "v1beta3.CapabilityType"
+       "$ref": "v1beta3.Capability"
       },
       "description": "droped capabilities"
      }
     }
    },
-   "v1beta3.CapabilityType": {
-    "id": "v1beta3.CapabilityType",
+   "v1beta3.Capability": {
+    "id": "v1beta3.Capability",
     "properties": {}
    },
    "v1beta3.ComponentCondition": {

--- a/api/swagger-spec/v1beta3.json
+++ b/api/swagger-spec/v1beta3.json
@@ -9575,8 +9575,8 @@
      }
     }
    },
-   "v1beta3.PersistentVolumeAccessMode": {
-    "id": "v1beta3.PersistentVolumeAccessMode",
+   "v1beta3.AccessModeType": {
+    "id": "v1beta3.AccessModeType",
     "properties": {}
    },
    "v1beta3.Binding": {
@@ -9609,21 +9609,21 @@
      "add": {
       "type": "array",
       "items": {
-       "$ref": "v1beta3.Capability"
+       "$ref": "v1beta3.CapabilityType"
       },
       "description": "added capabilities"
      },
      "drop": {
       "type": "array",
       "items": {
-       "$ref": "v1beta3.Capability"
+       "$ref": "v1beta3.CapabilityType"
       },
       "description": "droped capabilities"
      }
     }
    },
-   "v1beta3.Capability": {
-    "id": "v1beta3.Capability",
+   "v1beta3.CapabilityType": {
+    "id": "v1beta3.CapabilityType",
     "properties": {}
    },
    "v1beta3.ComponentCondition": {
@@ -10936,7 +10936,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta3.PersistentVolumeAccessMode"
+       "$ref": "v1beta3.AccessModeType"
       },
       "description": "the desired access modes the volume should have"
      },
@@ -10956,7 +10956,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta3.PersistentVolumeAccessMode"
+       "$ref": "v1beta3.AccessModeType"
       },
       "description": "the actual access modes the volume has"
      },
@@ -11013,7 +11013,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1beta3.PersistentVolumeAccessMode"
+       "$ref": "v1beta3.AccessModeType"
       },
       "description": "all ways the volume can be mounted"
      },

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -209,8 +209,8 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			priv := c.RandBool()
 			sc.Privileged = &priv
 			sc.Capabilities = &api.Capabilities{
-				Add:  make([]api.CapabilityType, 0),
-				Drop: make([]api.CapabilityType, 0),
+				Add:  make([]api.Capability, 0),
+				Drop: make([]api.Capability, 0),
 			}
 			c.Fuzz(&sc.Capabilities.Add)
 			c.Fuzz(&sc.Capabilities.Drop)

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -182,8 +182,8 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			protocols := []api.Protocol{api.ProtocolTCP, api.ProtocolUDP}
 			*p = protocols[c.Rand.Intn(len(protocols))]
 		},
-		func(p *api.AffinityType, c fuzz.Continue) {
-			types := []api.AffinityType{api.AffinityTypeClientIP, api.AffinityTypeNone}
+		func(p *api.ServiceAffinity, c fuzz.Continue) {
+			types := []api.ServiceAffinity{api.ServiceAffinityClientIP, api.ServiceAffinityNone}
 			*p = types[c.Rand.Intn(len(types))]
 		},
 		func(ct *api.Container, c fuzz.Continue) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -582,15 +582,15 @@ const (
 	PullIfNotPresent PullPolicy = "IfNotPresent"
 )
 
-// CapabilityType represent POSIX capabilities type
-type CapabilityType string
+// Capability represent POSIX capabilities type
+type Capability string
 
 // Capabilities represent POSIX capabilities that can be added or removed to a running container.
 type Capabilities struct {
 	// Added capabilities
-	Add []CapabilityType `json:"add,omitempty"`
+	Add []Capability `json:"add,omitempty"`
 	// Removed capabilities
-	Drop []CapabilityType `json:"drop,omitempty"`
+	Drop []Capability `json:"drop,omitempty"`
 }
 
 // ResourceRequirements describes the compute resource requirements.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -354,15 +354,15 @@ type EmptyDirVolumeSource struct {
 	// this will cover the most common needs.
 	// Optional: what type of storage medium should back this directory.
 	// The default is "" which means to use the node's default medium.
-	Medium StorageType `json:"medium"`
+	Medium StorageMedium `json:"medium"`
 }
 
-// StorageType defines ways that storage can be allocated to a volume.
-type StorageType string
+// StorageMedium defines ways that storage can be allocated to a volume.
+type StorageMedium string
 
 const (
-	StorageTypeDefault StorageType = ""       // use whatever the default is for the node
-	StorageTypeMemory  StorageType = "Memory" // use memory (tmpfs)
+	StorageMediumDefault StorageMedium = ""       // use whatever the default is for the node
+	StorageMediumMemory  StorageMedium = "Memory" // use memory (tmpfs)
 )
 
 // Protocol defines network protocols supported for things like conatiner ports.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -969,14 +969,14 @@ type ServiceList struct {
 }
 
 // Session Affinity Type string
-type AffinityType string
+type ServiceAffinity string
 
 const (
-	// AffinityTypeClientIP is the Client IP based.
-	AffinityTypeClientIP AffinityType = "ClientIP"
+	// ServiceAffinityClientIP is the Client IP based.
+	ServiceAffinityClientIP ServiceAffinity = "ClientIP"
 
-	// AffinityTypeNone - no session affinity.
-	AffinityTypeNone AffinityType = "None"
+	// ServiceAffinityNone - no session affinity.
+	ServiceAffinityNone ServiceAffinity = "None"
 )
 
 // ServiceStatus represents the current status of a service
@@ -1009,7 +1009,7 @@ type ServiceSpec struct {
 	PublicIPs []string `json:"publicIPs,omitempty"`
 
 	// Required: Supports "ClientIP" and "None".  Used to maintain session affinity.
-	SessionAffinity AffinityType `json:"sessionAffinity,omitempty"`
+	SessionAffinity ServiceAffinity `json:"sessionAffinity,omitempty"`
 }
 
 type ServicePort struct {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -251,7 +251,7 @@ type PersistentVolumeSpec struct {
 	// Source represents the location and type of a volume to mount.
 	PersistentVolumeSource `json:",inline"`
 	// AccessModes contains all ways the volume can be mounted
-	AccessModes []AccessModeType `json:"accessModes,omitempty"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty"`
 	// ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim.
 	// ClaimRef is expected to be non-nil when bound.
 	// claim.VolumeName is the authoritative bind between PV and PVC.
@@ -291,7 +291,7 @@ type PersistentVolumeClaimList struct {
 // and allows a Source for provider-specific attributes
 type PersistentVolumeClaimSpec struct {
 	// Contains the types of access modes required
-	AccessModes []AccessModeType `json:"accessModes,omitempty"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty"`
 	// Resources represents the minimum resources required
 	Resources ResourceRequirements `json:"resources,omitempty"`
 	// VolumeName is the binding reference to the PersistentVolume backing this claim
@@ -302,20 +302,20 @@ type PersistentVolumeClaimStatus struct {
 	// Phase represents the current phase of PersistentVolumeClaim
 	Phase PersistentVolumeClaimPhase `json:"phase,omitempty"`
 	// AccessModes contains all ways the volume backing the PVC can be mounted
-	AccessModes []AccessModeType `json:"accessModes,omitempty"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty"`
 	// Represents the actual resources of the underlying volume
 	Capacity ResourceList `json:"capacity,omitempty"`
 }
 
-type AccessModeType string
+type PersistentVolumeAccessMode string
 
 const (
 	// can be mounted read/write mode to exactly 1 host
-	ReadWriteOnce AccessModeType = "ReadWriteOnce"
+	ReadWriteOnce PersistentVolumeAccessMode = "ReadWriteOnce"
 	// can be mounted in read-only mode to many hosts
-	ReadOnlyMany AccessModeType = "ReadOnlyMany"
+	ReadOnlyMany PersistentVolumeAccessMode = "ReadOnlyMany"
 	// can be mounted in read/write mode to many hosts
-	ReadWriteMany AccessModeType = "ReadWriteMany"
+	ReadWriteMany PersistentVolumeAccessMode = "ReadWriteMany"
 )
 
 type PersistentVolumePhase string

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -2272,9 +2272,9 @@ func convert_v1_PersistentVolumeClaimSpec_To_api_PersistentVolumeClaimSpec(in *P
 		defaulting.(func(*PersistentVolumeClaimSpec))(in)
 	}
 	if in.AccessModes != nil {
-		out.AccessModes = make([]newer.AccessModeType, len(in.AccessModes))
+		out.AccessModes = make([]newer.PersistentVolumeAccessMode, len(in.AccessModes))
 		for i := range in.AccessModes {
-			out.AccessModes[i] = newer.AccessModeType(in.AccessModes[i])
+			out.AccessModes[i] = newer.PersistentVolumeAccessMode(in.AccessModes[i])
 		}
 	} else {
 		out.AccessModes = nil
@@ -2291,9 +2291,9 @@ func convert_api_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec(in *n
 		defaulting.(func(*newer.PersistentVolumeClaimSpec))(in)
 	}
 	if in.AccessModes != nil {
-		out.AccessModes = make([]AccessModeType, len(in.AccessModes))
+		out.AccessModes = make([]PersistentVolumeAccessMode, len(in.AccessModes))
 		for i := range in.AccessModes {
-			out.AccessModes[i] = AccessModeType(in.AccessModes[i])
+			out.AccessModes[i] = PersistentVolumeAccessMode(in.AccessModes[i])
 		}
 	} else {
 		out.AccessModes = nil
@@ -2311,9 +2311,9 @@ func convert_v1_PersistentVolumeClaimStatus_To_api_PersistentVolumeClaimStatus(i
 	}
 	out.Phase = newer.PersistentVolumeClaimPhase(in.Phase)
 	if in.AccessModes != nil {
-		out.AccessModes = make([]newer.AccessModeType, len(in.AccessModes))
+		out.AccessModes = make([]newer.PersistentVolumeAccessMode, len(in.AccessModes))
 		for i := range in.AccessModes {
-			out.AccessModes[i] = newer.AccessModeType(in.AccessModes[i])
+			out.AccessModes[i] = newer.PersistentVolumeAccessMode(in.AccessModes[i])
 		}
 	} else {
 		out.AccessModes = nil
@@ -2339,9 +2339,9 @@ func convert_api_PersistentVolumeClaimStatus_To_v1_PersistentVolumeClaimStatus(i
 	}
 	out.Phase = PersistentVolumeClaimPhase(in.Phase)
 	if in.AccessModes != nil {
-		out.AccessModes = make([]AccessModeType, len(in.AccessModes))
+		out.AccessModes = make([]PersistentVolumeAccessMode, len(in.AccessModes))
 		for i := range in.AccessModes {
-			out.AccessModes[i] = AccessModeType(in.AccessModes[i])
+			out.AccessModes[i] = PersistentVolumeAccessMode(in.AccessModes[i])
 		}
 	} else {
 		out.AccessModes = nil
@@ -2539,9 +2539,9 @@ func convert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in *PersistentV
 		return err
 	}
 	if in.AccessModes != nil {
-		out.AccessModes = make([]newer.AccessModeType, len(in.AccessModes))
+		out.AccessModes = make([]newer.PersistentVolumeAccessMode, len(in.AccessModes))
 		for i := range in.AccessModes {
-			out.AccessModes[i] = newer.AccessModeType(in.AccessModes[i])
+			out.AccessModes[i] = newer.PersistentVolumeAccessMode(in.AccessModes[i])
 		}
 	} else {
 		out.AccessModes = nil
@@ -2577,9 +2577,9 @@ func convert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(in *newer.Persi
 		return err
 	}
 	if in.AccessModes != nil {
-		out.AccessModes = make([]AccessModeType, len(in.AccessModes))
+		out.AccessModes = make([]PersistentVolumeAccessMode, len(in.AccessModes))
 		for i := range in.AccessModes {
-			out.AccessModes[i] = AccessModeType(in.AccessModes[i])
+			out.AccessModes[i] = PersistentVolumeAccessMode(in.AccessModes[i])
 		}
 	} else {
 		out.AccessModes = nil

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -84,17 +84,17 @@ func convert_v1_Capabilities_To_api_Capabilities(in *Capabilities, out *newer.Ca
 		defaulting.(func(*Capabilities))(in)
 	}
 	if in.Add != nil {
-		out.Add = make([]newer.CapabilityType, len(in.Add))
+		out.Add = make([]newer.Capability, len(in.Add))
 		for i := range in.Add {
-			out.Add[i] = newer.CapabilityType(in.Add[i])
+			out.Add[i] = newer.Capability(in.Add[i])
 		}
 	} else {
 		out.Add = nil
 	}
 	if in.Drop != nil {
-		out.Drop = make([]newer.CapabilityType, len(in.Drop))
+		out.Drop = make([]newer.Capability, len(in.Drop))
 		for i := range in.Drop {
-			out.Drop[i] = newer.CapabilityType(in.Drop[i])
+			out.Drop[i] = newer.Capability(in.Drop[i])
 		}
 	} else {
 		out.Drop = nil
@@ -107,17 +107,17 @@ func convert_api_Capabilities_To_v1_Capabilities(in *newer.Capabilities, out *Ca
 		defaulting.(func(*newer.Capabilities))(in)
 	}
 	if in.Add != nil {
-		out.Add = make([]CapabilityType, len(in.Add))
+		out.Add = make([]Capability, len(in.Add))
 		for i := range in.Add {
-			out.Add[i] = CapabilityType(in.Add[i])
+			out.Add[i] = Capability(in.Add[i])
 		}
 	} else {
 		out.Add = nil
 	}
 	if in.Drop != nil {
-		out.Drop = make([]CapabilityType, len(in.Drop))
+		out.Drop = make([]Capability, len(in.Drop))
 		for i := range in.Drop {
-			out.Drop[i] = CapabilityType(in.Drop[i])
+			out.Drop[i] = Capability(in.Drop[i])
 		}
 	} else {
 		out.Drop = nil

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -657,7 +657,7 @@ func convert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in *EmptyDirVol
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*EmptyDirVolumeSource))(in)
 	}
-	out.Medium = newer.StorageType(in.Medium)
+	out.Medium = newer.StorageMedium(in.Medium)
 	return nil
 }
 
@@ -665,7 +665,7 @@ func convert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in *newer.Empty
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*newer.EmptyDirVolumeSource))(in)
 	}
-	out.Medium = StorageType(in.Medium)
+	out.Medium = StorageMedium(in.Medium)
 	return nil
 }
 

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -4057,7 +4057,7 @@ func convert_v1_ServiceSpec_To_api_ServiceSpec(in *ServiceSpec, out *newer.Servi
 	} else {
 		out.PublicIPs = nil
 	}
-	out.SessionAffinity = newer.AffinityType(in.SessionAffinity)
+	out.SessionAffinity = newer.ServiceAffinity(in.SessionAffinity)
 	return nil
 }
 
@@ -4093,7 +4093,7 @@ func convert_api_ServiceSpec_To_v1_ServiceSpec(in *newer.ServiceSpec, out *Servi
 	} else {
 		out.PublicIPs = nil
 	}
-	out.SessionAffinity = AffinityType(in.SessionAffinity)
+	out.SessionAffinity = ServiceAffinity(in.SessionAffinity)
 	return nil
 }
 

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -69,7 +69,7 @@ func addDefaultingFuncs() {
 		},
 		func(obj *ServiceSpec) {
 			if obj.SessionAffinity == "" {
-				obj.SessionAffinity = AffinityTypeNone
+				obj.SessionAffinity = ServiceAffinityNone
 			}
 			for i := range obj.Ports {
 				sp := &obj.Ports[i]

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -159,8 +159,8 @@ func TestSetDefaultService(t *testing.T) {
 	svc := &current.Service{}
 	obj2 := roundTrip(t, runtime.Object(svc))
 	svc2 := obj2.(*current.Service)
-	if svc2.Spec.SessionAffinity != current.AffinityTypeNone {
-		t.Errorf("Expected default sesseion affinity type:%s, got: %s", current.AffinityTypeNone, svc2.Spec.SessionAffinity)
+	if svc2.Spec.SessionAffinity != current.ServiceAffinityNone {
+		t.Errorf("Expected default sesseion affinity type:%s, got: %s", current.ServiceAffinityNone, svc2.Spec.SessionAffinity)
 	}
 }
 

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -951,14 +951,14 @@ type ReplicationControllerList struct {
 }
 
 // Session Affinity Type string
-type AffinityType string
+type ServiceAffinity string
 
 const (
-	// AffinityTypeClientIP is the Client IP based.
-	AffinityTypeClientIP AffinityType = "ClientIP"
+	// ServiceAffinityClientIP is the Client IP based.
+	ServiceAffinityClientIP ServiceAffinity = "ClientIP"
 
-	// AffinityTypeNone - no session affinity.
-	AffinityTypeNone AffinityType = "None"
+	// ServiceAffinityNone - no session affinity.
+	ServiceAffinityNone ServiceAffinity = "None"
 )
 
 // ServiceStatus represents the current status of a service
@@ -987,7 +987,7 @@ type ServiceSpec struct {
 	PublicIPs []string `json:"publicIPs,omitempty" description:"externally visible IPs (e.g. load balancers) that should be proxied to this service"`
 
 	// Optional: Supports "ClientIP" and "None".  Used to maintain session affinity.
-	SessionAffinity AffinityType `json:"sessionAffinity,omitempty" description:"enable client IP based session affinity; must be ClientIP or None; defaults to None"`
+	SessionAffinity ServiceAffinity `json:"sessionAffinity,omitempty" description:"enable client IP based session affinity; must be ClientIP or None; defaults to None"`
 }
 
 type ServicePort struct {

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -366,7 +366,7 @@ type HostPathVolumeSource struct {
 type EmptyDirVolumeSource struct {
 	// Optional: what type of storage medium should back this directory.
 	// The default is "" which means to use the node's default medium.
-	Medium StorageType `json:"medium,omitempty" description:"type of storage used to back the volume; must be an empty string (default) or Memory"`
+	Medium StorageMedium `json:"medium,omitempty" description:"type of storage used to back the volume; must be an empty string (default) or Memory"`
 }
 
 // GlusterfsVolumeSource represents a Glusterfs Mount that lasts the lifetime of a pod
@@ -382,12 +382,12 @@ type GlusterfsVolumeSource struct {
 	ReadOnly bool `json:"readOnly,omitempty" description:"glusterfs volume to be mounted with read-only permissions"`
 }
 
-// StorageType defines ways that storage can be allocated to a volume.
-type StorageType string
+// StorageMedium defines ways that storage can be allocated to a volume.
+type StorageMedium string
 
 const (
-	StorageTypeDefault StorageType = ""       // use whatever the default is for the node
-	StorageTypeMemory  StorageType = "Memory" // use memory (tmpfs)
+	StorageMediumDefault StorageMedium = ""       // use whatever the default is for the node
+	StorageMediumMemory  StorageMedium = "Memory" // use memory (tmpfs)
 )
 
 // Protocol defines network protocols supported for things like conatiner ports.

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -590,15 +590,15 @@ const (
 	PullIfNotPresent PullPolicy = "IfNotPresent"
 )
 
-// CapabilityType represent POSIX capabilities type
-type CapabilityType string
+// Capability represent POSIX capabilities type
+type Capability string
 
 // Capabilities represent POSIX capabilities that can be added or removed to a running container.
 type Capabilities struct {
 	// Added capabilities
-	Add []CapabilityType `json:"add,omitempty" description:"added capabilities"`
+	Add []Capability `json:"add,omitempty" description:"added capabilities"`
 	// Removed capabilities
-	Drop []CapabilityType `json:"drop,omitempty" description:"droped capabilities"`
+	Drop []Capability `json:"drop,omitempty" description:"droped capabilities"`
 }
 
 // ResourceRequirements describes the compute resource requirements.

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -268,7 +268,7 @@ type PersistentVolumeSpec struct {
 	// Source represents the location and type of a volume to mount.
 	PersistentVolumeSource `json:",inline" description:"the actual volume backing the persistent volume"`
 	// AccessModes contains all ways the volume can be mounted
-	AccessModes []AccessModeType `json:"accessModes,omitempty" description:"all ways the volume can be mounted"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"all ways the volume can be mounted"`
 	// ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim.
 	// ClaimRef is expected to be non-nil when bound.
 	// claim.VolumeName is the authoritative bind between PV and PVC.
@@ -308,7 +308,7 @@ type PersistentVolumeClaimList struct {
 // and allows a Source for provider-specific attributes
 type PersistentVolumeClaimSpec struct {
 	// Contains the types of access modes required
-	AccessModes []AccessModeType `json:"accessModes,omitempty" description:"the desired access modes the volume should have"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"the desired access modes the volume should have"`
 	// Resources represents the minimum resources required
 	Resources ResourceRequirements `json:"resources,omitempty" description:"the desired resources the volume should have"`
 	// VolumeName is the binding reference to the PersistentVolume backing this claim
@@ -319,20 +319,20 @@ type PersistentVolumeClaimStatus struct {
 	// Phase represents the current phase of PersistentVolumeClaim
 	Phase PersistentVolumeClaimPhase `json:"phase,omitempty" description:"the current phase of the claim"`
 	// AccessModes contains all ways the volume backing the PVC can be mounted
-	AccessModes []AccessModeType `json:"accessModes,omitempty" description:"the actual access modes the volume has"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"the actual access modes the volume has"`
 	// Represents the actual resources of the underlying volume
 	Capacity ResourceList `json:"capacity,omitempty" description:"the actual resources the volume has"`
 }
 
-type AccessModeType string
+type PersistentVolumeAccessMode string
 
 const (
 	// can be mounted read/write mode to exactly 1 host
-	ReadWriteOnce AccessModeType = "ReadWriteOnce"
+	ReadWriteOnce PersistentVolumeAccessMode = "ReadWriteOnce"
 	// can be mounted in read-only mode to many hosts
-	ReadOnlyMany AccessModeType = "ReadOnlyMany"
+	ReadOnlyMany PersistentVolumeAccessMode = "ReadOnlyMany"
 	// can be mounted in read/write mode to many hosts
-	ReadWriteMany AccessModeType = "ReadWriteMany"
+	ReadWriteMany PersistentVolumeAccessMode = "ReadWriteMany"
 )
 
 type PersistentVolumePhase string

--- a/pkg/api/v1beta1/conversion_test.go
+++ b/pkg/api/v1beta1/conversion_test.go
@@ -771,11 +771,11 @@ func TestBadSecurityContextConversion(t *testing.T) {
 		"mismatched caps add": {
 			c: &current.Container{
 				Capabilities: current.Capabilities{
-					Add: []current.CapabilityType{"foo"},
+					Add: []current.Capability{"foo"},
 				},
 				SecurityContext: &current.SecurityContext{
 					Capabilities: &current.Capabilities{
-						Add: []current.CapabilityType{"bar"},
+						Add: []current.Capability{"bar"},
 					},
 				},
 			},
@@ -784,11 +784,11 @@ func TestBadSecurityContextConversion(t *testing.T) {
 		"mismatched caps drop": {
 			c: &current.Container{
 				Capabilities: current.Capabilities{
-					Drop: []current.CapabilityType{"foo"},
+					Drop: []current.Capability{"foo"},
 				},
 				SecurityContext: &current.SecurityContext{
 					Capabilities: &current.Capabilities{
-						Drop: []current.CapabilityType{"bar"},
+						Drop: []current.Capability{"bar"},
 					},
 				},
 			},

--- a/pkg/api/v1beta1/defaults.go
+++ b/pkg/api/v1beta1/defaults.go
@@ -74,7 +74,7 @@ func addDefaultingFuncs() {
 				obj.Protocol = ProtocolTCP
 			}
 			if obj.SessionAffinity == "" {
-				obj.SessionAffinity = AffinityTypeNone
+				obj.SessionAffinity = ServiceAffinityNone
 			}
 			for i := range obj.Ports {
 				sp := &obj.Ports[i]

--- a/pkg/api/v1beta1/defaults_test.go
+++ b/pkg/api/v1beta1/defaults_test.go
@@ -149,8 +149,8 @@ func TestSetDefaultService(t *testing.T) {
 	if svc2.Protocol != current.ProtocolTCP {
 		t.Errorf("Expected default protocol :%s, got: %s", current.ProtocolTCP, svc2.Protocol)
 	}
-	if svc2.SessionAffinity != current.AffinityTypeNone {
-		t.Errorf("Expected default sesseion affinity type:%s, got: %s", current.AffinityTypeNone, svc2.SessionAffinity)
+	if svc2.SessionAffinity != current.ServiceAffinityNone {
+		t.Errorf("Expected default sesseion affinity type:%s, got: %s", current.ServiceAffinityNone, svc2.SessionAffinity)
 	}
 }
 

--- a/pkg/api/v1beta1/defaults_test.go
+++ b/pkg/api/v1beta1/defaults_test.go
@@ -351,8 +351,8 @@ func TestSetDefaultSecurityContext(t *testing.T) {
 			c: current.Container{
 				Privileged: false,
 				Capabilities: current.Capabilities{
-					Add:  []current.CapabilityType{"foo"},
-					Drop: []current.CapabilityType{"bar"},
+					Add:  []current.Capability{"foo"},
+					Drop: []current.Capability{"bar"},
 				},
 				SecurityContext: &current.SecurityContext{
 					Privileged: &priv,
@@ -363,13 +363,13 @@ func TestSetDefaultSecurityContext(t *testing.T) {
 			c: current.Container{
 				Privileged: false,
 				Capabilities: current.Capabilities{
-					Add:  []current.CapabilityType{"foo"},
-					Drop: []current.CapabilityType{"bar"},
+					Add:  []current.Capability{"foo"},
+					Drop: []current.Capability{"bar"},
 				},
 				SecurityContext: &current.SecurityContext{
 					Capabilities: &current.Capabilities{
-						Add:  []current.CapabilityType{"foo"},
-						Drop: []current.CapabilityType{"bar"},
+						Add:  []current.Capability{"foo"},
+						Drop: []current.Capability{"bar"},
 					},
 				},
 			},
@@ -380,8 +380,8 @@ func TestSetDefaultSecurityContext(t *testing.T) {
 				SecurityContext: &current.SecurityContext{
 					Privileged: &priv,
 					Capabilities: &current.Capabilities{
-						Add:  []current.CapabilityType{"biz"},
-						Drop: []current.CapabilityType{"baz"},
+						Add:  []current.Capability{"biz"},
+						Drop: []current.Capability{"baz"},
 					},
 				},
 			},
@@ -389,14 +389,14 @@ func TestSetDefaultSecurityContext(t *testing.T) {
 		"upward defaulting priv": {
 			c: current.Container{
 				Capabilities: current.Capabilities{
-					Add:  []current.CapabilityType{"foo"},
-					Drop: []current.CapabilityType{"bar"},
+					Add:  []current.Capability{"foo"},
+					Drop: []current.Capability{"bar"},
 				},
 				SecurityContext: &current.SecurityContext{
 					Privileged: &privTrue,
 					Capabilities: &current.Capabilities{
-						Add:  []current.CapabilityType{"foo"},
-						Drop: []current.CapabilityType{"bar"},
+						Add:  []current.Capability{"foo"},
+						Drop: []current.Capability{"bar"},
 					},
 				},
 			},

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -267,15 +267,15 @@ type HostPathVolumeSource struct {
 type EmptyDirVolumeSource struct {
 	// Optional: what type of storage medium should back this directory.
 	// The default is "" which means to use the node's default medium.
-	Medium StorageType `json:"medium" description:"type of storage used to back the volume; must be an empty string (default) or Memory"`
+	Medium StorageMedium `json:"medium" description:"type of storage used to back the volume; must be an empty string (default) or Memory"`
 }
 
-// StorageType defines ways that storage can be allocated to a volume.
-type StorageType string
+// StorageMedium defines ways that storage can be allocated to a volume.
+type StorageMedium string
 
 const (
-	StorageTypeDefault StorageType = ""       // use whatever the default is for the node
-	StorageTypeMemory  StorageType = "Memory" // use memory (tmpfs)
+	StorageMediumDefault StorageMedium = ""       // use whatever the default is for the node
+	StorageMediumMemory  StorageMedium = "Memory" // use memory (tmpfs)
 )
 
 // Protocol defines network protocols supported for things like conatiner ports.

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -481,15 +481,15 @@ const (
 	PullIfNotPresent PullPolicy = "PullIfNotPresent"
 )
 
-// CapabilityType represent POSIX capabilities type
-type CapabilityType string
+// Capability represent POSIX capabilities type
+type Capability string
 
 // Capabilities represent POSIX capabilities that can be added or removed to a running container.
 type Capabilities struct {
 	// Added capabilities
-	Add []CapabilityType `json:"add,omitempty" description:"added capabilities"`
+	Add []Capability `json:"add,omitempty" description:"added capabilities"`
 	// Removed capabilities
-	Drop []CapabilityType `json:"drop,omitempty" description:"droped capabilities"`
+	Drop []Capability `json:"drop,omitempty" description:"droped capabilities"`
 }
 
 type ResourceRequirements struct {

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -174,7 +174,7 @@ type PersistentVolumeSpec struct {
 	// Source represents the location and type of a volume to mount.
 	PersistentVolumeSource `json:",inline" description:"the actual volume backing the persistent volume"`
 	// AccessModes contains all ways the volume can be mounted
-	AccessModes []AccessModeType `json:"accessModes,omitempty" description:"all ways the volume can be mounted"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"all ways the volume can be mounted"`
 	// ClaimRef is a non-binding reference to the claim bound to this volume
 	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim"`
 }
@@ -209,7 +209,7 @@ type PersistentVolumeClaimList struct {
 // and allows a Source for provider-specific attributes
 type PersistentVolumeClaimSpec struct {
 	// Contains the types of access modes required
-	AccessModes []AccessModeType `json:"accessModes,omitempty" description:"the desired access modes the volume should have"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"the desired access modes the volume should have"`
 	// Resources represents the minimum resources required
 	Resources ResourceRequirements `json:"resources,omitempty" description:"the desired resources the volume should have"`
 	// VolumeName is the binding reference to the PersistentVolume backing this claim
@@ -220,20 +220,20 @@ type PersistentVolumeClaimStatus struct {
 	// Phase represents the current phase of PersistentVolumeClaim
 	Phase PersistentVolumeClaimPhase `json:"phase,omitempty" description:"the current phase of the claim"`
 	// AccessModes contains all ways the volume backing the PVC can be mounted
-	AccessModes []AccessModeType `json:"accessModes,omitempty" description:"the actual access modes the volume has"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"the actual access modes the volume has"`
 	// Represents the actual resources of the underlying volume
 	Capacity ResourceList `json:"capacity,omitempty" description:"the actual resources the volume has"`
 }
 
-type AccessModeType string
+type PersistentVolumeAccessMode string
 
 const (
 	// can be mounted read/write mode to exactly 1 host
-	ReadWriteOnce AccessModeType = "ReadWriteOnce"
+	ReadWriteOnce PersistentVolumeAccessMode = "ReadWriteOnce"
 	// can be mounted in read-only mode to many hosts
-	ReadOnlyMany AccessModeType = "ReadOnlyMany"
+	ReadOnlyMany PersistentVolumeAccessMode = "ReadOnlyMany"
 	// can be mounted in read/write mode to many hosts
-	ReadWriteMany AccessModeType = "ReadWriteMany"
+	ReadWriteMany PersistentVolumeAccessMode = "ReadWriteMany"
 )
 
 type PersistentVolumePhase string

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -793,14 +793,14 @@ type PodTemplate struct {
 }
 
 // Session Affinity Type string
-type AffinityType string
+type ServiceAffinity string
 
 const (
-	// AffinityTypeClientIP is the Client IP based.
-	AffinityTypeClientIP AffinityType = "ClientIP"
+	// ServiceAffinityClientIP is the Client IP based.
+	ServiceAffinityClientIP ServiceAffinity = "ClientIP"
 
-	// AffinityTypeNone - no session affinity.
-	AffinityTypeNone AffinityType = "None"
+	// ServiceAffinityNone - no session affinity.
+	ServiceAffinityNone ServiceAffinity = "None"
 )
 
 const (
@@ -856,7 +856,7 @@ type Service struct {
 	ProxyPort int `json:"proxyPort,omitempty" description:"if non-zero, a pre-allocated host port used for this service by the proxy on each node; assigned by the master and ignored on input"`
 
 	// Optional: Supports "ClientIP" and "None".  Used to maintain session affinity.
-	SessionAffinity AffinityType `json:"sessionAffinity,omitempty" description:"enable client IP based session affinity; must be ClientIP or None; defaults to None"`
+	SessionAffinity ServiceAffinity `json:"sessionAffinity,omitempty" description:"enable client IP based session affinity; must be ClientIP or None; defaults to None"`
 
 	// Optional: Ports to expose on the service.  If this field is
 	// specified, the legacy fields (Port, PortName, Protocol, and

--- a/pkg/api/v1beta2/conversion_test.go
+++ b/pkg/api/v1beta2/conversion_test.go
@@ -586,11 +586,11 @@ func TestBadSecurityContextConversion(t *testing.T) {
 		"mismatched caps add": {
 			c: &current.Container{
 				Capabilities: current.Capabilities{
-					Add: []current.CapabilityType{"foo"},
+					Add: []current.Capability{"foo"},
 				},
 				SecurityContext: &current.SecurityContext{
 					Capabilities: &current.Capabilities{
-						Add: []current.CapabilityType{"bar"},
+						Add: []current.Capability{"bar"},
 					},
 				},
 			},
@@ -599,11 +599,11 @@ func TestBadSecurityContextConversion(t *testing.T) {
 		"mismatched caps drop": {
 			c: &current.Container{
 				Capabilities: current.Capabilities{
-					Drop: []current.CapabilityType{"foo"},
+					Drop: []current.Capability{"foo"},
 				},
 				SecurityContext: &current.SecurityContext{
 					Capabilities: &current.Capabilities{
-						Drop: []current.CapabilityType{"bar"},
+						Drop: []current.Capability{"bar"},
 					},
 				},
 			},

--- a/pkg/api/v1beta2/defaults.go
+++ b/pkg/api/v1beta2/defaults.go
@@ -75,7 +75,7 @@ func addDefaultingFuncs() {
 				obj.Protocol = ProtocolTCP
 			}
 			if obj.SessionAffinity == "" {
-				obj.SessionAffinity = AffinityTypeNone
+				obj.SessionAffinity = ServiceAffinityNone
 			}
 			for i := range obj.Ports {
 				sp := &obj.Ports[i]

--- a/pkg/api/v1beta2/defaults_test.go
+++ b/pkg/api/v1beta2/defaults_test.go
@@ -350,8 +350,8 @@ func TestSetDefaultSecurityContext(t *testing.T) {
 			c: current.Container{
 				Privileged: false,
 				Capabilities: current.Capabilities{
-					Add:  []current.CapabilityType{"foo"},
-					Drop: []current.CapabilityType{"bar"},
+					Add:  []current.Capability{"foo"},
+					Drop: []current.Capability{"bar"},
 				},
 				SecurityContext: &current.SecurityContext{
 					Privileged: &priv,
@@ -362,13 +362,13 @@ func TestSetDefaultSecurityContext(t *testing.T) {
 			c: current.Container{
 				Privileged: false,
 				Capabilities: current.Capabilities{
-					Add:  []current.CapabilityType{"foo"},
-					Drop: []current.CapabilityType{"bar"},
+					Add:  []current.Capability{"foo"},
+					Drop: []current.Capability{"bar"},
 				},
 				SecurityContext: &current.SecurityContext{
 					Capabilities: &current.Capabilities{
-						Add:  []current.CapabilityType{"foo"},
-						Drop: []current.CapabilityType{"bar"},
+						Add:  []current.Capability{"foo"},
+						Drop: []current.Capability{"bar"},
 					},
 				},
 			},
@@ -379,8 +379,8 @@ func TestSetDefaultSecurityContext(t *testing.T) {
 				SecurityContext: &current.SecurityContext{
 					Privileged: &priv,
 					Capabilities: &current.Capabilities{
-						Add:  []current.CapabilityType{"biz"},
-						Drop: []current.CapabilityType{"baz"},
+						Add:  []current.Capability{"biz"},
+						Drop: []current.Capability{"baz"},
 					},
 				},
 			},
@@ -388,14 +388,14 @@ func TestSetDefaultSecurityContext(t *testing.T) {
 		"upward defaulting priv": {
 			c: current.Container{
 				Capabilities: current.Capabilities{
-					Add:  []current.CapabilityType{"foo"},
-					Drop: []current.CapabilityType{"bar"},
+					Add:  []current.Capability{"foo"},
+					Drop: []current.Capability{"bar"},
 				},
 				SecurityContext: &current.SecurityContext{
 					Privileged: &privTrue,
 					Capabilities: &current.Capabilities{
-						Add:  []current.CapabilityType{"foo"},
-						Drop: []current.CapabilityType{"bar"},
+						Add:  []current.Capability{"foo"},
+						Drop: []current.Capability{"bar"},
 					},
 				},
 			},

--- a/pkg/api/v1beta2/defaults_test.go
+++ b/pkg/api/v1beta2/defaults_test.go
@@ -149,8 +149,8 @@ func TestSetDefaultService(t *testing.T) {
 	if svc2.Protocol != current.ProtocolTCP {
 		t.Errorf("Expected default protocol :%s, got: %s", current.ProtocolTCP, svc2.Protocol)
 	}
-	if svc2.SessionAffinity != current.AffinityTypeNone {
-		t.Errorf("Expected default sesseion affinity type:%s, got: %s", current.AffinityTypeNone, svc2.SessionAffinity)
+	if svc2.SessionAffinity != current.ServiceAffinityNone {
+		t.Errorf("Expected default sesseion affinity type:%s, got: %s", current.ServiceAffinityNone, svc2.SessionAffinity)
 	}
 }
 

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -135,7 +135,7 @@ type PersistentVolumeSpec struct {
 	// Source represents the location and type of a volume to mount.
 	PersistentVolumeSource `json:",inline" description:"the actual volume backing the persistent volume"`
 	// AccessModes contains all ways the volume can be mounted
-	AccessModes []AccessModeType `json:"accessModes,omitempty" description:"all ways the volume can be mounted"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"all ways the volume can be mounted"`
 	// ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim.
 	// ClaimRef is expected to be non-nil when bound.
 	// claim.VolumeName is the authoritative bind between PV and PVC.
@@ -172,7 +172,7 @@ type PersistentVolumeClaimList struct {
 // and allows a Source for provider-specific attributes
 type PersistentVolumeClaimSpec struct {
 	// Contains the types of access modes required
-	AccessModes []AccessModeType `json:"accessModes,omitempty" description:"the desired access modes the volume should have"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"the desired access modes the volume should have"`
 	// Resources represents the minimum resources required
 	Resources ResourceRequirements `json:"resources,omitempty" description:"the desired resources the volume should have"`
 	// VolumeName is the binding reference to the PersistentVolume backing this claim
@@ -183,20 +183,20 @@ type PersistentVolumeClaimStatus struct {
 	// Phase represents the current phase of PersistentVolumeClaim
 	Phase PersistentVolumeClaimPhase `json:"phase,omitempty" description:"the current phase of the claim"`
 	// AccessModes contains all ways the volume backing the PVC can be mounted
-	AccessModes []AccessModeType `json:"accessModes,omitempty" description:"the actual access modes the volume has"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"the actual access modes the volume has"`
 	// Represents the actual resources of the underlying volume
 	Capacity ResourceList `json:"capacity,omitempty" description:"the actual resources the volume has"`
 }
 
-type AccessModeType string
+type PersistentVolumeAccessMode string
 
 const (
 	// can be mounted read/write mode to exactly 1 host
-	ReadWriteOnce AccessModeType = "ReadWriteOnce"
+	ReadWriteOnce PersistentVolumeAccessMode = "ReadWriteOnce"
 	// can be mounted in read-only mode to many hosts
-	ReadOnlyMany AccessModeType = "ReadOnlyMany"
+	ReadOnlyMany PersistentVolumeAccessMode = "ReadOnlyMany"
 	// can be mounted in read/write mode to many hosts
-	ReadWriteMany AccessModeType = "ReadWriteMany"
+	ReadWriteMany PersistentVolumeAccessMode = "ReadWriteMany"
 )
 
 type PersistentVolumePhase string

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -799,14 +799,14 @@ type PodTemplate struct {
 }
 
 // Session Affinity Type string
-type AffinityType string
+type ServiceAffinity string
 
 const (
-	// AffinityTypeClientIP is the Client IP based.
-	AffinityTypeClientIP AffinityType = "ClientIP"
+	// ServiceAffinityClientIP is the Client IP based.
+	ServiceAffinityClientIP ServiceAffinity = "ClientIP"
 
-	// AffinityTypeNone - no session affinity.
-	AffinityTypeNone AffinityType = "None"
+	// ServiceAffinityNone - no session affinity.
+	ServiceAffinityNone ServiceAffinity = "None"
 )
 
 const (
@@ -864,7 +864,7 @@ type Service struct {
 	ProxyPort int `json:"proxyPort,omitempty" description:"if non-zero, a pre-allocated host port used for this service by the proxy on each node; assigned by the master and ignored on input"`
 
 	// Optional: Supports "ClientIP" and "None".  Used to maintain session affinity.
-	SessionAffinity AffinityType `json:"sessionAffinity,omitempty" description:"enable client IP based session affinity; must be ClientIP or None; defaults to None"`
+	SessionAffinity ServiceAffinity `json:"sessionAffinity,omitempty" description:"enable client IP based session affinity; must be ClientIP or None; defaults to None"`
 
 	// Optional: Ports to expose on the service.  If this field is
 	// specified, the legacy fields (Port, PortName, Protocol, and

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -466,17 +466,17 @@ const (
 	PullIfNotPresent PullPolicy = "PullIfNotPresent"
 )
 
-// CapabilityType represent POSIX capabilities type
-type CapabilityType string
+// Capability represent POSIX capabilities type
+type Capability string
 
 // Capabilities represent POSIX capabilities that can be added or removed to a running container.
 //
 // http://docs.k8s.io/containers.md#capabilities
 type Capabilities struct {
 	// Added capabilities
-	Add []CapabilityType `json:"add,omitempty" description:"added capabilities"`
+	Add []Capability `json:"add,omitempty" description:"added capabilities"`
 	// Removed capabilities
-	Drop []CapabilityType `json:"drop,omitempty" description:"droped capabilities"`
+	Drop []Capability `json:"drop,omitempty" description:"droped capabilities"`
 }
 
 type ResourceRequirements struct {

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -235,15 +235,15 @@ type HostPathVolumeSource struct {
 type EmptyDirVolumeSource struct {
 	// Optional: what type of storage medium should back this directory.
 	// The default is "" which means to use the node's default medium.
-	Medium StorageType `json:"medium" description:"type of storage used to back the volume; must be an empty string (default) or Memory"`
+	Medium StorageMedium `json:"medium" description:"type of storage used to back the volume; must be an empty string (default) or Memory"`
 }
 
-// StorageType defines ways that storage can be allocated to a volume.
-type StorageType string
+// StorageMedium defines ways that storage can be allocated to a volume.
+type StorageMedium string
 
 const (
-	StorageTypeDefault StorageType = ""       // use whatever the default is for the node
-	StorageTypeMemory  StorageType = "Memory" // use memory (tmpfs)
+	StorageMediumDefault StorageMedium = ""       // use whatever the default is for the node
+	StorageMediumMemory  StorageMedium = "Memory" // use memory (tmpfs)
 )
 
 // SecretVolumeSource adapts a Secret into a VolumeSource

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -471,7 +471,7 @@ func convert_v1beta3_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in *EmptyD
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*EmptyDirVolumeSource))(in)
 	}
-	out.Medium = newer.StorageType(in.Medium)
+	out.Medium = newer.StorageMedium(in.Medium)
 	return nil
 }
 
@@ -479,7 +479,7 @@ func convert_api_EmptyDirVolumeSource_To_v1beta3_EmptyDirVolumeSource(in *newer.
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*newer.EmptyDirVolumeSource))(in)
 	}
-	out.Medium = StorageType(in.Medium)
+	out.Medium = StorageMedium(in.Medium)
 	return nil
 }
 

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -84,17 +84,17 @@ func convert_api_Capabilities_To_v1beta3_Capabilities(in *newer.Capabilities, ou
 		defaulting.(func(*newer.Capabilities))(in)
 	}
 	if in.Add != nil {
-		out.Add = make([]CapabilityType, len(in.Add))
+		out.Add = make([]Capability, len(in.Add))
 		for i := range in.Add {
-			out.Add[i] = CapabilityType(in.Add[i])
+			out.Add[i] = Capability(in.Add[i])
 		}
 	} else {
 		out.Add = nil
 	}
 	if in.Drop != nil {
-		out.Drop = make([]CapabilityType, len(in.Drop))
+		out.Drop = make([]Capability, len(in.Drop))
 		for i := range in.Drop {
-			out.Drop[i] = CapabilityType(in.Drop[i])
+			out.Drop[i] = Capability(in.Drop[i])
 		}
 	} else {
 		out.Drop = nil
@@ -107,17 +107,17 @@ func convert_v1beta3_Capabilities_To_api_Capabilities(in *Capabilities, out *new
 		defaulting.(func(*Capabilities))(in)
 	}
 	if in.Add != nil {
-		out.Add = make([]newer.CapabilityType, len(in.Add))
+		out.Add = make([]newer.Capability, len(in.Add))
 		for i := range in.Add {
-			out.Add[i] = newer.CapabilityType(in.Add[i])
+			out.Add[i] = newer.Capability(in.Add[i])
 		}
 	} else {
 		out.Add = nil
 	}
 	if in.Drop != nil {
-		out.Drop = make([]newer.CapabilityType, len(in.Drop))
+		out.Drop = make([]newer.Capability, len(in.Drop))
 		for i := range in.Drop {
-			out.Drop[i] = newer.CapabilityType(in.Drop[i])
+			out.Drop[i] = newer.Capability(in.Drop[i])
 		}
 	} else {
 		out.Drop = nil

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -3871,7 +3871,7 @@ func convert_v1beta3_ServiceSpec_To_api_ServiceSpec(in *ServiceSpec, out *newer.
 	} else {
 		out.PublicIPs = nil
 	}
-	out.SessionAffinity = newer.AffinityType(in.SessionAffinity)
+	out.SessionAffinity = newer.ServiceAffinity(in.SessionAffinity)
 	return nil
 }
 
@@ -3907,7 +3907,7 @@ func convert_api_ServiceSpec_To_v1beta3_ServiceSpec(in *newer.ServiceSpec, out *
 	} else {
 		out.PublicIPs = nil
 	}
-	out.SessionAffinity = AffinityType(in.SessionAffinity)
+	out.SessionAffinity = ServiceAffinity(in.SessionAffinity)
 	return nil
 }
 

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -2086,9 +2086,9 @@ func convert_v1beta3_PersistentVolumeClaimSpec_To_api_PersistentVolumeClaimSpec(
 		defaulting.(func(*PersistentVolumeClaimSpec))(in)
 	}
 	if in.AccessModes != nil {
-		out.AccessModes = make([]newer.AccessModeType, len(in.AccessModes))
+		out.AccessModes = make([]newer.PersistentVolumeAccessMode, len(in.AccessModes))
 		for i := range in.AccessModes {
-			out.AccessModes[i] = newer.AccessModeType(in.AccessModes[i])
+			out.AccessModes[i] = newer.PersistentVolumeAccessMode(in.AccessModes[i])
 		}
 	} else {
 		out.AccessModes = nil
@@ -2105,9 +2105,9 @@ func convert_api_PersistentVolumeClaimSpec_To_v1beta3_PersistentVolumeClaimSpec(
 		defaulting.(func(*newer.PersistentVolumeClaimSpec))(in)
 	}
 	if in.AccessModes != nil {
-		out.AccessModes = make([]AccessModeType, len(in.AccessModes))
+		out.AccessModes = make([]PersistentVolumeAccessMode, len(in.AccessModes))
 		for i := range in.AccessModes {
-			out.AccessModes[i] = AccessModeType(in.AccessModes[i])
+			out.AccessModes[i] = PersistentVolumeAccessMode(in.AccessModes[i])
 		}
 	} else {
 		out.AccessModes = nil
@@ -2125,9 +2125,9 @@ func convert_v1beta3_PersistentVolumeClaimStatus_To_api_PersistentVolumeClaimSta
 	}
 	out.Phase = newer.PersistentVolumeClaimPhase(in.Phase)
 	if in.AccessModes != nil {
-		out.AccessModes = make([]newer.AccessModeType, len(in.AccessModes))
+		out.AccessModes = make([]newer.PersistentVolumeAccessMode, len(in.AccessModes))
 		for i := range in.AccessModes {
-			out.AccessModes[i] = newer.AccessModeType(in.AccessModes[i])
+			out.AccessModes[i] = newer.PersistentVolumeAccessMode(in.AccessModes[i])
 		}
 	} else {
 		out.AccessModes = nil
@@ -2153,9 +2153,9 @@ func convert_api_PersistentVolumeClaimStatus_To_v1beta3_PersistentVolumeClaimSta
 	}
 	out.Phase = PersistentVolumeClaimPhase(in.Phase)
 	if in.AccessModes != nil {
-		out.AccessModes = make([]AccessModeType, len(in.AccessModes))
+		out.AccessModes = make([]PersistentVolumeAccessMode, len(in.AccessModes))
 		for i := range in.AccessModes {
-			out.AccessModes[i] = AccessModeType(in.AccessModes[i])
+			out.AccessModes[i] = PersistentVolumeAccessMode(in.AccessModes[i])
 		}
 	} else {
 		out.AccessModes = nil
@@ -2353,9 +2353,9 @@ func convert_v1beta3_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in *Persis
 		return err
 	}
 	if in.AccessModes != nil {
-		out.AccessModes = make([]newer.AccessModeType, len(in.AccessModes))
+		out.AccessModes = make([]newer.PersistentVolumeAccessMode, len(in.AccessModes))
 		for i := range in.AccessModes {
-			out.AccessModes[i] = newer.AccessModeType(in.AccessModes[i])
+			out.AccessModes[i] = newer.PersistentVolumeAccessMode(in.AccessModes[i])
 		}
 	} else {
 		out.AccessModes = nil
@@ -2391,9 +2391,9 @@ func convert_api_PersistentVolumeSpec_To_v1beta3_PersistentVolumeSpec(in *newer.
 		return err
 	}
 	if in.AccessModes != nil {
-		out.AccessModes = make([]AccessModeType, len(in.AccessModes))
+		out.AccessModes = make([]PersistentVolumeAccessMode, len(in.AccessModes))
 		for i := range in.AccessModes {
-			out.AccessModes[i] = AccessModeType(in.AccessModes[i])
+			out.AccessModes[i] = PersistentVolumeAccessMode(in.AccessModes[i])
 		}
 	} else {
 		out.AccessModes = nil

--- a/pkg/api/v1beta3/conversion_test.go
+++ b/pkg/api/v1beta3/conversion_test.go
@@ -67,11 +67,11 @@ func TestBadSecurityContextConversion(t *testing.T) {
 		"mismatched caps add": {
 			c: &current.Container{
 				Capabilities: current.Capabilities{
-					Add: []current.CapabilityType{"foo"},
+					Add: []current.Capability{"foo"},
 				},
 				SecurityContext: &current.SecurityContext{
 					Capabilities: &current.Capabilities{
-						Add: []current.CapabilityType{"bar"},
+						Add: []current.Capability{"bar"},
 					},
 				},
 			},
@@ -80,11 +80,11 @@ func TestBadSecurityContextConversion(t *testing.T) {
 		"mismatched caps drop": {
 			c: &current.Container{
 				Capabilities: current.Capabilities{
-					Drop: []current.CapabilityType{"foo"},
+					Drop: []current.Capability{"foo"},
 				},
 				SecurityContext: &current.SecurityContext{
 					Capabilities: &current.Capabilities{
-						Drop: []current.CapabilityType{"bar"},
+						Drop: []current.Capability{"bar"},
 					},
 				},
 			},

--- a/pkg/api/v1beta3/defaults.go
+++ b/pkg/api/v1beta3/defaults.go
@@ -71,7 +71,7 @@ func addDefaultingFuncs() {
 		},
 		func(obj *ServiceSpec) {
 			if obj.SessionAffinity == "" {
-				obj.SessionAffinity = AffinityTypeNone
+				obj.SessionAffinity = ServiceAffinityNone
 			}
 			for i := range obj.Ports {
 				sp := &obj.Ports[i]

--- a/pkg/api/v1beta3/defaults_test.go
+++ b/pkg/api/v1beta3/defaults_test.go
@@ -360,8 +360,8 @@ func TestSetDefaultSecurityContext(t *testing.T) {
 			c: current.Container{
 				Privileged: false,
 				Capabilities: current.Capabilities{
-					Add:  []current.CapabilityType{"foo"},
-					Drop: []current.CapabilityType{"bar"},
+					Add:  []current.Capability{"foo"},
+					Drop: []current.Capability{"bar"},
 				},
 				SecurityContext: &current.SecurityContext{
 					Privileged: &priv,
@@ -372,13 +372,13 @@ func TestSetDefaultSecurityContext(t *testing.T) {
 			c: current.Container{
 				Privileged: false,
 				Capabilities: current.Capabilities{
-					Add:  []current.CapabilityType{"foo"},
-					Drop: []current.CapabilityType{"bar"},
+					Add:  []current.Capability{"foo"},
+					Drop: []current.Capability{"bar"},
 				},
 				SecurityContext: &current.SecurityContext{
 					Capabilities: &current.Capabilities{
-						Add:  []current.CapabilityType{"foo"},
-						Drop: []current.CapabilityType{"bar"},
+						Add:  []current.Capability{"foo"},
+						Drop: []current.Capability{"bar"},
 					},
 				},
 			},
@@ -389,8 +389,8 @@ func TestSetDefaultSecurityContext(t *testing.T) {
 				SecurityContext: &current.SecurityContext{
 					Privileged: &priv,
 					Capabilities: &current.Capabilities{
-						Add:  []current.CapabilityType{"biz"},
-						Drop: []current.CapabilityType{"baz"},
+						Add:  []current.Capability{"biz"},
+						Drop: []current.Capability{"baz"},
 					},
 				},
 			},
@@ -398,14 +398,14 @@ func TestSetDefaultSecurityContext(t *testing.T) {
 		"upward defaulting priv": {
 			c: current.Container{
 				Capabilities: current.Capabilities{
-					Add:  []current.CapabilityType{"foo"},
-					Drop: []current.CapabilityType{"bar"},
+					Add:  []current.Capability{"foo"},
+					Drop: []current.Capability{"bar"},
 				},
 				SecurityContext: &current.SecurityContext{
 					Privileged: &privTrue,
 					Capabilities: &current.Capabilities{
-						Add:  []current.CapabilityType{"foo"},
-						Drop: []current.CapabilityType{"bar"},
+						Add:  []current.Capability{"foo"},
+						Drop: []current.Capability{"bar"},
 					},
 				},
 			},

--- a/pkg/api/v1beta3/defaults_test.go
+++ b/pkg/api/v1beta3/defaults_test.go
@@ -159,8 +159,8 @@ func TestSetDefaultService(t *testing.T) {
 	svc := &current.Service{}
 	obj2 := roundTrip(t, runtime.Object(svc))
 	svc2 := obj2.(*current.Service)
-	if svc2.Spec.SessionAffinity != current.AffinityTypeNone {
-		t.Errorf("Expected default sesseion affinity type:%s, got: %s", current.AffinityTypeNone, svc2.Spec.SessionAffinity)
+	if svc2.Spec.SessionAffinity != current.ServiceAffinityNone {
+		t.Errorf("Expected default sesseion affinity type:%s, got: %s", current.ServiceAffinityNone, svc2.Spec.SessionAffinity)
 	}
 }
 

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -366,7 +366,7 @@ type HostPathVolumeSource struct {
 type EmptyDirVolumeSource struct {
 	// Optional: what type of storage medium should back this directory.
 	// The default is "" which means to use the node's default medium.
-	Medium StorageType `json:"medium,omitempty" description:"type of storage used to back the volume; must be an empty string (default) or Memory"`
+	Medium StorageMedium `json:"medium,omitempty" description:"type of storage used to back the volume; must be an empty string (default) or Memory"`
 }
 
 // GlusterfsVolumeSource represents a Glusterfs Mount that lasts the lifetime of a pod
@@ -382,12 +382,12 @@ type GlusterfsVolumeSource struct {
 	ReadOnly bool `json:"readOnly,omitempty" description:"glusterfs volume to be mounted with read-only permissions"`
 }
 
-// StorageType defines ways that storage can be allocated to a volume.
-type StorageType string
+// StorageMedium defines ways that storage can be allocated to a volume.
+type StorageMedium string
 
 const (
-	StorageTypeDefault StorageType = ""       // use whatever the default is for the node
-	StorageTypeMemory  StorageType = "Memory" // use memory (tmpfs)
+	StorageMediumDefault StorageMedium = ""       // use whatever the default is for the node
+	StorageMediumMemory  StorageMedium = "Memory" // use memory (tmpfs)
 )
 
 // Protocol defines network protocols supported for things like conatiner ports.

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -955,14 +955,14 @@ type ReplicationControllerList struct {
 }
 
 // Session Affinity Type string
-type AffinityType string
+type ServiceAffinity string
 
 const (
-	// AffinityTypeClientIP is the Client IP based.
-	AffinityTypeClientIP AffinityType = "ClientIP"
+	// ServiceAffinityClientIP is the Client IP based.
+	ServiceAffinityClientIP ServiceAffinity = "ClientIP"
 
-	// AffinityTypeNone - no session affinity.
-	AffinityTypeNone AffinityType = "None"
+	// ServiceAffinityNone - no session affinity.
+	ServiceAffinityNone ServiceAffinity = "None"
 )
 
 // ServiceStatus represents the current status of a service
@@ -991,7 +991,7 @@ type ServiceSpec struct {
 	PublicIPs []string `json:"publicIPs,omitempty" description:"externally visible IPs (e.g. load balancers) that should be proxied to this service"`
 
 	// Optional: Supports "ClientIP" and "None".  Used to maintain session affinity.
-	SessionAffinity AffinityType `json:"sessionAffinity,omitempty" description:"enable client IP based session affinity; must be ClientIP or None; defaults to None"`
+	SessionAffinity ServiceAffinity `json:"sessionAffinity,omitempty" description:"enable client IP based session affinity; must be ClientIP or None; defaults to None"`
 }
 
 type ServicePort struct {

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -590,15 +590,15 @@ const (
 	PullIfNotPresent PullPolicy = "IfNotPresent"
 )
 
-// CapabilityType represent POSIX capabilities type
-type CapabilityType string
+// Capability represent POSIX capabilities type
+type Capability string
 
 // Capabilities represent POSIX capabilities that can be added or removed to a running container.
 type Capabilities struct {
 	// Added capabilities
-	Add []CapabilityType `json:"add,omitempty" description:"added capabilities"`
+	Add []Capability `json:"add,omitempty" description:"added capabilities"`
 	// Removed capabilities
-	Drop []CapabilityType `json:"drop,omitempty" description:"droped capabilities"`
+	Drop []Capability `json:"drop,omitempty" description:"droped capabilities"`
 }
 
 // ResourceRequirements describes the compute resource requirements.

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -268,7 +268,7 @@ type PersistentVolumeSpec struct {
 	// Source represents the location and type of a volume to mount.
 	PersistentVolumeSource `json:",inline" description:"the actual volume backing the persistent volume"`
 	// AccessModes contains all ways the volume can be mounted
-	AccessModes []AccessModeType `json:"accessModes,omitempty" description:"all ways the volume can be mounted"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"all ways the volume can be mounted"`
 	// ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim.
 	// ClaimRef is expected to be non-nil when bound.
 	// claim.VolumeName is the authoritative bind between PV and PVC.
@@ -308,7 +308,7 @@ type PersistentVolumeClaimList struct {
 // and allows a Source for provider-specific attributes
 type PersistentVolumeClaimSpec struct {
 	// Contains the types of access modes required
-	AccessModes []AccessModeType `json:"accessModes,omitempty" description:"the desired access modes the volume should have"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"the desired access modes the volume should have"`
 	// Resources represents the minimum resources required
 	Resources ResourceRequirements `json:"resources,omitempty" description:"the desired resources the volume should have"`
 	// VolumeName is the binding reference to the PersistentVolume backing this claim
@@ -319,20 +319,20 @@ type PersistentVolumeClaimStatus struct {
 	// Phase represents the current phase of PersistentVolumeClaim
 	Phase PersistentVolumeClaimPhase `json:"phase,omitempty" description:"the current phase of the claim"`
 	// AccessModes contains all ways the volume backing the PVC can be mounted
-	AccessModes []AccessModeType `json:"accessModes,omitempty" description:"the actual access modes the volume has"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"the actual access modes the volume has"`
 	// Represents the actual resources of the underlying volume
 	Capacity ResourceList `json:"capacity,omitempty" description:"the actual resources the volume has"`
 }
 
-type AccessModeType string
+type PersistentVolumeAccessMode string
 
 const (
 	// can be mounted read/write mode to exactly 1 host
-	ReadWriteOnce AccessModeType = "ReadWriteOnce"
+	ReadWriteOnce PersistentVolumeAccessMode = "ReadWriteOnce"
 	// can be mounted in read-only mode to many hosts
-	ReadOnlyMany AccessModeType = "ReadOnlyMany"
+	ReadOnlyMany PersistentVolumeAccessMode = "ReadOnlyMany"
 	// can be mounted in read/write mode to many hosts
-	ReadWriteMany AccessModeType = "ReadWriteMany"
+	ReadWriteMany PersistentVolumeAccessMode = "ReadWriteMany"
 )
 
 type PersistentVolumePhase string

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -514,7 +514,7 @@ func ValidatePersistentVolumeStatusUpdate(newPv, oldPv *api.PersistentVolume) er
 func ValidatePersistentVolumeClaim(pvc *api.PersistentVolumeClaim) errs.ValidationErrorList {
 	allErrs := ValidateObjectMeta(&pvc.ObjectMeta, true, ValidatePersistentVolumeName)
 	if len(pvc.Spec.AccessModes) == 0 {
-		allErrs = append(allErrs, errs.NewFieldInvalid("persistentVolumeClaim.Spec.AccessModes", pvc.Spec.AccessModes, "at least 1 AccessModeType is required"))
+		allErrs = append(allErrs, errs.NewFieldInvalid("persistentVolumeClaim.Spec.AccessModes", pvc.Spec.AccessModes, "at least 1 PersistentVolumeAccessMode is required"))
 	}
 	if _, ok := pvc.Spec.Resources.Requests[api.ResourceStorage]; !ok {
 		allErrs = append(allErrs, errs.NewFieldInvalid("persistentVolumeClaim.Spec.Resources.Requests", pvc.Spec.Resources.Requests, "No Storage size specified"))

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -985,7 +985,7 @@ func ValidatePodTemplateUpdate(newPod, oldPod *api.PodTemplate) errs.ValidationE
 	return allErrs
 }
 
-var supportedSessionAffinityType = util.NewStringSet(string(api.AffinityTypeClientIP), string(api.AffinityTypeNone))
+var supportedSessionAffinityType = util.NewStringSet(string(api.ServiceAffinityClientIP), string(api.ServiceAffinityNone))
 
 // ValidateService tests if required fields in the service are set.
 func ValidateService(service *api.Service) errs.ValidationErrorList {

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -228,7 +228,7 @@ func TestValidatePersistentVolumes(t *testing.T) {
 				Capacity: api.ResourceList{
 					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
 				},
-				AccessModes: []api.AccessModeType{api.ReadWriteOnce},
+				AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
 				PersistentVolumeSource: api.PersistentVolumeSource{
 					HostPath: &api.HostPathVolumeSource{Path: "/foo"},
 				},
@@ -240,7 +240,7 @@ func TestValidatePersistentVolumes(t *testing.T) {
 				Capacity: api.ResourceList{
 					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
 				},
-				AccessModes: []api.AccessModeType{api.ReadWriteOnce},
+				AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
 				PersistentVolumeSource: api.PersistentVolumeSource{
 					HostPath: &api.HostPathVolumeSource{Path: "/foo"},
 				},
@@ -252,7 +252,7 @@ func TestValidatePersistentVolumes(t *testing.T) {
 				Capacity: api.ResourceList{
 					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
 				},
-				AccessModes: []api.AccessModeType{api.ReadWriteOnce},
+				AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
 				PersistentVolumeSource: api.PersistentVolumeSource{
 					HostPath: &api.HostPathVolumeSource{Path: "/foo"},
 				},
@@ -264,7 +264,7 @@ func TestValidatePersistentVolumes(t *testing.T) {
 				Capacity: api.ResourceList{
 					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
 				},
-				AccessModes: []api.AccessModeType{api.ReadWriteOnce},
+				AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
 			}),
 		},
 		"missing-capacity": {
@@ -324,7 +324,7 @@ func TestValidatePersistentVolumeClaim(t *testing.T) {
 		"good-claim": {
 			isExpectedFailure: false,
 			claim: testVolumeClaim("foo", "ns", api.PersistentVolumeClaimSpec{
-				AccessModes: []api.AccessModeType{
+				AccessModes: []api.PersistentVolumeAccessMode{
 					api.ReadWriteOnce,
 					api.ReadOnlyMany,
 				},
@@ -338,7 +338,7 @@ func TestValidatePersistentVolumeClaim(t *testing.T) {
 		"missing-namespace": {
 			isExpectedFailure: true,
 			claim: testVolumeClaim("foo", "", api.PersistentVolumeClaimSpec{
-				AccessModes: []api.AccessModeType{
+				AccessModes: []api.PersistentVolumeAccessMode{
 					api.ReadWriteOnce,
 					api.ReadOnlyMany,
 				},
@@ -362,7 +362,7 @@ func TestValidatePersistentVolumeClaim(t *testing.T) {
 		"no-resource-requests": {
 			isExpectedFailure: true,
 			claim: testVolumeClaim("foo", "ns", api.PersistentVolumeClaimSpec{
-				AccessModes: []api.AccessModeType{
+				AccessModes: []api.PersistentVolumeAccessMode{
 					api.ReadWriteOnce,
 				},
 			}),
@@ -370,7 +370,7 @@ func TestValidatePersistentVolumeClaim(t *testing.T) {
 		"invalid-resource-requests": {
 			isExpectedFailure: true,
 			claim: testVolumeClaim("foo", "ns", api.PersistentVolumeClaimSpec{
-				AccessModes: []api.AccessModeType{
+				AccessModes: []api.PersistentVolumeAccessMode{
 					api.ReadWriteOnce,
 				},
 				Resources: api.ResourceRequirements{

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -3175,8 +3175,8 @@ func TestValidateSecurityContext(t *testing.T) {
 		return &api.SecurityContext{
 			Privileged: &priv,
 			Capabilities: &api.Capabilities{
-				Add:  []api.CapabilityType{"foo"},
-				Drop: []api.CapabilityType{"bar"},
+				Add:  []api.Capability{"foo"},
+				Drop: []api.Capability{"bar"},
 			},
 			SELinuxOptions: &api.SELinuxOptions{
 				User:  "user",

--- a/pkg/client/persistentvolumeclaim_test.go
+++ b/pkg/client/persistentvolumeclaim_test.go
@@ -41,7 +41,7 @@ func TestPersistentVolumeClaimCreate(t *testing.T) {
 			Name: "abc",
 		},
 		Spec: api.PersistentVolumeClaimSpec{
-			AccessModes: []api.AccessModeType{
+			AccessModes: []api.PersistentVolumeAccessMode{
 				api.ReadWriteOnce,
 				api.ReadOnlyMany,
 			},
@@ -75,7 +75,7 @@ func TestPersistentVolumeClaimGet(t *testing.T) {
 			Namespace: "foo",
 		},
 		Spec: api.PersistentVolumeClaimSpec{
-			AccessModes: []api.AccessModeType{
+			AccessModes: []api.PersistentVolumeAccessMode{
 				api.ReadWriteOnce,
 				api.ReadOnlyMany,
 			},
@@ -130,7 +130,7 @@ func TestPersistentVolumeClaimUpdate(t *testing.T) {
 			ResourceVersion: "1",
 		},
 		Spec: api.PersistentVolumeClaimSpec{
-			AccessModes: []api.AccessModeType{
+			AccessModes: []api.PersistentVolumeAccessMode{
 				api.ReadWriteOnce,
 				api.ReadOnlyMany,
 			},
@@ -157,7 +157,7 @@ func TestPersistentVolumeClaimStatusUpdate(t *testing.T) {
 			ResourceVersion: "1",
 		},
 		Spec: api.PersistentVolumeClaimSpec{
-			AccessModes: []api.AccessModeType{
+			AccessModes: []api.PersistentVolumeAccessMode{
 				api.ReadWriteOnce,
 				api.ReadOnlyMany,
 			},

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -63,7 +63,7 @@ type TCPLoadBalancer interface {
 	// if so, what its IP address or hostname is.
 	GetTCPLoadBalancer(name, region string) (endpoint string, exists bool, err error)
 	// CreateTCPLoadBalancer creates a new tcp load balancer. Returns the IP address or hostname of the balancer
-	CreateTCPLoadBalancer(name, region string, externalIP net.IP, ports []int, hosts []string, affinityType api.AffinityType) (string, error)
+	CreateTCPLoadBalancer(name, region string, externalIP net.IP, ports []int, hosts []string, affinityType api.ServiceAffinity) (string, error)
 	// UpdateTCPLoadBalancer updates hosts under the specified load balancer.
 	UpdateTCPLoadBalancer(name, region string, hosts []string) error
 	// DeleteTCPLoadBalancer deletes a specified load balancer.

--- a/pkg/cloudprovider/fake/fake.go
+++ b/pkg/cloudprovider/fake/fake.go
@@ -101,7 +101,7 @@ func (f *FakeCloud) GetTCPLoadBalancer(name, region string) (endpoint string, ex
 
 // CreateTCPLoadBalancer is a test-spy implementation of TCPLoadBalancer.CreateTCPLoadBalancer.
 // It adds an entry "create" into the internal method call record.
-func (f *FakeCloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, ports []int, hosts []string, affinityType api.AffinityType) (string, error) {
+func (f *FakeCloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, ports []int, hosts []string, affinityType api.ServiceAffinity) (string, error) {
 	f.addCall("create")
 	f.Balancers = append(f.Balancers, FakeBalancer{name, region, externalIP, ports, hosts})
 	return f.ExternalIP.String(), f.Err

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -294,11 +294,11 @@ func isHTTPErrorCode(err error, code int) bool {
 }
 
 // translate from what K8s supports to what the cloud provider supports for session affinity.
-func translateAffinityType(affinityType api.AffinityType) GCEAffinityType {
+func translateAffinityType(affinityType api.ServiceAffinity) GCEAffinityType {
 	switch affinityType {
-	case api.AffinityTypeClientIP:
+	case api.ServiceAffinityClientIP:
 		return GCEAffinityTypeClientIP
-	case api.AffinityTypeNone:
+	case api.ServiceAffinityNone:
 		return GCEAffinityTypeNone
 	default:
 		glog.Errorf("unexpected affinity type: %v", affinityType)
@@ -309,7 +309,7 @@ func translateAffinityType(affinityType api.AffinityType) GCEAffinityType {
 // CreateTCPLoadBalancer is an implementation of TCPLoadBalancer.CreateTCPLoadBalancer.
 // TODO(a-robinson): Don't just ignore specified IP addresses. Check if they're
 // owned by the project and available to be used, and use them if they are.
-func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, ports []int, hosts []string, affinityType api.AffinityType) (string, error) {
+func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.IP, ports []int, hosts []string, affinityType api.ServiceAffinity) (string, error) {
 	err := gce.makeTargetPool(name, region, hosts, translateAffinityType(affinityType))
 	if err != nil {
 		if !isHTTPErrorCode(err, http.StatusConflict) {

--- a/pkg/cloudprovider/openstack/openstack.go
+++ b/pkg/cloudprovider/openstack/openstack.go
@@ -480,7 +480,7 @@ func (lb *LoadBalancer) GetTCPLoadBalancer(name, region string) (endpoint string
 // a list of regions (from config) and query/create loadbalancers in
 // each region.
 
-func (lb *LoadBalancer) CreateTCPLoadBalancer(name, region string, externalIP net.IP, ports []int, hosts []string, affinity api.AffinityType) (string, error) {
+func (lb *LoadBalancer) CreateTCPLoadBalancer(name, region string, externalIP net.IP, ports []int, hosts []string, affinity api.ServiceAffinity) (string, error) {
 	glog.V(4).Infof("CreateTCPLoadBalancer(%v, %v, %v, %v, %v, %v)", name, region, externalIP, ports, hosts, affinity)
 
 	if len(ports) > 1 {
@@ -489,9 +489,9 @@ func (lb *LoadBalancer) CreateTCPLoadBalancer(name, region string, externalIP ne
 
 	var persistence *vips.SessionPersistence
 	switch affinity {
-	case api.AffinityTypeNone:
+	case api.ServiceAffinityNone:
 		persistence = nil
-	case api.AffinityTypeClientIP:
+	case api.ServiceAffinityClientIP:
 		persistence = &vips.SessionPersistence{Type: "SOURCE_IP"}
 	default:
 		return "", fmt.Errorf("unsupported load balancer affinity: %v", affinity)

--- a/pkg/kubelet/rkt/cap.go
+++ b/pkg/kubelet/rkt/cap.go
@@ -116,10 +116,10 @@ func getAllCapabilities() string {
 	return strings.Join(capabilities, ",")
 }
 
-// TODO(yifan): This assumes that api.CapabilityType has the form of
+// TODO(yifan): This assumes that api.Capability has the form of
 // "CAP_SYS_ADMIN". We need to have a formal definition for
 // capabilities.
-func getCapabilities(caps []api.CapabilityType) string {
+func getCapabilities(caps []api.Capability) string {
 	var capList []string
 	for _, cap := range caps {
 		capList = append(capList, fmt.Sprintf("%q", cap))

--- a/pkg/master/controller.go
+++ b/pkg/master/controller.go
@@ -181,7 +181,7 @@ func (c *Controller) CreateMasterServiceIfNeeded(serviceName string, serviceIP n
 			// maintained by this code, not by the pod selector
 			Selector:        nil,
 			PortalIP:        serviceIP.String(),
-			SessionAffinity: api.AffinityTypeNone,
+			SessionAffinity: api.ServiceAffinityNone,
 		},
 	}
 	_, err := c.ServiceRegistry.CreateService(ctx, svc)

--- a/pkg/proxy/loadbalancer.go
+++ b/pkg/proxy/loadbalancer.go
@@ -29,7 +29,7 @@ type LoadBalancer interface {
 	// NextEndpoint returns the endpoint to handle a request for the given
 	// service-port and source address.
 	NextEndpoint(service ServicePortName, srcAddr net.Addr) (string, error)
-	NewService(service ServicePortName, sessionAffinityType api.AffinityType, stickyMaxAgeMinutes int) error
+	NewService(service ServicePortName, sessionAffinityType api.ServiceAffinity, stickyMaxAgeMinutes int) error
 	CleanupStaleStickySessions(service ServicePortName)
 }
 

--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -41,7 +41,7 @@ type serviceInfo struct {
 	socket              proxySocket
 	timeout             time.Duration
 	publicIPs           []string // TODO: make this net.IP
-	sessionAffinityType api.AffinityType
+	sessionAffinityType api.ServiceAffinity
 	stickyMaxAgeMinutes int
 }
 
@@ -208,8 +208,8 @@ func (proxier *Proxier) addServiceOnPort(service ServicePortName, protocol api.P
 		protocol:            protocol,
 		socket:              sock,
 		timeout:             timeout,
-		sessionAffinityType: api.AffinityTypeNone, // default
-		stickyMaxAgeMinutes: 180,                  // TODO: paramaterize this in the API.
+		sessionAffinityType: api.ServiceAffinityNone, // default
+		stickyMaxAgeMinutes: 180,                     // TODO: paramaterize this in the API.
 	}
 	proxier.setServiceInfo(service, si)
 

--- a/pkg/proxy/roundrobin_test.go
+++ b/pkg/proxy/roundrobin_test.go
@@ -351,7 +351,7 @@ func TestStickyLoadBalanceWorksWithSingleEndpoint(t *testing.T) {
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
 	}
-	loadBalancer.NewService(service, api.AffinityTypeClientIP, 0)
+	loadBalancer.NewService(service, api.ServiceAffinityClientIP, 0)
 	endpoints := make([]api.Endpoints, 1)
 	endpoints[0] = api.Endpoints{
 		ObjectMeta: api.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
@@ -375,7 +375,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpoints(t *testing.T) {
 		t.Errorf("Didn't fail with non-existent service")
 	}
 
-	loadBalancer.NewService(service, api.AffinityTypeClientIP, 0)
+	loadBalancer.NewService(service, api.ServiceAffinityClientIP, 0)
 	endpoints := make([]api.Endpoints, 1)
 	endpoints[0] = api.Endpoints{
 		ObjectMeta: api.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
@@ -409,7 +409,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpointsStickyNone(t *testing.T) {
 		t.Errorf("Didn't fail with non-existent service")
 	}
 
-	loadBalancer.NewService(service, api.AffinityTypeNone, 0)
+	loadBalancer.NewService(service, api.ServiceAffinityNone, 0)
 	endpoints := make([]api.Endpoints, 1)
 	endpoints[0] = api.Endpoints{
 		ObjectMeta: api.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
@@ -447,7 +447,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpointsRemoveOne(t *testing.T) {
 		t.Errorf("Didn't fail with non-existent service")
 	}
 
-	loadBalancer.NewService(service, api.AffinityTypeClientIP, 0)
+	loadBalancer.NewService(service, api.ServiceAffinityClientIP, 0)
 	endpoints := make([]api.Endpoints, 1)
 	endpoints[0] = api.Endpoints{
 		ObjectMeta: api.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
@@ -521,7 +521,7 @@ func TestStickyLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 		t.Errorf("Didn't fail with non-existent service")
 	}
 
-	loadBalancer.NewService(service, api.AffinityTypeClientIP, 0)
+	loadBalancer.NewService(service, api.ServiceAffinityClientIP, 0)
 	endpoints := make([]api.Endpoints, 1)
 	endpoints[0] = api.Endpoints{
 		ObjectMeta: api.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
@@ -581,7 +581,7 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
 	}
-	loadBalancer.NewService(fooService, api.AffinityTypeClientIP, 0)
+	loadBalancer.NewService(fooService, api.ServiceAffinityClientIP, 0)
 	endpoints := make([]api.Endpoints, 2)
 	endpoints[0] = api.Endpoints{
 		ObjectMeta: api.ObjectMeta{Name: fooService.Name, Namespace: fooService.Namespace},
@@ -593,7 +593,7 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 		},
 	}
 	barService := ServicePortName{types.NamespacedName{"testnamespace", "bar"}, ""}
-	loadBalancer.NewService(barService, api.AffinityTypeClientIP, 0)
+	loadBalancer.NewService(barService, api.ServiceAffinityClientIP, 0)
 	endpoints[1] = api.Endpoints{
 		ObjectMeta: api.ObjectMeta{Name: barService.Name, Namespace: barService.Namespace},
 		Subsets: []api.EndpointSubset{

--- a/pkg/registry/persistentvolume/etcd/etcd_test.go
+++ b/pkg/registry/persistentvolume/etcd/etcd_test.go
@@ -55,7 +55,7 @@ func validNewPersistentVolume(name string) *api.PersistentVolume {
 			Capacity: api.ResourceList{
 				api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
 			},
-			AccessModes: []api.AccessModeType{api.ReadWriteOnce},
+			AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
 			PersistentVolumeSource: api.PersistentVolumeSource{
 				HostPath: &api.HostPathVolumeSource{Path: "/foo"},
 			},

--- a/pkg/registry/persistentvolumeclaim/etcd/etcd_test.go
+++ b/pkg/registry/persistentvolumeclaim/etcd/etcd_test.go
@@ -53,7 +53,7 @@ func validNewPersistentVolumeClaim(name, ns string) *api.PersistentVolumeClaim {
 			Namespace: ns,
 		},
 		Spec: api.PersistentVolumeClaimSpec{
-			AccessModes: []api.AccessModeType{api.ReadWriteOnce},
+			AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
 			Resources: api.ResourceRequirements{
 				Requests: api.ResourceList{
 					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
@@ -334,7 +334,7 @@ func TestEtcdUpdateStatus(t *testing.T) {
 			ResourceVersion: "1",
 		},
 		Spec: api.PersistentVolumeClaimSpec{
-			AccessModes: []api.AccessModeType{api.ReadWriteOnce},
+			AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
 			Resources: api.ResourceRequirements{
 				Requests: api.ResourceList{
 					api.ResourceName(api.ResourceStorage): resource.MustParse("3Gi"),

--- a/pkg/registry/service/rest_test.go
+++ b/pkg/registry/service/rest_test.go
@@ -67,7 +67,7 @@ func TestServiceRegistryCreate(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 		Spec: api.ServiceSpec{
 			Selector:        map[string]string{"bar": "baz"},
-			SessionAffinity: api.AffinityTypeNone,
+			SessionAffinity: api.ServiceAffinityNone,
 			Ports: []api.ServicePort{{
 				Port:     6502,
 				Protocol: api.ProtocolTCP,
@@ -108,7 +108,7 @@ func TestServiceStorageValidatesCreate(t *testing.T) {
 			ObjectMeta: api.ObjectMeta{Name: ""},
 			Spec: api.ServiceSpec{
 				Selector:        map[string]string{"bar": "baz"},
-				SessionAffinity: api.AffinityTypeNone,
+				SessionAffinity: api.ServiceAffinityNone,
 				Ports: []api.ServicePort{{
 					Port:     6502,
 					Protocol: api.ProtocolTCP,
@@ -119,7 +119,7 @@ func TestServiceStorageValidatesCreate(t *testing.T) {
 			ObjectMeta: api.ObjectMeta{Name: "foo"},
 			Spec: api.ServiceSpec{
 				Selector:        map[string]string{"bar": "baz"},
-				SessionAffinity: api.AffinityTypeNone,
+				SessionAffinity: api.ServiceAffinityNone,
 				Ports: []api.ServicePort{{
 					Protocol: api.ProtocolTCP,
 				}},
@@ -161,7 +161,7 @@ func TestServiceRegistryUpdate(t *testing.T) {
 			ResourceVersion: svc.ResourceVersion},
 		Spec: api.ServiceSpec{
 			Selector:        map[string]string{"bar": "baz2"},
-			SessionAffinity: api.AffinityTypeNone,
+			SessionAffinity: api.ServiceAffinityNone,
 			Ports: []api.ServicePort{{
 				Port:     6502,
 				Protocol: api.ProtocolTCP,
@@ -204,7 +204,7 @@ func TestServiceStorageValidatesUpdate(t *testing.T) {
 			ObjectMeta: api.ObjectMeta{Name: ""},
 			Spec: api.ServiceSpec{
 				Selector:        map[string]string{"bar": "baz"},
-				SessionAffinity: api.AffinityTypeNone,
+				SessionAffinity: api.ServiceAffinityNone,
 				Ports: []api.ServicePort{{
 					Port:     6502,
 					Protocol: api.ProtocolTCP,
@@ -215,7 +215,7 @@ func TestServiceStorageValidatesUpdate(t *testing.T) {
 			ObjectMeta: api.ObjectMeta{Name: "foo"},
 			Spec: api.ServiceSpec{
 				Selector:        map[string]string{"ThisSelectorFailsValidation": "ok"},
-				SessionAffinity: api.AffinityTypeNone,
+				SessionAffinity: api.ServiceAffinityNone,
 				Ports: []api.ServicePort{{
 					Port:     6502,
 					Protocol: api.ProtocolTCP,
@@ -242,7 +242,7 @@ func TestServiceRegistryExternalService(t *testing.T) {
 		Spec: api.ServiceSpec{
 			Selector:                   map[string]string{"bar": "baz"},
 			CreateExternalLoadBalancer: true,
-			SessionAffinity:            api.AffinityTypeNone,
+			SessionAffinity:            api.ServiceAffinityNone,
 			Ports: []api.ServicePort{{
 				Port:     6502,
 				Protocol: api.ProtocolTCP,
@@ -269,7 +269,7 @@ func TestServiceRegistryDelete(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 		Spec: api.ServiceSpec{
 			Selector:        map[string]string{"bar": "baz"},
-			SessionAffinity: api.AffinityTypeNone,
+			SessionAffinity: api.ServiceAffinityNone,
 			Ports: []api.ServicePort{{
 				Port:     6502,
 				Protocol: api.ProtocolTCP,
@@ -291,7 +291,7 @@ func TestServiceRegistryDeleteExternal(t *testing.T) {
 		Spec: api.ServiceSpec{
 			Selector:                   map[string]string{"bar": "baz"},
 			CreateExternalLoadBalancer: true,
-			SessionAffinity:            api.AffinityTypeNone,
+			SessionAffinity:            api.ServiceAffinityNone,
 			Ports: []api.ServicePort{{
 				Port:     6502,
 				Protocol: api.ProtocolTCP,
@@ -315,7 +315,7 @@ func TestServiceRegistryUpdateExternalService(t *testing.T) {
 		Spec: api.ServiceSpec{
 			Selector:                   map[string]string{"bar": "baz"},
 			CreateExternalLoadBalancer: false,
-			SessionAffinity:            api.AffinityTypeNone,
+			SessionAffinity:            api.ServiceAffinityNone,
 			Ports: []api.ServicePort{{
 				Port:     6502,
 				Protocol: api.ProtocolTCP,
@@ -351,7 +351,7 @@ func TestServiceRegistryUpdateMultiPortExternalService(t *testing.T) {
 		Spec: api.ServiceSpec{
 			Selector:                   map[string]string{"bar": "baz"},
 			CreateExternalLoadBalancer: true,
-			SessionAffinity:            api.AffinityTypeNone,
+			SessionAffinity:            api.ServiceAffinityNone,
 			Ports: []api.ServicePort{{
 				Name:     "p",
 				Port:     6502,
@@ -490,7 +490,7 @@ func TestServiceRegistryIPAllocation(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 		Spec: api.ServiceSpec{
 			Selector:        map[string]string{"bar": "baz"},
-			SessionAffinity: api.AffinityTypeNone,
+			SessionAffinity: api.ServiceAffinityNone,
 			Ports: []api.ServicePort{{
 				Port:     6502,
 				Protocol: api.ProtocolTCP,
@@ -511,7 +511,7 @@ func TestServiceRegistryIPAllocation(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "bar"},
 		Spec: api.ServiceSpec{
 			Selector:        map[string]string{"bar": "baz"},
-			SessionAffinity: api.AffinityTypeNone,
+			SessionAffinity: api.ServiceAffinityNone,
 			Ports: []api.ServicePort{{
 				Port:     6502,
 				Protocol: api.ProtocolTCP,
@@ -540,7 +540,7 @@ func TestServiceRegistryIPAllocation(t *testing.T) {
 		Spec: api.ServiceSpec{
 			Selector:        map[string]string{"bar": "baz"},
 			PortalIP:        testIP,
-			SessionAffinity: api.AffinityTypeNone,
+			SessionAffinity: api.ServiceAffinityNone,
 			Ports: []api.ServicePort{{
 				Port:     6502,
 				Protocol: api.ProtocolTCP,
@@ -565,7 +565,7 @@ func TestServiceRegistryIPReallocation(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 		Spec: api.ServiceSpec{
 			Selector:        map[string]string{"bar": "baz"},
-			SessionAffinity: api.AffinityTypeNone,
+			SessionAffinity: api.ServiceAffinityNone,
 			Ports: []api.ServicePort{{
 				Port:     6502,
 				Protocol: api.ProtocolTCP,
@@ -588,7 +588,7 @@ func TestServiceRegistryIPReallocation(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "bar"},
 		Spec: api.ServiceSpec{
 			Selector:        map[string]string{"bar": "baz"},
-			SessionAffinity: api.AffinityTypeNone,
+			SessionAffinity: api.ServiceAffinityNone,
 			Ports: []api.ServicePort{{
 				Port:     6502,
 				Protocol: api.ProtocolTCP,
@@ -613,7 +613,7 @@ func TestServiceRegistryIPUpdate(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 		Spec: api.ServiceSpec{
 			Selector:        map[string]string{"bar": "baz"},
-			SessionAffinity: api.AffinityTypeNone,
+			SessionAffinity: api.ServiceAffinityNone,
 			Ports: []api.ServicePort{{
 				Port:     6502,
 				Protocol: api.ProtocolTCP,
@@ -657,7 +657,7 @@ func TestServiceRegistryIPExternalLoadBalancer(t *testing.T) {
 		Spec: api.ServiceSpec{
 			Selector:                   map[string]string{"bar": "baz"},
 			CreateExternalLoadBalancer: true,
-			SessionAffinity:            api.AffinityTypeNone,
+			SessionAffinity:            api.ServiceAffinityNone,
 			Ports: []api.ServicePort{{
 				Port:     6502,
 				Protocol: api.ProtocolTCP,

--- a/pkg/securitycontext/provider.go
+++ b/pkg/securitycontext/provider.go
@@ -81,8 +81,8 @@ func modifySecurityOption(config []string, name, value string) []string {
 	return config
 }
 
-// makeCapabilites creates string slices from CapabilityType slices
-func makeCapabilites(capAdd []api.CapabilityType, capDrop []api.CapabilityType) ([]string, []string) {
+// makeCapabilites creates string slices from Capability slices
+func makeCapabilites(capAdd []api.Capability, capDrop []api.Capability) ([]string, []string) {
 	var (
 		addCaps  []string
 		dropCaps []string

--- a/pkg/securitycontext/provider_test.go
+++ b/pkg/securitycontext/provider_test.go
@@ -154,8 +154,8 @@ func fullValidSecurityContext() *api.SecurityContext {
 	return &api.SecurityContext{
 		Privileged: &priv,
 		Capabilities: &api.Capabilities{
-			Add:  []api.CapabilityType{"addCapA", "addCapB"},
-			Drop: []api.CapabilityType{"dropCapA", "dropCapB"},
+			Add:  []api.Capability{"addCapA", "addCapB"},
+			Drop: []api.Capability{"dropCapA", "dropCapB"},
 		},
 		SELinuxOptions: &api.SELinuxOptions{
 			User:  "user",

--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -62,8 +62,8 @@ func (plugin *awsElasticBlockStorePlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.PersistentVolumeSource.AWSElasticBlockStore != nil || spec.VolumeSource.AWSElasticBlockStore != nil
 }
 
-func (plugin *awsElasticBlockStorePlugin) GetAccessModes() []api.AccessModeType {
-	return []api.AccessModeType{
+func (plugin *awsElasticBlockStorePlugin) GetAccessModes() []api.PersistentVolumeAccessMode {
+	return []api.PersistentVolumeAccessMode{
 		api.ReadWriteOnce,
 	}
 }

--- a/pkg/volume/aws_ebs/aws_ebs_test.go
+++ b/pkg/volume/aws_ebs/aws_ebs_test.go
@@ -58,7 +58,7 @@ func TestGetAccessModes(t *testing.T) {
 	}
 }
 
-func contains(modes []api.AccessModeType, mode api.AccessModeType) bool {
+func contains(modes []api.PersistentVolumeAccessMode, mode api.PersistentVolumeAccessMode) bool {
 	for _, m := range modes {
 		if m == mode {
 			return true

--- a/pkg/volume/empty_dir/empty_dir.go
+++ b/pkg/volume/empty_dir/empty_dir.go
@@ -80,7 +80,7 @@ func (plugin *emptyDirPlugin) newBuilderInternal(spec *volume.Spec, pod *api.Pod
 		// Legacy mode instances can be cleaned up but not created anew.
 		return nil, fmt.Errorf("legacy mode: can not create new instances")
 	}
-	medium := api.StorageTypeDefault
+	medium := api.StorageMediumDefault
 	if spec.VolumeSource.EmptyDir != nil { // Support a non-specified source as EmptyDir.
 		medium = spec.VolumeSource.EmptyDir.Medium
 	}
@@ -109,7 +109,7 @@ func (plugin *emptyDirPlugin) newCleanerInternal(volName string, podUID types.UI
 	ed := &emptyDir{
 		podUID:        podUID,
 		volName:       volName,
-		medium:        api.StorageTypeDefault, // might be changed later
+		medium:        api.StorageMediumDefault, // might be changed later
 		mounter:       mounter,
 		mountDetector: mountDetector,
 		plugin:        plugin,
@@ -140,7 +140,7 @@ const (
 type emptyDir struct {
 	podUID        types.UID
 	volName       string
-	medium        api.StorageType
+	medium        api.StorageMedium
 	mounter       mount.Interface
 	mountDetector mountDetector
 	plugin        *emptyDirPlugin
@@ -159,9 +159,9 @@ func (ed *emptyDir) SetUpAt(dir string) error {
 		return fmt.Errorf("legacy mode: can not create new instances")
 	}
 	switch ed.medium {
-	case api.StorageTypeDefault:
+	case api.StorageMediumDefault:
 		return ed.setupDefault(dir)
-	case api.StorageTypeMemory:
+	case api.StorageMediumMemory:
 		return ed.setupTmpfs(dir)
 	default:
 		return fmt.Errorf("unknown storage medium %q", ed.medium)
@@ -231,10 +231,10 @@ func (ed *emptyDir) TearDownAt(dir string) error {
 		return err
 	}
 	if isMnt && medium == mediumMemory {
-		ed.medium = api.StorageTypeMemory
+		ed.medium = api.StorageMediumMemory
 		return ed.teardownTmpfs(dir)
 	}
-	// assume StorageTypeDefault
+	// assume StorageMediumDefault
 	return ed.teardownDefault(dir)
 }
 

--- a/pkg/volume/empty_dir/empty_dir_test.go
+++ b/pkg/volume/empty_dir/empty_dir_test.go
@@ -70,7 +70,7 @@ func TestPlugin(t *testing.T) {
 
 	spec := &api.Volume{
 		Name:         "vol1",
-		VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{Medium: api.StorageTypeDefault}},
+		VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{Medium: api.StorageMediumDefault}},
 	}
 	mounter := mount.FakeMounter{}
 	mountDetector := fakeMountDetector{}
@@ -130,7 +130,7 @@ func TestPluginTmpfs(t *testing.T) {
 
 	spec := &api.Volume{
 		Name:         "vol1",
-		VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{Medium: api.StorageTypeMemory}},
+		VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{Medium: api.StorageMediumMemory}},
 	}
 	mounter := mount.FakeMounter{}
 	mountDetector := fakeMountDetector{}

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -68,8 +68,8 @@ func (plugin *gcePersistentDiskPlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.VolumeSource.GCEPersistentDisk != nil || spec.PersistentVolumeSource.GCEPersistentDisk != nil
 }
 
-func (plugin *gcePersistentDiskPlugin) GetAccessModes() []api.AccessModeType {
-	return []api.AccessModeType{
+func (plugin *gcePersistentDiskPlugin) GetAccessModes() []api.PersistentVolumeAccessMode {
+	return []api.PersistentVolumeAccessMode{
 		api.ReadWriteOnce,
 		api.ReadOnlyMany,
 	}

--- a/pkg/volume/gce_pd/gce_pd_test.go
+++ b/pkg/volume/gce_pd/gce_pd_test.go
@@ -55,7 +55,7 @@ func TestGetAccessModes(t *testing.T) {
 	}
 }
 
-func contains(modes []api.AccessModeType, mode api.AccessModeType) bool {
+func contains(modes []api.PersistentVolumeAccessMode, mode api.PersistentVolumeAccessMode) bool {
 	for _, m := range modes {
 		if m == mode {
 			return true

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -56,8 +56,8 @@ func (plugin *glusterfsPlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.VolumeSource.Glusterfs != nil || spec.PersistentVolumeSource.Glusterfs != nil
 }
 
-func (plugin *glusterfsPlugin) GetAccessModes() []api.AccessModeType {
-	return []api.AccessModeType{
+func (plugin *glusterfsPlugin) GetAccessModes() []api.PersistentVolumeAccessMode {
+	return []api.PersistentVolumeAccessMode{
 		api.ReadWriteOnce,
 		api.ReadOnlyMany,
 		api.ReadWriteMany,

--- a/pkg/volume/glusterfs/glusterfs_test.go
+++ b/pkg/volume/glusterfs/glusterfs_test.go
@@ -58,7 +58,7 @@ func TestGetAccessModes(t *testing.T) {
 	}
 }
 
-func contains(modes []api.AccessModeType, mode api.AccessModeType) bool {
+func contains(modes []api.PersistentVolumeAccessMode, mode api.PersistentVolumeAccessMode) bool {
 	for _, m := range modes {
 		if m == mode {
 			return true

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -52,8 +52,8 @@ func (plugin *hostPathPlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.VolumeSource.HostPath != nil || spec.PersistentVolumeSource.HostPath != nil
 }
 
-func (plugin *hostPathPlugin) GetAccessModes() []api.AccessModeType {
-	return []api.AccessModeType{
+func (plugin *hostPathPlugin) GetAccessModes() []api.PersistentVolumeAccessMode {
+	return []api.PersistentVolumeAccessMode{
 		api.ReadWriteOnce,
 	}
 }

--- a/pkg/volume/host_path/host_path_test.go
+++ b/pkg/volume/host_path/host_path_test.go
@@ -52,7 +52,7 @@ func TestGetAccessModes(t *testing.T) {
 		t.Errorf("Can't find the plugin by name")
 	}
 	if len(plug.GetAccessModes()) != 1 || plug.GetAccessModes()[0] != api.ReadWriteOnce {
-		t.Errorf("Expected %s AccessModeType", api.ReadWriteOnce)
+		t.Errorf("Expected %s PersistentVolumeAccessMode", api.ReadWriteOnce)
 	}
 }
 

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -65,8 +65,8 @@ func (plugin *ISCSIPlugin) CanSupport(spec *volume.Spec) bool {
 	return false
 }
 
-func (plugin *ISCSIPlugin) GetAccessModes() []api.AccessModeType {
-	return []api.AccessModeType{
+func (plugin *ISCSIPlugin) GetAccessModes() []api.PersistentVolumeAccessMode {
+	return []api.PersistentVolumeAccessMode{
 		api.ReadWriteOnce,
 		api.ReadOnlyMany,
 	}

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -55,8 +55,8 @@ func (plugin *nfsPlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.VolumeSource.NFS != nil
 }
 
-func (plugin *nfsPlugin) GetAccessModes() []api.AccessModeType {
-	return []api.AccessModeType{
+func (plugin *nfsPlugin) GetAccessModes() []api.PersistentVolumeAccessMode {
+	return []api.PersistentVolumeAccessMode{
 		api.ReadWriteOnce,
 		api.ReadOnlyMany,
 		api.ReadWriteMany,

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -57,7 +57,7 @@ func TestGetAccessModes(t *testing.T) {
 	}
 }
 
-func contains(modes []api.AccessModeType, mode api.AccessModeType) bool {
+func contains(modes []api.PersistentVolumeAccessMode, mode api.PersistentVolumeAccessMode) bool {
 	for _, m := range modes {
 		if m == mode {
 			return true

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -76,7 +76,7 @@ type VolumePlugin interface {
 type PersistentVolumePlugin interface {
 	VolumePlugin
 	// GetAccessModes describes the ways a given volume can be accessed/mounted.
-	GetAccessModes() []api.AccessModeType
+	GetAccessModes() []api.PersistentVolumeAccessMode
 }
 
 // VolumeHost is an interface that plugins can use to access the kubelet.

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -89,7 +89,7 @@ func (sv *secretVolume) SetUp() error {
 // This is the spec for the volume that this plugin wraps.
 var wrappedVolumeSpec = &volume.Spec{
 	Name:         "not-used",
-	VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{Medium: api.StorageTypeMemory}},
+	VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{Medium: api.StorageMediumMemory}},
 }
 
 func (sv *secretVolume) SetUpAt(dir string) error {

--- a/pkg/volume/testing.go
+++ b/pkg/volume/testing.go
@@ -104,8 +104,8 @@ func (plugin *FakeVolumePlugin) NewCleaner(volName string, podUID types.UID, mou
 	return &FakeVolume{podUID, volName, plugin}, nil
 }
 
-func (plugin *FakeVolumePlugin) GetAccessModes() []api.AccessModeType {
-	return []api.AccessModeType{}
+func (plugin *FakeVolumePlugin) GetAccessModes() []api.PersistentVolumeAccessMode {
+	return []api.PersistentVolumeAccessMode{}
 }
 
 type FakeVolume struct {

--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -20,7 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 )
 
-func GetAccessModesAsString(modes []api.AccessModeType) string {
+func GetAccessModesAsString(modes []api.PersistentVolumeAccessMode) string {
 	modesAsString := ""
 
 	if contains(modes, api.ReadWriteOnce) {
@@ -43,7 +43,7 @@ func appendAccessMode(modes *string, mode string) {
 	*modes += mode
 }
 
-func contains(modes []api.AccessModeType, mode api.AccessModeType) bool {
+func contains(modes []api.PersistentVolumeAccessMode, mode api.PersistentVolumeAccessMode) bool {
 	for _, m := range modes {
 		if m == mode {
 			return true

--- a/pkg/volumeclaimbinder/persistent_volume_claim_binder_test.go
+++ b/pkg/volumeclaimbinder/persistent_volume_claim_binder_test.go
@@ -57,7 +57,7 @@ func TestExampleObjects(t *testing.T) {
 		"claims/claim-01.yaml": {
 			expected: &api.PersistentVolumeClaim{
 				Spec: api.PersistentVolumeClaimSpec{
-					AccessModes: []api.AccessModeType{api.ReadWriteOnce},
+					AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
 					Resources: api.ResourceRequirements{
 						Requests: api.ResourceList{
 							api.ResourceName(api.ResourceStorage): resource.MustParse("3Gi"),
@@ -69,7 +69,7 @@ func TestExampleObjects(t *testing.T) {
 		"claims/claim-02.yaml": {
 			expected: &api.PersistentVolumeClaim{
 				Spec: api.PersistentVolumeClaimSpec{
-					AccessModes: []api.AccessModeType{api.ReadWriteOnce},
+					AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
 					Resources: api.ResourceRequirements{
 						Requests: api.ResourceList{
 							api.ResourceName(api.ResourceStorage): resource.MustParse("8Gi"),
@@ -81,7 +81,7 @@ func TestExampleObjects(t *testing.T) {
 		"volumes/local-01.yaml": {
 			expected: &api.PersistentVolume{
 				Spec: api.PersistentVolumeSpec{
-					AccessModes: []api.AccessModeType{api.ReadWriteOnce},
+					AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
 					Capacity: api.ResourceList{
 						api.ResourceName(api.ResourceStorage): resource.MustParse("10Gi"),
 					},
@@ -96,7 +96,7 @@ func TestExampleObjects(t *testing.T) {
 		"volumes/local-02.yaml": {
 			expected: &api.PersistentVolume{
 				Spec: api.PersistentVolumeSpec{
-					AccessModes: []api.AccessModeType{api.ReadWriteOnce},
+					AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
 					Capacity: api.ResourceList{
 						api.ResourceName(api.ResourceStorage): resource.MustParse("5Gi"),
 					},

--- a/pkg/volumeclaimbinder/persistent_volume_index_test.go
+++ b/pkg/volumeclaimbinder/persistent_volume_index_test.go
@@ -41,7 +41,7 @@ func TestMatchVolume(t *testing.T) {
 					Namespace: "myns",
 				},
 				Spec: api.PersistentVolumeClaimSpec{
-					AccessModes: []api.AccessModeType{api.ReadOnlyMany, api.ReadWriteOnce},
+					AccessModes: []api.PersistentVolumeAccessMode{api.ReadOnlyMany, api.ReadWriteOnce},
 					Resources: api.ResourceRequirements{
 						Requests: api.ResourceList{
 							api.ResourceName(api.ResourceStorage): resource.MustParse("8G"),
@@ -58,7 +58,7 @@ func TestMatchVolume(t *testing.T) {
 					Namespace: "myns",
 				},
 				Spec: api.PersistentVolumeClaimSpec{
-					AccessModes: []api.AccessModeType{api.ReadOnlyMany, api.ReadWriteOnce, api.ReadWriteMany},
+					AccessModes: []api.PersistentVolumeAccessMode{api.ReadOnlyMany, api.ReadWriteOnce, api.ReadWriteMany},
 					Resources: api.ResourceRequirements{
 						Requests: api.ResourceList{
 							api.ResourceName(api.ResourceStorage): resource.MustParse("5G"),
@@ -75,7 +75,7 @@ func TestMatchVolume(t *testing.T) {
 					Namespace: "myns",
 				},
 				Spec: api.PersistentVolumeClaimSpec{
-					AccessModes: []api.AccessModeType{api.ReadOnlyMany, api.ReadWriteOnce},
+					AccessModes: []api.PersistentVolumeAccessMode{api.ReadOnlyMany, api.ReadWriteOnce},
 					Resources: api.ResourceRequirements{
 						Requests: api.ResourceList{
 							api.ResourceName(api.ResourceStorage): resource.MustParse("1G"),
@@ -92,7 +92,7 @@ func TestMatchVolume(t *testing.T) {
 					Namespace: "myns",
 				},
 				Spec: api.PersistentVolumeClaimSpec{
-					AccessModes: []api.AccessModeType{api.ReadOnlyMany, api.ReadWriteOnce},
+					AccessModes: []api.PersistentVolumeAccessMode{api.ReadOnlyMany, api.ReadWriteOnce},
 					Resources: api.ResourceRequirements{
 						Requests: api.ResourceList{
 							api.ResourceName(api.ResourceStorage): resource.MustParse("999G"),
@@ -126,7 +126,7 @@ func TestSort(t *testing.T) {
 		volList.Add(pv)
 	}
 
-	volumes, err := volList.ListByAccessModes([]api.AccessModeType{api.ReadWriteOnce, api.ReadOnlyMany})
+	volumes, err := volList.ListByAccessModes([]api.PersistentVolumeAccessMode{api.ReadWriteOnce, api.ReadOnlyMany})
 	if err != nil {
 		t.Error("Unexpected error retrieving volumes by access modes:", err)
 	}
@@ -137,7 +137,7 @@ func TestSort(t *testing.T) {
 		}
 	}
 
-	volumes, err = volList.ListByAccessModes([]api.AccessModeType{api.ReadWriteOnce, api.ReadOnlyMany, api.ReadWriteMany})
+	volumes, err = volList.ListByAccessModes([]api.PersistentVolumeAccessMode{api.ReadWriteOnce, api.ReadOnlyMany, api.ReadWriteMany})
 	if err != nil {
 		t.Error("Unexpected error retrieving volumes by access modes:", err)
 	}
@@ -164,7 +164,7 @@ func createTestVolumes() []*api.PersistentVolume {
 				PersistentVolumeSource: api.PersistentVolumeSource{
 					GCEPersistentDisk: &api.GCEPersistentDiskVolumeSource{},
 				},
-				AccessModes: []api.AccessModeType{
+				AccessModes: []api.PersistentVolumeAccessMode{
 					api.ReadWriteOnce,
 					api.ReadOnlyMany,
 				},
@@ -182,7 +182,7 @@ func createTestVolumes() []*api.PersistentVolume {
 				PersistentVolumeSource: api.PersistentVolumeSource{
 					Glusterfs: &api.GlusterfsVolumeSource{},
 				},
-				AccessModes: []api.AccessModeType{
+				AccessModes: []api.PersistentVolumeAccessMode{
 					api.ReadWriteOnce,
 					api.ReadOnlyMany,
 					api.ReadWriteMany,
@@ -201,7 +201,7 @@ func createTestVolumes() []*api.PersistentVolume {
 				PersistentVolumeSource: api.PersistentVolumeSource{
 					GCEPersistentDisk: &api.GCEPersistentDiskVolumeSource{},
 				},
-				AccessModes: []api.AccessModeType{
+				AccessModes: []api.PersistentVolumeAccessMode{
 					api.ReadWriteOnce,
 					api.ReadOnlyMany,
 				},
@@ -221,7 +221,7 @@ func createTestVolumes() []*api.PersistentVolume {
 				PersistentVolumeSource: api.PersistentVolumeSource{
 					Glusterfs: &api.GlusterfsVolumeSource{},
 				},
-				AccessModes: []api.AccessModeType{
+				AccessModes: []api.PersistentVolumeAccessMode{
 					api.ReadWriteOnce,
 					api.ReadOnlyMany,
 					api.ReadWriteMany,
@@ -240,7 +240,7 @@ func createTestVolumes() []*api.PersistentVolume {
 				PersistentVolumeSource: api.PersistentVolumeSource{
 					GCEPersistentDisk: &api.GCEPersistentDiskVolumeSource{},
 				},
-				AccessModes: []api.AccessModeType{
+				AccessModes: []api.PersistentVolumeAccessMode{
 					api.ReadWriteOnce,
 					api.ReadOnlyMany,
 				},
@@ -258,7 +258,7 @@ func createTestVolumes() []*api.PersistentVolume {
 				PersistentVolumeSource: api.PersistentVolumeSource{
 					Glusterfs: &api.GlusterfsVolumeSource{},
 				},
-				AccessModes: []api.AccessModeType{
+				AccessModes: []api.PersistentVolumeAccessMode{
 					api.ReadWriteOnce,
 					api.ReadOnlyMany,
 					api.ReadWriteMany,

--- a/pkg/volumeclaimbinder/types.go
+++ b/pkg/volumeclaimbinder/types.go
@@ -49,7 +49,7 @@ func accessModesIndexFunc(obj interface{}) (string, error) {
 }
 
 // ListByAccessModes returns all volumes with the given set of AccessModeTypes *in order* of their storage capacity (low to high)
-func (pvIndex *persistentVolumeOrderedIndex) ListByAccessModes(modes []api.AccessModeType) ([]*api.PersistentVolume, error) {
+func (pvIndex *persistentVolumeOrderedIndex) ListByAccessModes(modes []api.PersistentVolumeAccessMode) ([]*api.PersistentVolume, error) {
 	pv := &api.PersistentVolume{
 		Spec: api.PersistentVolumeSpec{
 			AccessModes: modes,
@@ -88,7 +88,7 @@ func (pvIndex *persistentVolumeOrderedIndex) Find(pv *api.PersistentVolume, matc
 }
 
 // FindByAccessModesAndStorageCapacity is a convenience method that calls Find w/ requisite matchPredicate for storage
-func (pvIndex *persistentVolumeOrderedIndex) FindByAccessModesAndStorageCapacity(modes []api.AccessModeType, qty resource.Quantity) (*api.PersistentVolume, error) {
+func (pvIndex *persistentVolumeOrderedIndex) FindByAccessModesAndStorageCapacity(modes []api.PersistentVolumeAccessMode, qty resource.Quantity) (*api.PersistentVolume, error) {
 	pv := &api.PersistentVolume{
 		Spec: api.PersistentVolumeSpec{
 			AccessModes: modes,

--- a/test/e2e/empty_dir.go
+++ b/test/e2e/empty_dir.go
@@ -42,7 +42,7 @@ var _ = Describe("emptyDir", func() {
 	It("volume on tmpfs should have the correct mode", func() {
 		volumePath := "/test-volume"
 		source := &api.EmptyDirVolumeSource{
-			Medium: api.StorageTypeMemory,
+			Medium: api.StorageMediumMemory,
 		}
 		pod := testPodWithVolume(volumePath, source)
 
@@ -60,7 +60,7 @@ var _ = Describe("emptyDir", func() {
 		volumePath := "/test-volume"
 		filePath := path.Join(volumePath, "test-file")
 		source := &api.EmptyDirVolumeSource{
-			Medium: api.StorageTypeMemory,
+			Medium: api.StorageMediumMemory,
 		}
 		pod := testPodWithVolume(volumePath, source)
 

--- a/test/integration/persistent_volumes_test.go
+++ b/test/integration/persistent_volumes_test.go
@@ -119,7 +119,7 @@ func createTestClaims() []*api.PersistentVolumeClaim {
 				Namespace: api.NamespaceDefault,
 			},
 			Spec: api.PersistentVolumeClaimSpec{
-				AccessModes: []api.AccessModeType{api.ReadWriteOnce},
+				AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
 				Resources: api.ResourceRequirements{
 					Requests: api.ResourceList{
 						api.ResourceName(api.ResourceStorage): resource.MustParse("500G"),
@@ -133,7 +133,7 @@ func createTestClaims() []*api.PersistentVolumeClaim {
 				Namespace: api.NamespaceDefault,
 			},
 			Spec: api.PersistentVolumeClaimSpec{
-				AccessModes: []api.AccessModeType{api.ReadOnlyMany, api.ReadWriteOnce},
+				AccessModes: []api.PersistentVolumeAccessMode{api.ReadOnlyMany, api.ReadWriteOnce},
 				Resources: api.ResourceRequirements{
 					Requests: api.ResourceList{
 						api.ResourceName(api.ResourceStorage): resource.MustParse("8G"),
@@ -147,7 +147,7 @@ func createTestClaims() []*api.PersistentVolumeClaim {
 				Namespace: api.NamespaceDefault,
 			},
 			Spec: api.PersistentVolumeClaimSpec{
-				AccessModes: []api.AccessModeType{api.ReadOnlyMany, api.ReadWriteOnce, api.ReadWriteMany},
+				AccessModes: []api.PersistentVolumeAccessMode{api.ReadOnlyMany, api.ReadWriteOnce, api.ReadWriteMany},
 				Resources: api.ResourceRequirements{
 					Requests: api.ResourceList{
 						api.ResourceName(api.ResourceStorage): resource.MustParse("5G"),
@@ -175,7 +175,7 @@ func createTestVolumes() []*api.PersistentVolume {
 						FSType: "foo",
 					},
 				},
-				AccessModes: []api.AccessModeType{
+				AccessModes: []api.PersistentVolumeAccessMode{
 					api.ReadWriteOnce,
 					api.ReadOnlyMany,
 				},
@@ -196,7 +196,7 @@ func createTestVolumes() []*api.PersistentVolume {
 						Path:          "theloveyoutakeisequaltotheloveyoumake",
 					},
 				},
-				AccessModes: []api.AccessModeType{
+				AccessModes: []api.PersistentVolumeAccessMode{
 					api.ReadWriteOnce,
 					api.ReadOnlyMany,
 					api.ReadWriteMany,


### PR DESCRIPTION
Rename a few API types that had the word "Type" in their name but were not very good names.

This should have no user-impact.
