### PR TITLE
API server explicitly notify systemd of successful startup

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -95,6 +95,11 @@
 			"Rev": "6fe83ccda8fb9b7549c9ab4ba47f47858bc950aa"
 		},
 		{
+			"ImportPath": "github.com/coreos/go-systemd/daemon",
+			"Comment": "v2-27-g97e243d",
+			"Rev": "97e243d21a8e232e9d8af38ba2366dfcfceebeba"
+		},
+		{
 			"ImportPath": "github.com/coreos/go-systemd/dbus",
 			"Comment": "v2-27-g97e243d",
 			"Rev": "97e243d21a8e232e9d8af38ba2366dfcfceebeba"

--- a/Godeps/_workspace/src/github.com/coreos/go-systemd/daemon/sdnotify.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-systemd/daemon/sdnotify.go
@@ -1,0 +1,31 @@
+// Code forked from Docker project
+package daemon
+
+import (
+	"errors"
+	"net"
+	"os"
+)
+
+var SdNotifyNoSocket = errors.New("No socket")
+
+// SdNotify sends a message to the init daemon. It is common to ignore the error.
+func SdNotify(state string) error {
+	socketAddr := &net.UnixAddr{
+		Name: os.Getenv("NOTIFY_SOCKET"),
+		Net:  "unixgram",
+	}
+
+	if socketAddr.Name == "" {
+		return SdNotifyNoSocket
+	}
+
+	conn, err := net.DialUnix(socketAddr.Net, nil, socketAddr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	_, err = conn.Write([]byte(state))
+	return err
+}

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	forked "github.com/GoogleCloudPlatform/kubernetes/third_party/forked/coreos/go-etcd/etcd"
+	systemd "github.com/coreos/go-systemd/daemon"
 
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/golang/glog"
@@ -455,6 +456,7 @@ func (s *APIServer) Run(_ []string) error {
 						glog.Infof("Using self-signed cert (%s, %s)", s.TLSCertFile, s.TLSPrivateKeyFile)
 					}
 				}
+				_ = systemd.SdNotify("READY=1\n")
 				if err := secureServer.ListenAndServeTLS(s.TLSCertFile, s.TLSPrivateKeyFile); err != nil {
 					glog.Errorf("Unable to listen for secure (%v); will try again.", err)
 				}
@@ -468,6 +470,9 @@ func (s *APIServer) Run(_ []string) error {
 		ReadTimeout:    ReadWriteTimeout,
 		WriteTimeout:   ReadWriteTimeout,
 		MaxHeaderBytes: 1 << 20,
+	}
+	if secureLocation == "" {
+		_ = systemd.SdNotify("READY=1\n")
 	}
 	glog.Infof("Serving insecurely on %s", insecureLocation)
 	glog.Fatal(http.ListenAndServe())

--- a/contrib/init/systemd/kube-apiserver.service
+++ b/contrib/init/systemd/kube-apiserver.service
@@ -18,6 +18,7 @@ ExecStart=/usr/bin/kube-apiserver \
 	    $KUBE_ADMISSION_CONTROL \
 	    $KUBE_API_ARGS
 Restart=on-failure
+Type=notify
 LimitNOFILE=65536
 
 [Install]


### PR DESCRIPTION
Use the systemd $NOTIFY_SOCKET convention for kube-apiserver
startup. This allows it to be part of dependency trees and for
consumers to wait until it is listening on its ports.

The $NOTIFY_SOCKET protocol is described here:

http://www.freedesktop.org/software/systemd/man/sd_notify.html

Currently this is limited to the kube-apiserver process. Other
kube processes are internal kubernetes moving points. The API
server is the entry point relied on by callers.

100% stolen from Stef Walter from:
https://github.com/GoogleCloudPlatform/kubernetes/pull/8316
