### PR TITLE
AWS: e2e: Add support for getSigner for AWS

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1158,6 +1158,8 @@ func getSigner(provider string) (ssh.Signer, error) {
 	switch provider {
 	case "gce", "gke":
 		keyfile = "google_compute_engine"
+	case "aws":
+		keyfile = "kube_aws_rsa"
 	default:
 		return nil, fmt.Errorf("getSigner(...) not implemented for %s", provider)
 	}


### PR DESCRIPTION
Not really a lot to say about this:  Add the default key name for SSH for AWS for e2e.
