### PR TITLE
Serialization of 'IP' in endpoints should be 'ip'

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1098,7 +1098,7 @@ type EndpointSubset struct {
 type EndpointAddress struct {
 	// The IP of this endpoint.
 	// TODO: This should allow hostname or IP, see #4447.
-	IP string `json:"IP" description:"IP address of the endpoint"`
+	IP string `json:"ip" description:"IP address of the endpoint"`
 
 	// Optional: The kubernetes object related to the entry point.
 	TargetRef *ObjectReference `json:"targetRef,omitempty" description:"reference to object providing the endpoint"`


### PR DESCRIPTION
CamelCase rules are `initialsUpperCase` (e.g. `url`)

@thockin only changing for v1 since v1beta3 is locked
