### PR TITLE
minor fix in swagger spec

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -13288,7 +13288,8 @@
       "description": "the port number that is exposed"
      },
      "targetPort": {
-      "type": "string",
+      "type": "integer",
+      "format": "int32",
       "description": "the port to access on the pods targeted by the service; defaults to the service port"
      },
      "nodePort": {

--- a/api/swagger-spec/v1beta3.json
+++ b/api/swagger-spec/v1beta3.json
@@ -13294,7 +13294,8 @@
       "description": "the port number that is exposed"
      },
      "targetPort": {
-      "type": "string",
+      "type": "integer",
+      "format": "int32",
       "description": "the port to access on the pods targeted by the service; defaults to the service port"
      },
      "nodePort": {


### PR DESCRIPTION
Service Spec targetPort is an wrongly reported as "string" it should be and int32
