### PR TITLE
Use latest version of mount tester image

### DIFF
--- a/contrib/for-tests/mount-tester/Makefile
+++ b/contrib/for-tests/mount-tester/Makefile
@@ -1,15 +1,13 @@
 all: push
 
-TAG = 0.1
-
 mt: mt.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./mt.go
 
 image: mt
-	sudo docker build -t kubernetes/mounttest:$(TAG) .
+	sudo docker build -t kubernetes/mounttest .
 
 push: image
-	sudo docker push kubernetes/mounttest:$(TAG)
+	sudo docker push kubernetes/mounttest
 
 clean:
 	rm -f mt

--- a/examples/secrets/secret-pod.yaml
+++ b/examples/secrets/secret-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: kubernetes/mounttest:0.1
+      image: kubernetes/mounttest
       command: [ "/mt", "--file_content=/etc/secret-volume/data-1" ]
       volumeMounts:
           # name must match the volume name below

--- a/test/e2e/empty_dir.go
+++ b/test/e2e/empty_dir.go
@@ -86,7 +86,7 @@ func testPodWithVolume(path string, source *api.EmptyDirVolumeSource) *api.Pod {
 			Containers: []api.Container{
 				{
 					Name:  containerName,
-					Image: "kubernetes/mounttest:0.1",
+					Image: "kubernetes/mounttest",
 					VolumeMounts: []api.VolumeMount{
 						{
 							Name:      volumeName,

--- a/test/e2e/host_path.go
+++ b/test/e2e/host_path.go
@@ -126,7 +126,7 @@ func testPodWithHostVol(path string, source *api.HostPathVolumeSource) *api.Pod 
 			Containers: []api.Container{
 				{
 					Name:  containerName,
-					Image: "kubernetes/mounttest:0.1",
+					Image: "kubernetes/mounttest",
 					VolumeMounts: []api.VolumeMount{
 						{
 							Name:      volumeName,

--- a/test/e2e/secrets.go
+++ b/test/e2e/secrets.go
@@ -75,7 +75,7 @@ var _ = Describe("Secrets", func() {
 				Containers: []api.Container{
 					{
 						Name:  "secret-test",
-						Image: "kubernetes/mounttest:0.1",
+						Image: "kubernetes/mounttest",
 						Args: []string{
 							"--file_content=/etc/secret-volume/data-1",
 							"--file_mode=/etc/secret-volume/data-1"},

--- a/test/e2e/service_accounts.go
+++ b/test/e2e/service_accounts.go
@@ -65,7 +65,7 @@ var _ = Describe("ServiceAccounts", func() {
 				Containers: []api.Container{
 					{
 						Name:  "service-account-test",
-						Image: "kubernetes/mounttest:0.1",
+						Image: "kubernetes/mounttest",
 						Args: []string{
 							fmt.Sprintf("--file_content=%s/%s", serviceaccount.DefaultAPITokenMountPath, api.ServiceAccountTokenKey),
 						},


### PR DESCRIPTION
This changes the makefile for the mount test image to build and push the 'latest' version of the image and removes the hard-codings for version `0.1`.

@vmarmol 
