### PR TITLE
Revise user manual for kube binaries except kubectl

### DIFF
--- a/docs/man/kube-apiserver.1.md
+++ b/docs/man/kube-apiserver.1.md
@@ -14,67 +14,179 @@ The **kubernetes** API server validates and configures data for 3 types of objec
 The the kube-apiserver several options.
 
 # OPTIONS
-**--address**=""
-	The address on the local server to listen to. Default 127.0.0.1
+**--address**=127.0.0.1
+	DEPRECATED: see --insecure-bind-address instead
 
-**--allow_privileged**=""
+**--admission-control**="AlwaysAdmit"
+	Ordered list of plug-ins to do admission control of resources into cluster. Comma-delimited list of: AlwaysDeny, AlwaysAdmit, ServiceAccount, NamespaceExists, NamespaceLifecycle, NamespaceAutoProvision, LimitRanger, SecurityContextDeny, ResourceQuota
+
+**--admission-control-config-file**=""
+	File with admission control configuration.
+
+**--allow-privileged**=false
 	If true, allow privileged containers.
 
-**--alsologtostderr**=
-	log to standard error as well as files. Default is false.
+**--alsologtostderr**=false
+	log to standard error as well as files
 
-**--api_prefix**="/api"
-	The prefix for API requests on the server. Default '/api'
+**--api-burst**=200
+	API burst amount for the read only port
 
-**--cloud_config**=""
-	The path to the cloud provider configuration file. Empty string for no configuration file.
+**--api-prefix**="/api"
+	The prefix for API requests on the server. Default '/api'.
 
-**--cloud_provider**=""
-	The provider for cloud services. Empty string for no provider.
+**--api-rate**=10
+	API rate limit as QPS for the read only port
 
-**--cors_allowed_origins**=[]
-	List of allowed origins for CORS, comma separated. An allowed origin can be a regular expression to support subdomain matching. If this list is empty CORS will not be enabled.
+**--authorization-mode**="AlwaysAllow"
+	Selects how to do authorization on the secure port.  One of: AlwaysAllow,AlwaysDeny,ABAC
 
