### PR TITLE
fix panic in kubectl --validate when no apiVersion is passed

### DIFF
--- a/pkg/api/validation/schema.go
+++ b/pkg/api/validation/schema.go
@@ -79,11 +79,11 @@ func (s *SwaggerSchema) ValidateBytes(data []byte) error {
 	}
 	apiVersion := fields["apiVersion"]
 	if apiVersion == nil {
-		fmt.Errorf("apiVersion not set")
+		return fmt.Errorf("apiVersion not set")
 	}
 	kind := fields["kind"]
 	if kind == nil {
-		fmt.Errorf("kind not set")
+		return fmt.Errorf("kind not set")
 	}
 	return s.ValidateObject(obj, apiVersion.(string), "", apiVersion.(string)+"."+kind.(string))
 }


### PR DESCRIPTION
actually return validation errors instead of just creating them. whoops.

Fixes:  #9224
