### PR TITLE
Use the same redis configs in examples/guestbook-go as in examples/guestbook

### DIFF
--- a/examples/guestbook-go/redis-master-controller.json
+++ b/examples/guestbook-go/redis-master-controller.json
@@ -26,7 +26,7 @@
             "containers":[
                {
                   "name":"redis-master",
-                  "image":"gurpartap/redis",
+                  "image":"redis",
                   "ports":[
                      {
                         "name":"redis-server",

--- a/examples/guestbook-go/redis-slave-controller.json
+++ b/examples/guestbook-go/redis-slave-controller.json
@@ -26,12 +26,7 @@
             "containers":[
                {
                   "name":"redis-slave",
-                  "image":"gurpartap/redis",
-                  "command":[
-                     "sh",
-                     "-c",
-                     "redis-server /etc/redis/redis.conf --slaveof redis-master 6379"
-                  ],
+                  "image":"kubernetes/redis-slave:v2",
                   "ports":[
                      {
                         "name":"redis-server",


### PR DESCRIPTION
Plus updated kubectl outputs.
