### PR TITLE
Fix variable binding bug when saving logs

### DIFF
--- a/test/e2e/core.go
+++ b/test/e2e/core.go
@@ -76,7 +76,7 @@ func logCore(cmds []command, hosts []string, dir, provider string) {
 		fmt.Printf("SSH'ing to all nodes and running %s\n", cmd.cmd)
 		for _, host := range hosts {
 			wg.Add(1)
-			go func() {
+			go func(cmd command, host string) {
 				defer wg.Done()
 				logfile := fmt.Sprintf("%s/%s-%s.log", dir, host, cmd.component)
 				fmt.Printf("Writing to %s.\n", logfile)
@@ -87,7 +87,7 @@ func logCore(cmds []command, hosts []string, dir, provider string) {
 				if err := ioutil.WriteFile(logfile, []byte(stdout+stderr), 0777); err != nil {
 					fmt.Printf("Error writing logfile: %v\n", err)
 				}
-			}()
+			}(cmd, host)
 		}
 	}
 	wg.Wait()


### PR DESCRIPTION
Previously we were only saving logs from the last command.
