### PR TITLE
bump timeout back to previous time

### DIFF
--- a/pkg/kubectl/stop.go
+++ b/pkg/kubectl/stop.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	Interval = time.Millisecond * 100
-	Timeout  = time.Second * 20
+	Timeout  = time.Minute * 5
 )
 
 // A Reaper handles terminating an object as gracefully as possible.


### PR DESCRIPTION
@smarterclayton @bprashanth bumped timeout back to its previous time (https://github.com/GoogleCloudPlatform/kubernetes/pull/8560) since bulk deleting replication controllers currently needs more time (slow rc manager?).
