### PR TITLE
Configure lower NFS grace period.

### DIFF
--- a/test/images/volumes-tester/nfs/Dockerfile
+++ b/test/images/volumes-tester/nfs/Dockerfile
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:14.04
+FROM centos
 MAINTAINER Jan Safranek, jsafrane@redhat.com
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update -qq && apt-get install -y nfs-kernel-server -qq
+RUN yum -y install /usr/bin/ps nfs-utils && yum clean all
 RUN mkdir -p /exports
 ADD run_nfs.sh /usr/local/bin/
 ADD index.html /exports/index.html

--- a/test/images/volumes-tester/nfs/Makefile
+++ b/test/images/volumes-tester/nfs/Makefile
@@ -1,6 +1,6 @@
 all: push
 
-TAG = 0.2
+TAG = 0.3
 
 container:
 	docker build -t gcr.io/google_containers/volume-nfs . # Build new image and automatically tag it as latest

--- a/test/images/volumes-tester/nfs/run_nfs.sh
+++ b/test/images/volumes-tester/nfs/run_nfs.sh
@@ -31,7 +31,8 @@ function start()
     /usr/sbin/rpc.mountd -N 2 -N 3 -V 4 -V 4.1
 
     /usr/sbin/exportfs -r
-    /usr/sbin/rpc.nfsd -N 2 -N 3 -V 4 -V 4.1 2
+    # -G 10 to reduce grace time to 10 seconds (the lowest allowed)
+    /usr/sbin/rpc.nfsd -G 10 -N 2 -N 3 -V 4 -V 4.1 2
 
     echo "NFS started"
 }


### PR DESCRIPTION
e2e tests for NFS is quite slow due to NFS grace period. This patch lowers it to 10 seconds (i.e. the NFS server is actually usable after 10 seconds and not 90 as before).

Also, I rebased the images to CentOS to get better rpc.nfsd and ~40 MB smaller images.
