### PR TITLE
Use persistent-claim ReadOnly flag when mounting PVs

### DIFF
--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -45,6 +45,7 @@ type awsElasticBlockStorePlugin struct {
 }
 
 var _ volume.VolumePlugin = &awsElasticBlockStorePlugin{}
+var _ volume.PersistentVolumePlugin = &awsElasticBlockStorePlugin{}
 
 const (
 	awsElasticBlockStorePluginName = "kubernetes.io/aws-ebs"
@@ -74,11 +75,16 @@ func (plugin *awsElasticBlockStorePlugin) NewBuilder(spec *volume.Spec, pod *api
 }
 
 func (plugin *awsElasticBlockStorePlugin) newBuilderInternal(spec *volume.Spec, podUID types.UID, manager ebsManager, mounter mount.Interface) (volume.Builder, error) {
+	// EBSs used directly in a pod have a ReadOnly flag set by the pod author.
+	// EBSs used as a PersistentVolume gets the ReadOnly flag indirectly through the persistent-claim volume used to mount the PV
+	var readOnly bool
 	var ebs *api.AWSElasticBlockStoreVolumeSource
 	if spec.VolumeSource.AWSElasticBlockStore != nil {
 		ebs = spec.VolumeSource.AWSElasticBlockStore
+		readOnly = ebs.ReadOnly
 	} else {
 		ebs = spec.PersistentVolumeSource.AWSElasticBlockStore
+		readOnly = spec.ReadOnly
 	}
 
 	volumeID := ebs.VolumeID
@@ -87,7 +93,6 @@ func (plugin *awsElasticBlockStorePlugin) newBuilderInternal(spec *volume.Spec, 
 	if ebs.Partition != 0 {
 		partition = strconv.Itoa(ebs.Partition)
 	}
-	readOnly := ebs.ReadOnly
 
 	return &awsElasticBlockStore{
 		podUID:      podUID,

--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -240,6 +240,10 @@ func (ebs *awsElasticBlockStore) SetUpAt(dir string) error {
 	return nil
 }
 
+func (pd *awsElasticBlockStore) IsReadOnly() bool {
+	return pd.readOnly
+}
+
 func makeGlobalPDPath(host volume.VolumeHost, volumeID string) string {
 	// Clean up the URI to be more fs-friendly
 	name := volumeID

--- a/pkg/volume/aws_ebs/aws_ebs_test.go
+++ b/pkg/volume/aws_ebs/aws_ebs_test.go
@@ -196,13 +196,13 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))
 	plug, _ := plugMgr.FindPluginByName(awsElasticBlockStorePluginName)
-	spec := volume.NewSpecFromPersistentVolume(pv, false)
 
+	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes
+	spec := volume.NewSpecFromPersistentVolume(pv, true)
 	pod := &api.Pod{ObjectMeta: api.ObjectMeta{UID: types.UID("poduid")}}
 	builder, _ := plug.NewBuilder(spec, pod, volume.VolumeOptions{}, nil)
 
-	if builder.IsReadOnly() {
-		t.Errorf("Expected false for builder.IsReadOnly")
+	if !builder.IsReadOnly() {
+		t.Errorf("Expected true for builder.IsReadOnly")
 	}
-
 }

--- a/pkg/volume/aws_ebs/aws_ebs_test.go
+++ b/pkg/volume/aws_ebs/aws_ebs_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/mount"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
@@ -156,4 +158,51 @@ func TestPlugin(t *testing.T) {
 	} else if !os.IsNotExist(err) {
 		t.Errorf("SetUp() failed: %v", err)
 	}
+}
+
+func TestPersistentClaimReadOnlyFlag(t *testing.T) {
+	pv := &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			Name: "pvA",
+		},
+		Spec: api.PersistentVolumeSpec{
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				AWSElasticBlockStore: &api.AWSElasticBlockStoreVolumeSource{},
+			},
+			ClaimRef: &api.ObjectReference{
+				Name: "claimA",
+			},
+		},
+	}
+
+	claim := &api.PersistentVolumeClaim{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "claimA",
+			Namespace: "nsA",
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			VolumeName: "pvA",
+		},
+		Status: api.PersistentVolumeClaimStatus{
+			Phase: api.ClaimBound,
+		},
+	}
+
+	o := testclient.NewObjects(api.Scheme, api.Scheme)
+	o.Add(pv)
+	o.Add(claim)
+	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}
+
+	plugMgr := volume.VolumePluginMgr{}
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))
+	plug, _ := plugMgr.FindPluginByName(awsElasticBlockStorePluginName)
+	spec := volume.NewSpecFromPersistentVolume(pv, false)
+
+	pod := &api.Pod{ObjectMeta: api.ObjectMeta{UID: types.UID("poduid")}}
+	builder, _ := plug.NewBuilder(spec, pod, volume.VolumeOptions{}, nil)
+
+	if builder.IsReadOnly() {
+		t.Errorf("Expected false for builder.IsReadOnly")
+	}
+
 }

