### PR TITLE
Release 0.19.3

### DIFF
--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -1,8 +1,8 @@
 .PHONY:	clean build push
 
 IMAGE = etcd
-TAG = 2.0.9.1
-ETCD_VERSION = 2.0.9
+TAG = 2.0.12
+ETCD_VERSION = 2.0.12
 OUTPUT_DIR = $(IMAGE)-v$(ETCD_VERSION)-linux-amd64
 
 clean:
@@ -16,6 +16,6 @@ build: clean
 	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .
 
 push: build
-	gcloud preview docker push gcr.io/google_containers/$(IMAGE):$(TAG)
+	gcloud docker push gcr.io/google_containers/$(IMAGE):$(TAG)
 
 all:	push

--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -7,7 +7,7 @@
 "containers":[
     {
     "name": "etcd-container",
-    "image": "gcr.io/google_containers/etcd:2.0.9",
+    "image": "gcr.io/google_containers/etcd:2.0.12",
     "command": [
               "/usr/local/bin/etcd",
 	      "--addr",

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -36,8 +36,8 @@ package version
 var (
 	// TODO: Deprecate gitMajor and gitMinor, use only gitVersion instead.
 	gitMajor     string = "0"              // major version, always numeric
-	gitMinor     string = "19.1+"          // minor version, numeric possibly followed by "+"
-	gitVersion   string = "v0.19.1-dev"    // version from git, output of $(git describe)
+	gitMinor     string = "19.2"           // minor version, numeric possibly followed by "+"
+	gitVersion   string = "v0.19.2"        // version from git, output of $(git describe)
 	gitCommit    string = ""               // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 )

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -36,8 +36,8 @@ package version
 var (
 	// TODO: Deprecate gitMajor and gitMinor, use only gitVersion instead.
 	gitMajor     string = "0"              // major version, always numeric
-	gitMinor     string = "19.2+"          // minor version, numeric possibly followed by "+"
-	gitVersion   string = "v0.19.2-dev"    // version from git, output of $(git describe)
+	gitMinor     string = "19.3"           // minor version, numeric possibly followed by "+"
+	gitVersion   string = "v0.19.3"        // version from git, output of $(git describe)
 	gitCommit    string = ""               // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 )

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -36,8 +36,8 @@ package version
 var (
 	// TODO: Deprecate gitMajor and gitMinor, use only gitVersion instead.
 	gitMajor     string = "0"              // major version, always numeric
-	gitMinor     string = "19.2"           // minor version, numeric possibly followed by "+"
-	gitVersion   string = "v0.19.2"        // version from git, output of $(git describe)
+	gitMinor     string = "19.2+"          // minor version, numeric possibly followed by "+"
+	gitVersion   string = "v0.19.2-dev"    // version from git, output of $(git describe)
 	gitCommit    string = ""               // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 )

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -36,8 +36,8 @@ package version
 var (
 	// TODO: Deprecate gitMajor and gitMinor, use only gitVersion instead.
 	gitMajor     string = "0"              // major version, always numeric
-	gitMinor     string = "19.3"           // minor version, numeric possibly followed by "+"
-	gitVersion   string = "v0.19.3"        // version from git, output of $(git describe)
+	gitMinor     string = "19.3+"          // minor version, numeric possibly followed by "+"
+	gitVersion   string = "v0.19.3-dev"    // version from git, output of $(git describe)
 	gitCommit    string = ""               // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 )


### PR DESCRIPTION
Retry of #10184 (into release-0.19)
- Bump etcd to 2.0.12 #10140 (brendandburns)

Please note: v0.19.2 is an incorrect figment and a Release Engineering mistake on our side. I pointed the tags at the intermediate commit in case anyone went looking - it will build what's in the GCS bucket for 0.19.2.
