### PR TITLE
Stop exposing v1beta3 by default

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -152,6 +152,8 @@ func startComponents(firstManifestURL, secondManifestURL, apiVersion string) (st
 		glog.Fatalf("no public address for %s", host)
 	}
 
+	// Enable v1beta3 in master only if we are starting the components for that api version.
+	enableV1Beta3 := apiVersion == "v1beta3"
 	// Create a master and install handlers into mux.
 	m := master.New(&master.Config{
 		EtcdHelper:            helper,
@@ -160,6 +162,7 @@ func startComponents(firstManifestURL, secondManifestURL, apiVersion string) (st
 		EnableLogsSupport:     false,
 		EnableProfiling:       true,
 		APIPrefix:             "/api",
+		EnableV1Beta3:         enableV1Beta3,
 		Authorizer:            apiserver.NewAlwaysAllowAuthorizer(),
 		AdmissionControl:      admit.NewAlwaysAdmit(),
 		ReadWritePort:         portNumber,

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -275,7 +275,6 @@ func (s *APIServer) Run(_ []string) error {
 	}
 
 	// "api/legacy=false" allows users to disable legacy api versions.
-	// Right now, v1beta1 and v1beta2 are considered legacy.
 	disableLegacyAPIs := false
 	legacyAPIFlagValue, ok := s.RuntimeConfig["api/legacy"]
 	if ok && legacyAPIFlagValue == "false" {
@@ -283,10 +282,8 @@ func (s *APIServer) Run(_ []string) error {
 	}
 	_ = disableLegacyAPIs // hush the compiler while we don't have legacy APIs to disable.
 
-	// "api/v1beta3={true|false} allows users to enable/disable v1beta3 API.
-	// This takes preference over api/all and api/legacy, if specified.
-	disableV1beta3 := disableAllAPIs
-	disableV1beta3 = !s.getRuntimeConfigValue("api/v1beta3", !disableV1beta3)
+	// v1beta3 is disabled by default. Users can enable it using "api/v1beta3=true"
+	enableV1beta3 := s.getRuntimeConfigValue("api/v1beta3", false)
 
 	// "api/v1={true|false} allows users to enable/disable v1 API.
 	// This takes preference over api/all and api/legacy, if specified.
@@ -387,7 +384,7 @@ func (s *APIServer) Run(_ []string) error {
 		SupportsBasicAuth:      len(s.BasicAuthFile) > 0,
 		Authorizer:             authorizer,
 		AdmissionControl:       admissionController,
-		DisableV1Beta3:         disableV1beta3,
+		EnableV1Beta3:          enableV1beta3,
 		DisableV1:              disableV1,
 		MasterServiceNamespace: s.MasterServiceNamespace,
 		ClusterName:            s.ClusterName,

--- a/pkg/api/registered/registered.go
+++ b/pkg/api/registered/registered.go
@@ -35,7 +35,7 @@ func init() {
 	}
 
 	// The default list of supported api versions, in order of most preferred to the least.
-	defaultSupportedVersions := "v1,v1beta3"
+	defaultSupportedVersions := "v1"
 	// Env var KUBE_API_VERSIONS is a comma separated list of API versions that should be registered in the scheme.
 	// The versions should be in the order of most preferred to the least.
 	supportedVersions := os.Getenv("KUBE_API_VERSIONS")

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -95,8 +95,8 @@ type Config struct {
 	EnableUISupport       bool
 	// allow downstream consumers to disable swagger
 	EnableSwaggerSupport bool
-	// allow v1beta3 to be conditionally disabled
-	DisableV1Beta3 bool
+	// allow v1beta3 to be conditionally enabled
+	EnableV1Beta3 bool
 	// allow v1 to be conditionally disabled
 	DisableV1 bool
 	// allow downstream consumers to disable the index route
@@ -337,7 +337,7 @@ func New(c *Config) *Master {
 		authenticator:         c.Authenticator,
 		authorizer:            c.Authorizer,
 		admissionControl:      c.AdmissionControl,
-		v1beta3:               !c.DisableV1Beta3,
+		v1beta3:               c.EnableV1Beta3,
 		v1:                    !c.DisableV1,
 		requestContextMapper:  c.RequestContextMapper,
 

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -393,8 +393,10 @@ func TestAuthModeAlwaysAllow(t *testing.T) {
 		EnableUISupport:       false,
 		EnableIndex:           true,
 		APIPrefix:             "/api",
-		Authorizer:            apiserver.NewAlwaysAllowAuthorizer(),
-		AdmissionControl:      admit.NewAlwaysAdmit(),
+		// enable v1beta3 if we are testing that api version.
+		EnableV1Beta3:    testapi.Version() == "v1beta3",
+		Authorizer:       apiserver.NewAlwaysAllowAuthorizer(),
+		AdmissionControl: admit.NewAlwaysAdmit(),
 	})
 
 	transport := http.DefaultTransport
@@ -509,8 +511,10 @@ func TestAuthModeAlwaysDeny(t *testing.T) {
 		EnableUISupport:       false,
 		EnableIndex:           true,
 		APIPrefix:             "/api",
-		Authorizer:            apiserver.NewAlwaysDenyAuthorizer(),
-		AdmissionControl:      admit.NewAlwaysAdmit(),
+		// enable v1beta3 if we are testing that api version.
+		EnableV1Beta3:    testapi.Version() == "v1beta3",
+		Authorizer:       apiserver.NewAlwaysDenyAuthorizer(),
+		AdmissionControl: admit.NewAlwaysAdmit(),
 	})
 
 	transport := http.DefaultTransport
@@ -576,9 +580,11 @@ func TestAliceNotForbiddenOrUnauthorized(t *testing.T) {
 		EnableUISupport:       false,
 		EnableIndex:           true,
 		APIPrefix:             "/api",
-		Authenticator:         getTestTokenAuth(),
-		Authorizer:            allowAliceAuthorizer{},
-		AdmissionControl:      admit.NewAlwaysAdmit(),
+		// enable v1beta3 if we are testing that api version.
+		EnableV1Beta3:    testapi.Version() == "v1beta3",
+		Authenticator:    getTestTokenAuth(),
+		Authorizer:       allowAliceAuthorizer{},
+		AdmissionControl: admit.NewAlwaysAdmit(),
 	})
 
 	previousResourceVersion := make(map[string]float64)
@@ -663,9 +669,11 @@ func TestBobIsForbidden(t *testing.T) {
 		EnableUISupport:       false,
 		EnableIndex:           true,
 		APIPrefix:             "/api",
-		Authenticator:         getTestTokenAuth(),
-		Authorizer:            allowAliceAuthorizer{},
-		AdmissionControl:      admit.NewAlwaysAdmit(),
+		// enable v1beta3 if we are testing that api version.
+		EnableV1Beta3:    testapi.Version() == "v1beta3",
+		Authenticator:    getTestTokenAuth(),
+		Authorizer:       allowAliceAuthorizer{},
+		AdmissionControl: admit.NewAlwaysAdmit(),
 	})
 
 	transport := http.DefaultTransport
@@ -724,9 +732,11 @@ func TestUnknownUserIsUnauthorized(t *testing.T) {
 		EnableUISupport:       false,
 		EnableIndex:           true,
 		APIPrefix:             "/api",
-		Authenticator:         getTestTokenAuth(),
-		Authorizer:            allowAliceAuthorizer{},
-		AdmissionControl:      admit.NewAlwaysAdmit(),
+		// enable v1beta3 if we are testing that api version.
+		EnableV1Beta3:    testapi.Version() == "v1beta3",
+		Authenticator:    getTestTokenAuth(),
+		Authorizer:       allowAliceAuthorizer{},
+		AdmissionControl: admit.NewAlwaysAdmit(),
 	})
 
 	transport := http.DefaultTransport
@@ -804,9 +814,11 @@ func TestNamespaceAuthorization(t *testing.T) {
 		EnableUISupport:       false,
 		EnableIndex:           true,
 		APIPrefix:             "/api",
-		Authenticator:         getTestTokenAuth(),
-		Authorizer:            a,
-		AdmissionControl:      admit.NewAlwaysAdmit(),
+		// enable v1beta3 if we are testing that api version.
+		EnableV1Beta3:    testapi.Version() == "v1beta3",
+		Authenticator:    getTestTokenAuth(),
+		Authorizer:       a,
+		AdmissionControl: admit.NewAlwaysAdmit(),
 	})
 
 	previousResourceVersion := make(map[string]float64)
@@ -919,9 +931,11 @@ func TestKindAuthorization(t *testing.T) {
 		EnableUISupport:       false,
 		EnableIndex:           true,
 		APIPrefix:             "/api",
-		Authenticator:         getTestTokenAuth(),
-		Authorizer:            a,
-		AdmissionControl:      admit.NewAlwaysAdmit(),
+		// enable v1beta3 if we are testing that api version.
+		EnableV1Beta3:    testapi.Version() == "v1beta3",
+		Authenticator:    getTestTokenAuth(),
+		Authorizer:       a,
+		AdmissionControl: admit.NewAlwaysAdmit(),
 	})
 
 	previousResourceVersion := make(map[string]float64)
