### PR TITLE
Fix default service node port range in e2e test

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -36,7 +36,7 @@ import (
 )
 
 // This should match whatever the default/configured range is
-var ServiceNodePortRange = util.PortRange{Base: 30000, Size: 2767}
+var ServiceNodePortRange = util.PortRange{Base: 30000, Size: 2768}
 
 var _ = Describe("Services", func() {
 	var c *client.Client


### PR DESCRIPTION
While the command line parameter --service-node-port-range is inclusive, the
actual data structure is exclusive.

Compare https://github.com/GoogleCloudPlatform/kubernetes/blob/d8e522514481c9a8952c6333527212a2addde238/pkg/master/master.go#L253 for the default value, https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/util/port_range.go#L33 for the `Contains` definition and https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/util/port_range.go#L49 for the flags setter function.
