### PR TITLE
Fixes quoting on systemd drop-in for DOCKER_OPTS.

### DIFF
--- a/cluster/libvirt-coreos/user_data.yml
+++ b/cluster/libvirt-coreos/user_data.yml
@@ -88,7 +88,7 @@ coreos:
         - name: 50-opts.conf
           content: |
             [Service]
-            Environment=DOCKER_OPTS='--bridge=cbr0 --iptables=false'
+            Environment='DOCKER_OPTS=--bridge=cbr0 --iptables=false'
     - name: docker-tcp.socket
       command: start
       enable: yes


### PR DESCRIPTION
There's a quote typo in cluster/libvirt-coreos/user_data.yml, so the Docker daemon does not get all its options set:

```
$ make clean
$ make
$ export KUBERNETES_PROVIDER=libvirt-coreos
$ export KUBE_PUSH=local
$ ./cluster/kube-up.sh
$ ssh core@192.168.10.1
core@kubernetes-master ~ $ journalctl | grep DOCKER_OPT
Jun 10 11:45:10 kubernetes-master systemd[1]: [/etc/systemd/system/docker.service.d/50-opts.conf:2] Invalid environment assignment, ignoring: DOCKER_OPTS='--bridge=cbr0 --iptables=false'
core@kubernetes-master ~ $ ps -ef | grep docker | grep -v grep
root       586     1  0 11:45 ?        00:00:00 docker --daemon --host=fd:// --bridge=cbr0
```

With this patch:

```
core@kubernetes-master ~ $ journalctl | grep DOCKER_OPT
core@kubernetes-master ~ $ ps -ef | grep docker | grep -v grep
root       580     1  0 11:51 ?        00:00:00 docker --daemon --host=fd:// --bridge=cbr0 --iptables=false
core@kubernetes-master ~ $
```

Fix based on [systemd service documentation](http://www.freedesktop.org/software/systemd/man/systemd.service.html), section "Command lines".

/cc @lhuard1A
