### PR TITLE
Fix the race between configuring cbr0 and restarting static pods

### DIFF
--- a/cluster/saltbase/salt/docker/docker-defaults
+++ b/cluster/saltbase/salt/docker/docker-defaults
@@ -3,9 +3,5 @@ DOCKER_OPTS=""
 DOCKER_OPTS="${DOCKER_OPTS} {{grains.docker_opts}}"
 {% endif %}
 
-{% set docker_bridge = "" %}
-{% if grains['roles'][0] == 'kubernetes-pool' %}
-  {% set docker_bridge = "--bridge cbr0" %}
-{% endif %} 
-DOCKER_OPTS="${DOCKER_OPTS} {{docker_bridge}} --iptables=false --ip-masq=false"
+DOCKER_OPTS="${DOCKER_OPTS} --bridge=cbr0 --iptables=false --ip-masq=false"
 DOCKER_NOFILE=1000000

--- a/cluster/saltbase/salt/docker/docker-defaults
+++ b/cluster/saltbase/salt/docker/docker-defaults
@@ -2,6 +2,5 @@ DOCKER_OPTS=""
 {% if grains.docker_opts is defined and grains.docker_opts %}
 DOCKER_OPTS="${DOCKER_OPTS} {{grains.docker_opts}}"
 {% endif %}
-
 DOCKER_OPTS="${DOCKER_OPTS} --bridge=cbr0 --iptables=false --ip-masq=false"
 DOCKER_NOFILE=1000000

--- a/cluster/saltbase/salt/docker/docker-defaults
+++ b/cluster/saltbase/salt/docker/docker-defaults
@@ -2,5 +2,10 @@ DOCKER_OPTS=""
 {% if grains.docker_opts is defined and grains.docker_opts %}
 DOCKER_OPTS="${DOCKER_OPTS} {{grains.docker_opts}}"
 {% endif %}
-DOCKER_OPTS="${DOCKER_OPTS} --bridge cbr0 --iptables=false --ip-masq=false"
+
+{% set docker_bridge = "" %}
+{% if grains['roles'][0] == 'kubernetes-pool' %}
+  {% set docker_bridge = "--bridge cbr0" %}
+{% endif %} 
+DOCKER_OPTS="${DOCKER_OPTS} {{docker_bridge}} --iptables=false --ip-masq=false"
 DOCKER_NOFILE=1000000

--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -48,11 +48,6 @@ net.ipv4.ip_forward:
   sysctl.present:
     - value: 1
 
-cbr0:
-  container_bridge.ensure:
-    - cidr: {{ grains['cbr-cidr'] }}
-    - mtu: 1460
-
 {{ environment_file }}:
   file.managed:
     - source: salt://docker/docker-defaults
@@ -124,7 +119,6 @@ docker:
     - enable: True
     - watch:
       - file: {{ environment_file }}
-      - container_bridge: cbr0
 {% if override_docker_ver != '' %}
     - require:
       - pkg: lxc-docker-{{ override_docker_ver }}

--- a/cluster/saltbase/salt/kube-master-addons/init.sls
+++ b/cluster/saltbase/salt/kube-master-addons/init.sls
@@ -37,10 +37,19 @@ master-docker-image-tags:
   file.touch:
     - name: /srv/pillar/docker-images.sls
 
+# Current containervm image by default has both docker and kubelet
+# running. But during cluster creation stage, docker and kubelet
+# could be overwritten completely, or restarted due flag changes.
+# The ordering of salt states for service docker, kubelet and
+# master-addon below is very important to avoid the race between
+# salt restart docker or kubelet and kubelet start master components.
 kube-master-addons:
   service.running:
     - enable: True
     - restart: True
+    - require:
+      - service: docker
+      - service: kubelet
     - watch:
       - file: master-docker-image-tags
       - file: /etc/kubernetes/kube-master-addons.sh

--- a/cluster/saltbase/salt/kube-master-addons/init.sls
+++ b/cluster/saltbase/salt/kube-master-addons/init.sls
@@ -39,10 +39,17 @@ master-docker-image-tags:
 
 # Current containervm image by default has both docker and kubelet
 # running. But during cluster creation stage, docker and kubelet
