### PR TITLE
coreos: standalone: start etcd2

### DIFF
--- a/docs/getting-started-guides/coreos/cloud-configs/standalone.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/standalone.yaml
@@ -13,7 +13,7 @@ coreos:
     initial-cluster: master=http://0.0.0.0:2380
     initial-cluster-state: new
   units:
-    - name: etcd.service
+    - name: etcd2.service
       command: start
     - name: fleet.service
       command: start


### PR DESCRIPTION
We are configuring etcd2 but starting the old etcd service. This will work on a single machine but isn't the user's intention. This is untested, I just wanted to fix it first.
