### PR TITLE
Be strict about endpoint creation with undeclared numeric ports 

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -41,6 +41,7 @@ Changes to services are the most significant difference between v1beta3 and v1.
 * The `service.spec.portalIP` property is renamed to `service.spec.clusterIP`.
 * The `service.spec.createExternalLoadBalancer` property is removed. Specify `service.spec.type: "LoadBalancer"` to create an external load balancer instead.
 * The `service.spec.publicIPs` property is deprecated and now called `service.spec.deprecatedPublicIPs`. This property will be removed entirely when v1beta3 is removed. The vast majority of users of this field were using it to expose services on ports on the node. Those users should specify `service.spec.type: "NodePort"` instead. Read [External Services](services.md#external-services) for more info. If this is not sufficient for your use case, please file an issue or contact @thockin.
+* Endpoints for pods which do not explicitly expose numeric ports are deprecated. In a future version the endpoint controller will create endpoints for those pods anymore, in analogy to the case of named ports which are not defined for a pod, but referenced from a service.
 
 Some other difference between v1beta3 and v1:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,7 +41,7 @@ Changes to services are the most significant difference between v1beta3 and v1.
 * The `service.spec.portalIP` property is renamed to `service.spec.clusterIP`.
 * The `service.spec.createExternalLoadBalancer` property is removed. Specify `service.spec.type: "LoadBalancer"` to create an external load balancer instead.
 * The `service.spec.publicIPs` property is deprecated and now called `service.spec.deprecatedPublicIPs`. This property will be removed entirely when v1beta3 is removed. The vast majority of users of this field were using it to expose services on ports on the node. Those users should specify `service.spec.type: "NodePort"` instead. Read [External Services](services.md#external-services) for more info. If this is not sufficient for your use case, please file an issue or contact @thockin.
-* Endpoints for pods which do not explicitly expose numeric ports are deprecated. In a future version the endpoint controller will create endpoints for those pods anymore, in analogy to the case of named ports which are not defined for a pod, but referenced from a service.
+* Endpoints for pods which do not explicitly expose numeric ports are deprecated. In a future version the endpoint controller will not create endpoints for those pods anymore, in analogy to the case of named ports which are not defined for a pod, but referenced from a service.
 
 Some other difference between v1beta3 and v1:
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -76,6 +76,8 @@ deploying and evolving your `Services`.  For example, you can change the port
 number that pods expose in the next version of your backend software, without
 breaking clients.
 
+Also note that endpoints for pods without explicitly exposed numeric ports are deprecated. Hence, in order to address pods via a service the container ports – even the numeric ones – must be explicitly declared in the specification of the pod. Future versions of Kubernetes will not create endpoints otherwise and the pods will not be made available through services.
+
 Kubernetes `Services` support `TCP` and `UDP` for protocols.  The default
 is `TCP`.
 

--- a/pkg/service/endpoints_controller.go
+++ b/pkg/service/endpoints_controller.go
@@ -409,7 +409,14 @@ func findPort(pod *api.Pod, svcPort *api.ServicePort) (int, error) {
 			}
 		}
 	case util.IntstrInt:
-		return portName.IntVal, nil
+		p := portName.IntVal
+		for _, container := range pod.Spec.Containers {
+			for _, port := range container.Ports {
+				if port.ContainerPort == p && port.Protocol == svcPort.Protocol {
+					return portName.IntVal, nil
+				}
+			}
+		}
 	}
 
 	return 0, fmt.Errorf("no suitable port for manifest: %s", pod.UID)

--- a/pkg/service/endpoints_controller.go
+++ b/pkg/service/endpoints_controller.go
@@ -296,6 +296,7 @@ func (e *EndpointController) syncService(key string) {
 	}
 
 	subsets := []api.EndpointSubset{}
