### PR TITLE
Fixes thread leak from discarded watch

### DIFF
--- a/pkg/volume/util_test.go
+++ b/pkg/volume/util_test.go
@@ -95,7 +95,7 @@ func (c *mockScrubberClient) DeletePod(name, namespace string) error {
 	return nil
 }
 
-func (c *mockScrubberClient) WatchPod(name, namespace, resourceVersion string) func() *api.Pod {
+func (c *mockScrubberClient) WatchPod(name, namespace, resourceVersion string, stopChannel chan struct{}) func() *api.Pod {
 	return func() *api.Pod {
 		return c.pod
 	}


### PR DESCRIPTION
PV Recycling uses a scrubber pod to run "rm -rf" on a volume and creates a watch on the pod.   The watch is backed by a Reflector that is never closed.

This PR adds a stop channel and the caller of the watch defers a close on the channel.

@thockin @lavalamp 
