### PR TITLE
Make name of receiver uniform in tickRateLimiter

### DIFF
--- a/pkg/util/throttle.go
+++ b/pkg/util/throttle.go
@@ -90,20 +90,20 @@ func (t *tickRateLimiter) Stop() {
 	close(t.stop)
 }
 
-func (r *tickRateLimiter) run() {
+func (t *tickRateLimiter) run() {
 	for {
-		if !r.step() {
+		if !t.step() {
 			break
 		}
 	}
 }
 
-func (r *tickRateLimiter) step() bool {
+func (t *tickRateLimiter) step() bool {
 	select {
-	case <-r.ticker:
-		r.increment()
+	case <-t.ticker:
+		t.increment()
 		return true
-	case <-r.stop:
+	case <-t.stop:
 		return false
 	}
 }


### PR DESCRIPTION
It's much more readable to me if the name of the receiver var is uniform in all the funcs for a type.

@brendandburns 
