### PR TITLE
remove broken ginkgo Done concept from tests

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -72,7 +72,7 @@ var _ = Describe("Services", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should serve a basic endpoint from pods", func(done Done) {
+	It("should serve a basic endpoint from pods", func() {
 		serviceName := "endpoint-test2"
 		ns := namespaces[0]
 		labels := map[string]string{
@@ -133,14 +133,9 @@ var _ = Describe("Services", func() {
 		names = []string{}
 
 		validateEndpointsOrFail(c, ns, serviceName, map[string][]int{})
+	})
 
-		// We deferred Gingko pieces that may Fail, we aren't done.
-		defer func() {
-			close(done)
-		}()
-	}, 240.0)
-
-	It("should serve multiport endpoints from pods", func(done Done) {
+	It("should serve multiport endpoints from pods", func() {
 		// repacking functionality is intentionally not tested here - it's better to test it in an integration test.
 		serviceName := "multi-endpoint-test"
 		ns := namespaces[0]
@@ -234,12 +229,7 @@ var _ = Describe("Services", func() {
 		names = []string{}
 
 		validateEndpointsOrFail(c, ns, serviceName, map[string][]int{})
-
-		// We deferred Gingko pieces that may Fail, we aren't done.
-		defer func() {
-			close(done)
-		}()
-	}, 240.0)
+	})
 
 	It("should be able to create a functioning external load balancer", func() {
 		if !providerIs("gce", "gke", "aws") {


### PR DESCRIPTION
Fixes #8672.

Ideally, we should add a good general timeout mechanism to the framework or something, but getting this out is higher priority. The problem is that if ginkgo times the test out, it doesn't actually cause the function to exit, and then any failures that this function calls will apply to the next test. So that's pretty bad.
