### PR TITLE
Remove the clientID field from the apiserver request latency metric

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -63,7 +63,7 @@ var (
 			// Use buckets ranging from 125 ms to 8 seconds.
 			Buckets: prometheus.ExponentialBuckets(125000, 2.0, 7),
 		},
-		[]string{"verb", "resource", "client"},
+		[]string{"verb", "resource"},
 	)
 	requestLatenciesSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
@@ -84,7 +84,7 @@ func init() {
 // instrumenting basic request counter and latency metrics.
 func monitor(verb, resource *string, client string, httpCode *int, reqStart time.Time) {
 	requestCounter.WithLabelValues(*verb, *resource, client, strconv.Itoa(*httpCode)).Inc()
-	requestLatencies.WithLabelValues(*verb, *resource, client).Observe(float64((time.Since(reqStart)) / time.Microsecond))
+	requestLatencies.WithLabelValues(*verb, *resource).Observe(float64((time.Since(reqStart)) / time.Microsecond))
 	requestLatenciesSummary.WithLabelValues(*verb, *resource).Observe(float64((time.Since(reqStart)) / time.Microsecond))
 }
 


### PR DESCRIPTION
The cardinality is too high to be worth it, especially since client shouldn't affect latency. It could still be debated whether the requestCount metric should keep it, but I don't see any reason not to at least remove it from the latency metric given how much storage and processing cost it can add.

As discussed on #7169 - @smarterclayton @fgrzadkowski 
