### PR TITLE
improve output of kube_get_url & fix #6548

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -21,8 +21,8 @@ kube::util::sortable_date() {
 kube::util::wait_for_url() {
   local url=$1
   local prefix=${2:-}
-  local wait=${3:-0.2}
-  local times=${4:-10}
+  local wait=${3:-0.5}
+  local times=${4:-25}
 
   which curl >/dev/null || {
     kube::log::usage "curl must be installed"
@@ -30,16 +30,15 @@ kube::util::wait_for_url() {
   }
 
   local i
-
   for i in $(seq 1 $times); do
     local out
     if out=$(curl -fs $url 2>/dev/null); then
-      kube::log::status ${prefix}${out}
+      kube::log::status "On try ${i}, ${prefix}: ${out}"
       return 0
     fi
-    sleep $wait
+    sleep ${wait}
   done
-  kube::log::error "Timed out waiting for ${url}"
+  kube::log::error "Timed out waiting for ${prefix} to answer at ${url}; tried ${times} waiting ${wait} between each"
   return 1
 }
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -65,7 +65,7 @@ kube::log::status "Starting kubelet in masterless mode"
   --port="$KUBELET_PORT" \
   --healthz_port="${KUBELET_HEALTHZ_PORT}" 1>&2 &
 KUBELET_PID=$!
-kube::util::wait_for_url "http://127.0.0.1:${KUBELET_HEALTHZ_PORT}/healthz" "kubelet: " 0.2 25
+kube::util::wait_for_url "http://127.0.0.1:${KUBELET_HEALTHZ_PORT}/healthz" "kubelet(masterless)"
 kill ${KUBELET_PID} 1>&2 2>/dev/null
 
 kube::log::status "Starting kubelet in masterful mode"
@@ -81,7 +81,7 @@ kube::log::status "Starting kubelet in masterful mode"
   --healthz_port="${KUBELET_HEALTHZ_PORT}" 1>&2 &
 KUBELET_PID=$!
 
-kube::util::wait_for_url "http://127.0.0.1:${KUBELET_HEALTHZ_PORT}/healthz" "kubelet: " 0.2 25
+kube::util::wait_for_url "http://127.0.0.1:${KUBELET_HEALTHZ_PORT}/healthz" "kubelet"
 
 # Start kube-apiserver
 kube::log::status "Starting kube-apiserver"
@@ -98,17 +98,18 @@ kube::log::status "Starting kube-apiserver"
   --service-cluster-ip-range="10.0.0.0/24" 1>&2 &
 APISERVER_PID=$!
 
-kube::util::wait_for_url "http://127.0.0.1:${API_PORT}/healthz" "apiserver: "
+kube::util::wait_for_url "http://127.0.0.1:${API_PORT}/healthz" "apiserver"
 
 # Start controller manager
-kube::log::status "Starting CONTROLLER-MANAGER"
+kube::log::status "Starting controller-manager"
 "${KUBE_OUTPUT_HOSTBIN}/kube-controller-manager" \
   --machines="127.0.0.1" \
+  --port="${CTLRMGR_PORT}" \
   --master="127.0.0.1:${API_PORT}" 1>&2 &
 CTLRMGR_PID=$!
 
-kube::util::wait_for_url "http://127.0.0.1:${CTLRMGR_PORT}/healthz" "controller-manager: "
-kube::util::wait_for_url "http://127.0.0.1:${API_PORT}/api/v1beta3/nodes/127.0.0.1" "apiserver(nodes): " 0.2 25
+kube::util::wait_for_url "http://127.0.0.1:${CTLRMGR_PORT}/healthz" "controller-manager"
+kube::util::wait_for_url "http://127.0.0.1:${API_PORT}/api/v1beta3/nodes/127.0.0.1" "apiserver(nodes)"
 
 # Expose kubectl directly for readability
 PATH="${KUBE_OUTPUT_HOSTBIN}":$PATH


### PR DESCRIPTION
I've extended the timeout (by making the tries spaced .5 seconds instead of .2 seconds) and made all commands consistent. The high "try" numbers are enough to explain the occasional flake, so this probably fixes #6548.
