### PR TITLE
Node upgrade test

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -179,13 +179,13 @@ function get-kubeconfig-bearertoken() {
 function set_binary_version() {
   if [[ "${1}" == "latest_stable" ]]; then
     KUBE_VERSION=$(gsutil cat gs://kubernetes-release/release/stable.txt)
-    echo "Using latest stable version: ${KUBE_VERSION}"
+    echo "Using latest stable version: ${KUBE_VERSION}" >&2
   elif [[ "${1}" == "latest_release" ]]; then
     KUBE_VERSION=$(gsutil cat gs://kubernetes-release/release/latest.txt)
-    echo "Using latest release version: ${KUBE_VERSION}"
+    echo "Using latest release version: ${KUBE_VERSION}" >&2
   elif [[ "${1}" == "latest_ci" ]]; then
     KUBE_VERSION=$(gsutil cat gs://kubernetes-release/ci/latest.txt)
-    echo "Using latest ci version: ${KUBE_VERSION}"
+    echo "Using latest ci version: ${KUBE_VERSION}" >&2
   else
     KUBE_VERSION=${1}
   fi

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -34,10 +34,11 @@ source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
 function usage() {
   echo "!!! EXPERIMENTAL !!!"
   echo ""
-  echo "${0} [-M|-N] -l | <release or continuous integration version> | [latest_stable|latest_release|latest_ci]"
+  echo "${0} [-M|-N|-P] -l | <release or continuous integration version> | [latest_stable|latest_release|latest_ci]"
   echo "  Upgrades master and nodes by default"
   echo "  -M:  Upgrade master only"
   echo "  -N:  Upgrade nodes only"
+  echo "  -P:  Node upgrade prerequisites only (create a new instance template)"
   echo "  -l:  Use local(dev) binaries"
   echo ""
   echo "(... Fetching current release versions ...)"
@@ -109,21 +110,27 @@ function prepare-upgrade() {
   tars_from_version
 }
 
-# Reads kube-env metadata from master and extracts value from provided key.
+
+# Reads kube-env metadata from first node in MINION_NAMES.
 #
 # Assumed vars:
-#   MASTER_NAME
+#   MINION_NAMES
 #   PROJECT
 #   ZONE
+function get-node-env() {
+  # TODO(mbforbes): Make this more reliable with retries.
+  gcloud compute --project ${PROJECT} ssh --zone ${ZONE} ${MINION_NAMES[0]} --command \
+    "curl --fail --silent -H 'Metadata-Flavor: Google' \
+      'http://metadata/computeMetadata/v1/instance/attributes/kube-env'" 2>/dev/null
+}
+
+# Using provided node env, extracts value from provided key.
 #
 # Args:
-# $1 env key to use
+# $1 node env (kube-env of node; result of calling get-node-env)
+# $2 env key to use
 function get-env-val() {
-  # TODO(mbforbes): Make this more reliable with retries.
-  gcloud compute --project ${PROJECT} ssh --zone ${ZONE} ${MASTER_NAME} --command \
-    "curl --fail --silent -H 'Metadata-Flavor: Google' \
-      'http://metadata/computeMetadata/v1/instance/attributes/kube-env'" 2>/dev/null \
-    | grep ${1} | cut -d : -f 2 | cut -d \' -f 2
+  echo "${1}" | grep ${2} | cut -d : -f 2 | cut -d \' -f 2
 }
 
 # Assumed vars:
@@ -132,9 +139,40 @@ function get-env-val() {
 #   NODE_INSTANCE_PREFIX
 #   PROJECT
 #   ZONE
+#
+# Vars set:
+#   KUBELET_TOKEN
+#   KUBE_PROXY_TOKEN
+#   CA_CERT_BASE64
+#   EXTRA_DOCKER_OPTS
+#   KUBELET_CERT_BASE64
+#   KUBELET_KEY_BASE64
 function upgrade-nodes() {
-  local sanitized_version=$(echo ${KUBE_VERSION} | sed s/"\."/-/g)
-  echo "== Upgrading nodes to ${KUBE_VERSION}. =="
+  prepare-node-upgrade
+  do-node-upgrade
+}
+
+# prepare-node-upgrade creates a new instance template suitable for upgrading
+# to KUBE_VERSION and echos a single line with the name of the new template.
+#
+# Assumed vars:
+#   KUBE_VERSION
+#   MINION_SCOPES
+#   NODE_INSTANCE_PREFIX
+#   PROJECT
+#   ZONE
+#
+# Vars set:
+#   SANITIZED_VERSION
+#   KUBELET_TOKEN
+#   KUBE_PROXY_TOKEN
+#   CA_CERT_BASE64
+#   EXTRA_DOCKER_OPTS
+#   KUBELET_CERT_BASE64
+#   KUBELET_KEY_BASE64
+function prepare-node-upgrade() {
+  echo "== Preparing node upgrade (to ${KUBE_VERSION}). ==" >&2
+  SANITIZED_VERSION=$(echo ${KUBE_VERSION} | sed s/"\."/-/g)
 
   detect-minion-names
 
@@ -146,40 +184,65 @@ function upgrade-nodes() {
     scope_flags=("--no-scopes")
   fi
 
-  # Get required node tokens.
-  KUBELET_TOKEN=$(get-env-val "KUBELET_TOKEN")
-  KUBE_PROXY_TOKEN=$(get-env-val "KUBE_PROXY_TOKEN")
+  # Get required node env vars from exiting template.
+  local node_env=$(get-node-env)
+  KUBELET_TOKEN=$(get-env-val "${node_env}" "KUBELET_TOKEN")
+  KUBE_PROXY_TOKEN=$(get-env-val "${node_env}" "KUBE_PROXY_TOKEN")
+  CA_CERT_BASE64=$(get-env-val "${node_env}" "CA_CERT")
+  EXTRA_DOCKER_OPTS=$(get-env-val "${node_env}" "EXTRA_DOCKER_OPTS")
+  KUBELET_CERT_BASE64=$(get-env-val "${node_env}" "KUBELET_CERT")
+  KUBELET_KEY_BASE64=$(get-env-val "${node_env}" "KUBELET_KEY")
 
   # TODO(mbforbes): How do we ensure kube-env is written in a ${version}-
   #                 compatible way?
   write-node-env
+
   # TODO(mbforbes): Get configure-vm script from ${version}. (Must plumb this
   #                 through all create-node-instance-template implementations).
-  create-node-instance-template ${sanitized_version}
+  create-node-instance-template ${SANITIZED_VERSION}
+  # The following is echo'd so that callers can get the template name.
+  echo "${NODE_INSTANCE_PREFIX}-template-${SANITIZED_VERSION}"
+  echo "== Finished preparing node upgrade (to ${KUBE_VERSION}). ==" >&2
+}
 
+# Prereqs:
+# - prepare-node-upgrade should have been called successfully
+function do-node-upgrade() {
+  echo "== Upgrading nodes to ${KUBE_VERSION}. ==" >&2
   # Do the actual upgrade.
-  gcloud preview rolling-updates start \
-      --group "${NODE_INSTANCE_PREFIX}-group" \
-      --max-num-concurrent-instances 1 \
-      --max-num-failed-instances 0 \
-      --project "${PROJECT}" \
-      --zone "${ZONE}" \
-      --template "${NODE_INSTANCE_PREFIX}-template-${sanitized_version}"
+  # NOTE(mbforbes): If you are changing this gcloud command, update
+  #                 test/e2e/restart.go to match this EXACTLY.
+  gcloud preview rolling-updates \
+      --project="${PROJECT}" \
+      --zone="${ZONE}" \
+      start \
+      --group="${NODE_INSTANCE_PREFIX}-group" \
+      --template="${NODE_INSTANCE_PREFIX}-template-${SANITIZED_VERSION}" \
+      --instance-startup-timeout=300s \
+      --max-num-concurrent-instances=1 \
+      --max-num-failed-instances=0 \
+      --min-instance-update-time=0s
 
-  echo "== Done =="
+  # TODO(mbforbes): Wait for the rolling-update to finish.
+
+  echo "== Finished upgrading nodes to ${KUBE_VERSION}. ==" >&2
 }
 
 master_upgrade=true
 node_upgrade=true
+node_prereqs=false
 local_binaries=false
 
-while getopts ":MNlh" opt; do
+while getopts ":MNPlh" opt; do
   case ${opt} in
     M)
       node_upgrade=false
       ;;
     N)
       master_upgrade=false
+      ;;
+    P)
+      node_prereqs=true
       ;;
     l)
       local_binaries=true
@@ -213,6 +276,11 @@ fi
 
 prepare-upgrade
 
+if [[ "${node_prereqs}" == "true" ]]; then
+  prepare-node-upgrade
+  exit 0
+fi
+
 if [[ "${master_upgrade}" == "true" ]]; then
   upgrade-master
 fi
@@ -220,6 +288,7 @@ fi
 if [[ "${node_upgrade}" == "true" ]]; then
   if [[ "${local_binaries}" == "true" ]]; then
     echo "Upgrading nodes to local binaries is not yet supported." >&2
+    exit 1
   else
     upgrade-nodes
   fi

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -250,7 +250,7 @@ function detect-minion-names {
   MINION_NAMES=($(gcloud preview --project "${PROJECT}" instance-groups \
     --zone "${ZONE}" instances --group "${NODE_INSTANCE_PREFIX}-group" list \
     | cut -d'/' -f11))
-  echo "MINION_NAMES=${MINION_NAMES[*]}"
+  echo "MINION_NAMES=${MINION_NAMES[*]}" >&2
 }
 
 # Waits until the number of running nodes in the instance group is equal to NUM_NODES
@@ -415,8 +415,9 @@ function create-node-template {
     fi
   fi
 
-  local attempt=0
+  local attempt=1
   while true; do
+    echo "Attempt ${attempt} to create ${1}" >&2
     if ! gcloud compute instance-templates create "$1" \
       --project "${PROJECT}" \
       --machine-type "${MINION_SIZE}" \
@@ -428,12 +429,12 @@ function create-node-template {
       --network "${NETWORK}" \
       $2 \
       --can-ip-forward \
-      --metadata-from-file "$3","$4"; then
+      --metadata-from-file "$3","$4" >&2; then
         if (( attempt > 5 )); then
           echo -e "${color_red}Failed to create instance template $1 ${color_norm}" >&2
           exit 2
         fi
-        echo -e "${color_yellow}Attempt $(($attempt+1)) failed to create instance template $1. Retrying.${color_norm}" >&2
+        echo -e "${color_yellow}Attempt ${attempt} failed to create instance template $1. Retrying.${color_norm}" >&2
         attempt=$(($attempt+1))
     else
         break

--- a/pkg/util/ssh.go
+++ b/pkg/util/ssh.go
@@ -142,6 +142,8 @@ func (s *SSHTunnel) Close() error {
 	return nil
 }
 
+// RunSSHCommand returns the stdout, stderr, and exit code from running cmd on
+// host along with any SSH-level error.
 func RunSSHCommand(cmd, host string, signer ssh.Signer) (string, string, int, error) {
 	// Setup the config, dial the server, and open a session.
 	config := &ssh.ClientConfig{

--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -17,17 +17,16 @@ limitations under the License.
 package e2e
 
 import (
+	"bytes"
 	"fmt"
-	"io"
 	"net/http"
-	"os"
 	"os/exec"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/wait"
@@ -36,68 +35,176 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// version applies to upgrades; kube-push always pushes local binaries.
+const version = "latest_ci"
+
+// The following upgrade functions are passed into the framework below and used
+// to do the actual upgrades.
+
+var masterUpgrade = func() error {
+	_, _, err := runScript("hack/e2e-internal/e2e-upgrade.sh", "-M", version)
+	return err
+}
+
+var masterPush = func() error {
+	_, _, err := runScript("hack/e2e-internal/e2e-push.sh", "-m")
+	return err
+}
+
+var nodeUpgrade = func(f Framework, replicas int) error {
+	Logf("Preparing node upgarde by creating new instance template")
+	stdout, _, err := runScript("hack/e2e-internal/e2e-upgrade.sh", "-P", version)
+	if err != nil {
+		return err
+	}
+	tmpl := strings.TrimSpace(stdout)
+
+	Logf("Performing a node upgrade to %s; waiting at most %v per node", tmpl, restartPerNodeTimeout)
+	if err := migRollingUpdate(tmpl, restartPerNodeTimeout); err != nil {
+		return fmt.Errorf("error doing node upgrade via a migRollingUpdate to %s: %v", tmpl, err)
+	}
+
+	Logf("Waiting up to %v for all nodes to be ready after the upgrade", restartNodeReadyAgainTimeout)
+	if _, err := checkNodesReady(f.Client, restartNodeReadyAgainTimeout, testContext.CloudConfig.NumNodes); err != nil {
+		return err
+	}
+
+	Logf("Waiting up to %v for all pods to be running and ready after the upgrade", restartPodReadyAgainTimeout)
+	return waitForPodsRunningReady(f.Namespace.Name, replicas, restartPodReadyAgainTimeout)
+}
+
 var _ = Describe("Skipped", func() {
 	Describe("Cluster upgrade", func() {
-		svcName := "baz"
-		var podName string
-		framework := Framework{BaseName: "cluster-upgrade"}
-		var webserver *WebserverTest
+		svcName, replicas := "baz", 2
+		var rcName, ip string
+		var ingress api.LoadBalancerIngress
+		f := Framework{BaseName: "cluster-upgrade"}
+		var w *WebserverTest
 
 		BeforeEach(func() {
-			framework.beforeEach()
-			webserver = NewWebserverTest(framework.Client, framework.Namespace.Name, svcName)
-			pod := webserver.CreateWebserverPod()
-			podName = pod.Name
-			svc := webserver.BuildServiceSpec()
+			By("Setting up the service, RC, and pods")
+			f.beforeEach()
+			w = NewWebserverTest(f.Client, f.Namespace.Name, svcName)
+			rc := w.CreateWebserverRC(replicas)
+			rcName = rc.ObjectMeta.Name
+			svc := w.BuildServiceSpec()
 			svc.Spec.Type = api.ServiceTypeLoadBalancer
-			webserver.CreateService(svc)
+			w.CreateService(svc)
+
+			By("Waiting for the service to become reachable")
+			result, err := waitForLoadBalancerIngress(f.Client, svcName, f.Namespace.Name)
+			Expect(err).NotTo(HaveOccurred())
+			ingresses := result.Status.LoadBalancer.Ingress
+			if len(ingresses) != 1 {
+				Failf("Was expecting only 1 ingress IP but got %d (%v): %v", len(ingresses), ingresses, result)
+			}
+			ingress = ingresses[0]
+			Logf("Got load balancer ingress point %v", ingress)
+			ip = ingress.IP
+			if ip == "" {
+				ip = ingress.Hostname
+			}
+			testLoadBalancerReachable(ingress, 80)
+
+			// TODO(mbforbes): Add setup, validate, and teardown for:
+			//  - secrets
+			//  - volumes
+			//  - persistent volumes
 		})
 
 		AfterEach(func() {
-			framework.afterEach()
-			webserver.Cleanup()
+			f.afterEach()
+			w.Cleanup()
 		})
 
 		Describe("kube-push", func() {
 			It("of master should maintain responsive services", func() {
-				testClusterUpgrade(framework, svcName, podName, func() {
-					runUpgradeScript("hack/e2e-internal/e2e-push.sh", "-m")
-				})
+				By("Validating cluster before master upgrade")
+				expectNoError(validate(f, svcName, rcName, ingress, replicas))
+				By("Performing a master upgrade")
+				testMasterUpgrade(ip, masterPush)
+				By("Validating cluster after master upgrade")
+				expectNoError(validate(f, svcName, rcName, ingress, replicas))
 			})
 		})
 
-		Describe("gce-upgrade", func() {
-			It("of master should maintain responsive services", func() {
+		Describe("gce-upgrade-master", func() {
+			It("should maintain responsive services", func() {
+				// TODO(mbforbes): Add GKE support.
 				if !providerIs("gce") {
-					By(fmt.Sprintf("Skippingt test, which is not implemented for %s", testContext.Provider))
+					By(fmt.Sprintf("Skipping upgrade test, which is not implemented for %s", testContext.Provider))
 					return
 				}
-				testClusterUpgrade(framework, svcName, podName, func() {
-					runUpgradeScript("hack/e2e-internal/e2e-upgrade.sh", "-M", "-l")
-				})
+				By("Validating cluster before master upgrade")
+				expectNoError(validate(f, svcName, rcName, ingress, replicas))
+				By("Performing a master upgrade")
+				testMasterUpgrade(ip, masterUpgrade)
+				By("Validating cluster after master upgrade")
+				expectNoError(validate(f, svcName, rcName, ingress, replicas))
+			})
+		})
+
+		Describe("gce-upgrade-cluster", func() {
+			var tmplBefore, tmplAfter string
+			BeforeEach(func() {
+				By("Getting the node template before the upgrade")
+				var err error
+				tmplBefore, err = migTemplate()
+				expectNoError(err)
+			})
+
+			AfterEach(func() {
+				By("Cleaning up any unused node templates")
+				var err error
+				tmplAfter, err = migTemplate()
+				if err != nil {
+					Logf("Could not get node template post-upgrade; may have leaked template %s", tmplBefore)
+					return
+				}
+				if tmplBefore == tmplAfter {
+					// The node upgrade failed so there's no need to delete
+					// anything.
+					Logf("Node template %s is still in use; not cleaning up", tmplBefore)
+					return
+				}
+				// TODO(mbforbes): Distinguish between transient failures
+				// and "cannot delete--in use" errors and retry on the
+				// former.
+				Logf("Deleting node template %s", tmplBefore)
+				o, err := exec.Command("gcloud", "compute", "instance-templates",
+					fmt.Sprintf("--project=%s", testContext.CloudConfig.ProjectID),
+					"delete",
+					tmplBefore).CombinedOutput()
+				if err != nil {
+					Logf("gcloud compute instance-templates delete %s call failed with err: %v, output: %s",
+						tmplBefore, err, string(o))
+					Logf("May have leaked %s", tmplBefore)
+				}
+			})
+
+			It("should maintain a functioning cluster", func() {
+				// TODO(mbforbes): Add GKE support.
+				if !providerIs("gce") {
+					By(fmt.Sprintf("Skipping upgrade test, which is not implemented for %s", testContext.Provider))
+					return
+				}
+				By("Validating cluster before master upgrade")
+				expectNoError(validate(f, svcName, rcName, ingress, replicas))
+				By("Performing a master upgrade")
+				testMasterUpgrade(ip, masterUpgrade)
+				By("Validating cluster after master upgrade")
+				expectNoError(validate(f, svcName, rcName, ingress, replicas))
+				By("Performing a node upgrade")
+				testNodeUpgrade(f, nodeUpgrade, replicas)
+				By("Validating cluster after node upgrade")
+				expectNoError(validate(f, svcName, rcName, ingress, replicas))
 			})
 		})
 	})
 })
 
-func testClusterUpgrade(framework Framework, svcName, podName string, upgrade func()) {
-	result, err := waitForLoadBalancerIngress(framework.Client, svcName, framework.Namespace.Name)
-	Expect(err).NotTo(HaveOccurred())
-	ingresses := result.Status.LoadBalancer.Ingress
-	if len(ingresses) != 1 {
-		Failf("Was expecting only 1 ingress IP but got %d (%v): %v", len(ingresses), ingresses, result)
-	}
-	ingress := ingresses[0]
-	ip := ingress.IP
-	if ip == "" {
-		ip = ingress.Hostname
-	}
-
-	By("Waiting for pod to become reachable")
-	testLoadBalancerReachable(ingress, 80)
-	validateClusterUpgrade(framework, svcName, podName)
-
-	Logf("starting async validation")
+func testMasterUpgrade(ip string, mUp func() error) {
+	Logf("Starting async validation")
 	httpClient := http.Client{Timeout: 2 * time.Second}
 	done := make(chan struct{}, 1)
 	// Let's make sure we've finished the heartbeat before shutting things down.
@@ -107,55 +214,94 @@ func testClusterUpgrade(framework Framework, svcName, podName string, upgrade fu
 		wg.Add(1)
 		defer wg.Done()
 
-		expectNoError(wait.Poll(poll, singleCallTimeout, func() (bool, error) {
+		if err := wait.Poll(poll, singleCallTimeout, func() (bool, error) {
 			r, err := httpClient.Get("http://" + ip)
 			if err != nil {
+				Logf("Error reaching %s: %v", ip, err)
 				return false, nil
 			}
 			if r.StatusCode < http.StatusOK || r.StatusCode >= http.StatusNotFound {
+				Logf("Bad response; status: %d, response: %v", r.StatusCode, r)
 				return false, nil
 			}
 			return true, nil
-		}))
+		}); err != nil {
+			// We log the error here because the test will fail at the very end
+			// because this validation runs in another goroutine. Without this,
+			// a failure is very confusing to track down because from the logs
+			// everything looks fine.
+			msg := fmt.Sprintf("Failed to contact service during master upgrade: %v", err)
+			Logf(msg)
+			Failf(msg)
+		}
 	}, 200*time.Millisecond, done)
 
-	By("Starting upgrade")
-	upgrade()
+	Logf("Starting master upgrade")
+	expectNoError(mUp())
 	done <- struct{}{}
 	Logf("Stopping async validation")
 	wg.Wait()
-	Logf("Upgrade complete.")
-
-	By("Validating post upgrade state")
-	validateClusterUpgrade(framework, svcName, podName)
+	Logf("Master upgrade complete")
 }
 
-func runUpgradeScript(scriptPath string, args ...string) {
-	cmd := exec.Command(path.Join(testContext.RepoRoot, scriptPath), args...)
-	upgradeLogPath := path.Join(testContext.OutputDir, "upgrade-"+string(util.NewUUID())+".log")
-	Logf("Writing upgrade logs to %s", upgradeLogPath)
-	upgradeLog, err := os.Create(upgradeLogPath)
-	expectNoError(err)
+func testNodeUpgrade(f Framework, nUp func(f Framework, n int) error, replicas int) {
+	Logf("Starting node upgrade")
+	expectNoError(nUp(f, replicas))
+	Logf("Node upgrade complete")
 
-	cmd.Stdout = io.MultiWriter(os.Stdout, upgradeLog)
-	cmd.Stderr = io.MultiWriter(os.Stderr, upgradeLog)
-	if err := cmd.Run(); err != nil {
-		Failf("Upgrade failed: %v", err)
-	}
+	// TODO(mbforbes): Validate that:
+	// - the node software version truly changed
+
 }
 
-func validateClusterUpgrade(framework Framework, svcName, podName string) {
-	pods, err := framework.Client.Pods(framework.Namespace.Name).List(labels.Everything(), fields.Everything())
-	Expect(err).NotTo(HaveOccurred())
-	Expect(len(pods.Items) == 1).Should(BeTrue())
-	if podName != pods.Items[0].Name {
-		Failf("pod name should not have changed")
+// runScript runs script on testContext.RepoRoot using args and returns
+// stdout, stderr, and error.
+func runScript(script string, args ...string) (string, string, error) {
+	Logf("Running %s %v", script, args)
+	var bout, berr bytes.Buffer
+	cmd := exec.Command(path.Join(testContext.RepoRoot, script), args...)
+	cmd.Stdout, cmd.Stderr = &bout, &berr
+	err := cmd.Run()
+	stdout, stderr := bout.String(), berr.String()
+	if err != nil {
+		return "", "", fmt.Errorf("error running %s %v; got error %v, stdout %q, stderr %q",
+			script, args, err, stdout, stderr)
 	}
-	_, err = podRunningReady(&pods.Items[0])
-	Expect(err).NotTo(HaveOccurred())
-	svc, err := framework.Client.Services(framework.Namespace.Name).Get(svcName)
-	Expect(err).NotTo(HaveOccurred())
-	if svcName != svc.Name {
-		Failf("service name should not have changed")
+	Logf("stdout: %s", stdout)
+	Logf("stderr: %s", stderr)
+	return stdout, stderr, nil
+}
+
+func validate(f Framework, svcNameWant, rcNameWant string, ingress api.LoadBalancerIngress, podsWant int) error {
+	Logf("Beginning cluster validation")
+	// Verify RC.
+	rcs, err := f.Client.ReplicationControllers(f.Namespace.Name).List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("error listing RCs: %v", err)
 	}
+	if len(rcs.Items) != 1 {
+		return fmt.Errorf("wanted 1 RC with name %s, got %d", rcNameWant, len(rcs.Items))
+	}
+	if got := rcs.Items[0].Name; got != rcNameWant {
+		return fmt.Errorf("wanted RC name %q, got %q", rcNameWant, got)
+	}
+
+	// Verify pods.
+	if err := verifyPods(f.Client, f.Namespace.Name, rcNameWant, false, podsWant); err != nil {
+		return fmt.Errorf("failed to find %d %q pods: %v", podsWant, rcNameWant, err)
+	}
+
+	// Verify service.
+	svc, err := f.Client.Services(f.Namespace.Name).Get(svcNameWant)
+	if err != nil {
+		return fmt.Errorf("error getting service %s: %v", svcNameWant, err)
+	}
+	if svcNameWant != svc.Name {
+		return fmt.Errorf("wanted service name %q, got %q", svcNameWant, svc.Name)
+	}
+	// TODO(mbforbes): Make testLoadBalancerReachable return an error.
+	testLoadBalancerReachable(ingress, 80)
+
+	Logf("Cluster validation succeeded")
+	return nil
 }

--- a/test/e2e/rc.go
+++ b/test/e2e/rc.go
@@ -141,7 +141,7 @@ func ServeImageOrFail(c *client.Client, test string, image string) {
 	By("Trying to dial each unique pod")
 	retryTimeout := 2 * time.Minute
 	retryInterval := 5 * time.Second
-	err = wait.Poll(retryInterval, retryTimeout, podResponseChecker{c, ns, label, name, pods}.checkAllResponses)
+	err = wait.Poll(retryInterval, retryTimeout, podResponseChecker{c, ns, label, name, true, pods}.checkAllResponses)
 	if err != nil {
 		Failf("Did not get expected responses within the timeout period of %.2f seconds.", retryTimeout.Seconds())
 	}

--- a/test/e2e/reboot.go
+++ b/test/e2e/reboot.go
@@ -155,7 +155,8 @@ func issueSSHCommand(node *api.Node, provider, cmd string) error {
 // failed step, it will return false through result and not run the rest.
 func rebootNode(c *client.Client, provider, name, rebootCmd string, result chan bool) {
 	// Setup
-	ps := newPodStore(c, api.NamespaceDefault, labels.Everything(), fields.OneTermEqualSelector(client.PodHost, name))
+	ns := api.NamespaceDefault
+	ps := newPodStore(c, ns, labels.Everything(), fields.OneTermEqualSelector(client.PodHost, name))
 	defer ps.Stop()
 
 	// Get the node initially.
@@ -183,7 +184,7 @@ func rebootNode(c *client.Client, provider, name, rebootCmd string, result chan 
 
 	// For each pod, we do a sanity check to ensure it's running / healthy
 	// now, as that's what we'll be checking later.
-	if !checkPodsRunningReady(c, podNames, podReadyBeforeTimeout) {
+	if !checkPodsRunningReady(c, ns, podNames, podReadyBeforeTimeout) {
 		result <- false
 		return
 	}
@@ -209,7 +210,7 @@ func rebootNode(c *client.Client, provider, name, rebootCmd string, result chan 
 
 	// Ensure all of the pods that we found on this node before the reboot are
 	// running / healthy.
-	if !checkPodsRunningReady(c, podNames, rebootPodReadyAgainTimeout) {
+	if !checkPodsRunningReady(c, ns, podNames, rebootPodReadyAgainTimeout) {
 		result <- false
 		return
 	}

--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
@@ -34,9 +35,9 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var serveHostnameImage string = "gcr.io/google_containers/serve_hostname:1.1"
+const serveHostnameImage = "gcr.io/google_containers/serve_hostname:1.1"
 
-func resizeNodeInstanceGroup(size int) error {
+func resizeGroup(size int) error {
 	// TODO: make this hit the compute API directly instread of shelling out to gcloud.
 	output, err := exec.Command("gcloud", "preview", "managed-instance-groups", "--project="+testContext.CloudConfig.ProjectID, "--zone="+testContext.CloudConfig.Zone,
 		"resize", testContext.CloudConfig.NodeInstanceGroup, fmt.Sprintf("--new-size=%v", size)).CombinedOutput()
@@ -46,7 +47,7 @@ func resizeNodeInstanceGroup(size int) error {
 	return err
 }
 
-func nodeInstanceGroupSize() (int, error) {
+func groupSize() (int, error) {
 	// TODO: make this hit the compute API directly instread of shelling out to gcloud.
 	output, err := exec.Command("gcloud", "preview", "managed-instance-groups", "--project="+testContext.CloudConfig.ProjectID,
 		"--zone="+testContext.CloudConfig.Zone, "describe", testContext.CloudConfig.NodeInstanceGroup).CombinedOutput()
@@ -71,9 +72,9 @@ func nodeInstanceGroupSize() (int, error) {
 	return currentSize, nil
 }
 
-func waitForNodeInstanceGroupSize(size int) error {
+func waitForGroupSize(size int) error {
 	for start := time.Now(); time.Since(start) < 4*time.Minute; time.Sleep(5 * time.Second) {
-		currentSize, err := nodeInstanceGroupSize()
+		currentSize, err := groupSize()
 		if err != nil {
 			Logf("Failed to get node instance group size: %v", err)
 			continue
@@ -104,7 +105,7 @@ func waitForClusterSize(c *client.Client, size int) error {
 	return fmt.Errorf("timeout waiting for cluster size to be %d", size)
 }
 
-func newServiceWithNameSelector(name string) *api.Service {
+func svcByName(name string) *api.Service {
 	return &api.Service{
 		ObjectMeta: api.ObjectMeta{
 			Name: "test-service",
@@ -121,12 +122,12 @@ func newServiceWithNameSelector(name string) *api.Service {
 	}
 }
 
-func createServiceWithNameSelector(c *client.Client, ns, name string) error {
-	_, err := c.Services(ns).Create(newServiceWithNameSelector(name))
+func newSVCByName(c *client.Client, ns, name string) error {
+	_, err := c.Services(ns).Create(svcByName(name))
 	return err
 }
 
-func newPodOnNode(podName, nodeName string, image string) *api.Pod {
+func podOnNode(podName, nodeName string, image string) *api.Pod {
 	return &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name: podName,
@@ -148,18 +149,39 @@ func newPodOnNode(podName, nodeName string, image string) *api.Pod {
 	}
 }
 
-func createServeHostnamePodOnNode(c *client.Client, namespace, podName, nodeName string) error {
-	pod, err := c.Pods(namespace).Create(newPodOnNode(podName, nodeName, serveHostnameImage))
+func newPodOnNode(c *client.Client, namespace, podName, nodeName string) error {
+	pod, err := c.Pods(namespace).Create(podOnNode(podName, nodeName, serveHostnameImage))
 	if err == nil {
 		Logf("Created pod %s on node %s", pod.ObjectMeta.Name, nodeName)
 	} else {
-		Logf("Failed to create pod %s on node %s: %s", podName, nodeName, err)
+		Logf("Failed to create pod %s on node %s: %v", podName, nodeName, err)
 	}
 	return err
 }
 
-func newReplicationControllerWithNameSelector(name string, replicas int, image string) *api.ReplicationController {
+func rcByName(name string, replicas int, image string, labels map[string]string) *api.ReplicationController {
+	return rcByNameContainer(name, replicas, image, labels, api.Container{
+		Name:  name,
+		Image: image,
+	})
+}
+
+func rcByNamePort(name string, replicas int, image string, port int, labels map[string]string) *api.ReplicationController {
+	return rcByNameContainer(name, replicas, image, labels, api.Container{
+		Name:  name,
+		Image: image,
+		Ports: []api.ContainerPort{{ContainerPort: port}},
+	})
+}
+
+func rcByNameContainer(name string, replicas int, image string, labels map[string]string, c api.Container) *api.ReplicationController {
+	// Add "name": name to the labels, overwriting if it exists.
+	labels["name"] = name
 	return &api.ReplicationController{
+		TypeMeta: api.TypeMeta{
+			Kind:       "ReplicationController",
+			APIVersion: latest.Version,
+		},
 		ObjectMeta: api.ObjectMeta{
 			Name: name,
 		},
@@ -170,28 +192,24 @@ func newReplicationControllerWithNameSelector(name string, replicas int, image s
 			},
 			Template: &api.PodTemplateSpec{
 				ObjectMeta: api.ObjectMeta{
-					Labels: map[string]string{"name": name},
+					Labels: labels,
 				},
 				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name:  name,
-							Image: image,
-							Ports: []api.ContainerPort{{ContainerPort: 9376}},
-						},
-					},
+					Containers: []api.Container{c},
 				},
 			},
 		},
 	}
 }
 
-func createServeHostnameReplicationController(c *client.Client, ns, name string, replicas int) (*api.ReplicationController, error) {
+// newRCByName creates a replication controller with a selector by name of name.
+func newRCByName(c *client.Client, ns, name string, replicas int) (*api.ReplicationController, error) {
 	By(fmt.Sprintf("creating replication controller %s", name))
-	return c.ReplicationControllers(ns).Create(newReplicationControllerWithNameSelector(name, replicas, serveHostnameImage))
+	return c.ReplicationControllers(ns).Create(rcByNamePort(
+		name, replicas, serveHostnameImage, 9376, map[string]string{}))
 }
 
-func resizeReplicationController(c *client.Client, ns, name string, replicas int) error {
+func resizeRC(c *client.Client, ns, name string, replicas int) error {
 	rc, err := c.ReplicationControllers(ns).Get(name)
 	if err != nil {
 		return err
@@ -201,7 +219,7 @@ func resizeReplicationController(c *client.Client, ns, name string, replicas int
 	return err
 }
 
-func waitForPodsCreated(c *client.Client, ns, name string, replicas int) (*api.PodList, error) {
+func podsCreated(c *client.Client, ns, name string, replicas int) (*api.PodList, error) {
 	// List the pods, making sure we observe all the replicas.
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
 	for start := time.Now(); time.Since(start) < time.Minute; time.Sleep(5 * time.Second) {
@@ -218,7 +236,7 @@ func waitForPodsCreated(c *client.Client, ns, name string, replicas int) (*api.P
 	return nil, fmt.Errorf("Pod name %s: Gave up waiting for %d pods to come up", name, replicas)
 }
 
-func waitForPodsRunning(c *client.Client, pods *api.PodList) []error {
+func podsRunning(c *client.Client, pods *api.PodList) []error {
 	// Wait for the pods to enter the running state. Waiting loops until the pods
 	// are running so non-running pods cause a timeout for this test.
 	By("ensuring each pod is running")
@@ -233,24 +251,24 @@ func waitForPodsRunning(c *client.Client, pods *api.PodList) []error {
 	return e
 }
 
-func verifyPodsResponding(c *client.Client, ns, name string, pods *api.PodList) error {
+func podsResponding(c *client.Client, ns, name string, wantName bool, pods *api.PodList) error {
 	By("trying to dial each unique pod")
 	retryTimeout := 2 * time.Minute
 	retryInterval := 5 * time.Second
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
-	return wait.Poll(retryInterval, retryTimeout, podResponseChecker{c, ns, label, name, pods}.checkAllResponses)
+	return wait.Poll(retryInterval, retryTimeout, podResponseChecker{c, ns, label, name, wantName, pods}.checkAllResponses)
 }
 
-func waitForPodsCreatedRunningResponding(c *client.Client, ns, name string, replicas int) error {
-	pods, err := waitForPodsCreated(c, ns, name, replicas)
+func verifyPods(c *client.Client, ns, name string, wantName bool, replicas int) error {
+	pods, err := podsCreated(c, ns, name, replicas)
 	if err != nil {
 		return err
 	}
-	e := waitForPodsRunning(c, pods)
+	e := podsRunning(c, pods)
 	if len(e) > 0 {
 		return fmt.Errorf("Failed to wait for pods running: %v", e)
 	}
-	err = verifyPodsResponding(c, ns, name, pods)
+	err = podsResponding(c, ns, name, wantName, pods)
 	if err != nil {
 		return err
 	}
@@ -331,7 +349,7 @@ func performTemporaryNetworkFailure(c *client.Client, ns, rcName string, replica
 	waitForRCPodToDisappear(c, ns, rcName, podNameToDisappear)
 
 	By("verifying whether the pod from the unreachable node is recreated")
-	err := waitForPodsCreatedRunningResponding(c, ns, rcName, replicas)
+	err := verifyPods(c, ns, rcName, true, replicas)
 	Expect(err).NotTo(HaveOccurred())
 
 	// network traffic is unblocked in a defered function
@@ -372,10 +390,10 @@ var _ = Describe("Nodes", func() {
 				return
 			}
 			By("restoring the original node instance group size")
-			if err := resizeNodeInstanceGroup(testContext.CloudConfig.NumNodes); err != nil {
+			if err := resizeGroup(testContext.CloudConfig.NumNodes); err != nil {
 				Failf("Couldn't restore the original node instance group size: %v", err)
 			}
-			if err := waitForNodeInstanceGroupSize(testContext.CloudConfig.NumNodes); err != nil {
+			if err := waitForGroupSize(testContext.CloudConfig.NumNodes); err != nil {
 				Failf("Couldn't restore the original node instance group size: %v", err)
 			}
 			if err := waitForClusterSize(c, testContext.CloudConfig.NumNodes); err != nil {
@@ -396,20 +414,20 @@ var _ = Describe("Nodes", func() {
 			// The source for the Docker containter kubernetes/serve_hostname is in contrib/for-demos/serve_hostname
 			name := "my-hostname-delete-node"
 			replicas := testContext.CloudConfig.NumNodes
-			createServeHostnameReplicationController(c, ns, name, replicas)
-			err := waitForPodsCreatedRunningResponding(c, ns, name, replicas)
+			newRCByName(c, ns, name, replicas)
+			err := verifyPods(c, ns, name, true, replicas)
 			Expect(err).NotTo(HaveOccurred())
 
 			By(fmt.Sprintf("decreasing cluster size to %d", replicas-1))
-			err = resizeNodeInstanceGroup(replicas - 1)
+			err = resizeGroup(replicas - 1)
 			Expect(err).NotTo(HaveOccurred())
-			err = waitForNodeInstanceGroupSize(replicas - 1)
+			err = waitForGroupSize(replicas - 1)
 			Expect(err).NotTo(HaveOccurred())
 			err = waitForClusterSize(c, replicas-1)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying whether the pods from the removed node are recreated")
-			err = waitForPodsCreatedRunningResponding(c, ns, name, replicas)
+			err = verifyPods(c, ns, name, true, replicas)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -426,24 +444,24 @@ var _ = Describe("Nodes", func() {
 			// Create a replication controller for a service that serves its hostname.
 			// The source for the Docker containter kubernetes/serve_hostname is in contrib/for-demos/serve_hostname
 			name := "my-hostname-add-node"
-			createServiceWithNameSelector(c, ns, name)
+			newSVCByName(c, ns, name)
 			replicas := testContext.CloudConfig.NumNodes
-			createServeHostnameReplicationController(c, ns, name, replicas)
-			err := waitForPodsCreatedRunningResponding(c, ns, name, replicas)
+			newRCByName(c, ns, name, replicas)
+			err := verifyPods(c, ns, name, true, replicas)
 			Expect(err).NotTo(HaveOccurred())
 
 			By(fmt.Sprintf("increasing cluster size to %d", replicas+1))
-			err = resizeNodeInstanceGroup(replicas + 1)
+			err = resizeGroup(replicas + 1)
 			Expect(err).NotTo(HaveOccurred())
-			err = waitForNodeInstanceGroupSize(replicas + 1)
+			err = waitForGroupSize(replicas + 1)
 			Expect(err).NotTo(HaveOccurred())
 			err = waitForClusterSize(c, replicas+1)
 			Expect(err).NotTo(HaveOccurred())
 
 			By(fmt.Sprintf("increasing size of the replication controller to %d and verifying all pods are running", replicas+1))
-			err = resizeReplicationController(c, ns, name, replicas+1)
+			err = resizeRC(c, ns, name, replicas+1)
 			Expect(err).NotTo(HaveOccurred())
-			err = waitForPodsCreatedRunningResponding(c, ns, name, replicas+1)
+			err = verifyPods(c, ns, name, true, replicas+1)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -472,10 +490,10 @@ var _ = Describe("Nodes", func() {
 			// Create a replication controller for a service that serves its hostname.
 			// The source for the Docker containter kubernetes/serve_hostname is in contrib/for-demos/serve_hostname
 			name := "my-hostname-net"
-			createServiceWithNameSelector(c, ns, name)
+			newSVCByName(c, ns, name)
 			replicas := testContext.CloudConfig.NumNodes
-			createServeHostnameReplicationController(c, ns, name, replicas)
-			err := waitForPodsCreatedRunningResponding(c, ns, name, replicas)
+			newRCByName(c, ns, name, replicas)
+			err := verifyPods(c, ns, name, true, replicas)
 			Expect(err).NotTo(HaveOccurred(), "Each pod should start running and responding")
 
 			By("choose a node with at least one pod - we will block some network traffic on this node")
@@ -496,9 +514,9 @@ var _ = Describe("Nodes", func() {
 			// increasing the RC size is not a valid way to test this
 			// since we have no guarantees the pod will be scheduled on our node.
 			additionalPod := "additionalpod"
-			err = createServeHostnamePodOnNode(c, ns, additionalPod, node.Name)
+			err = newPodOnNode(c, ns, additionalPod, node.Name)
 			Expect(err).NotTo(HaveOccurred())
-			err = waitForPodsCreatedRunningResponding(c, ns, additionalPod, 1)
+			err = verifyPods(c, ns, additionalPod, true, 1)
 			Expect(err).NotTo(HaveOccurred())
 
 			// verify that it is really on the requested node


### PR DESCRIPTION
Addresses most of #7914. Will also fix TODOs 2 and 3 on [this comment](https://github.com/GoogleCloudPlatform/kubernetes/issues/8081#issuecomment-112499324) in #8081

This makes a few changes to allow more code reuse from other e2e tests.

Summary:
- `cluster_upgrade.go` now also does node upgrades and checks that resources created before function after
- `cluster/gce/upgrade.sh` is now fixed for node upgrades, and also has a `-P` option to only prepare a node upgrade (creating the new template and stopping)
- WebserverTest (`services.go`) nows uses RCs instead of pods. This means we now test RCs, and the pods survive node upgrades.
- renames and generalizes some stuff in `resize_nodes.go` and `restart.go`

+cc @mikedanese @davidopp @zmerlynn 
