### PR TITLE
stop monit kube-proxy on master node.

### DIFF
--- a/cluster/saltbase/salt/monit/init.sls
+++ b/cluster/saltbase/salt/monit/init.sls
@@ -20,6 +20,7 @@ monit:
     - group: root
     - mode: 644
 
+{% if "kubernetes-pool" in grains.get('roles', []) %}
 /etc/monit/conf.d/kube-proxy:
   file:
     - managed
@@ -27,6 +28,7 @@ monit:
     - user: root
     - group: root
     - mode: 644
+{% endif %}
 
 /etc/monit/monit_watcher.sh:
   file.managed:


### PR DESCRIPTION
Fixed #8783 

cc/ @roberthbailey 

With this PR, newly created master node wouldn't have those non-sense error in monit.log every 2 mins:

[UTC Jun  3 00:28:41] error    : 'kube-proxy' process is not running
[UTC Jun  3 00:28:41] info     : 'kube-proxy' trying to restart
[UTC Jun  3 00:28:41] info     : 'kube-proxy' start: /etc/init.d/kube-proxy
[UTC Jun  3 00:28:41] error    : Error: Could not execute /etc/init.d/kube-proxy
[UTC Jun  3 00:29:11] error    : 'kube-proxy' failed to start
