### PR TITLE
remove string "v1beta1" from streamer_test.go

### DIFF
--- a/pkg/registry/generic/rest/streamer_test.go
+++ b/pkg/registry/generic/rest/streamer_test.go
@@ -41,7 +41,7 @@ func TestInputStreamReader(t *testing.T) {
 	streamer := &LocationStreamer{
 		Location: u,
 	}
-	readCloser, _, _, err := streamer.InputStream("v1beta1", "text/plain")
+	readCloser, _, _, err := streamer.InputStream("", "")
 	if err != nil {
 		t.Errorf("Unexpected error when getting stream: %v", err)
 		return
@@ -57,7 +57,7 @@ func TestInputStreamNullLocation(t *testing.T) {
 	streamer := &LocationStreamer{
 		Location: nil,
 	}
-	readCloser, _, _, err := streamer.InputStream("v1beta1", "text/plain")
+	readCloser, _, _, err := streamer.InputStream("", "")
 	if err != nil {
 		t.Errorf("Unexpected error when getting stream with null location: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestInputStreamContentType(t *testing.T) {
 		Location:  location,
 		Transport: fakeTransport("application/json", "hello world"),
 	}
-	readCloser, _, contentType, err := streamer.InputStream("v1beta1", "text/plain")
+	readCloser, _, contentType, err := streamer.InputStream("", "")
 	if err != nil {
 		t.Errorf("Unexpected error when getting stream: %v", err)
 		return
@@ -105,7 +105,7 @@ func TestInputStreamTransport(t *testing.T) {
 		Location:  location,
 		Transport: fakeTransport("text/plain", message),
 	}
-	readCloser, _, _, err := streamer.InputStream("v1beta1", "text/plain")
+	readCloser, _, _, err := streamer.InputStream("", "")
 	if err != nil {
 		t.Errorf("Unexpected error when getting stream: %v", err)
 		return


### PR DESCRIPTION
Neither of the input parameters of InputStream() is used, so let them be empty strings.
#8087

@bgrant0607 @krousey @nikhiljindal 
