### PR TITLE
Repoint flannel-docker service to ~kubernetes namespace

### DIFF
--- a/cluster/juju/bundles/local.yaml
+++ b/cluster/juju/bundles/local.yaml
@@ -10,7 +10,7 @@ kubernetes-local:
         version: "v0.15.0"
     docker:
       charm: docker
-      branch: https://github.com/chuckbutler/docker-charm.git
+      branch: cs:trusty/docker
       num_units: 2
       options:
         latest: true
@@ -18,8 +18,7 @@ kubernetes-local:
         "gui-x": "0"
         "gui-y": "0"
     flannel-docker:
-      charm: flannel-docker
-      branch: https://github.com/chuckbutler/flannel-docker-charm.git
+      charm: cs:~kubernetes/trusty/flannel-docker
       annotations:
         "gui-x": "0"
         "gui-y": "300"

--- a/cluster/juju/bundles/local.yaml
+++ b/cluster/juju/bundles/local.yaml
@@ -9,8 +9,7 @@ kubernetes-local:
       options:
         version: "v0.15.0"
     docker:
-      charm: docker
-      branch: cs:trusty/docker
+      charm: cs:trusty/docker
       num_units: 2
       options:
         latest: true


### PR DESCRIPTION
This branch of the charm-store charm is tracking features targeted at
kubernetes based deployments, while the devel focus will continually be
in a state of experimentation and learning.

As all things awesome - deploy in lockstep from a source that has
extensive testing to ensure we aren't handing out experimental code that
hasn't been fully tested e2e w/ the kubernetes project.
