### PR TITLE
unlink testlibs from kube-apiserver and kubelet, remove test flags

### DIFF
--- a/pkg/kubelet/fake_pod_workers.go
+++ b/pkg/kubelet/fake_pod_workers.go
@@ -17,8 +17,6 @@ limitations under the License.
 package kubelet
 
 import (
-	"testing"
-
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
@@ -29,7 +27,7 @@ import (
 type fakePodWorkers struct {
 	syncPodFn    syncPodFnType
 	runtimeCache kubecontainer.RuntimeCache
-	t            *testing.T
+	t            TestingInterface
 }
 
 func (f *fakePodWorkers) UpdatePod(pod *api.Pod, mirrorPod *api.Pod, updateComplete func()) {
@@ -43,3 +41,7 @@ func (f *fakePodWorkers) UpdatePod(pod *api.Pod, mirrorPod *api.Pod, updateCompl
 }
 
 func (f *fakePodWorkers) ForgetNonExistingPodWorkers(desiredPods map[types.UID]empty) {}
+
+type TestingInterface interface {
+	Errorf(format string, args ...interface{})
+}


### PR DESCRIPTION
right now a few of our binaries have test flags:

```
      --httptest.serve=: if non-empty, httptest.NewServer serves on this address and blocks
      --test.bench=: regular expression to select benchmarks to run
      --test.benchmem=false: print memory allocations for benchmarks
      --test.benchtime=1s: approximate run time for each benchmark
      --test.blockprofile=: write a goroutine blocking profile to the named file after execution
      --test.blockprofilerate=1: if >= 0, calls runtime.SetBlockProfileRate()
      --test.coverprofile=: write a coverage profile to the named file after execution
      --test.cpu=: comma-separated list of number of CPUs to use for each test
      --test.cpuprofile=: write a cpu profile to the named file during execution
      --test.memprofile=: write a memory profile to the named file after execution
      --test.memprofilerate=0: if >=0, sets runtime.MemProfileRate
      --test.outputdir=: directory in which to write profiles
      --test.parallel=1: maximum test parallelism
      --test.run=: regular expression to select tests and examples to run
      --test.short=false: run smaller test suite to save time
      --test.timeout=0: if positive, sets an aggregate time limit for all tests
      --test.v=false: verbose: print additional output
```

This fixes #8744
/cc @thockin 
