### PR TITLE
Apiserver can proxy to nodes 

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/master/ports"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	forked "github.com/GoogleCloudPlatform/kubernetes/third_party/forked/coreos/go-etcd/etcd"
@@ -121,7 +122,7 @@ func NewAPIServer() *APIServer {
 
 		RuntimeConfig: make(util.ConfigurationMap),
 		KubeletConfig: client.KubeletConfig{
-			Port:        10250,
+			Port:        ports.KubeletPort,
 			EnableHttps: true,
 			HTTPTimeout: time.Duration(5) * time.Second,
 		},

--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"net/url"
 	"path"
 	"strconv"
@@ -146,6 +147,10 @@ func (s *Server) InstallDebuggingHandlers() {
 	s.mux.HandleFunc("/logs/", s.handleLogs)
 	s.mux.HandleFunc("/containerLogs/", s.handleContainerLogs)
 	s.mux.Handle("/metrics", prometheus.Handler())
+
+	s.mux.HandleFunc("/debug/pprof/", pprof.Index)
+	s.mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	s.mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 }
 
 // error serializes an error object into an HTTP response.

--- a/pkg/registry/minion/rest.go
+++ b/pkg/registry/minion/rest.go
@@ -129,7 +129,7 @@ func MatchNode(label labels.Selector, field fields.Selector) generic.Matcher {
 	}
 }
 
-// ResourceLocation returns a URL to which one can send traffic for the specified node.
+// ResourceLocation returns an URL and transport which one can use to send traffic for the specified node.
 func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGetter, ctx api.Context, id string) (*url.URL, http.RoundTripper, error) {
 	name, portReq, valid := util.SplitPort(id)
 	if !valid {
@@ -143,13 +143,13 @@ func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGet
 	node := nodeObj.(*api.Node)
 	host := node.Name // TODO: use node's IP, don't expect the name to resolve.
 
-	if portReq != "" {
-		return &url.URL{Host: net.JoinHostPort(host, portReq)}, nil, nil
-	}
-
 	scheme, port, transport, err := connection.GetConnectionInfo(host)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if portReq != "" {
+		return &url.URL{Scheme: scheme, Host: net.JoinHostPort(host, portReq)}, transport, nil
 	}
 
 	return &url.URL{

--- a/pkg/registry/minion/rest.go
+++ b/pkg/registry/minion/rest.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/master/ports"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -143,22 +144,20 @@ func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGet
 	node := nodeObj.(*api.Node)
 	host := node.Name // TODO: use node's IP, don't expect the name to resolve.
 
-	scheme, port, transport, err := connection.GetConnectionInfo(host)
-	if err != nil {
-		return nil, nil, err
+	if portReq == "" || strconv.Itoa(ports.KubeletPort) == portReq {
+		scheme, port, transport, err := connection.GetConnectionInfo(host)
+		if err != nil {
+			return nil, nil, err
+		}
+		return &url.URL{
+				Scheme: scheme,
+				Host: net.JoinHostPort(
+					host,
+					strconv.FormatUint(uint64(port), 10),
+				),
+			},
+			transport,
+			nil
 	}
-
-	if portReq != "" {
-		return &url.URL{Scheme: scheme, Host: net.JoinHostPort(host, portReq)}, transport, nil
-	}
-
-	return &url.URL{
-			Scheme: scheme,
-			Host: net.JoinHostPort(
-				host,
-				strconv.FormatUint(uint64(port), 10),
-			),
-		},
-		transport,
-		nil
+	return &url.URL{Host: net.JoinHostPort(host, portReq)}, nil, nil
 }


### PR DESCRIPTION
The apiserver's reverse proxy interrogates the resource for a scheme and transport to perform redirection. To redirect to a node, we need the kubelet transport, which the minion resource has but doesn't return when the proxy request has a port. 

Catching this in a unittest is a bit hard (ideas?), will send follow up pr with an integration test, since we don't have any for the proxy currently.

PR also enables debug endpoints for the kubelet (https://github.com/GoogleCloudPlatform/kubernetes/issues/9029)
@roberthbailey @lavalamp 
