### PR TITLE
Use --service-node-port-range flag value

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -225,7 +225,7 @@ func setDefaults(c *Config) {
 		}
 		c.ServiceClusterIPRange = serviceClusterIPRange
 	}
-	if c.ServiceNodePortRange.Size == 0 {
+	if c.ServiceNodePortRange == nil {
 		// TODO: Currently no way to specify an empty range (do we need to allow this?)
 		// We should probably allow this for clouds that don't require NodePort to do load-balancing (GCE)
 		// but then that breaks the strict nestedness of ServiceType.


### PR DESCRIPTION
Prevents "Node port range unspecified. Defaulting to 30000-32766." log message.
I believe the ServiceNodePortRange.Size field is always zero as it is set nowhere. As a resulte the --service-node-port-range flag value is ignored. So it is reasonable to compare ServiceNodePortRange with nil as it is done for ServiceClusterIPRange a few lines before.
