### PR TITLE
Eliminate possible infinite loop in exec

### DIFF
--- a/pkg/kubelet/dockertools/exec.go
+++ b/pkg/kubelet/dockertools/exec.go
@@ -25,6 +25,7 @@ import (
 
 	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/golang/glog"
 )
 
 // ExecHandler knows how to execute a command in a running Docker container.
@@ -123,6 +124,7 @@ func (*NativeExecHandler) ExecInContainer(client DockerInterface, container *doc
 		return err
 	}
 	tick := time.Tick(2 * time.Second)
+	count := 0
 	for {
 		inspect, err2 := client.InspectExec(execObj.ID)
 		if err2 != nil {
@@ -134,6 +136,13 @@ func (*NativeExecHandler) ExecInContainer(client DockerInterface, container *doc
 			}
 			break
 		}
+
+		count++
+		if count == 5 {
+			glog.Errorf("Exec session %s in container %s terminated but process still running!", execObj.ID, container.ID)
+			break
+		}
+
 		<-tick
 	}
 


### PR DESCRIPTION
If a user starts an exec session with a shell and leaves it idle long
enough, they will eventually hit the Kubelet's HTTP server's read/write
timeout of 5 minutes. At this time, the StartExec call to Docker exits,
but if the user requested a TTY, the exec'd process does not exit.
After StartExec finishes, we try to determine the exit code of the
exec'd process, but in this case, we'll never get it. This change exits
the loop after 5 tries if the process is still running.
