### PR TITLE
Add an advertise-address flag

### DIFF
--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -494,9 +494,10 @@ EOF
 token-url = ${TOKEN_URL}
 project-id = ${PROJECT_ID}
 EOF
+    EXTERNAL_IP=$(curl --fail --silent -H 'Metadata-Flavor: Google' "http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip")
     cat <<EOF >>/etc/salt/minion.d/grains.conf
   cloud_config: /etc/gce.conf
-  advertise_address: '${KUBERNETES_MASTER_NAME}'
+  advertise_address: '${EXTERNAL_IP}'
 EOF
   fi
 }

--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -496,6 +496,7 @@ project-id = ${PROJECT_ID}
 EOF
     cat <<EOF >>/etc/salt/minion.d/grains.conf
   cloud_config: /etc/gce.conf
+  advertise_address: '${KUBERNETES_MASTER_NAME}'
 EOF
   fi
 }

--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
@@ -22,6 +22,11 @@
 
 {% endif -%}
 
+{% set advertise_address = "" -%}
+{% if grains.advertise_address is defined -%}
+  {% set advertise_address = "--advertise-address=" + grains.advertise_address -%}
+{% endif -%}
+
 {% set address = "--address=127.0.0.1" -%}
 
 {% set cluster_name = "" -%}
@@ -29,9 +34,9 @@
   {% set cluster_name = "--cluster_name=" + pillar['instance_prefix'] -%}
 {% endif -%}
 
-{% set publicAddressOverride = "" -%}
+{% set bind_address = "" -%}
 {% if grains.publicAddressOverride is defined -%}
-  {% set publicAddressOverride = "--public_address_override=" + grains.publicAddressOverride -%}
+  {% set bind_address = "--bind-address=" + grains.publicAddressOverride -%}
 {% endif -%}
 
 {% set etcd_servers = "--etcd_servers=http://127.0.0.1:4001" -%}
@@ -75,8 +80,7 @@
 {% endif -%}
 
 {% set params = address + " " + etcd_servers + " " + cloud_provider + " " + cloud_config + " " + runtime_config + " " + admission_control + " " + service_cluster_ip_range + " " + client_ca_file + " " + basic_auth_file -%}
-{% set params = params + " " + cluster_name + " " + cert_file + " " + key_file + " --secure_port=" + secure_port + " " + token_auth_file + " " + publicAddressOverride + " " + pillar['log_level'] -%}
-
+{% set params = params + " " + cluster_name + " " + cert_file + " " + key_file + " --secure_port=" + secure_port + " " + token_auth_file + " " + publicAddressOverride + " " + pillar['log_level'] + " " + advertise_address -%}
 
 {
 "apiVersion": "v1beta3",

--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
@@ -80,7 +80,7 @@
 {% endif -%}
 
 {% set params = address + " " + etcd_servers + " " + cloud_provider + " " + cloud_config + " " + runtime_config + " " + admission_control + " " + service_cluster_ip_range + " " + client_ca_file + " " + basic_auth_file -%}
-{% set params = params + " " + cluster_name + " " + cert_file + " " + key_file + " --secure_port=" + secure_port + " " + token_auth_file + " " + publicAddressOverride + " " + pillar['log_level'] + " " + advertise_address -%}
+{% set params = params + " " + cluster_name + " " + cert_file + " " + key_file + " --secure_port=" + secure_port + " " + token_auth_file + " " + bind_address + " " + pillar['log_level'] + " " + advertise_address -%}
 
 {
 "apiVersion": "v1beta3",

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -58,6 +58,7 @@ type APIServer struct {
 	InsecureBindAddress        util.IP
 	InsecurePort               int
 	BindAddress                util.IP
+	AdvertiseAddress           util.IP
 	ReadOnlyPort               int
 	SecurePort                 int
 	ExternalHost               string
@@ -145,8 +146,13 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 		"Defaults to localhost.")
 	fs.Var(&s.InsecureBindAddress, "address", "DEPRECATED: see --insecure-bind-address instead")
 	fs.Var(&s.BindAddress, "bind-address", ""+
-		"The IP address on which to serve the --read-only-port and --secure-port ports. This "+
-		"address must be reachable by the rest of the cluster. If blank, all interfaces will be used.")
+		"The IP address on which to serve the --read-only-port and --secure-port ports. The "+
+		"associated interface(s) must be reachable by the rest of the cluster, and by CLI/web "+
+		"clients. If blank, all interfaces will be used (0.0.0.0).")
+	fs.Var(&s.AdvertiseAddress, "advertise-address", ""+
+		"The IP address on which to advertise the apiserver to members of the cluster. This "+
+		"address must be reachable by the rest of the cluster. If blank, all interfaces will be "+
+		"used.")
 	fs.Var(&s.BindAddress, "public-address-override", "DEPRECATED: see --bind-address instead")
 	fs.IntVar(&s.ReadOnlyPort, "read-only-port", s.ReadOnlyPort, ""+
 		"The port on which to serve read-only resources. If 0, don't serve read-only "+
@@ -356,7 +362,7 @@ func (s *APIServer) Run(_ []string) error {
 		CorsAllowedOriginList:  s.CorsAllowedOriginList,
 		ReadOnlyPort:           s.ReadOnlyPort,
 		ReadWritePort:          s.SecurePort,
-		PublicAddress:          net.IP(s.BindAddress),
+		PublicAddress:          net.IP(s.AdvertiseAddress),
 		Authenticator:          authenticator,
 		SupportsBasicAuth:      len(s.BasicAuthFile) > 0,
 		Authorizer:             authorizer,
@@ -443,6 +449,7 @@ func (s *APIServer) Run(_ []string) error {
 				if s.TLSCertFile == "" && s.TLSPrivateKeyFile == "" {
 					s.TLSCertFile = path.Join(s.CertDirectory, "apiserver.crt")
 					s.TLSPrivateKeyFile = path.Join(s.CertDirectory, "apiserver.key")
+					// TODO (cjcullen): Is PublicAddress the right address to sign a cert with?
 					if err := util.GenerateSelfSignedCert(config.PublicAddress.String(), s.TLSCertFile, s.TLSPrivateKeyFile); err != nil {
 						glog.Errorf("Unable to generate self signed cert: %v", err)
 					} else {

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -127,7 +127,7 @@ type Config struct {
 
 	// PublicAddress is the IP address where members of the cluster (kubelet,
 	// kube-proxy, services, etc.) can reach the master.
-	// If nil or 0.0.0.0, the first result from net.InterfaceAddrs will be used.
+	// If nil or 0.0.0.0, the host's default interface will be used.
 	PublicAddress net.IP
 
 	// Control the interval that pod, node IP, and node heath status caches

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -125,7 +125,9 @@ type Config struct {
 	// ExternalHost is the host name to use for external (public internet) facing URLs (e.g. Swagger)
 	ExternalHost string
 
-	// If nil, the first result from net.InterfaceAddrs will be used.
+	// PublicAddress is the IP address where members of the cluster (kubelet,
+	// kube-proxy, services, etc.) can reach the master.
+	// If nil or 0.0.0.0, the first result from net.InterfaceAddrs will be used.
 	PublicAddress net.IP
 
 	// Control the interval that pod, node IP, and node heath status caches


### PR DESCRIPTION
This allows the address that the apiserver binds to (possibly 0.0.0.0) to be different than the address on which members of the cluster can reach the apiserver (possibly not a local interface).
