### PR TITLE
kubectl log->logs in bash completions

### DIFF
--- a/contrib/completions/bash/kubectl
+++ b/contrib/completions/bash/kubectl
@@ -210,7 +210,7 @@ __custom_func() {
 	    __kubectl_get_resource
             return
             ;;
-	kubectl_log)
+	kubectl_logs)
 	    __kubectl_require_pod_and_container
 	    return
 	    ;;

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -82,7 +82,7 @@ __custom_func() {
 	    __kubectl_get_resource
             return
             ;;
-	kubectl_log)
+	kubectl_logs)
 	    __kubectl_require_pod_and_container
 	    return
 	    ;;


### PR DESCRIPTION
The kubectl log command switched to logs. But the bash completions code
was still looking for a singular
