### PR TITLE
Changing AWS examples / templates to use 0.19.3 release

### DIFF
--- a/docs/getting-started-guides/aws-coreos.md
+++ b/docs/getting-started-guides/aws-coreos.md
@@ -32,7 +32,7 @@ no security tokens, no basic auth). For demonstration purposes only.
 * Cluster bootstrapping using [cloud-config](https://coreos.com/docs/cluster-management/setup/cloudinit-cloud-config/)
 * Cross container networking with [flannel](https://github.com/coreos/flannel#flannel)
 * Auto worker registration with [kube-register](https://github.com/kelseyhightower/kube-register#kube-register)
-* Kubernetes v0.17.0 [official binaries](https://github.com/GoogleCloudPlatform/kubernetes/releases/tag/v0.17.0)
+* Kubernetes v0.19.3 [official binaries](https://github.com/GoogleCloudPlatform/kubernetes/releases/tag/v0.19.3)
 
 ## Prerequisites
 

--- a/docs/getting-started-guides/aws/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/aws/cloud-configs/master.yaml
@@ -100,7 +100,7 @@ coreos:
         After=network-online.target
 
         [Service]
-        ExecStart=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kubectl
+        ExecStart=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.19.3/bin/linux/amd64/kubectl
         ExecStart=/usr/bin/chmod +x /opt/bin/kubectl
         Type=oneshot
         RemainAfterExit=true
@@ -114,7 +114,7 @@ coreos:
         After=etcd2-waiter.service
 
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kube-apiserver
+        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.19.3/bin/linux/amd64/kube-apiserver
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-apiserver
         ExecStart=/opt/bin/kube-apiserver \
         --insecure-bind-address=0.0.0.0 \
@@ -132,7 +132,7 @@ coreos:
         After=kube-apiserver.service
 
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kube-controller-manager
+        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.19.3/bin/linux/amd64/kube-controller-manager
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-controller-manager
         ExecStart=/opt/bin/kube-controller-manager \
         --master=127.0.0.1:8080
@@ -148,7 +148,7 @@ coreos:
         After=kube-apiserver.service
 
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kube-scheduler
+        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.19.3/bin/linux/amd64/kube-scheduler
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-scheduler
         ExecStart=/opt/bin/kube-scheduler \
         --master=127.0.0.1:8080
@@ -164,7 +164,7 @@ coreos:
         After=kube-apiserver.service fleet.service
 
         [Service]
-        ExecStartPre=-/usr/bin/wget -nc -O /opt/bin/kube-register https://github.com/kelseyhightower/kube-register/releases/download/v0.0.3/kube-register-0.0.3-linux-amd64
+        ExecStartPre=-/usr/bin/wget -nc -O /opt/bin/kube-register https://github.com/kelseyhightower/kube-register/releases/download/v0.0.4/kube-register-0.0.4-linux-amd64
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-register
         ExecStart=/opt/bin/kube-register \
         --metadata=k8srole=node \

--- a/docs/getting-started-guides/aws/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/aws/cloud-configs/node.yaml
@@ -49,7 +49,7 @@ coreos:
         After=network-online.target
 
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kubelet
+        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.19.3/bin/linux/amd64/kubelet
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kubelet
         # wait for kubernetes master to be up and ready
         ExecStartPre=/opt/bin/wupiao <master-private-ip> 8080
@@ -68,7 +68,7 @@ coreos:
         After=network-online.target
 
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kube-proxy
+        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.19.3/bin/linux/amd64/kube-proxy
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
         # wait for kubernetes master to be up and ready
         ExecStartPre=/opt/bin/wupiao <master-private-ip> 8080

--- a/docs/getting-started-guides/aws/cloudformation-template.json
+++ b/docs/getting-started-guides/aws/cloudformation-template.json
@@ -1,37 +1,37 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "Kubernetes 0.18.2 on EC2 powered by CoreOS 681.0.0 (alpha)",
+  "Description": "Kubernetes 0.19.3 on EC2 powered by CoreOS 681.2.0 (stable)",
   "Mappings": {
       "RegionMap": {
           "eu-central-1" : {
-              "AMI" : "ami-4c4f7151"
+              "AMI" : "ami-eae5ddf7"
           },
           "ap-northeast-1" : {
-              "AMI" : "ami-3a35fd3a"
+              "AMI" : "ami-1a6fca1a"
           },
           "us-gov-west-1" : {
-              "AMI" : "ami-57117174"
+              "AMI" : "ami-e99fffca"
           },
           "sa-east-1" : {
-              "AMI" : "ami-fbcc4ae6"
+              "AMI" : "ami-b1cb49ac"
           },
           "ap-southeast-2" : {
-              "AMI" : "ami-593c4263"
+              "AMI" : "ami-23641e19"
           },
           "ap-southeast-1" : {
-              "AMI" : "ami-3a083668"
+              "AMI" : "ami-da030788"
           },
           "us-east-1" : {
-              "AMI" : "ami-40322028"
+              "AMI" : "ami-93ea17f8"
           },
           "us-west-2" : {
-              "AMI" : "ami-23b58613"
+              "AMI" : "ami-5d4d486d"
           },
           "us-west-1" : {
-              "AMI" : "ami-15618f51"
+              "AMI" : "ami-c967938d"
           },
           "eu-west-1" : {
-              "AMI" : "ami-8d1164fa"
+              "AMI" : "ami-5f2f5528"
           }
       }
   },
@@ -243,7 +243,7 @@
           "        Requires=network-online.target\n",
           "        After=network-online.target\n\n",
           "        [Service]\n",
-          "        ExecStart=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.18.2/bin/linux/amd64/kubectl\n",
+          "        ExecStart=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.19.3/bin/linux/amd64/kubectl\n",
           "        ExecStart=/usr/bin/chmod +x /opt/bin/kubectl\n",
           "        Type=oneshot\n",
           "        RemainAfterExit=true\n",
@@ -256,7 +256,7 @@
           "        Requires=etcd2-waiter.service\n",
           "        After=etcd2-waiter.service\n\n",
           "        [Service]\n",
-          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.18.2/bin/linux/amd64/kube-apiserver\n",
+          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.19.3/bin/linux/amd64/kube-apiserver\n",
           "        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-apiserver\n",
           "        ExecStart=/opt/bin/kube-apiserver \\\n",
           "        --insecure-bind-address=0.0.0.0 \\\n",
@@ -273,7 +273,7 @@
           "        Requires=kube-apiserver.service\n",
           "        After=kube-apiserver.service\n\n",
           "        [Service]\n",
-          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.18.2/bin/linux/amd64/kube-controller-manager\n",
+          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.19.3/bin/linux/amd64/kube-controller-manager\n",
           "        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-controller-manager\n",
           "        ExecStart=/opt/bin/kube-controller-manager \\\n",
           "        --master=127.0.0.1:8080\n",
@@ -288,7 +288,7 @@
           "        Requires=kube-apiserver.service\n",
           "        After=kube-apiserver.service\n\n",
           "        [Service]\n",
-          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.18.2/bin/linux/amd64/kube-scheduler\n",
+          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.19.3/bin/linux/amd64/kube-scheduler\n",
           "        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-scheduler\n",
           "        ExecStart=/opt/bin/kube-scheduler \\\n",
           "        --master=127.0.0.1:8080\n",
@@ -303,7 +303,7 @@
           "        Requires=kube-apiserver.service fleet.service\n",
           "        After=kube-apiserver.service fleet.service\n\n",
           "        [Service]\n",
-          "        ExecStartPre=-/usr/bin/wget -nc -O /opt/bin/kube-register https://github.com/kelseyhightower/kube-register/releases/download/v0.0.3/kube-register-0.0.3-linux-amd64\n",
+          "        ExecStartPre=-/usr/bin/wget -nc -O /opt/bin/kube-register https://github.com/kelseyhightower/kube-register/releases/download/v0.0.4/kube-register-0.0.4-linux-amd64\n",
           "        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-register\n",
           "        ExecStart=/opt/bin/kube-register \\\n",
           "        --metadata=k8srole=node \\\n",
@@ -367,7 +367,7 @@
           "        Requires=network-online.target\n",
           "        After=network-online.target\n\n",
           "        [Service]\n",
-          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.18.2/bin/linux/amd64/kubelet\n",
+          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.19.3/bin/linux/amd64/kubelet\n",
           "        ExecStartPre=/usr/bin/chmod +x /opt/bin/kubelet\n",
           "        ExecStart=/opt/bin/kubelet \\\n",
           "        --api-servers=", {"Fn::GetAtt" :["KubernetesMasterInstance" , "PrivateIp"]}, ":8080 \\\n",
@@ -383,7 +383,7 @@
           "        Requires=network-online.target\n",
           "        After=network-online.target\n\n",
           "        [Service]\n",
-          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.18.2/bin/linux/amd64/kube-proxy\n",
+          "        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v0.19.3/bin/linux/amd64/kube-proxy\n",
           "        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy\n",
           "        ExecStart=/opt/bin/kube-proxy \\\n",
           "        --master=http://", {"Fn::GetAtt" :["KubernetesMasterInstance" , "PrivateIp"]}, ":8080\n",

--- a/docs/getting-started-guides/aws/kubectl.md
+++ b/docs/getting-started-guides/aws/kubectl.md
@@ -25,10 +25,10 @@ certainly want the docs that go with that version.</h1>
 ## Download the kubectl CLI tool
 ```bash
 ### Darwin
-wget https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/darwin/amd64/kubectl
+wget https://storage.googleapis.com/kubernetes-release/release/v0.19.3/bin/darwin/amd64/kubectl
 
 ### Linux
-wget https://storage.googleapis.com/kubernetes-release/release/v0.17.0/bin/linux/amd64/kubectl
+wget https://storage.googleapis.com/kubernetes-release/release/v0.19.3/bin/linux/amd64/kubectl
 ```
 
 ### Copy kubectl to your path


### PR DESCRIPTION
- Fixes #10467
- Updating CoreOS AMI ids