@@ -1021,9 +1035,11 @@ func TestReadOnlyAuthorization(t *testing.T) {
 		EnableUISupport:       false,
 		EnableIndex:           true,
 		APIPrefix:             "/api",
-		Authenticator:         getTestTokenAuth(),
-		Authorizer:            a,
-		AdmissionControl:      admit.NewAlwaysAdmit(),
+		// enable v1beta3 if we are testing that api version.
+		EnableV1Beta3:    testapi.Version() == "v1beta3",
+		Authenticator:    getTestTokenAuth(),
+		Authorizer:       a,
+		AdmissionControl: admit.NewAlwaysAdmit(),
 	})
 
 	transport := http.DefaultTransport

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -139,8 +139,10 @@ func startMasterOrDie(masterConfig *master.Config) (*master.Master, *httptest.Se
 			EnableProfiling:   true,
 			EnableUISupport:   false,
 			APIPrefix:         "/api",
-			Authorizer:        apiserver.NewAlwaysAllowAuthorizer(),
-			AdmissionControl:  admit.NewAlwaysAdmit(),
+			// Enable v1bewta3 if we are testing that version
+			EnableV1Beta3:    testapi.Version() == "v1beta3",
+			Authorizer:       apiserver.NewAlwaysAllowAuthorizer(),
+			AdmissionControl: admit.NewAlwaysAdmit(),
 		}
 	} else {
 		helper = masterConfig.EtcdHelper
@@ -270,8 +272,10 @@ func RunAMaster(t *testing.T) (*master.Master, *httptest.Server) {
 		EnableProfiling:   true,
 		EnableUISupport:   false,
 		APIPrefix:         "/api",
-		Authorizer:        apiserver.NewAlwaysAllowAuthorizer(),
-		AdmissionControl:  admit.NewAlwaysAdmit(),
+		// Enable v1bewta3 if we are testing that version
+		EnableV1Beta3:    testapi.Version() == "v1beta3",
+		Authorizer:       apiserver.NewAlwaysAllowAuthorizer(),
+		AdmissionControl: admit.NewAlwaysAdmit(),
 	})
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/test/integration/scheduler_test.go
+++ b/test/integration/scheduler_test.go
@@ -73,8 +73,10 @@ func TestUnschedulableNodes(t *testing.T) {
 		EnableUISupport:       false,
 		EnableIndex:           true,
 		APIPrefix:             "/api",
-		Authorizer:            apiserver.NewAlwaysAllowAuthorizer(),
-		AdmissionControl:      admit.NewAlwaysAdmit(),
+		// Enable v1beta3 if we are testing that version.
+		EnableV1Beta3:    testapi.Version() == "v1beta3",
+		Authorizer:       apiserver.NewAlwaysAllowAuthorizer(),
+		AdmissionControl: admit.NewAlwaysAdmit(),
 	})
 
 	restClient := client.NewOrDie(&client.Config{Host: s.URL, Version: testapi.Version()})

