### PR TITLE
kubectl should error if versionless yaml is passed to resource builder

### DIFF
--- a/pkg/kubectl/resource/mapper.go
+++ b/pkg/kubectl/resource/mapper.go
@@ -42,7 +42,7 @@ func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
 		return nil, fmt.Errorf("unable to parse %q: %v", source, err)
 	}
 	data = json
-	version, kind, err := m.DataVersionAndKind(data)
+	version, kind, err := runtime.UnstructuredJSONScheme.DataVersionAndKind(data)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get type info from %q: %v", source, err)
 	}


### PR DESCRIPTION
Fixes: #9011

I was unable to added the version and kind checks that unstructuredJsonSchema does [here](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/runtime/unstructured.go#L82-L87) to SimpleMetaFactory [here](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/conversion/meta.go#L55) (which is what was used before) because it breaks pretty much all the conversion tests and a bunch of other tests.

Right now on master this will succeed (defaults to using api.LatestVersion).

new output:

```
➜  kubernetes git:(kubectl-version-err) ✗ cat bonkers/no-version.yml 
kind: Pod
metadata:
  labels:
    name: redis
    redis-sentinel: "true"
    role: master
  name: redis-master
spec:
  containers:
    - name: master
      image: kubernetes/redis:v1
      env:
        - name: MASTER
          value: "true"
      ports:
        - containerPort: 6379
      resources:
        limits:
          cpu: "1"
      volumeMounts:
        - mountPath: /redis-master-data
          name: data
    - name: sentinel
      image: kubernetes/redis:v1
      env:
        - name: SENTINEL
          value: "true"
      ports:
        - containerPort: 26379
  volumes:
    - name: data
      emptyDir: {}
➜  kubernetes git:(kubectl-version-err) ✗ kubectl create -f bonkers/no-version.yml --v=2
error: unable to load file "bonkers/no-version.yml": unable to get type info from "bonkers/no-version.yml": Object 'apiVersion' is missing in '{"kind":"Pod","metadata":{"labels":{"name":"redis","redis-sentinel":"true","role":"master"},"name":"redis-master"},"spec":{"containers":[{"env":[{"name":"MASTER","value":"true"}],"image":"kubernetes/redis:v1","name":"master","ports":[{"containerPort":6379}],"resources":{"limits":{"cpu":"1"}},"volumeMounts":[{"mountPath":"/redis-master-data","name":"data"}]},{"env":[{"name":"SENTINEL","value":"true"}],"image":"kubernetes/redis:v1","name":"sentinel","ports":[{"containerPort":26379}]}],"volumes":[{"emptyDir":{},"name":"data"}]}}'
error: no objects passed to create
```

cc @thockin @jlowdermilk 
