### PR TITLE
WIP: Allow user configuration of new machines

### DIFF
--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -95,5 +95,6 @@ CONTAINER_RUNTIME="${KUBE_CONTAINER_RUNTIME:-docker}"
 RKT_VERSION="${KUBE_RKT_VERSION:-0.5.5}"
 
 # Extra shell code to be appended to the end of the aws user-data
-# passed to minions on creation.
-EXTRA_MINION_USER_DATA=''
+# passed to new machines on creation.
+EXTRA_MINION_USER_DATA="${KUBE_EXTRA_MINION_USER_DATA:-}"
+EXTRA_MASTER_USER_DATA="${KUBE_EXTRA_MASTER_USER_DATA:-}"

--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -94,3 +94,6 @@ COREOS_CHANNEL="${COREOS_CHANNEL:-alpha}"
 CONTAINER_RUNTIME="${KUBE_CONTAINER_RUNTIME:-docker}"
 RKT_VERSION="${KUBE_RKT_VERSION:-0.5.5}"
 
+# Extra shell code to be appended to the end of the aws user-data
+# passed to minions on creation.
+EXTRA_MINION_USER_DATA=''

--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -96,5 +96,6 @@ RKT_VERSION="${KUBE_RKT_VERSION:-0.5.5}"
 
 # Extra shell code to be appended to the end of the aws user-data
 # passed to new machines on creation.
+# NOTE: Not currently supported by CoreOS
 EXTRA_MINION_USER_DATA="${KUBE_EXTRA_MINION_USER_DATA:-}"
 EXTRA_MASTER_USER_DATA="${KUBE_EXTRA_MASTER_USER_DATA:-}"

--- a/cluster/aws/config-test.sh
+++ b/cluster/aws/config-test.sh
@@ -90,3 +90,7 @@ KUBE_MINION_IMAGE="${KUBE_MINION_IMAGE:-}"
 COREOS_CHANNEL="${COREOS_CHANNEL:-alpha}"
 CONTAINER_RUNTIME="${KUBE_CONTAINER_RUNTIME:-docker}"
 RKT_VERSION="${KUBE_RKT_VERSION:-0.5.5}"
+
+# Extra shell code to be appended to the end of the aws user-data
+# passed to minions on creation.
+EXTRA_MINION_USER_DATA=''

--- a/cluster/aws/config-test.sh
+++ b/cluster/aws/config-test.sh
@@ -93,5 +93,6 @@ RKT_VERSION="${KUBE_RKT_VERSION:-0.5.5}"
 
 # Extra shell code to be appended to the end of the aws user-data
 # passed to minions on creation.
+# NOTE: Not currently supported by CoreOS
 EXTRA_MINION_USER_DATA="${KUBE_EXTRA_MINION_USER_DATA:-}"
 EXTRA_MASTER_USER_DATA="${KUBE_EXTRA_MASTER_USER_DATA:-}"

--- a/cluster/aws/config-test.sh
+++ b/cluster/aws/config-test.sh
@@ -93,4 +93,5 @@ RKT_VERSION="${KUBE_RKT_VERSION:-0.5.5}"
 
 # Extra shell code to be appended to the end of the aws user-data
 # passed to minions on creation.
-EXTRA_MINION_USER_DATA=''
+EXTRA_MINION_USER_DATA="${KUBE_EXTRA_MINION_USER_DATA:-}"
+EXTRA_MASTER_USER_DATA="${KUBE_EXTRA_MASTER_USER_DATA:-}"

