### PR TITLE
Return api/errors instead of raw etcd errors

### DIFF
--- a/pkg/api/errors/errors.go
+++ b/pkg/api/errors/errors.go
@@ -372,6 +372,11 @@ func IsServerTimeout(err error) bool {
 	return reasonForError(err) == api.StatusReasonServerTimeout
 }
 
+// IsInternalServerError determines if err is an error which indicates that there was an internal server error.
+func IsInternalServerError(err error) bool {
+	return reasonForError(err) == api.StatusReasonInternalError
+}
+
 // IsUnexpectedServerError returns true if the server response was not in the expected API format,
 // and may be the result of another HTTP actor.
 func IsUnexpectedServerError(err error) bool {
@@ -407,6 +412,14 @@ func SuggestsClientDelay(err error) (int, bool) {
 		}
 	}
 	return 0, false
+}
+
+func IsAPIStatusError(err error) bool {
+	switch err.(type) {
+	case *StatusError:
+		return true
+	}
+	return false
 }
 
 func reasonForError(err error) api.StatusReason {

--- a/pkg/api/errors/etcd/etcd.go
+++ b/pkg/api/errors/etcd/etcd.go
@@ -27,8 +27,10 @@ func InterpretGetError(err error, kind, name string) error {
 	switch {
 	case tools.IsEtcdNotFound(err):
 		return errors.NewNotFound(kind, name)
-	default:
+	case errors.IsAPIStatusError(err):
 		return err
+	default:
+		return errors.NewInternalError(err)
 	}
 }
 
@@ -38,8 +40,10 @@ func InterpretCreateError(err error, kind, name string) error {
 	switch {
 	case tools.IsEtcdNodeExist(err):
 		return errors.NewAlreadyExists(kind, name)
-	default:
+	case errors.IsAPIStatusError(err):
 		return err
+	default:
+		return errors.NewInternalError(err)
 	}
 }
 
@@ -49,8 +53,10 @@ func InterpretUpdateError(err error, kind, name string) error {
 	switch {
 	case tools.IsEtcdTestFailed(err), tools.IsEtcdNodeExist(err):
 		return errors.NewConflict(kind, name, err)
-	default:
+	case errors.IsAPIStatusError(err):
 		return err
+	default:
+		return errors.NewInternalError(err)
 	}
 }
 
@@ -60,7 +66,9 @@ func InterpretDeleteError(err error, kind, name string) error {
 	switch {
 	case tools.IsEtcdNotFound(err):
 		return errors.NewNotFound(kind, name)
-	default:
+	case errors.IsAPIStatusError(err):
 		return err
+	default:
+		return errors.NewInternalError(err)
 	}
 }

--- a/pkg/registry/etcd/etcd.go
+++ b/pkg/registry/etcd/etcd.go
@@ -108,7 +108,10 @@ func (r *Registry) CreateService(ctx api.Context, svc *api.Service) (*api.Servic
 	}
 	out := &api.Service{}
 	err = r.CreateObj(key, svc, out, 0)
-	return out, etcderr.InterpretCreateError(err, "service", svc.Name)
+	if err != nil {
+		err = etcderr.InterpretCreateError(err, "Service", svc.Name)
+	}
+	return out, err
 }
 
 // GetService obtains a Service specified by its name.
@@ -120,7 +123,7 @@ func (r *Registry) GetService(ctx api.Context, name string) (*api.Service, error
 	var svc api.Service
 	err = r.ExtractObj(key, &svc, false)
 	if err != nil {
-		return nil, etcderr.InterpretGetError(err, "service", name)
+		return nil, etcderr.InterpretGetError(err, "Service", name)
 	}
 	return &svc, nil
 }
@@ -133,7 +136,7 @@ func (r *Registry) DeleteService(ctx api.Context, name string) error {
 	}
 	err = r.Delete(key, true)
 	if err != nil {
-		return etcderr.InterpretDeleteError(err, "service", name)
+		return etcderr.InterpretDeleteError(err, "Service", name)
 	}
 
 	// TODO: can leave dangling endpoints, and potentially return incorrect
@@ -153,12 +156,15 @@ func (r *Registry) UpdateService(ctx api.Context, svc *api.Service) (*api.Servic
 	}
 	out := &api.Service{}
 	err = r.SetObj(key, svc, out, 0)
-	return out, etcderr.InterpretUpdateError(err, "service", svc.Name)
+	if err != nil {
+		err = etcderr.InterpretUpdateError(err, "Service", svc.Name)
+	}
+	return out, err
 }
 
 // WatchServices begins watching for new, changed, or deleted service configurations.
 func (r *Registry) WatchServices(ctx api.Context, label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	version, err := tools.ParseWatchResourceVersion(resourceVersion, "service")
+	version, err := tools.ParseWatchResourceVersion(resourceVersion, "Service")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/generic/etcd/etcd.go
+++ b/pkg/registry/generic/etcd/etcd.go
@@ -191,7 +191,9 @@ func (e *Etcd) CreateWithName(ctx api.Context, name string, obj runtime.Object) 
 		return err
 	}
 	err = e.Helper.CreateObj(key, obj, nil, ttl)
-	err = etcderr.InterpretCreateError(err, e.EndpointName, name)
+	if err != nil {
+		err = etcderr.InterpretCreateError(err, e.EndpointName, name)
+	}
 	if err == nil && e.Decorator != nil {
 		err = e.Decorator(obj)
 	}
@@ -250,7 +252,9 @@ func (e *Etcd) UpdateWithName(ctx api.Context, name string, obj runtime.Object) 
 		return err
 	}
 	err = e.Helper.SetObj(key, obj, nil, ttl)
-	err = etcderr.InterpretUpdateError(err, e.EndpointName, name)
+	if err != nil {
+		err = etcderr.InterpretUpdateError(err, e.EndpointName, name)
+	}
 	if err == nil && e.Decorator != nil {
 		err = e.Decorator(obj)
 	}

--- a/pkg/registry/pod/etcd/etcd_test.go
+++ b/pkg/registry/pod/etcd/etcd_test.go
@@ -153,7 +153,7 @@ func TestCreateRegistryError(t *testing.T) {
 
 	pod := validNewPod()
 	_, err := storage.Create(api.NewDefaultContext(), pod)
-	if err != fakeEtcdClient.Err {
+	if !errors.IsInternalServerError(err) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/pkg/registry/resourcequota/etcd/etcd_test.go
+++ b/pkg/registry/resourcequota/etcd/etcd_test.go
@@ -116,7 +116,7 @@ func TestCreateRegistryError(t *testing.T) {
 
 	resourcequota := validNewResourceQuota()
 	_, err := storage.Create(api.NewDefaultContext(), resourcequota)
-	if err != fakeEtcdClient.Err {
+	if !errors.IsInternalServerError(err) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
For https://github.com/GoogleCloudPlatform/kubernetes/issues/10064

Wrapping etcd errors in errors.NewInternalError(err)
