### PR TITLE
Watch kubelet flag file, so restart kubelet upon changes.

### DIFF
--- a/cluster/saltbase/salt/kubelet/init.sls
+++ b/cluster/saltbase/salt/kubelet/init.sls
@@ -72,4 +72,5 @@ kubelet:
 {% if grains['os_family'] != 'RedHat' %}
       - file: /etc/init.d/kubelet
 {% endif %}
+      - file: {{ environment_file }}
       - file: /var/lib/kubelet/kubernetes_auth


### PR DESCRIPTION
With this PR, kubelet flag change does trigger kubelet restart to pick up the new flagset. Here are the testing I had done last night:

1) Before flag change:

```
# ps -ef | grep kubelet
root     26779     1  2 16:25 ?        00:00:02 /usr/local/bin/kubelet --api_servers=https://kubernetes-master --enable-debugging-handlers=true --cloud_provider=gce --config=/etc/kubernetes/manifests --allow_privileged=False --v=2 --cluster_dns=10.0.0.10 --cluster_domain=cluster.local --configure-cbr0=true --cgroup_root=/ --system-container=/system

# kubelet --version
Kubernetes v0.18.0-284-g1d9434802305cb-dirty
```

2) Modified kubelet flag file:

```
$ git diff
diff --git a/cluster/saltbase/salt/kubelet/default b/cluster/saltbase/salt/kubelet/default
index afdf3ad..d08ec43 100644
--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -75,4 +75,4 @@
   {% set cgroup_root = "--cgroup_root=/" -%}
 {% endif -%}

-DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}}"
+DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}} --enable-load-reader=true"
```

3) kube_push above flag change and make sure it is the same build:

```
# ps -ef | grep kubelet
root      3168     1  4 16:42 ?        00:00:01 /usr/local/bin/kubelet --api_servers=https://kubernetes-master --enable-debugging-handlers=true --cloud_provider=gce --config=/etc/kubernetes/manifests --allow_privileged=False --v=2 --cluster_dns=10.0.0.10 --cluster_domain=cluster.local --configure-cbr0=true --cgroup_root=/ --system-container=/system --enable-load-reader=true
# kubelet --version
Kubernetes v0.18.0-284-g1d9434802305cb-dirty
```

I checked other daemons, and flag changes do trigger daemon restart.

Fix #9110 

cc/ @gmarek @davidopp 
