### PR TITLE
improve kubectl error message when an object with no kind is passed to the resource builder

### DIFF
--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -37,6 +37,8 @@ import (
 )
 
 // Visitor lets clients walk a list of resources.
+// TODO: we should rethink how we handle errors in the visit loop
+// (See https://github.com/GoogleCloudPlatform/kubernetes/pull/9357#issuecomment-109600305)
 type Visitor interface {
 	Visit(VisitorFunc) error
 }
@@ -220,7 +222,7 @@ func (v *PathVisitor) Visit(fn VisitorFunc) error {
 		if !v.IgnoreErrors {
 			return err
 		}
-		glog.V(2).Infof("Unable to load file %q: %v", v.Path, err)
+		fmt.Fprintf(os.Stderr, "error: unable to load file %q: %v\n", v.Path, err)
 		return nil
 	}
 	return fn(info)
@@ -283,7 +285,7 @@ func (v *DirectoryVisitor) Visit(fn VisitorFunc) error {
 			if !v.IgnoreErrors {
 				return err
 			}
-			glog.V(2).Infof("Unable to load file %q: %v", path, err)
+			fmt.Fprintf(os.Stderr, "error: unable to load file %q: %v\n", path, err)
 			return nil
 		}
 		return fn(info)
@@ -471,7 +473,7 @@ func (v *StreamVisitor) Visit(fn VisitorFunc) error {
 		info, err := v.InfoForData(ext.RawJSON, v.Source)
 		if err != nil {
 			if v.IgnoreErrors {
-				glog.Warningf("Could not read an encoded object from %s: %v", v.Source, err)
+				fmt.Fprintf(os.Stderr, "error: could not read an encoded object from %s: %v\n", v.Source, err)
 				glog.V(4).Infof("Unreadable: %s", string(ext.RawJSON))
 				continue
 			}


### PR DESCRIPTION
Kindless api objects have their error message printed instead of glogged.

Fixes #9010 

```
➜  kubernetes git:(kubectl-kind-err) ✗ cat bonkers/no-kind.yml 
apiVersion: v1beta3
metadata:
  labels:
    name: redis
    redis-sentinel: "true"
    role: master
  name: redis-master
spec:
  containers:
    - name: master
      image: kubernetes/redis:v1
      env:
        - name: MASTER
          value: "true"
      ports:
        - containerPort: 6379
      resources:
        limits:
          cpu: "1"
      volumeMounts:
        - mountPath: /redis-master-data
          name: data
    - name: sentinel
      image: kubernetes/redis:v1
      env:
        - name: SENTINEL
          value: "true"
      ports:
        - containerPort: 26379
  volumes:
    - name: data
      emptyDir: {}
➜  kubernetes git:(kubectl-kind-err) ✗ kubectl create -f bonkers/no-kind.yml
error: unable to load file "bonkers/no-kind.yml": kind not set in "bonkers/no-kind.yml"
error: no objects passed to create
```

Alternatively, we could not ContinueOnError by default. Any feelings @jlowdermilk @thockin?
