### PR TITLE
Correct copyright in proxysocket.go

### DIFF
--- a/pkg/proxy/proxysocket.go
+++ b/pkg/proxy/proxysocket.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 The Kubernetes Authors All rights reserved.
+Copyright 2015 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
I created this file earlier this year. It should say 2015 not 2014.
