### PR TITLE
RFC: Use containers to mount Kubernetes volumes

### DIFF
--- a/pkg/util/list.go
+++ b/pkg/util/list.go
@@ -21,6 +21,11 @@ import (
 	"strings"
 )
 
+/* StringList is list of strings, used e.g. to keep command line arguments.
+ * It splits the values by comma ','.
+ * After this code, the list contains {'a', 'b', 'c'}:
+ * list StringList; list.Set('a,b'); list.Set('c')
+ */
 type StringList []string
 
 func (sl *StringList) String() string {

--- a/pkg/util/mount/container_mount.go
+++ b/pkg/util/mount/container_mount.go
@@ -1,0 +1,120 @@
+// +build linux
+
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mount
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/exec"
+	"github.com/golang/glog"
+	"os"
+	"syscall"
+)
+
+// ContainerMounter is part of experimental support for running mount tools
+// in a container.
+type ContainerMounter struct {
+	executor ContainerExecutor
+	config   *MountConfig
+}
+
+// ContainerMounter implements mount.Interface
+var _ = Interface(&ContainerMounter{})
+
+func (cm *ContainerMounter) SetRunner(executor ContainerExecutor) {
+	cm.executor = executor
+}
+
+// Mount runs mount(8) in the containermount namespace.  Aside from this
+// aspect, Mount has the same semantics as the mounter returned by mount.New()
+func (cm *ContainerMounter) Mount(source string, target string, fstype string, options []string) error {
+	bind, bindRemountOpts := isBind(options)
+
+	if bind {
+		err := cm.doContainerMount(source, target, fstype, []string{"bind"})
+		if err != nil {
+			return err
+		}
+		return cm.doContainerMount(source, target, fstype, bindRemountOpts)
+	}
+
+	return cm.doContainerMount(source, target, fstype, options)
+}
+
+// doContainerMount nsenters the host's mount namespace and performs the
+// requested mount.
+func (cm *ContainerMounter) doContainerMount(source, target, fstype string, options []string) error {
+	spec := cm.findMountContainer(fstype)
+	if spec == nil {
+		return doMount(source, target, fstype, options)
+	}
+	cmd := []string{
+		"/bin/mount",
+	}
+	args := makeMountArgs(source, target, fstype, options)
+	cmd = append(cmd, args...)
+
+	glog.V(5).Infof("Mount command: %v", cmd)
+	out, err := cm.executor.RunInContainerBySelector(spec.Selector, spec.ContainerName, cmd)
+	glog.V(5).Infof("Output of containerized mount command: %s", string(out))
+	return err
+}
+
+func (cm *ContainerMounter) findMountContainer(fstype string) *MountContainerConfig {
+	spec, present := cm.config.MountContainers[fstype]
+	if !present {
+		// no container defined for this fstype, use standard mount
+		return nil
+	}
+	return spec
+}
+
+// Unmount runs umount(8) in the host's mount namespace.
+func (*ContainerMounter) Unmount(target string) error {
+	args := []string{
+		target,
+	}
+
+	glog.V(5).Infof("Unmount command: umount %v", args)
+	exec := exec.New()
+	outputBytes, err := exec.Command("umount", args...).CombinedOutput()
+	if len(outputBytes) != 0 {
+		glog.V(5).Infof("Output from mount command: %v", string(outputBytes))
+	}
+
+	return err
+}
+
+// List returns a list of all mounted filesystems in the host's mount namespace.
+func (*ContainerMounter) List() ([]MountPoint, error) {
+	return listProcMounts(hostProcMountsPath)
+}
+
+// IsMountPoint determines whether a path is a mountpoint by calling findmnt
+// in the host's root mount namespace.
+func (*ContainerMounter) IsMountPoint(file string) (bool, error) {
+	stat, err := os.Stat(file)
+	if err != nil {
+		return false, err
+	}
+	rootStat, err := os.Lstat(file + "/..")
+	if err != nil {
+		return false, err
+	}
+	// If the directory has the same device as parent, then it's not a mountpoint.
+	return stat.Sys().(*syscall.Stat_t).Dev != rootStat.Sys().(*syscall.Stat_t).Dev, nil
+}

--- a/pkg/util/mount/container_mount_unsupported.go
+++ b/pkg/util/mount/container_mount_unsupported.go
@@ -18,26 +18,28 @@ limitations under the License.
 
 package mount
 
-type NsenterMounter struct{}
+type ContainerMounter struct {
+	executor ContainerExecutor
+	config   *MountConfig
+}
 
-var _ = Interface(&NsenterMounter{})
+var _ = Interface(&ContainerMounter{})
 
