### PR TITLE
Updating the error message to say node instead of minion

### DIFF
--- a/pkg/registry/minion/etcd/etcd.go
+++ b/pkg/registry/minion/etcd/etcd.go
@@ -64,7 +64,7 @@ func NewStorage(h tools.EtcdHelper, connection client.ConnectionInfoGetter) (*RE
 			return obj.(*api.Node).Name, nil
 		},
 		PredicateFunc: minion.MatchNode,
-		EndpointName:  "minion",
+		EndpointName:  "node",
 
 		CreateStrategy: minion.Strategy,
 		UpdateStrategy: minion.Strategy,


### PR DESCRIPTION
Fixes 2nd part of https://github.com/GoogleCloudPlatform/kubernetes/issues/10156

Change:

```
$kubectl get nodes asdf
```

returned 
Earlier:
`Error from server: minion "asdf" not found`
Now:
`Error from server: node "asdf" not found`