-**--etcd_servers**=[]
-	List of etcd servers to watch (http://ip:port), comma separated
+**--authorization-policy-file**=""
+	File with authorization policy in csv format, used with --authorization-mode=ABAC, on the secure port.
 
-**--log_backtrace_at=**:0
+**--basic-auth-file**=""
+	If set, the file that will be used to admit requests to the secure port of the API server via http basic authentication.
+
+**--bind-address**=0.0.0.0
+	The IP address on which to serve the --read-only-port and --secure-port ports. This address must be reachable by the rest of the cluster. If blank, all interfaces will be used.
+
+**--cert-dir**="/var/run/kubernetes"
+	The directory where the TLS certs are located (by default /var/run/kubernetes). If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored.
+
+**--client-ca-file**=""
+	If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.
+
+**--cloud-config**=""
+	The path to the cloud provider configuration file.  Empty string for no configuration file.
+
+**--cloud-provider**=""
+	The provider for cloud services.  Empty string for no provider.
+
+**--cluster-name**="kubernetes"
+	The instance prefix for the cluster
+
+**--cors-allowed-origins**=[]
+	List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching.  If this list is empty CORS will not be enabled.
+
+**--etcd-config**=""
+	The config file for the etcd client. Mutually exclusive with -etcd-servers.
+
+**--etcd-prefix**="/registry"
+	The prefix for all resource paths in etcd.
+
+**--etcd-servers**=[]
+	List of etcd servers to watch (http://ip:port), comma separated. Mutually exclusive with -etcd-config
+
+**--event-ttl**=1h0m0s
+	Amount of time to retain events. Default 1 hour.
+
+**--external-hostname**=""
+	The hostname to use when generating externalized URLs for this master (e.g. Swagger API Docs.)
+
+**--insecure-bind-address**=127.0.0.1
+	The IP address on which to serve the --insecure-port (set to 0.0.0.0 for all interfaces). Defaults to localhost.
+
+**--insecure-port**=8080
+	The port on which to serve unsecured, unauthenticated access. Default 8080. It is assumed that firewall rules are set up such that this port is not reachable from outside of the cluster and that port 443 on the cluster's public address is proxied to this port. This is performed by nginx in the default setup.
+
+**--kubelet_certificate_authority**=""
+	Path to a cert. file for the certificate authority.
+
+**--kubelet_client_certificate**=""
+	Path to a client key file for TLS.
+
+**--kubelet_client_key**=""
+	Path to a client key file for TLS.
+
+**--kubelet_https**=true
+	Use https for kubelet connections
+
+**--kubelet_port**=10250
+	Kubelet port
+
+**--kubelet_timeout**=5s
+	Timeout for kubelet operations
+
+**--log_backtrace_at**=:0
 	when logging hits line file:N, emit a stack trace
 
-**--log_dir**=""
+**--log_dir**=
 	If non-empty, write log files in this directory
 
 **--log_flush_frequency**=5s
-	Maximum number of seconds between log flushes. Default is 5 seconds.
+	Maximum number of seconds between log flushes
 
-**--logtostderr**=
-	log to standard error instead of files. Default is false.
+**--logtostderr**=true
+	log to standard error instead of files
 
-**--kubelet_port**=10250
-	The port at which kubelet will be listening on the minions. Default is 10250.
+**--long-running-request-regexp**="[.*\\/watch$][^\\/proxy.*]"
+	A regular expression matching long running requests which should be excluded from maximum inflight request handling.
+
+**--master-service-namespace**="default"
+	The namespace from which the kubernetes master services should be injected into pods
+
+**--max-requests-inflight**=400
+	The maximum number of requests in flight at a given time.  When the server exceeds this, it rejects requests.  Zero for no limit.
+
+**--old-etcd-prefix**="/registry"
+	The previous prefix for all resource paths in etcd, if any.
 
 **--port**=8080
-	The port to listen on. Default is 8080.
+	DEPRECATED: see --insecure-port instead
 
-**--stderrthreshold**=0
-	logs at or above this threshold go to stderr. Default is 0.
+**--portal-net**=<nil>
+	A CIDR notation IP range from which to assign portal IPs. This must not overlap with any IP ranges assigned to nodes for pods.
 
-**--storage_version**=""
-	The version to store resources with. Defaults to server preferred.
+**--profiling**=true
+	Enable profiling via web interface host:port/debug/pprof/
+
+**--public-address-override**=0.0.0.0
+	DEPRECATED: see --bind-address instead
+
+**--read-only-port**=7080
+	The port on which to serve read-only resources. If 0, don't serve read-only at all. It is assumed that firewall rules are set up such that this port is not reachable from outside of the cluster.
+
+**--runtime-config**=
+	A set of key=value pairs that describe runtime configuration that may be passed to the apiserver. api/<version> key can be used to turn on/off specific api versions. api/all and api/legacy are special keys to control all and legacy api versions respectively.
+
+**--secure-port**=6443
+	The port on which to serve HTTPS with authentication and authorization. If 0, don't serve HTTPS at all.
+
+**--service-account-key-file**=""
+	File containing PEM-encoded x509 RSA private or public key, used to verify ServiceAccount tokens. If unspecified, --tls-private-key-file is used.
+
+**--service-account-lookup**=false
+	If true, validate ServiceAccount tokens exist in etcd as part of authentication.
+
+**--stderrthreshold**=2
+	logs at or above this threshold go to stderr
+
+**--storage-version**=""
+	The version to store resources with. Defaults to server preferred
+
+**--tls-cert-file**=""
+	File containing x509 Certificate for HTTPS.  (CA cert, if any, concatenated after server cert). If HTTPS serving is enabled, and --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key are generated for the public address and saved to /var/run/kubernetes.
+
+**--tls-private-key-file**=""
+	File containing x509 private key matching --tls-cert-file.
+
+**--token-auth-file**=""
+	If set, the file that will be used to secure the secure port of the API server via token authentication.
 
 **--v**=0
-	Log level for V logs.
+	log level for V logs
 
 **--version**=false
-	Print version information and quit. Default is false.
+	Print version information and quit
 
 **--vmodule**=
 	comma-separated list of pattern=N settings for file-filtered logging
 
 # EXAMPLES
 ```
-/usr/bin/kube-apiserver --logtostderr=true --v=0 --etcd_servers=http://127.0.0.1:4001 --address=0.0.0.0 --port=8080 --kubelet_port=10250 --allow_privileged=false
+/usr/bin/kube-apiserver --logtostderr=true --v=0 --etcd_servers=http://127.0.0.1:4001 --insecure_bind_address=127.0.0.1 --insecure_port=8080 --kubelet_port=10250 --portal_net=11.1.1.0/24 --allow_privileged=false
 ```
+
 # HISTORY
 October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
  on the kubernetes source material and internal work.

--- a/docs/man/kube-controller-manager.1.md
+++ b/docs/man/kube-controller-manager.1.md
@@ -14,82 +14,122 @@ The **kubernetes** controller manager is really a service that is layered on top
 The kube-controller-manager has several options.
 
 # OPTIONS
-**--address**=""
-	The address on the local server to listen to. Default 127.0.0.1.
+**--address**=127.0.0.1
+	The IP address to serve on (set to 0.0.0.0 for all interfaces)
 
-**--allow_privileged**="false"
-	If true, allow privileged containers.
-
-**--address=**"127.0.0.1"
-	The address to serve from.
+**--allocate-node-cidrs**=false
+	Should CIDRs for Pods be allocated and set on the cloud provider.
 
 **--alsologtostderr**=false
-	log to standard error as well as files.
+	log to standard error as well as files
 
-**--api_version**=""
-	The API version to use when talking to the server.
+**--cloud-config**=""
+	The path to the cloud provider configuration file.  Empty string for no configuration file.
 
-**--cloud_config**=""
-	The path to the cloud provider configuration file. Empty string for no configuration file.
+**--cloud-provider**=""
+	The provider for cloud services.  Empty string for no provider.
 
-**--cloud_provider**=""
-	The provider for cloud services. Empty string for no provider.
+**--cluster-cidr**=<nil>
+	CIDR Range for Pods in cluster.
 
-**--minion_regexp**=""
-	If non empty, and --cloud_provider is specified, a regular expression for matching minion VMs.
+**--concurrent-endpoint-syncs**=5
+	The number of endpoint syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load
 
-**--insecure_skip_tls_verify**=false
-	If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+**--concurrent_rc_syncs**=5
+	The number of replication controllers that are allowed to sync concurrently. Larger number = more reponsive replica management, but more CPU (and network) load
+
+**--deleting-pods-burst**=10
+	Number of nodes on which pods are bursty deleted in case of node failure. For more details look into RateLimiter.
+
+**--deleting-pods-qps**=0.1
+	Number of nodes per second on which pods are deleted in case of node failure.
+
+**--kubeconfig**=""
+	Path to kubeconfig file with authorization and master location information.
 
 **--log_backtrace_at**=:0
-	when logging hits line file:N, emit a stack trace.
+	when logging hits line file:N, emit a stack trace
 
-**--log_dir**=""
-	If non-empty, write log files in this directory.
+**--log_dir**=
+	If non-empty, write log files in this directory
 
 **--log_flush_frequency**=5s
-	Maximum number of seconds between log flushes.
+	Maximum number of seconds between log flushes
 
-**--logtostderr**=false
-	log to standard error instead of files.
+**--logtostderr**=true
+	log to standard error instead of files
 
 **--machines**=[]
-    List of machines to schedule onto, comma separated.
-
-**--pod_eviction_timeout**=5m
-    The grace peroid for deleting pods on failed nodes.
-
-**--sync_nodes**=true
-    If true, and --cloud_provider is specified, sync nodes from the cloud provider. Default true.
+	List of machines to schedule onto, comma separated.
 
 **--master**=""
-	The address of the Kubernetes API server.
+	The address of the Kubernetes API server (overrides any value in kubeconfig)
 
-**--node_sync_period**=10s
-    The period for syncing nodes from cloudprovider.
+**--minion-regexp**=""
+	If non empty, and --cloud-provider is specified, a regular expression for matching minion VMs.
+
+**--namespace-sync-period**=5m0s
+	The period for syncing namespace life-cycle updates
+
+**--node-memory**=3Gi
+	The amount of memory (in bytes) provisioned on each node
+
+**--node-milli-cpu**=1000
+	The amount of MilliCPU provisioned on each node
+
+**--node-monitor-grace-period**=40s
+	Amount of time which we allow running Node to be unresponsive before marking it unhealty. Must be N times more than kubelet's nodeStatusUpdateFrequency, where N means number of retries allowed for kubelet to post node status.
+
+**--node-monitor-period**=5s
+	The period for syncing NodeStatus in NodeController.
+
+**--node-startup-grace-period**=1m0s
+	Amount of time which we allow starting Node to be unresponsive before marking it unhealty.
+
+**--node-sync-period**=10s
+	The period for syncing nodes from cloudprovider. Longer periods will result in fewer calls to cloud provider, but may delay addition of new nodes to cluster.
+
+**--pod-eviction-timeout**=5m0s
+	The grace peroid for deleting pods on failed nodes.
 
 **--port**=10252
-    The port that the controller-manager's http service runs on.
+	The port that the controller-manager's http service runs on
 
-**--resource_quota_sync_period**=10s
-    The period for syncing quota usage status in the system.
+**--profiling**=true
+	Enable profiling via web interface host:port/debug/pprof/
 
-**--stderrthreshold**=0
-	logs at or above this threshold go to stderr.
+**--pvclaimbinder-sync-period**=10s
+	The period for syncing persistent volumes and persistent volume claims
+
+**--register-retry-count**=10
+	The number of retries for initial node registration.  Retry interval equals node-sync-period.
+
+**--resource-quota-sync-period**=10s
+	The period for syncing quota usage status in the system
+
+**--service-account-private-key-file**=""
+	Filename containing a PEM-encoded private RSA key used to sign service account tokens.
+
+**--stderrthreshold**=2
+	logs at or above this threshold go to stderr
+
+**--sync-nodes**=true
+	If true, and --cloud-provider is specified, sync nodes from the cloud provider. Default true.
 
 **--v**=0
-	log level for V logs.
+	log level for V logs
 
 **--version**=false
-	Print version information and quit.
+	Print version information and quit
 
 **--vmodule**=
-	comma-separated list of pattern=N settings for file-filtered logging.
+	comma-separated list of pattern=N settings for file-filtered logging
 
 # EXAMPLES
 ```
-/usr/bin/kube-controller-manager --logtostderr=true --v=0 --master=127.0.0.1:8080
+/usr/bin/kube-controller-manager --logtostderr=true --v=0 --master=127.0.0.1:8080 --machines=127.0.0.1 
 ```
+
 # HISTORY
 October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
  on the kubernetes source material and internal work.

--- a/docs/man/kube-proxy.1.md
+++ b/docs/man/kube-proxy.1.md
@@ -17,34 +17,40 @@ The kube-proxy takes several options.
 **--alsologtostderr**=false
 	log to standard error as well as files
 
-**--api_version=**""
-	The API version to use when talking to the server
+**--bind-address**=0.0.0.0
+	The IP address for the proxy server to serve on (set to 0.0.0.0 for all interfaces)
 
-**--bindaddress**="0.0.0.0"
-	The address for the proxy server to serve on (set to 0.0.0.0 or "" for all interfaces)
+**--healthz-bind-address**=127.0.0.1
+	The IP address for the health check server to serve on, defaulting to 127.0.0.1 (set to 0.0.0.0 for all interfaces)
 
-**--etcd_servers**=[]
-	List of etcd servers to watch (http://ip:port), comma separated (optional)
+**--healthz-port**=10249
+	The port to bind the health check server. Use 0 to disable.
 
-**--insecure_skip_tls_verify**=false
-	If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+**--kubeconfig**=""
+	Path to kubeconfig file with authorization information (the master location is set by the master flag).
 
 **--log_backtrace_at**=:0
 	when logging hits line file:N, emit a stack trace
 
-**--log_dir**=""
+**--log_dir**=
 	If non-empty, write log files in this directory
 
 **--log_flush_frequency**=5s
 	Maximum number of seconds between log flushes
 
-**--logtostderr**=false
+**--logtostderr**=true
 	log to standard error instead of files
 
 **--master**=""
-	The address of the Kubernetes API server
+	The address of the Kubernetes API server (overrides any value in kubeconfig)
 
-**--stderrthreshold**=0
+**--oom-score-adj**=-899
+	The oom_score_adj value for kube-proxy process. Values must be within the range [-1000, 1000]
+
+**--resource-container**="/kube-proxy"
+	Absolute name of the resource-only container to create and run the Kube-proxy in (Default: /kube-proxy).
+
+**--stderrthreshold**=2
 	logs at or above this threshold go to stderr
 
 **--v**=0
@@ -56,11 +62,11 @@ The kube-proxy takes several options.
 **--vmodule**=
 	comma-separated list of pattern=N settings for file-filtered logging
 
-
 # EXAMPLES
 ```
-/usr/bin/kube-proxy --logtostderr=true --v=0 --etcd_servers=http://127.0.0.1:4001
+/usr/bin/kube-proxy --logtostderr=true --v=0 --master=http://127.0.0.1:8080
 ```
+
 # HISTORY
 October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
  on the kubernetes source material and internal work.

--- a/docs/man/kube-scheduler.1.md
+++ b/docs/man/kube-scheduler.1.md
@@ -14,52 +14,59 @@ The **kubernetes** scheduler is a policy-rich, topology-aware, workload-specific
 The kube-scheduler can take several options.
 
 # OPTIONS
-**--address=**"127.0.0.1"
-	The address to serve from.
+**--address**=127.0.0.1
+	The IP address to serve on (set to 0.0.0.0 for all interfaces)
 
-**--alsologtostderr=**false
-	log to standard error as well as files.
+**--algorithm-provider**="DefaultProvider"
+	The scheduling algorithm provider to use, one of: DefaultProvider
 
-**--api_version=**""
-	The API version to use when talking to the server.
+**--alsologtostderr**=false
+	log to standard error as well as files
 
-**--insecure_skip_tls_verify**=false
-	If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+**--kubeconfig**=""
+	Path to kubeconfig file with authorization and master location information.
 
-**--log_backtrace_at=**:0
-	when logging hits line file:N, emit a stack trace.
+**--log_backtrace_at**=:0
+	when logging hits line file:N, emit a stack trace
 
-**--log_dir=**""
-	If non-empty, write log files in this directory.
+**--log_dir**=
+	If non-empty, write log files in this directory
 
 **--log_flush_frequency**=5s
-	Maximum number of seconds between log flushes.
+	Maximum number of seconds between log flushes
 
-**--logtostderr**=false
-	log to standard error instead of files.
+**--logtostderr**=true
+	log to standard error instead of files
 
-**--master=**""
-	The address of the Kubernetes API server.
+**--master**=""
+	The address of the Kubernetes API server (overrides any value in kubeconfig)
 
-**--port=**10251
-	The port that the scheduler's http service runs on.
+**--policy-config-file**=""
+	File with scheduler policy configuration
 
-**--stderrthreshold**=0
-	logs at or above this threshold go to stderr.
+**--port**=10251
+	The port that the scheduler's http service runs on
+
+**--profiling**=true
+	Enable profiling via web interface host:port/debug/pprof/
+
+**--stderrthreshold**=2
+	logs at or above this threshold go to stderr
 
 **--v**=0
-	log level for V logs.
+	log level for V logs
 
 **--version**=false
-	Print version information and quit.
+	Print version information and quit
 
 **--vmodule**=
-	comma-separated list of pattern=N settings for file-filtered logging.
+	comma-separated list of pattern=N settings for file-filtered logging
 
 # EXAMPLES
 ```
 /usr/bin/kube-scheduler --logtostderr=true --v=0 --master=127.0.0.1:8080
 ```
+
 # HISTORY
 October 2014, Originally compiled by Scott Collier (scollier@redhat.com) based
  on the kubernetes source material and internal work.

--- a/docs/man/kubelet.1.md
+++ b/docs/man/kubelet.1.md
@@ -11,95 +11,237 @@ kubelet \- Processes a container manifest so the containers are launched accordi
 
 The **kubernetes** kubelet runs on each node. The Kubelet works in terms of a container manifest. A container manifest is a YAML or JSON file that describes a pod. The Kubelet takes a set of manifests that are provided in various mechanisms and ensures that the containers described in those manifests are started and continue running.
 
-There are 4 ways that a container manifest can be provided to the Kubelet:
+There are 3 ways that a container manifest can be provided to the Kubelet:
 
-    File Path passed as a flag on the command line. This file is rechecked every 20 seconds (configurable with a flag).
-    HTTP endpoint HTTP endpoint passed as a parameter on the command line. This endpoint is checked every 20 seconds (also configurable with a flag).
-    etcd server The Kubelet will reach out and do a watch on an etcd server. The etcd path that is watched is /registry/hosts/$(uname -n). As this is a watch, changes are noticed and acted upon very quickly.
-    HTTP server The kubelet can also listen for HTTP and respond to a simple API (underspec'd currently) to submit a new manifest.
- 
+    File: Path passed as a flag on the command line. This file is rechecked every 20 seconds (configurable with a flag).
+    HTTP endpoint: HTTP endpoint passed as a parameter on the command line. This endpoint is checked every 20 seconds (also configurable with a flag).
+    HTTP server: The kubelet can also listen for HTTP and respond to a simple API (underspec'd currently) to submit a new manifest.
 
 # OPTIONS
-**--address**="127.0.0.1"
-	The address for the info server to serve on (set to 0.0.0.0 or "" for all interfaces).
+**--address**=0.0.0.0
+	The IP address for the info server to serve on (set to 0.0.0.0 for all interfaces)
 
-**--allow_privileged**=false
-	If true, allow containers to request privileged mode. [default=false].
+**--allow_dynamic_housekeeping**=true
+	Whether to allow the housekeeping interval to be dynamic
+
+**--allow-privileged**=false
+	If true, allow containers to request privileged mode. [default=false]
 
 **--alsologtostderr**=false
-	log to standard error as well as files.
+	log to standard error as well as files
+
+**--api-servers**=[]
+	List of Kubernetes API servers for publishing events, and reading pods and services. (ip:port), comma separated.
+
+**--boot_id_file**=/proc/sys/kernel/random/boot_id
+	Comma-separated list of files to check for boot-id. Use the first one that exists.
+
+**--cadvisor-port**=4194
+	The port of the localhost cAdvisor endpoint
+
+**--cert-dir**="/var/run/kubernetes"
+	The directory where the TLS certs are located (by default /var/run/kubernetes). If --tls_cert_file and --tls_private_key_file are provided, this flag will be ignored.
+
+**--cgroup_root**=""
+	Optional root cgroup to use for pods. This is handled by the container runtime on a best effort basis. Default: '', which means use the container runtime default.
+
+**--cloud-config**=""
+	The path to the cloud provider configuration file.  Empty string for no configuration file.
+
+**--cloud-provider**=""
+	The provider for cloud services.  Empty string for no provider.
+
+**--cluster-dns**=<nil>
+	IP address for a cluster DNS server.  If set, kubelet will configure all containers to use this for DNS resolution in addition to the host's DNS servers
+
+**--cluster-domain**=""
+	Domain for this cluster.  If set, kubelet will configure all containers to search this domain in addition to the host's search domains
 
 **--config**=""
-	Path to the config file or directory of files.
+	Path to the config file or directory of files
 
-**--docker_endpoint**=""
-	If non-empty, use this for the docker endpoint to communicate with.
+**--configure-cbr0**=false
+	If true, kubelet will configure cbr0 based on Node.Spec.PodCIDR.
 
-**--enable_server**=true
-	Enable the info server.
+**--container_hints**=/etc/cadvisor/container_hints.json
+	location of the container hints file
 
-**--etcd_servers**=[]
-	List of etcd servers to watch (http://ip:port), comma separated.
+**--container_runtime**="docker"
+	The container runtime to use. Possible values: 'docker', 'rkt'. Default: 'docker'.
 
-**--file_check_frequency**=20s
-	Duration between checking config files for new data.
+**--docker**=unix:///var/run/docker.sock
+	docker endpoint
 
-**--hostname_override**=""
+**--docker-daemon-container**="/docker-daemon"
+	Optional resource-only container in which to place the Docker Daemon. Empty for no container (Default: /docker-daemon).
+
+**--docker-endpoint**=""
+	If non-empty, use this for the docker endpoint to communicate with
+
+**--docker_only**=false
+	Only report docker containers in addition to root stats
+
+**--docker_root**=/var/lib/docker
+	Absolute path to the Docker state root directory (default: /var/lib/docker)
+
+**--docker_run**=/var/run/docker
+	Absolute path to the Docker run directory (default: /var/run/docker)
+
+**--enable-debugging-handlers**=true
+	Enables server endpoints for log collection and local running of containers and commands
+
+**--enable_load_reader**=false
+	Whether to enable cpu load reader
+
+**--enable-server**=true
+	Enable the info server
+
+**--event_storage_age_limit**=default=24h
+	Max length of time for which to store events (per type). Value is a comma separated list of key values, where the keys are event types (e.g.: creation, oom) or "default" and the value is a duration. Default is applied to all non-specified event types
+
+**--event_storage_event_limit**=default=100000
+	Max number of events to store (per type). Value is a comma separated list of key values, where the keys are event types (e.g.: creation, oom) or "default" and the value is an integer. Default is applied to all non-specified event types
+
+**--file-check-frequency**=20s
+	Duration between checking config files for new data
+
+**--global_housekeeping_interval**=1m0s
+	Interval between global housekeepings
+
+**--google-json-key**=""
+	The Google Cloud Platform Service Account JSON Key to use for authentication.
+
+**--healthz-bind-address**=127.0.0.1
+	The IP address for the healthz server to serve on, defaulting to 127.0.0.1 (set to 0.0.0.0 for all interfaces)
+
+**--healthz-port**=10248
+	The port of the localhost healthz endpoint
+
+**--host-network-sources**="file"
+	Comma-separated list of sources from which the Kubelet allows pods to use of host network. For all sources use "*" [default="file"]
+
+**--hostname-override**=""
 	If non-empty, will use this string as identification instead of the actual hostname.
 
-**--http_check_frequency**=20s
-	Duration between checking http for new data.
+**--housekeeping_interval**=1s
+	Interval between container housekeepings
+
+**--http-check-frequency**=20s
+	Duration between checking http for new data
+
+**--image-gc-high-threshold**=90
+	The percent of disk usage after which image garbage collection is always run. Default: 90%%
+
+**--image-gc-low-threshold**=80
+	The percent of disk usage before which image garbage collection is never run. Lowest disk usage to garbage collect to. Default: 80%%
+
+**--kubeconfig**=/var/lib/kubelet/kubeconfig
+	Path to a kubeconfig file, specifying how to authenticate to API server (the master location is set by the api-servers flag).
 
 **--log_backtrace_at**=:0
-	when logging hits line file:N, emit a stack trace.
+	when logging hits line file:N, emit a stack trace
 
-**--log_dir**=""
-	If non-empty, write log files in this directory.
+**--log_cadvisor_usage**=false
+	Whether to log the usage of the cAdvisor container
+
+**--log_dir**=
+	If non-empty, write log files in this directory
 
 **--log_flush_frequency**=5s
-	Maximum number of seconds between log flushes.
+	Maximum number of seconds between log flushes
 
-**--logtostderr**=false
-	log to standard error instead of files.
+**--logtostderr**=true
+	log to standard error instead of files
 
-**--manifest_url**=""
-	URL for accessing the container manifest.
+**--low-diskspace-threshold-mb**=256
+	The absolute free disk space, in MB, to maintain. When disk space falls below this threshold, new pods would be rejected. Default: 256
 
-**--pod_infra_container_image**="kubernetes/pause:latest"
-	The image that pod infra containers in each pod will use.
+**--machine_id_file**=/etc/machine-id,/var/lib/dbus/machine-id
+	Comma-separated list of files to check for machine-id. Use the first one that exists.
+
+**--manifest-url**=""
+	URL for accessing the container manifest
+
+**--master-service-namespace**="default"
+	The namespace from which the kubernetes master services should be injected into pods
+
+**--max_housekeeping_interval**=1m0s
+	Largest interval to allow between container housekeepings
+
+**--max_pods**=100
+	Number of Pods that can run on this Kubelet.
+
+**--maximum-dead-containers**=100
+	Maximum number of old instances of a containers to retain globally.  Each container takes up some disk space.  Default: 100.
+
+**--maximum-dead-containers-per-container**=5
+	Maximum number of old instances of a container to retain per container.  Each container takes up some disk space.  Default: 5.
+
+**--minimum-container-ttl-duration**=1m0s
+	Minimum age for a finished container before it is garbage collected.  Examples: '300ms', '10s' or '2h45m'
+
+**--network-plugin**=""
+	The name of the network plugin to be invoked for various events in kubelet/pod lifecycle
+
+**--node-status-update-frequency**=10s
+	Specifies how often kubelet posts node status to master. Note: be cautious when changing the constant, it must work with nodeMonitorGracePeriod in nodecontroller. Default: 10s
+
+**--oom-score-adj**=-900
+	The oom_score_adj value for kubelet process. Values must be within the range [-1000, 1000]
+
+**--pod-infra-container-image**="gcr.io/google_containers/pause:0.8.0"
+	The image whose network/ipc namespaces containers in each pod will use.
 
 **--port**=10250
-	The port for the info server to serve on.
+	The port for the info server to serve on
 
-**--registry_burst**=10
-	Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry_qps. Only used if --registry_qps > 0.
+**--read-only-port**=10255
+	The read-only port for the info server to serve on (set to 0 to disable)
 
-**--registry_qps**=0
-	If > 0, limit registry pull QPS to this value. If 0, unlimited. [default=0.0].
+**--registry-burst**=10
+	Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry_qps.  Only used if --registry_qps > 0
 
-**--root_dir**="/var/lib/kubelet"
+**--registry-qps**=0
+	If > 0, limit registry pull QPS to this value.  If 0, unlimited. [default=0.0]
+
+**--resource-container**="/kubelet"
+	Absolute name of the resource-only container to create and run the Kubelet in (Default: /kubelet).
+
+**--root-dir**="/var/lib/kubelet"
 	Directory path for managing kubelet files (volume mounts,etc).
 
-**--stderrthreshold**=0
-	logs at or above this threshold go to stderr.
+**--runonce**=false
+	If true, exit after spawning pods from local manifests or remote urls. Exclusive with --api_servers, and --enable-server
 
-**--sync_frequency**=10s
-	Max period between synchronizing running containers and config.
+**--stderrthreshold**=2
+	logs at or above this threshold go to stderr
+
+**--streaming-connection-idle-timeout**=0
+	Maximum time a streaming connection can be idle before the connection is automatically closed.  Example: '5m'
+
+**--sync-frequency**=10s
+	Max period between synchronizing running containers and config
+
+**--tls-cert-file**=""
+	File /gmrvcontaining x509 Certificate for HTTPS.  (CA cert, if any, concatenated after server cert). If --tls_cert_file and --tls_private_key_file are not provided, a self-signed certificate and key are generated for the public address and saved to the directory passed to --cert_dir.
+
+**--tls-private-key-file**=""
+	File containing x509 private key matching --tls_cert_file.
 
 **--v**=0
-	log level for V logs.
+	log level for V logs
 
 **--version**=false
-	Print version information and quit.
+	Print version information and quit
 
 **--vmodule**=
-	comma-separated list of pattern=N settings for file-filtered logging.
-
+	comma-separated list of pattern=N settings for file-filtered logging
 
 # EXAMPLES
 ```
-/usr/bin/kubelet --logtostderr=true --v=0 --etcd_servers=http://127.0.0.1:4001 --address=127.0.0.1 --port=10250 --hostname_override=127.0.0.1 --allow_privileged=false
+/usr/bin/kubelet --logtostderr=true --v=0 --api_servers=http://127.0.0.1:8080 --address=127.0.0.1 --port=10250 --hostname_override=127.0.0.1 --allow-privileged=false
 ```
+
 # HISTORY
 October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
  on the kubernetes source material and internal work.

--- a/docs/man/man1/kube-apiserver.1
+++ b/docs/man/man1/kube-apiserver.1
@@ -17,77 +17,225 @@ The the kube\-apiserver several options.
 
 .SH OPTIONS
 .PP
-\fB\-\-address\fP=""
-    The address on the local server to listen to. Default 127.0.0.1
+\fB\-\-address\fP=127.0.0.1
+    DEPRECATED: see \-\-insecure\-bind\-address instead
 
 .PP
-\fB\-\-allow\_privileged\fP=""
+\fB\-\-admission\-control\fP="AlwaysAdmit"
+    Ordered list of plug\-ins to do admission control of resources into cluster. Comma\-delimited list of: AlwaysDeny, AlwaysAdmit, ServiceAccount, NamespaceExists, NamespaceLifecycle, NamespaceAutoProvision, LimitRanger, SecurityContextDeny, ResourceQuota
+
+.PP
+\fB\-\-admission\-control\-config\-file\fP=""
+    File with admission control configuration.
+
+.PP
+\fB\-\-allow\-privileged\fP=false
     If true, allow privileged containers.
 
 .PP
-\fB\-\-alsologtostderr\fP=
-    log to standard error as well as files. Default is false.
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
 
 .PP
-\fB\-\-api\_prefix\fP="/api"
-    The prefix for API requests on the server. Default '/api'
+\fB\-\-api\-burst\fP=200
+    API burst amount for the read only port
 
 .PP
-\fB\-\-cloud\_config\fP=""
-    The path to the cloud provider configuration file. Empty string for no configuration file.
+\fB\-\-api\-prefix\fP="/api"
+    The prefix for API requests on the server. Default '/api'.
 
 .PP
-\fB\-\-cloud\_provider\fP=""
-    The provider for cloud services. Empty string for no provider.
+\fB\-\-api\-rate\fP=10
+    API rate limit as QPS for the read only port
 
 .PP
-\fB\-\-cors\_allowed\_origins\fP=[]
-    List of allowed origins for CORS, comma separated. An allowed origin can be a regular expression to support subdomain matching. If this list is empty CORS will not be enabled.
+\fB\-\-authorization\-mode\fP="AlwaysAllow"
+    Selects how to do authorization on the secure port.  One of: AlwaysAllow,AlwaysDeny,ABAC
 
 .PP
-\fB\-\-etcd\_servers\fP=[]
+\fB\-\-authorization\-policy\-file\fP=""
+    File with authorization policy in csv format, used with \-\-authorization\-mode=ABAC, on the secure port.
+
+.PP
+\fB\-\-basic\-auth\-file\fP=""
+    If set, the file that will be used to admit requests to the secure port of the API server via http basic authentication.
+
+.PP
+\fB\-\-bind\-address\fP=0.0.0.0
+    The IP address on which to serve the \-\-read\-only\-port and \-\-secure\-port ports. This address must be reachable by the rest of the cluster. If blank, all interfaces will be used.
+
+.PP
+\fB\-\-cert\-dir\fP="/var/run/kubernetes"
+    The directory where the TLS certs are located (by default /var/run/kubernetes). If \-\-tls\-cert\-file and \-\-tls\-private\-key\-file are provided, this flag will be ignored.
+
+.PP
+\fB\-\-client\-ca\-file\fP=""
+    If set, any request presenting a client certificate signed by one of the authorities in the client\-ca\-file is authenticated with an identity corresponding to the CommonName of the client certificate.
+
+.PP
+\fB\-\-cloud\-config\fP=""
+    The path to the cloud provider configuration file.  Empty string for no configuration file.
+
+.PP
+\fB\-\-cloud\-provider\fP=""
+    The provider for cloud services.  Empty string for no provider.
+
+.PP
+\fB\-\-cluster\-name\fP="kubernetes"
+    The instance prefix for the cluster
+
+.PP
+\fB\-\-cors\-allowed\-origins\fP=[]
+    List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching.  If this list is empty CORS will not be enabled.
+
+.PP
+\fB\-\-etcd\-config\fP=""
+    The config file for the etcd client. Mutually exclusive with \-etcd\-servers.
+
+.PP
+\fB\-\-etcd\-prefix\fP="/registry"
+    The prefix for all resource paths in etcd.
+
+.PP
+\fB\-\-etcd\-servers\fP=[]
     List of etcd servers to watch (
-\[la]http://ip:port\[ra]), comma separated
+\[la]http://ip:port\[ra]), comma separated. Mutually exclusive with \-etcd\-config
 
 .PP
-\fB\-\-log\_backtrace\_at=\fP:0
+\fB\-\-event\-ttl\fP=1h0m0s
+    Amount of time to retain events. Default 1 hour.
+
+.PP
+\fB\-\-external\-hostname\fP=""
+    The hostname to use when generating externalized URLs for this master (e.g. Swagger API Docs.)
+
+.PP
+\fB\-\-insecure\-bind\-address\fP=127.0.0.1
+    The IP address on which to serve the \-\-insecure\-port (set to 0.0.0.0 for all interfaces). Defaults to localhost.
+
+.PP
+\fB\-\-insecure\-port\fP=8080
+    The port on which to serve unsecured, unauthenticated access. Default 8080. It is assumed that firewall rules are set up such that this port is not reachable from outside of the cluster and that port 443 on the cluster's public address is proxied to this port. This is performed by nginx in the default setup.
+
+.PP
+\fB\-\-kubelet\_certificate\_authority\fP=""
+    Path to a cert. file for the certificate authority.
+
+.PP
+\fB\-\-kubelet\_client\_certificate\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-kubelet\_client\_key\fP=""
+    Path to a client key file for TLS.
+
+.PP
+\fB\-\-kubelet\_https\fP=true
+    Use https for kubelet connections
+
+.PP
+\fB\-\-kubelet\_port\fP=10250
+    Kubelet port
+
+.PP
+\fB\-\-kubelet\_timeout\fP=5s
+    Timeout for kubelet operations
+
+.PP
+\fB\-\-log\_backtrace\_at\fP=:0
     when logging hits line file:N, emit a stack trace
 
 .PP
-\fB\-\-log\_dir\fP=""
+\fB\-\-log\_dir\fP=
     If non\-empty, write log files in this directory
 
 .PP
 \fB\-\-log\_flush\_frequency\fP=5s
-    Maximum number of seconds between log flushes. Default is 5 seconds.
+    Maximum number of seconds between log flushes
 
 .PP
-\fB\-\-logtostderr\fP=
-    log to standard error instead of files. Default is false.
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
 
 .PP
-\fB\-\-kubelet\_port\fP=10250
-    The port at which kubelet will be listening on the minions. Default is 10250.
+\fB\-\-long\-running\-request\-regexp\fP="[.\fI\\/watch\$][^\\/proxy.\fP]"
+    A regular expression matching long running requests which should be excluded from maximum inflight request handling.
+
+.PP
+\fB\-\-master\-service\-namespace\fP="default"
+    The namespace from which the kubernetes master services should be injected into pods
+
+.PP
+\fB\-\-max\-requests\-inflight\fP=400
+    The maximum number of requests in flight at a given time.  When the server exceeds this, it rejects requests.  Zero for no limit.
+
+.PP
+\fB\-\-old\-etcd\-prefix\fP="/registry"
+    The previous prefix for all resource paths in etcd, if any.
 
 .PP
 \fB\-\-port\fP=8080
-    The port to listen on. Default is 8080.
+    DEPRECATED: see \-\-insecure\-port instead
 
 .PP
-\fB\-\-stderrthreshold\fP=0
-    logs at or above this threshold go to stderr. Default is 0.
+\fB\-\-portal\-net\fP=
+    A CIDR notation IP range from which to assign portal IPs. This must not overlap with any IP ranges assigned to nodes for pods.
 
 .PP
-\fB\-\-storage\_version\fP=""
-    The version to store resources with. Defaults to server preferred.
+\fB\-\-profiling\fP=true
+    Enable profiling via web interface host:port/debug/pprof/
+
+.PP
+\fB\-\-public\-address\-override\fP=0.0.0.0
+    DEPRECATED: see \-\-bind\-address instead
+
+.PP
+\fB\-\-read\-only\-port\fP=7080
+    The port on which to serve read\-only resources. If 0, don't serve read\-only at all. It is assumed that firewall rules are set up such that this port is not reachable from outside of the cluster.
+
+.PP
+\fB\-\-runtime\-config\fP=
+    A set of key=value pairs that describe runtime configuration that may be passed to the apiserver. api/ key can be used to turn on/off specific api versions. api/all and api/legacy are special keys to control all and legacy api versions respectively.
+
+.PP
+\fB\-\-secure\-port\fP=6443
+    The port on which to serve HTTPS with authentication and authorization. If 0, don't serve HTTPS at all.
+
+.PP
+\fB\-\-service\-account\-key\-file\fP=""
+    File containing PEM\-encoded x509 RSA private or public key, used to verify ServiceAccount tokens. If unspecified, \-\-tls\-private\-key\-file is used.
+
+.PP
+\fB\-\-service\-account\-lookup\fP=false
+    If true, validate ServiceAccount tokens exist in etcd as part of authentication.
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-storage\-version\fP=""
+    The version to store resources with. Defaults to server preferred
+
+.PP
+\fB\-\-tls\-cert\-file\fP=""
+    File containing x509 Certificate for HTTPS.  (CA cert, if any, concatenated after server cert). If HTTPS serving is enabled, and \-\-tls\-cert\-file and \-\-tls\-private\-key\-file are not provided, a self\-signed certificate and key are generated for the public address and saved to /var/run/kubernetes.
+
+.PP
+\fB\-\-tls\-private\-key\-file\fP=""
+    File containing x509 private key matching \-\-tls\-cert\-file.
+
+.PP
+\fB\-\-token\-auth\-file\fP=""
+    If set, the file that will be used to secure the secure port of the API server via token authentication.
 
 .PP
 \fB\-\-v\fP=0
-    Log level for V logs.
+    log level for V logs
 
 .PP
 \fB\-\-version\fP=false
-    Print version information and quit. Default is false.
+    Print version information and quit
 
 .PP
 \fB\-\-vmodule\fP=
@@ -98,7 +246,7 @@ The the kube\-apiserver several options.
 .RS
 
 .nf
-/usr/bin/kube\-apiserver \-\-logtostderr=true \-\-v=0 \-\-etcd\_servers=http://127.0.0.1:4001 \-\-address=0.0.0.0 \-\-port=8080 \-\-kubelet\_port=10250 \-\-allow\_privileged=false
+/usr/bin/kube\-apiserver \-\-logtostderr=true \-\-v=0 \-\-etcd\_servers=http://127.0.0.1:4001 \-\-insecure\_bind\_address=127.0.0.1 \-\-insecure\_port=8080 \-\-kubelet\_port=10250 \-\-portal\_net=11.1.1.0/24 \-\-allow\_privileged=false
 
 .fi
 
@@ -106,3 +254,6 @@ The the kube\-apiserver several options.
 .PP
 October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
  on the kubernetes source material and internal work.
+
+.PP
+[]()

--- a/docs/man/man1/kube-controller-manager.1
+++ b/docs/man/man1/kube-controller-manager.1
@@ -17,107 +17,159 @@ The kube\-controller\-manager has several options.
 
 .SH OPTIONS
 .PP
-\fB\-\-address\fP=""
-    The address on the local server to listen to. Default 127.0.0.1.
+\fB\-\-address\fP=127.0.0.1
+    The IP address to serve on (set to 0.0.0.0 for all interfaces)
 
 .PP
-\fB\-\-allow\_privileged\fP="false"
-    If true, allow privileged containers.
-
-.PP
-\fB\-\-address=\fP"127.0.0.1"
-    The address to serve from.
+\fB\-\-allocate\-node\-cidrs\fP=false
+    Should CIDRs for Pods be allocated and set on the cloud provider.
 
 .PP
 \fB\-\-alsologtostderr\fP=false
-    log to standard error as well as files.
+    log to standard error as well as files
 
 .PP
-\fB\-\-api\_version\fP=""
-    The API version to use when talking to the server.
+\fB\-\-cloud\-config\fP=""
+    The path to the cloud provider configuration file.  Empty string for no configuration file.
 
 .PP
-\fB\-\-cloud\_config\fP=""
-    The path to the cloud provider configuration file. Empty string for no configuration file.
+\fB\-\-cloud\-provider\fP=""
+    The provider for cloud services.  Empty string for no provider.
 
 .PP
-\fB\-\-cloud\_provider\fP=""
-    The provider for cloud services. Empty string for no provider.
+\fB\-\-cluster\-cidr\fP=
+    CIDR Range for Pods in cluster.
 
 .PP
-\fB\-\-minion\_regexp\fP=""
-    If non empty, and \-\-cloud\_provider is specified, a regular expression for matching minion VMs.
+\fB\-\-concurrent\-endpoint\-syncs\fP=5
+    The number of endpoint syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load
 
 .PP
-\fB\-\-insecure\_skip\_tls\_verify\fP=false
-    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+\fB\-\-concurrent\_rc\_syncs\fP=5
+    The number of replication controllers that are allowed to sync concurrently. Larger number = more reponsive replica management, but more CPU (and network) load
+
+.PP
+\fB\-\-deleting\-pods\-burst\fP=10
+    Number of nodes on which pods are bursty deleted in case of node failure. For more details look into RateLimiter.
+
+.PP
+\fB\-\-deleting\-pods\-qps\fP=0.1
+    Number of nodes per second on which pods are deleted in case of node failure.
+
+.PP
+\fB\-\-kubeconfig\fP=""
+    Path to kubeconfig file with authorization and master location information.
 
 .PP
 \fB\-\-log\_backtrace\_at\fP=:0
-    when logging hits line file:N, emit a stack trace.
+    when logging hits line file:N, emit a stack trace
 
 .PP
-\fB\-\-log\_dir\fP=""
-    If non\-empty, write log files in this directory.
+\fB\-\-log\_dir\fP=
+    If non\-empty, write log files in this directory
 
 .PP
 \fB\-\-log\_flush\_frequency\fP=5s
-    Maximum number of seconds between log flushes.
+    Maximum number of seconds between log flushes
 
 .PP
-\fB\-\-logtostderr\fP=false
-    log to standard error instead of files.
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
 
 .PP
 \fB\-\-machines\fP=[]
     List of machines to schedule onto, comma separated.
 
 .PP
-\fB\-\-pod\_eviction\_timeout\fP=5m
+\fB\-\-master\fP=""
+    The address of the Kubernetes API server (overrides any value in kubeconfig)
+
+.PP
+\fB\-\-minion\-regexp\fP=""
+    If non empty, and \-\-cloud\-provider is specified, a regular expression for matching minion VMs.
+
+.PP
+\fB\-\-namespace\-sync\-period\fP=5m0s
+    The period for syncing namespace life\-cycle updates
+
+.PP
+\fB\-\-node\-memory\fP=3Gi
+    The amount of memory (in bytes) provisioned on each node
+
+.PP
+\fB\-\-node\-milli\-cpu\fP=1000
+    The amount of MilliCPU provisioned on each node
+
+.PP
+\fB\-\-node\-monitor\-grace\-period\fP=40s
+    Amount of time which we allow running Node to be unresponsive before marking it unhealty. Must be N times more than kubelet's nodeStatusUpdateFrequency, where N means number of retries allowed for kubelet to post node status.
+
+.PP
+\fB\-\-node\-monitor\-period\fP=5s
+    The period for syncing NodeStatus in NodeController.
+
+.PP
+\fB\-\-node\-startup\-grace\-period\fP=1m0s
+    Amount of time which we allow starting Node to be unresponsive before marking it unhealty.
+
+.PP
+\fB\-\-node\-sync\-period\fP=10s
+    The period for syncing nodes from cloudprovider. Longer periods will result in fewer calls to cloud provider, but may delay addition of new nodes to cluster.
+
+.PP
+\fB\-\-pod\-eviction\-timeout\fP=5m0s
     The grace peroid for deleting pods on failed nodes.
 
 .PP
-\fB\-\-sync\_nodes\fP=true
-    If true, and \-\-cloud\_provider is specified, sync nodes from the cloud provider. Default true.
-
-.PP
-\fB\-\-master\fP=""
-    The address of the Kubernetes API server.
-
-.PP
-\fB\-\-node\_sync\_period\fP=10s
-    The period for syncing nodes from cloudprovider.
-
-.PP
 \fB\-\-port\fP=10252
-    The port that the controller\-manager's http service runs on.
+    The port that the controller\-manager's http service runs on
 
 .PP
-\fB\-\-resource\_quota\_sync\_period\fP=10s
-    The period for syncing quota usage status in the system.
+\fB\-\-profiling\fP=true
+    Enable profiling via web interface host:port/debug/pprof/
 
 .PP
-\fB\-\-stderrthreshold\fP=0
-    logs at or above this threshold go to stderr.
+\fB\-\-pvclaimbinder\-sync\-period\fP=10s
+    The period for syncing persistent volumes and persistent volume claims
+
+.PP
+\fB\-\-register\-retry\-count\fP=10
+    The number of retries for initial node registration.  Retry interval equals node\-sync\-period.
+
+.PP
+\fB\-\-resource\-quota\-sync\-period\fP=10s
+    The period for syncing quota usage status in the system
+
+.PP
+\fB\-\-service\-account\-private\-key\-file\fP=""
+    Filename containing a PEM\-encoded private RSA key used to sign service account tokens.
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-sync\-nodes\fP=true
+    If true, and \-\-cloud\-provider is specified, sync nodes from the cloud provider. Default true.
 
 .PP
 \fB\-\-v\fP=0
-    log level for V logs.
+    log level for V logs
 
 .PP
 \fB\-\-version\fP=false
-    Print version information and quit.
+    Print version information and quit
 
 .PP
 \fB\-\-vmodule\fP=
-    comma\-separated list of pattern=N settings for file\-filtered logging.
+    comma\-separated list of pattern=N settings for file\-filtered logging
 
 .SH EXAMPLES
 .PP
 .RS
 
 .nf
-/usr/bin/kube\-controller\-manager \-\-logtostderr=true \-\-v=0 \-\-master=127.0.0.1:8080
+/usr/bin/kube\-controller\-manager \-\-logtostderr=true \-\-v=0 \-\-master=127.0.0.1:8080 \-\-machines=127.0.0.1 
 
 .fi
 
@@ -125,3 +177,6 @@ The kube\-controller\-manager has several options.
 .PP
 October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
  on the kubernetes source material and internal work.
+
+.PP
+[]()

--- a/docs/man/man1/kube-proxy.1
+++ b/docs/man/man1/kube-proxy.1
@@ -21,28 +21,27 @@ The kube\-proxy takes several options.
     log to standard error as well as files
 
 .PP
-\fB\-\-api\_version=\fP""
-    The API version to use when talking to the server
+\fB\-\-bind\-address\fP=0.0.0.0
+    The IP address for the proxy server to serve on (set to 0.0.0.0 for all interfaces)
 
 .PP
-\fB\-\-bindaddress\fP="0.0.0.0"
-    The address for the proxy server to serve on (set to 0.0.0.0 or "" for all interfaces)
+\fB\-\-healthz\-bind\-address\fP=127.0.0.1
+    The IP address for the health check server to serve on, defaulting to 127.0.0.1 (set to 0.0.0.0 for all interfaces)
 
 .PP
-\fB\-\-etcd\_servers\fP=[]
-    List of etcd servers to watch (
-\[la]http://ip:port\[ra]), comma separated (optional)
+\fB\-\-healthz\-port\fP=10249
+    The port to bind the health check server. Use 0 to disable.
 
 .PP
-\fB\-\-insecure\_skip\_tls\_verify\fP=false
-    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+\fB\-\-kubeconfig\fP=""
+    Path to kubeconfig file with authorization information (the master location is set by the master flag).
 
 .PP
 \fB\-\-log\_backtrace\_at\fP=:0
     when logging hits line file:N, emit a stack trace
 
 .PP
-\fB\-\-log\_dir\fP=""
+\fB\-\-log\_dir\fP=
     If non\-empty, write log files in this directory
 
 .PP
@@ -50,15 +49,23 @@ The kube\-proxy takes several options.
     Maximum number of seconds between log flushes
 
 .PP
-\fB\-\-logtostderr\fP=false
+\fB\-\-logtostderr\fP=true
     log to standard error instead of files
 
 .PP
 \fB\-\-master\fP=""
-    The address of the Kubernetes API server
+    The address of the Kubernetes API server (overrides any value in kubeconfig)
 
 .PP
-\fB\-\-stderrthreshold\fP=0
+\fB\-\-oom\-score\-adj\fP=\-899
+    The oom\_score\_adj value for kube\-proxy process. Values must be within the range [\-1000, 1000]
+
+.PP
+\fB\-\-resource\-container\fP="/kube\-proxy"
+    Absolute name of the resource\-only container to create and run the Kube\-proxy in (Default: /kube\-proxy).
+
+.PP
+\fB\-\-stderrthreshold\fP=2
     logs at or above this threshold go to stderr
 
 .PP
@@ -78,7 +85,7 @@ The kube\-proxy takes several options.
 .RS
 
 .nf
-/usr/bin/kube\-proxy \-\-logtostderr=true \-\-v=0 \-\-etcd\_servers=http://127.0.0.1:4001
+/usr/bin/kube\-proxy \-\-logtostderr=true \-\-v=0 \-\-master=http://127.0.0.1:8080
 
 .fi
 
@@ -86,3 +93,6 @@ The kube\-proxy takes several options.
 .PP
 October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
  on the kubernetes source material and internal work.
+
+.PP
+[]()

--- a/docs/man/man1/kube-scheduler.1
+++ b/docs/man/man1/kube-scheduler.1
@@ -17,60 +17,68 @@ The kube\-scheduler can take several options.
 
 .SH OPTIONS
 .PP
-\fB\-\-address=\fP"127.0.0.1"
-    The address to serve from.
+\fB\-\-address\fP=127.0.0.1
+    The IP address to serve on (set to 0.0.0.0 for all interfaces)
 
 .PP
-\fB\-\-alsologtostderr=\fPfalse
-    log to standard error as well as files.
+\fB\-\-algorithm\-provider\fP="DefaultProvider"
+    The scheduling algorithm provider to use, one of: DefaultProvider
 
 .PP
-\fB\-\-api\_version=\fP""
-    The API version to use when talking to the server.
+\fB\-\-alsologtostderr\fP=false
+    log to standard error as well as files
 
 .PP
-\fB\-\-insecure\_skip\_tls\_verify\fP=false
-    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+\fB\-\-kubeconfig\fP=""
+    Path to kubeconfig file with authorization and master location information.
 
 .PP
-\fB\-\-log\_backtrace\_at=\fP:0
-    when logging hits line file:N, emit a stack trace.
+\fB\-\-log\_backtrace\_at\fP=:0
+    when logging hits line file:N, emit a stack trace
 
 .PP
-\fB\-\-log\_dir=\fP""
-    If non\-empty, write log files in this directory.
+\fB\-\-log\_dir\fP=
+    If non\-empty, write log files in this directory
 
 .PP
 \fB\-\-log\_flush\_frequency\fP=5s
-    Maximum number of seconds between log flushes.
+    Maximum number of seconds between log flushes
 
 .PP
-\fB\-\-logtostderr\fP=false
-    log to standard error instead of files.
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
 
 .PP
-\fB\-\-master=\fP""
-    The address of the Kubernetes API server.
+\fB\-\-master\fP=""
+    The address of the Kubernetes API server (overrides any value in kubeconfig)
 
 .PP
-\fB\-\-port=\fP10251
-    The port that the scheduler's http service runs on.
+\fB\-\-policy\-config\-file\fP=""
+    File with scheduler policy configuration
 
 .PP
-\fB\-\-stderrthreshold\fP=0
-    logs at or above this threshold go to stderr.
+\fB\-\-port\fP=10251
+    The port that the scheduler's http service runs on
+
+.PP
+\fB\-\-profiling\fP=true
+    Enable profiling via web interface host:port/debug/pprof/
+
+.PP
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
 
 .PP
 \fB\-\-v\fP=0
-    log level for V logs.
+    log level for V logs
 
 .PP
 \fB\-\-version\fP=false
-    Print version information and quit.
+    Print version information and quit
 
 .PP
 \fB\-\-vmodule\fP=
-    comma\-separated list of pattern=N settings for file\-filtered logging.
+    comma\-separated list of pattern=N settings for file\-filtered logging
 
 .SH EXAMPLES
 .PP
@@ -85,3 +93,6 @@ The kube\-scheduler can take several options.
 .PP
 October 2014, Originally compiled by Scott Collier (scollier@redhat.com) based
  on the kubernetes source material and internal work.
+
+.PP
+[]()

--- a/docs/man/man1/kubelet.1
+++ b/docs/man/man1/kubelet.1
@@ -13,127 +13,317 @@ kubelet \- Processes a container manifest so the containers are launched accordi
 The \fBkubernetes\fP kubelet runs on each node. The Kubelet works in terms of a container manifest. A container manifest is a YAML or JSON file that describes a pod. The Kubelet takes a set of manifests that are provided in various mechanisms and ensures that the containers described in those manifests are started and continue running.
 
 .PP
-There are 4 ways that a container manifest can be provided to the Kubelet:
+There are 3 ways that a container manifest can be provided to the Kubelet:
 
 .PP
 .RS
 
 .nf
-File Path passed as a flag on the command line. This file is rechecked every 20 seconds (configurable with a flag).
-HTTP endpoint HTTP endpoint passed as a parameter on the command line. This endpoint is checked every 20 seconds (also configurable with a flag).
-etcd server The Kubelet will reach out and do a watch on an etcd server. The etcd path that is watched is /registry/hosts/\$(uname \-n). As this is a watch, changes are noticed and acted upon very quickly.
-HTTP server The kubelet can also listen for HTTP and respond to a simple API (underspec'd currently) to submit a new manifest.
+File: Path passed as a flag on the command line. This file is rechecked every 20 seconds (configurable with a flag).
+HTTP endpoint: HTTP endpoint passed as a parameter on the command line. This endpoint is checked every 20 seconds (also configurable with a flag).
+HTTP server: The kubelet can also listen for HTTP and respond to a simple API (underspec'd currently) to submit a new manifest.
 
 .fi
 
 .SH OPTIONS
 .PP
-\fB\-\-address\fP="127.0.0.1"
-    The address for the info server to serve on (set to 0.0.0.0 or "" for all interfaces).
+\fB\-\-address\fP=0.0.0.0
+    The IP address for the info server to serve on (set to 0.0.0.0 for all interfaces)
 
 .PP
-\fB\-\-allow\_privileged\fP=false
-    If true, allow containers to request privileged mode. [default=false].
+\fB\-\-allow\_dynamic\_housekeeping\fP=true
+    Whether to allow the housekeeping interval to be dynamic
+
+.PP
+\fB\-\-allow\-privileged\fP=false
+    If true, allow containers to request privileged mode. [default=false]
 
 .PP
 \fB\-\-alsologtostderr\fP=false
-    log to standard error as well as files.
+    log to standard error as well as files
+
+.PP
+\fB\-\-api\-servers\fP=[]
+    List of Kubernetes API servers for publishing events, and reading pods and services. (ip:port), comma separated.
+
+.PP
+\fB\-\-boot\_id\_file\fP=/proc/sys/kernel/random/boot\_id
+    Comma\-separated list of files to check for boot\-id. Use the first one that exists.
+
+.PP
+\fB\-\-cadvisor\-port\fP=4194
+    The port of the localhost cAdvisor endpoint
+
+.PP
+\fB\-\-cert\-dir\fP="/var/run/kubernetes"
+    The directory where the TLS certs are located (by default /var/run/kubernetes). If \-\-tls\_cert\_file and \-\-tls\_private\_key\_file are provided, this flag will be ignored.
+
+.PP
+\fB\-\-cgroup\_root\fP=""
+    Optional root cgroup to use for pods. This is handled by the container runtime on a best effort basis. Default: '', which means use the container runtime default.
+
+.PP
+\fB\-\-cloud\-config\fP=""
+    The path to the cloud provider configuration file.  Empty string for no configuration file.
+
+.PP
+\fB\-\-cloud\-provider\fP=""
+    The provider for cloud services.  Empty string for no provider.
+
+.PP
+\fB\-\-cluster\-dns\fP=
+    IP address for a cluster DNS server.  If set, kubelet will configure all containers to use this for DNS resolution in addition to the host's DNS servers
+
+.PP
+\fB\-\-cluster\-domain\fP=""
+    Domain for this cluster.  If set, kubelet will configure all containers to search this domain in addition to the host's search domains
 
 .PP
 \fB\-\-config\fP=""
-    Path to the config file or directory of files.
+    Path to the config file or directory of files
 
 .PP
-\fB\-\-docker\_endpoint\fP=""
-    If non\-empty, use this for the docker endpoint to communicate with.
+\fB\-\-configure\-cbr0\fP=false
+    If true, kubelet will configure cbr0 based on Node.Spec.PodCIDR.
 
 .PP
-\fB\-\-enable\_server\fP=true
-    Enable the info server.
+\fB\-\-container\_hints\fP=/etc/cadvisor/container\_hints.json
+    location of the container hints file
 
 .PP
-\fB\-\-etcd\_servers\fP=[]
-    List of etcd servers to watch (
-\[la]http://ip:port\[ra]), comma separated.
+\fB\-\-container\_runtime\fP="docker"
+    The container runtime to use. Possible values: 'docker', 'rkt'. Default: 'docker'.
 
 .PP
-\fB\-\-file\_check\_frequency\fP=20s
-    Duration between checking config files for new data.
+\fB\-\-docker\fP=unix:///var/run/docker.sock
+    docker endpoint
 
 .PP
-\fB\-\-hostname\_override\fP=""
+\fB\-\-docker\-daemon\-container\fP="/docker\-daemon"
+    Optional resource\-only container in which to place the Docker Daemon. Empty for no container (Default: /docker\-daemon).
+
+.PP
+\fB\-\-docker\-endpoint\fP=""
+    If non\-empty, use this for the docker endpoint to communicate with
+
+.PP
+\fB\-\-docker\_only\fP=false
+    Only report docker containers in addition to root stats
+
+.PP
+\fB\-\-docker\_root\fP=/var/lib/docker
+    Absolute path to the Docker state root directory (default: /var/lib/docker)
+
+.PP
+\fB\-\-docker\_run\fP=/var/run/docker
+    Absolute path to the Docker run directory (default: /var/run/docker)
+
+.PP
+\fB\-\-enable\-debugging\-handlers\fP=true
+    Enables server endpoints for log collection and local running of containers and commands
+
+.PP
+\fB\-\-enable\_load\_reader\fP=false
+    Whether to enable cpu load reader
+
+.PP
+\fB\-\-enable\-server\fP=true
+    Enable the info server
+
+.PP
+\fB\-\-event\_storage\_age\_limit\fP=default=24h
+    Max length of time for which to store events (per type). Value is a comma separated list of key values, where the keys are event types (e.g.: creation, oom) or "default" and the value is a duration. Default is applied to all non\-specified event types
+
+.PP
+\fB\-\-event\_storage\_event\_limit\fP=default=100000
+    Max number of events to store (per type). Value is a comma separated list of key values, where the keys are event types (e.g.: creation, oom) or "default" and the value is an integer. Default is applied to all non\-specified event types
+
+.PP
+\fB\-\-file\-check\-frequency\fP=20s
+    Duration between checking config files for new data
+
+.PP
+\fB\-\-global\_housekeeping\_interval\fP=1m0s
+    Interval between global housekeepings
+
+.PP
+\fB\-\-google\-json\-key\fP=""
+    The Google Cloud Platform Service Account JSON Key to use for authentication.
+
+.PP
+\fB\-\-healthz\-bind\-address\fP=127.0.0.1
+    The IP address for the healthz server to serve on, defaulting to 127.0.0.1 (set to 0.0.0.0 for all interfaces)
+
+.PP
+\fB\-\-healthz\-port\fP=10248
+    The port of the localhost healthz endpoint
+
+.PP
+\fB\-\-host\-network\-sources\fP="file"
+    Comma\-separated list of sources from which the Kubelet allows pods to use of host network. For all sources use "*" [default="file"]
+
+.PP
+\fB\-\-hostname\-override\fP=""
     If non\-empty, will use this string as identification instead of the actual hostname.
 
 .PP
-\fB\-\-http\_check\_frequency\fP=20s
-    Duration between checking http for new data.
+\fB\-\-housekeeping\_interval\fP=1s
+    Interval between container housekeepings
+
+.PP
+\fB\-\-http\-check\-frequency\fP=20s
+    Duration between checking http for new data
+
+.PP
+\fB\-\-image\-gc\-high\-threshold\fP=90
+    The percent of disk usage after which image garbage collection is always run. Default: 90%%
+
+.PP
+\fB\-\-image\-gc\-low\-threshold\fP=80
+    The percent of disk usage before which image garbage collection is never run. Lowest disk usage to garbage collect to. Default: 80%%
+
+.PP
+\fB\-\-kubeconfig\fP=/var/lib/kubelet/kubeconfig
+    Path to a kubeconfig file, specifying how to authenticate to API server (the master location is set by the api\-servers flag).
 
 .PP
 \fB\-\-log\_backtrace\_at\fP=:0
-    when logging hits line file:N, emit a stack trace.
+    when logging hits line file:N, emit a stack trace
 
 .PP
-\fB\-\-log\_dir\fP=""
-    If non\-empty, write log files in this directory.
+\fB\-\-log\_cadvisor\_usage\fP=false
+    Whether to log the usage of the cAdvisor container
+
+.PP
+\fB\-\-log\_dir\fP=
+    If non\-empty, write log files in this directory
 
 .PP
 \fB\-\-log\_flush\_frequency\fP=5s
-    Maximum number of seconds between log flushes.
+    Maximum number of seconds between log flushes
 
 .PP
-\fB\-\-logtostderr\fP=false
-    log to standard error instead of files.
+\fB\-\-logtostderr\fP=true
+    log to standard error instead of files
 
 .PP
-\fB\-\-manifest\_url\fP=""
-    URL for accessing the container manifest.
+\fB\-\-low\-diskspace\-threshold\-mb\fP=256
+    The absolute free disk space, in MB, to maintain. When disk space falls below this threshold, new pods would be rejected. Default: 256
 
 .PP
-\fB\-\-pod\_infra\_container\_image\fP="kubernetes/pause:latest"
-    The image that pod infra containers in each pod will use.
+\fB\-\-machine\_id\_file\fP=/etc/machine\-id,/var/lib/dbus/machine\-id
+    Comma\-separated list of files to check for machine\-id. Use the first one that exists.
+
+.PP
+\fB\-\-manifest\-url\fP=""
+    URL for accessing the container manifest
+
+.PP
+\fB\-\-master\-service\-namespace\fP="default"
+    The namespace from which the kubernetes master services should be injected into pods
+
+.PP
+\fB\-\-max\_housekeeping\_interval\fP=1m0s
+    Largest interval to allow between container housekeepings
+
+.PP
+\fB\-\-max\_pods\fP=100
+    Number of Pods that can run on this Kubelet.
+
+.PP
+\fB\-\-maximum\-dead\-containers\fP=100
+    Maximum number of old instances of a containers to retain globally.  Each container takes up some disk space.  Default: 100.
+
+.PP
+\fB\-\-maximum\-dead\-containers\-per\-container\fP=5
+    Maximum number of old instances of a container to retain per container.  Each container takes up some disk space.  Default: 5.
+
+.PP
+\fB\-\-minimum\-container\-ttl\-duration\fP=1m0s
+    Minimum age for a finished container before it is garbage collected.  Examples: '300ms', '10s' or '2h45m'
+
+.PP
+\fB\-\-network\-plugin\fP=""
+    The name of the network plugin to be invoked for various events in kubelet/pod lifecycle
+
+.PP
+\fB\-\-node\-status\-update\-frequency\fP=10s
+    Specifies how often kubelet posts node status to master. Note: be cautious when changing the constant, it must work with nodeMonitorGracePeriod in nodecontroller. Default: 10s
+
+.PP
+\fB\-\-oom\-score\-adj\fP=\-900
+    The oom\_score\_adj value for kubelet process. Values must be within the range [\-1000, 1000]
+
+.PP
+\fB\-\-pod\-infra\-container\-image\fP="gcr.io/google\_containers/pause:0.8.0"
+    The image whose network/ipc namespaces containers in each pod will use.
 
 .PP
 \fB\-\-port\fP=10250
-    The port for the info server to serve on.
+    The port for the info server to serve on
 
 .PP
-\fB\-\-registry\_burst\fP=10
-    Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry\_qps. Only used if \-\-registry\_qps > 0.
+\fB\-\-read\-only\-port\fP=10255
+    The read\-only port for the info server to serve on (set to 0 to disable)
 
 .PP
-\fB\-\-registry\_qps\fP=0
-    If > 0, limit registry pull QPS to this value. If 0, unlimited. [default=0.0].
+\fB\-\-registry\-burst\fP=10
+    Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry\_qps.  Only used if \-\-registry\_qps > 0
 
 .PP
-\fB\-\-root\_dir\fP="/var/lib/kubelet"
+\fB\-\-registry\-qps\fP=0
+    If > 0, limit registry pull QPS to this value.  If 0, unlimited. [default=0.0]
+
+.PP
+\fB\-\-resource\-container\fP="/kubelet"
+    Absolute name of the resource\-only container to create and run the Kubelet in (Default: /kubelet).
+
+.PP
+\fB\-\-root\-dir\fP="/var/lib/kubelet"
     Directory path for managing kubelet files (volume mounts,etc).
 
 .PP
-\fB\-\-stderrthreshold\fP=0
-    logs at or above this threshold go to stderr.
+\fB\-\-runonce\fP=false
+    If true, exit after spawning pods from local manifests or remote urls. Exclusive with \-\-api\_servers, and \-\-enable\-server
 
 .PP
-\fB\-\-sync\_frequency\fP=10s
-    Max period between synchronizing running containers and config.
+\fB\-\-stderrthreshold\fP=2
+    logs at or above this threshold go to stderr
+
+.PP
+\fB\-\-streaming\-connection\-idle\-timeout\fP=0
+    Maximum time a streaming connection can be idle before the connection is automatically closed.  Example: '5m'
+
+.PP
+\fB\-\-sync\-frequency\fP=10s
+    Max period between synchronizing running containers and config
+
+.PP
+\fB\-\-tls\-cert\-file\fP=""
+    File /gmrvcontaining x509 Certificate for HTTPS.  (CA cert, if any, concatenated after server cert). If \-\-tls\_cert\_file and \-\-tls\_private\_key\_file are not provided, a self\-signed certificate and key are generated for the public address and saved to the directory passed to \-\-cert\_dir.
+
+.PP
+\fB\-\-tls\-private\-key\-file\fP=""
+    File containing x509 private key matching \-\-tls\_cert\_file.
 
 .PP
 \fB\-\-v\fP=0
-    log level for V logs.
+    log level for V logs
 
 .PP
 \fB\-\-version\fP=false
-    Print version information and quit.
+    Print version information and quit
 
 .PP
 \fB\-\-vmodule\fP=
-    comma\-separated list of pattern=N settings for file\-filtered logging.
+    comma\-separated list of pattern=N settings for file\-filtered logging
 
 .SH EXAMPLES
 .PP
 .RS
 
 .nf
-/usr/bin/kubelet \-\-logtostderr=true \-\-v=0 \-\-etcd\_servers=http://127.0.0.1:4001 \-\-address=127.0.0.1 \-\-port=10250 \-\-hostname\_override=127.0.0.1 \-\-allow\_privileged=false
+/usr/bin/kubelet \-\-logtostderr=true \-\-v=0 \-\-api\_servers=http://127.0.0.1:8080 \-\-address=127.0.0.1 \-\-port=10250 \-\-hostname\_override=127.0.0.1 \-\-allow\-privileged=false
 
 .fi
 
@@ -141,3 +331,9 @@ HTTP server The kubelet can also listen for HTTP and respond to a simple API (un
 .PP
 October 2014, Originally compiled by Scott Collier (scollier at redhat dot com) based
  on the kubernetes source material and internal work.
+
+.PP
+May 2015, Revised by Victor HU(huruifeng at huawei dot com) by kubernetes version 0.17
+
+.PP
+[]()


### PR DESCRIPTION
#8493, Updated options and examples based on kubernetes version 0.17. Some deprecated flags are kept in the manual for they're still taking effect. Those flags no longer in use are removed.
