### PR TITLE
E2E tests for Redis and Celery-RabbitMq examples

### DIFF
--- a/examples/redis/redis-controller.yaml
+++ b/examples/redis/redis-controller.yaml
@@ -18,7 +18,7 @@ spec:
         - containerPort: 6379
         resources:
           limits:
-            cpu: "0.5"
+            cpu: "0.1"
         volumeMounts:
         - mountPath: /redis-master-data
           name: data

--- a/examples/redis/redis-master.yaml
+++ b/examples/redis/redis-master.yaml
@@ -17,7 +17,7 @@ spec:
         - containerPort: 6379
       resources:
         limits:
-          cpu: "0.5"
+          cpu: "0.1"
       volumeMounts:
         - mountPath: /redis-master-data
           name: data

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -66,7 +66,7 @@ if [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then
 fi
 
 # Specialized tests which should be skipped by default for projects.
-GCE_DEFAULT_SKIP_TEST_REGEX="Skipped|Density|Reboot|Restart"
+GCE_DEFAULT_SKIP_TEST_REGEX="Skipped|Density|Reboot|Restart|Example"
 # The following tests are known to be flaky, and are thus run only in their own
 # -flaky- build variants.
 GCE_FLAKY_TEST_REGEX="Addon|Elasticsearch|Nodes.*network\spartition|Service\sendpoints\slatency|Shell.*services|readonly\sPD"

--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	podListTimeout     = time.Minute
+	serverStartTimeout = podStartTimeout + 3*time.Minute
+)
+
+var _ = Describe("Examples e2e", func() {
+	var c *client.Client
+	var ns string
+	var testingNs *api.Namespace
+	BeforeEach(func() {
+		var err error
+		c, err = loadClient()
+		expectNoError(err)
+		testingNs, err = createTestingNS("examples", c)
+		ns = testingNs.Name
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
+		if err := c.Namespaces().Delete(ns); err != nil {
+			Failf("Couldn't delete ns %s", err)
+		}
+	})
+
+	Describe("[Skipped][Example]Redis", func() {
+		It("should create and stop redis servers", func() {
+			mkpath := func(file string) string {
+				return filepath.Join(testContext.RepoRoot, "examples/redis", file)
+			}
+			bootstrapYaml := mkpath("redis-master.yaml")
+			sentinelServiceYaml := mkpath("redis-sentinel-service.yaml")
+			sentinelControllerYaml := mkpath("redis-sentinel-controller.yaml")
+			controllerYaml := mkpath("redis-controller.yaml")
+
+			bootstrapPodName := "redis-master"
+			redisRC := "redis"
+			sentinelRC := "redis-sentinel"
+			nsFlag := fmt.Sprintf("--namespace=%v", ns)
+			expectedOnServer := "The server is now ready to accept connections"
+			expectedOnSentinel := "+monitor master"
+
+			By("starting redis bootstrap")
+			runKubectl("create", "-f", bootstrapYaml, nsFlag)
+			cleanupBootstrap := true
+			defer func() {
+				if cleanupBootstrap {
+					cleanup(bootstrapYaml, ns, "name=redis", "name=redis-sentinel")
+				}
+			}()
+
+			err := waitForPodRunningInNamespace(c, bootstrapPodName, ns)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = lookForStringInLog(ns, bootstrapPodName, "master", expectedOnServer, serverStartTimeout)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = lookForStringInLog(ns, bootstrapPodName, "sentinel", expectedOnSentinel, serverStartTimeout)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("setting up services and controllers")
+			runKubectl("create", "-f", sentinelServiceYaml, nsFlag)
+			defer cleanup(sentinelServiceYaml, ns, "name=redis-sentinel")
+			runKubectl("create", "-f", sentinelControllerYaml, nsFlag)
+			defer cleanup(sentinelControllerYaml, ns, "name=redis-sentinel")
+			runKubectl("create", "-f", controllerYaml, nsFlag)
+			defer cleanup(controllerYaml, ns, "name=redis")
+
+			By("scaling up the deployment")
+			runKubectl("scale", "rc", redisRC, "--replicas=3", nsFlag)
+			runKubectl("scale", "rc", sentinelRC, "--replicas=3", nsFlag)
+
+			By("checking up the services")
+			checkAllLogs := func() {
+				forEachPod(c, ns, "name", "redis", func(pod api.Pod) {
+					if pod.Name != bootstrapPodName {
+						_, err := lookForStringInLog(ns, pod.Name, "redis", expectedOnServer, serverStartTimeout)
+						Expect(err).NotTo(HaveOccurred())
+					}
+				})
+				forEachPod(c, ns, "name", "redis-sentinel", func(pod api.Pod) {
+					if pod.Name != bootstrapPodName {
+						_, err := lookForStringInLog(ns, pod.Name, "sentinel", expectedOnSentinel, serverStartTimeout)
+						Expect(err).NotTo(HaveOccurred())
+					}
+				})
+			}
+			checkAllLogs()
+
+			By("turning down bootstrap")
+			runKubectl("delete", "-f", bootstrapYaml, nsFlag)
+			cleanupBootstrap = false
+			err = waitForRCPodToDisappear(c, ns, redisRC, bootstrapPodName)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for the new master election")
+			checkAllLogs()
+		})
+	})
+
+	Describe("[Skipped][Example]Celery-RabbitMQ", func() {
+		It("should create and stop celery+rabbitmq servers", func() {
+			mkpath := func(file string) string {
+				return filepath.Join(testContext.RepoRoot, "examples", "celery-rabbitmq", file)
+			}
+			rabbitmqServiceYaml := mkpath("rabbitmq-service.yaml")
+			rabbitmqControllerYaml := mkpath("rabbitmq-controller.yaml")
+			celeryControllerYaml := mkpath("celery-controller.yaml")
+			flowerControllerYaml := mkpath("flower-controller.yaml")
+			nsFlag := fmt.Sprintf("--namespace=%v", ns)
+
+			By("starting rabbitmq")
+			runKubectl("create", "-f", rabbitmqServiceYaml, nsFlag)
+			defer cleanup(rabbitmqServiceYaml, ns, "component=rabbitmq")
+			runKubectl("create", "-f", rabbitmqControllerYaml, nsFlag)
+			defer cleanup(rabbitmqControllerYaml, ns, "component=rabbitmq")
+			forEachPod(c, ns, "component", "rabbitmq", func(pod api.Pod) {
+				_, err := lookForStringInLog(ns, pod.Name, "rabbitmq", "Server startup complete", serverStartTimeout)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("starting celery")
+			runKubectl("create", "-f", celeryControllerYaml, nsFlag)
+			defer cleanup(celeryControllerYaml, ns, "component=celery")
+			forEachPod(c, ns, "component", "celery", func(pod api.Pod) {
+				_, err := lookForStringInFile(ns, pod.Name, "celery", "/data/celery.log", " ready.", serverStartTimeout)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("starting flower")
+			runKubectl("create", "-f", flowerControllerYaml, nsFlag)
+			defer cleanup(flowerControllerYaml, ns, "component=flower")
+			forEachPod(c, ns, "component", "flower", func(pod api.Pod) {
+				//TODO: Do a http request after a flower service is added to the example.
+			})
+		})
+	})
+})
+
+func forEachPod(c *client.Client, ns, selectorKey, selectorValue string, fn func(api.Pod)) {
+	var pods *api.PodList
+	var err error
+	for t := time.Now(); time.Since(t) < podListTimeout; time.Sleep(poll) {
+		pods, err = c.Pods(ns).List(labels.SelectorFromSet(labels.Set(map[string]string{selectorKey: selectorValue})), fields.Everything())
+		Expect(err).NotTo(HaveOccurred())
+		if len(pods.Items) > 0 {
+			break
+		}
+	}
+	if pods == nil || len(pods.Items) == 0 {
+		Failf("No pods found")
+	}
+	for _, pod := range pods.Items {
+		err = waitForPodRunningInNamespace(c, pod.Name, ns)
+		Expect(err).NotTo(HaveOccurred())
+		fn(pod)
+	}
+}
+
+func lookForStringInLog(ns, podName, container, expectedString string, timeout time.Duration) (result string, err error) {
+	return lookForString(expectedString, timeout, func() string {
+		return runKubectl("log", podName, container, fmt.Sprintf("--namespace=%v", ns))
+	})
+}
+
+func lookForStringInFile(ns, podName, container, file, expectedString string, timeout time.Duration) (result string, err error) {
+	return lookForString(expectedString, timeout, func() string {
+		return runKubectl("exec", podName, "-c", container, fmt.Sprintf("--namespace=%v", ns), "--", "cat", file)
+	})
+}
+
+// Looks for the given string in the output of fn, repeatedly calling fn until
+// the timeout is reached or the string is found. Returns last log and possibly
+// error if the string was not found.
+func lookForString(expectedString string, timeout time.Duration, fn func() string) (result string, err error) {
+	for t := time.Now(); time.Since(t) < timeout; time.Sleep(poll) {
+		result = fn()
+		if strings.Contains(result, expectedString) {
+			return
+		}
+	}
+	err = fmt.Errorf("Failed to find \"%s\"", expectedString)
+	return
+}


### PR DESCRIPTION
The tests create all the pods, services and rc following the examples ([Redis](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/examples/redis/README.md), [Celery](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/examples/celery-rabbitmq/README.md)) and check in the logs if the servers started correctly.
Issue: #10013 
