### PR TITLE
apiservier: avoid stacktracing when http.StatusUnauthorized.

### DIFF
--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -125,6 +125,8 @@ func RecoverPanics(handler http.Handler) http.Handler {
 				http.StatusTemporaryRedirect,
 				http.StatusConflict,
 				http.StatusNotFound,
+				http.StatusUnauthorized,
+				http.StatusForbidden,
 				errors.StatusUnprocessableEntity,
 				http.StatusSwitchingProtocols,
 			),


### PR DESCRIPTION
Also add tests for authentication.
