### PR TITLE
Added GOPATH vars and godep to generator script

### DIFF
--- a/hack/update-generated-conversions.sh
+++ b/hack/update-generated-conversions.sh
@@ -42,7 +42,7 @@ import (
 // AUTO-GENERATED FUNCTIONS START HERE
 EOF
 
-	go run cmd/kube-conversion/conversion.go -v ${version} -f - >>  $TMPFILE
+	GOPATH=$(godep path):$GOPATH go run cmd/kube-conversion/conversion.go -v ${version} -f - >>  $TMPFILE
 
 	cat >> $TMPFILE <<EOF
 // AUTO-GENERATED FUNCTIONS END HERE


### PR DESCRIPTION
hack/update-generated-conversions.sh does not understand my project's GOPATH.  Adding GOPATH to the generator script fixes the issue.

This is the output before and after the change:

```
$ hack/update-generated-conversions.sh 
Generating for version v1beta3
pkg/util/uuid.go:23:2: cannot find package "code.google.com/p/go-uuid/uuid" in any of:
    /Users/markturansky/Applications/go1.4.2/src/code.google.com/p/go-uuid/uuid (from $GOROOT)
    /Users/markturansky/Projects/src/code.google.com/p/go-uuid/uuid (from $GOPATH)
pkg/util/diff.go:26:2: cannot find package "github.com/davecgh/go-spew/spew" in any of:
    /Users/markturansky/Applications/go1.4.2/src/github.com/davecgh/go-spew/spew (from $GOROOT)
    /Users/markturansky/Projects/src/github.com/davecgh/go-spew/spew (from $GOPATH)
pkg/util/yaml/decoder.go:26:2: cannot find package "github.com/ghodss/yaml" in any of:
    /Users/markturansky/Applications/go1.4.2/src/github.com/ghodss/yaml (from $GOROOT)
    /Users/markturansky/Projects/src/github.com/ghodss/yaml (from $GOPATH)
pkg/util/yaml/decoder.go:27:2: cannot find package "github.com/golang/glog" in any of:
    /Users/markturansky/Applications/go1.4.2/src/github.com/golang/glog (from $GOROOT)
    /Users/markturansky/Projects/src/github.com/golang/glog (from $GOPATH)
pkg/util/time.go:23:2: cannot find package "github.com/google/gofuzz" in any of:
    /Users/markturansky/Applications/go1.4.2/src/github.com/google/gofuzz (from $GOROOT)
    /Users/markturansky/Projects/src/github.com/google/gofuzz (from $GOPATH)
pkg/api/resource/quantity.go:26:2: cannot find package "github.com/spf13/pflag" in any of:
    /Users/markturansky/Applications/go1.4.2/src/github.com/spf13/pflag (from $GOROOT)
    /Users/markturansky/Projects/src/github.com/spf13/pflag (from $GOPATH)
pkg/api/context.go:23:2: cannot find package "golang.org/x/net/context" in any of:
    /Users/markturansky/Applications/go1.4.2/src/golang.org/x/net/context (from $GOROOT)
    /Users/markturansky/Projects/src/golang.org/x/net/context (from $GOPATH)
pkg/api/resource/quantity.go:27:2: cannot find package "speter.net/go/exp/math/dec/inf" in any of:
    /Users/markturansky/Applications/go1.4.2/src/speter.net/go/exp/math/dec/inf (from $GOROOT)
    /Users/markturansky/Projects/src/speter.net/go/exp/math/dec/inf (from $GOPATH)

$ hack/update-generated-conversions.sh 
Generating for version v1beta3
Generating for version v1
```
