### PR TITLE
Move service account token generation into master

### DIFF
--- a/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
+++ b/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
@@ -17,14 +17,12 @@
 
 {% if grains.cloud is defined -%}
   {% set cloud_provider = "--cloud_provider=" + grains.cloud -%}
-  {% set service_account_key = " --service_account_private_key_file=/srv/kubernetes/server.key " -%}
-
   {% if grains.cloud in [ 'aws', 'gce' ] and grains.cloud_config is defined -%}
     {% set cloud_config = "--cloud_config=" + grains.cloud_config -%}
   {% endif -%}
 {% endif -%}
 
-{% set params = "--master=127.0.0.1:8080" + " " + cluster_name + " " + cluster_cidr + " " + allocate_node_cidrs + " " + cloud_provider  + " " + cloud_config + service_account_key + pillar['log_level'] -%}
+{% set params = "--master=127.0.0.1:8080" + " " + cluster_name + " " + cluster_cidr + " " + allocate_node_cidrs + " " + cloud_provider  + " " + cloud_config + " " + pillar['log_level'] -%}
 
 {
 "apiVersion": "v1beta3",

--- a/docs/man/kube-apiserver.1.md
+++ b/docs/man/kube-apiserver.1.md
@@ -153,7 +153,7 @@ The the kube-apiserver several options.
 	The port on which to serve HTTPS with authentication and authorization. If 0, don't serve HTTPS at all.
 
 **--service-account-key-file**=""
-	File containing PEM-encoded x509 RSA private or public key, used to verify ServiceAccount tokens. If unspecified, --tls-private-key-file is used.
+	File containing PEM-encoded x509 RSA private key, used to sign and verify ServiceAccount tokens. If unspecified, --tls-private-key-file is used.
 
 **--service-account-lookup**=false
 	If true, validate ServiceAccount tokens exist in etcd as part of authentication.

--- a/docs/man/kube-controller-manager.1.md
+++ b/docs/man/kube-controller-manager.1.md
@@ -107,9 +107,6 @@ The kube-controller-manager has several options.
 **--resource-quota-sync-period**=10s
 	The period for syncing quota usage status in the system
 
-**--service-account-private-key-file**=""
-	Filename containing a PEM-encoded private RSA key used to sign service account tokens.
-
 **--stderrthreshold**=2
 	logs at or above this threshold go to stderr
 

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -178,7 +178,6 @@ CTLRMGR_LOG=/tmp/kube-controller-manager.log
 sudo -E "${GO_OUT}/kube-controller-manager" \
   --v=${LOG_LEVEL} \
   --machines="127.0.0.1" \
-  --service_account_private_key_file="${SERVICE_ACCOUNT_KEY}" \
   --master="${API_HOST}:${API_PORT}" >"${CTLRMGR_LOG}" 2>&1 &
 CTLRMGR_PID=$!
 

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1873,6 +1873,32 @@ func deepCopy_api_ServiceAccountList(in ServiceAccountList, out *ServiceAccountL
 	return nil
 }
 
+func deepCopy_api_ServiceAccountTokenRequest(in ServiceAccountTokenRequest, out *ServiceAccountTokenRequest, c *conversion.Cloner) error {
+	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_util_Time(in.Expires, &out.Expires, c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deepCopy_api_ServiceAccountTokenResponse(in ServiceAccountTokenResponse, out *ServiceAccountTokenResponse, c *conversion.Cloner) error {
+	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_api_LocalObjectReference(in.Secret, &out.Secret, c); err != nil {
+		return err
+	}
+	return nil
+}
+
 func deepCopy_api_ServiceList(in ServiceList, out *ServiceList, c *conversion.Cloner) error {
 	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -2246,6 +2272,8 @@ func init() {
 		deepCopy_api_Service,
 		deepCopy_api_ServiceAccount,
 		deepCopy_api_ServiceAccountList,
+		deepCopy_api_ServiceAccountTokenRequest,
+		deepCopy_api_ServiceAccountTokenResponse,
 		deepCopy_api_ServiceList,
 		deepCopy_api_ServicePort,
 		deepCopy_api_ServiceSpec,

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -53,6 +53,8 @@ func init() {
 		&NamespaceList{},
 		&ServiceAccount{},
 		&ServiceAccountList{},
+		&ServiceAccountTokenRequest{},
+		&ServiceAccountTokenResponse{},
 		&Secret{},
 		&SecretList{},
 		&PersistentVolume{},
@@ -74,46 +76,48 @@ func init() {
 	Scheme.AddKnownTypeWithName("", "MinionList", &NodeList{})
 }
 
-func (*Pod) IsAnAPIObject()                       {}
-func (*PodList) IsAnAPIObject()                   {}
-func (*PodStatusResult) IsAnAPIObject()           {}
-func (*PodTemplate) IsAnAPIObject()               {}
-func (*PodTemplateList) IsAnAPIObject()           {}
-func (*ReplicationController) IsAnAPIObject()     {}
-func (*ReplicationControllerList) IsAnAPIObject() {}
-func (*Service) IsAnAPIObject()                   {}
-func (*ServiceList) IsAnAPIObject()               {}
-func (*Endpoints) IsAnAPIObject()                 {}
-func (*EndpointsList) IsAnAPIObject()             {}
-func (*Node) IsAnAPIObject()                      {}
-func (*NodeList) IsAnAPIObject()                  {}
-func (*Binding) IsAnAPIObject()                   {}
-func (*Status) IsAnAPIObject()                    {}
-func (*Event) IsAnAPIObject()                     {}
-func (*EventList) IsAnAPIObject()                 {}
-func (*ContainerManifest) IsAnAPIObject()         {}
-func (*ContainerManifestList) IsAnAPIObject()     {}
-func (*List) IsAnAPIObject()                      {}
-func (*LimitRange) IsAnAPIObject()                {}
-func (*LimitRangeList) IsAnAPIObject()            {}
-func (*ResourceQuota) IsAnAPIObject()             {}
-func (*ResourceQuotaList) IsAnAPIObject()         {}
-func (*Namespace) IsAnAPIObject()                 {}
-func (*NamespaceList) IsAnAPIObject()             {}
-func (*ServiceAccount) IsAnAPIObject()            {}
-func (*ServiceAccountList) IsAnAPIObject()        {}
-func (*Secret) IsAnAPIObject()                    {}
-func (*SecretList) IsAnAPIObject()                {}
-func (*PersistentVolume) IsAnAPIObject()          {}
-func (*PersistentVolumeList) IsAnAPIObject()      {}
-func (*PersistentVolumeClaim) IsAnAPIObject()     {}
-func (*PersistentVolumeClaimList) IsAnAPIObject() {}
-func (*DeleteOptions) IsAnAPIObject()             {}
-func (*ListOptions) IsAnAPIObject()               {}
-func (*PodLogOptions) IsAnAPIObject()             {}
-func (*PodExecOptions) IsAnAPIObject()            {}
-func (*PodProxyOptions) IsAnAPIObject()           {}
-func (*ComponentStatus) IsAnAPIObject()           {}
-func (*ComponentStatusList) IsAnAPIObject()       {}
-func (*SerializedReference) IsAnAPIObject()       {}
-func (*RangeAllocation) IsAnAPIObject()           {}
+func (*Pod) IsAnAPIObject()                         {}
+func (*PodList) IsAnAPIObject()                     {}
+func (*PodStatusResult) IsAnAPIObject()             {}
+func (*PodTemplate) IsAnAPIObject()                 {}
+func (*PodTemplateList) IsAnAPIObject()             {}
+func (*ReplicationController) IsAnAPIObject()       {}
+func (*ReplicationControllerList) IsAnAPIObject()   {}
+func (*Service) IsAnAPIObject()                     {}
+func (*ServiceList) IsAnAPIObject()                 {}
+func (*Endpoints) IsAnAPIObject()                   {}
+func (*EndpointsList) IsAnAPIObject()               {}
+func (*Node) IsAnAPIObject()                        {}
+func (*NodeList) IsAnAPIObject()                    {}
+func (*Binding) IsAnAPIObject()                     {}
+func (*Status) IsAnAPIObject()                      {}
+func (*Event) IsAnAPIObject()                       {}
+func (*EventList) IsAnAPIObject()                   {}
+func (*ContainerManifest) IsAnAPIObject()           {}
+func (*ContainerManifestList) IsAnAPIObject()       {}
+func (*List) IsAnAPIObject()                        {}
+func (*LimitRange) IsAnAPIObject()                  {}
+func (*LimitRangeList) IsAnAPIObject()              {}
+func (*ResourceQuota) IsAnAPIObject()               {}
+func (*ResourceQuotaList) IsAnAPIObject()           {}
+func (*Namespace) IsAnAPIObject()                   {}
+func (*NamespaceList) IsAnAPIObject()               {}
+func (*ServiceAccount) IsAnAPIObject()              {}
+func (*ServiceAccountList) IsAnAPIObject()          {}
+func (*ServiceAccountTokenRequest) IsAnAPIObject()  {}
+func (*ServiceAccountTokenResponse) IsAnAPIObject() {}
+func (*Secret) IsAnAPIObject()                      {}
+func (*SecretList) IsAnAPIObject()                  {}
+func (*PersistentVolume) IsAnAPIObject()            {}
+func (*PersistentVolumeList) IsAnAPIObject()        {}
+func (*PersistentVolumeClaim) IsAnAPIObject()       {}
+func (*PersistentVolumeClaimList) IsAnAPIObject()   {}
+func (*DeleteOptions) IsAnAPIObject()               {}
+func (*ListOptions) IsAnAPIObject()                 {}
+func (*PodLogOptions) IsAnAPIObject()               {}
+func (*PodExecOptions) IsAnAPIObject()              {}
+func (*PodProxyOptions) IsAnAPIObject()             {}
+func (*ComponentStatus) IsAnAPIObject()             {}
+func (*ComponentStatusList) IsAnAPIObject()         {}
+func (*SerializedReference) IsAnAPIObject()         {}
+func (*RangeAllocation) IsAnAPIObject()             {}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1192,6 +1192,22 @@ type ServiceAccountList struct {
 	Items []ServiceAccount `json:"items"`
 }
 
+// ServiceAccountTokenRequest is used to request a service account token
+type ServiceAccountTokenRequest struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+
+	Expires util.Time `json:"expires,omitempty"`
+}
+
+// ServiceAccountTokenResponse is used to return a reference to the secret containing the requested token
+type ServiceAccountTokenResponse struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+
+	Secret LocalObjectReference `json:"secret"`
+}
+
 // Endpoints is a collection of endpoints that implement the actual service.  Example:
 //   Name: "mysvc",
 //   Subsets: [

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -2060,6 +2060,38 @@ func convert_api_ServiceAccountList_To_v1_ServiceAccountList(in *api.ServiceAcco
 	return nil
 }
 
+func convert_api_ServiceAccountTokenRequest_To_v1_ServiceAccountTokenRequest(in *api.ServiceAccountTokenRequest, out *ServiceAccountTokenRequest, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.ServiceAccountTokenRequest))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.Expires, &out.Expires, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_ServiceAccountTokenResponse_To_v1_ServiceAccountTokenResponse(in *api.ServiceAccountTokenResponse, out *ServiceAccountTokenResponse, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.ServiceAccountTokenResponse))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_LocalObjectReference_To_v1_LocalObjectReference(&in.Secret, &out.Secret, s); err != nil {
+		return err
+	}
+	return nil
+}
+
 func convert_api_ServiceList_To_v1_ServiceList(in *api.ServiceList, out *ServiceList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ServiceList))(in)
