### PR TITLE
Create ProxyProvider abstraction.

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -95,7 +95,18 @@ func (s *ProxyServer) Run(_ []string) error {
 	if net.IP(s.BindAddress).To4() == nil {
 		protocol = iptables.ProtocolIpv6
 	}
+
+	// TODO: these will be conditionally created as particular implementations.
+	// See https://github.com/GoogleCloudPlatform/kubernetes/issues/3760
+	var proxier proxy.ProxyProvider
+	var loadBalancerHandler config.EndpointsConfigHandler
+
+	// This is a proxy.LoadBalancer which NewProxier needs but has methods we don't need for
+	// our config.EndpointsConfigHandler.
 	loadBalancer := proxy.NewLoadBalancerRR()
+	// set EndpointsConfigHandler to our loadBalancer
+	loadBalancerHandler = loadBalancer
+
 	proxier, err := proxy.NewProxier(loadBalancer, net.IP(s.BindAddress), iptables.New(exec.New(), protocol), s.PortRange)
 	if err != nil {
 		glog.Fatalf("Unable to create proxer: %v", err)
@@ -104,7 +115,7 @@ func (s *ProxyServer) Run(_ []string) error {
 	// Wire proxier to handle changes to services
 	serviceConfig.RegisterHandler(proxier)
 	// And wire loadBalancer to handle changes to endpoints to services
-	endpointsConfig.RegisterHandler(loadBalancer)
+	endpointsConfig.RegisterHandler(loadBalancerHandler)
 
 	// Note: RegisterHandler() calls need to happen before creation of Sources because sources
 	// only notify on changes, and the initial update (on process start) may be lost if no handlers

--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -64,6 +64,7 @@ func logTimeout(err error) bool {
 
 // Proxier is a simple proxy for TCP connections between a localhost:lport
 // and services that provide the actual implementations.
+// Implements ProxyProvider interface.
 type Proxier struct {
 	loadBalancer  LoadBalancer
 	mu            sync.Mutex // protects serviceMap

--- a/pkg/proxy/proxyprovider.go
+++ b/pkg/proxy/proxyprovider.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+//ProxyProvider is the interface provided by proxier implementations.
+type ProxyProvider interface {
+	OnUpdate(services []api.Service)
+	SyncLoop()
+}


### PR DESCRIPTION
Part of splitting up https://github.com/GoogleCloudPlatform/kubernetes/pull/9210 into smaller PRs this provides an interface for proxy implementations to implement.
