### PR TITLE
Update etcd version to 2.0.9 for ubuntu k8s

### DIFF
--- a/cluster/ubuntu/build.sh
+++ b/cluster/ubuntu/build.sh
@@ -40,7 +40,7 @@ cp flannel-${FLANNEL_VERSION}/flanneld binaries/minion
 
 # ectd
 echo "Download etcd release ..."
-ETCD_VERSION="v2.0.0"
+ETCD_VERSION="v2.0.9"
 ETCD="etcd-${ETCD_VERSION}-linux-amd64"
 if [ ! -f etcd.tar.gz ] ; then
     curl -L https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/${ETCD}.tar.gz -o etcd.tar.gz

--- a/docs/getting-started-guides/ubuntu.md
+++ b/docs/getting-started-guides/ubuntu.md
@@ -11,7 +11,7 @@ This document describes how to deploy kubernetes on ubuntu nodes, including 1 ma
 
 *3 These guide is tested OK on Ubuntu 14.04 LTS 64bit server, but it should also work on most Ubuntu versions*
 
-*4 Dependences of this guide: etcd-2.0.0, flannel-0.4.0, k8s-0.15.0, but it may work with higher versions*
+*4 Dependences of this guide: etcd-2.0.9, flannel-0.4.0, k8s-0.15.0, but it may work with higher versions*
 
 *5 All the remote servers can be ssh logged in without a password by using key authentication* 
 
@@ -24,7 +24,7 @@ then `$ cd kubernetes/cluster/ubuntu`.
 
 Then run `$ ./build.sh`, this will download all the needed binaries into `./binaries`.
 
-You can customize your etcd version, flannel version, k8s version by changing variable `ETCD_VERSION` , `FLANNEL_VERSION` and `K8S_VERSION` in build.sh, default etcd version is 2.0.0 , flannel version is 0.4.0 and K8s version is 0.15.0.
+You can customize your etcd version, flannel version, k8s version by changing variable `ETCD_VERSION` , `FLANNEL_VERSION` and `K8S_VERSION` in build.sh, default etcd version is 2.0.9, flannel version is 0.4.0 and K8s version is 0.15.0.
 
 Please make sure that there are `kube-apiserver`, `kube-controller-manager`, `kube-scheduler`, `kubelet`, `kube-proxy`, `etcd`, `etcdctl` and `flannel` in the binaries/master or binaries/minion directory.
 


### PR DESCRIPTION
Recently I met the same problem the same as https://github.com/GoogleCloudPlatform/kubernetes/issues/6059 .The solution is simple, just use 2.0.9 version of etcd and it has been merged https://github.com/GoogleCloudPlatform/kubernetes/pull/6544 for saltstack.So I update the doc and script.Tested OK!
 @rjnagal  Please merge it
