### PR TITLE
kubectl's dir should be 386 not x86 in x86 enviroment

### DIFF
--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -59,7 +59,7 @@ case "$(uname -m)" in
     host_arch=arm
     ;;
   i?86*)
-    host_arch=x86
+    host_arch=386
     ;;
   *)
     echo "Unsupported host arch. Must be x86_64, 386 or arm." >&2


### PR DESCRIPTION
Before applying this patch, `cluster/kubectl.sh` failed to find `kubectl` binary in x86 environment.
This results in users seeing the following error message.

> It looks as if you don't have a compiled kubectl binary
> 
> If you are running from a clone of the git repo, please run
> './build/run.sh hack/build-cross.sh'. Note that this requires having
> Docker installed.
> 
> If you are running from a binary release tarball, something is wrong. 
> Look at http://kubernetes.io/ for information on how to contact the 
> development team for help.

e.g. The latest release v0.17.1 contains the following binaries. Their directories are `386` not `x86`.
https://github.com/GoogleCloudPlatform/kubernetes/releases/tag/v0.17.1

```
$ tree platforms/
platforms/
├── darwin
│   ├── 386
│   │   └── kubectl
│   └── amd64
│       └── kubectl
├── linux
│   ├── 386
│   │   └── kubectl
│   ├── amd64
│   │   └── kubectl
│   └── arm
│       └── kubectl
└── windows
    └── amd64
            └── kubectl.exe
```
