### PR TITLE
generate-cert: allow for alternative paths

### DIFF
--- a/cluster/saltbase/salt/generate-cert/make-ca-cert.sh
+++ b/cluster/saltbase/salt/generate-cert/make-ca-cert.sh
@@ -46,7 +46,7 @@ if [[ -n "${extra_sans}" ]]; then
   sans="${sans},${extra_sans}"
 fi
 
-tmpdir=$(mktemp -d --tmpdir kubernetes_cacert.XXXXXX)
+tmpdir=$(mktemp -d -t kubernetes_cacert.XXXXXX)
 trap 'rm -rf "${tmpdir}"' EXIT
 cd "${tmpdir}"
 

--- a/cluster/saltbase/salt/generate-cert/make-ca-cert.sh
+++ b/cluster/saltbase/salt/generate-cert/make-ca-cert.sh
@@ -20,8 +20,8 @@ set -o pipefail
 
 cert_ip=$1
 extra_sans=${2:-}
-cert_dir=/srv/kubernetes
-cert_group=kube-cert
+cert_dir=${CERT_DIR:-/srv/kubernetes}
+cert_group=${CERT_GROUP:-kube-cert}
 
 mkdir -p "$cert_dir"
 

--- a/cluster/saltbase/salt/generate-cert/make-cert.sh
+++ b/cluster/saltbase/salt/generate-cert/make-cert.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cert_dir=/srv/kubernetes
-cert_group=kube-cert
+cert_dir=${CERT_DIR:-/srv/kubernetes}
+cert_group=${CERT_GROUP:-kube-cert}
 
 mkdir -p "$cert_dir"
 

--- a/cluster/saltbase/salt/kube-addons/kube-addon-update.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-update.sh
@@ -44,7 +44,9 @@
 
 
 # global config
-KUBECTL=${TEST_KUBECTL:-/usr/local/bin/kubectl}   # substitute for tests
+KUBECTL=${TEST_KUBECTL:-}   # substitute for tests
+KUBECTL=${KUBECTL:-${KUBECTL_BIN:-}}
+KUBECTL=${KUBECTL:-/usr/local/bin/kubectl}
 if [[ ! -x ${KUBECTL} ]]; then
     echo "ERROR: kubectl command (${KUBECTL}) not found or is not executable" 1>&2
     exit 1

--- a/cluster/saltbase/salt/kube-addons/kube-addons.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addons.sh
@@ -22,6 +22,7 @@ KUBECTL=${KUBECTL_BIN:-/usr/local/bin/kubectl}
 ADDON_CHECK_INTERVAL_SEC=${TEST_ADDON_CHECK_INTERVAL_SEC:-600}
 
 SYSTEM_NAMESPACE=kube-system
+token_dir=${TOKEN_DIR:-/srv/kubernetes}
 
 function create-kubeconfig-secret() {
   local -r token=$1
@@ -174,7 +175,7 @@ while read line; do
     # do not have DNS available will have to override the server.
     create-kubeconfig-secret "${token}" "${username}" "https://kubernetes.default"
   fi
-done < /srv/kubernetes/known_tokens.csv
+done < ${token_dir}/known_tokens.csv
 
 # Create admission_control objects if defined before any other addon services. If the limits
 # are defined in a namespace other than default, we should still create the limits for the


### PR DESCRIPTION
Instead of hard coding kube-cert and /srv/kubernetes allow these to be
overwritten by environment variables.  / is immutable on some systems
and so /srv is not a possible location to store data.
