### PR TITLE
add v1 to serialization_test.go

### DIFF
--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
 	apitesting "github.com/GoogleCloudPlatform/kubernetes/pkg/api/testing"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -91,11 +92,10 @@ func roundTripSame(t *testing.T, item runtime.Object, except ...string) {
 		fuzzInternalObject(t, "v1beta3", item, seed)
 		roundTrip(t, v1beta3.Codec, item)
 	}
-}
-
-func roundTripAll(t *testing.T, item runtime.Object) {
-	seed := rand.Int63()
-	roundTrip(t, v1beta3.Codec, fuzzInternalObject(t, "v1beta3", item, seed))
+	if !set.Has("v1") {
+		fuzzInternalObject(t, "v1", item, seed)
+		roundTrip(t, v1.Codec, item)
+	}
 }
 
 // For debugging problems


### PR DESCRIPTION
Only the last commit is relevant. Other commits are in #9169
#9070 #7018

@bgrant0607 @nikhiljindal @krousey

@smarterclayton, why do we need  function roundTripAll? It seems no one is calling it.
