### PR TITLE
Adding Perl client to list of User Libs

### DIFF
--- a/docs/client-libraries.md
+++ b/docs/client-libraries.md
@@ -11,6 +11,7 @@
    * [Ruby2](https://github.com/abonas/kubeclient)
    * [PHP](https://github.com/devstub/kubernetes-api-php-client)
    * [Node.js](https://github.com/tenxcloud/node-kubernetes-client)
+   * [Perl](https://metacpan.org/pod/Net::Kubernetes)
 
 
 


### PR DESCRIPTION
Adding a link to Net::Kubernetes perl module to list of user contributed client libraries.

Related issue: https://github.com/GoogleCloudPlatform/kubernetes/issues/10114
