### PR TITLE
Updated command to launch etcd docker container in mesos documentation

### DIFF
--- a/docs/getting-started-guides/mesos.md
+++ b/docs/getting-started-guides/mesos.md
@@ -68,7 +68,16 @@ $ export KUBERNETES_MASTER=http://${KUBERNETES_MASTER_IP}:8888
 Start etcd and verify that it is running:
 
 ```bash
-$ sudo docker run -d --hostname $(uname -n) --name etcd -p 4001:4001 -p 7001:7001 quay.io/coreos/etcd:v2.0.12
+$ sudo docker run -d -p 4001:4001 -p 2380:2380 -p 2379:2379 \
+ --name etcd quay.io/coreos/etcd:v2.0.13 \
+ -name etcd0 \
+ -advertise-client-urls http://${KUBERNETES_MASTER_IP}:2379,http://${KUBERNETES_MASTER_IP}:4001 \
+ -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \
+ -initial-advertise-peer-urls http://${KUBERNETES_MASTER_IP}:2380 \
+ -listen-peer-urls http://0.0.0.0:2380 \
+ -initial-cluster-token etcd-cluster-1 \
+ -initial-cluster etcd0=http://${KUBERNETES_MASTER_IP}:2380 \
+ -initial-cluster-state new
 ```
 
 ```bash


### PR DESCRIPTION
The command to run the etcd docker container didn't work for me. I kept getting a `connection refused` error when trying to CURL all the exposed ports of the container.

I was able to get it to work properly by referencing the command to launch the etcd container by using the command in the etcd documentation: https://github.com/coreos/etcd/blob/master/Documentation/docker_guide.md

This PR updates the docs so that the etcd container launches correctly.
