### PR TITLE
Prevent access to the /run and /exec endpoints on the master's kubelet

### DIFF
--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -22,11 +22,15 @@
   {% set api_servers_with_port = api_servers + ":6443" -%}
 {% endif -%}
 
-# Disable registration for the kubelet running on the master on GCE.
+# Disable registration for the kubelet running on the master on GCE. Also disable
+# the debugging handlers (/run and /exec) to prevent arbitrary code execution on
+# the master.
 # TODO(roberthbailey): Make this configurable via an env var in config-default.sh
+{% set debugging_handlers = "--enable-debugging-handlers=true" -%}
 {% if grains.cloud == 'gce' -%}
   {% if grains['roles'][0] == 'kubernetes-master' -%}
     {% set api_servers_with_port = "" -%}
+    {% set debugging_handlers = "--enable-debugging-handlers=false" -%}
   {% endif -%}
 {% endif -%}
 
@@ -71,4 +75,4 @@
   {% set cgroup_root = "--cgroup_root=/" -%}
 {% endif -%}
 
-DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{hostname_override}} {{cloud_provider}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}}"
+DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}}"


### PR DESCRIPTION
so that users can't run arbitrary code on the master.
