### PR TITLE
Update Elasticsearch cluster level service to add version label

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-controller.yaml
@@ -2,17 +2,20 @@ apiVersion: v1beta3
 kind: ReplicationController
 metadata:
   labels:
-    name: elasticsearch-logging
+    app: elasticsearch-logging
+    version: v1
     kubernetes.io/cluster-service: "true"
   name: elasticsearch-logging
 spec:
   replicas: 2
   selector:
-    name: elasticsearch-logging
+    app: elasticsearch-logging
+    version: v1
   template:
     metadata:
       labels:
-        name: elasticsearch-logging
+        app: elasticsearch-logging
+        version: v1
         kubernetes.io/cluster-service: "true"
     spec:
       containers:

--- a/cluster/addons/fluentd-elasticsearch/es-service.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1beta3
 kind: Service
 metadata:
   labels:
-    name: elasticsearch-logging
+    app: elasticsearch-logging
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Elasticsearch"
   name: elasticsearch-logging
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: es-port
   selector:
-    name: elasticsearch-logging
+    app: elasticsearch-logging


### PR DESCRIPTION
And stop using `name` as a label key, as per discussion with @bgrant0607 
Adding the version label supports a rolling-update of the `elasticsearch-logging` service which will continue to send traffic to the old and new pods during the transition (because the `app` label is stable).
