### PR TITLE
add ca cert to token controller and all service accounts

### DIFF
--- a/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
+++ b/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
@@ -28,7 +28,13 @@
   {% endif -%}
 {% endif -%}
 
-{% set params = "--master=127.0.0.1:8080" + " " + cluster_name + " " + cluster_cidr + " " + allocate_node_cidrs + " " + cloud_provider  + " " + cloud_config + service_account_key + pillar['log_level'] -%}
+{% set root_ca_file = "" -%}
+
+{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce' ]    %}
+   {% set root_ca_file = "--root_ca_file=/srv/kubernetes/ca.crt" -%}
+{% endif -%}
+
+{% set params = "--master=127.0.0.1:8080" + " " + cluster_name + " " + cluster_cidr + " " + allocate_node_cidrs + " " + cloud_provider  + " " + cloud_config + service_account_key + pillar['log_level'] + " " + root_ca_file -%}
 
 {
 "apiVersion": "v1beta3",

--- a/contrib/mesos/pkg/controllermanager/controllermanager.go
+++ b/contrib/mesos/pkg/controllermanager/controllermanager.go
@@ -157,9 +157,10 @@ func (s *CMServer) Run(_ []string) error {
 		} else {
 			serviceaccount.NewTokensController(
 				kubeClient,
-				serviceaccount.DefaultTokenControllerOptions(
-					serviceaccount.JWTTokenGenerator(privateKey),
-				),
+				serviceaccount.TokensControllerOptions{
+					TokenGenerator: serviceaccount.JWTTokenGenerator(privateKey),
+					RootCA:         kubeconfig.CAData,
+				},
 			).Run()
 		}
 	}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1998,6 +1998,8 @@ const (
 	ServiceAccountTokenKey = "token"
 	// ServiceAccountKubeconfigKey is the key of the optional kubeconfig data for SecretTypeServiceAccountToken secrets
 	ServiceAccountKubeconfigKey = "kubernetes.kubeconfig"
+	// ServiceAccountRootCAKey is the key of the optional root certificate authority for SecretTypeServiceAccountToken secrets
+	ServiceAccountRootCAKey = "ca.crt"
 
 	// SecretTypeDockercfg contains a dockercfg file that follows the same format rules as ~/.dockercfg
 	//

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1894,6 +1894,8 @@ const (
 	ServiceAccountTokenKey = "token"
 	// ServiceAccountKubeconfigKey is the key of the optional kubeconfig data for SecretTypeServiceAccountToken secrets
 	ServiceAccountKubeconfigKey = "kubernetes.kubeconfig"
+	// ServiceAccountRootCAKey is the key of the optional root certificate authority for SecretTypeServiceAccountToken secrets
+	ServiceAccountRootCAKey = "ca.crt"
 
 	// SecretTypeDockercfg contains a dockercfg file that follows the same format rules as ~/.dockercfg
 	//

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -1900,6 +1900,8 @@ const (
 	ServiceAccountTokenKey = "token"
 	// ServiceAccountKubeconfigKey is the key of the optional kubeconfig data for SecretTypeServiceAccountToken secrets
 	ServiceAccountKubeconfigKey = "kubernetes.kubeconfig"
+	// ServiceAccountRootCAKey is the key of the optional root certificate authority for SecretTypeServiceAccountToken secrets
+	ServiceAccountRootCAKey = "ca.crt"
 
 	// SecretTypeDockercfg contains a dockercfg file that follows the same format rules as ~/.dockercfg
 	//

--- a/pkg/serviceaccount/tokens_controller_test.go
+++ b/pkg/serviceaccount/tokens_controller_test.go
@@ -378,7 +378,7 @@ func TestTokenCreation(t *testing.T) {
 
 		client := testclient.NewSimpleFake(tc.ClientObjects...)
 
-		controller := NewTokensController(client, DefaultTokenControllerOptions(generator))
+		controller := NewTokensController(client, TokensControllerOptions{TokenGenerator: generator})
 
 		// Tell the token controller whether its stores have been synced
 		controller.serviceAccountsSynced = func() bool { return !tc.ServiceAccountsSyncPending }

--- a/pkg/util/crypto.go
+++ b/pkg/util/crypto.go
@@ -123,16 +123,16 @@ func certificatesFromFile(file string) ([]*x509.Certificate, error) {
 	if err != nil {
 		return nil, err
 	}
-	certs, err := certsFromPEM(pemBlock)
+	certs, err := CertsFromPEM(pemBlock)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %s", file, err)
 	}
 	return certs, nil
 }
 
-// certsFromPEM returns the x509.Certificates contained in the given PEM-encoded byte array
+// CertsFromPEM returns the x509.Certificates contained in the given PEM-encoded byte array
 // Returns an error if a certificate could not be parsed, or if the data does not contain any certificates
-func certsFromPEM(pemCerts []byte) ([]*x509.Certificate, error) {
+func CertsFromPEM(pemCerts []byte) ([]*x509.Certificate, error) {
 	ok := false
 	certs := []*x509.Certificate{}
 	for len(pemCerts) > 0 {

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -422,7 +422,7 @@ func startServiceAccountTestServer(t *testing.T) (*client.Client, client.Config,
 	})
 
 	// Start the service account and service account token controllers
-	tokenController := serviceaccount.NewTokensController(rootClient, serviceaccount.DefaultTokenControllerOptions(serviceaccount.JWTTokenGenerator(serviceAccountKey)))
+	tokenController := serviceaccount.NewTokensController(rootClient, serviceaccount.TokensControllerOptions{TokenGenerator: serviceaccount.JWTTokenGenerator(serviceAccountKey)})
 	tokenController.Run()
 	serviceAccountController := serviceaccount.NewServiceAccountsController(rootClient, serviceaccount.DefaultServiceAccountsControllerOptions())
 	serviceAccountController.Run()


### PR DESCRIPTION
Fixes #7648

```
cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt                        
-----BEGIN CERTIFICATE-----
MIIDXzCCAkegAwIBAgIJALCZOXppvtO1MA0GCSqGSIb3DQEBCwUAMCQxIjAgBgNV
BAMUGTEzMC4yMTEuMTU1LjQzQDE0MzUwOTk3MjkwHhcNMTUwNjIzMjI0ODQ5WhcN
MjUwNjIwMjI0ODQ5WjAkMSIwIAYDVQQDFBkxMzAuMjExLjE1NS40M0AxNDM1MDk5
NzI5MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5vwZGwINV2+qQtUJ
anaxlJ4qjQeKyThsdV/tT1VE9SroT7JiLMhIU2Wr1ETw76rPr8ao8yRkJordwqKo
ThVVc6XvLa1Y7SptL2Zw1ufvxuac3xfG96XMcIjm/x5BtNe3M5VUlyjMSkMYUrmy
hvM0/8sgzmQ6QBgL0+FSZkrGIdbAqG+EOcrn0rn/xngBhSlF1TSQmg6rG/qc9Kjw
eJBrJJ0TTowDl44a0i8n21qu4Vb0iAkGLi6OZI7mC4PzR2DR+0ciLQy/OTl8mC6s
Q4KwZwDd6ovQQxHB6n+VFJjT5zeOfbKbW83oJi+NAlJnk2O6nGz+ZLmvHHbRfxyf
htSltQIDAQABo4GTMIGQMB0GA1UdDgQWBBQ3ov6S1JYJ2ZlaZ5lAO9aAozwPxTBU
BgNVHSMETTBLgBQ3ov6S1JYJ2ZlaZ5lAO9aAozwPxaEopCYwJDEiMCAGA1UEAxQZ
MTMwLjIxMS4xNTUuNDNAMTQzNTA5OTcyOYIJALCZOXppvtO1MAwGA1UdEwQFMAMB
Af8wCwYDVR0PBAQDAgEGMA0GCSqGSIb3DQEBCwUAA4IBAQAMlSSZ2k+h+Y4RXPI2
mILYEuNf/L3Rnui8iZM4bQeDb8hszxe5KMVHCOF7z1R/iOrbk3KjTUZfcmlpcMNc
VSehj6h0m5vkdq9H4kM8iUPP3GS5W8l8wsd+FNCGNhlMR2i3bxrevRnaB4RbR0Hx
osGVL/+kiMCdO12Uak0Wm47qnGJsr48XFzbLQ2s1NckdWDTMO6ZteGa0oTW5NJ/Z
wpQ01HyT1WKm6r+7HtQC6VyecxGqhIYom1eBMNmPY8kg9aONUQBYRN3HJ8uQEE8D
bjmOH2F1Z2qD2ZAxrAOo2JJQqbFl1Xjp/3QbeN5W8Tj98PTo/R/aYtMZcmyAz4yY
DL/P
-----END CERTIFICATE-----
```

cc @lavalamp @erictune @thockin @roberthbailey 
