### PR TITLE
servicecontroller: last state applied to LB vs last state seen

### DIFF
--- a/pkg/cloudprovider/servicecontroller/servicecontroller_test.go
+++ b/pkg/cloudprovider/servicecontroller/servicecontroller_test.go
@@ -206,7 +206,7 @@ func TestUpdateNodesInExternalLoadBalancer(t *testing.T) {
 
 		var services []*cachedService
 		for _, service := range item.services {
-			services = append(services, &cachedService{service: service})
+			services = append(services, &cachedService{lastState: service, appliedState: service})
 		}
 		if err := controller.updateLoadBalancerHosts(services, hosts); err != nil {
 			t.Errorf("unexpected error: %v", err)


### PR DESCRIPTION
We need the last state seen for interpreting the change-stream,
separately we need to track the last state we successfully applied to the
load balancer.

cc @a-robinson 
