### PR TITLE
Fixed pointers bug in PATCH verb in the API

### DIFF
--- a/pkg/util/strategicpatch/patch.go
+++ b/pkg/util/strategicpatch/patch.go
@@ -100,6 +100,11 @@ func mergeMap(original, patch map[string]interface{}, t reflect.Type) (map[strin
 			original[k] = patchV
 			continue
 		}
+		// If the data type is a pointer, resolve the element.
+		if t.Kind() == reflect.Ptr {
+			t = t.Elem()
+		}
+
 		// If they're both maps or lists, recurse into the value.
 		// First find the fieldPatchStrategy and fieldPatchMergeKey.
 		fieldType, fieldPatchStrategy, fieldPatchMergeKey, err := forkedjson.LookupPatchMetadata(t, k)

--- a/pkg/util/strategicpatch/patch_test.go
+++ b/pkg/util/strategicpatch/patch_test.go
@@ -51,6 +51,7 @@ type MergeItem struct {
 	NonMergingList    []MergeItem
 	MergingIntList    []int `patchStrategy:"merge"`
 	NonMergingIntList []int
+	MergeItemPtr      *MergeItem `patchStrategy:"merge" patchMergeKey:"name"`
 	SimpleMap         map[string]string
 }
 
@@ -232,6 +233,41 @@ strategicMergePatchCases:
         - $patch: replace
     result:
       mergingList: []
+  - description: add new field inside pointers
+    original:
+      mergeItemPtr:
+        - name: 1
+    patch:
+      mergeItemPtr:
+        - name: 2
+    result:
+      mergeItemPtr:
+        - name: 1
+        - name: 2
+  - description: update nested pointers
+    original:
+      mergeItemPtr:
+        - name: 1
+          mergeItemPtr:
+            - name: 1
+            - name: 2
+              value: 2
+        - name: 2
+    patch:
+      mergeItemPtr:
+        - name: 1
+          mergeItemPtr:
+            - name: 1
+              value: 1
+    result:
+      mergeItemPtr:
+        - name: 1
+          mergeItemPtr:
+            - name: 1
+              value: 1
+            - name: 2
+              value: 2
+        - name: 2
 sortMergeListTestCases:
   - description: sort one list of maps
     original:
@@ -351,6 +387,40 @@ sortMergeListTestCases:
             - 1
             - 2
             - 3
+  - description: sort nested pointers of ints
+    original:
+      mergeItemPtr:
+        - name: 2
+          mergingIntList:
+            - 1
+            - 3
+            - 2
+        - name: 1
+          mergingIntList:
+            - 2
+            - 1
+    sorted:
+      mergeItemPtr:
+        - name: 1
+          mergingIntList:
+            - 1
+            - 2
+        - name: 2
+          mergingIntList:
+            - 1
+            - 2
+            - 3
+  - description: sort one pointer of maps
+    original:
+      mergeItemPtr:
+        - name: 1
+        - name: 3
+        - name: 2
+    sorted:
+      mergeItemPtr:
+        - name: 1
+        - name: 2
+        - name: 3
 `)
 
 func TestStrategicMergePatch(t *testing.T) {


### PR DESCRIPTION
I fixed the bug which gave an error if the data structure which was trying to be updated was a Pointer in the PATCH verb command. Added tests to check for the pointers as well now.

Fixes #8489
