### PR TITLE
Simplify getting started guide by providing only one download option.…

### DIFF
--- a/docs/getting-started-guides/gce.md
+++ b/docs/getting-started-guides/gce.md
@@ -19,16 +19,10 @@ If you want to use custom binaries or pure open source Kubernetes, please contin
 
 ### Starting a Cluster
 
-You can install a cluster with one of two one-liners:
+You can install a client and start a cluster with this command:
 
 ```bash
 curl -sS https://get.k8s.io | bash
-```
-
-or
-
-```bash
-wget -q -O - https://get.k8s.io | bash
 ```
 
 Once this command completes, you will have a master VM and four worker VMs, running as a Kubernetes cluster. By default, some containers will already be running on your cluster. Containers like `kibana` and `elasticsearch` provide [logging](../logging.md), while `heapster` provides [monitoring](../../cluster/addons/cluster-monitoring/README.md) services.


### PR DESCRIPTION
… Advanced user can still see the wget option when looking at https://get.k8s.io.

Addresses issue https://github.com/GoogleCloudPlatform/kubernetes/issues/9417
