### PR TITLE
Fix the race when monit is used to monitor services which are also

### DIFF
--- a/cluster/saltbase/salt/kube-proxy/initd
+++ b/cluster/saltbase/salt/kube-proxy/initd
@@ -40,6 +40,13 @@ DAEMON_USER=root
 #
 do_start()
 {
+        # Avoid a potential race at boot time when both monit and init.d start
+        # the same service
+        PIDS=$(pidof $DAEMON)
+        for PID in ${PIDS}; do
+            kill -9 $PID
+	done
+
         # Raise the file descriptor limit - we expect to open a lot of sockets!
         ulimit -n 65536
 

--- a/cluster/saltbase/salt/kubelet/initd
+++ b/cluster/saltbase/salt/kubelet/initd
@@ -39,6 +39,13 @@ DAEMON_USER=root
 #
 do_start()
 {
+        # Avoid a potential race at boot time when both monit and init.d start
+        # the same service
+        PIDS=$(pidof $DAEMON)
+        for PID in ${PIDS}; do
+            kill -9 $PID
+	done
+
         # Return
         #   0 if daemon has been started
         #   1 if daemon was already running


### PR DESCRIPTION
started at boot time via init.d at boot time.

Fixed #8742

I ran e2e tests earlier this morning, but failed due to e2e current breakage. I manually tested this on machine without current patch, manually running service kubelet start (not restart) will reproduce binding issue reported in #8742 

```
# ps -ef | grep kubelet
root      5609     1  1 17:38 ?        00:00:12 /usr/local/bin/kubelet --api_servers=https://kubernetes-master --cloud_provider=gce --config=/etc/kubernetes/manifests --allow_privileged=False --v=2 --cluster_dns=10.0.0.10 --cluster_domain=cluster.local --configure-cbr0=true --cgroup_root=/

# service kubelet start
[ ok ] Starting The Kubernetes container manager: kubelet.

# ps -ef | grep kubelet
root     16737     1  9 17:56 ?        00:00:01 /usr/local/bin/kubelet --api_servers=https://kubernetes-master --cloud_provider=gce --config=/etc/kubernetes/manifests --allow_privileged=False --v=2 --cluster_dns=10.0.0.10 --cluster_domain=cluster.local --configure-cbr0=true --cgroup_root=/

```

cc/ @vmarmol @roberthbailey 
