### PR TITLE
Remove readiness probes to Elasticsearch and Kibana logging

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-controller.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1beta3
+apiVersion: v1
 kind: ReplicationController
 metadata:
   name: elasticsearch-logging-v1
@@ -21,14 +21,7 @@ spec:
     spec:
       containers:
       - image: gcr.io/google_containers/elasticsearch:1.4
-        name: elasticsearch-logging
-        livenessProbe:
-          name: es-liveness
-          httpGet:
-            path: /
-            port: 9200
-          initialDelaySeconds: 30
-          timeoutSeconds: 5          
+        name: elasticsearch-logging         
         ports:
         - containerPort: 9200
           name: es-port

--- a/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1beta3
+apiVersion: v1
 kind: ReplicationController
 metadata:
   name: kibana-logging-v1
@@ -22,13 +22,6 @@ spec:
       containers:
       - name: kibana-logging
         image: gcr.io/google_containers/kibana:1.3
-        livenessProbe:
-          name: kibana-liveness
-          httpGet:
-            path: /
-            port: 5601
-          initialDelaySeconds: 30
-          timeoutSeconds: 5
         env:
           - name: "ELASTICSEARCH_URL"
             value: "http://elasticsearch-logging:9200"


### PR DESCRIPTION
To stabilize this test I need a readiness probe as well as a liveness probe.
