### PR TITLE
AWS: Run minions in Auto Scaling Group

### DIFF
--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -38,7 +38,6 @@ IAM_PROFILE_MINION="kubernetes-minion"
 LOG="/dev/null"
 
 MASTER_NAME="${INSTANCE_PREFIX}-master"
-MINION_NAMES=($(eval echo ${INSTANCE_PREFIX}-minion-{1..${NUM_MINIONS}}))
 MASTER_TAG="${INSTANCE_PREFIX}-master"
 MINION_TAG="${INSTANCE_PREFIX}-minion"
 MINION_SCOPES=""

--- a/cluster/aws/config-test.sh
+++ b/cluster/aws/config-test.sh
@@ -34,7 +34,6 @@ IAM_PROFILE_MINION="kubernetes-minion"
 LOG="/dev/null"
 
 MASTER_NAME="${INSTANCE_PREFIX}-master"
-MINION_NAMES=($(eval echo ${INSTANCE_PREFIX}-minion-{1..${NUM_MINIONS}}))
 MASTER_TAG="${INSTANCE_PREFIX}-master"
 MINION_TAG="${INSTANCE_PREFIX}-minion"
 MINION_SCOPES=""

--- a/cluster/aws/ubuntu/common.sh
+++ b/cluster/aws/ubuntu/common.sh
@@ -25,7 +25,6 @@ function detect-minion-image() {
 }
 
 function generate-minion-user-data {
-  i=$1
   # We pipe this to the ami as a startup script in the user-data field.  Requires a compatible ami
   echo "#! /bin/bash"
   echo "SALT_MASTER='${MASTER_INTERNAL_IP}'"
@@ -37,8 +36,7 @@ function generate-minion-user-data {
 }
 
 function check-minion() {
-  local minion_name=$1
-  local minion_ip=$2
+  local minion_ip=$1
 
   local output=$(ssh -oStrictHostKeyChecking=no -i "${AWS_SSH_KEY}" ${SSH_USER}@$minion_ip sudo docker ps -a 2>/dev/null)
   if [[ -z "${output}" ]]; then

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -90,6 +90,8 @@ type EC2 interface {
 	DescribeRouteTables(request *ec2.DescribeRouteTablesInput) ([]*ec2.RouteTable, error)
 	CreateRoute(request *ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error)
 	DeleteRoute(request *ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error)
+
+	ModifyInstanceAttribute(request *ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error)
 }
 
 // This is a simple pass-through of the ELB client interface, which allows for testing
@@ -412,6 +414,10 @@ func (s *awsSdkEC2) CreateRoute(request *ec2.CreateRouteInput) (*ec2.CreateRoute
 
 func (s *awsSdkEC2) DeleteRoute(request *ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error) {
 	return s.ec2.DeleteRoute(request)
+}
+
+func (s *awsSdkEC2) ModifyInstanceAttribute(request *ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error) {
+	return s.ec2.ModifyInstanceAttribute(request)
 }
 
 func init() {

--- a/pkg/cloudprovider/aws/aws_test.go
+++ b/pkg/cloudprovider/aws/aws_test.go
@@ -372,6 +372,10 @@ func (s *FakeEC2) DeleteRoute(request *ec2.DeleteRouteInput) (*ec2.DeleteRouteOu
 	panic("Not implemented")
 }
 
+func (s *FakeEC2) ModifyInstanceAttribute(request *ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error) {
+	panic("Not implemented")
+}
+
 type FakeELB struct {
 	aws *FakeAWSServices
 }


### PR DESCRIPTION
Run the minions in an auto-scaling group, to support resizing.  Should only affect AWS.

Depends on #9720 (first two commits are 9720)
