### PR TITLE
Add explicitly setting the runtime and option to set rkt version

### DIFF
--- a/docs/getting-started-guides/rkt/README.md
+++ b/docs/getting-started-guides/rkt/README.md
@@ -51,7 +51,7 @@ $ export KUBE_CONTAINER_RUNTIME=rkt
 
 You can optionally choose the version of rkt used by setting `KUBE_RKT_VERSION`:
 ```shell
-export KUBE_RKT_VERSION=0.5.6
+$ export KUBE_RKT_VERSION=0.5.6
 ```
 
 Then you can launch the cluster by:

--- a/docs/getting-started-guides/rkt/README.md
+++ b/docs/getting-started-guides/rkt/README.md
@@ -46,6 +46,12 @@ To use rkt as the container runtime for your CoreOS cluster on GCE, you need to 
 $ export KUBE_OS_DISTRIBUTION=coreos
 $ export KUBE_GCE_MINION_IMAGE=<image_id>
 $ export KUBE_GCE_MINION_PROJECT=coreos-cloud
+$ export KUBE_CONTAINER_RUNTIME=rkt
+```
+
+You can optionally choose the version of rkt used by setting `KUBE_RKT_VERSION`:
+```shell
+export KUBE_RKT_VERSION=0.5.6
 ```
 
 Then you can launch the cluster by:


### PR DESCRIPTION
To avoid any confusion, explicitly set the runtime for GCE: https://github.com/GoogleCloudPlatform/kubernetes/blob/17f6f86be688a415b50b0ae627f1695032a06969/cluster/gce/config-default.sh#L34
