### PR TITLE
run command is not available for kubectl

### DIFF
--- a/docs/getting-started-guides/docker-multinode/testing.md
+++ b/docs/getting-started-guides/docker-multinode/testing.md
@@ -18,7 +18,7 @@ If the status of any node is ```Unknown``` or ```NotReady``` your cluster is bro
 
 ### Run an application
 ```sh
-kubectl -s http://localhost:8080 run nginx --image=nginx --port=80
+kubectl -s http://localhost:8080 run-container nginx --image=nginx --port=80
 ```
 
 now run ```docker ps``` you should see nginx running.  You may need to wait a few minutes for the image to get pulled.

--- a/docs/getting-started-guides/docker-multinode/testing.md
+++ b/docs/getting-started-guides/docker-multinode/testing.md
@@ -18,7 +18,7 @@ If the status of any node is ```Unknown``` or ```NotReady``` your cluster is bro
 
 ### Run an application
 ```sh
-kubectl -s http://localhost:8080 run-container nginx --image=nginx --port=80
+kubectl run-container nginx --image=nginx --port=80 -s http://localhost:8080 
 ```
 
 now run ```docker ps``` you should see nginx running.  You may need to wait a few minutes for the image to get pulled.


### PR DESCRIPTION
I used http://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kubectl

But it seems we should use `run-container` instead of  `run`.

And `-s` should not be the first argument..

Close this if I made mistake.
