### PR TITLE
Align systemd environ file with optimal admission controllers

### DIFF
--- a/contrib/init/systemd/environ/apiserver
+++ b/contrib/init/systemd/environ/apiserver
@@ -20,7 +20,7 @@ KUBE_ETCD_SERVERS="--etcd_servers=http://127.0.0.1:4001"
 KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range=10.254.0.0/16"
 
 # default admission control policies
-KUBE_ADMISSION_CONTROL="--admission_control=NamespaceAutoProvision,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
+KUBE_ADMISSION_CONTROL="--admission_control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
 
 # Add your own!
 KUBE_API_ARGS=""


### PR DESCRIPTION
@eparis - this aligns the systemd environ with changes made to all salt based providers in #8696 

The major change here is you MUST create a namespace before putting pods in one.

The default namespace is created automatically by apiserver, so its more a factor if you use custom ones, a'la openshift.
