### PR TITLE
Salt: don't assume that master => cbr-cidr

### DIFF
--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -77,7 +77,7 @@
 {% endif -%}
 
 {% set pod_cidr = "" %}
-{% if grains['roles'][0] == 'kubernetes-master' %}
+{% if grains['roles'][0] == 'kubernetes-master' and grains.get('cbr-cidr') %}
   {% set pod_cidr = "--pod-cidr=" + grains['cbr-cidr'] %}
 {% endif %} 
 


### PR DESCRIPTION
In particular, this is required for vagrant

@derekwaynecarr I needed to do this to get #9381 to work on vagrant, but it does now appear to work.  Not sure if vagrant _should_ have a cbr-cidr on master?

@dchen1107 just in case we are deliberately introducing an error here to deal with a cbr0 race-condition?
