### PR TITLE
Revert "Validate service account name in pod spec"

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -963,11 +963,6 @@ func ValidatePodSpec(spec *api.PodSpec) errs.ValidationErrorList {
 	allErrs = append(allErrs, ValidateLabels(spec.NodeSelector, "nodeSelector")...)
 	allErrs = append(allErrs, validateHostNetwork(spec.HostNetwork, spec.Containers).Prefix("hostNetwork")...)
 	allErrs = append(allErrs, validateImagePullSecrets(spec.ImagePullSecrets).Prefix("imagePullSecrets")...)
-	if len(spec.ServiceAccount) > 0 {
-		if ok, msg := ValidateServiceAccountName(spec.ServiceAccount, false); !ok {
-			allErrs = append(allErrs, errs.NewFieldInvalid("serviceAccount", spec.ServiceAccount, msg))
-		}
-	}
 
 	if spec.ActiveDeadlineSeconds != nil {
 		if *spec.ActiveDeadlineSeconds <= 0 {

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -1052,7 +1052,6 @@ func TestValidatePodSpec(t *testing.T) {
 			NodeName:              "foobar",
 			DNSPolicy:             api.DNSClusterFirst,
 			ActiveDeadlineSeconds: &activeDeadlineSeconds,
-			ServiceAccount:        "acct",
 		},
 		{ // Populate HostNetwork.
 			Containers: []api.Container{
@@ -1092,12 +1091,6 @@ func TestValidatePodSpec(t *testing.T) {
 			DNSPolicy:     api.DNSPolicy("invalid"),
 			RestartPolicy: api.RestartPolicyAlways,
 			Containers:    []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
-		},
-		"bad service account name": {
-			Containers:     []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
-			RestartPolicy:  api.RestartPolicyAlways,
-			DNSPolicy:      api.DNSClusterFirst,
-			ServiceAccount: "invalidName",
 		},
 		"bad restart policy": {
 			RestartPolicy: "UnknowPolicy",


### PR DESCRIPTION
Reverts GoogleCloudPlatform/kubernetes#9688

Trying to debug 4 back to back e2e failures -- reverting changes made at the time close to when the tests started to fail.
