### PR TITLE
CoreOS cloud-configs - get nodes working in CoreOS 695.0.0+

### DIFF
--- a/docs/getting-started-guides/aws/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/aws/cloud-configs/node.yaml
@@ -15,6 +15,7 @@ write_files:
 coreos:
   etcd2:
     listen-client-urls: http://localhost:2379
+    advertise-client-urls: http://0.0.0.0:2379
     initial-cluster: master=http://<master-private-ip>:2380
     proxy: on
   fleet:

--- a/docs/getting-started-guides/coreos/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/node.yaml
@@ -12,6 +12,7 @@ write-files:
 coreos:
   etcd2:
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
+    advertise-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
     initial-cluster: master=http://<master-private-ip>:2380
     proxy: on
   fleet:


### PR DESCRIPTION
etcd 2.0.11 behavior changed. (github.com/coreos/etcd#2761)

/cc @pires @erictune @kelseyhightower @thockin 

(btw, fwiw - patch is backward compatible - i.e. thinks will still work with etcd2 in pre 695.0.0 revs) 
