### PR TITLE
Add explicit dependency of docker pkg on the deb download

### DIFF
--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -112,6 +112,8 @@ lxc-docker-{{ override_docker_ver }}:
   pkg.installed:
     - sources:
       - lxc-docker-{{ override_docker_ver }}: /var/cache/docker-install/{{ override_deb }}
+    - require:
+      - file: /var/cache/docker-install/{{ override_deb }}
 {% endif %}
 
 docker:


### PR DESCRIPTION
Salt ordering continues to surprise me.  I saw them execute
out of order, though I don't know why.  Adding an explicit
dependency to prevent out-of-order execution.
