### PR TITLE
Disable TestProc_doWithNestedXConcurrent

### DIFF
--- a/contrib/mesos/pkg/proc/proc_test.go
+++ b/contrib/mesos/pkg/proc/proc_test.go
@@ -347,8 +347,10 @@ func TestProc_doWithNestedX(t *testing.T) {
 	fatalAfter(t, p.Done(), 5*time.Second, "timed out waiting for process death")
 }
 
+// TODO(jdef): find a way to test this without killing CI builds.
 // intended to be run with -race
 func TestProc_doWithNestedXConcurrent(t *testing.T) {
+	t.Skip("disabled for causing CI timeouts.")
 	config := defaultConfig
 	config.actionQueueDepth = 0
 	p := newConfigured(config)


### PR DESCRIPTION
This test is killing more than 50% of shippable builds. Disabling to stop the madness. cc @jdef

Closes #10198
