### PR TITLE
Mesos: create static pod file source only for configured static pods

### DIFF
--- a/contrib/mesos/pkg/executor/service/service.go
+++ b/contrib/mesos/pkg/executor/service/service.go
@@ -387,8 +387,10 @@ func (ks *KubeletExecutorServer) createAndInitKubelet(
 		StaticPodsConfigPath: staticPodsConfigPath,
 	})
 
-	fileSourceUpdates := pc.Channel(kubelet.FileSource)
 	go exec.InitializeStaticPodsSource(func() {
+		// Create file source only when we are called back. Otherwise, it is never marked unseen.
+		fileSourceUpdates := pc.Channel(kubelet.FileSource)
+
 		kconfig.NewSourceFile(staticPodsConfigPath, kc.Hostname, kc.FileCheckFrequency, fileSourceUpdates)
 	})
 


### PR DESCRIPTION
The file source was created even when no static pods were configured.
In this case it was never marked as seen. As a consequence the kubelet
syncPods functions never deleted pods because it was too cautious due
an unseen pod source, leading to leaked pods.
