### PR TITLE
Remove the last provider-specific handling in kubectl.sh, ginkgo-e2e.sh

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -65,7 +65,7 @@ function create-kubeconfig() {
     user_args+=(
      "--token=${KUBE_BEARER_TOKEN}"
     )
-  else
+  elif [[ ! -z "${KUBE_USER:-}" && ! -z "${KUBE_PASSWORD:-}" ]]; then
     user_args+=(
      "--username=${KUBE_USER}"
      "--password=${KUBE_PASSWORD}"
@@ -87,7 +87,7 @@ function create-kubeconfig() {
   # If we have a bearer token, also create a credential entry with basic auth
   # so that it is easy to discover the basic auth password for your cluster
   # to use in a web browser.
-  if [[ ! -z "${KUBE_BEARER_TOKEN:-}" ]]; then
+  if [[ ! -z "${KUBE_BEARER_TOKEN:-}" && ! -z "${KUBE_USER:-}" && ! -z "${KUBE_PASSWORD:-}" ]]; then
     "${kubectl}" config set-credentials "${CONTEXT}-basic-auth" "--username=${KUBE_USER}" "--password=${KUBE_PASSWORD}"
   fi
 

--- a/cluster/juju/util.sh
+++ b/cluster/juju/util.sh
@@ -57,6 +57,9 @@ function kube-up() {
     sleep-status
     detect-master
     detect-minions
+
+    export KUBE_MASTER_IP="${KUBE_MASTER_IP}:8080"
+    export CONTEXT="juju"
 }
 
 function kube-down() {

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -346,11 +346,14 @@ function kube-up {
   }
 
     ((ii=ii+1))
-        
   done
   wait
 
   verify-cluster
+  detect-master
+  export KUBE_MASTER_IP="${KUBE_MASTER_IP}:8080"
+  export CONTEXT="ubuntu"
+  create-kubeconfig
 }
 
 function provision-master() {

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -60,13 +60,6 @@ if [[ -z "${AUTH_CONFIG:-}" ]];  then
       auth_config=(
       "--kubeconfig=${KUBECONFIG:-$DEFAULT_KUBECONFIG}"
       )
-      if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
-        # gcloud doesn't override the current-context, so we explicitly set it
-        detect-project &> /dev/null
-        auth_config+=(
-          "--context=gke_${PROJECT}_${ZONE}_${CLUSTER_NAME}"
-        )
-      fi
     fi
 else
   echo "Conformance Test.  No cloud-provider-specific preparation."


### PR DESCRIPTION
Last actual use for kubectl.sh. It can now be turned into an initialization script (#8817), just have to go through and correct [all the uses](https://github.com/GoogleCloudPlatform/kubernetes/search?utf8=%E2%9C%93&q=cluster%2Fkubectl.sh&type=Code).
