### PR TITLE
Do not override environment variable in ubuntu defaults

### DIFF
--- a/cluster/ubuntu/.gitignore
+++ b/cluster/ubuntu/.gitignore
@@ -1,0 +1,1 @@
+binaries

--- a/cluster/ubuntu/build.sh
+++ b/cluster/ubuntu/build.sh
@@ -31,7 +31,8 @@ mkdir -p binaries/minion
 
 # flannel
 echo "Download flannel release ..."
-FLANNEL_VERSION="0.4.0"
+FLANNEL_VERSION=${FLANNEL_VERSION:-"0.4.0"}
+echo "Flannel version is $FLANNEL_VERSION"
 if [ ! -f flannel.tar.gz ] ; then
   curl -L  https://github.com/coreos/flannel/releases/download/v${FLANNEL_VERSION}/flannel-${FLANNEL_VERSION}-linux-amd64.tar.gz -o flannel.tar.gz
   tar xzf flannel.tar.gz
@@ -41,10 +42,10 @@ cp flannel-${FLANNEL_VERSION}/flanneld binaries/minion
 
 # ectd
 echo "Download etcd release ..."
-ETCD_VERSION="v2.0.9"
-ETCD="etcd-${ETCD_VERSION}-linux-amd64"
+ETCD_VERSION=${ETCD_VERSION:-"2.0.9"}
+ETCD="etcd-v${ETCD_VERSION}-linux-amd64"
 if [ ! -f etcd.tar.gz ] ; then
-  curl -L https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/${ETCD}.tar.gz -o etcd.tar.gz
+  curl -L https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/${ETCD}.tar.gz -o etcd.tar.gz
   tar xzf etcd.tar.gz
 fi
 cp $ETCD/etcd $ETCD/etcdctl binaries/master
@@ -52,9 +53,9 @@ cp $ETCD/etcd $ETCD/etcdctl binaries/minion
 
 # k8s
 echo "Download kubernetes release ..."
-K8S_VERSION="v0.18.0"
+K8S_VERSION=${K8S_VERSION:-"0.18.0"}
 if [ ! -f kubernetes.tar.gz ] ; then
-  curl -L https://github.com/GoogleCloudPlatform/kubernetes/releases/download/${K8S_VERSION}/kubernetes.tar.gz -o kubernetes.tar.gz
+  curl -L https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v${K8S_VERSION}/kubernetes.tar.gz -o kubernetes.tar.gz
   tar xzf kubernetes.tar.gz
 fi
 pushd kubernetes/server

--- a/cluster/ubuntu/config-default.sh
+++ b/cluster/ubuntu/config-default.sh
@@ -17,42 +17,49 @@
 ## Contains configuration values for the Ubuntu cluster
 
 # Define all your cluster nodes, MASTER node comes first"
-# And separated with blank space like <user_1@ip_1> <user_2@ip_2> <user_3@ip_3>
-export nodes="vcap@10.10.103.250 vcap@10.10.103.162 vcap@10.10.103.223"
-# Define all your nodes role: a(master) or i(minion) or ai(both master and minion), must be the order same
-export roles=("ai" "i" "i")
+# And separated with blank space like <user_1@ip_1> <user_2@ip_2> <user_3@ip_3> 
+export nodes=${nodes:-"vcap@10.10.103.250 vcap@10.10.103.162 vcap@10.10.103.223"}
+# Define all your nodes role: a(master) or i(minion) or ai(both master and minion), must be the order same 
+roles=${roles:-"ai i i"}
+# If it practically impossible to set an array as an environment variable
+# from a script, so assume variable is a string then convert it to an array
+export roles=($roles)
+
 # Define minion numbers
 export NUM_MINIONS=${NUM_MINIONS:-3}
 # define the IP range used for service cluster IPs.
 # according to rfc 1918 ref: https://tools.ietf.org/html/rfc1918 choose a private ip range here.
-export SERVICE_CLUSTER_IP_RANGE=192.168.3.0/24  # formerly PORTAL_NET
+export SERVICE_CLUSTER_IP_RANGE=${SERVICE_CLUSTER_IP_RANGE:-192.168.3.0/24}  # formerly PORTAL_NET
 # define the IP range used for flannel overlay network, should not conflict with above SERVICE_CLUSTER_IP_RANGE
