### PR TITLE
add v1 to hack/test-go; let default value of Container.Security Context to be nil

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -623,6 +623,23 @@ func runPatchTest(c *client.Client) {
 				[]byte(`{"metadata":{"labels":{"$patch":"replace"}}}`),
 			},
 		},
+		"v1": {
+			api.JSONPatchType: {
+				[]byte(`[{"op":"add","path":"/metadata/labels","value":{"foo":"bar","baz":"qux"}}]`),
+				[]byte(`[{"op":"remove","path":"/metadata/labels/foo"}]`),
+				[]byte(`[{"op":"remove","path":"/metadata/labels"}]`),
+			},
+			api.MergePatchType: {
+				[]byte(`{"metadata":{"labels":{"foo":"bar","baz":"qux"}}}`),
+				[]byte(`{"metadata":{"labels":{"foo":null}}}`),
+				[]byte(`{"metadata":{"labels":null}}`),
+			},
+			api.StrategicMergePatchType: {
+				[]byte(`{"metadata":{"labels":{"foo":"bar","baz":"qux"}}}`),
+				[]byte(`{"metadata":{"labels":{"foo":null}}}`),
+				[]byte(`{"metadata":{"labels":{"$patch":"replace"}}}`),
+			},
+		},
 	}
 
 	pb := patchBodies[c.APIVersion()]

--- a/cmd/integration/v1-controller.json
+++ b/cmd/integration/v1-controller.json
@@ -1,0 +1,24 @@
+{
+  "kind": "ReplicationController",
+  "apiVersion": "v1",
+  "metadata": {
+     "name": "nginx-controller",
+     "labels": {"name": "nginx"}
+  },
+  "spec": {
+    "replicas": 2,
+    "selector": {"name": "nginx"},
+    "template": {
+       "metadata": {
+          "labels": {"name": "nginx"}
+       },
+       "spec": {
+           "containers": [{
+             "name": "nginx",
+             "image": "nginx",
+             "ports": [{"containerPort": 80}]
+           }]
+       }
+    }
+  }
+}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -140,6 +140,7 @@ func TestExampleObjectSchemas(t *testing.T) {
 	cases := map[string]map[string]runtime.Object{
 		"../cmd/integration": {
 			"v1beta3-controller": &api.ReplicationController{},
+			"v1-controller":      &api.ReplicationController{},
 		},
 		"../examples/guestbook": {
 			"frontend-controller":     &api.ReplicationController{},

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -52,7 +52,7 @@ KUBE_RACE=${KUBE_RACE:-}   # use KUBE_RACE="-race" to enable race testing
 # Set to the goveralls binary path to report coverage results to Coveralls.io.
 KUBE_GOVERALLS_BIN=${KUBE_GOVERALLS_BIN:-}
 # Comma separated list of API Versions that should be tested.
-KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1beta3"}
+KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1beta3,v1"}
 # Run tests with the standard (registry) and a custom etcd prefix
 # (kubernetes.io/registry).
 KUBE_TEST_ETCD_PREFIXES=${KUBE_TEST_ETCD_PREFIXES:-"registry,kubernetes.io/registry"}

--- a/pkg/api/v1beta3/defaults.go
+++ b/pkg/api/v1beta3/defaults.go
@@ -171,6 +171,9 @@ func defaultHostNetworkPorts(containers *[]Container) {
 // defaultSecurityContext performs the downward and upward merges of a pod definition
 func defaultSecurityContext(container *Container) {
 	if container.SecurityContext == nil {
+		if (len(container.Capabilities.Add) == 0) && (len(container.Capabilities.Drop) == 0) && (container.Privileged == false) {
+			return
+		}
 		glog.V(5).Infof("creating security context for container %s", container.Name)
 		container.SecurityContext = &SecurityContext{}
 	}

--- a/pkg/api/validation/testdata/v1/invalidPod.yaml
+++ b/pkg/api/validation/testdata/v1/invalidPod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    name: redis-master
+  name: name
+spec:
+  containers:
+  - args: "this is a bad command"
+    image: redis
+    name: master

--- a/pkg/api/validation/testdata/v1/invalidPod1.json
+++ b/pkg/api/validation/testdata/v1/invalidPod1.json
@@ -1,0 +1,19 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "name",
+    "labels": {
+      "name": "redis-master"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "master",
+        "image": "redis",
+        "args": "this is a bad command"
+      }
+    ]
+  }
+}

--- a/pkg/api/validation/testdata/v1/invalidPod2.json
+++ b/pkg/api/validation/testdata/v1/invalidPod2.json
@@ -1,0 +1,35 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "apache-php",
+    "labels": {
+      "name": "apache-php"
+    }
+  },
+  "spec": {
+    "volumes": [{
+        "name": "shared-disk"
+    }],
+    "containers": [
+      {
+        "name": "apache-php",
+        "image": "php:5.6.2-apache",
+        "ports": [
+          {
+            "name": "apache",
+            "hostPort": "13380",
+            "containerPort": 80,
+            "protocol": "TCP"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "name": "shared-disk",
+            "mountPath": "/var/www/html"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/pkg/api/validation/testdata/v1/invalidPod3.json
+++ b/pkg/api/validation/testdata/v1/invalidPod3.json
@@ -1,0 +1,35 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "apache-php",
+    "labels": {
+      "name": "apache-php"
+    }
+  },
+  "spec": {
+    "volumes": [
+        "name": "shared-disk"
+    ],
+    "containers": [
+      {
+        "name": "apache-php",
+        "image": "php:5.6.2-apache",
+        "ports": [
+          {
+            "name": "apache",
+            "hostPort": 13380,
+            "containerPort": 80,
+            "protocol": "TCP"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "name": "shared-disk",
+            "mountPath": "/var/www/html"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/pkg/api/validation/testdata/v1/validPod.yaml
+++ b/pkg/api/validation/testdata/v1/validPod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    name: redis-master
+  name: name
+spec:
+  containers:
+  - args:
+    - this
+    - is
+    - an
+    - ok
+    - command
+    image: redis
+    name: master

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/securitycontext"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
 )
@@ -161,7 +160,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 							Image: "foo",
 							TerminationMessagePath: "/dev/termination-log",
 							ImagePullPolicy:        "Always",
-							SecurityContext:        securitycontext.ValidSecurityContextWithContainerDefaults()}},
+						}},
 					},
 				}),
 		},
@@ -214,7 +213,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 							Image: "foo",
 							TerminationMessagePath: "/dev/termination-log",
 							ImagePullPolicy:        "Always",
-							SecurityContext:        securitycontext.ValidSecurityContextWithContainerDefaults()}},
+						}},
 					},
 				},
 				&api.Pod{
@@ -234,7 +233,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 							Image: "bar",
 							TerminationMessagePath: "/dev/termination-log",
 							ImagePullPolicy:        "IfNotPresent",
-							SecurityContext:        securitycontext.ValidSecurityContextWithContainerDefaults()}},
+						}},
 					},
 				}),
 		},


### PR DESCRIPTION
enable unit tests for v1; let default value of Container.Security Context to be nil
#7343 #9070 #7018

I made a separate PR #9088 for the v1 swagger-spec changes. I will rebase this PR on #9088 later.

@bgrant0607 @krousey @nikhiljindal @pmorie
