### PR TITLE
Remove the dead code checking kind empty

### DIFF
--- a/pkg/kubectl/resource/mapper.go
+++ b/pkg/kubectl/resource/mapper.go
@@ -47,9 +47,6 @@ func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to get type info from %q: %v", source, err)
 	}
-	if kind == "" {
-		return nil, fmt.Errorf("kind not set in %q", source)
-	}
 	mapping, err := m.RESTMapping(kind, version)
 	if err != nil {
 		return nil, fmt.Errorf("unable to recognize %q: %v", source, err)


### PR DESCRIPTION
In runtime.UnstructuredJSONScheme.DataVersionAndKind(data) function, it has already checked whether the kind is empty, so I remove the dead code in InfoForData function.
