### PR TITLE
Refactor Routes, and dynamically configure minion CIDRs on AWS

### DIFF
--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -41,10 +41,10 @@ MASTER_NAME="${INSTANCE_PREFIX}-master"
 MINION_NAMES=($(eval echo ${INSTANCE_PREFIX}-minion-{1..${NUM_MINIONS}}))
 MASTER_TAG="${INSTANCE_PREFIX}-master"
 MINION_TAG="${INSTANCE_PREFIX}-minion"
-MINION_IP_RANGES=($(eval echo "10.244.{1..${NUM_MINIONS}}.0/24"))
 MINION_SCOPES=""
 POLL_SLEEP_INTERVAL=3
 SERVICE_CLUSTER_IP_RANGE="10.0.0.0/16"  # formerly PORTAL_NET
+CLUSTER_IP_RANGE="${CLUSTER_IP_RANGE:-10.244.0.0/16}"
 MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
 # If set to Elastic IP, master instance will be associated with this IP.
 # If set to auto, a new Elastic IP will be aquired

--- a/cluster/aws/config-test.sh
+++ b/cluster/aws/config-test.sh
@@ -37,10 +37,10 @@ MASTER_NAME="${INSTANCE_PREFIX}-master"
 MINION_NAMES=($(eval echo ${INSTANCE_PREFIX}-minion-{1..${NUM_MINIONS}}))
 MASTER_TAG="${INSTANCE_PREFIX}-master"
 MINION_TAG="${INSTANCE_PREFIX}-minion"
-MINION_IP_RANGES=($(eval echo "10.244.{1..${NUM_MINIONS}}.0/24"))
 MINION_SCOPES=""
 POLL_SLEEP_INTERVAL=3
 SERVICE_CLUSTER_IP_RANGE="10.0.0.0/16"  # formerly PORTAL_NET
+CLUSTER_IP_RANGE="${CLUSTER_IP_RANGE:-10.245.0.0/16}"
 MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
 # If set to Elastic IP, master instance will be associated with this IP.
 # If set to auto, a new Elastic IP will be aquired

