### PR TITLE
Removing legacyBehavior param from pkg/client

### DIFF
--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -34,26 +34,25 @@ func (f HTTPClientFunc) Do(req *http.Request) (*http.Response, error) {
 type FakeRESTClient struct {
 	Client HTTPClient
 	Codec  runtime.Codec
-	Legacy bool
 	Req    *http.Request
 	Resp   *http.Response
 	Err    error
 }
 
 func (c *FakeRESTClient) Get() *Request {
-	return NewRequest(c, "GET", &url.URL{Host: "localhost"}, testapi.Version(), c.Codec, c.Legacy, c.Legacy)
+	return NewRequest(c, "GET", &url.URL{Host: "localhost"}, testapi.Version(), c.Codec)
 }
 
 func (c *FakeRESTClient) Put() *Request {
-	return NewRequest(c, "PUT", &url.URL{Host: "localhost"}, testapi.Version(), c.Codec, c.Legacy, c.Legacy)
+	return NewRequest(c, "PUT", &url.URL{Host: "localhost"}, testapi.Version(), c.Codec)
 }
 
 func (c *FakeRESTClient) Post() *Request {
-	return NewRequest(c, "POST", &url.URL{Host: "localhost"}, testapi.Version(), c.Codec, c.Legacy, c.Legacy)
+	return NewRequest(c, "POST", &url.URL{Host: "localhost"}, testapi.Version(), c.Codec)
 }
 
 func (c *FakeRESTClient) Delete() *Request {
-	return NewRequest(c, "DELETE", &url.URL{Host: "localhost"}, testapi.Version(), c.Codec, c.Legacy, c.Legacy)
+	return NewRequest(c, "DELETE", &url.URL{Host: "localhost"}, testapi.Version(), c.Codec)
 }
 
 func (c *FakeRESTClient) Do(req *http.Request) (*http.Response, error) {

--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -46,11 +46,6 @@ type Config struct {
 	// a RESTClient directly. When initializing a Client, will be set with the default
 	// code version.
 	Version string
-	// LegacyBehavior defines whether the RESTClient should follow conventions that
-	// existed prior to v1beta3 in Kubernetes - namely, namespace (if specified)
-	// not being part of the path, and resource names allowing mixed case. Set to
-	// true when using Kubernetes v1beta1 or v1beta2.
-	LegacyBehavior bool
 	// Codec specifies the encoding and decoding behavior for runtime.Objects passed
 	// to a RESTClient or Client. Required when initializing a RESTClient, optional
 	// when initializing a Client.
@@ -218,7 +213,6 @@ func SetKubernetesDefaults(config *Config) error {
 	if config.Codec == nil {
 		config.Codec = versionInterfaces.Codec
 	}
-	config.LegacyBehavior = (version == "v1beta1" || version == "v1beta2")
 	if config.QPS == 0.0 {
 		config.QPS = 5.0
 	}
@@ -245,7 +239,7 @@ func RESTClientFor(config *Config) (*RESTClient, error) {
 		return nil, err
 	}
 
-	client := NewRESTClient(baseURL, config.Version, config.Codec, config.LegacyBehavior, config.QPS, config.Burst)
+	client := NewRESTClient(baseURL, config.Version, config.Codec, config.QPS, config.Burst)
 
 	transport, err := TransportFor(config)
 	if err != nil {

--- a/pkg/client/helper_test.go
+++ b/pkg/client/helper_test.go
@@ -269,12 +269,11 @@ func TestSetKubernetesDefaults(t *testing.T) {
 		{
 			Config{},
 			Config{
-				Prefix:         "/api",
-				Version:        latest.Version,
-				Codec:          latest.Codec,
-				LegacyBehavior: (latest.Version == "v1beta1" || latest.Version == "v1beta2"),
-				QPS:            5,
-				Burst:          10,
+				Prefix:  "/api",
+				Version: latest.Version,
+				Codec:   latest.Codec,
+				QPS:     5,
+				Burst:   10,
 			},
 			false,
 		},

--- a/pkg/client/request_test.go
+++ b/pkg/client/request_test.go
@@ -70,14 +70,14 @@ func TestRequestWithErrorWontChange(t *testing.T) {
 }
 
 func TestRequestPreservesBaseTrailingSlash(t *testing.T) {
-	r := &Request{baseURL: &url.URL{}, path: "/path/", namespaceInQuery: true}
+	r := &Request{baseURL: &url.URL{}, path: "/path/"}
 	if s := r.URL().String(); s != "/path/" {
 		t.Errorf("trailing slash should be preserved: %s", s)
 	}
 }
 
 func TestRequestAbsPathPreservesTrailingSlash(t *testing.T) {
-	r := (&Request{baseURL: &url.URL{}, namespaceInQuery: true}).AbsPath("/foo/")
+	r := (&Request{baseURL: &url.URL{}}).AbsPath("/foo/")
 	if s := r.URL().String(); s != "/foo/" {
 		t.Errorf("trailing slash should be preserved: %s", s)
 	}
@@ -89,7 +89,7 @@ func TestRequestAbsPathPreservesTrailingSlash(t *testing.T) {
 }
 
 func TestRequestAbsPathJoins(t *testing.T) {
-	r := (&Request{baseURL: &url.URL{}, namespaceInQuery: true}).AbsPath("foo/bar", "baz")
+	r := (&Request{baseURL: &url.URL{}}).AbsPath("foo/bar", "baz")
 	if s := r.URL().String(); s != "foo/bar/baz" {
 		t.Errorf("trailing slash should be preserved: %s", s)
 	}
@@ -100,20 +100,11 @@ func TestRequestSetsNamespace(t *testing.T) {
 		baseURL: &url.URL{
 			Path: "/",
 		},
-		namespaceInQuery: true,
 	}).Namespace("foo")
 	if r.namespace == "" {
 		t.Errorf("namespace should be set: %#v", r)
 	}
-	if s := r.URL().String(); s != "?namespace=foo" {
-		t.Errorf("namespace should be in params: %s", s)
-	}
 
-	r = (&Request{
-		baseURL: &url.URL{
-			Path: "/",
-		},
-	}).Namespace("foo")
 	if s := r.URL().String(); s != "namespaces/foo" {
 		t.Errorf("namespace should be in path: %s", s)
 	}
@@ -217,7 +208,7 @@ func TestResultIntoWithErrReturnsErr(t *testing.T) {
 
 func TestURLTemplate(t *testing.T) {
 	uri, _ := url.Parse("http://localhost")
-	r := NewRequest(nil, "POST", uri, "test", nil, false, false)
+	r := NewRequest(nil, "POST", uri, "test", nil)
 	r.Prefix("pre1").Resource("r1").Namespace("ns").Name("nm").Param("p0", "v0")
 	full := r.URL()
 	if full.String() != "http://localhost/pre1/namespaces/ns/r1/nm?p0=v0" {
@@ -278,7 +269,7 @@ func TestTransformResponse(t *testing.T) {
 		{Response: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewReader(invalid))}, Data: invalid},
 	}
 	for i, test := range testCases {
-		r := NewRequest(nil, "", uri, testapi.Version(), testapi.Codec(), true, true)
+		r := NewRequest(nil, "", uri, testapi.Version(), testapi.Codec())
 		if test.Response.Body == nil {
 			test.Response.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
 		}
@@ -638,7 +629,7 @@ func TestRequestUpgrade(t *testing.T) {
 			Err: true,
 		},
 		{
-			Request: NewRequest(nil, "", uri, testapi.Version(), testapi.Codec(), true, true),
+			Request: NewRequest(nil, "", uri, testapi.Version(), testapi.Codec()),
 			Config: &Config{
 				Username: "u",
 				Password: "p",
@@ -647,7 +638,7 @@ func TestRequestUpgrade(t *testing.T) {
 			Err:             false,
 		},
 		{
-			Request: NewRequest(nil, "", uri, testapi.Version(), testapi.Codec(), true, true),
+			Request: NewRequest(nil, "", uri, testapi.Version(), testapi.Codec()),
 			Config: &Config{
 				BearerToken: "b",
 			},

--- a/pkg/client/restclient.go
+++ b/pkg/client/restclient.go
@@ -38,11 +38,6 @@ type RESTClient struct {
 	// A string identifying the version of the API this client is expected to use.
 	apiVersion string
 
-	// LegacyBehavior controls if URLs should encode the namespace as a query param,
-	// and if resource case is preserved for supporting older API conventions of
-	// Kubernetes.  Newer clients should leave this false.
-	LegacyBehavior bool
-
 	// Codec is the encoding and decoding scheme that applies to a particular set of
 	// REST resources.
 	Codec runtime.Codec
@@ -59,9 +54,8 @@ type RESTClient struct {
 
 // NewRESTClient creates a new RESTClient. This client performs generic REST functions
 // such as Get, Put, Post, and Delete on specified paths.  Codec controls encoding and
-// decoding of responses from the server. If this client should use the older, legacy
-// API conventions from Kubernetes API v1beta1 and v1beta2, set legacyBehavior true.
-func NewRESTClient(baseURL *url.URL, apiVersion string, c runtime.Codec, legacyBehavior bool, maxQPS float32, maxBurst int) *RESTClient {
+// decoding of responses from the server.
+func NewRESTClient(baseURL *url.URL, apiVersion string, c runtime.Codec, maxQPS float32, maxBurst int) *RESTClient {
 	base := *baseURL
 	if !strings.HasSuffix(base.Path, "/") {
 		base.Path += "/"
@@ -76,12 +70,8 @@ func NewRESTClient(baseURL *url.URL, apiVersion string, c runtime.Codec, legacyB
 	return &RESTClient{
 		baseURL:    &base,
 		apiVersion: apiVersion,
-
-		Codec: c,
-
-		LegacyBehavior: legacyBehavior,
-
-		Throttle: throttle,
+		Codec:      c,
+		Throttle:   throttle,
 	}
 }
 
@@ -101,7 +91,7 @@ func (c *RESTClient) Verb(verb string) *Request {
 	if c.Throttle != nil {
 		c.Throttle.Accept()
 	}
-	return NewRequest(c.Client, verb, c.baseURL, c.apiVersion, c.Codec, c.LegacyBehavior, c.LegacyBehavior).Timeout(c.Timeout)
+	return NewRequest(c.Client, verb, c.baseURL, c.apiVersion, c.Codec).Timeout(c.Timeout)
 }
 
 // Post begins a POST request. Short for c.Verb("POST").

--- a/pkg/client/restclient_test.go
+++ b/pkg/client/restclient_test.go
@@ -119,11 +119,9 @@ func TestDoRequestBearer(t *testing.T) {
 	defer testServer.Close()
 	request, _ := http.NewRequest("GET", testServer.URL, nil)
 	c, err := RESTClientFor(&Config{
-		Host:           testServer.URL,
-		Version:        testapi.Version(),
-		Codec:          testapi.Codec(),
-		LegacyBehavior: true,
-
+		Host:        testServer.URL,
+		Version:     testapi.Version(),
+		Codec:       testapi.Codec(),
 		BearerToken: "test",
 	})
 	if err != nil {
@@ -149,11 +147,9 @@ func TestDoRequestWithoutPassword(t *testing.T) {
 	testServer := httptest.NewServer(&fakeHandler)
 	defer testServer.Close()
 	c, err := RESTClientFor(&Config{
-		Host:           testServer.URL,
-		Version:        testapi.Version(),
-		Codec:          testapi.Codec(),
-		LegacyBehavior: true,
-
+		Host:     testServer.URL,
+		Version:  testapi.Version(),
+		Codec:    testapi.Codec(),
 		Username: "test",
 	})
 	if err != nil {
@@ -190,11 +186,9 @@ func TestDoRequestSuccess(t *testing.T) {
 	testServer := httptest.NewServer(&fakeHandler)
 	defer testServer.Close()
 	c, err := RESTClientFor(&Config{
-		Host:           testServer.URL,
-		Version:        testapi.Version(),
-		Codec:          testapi.Codec(),
-		LegacyBehavior: true,
-
+		Host:     testServer.URL,
+		Version:  testapi.Version(),
+		Codec:    testapi.Codec(),
 		Username: "user",
 		Password: "pass",
 	})
@@ -235,10 +229,9 @@ func TestDoRequestFailed(t *testing.T) {
 	testServer := httptest.NewServer(&fakeHandler)
 	defer testServer.Close()
 	c, err := RESTClientFor(&Config{
-		Host:           testServer.URL,
-		Version:        testapi.Version(),
-		Codec:          testapi.Codec(),
-		LegacyBehavior: true,
+		Host:    testServer.URL,
+		Version: testapi.Version(),
+		Codec:   testapi.Codec(),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -268,11 +261,9 @@ func TestDoRequestCreated(t *testing.T) {
 	testServer := httptest.NewServer(&fakeHandler)
 	defer testServer.Close()
 	c, err := RESTClientFor(&Config{
-		Host:           testServer.URL,
-		Version:        testapi.Version(),
-		Codec:          testapi.Codec(),
-		LegacyBehavior: true,
-
+		Host:     testServer.URL,
+		Version:  testapi.Version(),
+		Codec:    testapi.Codec(),
 		Username: "user",
 		Password: "pass",
 	})

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -49,8 +49,7 @@ func getFakeClient(t *testing.T, validURLs []string) (ClientPosterFunc, *httptes
 	return func(mapping *meta.RESTMapping) (RESTClientPoster, error) {
 		fakeCodec := testapi.Codec()
 		fakeUri, _ := url.Parse(server.URL + "/api/" + testapi.Version())
-		legacyBehavior := api.PreV1Beta3(testapi.Version())
-		return client.NewRESTClient(fakeUri, testapi.Version(), fakeCodec, legacyBehavior, 5, 10), nil
+		return client.NewRESTClient(fakeUri, testapi.Version(), fakeCodec, 5, 10), nil
 	}, server
 }
 


### PR DESCRIPTION
Now that we have deleted preV1beta3 APIs, this is not required anymore.
