### PR TITLE
Increased failCount param in RunRC function for e2e tests.

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -797,7 +797,7 @@ func RunRC(c *client.Client, name string, ns, image string, replicas int) error 
 	defer podStore.Stop()
 	pods := podStore.List()
 	current = len(pods)
-	failCount := 5
+	failCount := 24
 	for same < failCount && current < replicas {
 		Logf("%v Controller %s: Found %d pods out of %d", time.Now(), name, current, replicas)
 		if last < current {


### PR DESCRIPTION
The previous value was 10 (equivalent of 50sec) current is 24 (2min).
Time in brackets mean: how long should I wait for the next pod of RC to be created.

While we are creating 3000 pods for scalability tests it tends to fail.
