### PR TITLE
parse apiserver prefix from client config host spec

### DIFF
--- a/pkg/client/clientcmd/client_config.go
+++ b/pkg/client/clientcmd/client_config.go
@@ -18,6 +18,7 @@ package clientcmd
 
 import (
 	"io"
+	"net/url"
 	"os"
 
 	"github.com/imdario/mergo"
@@ -85,6 +86,13 @@ func (config DirectClientConfig) ClientConfig() (*client.Config, error) {
 
 	clientConfig := &client.Config{}
 	clientConfig.Host = configClusterInfo.Server
+	if u, err := url.ParseRequestURI(clientConfig.Host); err == nil && u.Opaque == "" && len(u.Path) > 1 {
+		clientConfig.Prefix = u.Path
+		u.Path = ""
+		u.RawQuery = ""
+		u.Fragment = ""
+		clientConfig.Host = u.String()
+	}
 	clientConfig.Version = configClusterInfo.APIVersion
 
 	// only try to read the auth information if we are secure

--- a/pkg/client/clientcmd/client_config_test.go
+++ b/pkg/client/clientcmd/client_config_test.go
@@ -141,9 +141,47 @@ func TestCreateClean(t *testing.T) {
 	}
 
 	matchStringArg(config.Clusters["clean"].Server, clientConfig.Host, t)
+	matchStringArg("", clientConfig.Prefix, t)
 	matchStringArg(config.Clusters["clean"].APIVersion, clientConfig.Version, t)
 	matchBoolArg(config.Clusters["clean"].InsecureSkipTLSVerify, clientConfig.Insecure, t)
 	matchStringArg(config.AuthInfos["clean"].Token, clientConfig.BearerToken, t)
+}
+
+func TestCreateCleanWithPrefix(t *testing.T) {
+	tt := []struct {
+		server string
+		host   string
+		prefix string
+	}{
+		{"https://anything.com:8080/foo/bar", "https://anything.com:8080", "/foo/bar"},
+		{"http://anything.com:8080/foo/bar", "http://anything.com:8080", "/foo/bar"},
+		{"http://anything.com:8080/foo/bar/", "http://anything.com:8080", "/foo/bar/"},
+		{"http://anything.com:8080/", "http://anything.com:8080/", ""},
+		{"http://anything.com:8080//", "http://anything.com:8080", "//"},
+		{"anything.com:8080/foo/bar", "anything.com:8080/foo/bar", ""},
+		{"anything.com:8080", "anything.com:8080", ""},
+		{"anything.com", "anything.com", ""},
+		{"anything", "anything", ""},
+		{"", "http://localhost:8080", ""},
+	}
+
+	for _, tc := range tt {
+		config := createValidTestConfig()
+
+		cleanConfig := config.Clusters["clean"]
+		cleanConfig.Server = tc.server
+		config.Clusters["clean"] = cleanConfig
+
+		clientBuilder := NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{})
+
+		clientConfig, err := clientBuilder.ClientConfig()
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		matchStringArg(tc.host, clientConfig.Host, t)
+		matchStringArg(tc.prefix, clientConfig.Prefix, t)
+	}
 }
 
 func TestCreateCleanDefault(t *testing.T) {
@@ -187,7 +225,7 @@ func matchBoolArg(expected, got bool, t *testing.T) {
 
 func matchStringArg(expected, got string, t *testing.T) {
 	if expected != got {
-		t.Errorf("Expected %v, got %v", expected, got)
+		t.Errorf("Expected %q, got %q", expected, got)
 	}
 }
 

--- a/pkg/kubectl/cmd/config/config_test.go
+++ b/pkg/kubectl/cmd/config/config_test.go
@@ -108,6 +108,35 @@ func TestSetIntoExistingStruct(t *testing.T) {
 	test.run(t)
 }
 
+func TestSetWithPathPrefixIntoExistingStruct(t *testing.T) {
+	expectedConfig := newRedFederalCowHammerConfig()
+	cc := expectedConfig.Clusters["cow-clusters"]
+	cinfo := &cc
+	cinfo.Server = "http://cow.org:8080/foo/baz"
+	expectedConfig.Clusters["cow-cluster"] = *cinfo
+	test := configCommandTest{
+		args:           []string{"set", "clusters.cow-cluster.server", "http://cow.org:8080/foo/baz"},
+		startingConfig: newRedFederalCowHammerConfig(),
+		expectedConfig: expectedConfig,
+	}
+
+	test.run(t)
+
+	dc := clientcmd.NewDefaultClientConfig(expectedConfig, &clientcmd.ConfigOverrides{})
+	dcc, err := dc.ClientConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expectedHost := "http://cow.org:8080"
+	if expectedHost != dcc.Host {
+		t.Fatalf("expected client.Config.Host = %q instead of %q", expectedHost, dcc.Host)
+	}
+	expectedPrefix := "/foo/baz"
+	if expectedPrefix != dcc.Prefix {
+		t.Fatalf("expected client.Config.Prefix = %q instead of %q", expectedPrefix, dcc.Prefix)
+	}
+}
+
 func TestUnsetStruct(t *testing.T) {
 	expectedConfig := newRedFederalCowHammerConfig()
 	delete(expectedConfig.AuthInfos, "red-user")


### PR DESCRIPTION
This allows apiserver to be hosted behind a proxy w/ proxypass-like rules that translate URLs. For example, from a client perspective the apiserver might live http://some-mesosphere-dcos-cluster/service/kubernetes/api and we'd want `kubectl` to be able to access that server. Mesosphere DCOS would translate /service/kubernetes/api --> /api by the time the request hits the apiserver.

This PR allows for a user to:

``` shell
:; export KUBERNETES_MASTER=http://some-mesosphere-dcos-cluster/service/kubernetes/api
```

.. and then use `kubectl` to interact with it.

/cc @guenter @davidopp @bgrant0607 
