### PR TITLE
enable v1 in hack/test-integration.go

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -165,6 +165,7 @@ func startComponents(firstManifestURL, secondManifestURL, apiVersion string) (st
 		ReadOnlyPort:          portNumber,
 		PublicAddress:         publicAddress,
 		CacheTimeout:          2 * time.Second,
+		EnableV1:              true,
 	})
 	handler.delegate = m.Handler
 

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -622,6 +622,23 @@ func runPatchTest(c *client.Client) {
 				[]byte(`{"metadata":{"labels":{"$patch":"replace"}}}`),
 			},
 		},
+		"v1": {
+			api.JSONPatchType: {
+				[]byte(`[{"op":"add","path":"/metadata/labels","value":{"foo":"bar","baz":"qux"}}]`),
+				[]byte(`[{"op":"remove","path":"/metadata/labels/foo"}]`),
+				[]byte(`[{"op":"remove","path":"/metadata/labels"}]`),
+			},
+			api.MergePatchType: {
+				[]byte(`{"metadata":{"labels":{"foo":"bar","baz":"qux"}}}`),
+				[]byte(`{"metadata":{"labels":{"foo":null}}}`),
+				[]byte(`{"metadata":{"labels":null}}`),
+			},
+			api.StrategicMergePatchType: {
+				[]byte(`{"metadata":{"labels":{"foo":"bar","baz":"qux"}}}`),
+				[]byte(`{"metadata":{"labels":{"foo":null}}}`),
+				[]byte(`{"metadata":{"labels":{"$patch":"replace"}}}`),
+			},
+		},
 	}
 
 	pb := patchBodies[c.APIVersion()]

