### PR TITLE
add unit test for allocator

### DIFF
--- a/pkg/registry/service/allocator/bitmap_test.go
+++ b/pkg/registry/service/allocator/bitmap_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+import (
+	"testing"
+)
+
+func TestAllocate(t *testing.T) {
+	max := 10
+	m := NewAllocationMap(max, "test")
+
+	if _, ok, _ := m.AllocateNext(); !ok {
+		t.Fatalf("unexpected error")
+	}
+	if m.count != 1 {
+		t.Errorf("expect to get %d, but got %d", 1, m.count)
+	}
+	if f := m.Free(); f != max-1 {
+		t.Errorf("expect to get %d, but got %d", max-1, f)
+	}
+}
+
+func TestAllocateMax(t *testing.T) {
+	max := 10
+	m := NewAllocationMap(max, "test")
+	for i := 0; i < max; i++ {
+		if _, ok, _ := m.AllocateNext(); !ok {
+			t.Fatalf("unexpected error")
+		}
+	}
+
+	if _, ok, _ := m.AllocateNext(); ok {
+		t.Errorf("unexpected success")
+	}
+	if f := m.Free(); f != 0 {
+		t.Errorf("expect to get %d, but got %d", 0, f)
+	}
+}
+
+func TestAllocateError(t *testing.T) {
+	m := NewAllocationMap(10, "test")
+	if ok, _ := m.Allocate(3); !ok {
+		t.Errorf("error allocate offset %v", 3)
+	}
+	if ok, _ := m.Allocate(3); ok {
+		t.Errorf("unexpected success")
+	}
+}
+
+func TestRelease(t *testing.T) {
+	offset := 3
+	m := NewAllocationMap(10, "test")
+	if ok, _ := m.Allocate(offset); !ok {
+		t.Errorf("error allocate offset %v", offset)
+	}
+
+	if !m.Has(offset) {
+		t.Errorf("expect offset %v allocated", offset)
+	}
+
+	if err := m.Release(offset); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if m.Has(offset) {
+		t.Errorf("expect offset %v not allocated", offset)
+	}
+}
+
+func TestSnapshotAndRestore(t *testing.T) {
+	offset := 3
+	m := NewAllocationMap(10, "test")
+	if ok, _ := m.Allocate(offset); !ok {
+		t.Errorf("error allocate offset %v", offset)
+	}
+	spec, bytes := m.Snapshot()
+
+	m2 := NewAllocationMap(10, "test")
+	err := m2.Restore(spec, bytes)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if m2.count != 1 {
+		t.Errorf("expect count to %d, but got %d", 0, m.count)
+	}
+	if !m2.Has(offset) {
+		t.Errorf("expect offset %v allocated", offset)
+	}
+}
+
+func TestContiguousAllocation(t *testing.T) {
+	max := 10
+	m := NewContiguousAllocationMap(max, "test")
+
+	for i := 0; i < max; i++ {
+		next, ok, _ := m.AllocateNext()
+		if !ok {
+			t.Fatalf("unexpected error")
+		}
+		if next != i {
+			t.Fatalf("expect next to %d, but got %d", i, next)
+		}
+	}
+
+	if _, ok, _ := m.AllocateNext(); ok {
+		t.Errorf("unexpected success")
+	}
+}

--- a/pkg/registry/service/allocator/utils_test.go
+++ b/pkg/registry/service/allocator/utils_test.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package allocator
 
-import "testing"
+import (
+	"math/big"
+	"testing"
+)
 
 func TestBitCount(t *testing.T) {
 	for i, c := range bitCounts {
@@ -28,6 +31,22 @@ func TestBitCount(t *testing.T) {
 		}
 		if actual != int(c) {
 			t.Errorf("%d should have %d bits but recorded as %d", i, actual, c)
+		}
+	}
+}
+
+func TestCountBits(t *testing.T) {
+	tests := []struct {
+		n        *big.Int
+		expected int
+	}{
+		{n: big.NewInt(int64(0)), expected: 0},
+		{n: big.NewInt(int64(0xffffffffff)), expected: 40},
+	}
+	for _, test := range tests {
+		actual := countBits(test.n)
+		if test.expected != actual {
+			t.Errorf("%d should have %d bits but recorded as %d", test.n, test.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
Add simple unit test to improve coverage.

@justinsb 

```
# before
ok      github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service/allocator    0.003s  coverage: 0.0% of statements
# after
ok      github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service/allocator    0.003s  coverage: 94.2% of statements
```
