### PR TITLE
AWS: Note about instance types

### DIFF
--- a/cluster/aws/options.md
+++ b/cluster/aws/options.md
@@ -38,6 +38,10 @@ export MASTER_SIZE=c4.large
 export MINION_SIZE=r3.large
 ```
 
+Please note: `kube-up` utilizes ephemeral storage available on instances for docker storage. EBS-only instance types do not
+support ephemeral storage and will default to docker storage on the root disk which is usually only 8GB.
+EBS-only instance types include `t2`, `c4`, and `m4`.
+
 **KUBE_ENABLE_MINION_PUBLIC_IP**
 
 Should a public IP automatically assigned to the minions? "true" or "false"  


### PR DESCRIPTION
Certain instance types don't support ephemeral disks which is generally fine. But, an active cluster will fill up the disk quite quickly if they are not present. In lieu of setting up EBS volumes on these instance types, add a note to the AWS options doc warning the user about the consequences of using these types.

@justinsb should the example for the master use a different instance type with this in mind? Perhaps, `c3.large` instead?
