### PR TITLE
Updating version number for heapster config files 

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -1,22 +1,22 @@
 apiVersion: v1
 kind: ReplicationController
 metadata: 
-  name: monitoring-heapster-v3
+  name: monitoring-heapster-v4
   namespace: default
   labels: 
     k8s-app: heapster
-    version: v3
+    version: v4
     kubernetes.io/cluster-service: "true"
 spec: 
   replicas: 1
   selector: 
     k8s-app: heapster
-    version: v3
+    version: v4
   template: 
     metadata: 
       labels: 
         k8s-app: heapster
-        version: v3
+        version: v4
         kubernetes.io/cluster-service: "true"
     spec: 
       containers: 

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -1,22 +1,22 @@
 apiVersion: v1
 kind: ReplicationController
 metadata: 
-  name: monitoring-heapster-v3
+  name: monitoring-heapster-v4
   namespace: default
   labels: 
     k8s-app: heapster
-    version: v3
+    version: v4
     kubernetes.io/cluster-service: "true"
 spec: 
   replicas: 1
   selector: 
     k8s-app: heapster
-    version: v3
+    version: v4
   template: 
     metadata: 
       labels: 
         k8s-app: heapster
-        version: v3
+        version: v4
         kubernetes.io/cluster-service: "true"
     spec: 
       containers: 

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -1,22 +1,22 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: monitoring-heapster-v3
+  name: monitoring-heapster-v4
   namespace: default 
   labels: 
     k8s-app: heapster
-    version: v3
+    version: v4
     kubernetes.io/cluster-service: "true"
 spec: 
   replicas: 1
   selector: 
     k8s-app: heapster
-    version: v3
+    version: v4
   template: 
     metadata: 
       labels: 
         k8s-app: heapster
-        version: v3
+        version: v4
         kubernetes.io/cluster-service: "true"
     spec: 
       containers: 

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -1,22 +1,22 @@
 apiVersion: v1
 kind: ReplicationController
 metadata: 
-  name: monitoring-heapster-v3
+  name: monitoring-heapster-v4
   namespace: default
   labels: 
     k8s-app: heapster
-    version: v3
+    version: v4
     kubernetes.io/cluster-service: "true"
 spec: 
   replicas: 1
   selector: 
     k8s-app: heapster
-    version: v3
+    version: v4
   template: 
     metadata: 
       labels: 
         k8s-app: heapster
-        version: v3
+        version: v4
         kubernetes.io/cluster-service: "true"
     spec: 
       containers: 


### PR DESCRIPTION
Heapster v0.14.1 was released with version tag 'v3' as part of kubernetes v0.19.1 recently.
Heapster was updated to v0.14.2, but the version tag was not updated. This PR updated the version tag to allow rolling updates of heapster in future releases.

cc @saad-ali 
