### PR TITLE
Introduce framework in e2e services; should log events on failure

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -40,6 +40,8 @@ import (
 var ServiceNodePortRange = util.PortRange{Base: 30000, Size: 2768}
 
 var _ = Describe("Services", func() {
+	f := NewFramework("services")
+
 	var c *client.Client
 	// Use these in tests.  They're unique for each test to prevent name collisions.
 	var namespaces [2]string
@@ -336,9 +338,8 @@ var _ = Describe("Services", func() {
 		SkipUnlessProviderIs("gce", "gke", "aws")
 
 		serviceName := "mutability-service-test"
-		ns := namespaces[0]
 
-		t := NewWebserverTest(c, ns, serviceName)
+		t := NewWebserverTest(f.Client, f.Namespace.Name, serviceName)
 		defer func() {
 			defer GinkgoRecover()
 			errs := t.Cleanup()
@@ -371,7 +372,7 @@ var _ = Describe("Services", func() {
 		t.CreateWebserverRC(1)
 
 		By("changing service " + serviceName + " to type=NodePort")
-		service, err = updateService(c, ns, serviceName, func(s *api.Service) {
+		service, err = updateService(f.Client, f.Namespace.Name, serviceName, func(s *api.Service) {
 			s.Spec.Type = api.ServiceTypeNodePort
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -394,19 +395,19 @@ var _ = Describe("Services", func() {
 			Failf("got unexpected len(Status.LoadBalancer.Ingresss) for NodePort service: %v", service)
 		}
 		By("hitting the pod through the service's NodePort")
-		ip := pickMinionIP(c)
+		ip := pickMinionIP(f.Client)
 		nodePort1 := port.NodePort // Save for later!
 		testReachable(ip, nodePort1)
 
 		By("changing service " + serviceName + " to type=LoadBalancer")
 		service.Spec.Type = api.ServiceTypeLoadBalancer
-		service, err = updateService(c, ns, serviceName, func(s *api.Service) {
+		service, err = updateService(f.Client, f.Namespace.Name, serviceName, func(s *api.Service) {
 			s.Spec.Type = api.ServiceTypeLoadBalancer
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		// Wait for the load balancer to be created asynchronously
-		service, err = waitForLoadBalancerIngress(c, serviceName, ns)
+		service, err = waitForLoadBalancerIngress(f.Client, serviceName, f.Namespace.Name)
 		Expect(err).NotTo(HaveOccurred())
 
 		if service.Spec.Type != api.ServiceTypeLoadBalancer {
@@ -427,7 +428,7 @@ var _ = Describe("Services", func() {
 			Failf("got unexpected Status.LoadBalancer.Ingresss[0] for LoadBalancer service: %v", service)
 		}
 		By("hitting the pod through the service's NodePort")
-		ip = pickMinionIP(c)
+		ip = pickMinionIP(f.Client)
 		testReachable(ip, nodePort1)
 		By("hitting the pod through the service's LoadBalancer")
 		testLoadBalancerReachable(ingress1, 80)
@@ -438,7 +439,7 @@ var _ = Describe("Services", func() {
 			//Check for (unlikely) assignment at bottom of range
 			nodePort2 = nodePort1 + 1
 		}
-		service, err = updateService(c, ns, serviceName, func(s *api.Service) {
+		service, err = updateService(f.Client, f.Namespace.Name, serviceName, func(s *api.Service) {
 			s.Spec.Ports[0].NodePort = nodePort2
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -462,7 +463,7 @@ var _ = Describe("Services", func() {
 		if providerIs("aws") {
 			// TODO: Make this less of a hack (or fix the underlying bug)
 			time.Sleep(time.Second * 120)
-			service, err = waitForLoadBalancerIngress(c, serviceName, ns)
+			service, err = waitForLoadBalancerIngress(f.Client, serviceName, f.Namespace.Name)
 			Expect(err).NotTo(HaveOccurred())
 
 			// We don't want the ingress point to change, but we should verify that the new ingress point still works
@@ -480,7 +481,7 @@ var _ = Describe("Services", func() {
 		testNotReachable(ip, nodePort1)
 
 		By("changing service " + serviceName + " back to type=ClusterIP")
-		service, err = updateService(c, ns, serviceName, func(s *api.Service) {
+		service, err = updateService(f.Client, f.Namespace.Name, serviceName, func(s *api.Service) {
 			s.Spec.Type = api.ServiceTypeClusterIP
 			s.Spec.Ports[0].NodePort = 0
 		})
@@ -498,17 +499,17 @@ var _ = Describe("Services", func() {
 		}
 
 		// Wait for the load balancer to be destroyed asynchronously
-		service, err = waitForLoadBalancerDestroy(c, serviceName, ns)
+		service, err = waitForLoadBalancerDestroy(f.Client, serviceName, f.Namespace.Name)
 		Expect(err).NotTo(HaveOccurred())
 
 		if len(service.Status.LoadBalancer.Ingress) != 0 {
 			Failf("got unexpected len(Status.LoadBalancer.Ingresss) for back-to-ClusterIP service: %v", service)
 		}
 		By("checking the NodePort (original) is closed")
-		ip = pickMinionIP(c)
+		ip = pickMinionIP(f.Client)
 		testNotReachable(ip, nodePort1)
 		By("checking the NodePort (updated) is closed")
-		ip = pickMinionIP(c)
+		ip = pickMinionIP(f.Client)
 		testNotReachable(ip, nodePort2)
 		By("checking the LoadBalancer is closed")
 		testLoadBalancerNotReachable(ingress2, 80)


### PR DESCRIPTION
Once #8887 merges this should show errors in load balancer creation.

Even before then, it may show another error.

Bug #8892
