### PR TITLE
Kubelet benchmarks

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -711,6 +711,8 @@ func createAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.Pod
 		MaxPerPodContainer: kc.MaxPerPodContainerCount,
 		MaxContainers:      kc.MaxContainerCount,
 	}
+	// TODO: Make this a part of the KubeletConfig
+	stopCh := make(chan struct{})
 
 	pc = makePodSourceConfig(kc)
 	k, err = kubelet.NewMainKubelet(
@@ -748,7 +750,9 @@ func createAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.Pod
 		kc.SystemContainer,
 		kc.ConfigureCBR0,
 		kc.MaxPods,
-		kc.DockerExecHandler)
+		kc.DockerExecHandler,
+		stopCh,
+	)
 
 	if err != nil {
 		return nil, nil, err

--- a/contrib/mesos/pkg/executor/service/service.go
+++ b/contrib/mesos/pkg/executor/service/service.go
@@ -316,6 +316,7 @@ func (ks *KubeletExecutorServer) createAndInitKubelet(
 
 	pc := kconfig.NewPodConfig(kconfig.PodConfigNotificationSnapshotAndUpdates, kc.Recorder)
 	updates := pc.Channel(MESOS_CFG_SOURCE)
+	stopCh := make(chan struct{})
 
 	klet, err := kubelet.NewMainKubelet(
 		kc.Hostname,
@@ -353,6 +354,7 @@ func (ks *KubeletExecutorServer) createAndInitKubelet(
 		kc.ConfigureCBR0,
 		kc.MaxPods,
 		kc.DockerExecHandler,
+		stopCh,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/kubelet/fake_pod_workers.go
+++ b/pkg/kubelet/fake_pod_workers.go
@@ -42,4 +42,4 @@ func (f *fakePodWorkers) UpdatePod(pod *api.Pod, mirrorPod *api.Pod, updateCompl
 	}
 }
 
-func (f *fakePodWorkers) ForgetNonExistingPodWorkers(desiredPods map[types.UID]empty) {}
+func (f *fakePodWorkers) ForgetNonExistingPodWorkers(desiredPods map[types.UID]Empty) {}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -147,7 +147,8 @@ func NewMainKubelet(
 	systemContainer string,
 	configureCBR0 bool,
 	pods int,
-	dockerExecHandler dockertools.ExecHandler) (*Kubelet, error) {
+	dockerExecHandler dockertools.ExecHandler,
+	stopCh chan struct{}) (*Kubelet, error) {
 	if rootDirectory == "" {
 		return nil, fmt.Errorf("invalid root directory %q", rootDirectory)
 	}
@@ -171,7 +172,7 @@ func NewMainKubelet(
 				return kubeClient.Services(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), resourceVersion)
 			},
 		}
-		cache.NewReflector(listWatch, &api.Service{}, serviceStore, 0).Run()
+		cache.NewReflector(listWatch, &api.Service{}, serviceStore, 0).RunUntil(stopCh)
 	}
 	serviceLister := &cache.StoreToServiceLister{serviceStore}
 
@@ -188,7 +189,7 @@ func NewMainKubelet(
 				return kubeClient.Nodes().Watch(labels.Everything(), fieldSelector, resourceVersion)
 			},
 		}
-		cache.NewReflector(listWatch, &api.Node{}, nodeStore, 0).Run()
+		cache.NewReflector(listWatch, &api.Node{}, nodeStore, 0).RunUntil(stopCh)
 	}
 	nodeLister := &cache.StoreToNodeLister{nodeStore}
 
