### PR TITLE
AWS: Update Master IAM Policy to Include ELB

### DIFF
--- a/cluster/aws/templates/iam/kubernetes-master-policy.json
+++ b/cluster/aws/templates/iam/kubernetes-master-policy.json
@@ -8,6 +8,11 @@
     },
     {
       "Effect": "Allow",
+      "Action": ["elasticloadbalancing:*"],
+      "Resource": ["*"]
+    },
+    {
+      "Effect": "Allow",
       "Action": "s3:*",
       "Resource": [
         "arn:aws:s3:::kubernetes-*"


### PR DESCRIPTION
It appears AWS IAM policies were not updated to allow for configuring load balancers. This is causing controller manager to throw a lot of errors when starting a new cluster.

@justinsb I'm not sure if the resource needs restricted any further, PTAL.
