### PR TITLE
Use Node IP Address instead of Node.Name in minion.ResourceLocation.

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -48,6 +48,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master/ports"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/mount"
+	nodeutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util/node"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
@@ -284,7 +285,7 @@ func (s *KubeletServer) Run(_ []string) error {
 	if s.TLSCertFile == "" && s.TLSPrivateKeyFile == "" {
 		s.TLSCertFile = path.Join(s.CertDirectory, "kubelet.crt")
 		s.TLSPrivateKeyFile = path.Join(s.CertDirectory, "kubelet.key")
-		if err := util.GenerateSelfSignedCert(util.GetHostname(s.HostnameOverride), s.TLSCertFile, s.TLSPrivateKeyFile); err != nil {
+		if err := util.GenerateSelfSignedCert(nodeutil.GetHostname(s.HostnameOverride), s.TLSCertFile, s.TLSPrivateKeyFile); err != nil {
 			return fmt.Errorf("unable to generate self signed cert: %v", err)
 		}
 		glog.V(4).Infof("Using self-signed cert (%s, %s)", s.TLSCertFile, s.TLSPrivateKeyFile)
@@ -528,7 +529,7 @@ func SimpleKubelet(client *client.Client,
 //   3 Standalone 'kubernetes' binary
 // Eventually, #2 will be replaced with instances of #3
 func RunKubelet(kcfg *KubeletConfig, builder KubeletBuilder) error {
-	kcfg.Hostname = util.GetHostname(kcfg.HostnameOverride)
+	kcfg.Hostname = nodeutil.GetHostname(kcfg.HostnameOverride)
 	eventBroadcaster := record.NewBroadcaster()
 	kcfg.Recorder = eventBroadcaster.NewRecorder(api.EventSource{Component: "kubelet", Host: kcfg.Hostname})
 	eventBroadcaster.StartLogging(glog.Infof)

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -42,9 +42,11 @@ import (
 	"google.golang.org/cloud/compute/metadata"
 )
 
-const ProviderName = "gce"
-
-const EXTERNAL_IP_METADATA_URL = "http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip"
+const (
+	ProviderName             = "gce"
+	EXTERNAL_IP_METADATA_URL = "http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip"
+	INTERNAL_IP_METADATA_URL = "http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/ip"
+)
 
 // GCECloud is an implementation of Interface, TCPLoadBalancer and Instances for Google Compute Engine.
 type GCECloud struct {
@@ -476,15 +478,17 @@ func (gce *GCECloud) getInstanceByName(name string) (*compute.Instance, error) {
 
 // NodeAddresses is an implementation of Instances.NodeAddresses.
 func (gce *GCECloud) NodeAddresses(_ string) ([]api.NodeAddress, error) {
+	internalIP, err := gce.metadataAccess(INTERNAL_IP_METADATA_URL)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get internal IP: %v", err)
+	}
 	externalIP, err := gce.metadataAccess(EXTERNAL_IP_METADATA_URL)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get external IP: %v", err)
 	}
-
 	return []api.NodeAddress{
+		{Type: api.NodeInternalIP, Address: internalIP},
 		{Type: api.NodeExternalIP, Address: externalIP},
-		// TODO(mbforbes): Remove NodeLegacyHostIP once v1beta1 is removed.
-		{Type: api.NodeLegacyHostIP, Address: externalIP},
 	}, nil
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -54,6 +54,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	utilErrors "github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/mount"
+	nodeutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util/node"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -1721,21 +1722,7 @@ func (kl *Kubelet) GetHostIP() (net.IP, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot get node: %v", err)
 	}
-	addresses := node.Status.Addresses
-	addressMap := make(map[api.NodeAddressType][]api.NodeAddress)
-	for i := range addresses {
-		addressMap[addresses[i].Type] = append(addressMap[addresses[i].Type], addresses[i])
-	}
-	if addresses, ok := addressMap[api.NodeLegacyHostIP]; ok {
-		return net.ParseIP(addresses[0].Address), nil
-	}
-	if addresses, ok := addressMap[api.NodeInternalIP]; ok {
-		return net.ParseIP(addresses[0].Address), nil
-	}
-	if addresses, ok := addressMap[api.NodeExternalIP]; ok {
-		return net.ParseIP(addresses[0].Address), nil
-	}
-	return nil, fmt.Errorf("host IP unknown; known addresses: %v", addresses)
+	return nodeutil.GetNodeHostIP(node)
 }
 
 // GetPods returns all pods bound to the kubelet and their spec, and the mirror

--- a/pkg/registry/minion/rest.go
+++ b/pkg/registry/minion/rest.go
@@ -33,6 +33,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
+	nodeutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util/node"
 )
 
 // nodeStrategy implements behavior for nodes
@@ -141,13 +142,16 @@ func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGet
 		return nil, nil, err
 	}
 	node := nodeObj.(*api.Node)
-	host := node.Name // TODO: use node's IP, don't expect the name to resolve.
-
-	if portReq != "" {
-		return &url.URL{Host: net.JoinHostPort(host, portReq)}, nil, nil
+	hostIP, err := nodeutil.GetNodeHostIP(node)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	scheme, port, transport, err := connection.GetConnectionInfo(host)
+	if portReq != "" {
+		return &url.URL{Host: net.JoinHostPort(hostIP.String(), portReq)}, nil, nil
+	}
+
+	scheme, port, transport, err := connection.GetConnectionInfo(hostIP.String())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -155,7 +159,7 @@ func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGet
 	return &url.URL{
 			Scheme: scheme,
 			Host: net.JoinHostPort(
-				host,
+				hostIP.String(),
 				strconv.FormatUint(uint64(port), 10),
 			),
 		},

--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -14,12 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package node
 
 import (
+	"fmt"
+	"net"
 	"os/exec"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/golang/glog"
 )
 
@@ -33,4 +36,22 @@ func GetHostname(hostnameOverride string) string {
 		hostname = string(nodename)
 	}
 	return strings.ToLower(strings.TrimSpace(hostname))
+}
+
+// GetNodeHostIP returns the provided node's IP, based on the priority:
+// 1. NodeInternalIP
+// 2. NodeExternalIP
+func GetNodeHostIP(node *api.Node) (net.IP, error) {
+	addresses := node.Status.Addresses
+	addressMap := make(map[api.NodeAddressType][]api.NodeAddress)
+	for i := range addresses {
+		addressMap[addresses[i].Type] = append(addressMap[addresses[i].Type], addresses[i])
+	}
+	if addresses, ok := addressMap[api.NodeInternalIP]; ok {
+		return net.ParseIP(addresses[0].Address), nil
+	}
+	if addresses, ok := addressMap[api.NodeExternalIP]; ok {
+		return net.ParseIP(addresses[0].Address), nil
+	}
+	return nil, fmt.Errorf("host IP unknown; known addresses: %v", addresses)
 }


### PR DESCRIPTION
Refactor GetNodeHostIP into pkg/util/node (instead of pkg/util to break import cycle).

Include internalIP in gce NodeAddresses. Remove NodeLegacyHostIP
