### PR TITLE
add GetRuntime() to Kubelet for easier integration with 3rd party kubele…

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2239,3 +2239,9 @@ func (kl *Kubelet) ListenAndServe(address net.IP, port uint, tlsOptions *TLSOpti
 func (kl *Kubelet) ListenAndServeReadOnly(address net.IP, port uint) {
 	ListenAndServeKubeletReadOnlyServer(kl, address, port)
 }
+
+// GetRuntime returns the current Runtime implementation in use by the kubelet. This func
+// is exported to simplify integration with third party kubelet extensions (e.g. kubernetes-mesos).
+func (kl *Kubelet) GetRuntime() kubecontainer.Runtime {
+	return kl.containerRuntime
+}


### PR DESCRIPTION
…t extensions, e.g. kubernetes-mesos

xref #8882 
xref https://github.com/mesosphere/kubernetes-mesos/issues/334

this PR is a prerequisite for upstreaming kubernetes-mesos.

/cc @davidopp @bgrant0607 @guenter @thockin 
