### PR TITLE
Remove the duplicate source (filename) in error message

### DIFF
--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -217,7 +217,7 @@ type URLVisitor struct {
 func (v *URLVisitor) Visit(fn VisitorFunc) error {
 	res, err := http.Get(v.URL.String())
 	if err != nil {
-		return fmt.Errorf("unable to access URL %q: %v\n", v.URL, err)
+		return err
 	}
 	defer res.Body.Close()
 	if res.StatusCode != 200 {
@@ -415,7 +415,7 @@ func (v *FileVisitor) Visit(fn VisitorFunc) error {
 	} else {
 		var err error
 		if f, err = os.Open(v.Path); err != nil {
-			return fmt.Errorf("unable to open %q: %v", v.Path, err)
+			return err
 		}
 	}
 	defer f.Close()
@@ -464,12 +464,12 @@ func (v *StreamVisitor) Visit(fn VisitorFunc) error {
 			continue
 		}
 		if err := ValidateSchema(ext.RawJSON, v.Schema); err != nil {
-			return err
+			return fmt.Errorf("error validating %q: %v", v.Source, err)
 		}
 		info, err := v.InfoForData(ext.RawJSON, v.Source)
 		if err != nil {
 			if v.IgnoreErrors {
-				fmt.Fprintf(os.Stderr, "error: could not read an encoded object from %s: %v\n", v.Source, err)
+				fmt.Fprintf(os.Stderr, "error: could not read an encoded object: %v\n", err)
 				glog.V(4).Infof("Unreadable: %s", string(ext.RawJSON))
 				continue
 			}


### PR DESCRIPTION
"kubectl create -f examples/secrets/secret.yaml" in version 19+, (modify one of the base64 encoded fields to be invalid)
the error message is:
error: unable to load file "examples/secrets/secret.yaml": unable to load "examples/secrets/secret.yaml": illegal base64 data at input byte 16
error: no objects passed to create

I found the source (filename) is duplicate,  this PR fix it.
