### PR TITLE
Allowing for HTTPS Probes

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -12722,6 +12722,10 @@
      "host": {
       "type": "string",
       "description": "hostname to connect to; defaults to pod IP"
+     },
+     "scheme": {
+      "type": "string",
+      "description": "scheme to connect with, must be HTTP or HTTPS, defaults to HTTP"
      }
     }
    },

--- a/api/swagger-spec/v1beta3.json
+++ b/api/swagger-spec/v1beta3.json
@@ -12724,6 +12724,10 @@
      "host": {
       "type": "string",
       "description": "hostname to connect to; defaults to pod IP"
+     },
+     "scheme": {
+      "type": "string",
+      "description": "scheme to connect with, must be HTTP or HTTPS, defaults to HTTP"
      }
     }
    },

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -933,12 +933,12 @@ function check-resources {
   fi
 
   if gcloud compute firewall-rules describe --project "${PROJECT}" "${MASTER_NAME}-https" &>/dev/null; then
-    KUBE_RESOURCE_FOUND="Firewal rules for ${MASTER_NAME}-https"
+    KUBE_RESOURCE_FOUND="Firewall rules for ${MASTER_NAME}-https"
     return 1
   fi
 
   if gcloud compute firewall-rules describe --project "${PROJECT}" "${MINION_TAG}-all" &>/dev/null; then
-    KUBE_RESOURCE_FOUND="Firewal rules for ${MASTER_NAME}-all"
+    KUBE_RESOURCE_FOUND="Firewall rules for ${MASTER_NAME}-all"
     return 1
   fi
 

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -88,7 +88,7 @@ func runApiServer(etcdClient tools.EtcdClient, addr net.IP, port int, masterServ
 		EtcdHelper: helper,
 		KubeletClient: &client.HTTPKubeletClient{
 			Client: http.DefaultClient,
-			Port:   10250,
+			Config: &client.KubeletConfig{Port: 10250},
 		},
 		EnableCoreControllers: true,
 		EnableLogsSupport:     false,

--- a/examples/openshift-origin/.gitignore
+++ b/examples/openshift-origin/.gitignore
@@ -1,2 +1,3 @@
 config/
 secret.json
+*.log

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -505,6 +505,7 @@ func deepCopy_api_HTTPGetAction(in HTTPGetAction, out *HTTPGetAction, c *convers
 		return err
 	}
 	out.Host = in.Host
+	out.Scheme = in.Scheme
 	return nil
 }
 

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -252,8 +252,9 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			s.Phase = api.NamespaceActive
 		},
 		func(http *api.HTTPGetAction, c fuzz.Continue) {
-			c.FuzzNoCustom(http)        // fuzz self without calling this function again
-			http.Path = "/" + http.Path // can't be blank
+			c.FuzzNoCustom(http)            // fuzz self without calling this function again
+			http.Path = "/" + http.Path     // can't be blank
+			http.Scheme = "x" + http.Scheme // can't be blank
 		},
 		func(ss *api.ServiceSpec, c fuzz.Continue) {
 			c.FuzzNoCustom(ss) // fuzz self without calling this function again

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -610,7 +610,19 @@ type HTTPGetAction struct {
 	Port util.IntOrString `json:"port,omitempty"`
 	// Optional: Host name to connect to, defaults to the pod IP.
 	Host string `json:"host,omitempty"`
+	// Optional: Scheme to use for connecting to the host, defaults to HTTP.
+	Scheme URIScheme `json:"scheme,omitempty"`
 }
+
+// URIScheme identifies the scheme used for connection to a host for Get actions
+type URIScheme string
+
+const (
+	// URISchemeHTTP means that the scheme used will be http://
+	URISchemeHTTP URIScheme = "HTTP"
+	// URISchemeHTTPS means that the scheme used will be https://
+	URISchemeHTTPS URIScheme = "HTTPS"
+)
 
 // TCPSocketAction describes an action based on opening a socket
 type TCPSocketAction struct {

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -592,6 +592,7 @@ func convert_api_HTTPGetAction_To_v1_HTTPGetAction(in *api.HTTPGetAction, out *H
 		return err
 	}
 	out.Host = in.Host
+	out.Scheme = URIScheme(in.Scheme)
 	return nil
 }
 
@@ -2903,6 +2904,7 @@ func convert_v1_HTTPGetAction_To_api_HTTPGetAction(in *HTTPGetAction, out *api.H
 		return err
 	}
 	out.Host = in.Host
+	out.Scheme = api.URIScheme(in.Scheme)
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -518,6 +518,7 @@ func deepCopy_v1_HTTPGetAction(in HTTPGetAction, out *HTTPGetAction, c *conversi
 		return err
 	}
 	out.Host = in.Host
+	out.Scheme = in.Scheme
 	return nil
 }
 

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -137,6 +137,9 @@ func addDefaultingFuncs() {
 			if obj.Path == "" {
 				obj.Path = "/"
 			}
+			if obj.Scheme == "" {
+				obj.Scheme = URISchemeHTTP
+			}
 		},
 		func(obj *NamespaceStatus) {
 			if obj.Phase == "" {

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -586,7 +586,19 @@ type HTTPGetAction struct {
 	Port util.IntOrString `json:"port" description:"number or name of the port to access on the container"`
 	// Optional: Host name to connect to, defaults to the pod IP.
 	Host string `json:"host,omitempty" description:"hostname to connect to; defaults to pod IP"`
+	// Optional: Scheme to use for connecting to the host, defaults to HTTP.
+	Scheme URIScheme `json:"scheme,omitempty" description:"scheme to connect with, must be HTTP or HTTPS, defaults to HTTP"`
 }
+
+// URIScheme identifies the scheme used for connection to a host for Get actions
+type URIScheme string
+
+const (
+	// URISchemeHTTP means that the scheme used will be http://
+	URISchemeHTTP URIScheme = "HTTP"
+	// URISchemeHTTPS means that the scheme used will be https://
+	URISchemeHTTPS URIScheme = "HTTPS"
+)
 
 // TCPSocketAction describes an action based on opening a socket
 type TCPSocketAction struct {

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -450,6 +450,7 @@ func convert_api_HTTPGetAction_To_v1beta3_HTTPGetAction(in *api.HTTPGetAction, o
 		return err
 	}
 	out.Host = in.Host
+	out.Scheme = URIScheme(in.Scheme)
 	return nil
 }
 
@@ -2515,6 +2516,7 @@ func convert_v1beta3_HTTPGetAction_To_api_HTTPGetAction(in *HTTPGetAction, out *
 		return err
 	}
 	out.Host = in.Host
+	out.Scheme = api.URIScheme(in.Scheme)
 	return nil
 }
 

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -522,6 +522,7 @@ func deepCopy_v1beta3_HTTPGetAction(in HTTPGetAction, out *HTTPGetAction, c *con
 		return err
 	}
 	out.Host = in.Host
+	out.Scheme = in.Scheme
 	return nil
 }
 

