### PR TITLE
Fix rethinkdb example

### DIFF
--- a/examples/rethinkdb/README.md
+++ b/examples/rethinkdb/README.md
@@ -12,14 +12,17 @@ Quick start
 -----------
 **Step 0**
 
-change the namespace of the current context to "rethinkdb"
+change the namespace of the current context to "rethinkdb", and create this
+namespace. (Note: the namespace is currently baked into the example image, so
+this is mandatory!)
 ```
 $kubectl config view -o template --template='{{index . "current-context"}}' | xargs -I {} kubectl config set-context {} --namespace=rethinkdb
+$kubectl create -f ns.yaml
 ```
 
 **Step 1**
 
-antmanler/rethinkdb will discover peer using endpoints provided by kubernetes_ro service,
+antmanler/rethinkdb will discover peer using endpoints provided by kubernetes service,
 so first create a service so the following pod can query its endpoint
 
 ```shell
@@ -36,7 +39,7 @@ rethinkdb-driver   db=influxdb   db=rethinkdb   10.0.27.114   28015/TCP
 
 **Step 2**
 
-start fist server in cluster
+start first server in cluster
 
 ```shell
 $kubectl create -f rc.yaml

--- a/examples/rethinkdb/ns.yaml
+++ b/examples/rethinkdb/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1beta3
+kind: Namespace
+metadata:
+  name: rethinkdb

--- a/examples/rethinkdb/rc.yaml
+++ b/examples/rethinkdb/rc.yaml
@@ -17,7 +17,7 @@ spec:
         role: replicas
     spec:
       containers:
-      - image: antmanler/rethinkdb:1.16.0
+      - image: gcr.io/crested_analogy_671/rethink:1
         name: rethinkdb
         ports:
         - containerPort: 8080


### PR DESCRIPTION
For #7444.

The rethinkdb example needs some help. We need to switch it over to using DNS for discovery, or at least not relying on the RO port. This change, which I haven't tested, uses a service account.

Unfortunately, we don't own the container here, and I'm not sure if we want to fork it or push changes to https://github.com/antmanler/rethinkdb-k8s. I'm making this PR to record my progress on this.

We'll need to take this example out or fix it, because the RO port is going away soon.

@antmanler
