### PR TITLE
Fix problem with ovs settings running under vagrant on Fedora-21

### DIFF
--- a/cluster/vagrant/provision-network.sh
+++ b/cluster/vagrant/provision-network.sh
@@ -50,7 +50,7 @@ function provision-network {
     echo "Add ovs bridge"
     ovs-vsctl del-br ${OVS_SWITCH} || true
     ovs-vsctl add-br ${OVS_SWITCH} -- set Bridge ${OVS_SWITCH} fail-mode=secure
-    ovs-vsctl set bridge ${OVS_SWITCH} protocols=OpenFlow13
+    ovs-vsctl set bridge ${OVS_SWITCH} protocols=OpenFlow10,OpenFlow11,OpenFlow12,OpenFlow13
     ovs-vsctl del-port ${OVS_SWITCH} ${TUNNEL_BASE}0 || true
     ovs-vsctl add-port ${OVS_SWITCH} ${TUNNEL_BASE}0 -- set Interface ${TUNNEL_BASE}0 type=${TUNNEL_BASE} options:remote_ip="flow" options:key="flow" ofport_request=10
 

--- a/docs/client-libraries.md
+++ b/docs/client-libraries.md
@@ -11,6 +11,7 @@
    * [Ruby2](https://github.com/abonas/kubeclient)
    * [PHP](https://github.com/devstub/kubernetes-api-php-client)
    * [Node.js](https://github.com/tenxcloud/node-kubernetes-client)
+   * [Perl](https://metacpan.org/pod/Net::Kubernetes)
 
 
 


### PR DESCRIPTION
Accept an expanded list of protocols for ovs bridge in the vagrant provider provision network script. This corrects an error seen after start up that prevents pods from communication via kubernetes service addresses.
