### PR TITLE
don't fail etcd SIGKILL test when apiserver returns an error

### DIFF
--- a/test/e2e/etcd_failure.go
+++ b/test/e2e/etcd_failure.go
@@ -123,7 +123,10 @@ func checkExistingRCRecovers(f Framework) {
 	By("deleting pods from existing replication controller")
 	expectNoError(wait.Poll(time.Millisecond*500, time.Second*30, func() (bool, error) {
 		pods, err := podClient.List(rcSelector, fields.Everything())
-		Expect(err).NotTo(HaveOccurred())
+		if err != nil {
+			Logf("apiserver returned error, as expected before recovery: %v", err)
+			return false, nil
+		}
 		if len(pods.Items) == 0 {
 			return false, nil
 		}
@@ -131,6 +134,7 @@ func checkExistingRCRecovers(f Framework) {
 			err = podClient.Delete(pod.Name, api.NewDeleteOptions(0))
 			Expect(err).NotTo(HaveOccurred())
 		}
+		Logf("apiserver has recovered")
 		return true, nil
 	}))
 


### PR DESCRIPTION
Before, the List call would block but now returns an etcd error which is reasonable. I think it's related to the etcd client version bump https://github.com/GoogleCloudPlatform/kubernetes/commit/7940c96b1606cbc6a706d3dbba7efdb00108aa0a#diff-28d90d2df6551b9d38c5a538a401bd33R330 (looks like it would always retry before, but now only retries twice)
