### PR TITLE
Explain that CoreOS 653.0.0+ is required for etcd2

### DIFF
--- a/docs/getting-started-guides/coreos/coreos_multinode_cluster.md
+++ b/docs/getting-started-guides/coreos/coreos_multinode_cluster.md
@@ -2,7 +2,9 @@
 
 Use the [master.yaml](cloud-configs/master.yaml) and [node.yaml](cloud-configs/node.yaml) cloud-configs to provision a multi-node Kubernetes cluster.
 
-> **Attention**: This requires at least CoreOS version **653.0.0**.
+> **Attention**: This requires at least CoreOS version **[653.0.0][coreos653]**, as this was the first release to include etcd2.
+
+[coreos653]: https://coreos.com/releases/#653.0.0
 
 ## Overview
 

--- a/docs/getting-started-guides/coreos/coreos_single_node_cluster.md
+++ b/docs/getting-started-guides/coreos/coreos_single_node_cluster.md
@@ -2,7 +2,9 @@
 
 Use the [standalone.yaml](cloud-configs/standalone.yaml) cloud-config to provision a single node Kubernetes cluster.
 
-> **Attention**: This requires at least CoreOS version **653.0.0**.
+> **Attention**: This requires at least CoreOS version **[653.0.0][coreos653]**, as this was the first release to include etcd2.
+
+[coreos653]: https://coreos.com/releases/#653.0.0
 
 ### CoreOS image versions
 


### PR DESCRIPTION
This way inquisitive people won't have to check the blame to see why
that version is required.
