### PR TITLE
Make cluster level Elasticsearch logging test reslient to pod restarts

### DIFF
--- a/test/e2e/es_cluster_logging.go
+++ b/test/e2e/es_cluster_logging.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/golang/glog"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -317,7 +318,7 @@ func ClusterLevelLoggingWithElasticsearch(f *Framework) {
 					missing++
 				}
 				if c < 0 || c > 1 {
-					Failf("Got incorrect count for node %d index %d: %d", n, i, c)
+					glog.Warningf("Got unexpected count for node %d index %d: %d", n, i, c)
 				}
 			}
 		}


### PR DESCRIPTION
If a pod is restarted then this test should be fine with seeing a log line repeated.
Attempt to address issue #9486
