### PR TITLE
Demote log spam

### DIFF
--- a/plugin/pkg/scheduler/algorithm/priorities/priorities.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/priorities.go
@@ -62,7 +62,7 @@ func calculateOccupancy(pod *api.Pod, node api.Node, pods []*api.Pod) algorithm.
 
 	cpuScore := calculateScore(totalMilliCPU, capacityMilliCPU, node.Name)
 	memoryScore := calculateScore(totalMemory, capacityMemory, node.Name)
-	glog.V(4).Infof(
+	glog.V(10).Infof(
 		"%v -> %v: Least Requested Priority, Absolute/Requested: (%d, %d) / (%d, %d) Score: (%d, %d)",
 		pod.Name, node.Name,
 		totalMilliCPU, totalMemory,
@@ -190,7 +190,7 @@ func calculateBalancedResourceAllocation(pod *api.Pod, node api.Node, pods []*ap
 		diff := math.Abs(cpuFraction - memoryFraction)
 		score = int(10 - diff*10)
 	}
-	glog.V(4).Infof(
+	glog.V(10).Infof(
 		"%v -> %v: Balanced Resource Allocation, Absolute/Requested: (%d, %d) / (%d, %d) Score: (%d)",
 		pod.Name, node.Name,
 		totalMilliCPU, totalMemory,


### PR DESCRIPTION
These messages are only useful if you want to debug a particular
scheduler assignment, and they are extremely verbose-- they each print
out a line per host per assignment. Let's try to keep our log messages
linear in the number of assignments.

(found while looking at logs for #8119)
