### PR TITLE
Actually pass down ServiceNodePortRange so it is used

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -391,6 +391,7 @@ func (s *APIServer) Run(_ []string) error {
 		SSHUser:                s.SSHUser,
 		SSHKeyfile:             s.SSHKeyfile,
 		InstallSSHKey:          installSSH,
+		ServiceNodePortRange:   s.ServiceNodePortRange,
 	}
 	m := master.New(config)
 

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -247,7 +247,7 @@ func setDefaults(c *Config) {
 		// We should probably allow this for clouds that don't require NodePort to do load-balancing (GCE)
 		// but then that breaks the strict nestedness of ServiceType.
 		// Review post-v1
-		defaultServiceNodePortRange := util.PortRange{Base: 30000, Size: 2767}
+		defaultServiceNodePortRange := util.PortRange{Base: 30000, Size: 2768}
 		c.ServiceNodePortRange = defaultServiceNodePortRange
 		glog.Infof("Node port range unspecified. Defaulting to %v.", c.ServiceNodePortRange)
 	}


### PR DESCRIPTION
I had forgotten to actually pass the ServiceNodePortRange down from the flags.

Also fix default range to match what we've documented (off-by-one)
