### PR TITLE
Use supplied etcd2 with CoreOS

### DIFF
--- a/cluster/libvirt-coreos/.gitignore
+++ b/cluster/libvirt-coreos/.gitignore
@@ -1,3 +1,2 @@
 /libvirt_storage_pool/
 /coreos_production_qemu_image.img.bz2
-/etcd-v2.0.9-linux-amd64.tar.gz

--- a/cluster/libvirt-coreos/coreos.xml
+++ b/cluster/libvirt-coreos/coreos.xml
@@ -35,11 +35,6 @@
       <target dir='kubernetes'/>
       <readonly/>
     </filesystem>
-    <filesystem type='mount' accessmode='squash'>
-      <source dir='${etcd_dir}'/>
-      <target dir='etcd'/>
-      <readonly/>
-    </filesystem>
     <interface type='network'>
        <mac address='52:54:00:00:00:${i}'/>
        <source network='kubernetes_global'/>

--- a/cluster/libvirt-coreos/user_data.yml
+++ b/cluster/libvirt-coreos/user_data.yml
@@ -17,22 +17,11 @@ coreos:
   etcd:
     name: ${name}
     addr: ${public_ip}:4001
-    # bind-addr: 0.0.0.0
+    bind-addr: 0.0.0.0
     peer-addr: ${public_ip}:7001
     # peers: {etcd_peers}
     discovery: ${discovery}
   units:
-    - name: etcd.service
-      drop-ins:
-        - name: opt-etcd2.conf
-          content: |
-            [Unit]
-            After=opt-etcd.mount
-            Requires=opt-etcd.mount
-
-            [Service]
-            ExecStart=
-            ExecStart=/opt/etcd/bin/etcd
     - name: static.network
       command: start
       content: |
@@ -112,17 +101,6 @@ coreos:
         [Mount]
         What=kubernetes
         Where=/opt/kubernetes
-        Options=ro,trans=virtio,version=9p2000.L
-        Type=9p
-    - name: opt-etcd.mount
-      command: start
-      content: |
-        [Unit]
-        ConditionVirtualization=|vm
-
-        [Mount]
-        What=etcd
-        Where=/opt/etcd
         Options=ro,trans=virtio,version=9p2000.L
         Type=9p
   update:

--- a/cluster/libvirt-coreos/user_data.yml
+++ b/cluster/libvirt-coreos/user_data.yml
@@ -14,12 +14,12 @@ write_files:
       RuntimeMaxUse=50M
 
 coreos:
-  etcd:
+  etcd2:
     name: ${name}
-    addr: ${public_ip}:4001
-    bind-addr: 0.0.0.0
-    peer-addr: ${public_ip}:7001
-    # peers: {etcd_peers}
+    advertise-client-urls: http://${public_ip}:2379
+    initial-advertise-peer-urls: http://${public_ip}:2380
+    listen-client-urls: http://${public_ip}:2379,http://${public_ip}:4001
+    listen-peer-urls: http://${public_ip}:2380,http://${public_ip}:7001
     discovery: ${discovery}
   units:
     - name: static.network
@@ -69,7 +69,7 @@ coreos:
         ExecStart=/usr/sbin/iptables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE ! -d ${CONTAINER_SUBNET}
         RemainAfterExit=yes
         Type=oneshot
-    - name: etcd.service
+    - name: etcd2.service
       command: start
     - name: docker.service
       command: start

--- a/cluster/libvirt-coreos/user_data_master.yml
+++ b/cluster/libvirt-coreos/user_data_master.yml
@@ -6,11 +6,11 @@ coreos:
       command: start
       content: |
         [Unit]
-        After=opt-kubernetes.mount etcd.service
+        After=opt-kubernetes.mount etcd2.service
         ConditionFileIsExecutable=/opt/kubernetes/bin/kube-apiserver
         Description=Kubernetes API Server
         Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-        Requires=opt-kubernetes.mount etcd.service
+        Requires=opt-kubernetes.mount etcd2.service
 
         [Service]
         ExecStart=/opt/kubernetes/bin/kube-apiserver \

--- a/cluster/libvirt-coreos/user_data_minion.yml
+++ b/cluster/libvirt-coreos/user_data_minion.yml
@@ -6,11 +6,11 @@ coreos:
       command: start
       content: |
         [Unit]
-        After=opt-kubernetes.mount etcd.service docker.socket
+        After=opt-kubernetes.mount etcd2.service docker.socket
         ConditionFileIsExecutable=/opt/kubernetes/bin/kubelet
         Description=Kubernetes Kubelet
         Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-        Requires=opt-kubernetes.mount etcd.service docker.socket
