### PR TITLE
Improve handling of Aggregate errors in cmdutil.CheckErr

### DIFF
--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -140,7 +140,7 @@ func MultipleErrors(prefix string, errs []error) string {
 func messageForError(err error) string {
 	msg, ok := StandardErrorMessage(err)
 	if !ok {
-		msg = err.Error()
+		msg = fmt.Sprintf("error: %s\n", err.Error())
 	}
 	return msg
 }


### PR DESCRIPTION
If no errors are included in the aggregate, simply return. If a single error included, treat as single error.
