### PR TITLE
AWS: Use RSA to Generate Fingerprint

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -263,7 +263,7 @@ function detect-ubuntu-image () {
 # Hopefully this will be done by the aws cli tool one day: https://github.com/aws/aws-cli/issues/191
 function get-aws-fingerprint {
   local -r pubkey_path=$1
-  ssh-keygen -f ${pubkey_path} -e -m PKCS8  | openssl pkey -pubin -outform DER | openssl md5 -c | sed -e 's/(stdin)= //g'
+  ssh-keygen -f ${pubkey_path} -e -m PKCS8  | openssl rsa -pubin -outform DER | openssl md5 -c | sed -e 's/(stdin)= //g'
 }
 
 # Import an SSH public key to AWS.


### PR DESCRIPTION
I took the daring leap into OS X 10.11 and found that `openssl` no longer supports the pkey command.  Update the aws script to use `rsa` instead which seems to be functionally equivalent. I verified rsa exists on older OS X and ubuntu as well and all seem to produce the same output.

@justinsb PTAL
