### PR TITLE
Fixed setNodeStatus to allow running on pods on OS X

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1839,6 +1839,7 @@ func (kl *Kubelet) setNodeStatus(node *api.Node) error {
 		node.Status.Capacity = api.ResourceList{
 			api.ResourceCPU:    *resource.NewMilliQuantity(0, resource.DecimalSI),
 			api.ResourceMemory: resource.MustParse("0Gi"),
+			api.ResourcePods:   *resource.NewQuantity(int64(kl.pods), resource.DecimalSI),
 		}
 		glog.Errorf("Error getting machine info: %v", err)
 	} else {


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/kubelet/kubelet.go#L1836

When cadvisor is unavailable, the node gets 0 CPU and RAM.   Capacity['pods'] does not exist.

Because there is no pod capacity, Kubelet running on OS X and using boot2docker cannot schedule any pods.  All fail because there are no pod resources available.

I don't know if this is the correct solution, but it fixes running on OS X.
