### PR TITLE
Added note about AWS env variable to specify location of private key

### DIFF
--- a/docs/getting-started-guides/aws.md
+++ b/docs/getting-started-guides/aws.md
@@ -40,6 +40,8 @@ export INSTANCE_PREFIX=k8s
 It will also try to create or reuse a keypair called "kubernetes", and IAM profiles called "kubernetes-master" and "kubernetes-minion".
 If these already exist, make sure you want them to be used here.
 
+NOTE: If using an existing keypair named "kubernetes" then you must set the `AWS_SSH_KEY` key to point to your private key.
+
 ### Alternatives
 A contributed [example](aws-coreos.md) allows you to setup a Kubernetes cluster based on [CoreOS](http://www.coreos.com), either using
 AWS CloudFormation or EC2 with user data (cloud-config).


### PR DESCRIPTION
In reference to #8682, updating docs to add env variable so that correct key is used when creating cluster in AWS.
