### PR TITLE
Fix rolling update e2e test

### DIFF
--- a/examples/update-demo/kitten-rc.yaml
+++ b/examples/update-demo/kitten-rc.yaml
@@ -3,7 +3,7 @@ kind: ReplicationController
 metadata:
   name: update-demo-kitten
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     name: update-demo
     version: kitten

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -101,7 +101,8 @@ var _ = Describe("Kubectl client", func() {
 			validateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
 			By("rolling-update to new replication controller")
 			runKubectl("rolling-update", "update-demo-nautilus", "--update-period=1s", "-f", kittenPath, fmt.Sprintf("--namespace=%v", ns))
-			validateController(c, kittenImage, 2, "update-demo", updateDemoSelector, getUDData("kitten.jpg", ns), ns)
+			// TODO: revisit the expected replicas once #9645 is resolved
+			validateController(c, kittenImage, 1, "update-demo", updateDemoSelector, getUDData("kitten.jpg", ns), ns)
 			// Everything will hopefully be cleaned up when the namespace is deleted.
 		})
 	})


### PR DESCRIPTION
Rolling update test is currently flaky. Also a rolling update to an rc with 0 replicas is bound to hide bugs.
https://github.com/GoogleCloudPlatform/kubernetes/issues/9645 @krousey 
