### PR TITLE
Embed version number in kube-dns RC

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -1,19 +1,21 @@
 apiVersion: v1beta3
 kind: ReplicationController
 metadata:
-  name: kube-dns
+  name: kube-dns-v1
   namespace: default
   labels:
-    k8s-app: kube-dns
+    k8s-app: kube-dns-v1
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: {{ pillar['dns_replicas'] }}
   selector:
     k8s-app: kube-dns
+    version: v1
   template:
     metadata:
       labels:
         k8s-app: kube-dns
+        version: v1
         kubernetes.io/cluster-service: "true"
     spec:
       containers:


### PR DESCRIPTION
This change gives an explicit name to the replication controller for kube-dns and it add a version label for the pods. The purpose of this change is to better support updates to this add-on service using a replication controller which which needs a new name (so v1 -> v2 for example) and which needs to main a service that maps to pods from v1 and v2 during transition (so a change in the version label while keeping the k8s-app label stable).
@thockin 
