### PR TITLE
Fix mesos plugin-test race

### DIFF
--- a/contrib/mesos/pkg/scheduler/plugin_test.go
+++ b/contrib/mesos/pkg/scheduler/plugin_test.go
@@ -120,7 +120,11 @@ func NewMockPodsListWatch(initialPodList api.PodList) *MockPodsListWatch {
 			return lw.fakeWatcher, nil
 		},
 		ListFunc: func() (runtime.Object, error) {
-			return &lw.list, nil
+			lw.lock.Lock()
+			defer lw.lock.Unlock()
+
+			listCopy, err := api.Scheme.DeepCopy(&lw.list)
+			return listCopy.(*api.PodList), err
 		},
 	}
 	return &lw


### PR DESCRIPTION
ListWatch returned the internal list of the MockPodsListWatch object, leading
to a race. Fixes travis builds.

Closes mesosphere/kubernetes-mesos#354