@@ -4368,6 +4400,38 @@ func convert_v1_ServiceAccountList_To_api_ServiceAccountList(in *ServiceAccountL
 	return nil
 }
 
+func convert_v1_ServiceAccountTokenRequest_To_api_ServiceAccountTokenRequest(in *ServiceAccountTokenRequest, out *api.ServiceAccountTokenRequest, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*ServiceAccountTokenRequest))(in)
+	}
+	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.Expires, &out.Expires, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1_ServiceAccountTokenResponse_To_api_ServiceAccountTokenResponse(in *ServiceAccountTokenResponse, out *api.ServiceAccountTokenResponse, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*ServiceAccountTokenResponse))(in)
+	}
+	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1_LocalObjectReference_To_api_LocalObjectReference(&in.Secret, &out.Secret, s); err != nil {
+		return err
+	}
+	return nil
+}
+
 func convert_v1_ServiceList_To_api_ServiceList(in *ServiceList, out *api.ServiceList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ServiceList))(in)
@@ -4742,6 +4806,8 @@ func init() {
 		convert_api_SecurityContext_To_v1_SecurityContext,
 		convert_api_SerializedReference_To_v1_SerializedReference,
 		convert_api_ServiceAccountList_To_v1_ServiceAccountList,
+		convert_api_ServiceAccountTokenRequest_To_v1_ServiceAccountTokenRequest,
+		convert_api_ServiceAccountTokenResponse_To_v1_ServiceAccountTokenResponse,
 		convert_api_ServiceAccount_To_v1_ServiceAccount,
 		convert_api_ServiceList_To_v1_ServiceList,
 		convert_api_ServicePort_To_v1_ServicePort,
@@ -4855,6 +4921,8 @@ func init() {
 		convert_v1_SecurityContext_To_api_SecurityContext,
 		convert_v1_SerializedReference_To_api_SerializedReference,
 		convert_v1_ServiceAccountList_To_api_ServiceAccountList,
+		convert_v1_ServiceAccountTokenRequest_To_api_ServiceAccountTokenRequest,
+		convert_v1_ServiceAccountTokenResponse_To_api_ServiceAccountTokenResponse,
 		convert_v1_ServiceAccount_To_api_ServiceAccount,
 		convert_v1_ServiceList_To_api_ServiceList,
 		convert_v1_ServicePort_To_api_ServicePort,

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1809,6 +1809,32 @@ func deepCopy_v1_ServiceAccountList(in ServiceAccountList, out *ServiceAccountLi
 	return nil
 }
 
+func deepCopy_v1_ServiceAccountTokenRequest(in ServiceAccountTokenRequest, out *ServiceAccountTokenRequest, c *conversion.Cloner) error {
+	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_util_Time(in.Expires, &out.Expires, c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deepCopy_v1_ServiceAccountTokenResponse(in ServiceAccountTokenResponse, out *ServiceAccountTokenResponse, c *conversion.Cloner) error {
+	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1_LocalObjectReference(in.Secret, &out.Secret, c); err != nil {
+		return err
+	}
+	return nil
+}
+
 func deepCopy_v1_ServiceList(in ServiceList, out *ServiceList, c *conversion.Cloner) error {
 	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -2179,6 +2205,8 @@ func init() {
 		deepCopy_v1_Service,
 		deepCopy_v1_ServiceAccount,
 		deepCopy_v1_ServiceAccountList,
+		deepCopy_v1_ServiceAccountTokenRequest,
+		deepCopy_v1_ServiceAccountTokenResponse,
 		deepCopy_v1_ServiceList,
 		deepCopy_v1_ServicePort,
 		deepCopy_v1_ServiceSpec,

--- a/pkg/api/v1/register.go
+++ b/pkg/api/v1/register.go
@@ -68,6 +68,8 @@ func addKnownTypes() {
 		&SecretList{},
 		&ServiceAccount{},
 		&ServiceAccountList{},
+		&ServiceAccountTokenRequest{},
+		&ServiceAccountTokenResponse{},
 		&PersistentVolume{},
 		&PersistentVolumeList{},
 		&PersistentVolumeClaim{},
@@ -87,44 +89,46 @@ func addKnownTypes() {
 	api.Scheme.AddKnownTypeWithName("v1", "MinionList", &NodeList{})
 }
 
-func (*Pod) IsAnAPIObject()                       {}
-func (*PodList) IsAnAPIObject()                   {}
-func (*PodStatusResult) IsAnAPIObject()           {}
-func (*PodTemplate) IsAnAPIObject()               {}
-func (*PodTemplateList) IsAnAPIObject()           {}
-func (*ReplicationController) IsAnAPIObject()     {}
-func (*ReplicationControllerList) IsAnAPIObject() {}
-func (*Service) IsAnAPIObject()                   {}
-func (*ServiceList) IsAnAPIObject()               {}
-func (*Endpoints) IsAnAPIObject()                 {}
-func (*EndpointsList) IsAnAPIObject()             {}
-func (*Node) IsAnAPIObject()                      {}
-func (*NodeList) IsAnAPIObject()                  {}
-func (*Binding) IsAnAPIObject()                   {}
-func (*Status) IsAnAPIObject()                    {}
-func (*Event) IsAnAPIObject()                     {}
-func (*EventList) IsAnAPIObject()                 {}
-func (*List) IsAnAPIObject()                      {}
-func (*LimitRange) IsAnAPIObject()                {}
-func (*LimitRangeList) IsAnAPIObject()            {}
-func (*ResourceQuota) IsAnAPIObject()             {}
-func (*ResourceQuotaList) IsAnAPIObject()         {}
-func (*Namespace) IsAnAPIObject()                 {}
-func (*NamespaceList) IsAnAPIObject()             {}
-func (*Secret) IsAnAPIObject()                    {}
-func (*SecretList) IsAnAPIObject()                {}
-func (*ServiceAccount) IsAnAPIObject()            {}
-func (*ServiceAccountList) IsAnAPIObject()        {}
-func (*PersistentVolume) IsAnAPIObject()          {}
-func (*PersistentVolumeList) IsAnAPIObject()      {}
-func (*PersistentVolumeClaim) IsAnAPIObject()     {}
-func (*PersistentVolumeClaimList) IsAnAPIObject() {}
-func (*DeleteOptions) IsAnAPIObject()             {}
-func (*ListOptions) IsAnAPIObject()               {}
-func (*PodLogOptions) IsAnAPIObject()             {}
-func (*PodExecOptions) IsAnAPIObject()            {}
-func (*PodProxyOptions) IsAnAPIObject()           {}
-func (*ComponentStatus) IsAnAPIObject()           {}
-func (*ComponentStatusList) IsAnAPIObject()       {}
-func (*SerializedReference) IsAnAPIObject()       {}
-func (*RangeAllocation) IsAnAPIObject()           {}
+func (*Pod) IsAnAPIObject()                         {}
+func (*PodList) IsAnAPIObject()                     {}
+func (*PodStatusResult) IsAnAPIObject()             {}
+func (*PodTemplate) IsAnAPIObject()                 {}
+func (*PodTemplateList) IsAnAPIObject()             {}
+func (*ReplicationController) IsAnAPIObject()       {}
+func (*ReplicationControllerList) IsAnAPIObject()   {}
+func (*Service) IsAnAPIObject()                     {}
+func (*ServiceList) IsAnAPIObject()                 {}
+func (*Endpoints) IsAnAPIObject()                   {}
+func (*EndpointsList) IsAnAPIObject()               {}
+func (*Node) IsAnAPIObject()                        {}
+func (*NodeList) IsAnAPIObject()                    {}
+func (*Binding) IsAnAPIObject()                     {}
+func (*Status) IsAnAPIObject()                      {}
+func (*Event) IsAnAPIObject()                       {}
+func (*EventList) IsAnAPIObject()                   {}
+func (*List) IsAnAPIObject()                        {}
+func (*LimitRange) IsAnAPIObject()                  {}
+func (*LimitRangeList) IsAnAPIObject()              {}
+func (*ResourceQuota) IsAnAPIObject()               {}
+func (*ResourceQuotaList) IsAnAPIObject()           {}
+func (*Namespace) IsAnAPIObject()                   {}
+func (*NamespaceList) IsAnAPIObject()               {}
+func (*Secret) IsAnAPIObject()                      {}
+func (*SecretList) IsAnAPIObject()                  {}
+func (*ServiceAccount) IsAnAPIObject()              {}
+func (*ServiceAccountList) IsAnAPIObject()          {}
+func (*ServiceAccountTokenRequest) IsAnAPIObject()  {}
+func (*ServiceAccountTokenResponse) IsAnAPIObject() {}
+func (*PersistentVolume) IsAnAPIObject()            {}
+func (*PersistentVolumeList) IsAnAPIObject()        {}
+func (*PersistentVolumeClaim) IsAnAPIObject()       {}
+func (*PersistentVolumeClaimList) IsAnAPIObject()   {}
+func (*DeleteOptions) IsAnAPIObject()               {}
+func (*ListOptions) IsAnAPIObject()                 {}
+func (*PodLogOptions) IsAnAPIObject()               {}
+func (*PodExecOptions) IsAnAPIObject()              {}
+func (*PodProxyOptions) IsAnAPIObject()             {}
+func (*ComponentStatus) IsAnAPIObject()             {}
+func (*ComponentStatusList) IsAnAPIObject()         {}
+func (*SerializedReference) IsAnAPIObject()         {}
+func (*RangeAllocation) IsAnAPIObject()             {}

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1184,6 +1184,22 @@ type ServiceAccountList struct {
 	Items []ServiceAccount `json:"items" description:"list of ServiceAccounts"`
 }
 
+// ServiceAccountTokenRequest is used to request a service account token
+type ServiceAccountTokenRequest struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"`
+
+	Expires util.Time `json:"expires,omitempty" description:"time at which to expire the requested token; if this value is empty no expiration is requested"`
+}
+
+// ServiceAccountTokenResponse is used to return a reference to the secret containing the requested token
+type ServiceAccountTokenResponse struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"`
+
+	Secret LocalObjectReference `json:"secret" description:"reference to the secret in the same namespace containing the requested token"`
+}
+
 // Endpoints is a collection of endpoints that implement the actual service.  Example:
 //   Name: "mysvc",
 //   Subsets: [

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -1880,6 +1880,38 @@ func convert_api_ServiceAccountList_To_v1beta3_ServiceAccountList(in *api.Servic
 	return nil
 }
 
+func convert_api_ServiceAccountTokenRequest_To_v1beta3_ServiceAccountTokenRequest(in *api.ServiceAccountTokenRequest, out *ServiceAccountTokenRequest, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.ServiceAccountTokenRequest))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.Expires, &out.Expires, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_ServiceAccountTokenResponse_To_v1beta3_ServiceAccountTokenResponse(in *api.ServiceAccountTokenResponse, out *ServiceAccountTokenResponse, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.ServiceAccountTokenResponse))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_LocalObjectReference_To_v1beta3_LocalObjectReference(&in.Secret, &out.Secret, s); err != nil {
+		return err
+	}
+	return nil
+}
+
 func convert_api_ServiceList_To_v1beta3_ServiceList(in *api.ServiceList, out *ServiceList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ServiceList))(in)
@@ -3942,6 +3974,38 @@ func convert_v1beta3_ServiceAccountList_To_api_ServiceAccountList(in *ServiceAcc
 	return nil
 }
 
+func convert_v1beta3_ServiceAccountTokenRequest_To_api_ServiceAccountTokenRequest(in *ServiceAccountTokenRequest, out *api.ServiceAccountTokenRequest, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*ServiceAccountTokenRequest))(in)
+	}
+	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.Expires, &out.Expires, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1beta3_ServiceAccountTokenResponse_To_api_ServiceAccountTokenResponse(in *ServiceAccountTokenResponse, out *api.ServiceAccountTokenResponse, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*ServiceAccountTokenResponse))(in)
+	}
+	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_LocalObjectReference_To_api_LocalObjectReference(&in.Secret, &out.Secret, s); err != nil {
+		return err
+	}
+	return nil
+}
+
 func convert_v1beta3_ServiceList_To_api_ServiceList(in *ServiceList, out *api.ServiceList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ServiceList))(in)
