### PR TITLE
enable networking test on a one-node local cluster

### DIFF
--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -121,8 +121,19 @@ var _ = Describe("Networking", func() {
 		filterNodes(nodes, func(node api.Node) bool {
 			return isNodeReadySetAsExpected(&node, true)
 		})
-		if len(nodes.Items) < 2 {
-			Failf("Less than two nodes were found Ready.")
+
+		if len(nodes.Items) == 0 {
+			Failf("No Ready nodes found.")
+		}
+		if len(nodes.Items) == 1 {
+			// in general, the test requires two nodes. But for local development, often a one node cluster
+			// is created, for simplicity and speed. (see issue #10012). We permit one-node test
+			// only in some cases
+			if !providerIs("local") {
+				Failf(fmt.Sprintf("The test requires two Ready nodes on %s, but found just one.", testContext.Provider))
+			}
+			Logf("Only one ready node is detected. The test has limited scope in such setting. " +
+				"Rerun it with at least two nodes to get complete coverage.")
 		}
 
 		podNames := LaunchNetTestPodPerNode(f, nodes, svcname, "1.4")


### PR DESCRIPTION
Resoves #10012

network test with one node is enabled for all setups but gce and gke

cc @lavalamp @jayunit100 