-export FLANNEL_NET=172.16.0.0/16
+export FLANNEL_NET=${FLANNEL_NET:-172.16.0.0/16}
+echo "FLANNEL_NET"
+echo $FLANNEL_NET
+export FLANNEL_OPTS=${FLANNEL_OPTS:-"Network": 172.16.0.0/16}
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,ServiceAccount,ResourceQuota
+ADMISSION_CONTROL=${ADMISSION_CONTROL:-NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,ServiceAccount,ResourceQuota}
 
 # Optional: Enable node logging.
 ENABLE_NODE_LOGGING=false
-LOGGING_DESTINATION=elasticsearch
+LOGGING_DESTINATION=${LOGGING_DESTINATION:-elasticsearch}
 
 # Optional: When set to true, Elasticsearch and Kibana will be setup as part of the cluster bring up.
 ENABLE_CLUSTER_LOGGING=false
-ELASTICSEARCH_LOGGING_REPLICAS=1
+ELASTICSEARCH_LOGGING_REPLICAS=${ELASTICSEARCH_LOGGING_REPLICAS:-1}
 
 # Optional: When set to true, heapster, Influxdb and Grafana will be setup as part of the cluster bring up.
 ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-true}"
 
 # Extra options to set on the Docker command line.  This is useful for setting
 # --insecure-registry for local registries.
-DOCKER_OPTS=""
+DOCKER_OPTS=${DOCKER_OPTS:-""}
 
 # Optional: Install cluster DNS.
 ENABLE_CLUSTER_DNS=true
 # DNS_SERVER_IP must be a IP in SERVICE_CLUSTER_IP_RANGE
-DNS_SERVER_IP="192.168.3.10"
-DNS_DOMAIN="cluster.local"
-DNS_REPLICAS=1
+DNS_SERVER_IP=${DNS_SERVER_IP:-"192.168.3.10"}
+DNS_DOMAIN=${DNS_DOMAIN:-"cluster.local"}
+DNS_REPLICAS=${DNS_REPLICAS:-1}
 
 # Optional: Enable setting flags for kube-apiserver to turn on behavior in active-dev
 #RUNTIME_CONFIG=""

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -146,39 +146,41 @@ function verify-cluster {
 
 function verify-master(){
   # verify master has all required daemons
-  echo "Validating master"
+  printf "Validating master"
   local -a required_daemon=("kube-apiserver" "kube-controller-manager" "kube-scheduler")
   local validated="1"
   until [[ "$validated" == "0" ]]; do
     validated="0"
     local daemon
     for daemon in "${required_daemon[@]}"; do
-      ssh "$MASTER" "pgrep -f ${daemon}" >/dev/null 2>&1 || {
+      ssh $SSH_OPTS "$MASTER" "pgrep -f ${daemon}" >/dev/null 2>&1 || {
         printf "."
         validated="1"
         sleep 2
       }
     done
   done
+  printf "\n"
 
 }
 
 function verify-minion(){
   # verify minion has all required daemons
-  echo "Validating ${1}"
+  printf "Validating ${1}"
   local -a required_daemon=("kube-proxy" "kubelet" "docker")
   local validated="1"
   until [[ "$validated" == "0" ]]; do
     validated="0"
     local daemon
     for daemon in "${required_daemon[@]}"; do
-      ssh "$1" "pgrep -f $daemon" >/dev/null 2>&1 || {
+      ssh $SSH_OPTS "$1" "pgrep -f $daemon" >/dev/null 2>&1 || {
         printf "."
         validated="1"
         sleep 2
       }
     done
   done
+  printf "\n"
 }
 
 function create-etcd-opts(){

--- a/docs/getting-started-guides/ubuntu.md
+++ b/docs/getting-started-guides/ubuntu.md
@@ -55,7 +55,7 @@ First configure the cluster information in cluster/ubuntu/config-default.sh, bel
 ```
 export nodes="vcap@10.10.103.250 vcap@10.10.103.162 vcap@10.10.103.223"
 
-export roles=("ai" "i" "i")
+export roles="ai i i"
 
 export NUM_MINIONS=${NUM_MINIONS:-3}
 


### PR DESCRIPTION
Here is the summery of changes
1. make sure `config-default.sh` doesn't override environment variables
   - It lets people run everything from the repo instead of creating their own file with their config parameters
2. use string instead of array in `config-default.sh` so it's possible to pass it as an environment variable from shell, and update the docs
3. try to start a daemon again if it isn't running on a minion or master node when verifying it
   - I have to manually start `kubeclt` on each of the nodes otherwise since it isn't running after the provisioning of minions or the master is finished.
