### PR TITLE
Create HTTP cloudprovider

### DIFF
--- a/docs/design/http-cloud-provider.md
+++ b/docs/design/http-cloud-provider.md
@@ -1,0 +1,536 @@
+<!-- BEGIN MUNGE: UNVERSIONED_WARNING -->
+
+<!-- BEGIN STRIP_FOR_RELEASE -->
+
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+
+<h2>PLEASE NOTE: This document applies to the HEAD of the source tree</h2>
+
+If you are using a released version of Kubernetes, you should
+refer to the docs that go with that version.
+
+<strong>
+The latest 1.0.x release of this document can be found
+[here](http://releases.k8s.io/release-1.0/docs/http-cloud-provider.md).
+
+Documentation for other releases can be found at
+[releases.k8s.io](http://releases.k8s.io).
+</strong>
+--
+
+<!-- END STRIP_FOR_RELEASE -->
+
+<!-- END MUNGE: UNVERSIONED_WARNING -->
+
+# HTTP Cloudprovider
+
+# Motivation
+
+Currently, the cloudproviders are designed so that they get directly compiled into kubernetes. It is very hard to add custom cloudproviders to the kubernetes platform without using a custom build of kubernetes. Therefore, we would like to build an HTTP Cloudprovider which would be able to send a HTTP request by converting the cloudprovider interfaces to an HTTP API. The cloudprovider would need an HTTP endpoint so that kubernetes would be able to send a request to them and then the cloudproviders would be able to send the desired service information back to kubernetes.
+
+# Specification
+
+The user should specify a config file in JSON format. The **clientURL** field is required which specifies the URL and port of the cloud provider.
+
+##### Example Config File:
+
+```json
+{
+    "clientURL" :"http://127.0.0.1:8080"
+}
+```
+
+First the API checks for which interfaces in [cloud.go](../pkg/cloudprovider/cloud.go) are implemented.
+
+A OPTIONS request for /cloudprovider/v1aplha1/{Interface} will return whether the interface is supported (200 Response Code) or not (501 Not Implemented Response Code).
+
+The following methods must be implemented by the HTTP cloudprovider.
+
+If you encounter an error in processing the request, return an HTTP 404 with a response body matching [api.Status](https://github.com/kubernetes/kubernetes/blob/master/pkg/api/v1/types.go#L1586-L1607)
+
+
+## Provider Name
+
+#### GET /cloudprovider/v1aplha1/providerName
+
+Returns the cloud provider name.
+
+##### Expected return value:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|providerName|Name of the cloud provider.|"my-cloud"|
+Example
+
+```json
+{
+    "providerName": "my-cloud"
+}
+```
+
+## Instances
+
+The instances interface allows the kubernetes platform to query the cloud provider about the instances currently within the cloud provider system.
+
+### Methods
+
+#### OPTIONS /cloudprovider/v1aplha1/instances
+
+Returns whether the Instance interface is supported or not.
+
+##### Expected return value:
+
+Empty 200 Response if supported else 501 Response
+
+
+#### GET /cloudprovider/v1aplha1/instances/{instanceName}/nodeAddresses
+
+Returns all node addresses for the given instance.
+
+##### Expected return value:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|nodeAddresses|List of node adress objects.||
+|nodeAddresses:type|The IP type relate to the node address. The types of addresses are restricted to the list below.|"InternalIP"|
+|nodeAddresses:address|The actual node's address.|"127.0.0.1"|
+
+Address Types
+
+|Name|Description|
+|----|-----------|
+|InternalIP|The node's Internal IP address.|
+|ExternalIP|The node's External IP address.|
+|Hostname|The hostname of the node.|
+|LegacyHostIP|The node's Host IP address.|
+Example
+
+```json
+{
+    "nodeAddresses": [
+        {
+            "type": "InternalIP",
+            "address": "127.0.0.1"
+        }
+    ]
+}
+```
+
+#### GET /cloudprovider/v1aplha1/instances/{instanceName}/ID
+
+Returns the Instance ID for the given instance.
+
+##### Expected return value:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|instanceID|ID of the cloud provider.|"my-cloud-name1"|
+Example
+
+```json
+{
+    "instanceID": "my-cloud-name1"
+}
+```
+
+#### GET /cloudprovider/v1aplha1/instances/{FQDN}
+
+Returns all instances where the name matches the word FQDN. FQDN is a go regular expression.
+
+##### Expected return value:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|instances|List of all instances matching the FQDN.||
+|instances:instanceName|Name of the instance.|"cloud-1"|
+Example
+
+```json
+{
+    "instances": [
+        {
+            "instanceName": "cloud-1"
+        }
+    ]
+}
+```
+
+
+#### GET /cloudprovider/v1aplha1/instances/node/{hostName}
+
+Returns the name of the node which is related to the specific host.
+
+##### Expected return value:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|nodeName|The name of the node in the host|"my-node"|
+Example
+
+```json
+{
+    "nodeName": "my-node"
+}
+```
+
+#### POST /cloudprovider/v1aplha1/instances/sshKey
+
+Adds the SSH Key provided to all the instances. Returns whether the key was added or not.
+
+##### Sender body:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|user|The user's whose SSH key needs to be added.|"name"|
+|keydata|The actual ssh key. Any format allowed not restricted to strings.|"zPjoihsswRTGIUHKLHIHO345@435"|
+Example
+
+```json
+{
+    "user": "name",
+    "keyData": "zPjoihsswRTGIUHKLHIHO345@435"
+}
+```
+
+##### Expected Return Value:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|SSHKeyAdded|Boolean value regarding whether the SSH Key was added or not.|false|
+Example
+
+```json
+{
+    "SSHKeyAdded": false
+}
+```
+
+## TCPLoadBalancers
+
+The TCPLoadBalancers interface allows the kubernetes platform to query the cloud provider about the Load Balancer the cloud provider has and requests to change the load balancer as required.
+
+### Methods
+
+#### OPTIONS /cloudprovider/v1aplha1/tcpLoadBalancers
+
+Know whether the interface is supported or not.
+
+##### Expected return value:
+
+Empty 200 Response if supported else 501 Response
+
+#### GET /cloudprovider/v1aplha1/tcpLoadBalancers/{region}/{name}
+
+Returns the TCP Load Balancer Status if it exists in the region with the particular name.
+
+##### Expected return value:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|ingress|List of ingress points for the load balancer.||
+|ingress:ip|The IP address of the ingress point. This is a optional field as only one of IP or hostname is required.|"127.0.0.1"|
+|ingress:hostname|The hostname of the ingress point. This is a optional field as only one of IP or hostname is required.|"my-cloud-host1"|
+|exists|Whether the TCP Load Balancer exists or not.|true|
+Example
+
+```json
+{
+    "ingress": [
+        {
+            "ip":"127.0.0.1",
+            "hostname":"my-cloud-host1"
+        }
+    ],
+    "exists":true
+}
+```
+
+#### POST /cloudprovider/v1aplha1/tcpLoadBalancers
+
+Creates a new tcp load balancer and return the status of the balancer.
+
+##### Sender body:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|loadBalancerName|The name of the TCP load balancer.|"my-tcp-balancer"|
+|region|The location of the load balancer.|"USA"|
+|externalIP|The external IP of the load balancer.|"127.0.0.1"|
+|ports|List of all the service port objects.||
+|ports:name|Name of the port. If only one port is present then this field is **optional**.|"SMTP"|
+|ports:protocol|The protocol the port works on. The value can only be either "UDP" or "TCP".|"TCP"|
+|ports:port|The port that will be exposed on the service.|1234|
+|ports:targetPort|The target port on pods selected by this service. This field is optional. It can be **string** or **int** type. If not provided, will use **ports:port** value.|1234|
+|ports:nodePort|The port on each node on which this service is exposed.|1234|
+|hosts|A list of all host names.||
+|hosts:hostname|A host name.|"my-cloud-host1"|
+|sessionAffinity|The session affinity. The value can only be either "None" or "ClientIP".|"None"|
+Example
+
+```json
+{
+    "loadBalancerName":"my-tcp-balancer",
+    "region":"USA",
+    "externalIP":"127.0.0.1",
+    "ports":[
+        {
+            "name":"SMTP",
+            "protocol":"TCP",
+            "port":1234,
+            "targetPort":1234,
+            "nodePort":1234
+        }
+    ],
+    "hosts":[
+        {
+            "hostname":"my-cloud-host1"
+        }
+    ],
+    "sessionAffinity":"None"
+}
+```
+
+##### Expected return value:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|ingress|List of ingress points for the load balancer.||
+|ingress:ip|The IP address of the ingress point. This is a optional field as only one of IP or hostname is required.|"127.0.0.1"|
+|ingress:hostname|The hostname of the ingress point. This is a optional field as only one of IP or hostname is required.|"my-cloud-host1"|
+|exists|Whether the TCP Load Balancer exists or not.|true|
+Example
+
+```json
+{
+    "ingress": [
+        {
+            "ip":"127.0.0.1",
+            "hostname":"my-cloud-host1"
+        }
+    ]
+}
+```
+
+#### PUT /cloudprovider/v1aplha1/tcpLoadBalancers/{region}/{name}
+
+Updates the hosts given in the Load Balancer specified.
+
+##### Sender body:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|hosts|A list of all host names.||
+|hosts:hostname|A host name.|"my-cloud-host1"|
+Example
+
+```json
+{
+    "hosts":[
+        {
+            "hostname":"my-cloud-host1"
+        }
+    ]
+}
+```
+
+##### Expected return body:
+
+Send back an empty 204 response if the object was updated successfully.
+
+#### DELETE /cloudprovider/v1aplha1/tcpLoadBalancers/{region}/{name}
+
+Deletes the specified Load Balancer.
+
+##### Expected return value:
+
+Send back an empty 204 response if the object was deleted successfully or it didn't exist before.
+
+## Zones
+
+The Zones interface allows the kubernetes platform to query the cloud provider about the Zones and which areas are having a failed state.
+
+### Methods
+
+#### OPTIONS /cloudprovider/v1aplha1/zones
+
+Know whether the interface is supported or not.
+
+##### Expected return value:
+
+Empty 200 Response if supported else 501 Response
+
+#### GET /cloudprovider/v1aplha1/zones
+
+Returns the Zone containing the current failure zone and locality region that the program is running in.
+
+##### Expected return value:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|failureDomain|The failure zone.|"my-zone-2"|
+|region|Locality region that the program is running in.|"USA"|
+Example
+
+```json
+{
+    "failureDomain":"my-zone-2",
+    "region":"USA"
+}
+```
+
+## Clusters
+
+The clusters interface allows the kubernetes platform to query information about the clusters inside the cloud provider.
+
+### Methods
+
+#### OPTIONS /cloudprovider/v1aplha1/clusters
+
+Know whether the interface is supported or not.
+
+##### Expected return value:
+
+Empty 200 Response if supported else 501 Response
+
+#### GET /cloudprovider/v1aplha1/clusters
+
+Returns a list of all clusters.
+
+##### Expected return value:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|clusters|The list of all cluster objects.||
+|clusters:clusterName|The name of the cluster.|"my-cluster"|
+Example
+
+```json
+{
+    "clusters": [
+        {
+            "clusterName":"my-cluster"
+        }
+    ]
+}
+```
+
+#### GET /cloudprovider/v1aplha1/clusters/{clusterName}/master
+
+Returns the address of the master of the cluster provided.
+
+##### Expected return value:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|masterAddress|The address of the master in the cluster. Can be a DNS Hostname or an IP Address.|"127.0.0.1"|
+Example
+
+```json
+{
+    "masterAddress":"127.0.0.1"
+}
+```
+
+## Routes
+
+The routes interface allows the kubernetes platform to query information about the routes and change them inside the cloud provider.
+
+### Methods
+
+#### OPTIONS /cloudprovider/v1aplha1/routes
+
+Know whether the interface is supported or not.
+
+##### Expected return value:
+
+Empty 200 Response if supported else 501 Response
+
+#### GET /cloudprovider/v1aplha1/routes/{clusterName}
+
+Returns a list of all the routes belonging to the specified cluster.
+
+##### Expected return value:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|routes|The list of route objects.||
+|routes:routeName|The name of the routing rule.|"abc"|
+|routes:targetInstance|The name of the instance as specified in routing rules for the cloud-provider.|"a1-small"|
+|routes:destinationCIDR|The CIDR format IP range that this routing rule applies to.|"192.168.1.0/24"|
+Example
+
+```json
+{
+    "routes": [
+        {
+            "routeName":"abc",
+            "targetInstance":"a1-small",
+            "destinationCIDR":"192.168.1.0/24"
+        }
+    ]
+}
+```
+
+#### POST /cloudprovider/v1aplha1/routes
+
+Creates a route inside the cloud provider and returns whether the route was created or not.
+
+##### Sender Body:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|clusterName|The name of the cluster in which the route needs to be created.|"my-cluster"|
+|nameHint|A more meaningful use of the route name created.|"hint"|
+|route|The route object which needs to be created||
+|route:routeName|The name of the routing rule.|"abc"|
+|route:targetInstance|The name of the instance as specified in routing rules for the cloud-provider.|"a1-small"|
+|route:destinationCIDR|The CIDR format IP range that this routing rule applies to.|"192.168.1.0/24"|
+Example
+
+```json
+{
+    "clusterName":"my-cluster",
+    "nameHint":"hint",
+    "route":
+    {
+        "routeName":"abc",
+        "targetInstance":"a1-small",
+        "destinationCIDR":"192.168.1.0/24"
+    }
+}
+```
+
+##### Expected Return Body:
+
+|Name|Description|Example Value|
+|----|-----------|-------------|
+|routeCreated|Whether the route was created or not.|true|
+Example
+
+```json
+{
+    "routeCreated":true
+}
+```
+
+#### DELETE /cloudprovider/v1aplha1/routes/{clusterName}/{routeName}
+
+Delete the requested route within the specified cluster.
+
+##### Expected return value:
+
+Send back an empty 204 response if the object was deleted successfully
+
+
+<!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/http-cloud-provider.md?pixel)]()
+<!-- END MUNGE: GENERATED_ANALYTICS -->

--- a/pkg/cloudprovider/providers/http/doc.go
+++ b/pkg/cloudprovider/providers/http/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package http_cloud is an implementation of Interface, TCPLoadBalancer
+// and Instances for HTTP API which will be able to communicate to custom cloyd providers.
+package http_cloud

--- a/pkg/cloudprovider/providers/http/http.go
+++ b/pkg/cloudprovider/providers/http/http.go
@@ -1,0 +1,654 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http_cloud
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+type httpCloud struct {
+	clientURL string
+}
+
+// The current provider name
+type ProviderName struct {
+	Name string `json:"providerName"`
+}
+
+type InstanceResources struct {
+	Resources []NodeResource `json:"resources"`
+}
+
+type NodeResource struct {
+	ResourceName string           `json:"resourceName"`
+	Quantity     ResourceQuantity `json:"quantity"`
+}
+
+type ResourceQuantity struct {
+	Amount int64  `json:"amount"`
+	Format string `json:"format"`
+}
+
+type InstanceNodeAddress struct {
+	Node []api.NodeAddress `json:"nodeAddresses"`
+}
+
+type InstanceID struct {
+	ID string `json:"instanceID"`
+}
+
+type InstanceList struct {
+	List []InstanceName `json:"instances"`
+}
+
+type InstanceName struct {
+	Name string `json:"instanceName"`
+}
+
+type InstanceSSHKey struct {
+	User string `json:"user"`
+	Key  []byte `json:"keyData"`
+}
+
+type InstanceNodeName struct {
+	Name string `json:"nodeName"`
+}
+
+type InstanceSSHKeyResponse struct {
+	KeyAdded bool `json:"SSHKeyAdded"`
+}
+
+type Zone struct {
+	Domain string `json:"failureDomain"`
+	Region string `json:"region"`
+}
+
+type ClusterList struct {
+	ClusterNames []ClusterName `json:"clusters"`
+}
+
+type ClusterName struct {
+	Name string `json:"clusterName"`
+}
+
+type ClusterMaster struct {
+	Address string `json:"masterAddress"`
+}
+
+type RouteList struct {
+	List []Route `json:"routes"`
+}
+
+type CreateRoute struct {
+	ClusterName string `json:"clusterName"`
+	NameHint    string `json:"nameHint"`
+	NewRoute    Route  `json:"route"`
+}
+
+type Route struct {
+	Name            string `json:"routeName"`
+	Target          string `json:"targetInstance"`
+	DestinationCIDR string `json:"destinationCIDR"`
+}
+
+type RouteCreatedStatus struct {
+	RouteCreated bool `json:"routeCreated"`
+}
+
+type TCPLoadBalancerStatus struct {
+	Ingress []api.LoadBalancerIngress `json:"ingress"`
+	Exists  bool                      `json:"exists"`
+}
+
+type TCPLoadBalancer struct {
+	Name            string            `json:"loadBalancerName"`
+	Region          string            `json:"region"`
+	IP              string            `json:"externalIP"`
+	Ports           []api.ServicePort `json:"ports"`
+	Hosts           []Hostnames       `json:"hosts"`
+	ServiceAffinity string            `json:"sessionAffinity"`
+}
+
+type Hostnames struct {
+	Name string `json:"hostname"`
+}
+
+type HostTCPLoadBalancer struct {
+	Hosts []Hostnames `json:"hosts"`
+}
+
+type Config struct {
+	ClientURL string `json:"clientURL"`
+}
+
+func init() {
+	cloudprovider.RegisterCloudProvider("http", func(config io.Reader) (cloudprovider.Interface, error) { return newHTTPCloud(config) })
+}
+
+// Creates a new instance of httpCloud through the config file sent.
+func newHTTPCloud(config io.Reader) (*httpCloud, error) {
+	if config != nil {
+		stream := streamToByte(config)
+		var conf Config
+		if err := json.Unmarshal(stream, &conf); err != nil {
+			return nil, fmt.Errorf("Unmarshalling JSON Config file Error: %s", err)
+		}
+		urlAddress := conf.ClientURL
+		// Validate URL
+		_, err := url.ParseRequestURI(urlAddress)
+		if err != nil {
+			return nil, fmt.Errorf("Can't parse the clientURL provided: %s", err)
+		}
+		// Handle Trailing slashes
+		urlAddress = strings.TrimRight(urlAddress, "/")
+		return &httpCloud{
+			clientURL: urlAddress,
+		}, nil
+	}
+	return nil, fmt.Errorf("Config file is empty or is not provided")
+}
+
+// Returns the cloud provider ID.
+func (h *httpCloud) ProviderName() string {
+	path := "/cloudprovider/v1aplha1/providerName"
+	var resp ProviderName
+
+	if err := h.get(path, &resp); err != nil {
+		return ""
+	} else {
+		return resp.Name
+	}
+}
+
+// Returns an implementation of Instances for HTTP cloud.
+func (h *httpCloud) Instances() (cloudprovider.Instances, bool) {
+	if h.supported("instances") {
+		return h, true
+	}
+	return nil, false
+}
+
+// Returns an implementation of Clusters for HTTP cloud.
+func (h *httpCloud) Clusters() (cloudprovider.Clusters, bool) {
+	if h.supported("clusters") {
+		return h, true
+	}
+	return nil, false
+}
+
+// Returns an implementation of TCPLoadBalancer for HTTP cloud.
+func (h *httpCloud) TCPLoadBalancer() (cloudprovider.TCPLoadBalancer, bool) {
+	if h.supported("tcpLoadBalancers") {
+		return h, true
+	}
+	return nil, false
+}
+
+// Returns an implementation of Zones for HTTP cloud.
+func (h *httpCloud) Zones() (cloudprovider.Zones, bool) {
+	if h.supported("zones") {
+		return h, true
+	}
+	return nil, false
+}
+
+// Returns an implementation of Routes for HTTP cloud.
+func (h *httpCloud) Routes() (cloudprovider.Routes, bool) {
+	if h.supported("routes") {
+		return h, true
+	}
+	return nil, false
+}
+
+// Returns the NodeAddresses of a particular machine instance.
+func (h *httpCloud) NodeAddresses(instance string) ([]api.NodeAddress, error) {
+	path := "/cloudprovider/v1aplha1/instances/" + instance + "/nodeAddresses"
+	var resp InstanceNodeAddress
+	if err := h.get(path, &resp); err != nil {
+		return nil, err
+	}
+	if ok, err := checkNodeAddressesValid(resp.Node); !ok {
+		return nil, err
+	}
+	return resp.Node, nil
+}
+
+// Returns the cloud provider ID of the specified instance (deprecated).
+func (h *httpCloud) ExternalID(instance string) (string, error) {
+	return "", errors.New("unimplemented")
+}
+
+// Returns the cloud provider ID of the specified instance.
+func (h *httpCloud) InstanceID(instance string) (string, error) {
+	path := "/cloudprovider/v1aplha1/instances/" + instance + "/ID"
+	var resp InstanceID
+	if err := h.get(path, &resp); err != nil {
+		return "", err
+	}
+	if resp.ID == "" {
+		return "", fmt.Errorf("Instance ID field is required and cannot be empty")
+	}
+	return resp.ID, nil
+}
+
+// Enumerates the set of minions instances known by the cloud provider.
+func (h *httpCloud) List(filter string) ([]string, error) {
+	path := "/cloudprovider/v1aplha1/instances/" + filter
+	var resp InstanceList
+	if err := h.get(path, &resp); err != nil {
+		return nil, err
+	}
+	var result []string
+	for _, instance := range resp.List {
+		if instance.Name == "" {
+			return nil, fmt.Errorf("Instance Name field is required and cannot be empty")
+		}
+		result = append(result, instance.Name)
+	}
+	return result, nil
+}
+
+// Adds an SSH public key as a legal identity for all instances.
+// Expected format for the key is standard ssh-keygen format: <protocol> <blob>.
+func (h *httpCloud) AddSSHKeyToAllInstances(user string, keyData []byte) error {
+	path := "/cloudprovider/v1aplha1/instances/sshKey"
+	requestType := "POST"
+	key := &InstanceSSHKey{
+		User: user,
+		Key:  keyData,
+	}
+	Body, _ := json.Marshal(key)
+	body := bytes.NewReader(Body)
+	JSONResp, err := h.sendHTTPRequest(requestType, path, body)
+	if err != nil {
+		return fmt.Errorf("HTTP request to cloudprovider failed: %v", err)
+	}
+	var resp InstanceSSHKeyResponse
+	if err := json.Unmarshal(JSONResp, &resp); err != nil {
+		return fmt.Errorf("Error in reading JSON response from the cloudprovider for %s %s: %v The response was: %s", requestType, path, err, body)
+	}
+	// If key is not added for the particular user, then return an error or else return nil.
+	if !resp.KeyAdded {
+		return fmt.Errorf("Error in adding SSH Key:%s for User:%s", keyData, user)
+	}
+	return nil
+}
+
+// Returns the name of the node we are currently running on given the hostname.
+func (h *httpCloud) CurrentNodeName(hostname string) (string, error) {
+	path := "/cloudprovider/v1aplha1/instances/node/" + hostname
+	var resp InstanceNodeName
+	if err := h.get(path, &resp); err != nil {
+		return "", err
+	}
+	if resp.Name == "" {
+		return "", fmt.Errorf("Node Name field is required and cannot be empty")
+	}
+	return resp.Name, nil
+}
+
+// Returns the Zone containing the current failure zone and locality region that the program is running in.
+func (h *httpCloud) GetZone() (cloudprovider.Zone, error) {
+	path := "/cloudprovider/v1aplha1/zones"
+	var resp Zone
+	if err := h.get(path, &resp); err != nil {
+		return cloudprovider.Zone{}, err
+	}
+	if resp.Domain == "" {
+		return cloudprovider.Zone{}, fmt.Errorf("zone:failureDomain field is required and should not be empty")
+	}
+	if resp.Region == "" {
+		return cloudprovider.Zone{}, fmt.Errorf("zone:region field is required and should not be empty")
+	}
+	return cloudprovider.Zone{
+		FailureDomain: resp.Domain,
+		Region:        resp.Region,
+	}, nil
+}
+
+// Returns a list of clusters currently running.
+func (h *httpCloud) ListClusters() ([]string, error) {
+	path := "/cloudprovider/v1aplha1/clusters"
+	var resp ClusterList
+	if err := h.get(path, &resp); err != nil {
+		return nil, err
+	}
+	if len(resp.ClusterNames) == 0 {
+		return nil, fmt.Errorf("No cluster names provided")
+	}
+	var result []string
+	for _, cluster := range resp.ClusterNames {
+		if cluster.Name == "" {
+			return nil, fmt.Errorf("Cluster name is requiread and cannot be empty")
+		}
+		result = append(result, cluster.Name)
+	}
+	return result, nil
+}
+
+// Returns the address of the master of the cluster.
+func (h *httpCloud) Master(clusterName string) (string, error) {
+	path := "/cloudprovider/v1aplha1/clusters/" + clusterName + "/master"
+	var resp ClusterMaster
+	if err := h.get(path, &resp); err != nil {
+		return "", err
+	}
+	if resp.Address == "" {
+		return "", fmt.Errorf("Master address value is required and cannot be empty")
+	}
+	return resp.Address, nil
+}
+
+// Returns a list of all the routes that belong to the specific clusterName.
+func (h *httpCloud) ListRoutes(clusterName string) ([]*cloudprovider.Route, error) {
+	path := "/cloudprovider/v1aplha1/routes/" + clusterName
+	var resp RouteList
+	if err := h.get(path, &resp); err != nil {
+		return nil, err
+	}
+	if ok, err := checkRouteValid(resp.List); !ok {
+		return nil, err
+	}
+	var routes []*cloudprovider.Route
+	for _, route := range resp.List {
+		routes = append(routes, &cloudprovider.Route{route.Name, route.Target, route.DestinationCIDR})
+	}
+
+	return routes, nil
+}
+
+// Creates a route inside the cloud provider and returns whether the route was created or not.
+func (h *httpCloud) CreateRoute(clusterName string, nameHint string, route *cloudprovider.Route) error {
+	path := "/cloudprovider/v1aplha1/routes"
+	requestType := "POST"
+	routeCreated := &CreateRoute{
+		ClusterName: clusterName,
+		NameHint:    nameHint,
+		NewRoute: Route{
+			Name:            route.Name,
+			Target:          route.TargetInstance,
+			DestinationCIDR: route.DestinationCIDR,
+		},
+	}
+	Body, _ := json.Marshal(routeCreated)
+	body := bytes.NewReader(Body)
+	JSONResp, err := h.sendHTTPRequest(requestType, path, body)
+	if err != nil {
+		return fmt.Errorf("HTTP request to cloudprovider failed: %v", err)
+	}
+	var resp RouteCreatedStatus
+	if err := json.Unmarshal(JSONResp, &resp); err != nil {
+		return fmt.Errorf("Error in reading JSON response from the cloudprovider for %s %s: %v The response was: %s", requestType, path, err, body)
+	}
+	// If key is not added for the particular user, then return an error or else return nil.
+	if !resp.RouteCreated {
+		return fmt.Errorf("Error in creating route: %s", route.Name)
+	}
+	return nil
+}
+
+// Delete the requested route.
+func (h *httpCloud) DeleteRoute(clusterName string, route *cloudprovider.Route) error {
+	path := "/cloudprovider/v1aplha1/routes/" + clusterName + "/" + route.Name
+	requestType := "DELETE"
+	_, err := h.sendHTTPRequest(requestType, path, nil)
+	if err != nil {
+		return fmt.Errorf("HTTP request to cloudprovider failed: %v", err)
+	}
+	return nil
+}
+
+// Returns the TCP Load Balancer Status if it exists in the region with the particular name.
+func (h *httpCloud) GetTCPLoadBalancer(name, region string) (status *api.LoadBalancerStatus, exists bool, err error) {
+	path := "/cloudprovider/v1aplha1/tcpLoadBalancers/" + region + "/" + name
+	var resp TCPLoadBalancerStatus
+	if err := h.get(path, &resp); err != nil {
+		return nil, false, err
+	}
+	if resp.Exists {
+		for _, ingress := range resp.Ingress {
+			if ingress.Hostname == "" && ingress.IP == "" {
+				return nil, false, fmt.Errorf("Either ingress:IP or ingress:hostname is required and cannot be empty")
+			}
+		}
+		return &api.LoadBalancerStatus{Ingress: resp.Ingress}, true, nil
+	}
+	return nil, false, nil
+}
+
+// Creates a new tcp load balancer and return the status of the balancer.
+func (h *httpCloud) EnsureTCPLoadBalancer(name, region string, externalIP net.IP, ports []*api.ServicePort, hosts []string, affinityType api.ServiceAffinity) (*api.LoadBalancerStatus, error) {
+	path := "/cloudprovider/v1aplha1/tcpLoadBalancers"
+	requestType := "POST"
+	var Ports []api.ServicePort
+	for _, servicePort := range ports {
+		Ports = append(Ports, *servicePort)
+	}
+	var Hosts []Hostnames
+	for _, host := range hosts {
+		Hosts = append(Hosts, Hostnames{Name: host})
+	}
+	balancer := &TCPLoadBalancer{
+		Name: name, Region: region, IP: string(externalIP), Ports: Ports, Hosts: Hosts, ServiceAffinity: string(affinityType),
+	}
+	Body, _ := json.Marshal(balancer)
+	body := bytes.NewReader(Body)
+	JSONResp, err := h.sendHTTPRequest(requestType, path, body)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request to cloudprovider failed: %v", err)
+	}
+	var resp api.LoadBalancerStatus
+	if err := json.Unmarshal(JSONResp, &resp); err != nil {
+		return nil, fmt.Errorf("Error in reading JSON response from the cloudprovider for %s %s: %v The response was: %s", requestType, path, err, body)
+	}
+	for _, ingress := range resp.Ingress {
+		if ingress.Hostname == "" && ingress.IP == "" {
+			return nil, fmt.Errorf("Either ingress:IP or ingress:hostname is required and cannot be empty")
+		}
+	}
+	return &api.LoadBalancerStatus{Ingress: resp.Ingress}, nil
+}
+
+// Updates the hosts given in the Load Balancer specified.
+func (h *httpCloud) UpdateTCPLoadBalancer(name, region string, hosts []string) error {
+	path := "/cloudprovider/v1aplha1/tcpLoadBalancers/" + region + "/" + name
+	requestType := "PUT"
+	var TCPHosts HostTCPLoadBalancer
+	for _, host := range hosts {
+		TCPHosts.Hosts = append(TCPHosts.Hosts, Hostnames{Name: host})
+	}
+	Body, _ := json.Marshal(TCPHosts)
+	body := bytes.NewReader(Body)
+	_, err := h.sendHTTPRequest(requestType, path, body)
+	if err != nil {
+		return fmt.Errorf("HTTP request to cloudprovider failed: %v", err)
+	}
+	return nil
+}
+
+// Deletes the specified Load Balancer.
+func (h *httpCloud) EnsureTCPLoadBalancerDeleted(name, region string) error {
+	path := "/cloudprovider/v1aplha1/tcpLoadBalancers/" + region + "/" + name
+	requestType := "DELETE"
+	_, err := h.sendHTTPRequest(requestType, path, nil)
+	if err != nil {
+		return fmt.Errorf("HTTP request to cloudprovider failed: %v", err)
+	}
+	return nil
+}
+
+// Sends HTTP requests for all interfaces support methods.
+func (h *httpCloud) supported(iface string) bool {
+	path := "/cloudprovider/v1aplha1/" + iface
+	requestType := "OPTIONS"
+	_, err := h.sendHTTPRequest(requestType, path, nil)
+	if err != nil {
+		glog.Errorf("%s not supported", iface)
+		return false
+	}
+	return true
+}
+
+// Creates a request for the specified type, path and body and then receives the reply back from the receiver.
+// If response code is not 200 or 204(for PUT or DELETE), then an error is sent out.
+func (h *httpCloud) sendHTTPRequest(requestType string, requestPath string, requestBody io.Reader) ([]byte, error) {
+	url := h.clientURL + requestPath
+	req, err := http.NewRequest(requestType, url, requestBody)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode == 200 || (requestType == "DELETE" && resp.StatusCode == 204) || (requestType == "PUT" && resp.StatusCode == 204) {
+		if err != nil {
+			return nil, err
+		} else {
+			return body, nil
+		}
+	} else if resp.StatusCode == 501 && requestType == "OPTIONS" {
+		// Interface supported or not
+		return nil, fmt.Errorf("Interface not supported")
+	} else {
+		var response api.Status
+		if err := json.Unmarshal(body, &response); err != nil {
+			return nil, fmt.Errorf("Error in reading JSON response from the cloudprovider for HTTP %d Error for %s %s: %v\n", resp.StatusCode, requestType, requestPath, err)
+		} else {
+			return nil, fmt.Errorf("Error from Cloudprovider for %s %s: HTTP %d Error with the current status as %s, the reason for failure is %s\n.", requestType, requestPath, resp.StatusCode, response.Message, response.Reason)
+		}
+	}
+}
+
+// Sends a HTTP Get Request and Unmarshals the JSON Response.
+func (h *httpCloud) get(path string, resp interface{}) error {
+	requestType := "GET"
+	body, err := h.sendHTTPRequest(requestType, path, nil)
+	if err != nil {
+		return fmt.Errorf("HTTP request to cloudprovider failed: %v", err)
+	}
+	if body != nil {
+		if err := json.Unmarshal(body, resp); err != nil {
+			return fmt.Errorf("Error in reading JSON response from the cloudprovider for %s %s: %v\n The response was: %s", requestType, path, err, body)
+		}
+	}
+	return nil
+}
+
+// Checks whether the NodeAddress struct has all the valid values or not.
+func checkNodeAddressesValid(Nodes []api.NodeAddress) (bool, error) {
+	types := []string{"InternalIP", "ExternalIP", "Hostname", "LegacyHostIP"}
+	for _, node := range Nodes {
+		if node.Address == "" {
+			return false, fmt.Errorf("nodeAdresses:address value is required and cannot be empty.")
+		}
+
+		match := false
+		for _, Type := range types {
+			if string(node.Type) == Type {
+				match = true
+			}
+		}
+		if !match {
+			return false, fmt.Errorf("nodeAdresses:type expected to be either InternalIP, ExternalIP, Hostname or LegacyHostIP. Got %s", node.Type)
+		}
+	}
+	return true, nil
+}
+
+// Checks whether the NodeResource struct has all the valid values or not.
+func checkResourcesValid(Resources []NodeResource) (bool, error) {
+	formats := []string{"DecimalExponent", "BinarySI", "DecimalSI"}
+	resources := []string{"cpu", "memory", "storage", "pods", "services", "replicationcontrollers", "resourcequotas", "secrets", "persistentvolumeclaims"}
+	for _, Resource := range Resources {
+		if Resource.Quantity.Amount == 0.0 {
+			return false, fmt.Errorf("resources:quantity:format value is required and cannot be 0.")
+		}
+		match := false
+		for _, Format := range formats {
+			if string(Resource.Quantity.Format) == Format {
+				match = true
+			}
+		}
+		if !match {
+			return false, fmt.Errorf("resources:quantity:format expected to be either DecimalExponent, BinarySI or DecimalSI. Got %s", Resource.Quantity.Format)
+		}
+		match = false
+		for _, Name := range resources {
+			if Resource.ResourceName == Name {
+				match = true
+			}
+		}
+		if !match {
+			return false, fmt.Errorf("resources:resourceName expected to be either cpu, memory, storage, pods, services, replicationcontrollers, resourcequotas, secrets or persistentvolumeclaims. Got %s", Resource.Quantity.Format)
+		}
+	}
+	return true, nil
+}
+
+// Checks whether the RouteList struct has valid values or not.
+func checkRouteValid(RouteList []Route) (bool, error) {
+	for _, route := range RouteList {
+		if route.Name == "" {
+			return false, fmt.Errorf("routeName is required and cannot be empty.")
+		}
+		if route.Target == "" {
+			return false, fmt.Errorf("targetInstance is required and cannot be empty.")
+		}
+		if route.DestinationCIDR == "" {
+			return false, fmt.Errorf("destinationCIDR is required and cannot be empty.")
+		}
+	}
+	return true, nil
+}
+
+// Creates the api.NodeResources Struct from a NodeResource struct which is received from a JSON response.
+func makeNodeResources(Resources []NodeResource) *api.NodeResources {
+	resourceList := api.ResourceList{}
+	for _, Resource := range Resources {
+		resourceList[api.ResourceName(Resource.ResourceName)] = *resource.NewQuantity(Resource.Quantity.Amount, resource.Format(Resource.Quantity.Format))
+	}
+	return &api.NodeResources{
+		Capacity: resourceList,
+	}
+}
+
+// Coverts the io.Reader stream to bytes
+func streamToByte(stream io.Reader) []byte {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(stream)
+	return buf.Bytes()
+}

