### PR TITLE
Ensure kubelet root is not a symlink

### DIFF
--- a/cluster/aws/templates/format-disks.sh
+++ b/cluster/aws/templates/format-disks.sh
@@ -75,5 +75,6 @@ else
   fi
   mkdir -p /mnt/kubelet
   ln -s /mnt/kubelet /var/lib/kubelet
+  KUBELET_ROOT="/mnt/kubelet"
 fi
 

--- a/cluster/aws/templates/salt-master.sh
+++ b/cluster/aws/templates/salt-master.sh
@@ -38,6 +38,12 @@ if [[ -n "${DOCKER_ROOT}" ]]; then
 EOF
 fi
 
+if [[ -n "${KUBELET_ROOT}" ]]; then
+  cat <<EOF >>/etc/salt/minion.d/grains.conf
+  kubelet_root: '$(echo "$KUBELET_ROOT" | sed -e "s/'/''/g")'
+EOF
+fi
+
 # Auto accept all keys from minions that try to join
 mkdir -p /etc/salt/master.d
 cat <<EOF >/etc/salt/master.d/auto-accept.conf

--- a/cluster/aws/templates/salt-minion.sh
+++ b/cluster/aws/templates/salt-minion.sh
@@ -55,6 +55,12 @@ if [[ -n "${DOCKER_ROOT}" ]]; then
 EOF
 fi
 
+if [[ -n "${KUBELET_ROOT}" ]]; then
+  cat <<EOF >>/etc/salt/minion.d/grains.conf
+  kubelet_root: '$(echo "$KUBELET_ROOT" | sed -e "s/'/''/g")'
+EOF
+fi
+
 install-salt
 
 service salt-minion start

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -53,6 +53,11 @@
   {% set docker_root = " --docker_root=" + grains.docker_root -%}
 {% endif -%}
 
+{% set kubelet_root = "" -%}
+{% if grains.kubelet_root is defined -%}
+  {% set kubelet_root = " --root_dir=" + grains.kubelet_root -%}
+{% endif -%}
+
 {% set configure_cbr0 = "" -%}
 {% if pillar['allocate_node_cidrs'] is defined -%}
   {% set configure_cbr0 = "--configure-cbr0=" + pillar['allocate_node_cidrs'] -%}
@@ -66,4 +71,4 @@
   {% set cgroup_root = "--cgroup_root=/" -%}
 {% endif -%}
 
-DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{hostname_override}} {{cloud_provider}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}}"
+DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{hostname_override}} {{cloud_provider}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}}"

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -69,7 +69,7 @@ func GetMountRefs(mounter Interface, mountPath string) ([]string, error) {
 	// Find all references to the device.
 	var refs []string
 	if deviceName == "" {
-		glog.Warningf("could not determine device for path: %s", mountPath)
+		glog.Warningf("could not determine device for path: %q", mountPath)
 	} else {
 		for i := range mps {
 			if mps[i].Device == deviceName && mps[i].Path != mountPath {

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -18,6 +18,8 @@ limitations under the License.
 // an alternate platform, we will need to abstract further.
 package mount
 
+import "github.com/golang/glog"
+
 type Interface interface {
 	// Mount mounts source to target as fstype with given options.
 	Mount(source string, target string, fstype string, options []string) error
@@ -66,9 +68,13 @@ func GetMountRefs(mounter Interface, mountPath string) ([]string, error) {
 
 	// Find all references to the device.
 	var refs []string
-	for i := range mps {
-		if mps[i].Device == deviceName && mps[i].Path != mountPath {
-			refs = append(refs, mps[i].Path)
+	if deviceName == "" {
+		glog.Warningf("could not determine device for path: %s", mountPath)
+	} else {
+		for i := range mps {
+			if mps[i].Device == deviceName && mps[i].Path != mountPath {
+				refs = append(refs, mps[i].Path)
+			}
 		}
 	}
 	return refs, nil

--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -289,6 +289,9 @@ func (pd *awsElasticBlockStore) TearDownAt(dir string) error {
 		glog.V(2).Info("Error getting mountrefs for ", dir, ": ", err)
 		return err
 	}
+	if len(refs) == 0 {
+		glog.Warning("Did not find pod-mount for ", dir, " during tear-down")
+	}
 	// Unmount the bind-mount inside this pod
 	if err := pd.mounter.Unmount(dir); err != nil {
 		glog.V(2).Info("Error unmounting dir ", dir, ": ", err)
@@ -307,6 +310,8 @@ func (pd *awsElasticBlockStore) TearDownAt(dir string) error {
 			glog.V(2).Info("Error detaching disk ", pd.volumeID, ": ", err)
 			return err
 		}
+	} else {
+		glog.V(2).Infof("Found multiple refs; won't detach EBS volume: %v", refs)
 	}
 	mountpoint, mntErr := pd.mounter.IsMountPoint(dir)
 	if mntErr != nil {


### PR DESCRIPTION
The dismount detection logic was broken when /var/lib/kubelet was a symlink. This is because mounts are reported with the canonicalized (dereferenced-symlinks) path, and that wasn't matching the path we expected.

We used a symlink on AWS to put /var/lib/kubelet onto /mnt/kubelet, but now we tell kubelet the correct path.

In that example, the mounts are reported as "/mnt/kubelet/...", but we were looking for "/var/lib/kubelet/..."
