### PR TITLE
Prevent the kubelet on the master from registering itself into the cluster on GCE.

### DIFF
--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -22,6 +22,14 @@
   {% set api_servers_with_port = api_servers + ":6443" -%}
 {% endif -%}
 
+# Disable registration for the kubelet running on the master on GCE.
+# TODO(roberthbailey): Make this configurable via an env var in config-default.sh
+{% if grains.cloud == 'gce' -%}
+  {% if grains['roles'][0] == 'kubernetes-master' -%}
+    {% set api_servers_with_port = "" -%}
+  {% endif -%}
+{% endif -%}
+
 {% set config = "--config=/etc/kubernetes/manifests" -%}
 {% set hostname_override = "" -%}
 {% if grains.hostname_override is defined -%}


### PR DESCRIPTION
This was earlier done as part of #6949 but removed when that PR was rolled back. Without it, the kubelet on the master attempts to register itself but presents a certificate that is not accepted by the master, which causes the apiserver logs to fill up with lines like

`I0521 20:53:40.031124 5 logs.go:41] http: TLS handshake error from 10.240.222.136:36021: remote error: bad certificate`
