### PR TITLE
Rephrase test descriptions.

### DIFF
--- a/test/e2e/host_path.go
+++ b/test/e2e/host_path.go
@@ -57,7 +57,7 @@ var _ = Describe("hostDir", func() {
 		}
 	})
 
-	It("MOD volume on tmpfs should have the correct mode", func() {
+	It("should give a volume the correct mode", func() {
 		volumePath := "/test-volume"
 		source := &api.HostPathVolumeSource{
 			Path: "/tmp",


### PR DESCRIPTION
I was reviewing test descriptions and I saw these didn't appear to match the convention.
I don't know if this will break hidden assumptions somewhere deep in jenkins about
what certain tests are called.
