### PR TITLE
Update instructions on auto-generating conversions. 

### DIFF
--- a/docs/devel/api_changes.md
+++ b/docs/devel/api_changes.md
@@ -254,6 +254,12 @@ regenerate auto-generated ones. To regenerate them:
    $ hack/update-generated-conversions.sh
 ```
 
+If running the above script is impossible due to compile errors, the easiest
+workaround is to comment out the code causing errors and let the script to
+regenerate it. If the auto-generated conversion methods are not used by the
+manually-written ones, it's fine to just remove the whole file and let the
+generator to create it from scratch.
+
 Unsurprisingly, adding manually written conversion also requires you to add tests to
 `pkg/api/<version>/conversion_test.go`.
 

--- a/hack/update-generated-deep-copies.sh
+++ b/hack/update-generated-deep-copies.sh
@@ -18,6 +18,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+function result_file_name() {
+	local version=$1
+	if [ "${version}" == "api" ]; then
+		echo "pkg/api/deep_copy_generated.go"
+	else
+		echo "pkg/api/${version}/deep_copy_generated.go"
+	fi
+}
+
 function generate_version() {
 	local version=$1
 	local TMPFILE="/tmp/deep_copy_generated.$(date +%s).go"
@@ -38,14 +47,14 @@ EOF
 EOF
 
 	gofmt -w -s $TMPFILE
-	if [ "${version}" == "api" ]; then
-		mv $TMPFILE pkg/api/deep_copy_generated.go
-	else
-		mv $TMPFILE pkg/api/${version}/deep_copy_generated.go
-	fi
+	mv $TMPFILE `result_file_name ${version}`
 }
 
 VERSIONS="api v1beta3 v1"
+# To avoid compile errors, remove the currently existing files.
+for ver in $VERSIONS; do
+	rm -f `result_file_name ${ver}`
+done
 for ver in $VERSIONS; do 
 	generate_version "${ver}"
 done


### PR DESCRIPTION
Also, fix the problem of non-compiling code for regenerating deep-copy functions.

cc @bgrant0607 
