### PR TITLE
WIP: Use the port allocator to allocate ports

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -80,6 +80,7 @@ type APIServer struct {
 	CorsAllowedOriginList      util.StringList
 	AllowPrivileged            bool
 	PortalNet                  util.IPNet // TODO: make this a list
+	ServiceNodePorts           util.PortRange
 	EnableLogsSupport          bool
 	MasterServiceNamespace     string
 	RuntimeConfig              util.ConfigurationMap
@@ -177,6 +178,7 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Var(&s.CorsAllowedOriginList, "cors-allowed-origins", "List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching.  If this list is empty CORS will not be enabled.")
 	fs.BoolVar(&s.AllowPrivileged, "allow-privileged", s.AllowPrivileged, "If true, allow privileged containers.")
 	fs.Var(&s.PortalNet, "portal-net", "A CIDR notation IP range from which to assign portal IPs. This must not overlap with any IP ranges assigned to nodes for pods.")
+	fs.Var(&s.ServiceNodePorts, "service-node-ports", "A port range to reserve for services with NodePort visibility.  Example: '30000-32767'.  Inclusive at both ends of the range.")
 	fs.StringVar(&s.MasterServiceNamespace, "master-service-namespace", s.MasterServiceNamespace, "The namespace from which the kubernetes master services should be injected into pods")
 	fs.Var(&s.RuntimeConfig, "runtime-config", "A set of key=value pairs that describe runtime configuration that may be passed to the apiserver. api/<version> key can be used to turn on/off specific api versions. api/all and api/legacy are special keys to control all and legacy api versions respectively.")
 	client.BindKubeletClientConfigFlags(fs, &s.KubeletConfig)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1036,6 +1036,9 @@ type ServicePort struct {
 	// of v1beta3 the default value is the sames as the Port field (an
 	// identity map).
 	TargetPort util.IntOrString `json:"targetPort"`
+
+	// TODO(justinsb): merge with NodePorts PR
+	NodePort int
 }
 
 // Service is a named abstraction of software service (for example, mysql) consisting of local port

--- a/pkg/master/controller.go
+++ b/pkg/master/controller.go
@@ -39,7 +39,7 @@ import (
 type Controller struct {
 	NamespaceRegistry namespace.Registry
 	ServiceRegistry   service.Registry
-	ServiceIPRegistry service.IPRegistry
+	ServiceIPRegistry service.RangeRegistry
 	EndpointRegistry  endpoint.Registry
 	PortalNet         *net.IPNet
 	// TODO: MasterCount is yucky

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -192,7 +192,7 @@ type Master struct {
 	namespaceRegistry namespace.Registry
 	serviceRegistry   service.Registry
 	endpointRegistry  endpoint.Registry
-	portalAllocator   service.IPRegistry
+	portalAllocator   service.RangeRegistry
 
 	// "Outputs"
 	Handler         http.Handler

--- a/pkg/registry/service/allocator/bitmap.go
+++ b/pkg/registry/service/allocator/bitmap.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+import (
+	"math/big"
+	"math/rand"
+	"sync"
+)
+
+// AllocationBitmap is a contiguous block of resources that can be allocated atomically.
+//
+// The internal structure of the range is (for an IP range):
+//
+//   For CIDR 10.0.0.0/24
+//   254 addresses usable out of 256 total (minus base and broadcast IPs)
+//     The number of usable addresses is r.max
+//
+//   CIDR base IP          CIDR broadcast IP
+//   10.0.0.0                     10.0.0.255
+//   |                                     |
+//   0 1 2 3 4 5 ...         ... 253 254 255
+//     |                              |
+//   r.base                     r.base + r.max
+//     |                              |
+//   first bit of r.allocated   last bit of r.allocated
+//
+// If an address is taken, the bit at offset:
+//
+//   bit offset := IP - r.base
+//
+// is set to one. r.count is always equal to the number of set bits and
+// can be recalculated at any time by counting the set bits in r.allocated.
+//
+// TODO: use RLE and compact the allocator to minimize space.
+type AllocationBitmap struct {
+	// strategy is the strategy for choosing the next available item out of the range
+	strategy allocateStrategy
+	// max is the maximum size of the usable items in the range
+	max int
+
+	// lock guards the following members
+	lock sync.Mutex
+	// count is the number of currently allocated elements in the range
+	count int
+	// allocated is a bit array of the allocated items in the range
+	allocated *big.Int
+}
+
+// allocateStrategy is a search strategy in the allocation map for a valid item.
+type allocateStrategy func(allocated *big.Int, max, count int) (int, bool)
+
+func NewAllocationMap(max int) *AllocationBitmap {
+	a := AllocationBitmap{
+		strategy:  randomScanStrategy,
+		allocated: big.NewInt(0),
+		count:     0,
+		max:       max,
+	}
+	return &a
+}
+
+// Allocate attempts to reserve the provided item.
+// Returns true if it was allocated, false if it was already in use
+func (r *AllocationBitmap) Allocate(offset int) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.allocated.Bit(offset) == 1 {
+		return false
+	}
+	r.allocated = r.allocated.SetBit(r.allocated, offset, 1)
+	r.count++
+	return true
+}
+
+// AllocateNext reserves one of the items from the pool.
+// (0, false) may be returned if there are no items left.
+func (r *AllocationBitmap) AllocateNext() (int, bool) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	next, ok := r.strategy(r.allocated, r.max, r.count)
+	if !ok {
+		return 0, false
+	}
+	r.count++
+	r.allocated = r.allocated.SetBit(r.allocated, next, 1)
+	return next, true
+}
+
+// Release releases the item back to the pool. Releasing an
+// unallocated item or an item out of the range is a no-op and
+// returns no error.
+func (r *AllocationBitmap) Release(offset int) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.allocated.Bit(offset) == 0 {
+		return
+	}
+
+	r.allocated = r.allocated.SetBit(r.allocated, offset, 0)
+	r.count--
+	return
+}
+
+// Has returns true if the provided item is already allocated and a call
+// to Allocate(offset) would fail.
+func (r *AllocationBitmap) Has(offset int) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.allocated.Bit(offset) == 1
+}
+
+// Free returns the count of items left in the range.
+func (r *AllocationBitmap) Free() int {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	return r.max - r.count
+}
+
+// Snapshot saves the current state of the pool.
+func (r *AllocationBitmap) Snapshot() []byte {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.allocated.Bytes()
+}
+
+// Restore restores the pool to the previously captured state.
+func (r *AllocationBitmap) Restore(data []byte) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.allocated = big.NewInt(0).SetBytes(data)
+	r.count = countBits(r.allocated)
+}
+
+// randomScanStrategy chooses a random address from the provided big.Int, and then
+// scans forward looking for the next available address (it will wrap the range if
+// necessary).
+func randomScanStrategy(allocated *big.Int, max, count int) (int, bool) {
+	if count >= max {
+		return 0, false
+	}
+	offset := rand.Intn(max)
+	for i := 0; i < max; i++ {
+		at := (offset + i) % max
+		if allocated.Bit(at) == 0 {
+			return at, true
+		}
+	}
+	return 0, false
+}

