### PR TITLE
Stop generating v1beta1,2 swagger spec

### DIFF
--- a/api/swagger-spec/resourceListing.json
+++ b/api/swagger-spec/resourceListing.json
@@ -6,14 +6,6 @@
     "description": "get available API versions"
    },
    {
-    "path": "/api/v1beta1",
-    "description": "API at /api/v1beta1 version v1beta1"
-   },
-   {
-    "path": "/api/v1beta2",
-    "description": "API at /api/v1beta2 version v1beta2"
-   },
-   {
     "path": "/api/v1beta3",
     "description": "API at /api/v1beta3 version v1beta3"
    },

--- a/hack/update-swagger-spec.sh
+++ b/hack/update-swagger-spec.sh
@@ -53,7 +53,7 @@ kube::log::status "Starting kube-apiserver"
   --etcd_servers="http://${ETCD_HOST}:${ETCD_PORT}" \
   --public_address_override="127.0.0.1" \
   --kubelet_port=${KUBELET_PORT} \
-  --runtime_config=api/v1beta3 \
+  --runtime_config=api/legacy=false \
   --service-cluster-ip-range="10.0.0.0/24" 1>&2 &
 APISERVER_PID=$!
 
@@ -64,8 +64,6 @@ kube::log::status "Updating " ${SWAGGER_ROOT_DIR}
 curl ${SWAGGER_API_PATH} > ${SWAGGER_ROOT_DIR}/resourceListing.json
 curl ${SWAGGER_API_PATH}version > ${SWAGGER_ROOT_DIR}/version.json
 curl ${SWAGGER_API_PATH}api > ${SWAGGER_ROOT_DIR}/api.json
-curl ${SWAGGER_API_PATH}api/v1beta1 > ${SWAGGER_ROOT_DIR}/v1beta1.json
-curl ${SWAGGER_API_PATH}api/v1beta2 > ${SWAGGER_ROOT_DIR}/v1beta2.json
 curl ${SWAGGER_API_PATH}api/v1beta3 > ${SWAGGER_ROOT_DIR}/v1beta3.json
 
 kube::log::status "SUCCESS"


### PR DESCRIPTION
Deleting v1beta1,2 swagger spec and modifying update-swagger-spec to stop generating it.
This is to stop showing v1beta1,2 apis at kubernetes.io/third_party/swagger-ui/, which should decrease its load time. Its too slow right now.
