### PR TITLE
Cleaning up apiserver method signatures

### DIFF
--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -226,7 +226,7 @@ func handleInternal(legacy bool, storage map[string]rest.Storage, admissionContr
 	container := restful.NewContainer()
 	container.Router(restful.CurlyRouter{})
 	mux := container.ServeMux
-	if err := group.InstallREST(&RestContainer{container, 0}, nil); err != nil {
+	if err := group.InstallREST(container); err != nil {
 		panic(fmt.Sprintf("unable to install container %s: %v", group.Version, err))
 	}
 	ws := new(restful.WebService)
@@ -1938,7 +1938,7 @@ func TestParentResourceIsRequired(t *testing.T) {
 		Codec:         newCodec,
 	}
 	container := restful.NewContainer()
-	if err := group.InstallREST(&RestContainer{container, 0}, nil); err == nil {
+	if err := group.InstallREST(container); err == nil {
 		t.Fatal("expected error")
 	}
 
@@ -1966,7 +1966,7 @@ func TestParentResourceIsRequired(t *testing.T) {
 		Codec:         newCodec,
 	}
 	container = restful.NewContainer()
-	if err := group.InstallREST(&RestContainer{container, 0}, nil); err != nil {
+	if err := group.InstallREST(container); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -185,7 +185,7 @@ func ConnectResource(connecter rest.Connecter, scope RequestScope, admit admissi
 }
 
 // ListResource returns a function that handles retrieving a list of resources from a rest.Storage object.
-func ListResource(r rest.Lister, rw rest.Watcher, scope RequestScope, forceWatch bool, minRequestTimeout int) restful.RouteFunction {
+func ListResource(r rest.Lister, rw rest.Watcher, scope RequestScope, forceWatch bool, minRequestTimeout time.Duration) restful.RouteFunction {
 	return func(req *restful.Request, res *restful.Response) {
 		w := res.ResponseWriter
 

--- a/pkg/apiserver/watch.go
+++ b/pkg/apiserver/watch.go
@@ -66,11 +66,11 @@ func (w *realTimeoutFactory) TimeoutCh() (<-chan time.Time, func() bool) {
 }
 
 // serveWatch handles serving requests to the server
-func serveWatch(watcher watch.Interface, scope RequestScope, w http.ResponseWriter, req *restful.Request, minRequestTimeout int) {
+func serveWatch(watcher watch.Interface, scope RequestScope, w http.ResponseWriter, req *restful.Request, minRequestTimeout time.Duration) {
 	var timeout time.Duration
 	if minRequestTimeout > 0 {
 		// Each watch gets a random timeout between minRequestTimeout and 2*minRequestTimeout to avoid thundering herds.
-		timeout = time.Duration(minRequestTimeout+rand.Intn(minRequestTimeout)) * time.Second
+		timeout = time.Duration(float64(minRequestTimeout) * (rand.Float64() + 1.0))
 	}
 	watchServer := &WatchServer{watcher, scope.Codec, func(obj runtime.Object) {
 		if err := setSelfLink(obj, req, scope.Namer); err != nil {


### PR DESCRIPTION
A lot of the changes in apiserver could have been represented more
cleanly - this returns the signatures to their older behavior (and
unbreaks OpenShift).

Not necessary for 1.0, but I'd like this merged afterwards so we can
rebase.
