### PR TITLE
Generate tokens for service accounts with no secrets

### DIFF
--- a/pkg/serviceaccount/tokens_controller_test.go
+++ b/pkg/serviceaccount/tokens_controller_test.go
@@ -143,6 +143,9 @@ func TestTokenCreation(t *testing.T) {
 	testcases := map[string]struct {
 		ClientObjects []runtime.Object
 
+		SecretsSyncPending         bool
+		ServiceAccountsSyncPending bool
+
 		ExistingServiceAccount *api.ServiceAccount
 		ExistingSecrets        []*api.Secret
 
@@ -165,6 +168,18 @@ func TestTokenCreation(t *testing.T) {
 				{Action: "update-serviceaccount", Value: serviceAccount(addTokenSecretReference(emptySecretReferences()))},
 			},
 		},
+		"new serviceaccount with no secrets with unsynced secret store": {
+			ClientObjects: []runtime.Object{serviceAccount(emptySecretReferences()), createdTokenSecret()},
+
+			SecretsSyncPending: true,
+
+			AddedServiceAccount: serviceAccount(emptySecretReferences()),
+			ExpectedActions: []testclient.FakeAction{
+				{Action: "create-secret", Value: createdTokenSecret()},
+				{Action: "get-serviceaccount", Value: "default"},
+				{Action: "update-serviceaccount", Value: serviceAccount(addTokenSecretReference(emptySecretReferences()))},
+			},
+		},
 		"new serviceaccount with missing secrets": {
 			ClientObjects: []runtime.Object{serviceAccount(missingSecretReferences()), createdTokenSecret()},
 
@@ -174,6 +189,14 @@ func TestTokenCreation(t *testing.T) {
 				{Action: "get-serviceaccount", Value: "default"},
 				{Action: "update-serviceaccount", Value: serviceAccount(addTokenSecretReference(missingSecretReferences()))},
 			},
+		},
+		"new serviceaccount with missing secrets with unsynced secret store": {
+			ClientObjects: []runtime.Object{serviceAccount(missingSecretReferences()), createdTokenSecret()},
+
+			SecretsSyncPending: true,
+
+			AddedServiceAccount: serviceAccount(missingSecretReferences()),
+			ExpectedActions:     []testclient.FakeAction{},
 		},
 		"new serviceaccount with non-token secrets": {
 			ClientObjects: []runtime.Object{serviceAccount(regularSecretReferences()), createdTokenSecret(), opaqueSecret()},
@@ -203,6 +226,18 @@ func TestTokenCreation(t *testing.T) {
 				{Action: "update-serviceaccount", Value: serviceAccount(addTokenSecretReference(emptySecretReferences()))},
 			},
 		},
+		"updated serviceaccount with no secrets with unsynced secret store": {
+			ClientObjects: []runtime.Object{serviceAccount(emptySecretReferences()), createdTokenSecret()},
+
+			SecretsSyncPending: true,
+
+			UpdatedServiceAccount: serviceAccount(emptySecretReferences()),
+			ExpectedActions: []testclient.FakeAction{
+				{Action: "create-secret", Value: createdTokenSecret()},
+				{Action: "get-serviceaccount", Value: "default"},
+				{Action: "update-serviceaccount", Value: serviceAccount(addTokenSecretReference(emptySecretReferences()))},
+			},
+		},
 		"updated serviceaccount with missing secrets": {
 			ClientObjects: []runtime.Object{serviceAccount(missingSecretReferences()), createdTokenSecret()},
 
@@ -212,6 +247,14 @@ func TestTokenCreation(t *testing.T) {
 				{Action: "get-serviceaccount", Value: "default"},
 				{Action: "update-serviceaccount", Value: serviceAccount(addTokenSecretReference(missingSecretReferences()))},
 			},
+		},
+		"updated serviceaccount with missing secrets with unsynced secret store": {
+			ClientObjects: []runtime.Object{serviceAccount(missingSecretReferences()), createdTokenSecret()},
+
+			SecretsSyncPending: true,
+
+			UpdatedServiceAccount: serviceAccount(missingSecretReferences()),
+			ExpectedActions:       []testclient.FakeAction{},
 		},
 		"updated serviceaccount with non-token secrets": {
 			ClientObjects: []runtime.Object{serviceAccount(regularSecretReferences()), createdTokenSecret(), opaqueSecret()},
@@ -262,6 +305,14 @@ func TestTokenCreation(t *testing.T) {
 				{Action: "delete-secret", Value: "token-secret-1"},
 			},
 		},
+		"added secret without serviceaccount with unsynced service account store": {
+			ClientObjects: []runtime.Object{serviceAccountTokenSecret()},
+
+			ServiceAccountsSyncPending: true,
+
+			AddedSecret:     serviceAccountTokenSecret(),
+			ExpectedActions: []testclient.FakeAction{},
+		},
 		"added secret with serviceaccount": {
 			ExistingServiceAccount: serviceAccount(tokenSecretReferences()),
 
@@ -285,6 +336,14 @@ func TestTokenCreation(t *testing.T) {
 			ExpectedActions: []testclient.FakeAction{
 				{Action: "delete-secret", Value: "token-secret-1"},
 			},
+		},
+		"updated secret without serviceaccount with unsynced service account store": {
+			ClientObjects: []runtime.Object{serviceAccountTokenSecret()},
+
+			ServiceAccountsSyncPending: true,
+
+			UpdatedSecret:   serviceAccountTokenSecret(),
+			ExpectedActions: []testclient.FakeAction{},
 		},
 		"updated secret with serviceaccount": {
 			ExistingServiceAccount: serviceAccount(tokenSecretReferences()),
@@ -335,9 +394,9 @@ func TestTokenCreation(t *testing.T) {
 
 		controller := NewTokensController(client, DefaultTokenControllerOptions(generator))
 
-		// Tell the token controller its stores have been synced
-		controller.serviceAccountsSynced = func() bool { return true }
-		controller.secretsSynced = func() bool { return true }
+		// Tell the token controller whether its stores have been synced
+		controller.serviceAccountsSynced = func() bool { return !tc.ServiceAccountsSyncPending }
+		controller.secretsSynced = func() bool { return !tc.SecretsSyncPending }
 
 		if tc.ExistingServiceAccount != nil {
 			controller.serviceAccounts.Add(tc.ExistingServiceAccount)


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/kubernetes/pull/8494 prevented the token controller responding to service account updates until both its stores were synced. That is correct for some checks (e.g. "are the secret references valid", etc), but in other cases, we don't need the other store.

The clearest example is:
1. Start the server
2. Start the token controller
3. Create a service account
4. Token controller sees the serviceaccount add event, but secret store isn't fully synced, so it ignores it

That means it has to wait for a relist before it will attempt to create a token for the service account, which means that pods that need a service account token will be blocked until then.

This limits the `isSynced` check to the paths that make use of the second store.
