### PR TITLE
Give pod infra container 50m of CPU.

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/lifecycle"
@@ -1249,6 +1250,15 @@ func (dm *DockerManager) createPodInfraContainer(pod *api.Pod) (kubeletTypes.Doc
 		Name:  PodInfraContainerName,
 		Image: dm.PodInfraContainerImage,
 		Ports: ports,
+
+		// The infra container should not need CPU, give it 50m to ensure this.
+		// NOTE: Re-examine in the future if this affects startup time, consider
+		// setting after startup.
+		Resources: api.ResourceRequirements{
+			Limits: api.ResourceList{
+				api.ResourceCPU: *resource.NewMilliQuantity(50, resource.DecimalSI),
+			},
+		},
 	}
 	ref, err := kubecontainer.GenerateContainerRef(pod, container)
 	if err != nil {


### PR DESCRIPTION
This gives pause containers 51 shares of CPU. 

It can be argued that this is not necessary (and I'm happy to accept that if it is the consensus :) ), but this will ensure this is the case if anything ever gets to running in this container. It also gives this desired state to the kernel's CPU scheduler.

Note that this may affect startup time on a very CPU-busy node since we'll wait for Docker to exec the pause image in the container (with limits applied). This is unlikely to happen since we do give each container some expected shares and the image does not do much work.

Will run e2e tomorrow.

/cc @dchen1107  @rjnagal
