### PR TITLE
Configured resource-only container /docker-daemon with 70% of node me…

### DIFF
--- a/pkg/kubelet/container_manager_unsupported.go
+++ b/pkg/kubelet/container_manager_unsupported.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/cadvisor"
 )
 
 type unsupportedContainerManager struct {
@@ -37,6 +38,6 @@ func (unsupportedContainerManager) SystemContainersLimit() api.ResourceList {
 	return api.ResourceList{}
 }
 
-func newContainerManager(dockerDaemonContainer, systemContainer, kubeletContainer string) (containerManager, error) {
+func newContainerManager(cadvisorInterface cadvisor.Interface, dockerDaemonContainer, systemContainer, kubeletContainer string) (containerManager, error) {
 	return &unsupportedContainerManager{}, nil
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -309,7 +309,7 @@ func NewMainKubelet(
 
 	// Setup container manager, can fail if the devices hierarchy is not mounted
 	// (it is required by Docker however).
-	containerManager, err := newContainerManager(dockerDaemonContainer, systemContainer, resourceContainer)
+	containerManager, err := newContainerManager(cadvisorInterface, dockerDaemonContainer, systemContainer, resourceContainer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the Container Manager: %v", err)
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -133,7 +133,7 @@ func newTestKubelet(t *testing.T) *TestKubelet {
 		t:            t,
 	}
 	kubelet.volumeManager = newVolumeManager()
-	kubelet.containerManager, _ = newContainerManager("", "", "")
+	kubelet.containerManager, _ = newContainerManager(mockCadvisor, "", "", "")
 	return &TestKubelet{kubelet, fakeDocker, mockCadvisor, fakeKubeClient, fakeMirrorClient}
 }
 
@@ -243,7 +243,7 @@ func newTestKubeletWithFakeRuntime(t *testing.T) *TestKubeletWithFakeRuntime {
 		t:            t,
 	}
 	kubelet.volumeManager = newVolumeManager()
-	kubelet.containerManager, _ = newContainerManager("", "", "")
+	kubelet.containerManager, _ = newContainerManager(mockCadvisor, "", "", "")
 	return &TestKubeletWithFakeRuntime{kubelet, fakeRuntime, mockCadvisor, fakeKubeClient, fakeMirrorClient}
 }
 

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -89,7 +89,7 @@ func TestRunOnce(t *testing.T) {
 		os:                  kubecontainer.FakeOS{},
 		volumeManager:       newVolumeManager(),
 	}
-	kb.containerManager, _ = newContainerManager("", "", "")
+	kb.containerManager, _ = newContainerManager(cadvisor, "", "", "")
 
 	kb.networkPlugin, _ = network.InitNetworkPlugin([]network.NetworkPlugin{}, "", network.NewFakeHost(nil))
 	if err := kb.setupDataDirs(); err != nil {


### PR DESCRIPTION
…mory capacity. This is a workaround to docker memory leakage issue.

Without this pr, /docker-daemon is configured with unlimited memory:

```
# cat /sys/fs/cgroup/memory/docker-daemon/memory.limit_in_bytes 
18446744073709551615
```

With this, it has 70% of node memory capacity: 

```
$ cluster/kubectl.sh describe nodes kubernetes-minion-b113
Name:           kubernetes-minion-b113
Labels:         kubernetes.io/hostname=kubernetes-minion-b113
CreationTimestamp:  Tue, 16 Jun 2015 11:03:35 -0700
Conditions:
  Type      Status  LastHeartbeatTime           LastTransitionTime          Reason                  Message
  Ready     True    Wed, 17 Jun 2015 11:22:52 -0700     Tue, 16 Jun 2015 11:03:45 -0700     kubelet is posting ready status     
Addresses:  10.240.87.219,104.197.16.208
Capacity:
 cpu:       1
 memory:    3800808Ki
 pods:      100
```

```
# cat /sys/fs/cgroup/memory/docker-daemon/memory.limit_in_bytes 
2724421632
```

Fix #9881

cc/ @rjnagal
