### PR TITLE
Don't assume we always SSH as the current user

### DIFF
--- a/pkg/util/ssh.go
+++ b/pkg/util/ssh.go
@@ -150,6 +150,8 @@ type sshDialer interface {
 // Real implementation of sshDialer
 type realSSHDialer struct{}
 
+var _ sshDialer = &realSSHDialer{}
+
 func (d *realSSHDialer) Dial(network, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
 	return ssh.Dial(network, addr, config)
 }

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1161,7 +1161,9 @@ func SSH(cmd, host, provider string) (string, string, int, error) {
 		return "", "", 0, fmt.Errorf("error getting signer for provider %s: '%v'", provider, err)
 	}
 
-	return util.RunSSHCommand(cmd, host, signer)
+	user := os.Getenv("KUBE_SSH_USER")
+	// RunSSHCommand will default to Getenv("USER") if user == ""
+	return util.RunSSHCommand(cmd, user, host, signer)
 }
 
 // getSigner returns an ssh.Signer for the provider ("gce", etc.) that can be


### PR DESCRIPTION
This works on gcloud (where the user is dynamically created by the tool),
but doesn't hold on other clouds (e.g. AWS).

The function in pkg/util now takes a user arg, and it is called only
from the e2e tests, which now check for env-var KUBE_SSH_USER, and then
fall back to the existing behaviour of env-var USER.

I am using this from Jenkins by directly setting the env-var:

```
export KUBE_SSH_USER=jenkins
...
hack/jenkins/e2e.sh
```
