### PR TITLE
Add a simple hostport-to-service proxy

### DIFF
--- a/contrib/for-demos/proxy-to-service/Dockerfile
+++ b/contrib/for-demos/proxy-to-service/Dockerfile
@@ -1,0 +1,8 @@
+# Alpine linux would be great for this, but it's DNS does not use seach paths.
+FROM progrium/busybox
+MAINTAINER Tim Hockin "thockin@google.com"
+
+RUN opkg-install socat
+
+# Usage: docker run -p <host-port>:<port> <this-container> <tcp|udp> <port> <service-name>
+ENTRYPOINT [ "sh", "-c", "PROTO=$(echo $0 | tr a-z A-Z); exec socat ${PROTO}-LISTEN:$1,reuseaddr,fork ${PROTO}:$2:$1" ]

--- a/contrib/for-demos/proxy-to-service/Makefile
+++ b/contrib/for-demos/proxy-to-service/Makefile
@@ -1,0 +1,17 @@
+# Makefile for the Docker image proxy-to-service
+# MAINTAINER: Tim Hockin <thockin@google.com>
+# If you update this image please bump the tag value before pushing.
+
+.PHONY: all container push
+
+TAG = v1
+PREFIX = gcr.io/google_containers
+NAME = proxy-to-service
+
+all: container
+
+container:
+	docker build -t $(PREFIX)/$(NAME):$(TAG) .
+
+push:
+	gcloud docker push $(PREFIX)/$(NAME):$(TAG)

--- a/contrib/for-demos/proxy-to-service/README.md
+++ b/contrib/for-demos/proxy-to-service/README.md
@@ -1,0 +1,48 @@
+# Proxy a pod port or host port to a kubernetes Service
+
+While Kubernetes provides the ability to map Services to ports on each node,
+those ports are in a special range set aside for allocations.  This means you
+can not not simply choose to expose a Service on port 80 on your nodes.  You
+also can not choose to expose it on some nodes but not others.  These things
+will be fixed in the future, but until then, here is a stop-gap measure you can
+use.
+
+The container image `gcr.io/google_containers/proxy-to-service:v1` is a very
+small container that will do port-forwarding for you.  You can use it to
+forward a pod port or a host port to a service.  Pods can choose any port or
+host port, and are not limited in the same way Services are.
+
+For example, suppose you want to forward a node's port 53 (DNS) to your
+cluster's DNS service.  The following pod would do the trick:
+
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dns-proxy
+spec:
+  containers:
+  - name: proxy-udp
+    image: gcr.io/google_containers/proxy-to-service:v1
+    args: [ "udp", "53", "kube-dns.default" ]
+    ports:
+    - name: udp
+      protocol: UDP
+      containerPort: 53
+      hostPort: 53
+  - name: proxy-tcp
+    image: gcr.io/google_containers/proxy-to-service:v1
+    args: [ "tcp", "53", "kube-dns.default" ]
+    ports:
+    - name: tcp
+      protocol: TCP
+      containerPort: 53
+      hostPort: 53
+```
+
+This creates a pod with two containers (one for TCP, one for UDP).  Each
+container receives traffic on a port (53 here) and forwards that traffic to the
+kube-dns service.  You can run this on as many or as few nodes as you want.
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/contrib/for-demos/proxy-to-service/README.md?pixel)]()


### PR DESCRIPTION
Example: a pod like the  below should
proxy port 53 TCP and UDP to the main DNS service.

```
apiVersion: v1beta3
kind: Pod
metadata:
  name: localhost-dns-proxy
spec:
  containers:
  - name: proxy-udp
    image: thockin/proxy-to-service:1.0
    args: [ "udp", "53", "kube-dns.default" ]
    ports:
    - name: udp
      protocol: UDP
      containerPort: 53
      hostPort: 53
  - name: proxy-tcp
    image: thockin/proxy-to-service:1.0
    args: [ "tcp", "53", "kube-dns.default" ]
    ports:
    - name: tcp
      protocol: TCP
      containerPort: 53
      hostPort: 53
```
