### PR TITLE
Handle overlapping controllers semi-deterministically

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -289,6 +289,19 @@ func (s activePods) Less(i, j int) bool {
 	return false
 }
 
+// overlappingControllers sorts a list of controllers by creation timestamp, using their names as a tie breaker.
+type overlappingControllers []api.ReplicationController
+
+func (o overlappingControllers) Len() int      { return len(o) }
+func (o overlappingControllers) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
+
+func (o overlappingControllers) Less(i, j int) bool {
+	if o[i].CreationTimestamp.Equal(o[j].CreationTimestamp) {
+		return o[i].Name < o[j].Name
+	}
+	return o[i].CreationTimestamp.Before(o[j].CreationTimestamp)
+}
+
 // filterActivePods returns pods that have not terminated.
 func filterActivePods(pods []api.Pod) []*api.Pod {
 	var result []*api.Pod

--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -209,6 +209,7 @@ func (rm *ReplicationManager) getPodControllers(pod *api.Pod) *api.ReplicationCo
 		glog.V(4).Infof("No controllers found for pod %v, replication manager will avoid syncing", pod.Name)
 		return nil
 	}
+	sort.Sort(overlappingControllers(controllers))
 	return &controllers[0]
 }
 

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -1108,3 +1108,45 @@ func TestRCManagerNotReady(t *testing.T) {
 	manager.syncReplicationController(rcKey)
 	validateSyncReplication(t, &fakePodControl, 1, 0)
 }
+
+// shuffle returns a new shuffled list of container controllers.
+func shuffle(controllers []*api.ReplicationController) []*api.ReplicationController {
+	numControllers := len(controllers)
+	randIndexes := rand.Perm(numControllers)
+	shuffled := make([]*api.ReplicationController, numControllers)
+	for i := 0; i < numControllers; i++ {
+		shuffled[i] = controllers[randIndexes[i]]
+	}
+	return shuffled
+}
+
+func TestOverlappingRCs(t *testing.T) {
+	client := client.NewOrDie(&client.Config{Host: "", Version: testapi.Version()})
+
+	for i := 0; i < 5; i++ {
+		manager := NewReplicationManager(client, 10)
+		manager.podStoreSynced = alwaysReady
+
+		// Create 10 rcs, shuffled them randomly and insert them into the rc manager's store
+		var controllers []*api.ReplicationController
+		for j := 1; j < 10; j++ {
+			controllerSpec := newReplicationController(1)
+			controllerSpec.CreationTimestamp = util.Date(2014, time.December, j, 0, 0, 0, 0, time.Local)
+			controllerSpec.Name = string(util.NewUUID())
+			controllers = append(controllers, controllerSpec)
+		}
+		shuffledControllers := shuffle(controllers)
+		for j, _ := range shuffledControllers {
+			manager.controllerStore.Store.Add(shuffledControllers[j])
+		}
+		// Add a pod and make sure only the oldest rc is synced
+		pods := newPodList(nil, 1, api.PodPending, controllers[0])
+		rcKey := getKey(controllers[0], t)
+
+		manager.addPod(&pods.Items[0])
+		queueRC, _ := manager.queue.Get()
+		if queueRC != rcKey {
+			t.Fatalf("Expected to find key %v in queue, found %v", rcKey, queueRC)
+		}
+	}
+}

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -59,6 +59,11 @@ func (t Time) Before(u Time) bool {
 	return t.Time.Before(u.Time)
 }
 
+// Equal reports whether the time instant t is equal to u.
+func (t Time) Equal(u Time) bool {
+	return t.Time.Equal(u.Time)
+}
+
 // Unix returns the local time corresponding to the given Unix time
 // by wrapping time.Unix.
 func Unix(sec int64, nsec int64) Time {


### PR DESCRIPTION
If the rc manager finds multiple controllers for a pod, it sorts them based on creation time, using rc name as a tie breaker. Watch latencies or creation delays with -f -dirname- could still lead to some level of non-determinism, but for the most part this should be OK.

@lavalamp 