@@ -4247,6 +4311,8 @@ func init() {
 		convert_api_SecurityContext_To_v1beta3_SecurityContext,
 		convert_api_SerializedReference_To_v1beta3_SerializedReference,
 		convert_api_ServiceAccountList_To_v1beta3_ServiceAccountList,
+		convert_api_ServiceAccountTokenRequest_To_v1beta3_ServiceAccountTokenRequest,
+		convert_api_ServiceAccountTokenResponse_To_v1beta3_ServiceAccountTokenResponse,
 		convert_api_ServiceAccount_To_v1beta3_ServiceAccount,
 		convert_api_ServiceList_To_v1beta3_ServiceList,
 		convert_api_ServicePort_To_v1beta3_ServicePort,
@@ -4354,6 +4420,8 @@ func init() {
 		convert_v1beta3_SecurityContext_To_api_SecurityContext,
 		convert_v1beta3_SerializedReference_To_api_SerializedReference,
 		convert_v1beta3_ServiceAccountList_To_api_ServiceAccountList,
+		convert_v1beta3_ServiceAccountTokenRequest_To_api_ServiceAccountTokenRequest,
+		convert_v1beta3_ServiceAccountTokenResponse_To_api_ServiceAccountTokenResponse,
 		convert_v1beta3_ServiceAccount_To_api_ServiceAccount,
 		convert_v1beta3_ServiceList_To_api_ServiceList,
 		convert_v1beta3_ServicePort_To_api_ServicePort,

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1808,6 +1808,32 @@ func deepCopy_v1beta3_ServiceAccountList(in ServiceAccountList, out *ServiceAcco
 	return nil
 }
 
+func deepCopy_v1beta3_ServiceAccountTokenRequest(in ServiceAccountTokenRequest, out *ServiceAccountTokenRequest, c *conversion.Cloner) error {
+	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_util_Time(in.Expires, &out.Expires, c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deepCopy_v1beta3_ServiceAccountTokenResponse(in ServiceAccountTokenResponse, out *ServiceAccountTokenResponse, c *conversion.Cloner) error {
+	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1beta3_LocalObjectReference(in.Secret, &out.Secret, c); err != nil {
+		return err
+	}
+	return nil
+}
+
 func deepCopy_v1beta3_ServiceList(in ServiceList, out *ServiceList, c *conversion.Cloner) error {
 	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -2179,6 +2205,8 @@ func init() {
 		deepCopy_v1beta3_Service,
 		deepCopy_v1beta3_ServiceAccount,
 		deepCopy_v1beta3_ServiceAccountList,
+		deepCopy_v1beta3_ServiceAccountTokenRequest,
+		deepCopy_v1beta3_ServiceAccountTokenResponse,
 		deepCopy_v1beta3_ServiceList,
 		deepCopy_v1beta3_ServicePort,
 		deepCopy_v1beta3_ServiceSpec,

--- a/pkg/api/v1beta3/register.go
+++ b/pkg/api/v1beta3/register.go
@@ -68,6 +68,8 @@ func addKnownTypes() {
 		&SecretList{},
 		&ServiceAccount{},
 		&ServiceAccountList{},
+		&ServiceAccountTokenRequest{},
+		&ServiceAccountTokenResponse{},
 		&PersistentVolume{},
 		&PersistentVolumeList{},
 		&PersistentVolumeClaim{},
@@ -87,44 +89,46 @@ func addKnownTypes() {
 	api.Scheme.AddKnownTypeWithName("v1beta3", "MinionList", &NodeList{})
 }
 
-func (*Pod) IsAnAPIObject()                       {}
-func (*PodList) IsAnAPIObject()                   {}
-func (*PodStatusResult) IsAnAPIObject()           {}
-func (*PodTemplate) IsAnAPIObject()               {}
-func (*PodTemplateList) IsAnAPIObject()           {}
-func (*ReplicationController) IsAnAPIObject()     {}
-func (*ReplicationControllerList) IsAnAPIObject() {}
-func (*Service) IsAnAPIObject()                   {}
-func (*ServiceList) IsAnAPIObject()               {}
-func (*Endpoints) IsAnAPIObject()                 {}
-func (*EndpointsList) IsAnAPIObject()             {}
-func (*Node) IsAnAPIObject()                      {}
-func (*NodeList) IsAnAPIObject()                  {}
-func (*Binding) IsAnAPIObject()                   {}
-func (*Status) IsAnAPIObject()                    {}
-func (*Event) IsAnAPIObject()                     {}
-func (*EventList) IsAnAPIObject()                 {}
-func (*List) IsAnAPIObject()                      {}
-func (*LimitRange) IsAnAPIObject()                {}
-func (*LimitRangeList) IsAnAPIObject()            {}
-func (*ResourceQuota) IsAnAPIObject()             {}
-func (*ResourceQuotaList) IsAnAPIObject()         {}
-func (*Namespace) IsAnAPIObject()                 {}
-func (*NamespaceList) IsAnAPIObject()             {}
-func (*Secret) IsAnAPIObject()                    {}
-func (*SecretList) IsAnAPIObject()                {}
-func (*ServiceAccount) IsAnAPIObject()            {}
-func (*ServiceAccountList) IsAnAPIObject()        {}
-func (*PersistentVolume) IsAnAPIObject()          {}
-func (*PersistentVolumeList) IsAnAPIObject()      {}
-func (*PersistentVolumeClaim) IsAnAPIObject()     {}
-func (*PersistentVolumeClaimList) IsAnAPIObject() {}
-func (*DeleteOptions) IsAnAPIObject()             {}
-func (*ListOptions) IsAnAPIObject()               {}
-func (*PodLogOptions) IsAnAPIObject()             {}
-func (*PodExecOptions) IsAnAPIObject()            {}
-func (*PodProxyOptions) IsAnAPIObject()           {}
-func (*ComponentStatus) IsAnAPIObject()           {}
-func (*ComponentStatusList) IsAnAPIObject()       {}
-func (*SerializedReference) IsAnAPIObject()       {}
-func (*RangeAllocation) IsAnAPIObject()           {}
+func (*Pod) IsAnAPIObject()                         {}
+func (*PodList) IsAnAPIObject()                     {}
+func (*PodStatusResult) IsAnAPIObject()             {}
+func (*PodTemplate) IsAnAPIObject()                 {}
+func (*PodTemplateList) IsAnAPIObject()             {}
+func (*ReplicationController) IsAnAPIObject()       {}
+func (*ReplicationControllerList) IsAnAPIObject()   {}
+func (*Service) IsAnAPIObject()                     {}
+func (*ServiceList) IsAnAPIObject()                 {}
+func (*Endpoints) IsAnAPIObject()                   {}
+func (*EndpointsList) IsAnAPIObject()               {}
+func (*Node) IsAnAPIObject()                        {}
+func (*NodeList) IsAnAPIObject()                    {}
+func (*Binding) IsAnAPIObject()                     {}
+func (*Status) IsAnAPIObject()                      {}
+func (*Event) IsAnAPIObject()                       {}
+func (*EventList) IsAnAPIObject()                   {}
+func (*List) IsAnAPIObject()                        {}
+func (*LimitRange) IsAnAPIObject()                  {}
+func (*LimitRangeList) IsAnAPIObject()              {}
+func (*ResourceQuota) IsAnAPIObject()               {}
+func (*ResourceQuotaList) IsAnAPIObject()           {}
+func (*Namespace) IsAnAPIObject()                   {}
+func (*NamespaceList) IsAnAPIObject()               {}
+func (*Secret) IsAnAPIObject()                      {}
+func (*SecretList) IsAnAPIObject()                  {}
+func (*ServiceAccount) IsAnAPIObject()              {}
+func (*ServiceAccountList) IsAnAPIObject()          {}
+func (*ServiceAccountTokenRequest) IsAnAPIObject()  {}
+func (*ServiceAccountTokenResponse) IsAnAPIObject() {}
+func (*PersistentVolume) IsAnAPIObject()            {}
+func (*PersistentVolumeList) IsAnAPIObject()        {}
+func (*PersistentVolumeClaim) IsAnAPIObject()       {}
+func (*PersistentVolumeClaimList) IsAnAPIObject()   {}
+func (*DeleteOptions) IsAnAPIObject()               {}
+func (*ListOptions) IsAnAPIObject()                 {}
+func (*PodLogOptions) IsAnAPIObject()               {}
+func (*PodExecOptions) IsAnAPIObject()              {}
+func (*PodProxyOptions) IsAnAPIObject()             {}
+func (*ComponentStatus) IsAnAPIObject()             {}
+func (*ComponentStatusList) IsAnAPIObject()         {}
+func (*SerializedReference) IsAnAPIObject()         {}
+func (*RangeAllocation) IsAnAPIObject()             {}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -1191,6 +1191,22 @@ type ServiceAccountList struct {
 	Items []ServiceAccount `json:"items" description:"list of ServiceAccounts"`
 }
 
+// ServiceAccountTokenRequest is used to request a service account token
+type ServiceAccountTokenRequest struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"`
+
+	Expires util.Time `json:"expires,omitempty" description:"time at which to expire the requested token; if this value is empty no expiration is requested"`
+}
+
+// ServiceAccountTokenResponse is used to return a reference to the secret containing the requested token
+type ServiceAccountTokenResponse struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"`
+
+	Secret LocalObjectReference `json:"secret" description:"reference to the secret in the same namespace containing the requested token"`
+}
+
 // Endpoints is a collection of endpoints that implement the actual service.  Example:
 //   Name: "mysvc",
 //   Subsets: [

--- a/pkg/apiserver/tokengen.go
+++ b/pkg/apiserver/tokengen.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	serviceaccountregistry "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/serviceaccount"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount"
+
+	"github.com/golang/glog"
+)
+
+func NewTokenGenerator(serviceAccountPrivateKeyFile string) serviceaccountregistry.TokenGenerator {
+	if len(serviceAccountPrivateKeyFile) == 0 {
+		return nil
+	}
+
+	privateKey, err := serviceaccount.ReadPrivateKey(serviceAccountPrivateKeyFile)
+	if err != nil {
+		glog.Fatalf("Error reading key for service account token generator: %v", err)
+	}
+
+	return serviceaccount.JWTTokenGenerator(privateKey)
+}

--- a/pkg/client/service_accounts.go
+++ b/pkg/client/service_accounts.go
@@ -34,6 +34,8 @@ type ServiceAccountsInterface interface {
 	List(label labels.Selector, field fields.Selector) (*api.ServiceAccountList, error)
 	Get(name string) (*api.ServiceAccount, error)
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+
+	RequestToken(serviceAccountName string, tokenRequest *api.ServiceAccountTokenRequest) (*api.ServiceAccountTokenResponse, error)
 }
 
 // serviceAccounts implements ServiceAccounts interface
@@ -122,4 +124,18 @@ func (s *serviceAccounts) Update(serviceAccount *api.ServiceAccount) (result *ap
 		Into(result)
 
 	return
+}
+
+func (s *serviceAccounts) RequestToken(serviceAccountName string, serviceAccountTokenRequest *api.ServiceAccountTokenRequest) (*api.ServiceAccountTokenResponse, error) {
+	result := &api.ServiceAccountTokenResponse{}
+	err := s.client.Post().
+		Namespace(s.namespace).
+		Resource("serviceAccounts").
+		Name(serviceAccountName).
+		SubResource("token").
+		Body(serviceAccountTokenRequest).
+		Do().
+		Into(result)
+
+	return result, err
 }

--- a/pkg/client/testclient/fake_service_accounts.go
+++ b/pkg/client/testclient/fake_service_accounts.go
@@ -59,3 +59,8 @@ func (c *FakeServiceAccounts) Watch(label labels.Selector, field fields.Selector
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-serviceAccounts", Value: resourceVersion})
 	return c.Fake.Watch, c.Fake.Err
 }
+
+func (c *FakeServiceAccounts) RequestToken(serviceAccountName string, tokenRequest *api.ServiceAccountTokenRequest) (*api.ServiceAccountTokenResponse, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "create-serviceaccounttokenresponse", Value: serviceAccountName}, &api.ServiceAccountTokenResponse{})
+	return obj.(*api.ServiceAccountTokenResponse), err
+}

--- a/pkg/registry/serviceaccount/interfaces.go
+++ b/pkg/registry/serviceaccount/interfaces.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccount
+
+import "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+
+type TokenGenerator interface {
+	// GenerateToken generates a token which will identify the given ServiceAccount.
+	// The returned token will be stored in the given (and yet-unpersisted) Secret.
+	GenerateToken(request api.ServiceAccountTokenRequest, serviceAccount api.ServiceAccount, secret api.Secret) (string, error)
+}

--- a/pkg/serviceaccount/tokens_controller.go
+++ b/pkg/serviceaccount/tokens_controller.go
@@ -17,7 +17,7 @@ limitations under the License.
 package serviceaccount
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -27,7 +27,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/controller/framework"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/secret"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -36,8 +35,6 @@ import (
 
 // TokensControllerOptions contains options for the TokensController
 type TokensControllerOptions struct {
-	// TokenGenerator is the generator to use to create new tokens
-	TokenGenerator TokenGenerator
 	// ServiceAccountResync is the time.Duration at which to fully re-list service accounts.
 	// If zero, re-list will be delayed as long as possible
 	ServiceAccountResync time.Duration
@@ -47,15 +44,14 @@ type TokensControllerOptions struct {
 }
 
 // DefaultTokenControllerOptions returns
-func DefaultTokenControllerOptions(tokenGenerator TokenGenerator) TokensControllerOptions {
-	return TokensControllerOptions{TokenGenerator: tokenGenerator}
+func DefaultTokenControllerOptions() TokensControllerOptions {
+	return TokensControllerOptions{}
 }
 
 // NewTokensController returns a new *TokensController.
 func NewTokensController(cl client.Interface, options TokensControllerOptions) *TokensController {
 	e := &TokensController{
 		client: cl,
-		token:  options.TokenGenerator,
 	}
 
 	e.serviceAccounts, e.serviceAccountController = framework.NewIndexerInformer(
@@ -108,7 +104,6 @@ type TokensController struct {
 	stopChan chan struct{}
 
 	client client.Interface
-	token  TokenGenerator
 
 	serviceAccounts cache.Indexer
 	secrets         cache.Indexer
@@ -198,8 +193,6 @@ func (e *TokensController) secretAdded(obj interface{}) {
 		if err := e.deleteSecret(secret); err != nil {
 			glog.Errorf("Error deleting secret %s/%s: %v", secret.Namespace, secret.Name, err)
 		}
-	} else {
-		e.generateTokenIfNeeded(serviceAccount, secret)
 	}
 }
 
@@ -218,8 +211,6 @@ func (e *TokensController) secretUpdated(oldObj interface{}, newObj interface{})
 		if err := e.deleteSecret(newSecret); err != nil {
 			glog.Errorf("Error deleting secret %s/%s: %v", newSecret.Namespace, newSecret.Name, err)
 		}
-	} else {
-		e.generateTokenIfNeeded(newServiceAccount, newSecret)
 	}
 }
 
@@ -271,30 +262,16 @@ func (e *TokensController) createSecretIfNeeded(serviceAccount *api.ServiceAccou
 
 // createSecret creates a secret of type ServiceAccountToken for the given ServiceAccount
 func (e *TokensController) createSecret(serviceAccount *api.ServiceAccount) error {
-	// Build the secret
-	secret := &api.Secret{
-		ObjectMeta: api.ObjectMeta{
-			Name:      secret.Strategy.GenerateName(fmt.Sprintf("%s-token-", serviceAccount.Name)),
-			Namespace: serviceAccount.Namespace,
-			Annotations: map[string]string{
-				api.ServiceAccountNameKey: serviceAccount.Name,
-				api.ServiceAccountUIDKey:  string(serviceAccount.UID),
-			},
-		},
-		Type: api.SecretTypeServiceAccountToken,
-		Data: map[string][]byte{},
-	}
+	tokenRequest := &api.ServiceAccountTokenRequest{}
 
-	// Generate the token
-	token, err := e.token.GenerateToken(*serviceAccount, *secret)
+	tokenResponse, err := e.client.ServiceAccounts(serviceAccount.Namespace).RequestToken(serviceAccount.Name, tokenRequest)
 	if err != nil {
 		return err
 	}
-	secret.Data[api.ServiceAccountTokenKey] = []byte(token)
 
-	// Save the secret
-	if _, err := e.client.Secrets(serviceAccount.Namespace).Create(secret); err != nil {
-		return err
+	secretName := tokenResponse.Secret.Name
+	if len(secretName) == 0 {
+		return errors.New("Token request was not fulfilled")
 	}
 
 	// We don't want to update the cache's copy of the service account
@@ -304,13 +281,13 @@ func (e *TokensController) createSecret(serviceAccount *api.ServiceAccount) erro
 	if err != nil {
 		return err
 	}
-	serviceAccount.Secrets = append(serviceAccount.Secrets, api.ObjectReference{Name: secret.Name})
+	serviceAccount.Secrets = append(serviceAccount.Secrets, api.ObjectReference{Name: secretName})
 
 	_, err = serviceAccounts.Update(serviceAccount)
 	if err != nil {
 		// we weren't able to use the token, try to clean it up.
-		glog.V(2).Infof("Deleting secret %s/%s because reference couldn't be added (%v)", secret.Namespace, secret.Name, err)
-		if err := e.client.Secrets(secret.Namespace).Delete(secret.Name); err != nil {
+		glog.V(2).Infof("Deleting secret %s/%s because reference couldn't be added (%v)", serviceAccount.Namespace, secretName, err)
+		if err := e.client.Secrets(serviceAccount.Namespace).Delete(secretName); err != nil {
 			glog.Error(err) // if we fail, just log it
 		}
 	}
@@ -320,38 +297,6 @@ func (e *TokensController) createSecret(serviceAccount *api.ServiceAccount) erro
 	}
 
 	return err
-}
-
-// generateTokenIfNeeded populates the token data for the given Secret if not already set
-func (e *TokensController) generateTokenIfNeeded(serviceAccount *api.ServiceAccount, secret *api.Secret) error {
-	if secret.Annotations == nil {
-		secret.Annotations = map[string]string{}
-	}
-	if secret.Data == nil {
-		secret.Data = map[string][]byte{}
-	}
-
-	tokenData, ok := secret.Data[api.ServiceAccountTokenKey]
-	if ok && len(tokenData) > 0 {
-		return nil
-	}
-
-	// Generate the token
-	token, err := e.token.GenerateToken(*serviceAccount, *secret)
-	if err != nil {
-		return err
-	}
-
-	// Set the token and annotations
-	secret.Data[api.ServiceAccountTokenKey] = []byte(token)
-	secret.Annotations[api.ServiceAccountNameKey] = serviceAccount.Name
-	secret.Annotations[api.ServiceAccountUIDKey] = string(serviceAccount.UID)
-
-	// Save the secret
-	if _, err := e.client.Secrets(secret.Namespace).Update(secret); err != nil {
-		return err
-	}
-	return nil
 }
 
 // deleteSecret deletes the given secret

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -419,10 +419,11 @@ func startServiceAccountTestServer(t *testing.T) (*client.Client, client.Config,
 		Authenticator:     authenticator,
 		Authorizer:        authorizer,
 		AdmissionControl:  serviceAccountAdmission,
+		TokenGenerator:    serviceaccount.JWTTokenGenerator(serviceAccountKey),
 	})
 
 	// Start the service account and service account token controllers
-	tokenController := serviceaccount.NewTokensController(rootClient, serviceaccount.DefaultTokenControllerOptions(serviceaccount.JWTTokenGenerator(serviceAccountKey)))
+	tokenController := serviceaccount.NewTokensController(rootClient, serviceaccount.DefaultTokenControllerOptions())
 	tokenController.Run()
 	serviceAccountController := serviceaccount.NewServiceAccountsController(rootClient, serviceaccount.DefaultServiceAccountsControllerOptions())
 	serviceAccountController.Run()


### PR DESCRIPTION
This moves service account token generation back into the master as a subresource of serviceaccount:

Example uses: 

``` sh
$ echo '{"kind":"ServiceAccountTokenRequest","apiVersion":"v1beta3"}' > tokenrequest.json
$ curl -X POST $API_ROOT/namespaces/$NS/serviceaccounts/$SERVICEACCOUNT/token -d @tokenrequest.json 

{
  "kind": "ServiceAccountTokenResponse",
  "apiVersion": "v1beta3",
  "metadata": {
    "selfLink": "/api/v1beta3/namespaces/default/serviceaccounts/default/token",
    "creationTimestamp": null
  },
  "secret": {
    "name": "default-token-joehc"
  }
}
```

``` go
tokenRequest := &api.ServiceAccountTokenRequest{}
tokenResponse, err := client.ServiceAccounts(myNamespace).CreateToken(myServiceAccountName, tokenRequest)
fmt.Println(tokenResponse.Secret.Name)
```

This has the following benefits:
- Controller manager is stateless again
- Token signing secret is kept in the master, not in controller processes
- Manual token creation is a straightforward POST of a token request, rather than having to know the right annotations to trigger the token controller to generate a token
- Manual token creation is synchronous, rather than creating a secret and waiting for the token_controller to populate the token data in it
- Provides a clear place to set options for the token (currently, just expiration time, but eventually, scopes or custom claims)
