### PR TITLE
Increase timeout for waiting for pods running in load test

### DIFF
--- a/test/e2e/load.go
+++ b/test/e2e/load.go
@@ -157,6 +157,7 @@ func generateRCConfigsForGroup(c *client.Client, ns, groupName string, size, cou
 			Client:    c,
 			Name:      groupName + "-" + strconv.Itoa(i),
 			Namespace: ns,
+			Timeout:   10 * time.Minute,
 			Image:     image,
 			Replicas:  size,
 		}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -157,6 +157,7 @@ type RCConfig struct {
 	Name          string
 	Namespace     string
 	PollInterval  time.Duration
+	Timeout       time.Duration
 	PodStatusFile *os.File
 	Replicas      int
 
@@ -969,10 +970,14 @@ func RunRC(config RCConfig) error {
 	if interval <= 0 {
 		interval = 10 * time.Second
 	}
+	timeout := config.Timeout
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
 	oldPods := make([]*api.Pod, 0)
 	oldRunning := 0
 	lastChange := time.Now()
-	for oldRunning != config.Replicas && time.Since(lastChange) < 5*time.Minute {
+	for oldRunning != config.Replicas && time.Since(lastChange) < timeout {
 		time.Sleep(interval)
 
 		running := 0


### PR DESCRIPTION
risk: very low (this change is only touching test code that is used in only scalability e2e tests)

Rationale behind this change:
- I've observed few situations (e.g. e2e-scalability runs on Jenkins: 1559 and 1560) where the test failed with: "Only x pods started out of 5"
- I've debugged it deeper and this was because of slow system. E.g. for run 1559 what happened was:
  - pods for controller "load-test-small-rc-86" were observed after creation at 23:47:57
  - however, they were scheduled respectively at: 23:48:25 23:48:51 23:54:09 23:54:24 23:56:37
  - all of them were finally started
- this basically shows that there were more than 5 minutes period, within which no pod from that rc was scheduled
- thus there were no changes, so this caused a test failure

So in the end all of the pods were started - thus I think we should wait longer until this happen and do all the measurements (e.g. scrape latency metrics) for the whole test.

<edit>

BTW - the scheduler was slow because of high latency of requests to apiserver - so this test would probably fail anyway in those situations, but with this change the error message will be much more obvious.
