### PR TITLE
Add ability to select AWS profile

### DIFF
--- a/docs/getting-started-guides/aws.md
+++ b/docs/getting-started-guides/aws.md
@@ -51,6 +51,13 @@ Getting started on AWS EC2
 2. Install and configure [AWS Command Line Interface](http://aws.amazon.com/cli)
 3. You need an AWS [instance profile and role](http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html) with EC2 full access.
 
+NOTE: This script use the 'default' AWS profile by default.
+You may explicitly set AWS profile to use using the `AWS_DEFAULT_PROFILE` environment variable:
+
+```bash
+export AWS_DEFAULT_PROFILE=myawsprofile
+```
+
 ## Cluster turnup
 
 ### Supported procedure: `get-kube`


### PR DESCRIPTION
`aws-cli` allows to setup named credential pairs which is quite useful. Let's utilize this cool feature.
