### PR TITLE
Respect DNS_DOMAIN setting in AWS+CoreOS

### DIFF
--- a/cluster/aws/coreos/node.yaml
+++ b/cluster/aws/coreos/node.yaml
@@ -70,7 +70,7 @@ coreos:
         --allow_privileged=False \
         --v=2 \
         --cluster_dns=10.0.0.10 \
-        --cluster_domain=kubernetes.local \
+        --cluster_domain=${DNS_DOMAIN} \
         --logtostderr=true \
         --hostname-override=${HOSTNAME_OVERRIDE} \
         --container-runtime=${KUBERNETES_CONTAINER_RUNTIME}


### PR DESCRIPTION
Without this change, CoreOS minion nodes are unable to perform short-name DNS lookups by default, as the default value for `DNS_DOMAIN` is `cluster.local`, which doesn't match the hard-coded value here.
