### PR TITLE
Disable load test from e2e-gce-scalability jenkins job

### DIFF
--- a/test/e2e/load.go
+++ b/test/e2e/load.go
@@ -97,7 +97,7 @@ var _ = Describe("Load capacity", func() {
 	}
 
 	for _, testArg := range loadTests {
-		name := fmt.Sprintf("[Performance suite] [Skipped] should be able to handle %v pods per node", testArg.podsPerNode)
+		name := fmt.Sprintf("[Skipped] should be able to handle %v pods per node", testArg.podsPerNode)
 
 		It(name, func() {
 			totalPods := testArg.podsPerNode * nodeCount


### PR DESCRIPTION
It's not stable enough and causes troubles. Since Thu and Fri are public holidays in Poland I'd prefer to disable it to have green jenkins over the long weekend.

@piosz 
