### PR TITLE
Fix node numbers for node list

### DIFF
--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -58,7 +58,9 @@ while true; do
   fi
 done
 echo "Found ${found} nodes."
-cat -n "${MINIONS_FILE}"
+echo -n "        "
+head -n 1 "${MINIONS_FILE}"
+tail -n +2 "${MINIONS_FILE}" | cat -n
 
 attempt=0
 while true; do


### PR DESCRIPTION
Fixes  #9250

```
... calling validate-cluster
Waiting for 4 ready nodes. 0 ready nodes, 0 registered. Retrying.
Waiting for 4 ready nodes. 0 ready nodes, 0 registered. Retrying.
Waiting for 4 ready nodes. 0 ready nodes, 4 registered. Retrying.
Found 4 nodes.
        NAME                     LABELS                                          STATUS
     1  kubernetes-minion-4rml   kubernetes.io/hostname=kubernetes-minion-4rml   Ready
     2  kubernetes-minion-93uf   kubernetes.io/hostname=kubernetes-minion-93uf   Ready
     3  kubernetes-minion-axre   kubernetes.io/hostname=kubernetes-minion-axre   Ready
     4  kubernetes-minion-oas5   kubernetes.io/hostname=kubernetes-minion-oas5   Ready
```
