### PR TITLE
Kubelet unit test cleanup

### DIFF
--- a/pkg/kubelet/dockertools/manager_test.go
+++ b/pkg/kubelet/dockertools/manager_test.go
@@ -88,7 +88,7 @@ func (*fakeOptionGenerator) GenerateRunContainerOptions(pod *api.Pod, container 
 	return &kubecontainer.RunContainerOptions{}, nil
 }
 
-func newTestDockerManager() (*DockerManager, *FakeDockerClient) {
+func newTestDockerManagerWithHTTPClient(fakeHTTPClient *fakeHTTP) (*DockerManager, *FakeDockerClient) {
 	fakeDocker := &FakeDockerClient{VersionInfo: docker.Env{"Version=1.1.3", "ApiVersion=1.15"}, Errors: make(map[string]error), RemovedImages: util.StringSet{}}
 	fakeRecorder := &record.FakeRecorder{}
 	readinessManager := kubecontainer.NewReadinessManager()
@@ -106,10 +106,14 @@ func newTestDockerManager() (*DockerManager, *FakeDockerClient) {
 		kubecontainer.FakeOS{},
 		networkPlugin,
 		optionGenerator,
-		&fakeHTTP{},
+		fakeHTTPClient,
 		runtimeHooks)
 
 	return dockerManager, fakeDocker
+}
+
+func newTestDockerManager() (*DockerManager, *FakeDockerClient) {
+	return newTestDockerManagerWithHTTPClient(&fakeHTTP{})
 }
 
 func matchString(t *testing.T, pattern, str string) bool {
@@ -1778,4 +1782,133 @@ func TestGetRestartCount(t *testing.T) {
 	// (i.e., remain the same).
 	fakeDocker.ExitedContainerList = []docker.APIContainers{}
 	verifyRestartCount(&pod, 2)
+}
+
+func TestSyncPodWithPodInfraCreatesContainerCallsHandler(t *testing.T) {
+	fakeHTTPClient := &fakeHTTP{}
+	dm, fakeDocker := newTestDockerManagerWithHTTPClient(fakeHTTPClient)
+
+	pod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			UID:       "12345678",
+			Name:      "foo",
+			Namespace: "new",
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name: "bar",
+					Lifecycle: &api.Lifecycle{
+						PostStart: &api.Handler{
+							HTTPGet: &api.HTTPGetAction{
+								Host: "foo",
+								Port: util.IntOrString{IntVal: 8080, Kind: util.IntstrInt},
+								Path: "bar",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	fakeDocker.ContainerList = []docker.APIContainers{
+		{
+			// pod infra container
+			Names: []string{"/k8s_POD." + strconv.FormatUint(generatePodInfraContainerHash(pod), 16) + "_foo_new_12345678_0"},
+			ID:    "9876",
+		},
+	}
+	fakeDocker.ContainerMap = map[string]*docker.Container{
+		"9876": {
+			ID:         "9876",
+			Config:     &docker.Config{},
+			HostConfig: &docker.HostConfig{},
+		},
+	}
+
+	runSyncPod(t, dm, fakeDocker, pod)
+
+	verifyCalls(t, fakeDocker, []string{
+		// Check the pod infra container.
+		"inspect_container",
+		// Create container.
+		"create", "start",
+	})
+
+	fakeDocker.Lock()
+	if len(fakeDocker.Created) != 1 ||
+		!matchString(t, "k8s_bar\\.[a-f0-9]+_foo_new_", fakeDocker.Created[0]) {
+		t.Errorf("Unexpected containers created %v", fakeDocker.Created)
+	}
+	fakeDocker.Unlock()
+	if fakeHTTPClient.url != "http://foo:8080/bar" {
+		t.Errorf("Unexpected handler: %q", fakeHTTPClient.url)
+	}
+}
+
+func TestSyncPodEventHandlerFails(t *testing.T) {
+	// Simulate HTTP failure.
+	fakeHTTPClient := &fakeHTTP{err: fmt.Errorf("test error")}
+	dm, fakeDocker := newTestDockerManagerWithHTTPClient(fakeHTTPClient)
+
+	pod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			UID:       "12345678",
+			Name:      "foo",
+			Namespace: "new",
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{Name: "bar",
+					Lifecycle: &api.Lifecycle{
+						PostStart: &api.Handler{
+							HTTPGet: &api.HTTPGetAction{
+								Host: "does.no.exist",
+								Port: util.IntOrString{IntVal: 8080, Kind: util.IntstrInt},
+								Path: "bar",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeDocker.ContainerList = []docker.APIContainers{
+		{
+			// pod infra container
+			Names: []string{"/k8s_POD." + strconv.FormatUint(generatePodInfraContainerHash(pod), 16) + "_foo_new_12345678_42"},
+			ID:    "9876",
+		},
+	}
+	fakeDocker.ContainerMap = map[string]*docker.Container{
+		"9876": {
+			ID:         "9876",
+			Config:     &docker.Config{},
+			HostConfig: &docker.HostConfig{},
+		},
+	}
+
+	runSyncPod(t, dm, fakeDocker, pod)
+
+	verifyCalls(t, fakeDocker, []string{
+		// Check the pod infra container.
+		"inspect_container",
+		// Create the container.
+		"create", "start",
+		// Kill the container since event handler fails.
+		"inspect_container", "stop",
+	})
+
+	// TODO(yifan): Check the stopped container's name.
+	if len(fakeDocker.Stopped) != 1 {
+		t.Fatalf("Wrong containers were stopped: %v", fakeDocker.Stopped)
+	}
+	dockerName, _, err := ParseDockerName(fakeDocker.Stopped[0])
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if dockerName.ContainerName != "bar" {
+		t.Errorf("Wrong stopped container, expected: bar, get: %q", dockerName.ContainerName)
+	}
 }

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -552,7 +552,13 @@ func TestSyncPodsDeletesWhenSourcesAreReady(t *testing.T) {
 	kubelet.sourcesReady = func() bool { return ready }
 
 	fakeRuntime.PodList = []*kubecontainer.Pod{
-		{ID: "12345678", Name: "foo", Namespace: "new", Containers: []*kubecontainer.Container{{Name: "bar"}}},
+		{
+			ID:   "12345678",
+			Name: "foo", Namespace: "new",
+			Containers: []*kubecontainer.Container{
+				{Name: "bar"},
+			},
+		},
 	}
 	if err := kubelet.SyncPods([]*api.Pod{}, emptyPodUIDs, map[string]*api.Pod{}, time.Now()); err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -733,7 +739,17 @@ func TestGetContainerInfo(t *testing.T) {
 	mockCadvisor := testKubelet.fakeCadvisor
 	mockCadvisor.On("DockerContainer", containerID, cadvisorReq).Return(containerInfo, nil)
 	fakeRuntime.PodList = []*kubecontainer.Pod{
-		{ID: "12345678", Name: "qux", Namespace: "ns", Containers: []*kubecontainer.Container{{Name: "foo", ID: types.UID(containerID)}}},
+		{
+			ID:        "12345678",
+			Name:      "qux",
+			Namespace: "ns",
+			Containers: []*kubecontainer.Container{
+				{
+					Name: "foo",
+					ID:   types.UID(containerID),
+				},
+			},
+		},
 	}
 	stats, err := kubelet.GetContainerInfo("qux_ns", "", "foo", cadvisorReq)
 	if err != nil {
@@ -806,7 +822,16 @@ func TestGetContainerInfoWhenCadvisorFailed(t *testing.T) {
 	cadvisorReq := &cadvisorApi.ContainerInfoRequest{}
 	mockCadvisor.On("DockerContainer", containerID, cadvisorReq).Return(containerInfo, cadvisorApiFailure)
 	fakeRuntime.PodList = []*kubecontainer.Pod{
-		{ID: "uuid", Name: "qux", Namespace: "ns", Containers: []*kubecontainer.Container{{Name: "foo", ID: types.UID(containerID)}}},
+		{
+			ID:        "uuid",
+			Name:      "qux",
+			Namespace: "ns",
+			Containers: []*kubecontainer.Container{
+				{Name: "foo",
+					ID: types.UID(containerID),
+				},
+			},
+		},
 	}
 	stats, err := kubelet.GetContainerInfo("qux_ns", "uuid", "foo", cadvisorReq)
 	if stats != nil {
@@ -881,7 +906,15 @@ func TestGetContainerInfoWithNoMatchingContainers(t *testing.T) {
 	kubelet := testKubelet.kubelet
 	mockCadvisor := testKubelet.fakeCadvisor
 	fakeRuntime.PodList = []*kubecontainer.Pod{
-		{ID: "12345678", Name: "qux", Namespace: "ns", Containers: []*kubecontainer.Container{{Name: "bar", ID: types.UID("fakeID")}}},
+		{
+			ID:        "12345678",
+			Name:      "qux",
+			Namespace: "ns",
+			Containers: []*kubecontainer.Container{
+				{Name: "bar",
+					ID: types.UID("fakeID"),
+				},
+			}},
 	}
 
 	stats, err := kubelet.GetContainerInfo("qux_ns", "", "foo", nil)
@@ -967,7 +1000,16 @@ func TestRunInContainer(t *testing.T) {
 
 	containerID := "abc1234"
 	fakeRuntime.PodList = []*kubecontainer.Pod{
-		{ID: "12345678", Name: "podFoo", Namespace: "nsFoo", Containers: []*kubecontainer.Container{{Name: "containerFoo", ID: types.UID(containerID)}}},
+		{
+			ID:        "12345678",
+			Name:      "podFoo",
+			Namespace: "nsFoo",
+			Containers: []*kubecontainer.Container{
+				{Name: "containerFoo",
+					ID: types.UID(containerID),
+				},
+			},
+		},
 	}
 	cmd := []string{"ls"}
 	_, err := kubelet.RunInContainer("podFoo_nsFoo", "", "containerFoo", cmd)
@@ -1942,7 +1984,15 @@ func TestExecInContainerNoSuchContainer(t *testing.T) {
 	podNamespace := "nsFoo"
 	containerID := "containerFoo"
 	fakeRuntime.PodList = []*kubecontainer.Pod{
-		{ID: "12345678", Name: podName, Namespace: podNamespace, Containers: []*kubecontainer.Container{{Name: "bar", ID: "barID"}}},
+		{
+			ID:        "12345678",
+			Name:      podName,
+			Namespace: podNamespace,
+			Containers: []*kubecontainer.Container{
+				{Name: "bar",
+					ID: "barID"},
+			},
+		},
 	}
 
 	err := kubelet.ExecInContainer(
@@ -1997,8 +2047,16 @@ func TestExecInContainer(t *testing.T) {
 	stderr := &fakeReadWriteCloser{}
 	tty := true
 	fakeRuntime.PodList = []*kubecontainer.Pod{
-		{ID: "12345678", Name: podName, Namespace: podNamespace, Containers: []*kubecontainer.Container{
-			{Name: containerID, ID: types.UID(containerID)}}},
+		{
+			ID:        "12345678",
+			Name:      podName,
+			Namespace: podNamespace,
+			Containers: []*kubecontainer.Container{
+				{Name: containerID,
+					ID: types.UID(containerID),
+				},
+			},
+		},
 	}
 
 	err := kubelet.ExecInContainer(
@@ -2076,7 +2134,15 @@ func TestPortForwardNoSuchContainer(t *testing.T) {
 	var port uint16 = 5000
 
 	fakeRuntime.PodList = []*kubecontainer.Pod{
-		{ID: "12345678", Name: podName, Namespace: podNamespace, Containers: []*kubecontainer.Container{{Name: "bar", ID: "barID"}}},
+		{
+			ID:        "12345678",
+			Name:      podName,
+			Namespace: podNamespace,
+			Containers: []*kubecontainer.Container{
+				{Name: "bar",
+					ID: "barID"},
+			},
+		},
 	}
 
 	err := kubelet.PortForward(
@@ -2898,8 +2964,17 @@ func TestGetContainerInfoForMirrorPods(t *testing.T) {
 	kubelet := testKubelet.kubelet
 
 	fakeRuntime.PodList = []*kubecontainer.Pod{
-		{ID: "1234", Name: "qux", Namespace: "ns", Containers: []*kubecontainer.Container{
-			{Name: "foo", ID: types.UID(containerID)}}},
+		{
+			ID:        "1234",
+			Name:      "qux",
+			Namespace: "ns",
+			Containers: []*kubecontainer.Container{
+				{
+					Name: "foo",
+					ID:   types.UID(containerID),
+				},
+			},
+		},
 	}
 
 	kubelet.podManager.SetPods(pods)
@@ -3265,7 +3340,14 @@ func TestSyncPodsSetStatusToFailedForPodsThatRunTooLong(t *testing.T) {
 	}
 
 	fakeRuntime.PodList = []*kubecontainer.Pod{
-		{ID: "12345678", Name: "bar", Namespace: "new", Containers: []*kubecontainer.Container{{Name: "foo"}}},
+		{
+			ID:        "12345678",
+			Name:      "bar",
+			Namespace: "new",
+			Containers: []*kubecontainer.Container{
+				{Name: "foo"},
+			},
+		},
 	}
 
 	// Let the pod worker sets the status to fail after this sync.
@@ -3313,7 +3395,14 @@ func TestSyncPodsDoesNotSetPodsThatDidNotRunTooLongToFailed(t *testing.T) {
 	}
 
 	fakeRuntime.PodList = []*kubecontainer.Pod{
-		{ID: "12345678", Name: "bar", Namespace: "new", Containers: []*kubecontainer.Container{{Name: "foo"}}},
+		{
+			ID:        "12345678",
+			Name:      "bar",
+			Namespace: "new",
+			Containers: []*kubecontainer.Container{
+				{Name: "foo"},
+			},
+		},
 	}
 
 	kubelet.podManager.SetPods(pods)


### PR DESCRIPTION
- Adapt most CommandRunner tests to use FakeRuntime
- Switch more tests from newTestKubelet to newTestKubeletWithFakeRuntime
- Move more docker-specific tests to dockertools/manager_test.go

After this PR, there should be only two tests in `kubelet_test.go` that use `FakeDockerClient` (from `newTestKubelet`) directly. Those tests require a bit more work and can be tackled later.
