### PR TITLE
Add dependencies on docker and kubelet service when copying master co…

### DIFF
--- a/cluster/saltbase/salt/kube-apiserver/init.sls
+++ b/cluster/saltbase/salt/kube-apiserver/init.sls
@@ -22,6 +22,19 @@
     - mode: 644
 
 # Copy kube-apiserver manifest to manifests folder for kubelet.
+# Current containervm image by default has both docker and kubelet
+# running. But during cluster creation stage, docker and kubelet
+# could be overwritten completely, or restarted due to flag changes.
+# The ordering of salt states for service docker, kubelet and
+# master-addon below is very important to avoid the race between
+# salt restart docker or kubelet and kubelet start master components.
+# Without the ordering of salt states, when gce instance boot up,
+# configure-vm.sh will run and download the release. At the end of
+# boot, run-salt will installs kube-apiserver.manifest files to
+# kubelet config directory before the installation of proper version
+# kubelet. Please see
+# https://github.com/GoogleCloudPlatform/kubernetes/issues/10122#issuecomment-114566063
+# for detail explanation on this very issue.
 /etc/kubernetes/manifests/kube-apiserver.manifest:
   file.managed:
     - source: salt://kube-apiserver/kube-apiserver.manifest
@@ -31,6 +44,9 @@
     - mode: 644
     - makedirs: true
     - dir_mode: 755
+    - require:
+      - service: docker
+      - service: kubelet
 
 #stop legacy kube-apiserver service
 stop_kube-apiserver:

--- a/cluster/saltbase/salt/kube-controller-manager/init.sls
+++ b/cluster/saltbase/salt/kube-controller-manager/init.sls
@@ -1,3 +1,9 @@
+# Copy kube-controller-manager manifest to manifests folder for kubelet.
+# The ordering of salt states for service docker, kubelet and
+# master-addon below is very important to avoid the race between
+# salt restart docker or kubelet and kubelet start master components.
+# Please see https://github.com/GoogleCloudPlatform/kubernetes/issues/10122#issuecomment-114566063
+# for detail explanation on this very issue.
 /etc/kubernetes/manifests/kube-controller-manager.manifest:
   file.managed:
     - source: salt://kube-controller-manager/kube-controller-manager.manifest
@@ -7,6 +13,9 @@
     - mode: 644
     - makedirs: true
     - dir_mode: 755
+    - require:
+      - service: docker
+      - service: kubelet
 
 /var/log/kube-controller-manager.log:
   file.managed:

--- a/cluster/saltbase/salt/kube-master-addons/init.sls
+++ b/cluster/saltbase/salt/kube-master-addons/init.sls
@@ -37,26 +37,10 @@ master-docker-image-tags:
   file.touch:
     - name: /srv/pillar/docker-images.sls
 
-# Current containervm image by default has both docker and kubelet
-# running. But during cluster creation stage, docker and kubelet
-# could be overwritten completely, or restarted due to flag changes.
-# The ordering of salt states for service docker, kubelet and
-# master-addon below is very important to avoid the race between
-# salt restart docker or kubelet and kubelet start master components.
-# Without the ordering of salt states, when gce instance boot up,
-# configure-vm.sh will run and download the release. At the end of
-# boot, run-salt will run kube-master-addons service which installs
-# master component manifest files to kubelet config directory before
-# the installation of proper version kubelet. Please see
-# https://github.com/GoogleCloudPlatform/kubernetes/issues/10122#issuecomment-114566063
-# for detail explanation on this very issue.
 kube-master-addons:
   service.running:
     - enable: True
     - restart: True
-    - require:
-      - service: docker
-      - service: kubelet
     - watch:
       - file: master-docker-image-tags
       - file: /etc/kubernetes/kube-master-addons.sh

--- a/cluster/saltbase/salt/kube-scheduler/init.sls
+++ b/cluster/saltbase/salt/kube-scheduler/init.sls
@@ -1,4 +1,9 @@
 # Copy kube-scheduler manifest to manifests folder for kubelet.
+# The ordering of salt states for service docker, kubelet and
+# master-addon below is very important to avoid the race between
+# salt restart docker or kubelet and kubelet start master components.
+# Please see https://github.com/GoogleCloudPlatform/kubernetes/issues/10122#issuecomment-114566063
+# for detail explanation on this very issue.
 /etc/kubernetes/manifests/kube-scheduler.manifest:
   file.managed:
     - source: salt://kube-scheduler/kube-scheduler.manifest
@@ -8,6 +13,9 @@
     - mode: 644
     - makedirs: true
     - dir_mode: 755
+    - require:
+      - service: docker
+      - service: kubelet
 
 /var/log/kube-scheduler.log:
   file.managed:


### PR DESCRIPTION
…mponents manifests to /etc/kubernetes/manifest

cc/ @thockin @brendandburns 

Earlier merged pr #10312 adds the dependencies between kube-master-addon and docker, kubelet to avoid the race, which is wrong. This pr creates the proper orders on copying those master component manifest file after docker and kubelet services are running. 

Here are some manual tests I have done on master node:

```
Remove manifest file
# rm -rf /etc/kubernetes/manifests/kube-apiserver.manifest

Run salt:
# salt-call state.highstate
....

Check if manifest is copied over
# ls -alt  /etc/kubernetes/manifests/kube-apiserver.manifest 
-rw-r--r-- 1 root root 3350 Jun 25 04:22 /etc/kubernetes/manifests/kube-apiserver.manifest
```

Failure tests: 

```
On master node, manually update salt file asking it depends on dockesr, instead of docker; then remove manifest file
# rm -rf /etc/kubernetes/manifests/kube-apiserver.manifest

Run salt. Salt failed to copy manifest file over:

# salt-call state.highstate
...
----------
          ID: /etc/kubernetes/manifests/kube-apiserver.manifest
    Function: file.managed
      Result: False
     Comment: The following requisites were not found:
                                 require:
                                     service: dockesr
     Changes:   
----------
...
```
