### PR TITLE
add dockercfg to secret describer

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -451,7 +451,8 @@ func describeSecret(secret *api.Secret) (string, error) {
 		fmt.Fprintf(out, "\nData\n====\n")
 		for k, v := range secret.Data {
 			switch {
-			case k == api.ServiceAccountTokenKey && secret.Type == api.SecretTypeServiceAccountToken:
+			case k == api.ServiceAccountTokenKey && secret.Type == api.SecretTypeServiceAccountToken,
+				k == api.DockerConfigKey && secret.Type == api.SecretTypeDockercfg:
 				fmt.Fprintf(out, "%s:\t%s\n", k, string(v))
 			default:
 				fmt.Fprintf(out, "%s:\t%d bytes\n", k, len(v))


### PR DESCRIPTION
Adds dockercfg to the secret describer for prettier output.

@liggitt how would you feel about doing this sort of display by default if the length of the secret was less than 4k and we had some confidence it was text?  There's got to be a library out there for codepage detection or some such.
