### PR TITLE
status hook for the container network

### DIFF
--- a/pkg/kubelet/network/exec/exec_test.go
+++ b/pkg/kubelet/network/exec/exec_test.go
@@ -19,12 +19,14 @@ limitations under the License.
 package exec
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
 	"testing"
+	"text/template"
 
 	"k8s.io/kubernetes/pkg/kubelet/network"
 )
@@ -32,7 +34,7 @@ import (
 // The temp dir where test plugins will be stored.
 const testPluginPath = "/tmp/fake/plugins/net"
 
-func installPluginUnderTest(t *testing.T, vendorName string, plugName string) {
+func installPluginUnderTest(t *testing.T, vendorName string, plugName string, execTemplateData *map[string]interface{}) {
 	vendoredName := plugName
 	if vendorName != "" {
 		vendoredName = fmt.Sprintf("%s~%s", vendorName, plugName)
@@ -51,8 +53,32 @@ func installPluginUnderTest(t *testing.T, vendorName string, plugName string) {
 	if err != nil {
 		t.Errorf("Failed to set exec perms on plugin")
 	}
-	writeStr := fmt.Sprintf("#!/bin/bash\necho -n $@ &> %s", path.Join(pluginDir, plugName+".out"))
-	_, err = f.WriteString(writeStr)
+	const execScriptTempl = `#!/bin/bash
+
+# If status hook is called print the expected json to stdout
+if [ "$1" == "status" ]; then
+  echo -n '{
+	"ip" : "{{.IPAddress}}"
+}'
+fi
+
+# Direct the arguments to a file to be tested against later
+echo -n $@ &> {{.OutputFile}}
+`
+	if execTemplateData == nil {
+		execTemplateData = &map[string]interface{}{
+			"IPAddress":  "10.20.30.40",
+			"OutputFile": path.Join(pluginDir, plugName+".out"),
+		}
+	}
+
+	tObj := template.Must(template.New("test").Parse(execScriptTempl))
+	buf := &bytes.Buffer{}
+	if err := tObj.Execute(buf, *execTemplateData); err != nil {
+		t.Errorf("Error in executing script template - %v", err)
+	}
+	execScript := buf.String()
+	_, err = f.WriteString(execScript)
 	if err != nil {
 		t.Errorf("Failed to write plugin exec")
 	}
@@ -70,7 +96,7 @@ func TestSelectPlugin(t *testing.T) {
 	// install some random plugin under testPluginPath
 	pluginName := fmt.Sprintf("test%d", rand.Intn(1000))
 	defer tearDownPlugin(pluginName)
-	installPluginUnderTest(t, "", pluginName)
+	installPluginUnderTest(t, "", pluginName, nil)
 
 	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, network.NewFakeHost(nil))
 	if err != nil {
@@ -86,7 +112,7 @@ func TestSelectVendoredPlugin(t *testing.T) {
 	pluginName := fmt.Sprintf("test%d", rand.Intn(1000))
 	defer tearDownPlugin(pluginName)
 	vendor := "mycompany"
-	installPluginUnderTest(t, vendor, pluginName)
+	installPluginUnderTest(t, vendor, pluginName, nil)
 
 	vendoredPluginName := fmt.Sprintf("%s/%s", vendor, pluginName)
 	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), vendoredPluginName, network.NewFakeHost(nil))
@@ -102,7 +128,7 @@ func TestSelectWrongPlugin(t *testing.T) {
 	// install some random plugin under testPluginPath
 	pluginName := fmt.Sprintf("test%d", rand.Intn(1000))
 	defer tearDownPlugin(pluginName)
-	installPluginUnderTest(t, "", pluginName)
+	installPluginUnderTest(t, "", pluginName, nil)
 
 	wrongPlugin := "abcd"
 	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), wrongPlugin, network.NewFakeHost(nil))
@@ -114,7 +140,7 @@ func TestSelectWrongPlugin(t *testing.T) {
 func TestPluginValidation(t *testing.T) {
 	pluginName := fmt.Sprintf("test%d", rand.Intn(1000))
 	defer tearDownPlugin(pluginName)
-	installPluginUnderTest(t, "", pluginName)
+	installPluginUnderTest(t, "", pluginName, nil)
 
 	// modify the perms of the pluginExecutable
 	f, err := os.Open(path.Join(testPluginPath, pluginName, pluginName))
@@ -137,7 +163,7 @@ func TestPluginValidation(t *testing.T) {
 func TestPluginSetupHook(t *testing.T) {
 	pluginName := fmt.Sprintf("test%d", rand.Intn(1000))
 	defer tearDownPlugin(pluginName)
-	installPluginUnderTest(t, "", pluginName)
+	installPluginUnderTest(t, "", pluginName, nil)
 
 	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, network.NewFakeHost(nil))
 
@@ -159,7 +185,7 @@ func TestPluginSetupHook(t *testing.T) {
 func TestPluginTearDownHook(t *testing.T) {
 	pluginName := fmt.Sprintf("test%d", rand.Intn(1000))
 	defer tearDownPlugin(pluginName)
-	installPluginUnderTest(t, "", pluginName)
+	installPluginUnderTest(t, "", pluginName, nil)
 
 	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, network.NewFakeHost(nil))
 
@@ -175,5 +201,30 @@ func TestPluginTearDownHook(t *testing.T) {
 	expectedOutput := "teardown podNamespace podName dockerid2345"
 	if string(output) != expectedOutput {
 		t.Errorf("Mismatch in expected output for teardown hook. Expected '%s', got '%s'", expectedOutput, string(output))
+	}
+}
+
+func TestPluginStatusHook(t *testing.T) {
+	pluginName := fmt.Sprintf("test%d", rand.Intn(1000))
+	defer tearDownPlugin(pluginName)
+	installPluginUnderTest(t, "", pluginName, nil)
+
+	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, network.NewFakeHost(nil))
+
+	ip, err := plug.Status("namespace", "name", "dockerid2345")
+	if err != nil {
+		t.Errorf("Expected nil got %v", err)
+	}
+	// check output of status hook
+	output, err := ioutil.ReadFile(path.Join(testPluginPath, pluginName, pluginName+".out"))
+	if err != nil {
+		t.Errorf("Expected nil")
+	}
+	expectedOutput := "status namespace name dockerid2345"
+	if string(output) != expectedOutput {
+		t.Errorf("Mismatch in expected output for status hook. Expected '%s', got '%s'", expectedOutput, string(output))
+	}
+	if ip.IP.String() != "10.20.30.40" {
+		t.Errorf("Mismatch in expected output for status hook. Expected '10.20.30.40', got '%s'", ip.IP.String())
 	}
 }

--- a/pkg/kubelet/network/plugins.go
+++ b/pkg/kubelet/network/plugins.go
@@ -18,6 +18,7 @@ package network
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/golang/glog"
@@ -47,6 +48,21 @@ type NetworkPlugin interface {
 
 	// TearDownPod is the method called before a pod's infra container will be deleted
 	TearDownPod(namespace string, name string, podInfraContainerID kubeletTypes.DockerID) error
+
+	// Status is the method called to obtain the ipv4 or ipv6 addresses of the container
+	Status(namespace string, name string, podInfraContainerID kubeletTypes.DockerID) (*PodNetworkStatus, error)
+}
+
+// PodNetworkStatus stores the network status of a pod (currently just the primary IP address)
+// This struct represents version "v1"
+type PodNetworkStatus struct {
+	api.TypeMeta `json:",inline"`
+
+	// IP is the primary ipv4/ipv6 address of the pod. Among other things it is the address that -
+	//   - kube expects to be reachable across the cluster
+	//   - service endpoints are constructed with
+	//   - will be reported in the PodStatus.PodIP field (will override the IP reported by docker)
+	IP net.IP `json:"ip" description:"Primary IP address of the pod"`
 }
 
 // Host is an interface that plugins can use to access the kubelet.
@@ -119,4 +135,8 @@ func (plugin *noopNetworkPlugin) SetUpPod(namespace string, name string, id kube
 
 func (plugin *noopNetworkPlugin) TearDownPod(namespace string, name string, id kubeletTypes.DockerID) error {
 	return nil
+}
+
+func (plugin *noopNetworkPlugin) Status(namespace string, name string, id kubeletTypes.DockerID) (*PodNetworkStatus, error) {
+	return nil, nil
 }


### PR DESCRIPTION
Extending the network plugin to include a status hook that gets the Pod's IPAddress information as decided by the network plugin. Until now, even though the network could be plumbed by a network plugin, the IPAddress of the pods was obtained from container runtime (e.g. docker inspect) only.

A 'status' API (and a corresponding hook in the exec plugin) lets the plugin give out the IPAddress as it deems fit. This feature is particularly necessary if the network plugin chose its own IPAM and not the one provided by container-runtime.

Marking this as a Work-In-Progress, feedback please.

@errordeveloper @jainvipin @mapuri @thockin @mrunalp @joeswaminathan
