### PR TITLE
Passing memory swap limit -1 by default. Docker remote API never chec…

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -587,6 +587,7 @@ func (dm *DockerManager) runContainer(
 			Image:        container.Image,
 			// Memory and CPU are set here for older versions of Docker (pre-1.6).
 			Memory:     memoryLimit,
+			MemorySwap: -1,
 			CPUShares:  cpuShares,
 			WorkingDir: container.WorkingDir,
 			Labels:     labels,
@@ -637,8 +638,9 @@ func (dm *DockerManager) runContainer(
 		NetworkMode:  netMode,
 		IpcMode:      ipcMode,
 		// Memory and CPU are set here for newer versions of Docker (1.6+).
-		Memory:    memoryLimit,
-		CPUShares: cpuShares,
+		Memory:     memoryLimit,
+		MemorySwap: -1,
+		CPUShares:  cpuShares,
 	}
 	if len(opts.DNS) > 0 {
 		hc.DNS = opts.DNS


### PR DESCRIPTION
…k if memory

swap is enabled by kernel or not, instead by default to set the limit to
memory \* 2, and return API error 500 if swap is not enabled.

Fixed #8814

Without this patch: 

```
$ cluster/kubectl.sh delete -f examples/limitrange/valid-pod.json
pods/valid-pod

$ kubectl describe pods valid-pod
W0605 18:08:46.055119    7605 request.go:291] field selector: v1beta3 - events - involvedObject.name - valid-pod: need to check if this is versioned correctly.
W0605 18:08:46.055288    7605 request.go:291] field selector: v1beta3 - events - involvedObject.namespace - default: need to check if this is versioned correctly.
W0605 18:08:46.055335    7605 request.go:291] field selector: v1beta3 - events - involvedObject.uid - 926efae8-0be8-11e5-adb1-42010af09ce5: need to check if this is versioned correctly.
Name:               valid-pod
Image(s):           gcr.io/google_containers/serve_hostname
Host:               e2e-test-dawnchen-minion-wkpa/104.197.91.127
Labels:             name=valid-pod
Status:             Pending
Replication Controllers:    <none>
Containers:
  kubernetes-serve-hostname:
    Image:  gcr.io/google_containers/serve_hostname
    State:  Waiting
      Reason:   API error (500): Cannot start container ae7d361ca227da8af9f931f096ae4e129c637ae83c709f3fbe59c1a1492eaae3: [8] System error: open /sys/fs/cgroup/memory/ae7d361ca227da8af9f931f096ae4e129c637ae83c709f3fbe59c1a1492eaae3/memory.memsw.limit_in_bytes: permission denied

    Ready:      False
    Restart Count:  0
Conditions:
  Type      Status
  Ready     False 
Events:
  FirstSeen             LastSeen            Count   From                    SubobjectPath                   Reason      Message
  Fri, 05 Jun 2015 18:08:42 -0700   Fri, 05 Jun 2015 18:08:42 -0700 1   {scheduler }                                        scheduled   Successfully assigned valid-pod to e2e-test-dawnchen-minion-wkpa
  Fri, 05 Jun 2015 18:08:42 -0700   Fri, 05 Jun 2015 18:08:42 -0700 1   {kubelet e2e-test-dawnchen-minion-wkpa} implicitly required container POD       pulled      Successfully pulled image "gcr.io/google_containers/pause:0.8.0"
  Fri, 05 Jun 2015 18:08:43 -0700   Fri, 05 Jun 2015 18:08:43 -0700 1   {kubelet e2e-test-dawnchen-minion-wkpa} implicitly required container POD       created     Created with docker id e768cf27d877cc842e5e6f319be9ee089b3ea888eeadfd846c5cbeb2536294ac
  Fri, 05 Jun 2015 18:08:43 -0700   Fri, 05 Jun 2015 18:08:43 -0700 1   {kubelet e2e-test-dawnchen-minion-wkpa} implicitly required container POD       started     Started with docker id e768cf27d877cc842e5e6f319be9ee089b3ea888eeadfd846c5cbeb2536294ac
  Fri, 05 Jun 2015 18:08:44 -0700   Fri, 05 Jun 2015 18:08:44 -0700 1   {kubelet e2e-test-dawnchen-minion-wkpa} spec.containers{kubernetes-serve-hostname}  created     Created with docker id ae7d361ca227da8af9f931f096ae4e129c637ae83c709f3fbe59c1a1492eaae3
  Fri, 05 Jun 2015 18:08:44 -0700   Fri, 05 Jun 2015 18:08:44 -0700 1   {kubelet e2e-test-dawnchen-minion-wkpa} spec.containers{kubernetes-serve-hostname}  failed      Failed to start with docker id ae7d361ca227da8af9f931f096ae4e129c637ae83c709f3fbe59c1a1492eaae3 with error: API error (500): Cannot start container ae7d361ca227da8af9f931f096ae4e129c637ae83c709f3fbe59c1a1492eaae3: [8] System error: open /sys/fs/cgroup/memory/ae7d361ca227da8af9f931f096ae4e129c637ae83c709f3fbe59c1a1492eaae3/memory.memsw.limit_in_bytes: permission denied

```

With this patch:

```
$ kubectl describe pods valid-pod
W0605 18:10:30.467730    7710 request.go:291] field selector: v1beta3 - events - involvedObject.name - valid-pod: need to check if this is versioned correctly.
W0605 18:10:30.468276    7710 request.go:291] field selector: v1beta3 - events - involvedObject.namespace - default: need to check if this is versioned correctly.
W0605 18:10:30.468288    7710 request.go:291] field selector: v1beta3 - events - involvedObject.uid - cf86b221-0be8-11e5-adb1-42010af09ce5: need to check if this is versioned correctly.
Name:               valid-pod
Image(s):           gcr.io/google_containers/serve_hostname
Host:               e2e-test-dawnchen-minion-wkpa/104.197.91.127
Labels:             name=valid-pod
Status:             Running
Replication Controllers:    <none>
Containers:
  kubernetes-serve-hostname:
    Image:      gcr.io/google_containers/serve_hostname
    State:      Running
      Started:      Fri, 05 Jun 2015 18:10:27 -0700
    Ready:      False
    Restart Count:  0
Conditions:
  Type      Status
  Ready     False 
Events:
  FirstSeen             LastSeen            Count   From                    SubobjectPath                   Reason      Message
  Fri, 05 Jun 2015 18:10:24 -0700   Fri, 05 Jun 2015 18:10:24 -0700 1   {scheduler }                                        scheduled   Successfully assigned valid-pod to e2e-test-dawnchen-minion-wkpa
  Fri, 05 Jun 2015 18:10:25 -0700   Fri, 05 Jun 2015 18:10:25 -0700 1   {kubelet e2e-test-dawnchen-minion-wkpa} implicitly required container POD       pulled      Successfully pulled image "gcr.io/google_containers/pause:0.8.0"
  Fri, 05 Jun 2015 18:10:26 -0700   Fri, 05 Jun 2015 18:10:26 -0700 1   {kubelet e2e-test-dawnchen-minion-wkpa} implicitly required container POD       created     Created with docker id f8f5c7d3350c018b6cc183b01747ea0bb9219432e848b686a7f9dcd6f8fba71d
  Fri, 05 Jun 2015 18:10:26 -0700   Fri, 05 Jun 2015 18:10:26 -0700 1   {kubelet e2e-test-dawnchen-minion-wkpa} implicitly required container POD       started     Started with docker id f8f5c7d3350c018b6cc183b01747ea0bb9219432e848b686a7f9dcd6f8fba71d
  Fri, 05 Jun 2015 18:10:27 -0700   Fri, 05 Jun 2015 18:10:27 -0700 1   {kubelet e2e-test-dawnchen-minion-wkpa} spec.containers{kubernetes-serve-hostname}  created     Created with docker id 39b0de7bbf74dc8eeb9f3cc5c16ead6787f6c2e2376760a2efbba212ac04d8d4
  Fri, 05 Jun 2015 18:10:27 -0700   Fri, 05 Jun 2015 18:10:27 -0700 1   {kubelet e2e-test-dawnchen-minion-wkpa} spec.containers{kubernetes-serve-hostname}  started     Started with docker id 39b0de7bbf74dc8eeb9f3cc5c16ead6787f6c2e2376760a2efbba212ac04d8d4

```

cc/ @vmarmol 
