### PR TITLE
remove --machines and related deprecated flags from code and docs

### DIFF
--- a/cluster/images/hyperkube/master-multi.json
+++ b/cluster/images/hyperkube/master-multi.json
@@ -12,7 +12,6 @@
               "/hyperkube",
               "controller-manager",
               "--master=127.0.0.1:8080",
-              "--machines=127.0.0.1",
               "--sync_nodes=true",
               "--v=2"
         ]

--- a/cluster/images/hyperkube/master.json
+++ b/cluster/images/hyperkube/master.json
@@ -12,7 +12,6 @@
               "/hyperkube",
               "controller-manager",
               "--master=127.0.0.1:8080",
-              "--machines=127.0.0.1",
               "--sync_nodes=true",
               "--v=2"
         ]

--- a/cluster/libvirt-coreos/user_data_master.yml
+++ b/cluster/libvirt-coreos/user_data_master.yml
@@ -36,8 +36,7 @@ coreos:
 
         [Service]
         ExecStart=/opt/kubernetes/bin/kube-controller-manager \
-        --master=127.0.0.1:8080 \
-        --machines=${machines}
+        --master=127.0.0.1:8080
         Restart=always
         RestartSec=2
 

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -31,7 +31,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
@@ -84,14 +83,6 @@ type CMServer struct {
 
 	Master     string
 	Kubeconfig string
-
-	// The following fields are deprecated and unused except in flag parsing.
-	MinionRegexp   string
-	MachineList    util.StringList
-	SyncNodeList   bool
-	SyncNodeStatus bool
-	NodeMilliCPU   int64
-	NodeMemory     resource.Quantity
 }
 
 // NewCMServer creates a new CMServer with a default config.
@@ -107,7 +98,6 @@ func NewCMServer() *CMServer {
 		PVClaimBinderSyncPeriod: 10 * time.Second,
 		RegisterRetryCount:      10,
 		PodEvictionTimeout:      5 * time.Minute,
-		SyncNodeList:            true,
 		ClusterName:             "kubernetes",
 	}
 	return &s
@@ -121,8 +111,6 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.CloudConfigFile, "cloud-config", s.CloudConfigFile, "The path to the cloud provider configuration file.  Empty string for no configuration file.")
 	fs.IntVar(&s.ConcurrentEndpointSyncs, "concurrent-endpoint-syncs", s.ConcurrentEndpointSyncs, "The number of endpoint syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load")
 	fs.IntVar(&s.ConcurrentRCSyncs, "concurrent_rc_syncs", s.ConcurrentRCSyncs, "The number of replication controllers that are allowed to sync concurrently. Larger number = more reponsive replica management, but more CPU (and network) load")
-	fs.StringVar(&s.MinionRegexp, "minion-regexp", s.MinionRegexp, "If non empty, and --cloud-provider is specified, a regular expression for matching minion VMs.")
-	fs.MarkDeprecated("minion-regexp", "will be removed in a future version")
 	fs.DurationVar(&s.NodeSyncPeriod, "node-sync-period", s.NodeSyncPeriod, ""+
 		"The period for syncing nodes from cloudprovider. Longer periods will result in "+
 		"fewer calls to cloud provider, but may delay addition of new nodes to cluster.")
@@ -134,12 +122,6 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.DeletingPodsBurst, "deleting-pods-burst", 10, "Number of nodes on which pods are bursty deleted in case of node failure. For more details look into RateLimiter.")
 	fs.IntVar(&s.RegisterRetryCount, "register-retry-count", s.RegisterRetryCount, ""+
 		"The number of retries for initial node registration.  Retry interval equals node-sync-period.")
-	fs.Var(&s.MachineList, "machines", "List of machines to schedule onto, comma separated.")
-	fs.MarkDeprecated("machines", "will be removed in a future version")
-	fs.BoolVar(&s.SyncNodeList, "sync-nodes", s.SyncNodeList, "If true, and --cloud-provider is specified, sync nodes from the cloud provider. Default true.")
-	fs.MarkDeprecated("sync-nodes", "will be removed in a future version")
-	fs.BoolVar(&s.SyncNodeStatus, "sync-node-status", s.SyncNodeStatus,
-		"DEPRECATED. Does not have any effect now and it will be removed in a later release.")
 	fs.DurationVar(&s.NodeMonitorGracePeriod, "node-monitor-grace-period", 40*time.Second,
 		"Amount of time which we allow running Node to be unresponsive before marking it unhealty. "+
 			"Must be N times more than kubelet's nodeStatusUpdateFrequency, "+
@@ -149,10 +131,6 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.NodeMonitorPeriod, "node-monitor-period", 5*time.Second,
 		"The period for syncing NodeStatus in NodeController.")
 	fs.StringVar(&s.ServiceAccountKeyFile, "service-account-private-key-file", s.ServiceAccountKeyFile, "Filename containing a PEM-encoded private RSA key used to sign service account tokens.")
-	fs.Int64Var(&s.NodeMilliCPU, "node-milli-cpu", s.NodeMilliCPU, "The amount of MilliCPU provisioned on each node")
-	fs.MarkDeprecated("node-milli-cpu", "will be removed in a future version")
-	fs.Var(resource.NewQuantityFlagValue(&s.NodeMemory), "node-memory", "The amount of memory (in bytes) provisioned on each node")
-	fs.MarkDeprecated("node-memory", "will be removed in a future version")
 	fs.BoolVar(&s.EnableProfiling, "profiling", true, "Enable profiling via web interface host:port/debug/pprof/")
 	fs.StringVar(&s.ClusterName, "cluster-name", s.ClusterName, "The instance prefix for the cluster")
 	fs.Var(&s.ClusterCIDR, "cluster-cidr", "CIDR Range for Pods in cluster.")
