### PR TITLE
Request resources that fit in the default configuration in examples/mysql-wordpress-pd.

### DIFF
--- a/examples/mysql-wordpress-pd/mysql.yaml
+++ b/examples/mysql-wordpress-pd/mysql.yaml
@@ -8,7 +8,7 @@ spec:
   containers: 
     - resources:
         limits :
-          cpu: 1
+          cpu: 0.5
       image: mysql
       name: mysql
       env:


### PR DESCRIPTION
Following #9204, request only part of a core.
