### PR TITLE
Make kubectl proxy serve ui from server.

### DIFF
--- a/pkg/kubectl/proxy_server.go
+++ b/pkg/kubectl/proxy_server.go
@@ -152,6 +152,12 @@ func NewProxyServer(filebase string, apiProxyPrefix string, staticPrefix string,
 		// Require user to explicitly request this behavior rather than
 		// serving their working directory by default.
 		mux.Handle(staticPrefix, newFileHandler(staticPrefix, filebase))
+	} else {
+		if !strings.HasPrefix(staticPrefix, "/static") {
+			proxyServer = stripLeaveSlash(staticPrefix, proxyServer)
+		}
+
+		mux.Handle(staticPrefix, proxyServer)
 	}
 	return &ProxyServer{handler: mux}, nil
 }


### PR DESCRIPTION
Currently, kubectl proxy serves static files from a local directory, if requested by a flag. If the flag is not present, it doesn't serve any static files. There is currently no way to serve the compiled static ui files from the server. This small change makes kubectl proxy serve static files from the api server, if no local directory is specified for static files.
