### PR TITLE
Support sequential Jenkins workflows.

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -225,9 +225,16 @@ fi
 # TODO(zml): We have a bunch of legacy Jenkins configs that are
 # expecting junit*.xml to be in ${WORKSPACE} root and it's Friday
 # afternoon, so just put the junit report where it's expected.
-for junit in ${ARTIFACTS}/junit*.xml; do
-  ln -s ${junit} ${WORKSPACE}
-done
+results=($(ls "${ARTIFACTS}" | grep "junit.*.xml")) || true
+if [[ ! -z ${results:-} ]]; then
+    for junit in "${results[@]}"; do
+        # Jenkins runs that trigger sequentially (e.g. step1 -> step2 -> ...) will
+        # have e2e test results overwrite each other because they all run in the
+        # same workspace. For those cases, we prefix the final location with the
+        # step name.
+        mv "${ARTIFACTS}/${junit}" "${WORKSPACE}/${JENKINS_STEP_PREFIX:-}${junit}"
+    done
+fi
 
 ### Clean up ###
 if [[ "${E2E_DOWN,,}" == "true" ]]; then


### PR DESCRIPTION
- Fixes a bug where, if there's no test output, the path `workspace/jenkins*.xml` will be made a simlink to `workspace/`.
- Adds support for Jenkins sequential e2e runs, which run in the same workspace and otherwise fail because `ln -s` finds an existing link. The following Jenkins config changes need to be made on each e2e step of a sequential workflow:
  - `JENKINS_STEP_PREFIX` is set in Jenkins config. For example, for a "step2" run, we set `export JENKINS_STEP_PREFIX="step2-"`.
  - The Jenkins config that looks for test results then only looks for test files from that run, such as "step2-junit*.xml".

I've tested the above in Jenkins already.
