### PR TITLE
Update Fluentd GCP image to v1.6

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
@@ -17,6 +17,9 @@ RUN apt-get -q update && \
     apt-get clean && \
     curl -s https://storage.googleapis.com/signals-agents/logging/google-fluentd-install.sh | sudo bash
 
+# Update gem for fluent-plugin-google-cloud
+RUN /usr/sbin/google-fluentd-gem update fluent-plugin-google-cloud
+
 # Copy the Fluentd configuration file for logging Docker container logs.
 COPY google-fluentd.conf /etc/google-fluentd/google-fluentd.conf
 

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -6,7 +6,7 @@
 .PHONY:	build push
 
 
-TAG = 1.5
+TAG = 1.6
 
 build:
 	docker build -t gcr.io/google_containers/fluentd-gcp:$(TAG) .

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.5
+    image: gcr.io/google_containers/fluentd-gcp:1.6
     env:
     - name: "FLUENTD_ARGS"
       value: "-qq"


### PR DESCRIPTION
This release uses a new gem for fluent-plugin-google-cloud that does not need DNS to be working in order to operate. Fixes a breakage of the Kubernetes to Cloud Logging pipeline.
@a-robinson @mr-salty
