### PR TITLE
Take 2: Fix the race between configuring cbr0 and restarting static pods

### DIFF
--- a/cluster/saltbase/salt/docker/docker-defaults
+++ b/cluster/saltbase/salt/docker/docker-defaults
@@ -2,5 +2,5 @@ DOCKER_OPTS=""
 {% if grains.docker_opts is defined and grains.docker_opts %}
 DOCKER_OPTS="${DOCKER_OPTS} {{grains.docker_opts}}"
 {% endif %}
-DOCKER_OPTS="${DOCKER_OPTS} --bridge cbr0 --iptables=false --ip-masq=false"
+DOCKER_OPTS="${DOCKER_OPTS} --bridge=cbr0 --iptables=false --ip-masq=false"
 DOCKER_NOFILE=1000000

--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -48,11 +48,6 @@ net.ipv4.ip_forward:
   sysctl.present:
     - value: 1
 
-cbr0:
-  container_bridge.ensure:
-    - cidr: {{ grains['cbr-cidr'] }}
-    - mtu: 1460
-
 {{ environment_file }}:
   file.managed:
     - source: salt://docker/docker-defaults
@@ -124,7 +119,6 @@ docker:
     - enable: True
     - watch:
       - file: {{ environment_file }}
-      - container_bridge: cbr0
 {% if override_docker_ver != '' %}
     - require:
       - pkg: lxc-docker-{{ override_docker_ver }}

--- a/cluster/saltbase/salt/kube-master-addons/init.sls
+++ b/cluster/saltbase/salt/kube-master-addons/init.sls
@@ -37,10 +37,26 @@ master-docker-image-tags:
   file.touch:
     - name: /srv/pillar/docker-images.sls
 
+# Current containervm image by default has both docker and kubelet
+# running. But during cluster creation stage, docker and kubelet
+# could be overwritten completely, or restarted due to flag changes.
+# The ordering of salt states for service docker, kubelet and
+# master-addon below is very important to avoid the race between
+# salt restart docker or kubelet and kubelet start master components.
+# Without the ordering of salt states, when gce instance boot up,
+# configure-vm.sh will run and download the release. At the end of
+# boot, run-salt will run kube-master-addons service which installs
+# master component manifest files to kubelet config directory before
+# the installation of proper version kubelet. Please see
+# https://github.com/GoogleCloudPlatform/kubernetes/issues/10122#issuecomment-114566063
+# for detail explanation on this very issue.
 kube-master-addons:
   service.running:
     - enable: True
     - restart: True
+    - require:
+      - service: docker
+      - service: kubelet
     - watch:
       - file: master-docker-image-tags
       - file: /etc/kubernetes/kube-master-addons.sh

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -76,4 +76,9 @@
   {% set cgroup_root = "--cgroup_root=/" -%}
 {% endif -%}
 
-DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}}"
+{% set pod_cidr = "" %}
+{% if grains['roles'][0] == 'kubernetes-master' %}
+  {% set pod_cidr = "--pod-cidr=" + grains['cbr-cidr'] %}
+{% endif %} 
+
+DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}} {{pod_cidr}}"

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -115,6 +115,7 @@ type KubeletServer struct {
 	DockerDaemonContainer          string
 	SystemContainer                string
 	ConfigureCBR0                  bool
+	PodCIDR                        string
 	MaxPods                        int
 	DockerExecHandlerName          string
 
@@ -241,7 +242,7 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.ConfigureCBR0, "configure-cbr0", s.ConfigureCBR0, "If true, kubelet will configure cbr0 based on Node.Spec.PodCIDR.")
 	fs.IntVar(&s.MaxPods, "max-pods", 100, "Number of Pods that can run on this Kubelet.")
 	fs.StringVar(&s.DockerExecHandlerName, "docker-exec-handler", s.DockerExecHandlerName, "Handler to use when executing a command in a container. Valid values are 'native' and 'nsenter'. Defaults to 'native'.")
