### PR TITLE
Use runtime cache to serve container /stats requests

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2208,10 +2208,12 @@ func (kl *Kubelet) GetContainerInfo(podFullName string, podUID types.UID, contai
 
 	podUID = kl.podManager.TranslatePodUID(podUID)
 
-	container, err := kl.findContainer(podFullName, podUID, containerName)
+	pods, err := kl.runtimeCache.GetPods()
 	if err != nil {
 		return nil, err
 	}
+	pod := kubecontainer.Pods(pods).FindPod(podFullName, podUID)
+	container := pod.FindContainerByName(containerName)
 	if container == nil {
 		return nil, ErrContainerNotFound
 	}


### PR DESCRIPTION
Since the runtime cache is only populated periodically, this can fail to find the container if the kubelet receives a /stats request right after the pod has been created. This is actually already possible, so this change should only increase the number of times it happens at the cost of not hammering docker when a node is saturated. 

@vishh thoughts? https://github.com/GoogleCloudPlatform/kubernetes/issues/9641