--- a/pkg/volume/empty_dir/empty_dir.go
+++ b/pkg/volume/empty_dir/empty_dir.go
@@ -143,6 +143,10 @@ func (ed *emptyDir) SetUpAt(dir string) error {
 	}
 }
 
+func (ed *emptyDir) IsReadOnly() bool {
+	return false
+}
+
 func (ed *emptyDir) setupDefault(dir string) error {
 	return os.MkdirAll(dir, 0750)
 }

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -229,6 +229,10 @@ func (b *gcePersistentDiskBuilder) SetUpAt(dir string) error {
 	return nil
 }
 
+func (pd *gcePersistentDisk) IsReadOnly() bool {
+	return pd.readOnly
+}
+
 func makeGlobalPDName(host volume.VolumeHost, devName string) string {
 	return path.Join(host.GetPluginDir(gcePersistentDiskPluginName), "mounts", devName)
 }

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -229,8 +229,8 @@ func (b *gcePersistentDiskBuilder) SetUpAt(dir string) error {
 	return nil
 }
 
-func (pd *gcePersistentDisk) IsReadOnly() bool {
-	return pd.readOnly
+func (b *gcePersistentDiskBuilder) IsReadOnly() bool {
+	return b.readOnly
 }
 
 func makeGlobalPDName(host volume.VolumeHost, devName string) string {

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -40,6 +40,7 @@ type gcePersistentDiskPlugin struct {
 }
 
 var _ volume.VolumePlugin = &gcePersistentDiskPlugin{}
+var _ volume.PersistentVolumePlugin = &gcePersistentDiskPlugin{}
 
 const (
 	gcePersistentDiskPluginName = "kubernetes.io/gce-pd"
@@ -70,11 +71,17 @@ func (plugin *gcePersistentDiskPlugin) NewBuilder(spec *volume.Spec, pod *api.Po
 }
 
 func (plugin *gcePersistentDiskPlugin) newBuilderInternal(spec *volume.Spec, podUID types.UID, manager pdManager, mounter mount.Interface) (volume.Builder, error) {
+	// GCEPDs used directly in a pod have a ReadOnly flag set by the pod author.
+	// GCEPDs used as a PersistentVolume gets the ReadOnly flag indirectly through the persistent-claim volume used to mount the PV
+	var readOnly bool
+
 	var gce *api.GCEPersistentDiskVolumeSource
 	if spec.VolumeSource.GCEPersistentDisk != nil {
 		gce = spec.VolumeSource.GCEPersistentDisk
+		readOnly = gce.ReadOnly
 	} else {
 		gce = spec.PersistentVolumeSource.GCEPersistentDisk
+		readOnly = spec.ReadOnly
 	}
 
 	pdName := gce.PDName
@@ -83,7 +90,6 @@ func (plugin *gcePersistentDiskPlugin) newBuilderInternal(spec *volume.Spec, pod
 	if gce.Partition != 0 {
 		partition = strconv.Itoa(gce.Partition)
 	}
-	readOnly := gce.ReadOnly
 
 	return &gcePersistentDiskBuilder{
 		gcePersistentDisk: &gcePersistentDisk{

--- a/pkg/volume/gce_pd/gce_pd_test.go
+++ b/pkg/volume/gce_pd/gce_pd_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/mount"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
@@ -169,5 +171,52 @@ func TestPlugin(t *testing.T) {
 	}
 	if !fakeManager.detachCalled {
 		t.Errorf("Detach watch not called")
+	}
+}
+
+func TestPersistentClaimReadOnlyFlag(t *testing.T) {
+	pv := &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			Name: "pvA",
+		},
+		Spec: api.PersistentVolumeSpec{
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				GCEPersistentDisk: &api.GCEPersistentDiskVolumeSource{},
+			},
+			ClaimRef: &api.ObjectReference{
+				Name: "claimA",
+			},
+		},
+	}
+
+	claim := &api.PersistentVolumeClaim{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "claimA",
+			Namespace: "nsA",
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			VolumeName: "pvA",
+		},
+		Status: api.PersistentVolumeClaimStatus{
+			Phase: api.ClaimBound,
+		},
+	}
+
+	o := testclient.NewObjects(api.Scheme, api.Scheme)
+	o.Add(pv)
+	o.Add(claim)
+	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}
+
+	plugMgr := volume.VolumePluginMgr{}
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))
+	plug, _ := plugMgr.FindPluginByName(gcePersistentDiskPluginName)
+
+	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes
+	spec := volume.NewSpecFromPersistentVolume(pv, true)
+	pod := &api.Pod{ObjectMeta: api.ObjectMeta{UID: types.UID("poduid")}}
+	builder, _ := plug.NewBuilder(spec, pod, volume.VolumeOptions{}, nil)
+
+	if !builder.IsReadOnly() {
+		t.Errorf("Expected true for builder.IsReadOnly")
 	}
 }

