### PR TITLE
Add a new contiguous allocator strategy option

### DIFF
--- a/pkg/registry/service/portallocator/allocator.go
+++ b/pkg/registry/service/portallocator/allocator.go
@@ -151,8 +151,7 @@ func (r *PortAllocator) Restore(pr util.PortRange, data []byte) error {
 	if !ok {
 		return fmt.Errorf("not a snapshottable allocator")
 	}
-	snapshottable.Restore(pr.String(), data)
-	return nil
+	return snapshottable.Restore(pr.String(), data)
 }
 
 // contains returns true and the offset if the port is in the range, and false


### PR DESCRIPTION
Also fix an error in port allocator.  I'm using contiguous allocation for a UID
and SELinux label allocator in OpenShift but will be backporting it post 1.0.

@justinsb something I missed during your code review or @thockin
