### PR TITLE
Fixed empty name error and also changed tests

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -212,10 +212,11 @@ func ValidateObjectMeta(meta *api.ObjectMeta, requiresNamespace bool, nameFn Val
 			allErrs = append(allErrs, errs.NewFieldInvalid("generateName", meta.GenerateName, qualifier))
 		}
 	}
-	// if the generated name validates, but the calculated value does not, it's a problem with generation, and we
+	// If the generated name validates, but the calculated value does not, it's a problem with generation, and we
 	// report it here. This may confuse users, but indicates a programming bug and still must be validated.
+	// If there are multiple fields out of which one is required then add a or as a seperator
 	if len(meta.Name) == 0 {
-		allErrs = append(allErrs, errs.NewFieldRequired("name"))
+		allErrs = append(allErrs, errs.NewFieldRequired("name or generateName"))
 	} else {
 		if ok, qualifier := nameFn(meta.Name, false); !ok {
 			allErrs = append(allErrs, errs.NewFieldInvalid("name", meta.Name, qualifier))

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -2245,7 +2245,7 @@ func TestValidateReplicationController(t *testing.T) {
 		for i := range errs {
 			field := errs[i].(*errors.ValidationError).Field
 			if !strings.HasPrefix(field, "spec.template.") &&
-				field != "metadata.name" &&
+				field != "metadata.name or metadata.generateName" &&
 				field != "metadata.namespace" &&
 				field != "spec.selector" &&
 				field != "spec.template" &&
@@ -2360,11 +2360,11 @@ func TestValidateNode(t *testing.T) {
 		for i := range errs {
 			field := errs[i].(*errors.ValidationError).Field
 			expectedFields := map[string]bool{
-				"metadata.name":        true,
-				"metadata.labels":      true,
-				"metadata.annotations": true,
-				"metadata.namespace":   true,
-				"spec.ExternalID":      true,
+				"metadata.name or metadata.generateName": true,
+				"metadata.labels":                        true,
+				"metadata.annotations":                   true,
+				"metadata.namespace":                     true,
+				"spec.ExternalID":                        true,
 			}
 			if expectedFields[field] == false {
 				t.Errorf("%s: missing prefix for: %v", k, errs[i])
@@ -2894,7 +2894,7 @@ func TestValidateResourceQuota(t *testing.T) {
 		for i := range errs {
 			field := errs[i].(*errors.ValidationError).Field
 			detail := errs[i].(*errors.ValidationError).Detail
-			if field != "metadata.name" && field != "metadata.namespace" {
+			if field != "metadata.name" && field != "metadata.name or metadata.generateName" && field != "metadata.namespace" {
 				t.Errorf("%s: missing prefix for: %v", k, field)
 			}
 			if detail != v.D {

--- a/pkg/util/fielderrors/fielderrors.go
+++ b/pkg/util/fielderrors/fielderrors.go
@@ -148,6 +148,7 @@ func NewFieldTooLong(field string, value interface{}, maxLength int) *Validation
 type ValidationErrorList []error
 
 // Prefix adds a prefix to the Field of every ValidationError in the list.
+// Also adds prefixes to multiple fields if you send an or seperator.
 // Returns the list for convenience.
 func (list ValidationErrorList) Prefix(prefix string) ValidationErrorList {
 	for i := range list {
@@ -155,7 +156,11 @@ func (list ValidationErrorList) Prefix(prefix string) ValidationErrorList {
 			if strings.HasPrefix(err.Field, "[") {
 				err.Field = prefix + err.Field
 			} else if len(err.Field) != 0 {
-				err.Field = prefix + "." + err.Field
+				fields := strings.SplitAfter(err.Field, " or ")
+				err.Field = ""
+				for j := range fields {
+					err.Field += prefix + "." + fields[j]
+				}
 			} else {
 				err.Field = prefix
 			}


### PR DESCRIPTION
I changed the error which the api returned when the metadata.name or generateName field is not provided. So now if you send in an OR separator between two fields, I changed prefix to take care of that case so that it shows that one of two field is required
#9284
