### PR TITLE
Add 'no' resource shortcut for nodes

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -32,7 +32,7 @@ const (
 	get_long = `Display one or many resources.
 
 Possible resources include pods (po), replication controllers (rc), services
-(svc), minions (mi), events (ev), or component statuses (cs).
+(svc), nodes (no), events (ev), or component statuses (cs).
 
 By specifying the output as 'template' and providing a Go template as the value
 of the --template flag, you can filter the attributes of the fetched resource(s).`

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -101,6 +101,7 @@ func expandResourceShortcut(resource string) string {
 		"ev":     "events",
 		"limits": "limitRanges",
 		"mi":     "minions",
+		"no":     "nodes",
 		"po":     "pods",
 		"pv":     "persistentVolumes",
 		"pvc":    "persistentVolumeClaims",


### PR DESCRIPTION
Also replaces ‘minion’ with ‘node’ in documentation within get.go
