### PR TITLE
AWS: Stop the master kubelet from registering as a node (like GCE does)

### DIFF
--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -22,13 +22,13 @@
   {% set api_servers_with_port = api_servers + ":6443" -%}
 {% endif -%}
 
-# Disable registration for the kubelet running on the master on GCE. Also disable
+# Disable registration for the kubelet running on the master on AWS, GCE, Vagrant. Also disable
 # the debugging handlers (/run and /exec) to prevent arbitrary code execution on
 # the master.
 # TODO(roberthbailey): Make this configurable via an env var in config-default.sh
 
 {% set debugging_handlers = "--enable-debugging-handlers=true" -%}
-{% if grains.cloud in ['gce', 'vagrant'] -%}
+{% if grains.cloud in ['aws', 'gce', 'vagrant'] -%}
   {% if grains['roles'][0] == 'kubernetes-master' -%}
     {% set api_servers_with_port = "" -%}
     {% set debugging_handlers = "--enable-debugging-handlers=false" -%}


### PR DESCRIPTION
For parity with GCE.  Also means that master pods don't appear in kubectl get pods (just like GCE).
