### PR TITLE
add debugging transport for client

### DIFF
--- a/pkg/client/debugging.go
+++ b/pkg/client/debugging.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/golang/glog"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+// RequestInfo keeps track of information about a request/response combination
+type RequestInfo struct {
+	RequestHeaders http.Header
+	RequestVerb    string
+	RequestURL     string
+
+	ResponseStatus  string
+	ResponseHeaders http.Header
+	ResponseErr     error
+
+	Duration time.Duration
+}
+
+// NewRequestInfo creates a new RequestInfo based on an http request
+func NewRequestInfo(req *http.Request) *RequestInfo {
+	reqInfo := &RequestInfo{}
+	reqInfo.RequestURL = req.URL.String()
+	reqInfo.RequestVerb = req.Method
+	reqInfo.RequestHeaders = req.Header
+
+	return reqInfo
+}
+
+// Complete adds information about the response to the RequestInfo
+func (r *RequestInfo) Complete(response *http.Response, err error) {
+	if err != nil {
+		r.ResponseErr = err
+		return
+	}
+	r.ResponseStatus = response.Status
+	r.ResponseHeaders = response.Header
+}
+
+// ToCurl returns a string that can be run as a command in a terminal (minus the body)
+func (r RequestInfo) ToCurl() string {
+	headers := ""
+	for key, values := range map[string][]string(r.RequestHeaders) {
+		for _, value := range values {
+			headers += fmt.Sprintf(` -H %q`, fmt.Sprintf("%s: %s", key, value))
+		}
+	}
+
+	return fmt.Sprintf("curl -k -v -X%s %s %s", r.RequestVerb, headers, r.RequestURL)
+}
+
+// DebuggingRoundTripper will display information about the requests passing through it based on what is configured
+type DebuggingRoundTripper struct {
+	delegatedRoundTripper http.RoundTripper
+
+	Levels util.StringSet
+}
+
+const (
+	JustURL         string = "url"
+	URLTiming       string = "urltiming"
+	CurlCommand     string = "curlcommand"
+	RequestHeaders  string = "requestheaders"
+	ResponseStatus  string = "responsestatus"
+	ResponseHeaders string = "responseheaders"
+)
+
+func NewDebuggingRoundTripper(rt http.RoundTripper, levels ...string) *DebuggingRoundTripper {
+	return &DebuggingRoundTripper{rt, util.NewStringSet(levels...)}
+}
+
+func (rt *DebuggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqInfo := NewRequestInfo(req)
+
+	if rt.Levels.Has(JustURL) {
+		glog.Infof("%s %s", reqInfo.RequestVerb, reqInfo.RequestURL)
+	}
+	if rt.Levels.Has(CurlCommand) {
+		glog.Infof("%s", reqInfo.ToCurl())
+
+	}
+	if rt.Levels.Has(RequestHeaders) {
+		glog.Infof("Request Headers:")
+		for key, values := range reqInfo.RequestHeaders {
+			for _, value := range values {
+				glog.Infof("    %s: %s", key, value)
+			}
+		}
+	}
+
+	startTime := time.Now()
+	response, err := rt.delegatedRoundTripper.RoundTrip(req)
+	reqInfo.Duration = time.Since(startTime)
+
+	reqInfo.Complete(response, err)
+
+	if rt.Levels.Has(URLTiming) {
+		glog.Infof("%s %s %s in %d milliseconds", reqInfo.RequestVerb, reqInfo.RequestURL, reqInfo.ResponseStatus, reqInfo.Duration.Nanoseconds()/int64(time.Millisecond))
+	}
+	if rt.Levels.Has(ResponseStatus) {
+		glog.Infof("Response Status: %s in %d milliseconds", reqInfo.ResponseStatus, reqInfo.Duration.Nanoseconds()/int64(time.Millisecond))
+	}
+	if rt.Levels.Has(ResponseHeaders) {
+		glog.Infof("Response Headers:")
+		for key, values := range reqInfo.ResponseHeaders {
+			for _, value := range values {
+				glog.Infof("    %s: %s", key, value)
+			}
+		}
+	}
+
+	return response, err
+}

--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -353,6 +353,18 @@ func TransportFor(config *Config) (http.RoundTripper, error) {
 			transport = http.DefaultTransport
 		}
 	}