--- a/cluster/aws/coreos/util.sh
+++ b/cluster/aws/coreos/util.sh
@@ -30,8 +30,8 @@ function detect-minion-image (){
 
 function generate-minion-user-data() {
   i=$1
+  # TODO(bakins): Is this actually used?
   MINION_PRIVATE_IP=$INTERNAL_IP_BASE.1${i}
-  MINION_IP_RANGE=${MINION_IP_RANGES[$i]}
 
   # this is a bit of a hack. We make all of our "variables" in
   # our cloud config controlled by env vars from this script
@@ -44,7 +44,6 @@ function generate-minion-user-data() {
       DNS_SERVER_IP=$(yaml-quote ${DNS_SERVER_IP:-})
       DNS_DOMAIN=$(yaml-quote ${DNS_DOMAIN:-})
       MASTER_IP=$(yaml-quote ${MASTER_INTERNAL_IP})
-      MINION_IP_RANGE=$(yaml-quote ${MINION_IP_RANGE})
       MINION_IP=$(yaml-quote ${MINION_PRIVATE_IP})
       KUBELET_TOKEN=$(yaml-quote ${KUBELET_TOKEN:-})
       KUBE_PROXY_TOKEN=$(yaml-quote ${KUBE_PROXY_TOKEN:-})

--- a/cluster/aws/templates/create-dynamic-salt-files.sh
+++ b/cluster/aws/templates/create-dynamic-salt-files.sh
@@ -22,6 +22,8 @@ mkdir -p /srv/salt-overlay/pillar
 cat <<EOF >/srv/salt-overlay/pillar/cluster-params.sls
 instance_prefix: '$(echo "$INSTANCE_PREFIX" | sed -e "s/'/''/g")'
 node_instance_prefix: '$(echo "$NODE_INSTANCE_PREFIX" | sed -e "s/'/''/g")'
+cluster_cidr: '$(echo "$CLUSTER_IP_RANGE" | sed -e "s/'/''/g")'
+allocate_node_cidrs: '$(echo "$ALLOCATE_NODE_CIDRS" | sed -e "s/'/''/g")'
 service_cluster_ip_range: '$(echo "$SERVICE_CLUSTER_IP_RANGE" | sed -e "s/'/''/g")'
 enable_cluster_monitoring: '$(echo "$ENABLE_CLUSTER_MONITORING" | sed -e "s/'/''/g")'
 enable_node_monitoring: '$(echo "$ENABLE_NODE_MONITORING" | sed -e "s/'/''/g")'

--- a/cluster/aws/templates/salt-minion.sh
+++ b/cluster/aws/templates/salt-minion.sh
@@ -26,7 +26,7 @@ cat <<EOF >/etc/salt/minion.d/grains.conf
 grains:
   roles:
     - kubernetes-pool
-  cbr-cidr: $MINION_IP_RANGE
+  cbr-cidr: 10.123.45.0/30
   cloud: aws
 EOF
 

--- a/cluster/aws/ubuntu/common.sh
+++ b/cluster/aws/ubuntu/common.sh
@@ -29,7 +29,6 @@ function generate-minion-user-data {
   # We pipe this to the ami as a startup script in the user-data field.  Requires a compatible ami
   echo "#! /bin/bash"
   echo "SALT_MASTER='${MASTER_INTERNAL_IP}'"
-  echo "MINION_IP_RANGE='${MINION_IP_RANGES[$i]}'"
   echo "DOCKER_OPTS='${EXTRA_DOCKER_OPTS:-}'"
   echo "readonly DOCKER_STORAGE='${DOCKER_STORAGE:-}'"
   grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/common.sh"

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -86,6 +86,10 @@ type EC2 interface {
 	DescribeSubnets(*ec2.DescribeSubnetsInput) ([]*ec2.Subnet, error)
 
 	CreateTags(*ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error)
+
+	DescribeRouteTables(request *ec2.DescribeRouteTablesInput) ([]*ec2.RouteTable, error)
+	CreateRoute(request *ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error)
+	DeleteRoute(request *ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error)
 }
 
 // This is a simple pass-through of the ELB client interface, which allows for testing
@@ -393,6 +397,23 @@ func (s *awsSdkEC2) CreateTags(request *ec2.CreateTagsInput) (*ec2.CreateTagsOut
 	return s.ec2.CreateTags(request)
 }
 
+func (s *awsSdkEC2) DescribeRouteTables(request *ec2.DescribeRouteTablesInput) ([]*ec2.RouteTable, error) {
+	// Not paged
+	response, err := s.ec2.DescribeRouteTables(request)
+	if err != nil {
+		return nil, fmt.Errorf("error listing AWS route tables: %v", err)
+	}
+	return response.RouteTables, nil
+}
+
+func (s *awsSdkEC2) CreateRoute(request *ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error) {
+	return s.ec2.CreateRoute(request)
+}
+
+func (s *awsSdkEC2) DeleteRoute(request *ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error) {
+	return s.ec2.DeleteRoute(request)
+}
+
 func init() {
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
 		creds := credentials.NewChainCredentials(
@@ -550,7 +571,7 @@ func (aws *AWSCloud) Zones() (cloudprovider.Zones, bool) {
 
 // Routes returns an implementation of Routes for Amazon Web Services.
 func (aws *AWSCloud) Routes() (cloudprovider.Routes, bool) {
-	return nil, false
+	return aws, true
 }
 
 // NodeAddresses is an implementation of Instances.NodeAddresses.

--- a/pkg/cloudprovider/aws/aws_routes.go
+++ b/pkg/cloudprovider/aws/aws_routes.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws_cloud
+
+import (
+	"fmt"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+func (s *AWSCloud) findRouteTable(clusterName string) (*ec2.RouteTable, error) {
+	request := &ec2.DescribeRouteTablesInput{}
+	filters := []*ec2.Filter{}
+	// This should be unnecessary (we already filter on TagNameKubernetesCluster,
+	// and something is broken if cluster name doesn't match, but anyway...
+	// TODO: All clouds should be cluster-aware by default
+	filters = append(filters, newEc2Filter("tag:"+TagNameKubernetesCluster, clusterName))
+	request.Filters = s.addFilters(filters)
+
+	tables, err := s.ec2.DescribeRouteTables(request)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(tables) == 0 {
+		return nil, fmt.Errorf("unable to find route table for AWS cluster: %s", clusterName)
+	}
+
+	if len(tables) != 1 {
+		return nil, fmt.Errorf("found multiple matching AWS route tables for AWS cluster: %s", clusterName)
+	}
+	return tables[0], nil
+}
+
+// ListRoutes implements Routes.ListRoutes
+// List all routes that match the filter
+func (s *AWSCloud) ListRoutes(clusterName string) ([]*cloudprovider.Route, error) {
+	table, err := s.findRouteTable(clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	var routes []*cloudprovider.Route
+	for _, r := range table.Routes {
+		instanceID := orEmpty(r.InstanceID)
+		destinationCIDR := orEmpty(r.DestinationCIDRBlock)
+
+		if instanceID == "" || destinationCIDR == "" {
+			continue
+		}
+
+		routeName := clusterName + "-" + destinationCIDR
+		routes = append(routes, &cloudprovider.Route{routeName, instanceID, destinationCIDR})
+	}
+
+	return routes, nil
+}
+
+// CreateRoute implements Routes.CreateRoute
+// Create the described route
+func (s *AWSCloud) CreateRoute(clusterName string, nameHint string, route *cloudprovider.Route) error {
+	table, err := s.findRouteTable(clusterName)
+	if err != nil {
+		return err
+	}
+
+	request := &ec2.CreateRouteInput{}
+	// TODO: use ClientToken for idempotency?
+	request.DestinationCIDRBlock = aws.String(route.DestinationCIDR)
+	request.InstanceID = aws.String(route.TargetInstance)
+	request.RouteTableID = table.RouteTableID
+
+	_, err = s.ec2.CreateRoute(request)
+	if err != nil {
+		return fmt.Errorf("error creating AWS route (%s): %v", route.DestinationCIDR, err)
+	}
+
+	return nil
+}
+
+// DeleteRoute implements Routes.DeleteRoute
+// Delete the specified route
+func (s *AWSCloud) DeleteRoute(clusterName string, route *cloudprovider.Route) error {
+	table, err := s.findRouteTable(clusterName)
+	if err != nil {
+		return err
+	}
+
+	request := &ec2.DeleteRouteInput{}
+	request.DestinationCIDRBlock = aws.String(route.DestinationCIDR)
+	request.RouteTableID = table.RouteTableID
+
+	_, err = s.ec2.DeleteRoute(request)
+	if err != nil {
+		return fmt.Errorf("error deleting AWS route (%s): %v", route.DestinationCIDR, err)
+	}
+
+	return nil
+}

--- a/pkg/cloudprovider/aws/aws_routes.go
+++ b/pkg/cloudprovider/aws/aws_routes.go
@@ -24,13 +24,11 @@ import (
 )
 
 func (s *AWSCloud) findRouteTable(clusterName string) (*ec2.RouteTable, error) {
-	request := &ec2.DescribeRouteTablesInput{}
-	filters := []*ec2.Filter{}
 	// This should be unnecessary (we already filter on TagNameKubernetesCluster,
 	// and something is broken if cluster name doesn't match, but anyway...
 	// TODO: All clouds should be cluster-aware by default
-	filters = append(filters, newEc2Filter("tag:"+TagNameKubernetesCluster, clusterName))
-	request.Filters = s.addFilters(filters)
+	filters := []*ec2.Filter{newEc2Filter("tag:"+TagNameKubernetesCluster, clusterName)}
+	request := &ec2.DescribeRouteTablesInput{Filters: s.addFilters(filters)}
 
 	tables, err := s.ec2.DescribeRouteTables(request)
 	if err != nil {

--- a/pkg/cloudprovider/aws/aws_test.go
+++ b/pkg/cloudprovider/aws/aws_test.go
@@ -360,6 +360,18 @@ func (ec2 *FakeEC2) CreateTags(*ec2.CreateTagsInput) (*ec2.CreateTagsOutput, err
 	panic("Not implemented")
 }
 
+func (s *FakeEC2) DescribeRouteTables(request *ec2.DescribeRouteTablesInput) ([]*ec2.RouteTable, error) {
+	panic("Not implemented")
+}
+
+func (s *FakeEC2) CreateRoute(request *ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error) {
+	panic("Not implemented")
+}
+
+func (s *FakeEC2) DeleteRoute(request *ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error) {
+	panic("Not implemented")
+}
+
 type FakeELB struct {
 	aws *FakeAWSServices
 }

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -119,6 +119,7 @@ type Instances interface {
 // Route is a representation of an advanced routing rule.
 type Route struct {
 	// Name is the name of the routing rule in the cloud-provider.
+	// It will be ignored in a Create (although nameHint may influence it)
 	Name string
 	// TargetInstance is the name of the instance as specified in routing rules
 	// for the cloud-provider (in gce: the Instance Name).
@@ -126,18 +127,19 @@ type Route struct {
 	// Destination CIDR is the CIDR format IP range that this routing rule
 	// applies to.
 	DestinationCIDR string
-	// Description is a free-form string. It can be useful for tagging Routes.
-	Description string
 }
 
 // Routes is an abstract, pluggable interface for advanced routing rules.
 type Routes interface {
-	// List all routes that match the filter
-	ListRoutes(filter string) ([]*Route, error)
-	// Create the described route
-	CreateRoute(route *Route) error
-	// Delete the specified route
-	DeleteRoute(name string) error
+	// List all managed routes that belong to the specified clusterName
+	ListRoutes(clusterName string) ([]*Route, error)
+	// Create the described managed route
+	// route.Name will be ignored, although the cloud-provider may use nameHint
+	// to create a more user-meaningful name.
+	CreateRoute(clusterName string, nameHint string, route *Route) error
+	// Delete the specified managed route
+	// Route should be as returned by ListRoutes
+	DeleteRoute(clusterName string, route *Route) error
 }
 
 var InstanceNotFound = errors.New("instance not found")

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -49,6 +49,8 @@ const (
 	INTERNAL_IP_METADATA_URL = "http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/ip"
 )
 
+const k8sNodeRouteTag = "k8s-node-route"
+
 // GCECloud is an implementation of Interface, TCPLoadBalancer and Instances for Google Compute Engine.
 type GCECloud struct {
 	service          *compute.Service
@@ -631,11 +633,19 @@ func getMetadataValue(metadata *compute.Metadata, key string) (string, bool) {
 	return "", false
 }
 
-func (gce *GCECloud) ListRoutes(filter string) ([]*cloudprovider.Route, error) {
-	listCall := gce.service.Routes.List(gce.projectID)
-	if len(filter) > 0 {
-		listCall = listCall.Filter("name eq " + filter)
+func truncateClusterName(clusterName string) string {
+	if len(clusterName) > 26 {
+		return clusterName[:26]
 	}
+	return clusterName
+}
+
+func (gce *GCECloud) ListRoutes(clusterName string) ([]*cloudprovider.Route, error) {
+	listCall := gce.service.Routes.List(gce.projectID)
+
+	prefix := truncateClusterName(clusterName)
+	listCall = listCall.Filter("name eq " + prefix + "-.*")
+
 	res, err := listCall.Do()
 	if err != nil {
 		return nil, err
@@ -645,21 +655,32 @@ func (gce *GCECloud) ListRoutes(filter string) ([]*cloudprovider.Route, error) {
 		if path.Base(r.Network) != gce.networkName {
 			continue
 		}
+		// Not managed if route description != "k8s-node-route"
+		if r.Description != k8sNodeRouteTag {
+			continue
+		}
+		// Not managed if route name doesn't start with <clusterName>
+		if !strings.HasPrefix(r.Name, prefix) {
+			continue
+		}
+
 		target := path.Base(r.NextHopInstance)
-		routes = append(routes, &cloudprovider.Route{r.Name, target, r.DestRange, r.Description})
+		routes = append(routes, &cloudprovider.Route{r.Name, target, r.DestRange})
 	}
 	return routes, nil
 }
 
-func (gce *GCECloud) CreateRoute(route *cloudprovider.Route) error {
+func (gce *GCECloud) CreateRoute(clusterName string, nameHint string, route *cloudprovider.Route) error {
+	routeName := truncateClusterName(clusterName) + "-" + nameHint
+
 	instanceName := canonicalizeInstanceName(route.TargetInstance)
 	insertOp, err := gce.service.Routes.Insert(gce.projectID, &compute.Route{
-		Name:            route.Name,
+		Name:            routeName,
 		DestRange:       route.DestinationCIDR,
 		NextHopInstance: fmt.Sprintf("zones/%s/instances/%s", gce.zone, instanceName),
 		Network:         fmt.Sprintf("global/networks/%s", gce.networkName),
 		Priority:        1000,
-		Description:     route.Description,
+		Description:     k8sNodeRouteTag,
 	}).Do()
 	if err != nil {
 		return err
@@ -667,9 +688,8 @@ func (gce *GCECloud) CreateRoute(route *cloudprovider.Route) error {
 	return gce.waitForGlobalOp(insertOp)
 }
 
-func (gce *GCECloud) DeleteRoute(name string) error {
-	instanceName := canonicalizeInstanceName(name)
-	deleteOp, err := gce.service.Routes.Delete(gce.projectID, instanceName).Do()
+func (gce *GCECloud) DeleteRoute(clusterName string, route *cloudprovider.Route) error {
+	deleteOp, err := gce.service.Routes.Delete(gce.projectID, route.Name).Do()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
WIP (edit: no longer, depended on 9728, now merged) but would greatly appreciate comments on the refactoring of the Routes interface (the first commit).  We assumed that routes have settable names, but that isn't the case everywhere.  I think the code is cleaner for the refactor.
