### PR TITLE
Support old and new style dns service names.

### DIFF
--- a/cluster/addons/dns/README.md
+++ b/cluster/addons/dns/README.md
@@ -13,6 +13,11 @@ crashes or scheduling changes).  This maps well to DNS, which has a long
 history of clients that, on purpose or on accident, do not respect DNS TTLs
 (see previous remark about Pod IPs changing).
 
+## DNS Name format for Services
+Services get a DNS name with the format my-svc.my-namespace.svc.cluster.local
+'svc' should not be used a namespace label to avoid conflicts.
+The old format of my-svc.my-namespace.cluster.local has been deprecated. 
+
 ## How do I find the DNS server?
 The DNS server itself runs as a Kubernetes Service.  This gives it a stable IP
 address.  When you run the SkyDNS service, you want to assign a static IP to use for
@@ -35,12 +40,12 @@ example, see `cluster/gce/config-default.sh`.
 ```shell
 ENABLE_CLUSTER_DNS=true
 DNS_SERVER_IP="10.0.0.10"
-DNS_DOMAIN="kubernetes.local"
+DNS_DOMAIN="cluster.local"
 DNS_REPLICAS=1
 ```
 
 This enables DNS with a DNS Service IP of `10.0.0.10` and a local domain of
-`kubernetes.local`, served by a single copy of SkyDNS.
+`cluster.local`, served by a single copy of SkyDNS.
 
 If you are not using a supported cluster setup, you will have to replicate some
 of this yourself.  First, each kubelet needs to run with the following flags

--- a/cluster/addons/dns/kube2sky/Makefile
+++ b/cluster/addons/dns/kube2sky/Makefile
@@ -4,7 +4,7 @@
 
 .PHONY: all kube2sky container push clean test
 
-TAG = 1.5
+TAG = 1.6
 PREFIX = gcr.io/google_containers
 
 all: container

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -28,7 +28,7 @@ spec:
         - -initial-cluster-token
         - skydns-etcd
       - name: kube2sky
-        image: gcr.io/google_containers/kube2sky:1.5
+        image: gcr.io/google_containers/kube2sky:1.6
         args:
         # command = "/kube2sky"
         - -domain={{ pillar['dns_domain'] }}

--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -72,6 +72,8 @@ var _ = Describe("DNS", func() {
 		// TODO: Spin up a separate test service and test that dns works for that service.
 		namesToResolve := []string{
 			"kubernetes-ro.default",
+			"kubernetes-ro.default.svc",
+			"kubernetes-ro.default.svc.cluster.local",
 			"kubernetes-ro.default.cluster.local",
 			"google.com",
 		}


### PR DESCRIPTION
"svc" is added as a dns service name to DNS service names.

Assume we have a service called ser1, with namespace ns1.
The old style service name would look like: ser1.ns1.cluster.local
The new style service name will be: ser1.ns1.svc.cluster.local

"svc" should not be used as a namespace label by kubernetes services. It can cause creation of DNS entries to fail.
The old-style DNS service names are deprecated and will be removed in future kubernetes versions.
