### PR TITLE
Nodeport GCE e2e fixes

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -923,6 +923,15 @@ function test-setup {
     --allow tcp:80 tcp:8080 \
     --network "${NETWORK}" \
     "${MINION_TAG}-${INSTANCE_PREFIX}-http-alt"
+
+  # Open up the NodePort range
+  # TODO(justinsb): Move to main setup, if we decide whether we want to do this by default.
+  gcloud compute firewall-rules create \
+    --project "${PROJECT}" \
+    --target-tags "${MINION_TAG}" \
+    --allow tcp:30000-32767,udp:30000-32767 \
+    --network "${NETWORK}" \
+    "${MINION_TAG}-${INSTANCE_PREFIX}-nodeports"
 }
 
 # Execute after running tests to perform any required clean-up. This is called
@@ -934,6 +943,10 @@ function test-teardown {
     --project "${PROJECT}" \
     --quiet \
     "${MINION_TAG}-${INSTANCE_PREFIX}-http-alt" || true
+  gcloud compute firewall-rules delete  \
+    --project "${PROJECT}" \
+    --quiet \
+    "${MINION_TAG}-${INSTANCE_PREFIX}-nodeports" || true
   "${KUBE_ROOT}/cluster/kube-down.sh"
 }
 

--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -171,6 +171,13 @@ function test-setup() {
     --project "${PROJECT}" \
     --target-tags "${MINION_TAG}" \
     --network="${NETWORK}"
+
+  "${GCLOUD}" compute firewall-rules create \
+    "${MINION_TAG}-${USER}-nodeports" \
+    --allow tcp:30000-32767,udp:30000-32767 \
+    --project "${PROJECT}" \
+    --target-tags "${MINION_TAG}" \
+    --network="${NETWORK}"
 }
 
 # Ensure that we have a password created for validating to the master.
@@ -285,8 +292,10 @@ function test-teardown() {
   MINION_TAG="k8s-${CLUSTER_NAME}-node"
 
   # First, remove anything we did with test-setup (currently, the firewall).
-  # NOTE: Keep in sync with name above in test-setup.
+  # NOTE: Keep in sync with names above in test-setup.
   "${GCLOUD}" compute firewall-rules delete "${MINION_TAG}-${USER}-http-alt" \
+    --project="${PROJECT}" || true
+  "${GCLOUD}" compute firewall-rules delete "${MINION_TAG}-${USER}-nodeports" \
     --project="${PROJECT}" || true
 
   # Then actually turn down the cluster.

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -488,6 +488,7 @@ var _ = Describe("Services", func() {
 
 		By("changing service " + serviceName + " back to type=ClusterIP")
 		service.Spec.Type = api.ServiceTypeClusterIP
+		service.Spec.Ports[0].NodePort = 0
 		service, err = c.Services(ns).Update(service)
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Big thing is that we need to tell the test scripts to open the firewall rules for NodePorts for e2e tests.  This is in the test-specific bit of gce/gke utils.sh.  I expect these should be moved so that the NodePort range is always opened for users (unless they directly ask otherwise), but I think that warrants more consideration, and I know we want to get e2e passing again.

WIP while I test myself with a full -down & -up.

The other issue is that I lost a line in my git-work that puts the NodePort to 0, which is required when changing from NodePort -> ClusterIP.

cc @dchen1107 
