### PR TITLE
Fixes #6264: Only add websocket upgrade header if client actually requests it

### DIFF
--- a/cluster/saltbase/salt/nginx/kubernetes-site
+++ b/cluster/saltbase/salt/nginx/kubernetes-site
@@ -61,6 +61,6 @@ server {
           # Support web sockets
           proxy_http_version 1.1;
           proxy_set_header Upgrade $http_upgrade;
-          proxy_set_header Connection "upgrade";
+          proxy_set_header Connection $connection_upgrade;
         }
 }

--- a/cluster/saltbase/salt/nginx/nginx.conf
+++ b/cluster/saltbase/salt/nginx/nginx.conf
@@ -52,6 +52,11 @@ http {
 	# gzip_http_version 1.1;
 	# gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
+	map $http_upgrade $connection_upgrade {
+		default upgrade;
+		''      close;
+	}
+
 	##
 	# Virtual Host Configs
 	##


### PR DESCRIPTION
Current behaviour always adds upgrade websocket header. This should only be added if client request contains this header.

The configuration for the optional upgrade header comes from the nginx docs at http://nginx.org/en/docs/http/websocket.html.
