### PR TITLE
Update docker k8s approach

### DIFF
--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -5,6 +5,7 @@ VERSION=v0.18.2
 all:
 	cp ../../saltbase/salt/helpers/safe_format_and_mount .
 	curl -O https://storage.googleapis.com/kubernetes-release/release/${VERSION}/bin/linux/amd64/hyperkube
+	sed -i "s/VERSION/${VERSION}/g" master-multi.json master.json
 	docker build -t gcr.io/google_containers/hyperkube:${VERSION} .
 	gcloud preview docker push gcr.io/google_containers/hyperkube:${VERSION}
 

--- a/cluster/images/hyperkube/master-multi.json
+++ b/cluster/images/hyperkube/master-multi.json
@@ -7,7 +7,7 @@
   "containers":[
     {
       "name": "controller-manager",
-      "image": "gcr.io/google_containers/hyperkube:v0.18.2",
+      "image": "gcr.io/google_containers/hyperkube:VERSION",
       "command": [
               "/hyperkube",
               "controller-manager",
@@ -19,7 +19,7 @@
     },
     {
       "name": "apiserver",
-      "image": "gcr.io/google_containers/hyperkube:v0.18.2",
+      "image": "gcr.io/google_containers/hyperkube:VERSION",
       "command": [
               "/hyperkube",
               "apiserver",
@@ -32,7 +32,7 @@
     },
     {
       "name": "scheduler",
-      "image": "gcr.io/google_containers/hyperkube:v0.18.2",
+      "image": "gcr.io/google_containers/hyperkube:VERSION",
       "command": [
               "/hyperkube",
               "scheduler",

--- a/cluster/images/hyperkube/master.json
+++ b/cluster/images/hyperkube/master.json
@@ -7,7 +7,7 @@
   "containers":[
     {
       "name": "controller-manager",
-      "image": "gcr.io/google_containers/hyperkube:v0.18.2",
+      "image": "gcr.io/google_containers/hyperkube:VERSION",
       "command": [
               "/hyperkube",
               "controller-manager",
@@ -19,7 +19,7 @@
     },
     {
       "name": "apiserver",
-      "image": "gcr.io/google_containers/hyperkube:v0.18.2",
+      "image": "gcr.io/google_containers/hyperkube:VERSION",
       "command": [
               "/hyperkube",
               "apiserver",
@@ -32,7 +32,7 @@
     },
     {
       "name": "scheduler",
-      "image": "gcr.io/google_containers/hyperkube:v0.18.2",
+      "image": "gcr.io/google_containers/hyperkube:VERSION",
       "command": [
               "/hyperkube",
               "scheduler",

--- a/docs/getting-started-guides/docker-multinode/master.md
+++ b/docs/getting-started-guides/docker-multinode/master.md
@@ -131,8 +131,8 @@ kubectl get nodes
 
 This should print:
 ```
-NAME        LABELS    STATUS
-127.0.0.1   <none>    Ready
+NAME        LABELS                             STATUS
+127.0.0.1   kubernetes.io/hostname=127.0.0.1   Ready
 ```
 
 If the status of the node is ```NotReady``` or ```Unknown``` please check that all of the containers you created are successfully running.

--- a/docs/getting-started-guides/docker-multinode/testing.md
+++ b/docs/getting-started-guides/docker-multinode/testing.md
@@ -8,9 +8,9 @@ kubectl get nodes
 
 That should show something like:
 ```
-NAME           LABELS    STATUS
-10.240.99.26   <none>    Ready
-127.0.0.1      <none>    Ready
+NAME           LABELS                                 STATUS
+10.240.99.26   kubernetes.io/hostname=10.240.99.26    Ready
+127.0.0.1      kubernetes.io/hostname=127.0.0.1       Ready
 ```
 
 If the status of any node is ```Unknown``` or ```NotReady``` your cluster is broken, double check that all containers are running properly, and if all else fails, contact us on IRC at

--- a/docs/getting-started-guides/docker-multinode/worker.md
+++ b/docs/getting-started-guides/docker-multinode/worker.md
@@ -103,31 +103,6 @@ The service proxy provides load-balancing between groups of containers defined b
 sudo docker run -d --net=host --privileged gcr.io/google_containers/hyperkube:v0.18.2 /hyperkube proxy --master=http://${MASTER_IP}:8080 --v=2
 ```
 
-
-### Add the node to the cluster
-
-On the master you created above, create a file named ```node.yaml``` make it's contents:
-
-```yaml
-apiVersion: v1
-kind: Node
-metadata:
-  name: ${NODE_IP}
-spec:
-  externalID: ${NODE_IP}
-status:
-  # Fill in appropriate values below
-  capacity:
-    cpu: "1"
-    memory: 3Gi
-```
-
-Make the API call to add the node, you should do this on the master node that you created above.  Otherwise you need to add ```-s=http://${MASTER_IP}:8080``` to point ```kubectl``` at the master.
-
-```sh
-./kubectl create -f node.yaml
-```
-
 ### Next steps
 
 Move on to [testing your cluster](testing.md) or [add another node](#adding-a-kubernetes-worker-node-via-docker)


### PR DESCRIPTION
Changes:
1 use `sed` to automatically replace the K8S version in master-multi.json and master.json
2 update the `kubectl get nodes` output with label exist.
3 remove the manually adding nodes procedure.Because since 0.18.2 the node can do self-register. `kubectl create -f node.yaml` will fail due to node already exists.
@brendandburns
