### PR TITLE
Revert "Cut release 0.18.2 with the fix for Docker + memory limits"

### DIFF
--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -36,8 +36,8 @@ package version
 var (
 	// TODO: Deprecate gitMajor and gitMinor, use only gitVersion instead.
 	gitMajor     string = "0"              // major version, always numeric
-	gitMinor     string = "18.2+"          // minor version, numeric possibly followed by "+"
-	gitVersion   string = "v0.18.2-dev"    // version from git, output of $(git describe)
+	gitMinor     string = "18.1+"          // minor version, numeric possibly followed by "+"
+	gitVersion   string = "v0.18.1-dev"    // version from git, output of $(git describe)
 	gitCommit    string = ""               // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 )


### PR DESCRIPTION
Reverts GoogleCloudPlatform/kubernetes#9426

This should have been against the release branch.
