### PR TITLE
Add a --e2e-output-dir for use in e2e tests (default is /tmp/)

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -60,8 +60,9 @@ var _ = Describe("Density", func() {
 		ns = nsForTesting.Name
 		expectNoError(err)
 		uuid = string(util.NewUUID())
-		expectNoError(os.Mkdir(fmt.Sprintf("/tmp/%s", uuid), 0777))
-		expectNoError(writePerfData(c, fmt.Sprintf("/tmp/%s", uuid), "before"))
+
+		expectNoError(os.Mkdir(fmt.Sprintf(testContext.OutputDir+"/%s", uuid), 0777))
+		expectNoError(writePerfData(c, fmt.Sprintf(testContext.OutputDir+"/%s", uuid), "before"))
 	})
 
 	AfterEach(func() {
@@ -81,7 +82,7 @@ var _ = Describe("Density", func() {
 			Failf("Couldn't delete ns %s", err)
 		}
 
-		expectNoError(writePerfData(c, fmt.Sprintf("/tmp/%s", uuid), "after"))
+		expectNoError(writePerfData(c, fmt.Sprintf(testContext.OutputDir+"/%s", uuid), "after"))
 
 		// Verify latency metrics
 		// TODO: Update threshold to 1s once we reach this goal
@@ -122,7 +123,7 @@ var _ = Describe("Density", func() {
 		It(name, func() {
 			totalPods := itArg.podsPerMinion * minionCount
 			RCName = "density" + strconv.Itoa(totalPods) + "-" + uuid
-			fileHndl, err := os.Create(fmt.Sprintf("/tmp/%s/pod_states.csv", uuid))
+			fileHndl, err := os.Create(fmt.Sprintf(testContext.OutputDir+"/%s/pod_states.csv", uuid))
 			expectNoError(err)
 			defer fileHndl.Close()
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -100,6 +100,7 @@ func init() {
 	flag.StringVar(&testContext.RepoRoot, "repo-root", "../../", "Root directory of kubernetes repository, for finding test files.")
 	flag.StringVar(&testContext.Provider, "provider", "", "The name of the Kubernetes provider (gce, gke, local, vagrant, etc.)")
 	flag.StringVar(&testContext.KubectlPath, "kubectl-path", "kubectl", "The kubectl binary to use. For development, you might use 'cluster/kubectl.sh' here.")
+	flag.StringVar(&testContext.OutputDir, "e2e-output-dir", "/tmp", "Output directory for interesting/useful test data, like performance data, benchmarks, and other metrics.")
 
 	// TODO: Flags per provider?  Rename gce-project/gce-zone?
 	flag.StringVar(&cloudConfig.MasterName, "kube-master", "", "Name of the kubernetes master. Only required if provider is gce or gke")

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -91,6 +91,7 @@ type TestContextType struct {
 	Provider    string
 	CloudConfig CloudConfig
 	KubectlPath string
+	OutputDir   string
 }
 
 var testContext TestContextType


### PR DESCRIPTION
heres a quick impl of an `--e2e-output-dir` option which is a long tem replacement for the recent "put perf data from density into /tmp ( #9316 ) . 

Why the new option rather than reuse `test.outputdir` ? Simply cause we cant bind to  `test.outputdir` , because another program (go test) uses it... 
And `go test` specifically documents that this dir is for "profiling" data of the `go test` program.

Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/9336