-func (*NsenterMounter) Mount(source string, target string, fstype string, options []string) error {
+func (*ContainerMounter) Mount(source string, target string, fstype string, options []string) error {
 	return nil
 }
 
-func (*NsenterMounter) Unmount(target string) error {
+func (*ContainerMounter) Unmount(target string) error {
 	return nil
 }
 
-func (*NsenterMounter) List() ([]MountPoint, error) {
+func (*ContainerMounter) List() ([]MountPoint, error) {
 	return []MountPoint{}, nil
 }
 
-func (*NsenterMounter) IsMountPoint(file string) (bool, error) {
+func (*ContainerMounter) IsMountPoint(file string) (bool, error) {
 	return false, nil
 }
 
-func (*NsenterMounter) SetRunner(executor ContainerExecutor) {
-
+func (cm *ContainerMounter) SetRunner(executor ContainerExecutor) {
 }

--- a/pkg/util/mount/fake.go
+++ b/pkg/util/mount/fake.go
@@ -40,6 +40,9 @@ func (f *FakeMounter) ResetLog() {
 	f.Log = []FakeAction{}
 }
 
+func (f *FakeMounter) SetRunner(executor ContainerExecutor) {
+}
+
 func (f *FakeMounter) Mount(source string, target string, fstype string, options []string) error {
 	f.MountPoints = append(f.MountPoints, MountPoint{Device: source, Path: target, Type: fstype})
 	f.Log = append(f.Log, FakeAction{Action: FakeActionMount, Target: target, Source: source, FSType: fstype})

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -141,6 +141,9 @@ func (*Mounter) List() ([]MountPoint, error) {
 	return listProcMounts(procMountsPath)
 }
 
+func (f *Mounter) SetRunner(executor ContainerExecutor) {
+}
+
 // IsMountPoint determines if a directory is a mountpoint, by comparing the device for the
 // directory with the device for it's parent.  If they are the same, it's not a mountpoint,
 // if they're different, it is.

--- a/pkg/util/mount/mount_test.go
+++ b/pkg/util/mount/mount_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mount
+
+import (
+	"testing"
+)
+
+func TestParseMountConfig(t *testing.T) {
+	// default config
+	cfg, err := ParseMountConfig("", []string{}, false)
+	if err != nil {
+		t.Errorf("expected MounterMount, got error %v", err)
+	}
+	if cfg.Mounter != MounterMount {
+		t.Errorf("expected MounterMount, got %v", cfg.Mounter)
+	}
+
+	// default config, containerized
+	cfg, err = ParseMountConfig("", []string{}, true)
+	if err != nil {
+		t.Errorf("expected MounterNsenter, got error %v", err)
+	}
+	if cfg.Mounter != MounterNsenter {
+		t.Errorf("expected MounterNsenter, got %v", cfg.Mounter)
+	}
+
+	// parsing of volumeMounter argument
+	cfg, err = ParseMountConfig("mount", []string{}, false)
+	if err != nil {
+		t.Errorf("expected MounterMount, got error %v", err)
+	}
+	if cfg.Mounter != MounterMount {
+		t.Errorf("expected MounterMount, got %v", cfg.Mounter)
+	}
+
+	cfg, err = ParseMountConfig("nsenter", []string{}, false)
+	if err != nil {
+		t.Errorf("expected MounterNsenter, got error %v", err)
+	}
+	if cfg.Mounter != MounterNsenter {
+		t.Errorf("expected MounterNsenter, got %v", cfg.Mounter)
+	}
+
+	cfg, err = ParseMountConfig("container", []string{"fs:name=value:container"}, false)
+	if err != nil {
+		t.Errorf("expected MounterContainer, got error %v", err)
+	}
+	if cfg.Mounter != MounterContainer {
+		t.Errorf("expected MounterContainer, got %v", cfg.Mounter)
+	}
+
+	cfg, err = ParseMountConfig("xxxinvalidxxx", []string{}, false)
+	if cfg != nil {
+		t.Errorf("expected error and nil config, got %v", cfg)
+	}
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+
+	// parsing of mountContainers argument
+	// single entry
+	val := []string{"fs:name=value:container"}
+	cfg, err = ParseMountConfig("container", val, false)
+	if err != nil {
+		t.Errorf("parsing '%s': expected configuration, got error %v", val, err)
+	}
+	mounter := cfg.MountContainers["fs"]
+	if mounter.Selector.String() != "name=value" || mounter.ContainerName != "container" {
+		t.Errorf("parsing '%s': expected selector 'name=value' and container 'container', got %v", val, mounter)
+	}
+
+	// multiple entries
+	val = []string{"fs1:name1=value1,name11=value11:container1", "fs2:name2=value2:container2", "fs3:name3=value3:container3"}
+	cfg, err = ParseMountConfig("container", val, false)
+	if err != nil {
+		t.Errorf("parsing '%s': expected configuration, got error %v", val, err)
+	}
+	mounter = cfg.MountContainers["fs1"]
+	if mounter.Selector.String() != "name1=value1,name11=value11" || mounter.ContainerName != "container1" {
+		t.Errorf("parsing '%s': expected selector 'name1=value1,name11=value11' and container 'container1', got %v", val, mounter)
+	}
+	mounter = cfg.MountContainers["fs2"]
+	if mounter.Selector.String() != "name2=value2" || mounter.ContainerName != "container2" {
+		t.Errorf("parsing '%s': expected selector 'name2=value2' and container 'container2', got %v", val, mounter)
+	}
+	mounter = cfg.MountContainers["fs3"]
+	if mounter.Selector.String() != "name3=value3" || mounter.ContainerName != "container3" {
+		t.Errorf("parsing '%s': expected selector 'name3=value3' and container 'container3', got %v", val, mounter)
+	}
+
+	// invalid entry: too few items
+	val = []string{"fs:pod"}
+	cfg, err = ParseMountConfig("container", val, false)
+	if err == nil {
+		t.Errorf("expected error when parsing %s", val)
+	}
+	// invalid entry: too many items
+	val = []string{"fs:name=value:container:junk"}
+	cfg, err = ParseMountConfig("container", val, false)
+	if err == nil {
+		t.Errorf("expected error when parsing %s", val)
+	}
+
+}

--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -35,3 +35,7 @@ func (mounter *Mounter) List() ([]MountPoint, error) {
 func (mounter *Mounter) IsMountPoint(file string) (bool, error) {
 	return false, nil
 }
+
+func (mounter *Mounter) SetRunner(executor ContainerExecutor) {
+
+}

--- a/pkg/util/mount/nsenter_mount.go
+++ b/pkg/util/mount/nsenter_mount.go
@@ -54,7 +54,7 @@ var _ = Interface(&NsenterMounter{})
 const (
 	hostRootFsPath     = "/rootfs"
 	hostProcMountsPath = "/rootfs/proc/mounts"
-	nsenterPath        = "/nsenter"
+	nsenterPath        = "/usr/bin/nsenter"
 )
 
 // Mount runs mount(8) in the host's root mount namespace.  Aside from this
@@ -150,4 +150,7 @@ func (*NsenterMounter) IsMountPoint(file string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func (*NsenterMounter) SetRunner(executor ContainerExecutor) {
 }

--- a/pkg/util/nosplit_list.go
+++ b/pkg/util/nosplit_list.go
@@ -1,5 +1,3 @@
-// +build !linux
-
 /*
 Copyright 2014 The Kubernetes Authors All rights reserved.
 
@@ -16,28 +14,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mount
+package util
 
-type NsenterMounter struct{}
+import (
+	"fmt"
+)
 
-var _ = Interface(&NsenterMounter{})
+/* NoSpliStringList is just a list of strings.
+ * Unlike util.StringList, it does not interpret the values in any way and it
+ * does not split the values by ','.
+ * After this code, the list contains {'a,b', 'c'}:
+ * list NoSplitStringList; list.Set('a,b'); list.Set('c')
+ */
+type NoSplitStringList []string
 
-func (*NsenterMounter) Mount(source string, target string, fstype string, options []string) error {
+func (sl *NoSplitStringList) String() string {
+	return fmt.Sprint(*sl)
+}
+
+func (sl *NoSplitStringList) Set(value string) error {
+	*sl = append(*sl, value)
 	return nil
 }
 
-func (*NsenterMounter) Unmount(target string) error {
-	return nil
-}
-
-func (*NsenterMounter) List() ([]MountPoint, error) {
-	return []MountPoint{}, nil
-}
-
-func (*NsenterMounter) IsMountPoint(file string) (bool, error) {
-	return false, nil
-}
-
-func (*NsenterMounter) SetRunner(executor ContainerExecutor) {
-
+func (*NoSplitStringList) Type() string {
+	return "noSplitStringList"
 }

--- a/pkg/util/nosplit_list_test.go
+++ b/pkg/util/nosplit_list_test.go
@@ -1,5 +1,3 @@
-// +build !linux
-
 /*
 Copyright 2014 The Kubernetes Authors All rights reserved.
 
@@ -16,28 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mount
+package util
 
-type NsenterMounter struct{}
+import (
+	"reflect"
+	"testing"
+)
 
-var _ = Interface(&NsenterMounter{})
-
-func (*NsenterMounter) Mount(source string, target string, fstype string, options []string) error {
-	return nil
-}
-
-func (*NsenterMounter) Unmount(target string) error {
-	return nil
-}
-
-func (*NsenterMounter) List() ([]MountPoint, error) {
-	return []MountPoint{}, nil
-}
-
-func (*NsenterMounter) IsMountPoint(file string) (bool, error) {
-	return false, nil
-}
-
-func (*NsenterMounter) SetRunner(executor ContainerExecutor) {
-
+func TestNoSplitStringListSet(t *testing.T) {
+	var sl NoSplitStringList
+	sl.Set("foo,bar")
+	sl.Set("hop")
+	expected := []string{"foo,bar", "hop"}
+	if reflect.DeepEqual(expected, []string(sl)) == false {
+		t.Errorf("expected: %v, got: %v:", expected, sl)
+	}
 }

--- a/pkg/volume/git_repo/git_repo_test.go
+++ b/pkg/volume/git_repo/git_repo_test.go
@@ -120,7 +120,7 @@ func TestPlugin(t *testing.T) {
 		},
 	}
 	pod := &api.Pod{ObjectMeta: api.ObjectMeta{UID: types.UID("poduid")}}
-	builder, err := plug.NewBuilder(volume.NewSpecFromVolume(spec), pod, volume.VolumeOptions{""}, mount.New())
+	builder, err := plug.NewBuilder(volume.NewSpecFromVolume(spec), pod, volume.VolumeOptions{""}, mount.New(nil))
 	if err != nil {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestPlugin(t *testing.T) {
 		}
 	}
 
-	cleaner, err := plug.NewCleaner("vol1", types.UID("poduid"), mount.New())
+	cleaner, err := plug.NewCleaner("vol1", types.UID("poduid"), mount.New(nil))
 	if err != nil {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}

--- a/pkg/volume/secret/secret_test.go
+++ b/pkg/volume/secret/secret_test.go
@@ -272,7 +272,7 @@ func doTestSecretDataInVolume(volumePath string, secret api.Secret, t *testing.T
 }
 
 func doTestCleanAndTeardown(plugin volume.VolumePlugin, podUID types.UID, testVolumeName, volumePath string, t *testing.T) {
-	cleaner, err := plugin.NewCleaner(testVolumeName, podUID, mount.New())
+	cleaner, err := plugin.NewCleaner(testVolumeName, podUID, mount.New(nil))
 	if err != nil {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}


### PR DESCRIPTION
On limited docker hosts, such as CoreOS or Atomic Host, one cannot easily install utilities that are necessary to mount various filesystems such as Gluster. This PR contains a proof of concept how to use containerized mount tools to mount Kubernetes volumes. It's just to gather some feedback, some parts are missing on Docker side (see below).
## Design

In order to mount a Kubernetes volume from a container we must:
1. Find a way, how a container can mount stuff, which is then visible to the host and other pods/containers.
- There is [a little container](https://github.com/rootfs/install-glusterfs-on-fc21) with 'magic' ld.preload.so. This is pretty ugly solution, but it's good enough to test this proof of concept.
- There is [Docker PR](https://github.com/docker/docker/pull/14097) to implement a new Docker option not to fork mount namespace, so all mounts done by a container will be visible to the host.
1. Kubernetes need to maintain so-called mount pods, where the mount utilities like `mount.gluster` or `mount.ceph` will be installed. It must run these pod(s) on every node.
   - [Static pods](https://github.com/GoogleCloudPlatform/kubernetes/pull/10093) were used for testing of this proof of concept.
   - Any other way can be used, e.g. #1518 when it's implemented.
2. Kubernetes must be taught to use these mount pods to mount volumes. **That's the code in this PR**.
   It's actually quite simple, appropriate mount commands are executed in context of appropriate mount container, like `docker exec <mount container ID> mount -t <fs> <what> <where>`. Some new kubelet command line options were introduced to tell kubelet what pods/containers to use for what filesystems. E.g. for mounting of Gluster stuff using the pod with label `name=mounter` and container named `glusterfs`, one would start kubelet in this way:
   
   ```
   kubelet --volume-mounter=container --mount-container=glusterfs:name=mounter:glusterfs
   ```
## Further steps

This code is just a proof of concept. Some steps may be necessary to make it production ready:
- Kubelet configuration is ugly, is there a way, how to configure them globally?
- Think hard about security.
- Combine it with NsenterMounter when kubelet itself runs inside a container. Now `kubelet` does plain `/bin/unmount` to destroy volumes, we may need `nsenter /bin/umount`.