-# could be overwritten completely, or restarted due flag changes.
+# could be overwritten completely, or restarted due to flag changes.
 # The ordering of salt states for service docker, kubelet and
 # master-addon below is very important to avoid the race between
 # salt restart docker or kubelet and kubelet start master components.
+# Without the ordering of salt states, when gce instance boot up,
+# configure-vm.sh will run and download the release. At the end of
+# boot, run-salt will run kube-master-addons service which installs
+# master component manifest files to kubelet config directory before
+# the installation of proper version kubelet. Please see
+# https://github.com/GoogleCloudPlatform/kubernetes/issues/10122#issuecomment-114566063
+# for detail explanation on this very issue.
 kube-master-addons:
   service.running:
     - enable: True

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -76,4 +76,9 @@
   {% set cgroup_root = "--cgroup_root=/" -%}
 {% endif -%}
 
-DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}}"
+{% set pod_cidr = "" %}
+{% if grains['roles'][0] == 'kubernetes-master' %}
+  {% set pod_cidr = "--pod-cidr=" + grains['cbr-cidr'] %}
+{% endif %} 
+
+DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}} {{pod_cidr}}"

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -115,6 +115,7 @@ type KubeletServer struct {
 	DockerDaemonContainer          string
 	SystemContainer                string
 	ConfigureCBR0                  bool
+	PodCIDR                        string
 	MaxPods                        int
 	DockerExecHandlerName          string
 
@@ -241,7 +242,7 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.ConfigureCBR0, "configure-cbr0", s.ConfigureCBR0, "If true, kubelet will configure cbr0 based on Node.Spec.PodCIDR.")
 	fs.IntVar(&s.MaxPods, "max-pods", 100, "Number of Pods that can run on this Kubelet.")
 	fs.StringVar(&s.DockerExecHandlerName, "docker-exec-handler", s.DockerExecHandlerName, "Handler to use when executing a command in a container. Valid values are 'native' and 'nsenter'. Defaults to 'native'.")
-
+	fs.StringVar(&s.PodCIDR, "pod-cidr", "", "The CIDR to use for pod IP addresses, only used in standalone mode.  In cluster mode, this is obtained from the master.")
 	// Flags intended for testing, not recommended used in production environments.
 	fs.BoolVar(&s.ReallyCrashForTesting, "really-crash-for-testing", s.ReallyCrashForTesting, "If true, when panics occur crash. Intended for testing.")
 	fs.Float64Var(&s.ChaosChance, "chaos-chance", s.ChaosChance, "If > 0.0, introduce random client errors and latency. Intended for testing. [default=0.0]")
@@ -361,6 +362,7 @@ func (s *KubeletServer) Run(_ []string) error {
 		DockerDaemonContainer:     s.DockerDaemonContainer,
 		SystemContainer:           s.SystemContainer,
 		ConfigureCBR0:             s.ConfigureCBR0,
+		PodCIDR:                   s.PodCIDR,
 		MaxPods:                   s.MaxPods,
 		DockerExecHandler:         dockerExecHandler,
 	}
@@ -714,6 +716,7 @@ type KubeletConfig struct {
 	DockerDaemonContainer          string
 	SystemContainer                string
 	ConfigureCBR0                  bool
+	PodCIDR                        string
 	MaxPods                        int
 	DockerExecHandler              dockertools.ExecHandler
 }
@@ -771,6 +774,7 @@ func createAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.Pod
 		kc.DockerDaemonContainer,
 		kc.SystemContainer,
 		kc.ConfigureCBR0,
+		kc.PodCIDR,
 		kc.MaxPods,
 		kc.DockerExecHandler)
 

--- a/contrib/mesos/pkg/executor/service/service.go
+++ b/contrib/mesos/pkg/executor/service/service.go
@@ -354,6 +354,7 @@ func (ks *KubeletExecutorServer) createAndInitKubelet(
 		kc.DockerDaemonContainer,
 		kc.SystemContainer,
 		kc.ConfigureCBR0,
+		kc.PodCIDR,
 		kc.MaxPods,
 		kc.DockerExecHandler,
 	)

--- a/pkg/kubelet/container_bridge.go
+++ b/pkg/kubelet/container_bridge.go
@@ -85,6 +85,9 @@ func ensureCbr0(wantCIDR *net.IPNet) error {
 	return nil
 }
 
