### PR TITLE
AWS: Enable restart e2e tests

### DIFF
--- a/test/e2e/reboot.go
+++ b/test/e2e/reboot.go
@@ -94,7 +94,7 @@ func testReboot(c *client.Client, rebootCmd string) {
 	// there (the limiting factor is the implementation of util.go's
 	// getSigner(...)).
 	provider := testContext.Provider
-	if !providerIs("gce") {
+	if !providerIs("aws", "gce") {
 		By(fmt.Sprintf("Skipping reboot test, which is not implemented for %s", provider))
 		return
 	}


### PR DESCRIPTION
AWS should support this; it will (possibly only once all my PRs have merged, but I believe it actually does support this even now)
