### PR TITLE
Added inline  links to "services" "pods" "namespaces" "secrets"  and …

### DIFF
--- a/examples/elasticsearch/README.md
+++ b/examples/elasticsearch/README.md
@@ -3,14 +3,14 @@
 This directory contains the source for a Docker image that creates an instance
 of [Elasticsearch](https://www.elastic.co/products/elasticsearch) 1.5.2 which can 
 be used to automatically form clusters when used
-with replication controllers. This will not work with the library Elasticsearch image
+with [replication controllers](../../docs/replication-controller.md). This will not work with the library Elasticsearch image
 because multicast discovery will not find the other pod IPs needed to form a cluster. This
-image detects other Elasticsearch pods running in a specified namespace with a given
+image detects other Elasticsearch [pods](../../docs/pods.md) running in a specified [namespace](../../docs/namespaces.md) with a given
 label selector. The detected instances are used to form a list of peer hosts which
 are used as part of the unicast discovery mechansim for Elasticsearch. The detection
 of the peer nodes is done by a program which communicates with the Kubernetes API
 server to get a list of matching Elasticsearch pods. To enable authenticated
-communication this image needs a secret to be mounted at `/etc/apiserver-secret`
+communication this image needs a [secret](../../docs/secrets.md) to be mounted at `/etc/apiserver-secret`
 with the basic authentication username and password.
 
 Here is an example replication controller specification that creates 4 instances of Elasticsearch which is in the file
@@ -113,7 +113,7 @@ $ kubectl create -f music-rc.yaml --namespace=mytunes
 replicationcontrollers/music-db
 
 ```
-It's also useful to have a service with an external load balancer for accessing the Elasticsearch
+It's also useful to have a [service](../../docs/services.md) with an external load balancer for accessing the Elasticsearch
 cluster which can be found in the file [music-service.yaml](music-service.yaml).
 ```
 apiVersion: v1beta3

--- a/examples/guestbook-go/README.md
+++ b/examples/guestbook-go/README.md
@@ -13,7 +13,7 @@ $ hack/dev-build-and-up.sh
 
 ### Step One: Turn up the redis master.
 
-Use the file `examples/guestbook-go/redis-master-controller.json` to create a replication controller which manages a single pod. The pod runs a redis key-value server in a container. Using a replication controller is the preferred way to launch long-running pods, even for 1 replica, so the pod will benefit from self-healing mechanism in kubernetes.
+Use the file `examples/guestbook-go/redis-master-controller.json` to create a [replication controller](../../docs/replication-controller.md) which manages a single [pod](../../docs/pods.md). The pod runs a redis key-value server in a container. Using a replication controller is the preferred way to launch long-running pods, even for 1 replica, so the pod will benefit from self-healing mechanism in kubernetes.
 
 Create the redis master replication controller in your Kubernetes cluster using the `kubectl` CLI:
 
@@ -50,7 +50,7 @@ d5c458dabe50        gurpartap/redis:latest                 "/usr/local/bin/redi 
 (Note that initial `docker pull` may take a few minutes, depending on network conditions.)
 
 ### Step Two: Turn up the master service.
-A Kubernetes 'service' is a named load balancer that proxies traffic to one or more containers. The services in a Kubernetes cluster are discoverable inside other containers via environment variables or DNS. Services find the containers to load balance based on pod labels.
+A Kubernetes '[service](../../docs/services.md)' is a named load balancer that proxies traffic to one or more containers. The services in a Kubernetes cluster are discoverable inside other containers via environment variables or DNS. Services find the containers to load balance based on pod labels.
 
 The pod that you created in Step One has the label `name=redis` and `role=master`. The selector field of the service determines which pods will receive the traffic sent to the service.  Use the file `examples/guestbook-go/redis-master-service.json` to create the service in the `kubectl` cli:
 

--- a/examples/hazelcast/README.md
+++ b/examples/hazelcast/README.md
@@ -4,7 +4,7 @@ The following document describes the development of a _cloud native_ [Hazelcast]
 
 Any topology changes are communicated and handled by Hazelcast nodes themselves.
 
-This document also attempts to describe the core components of Kubernetes, _Pods_, _Services_ and _Replication Controllers_.
+This document also attempts to describe the core components of Kubernetes: _Pods_, _Services_, and _Replication Controllers_.
 
 ### Prerequisites
 This example assumes that you have a Kubernetes cluster installed and running, and that you have installed the `kubectl` command line tool somewhere in your path.  Please see the [getting started](https://github.com/GoogleCloudPlatform/kubernetes/tree/master/docs/getting-started-guides) for installation instructions for your platform.
@@ -20,13 +20,13 @@ Source is freely available at:
 * Docker Trusted Build - https://registry.hub.docker.com/u/pires/hazelcast-k8s
 
 ### Simple Single Pod Hazelcast Node
-In Kubernetes, the atomic unit of an application is a [_Pod_](http://docs.k8s.io/pods.md).  A Pod is one or more containers that _must_ be scheduled onto the same host.  All containers in a pod share a network namespace, and may optionally share mounted volumes. 
+In Kubernetes, the atomic unit of an application is a [_Pod_](../../docs/pods.md).  A Pod is one or more containers that _must_ be scheduled onto the same host.  All containers in a pod share a network namespace, and may optionally share mounted volumes. 
 
 In this case, we shall not run a single Hazelcast pod, because the discovery mechanism now relies on a service definition.
 
 
 ### Adding a Hazelcast Service
-In Kubernetes a _Service_ describes a set of Pods that perform the same task.  For example, the set of nodes in a Hazelcast cluster.  An important use for a Service is to create a load balancer which distributes traffic across members of the set.  But a _Service_ can also be used as a standing query which makes a dynamically changing set of Pods available via the Kubernetes API.  This is actually how our discovery mechanism works, by relying on the service to discover other Hazelcast pods.
+In Kubernetes a _[Service](../../docs/services.md)_ describes a set of Pods that perform the same task.  For example, the set of nodes in a Hazelcast cluster.  An important use for a Service is to create a load balancer which distributes traffic across members of the set.  But a _Service_ can also be used as a standing query which makes a dynamically changing set of Pods available via the Kubernetes API.  This is actually how our discovery mechanism works, by relying on the service to discover other Hazelcast pods.
 
 Here is the service description:
 ```yaml
@@ -54,7 +54,7 @@ $ kubectl create -f hazelcast-service.yaml
 ### Adding replicated nodes
 The real power of Kubernetes and Hazelcast lies in easily building a replicated, scalable Hazelcast cluster.
 
-In Kubernetes a _Replication Controller_ is responsible for replicating sets of identical pods.  Like a _Service_ it has a selector query which identifies the members of it's set.  Unlike a _Service_ it also has a desired number of replicas, and it will create or delete _Pods_ to ensure that the number of _Pods_ matches up with it's desired state.
+In Kubernetes a _[Replication Controller](../../docs/replication-controller.md)_ is responsible for replicating sets of identical pods.  Like a _Service_ it has a selector query which identifies the members of it's set.  Unlike a _Service_ it also has a desired number of replicas, and it will create or delete _Pods_ to ensure that the number of _Pods_ matches up with it's desired state.
 
 Replication Controllers will "adopt" existing pods that match their selector query, so let's create a Replication Controller with a single replica to adopt our existing Hazelcast Pod.
 


### PR DESCRIPTION
Added inline links to "services" "pods" "namespaces" and "replication controllers" (using relative linking ../../folder/filename.md)

(second batch of file changes - see issue #8701 for full list of files to be fixed)
