### PR TITLE
Update update-demo to work for v1, and don't use localhost domain name

### DIFF
--- a/examples/update-demo/kitten-rc.yaml
+++ b/examples/update-demo/kitten-rc.yaml
@@ -3,7 +3,7 @@ kind: ReplicationController
 metadata:
   name: update-demo-kitten
 spec:
-  replicas: 1
+  replicas: 4
   selector:
     name: update-demo
     version: kitten

--- a/examples/update-demo/local/index.html
+++ b/examples/update-demo/local/index.html
@@ -22,9 +22,9 @@ limitations under the License.
 </head>
 <body ng-controller="ButtonsCtrl">
   <div ng-repeat="server in servers" class="pod">
-    <img src="http://localhost:8001/api/v1/proxy/namespaces/default/pods/{{server.podName}}/{{server.image}}" height="100px" width="100px" />
+    <img src="/api/v1/proxy/namespaces/default/pods/{{server.podName}}/{{server.image}}" height="100px" width="100px" />
     <b>ID:</b> {{server.podName}}<br>
-    <b>Host:</b> <a href="http://localhost:8001/api/v1/proxy/namespaces/default/pods/{{server.podName}}/data.json">{{server.host}}</a><br>
+    <b>Host:</b> <a href="/api/v1/proxy/namespaces/default/pods/{{server.podName}}/data.json">{{server.host}}</a><br>
     <b>Status:</b> {{server.status}}<br>
     <b>Image:</b> {{server.dockerImage}}<br>
     <b>Labels:</b>

--- a/examples/update-demo/local/script.js
+++ b/examples/update-demo/local/script.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-var base = "http://localhost:8001/api/v1/";
+var base = "/api/v1/";
 
 var updateImage = function($http, server) {
   $http.get(base + "proxy/namespaces/default/pods/" + server.podName + "/data.json")
@@ -33,7 +33,7 @@ var updateServer = function($http, server) {
     .success(function(data) {
       console.log(data);
       server.labels = data.metadata.labels;
-      server.host = data.spec.host.split('.')[0];
+      server.host = data.status.hostIP.split('.')[0];
       server.status = data.status.phase;
       server.dockerImage = data.status.containerStatuses[0].image;
       updateImage($http, server);

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -102,7 +102,7 @@ var _ = Describe("Kubectl client", func() {
 			By("rolling-update to new replication controller")
 			runKubectl("rolling-update", "update-demo-nautilus", "--update-period=1s", "-f", kittenPath, fmt.Sprintf("--namespace=%v", ns))
 			// TODO: revisit the expected replicas once #9645 is resolved
-			validateController(c, kittenImage, 1, "update-demo", updateDemoSelector, getUDData("kitten.jpg", ns), ns)
+			validateController(c, kittenImage, 4, "update-demo", updateDemoSelector, getUDData("kitten.jpg", ns), ns)
 			// Everything will hopefully be cleaned up when the namespace is deleted.
 		})
 	})


### PR DESCRIPTION
Currently, this example doesn't work, because the host field has moved from `spec.host` to `status.hostIP`, (script.js:35).

In addition, I made the `kitten-rc.yaml` create 4 replicas in order to watch the rolling update better, and I removed the `localhost` domain name from the example, so that if someone wants to host the example on one machine and see it on another, they can.
