### PR TITLE
Do not set container requests in limit ranger for Kube 1.0

### DIFF
--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -145,10 +145,6 @@ func defaultContainerResourceRequirements(limitRange *api.LimitRange) api.Resour
 				value := v.Copy()
 				requirements.Limits[k] = *value
 			}
-			for k, v := range limit.Min {
-				value := v.Copy()
-				requirements.Requests[k] = *value
-			}
 		}
 	}
 	return requirements

--- a/plugin/pkg/admission/limitranger/admission_test.go
+++ b/plugin/pkg/admission/limitranger/admission_test.go
@@ -84,7 +84,7 @@ func TestDefaultContainerResourceRequirements(t *testing.T) {
 	limitRange := validLimitRange()
 	expected := api.ResourceRequirements{
 		Limits:   getResourceList("50m", "5Mi"),
-		Requests: getResourceList("25m", "1Mi"),
+		Requests: api.ResourceList{},
 	}
 
 	actual := defaultContainerResourceRequirements(&limitRange)
@@ -118,10 +118,7 @@ func TestMergePodResourceRequirements(t *testing.T) {
 			api.ResourceCPU:    defaultRequirements.Limits[api.ResourceCPU],
 			api.ResourceMemory: resource.MustParse("512Mi"),
 		},
-		Requests: api.ResourceList{
-			api.ResourceCPU:    defaultRequirements.Requests[api.ResourceCPU],
-			api.ResourceMemory: defaultRequirements.Requests[api.ResourceMemory],
-		},
+		Requests: api.ResourceList{},
 	}
 	mergePodResourceRequirements(&pod, &defaultRequirements)
 	for i := range pod.Spec.Containers {


### PR DESCRIPTION
The LimitRanger admission plug-in was setting container.requests to the limitRange.Min if there were no minimum requests specified.  Since requests on a container is not supported in 1.0, I am disabling this part of the LimitRanger plug-in and we can revisit at a later time.

/cc @bgrant0607 
