### PR TITLE
Make util.empty public for conversions

### DIFF
--- a/pkg/util/set.go
+++ b/pkg/util/set.go
@@ -21,10 +21,12 @@ import (
 	"sort"
 )
 
-type empty struct{}
+// Empty is public since it is used by some internal API objects for conversions between external
+// string arrays and internal sets, and conversion logic requires public types today.
+type Empty struct{}
 
 // StringSet is a set of strings, implemented via map[string]struct{} for minimal memory consumption.
-type StringSet map[string]empty
+type StringSet map[string]Empty
 
 // NewStringSet creates a StringSet from a list of values.
 func NewStringSet(items ...string) StringSet {
@@ -48,7 +50,7 @@ func KeySet(theMap reflect.Value) StringSet {
 // Insert adds items to the set.
 func (s StringSet) Insert(items ...string) {
 	for _, item := range items {
-		s[item] = empty{}
+		s[item] = Empty{}
 	}
 }
 


### PR DESCRIPTION
Some downstream components want to use a StringSet in their internal
objects, but leaving util.empty private means that generated conversions
cannot create constructors generically for those objects.  This makes
Empty public until such a time as the generator supports private types.
