### PR TITLE
Make elasticsearch port less 15 chars

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-controller.yaml
@@ -27,7 +27,7 @@ spec:
           name: es-port
           protocol: TCP
         - containerPort: 9300
-          name: es-transport-port
+          name: es-trans-port
           protocol: TCP
         volumeMounts:
         - name: es-persistent-storage

--- a/docs/getting-started-guides/coreos/azure/addons/fluentd-elasticsearch/es-controller.yaml
+++ b/docs/getting-started-guides/coreos/azure/addons/fluentd-elasticsearch/es-controller.yaml
@@ -27,7 +27,7 @@ spec:
           name: es-port
           protocol: TCP
         - containerPort: 9300
-          name: es-transport-port
+          name: es-trans-port
           protocol: TCP
         volumeMounts:
         - name: es-persistent-storage

--- a/pkg/api/replication_controller_example.json
+++ b/pkg/api/replication_controller_example.json
@@ -54,7 +54,7 @@
                                 "protocol": "TCP"
                             },
                             {
-                                "name": "es-transport-port",
+                                "name": "es-trans-port",
                                 "containerPort": 9300,
                                 "protocol": "TCP"
                             }

--- a/release-0.19.0/docs/getting-started-guides/coreos/azure/addons/fluentd-elasticsearch/es-controller.yaml
+++ b/release-0.19.0/docs/getting-started-guides/coreos/azure/addons/fluentd-elasticsearch/es-controller.yaml
@@ -27,7 +27,7 @@ spec:
           name: es-port
           protocol: TCP
         - containerPort: 9300
-          name: es-transport-port
+          name: es-trans-port
           protocol: TCP
         volumeMounts:
         - name: es-persistent-storage

--- a/release-0.20.0/docs/getting-started-guides/coreos/azure/addons/fluentd-elasticsearch/es-controller.yaml
+++ b/release-0.20.0/docs/getting-started-guides/coreos/azure/addons/fluentd-elasticsearch/es-controller.yaml
@@ -27,7 +27,7 @@ spec:
           name: es-port
           protocol: TCP
         - containerPort: 9300
-          name: es-transport-port
+          name: es-trans-port
           protocol: TCP
         volumeMounts:
         - name: es-persistent-storage


### PR DESCRIPTION
4b13faa34643a95c24e833e6bc14c2f09a00d392 changed the limit on port name
from 64 to 15. So we need to make our port names smaller.
