### PR TITLE
Remove useless master component images after saving image as tar file.

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -631,6 +631,9 @@ function kube::release::create_docker_images_for_server() {
         echo $md5_sum > ${1}/${binary_name}.docker_tag
 
         rm -rf ${docker_build_path}
+
+        kube::log::status "Deleting docker image ${docker_image_tag}"
+        "${DOCKER[@]}" rmi ${docker_image_tag}
       ) &
     done
 


### PR DESCRIPTION
cc/ @ixdy @ArtfulCoder 

This pr should prevent disk full issue caused by uncleaned master component images. 