--- a/pkg/cloudprovider/providers/http/http_test.go
+++ b/pkg/cloudprovider/providers/http/http_test.go
@@ -1,0 +1,673 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http_cloud
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/util"
+)
+
+// This is a test server which would respond to any incoming HTTP requests
+func startHTTPTestServer() *httptest.Server {
+	http_handler := func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			switch r.URL.Path {
+			// This one is just to test a basic HTTP request can be responded to
+			case "/testing":
+				w.Write([]byte(`Testing works`))
+			case "/cloudprovider/v1aplha1/instances/my-cloud/nodeAddresses":
+				resp := &InstanceNodeAddress{
+					Node: []api.NodeAddress{
+						{Type: "InternalIP", Address: "internalIP"},
+						{Type: "ExternalIP", Address: "externalIP"},
+					},
+				}
+				NodeAddressesResponse, _ := json.Marshal(resp)
+				w.Write(NodeAddressesResponse)
+			case "/cloudprovider/v1aplha1/instances/my-cloud/ID":
+				resp := &InstanceID{
+					ID: "my-cloud-1",
+				}
+				InstanceIDResponse, _ := json.Marshal(resp)
+				w.Write(InstanceIDResponse)
+			case "/cloudprovider/v1aplha1/instances/my-":
+				resp := &InstanceList{
+					List: []InstanceName{
+						{Name: "my-cloud-1"},
+						{Name: "my-cloud-2"},
+					},
+				}
+				InstanceListResponse, _ := json.Marshal(resp)
+				w.Write(InstanceListResponse)
+			case "/cloudprovider/v1aplha1/instances/node/my-host":
+				resp := &InstanceNodeName{
+					Name: "my-node",
+				}
+				InstanceIDResponse, _ := json.Marshal(resp)
+				w.Write(InstanceIDResponse)
+			case "/cloudprovider/v1aplha1/providerName":
+				resp := &ProviderName{
+					Name: "my-cloud",
+				}
+				ProviderNameResponse, _ := json.Marshal(resp)
+				w.Write(ProviderNameResponse)
+			case "/cloudprovider/v1aplha1/zones":
+				resp := &Zone{
+					Domain: "my-zone-2",
+					Region: "USA",
+				}
+				ZoneResponse, _ := json.Marshal(resp)
+				w.Write(ZoneResponse)
+			case "/cloudprovider/v1aplha1/clusters":
+				resp := &ClusterList{
+					ClusterNames: []ClusterName{
+						{Name: "my-cluster-1"},
+						{Name: "my-cluster-2"},
+					},
+				}
+				ClusterListResponse, _ := json.Marshal(resp)
+				w.Write(ClusterListResponse)
+			case "/cloudprovider/v1aplha1/clusters/my-cluster-1/master":
+				resp := &ClusterMaster{
+					Address: "127.0.0.1",
+				}
+				ClusterMasterResponse, _ := json.Marshal(resp)
+				w.Write(ClusterMasterResponse)
+			case "/cloudprovider/v1aplha1/routes/my-cluster-1":
+				resp := &RouteList{
+					List: []Route{
+						{Name: "my-route-1", Target: "a1-small", DestinationCIDR: "192.168.1.0/24"},
+						{Name: "my-route-2", Target: "a1-big", DestinationCIDR: "192.168.1.1/24"},
+					},
+				}
+				RoutesListResponse, _ := json.Marshal(resp)
+				w.Write(RoutesListResponse)
+			case "/cloudprovider/v1aplha1/tcpLoadBalancers/USA/my-tcp-balancer":
+				resp := &TCPLoadBalancerStatus{
+					Ingress: []api.LoadBalancerIngress{
+						{IP: "127.0.0.1", Hostname: "my-cloud-host1"},
+						{Hostname: "my-cloud-host2"},
+						{IP: "127.0.0.2"},
+					},
+					Exists: true,
+				}
+				TCPLoadBalancerResponse, _ := json.Marshal(resp)
+				w.Write(TCPLoadBalancerResponse)
+			default:
+				http.NotFound(w, r)
+				return
+			}
+		case "POST":
+			switch r.URL.Path {
+			case "/cloudprovider/v1aplha1/instances/sshKey":
+				var resp InstanceSSHKey
+				body, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					glog.Errorf("Error reading the request")
+				}
+				if err = json.Unmarshal(body, &resp); err != nil {
+					glog.Errorf("Error in reading JSON response for %s %s: %v The response was: %s", "POST", r.URL.Path, err, body)
+				}
+				var respBody *InstanceSSHKeyResponse
+				if string(resp.Key[:]) == "@my-cloud-1SampleKey1" {
+					respBody = &InstanceSSHKeyResponse{
+						KeyAdded: true,
+					}
+				} else {
+					respBody = &InstanceSSHKeyResponse{
+						KeyAdded: false,
+					}
+				}
+				SSHKeyAddedResponse, _ := json.Marshal(respBody)
+				w.Write(SSHKeyAddedResponse)
+			case "/cloudprovider/v1aplha1/routes":
+				var resp CreateRoute
+				body, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					glog.Errorf("Error reading the request")
+				}
+				if err = json.Unmarshal(body, &resp); err != nil {
+					glog.Errorf("Error in reading JSON response for %s %s: %v The response was: %s", "POST", r.URL.Path, err, body)
+				}
+				var respBody RouteCreatedStatus
+				if resp.NewRoute.Name == "my-route-1" {
+					respBody = RouteCreatedStatus{
+						RouteCreated: true,
+					}
+				} else {
+					respBody = RouteCreatedStatus{
+						RouteCreated: false,
+					}
+				}
+				RouteCreatedResponse, _ := json.Marshal(respBody)
+				w.Write(RouteCreatedResponse)
+			case "/cloudprovider/v1aplha1/tcpLoadBalancers":
+				resp := &TCPLoadBalancerStatus{
+					Ingress: []api.LoadBalancerIngress{
+						{Hostname: "my-cloud-host1"},
+						{Hostname: "my-cloud-host2"},
+					},
+					Exists: true,
+				}
+				TCPLoadBalancerResponse, _ := json.Marshal(resp)
+				w.Write(TCPLoadBalancerResponse)
+			default:
+				http.NotFound(w, r)
+				return
+			}
+		case "PUT":
+			switch r.URL.Path {
+			case "/cloudprovider/v1aplha1/tcpLoadBalancers/USA/my-tcp-balancer":
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				http.NotFound(w, r)
+				return
+			}
+		case "DELETE":
+			switch r.URL.Path {
+			case "/cloudprovider/v1aplha1/routes/my-cluster-1/my-route-1":
+				w.WriteHeader(http.StatusNoContent)
+			case "/cloudprovider/v1aplha1/tcpLoadBalancers/USA/my-tcp-balancer":
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				http.NotFound(w, r)
+				return
+			}
+		case "OPTIONS":
+			switch r.URL.Path {
+			case "/cloudprovider/v1aplha1/instances":
+				w.WriteHeader(http.StatusOK)
+			case "/cloudprovider/v1aplha1/tcpLoadBalancers":
+				w.WriteHeader(http.StatusOK)
+			case "/cloudprovider/v1aplha1/zones":
+				w.WriteHeader(http.StatusOK)
+			case "/cloudprovider/v1aplha1/clusters":
+				w.WriteHeader(http.StatusOK)
+			case "/cloudprovider/v1aplha1/routes":
+				w.WriteHeader(http.StatusOK)
+			default:
+				w.WriteHeader(http.StatusNotImplemented)
+				return
+			}
+		}
+	}
+	return httptest.NewServer(http.HandlerFunc(http_handler))
+}
+
+func TestSendHTTPRequests(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	resp, err := http_cloud.sendHTTPRequest("GET", "/testing", nil)
+	if err != nil {
+		t.Fatalf("HTTP Request not send: %s", err)
+	}
+	expectedResponse := []byte(`Testing works`)
+	if !bytes.Equal(expectedResponse, resp) {
+		t.Fatalf("Expected %s, got %s", expectedResponse, resp)
+	}
+}
+
+func TestNewHttpCloud(t *testing.T) {
+	config := []byte(`{
+		"clientURL": "http://127.0.0.1"}`)
+	r := bytes.NewReader(config)
+	expectedAddress := "http://127.0.0.1"
+	if http_cloud, err := newHTTPCloud(r); err != nil {
+		t.Fatalf("New Http Cloud returned an error: %s", err)
+	} else if http_cloud.clientURL != expectedAddress {
+		t.Fatalf("Client URL not correct got %s, expected %s", http_cloud.clientURL, expectedAddress)
+	}
+}
+
+func TestNewHttpCloudEmptyURL(t *testing.T) {
+	config := []byte(`{
+		"clientURL": ""}`)
+	r := bytes.NewReader(config)
+	if _, err := newHTTPCloud(r); err == nil {
+		t.Fatalf("New Http Cloud doesn't return an error on empty string")
+	}
+}
+
+func TestNewHttpCloudWrongURL(t *testing.T) {
+	config := []byte(`{
+		"clientURL": "hello"}`)
+	r := bytes.NewReader(config)
+	if _, err := newHTTPCloud(r); err == nil {
+		t.Fatalf("New Http Cloud doesn't return an error on wrong url ")
+	}
+}
+
+func TestNewHttpCloudSubResources(t *testing.T) {
+	config := []byte(`{
+		"clientURL": "http://127.0.0.1/kube-api"}`)
+	r := bytes.NewReader(config)
+	expectedAddress := "http://127.0.0.1/kube-api"
+	if http_cloud, err := newHTTPCloud(r); err != nil {
+		t.Fatalf("New Http Cloud returned an error: %s", err)
+	} else if http_cloud.clientURL != expectedAddress {
+		t.Fatalf("Client URL not correct got %s, expected %s", http_cloud.clientURL, expectedAddress)
+	}
+}
+
+func TestNewHttpCloudTrailingSlashes(t *testing.T) {
+	config := []byte(`{
+		"clientURL": "http://127.0.0.1/"}`)
+	r := bytes.NewReader(config)
+	expectedAddress := "http://127.0.0.1"
+	if http_cloud, err := newHTTPCloud(r); err != nil {
+		t.Fatalf("New Http Cloud returned an error: %s", err)
+	} else if http_cloud.clientURL != expectedAddress {
+		t.Fatalf("Client URL not correct got %s, expected %s", http_cloud.clientURL, expectedAddress)
+	}
+}
+func TestInstancesSupport(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	instance, supported := http_cloud.Instances()
+	if instance != http_cloud && supported {
+		t.Fatalf("Instance returned is not the same calling instance")
+	}
+	if !supported {
+		t.Fatalf("Wrong value returned, expected true, got false")
+	}
+}
+func TestZonesSupport(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	zones, supported := http_cloud.Zones()
+	if zones != http_cloud && supported {
+		t.Fatalf("Instance returned is not the same calling instance")
+	}
+	if !supported {
+		t.Fatalf("Wrong value returned, expected true, got false")
+	}
+}
+func TestClustersSupport(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	clusters, supported := http_cloud.Clusters()
+	if clusters != http_cloud && supported {
+		t.Fatalf("Instance returned is not the same calling instance")
+	}
+	if !supported {
+		t.Fatalf("Wrong value returned, expected true, got false")
+	}
+}
+func TestRoutesSupport(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	routes, supported := http_cloud.Routes()
+	if routes != http_cloud && supported {
+		t.Fatalf("Instance returned is not the same calling instance")
+	}
+	if !supported {
+		t.Fatalf("Wrong value returned, expected true, got false")
+	}
+}
+func TestTCPLoadBalancerSupport(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	balancer, supported := http_cloud.TCPLoadBalancer()
+	if balancer != http_cloud && supported {
+		t.Fatalf("Instance returned is not the same calling instance")
+	}
+	if !supported {
+		t.Fatalf("Wrong value returned, expected true, got false")
+	}
+}
+
+func TestInstancesNodeAddresses(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	nodeAddresses, err := http_cloud.NodeAddresses("my-cloud")
+	if err != nil {
+		t.Fatalf("Node Addresses returns an error: %s", err)
+	}
+	if len(nodeAddresses) != 2 {
+		t.Fatalf("Node Addresses size is too small, node addresses not returned correctly")
+	}
+	expectedType := "InternalIP"
+	if string(nodeAddresses[0].Type) != expectedType {
+		t.Fatalf("Node Addresses value is wrong, expected %s, got %s", expectedType, nodeAddresses[0].Type)
+	}
+}
+
+func TestInstancesID(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	instanceID, err := http_cloud.InstanceID("my-cloud")
+	if err != nil {
+		t.Fatalf("InstanceID returns an error: %s", err)
+	}
+	expectedID := "my-cloud-1"
+	if instanceID != expectedID {
+		t.Fatalf("Instance ID value is wrong, expected %s, got %s", expectedID, instanceID)
+	}
+}
+
+func TestInstancesList(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	instanceNames, err := http_cloud.List("my-")
+	if err != nil {
+		t.Fatalf("List returns an error: %s", err)
+	}
+	expectedNames := []string{"my-cloud-1", "my-cloud-2"}
+	for i, name := range instanceNames {
+		if expectedNames[i] != name {
+			t.Fatalf("Instance name is wrong, expected %s, got %s", expectedNames[i], name)
+		}
+	}
+}
+
+func TestSSHKeyAdded(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	body := []byte(`@my-cloud-1SampleKey1`)
+	err := http_cloud.AddSSHKeyToAllInstances("user", body)
+	if err != nil {
+		t.Fatalf("List returns an error: %s", err)
+	}
+}
+
+func TestCurrentNodeName(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	nodeName, err := http_cloud.CurrentNodeName("my-host")
+	if err != nil {
+		t.Fatalf("CurrentNodeName returns an error: %s", err)
+	}
+	expectedNodeName := "my-node"
+	if nodeName != expectedNodeName {
+		t.Fatalf("Current node name value is wrong, expected %s, got %s", expectedNodeName, nodeName)
+	}
+}
+
+func TestProviderName(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	providerName := http_cloud.ProviderName()
+	expectedReturn := "my-cloud"
+	if providerName != expectedReturn {
+		t.Fatalf("Wrong cloud provider name, expected %s, got %s", expectedReturn, providerName)
+	}
+}
+
+func TestGetZone(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	zone, err := http_cloud.GetZone()
+	if err != nil {
+		t.Fatalf("GetZone returns an error: %s", err)
+	}
+	expectedDomain := "my-zone-2"
+	expectedRegion := "USA"
+	if zone.FailureDomain != expectedDomain {
+		t.Fatalf("Wrong failure domain, expected %s, got %s", expectedDomain, zone.FailureDomain)
+	}
+	if zone.Region != expectedRegion {
+		t.Fatalf("Wrong region, expected %s, got %s", expectedRegion, zone.Region)
+	}
+}
+
+func TestListClusters(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	clusterList, err := http_cloud.ListClusters()
+	if err != nil {
+		t.Fatalf("ListCluster returns an error: %s", err)
+	}
+	expectedList := []string{"my-cluster-1", "my-cluster-2"}
+	for i, name := range clusterList {
+		if expectedList[i] != name {
+			t.Fatalf("Cluster name is wrong, expected %s, got %s", expectedList[i], name)
+		}
+	}
+}
+
+func TestClusterMaster(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	masterAddress, err := http_cloud.Master("my-cluster-1")
+	if err != nil {
+		t.Fatalf("Master returns an error: %s", err)
+	}
+	expectedAddress := "127.0.0.1"
+	if masterAddress != expectedAddress {
+		t.Fatalf("Wrong master address, expected %s, got %s", expectedAddress, masterAddress)
+	}
+}
+
+func TestListRoute(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	routeList, err := http_cloud.ListRoutes("my-cluster-1")
+	if err != nil {
+		t.Fatalf("ListRoutes returns an error: %s", err)
+	}
+	expectedList := []string{"my-route-1", "my-route-2"}
+	for i, list := range routeList {
+		if expectedList[i] != (*list).Name {
+			t.Fatalf("Route name is wrong, expected %s, got %s", expectedList[i], (*list).Name)
+		}
+	}
+}
+
+func TestCreateRoute(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	route := &cloudprovider.Route{Name: "my-route-1", TargetInstance: "a1-small", DestinationCIDR: "192.168.1.0/24"}
+	err := http_cloud.CreateRoute("my-cluster-1", "hint", route)
+	if err != nil {
+		t.Fatalf("CreateRoute returns an error: %s", err)
+	}
+}
+
+func TestDeleteRoute(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	route := &cloudprovider.Route{Name: "my-route-1", TargetInstance: "a1-small", DestinationCIDR: "192.168.1.0/24"}
+	err := http_cloud.DeleteRoute("my-cluster-1", route)
+	if err != nil {
+		t.Fatalf("CreateRoute returns an error: %s", err)
+	}
+}
+
+func TestGetTCPLoadBalancer(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	status, exists, err := http_cloud.GetTCPLoadBalancer("my-tcp-balancer", "USA")
+	if err != nil {
+		t.Fatalf("GetTCPLoadBalancer returns an error: %s", err)
+	}
+	if !exists {
+		t.Fatalf("TCP Load Balancer does not exist")
+	}
+	if len((*status).Ingress) != 3 {
+		t.Fatalf("TCP Load Balancer size expected 3 got %d", len((*status).Ingress))
+	}
+	expectedHostList := []string{"my-cloud-host1", "my-cloud-host2", ""}
+	expectedIPList := []string{"127.0.0.1", "", "127.0.0.2"}
+	IngressList := (*status).Ingress
+	for i, list := range IngressList {
+		if expectedHostList[i] != list.Hostname {
+			t.Fatalf("Route name is wrong, expected %s, got %s", expectedHostList[i], list.Hostname)
+		}
+		if expectedIPList[i] != list.IP {
+			t.Fatalf("Route name is wrong, expected %s, got %s", expectedIPList[i], list.IP)
+		}
+	}
+}
+
+func TestEnsureTCPLoadBalancer(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	name := "my-tcp-balancer"
+	region := "USA"
+	externalIP := net.IP([]byte(`127.0.0.1`))
+	var ports []*api.ServicePort
+	port1 := &api.ServicePort{
+		Name:       "SMTP",
+		Protocol:   api.ProtocolTCP,
+		Port:       1234,
+		TargetPort: util.NewIntOrStringFromInt(1234),
+		NodePort:   1234,
+	}
+	port2 := &api.ServicePort{
+		Name:       "SMTP",
+		Protocol:   api.ProtocolTCP,
+		Port:       1234,
+		TargetPort: util.NewIntOrStringFromString("1234"),
+		NodePort:   1234,
+	}
+	ports = append(ports, port1)
+	ports = append(ports, port2)
+	hosts := []string{"my-cloud-host1", "my-cloud-host2"}
+	affinityType := api.ServiceAffinityClientIP
+	status, err := http_cloud.EnsureTCPLoadBalancer(name, region, externalIP, ports, hosts, affinityType)
+	if err != nil {
+		t.Fatalf("Error in CreateTCPLoadBalancer: %s", err)
+	}
+	if len((*status).Ingress) != 2 {
+		t.Fatalf("TCP Load Balancer size expected 3 got %d", len((*status).Ingress))
+	}
+	expectedHostList := []string{"my-cloud-host1", "my-cloud-host2"}
+	IngressList := (*status).Ingress
+	for i, list := range IngressList {
+		if expectedHostList[i] != list.Hostname {
+			t.Fatalf("Route name is wrong, expected %s, got %s", expectedHostList[i], list.Hostname)
+		}
+	}
+}
+
+func TestUpdateTCPLoadBalancer(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	hosts := []string{"my-cloud-host1", "my-cloud-host2"}
+	err := http_cloud.UpdateTCPLoadBalancer("my-tcp-balancer", "USA", hosts)
+	if err != nil {
+		t.Fatalf("UpdateTCPLoadBalancer returns an error: %s", err)
+	}
+}
+
+func TestDeleteTCPLoadBalancer(t *testing.T) {
+	server := startHTTPTestServer()
+	defer server.Close()
+
+	http_cloud := &httpCloud{
+		clientURL: server.URL,
+	}
+	err := http_cloud.EnsureTCPLoadBalancerDeleted("my-tcp-balancer", "USA")
+	if err != nil {
+		t.Fatalf("CreateRoute returns an error: %s", err)
+	}
+}

--- a/pkg/cloudprovider/providers/providers.go
+++ b/pkg/cloudprovider/providers/providers.go
@@ -20,6 +20,7 @@ import (
 	// Cloud providers
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
+	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/http"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/mesos"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/ovirt"


### PR DESCRIPTION
The HTTP cloudprovider is an HTTP API  which can communicate with custom cloudproviders which are not currently directly compiled into kubernetes and currently require a custom build of kubernetes to work with kubernetes. This API would remove that requirement as the HTTP API implements all the cloudprovider interfaces and then sends HTTP requests to the cloudprovider which would then reply back with the desired response to kubernetes.  
