### PR TITLE
serialize dockercfg with matching auth field

### DIFF
--- a/pkg/credentialprovider/config.go
+++ b/pkg/credentialprovider/config.go
@@ -175,6 +175,13 @@ func (ident *DockerConfigEntry) UnmarshalJSON(data []byte) error {
 	return err
 }
 
+func (ident DockerConfigEntry) MarshalJSON() ([]byte, error) {
+	toEncode := dockerConfigEntryWithAuth{ident.Username, ident.Password, ident.Email, ""}
+	toEncode.Auth = encodeDockerConfigFieldAuth(ident.Username, ident.Password)
+
+	return json.Marshal(toEncode)
+}
+
 // decodeDockerConfigFieldAuth deserializes the "auth" field from dockercfg into a
 // username and a password. The format of the auth field is base64(<username>:<password>).
 func decodeDockerConfigFieldAuth(field string) (username, password string, err error) {
@@ -193,13 +200,6 @@ func decodeDockerConfigFieldAuth(field string) (username, password string, err e
 	password = parts[1]
 
 	return
-}
-
-func (ident DockerConfigEntry) ConvertToDockerConfigCompatible() dockerConfigEntryWithAuth {
-	ret := dockerConfigEntryWithAuth{ident.Username, ident.Password, ident.Email, ""}
-	ret.Auth = encodeDockerConfigFieldAuth(ident.Username, ident.Password)
-
-	return ret
 }
 
 func encodeDockerConfigFieldAuth(username, password string) string {

--- a/pkg/credentialprovider/config_test.go
+++ b/pkg/credentialprovider/config_test.go
@@ -184,9 +184,7 @@ func TestDockerConfigEntryJSONCompatibleEncode(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		toEncode := tt.input.ConvertToDockerConfigCompatible()
-
-		actual, err := json.Marshal(toEncode)
+		actual, err := json.Marshal(tt.input)
 		if err != nil {
 			t.Errorf("case %d: unexpected error: %v", i, err)
 		}


### PR DESCRIPTION
The default serialization of `DockerConfigEntry` doesn't include the `auth` element.  Since `.dockercfg` files created by docker have this field set, this confuses some tools.

This just changes the serialization to create the matching `auth` element based on the user/password.
