### PR TITLE
kubelet: skipping registration when not needed

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -715,6 +715,11 @@ func (kl *Kubelet) initialNodeStatus() (*api.Node, error) {
 
 // registerWithApiserver registers the node with the cluster master.
 func (kl *Kubelet) registerWithApiserver() {
+	if _, err := kl.kubeClient.Nodes().Get(kl.hostname); err == nil {
+		glog.V(2).Infof("Node found, skipping registration with ApiServer")
+		return
+	}
+	glog.V(2).Infof("Node not found, registering with ApiServer")
 	step := 100 * time.Millisecond
 	for {
 		time.Sleep(step)


### PR DESCRIPTION
In order to avoid creation of a new Node entity at every kubelet restart (information loss), the registration is perfomed only when the node is not found.
