### PR TITLE
Fix persistent volumes.

### DIFF
--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -80,7 +80,13 @@ func (plugin *ISCSIPlugin) NewBuilder(spec *volume.Spec, pod *api.Pod, _ volume.
 }
 
 func (plugin *ISCSIPlugin) newBuilderInternal(spec *volume.Spec, podUID types.UID, manager diskManager, mounter mount.Interface) (volume.Builder, error) {
-	iscsi := spec.VolumeSource.ISCSI
+	var iscsi *api.ISCSIVolumeSource
+	if spec.VolumeSource.ISCSI != nil {
+		iscsi = spec.VolumeSource.ISCSI
+	} else {
+		iscsi = spec.PersistentVolumeSource.ISCSI
+	}
+
 	lun := strconv.Itoa(iscsi.Lun)
 
 	return &iscsiDisk{

--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -96,7 +96,7 @@ func (fake *fakeDiskManager) DetachDisk(disk iscsiDisk, mntPath string) error {
 	return nil
 }
 
-func TestPlugin(t *testing.T) {
+func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
 
@@ -104,20 +104,9 @@ func TestPlugin(t *testing.T) {
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
-	spec := &api.Volume{
-		Name: "vol1",
-		VolumeSource: api.VolumeSource{
-			ISCSI: &api.ISCSIVolumeSource{
-				TargetPortal: "127.0.0.1:3260",
-				IQN:          "iqn.2014-12.server:storage.target01",
-				FSType:       "ext4",
-				Lun:          0,
-			},
-		},
-	}
 	fakeManager := &fakeDiskManager{}
 	fakeMounter := &mount.FakeMounter{}
-	builder, err := plug.(*ISCSIPlugin).newBuilderInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), fakeManager, fakeMounter)
+	builder, err := plug.(*ISCSIPlugin).newBuilderInternal(spec, types.UID("poduid"), fakeManager, fakeMounter)
 	if err != nil {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
@@ -171,4 +160,38 @@ func TestPlugin(t *testing.T) {
 	if !fakeManager.detachCalled {
 		t.Errorf("Detach was not called")
 	}
+}
+
+func TestPluginVolume(t *testing.T) {
+	vol := &api.Volume{
+		Name: "vol1",
+		VolumeSource: api.VolumeSource{
+			ISCSI: &api.ISCSIVolumeSource{
+				TargetPortal: "127.0.0.1:3260",
+				IQN:          "iqn.2014-12.server:storage.target01",
+				FSType:       "ext4",
+				Lun:          0,
+			},
+		},
+	}
+	doTestPlugin(t, volume.NewSpecFromVolume(vol))
+}
+
+func TestPluginPersistentVolume(t *testing.T) {
+	vol := &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			Name: "vol1",
+		},
+		Spec: api.PersistentVolumeSpec{
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				ISCSI: &api.ISCSIVolumeSource{
+					TargetPortal: "127.0.0.1:3260",
+					IQN:          "iqn.2014-12.server:storage.target01",
+					FSType:       "ext4",
+					Lun:          0,
+				},
+			},
+		},
+	}
+	doTestPlugin(t, volume.NewSpecFromPersistentVolume(vol))
 }

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -68,15 +68,23 @@ func (plugin *nfsPlugin) NewBuilder(spec *volume.Spec, pod *api.Pod, _ volume.Vo
 }
 
 func (plugin *nfsPlugin) newBuilderInternal(spec *volume.Spec, pod *api.Pod, mounter mount.Interface) (volume.Builder, error) {
+	var source *api.NFSVolumeSource
+
+	if spec.VolumeSource.NFS != nil {
+		source = spec.VolumeSource.NFS
+	} else {
+		source = spec.PersistentVolumeSource.NFS
+	}
 	return &nfs{
 		volName:    spec.Name,
-		server:     spec.VolumeSource.NFS.Server,
-		exportPath: spec.VolumeSource.NFS.Path,
-		readOnly:   spec.VolumeSource.NFS.ReadOnly,
+		server:     source.Server,
+		exportPath: source.Path,
+		readOnly:   source.ReadOnly,
 		mounter:    mounter,
 		pod:        pod,
 		plugin:     plugin,
 	}, nil
+
 }
 
 func (plugin *nfsPlugin) NewCleaner(volName string, podUID types.UID, mounter mount.Interface) (volume.Cleaner, error) {

--- a/pkg/volume/rbd/rbd_test.go
+++ b/pkg/volume/rbd/rbd_test.go
@@ -65,7 +65,7 @@ func (fake *fakeDiskManager) DetachDisk(disk rbd, mntPath string) error {
 	return nil
 }
 
-func TestPlugin(t *testing.T) {
+func doTestPlugin(t *testing, spec *volume.SpecT) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
 
@@ -73,17 +73,7 @@ func TestPlugin(t *testing.T) {
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
-	spec := &api.Volume{
-		Name: "vol1",
-		VolumeSource: api.VolumeSource{
-			RBD: &api.RBDVolumeSource{
-				CephMonitors: []string{"a", "b"},
-				RBDImage:     "bar",
-				FSType:       "ext4",
-			},
-		},
-	}
-	builder, err := plug.(*RBDPlugin).newBuilderInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), &fakeDiskManager{}, &mount.FakeMounter{}, "secrets")
+	builder, err := plug.(*RBDPlugin).newBuilderInternal(spec, types.UID("poduid"), &fakeDiskManager{}, &mount.FakeMounter{}, "secrets")
 	if err != nil {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
@@ -130,4 +120,36 @@ func TestPlugin(t *testing.T) {
 	} else if !os.IsNotExist(err) {
 		t.Errorf("SetUp() failed: %v", err)
 	}
+}
+
+func TestPluginVolume(t *testing.T) {
+	vol := &api.Volume{
+		Name: "vol1",
+		VolumeSource: api.VolumeSource{
+			RBD: &api.RBDVolumeSource{
+				CephMonitors: []string{"a", "b"},
+				RBDImage:     "bar",
+				FSType:       "ext4",
+			},
+		},
+	}
+	doTestPlugin(t, volume.NewSpecFromVolume(vol))
+}
+func TestPluginPersistentVolume(t *testing.T) {
+	vol := &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			Name: "vol1",
+		},
+		Spec: api.PersistentVolumeSpec{
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				RBD: &api.RBDVolumeSource{
+					CephMonitors: []string{"a", "b"},
+					RBDImage:     "bar",
+					FSType:       "ext4",
+				},
+			},
+		},
+	}
+
+	doTestPlugin(t, volume.NewSpecFromPersistentVolume(vol))
 }


