### PR TITLE
Add groups to service account user.Info

### DIFF
--- a/pkg/controller/serviceaccount/util.go
+++ b/pkg/controller/serviceaccount/util.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccount
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
+)
+
+const (
+	ServiceAccountUsernamePrefix    = "system:serviceaccount:"
+	ServiceAccountUsernameSeparator = ":"
+	ServiceAccountGroupPrefix       = "system:serviceaccounts:"
+	AllServiceAccountsGroup         = "system:serviceaccounts"
+)
+
+// MakeUsername generates a username from the given namespace and ServiceAccount name.
+// The resulting username can be passed to SplitUsername to extract the original namespace and ServiceAccount name.
+func MakeUsername(namespace, name string) string {
+	return ServiceAccountUsernamePrefix + namespace + ServiceAccountUsernameSeparator + name
+}
+
+var invalidUsernameErr = fmt.Errorf("Username must be in the form %s", MakeUsername("namespace", "name"))
+
+// SplitUsername returns the namespace and ServiceAccount name embedded in the given username,
+// or an error if the username is not a valid name produced by MakeUsername
+func SplitUsername(username string) (string, string, error) {
+	if !strings.HasPrefix(username, ServiceAccountUsernamePrefix) {
+		return "", "", invalidUsernameErr
+	}
+	trimmed := strings.TrimPrefix(username, ServiceAccountUsernamePrefix)
+	parts := strings.Split(trimmed, ServiceAccountUsernameSeparator)
+	if len(parts) != 2 {
+		return "", "", invalidUsernameErr
+	}
+	namespace, name := parts[0], parts[1]
+	if ok, _ := validation.ValidateNamespaceName(namespace, false); !ok {
+		return "", "", invalidUsernameErr
+	}
+	if ok, _ := validation.ValidateServiceAccountName(name, false); !ok {
+		return "", "", invalidUsernameErr
+	}
+	return namespace, name, nil
+}
+
+// MakeGroupNames generates service account group names for the given namespace and ServiceAccount name
+func MakeGroupNames(namespace, name string) []string {
+	return []string{
+		AllServiceAccountsGroup,
+		MakeNamespaceGroupName(namespace),
+	}
+}
+
+// MakeNamespaceGroupName returns the name of the group all service accounts in the namespace are included in
+func MakeNamespaceGroupName(namespace string) string {
+	return ServiceAccountGroupPrefix + namespace
+}
+
+// UserInfo returns a user.Info interface for the given namespace, service account name and UID
+func UserInfo(namespace, name, uid string) user.Info {
+	return &user.DefaultInfo{
+		Name:   MakeUsername(namespace, name),
+		UID:    uid,
+		Groups: MakeGroupNames(namespace, name),
+	}
+}

--- a/pkg/controller/serviceaccount/util_test.go
+++ b/pkg/controller/serviceaccount/util_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccount
+
+import "testing"
+
+func TestMakeUsername(t *testing.T) {
+
+	testCases := map[string]struct {
+		Namespace   string
+		Name        string
+		ExpectedErr bool
+	}{
+		"valid": {
+			Namespace:   "foo",
+			Name:        "bar",
+			ExpectedErr: false,
+		},
+		"empty": {
+			ExpectedErr: true,
+		},
+		"empty namespace": {
+			Namespace:   "",
+			Name:        "foo",
+			ExpectedErr: true,
+		},
+		"empty name": {
+			Namespace:   "foo",
+			Name:        "",
+			ExpectedErr: true,
+		},
+		"extra segments": {
+			Namespace:   "foo",
+			Name:        "bar:baz",
+			ExpectedErr: true,
+		},
+		"invalid chars in namespace": {
+			Namespace:   "foo ",
+			Name:        "bar",
+			ExpectedErr: true,
+		},
+		"invalid chars in name": {
+			Namespace:   "foo",
+			Name:        "bar ",
+			ExpectedErr: true,
+		},
+	}
+
+	for k, tc := range testCases {
+		username := MakeUsername(tc.Namespace, tc.Name)
+
+		namespace, name, err := SplitUsername(username)
+		if (err != nil) != tc.ExpectedErr {
+			t.Errorf("%s: Expected error=%v, got %v", k, tc.ExpectedErr, err)
+			continue
+		}
+		if err != nil {
+			continue
+		}
+
+		if namespace != tc.Namespace {
+			t.Errorf("%s: Expected namespace %q, got %q", k, tc.Namespace, namespace)
+		}
+		if name != tc.Name {
+			t.Errorf("%s: Expected name %q, got %q", k, tc.Name, name)
+		}
+	}
+}


### PR DESCRIPTION
- Adds the `system:` prefix to service account usernames to follow the pattern for other system-created usernames
- Adds two groups to the `user.Info` returned from the JWT authenticator
  - `system:serviceaccounts`, which is useful for granting authorization to all service accounts
  - `system:serviceaccounts:<namespace>`, which is useful for granting authorization to all service accounts in a given namespace