--- a/pkg/api/v1beta3/defaults.go
+++ b/pkg/api/v1beta3/defaults.go
@@ -141,6 +141,9 @@ func addDefaultingFuncs() {
 			if obj.Path == "" {
 				obj.Path = "/"
 			}
+			if obj.Scheme == "" {
+				obj.Scheme = URISchemeHTTP
+			}
 		},
 		func(obj *NamespaceStatus) {
 			if obj.Phase == "" {

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -586,7 +586,19 @@ type HTTPGetAction struct {
 	Port util.IntOrString `json:"port" description:"number or name of the port to access on the container"`
 	// Optional: Host name to connect to, defaults to the pod IP.
 	Host string `json:"host,omitempty" description:"hostname to connect to; defaults to pod IP"`
+	// Optional: Scheme to use for connecting to the host, defaults to HTTP.
+	Scheme URIScheme `json:"scheme,omitempty" description:"scheme to connect with, must be HTTP or HTTPS, defaults to HTTP"`
 }
+
+// URIScheme identifies the scheme used for connection to a host for Get actions
+type URIScheme string
+
+const (
+	// URISchemeHTTP means that the scheme used will be http://
+	URISchemeHTTP URIScheme = "HTTP"
+	// URISchemeHTTPS means that the scheme used will be https://
+	URISchemeHTTPS URIScheme = "HTTPS"
+)
 
 // TCPSocketAction describes an action based on opening a socket
 type TCPSocketAction struct {

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -762,6 +762,10 @@ func validateHTTPGetAction(http *api.HTTPGetAction) errs.ValidationErrorList {
 	} else if http.Port.Kind == util.IntstrString && len(http.Port.StrVal) == 0 {
 		allErrors = append(allErrors, errs.NewFieldRequired("port"))
 	}
+	supportedSchemes := util.NewStringSet(string(api.URISchemeHTTP), string(api.URISchemeHTTPS))
+	if !supportedSchemes.Has(string(http.Scheme)) {
+		allErrors = append(allErrors, errs.NewFieldInvalid("scheme", http.Scheme, fmt.Sprintf("must be one of %v", supportedSchemes.List())))
+	}
 	return allErrors
 }
 

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -712,9 +712,9 @@ func TestValidateProbe(t *testing.T) {
 func TestValidateHandler(t *testing.T) {
 	successCases := []api.Handler{
 		{Exec: &api.ExecAction{Command: []string{"echo"}}},
-		{HTTPGet: &api.HTTPGetAction{Path: "/", Port: util.NewIntOrStringFromInt(1), Host: ""}},
-		{HTTPGet: &api.HTTPGetAction{Path: "/foo", Port: util.NewIntOrStringFromInt(65535), Host: "host"}},
-		{HTTPGet: &api.HTTPGetAction{Path: "/", Port: util.NewIntOrStringFromString("port"), Host: ""}},
+		{HTTPGet: &api.HTTPGetAction{Path: "/", Port: util.NewIntOrStringFromInt(1), Host: "", Scheme: "HTTP"}},
+		{HTTPGet: &api.HTTPGetAction{Path: "/foo", Port: util.NewIntOrStringFromInt(65535), Host: "host", Scheme: "HTTP"}},
+		{HTTPGet: &api.HTTPGetAction{Path: "/", Port: util.NewIntOrStringFromString("port"), Host: "", Scheme: "HTTP"}},
 	}
 	for _, h := range successCases {
 		if errs := validateHandler(&h); len(errs) != 0 {

--- a/pkg/client/kubelet_test.go
+++ b/pkg/client/kubelet_test.go
@@ -57,7 +57,7 @@ func TestHTTPKubeletClient(t *testing.T) {
 
 	c := &HTTPKubeletClient{
 		Client: http.DefaultClient,
-		Port:   uint(port),
+		Config: &KubeletConfig{Port: uint(port)},
 	}
 	gotObj, _, err := c.HealthCheck(parts[0])
 	if err != nil {
@@ -91,7 +91,7 @@ func TestHTTPKubeletClientError(t *testing.T) {
 
 	c := &HTTPKubeletClient{
 		Client: http.DefaultClient,
-		Port:   uint(port),
+		Config: &KubeletConfig{Port: uint(port)},
 	}
 	gotObj, _, err := c.HealthCheck(parts[0])
 	if gotObj != expectObj {

--- a/pkg/probe/http/http_test.go
+++ b/pkg/probe/http/http_test.go
@@ -29,24 +29,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/probe"
 )
 
-func TestFormatURL(t *testing.T) {
-	testCases := []struct {
-		host   string
-		port   int
-		path   string
-		result string
-	}{
-		{"localhost", 93, "", "http://localhost:93"},
-		{"localhost", 93, "/path", "http://localhost:93/path"},
-	}
-	for _, test := range testCases {
-		url := formatURL(test.host, test.port, test.path)
-		if url != test.result {
-			t.Errorf("Expected %s, got %s", test.result, url)
-		}
-	}
-}
-
 func TestHTTPProbeChecker(t *testing.T) {
 	handleReq := func(s int, body string) func(w http.ResponseWriter) {
 		return func(w http.ResponseWriter) {
@@ -74,15 +56,15 @@ func TestHTTPProbeChecker(t *testing.T) {
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
-		host, port, err := net.SplitHostPort(u.Host)
+		_, port, err := net.SplitHostPort(u.Host)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
-		p, err := strconv.Atoi(port)
+		_, err = strconv.Atoi(port)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
-		health, output, err := prober.Probe(host, p, "", 1*time.Second)
+		health, output, err := prober.Probe(u, 1*time.Second)
 		if test.health == probe.Unknown && err == nil {
 			t.Errorf("Expected error")
 		}


### PR DESCRIPTION
Changed the `HTTPGetAction` API object to allow user-defined schemes in order to allow HTTPS readiness checks. This allows users to specify the scheme of their `HTTPGetAction`s, which should also allow us to support http2, websockets, etc if wanted. 

Changed default `HTTPProber` to use a `TLSConfig` with `InsecureSkipVerify` set to true in order to skip TLS for probe Gets.

@smarterclayton @mikedanese 

Fixes #9866 