-
+	fs.StringVar(&s.PodCIDR, "pod-cidr", "", "The CIDR to use for pod IP addresses, only used in standalone mode.  In cluster mode, this is obtained from the master.")
 	// Flags intended for testing, not recommended used in production environments.
 	fs.BoolVar(&s.ReallyCrashForTesting, "really-crash-for-testing", s.ReallyCrashForTesting, "If true, when panics occur crash. Intended for testing.")
 	fs.Float64Var(&s.ChaosChance, "chaos-chance", s.ChaosChance, "If > 0.0, introduce random client errors and latency. Intended for testing. [default=0.0]")
@@ -361,6 +362,7 @@ func (s *KubeletServer) Run(_ []string) error {
 		DockerDaemonContainer:     s.DockerDaemonContainer,
 		SystemContainer:           s.SystemContainer,
 		ConfigureCBR0:             s.ConfigureCBR0,
+		PodCIDR:                   s.PodCIDR,
 		MaxPods:                   s.MaxPods,
 		DockerExecHandler:         dockerExecHandler,
 	}
@@ -714,6 +716,7 @@ type KubeletConfig struct {
 	DockerDaemonContainer          string
 	SystemContainer                string
 	ConfigureCBR0                  bool
+	PodCIDR                        string
 	MaxPods                        int
 	DockerExecHandler              dockertools.ExecHandler
 }
@@ -771,6 +774,7 @@ func createAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.Pod
 		kc.DockerDaemonContainer,
 		kc.SystemContainer,
 		kc.ConfigureCBR0,
+		kc.PodCIDR,
 		kc.MaxPods,
 		kc.DockerExecHandler)
 

--- a/contrib/mesos/pkg/executor/service/service.go
+++ b/contrib/mesos/pkg/executor/service/service.go
@@ -354,6 +354,7 @@ func (ks *KubeletExecutorServer) createAndInitKubelet(
 		kc.DockerDaemonContainer,
 		kc.SystemContainer,
 		kc.ConfigureCBR0,
+		kc.PodCIDR,
 		kc.MaxPods,
 		kc.DockerExecHandler,
 	)

--- a/pkg/kubelet/container_bridge.go
+++ b/pkg/kubelet/container_bridge.go
@@ -19,15 +19,55 @@ package kubelet
 import (
 	"bytes"
 	"net"
+	"os"
 	"os/exec"
 	"regexp"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
 )
 
 var cidrRegexp = regexp.MustCompile(`inet ([0-9a-fA-F.:]*/[0-9]*)`)
 
