### PR TITLE
TestCreateCleanWithPrefix was failing if env variables existed

### DIFF
--- a/pkg/client/clientcmd/client_config_test.go
+++ b/pkg/client/clientcmd/client_config_test.go
@@ -162,8 +162,11 @@ func TestCreateCleanWithPrefix(t *testing.T) {
 		{"anything.com:8080", "anything.com:8080", ""},
 		{"anything.com", "anything.com", ""},
 		{"anything", "anything", ""},
-		{"", "http://localhost:8080", ""},
 	}
+
+	// WARNING: EnvVarCluster.Server is set during package loading time and can not be overriden by os.Setenv inside this test
+	EnvVarCluster.Server = ""
+	tt = append(tt, struct{ server, host, prefix string }{"", "http://localhost:8080", ""})
 
 	for _, tc := range tt {
 		config := createValidTestConfig()


### PR DESCRIPTION
Refs #9578

`DirectClientConfig` is automatically loading environmental variables that might mess up with tests. This PR is adding an extra bool to ignore the environment.

Thanks to @jdef for the idea

/cc @ghodss 
