### PR TITLE
Add 'docker.io' and 'index.docker.io' to default registry matcher

### DIFF
--- a/pkg/credentialprovider/keyring.go
+++ b/pkg/credentialprovider/keyring.go
@@ -106,8 +106,17 @@ const defaultRegistryHost = "index.docker.io/v1/"
 func isDefaultRegistryMatch(image string) bool {
 	parts := strings.SplitN(image, "/", 2)
 
+	if len(parts[0]) == 0 {
+		return false
+	}
+
 	if len(parts) == 1 {
 		// e.g. library/ubuntu
+		return true
+	}
+
+	if parts[0] == "docker.io" || parts[0] == "index.docker.io" {
+		// resolve docker.io/image and index.docker.io/image as default registry
 		return true
 	}
 

--- a/pkg/credentialprovider/keyring_test.go
+++ b/pkg/credentialprovider/keyring_test.go
@@ -238,6 +238,26 @@ func TestKeyringHitWithQualifiedDockerHub(t *testing.T) {
 	}
 }
 
+func TestIsDefaultRegistryMatch(t *testing.T) {
+	samples := []map[bool]string{
+		{true: "foo/bar"},
+		{true: "docker.io/foo/bar"},
+		{true: "index.docker.io/foo/bar"},
+		{true: "foo"},
+		{false: ""},
+		{false: "registry.tld/foo/bar"},
+		{false: "registry:5000/foo/bar"},
+		{false: "myhostdocker.io/foo/bar"},
+	}
+	for _, sample := range samples {
+		for expected, imageName := range sample {
+			if got := isDefaultRegistryMatch(imageName); got != expected {
+				t.Errorf("Expected '%s' to be %s, got %s", imageName, expected, got)
+			}
+		}
+	}
+}
+
 type testProvider struct {
 	Count int
 }


### PR DESCRIPTION
Signed-off-by: Michal Fojtik mfojtik@redhat.com
