### PR TITLE
Added inline links to "services" "pods" "namespaces" and "replication…

### DIFF
--- a/examples/kubernetes-namespaces/README.md
+++ b/examples/kubernetes-namespaces/README.md
@@ -1,6 +1,6 @@
 ## Kubernetes Namespaces
 
-Kubernetes Namespaces help different projects, teams, or customers to share a Kubernetes cluster.
+Kubernetes _[namespaces](../../docs/namespaces.md)_ help different projects, teams, or customers to share a Kubernetes cluster.
 
 It does this by providing the following:
 
@@ -15,8 +15,8 @@ This example demonstrates how to use Kubernetes namespaces to subdivide your clu
 
 This example assumes the following:
 
-1. You have an existing Kubernetes cluster.
-2. You have a basic understanding of Kubernetes pods, services, and replication controllers.
+1. You have an [existing Kubernetes cluster](../../docs/getting-started-guides).
+2. You have a basic understanding of Kubernetes _[pods](../../docs/pods.md)_, _[services](../../docs/services.md)_, and _[replication controllers](../../docs/replication-controller.md)_.
 
 ### Step One: Understand the default namespace
 

--- a/examples/logging-demo/README.md
+++ b/examples/logging-demo/README.md
@@ -1,6 +1,6 @@
 # Elasticsearch/Kibana Logging Demonstration
-This directory contains two pod specifications which can be used as synthetic
-loggig sources. The pod specification in [synthetic_0_25lps.yaml](synthetic_0_25lps.yaml)
+This directory contains two [pod](../../docs/pods.md) specifications which can be used as synthetic
+logging sources. The pod specification in [synthetic_0_25lps.yaml](synthetic_0_25lps.yaml)
 describes a pod that just emits a log message once every 4 seconds:
 ```
 # This pod specification creates an instance of a synthetic logger. The logger
@@ -49,7 +49,7 @@ synthetic-logger-10lps-pod
 Visiting the Kibana dashboard should make it clear that logs are being collected from the two synthetic loggers:
 ![Synthetic loggers](synth-logger.png)
 
-You can report the running pods, replication controllers and services with another Makefile rule:
+You can report the running pods, [replication controllers](../../docs/replication-controller.md), and [services](../../docs/services.md) with another Makefile rule:
 ```
 $ make get
 ../../../kubectl.sh get pods

--- a/examples/phabricator/README.md
+++ b/examples/phabricator/README.md
@@ -6,7 +6,7 @@ The example combines a web frontend and an external service that provides MySQL 
 
 ### Step Zero: Prerequisites
 
-This example assumes that you have a basic understanding of kubernetes services and that you have forked the repository and [turned up a Kubernetes cluster](https://github.com/GoogleCloudPlatform/kubernetes#contents):
+This example assumes that you have a basic understanding of kubernetes [services](../../docs/services.md) and that you have forked the repository and [turned up a Kubernetes cluster](../../docs/getting-started-guides):
 
 ```shell
 $ cd kubernetes
@@ -21,7 +21,7 @@ In the remaining part of this example we will assume that your instance is named
 
 ### Step Two: Turn up the phabricator
 
-To start Phabricator server use the file [`examples/phabricator/phabricator-controller.json`](phabricator-controller.json) which describes a replication controller with a single pod running an Apache server with Phabricator PHP source:
+To start Phabricator server use the file [`examples/phabricator/phabricator-controller.json`](phabricator-controller.json) which describes a [replication controller](../../docs/replication-controller.md) with a single [pod](../../docs/pods.md) running an Apache server with Phabricator PHP source:
 
 ```js
 {


### PR DESCRIPTION
Added inline links to "services" "pods" "namespaces" and "replication controllers" (using relative linking ../../folder/filename.md)

(third batch of file changes - see issue #8701 for full list of files to be fixed)