+        Requires=opt-kubernetes.mount etcd2.service docker.socket
 
         [Service]
         ExecStart=/opt/kubernetes/bin/kubelet \
@@ -29,11 +29,11 @@ coreos:
       command: start
       content: |
         [Unit]
-        After=opt-kubernetes.mount etcd.service
+        After=opt-kubernetes.mount etcd2.service
         ConditionFileIsExecutable=/opt/kubernetes/bin/kube-proxy
         Description=Kubernetes Proxy
         Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-        Requires=opt-kubernetes.mount etcd.service
+        Requires=opt-kubernetes.mount etcd2.service
 
         [Service]
         ExecStart=/opt/kubernetes/bin/kube-proxy \

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -26,8 +26,6 @@ export LIBVIRT_DEFAULT_URI=qemu:///system
 readonly POOL=kubernetes
 readonly POOL_PATH="$(cd $ROOT && pwd)/libvirt_storage_pool"
 
-ETCD_VERSION=${ETCD_VERSION:-v2.0.9}
-
 # join <delim> <list...>
 # Concatenates the list elements with the delimiter passed as first parameter
 #
@@ -96,9 +94,6 @@ function destroy-pool {
         virsh vol-delete $vol --pool $POOL
       done
 
-  rm -rf "$POOL_PATH"/etcd/*
-  virsh vol-delete etcd --pool $POOL || true
-
   [[ "$1" == 'keep_base_image' ]] && return
 
   set +e
@@ -144,18 +139,6 @@ function initialize-pool {
   if [[ "$ENABLE_CLUSTER_DNS" == "true" ]]; then
       render-template "$ROOT/skydns-svc.yaml" > "$POOL_PATH/kubernetes/addons/skydns-svc.yaml"
       render-template "$ROOT/skydns-rc.yaml"  > "$POOL_PATH/kubernetes/addons/skydns-rc.yaml"
-  fi
-
-  mkdir -p "$POOL_PATH/etcd"
-  if [[ ! -f "$ROOT/etcd-${ETCD_VERSION}-linux-amd64.tar.gz" ]]; then
-      wget -P "$ROOT" https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz
-  fi
-  if [[ "$ROOT/etcd-${ETCD_VERSION}-linux-amd64.tar.gz" -nt "$POOL_PATH/etcd/etcd" ]]; then
-      tar -x -C "$POOL_PATH/etcd" -f "$ROOT/etcd-${ETCD_VERSION}-linux-amd64.tar.gz" etcd-${ETCD_VERSION}-linux-amd64
-      rm -rf "$POOL_PATH/etcd/bin/*"
-      mkdir -p "$POOL_PATH/etcd/bin"
-      mv "$POOL_PATH"/etcd/etcd-${ETCD_VERSION}-linux-amd64/{etcd,etcdctl} "$POOL_PATH/etcd/bin"
-      rm -rf "$POOL_PATH/etcd/etcd-${ETCD_VERSION}-linux-amd64"
   fi
 
   virsh pool-refresh $POOL
@@ -206,7 +189,6 @@ function kube-up {
 
   readonly ssh_keys="$(cat ~/.ssh/id_*.pub | sed 's/^/  - /')"
   readonly kubernetes_dir="$POOL_PATH/kubernetes"
-  readonly etcd_dir="$POOL_PATH/etcd"
   readonly discovery=$(curl -s https://discovery.etcd.io/new)
 
   readonly machines=$(join , "${KUBE_MINION_IP_ADDRESSES[@]}")

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -189,7 +189,7 @@ function kube-up {
 
   readonly ssh_keys="$(cat ~/.ssh/id_*.pub | sed 's/^/  - /')"
   readonly kubernetes_dir="$POOL_PATH/kubernetes"
-  readonly discovery=$(curl -s https://discovery.etcd.io/new)
+  readonly discovery=$(curl -s https://discovery.etcd.io/new?size=$((NUM_MINIONS + 1)))
 
   readonly machines=$(join , "${KUBE_MINION_IP_ADDRESSES[@]}")
 


### PR DESCRIPTION
Commit https://github.com/GoogleCloudPlatform/kubernetes/commit/11556dc927247b96d1a18e45e48876e75ce3edab has introduced an extra download for `etcd` 2.0.9 with the intention to revert when CoreOS shipped `etcd2`. This is now the case, however `etcd` 0.4.9 is shipped as `etcd` and `etcd` 2.0.11 as `etcd2`. This PR reverts to using shipped `etcd` and makes use of `etcd2`.
