### PR TITLE
Add readiness probe to Elasticsearch and Kibana logging pods

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-controller.yaml
@@ -22,6 +22,13 @@ spec:
       containers:
       - image: gcr.io/google_containers/elasticsearch:1.4
         name: elasticsearch-logging
+        livenessProbe:
+          name: es-liveness
+          httpGet:
+            path: /
+            port: 9200
+          initialDelaySeconds: 30
+          timeoutSeconds: 5          
         ports:
         - containerPort: 9200
           name: es-port

--- a/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
@@ -22,6 +22,13 @@ spec:
       containers:
       - name: kibana-logging
         image: gcr.io/google_containers/kibana:1.3
+        livenessProbe:
+          name: kibana-liveness
+          httpGet:
+            path: /
+            port: 5601
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
         env:
           - name: "ELASTICSEARCH_URL"
             value: "http://elasticsearch-logging:9200"


### PR DESCRIPTION
To address #9486 this PR adds readiness probes to the Elasticsearch and Kibana pods to try and ensure the service maps requests to ready pods.
@quinton-hoole 