--- a/cluster/aws/coreos/util.sh
+++ b/cluster/aws/coreos/util.sh
@@ -51,9 +51,6 @@ function generate-minion-user-data() {
       KUBERNETES_CONTAINER_RUNTIME=$(yaml-quote ${CONTAINER_RUNTIME})
       RKT_VERSION=$(yaml-quote ${RKT_VERSION})
 EOF
-  if [[ -n "${EXTRA_MINION_USER_DATA}" ]]; then
-     echo "${EXTRA_MINION_USER_DATA}"
-  fi
 }
 
 function check-minion() {

--- a/cluster/aws/coreos/util.sh
+++ b/cluster/aws/coreos/util.sh
@@ -51,6 +51,9 @@ function generate-minion-user-data() {
       KUBERNETES_CONTAINER_RUNTIME=$(yaml-quote ${CONTAINER_RUNTIME})
       RKT_VERSION=$(yaml-quote ${RKT_VERSION})
 EOF
+  if [[ -n "${EXTRA_MINION_USER_DATA}" ]]; then
+     echo "${EXTRA_MINION_USER_DATA}"
+  fi
 }
 
 function check-minion() {

--- a/cluster/aws/options.md
+++ b/cluster/aws/options.md
@@ -80,6 +80,10 @@ Value defaults to empty string.
 Setting this variable to a string containing bash code allows the user to do some additional system configuration of
 every minion.
 
+## EXTRA_MASTER_USER_DATA
+
+This is the same thing as `EXTRA_MINION_USER_DATA` but for the master instead.
+
 **KUBE_OS_DISTRIBUTION**
 
 The distribution to use.  Valid options: `wheezy`, `ubuntu`, `coreos`.

--- a/cluster/aws/options.md
+++ b/cluster/aws/options.md
@@ -70,6 +70,16 @@ will run on this storage if available, as typically the root disk is comparative
 
 If your machines don't have any ephemeral disks, this will default to the aufs driver on your root disk (with no LVM).
 
+## EXTRA_MINION_USER_DATA
+
+If set to non-empty the contents of this variable will be appended to the end of the "minon-user-data" before it's
+passed to AWS. minion-user-data is a script that gets run on a new AWS instance on instance creation.
+
+Value defaults to empty string.
+
+Setting this variable to a string containing bash code allows the user to do some additional system configuration of
+every minion.
+
 **KUBE_OS_DISTRIBUTION**
 
 The distribution to use.  Valid options: `wheezy`, `ubuntu`, `coreos`.

--- a/cluster/aws/options.md
+++ b/cluster/aws/options.md
@@ -70,19 +70,17 @@ will run on this storage if available, as typically the root disk is comparative
 
 If your machines don't have any ephemeral disks, this will default to the aufs driver on your root disk (with no LVM).
 
-## EXTRA_MINION_USER_DATA
+## KUGE_EXTRA_MINION_USER_DATA and KUGE_EXTRA_MASTER_USER_DATA
+Note: Not currently supported by CoreOS
 
-If set to non-empty the contents of this variable will be appended to the end of the "minon-user-data" before it's
-passed to AWS. minion-user-data is a script that gets run on a new AWS instance on instance creation.
+If set to non-empty the contents of this variable will be appended to the end of the  the miinion or master user-data 
+respectively, before each is passed to AWS. The user-data is a script that gets run on a new AWS instance upon instance
+creation.
 
 Value defaults to empty string.
 
-Setting this variable to a string containing bash code allows the user to do some additional system configuration of
-every minion.
-
-## EXTRA_MASTER_USER_DATA
-
-This is the same thing as `EXTRA_MINION_USER_DATA` but for the master instead.
+Setting these variables to strings containing bash code allows the user to do some additional system configuration of
+every minion, or the master.
 
 **KUBE_OS_DISTRIBUTION**
 

--- a/cluster/aws/options.md
+++ b/cluster/aws/options.md
@@ -70,7 +70,7 @@ will run on this storage if available, as typically the root disk is comparative
 
 If your machines don't have any ephemeral disks, this will default to the aufs driver on your root disk (with no LVM).
 
-## KUGE_EXTRA_MINION_USER_DATA and KUGE_EXTRA_MASTER_USER_DATA
+## KUBE_EXTRA_MINION_USER_DATA and KUBE_EXTRA_MASTER_USER_DATA
 Note: Not currently supported by CoreOS
 
 If set to non-empty the contents of this variable will be appended to the end of the  the miinion or master user-data 

--- a/cluster/aws/ubuntu/common.sh
+++ b/cluster/aws/ubuntu/common.sh
@@ -33,6 +33,9 @@ function generate-minion-user-data {
   grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/common.sh"
   grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/format-disks.sh"
   grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/salt-minion.sh"
+  if [[ -n "${EXTRA_MINION_USER_DATA}" ]]; then
+    echo "${EXTRA_MINION_USER_DATA}"
+  fi
 }
 
 function check-minion() {

--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -760,6 +760,9 @@ function kube-up {
     grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/create-dynamic-salt-files.sh"
     grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/download-release.sh"
     grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/salt-master.sh"
+    if [[ -n "${EXTRA_MASTER_USER_DATA}" ]]; then
+      echo "${EXTRA_MASTER_USR_DATA}"
+    fi
   ) > "${KUBE_TEMP}/master-start.sh"
 
   echo "Starting Master"

--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -761,7 +761,7 @@ function kube-up {
     grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/download-release.sh"
     grep -v "^#" "${KUBE_ROOT}/cluster/aws/templates/salt-master.sh"
     if [[ -n "${EXTRA_MASTER_USER_DATA}" ]]; then
-      echo "${EXTRA_MASTER_USR_DATA}"
+      echo "${EXTRA_MASTER_USER_DATA}"
     fi
   ) > "${KUBE_TEMP}/master-start.sh"
 


### PR DESCRIPTION
The idea is to let someone specify bash commands that run at the end of the initial setup script. They could, for example do this:
EXTRA_MINION_USER_DATA="${cat some_script_file}" 

And thus users can have some extra configuration occur each time a new minion is created. 
