### PR TITLE
Example for policy config file for scheduler

### DIFF
--- a/examples/scheduler-policy-config.json
+++ b/examples/scheduler-policy-config.json
@@ -1,0 +1,17 @@
+{
+"kind" : "Policy",
+"apiVersion" : "v1",
+"predicates" : [
+	{"name" : "PodFitsPorts"},
+	{"name" : "PodFitsResources"},
+	{"name" : "NoDiskConflict"},
+	{"name" : "MatchNodeSelector"},
+	{"name" : "HostName"}
+	],
+"priorities" : [
+	{"name" : "LeastRequestedPriority", "weight" : 1},
+	{"name" : "BalancedResourceAllocation", "weight" : 1},
+	{"name" : "ServiceSpreadingPriority", "weight" : 1},
+	{"name" : "EqualPriority", "weight" : 1}
+	]
+}


### PR DESCRIPTION
Add a json file which can be used with --policy-config-file argument when starting kube-scheduler.

This serves as an example for new Kubernetes users so that they can quickly understand how to use '--policy-config-file' argument and have a brief idea about the scheduler policy.
