### PR TITLE
Updating heapster service labels to make it compatible with `kubectl cluster-info`

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-service.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: monitoring-heapster
   labels: 
     kubernetes.io/cluster-service: "true"
-    name: monitoring-heapster
+    kubernetes.io/name: "Heapster"
 spec: 
   ports: 
     - port: 80

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-service.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: monitoring-heapster
   labels: 
     kubernetes.io/cluster-service: "true"
-    name: monitoring-heapster
+    kubernetes.io/name: "Heapster"
 spec: 
   ports: 
     - port: 80

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-service.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-service.yaml
@@ -4,9 +4,8 @@ metadata:
   name: monitoring-influxdb
   namespace: default 
   labels: 
-    k8s-app: influxGrafana
     kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "influxGrafana"
+    kubernetes.io/name: "InfluxDB"
 spec: 
   ports: 
     - name: http

--- a/cluster/addons/cluster-monitoring/standalone/heapster-service.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: monitoring-heapster
   labels: 
     kubernetes.io/cluster-service: "true"
-    name: monitoring-heapster
+    kubernetes.io/name: "Heapster"
 spec: 
   ports: 
     - port: 80


### PR DESCRIPTION
Fixes #9875  
