### PR TITLE
Juju provider petstore action  & kubectl.sh fix 

### DIFF
--- a/cluster/juju/bundles/local.yaml
+++ b/cluster/juju/bundles/local.yaml
@@ -18,7 +18,8 @@ kubernetes-local:
         "gui-x": "0"
         "gui-y": "0"
     flannel-docker:
-      charm: cs:trusty/flannel-docker
+      charm: flannel-docker
+      branch: https://github.com/chuckbutler/flannel-docker-charm.git
       annotations:
         "gui-x": "0"
         "gui-y": "300"
@@ -35,8 +36,12 @@ kubernetes-local:
   relations:
     - - "flannel-docker:network"
       - "docker:network"
+    - - "flannel-docker:network"
+      - "kubernetes-master:network"
     - - "flannel-docker:docker-host"
       - "docker:juju-info"
+    - - "flannel-docker:docker-host"
+      - "kubernetes-master:juju-info"
     - - "flannel-docker:db"
       - "etcd:client"
     - - "kubernetes:docker-host"

--- a/cluster/juju/charms/trusty/kubernetes-master/actions.yaml
+++ b/cluster/juju/charms/trusty/kubernetes-master/actions.yaml
@@ -1,0 +1,3 @@
+petstore:
+    description: Deploy the Kubernetes Petstore app
+

--- a/cluster/juju/charms/trusty/kubernetes-master/actions/lib/parse_get_pods
+++ b/cluster/juju/charms/trusty/kubernetes-master/actions/lib/parse_get_pods
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+import json
+import sys
+
+
+def parse_pod_output():
+    out = sys.stdin.readlines()
+    foo = json.loads(' '.join(out))
+    for item in foo['items']:
+        name_slugs = set(item['metadata']['name'].split('-'))
+        if 'fectrl' in name_slugs:
+            if item['status']['phase'] == "Running":
+                print item['status']['podIP']
+
+if __name__ == "__main__":
+        parse_pod_output()

--- a/cluster/juju/charms/trusty/kubernetes-master/actions/petstore
+++ b/cluster/juju/charms/trusty/kubernetes-master/actions/petstore
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -eux
+
+export KUBE_MASTER_IP=0.0.0.0
+export KUBERNETES_MASTER=http://$KUBE_MASTER_IP
+
+# The test is a bit spammy with files, head over to /tmp to discard when done
+cd /tmp
+
+# Need to update the script with the proposed IP of the web-head pod
+# Currently its set to 10.1.4.89
+
+sed -i 's/pass_http=0/exit 0/' /opt/kubernetes/examples/k8petstore/k8petstore.sh
+/opt/kubernetes/examples/k8petstore/k8petstore.sh
+
+# Loop until the daemon has come online
+counter=0
+KUBE_POD_STATUS="Pending"
+while [ "$KUBE_POD_STATUS" == "Pending" ]
+do
+    if [[ counter -eq 200 ]]; then
+	echo "Pod failed to come online. Timeout reached"
+	exit 1
+    fi
+    CUR_STATUS=$(kubectl get pods -o json | $CHARM_DIR/actions/lib/parse_get_pods)
+    if [ ! -z "$CUR_STATUS" ]; then
+	KUBE_POD_STATUS=$CUR_STATUS
+    fi
+    sleep 1
+    counter+=1
+done
+
+sed -i 's/exit 0/pass_http=0/' /opt/kubernetes/examples/k8petstore/k8petstore.sh
+sed -i "s/PUBLIC_IP=\"10.1.4.89\"/PUBLIC_IP=\"$KUBE_POD_STATUS\"/"  /opt/kubernetes/examples/k8petstore/k8petstore.sh
+/opt/kubernetes/examples/k8petstore/k8petstore.sh
+
+# Return execution to the CHARM_DIR for further actions
+cd $CHARM_DIR
+

--- a/cluster/juju/charms/trusty/kubernetes-master/hooks/hooks.py
+++ b/cluster/juju/charms/trusty/kubernetes-master/hooks/hooks.py
@@ -141,6 +141,11 @@ def relation_changed():
     # Send api endpoint to minions
     notify_minions()
 
+@hooks.hook('network-relation-changed')
+def network_relation_changed():
+    relation_id = hookenv.relation_id()
+    hookenv.relation_set(relation_id, ignore_errors=True)
+
 
 def notify_minions():
     print("Notify minions.")

--- a/cluster/juju/charms/trusty/kubernetes-master/metadata.yaml
+++ b/cluster/juju/charms/trusty/kubernetes-master/metadata.yaml
@@ -17,3 +17,5 @@ provides:
 requires:
   etcd:
     interface: etcd
+  network:
+      interface: overlay-network

--- a/cluster/juju/util.sh
+++ b/cluster/juju/util.sh
@@ -58,7 +58,7 @@ function kube-down() {
 function detect-master() {
     local kubestatus
     # Capturing a newline, and my awk-fu was weak - pipe through tr -d
-    kubestatus=$(juju status --format=oneline kubernetes-master | awk '{print $3}' | tr -d "\n")
+    kubestatus=$(juju status --format=oneline kubernetes-master | grep kubernetes-master/0 | awk '{print $3}' | tr -d "\n")
     export KUBE_MASTER_IP=${kubestatus}
     export KUBE_MASTER=${KUBE_MASTER_IP}
     export KUBERNETES_MASTER=http://${KUBE_MASTER}:8080

--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -105,7 +105,7 @@ if [[ "$KUBERNETES_PROVIDER" == "gke" ]]; then
   config=(
     "--context=gke_${PROJECT}_${ZONE}_${CLUSTER_NAME}"
   )
-elif [[ "$KUBERNETES_PROVIDER" == "ubuntu" ]]; then
+elif [[ "$KUBERNETES_PROVIDER" == "ubuntu" || "$KUBERNETES_PROVIDER" == "juju" ]]; then
   detect-master > /dev/null
   config=(
     "--server=http://${KUBE_MASTER_IP}:8080"

--- a/docs/getting-started-guides/juju.md
+++ b/docs/getting-started-guides/juju.md
@@ -5,7 +5,6 @@ wide number of clouds, supporting service orchestration once the bundle of
 services has been deployed.
 
 
-
 ### Prerequisites
 
 > Note: If you're running kube-up, on ubuntu - all of the dependencies
@@ -165,7 +164,22 @@ We can add minion units like so:
     juju add-unit docker # creates unit docker/2, kubernetes/2, docker-flannel/2
 
 
+## Launch the "petstore" example app
+
+The petstore example is available as a
+[juju action](https://jujucharms.com/docs/devel/actions).
+
+    juju action do kubernetes-master/0
+
+
+Note: this example includes curl statements to exercise the app.
+
+
 ## Tear down cluster
+
+    ./kube-down.sh
+
+or
 
     juju destroy-environment --force `juju env`
 


### PR DESCRIPTION
This PR adds a convenience command for the juju provider for launching the petstore example: 

```
$ juju action do kubernetes-master/0 petstore
```

Credit for this work goes to @chuckbutler.

Also included: a fix to make `cluster/kubectl.sh` work with the juju provider. 
