### PR TITLE
Explicitly specifying 0 replicas since default changed

### DIFF
--- a/examples/update-demo/kitten-rc.yaml
+++ b/examples/update-demo/kitten-rc.yaml
@@ -3,6 +3,7 @@ kind: ReplicationController
 metadata:
   name: update-demo-kitten
 spec:
+  replicas: 0
   selector:
     name: update-demo
     version: kitten


### PR DESCRIPTION
The default number of replicas in v1 in now 1 instead of 0. This is causing an e2e failure:

```
Kubernetes e2e suite.Kubectl client Update Demo should do a rolling update of a replication controller
```

@ArtfulCoder 
