### PR TITLE
GKE upgrade tests

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -44,6 +44,7 @@ function usage() {
   echo "(... Fetching current release versions ...)"
   echo ""
 
+  # NOTE: IF YOU CHANGE THE FOLLOWING LIST, ALSO UPDATE test/e2e/cluster_upgrade.go
   local latest_release
   local latest_stable
   local latest_ci
@@ -53,7 +54,7 @@ function usage() {
   latest_ci=$(gsutil cat gs://kubernetes-release/ci/latest.txt)
 
   echo "To upgrade to:"
-  echo "  latest stable: ${0} ${latest_stable}"
+  echo "  latest stable:  ${0} ${latest_stable}"
   echo "  latest release: ${0} ${latest_release}"
   echo "  latest ci:      ${0} ${latest_ci}"
 }

--- a/cluster/gke/config-common.sh
+++ b/cluster/gke/config-common.sh
@@ -18,7 +18,6 @@
 # Specifically, the following environment variables are assumed:
 # - CLUSTER_NAME  (the name of the cluster)
 
-MASTER_NAME="k8s-${CLUSTER_NAME}-master"
 ZONE="${ZONE:-us-central1-f}"
 NUM_MINIONS="${NUM_MINIONS:-2}"
 CLUSTER_API_VERSION="${CLUSTER_API_VERSION:-}"

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -97,6 +97,7 @@ export PATH=$(dirname "${e2e_test}"):"${PATH}"
   --provider="${KUBERNETES_PROVIDER}" \
   --gce-project="${PROJECT:-}" \
   --gce-zone="${ZONE:-}" \
+  --gke-cluster="${CLUSTER_NAME:-}" \
   --kube-master="${KUBE_MASTER:-}" \
   --cluster-tag="${CLUSTER_ID:-}" \
   --repo-root="${KUBE_VERSION_ROOT}" \

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -89,6 +89,7 @@ func init() {
 	flag.StringVar(&cloudConfig.MasterName, "kube-master", "", "Name of the kubernetes master. Only required if provider is gce or gke")
 	flag.StringVar(&cloudConfig.ProjectID, "gce-project", "", "The GCE project being used, if applicable")
 	flag.StringVar(&cloudConfig.Zone, "gce-zone", "", "GCE zone being used, if applicable")
+	flag.StringVar(&cloudConfig.Cluster, "gke-cluster", "", "GKE name of cluster being used, if applicable")
 	flag.StringVar(&cloudConfig.NodeInstanceGroup, "node-instance-group", "", "Name of the managed instance group for nodes. Valid only for gce")
 	flag.IntVar(&cloudConfig.NumNodes, "num-nodes", -1, "Number of nodes in the cluster")
 

--- a/test/e2e/restart.go
+++ b/test/e2e/restart.go
@@ -251,6 +251,7 @@ func migTemplate() (string, error) {
 	var errLast error
 	var templ string
 	key := "instanceTemplate"
+	// TODO(mbforbes): Refactor this to use cluster_upgrade.go:retryCmd(...)
 	if wait.Poll(poll, singleCallTimeout, func() (bool, error) {
 		// TODO(mbforbes): make this hit the compute API directly instead of
 		// shelling out to gcloud.
@@ -289,6 +290,7 @@ func migRollingUpdateStart(templ string, nt time.Duration) (string, error) {
 	var errLast error
 	var id string
 	prefix, suffix := "Started [", "]."
+	// TODO(mbforbes): Refactor this to use cluster_upgrade.go:retryCmd(...)
 	if err := wait.Poll(poll, singleCallTimeout, func() (bool, error) {
 		// TODO(mbforbes): make this hit the compute API directly instead of
 		//                 shelling out to gcloud.
@@ -345,6 +347,7 @@ func migRollingUpdatePoll(id string, nt time.Duration) error {
 	start, timeout := time.Now(), nt*time.Duration(testContext.CloudConfig.NumNodes)
 	var errLast error
 	Logf("Waiting up to %v for MIG rolling update to complete.", timeout)
+	// TODO(mbforbes): Refactor this to use cluster_upgrade.go:retryCmd(...)
 	if wait.Poll(restartPoll, timeout, func() (bool, error) {
 		o, err := exec.Command("gcloud", "preview", "rolling-updates",
 			fmt.Sprintf("--project=%s", testContext.CloudConfig.ProjectID),

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -87,6 +87,7 @@ const (
 type CloudConfig struct {
 	ProjectID         string
 	Zone              string
+	Cluster           string
 	MasterName        string
 	NodeInstanceGroup string
 	NumNodes          int


### PR DESCRIPTION
GKE node (#7914) and master (#8081) upgrade tests. Adds support for running `cluster_upgrade.go` with the GKE provider.

Final TODOs after this to close those issues are:
- verify software version really changed after upgrade
- setup jenkins jobs to run all of these; ensure they're green

After that, our next TODOs are:
- test volumes, persistent volumes, and secrets
- some refactoring, cleanup, and consistency (I sprinkled TODOs in the code for these things)

+cc @mikedanese @zmerlynn @quinton-hoole @ixdy 