--- a/cmd/integration/v1-controller.json
+++ b/cmd/integration/v1-controller.json
@@ -1,0 +1,24 @@
+{
+  "kind": "ReplicationController",
+  "apiVersion": "v1",
+  "metadata": {
+     "name": "nginx-controller",
+     "labels": {"name": "nginx"}
+  },
+  "spec": {
+    "replicas": 2,
+    "selector": {"name": "nginx"},
+    "template": {
+       "metadata": {
+          "labels": {"name": "nginx"}
+       },
+       "spec": {
+           "containers": [{
+             "name": "nginx",
+             "image": "nginx",
+             "ports": [{"containerPort": 80}]
+           }]
+       }
+    }
+  }
+}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -140,6 +140,7 @@ func TestExampleObjectSchemas(t *testing.T) {
 	cases := map[string]map[string]runtime.Object{
 		"../cmd/integration": {
 			"v1beta3-controller": &api.ReplicationController{},
+			"v1-controller":      &api.ReplicationController{},
 		},
 		"../examples/guestbook": {
 			"frontend-controller":     &api.ReplicationController{},

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -52,7 +52,7 @@ KUBE_RACE=${KUBE_RACE:-}   # use KUBE_RACE="-race" to enable race testing
 # Set to the goveralls binary path to report coverage results to Coveralls.io.
 KUBE_GOVERALLS_BIN=${KUBE_GOVERALLS_BIN:-}
 # Comma separated list of API Versions that should be tested.
-KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1beta3"}
+KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1beta3,v1"}
 # Run tests with the standard (registry) and a custom etcd prefix
 # (kubernetes.io/registry).
 KUBE_TEST_ETCD_PREFIXES=${KUBE_TEST_ETCD_PREFIXES:-"registry,kubernetes.io/registry"}

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -25,7 +25,8 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 # Comma separated list of API Versions that should be tested.
-KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1beta3"}
+KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1beta3,v1"}
+
 KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=${KUBE_INTEGRATION_TEST_MAX_CONCURRENCY:-"-1"}
 LOG_LEVEL=${LOG_LEVEL:-2}
 

--- a/pkg/api/latest/latest_test.go
+++ b/pkg/api/latest/latest_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	internal "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1"
 )
 
 func TestResourceVersioner(t *testing.T) {

--- a/pkg/api/latest/latest_test.go
+++ b/pkg/api/latest/latest_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	internal "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1"
 )
 
 func TestResourceVersioner(t *testing.T) {

--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -117,6 +117,32 @@ func addConversionFuncs() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
+	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Secret",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "type":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+	err = api.Scheme.AddFieldLabelConversionFunc("v1", "ServiceAccount",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
 }
 
 func convert_v1_StatusDetails_To_api_StatusDetails(in *StatusDetails, out *api.StatusDetails, s conversion.Scope) error {

--- a/pkg/api/v1beta3/defaults.go
+++ b/pkg/api/v1beta3/defaults.go
@@ -171,6 +171,9 @@ func defaultHostNetworkPorts(containers *[]Container) {
 // defaultSecurityContext performs the downward and upward merges of a pod definition
 func defaultSecurityContext(container *Container) {
 	if container.SecurityContext == nil {
+		if (len(container.Capabilities.Add) == 0) && (len(container.Capabilities.Drop) == 0) && (container.Privileged == false) {
+			return
+		}
 		glog.V(5).Infof("creating security context for container %s", container.Name)
 		container.SecurityContext = &SecurityContext{}
 	}

--- a/pkg/api/validation/testdata/v1/invalidPod.yaml
+++ b/pkg/api/validation/testdata/v1/invalidPod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    name: redis-master
+  name: name
+spec:
+  containers:
+  - args: "this is a bad command"
+    image: redis
+    name: master

--- a/pkg/api/validation/testdata/v1/invalidPod1.json
+++ b/pkg/api/validation/testdata/v1/invalidPod1.json
@@ -1,0 +1,19 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "name",
+    "labels": {
+      "name": "redis-master"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "master",
+        "image": "redis",
+        "args": "this is a bad command"
+      }
+    ]
+  }
+}

--- a/pkg/api/validation/testdata/v1/invalidPod2.json
+++ b/pkg/api/validation/testdata/v1/invalidPod2.json
@@ -1,0 +1,35 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "apache-php",
+    "labels": {
+      "name": "apache-php"
+    }
+  },
+  "spec": {
+    "volumes": [{
+        "name": "shared-disk"
+    }],
+    "containers": [
+      {
+        "name": "apache-php",
+        "image": "php:5.6.2-apache",
+        "ports": [
+          {
+            "name": "apache",
+            "hostPort": "13380",
+            "containerPort": 80,
+            "protocol": "TCP"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "name": "shared-disk",
+            "mountPath": "/var/www/html"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/pkg/api/validation/testdata/v1/invalidPod3.json
+++ b/pkg/api/validation/testdata/v1/invalidPod3.json
@@ -1,0 +1,35 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "apache-php",
+    "labels": {
+      "name": "apache-php"
+    }
+  },
+  "spec": {
+    "volumes": [
+        "name": "shared-disk"
+    ],
+    "containers": [
+      {
+        "name": "apache-php",
+        "image": "php:5.6.2-apache",
+        "ports": [
+          {
+            "name": "apache",
+            "hostPort": 13380,
+            "containerPort": 80,
+            "protocol": "TCP"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "name": "shared-disk",
+            "mountPath": "/var/www/html"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/pkg/api/validation/testdata/v1/validPod.yaml
+++ b/pkg/api/validation/testdata/v1/validPod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    name: redis-master
+  name: name
+spec:
+  containers:
+  - args:
+    - this
+    - is
+    - an
+    - ok
+    - command
+    image: redis
+    name: master

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/securitycontext"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
 )
@@ -161,7 +160,8 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 							Image: "foo",
 							TerminationMessagePath: "/dev/termination-log",
 							ImagePullPolicy:        "Always",
-							SecurityContext:        securitycontext.ValidSecurityContextWithContainerDefaults()}},
+							//SecurityContext:        securitycontext.ValidSecurityContextWithContainerDefaults()
+						}},
 					},
 				}),
 		},
@@ -214,7 +214,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 							Image: "foo",
 							TerminationMessagePath: "/dev/termination-log",
 							ImagePullPolicy:        "Always",
-							SecurityContext:        securitycontext.ValidSecurityContextWithContainerDefaults()}},
+						}},
 					},
 				},
 				&api.Pod{
@@ -234,7 +234,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 							Image: "bar",
 							TerminationMessagePath: "/dev/termination-log",
 							ImagePullPolicy:        "IfNotPresent",
-							SecurityContext:        securitycontext.ValidSecurityContextWithContainerDefaults()}},
+						}},
 					},
 				}),
 		},

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -160,7 +160,6 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 							Image: "foo",
 							TerminationMessagePath: "/dev/termination-log",
 							ImagePullPolicy:        "Always",
