### PR TITLE
Its bad to spawn a gofunc per quota with large number of quotas

### DIFF
--- a/pkg/resourcequota/resource_quota_controller.go
+++ b/pkg/resourcequota/resource_quota_controller.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resourcequota
 
 import (
-	"sync"
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -63,19 +62,13 @@ func (rm *ResourceQuotaManager) synchronize() {
 		glog.Errorf("Synchronization error: %v (%#v)", err, err)
 	}
 	resourceQuotas = list.Items
-	wg := sync.WaitGroup{}
-	wg.Add(len(resourceQuotas))
 	for ix := range resourceQuotas {
-		go func(ix int) {
-			defer wg.Done()
-			glog.V(4).Infof("periodic sync of %v/%v", resourceQuotas[ix].Namespace, resourceQuotas[ix].Name)
-			err := rm.syncHandler(resourceQuotas[ix])
-			if err != nil {
-				glog.Errorf("Error synchronizing: %v", err)
-			}
-		}(ix)
+		glog.V(4).Infof("periodic sync of %v/%v", resourceQuotas[ix].Namespace, resourceQuotas[ix].Name)
+		err := rm.syncHandler(resourceQuotas[ix])
+		if err != nil {
+			glog.Errorf("Error synchronizing: %v", err)
+		}
 	}
-	wg.Wait()
 }
 
 // FilterQuotaPods eliminates pods that no longer have a cost against the quota


### PR DESCRIPTION
**Scenario:**
1. Create 500 namespaces
2. Create a quota per namespace
3. Wait

**Result:**
System crashes

**Cause:**
We had a legacy pattern of creating a gofunc per quota during every synch period.

**Fix:**
Process quota updates in sequence during synch loop.

**Related issue:**
https://github.com/openshift/origin/issues/3126

**Future enhancements:**
I have other optimization strategies in mind, but this stops bleeding and stabilizes the system.

/cc @smarterclayton 
