### PR TITLE
Remove raw binaries from distro that are already included in docker image

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -648,6 +648,9 @@ function kube::release::create_docker_images_for_server() {
 
         kube::log::status "Deleting docker image ${docker_image_tag}"
         "${DOCKER[@]}" rmi ${docker_image_tag} 2>/dev/null || true
+
+        # Now, that we have created docker images we can safely delete raw binary.
+        rm -f $1/${binary_name}
       ) &
     done
 


### PR DESCRIPTION
Fixes #9253

To test whether this PR is correct I run build a release then run kube-up.sh and verified that scheduler, controller manager and apiserver run as expected.

@justinsb 
