### PR TITLE
Wait longer for firewall creation during e2e cluster setup.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -978,21 +978,37 @@ function test-setup {
 
   # Open up port 80 & 8080 so common containers on minions can be reached
   # TODO(roberthbailey): Remove this once we are no longer relying on hostPorts.
+  local start=`date +%s`
   gcloud compute firewall-rules create \
     --project "${PROJECT}" \
     --target-tags "${MINION_TAG}" \
     --allow tcp:80,tcp:8080 \
     --network "${NETWORK}" \
-    "${MINION_TAG}-${INSTANCE_PREFIX}-http-alt"
+    "${MINION_TAG}-${INSTANCE_PREFIX}-http-alt" 2> /dev/null || true
+  # As there is no simple way to wait longer for this operation we need to manually
+  # wait some additional time (20 minutes altogether).
+  until gcloud compute firewall-rules describe "${MINION_TAG}-${INSTANCE_PREFIX}-http-alt" 2> /dev/null || [ $(($start + 1200)) -lt `date +%s` ]
+  do sleep 5
+  done
+  # Check if the firewall rule exists and fail if it does not.
+  gcloud compute firewall-rules describe "${MINION_TAG}-${INSTANCE_PREFIX}-http-alt"
 
   # Open up the NodePort range
   # TODO(justinsb): Move to main setup, if we decide whether we want to do this by default.
+  start=`date +%s`
   gcloud compute firewall-rules create \
     --project "${PROJECT}" \
     --target-tags "${MINION_TAG}" \
     --allow tcp:30000-32767,udp:30000-32767 \
     --network "${NETWORK}" \
-    "${MINION_TAG}-${INSTANCE_PREFIX}-nodeports"
+    "${MINION_TAG}-${INSTANCE_PREFIX}-nodeports" 2> /dev/null || true
+  # As there is no simple way to wait longer for this operation we need to manually
+  # wait some additional time (20 minutes altogether).
+  until gcloud compute firewall-rules describe "${MINION_TAG}-${INSTANCE_PREFIX}-nodeports" 2> /dev/null || [ $(($start + 1200)) -lt `date +%s` ]
+  do sleep 5
+  done
+  # Check if the firewall rule exists and fail if it does not.
+  gcloud compute firewall-rules describe "${MINION_TAG}-${INSTANCE_PREFIX}-nodeports"
 }
 
 # Execute after running tests to perform any required clean-up. This is called


### PR DESCRIPTION
This should fix failing cluster creations in scalability jenkins job.

@quinton-hoole @roberthbailey @wojtek-t 
