### PR TITLE
Add client field mappings for v1

### DIFF
--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -359,6 +359,25 @@ var fieldMappings = versionToResourceToFieldMapping{
 			ObjectNameField: "metadata.name",
 		},
 	},
+	"v1": resourceTypeToFieldMapping{
+		"nodes": clientFieldNameToAPIVersionFieldName{
+			ObjectNameField:   "metadata.name",
+			NodeUnschedulable: "spec.unschedulable",
+		},
+		"minions": clientFieldNameToAPIVersionFieldName{
+			ObjectNameField:   "metadata.name",
+			NodeUnschedulable: "spec.unschedulable",
+		},
+		"pods": clientFieldNameToAPIVersionFieldName{
+			PodHost: "spec.host",
+		},
+		"secrets": clientFieldNameToAPIVersionFieldName{
+			SecretType: "type",
+		},
+		"serviceAccounts": clientFieldNameToAPIVersionFieldName{
+			ObjectNameField: "metadata.name",
+		},
+	},
 }
 
 // FieldsSelectorParam adds the given selector as a query parameter with the name paramName.


### PR DESCRIPTION
When making client requests that contain field selectors against v1, errors show up in the log about field mappings not existing for that version. This adds mappings equal to v1beta3 for v1
