### PR TITLE
WIP: Announce webserver port in NodePort e2e test

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1129,7 +1129,7 @@ func (t *WebserverTest) BuildServiceSpec() *api.Service {
 // CreateWebserverRC creates rc-backed pods with the well-known webserver
 // configuration and records it for cleanup.
 func (t *WebserverTest) CreateWebserverRC(replicas int) *api.ReplicationController {
-	rcSpec := rcByName(t.name, replicas, t.image, t.Labels)
+	rcSpec := rcByNamePort(t.name, replicas, t.image, 80, t.Labels)
 	rcAct, err := t.createRC(rcSpec)
 	if err != nil {
 		Failf("Failed to create rc %s: %v", rcSpec.Name, err)


### PR DESCRIPTION
In k8s's default networking model container ports in pod specs are not necessary
in order to get an endpoint for a given service via the endpoint controller. In
other setups like Mesos this information is essential to allow the creation of
necessary port forwardings.

Fixes mesosphere/kubernetes-mesos#365: "Services should be able to create a functioning NodePort service",
