### PR TITLE
Added vagrant-libvirt plugin to vagrant provider check in install script

### DIFF
--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -52,6 +52,7 @@ function verify-prereqs {
       vmrun vmware_workstation vagrant-vmware-workstation
       prlctl parallels vagrant-parallels
       VBoxManage virtualbox ''
+      virsh libvirt vagrant-libvirt
   )
   local provider_found=''
   local provider_bin


### PR DESCRIPTION
A fix for issue #6900.
Even though vagrant-libvirt is a supported provider the install script did not have it down as a valid provider in its checks resulting in error "Can't find the necessary components for the libvirt vagrant provider, please fix and retry"
