### PR TITLE
Changed printing in a test file

### DIFF
--- a/pkg/kubectl/cmd/delete_test.go
+++ b/pkg/kubectl/cmd/delete_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -240,7 +239,7 @@ func TestDeleteMultipleObjectContinueOnMissing(t *testing.T) {
 	cmd.Flags().Set("filename", "../../../examples/guestbook/frontend-service.json")
 	cmd.Flags().Set("cascade", "false")
 	filenames := cmd.Flags().Lookup("filename").Value.(*util.StringList)
-	fmt.Printf("filenames: %v\n", filenames)
+	t.Logf("filenames: %v\n", filenames)
 	err := RunDelete(f, buf, cmd, []string{}, *filenames)
 	if err == nil || !errors.IsNotFound(err) {
 		t.Errorf("unexpected error: expected NotFound, got %v", err)


### PR DESCRIPTION
Inside tests it is better to use `t.Log` instead of `fmt` so information are printed only when requested.
