### PR TITLE
Quick fix for listPods with nil parameters

### DIFF
--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -359,6 +359,9 @@ func (r *Request) FieldsSelectorParam(s fields.Selector) *Request {
 	if r.err != nil {
 		return r
 	}
+	if s == nil {
+		return r
+	}
 	if s.Empty() {
 		return r
 	}
@@ -375,6 +378,9 @@ func (r *Request) FieldsSelectorParam(s fields.Selector) *Request {
 // LabelsSelectorParam adds the given selector as a query parameter
 func (r *Request) LabelsSelectorParam(s labels.Selector) *Request {
 	if r.err != nil {
+		return r
+	}
+	if s == nil {
 		return r
 	}
 	if s.Empty() {


### PR DESCRIPTION
Hello everyone,

Quick fix for a small issue encountered today using client.ListPods() with labels and fields selectors at nil. 

Thanks.
