### PR TITLE
Add pre-commit hook to update generated deep copies

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -106,6 +106,12 @@ if ! hack/verify-generated-conversions.sh > /dev/null; then
   echo "To regenerate conversions, run:"
   echo "  hack/update-generated-conversions.sh"
   exit_code=1
+elif ! hack/verify-generated-deep-copies.sh > /dev/null; then
+  echo "${red}ERROR!"
+  echo "Some conversions functions need regeneration."
+  echo "To regenerate conversions, run:"
+  echo "  hack/update-generated-deep-copies.sh"
+  exit_code=1
 else
   echo "${green}OK"
 fi


### PR DESCRIPTION
TestNoManualChangesToGenerateDeepCopies fails without, passes with. Maybe this should be a presubmit hook if it isn't already?
@wojtek-t 
