### PR TITLE
Fix namespace controller on delete to not care if item not found

### DIFF
--- a/pkg/namespace/namespace_controller.go
+++ b/pkg/namespace/namespace_controller.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/controller/framework"
@@ -28,6 +29,8 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+
+	"github.com/golang/glog"
 )
 
 // NamespaceManager is responsible for performing actions dependent upon a namespace phase
@@ -52,11 +55,17 @@ func NewNamespaceManager(kubeClient client.Interface, resyncPeriod time.Duration
 		framework.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				namespace := obj.(*api.Namespace)
-				syncNamespace(kubeClient, *namespace)
+				err := syncNamespace(kubeClient, *namespace)
+				if err != nil {
+					glog.Error(err)
+				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				namespace := newObj.(*api.Namespace)
-				syncNamespace(kubeClient, *namespace)
+				err := syncNamespace(kubeClient, *namespace)
+				if err != nil {
+					glog.Error(err)
+				}
 			},
 		},
 	)
@@ -169,7 +178,10 @@ func syncNamespace(kubeClient client.Interface, namespace api.Namespace) (err er
 	// if the namespace is already finalized, delete it
 	if finalized(namespace) {
 		err = kubeClient.Namespaces().Delete(namespace.Name)
-		return err
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+		return nil
 	}
 
 	// there may still be content for us to remove
@@ -187,7 +199,9 @@ func syncNamespace(kubeClient client.Interface, namespace api.Namespace) (err er
 	// now check if all finalizers have reported that we delete now
 	if finalized(*result) {
 		err = kubeClient.Namespaces().Delete(namespace.Name)
-		return err
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
 	}
 
 	return nil
@@ -200,7 +214,7 @@ func deleteLimitRanges(kubeClient client.Interface, ns string) error {
 	}
 	for i := range items.Items {
 		err := kubeClient.LimitRanges(ns).Delete(items.Items[i].Name)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -214,7 +228,7 @@ func deleteResourceQuotas(kubeClient client.Interface, ns string) error {
 	}
 	for i := range resourceQuotas.Items {
 		err := kubeClient.ResourceQuotas(ns).Delete(resourceQuotas.Items[i].Name)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -228,7 +242,7 @@ func deleteServiceAccounts(kubeClient client.Interface, ns string) error {
 	}
 	for i := range items.Items {
 		err := kubeClient.ServiceAccounts(ns).Delete(items.Items[i].Name)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -242,7 +256,7 @@ func deleteServices(kubeClient client.Interface, ns string) error {
 	}
 	for i := range items.Items {
 		err := kubeClient.Services(ns).Delete(items.Items[i].Name)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -256,7 +270,7 @@ func deleteReplicationControllers(kubeClient client.Interface, ns string) error 
 	}
 	for i := range items.Items {
 		err := kubeClient.ReplicationControllers(ns).Delete(items.Items[i].Name)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -270,7 +284,7 @@ func deletePods(kubeClient client.Interface, ns string) error {
 	}
 	for i := range items.Items {
 		err := kubeClient.Pods(ns).Delete(items.Items[i].Name, nil)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -284,7 +298,7 @@ func deleteEvents(kubeClient client.Interface, ns string) error {
 	}
 	for i := range items.Items {
 		err := kubeClient.Events(ns).Delete(items.Items[i].Name)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -298,7 +312,7 @@ func deleteSecrets(kubeClient client.Interface, ns string) error {
 	}
 	for i := range items.Items {
 		err := kubeClient.Secrets(ns).Delete(items.Items[i].Name)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -312,7 +326,7 @@ func deletePersistentVolumeClaims(kubeClient client.Interface, ns string) error 
 	}
 	for i := range items.Items {
 		err := kubeClient.PersistentVolumeClaims(ns).Delete(items.Items[i].Name)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/pkg/registry/namespace/etcd/etcd.go
+++ b/pkg/registry/namespace/etcd/etcd.go
@@ -102,7 +102,7 @@ func (r *REST) Delete(ctx api.Context, name string, options *api.DeleteOptions) 
 
 	// prior to final deletion, we must ensure that finalizers is empty
 	if len(namespace.Spec.Finalizers) != 0 {
-		err = apierrors.NewConflict("Namespace", namespace.Name, fmt.Errorf("Termination is in progress, waiting for %v", namespace.Spec.Finalizers))
+		err = apierrors.NewConflict("Namespace", namespace.Name, fmt.Errorf("The system is ensuring all content is removed from this namespace.  Upon completion, this namespace will automatically be purged by the system."))
 		return nil, err
 	}
 	return r.Etcd.Delete(ctx, name, nil)

--- a/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -75,7 +75,7 @@ func (l *lifecycle) Admit(a admission.Attributes) (err error) {
 		return nil
 	}
 
-	return admission.NewForbidden(a, fmt.Errorf("Namespace %s is terminating", a.GetNamespace()))
+	return admission.NewForbidden(a, fmt.Errorf("Unable to create new content in namespace %s because it is being terminated.", a.GetNamespace()))
 }
 
 // NewLifecycle creates a new namespace lifecycle admission control handler


### PR DESCRIPTION
Fixes #9197 

The core issue was the following:
1. namespace X was marked for deletion
2. namespace controller observes X is marked for deletion and deletes all content
3. controller deleted service accounts in X
4. token controller sees a service account was deleted and then deletes that service accounts secrets
5. namespace controller tries to delete secrets in X, gets not found error on a delete call
   that error then propagated back up to namespace controller and caused it to wait until next resync period to delete
6. upon next resync period, things were deleted as expected.

That process if happens took O(minutes)

The fix is to change the namespace controller to ignore errs.IsNotFound on any delete operation since the thing it was trying to delete was already deleted.

This makes namespace deletion take O(second)

I tested on GCE with a namespace with 100 pods, and still had namespace deletion O(<30s).

/cc @thockin @liggitt 