@@ -209,10 +187,6 @@ func (s *CMServer) Run(_ []string) error {
 	go controllerManager.Run(s.ConcurrentRCSyncs, util.NeverStop)
 
 	cloud := cloudprovider.InitCloudProvider(s.CloudProvider, s.CloudConfigFile)
-
-	if s.SyncNodeStatus {
-		glog.Warning("DEPRECATION NOTICE: sync-node-status flag is being deprecated. It has no effect now and it will be removed in a future version.")
-	}
 
 	nodeController := nodecontroller.NewNodeController(cloud, kubeClient, s.RegisterRetryCount,
 		s.PodEvictionTimeout, nodecontroller.NewPodEvictor(util.NewTokenBucketRateLimiter(s.DeletingPodsQps, s.DeletingPodsBurst)),

--- a/docs/getting-started-guides/centos/centos_manual_config.md
+++ b/docs/getting-started-guides/centos/centos_manual_config.md
@@ -111,12 +111,6 @@ KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range=10.254.0.0/16"
 KUBE_API_ARGS=""
 ```
 
-* Edit /etc/kubernetes/controller-manager to appear as such:
-```
-# Comma separated list of minions
-KUBELET_ADDRESSES="--machines=centos-minion"
-```
-
 * Start the appropriate services on master:
 
 ```

--- a/docs/getting-started-guides/coreos/cloud-configs/standalone.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/standalone.yaml
@@ -90,7 +90,7 @@ coreos:
         --logtostderr=true
         Restart=always
         RestartSec=10
-    - name: kube-controller-manager.service 
+    - name: kube-controller-manager.service
       command: start
       content: |
         [Unit]
@@ -103,7 +103,6 @@ coreos:
         ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.18.2/bin/linux/amd64/kube-controller-manager
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-controller-manager
         ExecStart=/opt/bin/kube-controller-manager \
-        --machines=127.0.0.1 \
         --master=127.0.0.1:8080 \
         --logtostderr=true
         Restart=always

--- a/docs/man/kube-controller-manager.1.md
+++ b/docs/man/kube-controller-manager.1.md
@@ -59,23 +59,11 @@ The kube-controller-manager has several options.
 **--logtostderr**=true
 	log to standard error instead of files
 
-**--machines**=[]
-	List of machines to schedule onto, comma separated.
-
 **--master**=""
 	The address of the Kubernetes API server (overrides any value in kubeconfig)
 
-**--minion-regexp**=""
-	If non empty, and --cloud-provider is specified, a regular expression for matching minion VMs.
-
 **--namespace-sync-period**=5m0s
 	The period for syncing namespace life-cycle updates
-
-**--node-memory**=3Gi
-	The amount of memory (in bytes) provisioned on each node
-
-**--node-milli-cpu**=1000
-	The amount of MilliCPU provisioned on each node
 
 **--node-monitor-grace-period**=40s
 	Amount of time which we allow running Node to be unresponsive before marking it unhealty. Must be N times more than kubelet's nodeStatusUpdateFrequency, where N means number of retries allowed for kubelet to post node status.
@@ -113,9 +101,6 @@ The kube-controller-manager has several options.
 **--stderrthreshold**=2
 	logs at or above this threshold go to stderr
 
-**--sync-nodes**=true
-	If true, and --cloud-provider is specified, sync nodes from the cloud provider. Default true.
-
 **--v**=0
 	log level for V logs
 
@@ -127,7 +112,7 @@ The kube-controller-manager has several options.
 
 # EXAMPLES
 ```
-/usr/bin/kube-controller-manager --logtostderr=true --v=0 --master=127.0.0.1:8080 --machines=127.0.0.1 
+/usr/bin/kube-controller-manager --logtostderr=true --v=0 --master=127.0.0.1:8080
 ```
 
 # HISTORY

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -228,7 +228,6 @@ function start_controller_manager {
     CTLRMGR_LOG=/tmp/kube-controller-manager.log
     sudo -E "${GO_OUT}/kube-controller-manager" \
       --v=${LOG_LEVEL} \
-      --machines="127.0.0.1" \
       --service_account_private_key_file="${SERVICE_ACCOUNT_KEY}" \
       --master="${API_HOST}:${API_PORT}" >"${CTLRMGR_LOG}" 2>&1 &
     CTLRMGR_PID=$!

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -103,7 +103,6 @@ kube::util::wait_for_url "http://127.0.0.1:${API_PORT}/healthz" "apiserver"
 # Start controller manager
 kube::log::status "Starting controller-manager"
 "${KUBE_OUTPUT_HOSTBIN}/kube-controller-manager" \
-  --machines="127.0.0.1" \
   --port="${CTLRMGR_PORT}" \
   --master="127.0.0.1:${API_PORT}" 1>&2 &
 CTLRMGR_PID=$!


### PR DESCRIPTION
Flag was dead. Kept around for compatibility. Nodes will register themselves by default now.

Fixes #10295

@lavalamp 
