### PR TITLE
Fix build with --use_go_build (e2e.test failure)

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -327,20 +327,20 @@ kube::golang::build_binaries_for_platform() {
 
   if [[ -n ${use_go_build:-} ]]; then
     kube::log::progress "    "
-    for binary in "${binaries[@]}"; do
-      local outfile=$(kube::golang::output_filename_for_binary "${binary}" \
-        "${platform}")
-      if kube::golang::is_statically_linked_library "${binary}"; then
-        CGO_ENABLED=0 go build -o "${outfile}" \
-          "${goflags[@]:+${goflags[@]}}" \
-          -ldflags "${version_ldflags}" \
-          "${binary}"
-      else
-        go build -o "${outfile}" \
-          "${goflags[@]:+${goflags[@]}}" \
-          -ldflags "${version_ldflags}" \
-          "${binary}"
-      fi
+    for binary in "${statics[@]:+${statics[@]}}"; do
+      local outfile=$(kube::golang::output_filename_for_binary "${binary}" "${platform}")
+      CGO_ENABLED=0 go build -o "${outfile}" \
+        "${goflags[@]:+${goflags[@]}}" \
+        -ldflags "${version_ldflags}" \
+        "${binary}"
+      kube::log::progress "*"
+    done
+    for binary in "${nonstatics[@]:+${nonstatics[@]}}"; do
+      local outfile=$(kube::golang::output_filename_for_binary "${binary}" "${platform}")
+      go build -o "${outfile}" \
+        "${goflags[@]:+${goflags[@]}}" \
+        -ldflags "${version_ldflags}" \
+        "${binary}"
       kube::log::progress "*"
     done
     kube::log::progress "\n"


### PR DESCRIPTION
hack/build-go.sh --use_go_build would fail because e2e.test was not being
excluded from the set of things that we were "go build"ing

Instead of walking all binaries, only walk static and nonstatic

```
$ hack/build-go.sh
+++ [0524 18:09:51] Building go targets for linux/amd64:
    cmd/kube-proxy
    cmd/kube-apiserver
    cmd/kube-controller-manager
    cmd/kubelet
    cmd/hyperkube
    cmd/kubernetes
    plugin/cmd/kube-scheduler
    cmd/kubectl
    cmd/integration
    cmd/gendocs
    cmd/genman
    cmd/genbashcomp
    examples/k8petstore/web-server
    github.com/onsi/ginkgo/ginkgo
    test/e2e/e2e.test
+++ [0524 18:09:51] +++ Warning: stdlib pkg with cgo flag not found.
+++ [0524 18:09:51] +++ Warning: stdlib pkg cannot be rebuilt since /usr/lib/golang/pkg is not writable by eparis
+++ [0524 18:09:51] +++ Warning: Make /usr/lib/golang/pkg writable for eparis for a one-time stdlib install, Or
+++ [0524 18:09:51] +++ Warning: Rebuild stdlib using the command 'CGO_ENABLED=0 go install -a -installsuffix cgo std'
+++ [0524 18:09:51] +++ Falling back to go build, which is slower
    **************can't load package: package github.com/GoogleCloudPlatform/kubernetes/test/e2e/e2e.test: cannot find package "github.com/GoogleCloudPlatform/kubernetes/test/e2e/e2e.test" in any of:
    /usr/lib/golang/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/e2e.test (from $GOROOT)
    /storage/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/e2e.test (from $GOPATH)
    /storage/kubernetes/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/e2e.test
!!! Error in /storage/kubernetes/hack/lib/golang.sh:339
  'go build -o "${outfile}" "${goflags[@]:+${goflags[@]}}" -ldflags "${version_ldflags}" "${binary}"' exited with status 1
Call stack:
  1: /storage/kubernetes/hack/lib/golang.sh:339 kube::golang::build_binaries_for_platform(...)
  2: /storage/kubernetes/hack/lib/golang.sh:488 kube::golang::build_binaries(...)
  3: hack/build-go.sh:26 main(...)
Exiting with status 1
!!! Error in /storage/kubernetes/hack/lib/golang.sh:406
  '( kube::golang::setup_env; local version_ldflags; version_ldflags=$(kube::version::ldflags); local host_platform; host_platform=$(kube::golang::host_platform); local goflags; eval "goflags=(${KUBE_GOFLAGS:-})"; local use_go_build; local -a targets=(); local arg; for arg in "$@";
do
    if [[ "${arg}" == "--use_go_build" ]]; then
        use_go_build=true;
    else
        if [[ "${arg}" == -* ]]; then
            goflags+=("${arg}");
        else
            targets+=("${arg}");
        fi;
    fi;
done; if [[ ${#targets[@]} -eq 0 ]]; then
    targets=("${KUBE_ALL_TARGETS[@]}");
fi; local -a platforms=("${KUBE_BUILD_PLATFORMS[@]:+${KUBE_BUILD_PLATFORMS[@]}}"); if [[ ${#platforms[@]} -eq 0 ]]; then
    platforms=("${host_platform}");
fi; local binaries; binaries=($(kube::golang::binaries_from_targets "${targets[@]}")); local parallel=false; if [[ ${#platforms[@]} -gt 1 ]]; then
    local gigs; gigs=$(kube::golang::get_physmem); if [[ ${gigs} -gt ${KUBE_PARALLEL_BUILD_MEMORY} ]]; then
        kube::log::status "Multiple platforms requested and available ${gigs}G > threshold ${KUBE_PARALLEL_BUILD_MEMORY}G, building platforms in parallel"; parallel=true;
    else
        kube::log::status "Multiple platforms requested, but available ${gigs}G < threshold ${KUBE_PARALLEL_BUILD_MEMORY}G, building platforms in serial"; parallel=false;
    fi;
fi; if [[ "${parallel}" == "true" ]]; then
    kube::log::status "Building go targets for ${platforms[@]} in parallel (output will appear in a burst when complete):" "${targets[@]}"; local platform; for platform in "${platforms[@]}";
    do
        ( kube::golang::set_platform_envs "${platform}"; kube::log::status "${platform}: go build started"; kube::golang::build_binaries_for_platform ${platform} ${use_go_build:-}; kube::log::status "${platform}: go build finished" ) &> "/tmp//${platform//\//_}.build" &
    done; local fails=0; for job in $(jobs -p);
    do
        wait ${job} || let "fails+=1";
    done; for platform in "${platforms[@]}";
    do
        cat "/tmp//${platform//\//_}.build";
    done; exit ${fails};
else
    for platform in "${platforms[@]}";
    do
        kube::log::status "Building go targets for ${platform}:" "${targets[@]}"; kube::golang::set_platform_envs "${platform}"; kube::golang::build_binaries_for_platform ${platform} ${use_go_build:-};
    done;
fi )' exited with status 1
Call stack:
  1: /storage/kubernetes/hack/lib/golang.sh:406 kube::golang::build_binaries(...)
  2: hack/build-go.sh:26 main(...)
Exiting with status 1
```
