### PR TITLE
quick fix to global (and possibly shadowing) client var

### DIFF
--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -31,8 +31,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var c *client.Client = nil
-
 func LaunchNetTestPodPerNode(nodes *api.NodeList, name string, c *client.Client, ns string) []string {
 	podNames := []string{}
 

--- a/test/e2e/reboot.go
+++ b/test/e2e/reboot.go
@@ -55,6 +55,9 @@ const (
 )
 
 var _ = Describe("Reboot", func() {
+
+	var c *client.Client = nil
+
 	BeforeEach(func() {
 		var err error
 		c, err = loadClient()

--- a/test/e2e/ssh.go
+++ b/test/e2e/ssh.go
@@ -20,11 +20,16 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("SSH", func() {
+
+	var c *client.Client = nil
+
 	BeforeEach(func() {
 		var err error
 		c, err = loadClient()


### PR DESCRIPTION
Hey guys ! I mistakenly added a global client variable a while back , was just dutifully noticed by folks in #8630 .  

It turns out that this is being used by a few of the tests on accident - people just imported it without checking where it was coming from.

Lets clean this guy up ! heres a PR its untested (still wrapping my head around the new e2e command line options), but i think it will work perfectly.