+
+	switch {
+	case bool(glog.V(9)):
+		transport = NewDebuggingRoundTripper(transport, CurlCommand, URLTiming, ResponseHeaders)
+	case bool(glog.V(8)):
+		transport = NewDebuggingRoundTripper(transport, JustURL, RequestHeaders, ResponseStatus, ResponseHeaders)
+	case bool(glog.V(7)):
+		transport = NewDebuggingRoundTripper(transport, JustURL, RequestHeaders, ResponseStatus)
+	case bool(glog.V(6)):
+		transport = NewDebuggingRoundTripper(transport, URLTiming)
+	}
+
 	if config.WrapTransport != nil {
 		transport = config.WrapTransport(transport)
 	}

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -459,8 +459,10 @@ func (r *Request) Body(obj interface{}) *Request {
 			r.err = err
 			return r
 		}
+		glog.V(8).Infof("Request Body: %s", string(data))
 		r.body = bytes.NewBuffer(data)
 	case []byte:
+		glog.V(8).Infof("Request Body: %s", string(t))
 		r.body = bytes.NewBuffer(t)
 	case io.Reader:
 		r.body = t
@@ -470,6 +472,7 @@ func (r *Request) Body(obj interface{}) *Request {
 			r.err = err
 			return r
 		}
+		glog.V(8).Infof("Request Body: %s", string(data))
 		r.body = bytes.NewBuffer(data)
 	default:
 		r.err = fmt.Errorf("unknown type used for body: %+v", obj)
@@ -756,6 +759,8 @@ func (r *Request) transformResponse(resp *http.Response, req *http.Request) Resu
 			body = data
 		}
 	}
+	glog.V(8).Infof("Response Body: %s", string(body))
+
 	// Did the server give us a status response?
 	isStatusResponse := false
 	var status api.Status
@@ -811,6 +816,8 @@ func (r *Request) transformUnstructuredResponseError(resp *http.Response, req *h
 			body = data
 		}
 	}
