### PR TITLE
fix variable shadowing bug where provided RootCA would always be a nil byte slice

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -250,7 +250,7 @@ func (s *CMServer) Run(_ []string) error {
 	var rootCA []byte
 
 	if s.RootCAFile != "" {
-		rootCA, err := ioutil.ReadFile(s.RootCAFile)
+		rootCA, err = ioutil.ReadFile(s.RootCAFile)
 		if err != nil {
 			return fmt.Errorf("error reading root-ca-file at %s: %v", s.RootCAFile, err)
 		}


### PR DESCRIPTION
Happened addressing a late comment and I didn't retest... The shame.

@thockin @lavalamp @liggitt 

```
➜  kubernetes git:(shadow) ✗ k exec -ti kube-dns-v3-ltpbc -c kube2sky -- cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt                                                                                                                              
-----BEGIN CERTIFICATE-----
MIIDXzCCAkegAwIBAgIJAIvV/pyxHxjgMA0GCSqGSIb3DQEBCwUAMCQxIjAgBgNV
BAMUGTEwNC4xNTQuNjQuMTIyQDE0MzUyNTc3MTIwHhcNMTUwNjI1MTg0MTUyWhcN
MjUwNjIyMTg0MTUyWjAkMSIwIAYDVQQDFBkxMDQuMTU0LjY0LjEyMkAxNDM1MjU3
NzEyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0qkJGf1yEonsOj/B
kAmGuvoF2rxl1iVbW4jT4kVS5JN/rSCFSNj8pQ6nXQ8sKO0nL16FwfJhV4r3uc/k
SlvwIdlXrLfozzF+JLAiHDyOnS/NxTIVfQFmxD+ccLIJEuoVvF554KgZ27RR9R3j
Mks5uCwAa5IvZY2cAL0xeXKvtimz5nxRh2e4sd+w5kAcQjM5E0KyaIHFhRI2tkNz
hVgmstxx9jqNWBxrScGenUL3Otd/OZ9IsyMa4rRRH/+vYYMOmtG4VS+ZpBG+hTs0
Y8XDgS/LWkyyxDNs3lp4QETxpKJYi0eCF3hEH+x/7zeTakygF0xXb/RN+EywJT26
mh2/7QIDAQABo4GTMIGQMB0GA1UdDgQWBBSHQQ06n40PpiyIElJSXcMGSNSJsDBU
BgNVHSMETTBLgBSHQQ06n40PpiyIElJSXcMGSNSJsKEopCYwJDEiMCAGA1UEAxQZ
MTA0LjE1NC42NC4xMjJAMTQzNTI1NzcxMoIJAIvV/pyxHxjgMAwGA1UdEwQFMAMB
Af8wCwYDVR0PBAQDAgEGMA0GCSqGSIb3DQEBCwUAA4IBAQAH3Lre+5mg5TI5lWZf
J7gx8HMH7OaNS6iXTzUu9H4JU0LhZLiGXuqytxNA2ajuoIgs3wDEVUzHMiKK+ag2
Xd3tnBUs0Nafba2yPmV1EqxI2N8UAAsdcP0MgVtzV/GpYgKduuDDexpz5ivYlv5i
zP1vGSU2vciCaoBbAp87X/Wz5ONKqbi/mBMGgCLn9U4HBCjopQeziPUvQdT9CJKp
zDi8AoA2ZGTwRqQc458kVDOzgkfqRRIqt7Vo9eWvkFsQ/k/IdD5QNImAJ7w+05mz
u5rLXcwA7+NSUeVcFUtueVH5p6lH2b/K6Xm7GSLVq1WtxeRZiaseHJRJZ/UBB6dw
EVic
-----END CERTIFICATE-----
```
