### PR TITLE
Add MASTER env variable to examples/redis/redis-controller.yaml

### DIFF
--- a/examples/redis/redis-controller.yaml
+++ b/examples/redis/redis-controller.yaml
@@ -14,6 +14,9 @@ spec:
       containers:
       - name: redis
         image: kubernetes/redis:v1
+        env:
+        - name: MASTER
+          value: "true"
         ports:
         - containerPort: 6379
         resources:


### PR DESCRIPTION
The master redis pod doesn't start without this variable (it is present in `examples/redis/redis-master.yaml` but not in `examples/redis/redis-controller.yaml`):

```
./cluster/kubectl.sh logs redis-jaomt
Could not connect to Redis at -p:6379: Name or service not known
Failed to find master.
```

With the variable:

``````
./cluster/kubectl.sh logs redis-vdwea
                _._                                                  
           _.-``__ ''-._                                             
      _.-``    `.  `_.  ''-._           Redis 2.8.19 (00000000/0) 64 bit
  .-`` .-```.  ```\/    _.,_ ''-._                                   
 (    '      ,       .-`  | `,    )     Running in stand alone mode
 |`-._`-...-` __...-.``-._|'` _.-'|     Port: 6379
 |    `-._   `._    /     _.-'    |     PID: 8
  `-._    `-._  `-./  _.-'    _.-'                                   
 |`-._`-._    `-.__.-'    _.-'_.-'|                                  
 |    `-._`-._        _.-'_.-'    |           http://redis.io        
  `-._    `-._`-.__.-'_.-'    _.-'                                   
 |`-._`-._    `-.__.-'    _.-'_.-'|                                  
 |    `-._`-._        _.-'_.-'    |                                  
  `-._    `-._`-.__.-'_.-'    _.-'                                   
      `-._    `-.__.-'    _.-'                                       
          `-._        _.-'                                           
              `-.__.-'                                               

[8] 19 Jun 11:57:15.323 # Server started, Redis version 2.8.19
[8] 19 Jun 11:57:15.323 # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
[8] 19 Jun 11:57:15.323 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
[8] 19 Jun 11:57:15.323 # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
[8] 19 Jun 11:57:15.323 * The server is now ready to accept connections on port 6379
``````