### PR DESCRIPTION
Check Spec.PersistentVolumeSource in NFS, RBD, Gluster and iSCSI volume
plugins.

Without the patch, kubelet catches SIGSEGV in `nfsPlugin.newBuilderInternal()`:

```
    return &nfs{
        volName:    spec.Name,
        server:     spec.VolumeSource.NFS.Server,
        exportPath: spec.VolumeSource.NFS.Path,
        readOnly:   spec.VolumeSource.NFS.ReadOnly,
```

`spec.VolumeSource` is `nil` there, the volume is specified in `spec.PersistentVolumeSource`.

```
E0601 14:10:49.822245   27019 util.go:69] Recovered from panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
/home/jsafrane/project/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/util.go:63
/home/jsafrane/project/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/util.go:54
/usr/lib/golang/src/runtime/asm_amd64.s:401
/usr/lib/golang/src/runtime/panic.go:387
/usr/lib/golang/src/runtime/panic.go:42
/usr/lib/golang/src/runtime/sigpanic_unix.go:26
/home/jsafrane/project/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/volume/nfs/nfs.go:78
/home/jsafrane/project/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/volume/nfs/nfs.go:67
/home/jsafrane/project/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/volumes.go:92
/home/jsafrane/project/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/volumes.go:60
/home/jsafrane/project/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/volume/persistent_claim/persistent_claim.go:81
/home/jsafrane/project/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/volumes.go:92
/home/jsafrane/project/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/volumes.go:112
/home/jsafrane/project/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/kubelet.go:1120
/home/jsafrane/project/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/kubelet.go:324
/home/jsafrane/project/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/pod_workers.go:106
/home/jsafrane/project/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/pod_workers.go:115
/home/jsafrane/project/go/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/pod_workers.go:136
/usr/lib/golang/src/runtime/asm_amd64.s:2232
```
