### PR TITLE
Wake up rcs when pods get DeletionFinalStateUnknown tombstones

### DIFF
--- a/pkg/client/cache/delta_fifo_test.go
+++ b/pkg/client/cache/delta_fifo_test.go
@@ -27,6 +27,24 @@ func testPop(f *DeltaFIFO) testFifoObject {
 	return f.Pop().(Deltas).Newest().Object.(testFifoObject)
 }
 
+// keyLookupFunc adapts a raw function to be a KeyLookup.
+type keyLookupFunc func() []string
+
+// ListKeys just calls kl.
+func (kl keyLookupFunc) ListKeys() []string {
+	return kl()
+}
+
+// GetByKey returns the key if it exists in the list returned by kl.
+func (kl keyLookupFunc) GetByKey(key string) (interface{}, bool, error) {
+	for _, v := range kl() {
+		if v == key {
+			return key, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
 func TestDeltaFIFO_basic(t *testing.T) {
 	f := NewDeltaFIFO(testFifoObjectKeyFunc, nil, nil)
 	const amount = 500
@@ -174,7 +192,7 @@ func TestDeltaFIFO_ReplaceMakesDeletions(t *testing.T) {
 	f := NewDeltaFIFO(
 		testFifoObjectKeyFunc,
 		nil,
-		KeyListerFunc(func() []string {
+		keyLookupFunc(func() []string {
 			return []string{"foo", "bar", "baz"}
 		}),
 	)
@@ -184,7 +202,9 @@ func TestDeltaFIFO_ReplaceMakesDeletions(t *testing.T) {
 	expectedList := []Deltas{
 		{{Deleted, mkFifoObj("baz", 10)}},
 		{{Sync, mkFifoObj("foo", 5)}},
-		{{Deleted, DeletedFinalStateUnknown{Key: "bar"}}},
+		// Since "bar" didn't have a delete event and wasn't in the Replace list
+		// it should get a tombstone key with the right Obj.
+		{{Deleted, DeletedFinalStateUnknown{Key: "bar", Obj: "bar"}}},
 	}
 
 	for _, expected := range expectedList {
@@ -259,9 +279,9 @@ func TestDeltaFIFO_KeyOf(t *testing.T) {
 		key string
 	}{
 		{obj: testFifoObject{name: "A"}, key: "A"},
-		{obj: DeletedFinalStateUnknown{Key: "B"}, key: "B"},
+		{obj: DeletedFinalStateUnknown{Key: "B", Obj: nil}, key: "B"},
 		{obj: Deltas{{Object: testFifoObject{name: "C"}}}, key: "C"},
-		{obj: Deltas{{Object: DeletedFinalStateUnknown{Key: "D"}}}, key: "D"},
+		{obj: Deltas{{Object: DeletedFinalStateUnknown{Key: "D", Obj: nil}}}, key: "D"},
 	}
 
 	for _, item := range table {

--- a/pkg/cloudprovider/servicecontroller/servicecontroller.go
+++ b/pkg/cloudprovider/servicecontroller/servicecontroller.go
@@ -361,6 +361,16 @@ func (s *serviceCache) ListKeys() []string {
 	return keys
 }
 
+// GetByKey returns the value stored in the serviceMap under the given key
+func (s *serviceCache) GetByKey(key string) (interface{}, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if v, ok := s.serviceMap[key]; ok {
+		return v, true, nil
+	}
+	return nil, false, nil
+}
+
 // ListKeys implements the interface required by DeltaFIFO to list the keys we
 // already know about.
 func (s *serviceCache) allServices() []*cachedService {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -638,7 +638,7 @@ func RunRC(c *client.Client, name string, ns, image string, replicas int) error 
 	current := 0
 	same := 0
 
-	By(fmt.Sprintf("Creating replication controller %s", name))
+	By(fmt.Sprintf("%v Creating replication controller %s", time.Now(), name))
 	rc := &api.ReplicationController{
 		ObjectMeta: api.ObjectMeta{
 			Name: name,
@@ -668,7 +668,7 @@ func RunRC(c *client.Client, name string, ns, image string, replicas int) error 
 	if err != nil {
 		return fmt.Errorf("Error creating replication controller: %v", err)
 	}
-	Logf("Created replication controller with name: %v, namespace: %v, replica count: %v", rc.Name, ns, rc.Spec.Replicas)
+	Logf("%v Created replication controller with name: %v, namespace: %v, replica count: %v", time.Now(), rc.Name, ns, rc.Spec.Replicas)
 
 	By(fmt.Sprintf("Making sure all %d replicas of rc %s in namespace %s exist", replicas, name, ns))
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
@@ -679,7 +679,7 @@ func RunRC(c *client.Client, name string, ns, image string, replicas int) error 
 	current = len(pods.Items)
 	failCount := 5
 	for same < failCount && current < replicas {
-		Logf("Controller %s: Found %d pods out of %d", name, current, replicas)
+		Logf("%v Controller %s: Found %d pods out of %d", time.Now(), name, current, replicas)
 		if last < current {
 			same = 0
 		} else if last == current {
@@ -703,9 +703,9 @@ func RunRC(c *client.Client, name string, ns, image string, replicas int) error 
 	if current != replicas {
 		return fmt.Errorf("Controller %s: Only found %d replicas out of %d", name, current, replicas)
 	}
-	Logf("Controller %s in ns %s: Found %d pods out of %d", name, ns, current, replicas)
+	Logf("%v Controller %s in ns %s: Found %d pods out of %d", time.Now(), name, ns, current, replicas)
 
-	By(fmt.Sprintf("Waiting for all %d replicas to be running with a max container failures of %d", replicas, maxContainerFailures))
+	By(fmt.Sprintf("%v Waiting for all %d replicas to be running with a max container failures of %d", time.Now(), replicas, maxContainerFailures))
 	same = 0
 	last = 0
 	failCount = 10


### PR DESCRIPTION
1. Delta fifo includes (possibly stale) version of the object in DeletetionFinalStateUnknown keys
2. Rc manager wakes up the appropriate rc without waiting for next relist when it encounters a  tombstone
