### PR TITLE
Increase the length of sliding window for latency metrics

### DIFF
--- a/pkg/apiserver/metrics/metrics.go
+++ b/pkg/apiserver/metrics/metrics.go
@@ -48,6 +48,8 @@ var (
 		prometheus.SummaryOpts{
 			Name: "apiserver_request_latencies_summary",
 			Help: "Response latency summary in microseconds for each verb and resource.",
+			// Make the sliding window of 1h.
+			MaxAge: time.Hour,
 		},
 		[]string{"verb", "resource"},
 	)

--- a/pkg/client/metrics/metrics.go
+++ b/pkg/client/metrics/metrics.go
@@ -31,6 +31,7 @@ var (
 			Subsystem: restClientSubsystem,
 			Name:      "request_latency_microseconds",
 			Help:      "Request latency in microseconds. Broken down by verb and URL",
+			MaxAge:    time.Hour,
 		},
 		[]string{"verb", "url"},
 	)


### PR DESCRIPTION
Ref #10389 

Increase the sliding window for latency metrics used by scalability tests to 1h.

cc @piosz @fgrzadkowski 