--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -118,7 +118,7 @@ func (b *gitRepoVolumeBuilder) SetUp() error {
 	return b.SetUpAt(b.GetPath())
 }
 
-func (gr *gitRepo) IsReadOnly() bool {
+func (b *gitRepoVolumeBuilder) IsReadOnly() bool {
 	return false
 }
 

--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -118,6 +118,10 @@ func (b *gitRepoVolumeBuilder) SetUp() error {
 	return b.SetUpAt(b.GetPath())
 }
 
+func (gr *gitRepo) IsReadOnly() bool {
+	return false
+}
+
 // This is the spec for the volume that this plugin wraps.
 var wrappedVolumeSpec = &volume.Spec{
 	Name:         "not-used",

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -99,7 +99,7 @@ func (plugin *glusterfsPlugin) newBuilderInternal(spec *volume.Spec, ep *api.End
 		},
 		hosts:    ep,
 		path:     source.Path,
-		readonly: readOnly,
+		readOnly: readOnly,
 		exe:      exe}, nil
 }
 
@@ -128,7 +128,8 @@ type glusterfsBuilder struct {
 	*glusterfs
 	hosts    *api.Endpoints
 	path     string
-	readonly bool
+	readOnly bool
+	mounter  mount.Interface
 	exe      exec.Interface
 }
 
