### PR TITLE
AWS: Include (idempotent) ensure-temp-dir in upload-server-tars

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -359,6 +359,8 @@ function upload-server-tars() {
   SERVER_BINARY_TAR_URL=
   SALT_TAR_URL=
 
+  ensure-temp-dir
+
   if [[ -z ${AWS_S3_BUCKET-} ]]; then
       local project_hash=
       local key=$(aws configure get aws_access_key_id)


### PR DESCRIPTION
This way we won't forget it.  Fixes kube-push, where I forgot it.
