### PR TITLE
make use-context return error when context does not exist

### DIFF
--- a/pkg/kubectl/cmd/config/config_test.go
+++ b/pkg/kubectl/cmd/config/config_test.go
@@ -44,13 +44,6 @@ func newRedFederalCowHammerConfig() clientcmdapi.Config {
 	}
 }
 
-type configCommandTest struct {
-	args            []string
-	startingConfig  clientcmdapi.Config
-	expectedConfig  clientcmdapi.Config
-	expectedOutputs []string
-}
-
 func ExampleView() {
 	expectedConfig := newRedFederalCowHammerConfig()
 	test := configCommandTest{
@@ -83,13 +76,33 @@ func ExampleView() {
 
 func TestSetCurrentContext(t *testing.T) {
 	expectedConfig := newRedFederalCowHammerConfig()
-	expectedConfig.CurrentContext = "the-new-context"
+	startingConfig := newRedFederalCowHammerConfig()
+
+	newContextName := "the-new-context"
+	newContext := clientcmdapi.NewContext()
+
+	startingConfig.Contexts[newContextName] = *newContext
+	expectedConfig.Contexts[newContextName] = *newContext
+
+	expectedConfig.CurrentContext = newContextName
+
 	test := configCommandTest{
 		args:           []string{"use-context", "the-new-context"},
-		startingConfig: newRedFederalCowHammerConfig(),
+		startingConfig: startingConfig,
 		expectedConfig: expectedConfig,
 	}
 
+	test.run(t)
+}
+
+func TestSetNonExistantContext(t *testing.T) {
+	expectedConfig := newRedFederalCowHammerConfig()
+	test := configCommandTest{
+		args:            []string{"use-context", "non-existant-config"},
+		startingConfig:  expectedConfig,
+		expectedConfig:  expectedConfig,
+		expectedOutputs: []string{`No context exists with the name: "non-existant-config"`},
+	}
 	test.run(t)
 }
 
@@ -689,6 +702,13 @@ func testConfigCommand(args []string, startingConfig clientcmdapi.Config) (strin
 	config := getConfigFromFileOrDie(fakeKubeFile.Name())
 
 	return buf.String(), *config
+}
+
+type configCommandTest struct {
+	args            []string
+	startingConfig  clientcmdapi.Config
+	expectedConfig  clientcmdapi.Config
+	expectedOutputs []string
 }
 
 func (test configCommandTest) run(t *testing.T) string {

--- a/pkg/kubectl/cmd/config/use_context.go
+++ b/pkg/kubectl/cmd/config/use_context.go
@@ -22,6 +22,8 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+
+	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
 )
 
 type useContextOptions struct {
@@ -43,7 +45,7 @@ func NewCmdConfigUseContext(out io.Writer, configAccess ConfigAccess) *cobra.Com
 
 			err := options.run()
 			if err != nil {
-				fmt.Printf("%v\n", err)
+				fmt.Fprintf(out, "%v\n", err)
 			}
 		},
 	}
@@ -52,12 +54,12 @@ func NewCmdConfigUseContext(out io.Writer, configAccess ConfigAccess) *cobra.Com
 }
 
 func (o useContextOptions) run() error {
-	err := o.validate()
+	config, err := o.configAccess.GetStartingConfig()
 	if err != nil {
 		return err
 	}
 
-	config, err := o.configAccess.GetStartingConfig()
+	err = o.validate(config)
 	if err != nil {
 		return err
 	}
@@ -82,10 +84,16 @@ func (o *useContextOptions) complete(cmd *cobra.Command) bool {
 	return true
 }
 
-func (o useContextOptions) validate() error {
+func (o useContextOptions) validate(config *clientcmdapi.Config) error {
 	if len(o.contextName) == 0 {
 		return errors.New("You must specify a current-context")
 	}
 
-	return nil
+	for name := range config.Contexts {
+		if name == o.contextName {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("No context exists with the name: %q.", o.contextName)
 }


### PR DESCRIPTION
Fixes #10357 

```
➜  kubernetes git:(master) ✗ k config use-context local
➜  kubernetes git:(master) ✗ k config use-context yolo
No context exists with the name. "yolo" 
```
