### PR TITLE
Do not register cross namespace actions with subresources in path

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -5675,43 +5675,6 @@
       "consumes": [
        "*/*"
       ]
-     },
-     {
-      "type": "v1.Binding",
-      "method": "POST",
-      "summary": "create binding of a Binding",
-      "nickname": "createBindingBinding",
-      "parameters": [
-       {
-        "type": "string",
-        "paramType": "query",
-        "name": "pretty",
-        "description": "If 'true', then the output is pretty printed.",
-        "required": false,
-        "allowMultiple": false
-       },
-       {
-        "type": "v1.Binding",
-        "paramType": "body",
-        "name": "body",
-        "description": "",
-        "required": true,
-        "allowMultiple": false
-       }
-      ],
-      "responseMessages": [
-       {
-        "code": 200,
-        "message": "OK",
-        "responseModel": "v1.Binding"
-       }
-      ],
-      "produces": [
-       "application/json"
-      ],
-      "consumes": [
-       "*/*"
-      ]
      }
     ]
    },

--- a/api/swagger-spec/v1beta3.json
+++ b/api/swagger-spec/v1beta3.json
@@ -5675,43 +5675,6 @@
       "consumes": [
        "*/*"
       ]
-     },
-     {
-      "type": "v1beta3.Binding",
-      "method": "POST",
-      "summary": "create binding of a Binding",
-      "nickname": "createBindingBinding",
-      "parameters": [
-       {
-        "type": "string",
-        "paramType": "query",
-        "name": "pretty",
-        "description": "If 'true', then the output is pretty printed.",
-        "required": false,
-        "allowMultiple": false
-       },
-       {
-        "type": "v1beta3.Binding",
-        "paramType": "body",
-        "name": "body",
-        "description": "",
-        "required": true,
-        "allowMultiple": false
-       }
-      ],
-      "responseMessages": [
-       {
-        "code": 200,
-        "message": "OK",
-        "responseModel": "v1beta3.Binding"
-       }
-      ],
-      "produces": [
-       "application/json"
-      ],
-      "consumes": [
-       "*/*"
-      ]
      }
     ]
    },


### PR DESCRIPTION
Fixes `#/apis/56/operations/2/method: Operation method already defined: POST` errors from https://github.com/GoogleCloudPlatform/kubernetes/issues/9964
