### PR TITLE
Add available volumes to binder index when not present

### DIFF
--- a/pkg/volumeclaimbinder/persistent_volume_claim_binder.go
+++ b/pkg/volumeclaimbinder/persistent_volume_claim_binder.go
@@ -158,6 +158,14 @@ func syncVolume(volumeIndex *persistentVolumeOrderedIndex, binderClient binderCl
 
 	// available volumes await a claim
 	case api.VolumeAvailable:
+		// TODO:  remove api.VolumePending phase altogether
+		_, exists, err := volumeIndex.Get(volume)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			volumeIndex.Add(volume)
+		}
 		if volume.Spec.ClaimRef != nil {
 			_, err := binderClient.GetPersistentVolumeClaim(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name)
 			if err == nil {


### PR DESCRIPTION
Resolves #9273

Short term fix is to add the PVs to the index.

Long term fix is to remove the Pending phase entirely.

unit test exposes the bug.

@thockin 
