### PR TITLE
Give explicit version number to Kibana RC

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
@@ -1,20 +1,21 @@
 apiVersion: v1beta3
 kind: ReplicationController
 metadata:
+  name: kibana-logging-v1
+  namespace: default
   labels:
-    app: kibana-logging
+    k8s-app: kibana-logging
     version: v1
     kubernetes.io/cluster-service: "true"
-  name: kibana-logging
 spec:
   replicas: 1
   selector:
-    app: kibana-logging
+    k8s-app: kibana-logging
     version: v1
   template:
     metadata:
       labels:
-        app: kibana-logging
+        k8s-app: kibana-logging
         version: v1
         kubernetes.io/cluster-service: "true"
     spec:

--- a/cluster/addons/fluentd-elasticsearch/kibana-service.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-service.yaml
@@ -2,15 +2,16 @@
 apiVersion: v1beta3
 kind: Service
 metadata:
+  name: kibana-logging
+  namespace: default
   labels:
-    app: kibana-logging
+    k8s-app: kibana-logging
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Kibana"
-  name: kibana-logging
 spec:
   ports:
   - port: 5601
     protocol: TCP
     targetPort: kibana-port
   selector:
-    app: kibana-logging
+    k8s-app: kibana-logging


### PR DESCRIPTION
This PR:
- Gives an explicit version number to the Kibana logging RC to better support rolling updates.
- Switches the app label key to k8s-app to be more consistent with other system cluster services.
- Makes the default namespace requirement explicit.