+	podsByUndeclaredNumericPorts := make(map[int][]*api.Pod)
 	for i := range pods.Items {
 		pod := &pods.Items[i]
 
@@ -304,7 +305,20 @@ func (e *EndpointController) syncService(key string) {
 
 			portName := servicePort.Name
 			portProto := servicePort.Protocol
+
 			portNum, err := findPort(pod, servicePort)
+
+			// handle DEPRECATED undeclared numeric ports gracefully for now.
+			// Only print out a warning below, but accept the targetPort of the
+			// service without verification.
+			if err != nil && servicePort.TargetPort.Kind == util.IntstrInt {
+				portNum, err = servicePort.TargetPort.IntVal, nil
+				pods, ok := podsByUndeclaredNumericPorts[portNum]
+				if !ok {
+					pods = []*api.Pod{}
+				}
+				podsByUndeclaredNumericPorts[portNum] = append(pods, pod)
+			}
 			if err != nil {
 				glog.V(4).Infof("Failed to find port for service %s/%s: %v", service.Namespace, service.Name, err)
 				continue
@@ -352,6 +366,15 @@ func (e *EndpointController) syncService(key string) {
 		glog.V(5).Infof("endpoints are equal for %s/%s, skipping update", service.Namespace, service.Name)
 		return
 	}
+
+	// print DEPRECATION warning if an undeclared numeric port was found in any
+	// of the selected pods of the service
+	if len(podsByUndeclaredNumericPorts) > 0 {
+		for port := range podsByUndeclaredNumericPorts {
+			glog.Warningf("DEPRECATION NOTICE: the service %s/%s points to pods which do not explicitly declare the numeric port %v", service.Namespace, service.Name, port)
+		}
+	}
+
 	newEndpoints := currentEndpoints
 	newEndpoints.Subsets = subsets
 	newEndpoints.Labels = service.Labels

--- a/pkg/service/endpoints_controller_test.go
+++ b/pkg/service/endpoints_controller_test.go
@@ -74,7 +74,7 @@ func TestFindPort(t *testing.T) {
 		containers: []api.Container{{}},
 		port:       util.NewIntOrStringFromInt(93),
 		expected:   93,
-		pass:       true,
+		pass:       false,
 	}, {
 		name: "valid int, with ports",
 		containers: []api.Container{{Ports: []api.ContainerPort{{
@@ -88,7 +88,7 @@ func TestFindPort(t *testing.T) {
 		}}}},
 		port:     util.NewIntOrStringFromInt(93),
 		expected: 93,
-		pass:     true,
+		pass:     false,
 	}, {
 		name:       "valid str, no ports",
 		containers: []api.Container{{}},
@@ -142,7 +142,7 @@ func TestFindPort(t *testing.T) {
 		if err == nil && !tc.pass {
 			t.Errorf("unexpected non-error for %s: %d", tc.name, port)
 		}
-		if port != tc.expected {
+		if err == nil && port != tc.expected {
 			t.Errorf("wrong result for %s: expected %d, got %d", tc.name, tc.expected, port)
 		}
 	}

--- a/pkg/service/endpoints_controller_test.go
+++ b/pkg/service/endpoints_controller_test.go
@@ -56,7 +56,7 @@ func addPods(store cache.Store, namespace string, nPods int, nPorts int) {
 		}
 		for j := 0; j < nPorts; j++ {
 			p.Spec.Containers[0].Ports = append(p.Spec.Containers[0].Ports,
-				api.ContainerPort{Name: fmt.Sprintf("port%d", i), ContainerPort: 8080 + j})
+				api.ContainerPort{Name: fmt.Sprintf("port%d", i), ContainerPort: 8080 + j, Protocol: "TCP"})
 		}
 		store.Add(p)
 	}

--- a/pkg/service/endpoints_controller_test.go
+++ b/pkg/service/endpoints_controller_test.go
@@ -405,7 +405,7 @@ func TestSyncEndpointsItems(t *testing.T) {
 			Selector: map[string]string{"foo": "bar"},
 			Ports: []api.ServicePort{
 				{Name: "port0", Port: 80, Protocol: "TCP", TargetPort: util.NewIntOrStringFromInt(8080)},
-				{Name: "port1", Port: 88, Protocol: "TCP", TargetPort: util.NewIntOrStringFromInt(8088)},
+				{Name: "port1", Port: 88, Protocol: "TCP", TargetPort: util.NewIntOrStringFromInt(8081)},
 			},
 		},
 	})
@@ -418,7 +418,7 @@ func TestSyncEndpointsItems(t *testing.T) {
 		},
 		Ports: []api.EndpointPort{
 			{Name: "port0", Port: 8080, Protocol: "TCP"},
-			{Name: "port1", Port: 8088, Protocol: "TCP"},
+			{Name: "port1", Port: 8081, Protocol: "TCP"},
 		},
 	}}
 	data := runtime.EncodeOrDie(testapi.Codec(), &api.Endpoints{
@@ -451,7 +451,7 @@ func TestSyncEndpointsItemsWithLabels(t *testing.T) {
 			Selector: map[string]string{"foo": "bar"},
 			Ports: []api.ServicePort{
 				{Name: "port0", Port: 80, Protocol: "TCP", TargetPort: util.NewIntOrStringFromInt(8080)},
-				{Name: "port1", Port: 88, Protocol: "TCP", TargetPort: util.NewIntOrStringFromInt(8088)},
+				{Name: "port1", Port: 88, Protocol: "TCP", TargetPort: util.NewIntOrStringFromInt(8081)},
 			},
 		},
 	})
@@ -464,7 +464,7 @@ func TestSyncEndpointsItemsWithLabels(t *testing.T) {
 		},
 		Ports: []api.EndpointPort{
 			{Name: "port0", Port: 8080, Protocol: "TCP"},
-			{Name: "port1", Port: 8088, Protocol: "TCP"},
+			{Name: "port1", Port: 8081, Protocol: "TCP"},
 		},
 	}}
 	data := runtime.EncodeOrDie(testapi.Codec(), &api.Endpoints{

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1129,7 +1129,7 @@ func (t *WebserverTest) BuildServiceSpec() *api.Service {
 // CreateWebserverRC creates rc-backed pods with the well-known webserver
 // configuration and records it for cleanup.
 func (t *WebserverTest) CreateWebserverRC(replicas int) *api.ReplicationController {
-	rcSpec := rcByName(t.name, replicas, t.image, t.Labels)
+	rcSpec := rcByNamePort(t.name, replicas, t.image, 80, t.Labels)
 	rcAct, err := t.createRC(rcSpec)
 	if err != nil {
 		Failf("Failed to create rc %s: %v", rcSpec.Name, err)


### PR DESCRIPTION
The Mesos cloud provider depends on the declaration of ports in the pod
spec in order to create port forwardings from the container IP to the host. In the case of the Mesos endpoint controller these host ports are then used as the endpoints for Kubernetes services.

The old endpoint controller code only checks that named port in service specs are actually existing in the selected pods. If not, an endpoint is not created for a given pod. 

In contrast endpoints for numeric ports are blindly created, independently whether it is declared in the pod spec or not.

This PR deprecates undeclared port by showing a "DEPRECATION NOTICE" in the endpoint controller logs.

Fixes mesosphere/kubernetes-mesos#365
