### PR TITLE
Service account documentation improvement

### DIFF
--- a/docs/accessing-the-cluster.md
+++ b/docs/accessing-the-cluster.md
@@ -102,10 +102,10 @@ the `kubernetes` DNS name, which resolves to a Service IP which in turn
 will be routed to an apiserver.
 
 The recommended way to authenticate to the apiserver is with a
-[service account](../docs/service_accounts.md).  By default, a pod
+[service account](service_accounts.md) credential.  By default, a pod
 is associated with a service account, and a credential (token) for that
 service account is placed into the filesystem tree of each container in that pod,
-at `/var/run/secrets/kubernetes.io/serviceaccount`.
+at `/var/run/secrets/kubernetes.io/serviceaccount/token`.
 
 From within a pod the recommended ways to connect to API are:
   - run a kubectl proxy as one of the containers in the pod, or as a background
@@ -115,6 +115,7 @@ From within a pod the recommended ways to connect to API are:
     in a pod](../examples/kubectl-container/).
   - use the Go client library, and create a client using the `client.NewInContainer()` factory.
     This handles locating and authenticating to the apiserver.
+In each case, the credentials of the pod are used to communicate securely with the apiserver.
 
 
 ## <a name="otherservices"></a>Accessing services running on the cluster

--- a/docs/images.md
+++ b/docs/images.md
@@ -68,7 +68,7 @@ This can be used to preload certain images for speed or as an alternative to aut
 
 All pods will have read access to any pre-pulled images.
 
-### Specifying ImagePullKeys on a Pod
+### Specifying ImagePullSecrets on a Pod
 Kubernetes supports specifying registry keys on a pod.
 
 First, create a `.dockercfg`, such as running `docker login <registry.domain>`.

--- a/docs/service_accounts.md
+++ b/docs/service_accounts.md
@@ -1,14 +1,93 @@
 # Service Accounts
-A serviceAccount provides an identity for processes that run in a Pod.
-The behavior of the the serviceAccount object is implemented via a plugin
-called an [Admission Controller]( admission_controllers.md). When this plugin is active
-(and it is by default on most distributions), then it does the following when a pod is created or modified:
-  1. If the pod does not have a ```ServiceAccount```, it modifies the pod's ```ServiceAccount``` to "default".
-  2. It ensures that the ```ServiceAccount``` referenced by a pod exists.
-  3. If ```LimitSecretReferences``` is true, it rejects the pod if the pod references ```Secret``` objects which the pods
-```ServiceAccount``` does not reference.
-  4. If the pod does not contain any ```ImagePullSecrets```, the ```ImagePullSecrets``` of the
-```ServiceAccount``` are added to the pod.
-  5. If ```MountServiceAccountToken``` is true, it adds a ```VolumeMount``` with the pod's ```ServiceAccount``` API token secret to containers in the pod.
+
+A service account provides an identity for processes that run in a Pod.
+
+*This is a user introduction to Service Accounts.  See also the 
+[Cluster Admin Guide to Service Accounts](service_accounts_admin.md).*
+
+*Note: This document descibes how service accounts behave in a cluster set up
+as recommended by the Kubernetes project.  Your cluster administrator may have
+customized the behavior in your cluster, in which case this documentation may
+not apply.*
+
+When you (a human) access the cluster (e.g. using kubectl), you are
+authenticated by the apiserver as a particular User Account (currently this is
+usually "admin", unless your cluster administrator has customized your
+cluster).  Processes in containers inside pods can also contact the apiserver.
+When they do, they are authenticated as a particular Service Account (e.g.
+"default").
+
+## Using the Default Service Account to access the API server.
+
+When you create a pod, you do not need to specify a service account.  It is
+automatically assigned the `default` service account of the same namespace.  If
+you get the raw json or yaml for a pod you have created (e.g. `kubectl get
+pods/podname -o yaml`), you can see the `spec.serviceAccount` field has been
+[automatically set](working_with_resources.md#resources-are-automatically-modified).
+
+You can access the API using a proxy or with a client library, as described in
+[Accessing the Cluster](accessing-the-cluster.md#accessing-the-api-from-a-pod).
+
+## Using Multiple Service Accounts
+
+Every namespace has a default service account resource called "default".
+You can list this and any other serviceAccount resources in the namespace with this command:
+```
+kubectl get serviceAccounts
+$ NAME      SECRETS
+default   1
+```
+
+You can create additional serviceAccounts like this:
+```
+$ cat > serviceaccount.yaml <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-robot
+EOF
+$ kubectl create -f serviceaccount.json
+serviceacccounts/build-robot
+```
+
+If you get a complete dump of the service account object, like this:
+```
+$ kubectl get serviceacccounts/build-robot -o yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: 2015-06-16T00:12:59Z
+  name: build-robot
+  namespace: default
+  resourceVersion: "272500"
+  selfLink: /api/v1/namespaces/default/serviceaccounts/build-robot
+  uid: 721ab723-13bc-11e5-aec2-42010af0021e
+secrets:
+- name: build-robot-token-bvbk5
+```
+then you will see that a token has automatically been created and is referenced by the service account.
+
+In the future, you will be able to configure different access policies for each service account.
+
+To use a non-default service account, simply set the `spec.serviceAccount`
+field of a pod to the set to the name of the service account you wish to use.
+
+The service account has to exist at the time the pod is created, or it will be rejected.
+
+You cannot update the service account of an already created pod.  
+
+You can clean up the service account from this example like this:
+```
+$ kubectl delete serviceaccount/build-robot
+```
+
+<!-- TODO: describe how to create a pod with no Service Account. -->
+
+## Adding Secrets to a service account.
+TODO: Test and explain how to use additional non-K8s secrets with an existing service account.
+
+TODO explain:
+  - The token goes to: "/var/run/secrets/kubernetes.io/serviceaccount/$WHATFILENAME"
+
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/service_accounts.md?pixel)]()

