### PR TITLE
fix unbound variable bug in cluster/common.sh

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -169,7 +169,7 @@ function get-kubeconfig-bearertoken() {
   fi
 }
 
-# Sets binary_version variable to the version passed in as an argument, or if argument is
+# Sets KUBE_VERSION variable to the version passed in as an argument, or if argument is
 # latest_stable, latest_release, or latest_ci fetches and sets the correponding version number
 #
 # Args:
@@ -179,13 +179,13 @@ function get-kubeconfig-bearertoken() {
 function set_binary_version() {
   if [[ "${1}" == "latest_stable" ]]; then
     KUBE_VERSION=$(gsutil cat gs://kubernetes-release/release/stable.txt)
-    echo "Using latest stable version: ${binary_version}"
+    echo "Using latest stable version: ${KUBE_VERSION}"
   elif [[ "${1}" == "latest_release" ]]; then
     KUBE_VERSION=$(gsutil cat gs://kubernetes-release/release/latest.txt)
-    echo "Using latest release version: ${binary_version}"
+    echo "Using latest release version: ${KUBE_VERSION}"
   elif [[ "${1}" == "latest_ci" ]]; then
     KUBE_VERSION=$(gsutil cat gs://kubernetes-release/ci/latest.txt)
-    echo "Using latest ci version: ${binary_version}"
+    echo "Using latest ci version: ${KUBE_VERSION}"
   else
     KUBE_VERSION=${1}
   fi


### PR DESCRIPTION
Fixes:

```
➜  kubernetes git:(master) ./cluster/gce/upgrade.sh -M latest_release
./cluster/gce/../../cluster/gce/../../cluster/common.sh: line 185: binary_version: unbound variable
```