--- a/test/integration/secret_test.go
+++ b/test/integration/secret_test.go
@@ -66,8 +66,10 @@ func TestSecrets(t *testing.T) {
 		EnableUISupport:       false,
 		EnableIndex:           true,
 		APIPrefix:             "/api",
-		Authorizer:            apiserver.NewAlwaysAllowAuthorizer(),
-		AdmissionControl:      admit.NewAlwaysAdmit(),
+		// Enable v1beta3 if we are testing that version.
+		EnableV1Beta3:    testapi.Version() == "v1beta3",
+		Authorizer:       apiserver.NewAlwaysAllowAuthorizer(),
+		AdmissionControl: admit.NewAlwaysAdmit(),
 	})
 
 	framework.DeleteAllEtcdKeys()

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -416,9 +416,11 @@ func startServiceAccountTestServer(t *testing.T) (*client.Client, client.Config,
 		EnableUISupport:   false,
 		EnableIndex:       true,
 		APIPrefix:         "/api",
-		Authenticator:     authenticator,
-		Authorizer:        authorizer,
-		AdmissionControl:  serviceAccountAdmission,
+		// Enable v1beta3 if we are testing that version.
+		EnableV1Beta3:    testapi.Version() == "v1beta3",
+		Authenticator:    authenticator,
+		Authorizer:       authorizer,
+		AdmissionControl: serviceAccountAdmission,
 	})
 
 	// Start the service account and service account token controllers

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -80,8 +80,10 @@ func runAMaster(t *testing.T) (*master.Master, *httptest.Server) {
 		EnableProfiling:       true,
 		EnableUISupport:       false,
 		APIPrefix:             "/api",
-		Authorizer:            apiserver.NewAlwaysAllowAuthorizer(),
-		AdmissionControl:      admit.NewAlwaysAdmit(),
+		// Enable v1beta3 if we are testing that version.
+		EnableV1Beta3:    testapi.Version() == "v1beta3",
+		Authorizer:       apiserver.NewAlwaysAllowAuthorizer(),
+		AdmissionControl: admit.NewAlwaysAdmit(),
 	})
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
For https://github.com/GoogleCloudPlatform/kubernetes/issues/10501

Updating code to not register and expose v1beta3 api by default. It can still be registered and exposed by  modifying environment variables.
