### PR TITLE
Run Docker containers as top-level containers in Debian.

### DIFF
--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -58,4 +58,10 @@
   {% set configure_cbr0 = "--configure-cbr0=" + pillar['allocate_node_cidrs'] -%}
 {% endif -%}
 
-DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{hostname_override}} {{cloud_provider}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{configure_cbr0}}"
+# Run containers under the root cgroup.
+{% set cgroup_root = "" -%}
+{% if grains['os_family'] == 'Debian' -%}
+  {% set cgroup_root = "--cgroup_root=/" -%}
+{% endif -%}
+
+DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{hostname_override}} {{cloud_provider}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{configure_cbr0}} {{cgroup_root}}"


### PR DESCRIPTION
This should fix the issue for GCE/GKE, I'll work on libcontainer/Docker changes to fix overall.

Part of #8215

/cc @rjnagal @dchen1107 

Ran e2e and the run came back green!
