### PR TITLE
improve error messages from poll

### DIFF
--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -256,7 +256,7 @@ func podsResponding(c *client.Client, ns, name string, wantName bool, pods *api.
 	retryTimeout := 2 * time.Minute
 	retryInterval := 5 * time.Second
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
-	return wait.Poll(retryInterval, retryTimeout, podResponseChecker{c, ns, label, name, wantName, pods}.checkAllResponses)
+	return wait.PollMsg("pods are responding", retryInterval, retryTimeout, podResponseChecker{c, ns, label, name, wantName, pods}.checkAllResponses)
 }
 
 func verifyPods(c *client.Client, ns, name string, wantName bool, replicas int) error {

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1008,9 +1008,10 @@ func testReachable(ip string, port int) {
 		Failf("Got port==0 for reachability check (%s)", url)
 	}
 
-	By(fmt.Sprintf("Waiting up to %v for %s to be reachable", podStartTimeout, url))
+	desc := fmt.Sprintf("url %s:%d to be reachable", ip, port)
+	By(fmt.Sprintf("Waiting up to %v for %s", podStartTimeout, desc))
 	start := time.Now()
-	expectNoError(wait.Poll(poll, podStartTimeout, func() (bool, error) {
+	expectNoError(wait.PollMsg(desc, poll, podStartTimeout, func() (bool, error) {
 		resp, err := httpGetNoConnectionPool(url)
 		if err != nil {
 			Logf("Got error waiting for reachability of %s: %v (%v)", url, err, time.Since(start))
@@ -1042,8 +1043,9 @@ func testNotReachable(ip string, port int) {
 		Failf("Got port==0 for non-reachability check (%s)", url)
 	}
 
-	By(fmt.Sprintf("Waiting up to %v for %s to be *not* reachable", podStartTimeout, url))
-	expectNoError(wait.Poll(poll, podStartTimeout, func() (bool, error) {
+	desc := fmt.Sprintf("url %s:%d is *not* reachable", ip, port)
+	By(fmt.Sprintf("Waiting up to %v for %s", podStartTimeout, desc))
+	expectNoError(wait.PollMsg(desc, poll, podStartTimeout, func() (bool, error) {
 		resp, err := httpGetNoConnectionPool(url)
 		if err != nil {
 			Logf("Successfully waited for the url %s to be unreachable.", url)


### PR DESCRIPTION
Poll timeout was returned as `timed out waiting for the condition`. If the error was checked like this

```
        Expect(err).NotTo(HaveOccurred())
```

We got a meaningless message.

I added a new function PollMsg that takes a description of the condition. It is printed in the timeout message.