@@ -159,6 +160,10 @@ func (b *glusterfsBuilder) SetUpAt(dir string) error {
 	c := &glusterfsCleaner{b.glusterfs}
 	c.cleanup(dir)
 	return err
+}
+
+func (glusterfsVolume *glusterfs) IsReadOnly() bool {
+	return glusterfsVolume.readOnly
 }
 
 func (glusterfsVolume *glusterfs) GetPath() string {
@@ -212,7 +217,7 @@ func (b *glusterfsBuilder) setUpAtInternal(dir string) error {
 	var errs error
 
 	options := []string{}
-	if b.readonly {
+	if glusterfsVolume.readOnly {
 		options = append(options, "ro")
 	}
 

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -129,7 +129,6 @@ type glusterfsBuilder struct {
 	hosts    *api.Endpoints
 	path     string
 	readOnly bool
-	mounter  mount.Interface
 	exe      exec.Interface
 }
 
@@ -162,8 +161,8 @@ func (b *glusterfsBuilder) SetUpAt(dir string) error {
 	return err
 }
 
-func (glusterfsVolume *glusterfs) IsReadOnly() bool {
-	return glusterfsVolume.readOnly
+func (b *glusterfsBuilder) IsReadOnly() bool {
+	return b.readOnly
 }
 
 func (glusterfsVolume *glusterfs) GetPath() string {
@@ -217,7 +216,7 @@ func (b *glusterfsBuilder) setUpAtInternal(dir string) error {
 	var errs error
 
 	options := []string{}
-	if glusterfsVolume.readOnly {
+	if b.readOnly {
 		options = append(options, "ro")
 	}
 

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -39,6 +39,7 @@ type glusterfsPlugin struct {
 }
 
 var _ volume.VolumePlugin = &glusterfsPlugin{}
+var _ volume.PersistentVolumePlugin = &glusterfsPlugin{}
 
 const (
 	glusterfsPluginName = "kubernetes.io/glusterfs"
@@ -65,7 +66,7 @@ func (plugin *glusterfsPlugin) GetAccessModes() []api.PersistentVolumeAccessMode
 }
 
 func (plugin *glusterfsPlugin) NewBuilder(spec *volume.Spec, pod *api.Pod, _ volume.VolumeOptions, mounter mount.Interface) (volume.Builder, error) {
-	source := plugin.getGlusterVolumeSource(spec)
+	source, _ := plugin.getGlusterVolumeSource(spec)
 	ep_name := source.EndpointsName
 	ns := pod.Namespace
 	ep, err := plugin.host.GetKubeClient().Endpoints(ns).Get(ep_name)
@@ -77,16 +78,18 @@ func (plugin *glusterfsPlugin) NewBuilder(spec *volume.Spec, pod *api.Pod, _ vol
 	return plugin.newBuilderInternal(spec, ep, pod, mounter, exec.New())
 }
 
-func (plugin *glusterfsPlugin) getGlusterVolumeSource(spec *volume.Spec) *api.GlusterfsVolumeSource {
+func (plugin *glusterfsPlugin) getGlusterVolumeSource(spec *volume.Spec) (*api.GlusterfsVolumeSource, bool) {
+	// Glusterfs volumes used directly in a pod have a ReadOnly flag set by the pod author.
+	// Glusterfs volumes used as a PersistentVolume gets the ReadOnly flag indirectly through the persistent-claim volume used to mount the PV
 	if spec.VolumeSource.Glusterfs != nil {
-		return spec.VolumeSource.Glusterfs
+		return spec.VolumeSource.Glusterfs, spec.VolumeSource.Glusterfs.ReadOnly
 	} else {
-		return spec.PersistentVolumeSource.Glusterfs
+		return spec.PersistentVolumeSource.Glusterfs, spec.ReadOnly
 	}
 }
 
 func (plugin *glusterfsPlugin) newBuilderInternal(spec *volume.Spec, ep *api.Endpoints, pod *api.Pod, mounter mount.Interface, exe exec.Interface) (volume.Builder, error) {
-	source := plugin.getGlusterVolumeSource(spec)
+	source, readOnly := plugin.getGlusterVolumeSource(spec)
 	return &glusterfsBuilder{
 		glusterfs: &glusterfs{
 			volName: spec.Name,
@@ -96,7 +99,7 @@ func (plugin *glusterfsPlugin) newBuilderInternal(spec *volume.Spec, ep *api.End
 		},
 		hosts:    ep,
 		path:     source.Path,
-		readonly: source.ReadOnly,
+		readonly: readOnly,
 		exe:      exe}, nil
 }
 

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -72,12 +72,12 @@ func (plugin *hostPathPlugin) GetAccessModes() []api.PersistentVolumeAccessMode 
 func (plugin *hostPathPlugin) NewBuilder(spec *volume.Spec, pod *api.Pod, _ volume.VolumeOptions, _ mount.Interface) (volume.Builder, error) {
 	if spec.VolumeSource.HostPath != nil {
 		return &hostPathBuilder{
-			hostPath:     spec.VolumeSource.HostPath,
+			hostPath: &hostPath{path: spec.VolumeSource.HostPath.Path},
 			readOnly: false,
 		}, nil
 	} else {
 		return &hostPathBuilder{
-			hostPath:     spec.PersistentVolumeSource.HostPath,
+			hostPath: &hostPath{path: spec.PersistentVolumeSource.HostPath.Path},
 			readOnly: spec.ReadOnly,
 		}, nil
 	}
@@ -102,7 +102,7 @@ func newRecycler(spec *volume.Spec, host volume.VolumeHost) (volume.Recycler, er
 // HostPath volumes represent a bare host file or directory mount.
 // The direct at the specified path will be directly exposed to the container.
 type hostPath struct {
-	path     string
+	path string
 }
 
 func (hp *hostPath) GetPath() string {

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -119,6 +119,14 @@ func (b *hostPathBuilder) SetUpAt(dir string) error {
 	return fmt.Errorf("SetUpAt() does not make sense for host paths")
 }
 
+func (b *hostPathBuilder) IsReadOnly() bool {
+	return false
+}
+
+func (b *hostPathBuilder) GetPath() string {
+	return b.path
+}
+
 type hostPathCleaner struct {
 	*hostPath
 }

--- a/pkg/volume/host_path/host_path_test.go
+++ b/pkg/volume/host_path/host_path_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
 )
@@ -140,5 +142,52 @@ func TestPlugin(t *testing.T) {
 
 	if err := cleaner.TearDown(); err != nil {
 		t.Errorf("Expected success, got: %v", err)
+	}
+}
+
+func TestPersistentClaimReadOnlyFlag(t *testing.T) {
+	pv := &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			Name: "pvA",
+		},
+		Spec: api.PersistentVolumeSpec{
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				HostPath: &api.HostPathVolumeSource{"foo"},
+			},
+			ClaimRef: &api.ObjectReference{
+				Name: "claimA",
+			},
+		},
+	}
+
+	claim := &api.PersistentVolumeClaim{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "claimA",
+			Namespace: "nsA",
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			VolumeName: "pvA",
+		},
+		Status: api.PersistentVolumeClaimStatus{
+			Phase: api.ClaimBound,
+		},
+	}
+
+	o := testclient.NewObjects(api.Scheme, api.Scheme)
+	o.Add(pv)
+	o.Add(claim)
+	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}
+
+	plugMgr := volume.VolumePluginMgr{}
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))
+	plug, _ := plugMgr.FindPluginByName(hostPathPluginName)
+
+	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes
+	spec := volume.NewSpecFromPersistentVolume(pv, true)
+	pod := &api.Pod{ObjectMeta: api.ObjectMeta{UID: types.UID("poduid")}}
+	builder, _ := plug.NewBuilder(spec, pod, volume.VolumeOptions{}, nil)
+
+	if !builder.IsReadOnly() {
+		t.Errorf("Expected true for builder.IsReadOnly")
 	}
 }

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -183,6 +183,10 @@ type iscsiDiskCleaner struct {
 
 var _ volume.Cleaner = &iscsiDiskCleaner{}
 
+func (b *iscsiDiskBuilder) IsReadOnly() bool {
+	return b.readOnly
+}
+
 // Unmounts the bind mount, and detaches the disk only if the disk
 // resource was the last reference to that disk on the kubelet.
 func (c *iscsiDiskCleaner) TearDown() error {

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -39,6 +39,7 @@ type iscsiPlugin struct {
 }
 
 var _ volume.VolumePlugin = &iscsiPlugin{}
+var _ volume.PersistentVolumePlugin = &iscsiPlugin{}
 
 const (
 	iscsiPluginName = "kubernetes.io/iscsi"
@@ -80,11 +81,16 @@ func (plugin *iscsiPlugin) NewBuilder(spec *volume.Spec, pod *api.Pod, _ volume.
 }
 
 func (plugin *iscsiPlugin) newBuilderInternal(spec *volume.Spec, podUID types.UID, manager diskManager, mounter mount.Interface) (volume.Builder, error) {
+	// iscsi volumes used directly in a pod have a ReadOnly flag set by the pod author.
+	// iscsi volumes used as a PersistentVolume gets the ReadOnly flag indirectly through the persistent-claim volume used to mount the PV
+	var readOnly bool
 	var iscsi *api.ISCSIVolumeSource
 	if spec.VolumeSource.ISCSI != nil {
 		iscsi = spec.VolumeSource.ISCSI
+		readOnly = iscsi.ReadOnly
 	} else {
 		iscsi = spec.PersistentVolumeSource.ISCSI
+		readOnly = spec.ReadOnly
 	}
 
 	lun := strconv.Itoa(iscsi.Lun)
@@ -99,9 +105,8 @@ func (plugin *iscsiPlugin) newBuilderInternal(spec *volume.Spec, podUID types.UI
 			manager: manager,
 			mounter: mounter,
 			plugin:  plugin},
-
 		fsType:   iscsi.FSType,
-		readOnly: iscsi.ReadOnly,
+		readOnly: readOnly,
 	}, nil
 }
 

--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/mount"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
@@ -193,5 +195,57 @@ func TestPluginPersistentVolume(t *testing.T) {
 			},
 		},
 	}
-	doTestPlugin(t, volume.NewSpecFromPersistentVolume(vol))
+	doTestPlugin(t, volume.NewSpecFromPersistentVolume(vol, false))
+}
+
+func TestPersistentClaimReadOnlyFlag(t *testing.T) {
+	pv := &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			Name: "pvA",
+		},
+		Spec: api.PersistentVolumeSpec{
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				ISCSI: &api.ISCSIVolumeSource{
+					TargetPortal: "127.0.0.1:3260",
+					IQN:          "iqn.2014-12.server:storage.target01",
+					FSType:       "ext4",
+					Lun:          0,
+				},
+			},
+			ClaimRef: &api.ObjectReference{
+				Name: "claimA",
+			},
+		},
+	}
+
+	claim := &api.PersistentVolumeClaim{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "claimA",
+			Namespace: "nsA",
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			VolumeName: "pvA",
+		},
+		Status: api.PersistentVolumeClaimStatus{
+			Phase: api.ClaimBound,
+		},
+	}
+
+	o := testclient.NewObjects(api.Scheme, api.Scheme)
+	o.Add(pv)
+	o.Add(claim)
+	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}
+
+	plugMgr := volume.VolumePluginMgr{}
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))
+	plug, _ := plugMgr.FindPluginByName(iscsiPluginName)
+
+	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes
+	spec := volume.NewSpecFromPersistentVolume(pv, true)
+	pod := &api.Pod{ObjectMeta: api.ObjectMeta{UID: types.UID("poduid")}}
+	builder, _ := plug.NewBuilder(spec, pod, volume.VolumeOptions{}, nil)
+
+	if !builder.IsReadOnly() {
+		t.Errorf("Expected true for builder.IsReadOnly")
+	}
 }

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -188,6 +188,15 @@ type nfsCleaner struct {
 	*nfs
 }
 
