### PR TITLE
Reset latency metrics before starting scalability tests

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -98,11 +98,7 @@ var _ = Describe("Density", func() {
 		expectNoError(err)
 		uuid = string(util.NewUUID())
 
-		// Print latency metrics before the test.
-		// TODO: Remove this once we reset metrics before the test.
-		_, err = HighLatencyRequests(c, 3*time.Second, util.NewStringSet("events"))
-		expectNoError(err)
-
+		expectNoError(resetMetrics(c))
 		expectNoError(os.Mkdir(fmt.Sprintf(testContext.OutputDir+"/%s", uuid), 0777))
 		expectNoError(writePerfData(c, fmt.Sprintf(testContext.OutputDir+"/%s", uuid), "before"))
 	})

--- a/test/e2e/load.go
+++ b/test/e2e/load.go
@@ -73,6 +73,8 @@ var _ = Describe("Load capacity", func() {
 		nsForTesting, err := createTestingNS("load", c)
 		ns = nsForTesting.Name
 		expectNoError(err)
+
+		expectNoError(resetMetrics(c))
 	})
 
 	// TODO add flag that allows to skip cleanup on failure
@@ -85,7 +87,6 @@ var _ = Describe("Load capacity", func() {
 		}
 
 		// Verify latency metrics
-		// TODO: We should reset metrics before the test. Currently previous tests influence latency metrics.
 		highLatencyRequests, err := HighLatencyRequests(c, 1*time.Second, util.NewStringSet("events"))
 		expectNoError(err, "Too many instances metrics above the threshold")
 		Expect(highLatencyRequests).NotTo(BeNumerically(">", 0))

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1395,6 +1395,19 @@ func HighLatencyRequests(c *client.Client, threshold time.Duration, ignoredResou
 	return len(badMetrics), nil
 }
 
+// Reset latency metrics in apiserver.
+func resetMetrics(c *client.Client) error {
+	Logf("Resetting latency metrics in apiserver...")
+	body, err := c.Get().AbsPath("/resetMetrics").DoRaw()
+	if err != nil {
+		return err
+	}
+	if string(body) != "metrics reset\n" {
+		return fmt.Errorf("Unexpected response: ", string(body))
+	}
+	return nil
+}
+
 // Retrieve metrics information
 func getMetrics(c *client.Client) (string, error) {
 	body, err := c.Get().AbsPath("/metrics").DoRaw()


### PR DESCRIPTION
This PR resets metrics before starting scalability test, which makes the results much more accurate.

This is a follow-up on #10216 - should be merged only after that PR is merged.

cc @piosz 
