### PR TITLE
Add a validation error if memory is too low.

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1796,7 +1796,7 @@ func ValidateResourceRequirements(requirements *api.ResourceRequirements, fldPat
 	}
 	quantity, found := requirements.Limits[api.ResourceMemory]
 	if found && quantity.Value() < 4*1024*1024 {
-		allErrs = append(allErrs, errs.NewFieldInvalid("resources.limits[memory]", quantity.String(), "Memory must be at least 4Mb"))
+		allErrs = append(allErrs, errs.NewFieldInvalid("resources.limits[memory]", quantity.String(), "Memory must be at least 4MiB"))
 	}
 	reqPath := fldPath.Child("requests")
 	for resourceName, quantity := range requirements.Requests {

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1794,6 +1794,10 @@ func ValidateResourceRequirements(requirements *api.ResourceRequirements, fldPat
 			}
 		}
 	}
+	quantity, found := requirements.Limits[api.ResourceMemory]
+	if found && quantity.Value() < 4*1024*1024 {
+		allErrs = append(allErrs, errs.NewFieldInvalid("resources.limits[memory]", quantity.String(), "Memory must be at least 4Mb"))
+	}
 	reqPath := fldPath.Child("requests")
 	for resourceName, quantity := range requirements.Requests {
 		fldPath := reqPath.Key(string(resourceName))


### PR DESCRIPTION
Noticed this while implementing the memory resources e2e test.  Right now, if memory is < 4Gb we accept, schedule and then fail the pod.
