### PR TITLE
Add a way to pass arguments to the Ginkgo runner itself.

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -83,11 +83,11 @@ else
   NODE_INSTANCE_GROUP=""
 fi
 
-ginkgo_args=()
+# Use eval to preserve embedded quoted strings.
+eval "ginkgo_args=(${GINKGO_ARGS:-})"
 if [[ ${GINKGO_PARALLEL} =~ ^[yY]$ ]]; then
   ginkgo_args+=("-p")
 fi
-
 
 # The --host setting is used only when providing --auth_config
 # If --kubeconfig is used, the host to use is retrieved from the .kubeconfig

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -37,8 +37,13 @@ else
     export HOME=${WORKSPACE} # Nothing should want Jenkins $HOME
 fi
 
-# Additional parameters that are passed to ginkgo runner.
+# TODO: clean up this mess.
+# Additional parameters that are passed to the Ginkgo runner.
+GINKGO_ARGS=${GINKGO_ARGS:-"--noColor"}
+# Additional parameters that are passed to the Ginkgo e2e tests.
 GINKGO_TEST_ARGS=${GINKGO_TEST_ARGS:-""}
+# Addditional parameters that are passed to hack/e2e.go
+E2E_OPT=${E2E_OPT:-""}
 
 if [[ "${PERFORMANCE:-}" == "true" ]]; then
     if [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then
@@ -219,7 +224,10 @@ fi
 # Jenkins will look at the junit*.xml files for test failures, so don't exit
 # with a nonzero error code if it was only tests that failed.
 if [[ "${E2E_TEST,,}" == "true" ]]; then
-    go run ./hack/e2e.go ${E2E_OPT} -v --test --test_args="${GINKGO_TEST_ARGS}--ginkgo.noColor" || true
+    # GINKGO_ARGS is parsed by the Ginkgo runner itself, whereas the --test_args
+    # flag is parsed by the test.
+    export GINKGO_ARGS
+    go run ./hack/e2e.go ${E2E_OPT} -v --test --test_args="${GINKGO_TEST_ARGS}" || true
 fi
 
 # TODO(zml): We have a bunch of legacy Jenkins configs that are


### PR DESCRIPTION
Use this new environment variable (GINKGO_ARGS) to disable color in all
Jenkins builds.

Also make E2E_OPT optional in the Jenkins e2e tests, defaulting to empty
string, the most common setting.
