### PR TITLE
Add `_tmp` to gitignore to prevent user staging it from an incomplete build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 /output
 /_output/**
 /_output
+/_tmp/**
+/_tmp
 
 # Emacs save files
 *~


### PR DESCRIPTION
Add `_tmp` to gitignore to prevent user staging it from an incomplete build
