### PR TITLE
e2e: Set (short) timeout for http request polling

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1091,12 +1091,14 @@ func testNotReachable(ip string, port int) {
 
 // Does an HTTP GET, but does not reuse TCP connections
 // This masks problems where the iptables rule has changed, but we don't see it
+// This is intended for relatively quick requests (status checks), so we set a short (5 seconds) timeout
 func httpGetNoConnectionPool(url string) (*http.Response, error) {
 	tr := &http.Transport{
 		DisableKeepAlives: true,
 	}
 	client := &http.Client{
 		Transport: tr,
+		Timeout:   5 * time.Second,
 	}
 
 	return client.Get(url)


### PR DESCRIPTION
In the e2e tests, set a 5s timeout on HTTP requests when we're checking whether a url is reachable.

We run this in a loop anyway, and we also check that a service is _not_ reachable (once we've closed it), so having a sensible timeout helps the tests run much faster.
