### PR TITLE
Assign host's IPAddress to podIP when pod shares the host's network

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2161,6 +2161,9 @@ func (kl *Kubelet) generatePodStatus(pod *api.Pod) (api.PodStatus, error) {
 			glog.V(4).Infof("Cannot get host IP: %v", err)
 		} else {
 			podStatus.HostIP = hostIP.String()
+			if pod.Spec.HostNetwork && podStatus.PodIP == "" {
+				podStatus.PodIP = hostIP.String()
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #10022 
