### PR TITLE
Jenkins GCE e2e: "Service endpoints latency" is not flaky in parallel

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -69,7 +69,7 @@ fi
 GCE_DEFAULT_SKIP_TEST_REGEX="Skipped|Density|Reboot|Restart"
 # The following tests are known to be flaky, and are thus run only in their own
 # -flaky- build variants.
-GCE_FLAKY_TEST_REGEX="Addon|Elasticsearch|Nodes.*network\spartition|Service\sendpoints\slatency|Shell.*services|readonly\sPD"
+GCE_FLAKY_TEST_REGEX="Addon|Elasticsearch|Nodes.*network\spartition|Shell.*services|readonly\sPD"
 # Tests which are not able to be run in parallel.
 GCE_PARALLEL_SKIP_TEST_REGEX="${GCE_DEFAULT_SKIP_TEST_REGEX}|Etcd|NetworkingNew|Nodes\sNetwork|Nodes\sResize"
 # Tests which are known to be flaky when run in parallel.


### PR DESCRIPTION
This test had been enabled on `kubernetes-gce-e2e-parallel` but not `kubernetes-pull-build-test-e2e-gce`. It passed the 30 times it ran on the former before it started getting skipped, so I think it's safe to re-enable it on our stable parallel runs.
