### PR TITLE
Retry namespace creation for e2e tests

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -364,12 +364,21 @@ func createTestingNS(baseName string, c *client.Client) (*api.Namespace, error) 
 		},
 		Status: api.NamespaceStatus{},
 	}
-	got, err := c.Namespaces().Create(namespaceObj)
-	if err != nil {
-		return got, err
+	// Be robust about making the namespace creation call.
+	var got *api.Namespace
+	if err := wait.Poll(poll, singleCallTimeout, func() (bool, error) {
+		var err error
+		got, err = c.Namespaces().Create(namespaceObj)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return nil, err
 	}
+
 	if err := waitForDefaultServiceAccountInNamespace(c, got.Name); err != nil {
-		return got, err
+		return nil, err
 	}
 	return got, nil
 }


### PR DESCRIPTION
Addresses #10289
I do not tackle namespace deletion since that is a more subtle issue: see #10217 @wojtek-t 
@quinton-hoole @ixdy 
