### PR TITLE
Fix expected message in test case

### DIFF
--- a/pkg/api/errors/errors_test.go
+++ b/pkg/api/errors/errors_test.go
@@ -149,7 +149,7 @@ func TestNewInvalid(t *testing.T) {
 	}
 	for i, testCase := range testCases {
 		vErr, expected := testCase.Err, testCase.Details
-		expected.Causes[0].Message = vErr.Error()
+		expected.Causes[0].Message = vErr.ErrorBody()
 		err := NewInvalid("kind", "name", fielderrors.ValidationErrorList{vErr})
 		status := err.(*StatusError).ErrStatus
 		if status.Code != 422 || status.Reason != api.StatusReasonInvalid {


### PR DESCRIPTION
Following 15766bfbbc494c6c9968906a2fdd762fd0590882, some test cases broke as they still expected repeated field names.

@thockin 
