### PR TITLE
Fix permissions in e2e volume tests.

### DIFF
--- a/contrib/for-tests/volumes-tester/gluster/Dockerfile
+++ b/contrib/for-tests/volumes-tester/gluster/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update -qq && apt-get install -y glusterfs-server -qq
 ADD glusterd.vol /etc/glusterfs/
 ADD run_gluster.sh /usr/local/bin/
 ADD index.html /vol/
+RUN chmod 644 /vol/index.html
 
 EXPOSE 24007/tcp 24008/tcp 49152/tcp
 

--- a/contrib/for-tests/volumes-tester/nfs/Dockerfile
+++ b/contrib/for-tests/volumes-tester/nfs/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update -qq && apt-get install -y nfs-kernel-server -qq
 RUN mkdir -p /exports
 ADD run_nfs.sh /usr/local/bin/
 ADD index.html /exports/index.html
+RUN chmod 644 /exports/index.html
 
 EXPOSE 2049/tcp
 


### PR DESCRIPTION
I noticed that the docker images `gcr.io/google_containers/volume-gluster` and `gcr.io/google_containers/volume-nfs` provide `index.html` file with `0640` permissions, i.e. the 'world' (=nginx process) cannot read them.

I checked that both `index.html` files have correct `0644` permissions in git and `docker build` should not change it to `0640`, at least it does not do so on my system, Why the official images have wrong permissions remains a mystery to me.

Anyway, just to make the test working, one `chmod` in Dockerfile won't harm.