@@ -237,7 +238,7 @@ func NewMainKubelet(
 		clusterDomain:                  clusterDomain,
 		clusterDNS:                     clusterDNS,
 		serviceLister:                  serviceLister,
-		nodeLister:                     nodeLister,
+		NodeLister:                     nodeLister,
 		runtimeMutex:                   sync.Mutex{},
 		runtimeUpThreshold:             maxWaitForContainerRuntime,
 		lastTimestampRuntimeUp:         time.Time{},
@@ -354,6 +355,7 @@ type serviceLister interface {
 	List() (api.ServiceList, error)
 }
 
+// nodeLister is a testing abstraction for the methods of a StoreToNodeLister used by the kubelet.
 type nodeLister interface {
 	List() (machines api.NodeList, err error)
 	GetNodeInfo(id string) (*api.Node, error)
@@ -400,7 +402,7 @@ type Kubelet struct {
 
 	masterServiceNamespace string
 	serviceLister          serviceLister
-	nodeLister             nodeLister
+	NodeLister             nodeLister
 
 	// Last timestamp when runtime responsed on ping.
 	// Mutex is used to protect this value.
@@ -633,7 +635,7 @@ func (kl *Kubelet) GetNode() (*api.Node, error) {
 	if kl.standaloneMode {
 		return nil, errors.New("no node entry for kubelet in standalone mode")
 	}
-	l, err := kl.nodeLister.List()
+	l, err := kl.NodeLister.List()
 	if err != nil {
 		return nil, errors.New("cannot list nodes")
 	}
@@ -659,6 +661,22 @@ func (kl *Kubelet) StartGarbageCollection() {
 			glog.Errorf("Image garbage collection failed: %v", err)
 		}
 	}, 5*time.Minute)
+}
+
+// GetPodStatusChannel retruns a channel on which to receive status updates. Only used for testing.
+func (kl *Kubelet) GetPodStatusChannel() chan PodStatusSyncRequest {
+	return kl.statusManager.podStatusChannel
+}
+
+// GetContainerRuntime returns the container runtime used by the kubelet. Only used for testing.
+func (kl *Kubelet) GetContainerRuntime() kubecontainer.Runtime {
+	return kl.containerRuntime
+}
+
+// StartStatusManager starts the status manager, which listens for pod updates to send to the apiserver. Only used for testing
+// since the kubelet always starts the status manager.
+func (kl *Kubelet) StartStatusManager() {
+	kl.statusManager.Start()
 }
 
 // Run starts the kubelet reacting to config updates
@@ -1072,7 +1090,7 @@ func (kl *Kubelet) killPod(pod kubecontainer.Pod) error {
 	return kl.containerRuntime.KillPod(pod)
 }
 
-type empty struct{}
+type Empty struct{}
 
 // makePodDataDirs creates the dirs for the pod datas.
 func (kl *Kubelet) makePodDataDirs(pod *api.Pod) error {
@@ -1350,6 +1368,11 @@ func (kl *Kubelet) filterOutTerminatedPods(allPods []*api.Pod) []*api.Pod {
 	return pods
 }
 
+// NotifyPodWorker notifies the appropriate pod worker about a pod event. Isolated into a function for testing.
+func (kl *Kubelet) NotifyPodWorker(pod, mirrorPod *api.Pod, updateCompleteFn func()) {
+	kl.podWorkers.UpdatePod(pod, mirrorPod, updateCompleteFn)
+}
+
 // SyncPods synchronizes the configured list of pods (desired state) with the host current state.
 func (kl *Kubelet) SyncPods(allPods []*api.Pod, podSyncTypes map[types.UID]SyncPodType,
 	mirrorPods map[string]*api.Pod, start time.Time) error {
@@ -1366,10 +1389,9 @@ func (kl *Kubelet) SyncPods(allPods []*api.Pod, podSyncTypes map[types.UID]SyncP
 
 	// Handles pod admission.
 	pods := kl.admitPods(allPods, podSyncTypes)
-
 	glog.V(4).Infof("Desired: %#v", pods)
 	var err error
-	desiredPods := make(map[types.UID]empty)
+	desiredPods := make(map[types.UID]Empty)
 
 	runningPods, err := kl.runtimeCache.GetPods()
 	if err != nil {
@@ -1381,10 +1403,10 @@ func (kl *Kubelet) SyncPods(allPods []*api.Pod, podSyncTypes map[types.UID]SyncP
 	for _, pod := range pods {
 		podFullName := kubecontainer.GetPodFullName(pod)
 		uid := pod.UID
-		desiredPods[uid] = empty{}
+		desiredPods[uid] = Empty{}
 
 		// Run the sync in an async manifest worker.
-		kl.podWorkers.UpdatePod(pod, mirrorPods[podFullName], func() {
+		kl.NotifyPodWorker(pod, mirrorPods[podFullName], func() {
 			metrics.PodWorkerLatency.WithLabelValues(podSyncTypes[pod.UID].String()).Observe(metrics.SinceInMicroseconds(start))
 		})
 
@@ -1404,7 +1426,7 @@ func (kl *Kubelet) SyncPods(allPods []*api.Pod, podSyncTypes map[types.UID]SyncP
 	}
 
 	// Kill containers associated with unwanted pods.
-	err = kl.killUnwantedPods(desiredPods, runningPods)
+	err = kl.KillUnwantedPods(desiredPods, runningPods)
 	if err != nil {
 		glog.Errorf("Failed killing unwanted containers: %v", err)
 	}
@@ -1445,8 +1467,8 @@ func (kl *Kubelet) SyncPods(allPods []*api.Pod, podSyncTypes map[types.UID]SyncP
 	return err
 }
 
-// killUnwantedPods kills the unwanted, running pods in parallel.
-func (kl *Kubelet) killUnwantedPods(desiredPods map[types.UID]empty,
+// KillUnwantedPods kills the unwanted, running pods in parallel.
+func (kl *Kubelet) KillUnwantedPods(desiredPods map[types.UID]Empty,
 	runningPods []*kubecontainer.Pod) error {
 	ch := make(chan error, len(runningPods))
 	defer close(ch)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -106,7 +106,7 @@ func newTestKubelet(t *testing.T) *TestKubelet {
 	kubelet.sourcesReady = func() bool { return true }
 	kubelet.masterServiceNamespace = api.NamespaceDefault
 	kubelet.serviceLister = testServiceLister{}
-	kubelet.nodeLister = testNodeLister{}
+	kubelet.NodeLister = testNodeLister{}
 	kubelet.readinessManager = kubecontainer.NewReadinessManager()
 	kubelet.recorder = fakeRecorder
 	kubelet.statusManager = newStatusManager(fakeKubeClient)
@@ -217,7 +217,7 @@ func newTestKubeletWithFakeRuntime(t *testing.T) *TestKubeletWithFakeRuntime {
 	kubelet.sourcesReady = func() bool { return true }
 	kubelet.masterServiceNamespace = api.NamespaceDefault
 	kubelet.serviceLister = testServiceLister{}
-	kubelet.nodeLister = testNodeLister{}
+	kubelet.NodeLister = testNodeLister{}
 	kubelet.readinessManager = kubecontainer.NewReadinessManager()
 	kubelet.recorder = fakeRecorder
 	kubelet.statusManager = newStatusManager(fakeKubeClient)
@@ -2284,7 +2284,7 @@ func TestHandlePortConflicts(t *testing.T) {
 func TestHandleNodeSelector(t *testing.T) {
 	testKubelet := newTestKubeletWithFakeRuntime(t)
 	kl := testKubelet.kubelet
-	kl.nodeLister = testNodeLister{nodes: []api.Node{
+	kl.NodeLister = testNodeLister{nodes: []api.Node{
 		{ObjectMeta: api.ObjectMeta{Name: testKubeletHostname, Labels: map[string]string{"key": "B"}}},
 	}}
 	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorApi.MachineInfo{}, nil)

--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -31,7 +31,7 @@ import (
 // PodWorkers is an abstract interface for testability.
 type PodWorkers interface {
 	UpdatePod(pod *api.Pod, mirrorPod *api.Pod, updateComplete func())
-	ForgetNonExistingPodWorkers(desiredPods map[types.UID]empty)
+	ForgetNonExistingPodWorkers(desiredPods map[types.UID]Empty)
 }
 
 type syncPodFnType func(*api.Pod, *api.Pod, kubecontainer.Pod, SyncPodType) error
@@ -171,7 +171,7 @@ func (p *podWorkers) UpdatePod(pod *api.Pod, mirrorPod *api.Pod, updateComplete 
 	}
 }
 
-func (p *podWorkers) ForgetNonExistingPodWorkers(desiredPods map[types.UID]empty) {
+func (p *podWorkers) ForgetNonExistingPodWorkers(desiredPods map[types.UID]Empty) {
 	p.podLock.Lock()
 	defer p.podLock.Unlock()
 	for key, channel := range p.podUpdates {

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -165,9 +165,9 @@ func TestForgetNonExistingPodWorkers(t *testing.T) {
 		t.Errorf("Incorrect number of open channels %v", len(podWorkers.podUpdates))
 	}
 
-	desiredPods := map[types.UID]empty{}
-	desiredPods[types.UID(2)] = empty{}
-	desiredPods[types.UID(14)] = empty{}
+	desiredPods := map[types.UID]Empty{}
+	desiredPods[types.UID(2)] = Empty{}
+	desiredPods[types.UID(14)] = Empty{}
 	podWorkers.ForgetNonExistingPodWorkers(desiredPods)
 	if len(podWorkers.podUpdates) != 2 {
 		t.Errorf("Incorrect number of open channels %v", len(podWorkers.podUpdates))
@@ -179,7 +179,7 @@ func TestForgetNonExistingPodWorkers(t *testing.T) {
 		t.Errorf("No updates channel for pod 14")
 	}
 
-	podWorkers.ForgetNonExistingPodWorkers(map[types.UID]empty{})
+	podWorkers.ForgetNonExistingPodWorkers(map[types.UID]Empty{})
 	if len(podWorkers.podUpdates) != 0 {
 		t.Errorf("Incorrect number of open channels %v", len(podWorkers.podUpdates))
 	}

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -81,7 +81,7 @@ func TestRunOnce(t *testing.T) {
 		rootDirectory:       "/tmp/kubelet",
 		recorder:            &record.FakeRecorder{},
 		cadvisor:            cadvisor,
-		nodeLister:          testNodeLister{},
+		NodeLister:          testNodeLister{},
 		statusManager:       newStatusManager(nil),
 		containerRefManager: kubecontainer.NewRefManager(),
 		readinessManager:    kubecontainer.NewReadinessManager(),

--- a/test/integration/framework/kubelet_utils.go
+++ b/test/integration/framework/kubelet_utils.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+
+	kubeletapp "github.com/GoogleCloudPlatform/kubernetes/cmd/kubelet/app"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/cadvisor"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
+	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	nodeutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util/node"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/empty_dir"
+
+	"github.com/golang/glog"
+)
+
+// StartPodWorkers starts pod workers for the given pods.
+func StartPodWorkers(k *kubelet.Kubelet, pods *api.PodList, wait bool) {
+	// Start pod workers in parallel
+	RunParallel(func(id int) error {
+		k.NotifyPodWorker(&pods.Items[id], nil, func() {})
+		return nil
+	}, len(pods.Items), 0)
+
+	if !wait {
+		return
+	}
+	podUpdates := k.GetPodStatusChannel()
+	for i := 0; i < len(pods.Items); i++ {
+		update := <-podUpdates
+		if update.Status.Phase != api.PodRunning {
+			glog.Fatalf("Pod %v not in Running, status: %+v", update.Pod.Name, update.Status)
+		}
+	}
+
+}
+
+// GetPods returns a list of pods. Note the type.
+func GetPods(k *kubelet.Kubelet, all bool) []*container.Pod {
+	runningPods, err := k.GetContainerRuntime().GetPods(all)
+	if err != nil {
+		glog.Fatalf("Could not get pods: %v", err)
+	}
+	return runningPods
+}
+
+// NewPodList creates a list of pods assigned to the given host with the given status.
+func NewPodList(count int, hostname string, status api.PodPhase) *api.PodList {
+	pods := []api.Pod{}
+	for i := 0; i < count; i++ {
+		newPod := api.Pod{
+			TypeMeta: api.TypeMeta{
+				Kind:       "Pod",
+				APIVersion: testapi.Version(),
+			},
+			ObjectMeta: api.ObjectMeta{
+				Name: fmt.Sprintf("pod%d", i),
+				UID:  util.NewUUID(),
+				// TODO: Pass in the labels
+				Labels:    map[string]string{"name": "foo"},
+				Namespace: TestNS,
+			},
+			Status: api.PodStatus{
+				Phase: status,
+			},
+			Spec: api.PodSpec{
+				NodeName: hostname,
+				Containers: []api.Container{
+					{
+						Name:  "bar",
+						Image: "kubernetes/pause",
+					},
+				},
+			},
+		}
+		pods = append(pods, newPod)
+	}
+	return &api.PodList{
+		Items: pods,
+	}
+}
+
+// TestKubeletConfig is used to configure the test kubelet.
+type TestKubeletConfig struct {
+	// The restclient the kubelet uses to talk to the apiserver. For normal kubelet
+	// benchmarks this shouldn't be necessary. If you need a master, you can call
+	// NewMasterComponents just like the master benchmarks.
+	// TODO: Pipe the restclient to the kubelet gracefully, if you need this
+	// behavior today you need to modify the call to NewMainKubelet below.
+	RestClient *client.Client
+	// Use a fake docker if true.
+	FakeDocker bool
+	// Start the status manager if true. Note that this option only makes sense with
+	// a running apiserver and working restclient.
+	StartStatusManager bool
+	// Start watchers for services and nodes. Note that this option only makes sense
+	// with a running apiserver and working restclient.
+	StartWatchers bool
+}
+
+// CreateKubeletOrDie creates a kubelet based on the given TestKubeletConfig.
+func CreateKubeletOrDie(tkc *TestKubeletConfig) *kubelet.Kubelet {
+	dockerEndpoint := ""
+	if tkc.FakeDocker {
+		dockerEndpoint = "fake://"
+	}
+	dockerClient := dockertools.ConnectToDockerOrDie(dockerEndpoint)
+	testRootDir := makeTempDirOrDie("kubelet_integ_1.", "")
+	configFilePath := makeTempDirOrDie("config", testRootDir)
+	cadvisorInterface := new(cadvisor.Fake)
+
+	kc := kubeletapp.SimpleKubelet(
+		tkc.RestClient, dockerClient, "localhost", testRootDir, "", "127.0.0.1", 10250,
+		api.NamespaceDefault, empty_dir.ProbeVolumePlugins(), nil,
+		cadvisorInterface, configFilePath, nil, kubecontainer.FakeOS{})
+
+	// TODO: Enable/Disable via test config
+	//pc = makePodSourceConfig(kc)
+
+	gcPolicy := kubelet.ContainerGCPolicy{
+		MinAge:             kc.MinimumGCAge,
+		MaxPerPodContainer: kc.MaxPerPodContainerCount,
+		MaxContainers:      kc.MaxContainerCount,
+	}
+
+	kStopCh := make(chan struct{})
+	k, err := kubelet.NewMainKubelet(
+		nodeutil.GetHostname(kc.HostnameOverride),
+		kc.DockerClient,
+		// TODO: Pipe this through from caller when we need a client. This is hardcoded as nil
+		// because the type is an interface.
+		nil,
+		kc.RootDirectory,
+		kc.PodInfraContainerImage,
+		kc.SyncFrequency,
+		float32(kc.RegistryPullQPS),
+		kc.RegistryBurst,
+		gcPolicy,
+		// SeenAllSources,
+		func() bool { return true },
+		kc.RegisterNode,
+		kc.StandaloneMode,
+		kc.ClusterDomain,
+		net.IP(kc.ClusterDNS),
+		kc.MasterServiceNamespace,
+		kc.VolumePlugins,
+		kc.NetworkPlugins,
+		kc.NetworkPluginName,
+		kc.StreamingConnectionIdleTimeout,
+		&record.FakeRecorder{},
+		kc.CadvisorInterface,
+		kc.ImageGCPolicy,
+		kc.DiskSpacePolicy,
+		kc.Cloud,
+		kc.NodeStatusUpdateFrequency,
+		kc.ResourceContainer,
+		kc.OSInterface,
+		kc.CgroupRoot,
+		kc.ContainerRuntime,
+		kc.Mounter,
+		kc.DockerDaemonContainer,
+		kc.SystemContainer,
+		kc.ConfigureCBR0,
+		kc.MaxPods,
+		kc.DockerExecHandler,
+		kStopCh,
+	)
+
+	if err != nil {
+		glog.Fatalf("Unexpected error %v", err)
+	}
+	if !tkc.StartWatchers {
+		// We are going to hand populate the kubelet stores, so turn off all watchers.
+		close(kStopCh)
+	}
+
+	node := &api.Node{
+		ObjectMeta: api.ObjectMeta{Name: "localhost"},
+		Status: api.NodeStatus{
+			Addresses: []api.NodeAddress{
+				{
+					Type:    api.NodeLegacyHostIP,
+					Address: "127.0.0.1",
+				},
+			},
+		},
+	}
+	if nl, ok := k.NodeLister.(*cache.StoreToNodeLister); ok {
+		nl.Store.Replace([]interface{}{node})
+	} else {
+		glog.Fatalf("Unable to insert node into kubelet's nodestore")
+	}
+
+	if _, err := k.GetNode(); err != nil {
+		glog.Fatalf("Unexpected error %v", err)
+	}
+	if tkc.StartStatusManager {
+		k.StartStatusManager()
+	}
+	return k
+}
+
+func makeTempDirOrDie(prefix string, baseDir string) string {
+	if baseDir == "" {
+		baseDir = "/tmp"
+	}
+	tempDir, err := ioutil.TempDir(baseDir, prefix)
+	if err != nil {
+		glog.Fatalf("Can't make a temp rootdir: %v", err)
+	}
+	if err = os.MkdirAll(tempDir, 0750); err != nil {
+		glog.Fatalf("Can't mkdir(%q): %v", tempDir, err)
+	}
+	return tempDir
+}

--- a/test/integration/kubelet_benchmark_test.go
+++ b/test/integration/kubelet_benchmark_test.go
@@ -1,0 +1,63 @@
+// +build benchmark,!no-etcd,!integration
+
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
+	"github.com/GoogleCloudPlatform/kubernetes/test/integration/framework"
+)
+
+// Simple kubelet benchmarks.
+// Example usage: go test -bench BenchmarkKubeletCreate -tags 'benchmark' -benchtime 0s -bench-pods 30 -bench-quiet 1
+//
+// TODO:
+// 1. Expose FakeDocker as a cmd line flag.
+// 2. Figure out a way to cleanup containers created by real docker.
+// 3. Support clean kublet restarts so we can run multiple iterations of the benchmark.
+
+func BenchmarkKubeletCreates(b *testing.B) {
+	b.StopTimer()
+
+	// FakeDocker = false uses docker on host machine.
+	k := framework.CreateKubeletOrDie(&framework.TestKubeletConfig{RestClient: nil, FakeDocker: true})
+	pods := framework.NewPodList(GetPods(b.N), "localhost", api.PodPending)
+
+	b.StartTimer()
+	framework.StartPodWorkers(k, pods, true)
+	b.StopTimer()
+
+	k.KillUnwantedPods(map[types.UID]kubelet.Empty{}, framework.GetPods(k, false))
+}
+
+func BenchmarkKubeletDeletes(b *testing.B) {
+	b.StopTimer()
+
+	// FakeDocker = false uses docker on host machine.
+	k := framework.CreateKubeletOrDie(&framework.TestKubeletConfig{RestClient: nil, FakeDocker: true})
+	pods := framework.NewPodList(GetPods(b.N), "localhost", api.PodPending)
+	framework.StartPodWorkers(k, pods, true)
+	runningPods := framework.GetPods(k, false)
+
+	b.StartTimer()
+	k.KillUnwantedPods(map[types.UID]kubelet.Empty{}, runningPods)
+}

--- a/test/integration/master_benchmark_test.go
+++ b/test/integration/master_benchmark_test.go
@@ -70,10 +70,10 @@ func init() {
 	framework.DeleteAllEtcdKeys()
 }
 
-// getPods returns the cmd line -pods or b.N if -pods wasn't specified.
-// Benchmarks can call getPods to get the number of pods they need to
+// GetPods returns the cmd line -pods or b.N if -pods wasn't specified.
+// Benchmarks can call GetPods to get the number of pods they need to
 // create for a given benchmark.
-func getPods(bN int) int {
+func GetPods(bN int) int {
 	if Pods < 0 {
 		return bN
 	}
@@ -117,7 +117,7 @@ func BenchmarkPodList(b *testing.B) {
 	m := framework.NewMasterComponents(&framework.Config{nil, true, false, 250.0, 500})
 	defer m.Stop(true, true)
 
-	numPods, numTasks, iter := getPods(b.N), getTasks(b.N), getIterations(b.N)
+	numPods, numTasks, iter := GetPods(b.N), getTasks(b.N), getIterations(b.N)
 	podsPerNode := numPods / numTasks
 	if podsPerNode < 1 {
 		podsPerNode = 1
@@ -156,7 +156,7 @@ func BenchmarkPodListEtcd(b *testing.B) {
 	m := framework.NewMasterComponents(&framework.Config{nil, true, false, 250.0, 500})
 	defer m.Stop(true, true)
 
-	numPods, numTasks, iter := getPods(b.N), getTasks(b.N), getIterations(b.N)
+	numPods, numTasks, iter := GetPods(b.N), getTasks(b.N), getIterations(b.N)
 	podsPerNode := numPods / numTasks
 	if podsPerNode < 1 {
 		podsPerNode = 1


### PR DESCRIPTION
Simple kubelet benchmarks that don't need anything except a container runtime (and even that's optional). Apparently it takes < 30s to get 30 pods to running on an n1-standard-1, and < 10s to delete 100 pods. 

However a concurrent docker ps takes 18s :(
