### PR TITLE
AWS: Disable thin LVM provisioning on wheezy

### DIFF
--- a/cluster/aws/templates/format-disks.sh
+++ b/cluster/aws/templates/format-disks.sh
@@ -119,10 +119,17 @@ else
 
       # Create a docker lv, use docker on it
       # 95% goes to the docker thin-pool
-      lvcreate -l 95%VG --thinpool docker-thinpool vg-ephemeral
+      release=`lsb_release -c -s`
+      if [[ "${release}" != "wheezy" ]] ; then
+        lvcreate -l 95%VG --thinpool docker-thinpool vg-ephemeral
 
-      THINPOOL_SIZE=$(lvs vg-ephemeral/docker-thinpool -o LV_SIZE --noheadings --units M --nosuffix)
-      lvcreate -V${THINPOOL_SIZE}M -T vg-ephemeral/docker-thinpool -n docker
+        THINPOOL_SIZE=$(lvs vg-ephemeral/docker-thinpool -o LV_SIZE --noheadings --units M --nosuffix)
+        lvcreate -V${THINPOOL_SIZE}M -T vg-ephemeral/docker-thinpool -n docker
+      else
+        # Thin provisioning not supported by Wheezy
+        echo "Detected wheezy; won't use LVM thin provisioning"
+        lvcreate -l 95%VG -n docker vg-ephemeral
+      fi
 
       mkfs -t ext4 /dev/vg-ephemeral/docker
       mkdir -p /mnt/docker


### PR DESCRIPTION
This adds on to #9297.  (I don't think github supports dependent commits.)

It detects wheezy and disables thin provisioning with aufs.

It doesn't change devicemapper, because I don't think there's anything we can do here.  If the user chooses DOCKER_STORAGE=devicemapper with KUBE_OS_DISTRIBUTION=wheezy, it simply won't work.  I'm assuming if they're doing this they also chose a different AWS_IMAGE with a backport of the LVM2 thin provisioning support from Jessie.

Wheezy is in a tricky state anyway, because it has a really old kernel.  I'm investigating whether we should just prefer Jessie.
