### PR TITLE
Fix Vagrant node registration and kube-push

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -215,7 +215,7 @@ external_auth:
       - .*
 rest_cherrypy:
   port: 8000
-  host: 127.0.0.1
+  host: ${MASTER_IP}
   disable_ssl: True
   webhook_disable_auth: True
 EOF
@@ -248,5 +248,5 @@ else
   # set up to run highstate as new minions join for the first time.
   echo "Executing configuration"
   salt '*' mine.update
-  salt --show-timeout --force-color '*' state.highstate
+  salt --force-color '*' state.highstate
 fi

--- a/pkg/cloudprovider/vagrant/vagrant.go
+++ b/pkg/cloudprovider/vagrant/vagrant.go
@@ -73,7 +73,7 @@ type SaltMinionsResponse struct {
 // newVagrantCloud creates a new instance of VagrantCloud configured to talk to the Salt REST API.
 func newVagrantCloud() (*VagrantCloud, error) {
 	return &VagrantCloud{
-		saltURL:  "http://127.0.0.1:8000",
+		saltURL:  "http://kubernetes-master:8000",
 		saltUser: "vagrant",
 		saltPass: "vagrant",
 		saltAuth: "pam",


### PR DESCRIPTION
This makes the following fixes to the Vagrant setup:
1. Fix node kubelet registration.  Kubelet uses cloud-provider now, and the vagrant provider was backed by the salt-api.  The salt-api was previously only available on the master over 127.0.0.1.  To make it accessible to the nodes, had to listen on the MASTER_IP, and update the cloud provider code to reference by host name.
2. Fix kube-push as recent versions of salt do not support --show-timeout flag

These changes make the cluster come up successfully.
