### PR TITLE
Make DNS not need its own token

### DIFF
--- a/cluster/addons/dns/README.md
+++ b/cluster/addons/dns/README.md
@@ -109,7 +109,7 @@ Create a file named busybox.yaml with the
 following contents:
 
 ```yaml
-apiVersion: v1beta3
+apiVersion: v1
 kind: Pod
 metadata:
   name: busybox

--- a/cluster/addons/dns/kube2sky/Changelog
+++ b/cluster/addons/dns/kube2sky/Changelog
@@ -1,3 +1,7 @@
+## Version 1.10 (Jun 19 2015 Tim Hockin <thockin@google.com>)
+- Fall back on service account tokens if no other auth is specified.
+
+
 ## Version 1.9 (May 28 2015 Abhishek Shah <abshah@google.com>)
 - Add SRV support.
 

--- a/cluster/addons/dns/kube2sky/Changelog
+++ b/cluster/addons/dns/kube2sky/Changelog
@@ -1,12 +1,16 @@
-* Fri May 15 2015  Tim Hockin <thockin@google.com>
-  - First Changelog entry
-  - Current version is 1.4
+## Version 1.9 (May 28 2015 Abhishek Shah <abshah@google.com>)
+- Add SRV support.
+
+
+## Version 1.8 (May 28 2015 Vishnu Kannan <vishnuk@google.com>)
+- Avoid making connections to the master insecure by default
+- Let users override the master URL in kubeconfig via a flag
 
 
 ## Version 1.7 (May 25 2015 Vishnu Kannan <vishnuk@google.com>)
-- Adding support for headless services. All pods backing a headless service is addressible via DNS RR.
+- Adding support for headless services. All pods backing a headless service is
+addressible via DNS RR.
 
 
-## Version 1.8 (May 18 2015 Vishnu Kannan <vishnuk@google.com>)
-- Avoid making connections to the master insecure by default
-- Let users override the master URL in kubeconfig via a flag
+## Version 1.4 (Fri May 15 2015 Tim Hockin <thockin@google.com>)
+- First Changelog entry

--- a/cluster/addons/dns/kube2sky/Makefile
+++ b/cluster/addons/dns/kube2sky/Makefile
@@ -4,7 +4,7 @@
 
 .PHONY: all kube2sky container push clean test
 
-TAG = 1.9
+TAG = 1.10
 PREFIX = gcr.io/google_containers
 
 all: container

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -1,21 +1,22 @@
 apiVersion: v1beta3
 kind: ReplicationController
 metadata:
-  name: kube-dns-v3
+  name: kube-dns-v4
   namespace: default
   labels:
-    k8s-app: kube-dns-v3
+    k8s-app: kube-dns
+    version: v4
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: {{ pillar['dns_replicas'] }}
   selector:
     k8s-app: kube-dns
-    version: v3
+    version: v4
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v3
+        version: v4
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
@@ -30,7 +31,7 @@ spec:
         - -initial-cluster-token
         - skydns-etcd
       - name: kube2sky
-        image: gcr.io/google_containers/kube2sky:1.9
+        image: gcr.io/google_containers/kube2sky:1.10
         args:
         # command = "/kube2sky"
         - -domain={{ pillar['dns_domain'] }}

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -1,4 +1,4 @@
-apiVersion: v1beta3
+apiVersion: v1
 kind: ReplicationController
 metadata:
   name: kube-dns-v4

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -54,7 +54,7 @@ spec:
             command:
             - /bin/sh
             - -c
-            - nslookup kubernetes.default.{{ pillar['dns_domain'] }} localhost >/dev/null
+            - nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} localhost >/dev/null
           initialDelaySeconds: 30
           timeoutSeconds: 5
       dnsPolicy: Default  # Don't use cluster DNS.

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -35,11 +35,6 @@ spec:
         args:
         # command = "/kube2sky"
         - -domain={{ pillar['dns_domain'] }}
-        - -kubecfg_file=/etc/dns_token/kubeconfig
-        volumeMounts:
-        - mountPath: /etc/dns_token
-          name: dns-token
-          readOnly: true
       - name: skydns
         image: gcr.io/google_containers/skydns:2015-03-11-001
         args:
@@ -63,7 +58,3 @@ spec:
           initialDelaySeconds: 30
           timeoutSeconds: 5
       dnsPolicy: Default  # Don't use cluster DNS.
-      volumes:
-      - name: dns-token
-        secret:
-          secretName: token-system-dns

--- a/cluster/addons/dns/skydns-svc.yaml.in
+++ b/cluster/addons/dns/skydns-svc.yaml.in
@@ -1,4 +1,4 @@
-apiVersion: v1beta3
+apiVersion: v1
 kind: Service
 metadata:
   name: kube-dns
@@ -10,7 +10,7 @@ metadata:
 spec:
   selector:
     k8s-app: kube-dns
-  portalIP:  {{ pillar['dns_server'] }}
+  clusterIP:  {{ pillar['dns_server'] }}
   ports:
   - name: dns
     port: 53


### PR DESCRIPTION
Different than the previous attempt, this still uses the DNS token, but enables kube2sky to work in insecure mode without it.