-							//SecurityContext:        securitycontext.ValidSecurityContextWithContainerDefaults()
 						}},
 					},
 				}),

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -397,6 +397,7 @@ func TestAuthModeAlwaysAllow(t *testing.T) {
 		APIPrefix:             "/api",
 		Authorizer:            apiserver.NewAlwaysAllowAuthorizer(),
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		EnableV1:              true,
 	})
 
 	transport := http.DefaultTransport
@@ -537,6 +538,7 @@ func TestAuthModeAlwaysDeny(t *testing.T) {
 		APIPrefix:             "/api",
 		Authorizer:            apiserver.NewAlwaysDenyAuthorizer(),
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		EnableV1:              true,
 	})
 
 	transport := http.DefaultTransport
@@ -605,6 +607,7 @@ func TestAliceNotForbiddenOrUnauthorized(t *testing.T) {
 		Authenticator:         getTestTokenAuth(),
 		Authorizer:            allowAliceAuthorizer{},
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		EnableV1:              true,
 	})
 
 	previousResourceVersion := make(map[string]float64)
@@ -692,6 +695,7 @@ func TestBobIsForbidden(t *testing.T) {
 		Authenticator:         getTestTokenAuth(),
 		Authorizer:            allowAliceAuthorizer{},
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		EnableV1:              true,
 	})
 
 	transport := http.DefaultTransport
@@ -753,6 +757,7 @@ func TestUnknownUserIsUnauthorized(t *testing.T) {
 		Authenticator:         getTestTokenAuth(),
 		Authorizer:            allowAliceAuthorizer{},
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		EnableV1:              true,
 	})
 
 	transport := http.DefaultTransport
@@ -833,6 +838,7 @@ func TestNamespaceAuthorization(t *testing.T) {
 		Authenticator:         getTestTokenAuth(),
 		Authorizer:            a,
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		EnableV1:              true,
 	})
 
 	previousResourceVersion := make(map[string]float64)
@@ -948,6 +954,7 @@ func TestKindAuthorization(t *testing.T) {
 		Authenticator:         getTestTokenAuth(),
 		Authorizer:            a,
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		EnableV1:              true,
 	})
 
 	previousResourceVersion := make(map[string]float64)
@@ -1050,6 +1057,7 @@ func TestReadOnlyAuthorization(t *testing.T) {
 		Authenticator:         getTestTokenAuth(),
 		Authorizer:            a,
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		EnableV1:              true,
 	})
 
 	transport := http.DefaultTransport

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -272,6 +272,7 @@ func RunAMaster(t *testing.T) (*master.Master, *httptest.Server) {
 		APIPrefix:         "/api",
 		Authorizer:        apiserver.NewAlwaysAllowAuthorizer(),
 		AdmissionControl:  admit.NewAlwaysAdmit(),
+		EnableV1:          true,
 	})
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/test/integration/scheduler_test.go
+++ b/test/integration/scheduler_test.go
@@ -75,6 +75,7 @@ func TestUnschedulableNodes(t *testing.T) {
 		APIPrefix:             "/api",
 		Authorizer:            apiserver.NewAlwaysAllowAuthorizer(),
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		EnableV1:              true,
 	})
 
 	restClient := client.NewOrDie(&client.Config{Host: s.URL, Version: testapi.Version()})

--- a/test/integration/secret_test.go
+++ b/test/integration/secret_test.go
@@ -68,6 +68,7 @@ func TestSecrets(t *testing.T) {
 		APIPrefix:             "/api",
 		Authorizer:            apiserver.NewAlwaysAllowAuthorizer(),
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		EnableV1:              true,
 	})
 
 	framework.DeleteAllEtcdKeys()

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -419,6 +419,7 @@ func startServiceAccountTestServer(t *testing.T) (*client.Client, client.Config,
 		Authenticator:     authenticator,
 		Authorizer:        authorizer,
 		AdmissionControl:  serviceAccountAdmission,
+		EnableV1:          true,
 	})
 
 	// Start the service account and service account token controllers

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -82,6 +82,7 @@ func runAMaster(t *testing.T) (*master.Master, *httptest.Server) {
 		APIPrefix:             "/api",
 		Authorizer:            apiserver.NewAlwaysAllowAuthorizer(),
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		EnableV1:              true,
 	})
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
enable v1 integration tests.

The first 2 commits are in #9101.
#9070 #7018

@bgrant0607 @krousey @nikhiljindal 
