### PR TITLE
Fix kubelet deadlock

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -57,7 +57,8 @@ type Runtime interface {
 	// KillPod kills all the containers of a pod.
 	KillPod(pod Pod) error
 	// GetPodStatus retrieves the status of the pod, including the information of
-	// all containers in the pod.
+	// all containers in the pod. Clients of this interface assume the containers
+	// statuses in a pod always have a deterministic ordering (eg: sorted by name).
 	GetPodStatus(*api.Pod) (*api.PodStatus, error)
 	// PullImage pulls an image from the network to local storage using the supplied
 	// secrets if necessary.

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -470,7 +471,9 @@ func (dm *DockerManager) GetPodStatus(pod *api.Pod) (*api.PodStatus, error) {
 		}
 		podStatus.ContainerStatuses = append(podStatus.ContainerStatuses, *status)
 	}
-
+	// TODO: Move this to a custom equals method on the pod status. A container manager
+	// shouldn't have to guarantee order.
+	sort.Sort(kubeletTypes.SortedContainerStatuses(podStatus.ContainerStatuses))
 	return &podStatus, nil
 }
 

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -471,8 +471,9 @@ func (dm *DockerManager) GetPodStatus(pod *api.Pod) (*api.PodStatus, error) {
 		}
 		podStatus.ContainerStatuses = append(podStatus.ContainerStatuses, *status)
 	}
-	// TODO: Move this to a custom equals method on the pod status. A container manager
-	// shouldn't have to guarantee order.
+	// Sort the container statuses since clients of this interface expect the list
+	// of containers in a pod to behave like the output of `docker list`, which has a
+	// deterministic order.
 	sort.Sort(kubeletTypes.SortedContainerStatuses(podStatus.ContainerStatuses))
 	return &podStatus, nil
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1816,11 +1816,14 @@ func (kl *Kubelet) GetPodByName(namespace, name string) (*api.Pod, bool) {
 }
 
 func (kl *Kubelet) updateRuntimeUp() {
+	start := time.Now()
 	err := waitUntilRuntimeIsUp(kl.containerRuntime, 100*time.Millisecond)
 	kl.runtimeMutex.Lock()
 	defer kl.runtimeMutex.Unlock()
 	if err == nil {
 		kl.lastTimestampRuntimeUp = time.Now()
+	} else {
+		glog.Errorf("Container runtime sanity check failed after %v, err: %v", time.Since(start), err)
 	}
 }
 

--- a/pkg/kubelet/status_manager.go
+++ b/pkg/kubelet/status_manager.go
@@ -96,6 +96,12 @@ func (s *statusManager) SetPodStatus(pod *api.Pod, status api.PodStatus) {
 		}
 	}
 
+	// TODO: Holding a lock during blocking operations is dangerous. Refactor so this isn't necessary.
+	// The intent here is to prevent concurrent updates to a pod's status from
+	// clobbering each other so the phase of a pod progresses monotonically.
+	// Currently this routine is not called for the same pod from multiple
+	// workers and/or the kubelet but dropping the lock before sending the
+	// status down the channel feels like an easy way to get a bullet in foot.
 	if !found || !reflect.DeepEqual(oldStatus, status) {
 		s.podStatuses[podFullName] = status
 		s.podStatusChannel <- podStatusSyncRequest{pod, status}
@@ -148,6 +154,10 @@ func (s *statusManager) syncBatch() error {
 	// We failed to update status. In order to make sure we retry next time
 	// we delete cached value. This may result in an additional update, but
 	// this is ok.
-	s.DeletePodStatus(podFullName)
+	// Doing this synchronously will lead to a deadlock if the podStatusChannel
+	// is full, and the pod worker holding the lock is waiting on this method
+	// to clear the channel. Even if this delete never runs subsequent container
+	// changes on the node should trigger updates.
+	go s.DeletePodStatus(podFullName)
 	return fmt.Errorf("error updating status for pod %q: %v", pod.Name, err)
 }

--- a/pkg/kubelet/types/types.go
+++ b/pkg/kubelet/types/types.go
@@ -19,7 +19,11 @@ package types
 import (
 	"net/http"
 	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 )
+
+// TODO: Reconcile custom types in kubelet/types and this subpackage
 
 // DockerID is an ID of docker container. It is a type to make it clear when we're working with docker container Ids
 type DockerID string
@@ -55,4 +59,14 @@ func (t *Timestamp) Get() time.Time {
 // layout.
 func (t *Timestamp) GetString() string {
 	return t.time.Format(time.RFC3339Nano)
+}
+
+// A type to help sort container statuses based on container names.
+type SortedContainerStatuses []api.ContainerStatus
+
+func (s SortedContainerStatuses) Len() int      { return len(s) }
+func (s SortedContainerStatuses) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func (s SortedContainerStatuses) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
 }


### PR DESCRIPTION
1. User deletes all multi container pods on a node at once, after the containers have started 
2. All pods are synced for each delete notification
3. Each pod sends a status update because of the bug in my first commit
4. Status manager's podStatusChannel fills up
5. An update fails becuase a pod in the channel has already been deleted from the apiserver
6. Status manager deadlock
7. SyncPods enters the deadlock next time it tries to talk to the status manager

@dchen1107 
