### PR TITLE
Changed ISCSI plugin name from exported to private

### DIFF
--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -106,7 +106,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	}
 	fakeManager := &fakeDiskManager{}
 	fakeMounter := &mount.FakeMounter{}
-	builder, err := plug.(*ISCSIPlugin).newBuilderInternal(spec, types.UID("poduid"), fakeManager, fakeMounter)
+	builder, err := plug.(*iscsiPlugin).newBuilderInternal(spec, types.UID("poduid"), fakeManager, fakeMounter)
 	if err != nil {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
@@ -141,7 +141,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	}
 
 	fakeManager = &fakeDiskManager{}
-	cleaner, err := plug.(*ISCSIPlugin).newCleanerInternal("vol1", types.UID("poduid"), fakeManager, fakeMounter)
+	cleaner, err := plug.(*iscsiPlugin).newCleanerInternal("vol1", types.UID("poduid"), fakeManager, fakeMounter)
 	if err != nil {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}

--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -69,7 +69,7 @@ func getDevicePrefixRefCount(mounter mount.Interface, deviceNamePrefix string) (
 
 // make a directory like /var/lib/kubelet/plugins/kubernetes.io/pod/iscsi/portal-iqn-some_iqn-lun-0
 func makePDNameInternal(host volume.VolumeHost, portal string, iqn string, lun string) string {
-	return path.Join(host.GetPluginDir(ISCSIPluginName), "iscsi", portal+"-iqn-"+iqn+"-lun-"+lun)
+	return path.Join(host.GetPluginDir(iscsiPluginName), "iscsi", portal+"-iqn-"+iqn+"-lun-"+lun)
 }
 
 type ISCSIUtil struct{}


### PR DESCRIPTION
Private implementations are consistent with the other volumes.

Variable name change only.  No API changes, no behavior changes.

@thockin  @rootfs 