+	glog.V(8).Infof("Response Body: %s", string(body))
+
 	message := "unknown"
 	if isTextResponse(resp) {
 		message = strings.TrimSpace(string(body))


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/8610.

This dumps detailed information about REST request based on your logging level.  Different levels produce different information.  For instance

```
[deads@deads-dev-01 kubernetes]$ $kubectl get pods --v=6
I0618 13:33:42.614135   23411 debugging_client.go:120] GET https://localhost:8443/api 200 OK in 22 milliseconds
I0618 13:33:42.629394   23411 debugging_client.go:120] GET https://localhost:8443/api/v1/namespaces/foo/pods 200 OK in 14 milliseconds
NAME      READY     REASON    RESTARTS   AGE


[deads@deads-dev-01 kubernetes]$ $kubectl get pods --v=7
I0618 13:33:45.439789   23422 debugging_client.go:98] GET https://localhost:8443/api
I0618 13:33:45.439846   23422 debugging_client.go:105] Request Headers:
I0618 13:33:45.439856   23422 debugging_client.go:108]     User-Agent: kubectl/v0.18.2 (linux/amd64) kubernetes/5c41bc2
I0618 13:33:45.439866   23422 debugging_client.go:108]     Authorization: Bearer sbug3JSvS-PA3GGYvRwuQKz_n7mtxPfLRaTcO4ajFOY
I0618 13:33:45.455468   23422 debugging_client.go:123] Response Status: 200 OK in 15 milliseconds
I0618 13:33:45.455837   23422 debugging_client.go:98] GET https://localhost:8443/api/v1/namespaces/foo/pods
I0618 13:33:45.455852   23422 debugging_client.go:105] Request Headers:
I0618 13:33:45.455862   23422 debugging_client.go:108]     User-Agent: kubectl/v0.18.2 (linux/amd64) kubernetes/5c41bc2
I0618 13:33:45.455872   23422 debugging_client.go:108]     Authorization: Bearer sbug3JSvS-PA3GGYvRwuQKz_n7mtxPfLRaTcO4ajFOY
I0618 13:33:45.470806   23422 debugging_client.go:123] Response Status: 200 OK in 14 milliseconds
NAME      READY     REASON    RESTARTS   AGE


[deads@deads-dev-01 kubernetes]$ $kubectl get pods --v=8
I0618 13:33:48.018687   23434 debugging_client.go:98] GET https://localhost:8443/api
I0618 13:33:48.018751   23434 debugging_client.go:105] Request Headers:
I0618 13:33:48.018762   23434 debugging_client.go:108]     User-Agent: kubectl/v0.18.2 (linux/amd64) kubernetes/5c41bc2
I0618 13:33:48.018771   23434 debugging_client.go:108]     Authorization: Bearer sbug3JSvS-PA3GGYvRwuQKz_n7mtxPfLRaTcO4ajFOY
I0618 13:33:48.034233   23434 debugging_client.go:123] Response Status: 200 OK in 15 milliseconds
I0618 13:33:48.034265   23434 debugging_client.go:126] Response Headers:
I0618 13:33:48.034275   23434 debugging_client.go:129]     Cache-Control: no-store
I0618 13:33:48.034284   23434 debugging_client.go:129]     Content-Type: application/json
I0618 13:33:48.034293   23434 debugging_client.go:129]     Date: Thu, 18 Jun 2015 17:33:48 GMT
I0618 13:33:48.034302   23434 debugging_client.go:129]     Content-Length: 47
I0618 13:33:48.034353   23434 request.go:762] Response Body: {
  "versions": [
    "v1beta3",
    "v1"
  ]
}
I0618 13:33:48.034645   23434 debugging_client.go:98] GET https://localhost:8443/api/v1/namespaces/foo/pods
I0618 13:33:48.034659   23434 debugging_client.go:105] Request Headers:
I0618 13:33:48.034668   23434 debugging_client.go:108]     User-Agent: kubectl/v0.18.2 (linux/amd64) kubernetes/5c41bc2
I0618 13:33:48.034677   23434 debugging_client.go:108]     Authorization: Bearer sbug3JSvS-PA3GGYvRwuQKz_n7mtxPfLRaTcO4ajFOY
I0618 13:33:48.049494   23434 debugging_client.go:123] Response Status: 200 OK in 14 milliseconds
I0618 13:33:48.049516   23434 debugging_client.go:126] Response Headers:
I0618 13:33:48.049521   23434 debugging_client.go:129]     Date: Thu, 18 Jun 2015 17:33:48 GMT
I0618 13:33:48.049525   23434 debugging_client.go:129]     Content-Length: 125
I0618 13:33:48.049529   23434 debugging_client.go:129]     Cache-Control: no-store
I0618 13:33:48.049532   23434 debugging_client.go:129]     Content-Type: application/json
I0618 13:33:48.049561   23434 request.go:762] Response Body: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/foo/pods","resourceVersion":"429"},"items":[]}
NAME      READY     REASON    RESTARTS   AGE


[deads@deads-dev-01 kubernetes]$ $kubectl get pods --v=9
I0618 13:33:54.294448   23447 debugging_client.go:101] curl -k -v -XGET  -H "User-Agent: kubectl/v0.18.2 (linux/amd64) kubernetes/5c41bc2" -H "Authorization: Bearer sbug3JSvS-PA3GGYvRwuQKz_n7mtxPfLRaTcO4ajFOY" https://localhost:8443/api
I0618 13:33:54.310532   23447 debugging_client.go:120] GET https://localhost:8443/api 200 OK in 16 milliseconds
I0618 13:33:54.310555   23447 debugging_client.go:126] Response Headers:
I0618 13:33:54.310561   23447 debugging_client.go:129]     Content-Type: application/json
I0618 13:33:54.310567   23447 debugging_client.go:129]     Date: Thu, 18 Jun 2015 17:33:54 GMT
I0618 13:33:54.310573   23447 debugging_client.go:129]     Content-Length: 47
I0618 13:33:54.310578   23447 debugging_client.go:129]     Cache-Control: no-store
I0618 13:33:54.310640   23447 request.go:762] Response Body: {
  "versions": [
    "v1beta3",
    "v1"
  ]
}
I0618 13:33:54.310968   23447 debugging_client.go:101] curl -k -v -XGET  -H "Authorization: Bearer sbug3JSvS-PA3GGYvRwuQKz_n7mtxPfLRaTcO4ajFOY" -H "User-Agent: kubectl/v0.18.2 (linux/amd64) kubernetes/5c41bc2" https://localhost:8443/api/v1/namespaces/foo/pods
I0618 13:33:54.331508   23447 debugging_client.go:120] GET https://localhost:8443/api/v1/namespaces/foo/pods 200 OK in 20 milliseconds
I0618 13:33:54.331552   23447 debugging_client.go:126] Response Headers:
I0618 13:33:54.331562   23447 debugging_client.go:129]     Cache-Control: no-store
I0618 13:33:54.331573   23447 debugging_client.go:129]     Content-Type: application/json
I0618 13:33:54.331597   23447 debugging_client.go:129]     Date: Thu, 18 Jun 2015 17:33:54 GMT
I0618 13:33:54.331607   23447 debugging_client.go:129]     Content-Length: 125
I0618 13:33:54.331654   23447 request.go:762] Response Body: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/foo/pods","resourceVersion":"429"},"items":[]}
NAME      READY     REASON    RESTARTS   AGE

```
