### PR TITLE
Add diagnostics to check for not ready endpoints

### DIFF
--- a/test/e2e/es_cluster_logging.go
+++ b/test/e2e/es_cluster_logging.go
@@ -240,6 +240,19 @@ func ClusterLevelLoggingWithElasticsearch(f *Framework) {
 	missing := 0
 	expected := nodeCount * countTo
 	for start := time.Now(); time.Since(start) < graceTime; time.Sleep(10 * time.Second) {
+
+		// Debugging code to report the status of the elasticsearch logging endpoints.
+		esPods, err := f.Client.Pods(api.NamespaceDefault).List(labels.Set{"k8s-app": "elasticsearch-logging"}.AsSelector(), fields.Everything())
+		if err != nil {
+			Logf("Attempt to list Elasticsearch nodes encountered a problem -- may retry: %v", err)
+			continue
+		} else {
+			for i, pod := range esPods.Items {
+				Logf("pod %d: %s PodIP %s phase %s condition %+v", i, pod.Name, pod.Status.PodIP, pod.Status.Phase,
+					pod.Status.Conditions)
+			}
+		}
+
 		// Ask Elasticsearch to return all the log lines that were tagged with the underscore
 		// verison of the name. Ask for twice as many log lines as we expect to check for
 		// duplication bugs.


### PR DESCRIPTION
We suspect that a service might be mapping calls to a not ready endpoint. This adds diagnostics to look for this situation. To try and address issue #9486

```
Cluster level logging using Elasticsearch 
  should check that logs from pods on all nodes are ingested into Elasticsearch
  /usr/local/google/home/satnam/gocode/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/es_cluster_logging.go:39
[BeforeEach] Cluster level logging using Elasticsearch
  /usr/local/google/home/satnam/gocode/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/framework.go:47
STEP: Creating a kubernetes client
>>> testContext.KubeConfig: /usr/local/google/home/satnam/.kube/config
STEP: Building a namespace api object
INFO: Waiting up to 2m0s for service account default to be provisioned in ns e2e-tests-es-logging-fe74a
INFO: Service account default in ns e2e-tests-es-logging-fe74a found. (40.869294ms)
STEP: Waiting for a default service account to be provisioned in namespace
INFO: Waiting up to 2m0s for service account default to be provisioned in ns e2e-tests-es-logging-fe74a
INFO: Service account default in ns e2e-tests-es-logging-fe74a found. (42.427788ms)
[It] should check that logs from pods on all nodes are ingested into Elasticsearch
  /usr/local/google/home/satnam/gocode/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/es_cluster_logging.go:39
STEP: Checking the Elasticsearch service exists.
STEP: Checking to make sure the Elasticsearch pods are running
STEP: Checking to make sure we are talking to an Elasticsearch service.
STEP: Checking health of Elasticsearch service.
INFO: Found 2 nodes.
INFO: Node e2e-test-satnam-minion-3tbc condition 1/1: type: Ready, status: True
INFO: Successfully found node e2e-test-satnam-minion-3tbc readiness to be true
INFO: Node e2e-test-satnam-minion-tnz3 condition 1/1: type: Ready, status: True
INFO: Successfully found node e2e-test-satnam-minion-tnz3 readiness to be true
INFO: Found 2 healthy nodes.
STEP: Waiting for the pods to succeed.
INFO: Waiting up to 5m0s for pod synthlogger-0                                           status to be success or failure
INFO: No Status.Info for container 'synth-logger' in pod 'synthlogger-0' yet
INFO: Waiting for pod synthlogger-0                                           in namespace 'e2e-tests-es-logging-fe74a' status to be 'success or failure'(found phase: "Pending", readiness: false) (40.004404ms elapsed)
STEP: Saw pod success
INFO: Waiting up to 5m0s for pod synthlogger-1                                           status to be success or failure
STEP: Saw pod success
STEP: Checking all the log lines were ingested into Elasticsearch
INFO: pod 0: elasticsearch-logging-v1-q2lti PodIP 10.245.0.3 phase Running condition [{Type:Ready Status:True}]
INFO: pod 1: elasticsearch-logging-v1-sgqtu PodIP 10.245.1.3 phase Running condition [{Type:Ready Status:True}]
INFO: After 115.390572ms expecting to find 200 log lines but saw only 0
INFO: pod 0: elasticsearch-logging-v1-q2lti PodIP 10.245.0.3 phase Running condition [{Type:Ready Status:True}]
INFO: pod 1: elasticsearch-logging-v1-sgqtu PodIP 10.245.1.3 phase Running condition [{Type:Ready Status:True}]
INFO: After 10.218420681s expecting to find 200 log lines but saw only 0
INFO: pod 0: elasticsearch-logging-v1-q2lti PodIP 10.245.0.3 phase Running condition [{Type:Ready Status:True}]
INFO: pod 1: elasticsearch-logging-v1-sgqtu PodIP 10.245.1.3 phase Running condition [{Type:Ready Status:True}]
INFO: After 20.422526386s found all 200 log lines
[AfterEach] Cluster level logging using Elasticsearch
  /usr/local/google/home/satnam/gocode/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/framework.go:48
STEP: Destroying namespace "e2e-tests-es-logging-fe74a" for this suite.

• [SLOW TEST:56.468 seconds]
Cluster level logging using Elasticsearch
/usr/local/google/home/satnam/gocode/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/es_cluster_logging.go:40
  should check that logs from pods on all nodes are ingested into Elasticsearch
  /usr/local/google/home/satnam/gocode/src/github.com/GoogleCloudPlatform/kubernetes/_output/local/go/src/github.com/GoogleCloudPlatform/kubernetes/test/e2e/es_cluster_logging.go:39
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
Ran 1 of 86 Specs in 56.469 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 85 Skipped PASS

Ginkgo ran 1 suite in 1m2.065102015s
Test Suite Passed
```

@quinton-hoole @thockin 
