### PR TITLE
Validate port protocol case strictly

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -610,7 +610,7 @@ func validatePorts(ports []api.ContainerPort) errs.ValidationErrorList {
 		}
 		if len(port.Protocol) == 0 {
 			pErrs = append(pErrs, errs.NewFieldRequired("protocol"))
-		} else if !supportedPortProtocols.Has(strings.ToUpper(string(port.Protocol))) {
+		} else if !supportedPortProtocols.Has(string(port.Protocol)) {
 			pErrs = append(pErrs, errs.NewFieldNotSupported("protocol", port.Protocol))
 		}
 		allErrs = append(allErrs, pErrs.PrefixIndex(i)...)
@@ -1139,7 +1139,7 @@ func validateServicePort(sp *api.ServicePort, requireName bool, allNames *util.S
 
 	if len(sp.Protocol) == 0 {
 		allErrs = append(allErrs, errs.NewFieldRequired("protocol"))
-	} else if !supportedPortProtocols.Has(strings.ToUpper(string(sp.Protocol))) {
+	} else if !supportedPortProtocols.Has(string(sp.Protocol)) {
 		allErrs = append(allErrs, errs.NewFieldNotSupported("protocol", sp.Protocol))
 	}
 
@@ -1627,7 +1627,7 @@ func validateEndpointPort(port *api.EndpointPort, requireName bool) errs.Validat
 	}
 	if len(port.Protocol) == 0 {
 		allErrs = append(allErrs, errs.NewFieldRequired("protocol"))
-	} else if !supportedPortProtocols.Has(strings.ToUpper(string(port.Protocol))) {
+	} else if !supportedPortProtocols.Has(string(port.Protocol)) {
 		allErrs = append(allErrs, errs.NewFieldNotSupported("protocol", port.Protocol))
 	}
 	return allErrs

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -493,7 +493,6 @@ func TestValidatePorts(t *testing.T) {
 		{Name: "easy", ContainerPort: 82, Protocol: "TCP"},
 		{Name: "as", ContainerPort: 83, Protocol: "UDP"},
 		{Name: "do-re-me", ContainerPort: 84, Protocol: "UDP"},
-		{Name: "baby-you-and-me", ContainerPort: 82, Protocol: "tcp"},
 		{ContainerPort: 85, Protocol: "TCP"},
 	}
 	if errs := validatePorts(successCase); len(errs) != 0 {
@@ -522,6 +521,7 @@ func TestValidatePorts(t *testing.T) {
 		"zero container port":    {[]api.ContainerPort{{ContainerPort: 0, Protocol: "TCP"}}, errors.ValidationErrorTypeInvalid, "[0].containerPort", portRangeErrorMsg},
 		"invalid container port": {[]api.ContainerPort{{ContainerPort: 65536, Protocol: "TCP"}}, errors.ValidationErrorTypeInvalid, "[0].containerPort", portRangeErrorMsg},
 		"invalid host port":      {[]api.ContainerPort{{ContainerPort: 80, HostPort: 65536, Protocol: "TCP"}}, errors.ValidationErrorTypeInvalid, "[0].hostPort", portRangeErrorMsg},
+		"invalid protocol case":  {[]api.ContainerPort{{ContainerPort: 80, Protocol: "tcp"}}, errors.ValidationErrorTypeNotSupported, "[0].protocol", ""},
 		"invalid protocol":       {[]api.ContainerPort{{ContainerPort: 80, Protocol: "ICMP"}}, errors.ValidationErrorTypeNotSupported, "[0].protocol", ""},
 		"protocol required":      {[]api.ContainerPort{{Name: "abc", ContainerPort: 80}}, errors.ValidationErrorTypeRequired, "[0].protocol", ""},
 	}

--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -18,6 +18,9 @@ package e2e
 
 import (
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
@@ -25,8 +28,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/wait"
-	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -237,7 +238,7 @@ var _ = Describe("DNS", func() {
 			Spec: api.ServiceSpec{
 				ClusterIP: "None",
 				Ports: []api.ServicePort{
-					{Port: 80, Name: "http", Protocol: "tcp"},
+					{Port: 80, Name: "http", Protocol: "TCP"},
 				},
 				Selector: testServiceSelector,
 			},
@@ -257,7 +258,7 @@ var _ = Describe("DNS", func() {
 			},
 			Spec: api.ServiceSpec{
 				Ports: []api.ServicePort{
-					{Port: 80, Name: "http", Protocol: "tcp"},
+					{Port: 80, Name: "http", Protocol: "TCP"},
 				},
 				Selector: testServiceSelector,
 			},


### PR DESCRIPTION
This tightens validation on port protocol allowed values.

Currently, port protocol validation allows case-insensitive matching of "tcp" or "udp". However, other parts of the system rely on exact matches to the API constants:

```
pkg/api/validation/validation.go:
 1085   if service.Spec.Type == api.ServiceTypeLoadBalancer {
 1086       for i := range service.Spec.Ports {
 1087:          if service.Spec.Ports[i].Protocol != api.ProtocolTCP {
 1088               allErrs = append(allErrs, errs.NewFieldInvalid(fmt.Sprintf("spec.ports[%d].protocol", i), service.Spec.Ports[i].Protocol, "cannot create an external load balancer with non-TCP ports"))
 1089           }

pkg/cloudprovider/servicecontroller/servicecontroller.go:
  461       // it's supported.
  462       sp := &service.Spec.Ports[i]
  463:      if sp.Protocol != api.ProtocolTCP {
  464           return nil, fmt.Errorf("external load balancers for non TCP services are not currently supported.")
  465       }

pkg/master/controller.go:
  241   }
  242   p := &sub.Ports[0]
  243:  if p.Port != port || p.Protocol != api.ProtocolTCP {
  244       return false, false
  245   }
```

Other places where exact comparisons are expected between objects:

```
contrib/mesos/pkg/service/endpoints_controller.go:
400:                if port.Name == name && port.Protocol == svcPort.Protocol {
401:                    return findMappedPortName(pod, port.Protocol, name)

contrib/mesos/pkg/service/endpoints_controller.go:
414:                if port.ContainerPort == p && port.Protocol == svcPort.Protocol {
415:                    return findMappedPort(pod, port.Protocol, p)

pkg/service/endpoints_controller.go:
406:                if port.Name == name && port.Protocol == svcPort.Protocol {
```

Allowing a service or endpoint to be created with loose protocol validation, only to fail other parts of the system with strict checking isn't good.
