### PR TITLE
Don't die if the "docker rmi" fails

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -633,7 +633,7 @@ function kube::release::create_docker_images_for_server() {
         rm -rf ${docker_build_path}
 
         kube::log::status "Deleting docker image ${docker_image_tag}"
-        "${DOCKER[@]}" rmi ${docker_image_tag}
+        "${DOCKER[@]}" rmi ${docker_image_tag} 2>/dev/null || true
       ) &
     done
 


### PR DESCRIPTION
Slightly neuters #8955, but we haven't had a build succeed in a while
for whatever reason. (I checked on Jenkins and the images in the build
log where deletion was attempted were actually deleted, so I think
this is primarily an exit code / API issue of some sort.)
