### PR TITLE
Fix bug in quota describe output

### DIFF
--- a/pkg/api/resource/quantity.go
+++ b/pkg/api/resource/quantity.go
@@ -190,7 +190,9 @@ func ParseQuantity(str string) (*Quantity, error) {
 	// of an amount.
 	// Arguably, this should be inf.RoundHalfUp (normal rounding), but
 	// that would have the side effect of rounding values < .5m to zero.
-	amount.Round(amount, 3, inf.RoundUp)
+	if v, ok := amount.Unscaled(); v != int64(0) || !ok {
+		amount.Round(amount, 3, inf.RoundUp)
+	}
 
 	// The max is just a simple cap.
 	if amount.Cmp(maxAllowed) > 0 {
@@ -234,6 +236,11 @@ func removeFactors(d, factor *big.Int) (result *big.Int, times int) {
 //   rounded up. (1.1i becomes 2i.)
 func (q *Quantity) Canonicalize() (string, suffix) {
 	if q.Amount == nil {
+		return "0", ""
+	}
+
+	// zero is zero always
+	if q.Amount.Cmp(&inf.Dec{}) == 0 {
 		return "0", ""
 	}
 

--- a/pkg/api/resource/quantity_test.go
+++ b/pkg/api/resource/quantity_test.go
@@ -57,6 +57,26 @@ func TestDec(t *testing.T) {
 	}
 }
 
+// TestQuantityParseZero ensures that when a 0 quantity is passed, its string value is 0
+func TestQuantityParseZero(t *testing.T) {
+	zero := MustParse("0")
+	if expected, actual := "0", zero.String(); expected != actual {
+		t.Errorf("Expected %v, actual %v", expected, actual)
+	}
+}
+
+// Verifies that you get 0 as canonical value if internal value is 0, and not 0<suffix>
+func TestQuantityCanocicalizeZero(t *testing.T) {
+	val := MustParse("1000m")
+	x := val.Amount
+	y := dec(1, 0)
+	z := val.Amount.Sub(x, y)
+	zero := Quantity{z, DecimalSI}
+	if expected, actual := "0", zero.String(); expected != actual {
+		t.Errorf("Expected %v, actual %v", expected, actual)
+	}
+}
+
 func TestQuantityParse(t *testing.T) {
 	table := []struct {
 		input  string


### PR DESCRIPTION
There are resource quota values that are just counting number of an item (services, pods, secrets, etc.).  When there are none of that particular item in the namespace, the quota describe output is confusing because we default to show a "m" suffix.  When there is 0 of something, its just zero and there is no needed to specify a unit for `DecimalSI` notation.  By removing the suffix, our quota describer makes more sense since most people will ask, what does 0m services mean.

BEFORE:

``` shell
cluster/kubectl.sh describe quota quota --namespace=quota-example
Name:           quota
Resource        Used        Hard
--------        ----        ----
persistentvolumeclaims  0m      10
services        0m      5
```

AFTER:

``` shell
cluster/kubectl.sh describe quota quota --namespace=quota-example
Name:           quota
Resource        Used        Hard
--------        ----        ----
persistentvolumeclaims  0       10
services        0       5
```
