### PR TITLE
log when multiple RCs match a pod

### DIFF
--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -17,8 +17,10 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -209,6 +211,14 @@ func (rm *ReplicationManager) getPodControllers(pod *api.Pod) *api.ReplicationCo
 		glog.V(4).Infof("No controllers found for pod %v, replication manager will avoid syncing", pod.Name)
 		return nil
 	}
+	if len(controllers) > 1 {
+		rcNames := []string{}
+		for _, controller := range controllers {
+			rcNames = append(rcNames, fmt.Sprintf("%s/%s", controller.Namespace, controller.Name))
+		}
+		util.HandleError(fmt.Errorf("Multiple controllers matched for pod %s/%s.  Choosing the first of: %s.", pod.Namespace, pod.Name, strings.Join(rcNames, ", ")))
+	}
+
 	return &controllers[0]
 }
 


### PR DESCRIPTION
Multiple RCs can match a pod.  When that happens, only the first one gets notified.  This results in crazy behavior as one RC scales down and one scales up (as a for instance).

This pull is just about identifying the problem.  I'll see about making selection criteria more specific in a separate pull.

@smarterclayton ptal