--- a/docs/service_accounts_admin.md
+++ b/docs/service_accounts_admin.md
@@ -1,0 +1,84 @@
+# Cluster Admin Guide to Service Accounts
+
+*This is a Cluster Administrator guide to service accounts.  It assumes knowledge of
+the [User Guide to Service Accounts](service_accounts.md).*
+
+*Support for authorization and user accounts is planned but incomplete.  Sometimes
+incomplete features are referred to in order to better describe service accounts.*
+
+## User accounts vs service accounts
+
+Kubernetes distinguished between the concept of a user account and a service accounts
+for a number of reasons:
+  - User accounts are for humans.  Service accounts are for processes, which
+    run in pods.
+  - User accounts are intended to be global. Names must be unique across all
+    namespaces of a cluster, future user resource will not be namespaced).
+    Service accounts are namespaced.
+  - Typically, a clusters User accounts might be synced from a corporate
+    database, where new user account creation requires special privileges and
+    is tied to complex business  processes.  Service account creation is intended
+    to be more lightweight, allowing cluster users to create service accounts for
+    specific tasks (i.e. principle of least privilege).
+  - Auditing considerations for humans and service accounts may differ.
+  - A config bundle for a complex system may include definition of various service
+    accounts for components of that system.  Because service accounts can be created
+    ad-hoc and have namespaced names, such config is portable. 
+
+##  Service account automation
+
+Three separate components cooperate to implement the automation around service accounts:
+  - A Service account admission controller
+  - A Token controller
+  - A Service account controller
+
+### Service Account Admission Controller
+
+The modification of pods is implemented via a plugin
+called an [Admission Controller](admission_controllers.md). It is part of the apiserver.
+It acts synchronously to modify pods as they are created or updated. When this plugin is active
+(and it is by default on most distributions), then it does the following when a pod is created or modified:
+  1. If the pod does not have a `ServiceAccount` set, it sets the `ServiceAccount` to `default`.
+  2. It ensures that the `ServiceAccount` referenced by the pod exists, and otherwise rejects it.
+  4. If the pod does not contain any `ImagePullSecrets`, then `ImagePullSecrets` of the
+`ServiceAccount` are added to the pod.
+  5. It adds a `volume` to the pod which contains a token for API access.
+  6. It adds a `volumeSource` to each container of the pod mounted at `/var/run/secrets/kubernetes.io/serviceaccount`.
+
+### Token Controller
+TokenController runs as part of controller-manager. It acts asynchronously. It:
+- observes serviceAccount creation and creates a corresponding Secret to allow API access.
+- observes serviceAccount deletion and deletes all corresponding ServiceAccountToken Secrets
+- observes secret addition, and ensures the referenced ServiceAccount exists, and adds a token to the secret if needed
+- observer secret deleteion and removes a reference from the corresponding ServiceAccount if needed
+
+#### To create additional API tokens
+
+A controller loop ensures a secret with an API token exists for each service
+account. To create additional API tokens for a service account, create a secret
+of type `ServiceAccountToken` with an annotation referencing the service
+account, and the controller will update it with a generated token:
+
+```
+secret.json:
+{
+	"kind": "Secret",
+	"metadata": {
+		"name": "mysecretname",
+		"annotations": {
+			"kubernetes.io/service-account.name": "myserviceaccount"
+		}
+	}
+	"type": "kubernetes.io/service-account-token"
+}
+
+$ kubectl create -f secret.json
+$ kubectl describe secret mysecretname
+```
+
+#### To delete/invalidate a service account token:
+```
+kubectl delete secret mysecretname
+```
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/service_accounts_admin.md?pixel)]()


### PR DESCRIPTION
Fixes #9344.

Depends on #9821.

Update Secrets documentation to explain how secrets can be
created/used manually, or automatically with service accounts.

Greatly expanded service account documentation.

Added a service account admin guide.

Lots of cross-references.