+// Check if cbr0 network interface is configured or not, and take action
+// when the configuration is missing on the node, and propagate the rest
+// error to kubelet to handle.
 func cbr0Exists() (bool, error) {
 	if _, err := os.Stat("/sys/class/net/cbr0"); err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -147,6 +147,7 @@ func NewMainKubelet(
 	dockerDaemonContainer string,
 	systemContainer string,
 	configureCBR0 bool,
+	podCIDR string,
 	pods int,
 	dockerExecHandler dockertools.ExecHandler) (*Kubelet, error) {
 	if rootDirectory == "" {
@@ -261,6 +262,7 @@ func NewMainKubelet(
 		cgroupRoot:                     cgroupRoot,
 		mounter:                        mounter,
 		configureCBR0:                  configureCBR0,
+		podCIDR:                        podCIDR,
 		pods:                           pods,
 		syncLoopMonitor:                util.AtomicValue{},
 	}
@@ -317,6 +319,10 @@ func NewMainKubelet(
 		return nil, fmt.Errorf("failed to create the Container Manager: %v", err)
 	}
 	klet.containerManager = containerManager
+
+	// Start syncing node status immediately, this may set up things the runtime needs to run.
+	go klet.syncNodeStatus()
+	go klet.syncNetworkStatus()
 
 	// Wait for the runtime to be up with a timeout.
 	if err := waitUntilRuntimeIsUp(klet.containerRuntime, maxWaitForContainerRuntime); err != nil {
@@ -412,6 +418,9 @@ type Kubelet struct {
 	runtimeUpThreshold     time.Duration
 	lastTimestampRuntimeUp time.Time
 
+	// Network Status information
+	networkConfigured bool
+
 	// Volume plugins.
 	volumePluginMgr volume.VolumePluginMgr
 
@@ -489,6 +498,7 @@ type Kubelet struct {
 	// Whether or not kubelet should take responsibility for keeping cbr0 in
 	// the correct state.
 	configureCBR0 bool
+	podCIDR       string
 
 	// Number of Pods which can be run by this Kubelet
 	pods int
@@ -707,7 +717,6 @@ func (kl *Kubelet) Run(updates <-chan PodUpdate) {
 	}
 
 	go util.Until(kl.updateRuntimeUp, 5*time.Second, util.NeverStop)
-	go kl.syncNodeStatus()
 	// Run the system oom watcher forever.
 	kl.statusManager.Start()
 	kl.syncLoop(updates, kl)
@@ -1705,6 +1714,10 @@ func (kl *Kubelet) syncLoopIteration(updates <-chan PodUpdate, handler SyncHandl
 		glog.Infof("Skipping pod synchronization, container runtime is not up.")
 		return
 	}
+	if !kl.networkConfigured {
+		time.Sleep(5 * time.Second)
+		glog.Infof("Skipping pod synchronization, network is not configured")
+	}
 	unsyncedPod := false
 	podSyncTypes := make(map[types.UID]SyncPodType)
 	select {
@@ -1892,6 +1905,22 @@ func (kl *Kubelet) recordNodeStatusEvent(event string) {
 // Maintains Node.Spec.Unschedulable value from previous run of tryUpdateNodeStatus()
 var oldNodeUnschedulable bool
 
+func (kl *Kubelet) syncNetworkStatus() {
+	for {
+		networkConfigured := true
+		if kl.configureCBR0 {
+			if len(kl.podCIDR) == 0 {
+				networkConfigured = false
+			} else if err := kl.reconcileCBR0(kl.podCIDR); err != nil {
+				networkConfigured = false
+				glog.Errorf("Error configuring cbr0: %v", err)
+			}
+		}
+		kl.networkConfigured = networkConfigured
+		time.Sleep(30 * time.Second)
+	}
+}
+
 // setNodeStatus fills in the Status fields of the given Node, overwriting
 // any fields that are currently set.
 func (kl *Kubelet) setNodeStatus(node *api.Node) error {
@@ -1922,16 +1951,6 @@ func (kl *Kubelet) setNodeStatus(node *api.Node) error {
 			} else {
 				node.Status.Addresses = []api.NodeAddress{{Type: api.NodeLegacyHostIP, Address: addrs[0].String()}}
 			}
-		}
-	}
-
-	networkConfigured := true
-	if kl.configureCBR0 {
-		if len(node.Spec.PodCIDR) == 0 {
-			networkConfigured = false
-		} else if err := kl.reconcileCBR0(node.Spec.PodCIDR); err != nil {
-			networkConfigured = false
-			glog.Errorf("Error configuring cbr0: %v", err)
 		}
 	}
 
@@ -1982,7 +2001,7 @@ func (kl *Kubelet) setNodeStatus(node *api.Node) error {
 	currentTime := util.Now()
 	var newNodeReadyCondition api.NodeCondition
 	var oldNodeReadyConditionStatus api.ConditionStatus
-	if containerRuntimeUp && networkConfigured {
+	if containerRuntimeUp && kl.networkConfigured {
 		newNodeReadyCondition = api.NodeCondition{
 			Type:              api.NodeReady,
 			Status:            api.ConditionTrue,
@@ -1994,7 +2013,7 @@ func (kl *Kubelet) setNodeStatus(node *api.Node) error {
 		if !containerRuntimeUp {
 			reasons = append(reasons, "container runtime is down")
 		}
-		if !networkConfigured {
+		if !kl.networkConfigured {
 			reasons = append(reasons, "network not configured correctly")
 		}
 		newNodeReadyCondition = api.NodeCondition{
@@ -2056,6 +2075,8 @@ func (kl *Kubelet) tryUpdateNodeStatus() error {
 	if node == nil {
 		return fmt.Errorf("no node instance returned for %q", kl.nodeName)
 	}
+	kl.podCIDR = node.Spec.PodCIDR
+
 	if err := kl.setNodeStatus(node); err != nil {
 		return err
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -127,6 +127,7 @@ func newTestKubelet(t *testing.T) *TestKubelet {
 	}
 	kubelet.volumeManager = newVolumeManager()
 	kubelet.containerManager, _ = newContainerManager(mockCadvisor, "", "", "")
+	kubelet.networkConfigured = true
 	return &TestKubelet{kubelet, fakeRuntime, mockCadvisor, fakeKubeClient, fakeMirrorClient}
 }
 

--- a/pkg/kubelet/status_manager.go
+++ b/pkg/kubelet/status_manager.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
-	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
@@ -60,8 +59,6 @@ func (s *statusManager) Start() {
 		err := s.syncBatch()
 		if err != nil {
 			glog.Warningf("Failed to updated pod status: %v", err)
-			// Errors and tight-looping are bad, m-kay
-			time.Sleep(30 * time.Second)
 		}
 	}, 0)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -198,6 +198,20 @@ func CompileRegexps(regexpStrings []string) ([]*regexp.Regexp, error) {
 	return regexps, nil
 }
 
+// Detects if using systemd as the init system
+// Please note that simply reading /proc/1/cmdline can be misleading because
+// some installation of various init programs can automatically make /sbin/init
+// a symlink or even a renamed version of their main program.
+// TODO(dchen1107): realiably detects the init system using on the system:
+// systemd, upstart, initd, etc.
+func UsingSystemdInitSystem() bool {
+	if _, err := os.Stat("/run/systemd/system"); err != nil {
+		return true
+	}
+
+	return false
+}
+
 // Writes 'value' to /proc/<pid>/oom_score_adj. PID = 0 means self
 func ApplyOomScoreAdj(pid int, value int) error {
 	if value < -1000 || value > 1000 {


### PR DESCRIPTION
The pr is based on #10153. It doesn't execute any podSpecs until network configuration is done no matter it is master nodes or minion nodes, the detail can be found at  https://github.com/GoogleCloudPlatform/kubernetes/pull/10153#issuecomment-113729964. 

Fixed #10122 and fixed  #9822.

Since I couldn't reproduce either  #10122 or #9822 on GCE, I run cluster/kube-down.sh && hack/dev-build-and-up.sh && gcutil ssh kubernetes-master sudo docker ps -a for 10 times, and make sure there are no docker containers (kube-apiserver, etcd, pause...) killed at the booting time.
