### PR TITLE
Release 0.20.2

### DIFF
--- a/cluster/saltbase/salt/kube-addons/kube-addons.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addons.sh
@@ -136,12 +136,12 @@ fi
 
 # Wait for the default service account
 token_found=""
-while [ -z "${token_made}" ]; do
+while [ -z "${token_found}" ]; do
   sleep .5
-  token_found=$(${KUBECTL} get serviceaccount default -o template -t "{{with index .secrets 0}}{{.name}}{{end}}" || echo "")
+  token_found=$(${KUBECTL} get serviceaccount default -o template -t "{{with index .secrets 0}}{{.name}}{{end}}" || true)
 done
 
-echo "default service account has token ${token_found}"
+echo "== default service account has token ${token_found} =="
 
 # Generate secrets for "internal service accounts".
 # TODO(etune): move to a completely yaml/object based
@@ -180,6 +180,3 @@ while true; do
   `dirname $0`/kube-addon-update.sh /etc/kubernetes/addons
   sleep $ADDON_CHECK_INTERVAL_SEC
 done
-
-
-

--- a/cluster/saltbase/salt/kube-addons/kube-addons.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addons.sh
@@ -134,6 +134,15 @@ for k,v in yaml.load(sys.stdin).iteritems():
 ''' < "${kube_env_yaml}")
 fi
 
+# Wait for the default service account
+token_found=""
+while [ -z "${token_made}" ]; do
+  sleep .5
+  token_found=$(${KUBECTL} get serviceaccount default -o template -t "{{with index .secrets 0}}{{.name}}{{end}}" || echo "")
+done
+
+echo "default service account has token ${token_found}"
+
 # Generate secrets for "internal service accounts".
 # TODO(etune): move to a completely yaml/object based
 # workflow so that service accounts can be created

--- a/cluster/saltbase/salt/kubelet/kubelet.service
+++ b/cluster/saltbase/salt/kubelet/kubelet.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=Kubernetes Kubelet Server
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-After=docker.service
-Requires=docker.service
 
 [Service]
 EnvironmentFile=/etc/sysconfig/kubelet

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -36,8 +36,8 @@ package version
 var (
 	// TODO: Deprecate gitMajor and gitMinor, use only gitVersion instead.
 	gitMajor     string = "0"              // major version, always numeric
-	gitMinor     string = "20.2"           // minor version, numeric possibly followed by "+"
-	gitVersion   string = "v0.20.2"        // version from git, output of $(git describe)
+	gitMinor     string = "20.2+"          // minor version, numeric possibly followed by "+"
+	gitVersion   string = "v0.20.2-dev"    // version from git, output of $(git describe)
 	gitCommit    string = ""               // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 )

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -36,8 +36,8 @@ package version
 var (
 	// TODO: Deprecate gitMajor and gitMinor, use only gitVersion instead.
 	gitMajor     string = "0"              // major version, always numeric
-	gitMinor     string = "20.1+"          // minor version, numeric possibly followed by "+"
-	gitVersion   string = "v0.20.1-dev"    // version from git, output of $(git describe)
+	gitMinor     string = "20.2"           // minor version, numeric possibly followed by "+"
+	gitVersion   string = "v0.20.2"        // version from git, output of $(git describe)
 	gitCommit    string = ""               // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 )


### PR DESCRIPTION
Cherrypick 3 PRs into v0.20.2:
- Don't make kubelet systemd service depend on Docker #10400
- Kubelet doesn't fight apiserver for cputime on the master. #10471
- Wait until a token shows up to start addons (redux) #10542
