### PR TITLE
Replace Java client library reference with up to date client library

### DIFF
--- a/docs/client-libraries.md
+++ b/docs/client-libraries.md
@@ -6,7 +6,7 @@
 ### User Contributed
 *Note: Libraries provided by outside parties are supported by their authors, not the core Kubernetes team*
 
-   * [Java](https://github.com/nirmal070125/KubernetesAPIJavaClient)
+   * [Java](https://github.com/fabric8io/fabric8/tree/master/components/kubernetes-api)
    * [Ruby1](https://github.com/Ch00k/kuber)
    * [Ruby2](https://github.com/abonas/kubeclient)
    * [PHP](https://github.com/devstub/kubernetes-api-php-client)


### PR DESCRIPTION
Noticed that the Java client library referenced in client-libraries.md is out of date so thought would be good to update to reference the fabric8 Java client API which is actively developed.
