### PR TITLE
Support both GET and POST methods in api server for /exec and /portforward

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -5957,6 +5957,36 @@
       "consumes": [
        "*/*"
       ]
+     },
+     {
+      "type": "string",
+      "method": "POST",
+      "summary": "connect POST requests to exec of Pod",
+      "nickname": "connectPostPodExec",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
      }
     ]
    },
@@ -6020,6 +6050,36 @@
       "method": "GET",
       "summary": "connect GET requests to portforward of Pod",
       "nickname": "connectGetPodPortforward",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "POST",
+      "summary": "connect POST requests to portforward of Pod",
+      "nickname": "connectPostPodPortforward",
       "parameters": [
        {
         "type": "string",

--- a/api/swagger-spec/v1beta3.json
+++ b/api/swagger-spec/v1beta3.json
@@ -5957,6 +5957,36 @@
       "consumes": [
        "*/*"
       ]
+     },
+     {
+      "type": "string",
+      "method": "POST",
+      "summary": "connect POST requests to exec of Pod",
+      "nickname": "connectPostPodExec",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
      }
     ]
    },
@@ -6020,6 +6050,36 @@
       "method": "GET",
       "summary": "connect GET requests to portforward of Pod",
       "nickname": "connectGetPodPortforward",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "POST",
+      "summary": "connect POST requests to portforward of Pod",
+      "nickname": "connectPostPodPortforward",
       "parameters": [
        {
         "type": "string",

--- a/pkg/registry/pod/etcd/etcd.go
+++ b/pkg/registry/pod/etcd/etcd.go
@@ -283,7 +283,8 @@ func (r *ProxyREST) Connect(ctx api.Context, id string, opts runtime.Object) (re
 	return genericrest.NewUpgradeAwareProxyHandler(location, nil, false), nil
 }
 
-var upgradeableMethods = []string{"GET"}
+// Support both GET and POST methods. Over time, we want to move all clients to start using POST and then stop supporting GET.
+var upgradeableMethods = []string{"GET", "POST"}
 
 // ExecREST implements the exec subresource for a Pod
 type ExecREST struct {

--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -249,7 +249,7 @@ func ExecLocation(getter ResourceGetter, connInfo client.ConnectionInfoGetter, c
 	nodeHost := pod.Spec.NodeName
 	if len(nodeHost) == 0 {
 		// If pod has not been assigned a host, return an empty location
-		return nil, nil, fmt.Errorf("pod %s does not have a host assigned", name)
+		return nil, nil, errors.NewBadRequest(fmt.Sprintf("pod %s does not have a host assigned", name))
 	}
 	nodeScheme, nodePort, nodeTransport, err := connInfo.GetConnectionInfo(nodeHost)
 	if err != nil {

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -275,6 +275,16 @@ func getTestRequests() []struct {
 		{"POST", timeoutPath("pods", api.NamespaceDefault, ""), aPod, code201},
 		{"PUT", timeoutPath("pods", api.NamespaceDefault, "a"), aPod, code200},
 		{"GET", path("pods", api.NamespaceDefault, "a"), "", code200},
+		// GET and POST for /exec should return Bad Request (400) since the pod has not been assigned a node yet.
+		{"GET", path("pods", api.NamespaceDefault, "a") + "/exec", "", code400},
+		{"POST", path("pods", api.NamespaceDefault, "a") + "/exec", "", code400},
+		// PUT for /exec should return Method Not Allowed (405).
+		{"PUT", path("pods", api.NamespaceDefault, "a") + "/exec", "", code405},
+		// GET and POST for /portforward should return Bad Request (400) since the pod has not been assigned a node yet.
+		{"GET", path("pods", api.NamespaceDefault, "a") + "/portforward", "", code400},
+		{"POST", path("pods", api.NamespaceDefault, "a") + "/portforward", "", code400},
+		// PUT for /portforward should return Method Not Allowed (405).
+		{"PUT", path("pods", api.NamespaceDefault, "a") + "/portforward", "", code405},
 		{"PATCH", path("pods", api.NamespaceDefault, "a"), "{%v}", code200},
 		{"DELETE", timeoutPath("pods", api.NamespaceDefault, "a"), deleteNow, code200},
 


### PR DESCRIPTION
First part of https://github.com/GoogleCloudPlatform/kubernetes/issues/10366.

This just updates API server to start supporting both GET and POST methods.
Will send another PR to update kubectl.