+func (nfsVolume *nfs) IsReadOnly() bool {
+	return nfsVolume.readOnly
+}
+
+func (nfsVolume *nfs) GetPath() string {
+	name := nfsPluginName
+	return nfsVolume.plugin.host.GetPodVolumeDir(nfsVolume.pod.UID, util.EscapeQualifiedNameForDisk(name), nfsVolume.volName)
+}
+
 var _ volume.Cleaner = &nfsCleaner{}
 
 func (c *nfsCleaner) TearDown() error {

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -187,20 +187,21 @@ func (b *nfsBuilder) SetUpAt(dir string) error {
 	return nil
 }
 
+func (b *nfsBuilder) IsReadOnly() bool {
+	return b.readOnly
+}
+
+//
+//func (c *nfsCleaner) GetPath() string {
+//	name := nfsPluginName
+//	return c.plugin.host.GetPodVolumeDir(c.pod.UID, util.EscapeQualifiedNameForDisk(name), c.volName)
+//}
+
+var _ volume.Cleaner = &nfsCleaner{}
+
 type nfsCleaner struct {
 	*nfs
 }
-
-func (nfsVolume *nfs) IsReadOnly() bool {
-	return nfsVolume.readOnly
-}
-
-func (nfsVolume *nfs) GetPath() string {
-	name := nfsPluginName
-	return nfsVolume.plugin.host.GetPodVolumeDir(nfsVolume.pod.UID, util.EscapeQualifiedNameForDisk(name), nfsVolume.volName)
-}
-
-var _ volume.Cleaner = &nfsCleaner{}
 
 func (c *nfsCleaner) TearDown() error {
 	return c.TearDownAt(c.GetPath())

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -76,11 +76,13 @@ func (plugin *nfsPlugin) NewBuilder(spec *volume.Spec, pod *api.Pod, _ volume.Vo
 
 func (plugin *nfsPlugin) newBuilderInternal(spec *volume.Spec, pod *api.Pod, mounter mount.Interface) (volume.Builder, error) {
 	var source *api.NFSVolumeSource
-
+	var readOnly bool
 	if spec.VolumeSource.NFS != nil {
 		source = spec.VolumeSource.NFS
+		readOnly = spec.VolumeSource.NFS.ReadOnly
 	} else {
 		source = spec.PersistentVolumeSource.NFS
+		readOnly = spec.ReadOnly
 	}
 	return &nfsBuilder{
 		nfs: &nfs{
@@ -91,7 +93,8 @@ func (plugin *nfsPlugin) newBuilderInternal(spec *volume.Spec, pod *api.Pod, mou
 		},
 		server:     source.Server,
 		exportPath: source.Path,
-		readOnly:   source.ReadOnly}, nil
+		readOnly:   readOnly,
+	}, nil
 }
 
 func (plugin *nfsPlugin) NewCleaner(volName string, podUID types.UID, mounter mount.Interface) (volume.Cleaner, error) {

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/mount"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
@@ -199,5 +201,52 @@ func TestPluginPersistentVolume(t *testing.T) {
 		},
 	}
 
-	doTestPlugin(t, volume.NewSpecFromPersistentVolume(vol))
+	doTestPlugin(t, volume.NewSpecFromPersistentVolume(vol, false))
+}
+
+func TestPersistentClaimReadOnlyFlag(t *testing.T) {
+	pv := &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			Name: "pvA",
+		},
+		Spec: api.PersistentVolumeSpec{
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				NFS: &api.NFSVolumeSource{},
+			},
+			ClaimRef: &api.ObjectReference{
+				Name: "claimA",
+			},
+		},
+	}
+
+	claim := &api.PersistentVolumeClaim{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "claimA",
+			Namespace: "nsA",
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			VolumeName: "pvA",
+		},
+		Status: api.PersistentVolumeClaimStatus{
+			Phase: api.ClaimBound,
+		},
+	}
+
+	o := testclient.NewObjects(api.Scheme, api.Scheme)
+	o.Add(pv)
+	o.Add(claim)
+	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}
+
+	plugMgr := volume.VolumePluginMgr{}
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))
+	plug, _ := plugMgr.FindPluginByName(nfsPluginName)
+
+	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes
+	spec := volume.NewSpecFromPersistentVolume(pv, true)
+	pod := &api.Pod{ObjectMeta: api.ObjectMeta{UID: types.UID("poduid")}}
+	builder, _ := plug.NewBuilder(spec, pod, volume.VolumeOptions{}, nil)
+
+	if !builder.IsReadOnly() {
+		t.Errorf("Expected true for builder.IsReadOnly")
+	}
 }

