### PR TITLE
Use blank default for old-etcd-prefix

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -118,7 +118,6 @@ func NewAPIServer() *APIServer {
 		AuthorizationMode:      "AlwaysAllow",
 		AdmissionControl:       "AlwaysAdmit",
 		EtcdPathPrefix:         master.DefaultEtcdPathPrefix,
-		OldEtcdPathPrefix:      master.DefaultEtcdPathPrefix,
 		EnableLogsSupport:      true,
 		MasterServiceNamespace: api.NamespaceDefault,
 		ClusterName:            "kubernetes",


### PR DESCRIPTION
On new installations, just specifying --etc-prefix will cause a failure because it will always run the etcd key migration code (old-etcd-prefix is defaulting to "/registry")

It seems odd to have to specify both --etcd-prefix and --old-etcd-prefix to actually use that prefix, when old prefix should probably only be used if actually migrating data.
