### PR TITLE
Work around for PDs stop mounting after a few hours issue

### DIFF
--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -102,6 +102,11 @@ func doMount(source string, target string, fstype string, options []string) erro
 		glog.Errorf("Mount failed: %v\nMounting arguments: %s %s %s %v\nOutput: %s\n",
 			err, source, target, fstype, options, string(output))
 	}
+	// TODO: This is a temporary work around for Issue #7972. Once the underlying issue has been resolved, this can be removed.
+	_, udeverr := exec.Command("udevadm", "trigger").CombinedOutput()
+	if udeverr != nil {
+		glog.Errorf("udevadm trigger failed while mounting %q to %q with: %v\n", source, target, udeverr)
+	}
 	return err
 }
 
@@ -133,6 +138,13 @@ func (mounter *Mounter) Unmount(target string) error {
 		glog.Errorf("Unmount failed: %v\nUnmounting arguments: %s\nOutput: %s\n", err, target, string(output))
 		return err
 	}
+	// TODO: This is a temporary work around for Issue #7972. Once the underlying issue has been resolved, this can be removed.
+	_, udeverr := exec.Command("udevadm", "trigger").CombinedOutput()
+	if udeverr != nil {
+		glog.Errorf("udevadm trigger failed while unmounting %q with: %v\n", target, udeverr)
+	}
+	return err
+
 	return nil
 }
 


### PR DESCRIPTION
This is a temporary work around for #7972 

The problem was that if we repeatedly create, attach, mount, unmount, detach, and delete a PD from a GCE instance (PD soak test did this), after a few hours the GCE instance gets corrupted and stops attaching PDs correctly.

The real fix lies on the GCE side, in the meantime, they suggest this as a safe work around (to be removed once the GCE fix is in).

I've tested it locally and can confirm that this fixes the issue.

It did expose another issue where PDs sometimes don't get deleted correctly (much less severe than #7972). I'll create a separate issue to track that.

CC @quinton-hoole  @brendanburns @dchen1107 
