### PR TITLE
Reduce reaper poll interval and wait while resizing

### DIFF
--- a/pkg/kubectl/cmd/resize.go
+++ b/pkg/kubectl/cmd/resize.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -40,9 +39,6 @@ $ kubectl resize --replicas=3 replicationcontrollers foo
 
 // If the replication controller named foo's current size is 2, resize foo to 3.
 $ kubectl resize --current-replicas=2 --replicas=3 replicationcontrollers foo`
-
-	retryFrequency = 100 * time.Millisecond
-	retryTimeout   = 10 * time.Second
 )
 
 func NewCmdResize(f *cmdutil.Factory, out io.Writer) *cobra.Command {
@@ -104,9 +100,9 @@ func RunResize(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 	resourceVersion := cmdutil.GetFlagString(cmd, "resource-version")
 	currentSize := cmdutil.GetFlagInt(cmd, "current-replicas")
 	precondition := &kubectl.ResizePrecondition{currentSize, resourceVersion}
-	retry := &kubectl.RetryParams{Interval: retryFrequency, Timeout: retryTimeout}
-
-	if err := resizer.Resize(info.Namespace, info.Name, uint(count), precondition, retry, nil); err != nil {
+	retry := kubectl.NewRetryParams(kubectl.Interval, kubectl.Timeout)
+	waitForReplicas := kubectl.NewRetryParams(kubectl.Interval, kubectl.Timeout)
+	if err := resizer.Resize(info.Namespace, info.Name, uint(count), precondition, retry, waitForReplicas); err != nil {
 		return err
 	}
 	fmt.Fprint(out, "resized\n")

--- a/pkg/kubectl/stop.go
+++ b/pkg/kubectl/stop.go
@@ -26,9 +26,8 @@ import (
 )
 
 const (
-	shortInterval = time.Millisecond * 100
-	interval      = time.Second * 3
-	timeout       = time.Minute * 5
+	Interval = time.Millisecond * 100
+	Timeout  = time.Second * 20
 )
 
 // A Reaper handles terminating an object as gracefully as possible.
@@ -52,7 +51,7 @@ func IsNoSuchReaperError(err error) bool {
 func ReaperFor(kind string, c client.Interface) (Reaper, error) {
 	switch kind {
 	case "ReplicationController":
-		return &ReplicationControllerReaper{c, interval, timeout}, nil
+		return &ReplicationControllerReaper{c, Interval, Timeout}, nil
 	case "Pod":
 		return &PodReaper{c}, nil
 	case "Service":
@@ -83,8 +82,8 @@ func (reaper *ReplicationControllerReaper) Stop(namespace, name string, gracePer
 	if err != nil {
 		return "", err
 	}
-	retry := &RetryParams{shortInterval, reaper.timeout}
-	waitForReplicas := &RetryParams{reaper.pollInterval, reaper.timeout}
+	retry := NewRetryParams(reaper.pollInterval, reaper.timeout)
+	waitForReplicas := NewRetryParams(reaper.pollInterval, reaper.timeout)
 	if err = resizer.Resize(namespace, name, 0, nil, retry, waitForReplicas); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
When reaping a replication controller that handles an arbitrary amount of replicas, missing an interval means that `kubectl stop|delete` have to wait 3 more seconds to finish which seems more expensive from a user pov than a GET per 100ms. 

Also I think `kubectl resize` should wait for all replicas to spin up before exiting. Feels more safe to know that your replication controller status is up to date.

cc: @smarterclayton 