--- a/pkg/volume/persistent_claim/persistent_claim.go
+++ b/pkg/volume/persistent_claim/persistent_claim.go
@@ -53,7 +53,6 @@ func (plugin *persistentClaimPlugin) CanSupport(spec *volume.Spec) bool {
 }
 
 func (plugin *persistentClaimPlugin) NewBuilder(spec *volume.Spec, pod *api.Pod, opts volume.VolumeOptions, mounter mount.Interface) (volume.Builder, error) {
-	plugin.readOnly = spec.ReadOnly
 	claim, err := plugin.host.GetKubeClient().PersistentVolumeClaims(pod.Namespace).Get(spec.VolumeSource.PersistentVolumeClaim.ClaimName)
 	if err != nil {
 		glog.Errorf("Error finding claim: %+v\n", spec.VolumeSource.PersistentVolumeClaim.ClaimName)

--- a/pkg/volume/persistent_claim/persistent_claim.go
+++ b/pkg/volume/persistent_claim/persistent_claim.go
@@ -78,7 +78,7 @@ func (plugin *persistentClaimPlugin) NewBuilder(spec *volume.Spec, pod *api.Pod,
 		return nil, err
 	}
 
-	builder, err := plugin.host.NewWrapperBuilder(volume.NewSpecFromPersistentVolume(pv), pod, opts, mounter)
+	builder, err := plugin.host.NewWrapperBuilder(volume.NewSpecFromPersistentVolume(pv, spec.ReadOnly), pod, opts, mounter)
 	if err != nil {
 		glog.Errorf("Error creating builder for claim: %+v\n", claim.Name)
 		return nil, err

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -134,6 +134,7 @@ type Spec struct {
 	Name                   string
 	VolumeSource           api.VolumeSource
 	PersistentVolumeSource api.PersistentVolumeSource
+	ReadOnly               bool
 }
 
 // NewSpecFromVolume creates an Spec from an api.Volume
@@ -145,10 +146,11 @@ func NewSpecFromVolume(vs *api.Volume) *Spec {
 }
 
 // NewSpecFromPersistentVolume creates an Spec from an api.PersistentVolume
-func NewSpecFromPersistentVolume(pv *api.PersistentVolume) *Spec {
+func NewSpecFromPersistentVolume(pv *api.PersistentVolume, readOnly bool) *Spec {
 	return &Spec{
 		Name: pv.Name,
 		PersistentVolumeSource: pv.Spec.PersistentVolumeSource,
+		ReadOnly:               readOnly,
 	}
 }
 

--- a/pkg/volume/plugins_test.go
+++ b/pkg/volume/plugins_test.go
@@ -43,7 +43,7 @@ func TestSpecSourceConverters(t *testing.T) {
 		},
 	}
 
-	converted = NewSpecFromPersistentVolume(pv)
+	converted = NewSpecFromPersistentVolume(pv, false)
 	if converted.PersistentVolumeSource.AWSElasticBlockStore == nil {
 		t.Errorf("Unexpected nil AWSElasticBlockStore: %+v", converted)
 	}

--- a/pkg/volume/rbd/disk_manager.go
+++ b/pkg/volume/rbd/disk_manager.go
@@ -62,11 +62,7 @@ func diskSetUp(manager diskManager, b rbdBuilder, volPath string, mounter mount.
 	}
 	// Perform a bind mount to the full path to allow duplicate mounts of the same disk.
 	options := []string{"bind"}
-<<<<<<< HEAD
-	if b.ReadOnly {
-=======
-	if disk.readOnly {
->>>>>>> rebased and updated to latest
+	if b.IsReadOnly() {
 		options = append(options, "ro")
 	}
 	err = mounter.Mount(globalPDPath, volPath, "", options)

--- a/pkg/volume/rbd/disk_manager.go
+++ b/pkg/volume/rbd/disk_manager.go
@@ -62,7 +62,11 @@ func diskSetUp(manager diskManager, b rbdBuilder, volPath string, mounter mount.
 	}
 	// Perform a bind mount to the full path to allow duplicate mounts of the same disk.
 	options := []string{"bind"}
+<<<<<<< HEAD
 	if b.ReadOnly {
+=======
+	if disk.readOnly {
+>>>>>>> rebased and updated to latest
 		options = append(options, "ro")
 	}
 	err = mounter.Mount(globalPDPath, volPath, "", options)

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -216,6 +216,10 @@ type rbdCleaner struct {
 
 var _ volume.Cleaner = &rbdCleaner{}
 
+func (b *rbd) IsReadOnly() bool {
+	return b.ReadOnly
+}
+
 // Unmounts the bind mount, and detaches the disk only if the disk
 // resource was the last reference to that disk on the kubelet.
 func (c *rbdCleaner) TearDown() error {

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -39,6 +39,7 @@ type rbdPlugin struct {
 }
 
 var _ volume.VolumePlugin = &rbdPlugin{}
+var _ volume.PersistentVolumePlugin = &rbdPlugin{}
 
 const (
 	rbdPluginName = "kubernetes.io/rbd"
@@ -74,7 +75,7 @@ func (plugin *rbdPlugin) GetAccessModes() []api.PersistentVolumeAccessMode {
 
 func (plugin *rbdPlugin) NewBuilder(spec *volume.Spec, pod *api.Pod, _ volume.VolumeOptions, mounter mount.Interface) (volume.Builder, error) {
 	secret := ""
-	source := plugin.getRBDVolumeSource(spec)
+	source, _ := plugin.getRBDVolumeSource(spec)
 
 	if source.SecretRef != nil {
 		kubeClient := plugin.host.GetKubeClient()
@@ -97,16 +98,18 @@ func (plugin *rbdPlugin) NewBuilder(spec *volume.Spec, pod *api.Pod, _ volume.Vo
 	return plugin.newBuilderInternal(spec, pod.UID, &RBDUtil{}, mounter, secret)
 }
 
-func (plugin *rbdPlugin) getRBDVolumeSource(spec *volume.Spec) *api.RBDVolumeSource {
+func (plugin *rbdPlugin) getRBDVolumeSource(spec *volume.Spec) (*api.RBDVolumeSource, bool) {
+	// rbd volumes used directly in a pod have a ReadOnly flag set by the pod author.
+	// rbd volumes used as a PersistentVolume gets the ReadOnly flag indirectly through the persistent-claim volume used to mount the PV
 	if spec.VolumeSource.RBD != nil {
-		return spec.VolumeSource.RBD
+		return spec.VolumeSource.RBD, spec.VolumeSource.RBD.ReadOnly
 	} else {
-		return spec.PersistentVolumeSource.RBD
+		return spec.PersistentVolumeSource.RBD, spec.ReadOnly
 	}
 }
 
 func (plugin *rbdPlugin) newBuilderInternal(spec *volume.Spec, podUID types.UID, manager diskManager, mounter mount.Interface, secret string) (volume.Builder, error) {
-	source := plugin.getRBDVolumeSource(spec)
+	source, readOnly := plugin.getRBDVolumeSource(spec)
 	pool := source.RBDPool
 	if pool == "" {
 		pool = "rbd"
@@ -126,7 +129,7 @@ func (plugin *rbdPlugin) newBuilderInternal(spec *volume.Spec, podUID types.UID,
 			volName:  spec.Name,
 			Image:    source.RBDImage,
 			Pool:     pool,
-			ReadOnly: source.ReadOnly,
+			ReadOnly: readOnly,
 			manager:  manager,
 			mounter:  mounter,
 			plugin:   plugin,

--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -161,11 +161,7 @@ func (util *RBDUtil) loadRBD(rbd *rbd, mnt string) error {
 
 func (util *RBDUtil) fencing(b rbdBuilder) error {
 	// no need to fence readOnly
-<<<<<<< HEAD
-	if b.ReadOnly {
-=======
-	if rbd.readOnly {
->>>>>>> rebased and updated to latest
+	if b.IsReadOnly() {
 		return nil
 	}
 	return util.rbdLock(b, true)
@@ -173,11 +169,7 @@ func (util *RBDUtil) fencing(b rbdBuilder) error {
 
 func (util *RBDUtil) defencing(c rbdCleaner) error {
 	// no need to fence readOnly
-<<<<<<< HEAD
 	if c.ReadOnly {
-=======
-	if rbd.readOnly {
->>>>>>> rebased and updated to latest
 		return nil
 	}
 

--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -161,7 +161,11 @@ func (util *RBDUtil) loadRBD(rbd *rbd, mnt string) error {
 
 func (util *RBDUtil) fencing(b rbdBuilder) error {
 	// no need to fence readOnly
+<<<<<<< HEAD
 	if b.ReadOnly {
+=======
+	if rbd.readOnly {
+>>>>>>> rebased and updated to latest
 		return nil
 	}
 	return util.rbdLock(b, true)
@@ -169,7 +173,11 @@ func (util *RBDUtil) fencing(b rbdBuilder) error {
 
 func (util *RBDUtil) defencing(c rbdCleaner) error {
 	// no need to fence readOnly
+<<<<<<< HEAD
 	if c.ReadOnly {
+=======
+	if rbd.readOnly {
+>>>>>>> rebased and updated to latest
 		return nil
 	}
 

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -168,6 +168,10 @@ func (b *secretVolumeBuilder) SetUpAt(dir string) error {
 	return nil
 }
 
+func (sv *secretVolume) IsReadOnly() bool {
+	return false
+}
+
 func totalSecretBytes(secret *api.Secret) int {
 	totalSize := 0
 	for _, bytes := range secret.Data {

--- a/pkg/volume/testing.go
+++ b/pkg/volume/testing.go
@@ -127,6 +127,10 @@ func (fv *FakeVolume) SetUpAt(dir string) error {
 	return os.MkdirAll(dir, 0750)
 }
 
+func (fv *FakeVolume) IsReadOnly() bool {
+	return false
+}
+
 func (fv *FakeVolume) GetPath() string {
 	return path.Join(fv.Plugin.Host.GetPodVolumeDir(fv.PodUID, util.EscapeQualifiedNameForDisk(fv.Plugin.PluginName), fv.VolName))
 }

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -41,6 +41,9 @@ type Builder interface {
 	// directory path, which may or may not exist yet.  This may be called
 	// more than once, so implementations must be idempotent.
 	SetUpAt(dir string) error
+	// IsReadOnly is a flag that gives the builder's ReadOnly attribute.
+	// All persistent volumes have a private readOnly flag in their builders.
+	IsReadOnly() bool
 }
 
 // Cleaner interface provides methods to cleanup/unmount the volumes.

--- a/pkg/volumeclaimbinder/persistent_volume_recycler.go
+++ b/pkg/volumeclaimbinder/persistent_volume_recycler.go
@@ -123,7 +123,7 @@ func (recycler *PersistentVolumeRecycler) handleRecycle(pv *api.PersistentVolume
 	currentPhase := pv.Status.Phase
 	nextPhase := currentPhase
 
-	spec := volume.NewSpecFromPersistentVolume(pv)
+	spec := volume.NewSpecFromPersistentVolume(pv, false)
 	plugin, err := recycler.pluginMgr.FindRecyclablePluginBySpec(spec)
 	if err != nil {
 		return fmt.Errorf("Could not find recyclable volume plugin for spec: %+v", err)


### PR DESCRIPTION
Resolves #10244 

A valid use case is GCEPD:   Mounted once read/write or mounted many times read-only.

@thockin 

will add unit tests for each volume effected.
