### PR TITLE
Parameterized kubectl once and for all :)

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -88,9 +88,12 @@ if [[ ${GINKGO_PARALLEL} =~ ^[yY]$ ]]; then
   ginkgo_args+=("-p")
 fi
 
+
 # The --host setting is used only when providing --auth_config
 # If --kubeconfig is used, the host to use is retrieved from the .kubeconfig
 # file and the one provided with --host is ignored.
+# Add path for things like running kubectl binary.
+export PATH=$(dirname "${e2e_test}"):"${PATH}"
 "${ginkgo}" "${ginkgo_args[@]:+${ginkgo_args[@]}}" "${e2e_test}" -- \
   "${auth_config[@]:+${auth_config[@]}}" \
   --host="https://${KUBE_MASTER_IP-}" \

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -82,6 +82,7 @@ func init() {
 	flag.StringVar(&testContext.Host, "host", "", "The host, or apiserver, to connect to")
 	flag.StringVar(&testContext.RepoRoot, "repo-root", "../../", "Root directory of kubernetes repository, for finding test files.")
 	flag.StringVar(&testContext.Provider, "provider", "", "The name of the Kubernetes provider (gce, gke, local, vagrant, etc.)")
+	flag.StringVar(&testContext.KubectlPath, "kubectl-path", "kubectl", "The kubectl binary to use. For development, you might use 'cluster/kubectl.sh' here.")
 
 	// TODO: Flags per provider?  Rename gce-project/gce-zone?
 	flag.StringVar(&cloudConfig.MasterName, "kube-master", "", "Name of the kubernetes master. Only required if provider is gce or gke")


### PR DESCRIPTION
Parameterizes `kubectl.sh`.  
This is IMO the best solution, it may require a very minor change to your CI.

```
_output/local/bin/linux/amd64/e2e.test  \
-provider="local" --host="http://127.0.0.1:8080" \
-ginkgo.focus="kubectl*" \
-kubeconfig=/opt/kube-creds \
-KubectlPath="cluster/kubectl.sh" \
-repo-root=/home/jay/gopath/src/github.com/GoogleCloudPlatform/kubernetes/
```
