### PR TITLE
Fix makefiles for NFS and Gluster images

### DIFF
--- a/contrib/for-tests/volumes-tester/gluster/Makefile
+++ b/contrib/for-tests/volumes-tester/gluster/Makefile
@@ -3,9 +3,11 @@ all: push
 TAG = 0.1
 
 container:
-	docker build -t gcr.io/google_containers/volume-gluster:$(TAG) .
+	docker build -t gcr.io/google_containers/volume-gluster . # Build new image and automatically tag it as latest
+	docker tag gcr.io/google_containers/volume-gluster gcr.io/google_containers/volume-gluster:$(TAG)  # Add the version tag to the latest image 
 
 push: container
-	gcloud preview docker push gcr.io/google_containers/volume-gluster:$(TAG)
+	gcloud preview docker push gcr.io/google_containers/volume-gluster # Push image tagged as latest to repository
+	gcloud preview docker push gcr.io/google_containers/volume-gluster:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
 
 clean:

--- a/contrib/for-tests/volumes-tester/nfs/Makefile
+++ b/contrib/for-tests/volumes-tester/nfs/Makefile
@@ -3,9 +3,11 @@ all: push
 TAG = 0.1
 
 container:
-	docker build -t gcr.io/google_containers/volume-nfs:$(TAG) .
+	docker build -t gcr.io/google_containers/volume-nfs . # Build new image and automatically tag it as latest
+	docker tag gcr.io/google_containers/volume-nfs gcr.io/google_containers/volume-nfs:$(TAG) # Add the version tag to the latest image 
 
 push: container
-	gcloud preview docker push gcr.io/google_containers/volume-nfs:$(TAG)
+	gcloud preview docker push gcr.io/google_containers/volume-nfs # Push image tagged as latest to repository
+	gcloud preview docker push gcr.io/google_containers/volume-nfs:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
 
 clean:


### PR DESCRIPTION
Follow up to [this comment](https://github.com/GoogleCloudPlatform/kubernetes/pull/7435#discussion-diff-31237833) in #7435

Modified the makefiles for the NFS and Gluster docker images so that the latest tag is properly applied.

On-call: These images are used for NFS and Gluster E2E tests (currently disabled), so this PR should be ok for 1.0 ("test related fixes" exemption).

With this change all the following commands now work:

```
gcloud preview docker pull gcr.io/google_containers/volume-gluster:0.1
gcloud preview docker pull gcr.io/google_containers/volume-nfs:0.1
gcloud preview docker pull gcr.io/google_containers/volume-gluster:latest
gcloud preview docker pull gcr.io/google_containers/volume-nfs:latest
gcloud preview docker pull gcr.io/google_containers/volume-gluster
gcloud preview docker pull gcr.io/google_containers/volume-nfs
```

CC @timothysc, @jsafrane, @childsb
