### PR TITLE
Give explicit version number to Elasticsearch logging RC

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-controller.yaml
@@ -1,20 +1,21 @@
 apiVersion: v1beta3
 kind: ReplicationController
 metadata:
+  name: elasticsearch-logging-v1
+  namespace: default
   labels:
-    app: elasticsearch-logging
+    k8s-app: elasticsearch-logging
     version: v1
     kubernetes.io/cluster-service: "true"
-  name: elasticsearch-logging
 spec:
   replicas: 2
   selector:
-    app: elasticsearch-logging
+    k8s-app: elasticsearch-logging
     version: v1
   template:
     metadata:
       labels:
-        app: elasticsearch-logging
+        k8s-app: elasticsearch-logging
         version: v1
         kubernetes.io/cluster-service: "true"
     spec:

--- a/cluster/addons/fluentd-elasticsearch/es-service.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-service.yaml
@@ -1,15 +1,16 @@
 apiVersion: v1beta3
 kind: Service
 metadata:
+  name: elasticsearch-logging
+  namespace: default
   labels:
-    app: elasticsearch-logging
+    k8s-app: elasticsearch-logging
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Elasticsearch"
-  name: elasticsearch-logging
 spec:
   ports:
   - port: 9200
     protocol: TCP
     targetPort: es-port
   selector:
-    app: elasticsearch-logging
+    k8s-app: elasticsearch-logging


### PR DESCRIPTION
This PR:
- Gives an explicit version number to the Elasticsearch logging RC to better support rolling updates.
- Switches the `app` label key to `k8s-app` to be more consistent with other system cluster services.
- Makes the `default` namespace requirement explicit.
