### PR TITLE
kube_addons - Adding variable with default for kubectl bin. 

### DIFF
--- a/cluster/saltbase/salt/kube-addons/kube-addons.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addons.sh
@@ -17,7 +17,7 @@
 # The business logic for whether a given object should be created
 # was already enforced by salt, and /etc/kubernetes/addons is the
 # managed result is of that. Start everything below that directory.
-KUBECTL=/usr/local/bin/kubectl
+KUBECTL=${KUBECTL_BIN:-/usr/local/bin/kubectl}
 
 function create-kubeconfig-secret() {
   local -r token=$1


### PR DESCRIPTION
Added a way to specify the `kubectl` path. Issue seen using the CentOS yum version of Kubernetes installs the `kubectl` in `/usr/bin`.

Fixes issue  #9599 
