### PR TITLE
Automatically lookup cluster DNS/Domain service

### DIFF
--- a/cluster/addons/dns/README.md
+++ b/cluster/addons/dns/README.md
@@ -65,10 +65,13 @@ Of course, giving services a name is just half of the problem - DNS names need a
 domain also.  This implementation uses a configurable local domain, which can
 also be passed to containers by kubelet as a DNS search suffix.
 
+Kubelets automatically find the DNS server by looking for a service in the default
+namespace called `kubernetes-dns`. The DNS domain is found by looking at an
+annotation on that service called `kubernetes.io/cluster-domain`.
+
 ## How do I configure it?
 The easiest way to use DNS is to use a supported kubernetes cluster setup,
-which should have the required logic to read some config variables and plumb
-them all the way down to kubelet.
+which should have the required logic to read some config variables.
 
 Supported environments offer the following config flags, which are used at
 cluster turn-up to create the SkyDNS pods and configure the kubelets.  For
@@ -85,15 +88,9 @@ This enables DNS with a DNS Service IP of `10.0.0.10` and a local domain of
 `cluster.local`, served by a single copy of SkyDNS.
 
 If you are not using a supported cluster setup, you will have to replicate some
-of this yourself.  First, each kubelet needs to run with the following flags
-set:
+of this yourself.
 
-```
---cluster_dns=<DNS service ip>
---cluster_domain=<default local domain>
-```
-
-Second, you need to start the DNS server ReplicationController and Service. See
+First, you need to start the DNS server ReplicationController and Service. See
 the example files ([ReplicationController](skydns-rc.yaml.in) and
 [Service](skydns-svc.yaml.in)), but keep in mind that these are templated for
 Salt.  You will need to replace the `{{ <param> }}` blocks with your own values

--- a/cluster/addons/dns/skydns-svc.yaml.in
+++ b/cluster/addons/dns/skydns-svc.yaml.in
@@ -1,12 +1,14 @@
 apiVersion: v1beta3
 kind: Service
 metadata:
-  name: kube-dns
+  name: kubernetes-dns
   namespace: default
   labels:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "KubeDNS"
+  annotations:
+    kubernetes.io/cluster-domain: {{ pillar['dns_domain'] }}
 spec:
   selector:
     k8s-app: kube-dns

--- a/cluster/ubuntu/skydns-svc.yaml.template
+++ b/cluster/ubuntu/skydns-svc.yaml.template
@@ -1,6 +1,6 @@
 kind: Service
 apiVersion: v1beta1
-id: kube-dns
+id: kubernetes-dns
 namespace: default
 protocol: UDP
 port: 53
@@ -10,5 +10,7 @@ labels:
   k8s-app: kube-dns
   name: kube-dns
   kubernetes.io/cluster-service: "true"
+annotations:
+  kubernetes.io/cluster-domain: {{ pillar['dns_domain'] }}
 selector:
   k8s-app: kube-dns

--- a/docs/accessing-the-cluster.md
+++ b/docs/accessing-the-cluster.md
@@ -162,7 +162,7 @@ $ kubectl cluster-info
   Kubernetes master is running at https://104.197.5.247
   elasticsearch-logging is running at https://104.197.5.247/api/v1/proxy/namespaces/default/services/elasticsearch-logging
   kibana-logging is running at https://104.197.5.247/api/v1/proxy/namespaces/default/services/kibana-logging
-  kube-dns is running at https://104.197.5.247/api/v1/proxy/namespaces/default/services/kube-dns
+  kubernetes-dns is running at https://104.197.5.247/api/v1/proxy/namespaces/default/services/kubernetes-dns
   grafana is running at https://104.197.5.247/api/v1/proxy/namespaces/default/services/monitoring-grafana
   heapster is running at https://104.197.5.247/api/v1/proxy/namespaces/default/services/monitoring-heapster
 ```

--- a/docs/getting-started-guides/gce.md
+++ b/docs/getting-started-guides/gce.md
@@ -102,7 +102,7 @@ should show a set of [services](../services.md) that look something like this:
 NAME                    LABELS                                                                                              SELECTOR                        IP(S)            PORT(S)
 elasticsearch-logging   k8s-app=elasticsearch-logging,kubernetes.io/cluster-service=true,kubernetes.io/name=Elasticsearch   k8s-app=elasticsearch-logging   10.0.198.255     9200/TCP
 kibana-logging          k8s-app=kibana-logging,kubernetes.io/cluster-service=true,kubernetes.io/name=Kibana                 k8s-app=kibana-logging          10.0.56.44       5601/TCP
-kube-dns                k8s-app=kube-dns,kubernetes.io/cluster-service=true,kubernetes.io/name=KubeDNS                      k8s-app=kube-dns                10.0.0.10        53/UDP
+kubernetes-dns          k8s-app=kube-dns,kubernetes.io/cluster-service=true,kubernetes.io/name=KubeDNS                      k8s-app=kube-dns                10.0.0.10        53/UDP
 kubernetes              component=apiserver,provider=kubernetes                                                             <none>                          10.0.0.1         443/TCP
 ```
 

--- a/examples/logging-demo/README.md
+++ b/examples/logging-demo/README.md
@@ -163,7 +163,7 @@ $ kubectl cluster-info
 Kubernetes master is running at https://104.154.60.226
 Elasticsearch is running at https://104.154.60.226/api/v1/proxy/namespaces/default/services/elasticsearch-logging
 Kibana is running at https://104.154.60.226/api/v1/proxy/namespaces/default/services/kibana-logging
-KubeDNS is running at https://104.154.60.226/api/v1/proxy/namespaces/default/services/kube-dns
+KubeDNS is running at https://104.154.60.226/api/v1/proxy/namespaces/default/services/kubernetes-dns
 ```
 
 To find the user name and password to access the URLs,


### PR DESCRIPTION
Lookup Cluster DNS Service if not specified on command line.

This avoids the need to meticulously:
1. Allocate and choose a cluster DNS IP
2. Reconfigure kubelet `--cluster-dxxxx` startup args on all nodes

We now lookup the cluster DNS IP and cluster Domain from the Services in Kubernetes. This happens if a kubelet did not receive `--cluster-dns` and `--cluster-domain` arguments on the command line.

The DNS service must be called 'kubernetes-dns' and be in the 'default' namespace to be found. The service's ClusterIP is used as the DNS IP address. The following label on the service is used as the domain name:

```
 kubernetes.io/cluster-domain = example.local
```

This eases deployment of new kubernetes nodes, by removing variables that need to be configured when deploying nodes.

This is a backwards compatible change.
