### PR TITLE
stabilization of Network.should survive network partition.

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -378,6 +378,7 @@ func createTestingNS(baseName string, c *client.Client) (*api.Namespace, error) 
 func waitForPodRunningInNamespace(c *client.Client, podName string, namespace string) error {
 	return waitForPodCondition(c, namespace, podName, "running", podStartTimeout, func(pod *api.Pod) (bool, error) {
 		if pod.Status.Phase == api.PodRunning {
+			Logf("Found pod '%s' on node '%s'", podName, pod.Spec.NodeName)
 			return true, nil
 		}
 		if pod.Status.Phase == api.PodFailed {


### PR DESCRIPTION
fixes #9487

@jszczepkowski is a good person for review.

@lavalamp please have a look if my assumptions, stated in comments, about the scheduler are valid (in the last step we want to check if new pods can be scheduled on the node that has just recovered from network partition - this is an important check so we can't just remove it; but maybe we can still improve it).
