### PR TITLE
Contrib/git sync

### DIFF
--- a/contrib/git-sync/demo/config/pod.yaml
+++ b/contrib/git-sync/demo/config/pod.yaml
@@ -1,50 +1,47 @@
-id: blog-pod
+apiVersion: v1beta3
 kind: Pod
-apiVersion: v1beta1
-desiredState:
-  manifest:
-    version: v1beta1
-    containers:
-    - name: git-sync
-      image: proppy/git-sync
-      imagePullPolicy: PullAlways
-      env:
-      - name: GIT_SYNC_REPO
-        value: https://github.com/GoogleCloudPlatform/kubernetes.git
-      - name: GIT_SYNC_DEST
-        value: /git
-      volumeMounts:
-      - name: markdown
-        mountPath: /git
-    - name: hugo
-      image: proppy/hugo
-      imagePullPolicy: PullAlways
-      env:
-      - name: HUGO_SRC
-        value: /src/contrib/git-sync/demo/blog
-      - name: HUGO_BUILD_DRAFT
-        value: 'true'
-      - name: HUGO_BASE_URL
-        value: example.com
-      volumeMounts:
-      - name: markdown
-        mountPath: /src
-      - name: html
-        mountPath: /dest
-    - name: nginx
-      image: nginx
-      volumeMounts:
-      - name: html
-        mountPath: /usr/share/nginx/html
-      ports:
-      - name: http-server
-        containerPort: 80
-    volumes:
+metadata:
+  labels:
+    name: blog
+  name: blog-pod
+spec:
+  containers:
+  - name: git-sync
+    image: gcr.io/google_containers/git-sync
+    imagePullPolicy: Always
+    volumeMounts:
     - name: markdown
-      source:
-        emptyDir: {}
+      mountPath: /git
+    env:
+    - name: GIT_SYNC_REPO
+      value: https://github.com/GoogleCloudPlatform/kubernetes.git
+    - name: GIT_SYNC_DEST
+      value: /git
+  - name: hugo
+    image: gcr.io/google_containers/hugo
+    imagePullPolicy: Always
+    volumeMounts:
+    - name: markdown
+      mountPath: /src
     - name: html
-      source:
-        emptyDir: {}
-labels:
-  name: blog
+      mountPath: /dest
+    env:
+    - name: HUGO_SRC
+      value: /src/contrib/git-sync/demo/blog
+    - name: HUGO_BUILD_DRAFT
+      value: "true"
+    - name: HUGO_BASE_URL
+      value: example.com
+  - name: nginx
+    image: nginx
+    volumeMounts:
+    - name: html
+      mountPath: /usr/share/nginx/html
+    ports:
+    - name: http-server
+      containerPort: 80
+  volumes:
+  - name: markdown
+    emptyDir: {}
+  - name: html
+    emptyDir: {}

--- a/contrib/git-sync/demo/config/pod.yaml
+++ b/contrib/git-sync/demo/config/pod.yaml
@@ -38,8 +38,7 @@ spec:
     - name: html
       mountPath: /usr/share/nginx/html
     ports:
-    - name: http-server
-      containerPort: 80
+    - containerPort: 80
   volumes:
   - name: markdown
     emptyDir: {}

--- a/contrib/git-sync/demo/config/service.yaml
+++ b/contrib/git-sync/demo/config/service.yaml
@@ -1,8 +1,10 @@
-id: blog-service
+apiVersion: v1beta3
 kind: Service
-apiVersion: v1beta1
-port: 80
-containerPort: 80
-selector:
-  name: blog
-createExternalLoadBalancer: true
+metadata:
+  name: blog-service
+spec:
+  createExternalLoadBalancer: true
+  ports:
+  - port: 80
+  selector:
+    name: blog

--- a/contrib/git-sync/main.go
+++ b/contrib/git-sync/main.go
@@ -66,12 +66,14 @@ func main() {
 	if _, err := exec.LookPath("git"); err != nil {
 		log.Fatalf("required git executable not found: %v", err)
 	}
-	if err := syncRepo(*flRepo, *flDest, *flBranch, *flRev); err != nil {
-		log.Fatalf("error syncing repo: %v", err)
+	for {
+		if err := syncRepo(*flRepo, *flDest, *flBranch, *flRev); err != nil {
+			log.Fatalf("error syncing repo: %v", err)
+		}
+		log.Printf("wait %d seconds", *flWait)
+		time.Sleep(time.Duration(*flWait) * time.Second)
+		log.Println("done")
 	}
-	log.Printf("wait %d seconds", *flWait)
-	time.Sleep(time.Duration(*flWait) * time.Second)
-	log.Println("done")
 }
 
 // syncRepo syncs the branch of a given repository to the destination at the given rev.


### PR DESCRIPTION
update contrib/git-sync/demo to v1beta3;

let the contrib/git-sync/main.go use a for-loop, rather than relying on the pod's restart policy, to periodically pull from the repo;

@krousey @proppy @yujuhong 

fix #8327
ref #8087

@proppy, you can change the image field in the pod configuration back to your repo after you update the image. Thanks.
