### PR TITLE
change shell var MINION_SCOPES to user setable

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -41,7 +41,8 @@ MASTER_TAG="${INSTANCE_PREFIX}-master"
 MINION_TAG="${INSTANCE_PREFIX}-minion"
 MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
 CLUSTER_IP_RANGE="${CLUSTER_IP_RANGE:-10.244.0.0/16}"
-MINION_SCOPES=("storage-ro" "compute-rw" "https://www.googleapis.com/auth/monitoring" "https://www.googleapis.com/auth/logging.write")
+MINION_SCOPES="${MINION_SCOPES:-compute-rw,monitoring,logging-write,storage-ro}"
+
 # Increase the sleep interval value if concerned about API rate limits. 3, in seconds, is the default.
 POLL_SLEEP_INTERVAL=3
 SERVICE_CLUSTER_IP_RANGE="10.0.0.0/16"  # formerly PORTAL_NET

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -42,7 +42,7 @@ MASTER_TAG="${INSTANCE_PREFIX}-master"
 MINION_TAG="${INSTANCE_PREFIX}-minion"
 CLUSTER_IP_RANGE="${CLUSTER_IP_RANGE:-10.245.0.0/16}"
 MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
-MINION_SCOPES=("storage-ro" "compute-rw" "https://www.googleapis.com/auth/logging.write" "https://www.googleapis.com/auth/monitoring")
+MINION_SCOPES="${MINION_SCOPES:-compute-rw,monitoring,logging-write,storage-ro}"
 # Increase the sleep interval value if concerned about API rate limits. 3, in seconds, is the default.
 POLL_SLEEP_INTERVAL=3
 SERVICE_CLUSTER_IP_RANGE="10.0.0.0/16"  # formerly PORTAL_NET

--- a/cluster/gce/coreos/helper.sh
+++ b/cluster/gce/coreos/helper.sh
@@ -140,7 +140,7 @@ function create-node-instance-template {
   if [[ -n ${1:-} ]]; then
     suffix="-${1}"
   fi
-   create-node-template "${NODE_INSTANCE_PREFIX}-template${suffix}" "${scope_flags[*]}" \
+   create-node-template "${NODE_INSTANCE_PREFIX}-template${suffix}" "${scope_flags}" \
     "kube-env=${KUBE_TEMP}/node-kube-env.yaml" \
     "user-data=${KUBE_ROOT}/cluster/gce/coreos/node.yaml"
 }

--- a/cluster/gce/debian/helper.sh
+++ b/cluster/gce/debian/helper.sh
@@ -120,7 +120,7 @@ function create-node-instance-template {
   if [[ -n ${1:-} ]]; then
     suffix="-${1}"
   fi
-  create-node-template "${NODE_INSTANCE_PREFIX}-template${suffix}" "${scope_flags[*]}" \
+  create-node-template "${NODE_INSTANCE_PREFIX}-template${suffix}" "${scope_flags}" \
     "startup-script=${KUBE_ROOT}/cluster/gce/configure-vm.sh" \
     "kube-env=${KUBE_TEMP}/node-kube-env.yaml"
 }

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -178,11 +178,11 @@ function prepare-node-upgrade() {
   detect-minion-names
 
   # TODO(mbforbes): Refactor setting scope flags.
-  local -a scope_flags=()
-  if (( "${#MINION_SCOPES[@]}" > 0 )); then
-    scope_flags=("--scopes" "$(join_csv ${MINION_SCOPES[@]})")
+  local scope_flags=
+  if [ -n "${MINION_SCOPES}" ]; then
+    scope_flags="--scopes ${MINION_SCOPES}"
   else
-    scope_flags=("--no-scopes")
+    scope_flags="--no-scopes"
   fi
 
   # Get required node env vars from exiting template.

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -685,11 +685,11 @@ function kube-up {
   echo "Creating minions."
 
   # TODO(mbforbes): Refactor setting scope flags.
-  local -a scope_flags=()
-  if (( "${#MINION_SCOPES[@]}" > 0 )); then
-    scope_flags=("--scopes" "$(join_csv ${MINION_SCOPES[@]})")
+  local scope_flags=
+  if [ -n "${MINION_SCOPES}" ]; then
+    scope_flags="--scopes ${MINION_SCOPES}"
   else
-    scope_flags=("--no-scopes")
+    scope_flags="--no-scopes"
   fi
 
   write-node-env
@@ -1007,11 +1007,11 @@ function prepare-push() {
     write-node-env
 
     # TODO(mbforbes): Refactor setting scope flags.
-    local -a scope_flags=()
-    if (( "${#MINION_SCOPES[@]}" > 0 )); then
-      scope_flags=("--scopes" "${MINION_SCOPES[@]}")
+    local scope_flags=
+    if [ -n "${MINION_SCOPES}" ]; then
+      scope_flags="--scopes ${MINION_SCOPES}"
     else
-      scope_flags=("--no-scopes")
+      scope_flags="--no-scopes"
     fi
 
     # Ugly hack: Since it is not possible to delete instance-template that is currently

--- a/cluster/gke/config-common.sh
+++ b/cluster/gke/config-common.sh
@@ -30,6 +30,7 @@ GCLOUD="${GCLOUD:-gcloud}"
 CMD_GROUP="${CMD_GROUP:-alpha}"
 GCLOUD_CONFIG_DIR="${GCLOUD_CONFIG_DIR:-${HOME}/.config/gcloud/kubernetes}"
 ENABLE_CLUSTER_DNS=false
+MINION_SCOPES="${MINION_SCOPES:-"compute-rw,storage-ro"}"
 
 # This is a hack, but I keep setting this when I run commands manually, and
 # then things grossly fail during normal runs because cluster/kubecfg.sh and

--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -112,6 +112,7 @@ function verify-prereqs() {
 #   ZONE
 #   CLUSTER_API_VERSION (optional)
 #   NUM_MINIONS
+#   MINION_SCOPES
 function kube-up() {
   echo "... in kube-up()" >&2
   detect-project >&2
@@ -142,6 +143,7 @@ function kube-up() {
     "--project=${PROJECT}"
     "--num-nodes=${NUM_MINIONS}"
     "--network=${NETWORK}"
+    "--scopes=${MINION_SCOPES}"
   )
   if [[ ! -z "${DOGFOOD_GCLOUD:-}" ]]; then
     create_args+=("--cluster-version=${CLUSTER_API_VERSION:-}")


### PR DESCRIPTION
@mbforbes @roberthbailey The scope of this grew slightly because we cannot pass a bash array as an environment variable, so I had to refactor and change MINION_SCOPES to a string for GCE and GKE. So actually MINION_SCOPES was not even customizable in GCE previously. So this may mean this feature needs to wait until post 1.0, but hopefully it is helpful at some point. Until it is merged, I will probably maintain my own branch.

Because bash arrays may not be environment variables
 (see: https://stackoverflow.com/questions/5564418/exporting-an-array-in-bash-script)
 we have to change the MINION_SCOPES array to a string
- prefers aliases instead of full URLs for scopes

tested under GKE, needs GCE testing

Close #10458 
