### PR TITLE
Change density relist period to better reflect the kubelet's watch

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -268,7 +268,7 @@ var _ = Describe("Density", func() {
 						},
 					},
 					&api.Pod{},
-					time.Minute*5,
+					0,
 					framework.ResourceEventHandlerFuncs{
 						AddFunc: func(obj interface{}) {
 							p, ok := obj.(*api.Pod)


### PR DESCRIPTION
The kubelet has a 0 relist period, so we should watch the same way. Since density usually takes 8m a 5m relist is bound to affect 99% latency measurements.

@gmarek @davidopp 
