### PR TITLE
Revert "Enhance error message from kubectl when 'kind' is empty"

### DIFF
--- a/pkg/kubectl/resource/mapper.go
+++ b/pkg/kubectl/resource/mapper.go
@@ -46,9 +46,6 @@ func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to get type info from %q: %v", source, err)
 	}
-	if kind == "" {
-		return nil, fmt.Errorf("kind not set in %q", source)
-	}
 	mapping, err := m.RESTMapping(kind, version)
 	if err != nil {
 		return nil, fmt.Errorf("unable to recognize %q: %v", source, err)


### PR DESCRIPTION
Reverts GoogleCloudPlatform/kubernetes#8404 - merge window was closed.
