### PR TITLE
Fix kubectl run broken at HEAD

### DIFF
--- a/pkg/kubectl/run.go
+++ b/pkg/kubectl/run.go
@@ -29,8 +29,8 @@ type BasicReplicationController struct{}
 func (BasicReplicationController) ParamNames() []GeneratorParam {
 	return []GeneratorParam{
 		{"labels", false},
-		{"default-name", true},
-		{"name", false},
+		{"default-name", false},
+		{"name", true},
 		{"replicas", true},
 		{"image", true},
 		{"port", false},


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/9068

`$ kubectl run` is broken at HEAD without this change.
