### PR TITLE
Counter pod used in logging blog article

### DIFF
--- a/examples/blog-logging/counter-pod.yaml
+++ b/examples/blog-logging/counter-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: counter
+spec:
+  containers:
+  - name: count
+    image: ubuntu:14.04
+    args: [bash, -c, 
+           'for ((i = 0; ; i++)); do echo "$i: $(date)"; sleep 1; done']
+
+


### PR DESCRIPTION
I'd like this example file to be available to it can be accessed by the logging blog article.
