### PR TITLE
Add clarity around overlapping controllers

### DIFF
--- a/docs/user-guide/replication-controller.md
+++ b/docs/user-guide/replication-controller.md
@@ -73,7 +73,7 @@ Pods created by a replication controller are intended to be fungible and semanti
 
 The population of pods that a replication controller is monitoring is defined with a [label selector](labels.md#label-selectors), which creates a loosely coupled relationship between the controller and the pods controlled, in contrast to pods, which are more tightly coupled to their definition. We deliberately chose not to represent the set of pods controlled using a fixed-length array of pod specifications, because our experience is that approach increases complexity of management operations, for both clients and the system.
 
-The replication controller should verify that the pods created from the specified template have labels that match its label selector. Though it isn't verified yet, you should also ensure that only one replication controller controls any given pod, by ensuring that the label selectors of replication controllers do not target overlapping sets.
+The replication controller should verify that the pods created from the specified template have labels that match its label selector. Though it isn't verified yet, you should also ensure that only one replication controller controls any given pod, by ensuring that the label selectors of replication controllers do not target overlapping sets. If you do end up with multiple controllers that have overlapping selectors, you will have to manage the deletion yourself with --cascade=false until there are no controllers with an overlapping superset of selectors.
 
 Note that replication controllers may themselves have labels and would generally carry the labels their corresponding pods have in common, but these labels do not affect the behavior of the replication controllers.
 

--- a/pkg/client/testclient/fake_replication_controllers.go
+++ b/pkg/client/testclient/fake_replication_controllers.go
@@ -35,7 +35,7 @@ const (
 	UpdateControllerAction = "update-replicationController"
 	WatchControllerAction  = "watch-replicationController"
 	DeleteControllerAction = "delete-replicationController"
-	ListControllerAction   = "list-replicationControllers"
+	ListControllerAction   = "list-replicationController"
 	CreateControllerAction = "create-replicationController"
 )
 

--- a/pkg/kubectl/stop_test.go
+++ b/pkg/kubectl/stop_test.go
@@ -27,14 +27,19 @@ import (
 )
 
 func TestReplicationControllerStop(t *testing.T) {
+	name := "foo"
+	ns := "default"
 	fake := testclient.NewSimpleFake(&api.ReplicationController{
+		ObjectMeta: api.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
 		Spec: api.ReplicationControllerSpec{
 			Replicas: 0,
 		},
 	})
 	reaper := ReplicationControllerReaper{fake, time.Millisecond, time.Millisecond}
-	name := "foo"
-	s, err := reaper.Stop("default", name, 0, nil)
+	s, err := reaper.Stop(ns, name, 0, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -42,12 +47,12 @@ func TestReplicationControllerStop(t *testing.T) {
 	if s != expected {
 		t.Errorf("expected %s, got %s", expected, s)
 	}
-	if len(fake.Actions) != 6 {
-		t.Errorf("unexpected actions: %v, expected 6 actions (get, get, update, get, get, delete)", fake.Actions)
+	if len(fake.Actions) != 7 {
+		t.Errorf("unexpected actions: %v, expected 6 actions (get, list, get, update, get, get, delete)", fake.Actions)
 	}
-	for i, action := range []string{"get", "get", "update", "get", "get", "delete"} {
+	for i, action := range []string{"get", "list", "get", "update", "get", "get", "delete"} {
 		if fake.Actions[i].Action != action+"-replicationController" {
-			t.Errorf("unexpected action: %v, expected %s-replicationController", fake.Actions[i], action)
+			t.Errorf("unexpected action: %+v, expected %s-replicationController", fake.Actions[i], action)
 		}
 	}
 }


### PR DESCRIPTION
Spinoff from https://github.com/GoogleCloudPlatform/kubernetes/pull/10443
- Raise an error when kubectl stop detects overlapping rcs
- Add documentation about how to handle overlapping rcs

@lavalamp @bgrant0607 
