### PR TITLE
Increase timeout for deleting RC in e2e tests.

### DIFF
--- a/pkg/kubectl/stop.go
+++ b/pkg/kubectl/stop.go
@@ -60,6 +60,10 @@ func ReaperFor(kind string, c client.Interface) (Reaper, error) {
 	return nil, &NoSuchReaperError{kind}
 }
 
+func ReaperForReplicationController(c client.Interface, timeout time.Duration) (Reaper, error) {
+	return &ReplicationControllerReaper{c, Interval, timeout}, nil
+}
+
 type ReplicationControllerReaper struct {
 	client.Interface
 	pollInterval, timeout time.Duration

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -827,11 +827,14 @@ func waitForRCPodsRunning(c *client.Client, ns, rcName string) error {
 // Delete a Replication Controller and all pods it spawned
 func DeleteRC(c *client.Client, ns, name string) error {
 	By(fmt.Sprintf("Deleting replication controller %s in namespace %s", name, ns))
-	reaper, err := kubectl.ReaperFor("ReplicationController", c)
+	reaper, err := kubectl.ReaperForReplicationController(c, 10*time.Minute)
 	if err != nil {
 		return err
 	}
+	startTime := time.Now()
 	_, err = reaper.Stop(ns, name, api.NewDeleteOptions(0))
+	deleteRCTime := time.Now().Sub(startTime)
+	Logf("Deleting RC took: %v", deleteRCTime)
 	return err
 }
 


### PR DESCRIPTION
Ref #7561 

I wasn't able to reproduce the the timeout - for me it takes 2m30s - 3m30s. However, I'm increasing a limit with additional logging on how long did it take - we will be able to look into its results on Jenkins thanks to it.
