### PR TITLE
Add system: prefix to service account usernames

### DIFF
--- a/pkg/serviceaccount/jwt.go
+++ b/pkg/serviceaccount/jwt.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	ServiceAccountUsernamePrefix    = "serviceaccount"
+	ServiceAccountUsernamePrefix    = "system:serviceaccount"
 	ServiceAccountUsernameSeparator = ":"
 
 	Issuer = "kubernetes/serviceaccount"
@@ -84,11 +84,15 @@ func MakeUsername(namespace, name string) string {
 // SplitUsername returns the namespace and ServiceAccount name embedded in the given username,
 // or an error if the username is not a valid name produced by MakeUsername
 func SplitUsername(username string) (string, string, error) {
-	parts := strings.Split(username, ServiceAccountUsernameSeparator)
-	if len(parts) != 3 || parts[0] != ServiceAccountUsernamePrefix || len(parts[1]) == 0 || len(parts[2]) == 0 {
+	if !strings.HasPrefix(username, ServiceAccountUsernamePrefix+ServiceAccountUsernameSeparator) {
 		return "", "", fmt.Errorf("Username must be in the form %s", MakeUsername("namespace", "name"))
 	}
-	return parts[1], parts[2], nil
+	username = strings.TrimPrefix(username, ServiceAccountUsernamePrefix+ServiceAccountUsernameSeparator)
+	parts := strings.Split(username, ServiceAccountUsernameSeparator)
+	if len(parts) != 2 || len(parts[0]) == 0 || len(parts[1]) == 0 {
+		return "", "", fmt.Errorf("Username must be in the form %s", MakeUsername("namespace", "name"))
+	}
+	return parts[0], parts[1], nil
 }
 
 // JWTTokenGenerator returns a TokenGenerator that generates signed JWT tokens, using the given privateKey.

--- a/pkg/serviceaccount/jwt_test.go
+++ b/pkg/serviceaccount/jwt_test.go
@@ -121,7 +121,7 @@ func TestReadPublicKey(t *testing.T) {
 }
 
 func TestTokenGenerateAndValidate(t *testing.T) {
-	expectedUserName := "serviceaccount:test:my-service-account"
+	expectedUserName := "system:serviceaccount:test:my-service-account"
 	expectedUserUID := "12345"
 
 	// Related API objects
@@ -239,6 +239,25 @@ func TestTokenGenerateAndValidate(t *testing.T) {
 		if user.GetUID() != tc.ExpectedUserUID {
 			t.Errorf("%s: Expected userUID=%v, got %v", k, tc.ExpectedUserUID, user.GetUID())
 			continue
+		}
+	}
+}
+
+func TestMakeSplitUsername(t *testing.T) {
+	username := MakeUsername("ns", "name")
+	ns, name, err := SplitUsername(username)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	if ns != "ns" || name != "name" {
+		t.Errorf("Expected ns/name, got %s/%s", ns, name)
+	}
+
+	invalid := []string{"test", "system:serviceaccount", "system:serviceaccount:", "system:serviceaccount:ns", "system:serviceaccount:ns:name:extra"}
+	for _, n := range invalid {
+		_, _, err := SplitUsername("test")
+		if err == nil {
+			t.Errorf("Expected error for %s", n)
 		}
 	}
 }


### PR DESCRIPTION
Split out the `system:` prefix portion of https://github.com/GoogleCloudPlatform/kubernetes/pull/8607

The groups bits should be deferred post-1.0, but I'd like to standardize the service account usernames to be under the "system:" prefix before people start writing authorization rules against them.
