### PR TITLE
Add version label to Kibana controller and service

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
@@ -2,18 +2,21 @@ apiVersion: v1beta3
 kind: ReplicationController
 metadata:
   labels:
-    name: kibana-logging
+    app: kibana-logging
+    version: v1
     kubernetes.io/cluster-service: "true"
   name: kibana-logging
 spec:
   replicas: 1
   selector:
-    name: kibana-logging
+    app: kibana-logging
+    version: v1
   template:
     metadata:
       labels:
+        app: kibana-logging
+        version: v1
         kubernetes.io/cluster-service: "true"
-        name: kibana-logging
     spec:
       containers:
       - name: kibana-logging

--- a/cluster/addons/fluentd-elasticsearch/kibana-service.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1beta3
 kind: Service
 metadata:
   labels:
-    name: kibana-logging
+    app: kibana-logging
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Kibana"
   name: kibana-logging
@@ -13,4 +13,4 @@ spec:
     protocol: TCP
     targetPort: kibana-port
   selector:
-    name: kibana-logging
+    app: kibana-logging


### PR DESCRIPTION
And stop using `name` as a label key, as per the request of @bgrant0607 
The additional `version` label makes it possible to use this with a rolling update and maintain the `service`.
