### PR TITLE
In scalability tests wait until terminating namespaces are deleted

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -158,7 +158,7 @@ var _ = Describe("Density", func() {
 
 	for _, testArg := range densityTests {
 		name := fmt.Sprintf("should allow starting %d pods per node", testArg.podsPerMinion)
-		if testArg.podsPerMinion <= 30 {
+		if testArg.podsPerMinion == 30 {
 			name = "[Performance suite] " + name
 		}
 		if testArg.skip {

--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -156,7 +156,7 @@ var _ = Describe("Density", func() {
 		// TODO: Reenable once we can measure latency only from a single test.
 		// TODO: Expose runLatencyTest as ginkgo flag.
 		{podsPerMinion: 3, skip: true, runLatencyTest: false, interval: 10 * time.Second},
-		{podsPerMinion: 30, skip: true, runLatencyTest: false, interval: 10 * time.Second},
+		{podsPerMinion: 30, skip: true, runLatencyTest: true, interval: 10 * time.Second},
 		// More than 30 pods per node is outside our v1.0 goals.
 		// We might want to enable those tests in the future.
 		{podsPerMinion: 50, skip: true, runLatencyTest: false, interval: 10 * time.Second},

--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -86,6 +86,13 @@ var _ = Describe("Density", func() {
 		expectNoError(err)
 		minionCount = len(minions.Items)
 		Expect(minionCount).NotTo(BeZero())
+
+		// Terminating a namespace (deleting the remaining objects from it - which
+		// generally means events) can affect the current run. Thus we wait for all
+		// terminating namespace to be finally deleted before starting this test.
+		err = deleteTestingNS(c)
+		expectNoError(err)
+
 		nsForTesting, err := createTestingNS("density", c)
 		ns = nsForTesting.Name
 		expectNoError(err)

--- a/test/e2e/load.go
+++ b/test/e2e/load.go
@@ -63,6 +63,13 @@ var _ = Describe("Load capacity", func() {
 		expectNoError(err)
 		nodeCount = len(nodes.Items)
 		Expect(nodeCount).NotTo(BeZero())
+
+		// Terminating a namespace (deleting the remaining objects from it - which
+		// generally means events) can affect the current run. Thus we wait for all
+		// terminating namespace to be finally deleted before starting this test.
+		err = deleteTestingNS(c)
+		expectNoError(err)
+
 		nsForTesting, err := createTestingNS("load", c)
 		ns = nsForTesting.Name
 		expectNoError(err)


### PR DESCRIPTION
Background deleting objects from a terminating namespace (events) can affect the metrics of the test that is really running.

Also two small changes:
- don't run 3 pods per node test as part of e2e-scalability
- generate startup-latency metrics while running those tests

Risk: low (only modifying e2e scalability tests - not touching production code)

cc @fgrzadkowski @piosz 
