### PR TITLE
add external load balancer setting back in to the frontend service of the guestbook example

### DIFF
--- a/examples/guestbook/frontend-service.json
+++ b/examples/guestbook/frontend-service.json
@@ -8,6 +8,7 @@
       }
    },
    "spec":{
+      "createExternalLoadBalancer": true,
       "ports": [
         {
           "port":80,


### PR DESCRIPTION
As per conversation w/ Brendan, confirmed that this should still be be here. (Guessing that this was fallout from a script conversion and other examples might need this fix; haven't checked yet).