+func createCBR0(wantCIDR *net.IPNet) error {
+	// recreate cbr0 with wantCIDR
+	if err := exec.Command("brctl", "addbr", "cbr0").Run(); err != nil {
+		glog.Error(err)
+		return err
+	}
+	if err := exec.Command("ip", "addr", "add", wantCIDR.String(), "dev", "cbr0").Run(); err != nil {
+		glog.Error(err)
+		return err
+	}
+	if err := exec.Command("ip", "link", "set", "dev", "cbr0", "up").Run(); err != nil {
+		glog.Error(err)
+		return err
+	}
+	// restart docker
+	// For now just log the error. The containerRuntime check will catch docker failures.
+	// TODO (dawnchen) figure out what we should do for rkt here.
+	if util.UsingSystemdInitSystem() {
+		if err := exec.Command("systemctl", "restart", "docker").Run(); err != nil {
+			glog.Error(err)
+		}
+	} else {
+		if err := exec.Command("service", "docker", "restart").Run(); err != nil {
+			glog.Error(err)
+		}
+	}
+	glog.V(2).Info("Recreated cbr0 and restarted docker")
+	return nil
+}
+
 func ensureCbr0(wantCIDR *net.IPNet) error {
+	exists, err := cbr0Exists()
+	if err != nil {
+		return err
+	}
+	if !exists {
+		glog.V(2).Infof("CBR0 doesn't exist, attempting to create it with range: %s", wantCIDR)
+		return createCBR0(wantCIDR)
+	}
 	if !cbr0CidrCorrect(wantCIDR) {
 		glog.V(2).Infof("Attempting to recreate cbr0 with address range: %s", wantCIDR)
 
@@ -40,28 +80,22 @@ func ensureCbr0(wantCIDR *net.IPNet) error {
 			glog.Error(err)
 			return err
 		}
-		// recreate cbr0 with wantCIDR
-		if err := exec.Command("brctl", "addbr", "cbr0").Run(); err != nil {
-			glog.Error(err)
-			return err
-		}
-		if err := exec.Command("ip", "addr", "add", wantCIDR.String(), "dev", "cbr0").Run(); err != nil {
-			glog.Error(err)
-			return err
-		}
-		if err := exec.Command("ip", "link", "set", "dev", "cbr0", "up").Run(); err != nil {
-			glog.Error(err)
-			return err
-		}
-		// restart docker
-		if err := exec.Command("service", "docker", "restart").Run(); err != nil {
-			glog.Error(err)
-			// For now just log the error. The containerRuntime check will catch docker failures.
-			// TODO (dawnchen) figure out what we should do for rkt here.
-		}
-		glog.V(2).Info("Recreated cbr0 and restarted docker")
+		return createCBR0(wantCIDR)
 	}
 	return nil
+}
+
+// Check if cbr0 network interface is configured or not, and take action
+// when the configuration is missing on the node, and propagate the rest
+// error to kubelet to handle.
+func cbr0Exists() (bool, error) {
+	if _, err := os.Stat("/sys/class/net/cbr0"); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func cbr0CidrCorrect(wantCIDR *net.IPNet) bool {
@@ -79,6 +113,7 @@ func cbr0CidrCorrect(wantCIDR *net.IPNet) bool {
 		return false
 	}
 	cbr0CIDR.IP = cbr0IP
+
 	glog.V(5).Infof("Want cbr0 CIDR: %s, have cbr0 CIDR: %s", wantCIDR, cbr0CIDR)
 	return wantCIDR.IP.Equal(cbr0IP) && bytes.Equal(wantCIDR.Mask, cbr0CIDR.Mask)
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1918,6 +1918,10 @@ func (kl *Kubelet) syncNetworkStatus() {
 
 	networkConfigured := true
 	if kl.configureCBR0 {
+		if err := ensureIPTablesMasqRule(); err != nil {
+			networkConfigured = false
+			glog.Errorf("Error on adding ip table rules: %v", err)
+		}
 		if len(kl.podCIDR) == 0 {
 			networkConfigured = false
 		} else if err := kl.reconcileCBR0(kl.podCIDR); err != nil {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -127,6 +127,7 @@ func newTestKubelet(t *testing.T) *TestKubelet {
 	}
 	kubelet.volumeManager = newVolumeManager()
 	kubelet.containerManager, _ = newContainerManager(mockCadvisor, "", "", "")
+	kubelet.networkConfigured = true
 	return &TestKubelet{kubelet, fakeRuntime, mockCadvisor, fakeKubeClient, fakeMirrorClient}
 }
 

--- a/pkg/kubelet/status_manager.go
+++ b/pkg/kubelet/status_manager.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubelet
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -144,7 +143,8 @@ func (s *statusManager) RemoveOrphanedStatuses(podFullNames map[string]bool) {
 // syncBatch syncs pods statuses with the apiserver.
 func (s *statusManager) syncBatch() error {
 	if s.kubeClient == nil {
-		return errors.New("Kubernetes client is nil, skipping pod status updates")
+		glog.V(4).Infof("Kubernetes client is nil, skipping pod status updates")
+		return nil
 	}
 	syncRequest := <-s.podStatusChannel
 	pod := syncRequest.pod

--- a/pkg/kubelet/status_manager.go
+++ b/pkg/kubelet/status_manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubelet
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -142,6 +143,9 @@ func (s *statusManager) RemoveOrphanedStatuses(podFullNames map[string]bool) {
 
 // syncBatch syncs pods statuses with the apiserver.
 func (s *statusManager) syncBatch() error {
+	if s.kubeClient == nil {
+		return errors.New("Kubernetes client is nil, skipping pod status updates")
+	}
 	syncRequest := <-s.podStatusChannel
 	pod := syncRequest.pod
 	podFullName := kubecontainer.GetPodFullName(pod)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -198,6 +198,20 @@ func CompileRegexps(regexpStrings []string) ([]*regexp.Regexp, error) {
 	return regexps, nil
 }
 
+// Detects if using systemd as the init system
+// Please note that simply reading /proc/1/cmdline can be misleading because
+// some installation of various init programs can automatically make /sbin/init
+// a symlink or even a renamed version of their main program.
+// TODO(dchen1107): realiably detects the init system using on the system:
+// systemd, upstart, initd, etc.
+func UsingSystemdInitSystem() bool {
+	if _, err := os.Stat("/run/systemd/system"); err != nil {
+		return true
+	}
+
+	return false
+}
+
 // Writes 'value' to /proc/<pid>/oom_score_adj. PID = 0 means self
 func ApplyOomScoreAdj(pid int, value int) error {
 	if value < -1000 || value > 1000 {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -205,7 +205,7 @@ func CompileRegexps(regexpStrings []string) ([]*regexp.Regexp, error) {
 // TODO(dchen1107): realiably detects the init system using on the system:
 // systemd, upstart, initd, etc.
 func UsingSystemdInitSystem() bool {
-	if _, err := os.Stat("/run/systemd/system"); err != nil {
+	if _, err := os.Stat("/run/systemd/system"); err == nil {
 		return true
 	}
 


### PR DESCRIPTION
The pr rever-revert "Fix the race between configuring cbr0 and restarting static pods", also
- add iptables rule for MASQUERADE for egress
- make sure mtu=1460 for cbr0

With this pr, the new cluster I brought up, I checked both master and minion on network configurations:

On master node:

```
root@kubernetes-master:/var/log# iptables-save | grep MASQUERADE
-A POSTROUTING ! -d 10.0.0.0/8 -o eth0 -j MASQUERADE

# ip addr show
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN 
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1460 qdisc pfifo_fast state UP qlen 1000
    link/ether 42:01:0a:f0:9c:cf brd ff:ff:ff:ff:ff:ff
    inet 10.240.156.207/32 brd 10.240.156.207 scope global eth0
       valid_lft forever preferred_lft forever
4: cbr0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1460 qdisc noqueue state UNKNOWN 
    link/ether f6:1f:bd:10:27:48 brd ff:ff:ff:ff:ff:ff
    inet 10.246.0.1/24 scope global cbr0
       valid_lft forever preferred_lft forever
```

On Minion node

```
root@kubernetes-minion-fptt:/var/log# iptables-save | grep MASQUERADE
-A POSTROUTING ! -d 10.0.0.0/8 -o eth0 -j MASQUERADE

root@kubernetes-minion-fptt:/var/log# ip addr show
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN 
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1460 qdisc pfifo_fast state UP qlen 1000
    link/ether 42:01:0a:f0:4d:8c brd ff:ff:ff:ff:ff:ff
    inet 10.240.77.140/32 brd 10.240.77.140 scope global eth0
       valid_lft forever preferred_lft forever
4: cbr0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1460 qdisc noqueue state UP 
    link/ether 4a:83:23:02:49:e6 brd ff:ff:ff:ff:ff:ff
    inet 10.244.0.1/24 scope global cbr0
       valid_lft forever preferred_lft forever
6: vethe9346d5: <BROADCAST,UP,LOWER_UP> mtu 1460 qdisc noqueue master cbr0 state UP 
    link/ether 4a:83:23:02:49:e6 brd ff:ff:ff:ff:ff:ff
```

I did manual tests to verify internet connection from inside of container too;

```
# docker ps
CONTAINER ID        IMAGE                                      COMMAND                CREATED             STATUS              PORTS               NAMES
15157eba242a        redis:latest                               "/entrypoint.sh redi   33 seconds ago      Up 32 seconds                           k8s_master.718e46d0_redis-master-mhbst_default_7e7c1eae-1ac3-11e5-8010-42010af09ccf_163b0101                                        
0753208fa688        gcr.io/google_containers/pause:0.8.0       "/pause"               44 seconds ago      Up 43 seconds                           k8s_POD.49eee8c2_redis-master-mhbst_default_7e7c1eae-1ac3-11e5-8010-42010af09ccf_9ab956a2                                           

# docker exec -t -i 15157eba242a sh
# ping google.com
PING google.com (74.125.70.100): 48 data bytes
56 bytes from 74.125.70.100: icmp_seq=0 ttl=50 time=0.954 ms
56 bytes from 74.125.70.100: icmp_seq=1 ttl=50 time=0.809 ms
56 bytes from 74.125.70.100: icmp_seq=2 ttl=50 time=0.815 ms
...
```

Fix #10122 and #9822