--- a/pkg/registry/service/allocator/bitmap.go
+++ b/pkg/registry/service/allocator/bitmap.go
@@ -97,7 +97,7 @@ func (r *AllocationBitmap) Allocate(offset int) (bool, error) {
 }
 
 // AllocateNext reserves one of the items from the pool.
-// (0, false) may be returned if there are no items left.
+// (0, false, nil) may be returned if there are no items left.
 func (r *AllocationBitmap) AllocateNext() (int, bool, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()

--- a/pkg/registry/service/allocator/interfaces.go
+++ b/pkg/registry/service/allocator/interfaces.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+// Interface manages the allocation of items out of a range. Interface
+// should be threadsafe.
+type Interface interface {
+	Allocate(int) (bool, error)
+	AllocateNext() (int, bool, error)
+	Release(int) error
+
+	// For testing
+	Has(int) bool
+
+	// For testing
+	Free() int
+}
+
+// Snapshottable is an Interface that can be snapshotted and restored. Snapshottable
+// should be threadsafe.
+type Snapshottable interface {
+	Interface
+	Snapshot() (string, []byte)
+	Restore(string, []byte) error
+}
+
+type AllocatorFactory func(max int, rangeSpec string) Interface

--- a/pkg/registry/service/allocator/utils.go
+++ b/pkg/registry/service/allocator/utils.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+import "math/big"
+
+// countBits returns the number of set bits in n
+func countBits(n *big.Int) int {
+	var count int = 0
+	for _, b := range n.Bytes() {
+		count += int(bitCounts[b])
+	}
+	return count
+}
+
+// bitCounts is all of the bits counted for each number between 0-255
+var bitCounts = []int8{
+	0, 1, 1, 2, 1, 2, 2, 3,
+	1, 2, 2, 3, 2, 3, 3, 4,
+	1, 2, 2, 3, 2, 3, 3, 4,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	1, 2, 2, 3, 2, 3, 3, 4,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	1, 2, 2, 3, 2, 3, 3, 4,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	4, 5, 5, 6, 5, 6, 6, 7,
+	1, 2, 2, 3, 2, 3, 3, 4,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	4, 5, 5, 6, 5, 6, 6, 7,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	4, 5, 5, 6, 5, 6, 6, 7,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	4, 5, 5, 6, 5, 6, 6, 7,
+	4, 5, 5, 6, 5, 6, 6, 7,
+	5, 6, 6, 7, 6, 7, 7, 8,
+}

--- a/pkg/registry/service/allocator/utils_test.go
+++ b/pkg/registry/service/allocator/utils_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+import "testing"
+
+func TestBitCount(t *testing.T) {
+	for i, c := range bitCounts {
+		actual := 0
+		for j := 0; j < 8; j++ {
+			if ((1 << uint(j)) & i) != 0 {
+				actual++
+			}
+		}
+		if actual != int(c) {
+			t.Errorf("%d should have %d bits but recorded as %d", i, actual, c)
+		}
+	}
+}

--- a/pkg/registry/service/ipallocator/allocator_test.go
+++ b/pkg/registry/service/ipallocator/allocator_test.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
@@ -181,7 +182,17 @@ func TestSnapshot(t *testing.T) {
 		ip = append(ip, n)
 	}
 
-	network, data := r.Snapshot()
+	var dst api.RangeAllocation
+	err = r.Snapshot(&dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, network, err := net.ParseCIDR(dst.Range)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if !network.IP.Equal(cidr.IP) || network.Mask.String() != cidr.Mask.String() {
 		t.Fatalf("mismatched networks: %s : %s", network, cidr)
 	}
@@ -191,11 +202,11 @@ func TestSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 	other := NewCIDRRange(otherCidr)
-	if err := r.Restore(otherCidr, data); err != ErrMismatchedNetwork {
+	if err := r.Restore(otherCidr, dst.Data); err != ErrMismatchedNetwork {
 		t.Fatal(err)
 	}
 	other = NewCIDRRange(network)
-	if err := other.Restore(network, data); err != nil {
+	if err := other.Restore(network, dst.Data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/registry/service/ipallocator/allocator_test.go
+++ b/pkg/registry/service/ipallocator/allocator_test.go
@@ -142,25 +142,11 @@ func TestAllocateSmall(t *testing.T) {
 		}
 	}
 
-	if r.count != 2 && r.Free() != 0 && r.max != 2 {
+	if r.Free() != 0 {
 		t.Fatalf("unexpected range: %v", r)
 	}
 
 	t.Logf("allocated: %v", found)
-}
-
-func TestBitCount(t *testing.T) {
-	for i, c := range bitCounts {
-		actual := 0
-		for j := 0; j < 8; j++ {
-			if ((1 << uint(j)) & i) != 0 {
-				actual++
-			}
-		}
-		if actual != int(c) {
-			t.Errorf("%d should have %d bits but recorded as %d", i, actual, c)
-		}
-	}
 }
 
 func TestRangeSize(t *testing.T) {

--- a/pkg/registry/service/ipallocator/controller/repair.go
+++ b/pkg/registry/service/ipallocator/controller/repair.go
@@ -46,12 +46,12 @@ type Repair struct {
 	interval time.Duration
 	registry service.Registry
 	network  *net.IPNet
-	alloc    service.IPRegistry
+	alloc    service.RangeRegistry
 }
 
 // NewRepair creates a controller that periodically ensures that all portalIPs are uniquely allocated across the cluster
 // and generates informational warnings for a cluster that is not in sync.
-func NewRepair(interval time.Duration, registry service.Registry, network *net.IPNet, alloc service.IPRegistry) *Repair {
+func NewRepair(interval time.Duration, registry service.Registry, network *net.IPNet, alloc service.RangeRegistry) *Repair {
 	return &Repair{
 		interval: interval,
 		registry: registry,

--- a/pkg/registry/service/ipallocator/controller/repair.go
+++ b/pkg/registry/service/ipallocator/controller/repair.go
@@ -111,7 +111,10 @@ func (c *Repair) RunOnce() error {
 		}
 	}
 
-	service.SnapshotRange(latest, r)
+	err = r.Snapshot(latest)
+	if err != nil {
+		return fmt.Errorf("unable to persist the updated service IP allocations: %v", err)
+	}
 
 	if err := c.alloc.CreateOrUpdate(latest); err != nil {
 		return fmt.Errorf("unable to persist the updated service IP allocations: %v", err)

--- a/pkg/registry/service/ipallocator/controller/repair_test.go
+++ b/pkg/registry/service/ipallocator/controller/repair_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service/ipallocator"
 )
 
-type mockIPRegistry struct {
+type mockRangeRegistry struct {
 	getCalled bool
 	item      *api.RangeAllocation
 	err       error
@@ -37,12 +37,12 @@ type mockIPRegistry struct {
 	updateErr    error
 }
 
-func (r *mockIPRegistry) Get() (*api.RangeAllocation, error) {
+func (r *mockRangeRegistry) Get() (*api.RangeAllocation, error) {
 	r.getCalled = true
 	return r.item, r.err
 }
 
-func (r *mockIPRegistry) CreateOrUpdate(alloc *api.RangeAllocation) error {
+func (r *mockRangeRegistry) CreateOrUpdate(alloc *api.RangeAllocation) error {
 	r.updateCalled = true
 	r.updated = alloc
 	return r.updateErr
@@ -51,7 +51,7 @@ func (r *mockIPRegistry) CreateOrUpdate(alloc *api.RangeAllocation) error {
 func TestRepair(t *testing.T) {
 	registry := registrytest.NewServiceRegistry()
 	_, cidr, _ := net.ParseCIDR("192.168.1.0/24")
-	ipregistry := &mockIPRegistry{
+	ipregistry := &mockRangeRegistry{
 		item: &api.RangeAllocation{},
 	}
 	r := NewRepair(0, registry, cidr, ipregistry)
@@ -63,7 +63,7 @@ func TestRepair(t *testing.T) {
 		t.Errorf("unexpected ipregistry: %#v", ipregistry)
 	}
 
-	ipregistry = &mockIPRegistry{
+	ipregistry = &mockRangeRegistry{
 		item:      &api.RangeAllocation{},
 		updateErr: fmt.Errorf("test error"),
 	}
@@ -80,7 +80,7 @@ func TestRepairEmpty(t *testing.T) {
 	network, data := previous.Snapshot()
 
 	registry := registrytest.NewServiceRegistry()
-	ipregistry := &mockIPRegistry{
+	ipregistry := &mockRangeRegistry{
 		item: &api.RangeAllocation{
 			ObjectMeta: api.ObjectMeta{
 				ResourceVersion: "1",
@@ -130,7 +130,7 @@ func TestRepairWithExisting(t *testing.T) {
 		},
 	}
 
-	ipregistry := &mockIPRegistry{
+	ipregistry := &mockRangeRegistry{
 		item: &api.RangeAllocation{
 			ObjectMeta: api.ObjectMeta{
 				ResourceVersion: "1",

--- a/pkg/registry/service/ipallocator/controller/repair_test.go
+++ b/pkg/registry/service/ipallocator/controller/repair_test.go
@@ -77,7 +77,12 @@ func TestRepairEmpty(t *testing.T) {
 	_, cidr, _ := net.ParseCIDR("192.168.1.0/24")
 	previous := ipallocator.NewCIDRRange(cidr)
 	previous.Allocate(net.ParseIP("192.168.1.10"))
-	network, data := previous.Snapshot()
+
+	var dst api.RangeAllocation
+	err := previous.Snapshot(&dst)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	registry := registrytest.NewServiceRegistry()
 	ipregistry := &mockRangeRegistry{
@@ -85,8 +90,8 @@ func TestRepairEmpty(t *testing.T) {
 			ObjectMeta: api.ObjectMeta{
 				ResourceVersion: "1",
 			},
-			Range: network.String(),
-			Data:  data,
+			Range: dst.Range,
+			Data:  dst.Data,
 		},
 	}
 	r := NewRepair(0, registry, cidr, ipregistry)
@@ -105,7 +110,13 @@ func TestRepairEmpty(t *testing.T) {
 func TestRepairWithExisting(t *testing.T) {
 	_, cidr, _ := net.ParseCIDR("192.168.1.0/24")
 	previous := ipallocator.NewCIDRRange(cidr)
-	network, data := previous.Snapshot()
+
+	var dst api.RangeAllocation
+	err := previous.Snapshot(&dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	registry := registrytest.NewServiceRegistry()
 	registry.List = api.ServiceList{
 		Items: []api.Service{
@@ -135,8 +146,8 @@ func TestRepairWithExisting(t *testing.T) {
 			ObjectMeta: api.ObjectMeta{
 				ResourceVersion: "1",
 			},
-			Range: network.String(),
-			Data:  data,
+			Range: dst.Range,
+			Data:  dst.Data,
 		},
 	}
 	r := NewRepair(0, registry, cidr, ipregistry)

--- a/pkg/registry/service/ipallocator/etcd/etcd.go
+++ b/pkg/registry/service/ipallocator/etcd/etcd.go
@@ -42,9 +42,9 @@ type Etcd struct {
 	last   string
 }
 
-// Etcd implements ipallocator.Interface and service.IPRegistry
+// Etcd implements ipallocator.Interface and service.RangeRegistry
 var _ ipallocator.Interface = &Etcd{}
-var _ service.IPRegistry = &Etcd{}
+var _ service.RangeRegistry = &Etcd{}
 
 const baseKey = "/ranges/serviceips"
 

--- a/pkg/registry/service/ipallocator/etcd/etcd_test.go
+++ b/pkg/registry/service/ipallocator/etcd/etcd_test.go
@@ -117,30 +117,4 @@ func TestStore(t *testing.T) {
 		t.Fatalf("%s is empty: %#v", key(), obj)
 	}
 	t.Logf("data: %#v", obj.R.Node)
-
-	// TODO: Reintroduce this aspect of the test?
-	//	other := ipallocator.NewCIDRRange(cidr)
-	//
-	//	allocation := &api.RangeAllocation{}
-	//	if err := storage.(*allocator_etcd.Etcd).helper.ExtractObj(key(), allocation, false); err != nil {
-	//		t.Fatal(err)
-	//	}
-	//	if allocation.ResourceVersion != "1" {
-	//		t.Fatalf("%#v", allocation)
-	//	}
-	//	if allocation.Range != "192.168.1.0/24" {
-	//		t.Errorf("unexpected stored Range: %s", allocation.Range)
-	//	}
-	//	if err := other.Restore(cidr, allocation.Data); err != nil {
-	//		t.Fatal(err)
-	//	}
-	//	if !other.Has(net.ParseIP("192.168.1.2")) {
-	//		t.Fatalf("could not restore allocated IP: %#v", other)
-	//	}
-	//
-	//	other = ipallocator.NewCIDRRange(cidr)
-	//	otherStorage := allocator_etcd.NewEtcd(other, storage.(*allocator_etcd.Etcd).helper)
-	//	if err := otherStorage.Allocate(net.ParseIP("192.168.1.2")); err != ipallocator.ErrAllocated {
-	//		t.Fatal(err)
-	//	}
 }

--- a/pkg/registry/service/portallocator/allocator.go
+++ b/pkg/registry/service/portallocator/allocator.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portallocator
+
+import (
+	"errors"
+	"fmt"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service/allocator"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+// Interface manages the allocation of IP addresses out of a range. Interface
+// should be threadsafe.
+type Interface interface {
+	Allocate(int) error
+	AllocateNext() (int, error)
+	Release(int) error
+}
+
+var (
+	ErrFull              = errors.New("range is full")
+	ErrNotInRange        = errors.New("provided port is not in the valid range")
+	ErrAllocated         = errors.New("provided port is already allocated")
+	ErrMismatchedNetwork = errors.New("the provided port range does not match the current port range")
+)
+
+type PortAllocator struct {
+	portRange util.PortRange
+
+	alloc allocator.Interface
+}
+
+// PortAllocator implements Interface and Snapshottable
+var _ Interface = &PortAllocator{}
+
+// NewPortAllocatorCustom creates a PortAllocator over a util.PortRange, calling allocatorFactory to construct the backing store.
+func NewPortAllocatorCustom(pr util.PortRange, allocatorFactory allocator.AllocatorFactory) *PortAllocator {
+	max := pr.Size
+	rangeSpec := pr.String()
+
+	a := &PortAllocator{
+		portRange: pr,
+	}
+	a.alloc = allocatorFactory(max, rangeSpec)
+	return a
+}
+
+// Helper that wraps NewAllocatorCIDRRange, for creating a range backed by an in-memory store.
+func NewPortAllocator(pr util.PortRange) *PortAllocator {
+	return NewPortAllocatorCustom(pr, func(max int, rangeSpec string) allocator.Interface {
+		return allocator.NewAllocationMap(max, rangeSpec)
+	})
+}
+
+// Free returns the count of IP addresses left in the range.
+func (r *PortAllocator) Free() int {
+	return r.alloc.Free()
+}
+
+// Allocate attempts to reserve the provided IP. ErrNotInRange or
+// ErrAllocated will be returned if the IP is not valid for this range
+// or has already been reserved.  ErrFull will be returned if there
+// are no addresses left.
+func (r *PortAllocator) Allocate(port int) error {
+	ok, offset := r.contains(port)
+	if !ok {
+		return ErrNotInRange
+	}
+
+	allocated, err := r.alloc.Allocate(offset)
+	if err != nil {
+		return err
+	}
+	if !allocated {
+		return ErrAllocated
+	}
+	return nil
+}
+
+// AllocateNext reserves one of the ports from the pool. ErrFull may
+// be returned if there are no addresses left.
+func (r *PortAllocator) AllocateNext() (int, error) {
+	offset, ok, err := r.alloc.AllocateNext()
+	if err != nil {
+		return 0, err
+	}
+	if !ok {
+		return 0, ErrFull
+	}
+	return r.portRange.Base + offset, nil
+}
+
+// Release releases the port back to the pool. Releasing an
+// unallocated port or a port out of the range is a no-op and
+// returns no error.
+func (r *PortAllocator) Release(port int) error {
+	ok, offset := r.contains(port)
+	if !ok {
+		// TODO: log a warning
+		return nil
+	}
+
+	r.alloc.Release(offset)
+	return nil
+}
+
+// Has returns true if the provided port is already allocated and a call
+// to Allocate(port) would fail with ErrAllocated.
+func (r *PortAllocator) Has(port int) bool {
+	ok, offset := r.contains(port)
+	if !ok {
+		return false
+	}
+
+	return r.alloc.Has(offset)
+}
+
+// Snapshot saves the current state of the pool.
+func (r *PortAllocator) Snapshot(dst *api.RangeAllocation) error {
+	snapshottable, ok := r.alloc.(allocator.Snapshottable)
+	if !ok {
+		return fmt.Errorf("Not a snapshottable allocator")
+	}
+	rangeString, data := snapshottable.Snapshot()
+	dst.Range = rangeString
+	dst.Data = data
+	return nil
+}
+
+// Restore restores the pool to the previously captured state. ErrMismatchedNetwork
+// is returned if the provided IPNet range doesn't exactly match the previous range.
+func (r *PortAllocator) Restore(pr util.PortRange, data []byte) error {
+	if pr.String() != r.portRange.String() {
+		return ErrMismatchedNetwork
+	}
+	snapshottable, ok := r.alloc.(allocator.Snapshottable)
+	if !ok {
+		return fmt.Errorf("Not a snapshottable allocator")
+	}
+	snapshottable.Restore(pr.String(), data)
+	return nil
+}
+
+// contains returns true and the offset if the ip is in the range, and false
+// and nil otherwise. The first and last addresses of the CIDR are omitted.
+func (r *PortAllocator) contains(port int) (bool, int) {
+	if !r.portRange.Contains(port) {
+		return false, 0
+	}
+
+	offset := port - r.portRange.Base
+	return true, offset
+}

--- a/pkg/registry/service/portallocator/allocator_test.go
+++ b/pkg/registry/service/portallocator/allocator_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portallocator
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"strconv"
+)
+
+func TestAllocate(t *testing.T) {
+	pr, err := util.ParsePortRange("10000-10200")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := NewPortAllocator(*pr)
+	if f := r.Free(); f != 201 {
+		t.Errorf("unexpected free %d", f)
+	}
+	found := util.NewStringSet()
+	count := 0
+	for r.Free() > 0 {
+		p, err := r.AllocateNext()
+		if err != nil {
+			t.Fatalf("error @ %d: %v", count, err)
+		}
+		count++
+		if !pr.Contains(p) {
+			t.Fatalf("allocated %s which is outside of %s", p, pr)
+		}
+		if found.Has(strconv.Itoa(p)) {
+			t.Fatalf("allocated %s twice @ %d", p, count)
+		}
+		found.Insert(strconv.Itoa(p))
+	}
+	if _, err := r.AllocateNext(); err != ErrFull {
+		t.Fatal(err)
+	}
+
+	released := 10005
+	if err := r.Release(released); err != nil {
+		t.Fatal(err)
+	}
+	if f := r.Free(); f != 1 {
+		t.Errorf("unexpected free %d", f)
+	}
+	p, err := r.AllocateNext()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if released != p {
+		t.Errorf("unexpected %s : %s", p, released)
+	}
+
+	if err := r.Release(released); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Allocate(1); err != ErrNotInRange {
+		t.Fatal(err)
+	}
+	if err := r.Allocate(10001); err != ErrAllocated {
+		t.Fatal(err)
+	}
+	if err := r.Allocate(20000); err != ErrNotInRange {
+		t.Fatal(err)
+	}
+	if err := r.Allocate(10201); err != ErrNotInRange {
+		t.Fatal(err)
+	}
+	if f := r.Free(); f != 1 {
+		t.Errorf("unexpected free %d", f)
+	}
+	if err := r.Allocate(released); err != nil {
+		t.Fatal(err)
+	}
+	if f := r.Free(); f != 0 {
+		t.Errorf("unexpected free %d", f)
+	}
+}
+
+func TestSnapshot(t *testing.T) {
+	pr, err := util.ParsePortRange("10000-10200")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := NewPortAllocator(*pr)
+	ip := []int{}
+	for i := 0; i < 10; i++ {
+		n, err := r.AllocateNext()
+		if err != nil {
+			t.Fatal(err)
+		}
+		ip = append(ip, n)
+	}
+
+	var dst api.RangeAllocation
+	err = r.Snapshot(&dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pr2, err := util.ParsePortRange(dst.Range)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pr.String() != pr2.String() {
+		t.Fatalf("mismatched networks: %s : %s", pr, pr2)
+	}
+
+	otherPr, err := util.ParsePortRange("200-300")
+	if err != nil {
+		t.Fatal(err)
+	}
+	other := NewPortAllocator(*otherPr)
+	if err := r.Restore(*otherPr, dst.Data); err != ErrMismatchedNetwork {
+		t.Fatal(err)
+	}
+	other = NewPortAllocator(*pr2)
+	if err := other.Restore(*pr2, dst.Data); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, n := range ip {
+		if !other.Has(n) {
+			t.Errorf("restored range does not have %s", n)
+		}
+	}
+	if other.Free() != r.Free() {
+		t.Errorf("counts do not match: %d", other.Free())
+	}
+}

--- a/pkg/registry/service/portallocator/controller/repair.go
+++ b/pkg/registry/service/portallocator/controller/repair.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service/portallocator"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+// See ipallocator/controller/repair.go; this is a copy for ports.
+type Repair struct {
+	interval  time.Duration
+	registry  service.Registry
+	portRange util.PortRange
+	alloc     service.RangeRegistry
+}
+
+// NewRepair creates a controller that periodically ensures that all portalIPs are uniquely allocated across the cluster
+// and generates informational warnings for a cluster that is not in sync.
+func NewRepair(interval time.Duration, registry service.Registry, portRange util.PortRange, alloc service.RangeRegistry) *Repair {
+	return &Repair{
+		interval:  interval,
+		registry:  registry,
+		portRange: portRange,
+		alloc:     alloc,
+	}
+}
+
+// RunUntil starts the controller until the provided ch is closed.
+func (c *Repair) RunUntil(ch chan struct{}) {
+	util.Until(func() {
+		if err := c.RunOnce(); err != nil {
+			util.HandleError(err)
+		}
+	}, c.interval, ch)
+}
+
+// RunOnce verifies the state of the portal IP allocations and returns an error if an unrecoverable problem occurs.
+func (c *Repair) RunOnce() error {
+	latest, err := c.alloc.Get()
+	if err != nil {
+		return fmt.Errorf("unable to refresh the port block: %v", err)
+	}
+
+	ctx := api.WithNamespace(api.NewDefaultContext(), api.NamespaceAll)
+	list, err := c.registry.ListServices(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to refresh the port block: %v", err)
+	}
+
+	r := portallocator.NewPortAllocator(c.portRange)
+	for _, svc := range list.Items {
+		ports := []int{}
+
+		// TODO(justinsb): Collect NodePorts
+		if len(ports) == 0 {
+			continue
+		}
+
+		for _, port := range ports {
+			switch err := r.Allocate(port); err {
+			case nil:
+			case portallocator.ErrAllocated:
+				// TODO: send event
+				// portal IP is broken, reallocate
+				util.HandleError(fmt.Errorf("the port %d for service %s/%s was assigned to multiple services; please recreate", port, svc.Name, svc.Namespace))
+			case portallocator.ErrNotInRange:
+				// TODO: send event
+				// portal IP is broken, reallocate
+				util.HandleError(fmt.Errorf("the port %d for service %s/%s is not within the port range %v; please recreate", port, svc.Name, svc.Namespace, c.portRange))
+			case portallocator.ErrFull:
+				// TODO: send event
+				return fmt.Errorf("the port range %v is full; you must widen the port range in order to create new services", c.portRange)
+			default:
+				return fmt.Errorf("unable to allocate port %d for service %s/%s due to an unknown error, exiting: %v", port, svc.Name, svc.Namespace, err)
+			}
+		}
+	}
+
+	err = r.Snapshot(latest)
+	if err != nil {
+		return fmt.Errorf("unable to persist the updated port allocations: %v", err)
+	}
+
+	if err := c.alloc.CreateOrUpdate(latest); err != nil {
+		return fmt.Errorf("unable to persist the updated port allocations: %v", err)
+	}
+	return nil
+}

--- a/pkg/registry/service/portallocator/operation.go
+++ b/pkg/registry/service/portallocator/operation.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portallocator
+
+// Encapsulates the semantics of a port allocation 'transaction':
+// It is better to leak ports than to double-allocate them,
+// so we allocate immediately, but defer release.
+// On commit we best-effort release the deferred releases.
+// On rollback we best-effort release any allocations we did.
+//
+// Pattern for use:
+//   op := StartPortAllocationOperation(...)
+//   defer op.Finish
+//   ...
+//   write(updatedOwner)
+///  op.Commit()
+type portAllocationOperation struct {
+	pa              Interface
+	allocated       []int
+	releaseDeferred []int
+	shouldRollback  bool
+}
+
+// Creates a portAllocationOperation, tracking a set of allocations & releases
+func StartOperation(pa Interface) *portAllocationOperation {
+	op := &portAllocationOperation{}
+	op.pa = pa
+	op.allocated = []int{}
+	op.releaseDeferred = []int{}
+	op.shouldRollback = true
+	return op
+}
+
+// Will rollback unless marked as shouldRollback = false by a Commit().  Call from a defer block
+func (op *portAllocationOperation) Finish() {
+	if op.shouldRollback {
+		op.Rollback()
+	}
+}
+
+// (Try to) undo any operations we did
+func (op *portAllocationOperation) Rollback() []error {
+	errors := []error{}
+
+	for _, allocated := range op.allocated {
+		err := op.pa.Release(allocated)
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+// (Try to) perform any deferred operations.
+// Note that even if this fails, we don't rollback; we always want to err on the side of over-allocation,
+// and Commit should be called _after_ the owner is written
+func (op *portAllocationOperation) Commit() []error {
+	errors := []error{}
+
+	for _, release := range op.releaseDeferred {
+		err := op.pa.Release(release)
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	// Even on error, we don't rollback
+	// Problems should be fixed by an eventual reconciliation / restart
+	op.shouldRollback = false
+
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// Allocates a port, and record it for future rollback
+func (op *portAllocationOperation) Allocate(port int) error {
+	err := op.pa.Allocate(port)
+	if err == nil {
+		op.allocated = append(op.allocated, port)
+	}
+	return err
+}
+
+// Allocates a port, and record it for future rollback
+func (op *portAllocationOperation) AllocateNext() (int, error) {
+	port, err := op.pa.AllocateNext()
+	if err == nil {
+		op.allocated = append(op.allocated, port)
+	}
+	return port, err
+}
+
+// Marks a port so that it will be released if this operation Commits
+func (op *portAllocationOperation) ReleaseDeferred(port int) {
+	op.releaseDeferred = append(op.releaseDeferred, port)
+}

--- a/pkg/registry/service/registry.go
+++ b/pkg/registry/service/registry.go
@@ -20,9 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service/allocator"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
-	"net"
 )
 
 // Registry is an interface for things that know how to store services.
@@ -43,13 +41,4 @@ type RangeRegistry interface {
 	// CreateOrUpdate should create or update the provide allocation, unless a conflict
 	// has occured since the item was last created.
 	CreateOrUpdate(*api.RangeAllocation) error
-}
-
-// RestoreRange updates a snapshottable ipallocator from a RangeAllocation
-func RestoreRange(dst allocator.Snapshottable, src *api.RangeAllocation) error {
-	_, _, err := net.ParseCIDR(src.Range)
-	if err != nil {
-		return err
-	}
-	return dst.Restore(src.Range, src.Data)
 }

--- a/pkg/registry/service/registry.go
+++ b/pkg/registry/service/registry.go
@@ -17,13 +17,12 @@ limitations under the License.
 package service
 
 import (
-	"net"
-
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service/ipallocator"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service/allocator"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+	"net"
 )
 
 // Registry is an interface for things that know how to store services.
@@ -47,17 +46,10 @@ type RangeRegistry interface {
 }
 
 // RestoreRange updates a snapshottable ipallocator from a RangeAllocation
-func RestoreRange(dst ipallocator.Snapshottable, src *api.RangeAllocation) error {
-	_, network, err := net.ParseCIDR(src.Range)
+func RestoreRange(dst allocator.Snapshottable, src *api.RangeAllocation) error {
+	_, _, err := net.ParseCIDR(src.Range)
 	if err != nil {
 		return err
 	}
-	return dst.Restore(network, src.Data)
-}
-
-// SnapshotRange updates a RangeAllocation to match a snapshottable ipallocator
-func SnapshotRange(dst *api.RangeAllocation, src ipallocator.Snapshottable) {
-	network, data := src.Snapshot()
-	dst.Range = network.String()
-	dst.Data = data
+	return dst.Restore(src.Range, src.Data)
 }

--- a/pkg/registry/service/registry.go
+++ b/pkg/registry/service/registry.go
@@ -36,8 +36,8 @@ type Registry interface {
 	WatchServices(ctx api.Context, labels labels.Selector, fields fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
-// IPRegistry is a registry that can retrieve or persist a RangeAllocation object.
-type IPRegistry interface {
+// RangeRegistry is a registry that can retrieve or persist a RangeAllocation object.
+type RangeRegistry interface {
 	// Get returns the latest allocation, an empty object if no allocation has been made,
 	// or an error if the allocation could not be retrieved.
 	Get() (*api.RangeAllocation, error)

--- a/pkg/registry/service/rest.go
+++ b/pkg/registry/service/rest.go
@@ -33,6 +33,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/endpoint"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/minion"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service/ipallocator"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service/portallocator"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
@@ -41,22 +42,24 @@ import (
 
 // REST adapts a service registry into apiserver's RESTStorage model.
 type REST struct {
-	registry    Registry
-	machines    minion.Registry
-	endpoints   endpoint.Registry
-	portals     ipallocator.Interface
-	clusterName string
+	registry         Registry
+	machines         minion.Registry
+	endpoints        endpoint.Registry
+	portals          ipallocator.Interface
+	serviceNodePorts portallocator.Interface
+	clusterName      string
 }
 
 // NewStorage returns a new REST.
 func NewStorage(registry Registry, machines minion.Registry, endpoints endpoint.Registry, portals ipallocator.Interface,
-	clusterName string) *REST {
+	serviceNodePorts portallocator.Interface, clusterName string) *REST {
 	return &REST{
-		registry:    registry,
-		machines:    machines,
-		endpoints:   endpoints,
-		portals:     portals,
-		clusterName: clusterName,
+		registry:         registry,
+		machines:         machines,
+		endpoints:        endpoints,
+		portals:          portals,
+		serviceNodePorts: serviceNodePorts,
+		clusterName:      clusterName,
 	}
 }
 

--- a/pkg/registry/service/rest_test.go
+++ b/pkg/registry/service/rest_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service/ipallocator"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service/portallocator"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 func NewTestREST(t *testing.T, endpoints *api.EndpointsList) (*REST, *registrytest.ServiceRegistry) {
@@ -40,7 +42,12 @@ func NewTestREST(t *testing.T, endpoints *api.EndpointsList) (*REST, *registryte
 	}
 	nodeRegistry := registrytest.NewMinionRegistry(machines, api.NodeResources{})
 	r := ipallocator.NewCIDRRange(makeIPNet(t))
-	storage := NewStorage(registry, nodeRegistry, endpointRegistry, r, "kubernetes")
+
+	portRange := util.PortRange{Base: 30000, Size: 1000}
+	portAllocator := portallocator.NewPortAllocator(portRange)
+
+	storage := NewStorage(registry, nodeRegistry, endpointRegistry, r, portAllocator, "kubernetes")
+
 	return storage, registry
 }
 


### PR DESCRIPTION
This is derived from #8553, and shows how we allocate ports without getting into an error case if we fail mid-operation.

Tests failing because we're into the inter-dependent territory now.

This is the new commit: https://github.com/justinsb/kubernetes/commit/d9dffd52974db0331964bb74321fe850fd3fb25f

cc @thockin 
