### PR TITLE
Fix Vagrant kube-up - missed file watch on systemd stops kubelet starting on initial kube-up

### DIFF
--- a/cluster/saltbase/salt/kubelet/init.sls
+++ b/cluster/saltbase/salt/kubelet/init.sls
@@ -72,5 +72,8 @@ kubelet:
 {% if grains['os_family'] != 'RedHat' %}
       - file: /etc/init.d/kubelet
 {% endif %}
+{% if grains['os_family'] == 'RedHat' %}
+      - file: /usr/lib/systemd/system/kubelet.service
+{% endif %}
       - file: {{ environment_file }}
       - file: /var/lib/kubelet/kubernetes_auth


### PR DESCRIPTION
The Kubelet was not starting because service.running phase of Kubelet was executing before the service file was authored to disk when on systemd environment.

Fixes #10522 
