### PR TITLE
Missed update to kube-proxy when removing nginx on vagrant

### DIFF
--- a/cluster/saltbase/salt/kube-proxy/default
+++ b/cluster/saltbase/salt/kube-proxy/default
@@ -18,7 +18,7 @@
   {% endif -%}
 
   # TODO: remove nginx for other cloud providers.
-  {% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce' ]  %}
+  {% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce', 'vagrant' ]  %}
      {% set api_servers_with_port = api_servers -%}
   {% else -%}
     {% set api_servers_with_port = api_servers + ":6443" -%}


### PR DESCRIPTION
The vagrant kube-proxy setup was still trying to hit on 6443 instead of 443.
