### PR TITLE
Update the services web ui for nodeport and loadbalancer

### DIFF
--- a/pkg/ui/datafile.go
+++ b/pkg/ui/datafile.go
@@ -71,7 +71,7 @@ func www_app_assets_css_app_css() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/css/app.css", size: 32046, mode: os.FileMode(420), modTime: time.Unix(1433785222, 0)}
+	info := bindata_file_info{name: "www/app/assets/css/app.css", size: 32046, mode: os.FileMode(420), modTime: time.Unix(1433786409, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -88,7 +88,7 @@ func www_app_assets_img_docarrow_png() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/img/docArrow.png", size: 373, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/assets/img/docArrow.png", size: 373, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -109,7 +109,7 @@ func www_app_assets_img_ic_arrow_drop_down_24px_svg() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/img/ic_arrow_drop_down_24px.svg", size: 166, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/assets/img/ic_arrow_drop_down_24px.svg", size: 166, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -151,7 +151,7 @@ func www_app_assets_img_ic_arrow_drop_up_24px_svg() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/img/ic_arrow_drop_up_24px.svg", size: 795, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/assets/img/ic_arrow_drop_up_24px.svg", size: 795, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -168,7 +168,7 @@ func www_app_assets_img_ic_keyboard_arrow_left_24px_svg() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/img/ic_keyboard_arrow_left_24px.svg", size: 151, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/assets/img/ic_keyboard_arrow_left_24px.svg", size: 151, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -185,7 +185,7 @@ func www_app_assets_img_ic_keyboard_arrow_right_24px_svg() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/img/ic_keyboard_arrow_right_24px.svg", size: 149, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/assets/img/ic_keyboard_arrow_right_24px.svg", size: 149, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -202,7 +202,7 @@ func www_app_assets_img_icons_arrow_back_png() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/img/icons/arrow-back.png", size: 635, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/assets/img/icons/arrow-back.png", size: 635, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -219,7 +219,7 @@ func www_app_assets_img_icons_favicon_png() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/img/icons/favicon.png", size: 1663, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/assets/img/icons/favicon.png", size: 1663, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -236,7 +236,7 @@ func www_app_assets_img_icons_ic_arrow_forward_24px_svg() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/img/icons/ic_arrow_forward_24px.svg", size: 158, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/assets/img/icons/ic_arrow_forward_24px.svg", size: 158, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -253,7 +253,7 @@ func www_app_assets_img_icons_ic_cancel_24px_svg() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/img/icons/ic_cancel_24px.svg", size: 276, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/assets/img/icons/ic_cancel_24px.svg", size: 276, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -270,7 +270,7 @@ func www_app_assets_img_icons_ic_close_24px_svg() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/img/icons/ic_close_24px.svg", size: 202, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/assets/img/icons/ic_close_24px.svg", size: 202, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -300,7 +300,7 @@ func www_app_assets_img_icons_ic_menu_svg() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/img/icons/ic_menu.svg", size: 791, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/assets/img/icons/ic_menu.svg", size: 791, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -340,7 +340,7 @@ func www_app_assets_img_icons_ic_menu_24px_svg() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/img/icons/ic_menu_24px.svg", size: 841, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/assets/img/icons/ic_menu_24px.svg", size: 841, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -357,7 +357,7 @@ func www_app_assets_img_icons_list_control_down_png() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/img/icons/list_control_down.png", size: 309, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/assets/img/icons/list_control_down.png", size: 309, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -379,7 +379,7 @@ func www_app_assets_img_kubernetes_svg() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/img/kubernetes.svg", size: 11663, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/assets/img/kubernetes.svg", size: 11663, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2115,7 +2115,7 @@ app.controller('ListServicesCtrl', [
                 var n = '';
                 if(p.name)
                   n = p.name + ': ';
-                 n = n + p.port;
+                n = n + p.port;
                 return n;
                }).join(', ');
             }
@@ -3091,7 +3091,7 @@ func www_app_assets_js_app_js() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/js/app.js", size: 91412, mode: os.FileMode(420), modTime: time.Unix(1433785222, 0)}
+	info := bindata_file_info{name: "www/app/assets/js/app.js", size: 91411, mode: os.FileMode(420), modTime: time.Unix(1433786408, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3133,7 +3133,7 @@ func www_app_assets_js_base_js() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/assets/js/base.js", size: 477048, mode: os.FileMode(420), modTime: time.Unix(1433785197, 0)}
+	info := bindata_file_info{name: "www/app/assets/js/base.js", size: 477048, mode: os.FileMode(420), modTime: time.Unix(1433786380, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3150,7 +3150,7 @@ func www_app_components_dashboard_img_icons_ic_arrow_drop_down_18px_svg() (*asse
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/img/icons/ic_arrow_drop_down_18px.svg", size: 114, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/img/icons/ic_arrow_drop_down_18px.svg", size: 114, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3171,7 +3171,7 @@ func www_app_components_dashboard_img_icons_ic_arrow_drop_down_24px_svg() (*asse
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/img/icons/ic_arrow_drop_down_24px.svg", size: 166, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/img/icons/ic_arrow_drop_down_24px.svg", size: 166, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3188,7 +3188,7 @@ func www_app_components_dashboard_img_icons_ic_close_18px_svg() (*asset, error) 
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/img/icons/ic_close_18px.svg", size: 215, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/img/icons/ic_close_18px.svg", size: 215, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3205,7 +3205,7 @@ func www_app_components_dashboard_img_icons_ic_close_24px_svg() (*asset, error) 
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/img/icons/ic_close_24px.svg", size: 202, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/img/icons/ic_close_24px.svg", size: 202, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3287,7 +3287,7 @@ func www_app_components_dashboard_manifest_json() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/manifest.json", size: 1854, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/manifest.json", size: 1854, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3304,7 +3304,7 @@ func www_app_components_dashboard_pages_footer_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/pages/footer.html", size: 7, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/pages/footer.html", size: 7, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3347,7 +3347,7 @@ func www_app_components_dashboard_pages_header_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/pages/header.html", size: 1313, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/pages/header.html", size: 1313, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3371,7 +3371,7 @@ func www_app_components_dashboard_pages_home_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/pages/home.html", size: 247, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/pages/home.html", size: 247, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3422,7 +3422,7 @@ func www_app_components_dashboard_views_groups_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/groups.html", size: 1298, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/groups.html", size: 1298, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3446,7 +3446,7 @@ func www_app_components_dashboard_views_listevents_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/listEvents.html", size: 326, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/listEvents.html", size: 326, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3470,7 +3470,7 @@ func www_app_components_dashboard_views_listminions_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/listMinions.html", size: 348, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/listMinions.html", size: 348, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3494,7 +3494,7 @@ func www_app_components_dashboard_views_listpods_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/listPods.html", size: 345, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/listPods.html", size: 345, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3570,7 +3570,7 @@ func www_app_components_dashboard_views_listpodscards_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/listPodsCards.html", size: 1967, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/listPodsCards.html", size: 1967, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3604,7 +3604,7 @@ func www_app_components_dashboard_views_listpodsvisualizer_html() (*asset, error
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/listPodsVisualizer.html", size: 841, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/listPodsVisualizer.html", size: 841, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3628,7 +3628,7 @@ func www_app_components_dashboard_views_listreplicationcontrollers_html() (*asse
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/listReplicationControllers.html", size: 363, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/listReplicationControllers.html", size: 363, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3652,7 +3652,7 @@ func www_app_components_dashboard_views_listservices_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/listServices.html", size: 349, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/listServices.html", size: 349, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3758,7 +3758,7 @@ func www_app_components_dashboard_views_node_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/node.html", size: 2307, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/node.html", size: 2307, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3784,7 +3784,7 @@ func www_app_components_dashboard_views_partials_cadvisor_html() (*asset, error)
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/partials/cadvisor.html", size: 454, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/partials/cadvisor.html", size: 454, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3821,7 +3821,7 @@ func www_app_components_dashboard_views_partials_groupbox_html() (*asset, error)
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/partials/groupBox.html", size: 769, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/partials/groupBox.html", size: 769, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3880,7 +3880,7 @@ func www_app_components_dashboard_views_partials_groupitem_html() (*asset, error
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/partials/groupItem.html", size: 2213, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/partials/groupItem.html", size: 2213, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3930,7 +3930,7 @@ func www_app_components_dashboard_views_partials_podtilesbyname_html() (*asset, 
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/partials/podTilesByName.html", size: 1287, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/partials/podTilesByName.html", size: 1287, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3980,7 +3980,7 @@ func www_app_components_dashboard_views_partials_podtilesbyserver_html() (*asset
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/partials/podTilesByServer.html", size: 1281, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/partials/podTilesByServer.html", size: 1281, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4111,7 +4111,7 @@ func www_app_components_dashboard_views_pod_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/pod.html", size: 4149, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/pod.html", size: 4149, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4181,7 +4181,7 @@ var _www_app_components_dashboard_views_replication_html = []byte(`<div dashboar
               </div>
 
               <div ng-repeat="(label, value) in replicationController.spec.selector">
-                <a ng-href="#/dashboard/groups/type/selector/{{label}}={{value}},type=pod">{{label}}={{value}}</a>
+                <a ng-href="#/dashboard/groups/type/selector/{{label}}={{value}},type=pod">{{label}}: {{value}}</a>
               </div>
             </td>
           </tr>
@@ -4228,7 +4228,7 @@ func www_app_components_dashboard_views_replication_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/replication.html", size: 3207, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/replication.html", size: 3208, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4266,6 +4266,11 @@ var _www_app_components_dashboard_views_service_html = []byte(`<div dashboard-he
                   {{port.name}}:
                 </span>
                 {{port.port}}/{{port.protocol}}
+
+                <div ng-show="port.nodePort && port.nodePort != 0">
+                  Node Port: {{port.nodePort}}/{{port.protocol}}
+                </div>
+
              </div>
             </td>
           </tr>
@@ -4278,10 +4283,12 @@ var _www_app_components_dashboard_views_service_html = []byte(`<div dashboard-he
             </td>
           </tr>
 
-          <tr ng-show="service.spec.publicIPs">
-            <td class="name">Public IPs</td>
+          <tr ng-show="service.status.loadBalancer.ingress">
+            <td class="name">LoadBalancer Ingress</td>
             <td class="value">
-              {{service.spec.publicIPs | join:', '}}
+              <span ng-repeat="lb in service.status.loadBalancer.ingress">
+                {{lb.ip || lb.hostname}}{{$last ? '' : ', '}}
+              </span>
             </td>
           </tr>
 
@@ -4309,7 +4316,6 @@ var _www_app_components_dashboard_views_service_html = []byte(`<div dashboard-he
               </span>
             </td>
           </tr>
-
 
           <tr>
             <td class="name">Related Pods</td>
@@ -4359,7 +4365,7 @@ func www_app_components_dashboard_views_service_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/components/dashboard/views/service.html", size: 3539, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/components/dashboard/views/service.html", size: 3825, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4434,7 +4440,7 @@ func www_app_index_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/index.html", size: 2569, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/index.html", size: 2569, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4451,7 +4457,7 @@ func www_app_vendor_angular_json_human_dist_angular_json_human_css() (*asset, er
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/vendor/angular-json-human/dist/angular-json-human.css", size: 1151, mode: os.FileMode(420), modTime: time.Unix(1433785221, 0)}
+	info := bindata_file_info{name: "www/app/vendor/angular-json-human/dist/angular-json-human.css", size: 1151, mode: os.FileMode(420), modTime: time.Unix(1433786408, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4473,7 +4479,7 @@ func www_app_vendor_angular_material_angular_material_css() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/vendor/angular-material/angular-material.css", size: 159606, mode: os.FileMode(420), modTime: time.Unix(1433785197, 0)}
+	info := bindata_file_info{name: "www/app/vendor/angular-material/angular-material.css", size: 159606, mode: os.FileMode(420), modTime: time.Unix(1433786380, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4494,7 +4500,7 @@ func www_app_vendor_d3_d3_min_js() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/vendor/d3/d3.min.js", size: 151123, mode: os.FileMode(420), modTime: time.Unix(1433785221, 0)}
+	info := bindata_file_info{name: "www/app/vendor/d3/d3.min.js", size: 151123, mode: os.FileMode(420), modTime: time.Unix(1433786408, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4511,7 +4517,7 @@ func www_app_views_partials_404_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/views/partials/404.html", size: 60, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/views/partials/404.html", size: 60, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4542,7 +4548,7 @@ func www_app_views_partials_kubernetes_ui_menu_tmpl_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/views/partials/kubernetes-ui-menu.tmpl.html", size: 764, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/views/partials/kubernetes-ui-menu.tmpl.html", size: 764, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4606,7 +4612,7 @@ func www_app_views_partials_md_table_tmpl_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/views/partials/md-table.tmpl.html", size: 3057, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/views/partials/md-table.tmpl.html", size: 3057, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4633,7 +4639,7 @@ func www_app_views_partials_menu_toggle_tmpl_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "www/app/views/partials/menu-toggle.tmpl.html", size: 587, mode: os.FileMode(420), modTime: time.Unix(1433785189, 0)}
+	info := bindata_file_info{name: "www/app/views/partials/menu-toggle.tmpl.html", size: 587, mode: os.FileMode(420), modTime: time.Unix(1433786373, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/www/app/assets/js/app.js
+++ b/www/app/assets/js/app.js
@@ -1729,7 +1729,7 @@ app.controller('ListServicesCtrl', [
                 var n = '';
                 if(p.name)
                   n = p.name + ': ';
-                 n = n + p.port;
+                n = n + p.port;
                 return n;
                }).join(', ');
             }

--- a/www/app/components/dashboard/views/replication.html
+++ b/www/app/components/dashboard/views/replication.html
@@ -63,7 +63,7 @@
               </div>
 
               <div ng-repeat="(label, value) in replicationController.spec.selector">
-                <a ng-href="#/dashboard/groups/type/selector/{{label}}={{value}},type=pod">{{label}}={{value}}</a>
+                <a ng-href="#/dashboard/groups/type/selector/{{label}}={{value}},type=pod">{{label}}: {{value}}</a>
               </div>
             </td>
           </tr>

--- a/www/app/components/dashboard/views/service.html
+++ b/www/app/components/dashboard/views/service.html
@@ -31,6 +31,11 @@
                   {{port.name}}:
                 </span>
                 {{port.port}}/{{port.protocol}}
+
+                <div ng-show="port.nodePort && port.nodePort != 0">
+                  Node Port: {{port.nodePort}}/{{port.protocol}}
+                </div>
+
              </div>
             </td>
           </tr>
@@ -43,10 +48,12 @@
             </td>
           </tr>
 
-          <tr ng-show="service.spec.publicIPs">
-            <td class="name">Public IPs</td>
+          <tr ng-show="service.status.loadBalancer.ingress">
+            <td class="name">LoadBalancer Ingress</td>
             <td class="value">
-              {{service.spec.publicIPs | join:', '}}
+              <span ng-repeat="lb in service.status.loadBalancer.ingress">
+                {{lb.ip || lb.hostname}}{{$last ? '' : ', '}}
+              </span>
             </td>
           </tr>
 
@@ -74,7 +81,6 @@
               </span>
             </td>
           </tr>
-
 
           <tr>
             <td class="name">Related Pods</td>

--- a/www/master/components/dashboard/js/modules/controllers/listServicesController.js
+++ b/www/master/components/dashboard/js/modules/controllers/listServicesController.js
@@ -86,7 +86,7 @@ app.controller('ListServicesCtrl', [
                 var n = '';
                 if(p.name)
                   n = p.name + ': ';
-                 n = n + p.port;
+                n = n + p.port;
                 return n;
                }).join(', ');
             }

--- a/www/master/components/dashboard/views/replication.html
+++ b/www/master/components/dashboard/views/replication.html
@@ -63,7 +63,7 @@
               </div>
 
               <div ng-repeat="(label, value) in replicationController.spec.selector">
-                <a ng-href="#/dashboard/groups/type/selector/{{label}}={{value}},type=pod">{{label}}={{value}}</a>
+                <a ng-href="#/dashboard/groups/type/selector/{{label}}={{value}},type=pod">{{label}}: {{value}}</a>
               </div>
             </td>
           </tr>

--- a/www/master/components/dashboard/views/service.html
+++ b/www/master/components/dashboard/views/service.html
@@ -31,6 +31,11 @@
                   {{port.name}}:
                 </span>
                 {{port.port}}/{{port.protocol}}
+
+                <div ng-show="port.nodePort && port.nodePort != 0">
+                  Node Port: {{port.nodePort}}/{{port.protocol}}
+                </div>
+
              </div>
             </td>
           </tr>
@@ -43,10 +48,12 @@
             </td>
           </tr>
 
-          <tr ng-show="service.spec.publicIPs">
-            <td class="name">Public IPs</td>
+          <tr ng-show="service.status.loadBalancer.ingress">
+            <td class="name">LoadBalancer Ingress</td>
             <td class="value">
-              {{service.spec.publicIPs | join:', '}}
+              <span ng-repeat="lb in service.status.loadBalancer.ingress">
+                {{lb.ip || lb.hostname}}{{$last ? '' : ', '}}
+              </span>
             </td>
           </tr>
 
@@ -74,7 +81,6 @@
               </span>
             </td>
           </tr>
-
 
           <tr>
             <td class="name">Related Pods</td>


### PR DESCRIPTION
This updates the web ui services page with the new fields shown in `kubectl describe service`.
- Added NodePort and Loadbalancer
- Removed PublicIPs

Currently depends on #8611 and #8612 which should be merged shortly. 

This is also a part of the updates listed in #7122
