### PR TITLE
Create default LimitRange object for cluster: 100m cpu.share per container

### DIFF
--- a/cluster/saltbase/salt/kube-addons/kube-addons.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addons.sh
@@ -110,6 +110,14 @@ while read line; do
   create-kubeconfig-secret "${token}" "${username}"
 done < /srv/kubernetes/known_tokens.csv
 
+# Create admission_control objects if defined before any other addon services. If the limits
+# are defined in a namespace other than default, we should still create the limits for the
+# default namespace.
+for obj in $(find /etc/kubernetes/admission-controls \( -name \*.yaml -o -name \*.json \)); do
+  start_addon ${obj} 100 10 &
+  echo "++ obj ${obj} is created ++"
+done
+
 for obj in $(find /etc/kubernetes/addons \( -name \*.yaml -o -name \*.json \)); do
   start_addon ${obj} 100 10 &
   echo "++ addon ${obj} starting in pid $! ++"

--- a/cluster/saltbase/salt/kube-admission-controls/init.sls
+++ b/cluster/saltbase/salt/kube-admission-controls/init.sls
@@ -1,0 +1,10 @@
+{% if 'LimitRanger' in pillar.get('admission_control', '') %}
+/etc/kubernetes/admission-controls/limit-range:
+  file.recurse:
+    - source: salt://kube-admission-controls/limit-range
+    - include_pat: E@(^.+\.yaml$|^.+\.json$)
+    - user: root
+    - group: root
+    - dir_mode: 755
+    - file_mode: 644
+{% endif %}

--- a/cluster/saltbase/salt/kube-admission-controls/limit-range/limit-range.yaml
+++ b/cluster/saltbase/salt/kube-admission-controls/limit-range/limit-range.yaml
@@ -1,0 +1,9 @@
+apiVersion: "v1beta3"
+kind: "LimitRange"
+metadata:
+  name: "limits"
+spec:
+  limits:
+    - type: "Container"
+      default:
+        cpu: "100m"

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -39,6 +39,7 @@ base:
     - cadvisor
     - kube-client-tools
     - kube-master-addons
+    - kube-admission-controls
 {% if grains['cloud'] is defined and grains['cloud'] != 'vagrant' %}
     - logrotate
 {% endif %}


### PR DESCRIPTION
This is to prevent not overcommiting our node in current eco-system when 1) scheduler doesn't check node usage 2) resource limit/request of a pod / container is not mandatory

```
$ cluster/kubectl.sh describe LimitRanges limits
Name:       limits
Type        Resource    Min Max Default
----        --------    --- --- ---
Container   cpu     100m    -   100m

$ cluster/kubectl.sh create -f examples/pod.yaml 
pods/nginx

$ cluster/kubectl.sh get -o template --template={{.spec.containers}} pods nginx
[map[imagePullPolicy:IfNotPresent securityContext:map[capabilities:map[] privileged:false] name:nginx volumeMounts:[map[name:default-token-3e013 readOnly:true mountPath:/var/run/secrets/kubernetes.io/serviceaccount]] resources:map[limits:map[cpu:100m] requests:map[cpu:100m]] terminationMessagePath:/dev/termination-log capabilities:map[] image:nginx ports:[map[containerPort:80 protocol:TCP]]]]
```
#7795

cc/ @bgrant0607 @vmarmol 
