### PR TITLE
Making use of OpenShift readiness endpoint in example

### DIFF
--- a/examples/openshift-origin/openshift-controller.yaml
+++ b/examples/openshift-origin/openshift-controller.yaml
@@ -27,6 +27,18 @@ spec:
             - mountPath: /config
               name: config
               readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: 8443
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8443
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
       volumes: 
         - name: config
           secret:

--- a/pkg/kubelet/container/readiness_manager.go
+++ b/pkg/kubelet/container/readiness_manager.go
@@ -28,7 +28,7 @@ type ReadinessManager struct {
 	states map[string]bool
 }
 
-// NewReadinessManager creates ane returns a readiness manager with empty
+// NewReadinessManager creates and returns a readiness manager with empty
 // contents.
 func NewReadinessManager() *ReadinessManager {
 	return &ReadinessManager{states: make(map[string]bool)}


### PR DESCRIPTION
Updating OpenShift replication controller spec to make use of OpenShft readiness endpoint.

Fixes #9475. Merge after https://github.com/openshift/origin/pull/2952 is pulled in.
@derekwaynecarr 
