### PR TITLE
remove ReplicationControllerSpec.TemplateRef

### DIFF
--- a/docs/getting-started-guides/rkt/README.md
+++ b/docs/getting-started-guides/rkt/README.md
@@ -54,3 +54,6 @@ $ kube-up.sh
 ```
 
 Note that we are still working on making all containerized the master components run smoothly in rkt. Before that we are not able to run the master node with rkt yet.
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/getting-started-guides/rkt/README.md?pixel)]()

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1582,14 +1582,6 @@ func deepCopy_api_ReplicationControllerSpec(in ReplicationControllerSpec, out *R
 	} else {
 		out.Selector = nil
 	}
-	if in.TemplateRef != nil {
-		out.TemplateRef = new(ObjectReference)
-		if err := deepCopy_api_ObjectReference(*in.TemplateRef, out.TemplateRef, c); err != nil {
-			return err
-		}
-	} else {
-		out.TemplateRef = nil
-	}
 	if in.Template != nil {
 		out.Template = new(PodTemplateSpec)
 		if err := deepCopy_api_PodTemplateSpec(*in.Template, out.Template, c); err != nil {

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -106,8 +106,8 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			j.Target.Name = c.RandString()
 		},
 		func(j *api.ReplicationControllerSpec, c fuzz.Continue) {
-			c.FuzzNoCustom(j)   // fuzz self without calling this function again
-			j.TemplateRef = nil // this is required for round trip
+			c.FuzzNoCustom(j) // fuzz self without calling this function again
+			//j.TemplateRef = nil // this is required for round trip
 		},
 		func(j *api.ReplicationControllerStatus, c fuzz.Continue) {
 			// only replicas round trips

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -966,7 +966,7 @@ type ReplicationControllerSpec struct {
 	// TemplateRef is a reference to an object that describes the pod that will be created if
 	// insufficient replicas are detected. This reference is ignored if a Template is set.
 	// Must be set before converting to a v1beta3 API object
-	TemplateRef *ObjectReference `json:"templateRef,omitempty"`
+	//TemplateRef *ObjectReference `json:"templateRef,omitempty"`
 
 	// Template is the object that describes the pod that will be created if
 	// insufficient replicas are detected. Internally, this takes precedence over a

--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -193,14 +193,14 @@ func convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *a
 	} else {
 		out.Selector = nil
 	}
-	if in.TemplateRef != nil {
-		out.TemplateRef = new(ObjectReference)
-		if err := convert_api_ObjectReference_To_v1_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
-			return err
-		}
-	} else {
-		out.TemplateRef = nil
-	}
+	//if in.TemplateRef != nil {
+	//	out.TemplateRef = new(ObjectReference)
+	//	if err := convert_api_ObjectReference_To_v1_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
+	//		return err
+	//	}
+	//} else {
+	//	out.TemplateRef = nil
+	//}
 	if in.Template != nil {
 		out.Template = new(PodTemplateSpec)
 		if err := convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in.Template, out.Template, s); err != nil {
@@ -225,14 +225,14 @@ func convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(in *R
 	} else {
 		out.Selector = nil
 	}
-	if in.TemplateRef != nil {
-		out.TemplateRef = new(api.ObjectReference)
-		if err := convert_v1_ObjectReference_To_api_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
-			return err
-		}
-	} else {
-		out.TemplateRef = nil
-	}
+	//if in.TemplateRef != nil {
+	//	out.TemplateRef = new(api.ObjectReference)
+	//	if err := convert_v1_ObjectReference_To_api_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
+	//		return err
+	//	}
+	//} else {
+	//	out.TemplateRef = nil
+	//}
 	if in.Template != nil {
 		out.Template = new(api.PodTemplateSpec)
 		if err := convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, out.Template, s); err != nil {

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1518,14 +1518,6 @@ func deepCopy_v1_ReplicationControllerSpec(in ReplicationControllerSpec, out *Re
 	} else {
 		out.Selector = nil
 	}
-	if in.TemplateRef != nil {
-		out.TemplateRef = new(ObjectReference)
-		if err := deepCopy_v1_ObjectReference(*in.TemplateRef, out.TemplateRef, c); err != nil {
-			return err
-		}
-	} else {
-		out.TemplateRef = nil
-	}
 	if in.Template != nil {
 		out.Template = new(PodTemplateSpec)
 		if err := deepCopy_v1_PodTemplateSpec(*in.Template, out.Template, c); err != nil {

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -962,7 +962,7 @@ type ReplicationControllerSpec struct {
 
 	// TemplateRef is a reference to an object that describes the pod that will be created if
 	// insufficient replicas are detected.
-	TemplateRef *ObjectReference `json:"templateRef,omitempty" description:"reference to an object that describes the pod that will be created if insufficient replicas are detected"`
+	//TemplateRef *ObjectReference `json:"templateRef,omitempty" description:"reference to an object that describes the pod that will be created if insufficient replicas are detected"`
 
 	// Template is the object that describes the pod that will be created if
 	// insufficient replicas are detected. This takes precedence over a

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -474,13 +474,13 @@ func addConversionFuncs() {
 			if err := s.Convert(&in.Selector, &out.ReplicaSelector, 0); err != nil {
 				return err
 			}
-			if in.TemplateRef != nil && in.Template == nil {
-				return &api.ConversionError{
-					In:      in,
-					Out:     out,
-					Message: "objects with a template ref cannot be converted to older objects, must populate template",
-				}
-			}
+			//if in.TemplateRef != nil && in.Template == nil {
+			//	return &api.ConversionError{
+			//		In:      in,
+			//		Out:     out,
+			//		Message: "objects with a template ref cannot be converted to older objects, must populate template",
+			//	}
+			//}
 			if in.Template != nil {
 				if err := s.Convert(in.Template, &out.PodTemplate, 0); err != nil {
 					return err

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -253,13 +253,13 @@ func addConversionFuncs() {
 			if err := s.Convert(&in.Selector, &out.ReplicaSelector, 0); err != nil {
 				return err
 			}
-			if in.TemplateRef != nil && in.Template == nil {
-				return &api.ConversionError{
-					In:      in,
-					Out:     out,
-					Message: "objects with a template ref cannot be converted to older objects, must populate template",
-				}
-			}
+			//if in.TemplateRef != nil && in.Template == nil {
+			//	return &api.ConversionError{
+			//		In:      in,
+			//		Out:     out,
+			//		Message: "objects with a template ref cannot be converted to older objects, must populate template",
+			//	}
+			//}
 			if in.Template != nil {
 				if err := s.Convert(in.Template, &out.PodTemplate, 0); err != nil {
 					return err

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -1593,14 +1593,6 @@ func convert_api_ReplicationControllerSpec_To_v1beta3_ReplicationControllerSpec(
 	} else {
 		out.Selector = nil
 	}
-	if in.TemplateRef != nil {
-		out.TemplateRef = new(ObjectReference)
-		if err := convert_api_ObjectReference_To_v1beta3_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
-			return err
-		}
-	} else {
-		out.TemplateRef = nil
-	}
 	if in.Template != nil {
 		out.Template = new(PodTemplateSpec)
 		if err := convert_api_PodTemplateSpec_To_v1beta3_PodTemplateSpec(in.Template, out.Template, s); err != nil {
@@ -3738,14 +3730,6 @@ func convert_v1beta3_ReplicationControllerSpec_To_api_ReplicationControllerSpec(
 		}
 	} else {
 		out.Selector = nil
-	}
-	if in.TemplateRef != nil {
-		out.TemplateRef = new(api.ObjectReference)
-		if err := convert_v1beta3_ObjectReference_To_api_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
-			return err
-		}
-	} else {
-		out.TemplateRef = nil
 	}
 	if in.Template != nil {
 		out.Template = new(api.PodTemplateSpec)

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1517,14 +1517,6 @@ func deepCopy_v1beta3_ReplicationControllerSpec(in ReplicationControllerSpec, ou
 	} else {
 		out.Selector = nil
 	}
-	if in.TemplateRef != nil {
-		out.TemplateRef = new(ObjectReference)
-		if err := deepCopy_v1beta3_ObjectReference(*in.TemplateRef, out.TemplateRef, c); err != nil {
-			return err
-		}
-	} else {
-		out.TemplateRef = nil
-	}
 	if in.Template != nil {
 		out.Template = new(PodTemplateSpec)
 		if err := deepCopy_v1beta3_PodTemplateSpec(*in.Template, out.Template, c); err != nil {

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -966,7 +966,7 @@ type ReplicationControllerSpec struct {
 
 	// TemplateRef is a reference to an object that describes the pod that will be created if
 	// insufficient replicas are detected.
-	TemplateRef *ObjectReference `json:"templateRef,omitempty" description:"reference to an object that describes the pod that will be created if insufficient replicas are detected"`
+	//TemplateRef *ObjectReference `json:"templateRef,omitempty" description:"reference to an object that describes the pod that will be created if insufficient replicas are detected"`
 
 	// Template is the object that describes the pod that will be created if
 	// insufficient replicas are detected. This takes precedence over a


### PR DESCRIPTION
remove ReplicationControllerSpec.TemplateRef from v1beta3/types.go and v1/types.go for now
#8109 #7018

@bgrant0607 @krousey 
