### PR TITLE
make pod/RC matches check respect CreatedBy annotation

### DIFF
--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+const (
+	CreatedByAnnotation = "kubernetes.io/created-by"
+)

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -31,8 +31,7 @@ import (
 )
 
 const (
-	CreatedByAnnotation = "kubernetes.io/created-by"
-	updateRetries       = 1
+	updateRetries = 1
 )
 
 // Expectations are a way for replication controllers to tell the rc manager what they expect. eg:
@@ -231,7 +230,7 @@ func (r RealPodControl) createReplica(namespace string, controller *api.Replicat
 		return fmt.Errorf("unable to serialize controller reference: %v", err)
 	}
 
-	desiredAnnotations[CreatedByAnnotation] = string(createdByRefJson)
+	desiredAnnotations[api.CreatedByAnnotation] = string(createdByRefJson)
 
 	// use the dash (if the name isn't too long) to make the pod name a bit prettier
 	prefix := fmt.Sprintf("%s-", controller.Name)
@@ -298,6 +297,18 @@ func filterActivePods(pods []api.Pod) []*api.Pod {
 			result = append(result, &pods[i])
 		}
 	}
+	return result
+}
+
+// filterPodsOnMatching returns pods that match the RC
+func filterPodsOnMatching(pods []*api.Pod, rc *api.ReplicationController) []*api.Pod {
+	var result []*api.Pod
+	for i := range pods {
+		if cache.PodMatchesRC(pods[i], rc) {
+			result = append(result, pods[i])
+		}
+	}
+
 	return result
 }
 

--- a/pkg/controller/replication_controller.go
+++ b/pkg/controller/replication_controller.go
@@ -396,7 +396,9 @@ func (rm *ReplicationManager) syncReplicationController(key string) error {
 	}
 
 	// TODO: Do this in a single pass, or use an index.
-	filteredPods := filterActivePods(podList.Items)
+	activePods := filterActivePods(podList.Items)
+	filteredPods := filterPodsOnMatching(activePods, &controller)
+
 	if rcNeedsSync {
 		rm.manageReplicas(filteredPods, &controller)
 	}


### PR DESCRIPTION
Follow on to https://github.com/GoogleCloudPlatform/kubernetes/pull/10415

This makes the the "matches" check between an RC and a pod respect the CreatedBy annotation.  If a pod doesn't have an "CreatedBy" annotation, then a match between the RC selector is considered sufficient for a match.  If the pod does have a "CreatedBy" annotation, then the annotation's UID must match the RC UID to be considered a match.  This alleviates problems of having a single pod match multiple unrelated RCs.

By respecting strong ownership when the information is present, pods created by one RC will not confuse another RC, but if a user wants to do something crazy like create their own pods for the RC to kill they can still do that.

On a related note, what is the use-case for allowing RCs to delete pods they did not create?

/cc from other discussion @smarterclayton @lavalamp @bgrant0607 @bprashanth @roberthbailey
