### PR TITLE
Improve error output of kubectl update

### DIFF
--- a/pkg/kubectl/cmd/update.go
+++ b/pkg/kubectl/cmd/update.go
@@ -48,7 +48,7 @@ func NewCmdUpdate(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 		Example: update_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunUpdate(f, out, cmd, args, filenames)
-			cmdutil.CheckErr(err)
+			cmdutil.CheckCustomErr("Update failed", err)
 		},
 	}
 	usage := "Filename, directory, or URL to file to use to update the resource."


### PR DESCRIPTION
This PR addresses issue #9721 to improve theerror  output of `kubectl update`.
`NewCmdUpdate` is changed to used a modified version of `CheckErr` called `CheckCustomErr` which can accept a custom error prefix message. Unfortunately, the text segment we want to report ("may not update fields other than container.image") which is originally stored in a separate field is unfortunately conflated with a larger text message that includes details of the spec being updated.  To avoid making significant changes to the error types used in the code base I decided to do the horrible but expedient thing: extract out the required string by looking for text after "}': ". Now the error message is:

```
$ kubectl update -f counter-pod.yaml 
Update failed: may not update fields other than container.image
```

which is exactly what @erictune requested.
