### PR TITLE
Warn about needing a trailing slash via service proxy

### DIFF
--- a/pkg/kubectl/cmd/clusterinfo.go
+++ b/pkg/kubectl/cmd/clusterinfo.go
@@ -95,6 +95,15 @@ func printService(out io.Writer, name, link string) {
 	fmt.Fprintf(out, " is running at ")
 	ct.ChangeColor(ct.Yellow, false, ct.None, false)
 	fmt.Fprint(out, link)
+	// TODO: Remove the special case for services which need to be accessed
+	// by tools like curl when the bug that requires a trailing slash
+	// is fixed.
+	if name == "Elasticsearch" {
+		fmt.Fprintf(out, "/ ")
+	}
 	ct.ResetColor()
+	if name == "Elasticsearch" {
+		fmt.Fprint(out, " (note the trailing slash)")
+	}
 	fmt.Fprintln(out, "")
 }


### PR DESCRIPTION
Our bug which requires a trailing slash when accessing services via the proxy at the master is causing trouble for our users e.g. issue #8513. For now, warn about needing a trailing slash to access Elasticsearch via curl. The other cluster level services are accessed via a browser from where we no longer need the trailing slash.
@jlowdermilk 

```
$ kubectl cluster-info
Kubernetes master is running at https://104.154.70.171
Elasticsearch is running at https://104.154.70.171/api/v1beta3/proxy/namespaces/default/services/elasticsearch-logging/  (note the trailing slash)
Kibana is running at https://104.154.70.171/api/v1beta3/proxy/namespaces/default/services/kibana-logging
KubeDNS is running at https://104.154.70.171/api/v1beta3/proxy/namespaces/default/services/kube-dns
Grafana is running at https://104.154.70.171/api/v1beta3/proxy/namespaces/default/services/monitoring-grafana
```
