### PR TITLE
Support multiple API groups in runtime.Scheme

### DIFF
--- a/cmd/genconversion/conversion.go
+++ b/cmd/genconversion/conversion.go
@@ -54,7 +54,7 @@ func main() {
 	generator := pkg_runtime.NewConversionGenerator(api.Scheme.Raw())
 	// TODO(wojtek-t): Change the overwrites to a flag.
 	generator.OverwritePackage(*version, "")
-	for _, knownType := range api.Scheme.KnownTypes(*version) {
+	for _, knownType := range api.Scheme.KnownTypes(api.Group, *version) {
 		if err := generator.GenerateConversionsForType(*version, knownType); err != nil {
 			glog.Errorf("error while generating conversion functions for %v: %v", knownType, err)
 		}

--- a/cmd/gendeepcopy/deep_copy.go
+++ b/cmd/gendeepcopy/deep_copy.go
@@ -63,7 +63,7 @@ func main() {
 		vals := strings.Split(overwrite, "=")
 		generator.OverwritePackage(vals[0], vals[1])
 	}
-	for _, knownType := range api.Scheme.KnownTypes(knownVersion) {
+	for _, knownType := range api.Scheme.KnownTypes(api.Group, knownVersion) {
 		if err := generator.AddType(knownType); err != nil {
 			glog.Errorf("error while generating deep copy functions for %v: %v", knownType, err)
 		}

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -50,6 +50,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/probe"
+	kuberuntime "github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/service"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -496,7 +497,7 @@ func runSelfLinkTestOnNamespace(c *client.Client, namespace string) {
 
 func runAtomicPutTest(c *client.Client) {
 	svcBody := api.Service{
-		TypeMeta: api.TypeMeta{
+		TypeMeta: kuberuntime.TypeMeta{
 			APIVersion: c.APIVersion(),
 		},
 		ObjectMeta: api.ObjectMeta{
@@ -578,7 +579,7 @@ func runPatchTest(c *client.Client) {
 	name := "patchservice"
 	resource := "services"
 	svcBody := api.Service{
-		TypeMeta: api.TypeMeta{
+		TypeMeta: kuberuntime.TypeMeta{
 			APIVersion: c.APIVersion(),
 		},
 		ObjectMeta: api.ObjectMeta{

--- a/contrib/mesos/pkg/executor/executor_test.go
+++ b/contrib/mesos/pkg/executor/executor_test.go
@@ -660,7 +660,7 @@ func TestExecutorFrameworkMessage(t *testing.T) {
 func NewTestPod(i int) *api.Pod {
 	name := fmt.Sprintf("pod%d", i)
 	return &api.Pod{
-		TypeMeta: api.TypeMeta{APIVersion: testapi.Version()},
+		TypeMeta: runtime.TypeMeta{APIVersion: testapi.Version()},
 		ObjectMeta: api.ObjectMeta{
 			Name:      name,
 			Namespace: api.NamespaceDefault,

--- a/contrib/mesos/pkg/scheduler/plugin_test.go
+++ b/contrib/mesos/pkg/scheduler/plugin_test.go
@@ -191,7 +191,7 @@ func (lw *MockPodsListWatch) Delete(pod *api.Pod, notify bool) {
 func NewTestPod(i int) *api.Pod {
 	name := fmt.Sprintf("pod%d", i)
 	return &api.Pod{
-		TypeMeta: api.TypeMeta{APIVersion: testapi.Version()},
+		TypeMeta: runtime.TypeMeta{APIVersion: testapi.Version()},
 		ObjectMeta: api.ObjectMeta{
 			Name:      name,
 			Namespace: "default",

--- a/pkg/api/copy_test.go
+++ b/pkg/api/copy_test.go
@@ -30,8 +30,8 @@ func TestDeepCopyApiObjects(t *testing.T) {
 	for i := 0; i < *fuzzIters; i++ {
 		for _, version := range []string{"", testapi.Version()} {
 			f := apitesting.FuzzerFor(t, version, rand.NewSource(rand.Int63()))
-			for kind := range api.Scheme.KnownTypes(version) {
-				item, err := api.Scheme.New(version, kind)
+			for kind := range api.Scheme.KnownTypes(api.Group, version) {
+				item, err := api.Scheme.New(api.Group, version, kind)
 				if err != nil {
 					t.Fatalf("Could not create a %s: %s", kind, err)
 				}

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -37,7 +37,7 @@ func deepCopy_api_AWSElasticBlockStoreVolumeSource(in AWSElasticBlockStoreVolume
 }
 
 func deepCopy_api_Binding(in Binding, out *Binding, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -78,7 +78,7 @@ func deepCopy_api_ComponentCondition(in ComponentCondition, out *ComponentCondit
 }
 
 func deepCopy_api_ComponentStatus(in ComponentStatus, out *ComponentStatus, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -98,7 +98,7 @@ func deepCopy_api_ComponentStatus(in ComponentStatus, out *ComponentStatus, c *c
 }
 
 func deepCopy_api_ComponentStatusList(in ComponentStatusList, out *ComponentStatusList, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -288,7 +288,7 @@ func deepCopy_api_ContainerStatus(in ContainerStatus, out *ContainerStatus, c *c
 }
 
 func deepCopy_api_DeleteOptions(in DeleteOptions, out *DeleteOptions, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if in.GracePeriodSeconds != nil {
@@ -350,7 +350,7 @@ func deepCopy_api_EndpointSubset(in EndpointSubset, out *EndpointSubset, c *conv
 }
 
 func deepCopy_api_Endpoints(in Endpoints, out *Endpoints, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -370,7 +370,7 @@ func deepCopy_api_Endpoints(in Endpoints, out *Endpoints, c *conversion.Cloner) 
 }
 
 func deepCopy_api_EndpointsList(in EndpointsList, out *EndpointsList, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -416,7 +416,7 @@ func deepCopy_api_EnvVarSource(in EnvVarSource, out *EnvVarSource, c *conversion
 }
 
 func deepCopy_api_Event(in Event, out *Event, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -441,7 +441,7 @@ func deepCopy_api_Event(in Event, out *Event, c *conversion.Cloner) error {
 }
 
 func deepCopy_api_EventList(in EventList, out *EventList, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -572,7 +572,7 @@ func deepCopy_api_Lifecycle(in Lifecycle, out *Lifecycle, c *conversion.Cloner) 
 }
 
 func deepCopy_api_LimitRange(in LimitRange, out *LimitRange, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -626,7 +626,7 @@ func deepCopy_api_LimitRangeItem(in LimitRangeItem, out *LimitRangeItem, c *conv
 }
 
 func deepCopy_api_LimitRangeList(in LimitRangeList, out *LimitRangeList, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -660,7 +660,7 @@ func deepCopy_api_LimitRangeSpec(in LimitRangeSpec, out *LimitRangeSpec, c *conv
 }
 
 func deepCopy_api_List(in List, out *List, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -688,7 +688,7 @@ func deepCopy_api_ListMeta(in ListMeta, out *ListMeta, c *conversion.Cloner) err
 }
 
 func deepCopy_api_ListOptions(in ListOptions, out *ListOptions, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if newVal, err := c.DeepCopy(in.LabelSelector); err != nil {
@@ -739,7 +739,7 @@ func deepCopy_api_NFSVolumeSource(in NFSVolumeSource, out *NFSVolumeSource, c *c
 }
 
 func deepCopy_api_Namespace(in Namespace, out *Namespace, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -755,7 +755,7 @@ func deepCopy_api_Namespace(in Namespace, out *Namespace, c *conversion.Cloner) 
 }
 
 func deepCopy_api_NamespaceList(in NamespaceList, out *NamespaceList, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -792,7 +792,7 @@ func deepCopy_api_NamespaceStatus(in NamespaceStatus, out *NamespaceStatus, c *c
 }
 
 func deepCopy_api_Node(in Node, out *Node, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -828,7 +828,7 @@ func deepCopy_api_NodeCondition(in NodeCondition, out *NodeCondition, c *convers
 }
 
 func deepCopy_api_NodeList(in NodeList, out *NodeList, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -963,7 +963,7 @@ func deepCopy_api_ObjectReference(in ObjectReference, out *ObjectReference, c *c
 }
 
 func deepCopy_api_PersistentVolume(in PersistentVolume, out *PersistentVolume, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -979,7 +979,7 @@ func deepCopy_api_PersistentVolume(in PersistentVolume, out *PersistentVolume, c
 }
 
 func deepCopy_api_PersistentVolumeClaim(in PersistentVolumeClaim, out *PersistentVolumeClaim, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -995,7 +995,7 @@ func deepCopy_api_PersistentVolumeClaim(in PersistentVolumeClaim, out *Persisten
 }
 
 func deepCopy_api_PersistentVolumeClaimList(in PersistentVolumeClaimList, out *PersistentVolumeClaimList, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1062,7 +1062,7 @@ func deepCopy_api_PersistentVolumeClaimVolumeSource(in PersistentVolumeClaimVolu
 }
 
 func deepCopy_api_PersistentVolumeList(in PersistentVolumeList, out *PersistentVolumeList, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1185,7 +1185,7 @@ func deepCopy_api_PersistentVolumeStatus(in PersistentVolumeStatus, out *Persist
 }
 
 func deepCopy_api_Pod(in Pod, out *Pod, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1207,7 +1207,7 @@ func deepCopy_api_PodCondition(in PodCondition, out *PodCondition, c *conversion
 }
 
 func deepCopy_api_PodExecOptions(in PodExecOptions, out *PodExecOptions, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	out.Stdin = in.Stdin
@@ -1227,7 +1227,7 @@ func deepCopy_api_PodExecOptions(in PodExecOptions, out *PodExecOptions, c *conv
 }
 
 func deepCopy_api_PodList(in PodList, out *PodList, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1247,7 +1247,7 @@ func deepCopy_api_PodList(in PodList, out *PodList, c *conversion.Cloner) error 
 }
 
 func deepCopy_api_PodLogOptions(in PodLogOptions, out *PodLogOptions, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	out.Container = in.Container
@@ -1257,7 +1257,7 @@ func deepCopy_api_PodLogOptions(in PodLogOptions, out *PodLogOptions, c *convers
 }
 
 func deepCopy_api_PodProxyOptions(in PodProxyOptions, out *PodProxyOptions, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	out.Path = in.Path
@@ -1361,7 +1361,7 @@ func deepCopy_api_PodStatus(in PodStatus, out *PodStatus, c *conversion.Cloner) 
 }
 
 func deepCopy_api_PodStatusResult(in PodStatusResult, out *PodStatusResult, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1374,7 +1374,7 @@ func deepCopy_api_PodStatusResult(in PodStatusResult, out *PodStatusResult, c *c
 }
 
 func deepCopy_api_PodTemplate(in PodTemplate, out *PodTemplate, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1387,7 +1387,7 @@ func deepCopy_api_PodTemplate(in PodTemplate, out *PodTemplate, c *conversion.Cl
 }
 
 func deepCopy_api_PodTemplateList(in PodTemplateList, out *PodTemplateList, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1452,7 +1452,7 @@ func deepCopy_api_RBDVolumeSource(in RBDVolumeSource, out *RBDVolumeSource, c *c
 }
 
 func deepCopy_api_RangeAllocation(in RangeAllocation, out *RangeAllocation, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1471,7 +1471,7 @@ func deepCopy_api_RangeAllocation(in RangeAllocation, out *RangeAllocation, c *c
 }
 
 func deepCopy_api_ReplicationController(in ReplicationController, out *ReplicationController, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1487,7 +1487,7 @@ func deepCopy_api_ReplicationController(in ReplicationController, out *Replicati
 }
 
 func deepCopy_api_ReplicationControllerList(in ReplicationControllerList, out *ReplicationControllerList, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1534,7 +1534,7 @@ func deepCopy_api_ReplicationControllerStatus(in ReplicationControllerStatus, ou
 }
 
 func deepCopy_api_ResourceQuota(in ResourceQuota, out *ResourceQuota, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1550,7 +1550,7 @@ func deepCopy_api_ResourceQuota(in ResourceQuota, out *ResourceQuota, c *convers
 }
 
 func deepCopy_api_ResourceQuotaList(in ResourceQuotaList, out *ResourceQuotaList, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1650,7 +1650,7 @@ func deepCopy_api_SELinuxOptions(in SELinuxOptions, out *SELinuxOptions, c *conv
 }
 
 func deepCopy_api_Secret(in Secret, out *Secret, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1673,7 +1673,7 @@ func deepCopy_api_Secret(in Secret, out *Secret, c *conversion.Cloner) error {
 }
 
 func deepCopy_api_SecretList(in SecretList, out *SecretList, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1730,7 +1730,7 @@ func deepCopy_api_SecurityContext(in SecurityContext, out *SecurityContext, c *c
 }
 
 func deepCopy_api_SerializedReference(in SerializedReference, out *SerializedReference, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectReference(in.Reference, &out.Reference, c); err != nil {
@@ -1740,7 +1740,7 @@ func deepCopy_api_SerializedReference(in SerializedReference, out *SerializedRef
 }
 
 func deepCopy_api_Service(in Service, out *Service, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1756,7 +1756,7 @@ func deepCopy_api_Service(in Service, out *Service, c *conversion.Cloner) error 
 }
 
 func deepCopy_api_ServiceAccount(in ServiceAccount, out *ServiceAccount, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1786,7 +1786,7 @@ func deepCopy_api_ServiceAccount(in ServiceAccount, out *ServiceAccount, c *conv
 }
 
 func deepCopy_api_ServiceAccountList(in ServiceAccountList, out *ServiceAccountList, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1806,7 +1806,7 @@ func deepCopy_api_ServiceAccountList(in ServiceAccountList, out *ServiceAccountL
 }
 
 func deepCopy_api_ServiceList(in ServiceList, out *ServiceList, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1877,7 +1877,7 @@ func deepCopy_api_ServiceStatus(in ServiceStatus, out *ServiceStatus, c *convers
 }
 
 func deepCopy_api_Status(in Status, out *Status, c *conversion.Cloner) error {
-	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1926,12 +1926,6 @@ func deepCopy_api_TCPSocketAction(in TCPSocketAction, out *TCPSocketAction, c *c
 	if err := deepCopy_util_IntOrString(in.Port, &out.Port, c); err != nil {
 		return err
 	}
-	return nil
-}
-
-func deepCopy_api_TypeMeta(in TypeMeta, out *TypeMeta, c *conversion.Cloner) error {
-	out.Kind = in.Kind
-	out.APIVersion = in.APIVersion
 	return nil
 }
 
@@ -2053,6 +2047,13 @@ func deepCopy_resource_Quantity(in resource.Quantity, out *resource.Quantity, c 
 		out.Amount = nil
 	}
 	out.Format = in.Format
+	return nil
+}
+
+func deepCopy_runtime_TypeMeta(in runtime.TypeMeta, out *runtime.TypeMeta, c *conversion.Cloner) error {
+	out.APIGroup = in.APIGroup
+	out.APIVersion = in.APIVersion
+	out.Kind = in.Kind
 	return nil
 }
 
@@ -2184,11 +2185,11 @@ func init() {
 		deepCopy_api_StatusCause,
 		deepCopy_api_StatusDetails,
 		deepCopy_api_TCPSocketAction,
-		deepCopy_api_TypeMeta,
 		deepCopy_api_Volume,
 		deepCopy_api_VolumeMount,
 		deepCopy_api_VolumeSource,
 		deepCopy_resource_Quantity,
+		deepCopy_runtime_TypeMeta,
 		deepCopy_util_IntOrString,
 		deepCopy_util_Time,
 	)

--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -110,7 +110,7 @@ func init() {
 
 	// enumerate all supported versions, get the kinds, and register with the mapper how to address our resources.
 	for _, version := range versions {
-		for kind := range api.Scheme.KnownTypes(version) {
+		for kind := range api.Scheme.KnownTypes(api.Group, version) {
 			if ignoredKinds.Has(kind) {
 				continue
 			}

--- a/pkg/api/meta/restmapper_test.go
+++ b/pkg/api/meta/restmapper_test.go
@@ -46,7 +46,7 @@ func (fakeConvertor) ConvertToVersion(in runtime.Object, _ string) (runtime.Obje
 	return in, nil
 }
 
-func (fakeConvertor) ConvertFieldLabel(version, kind, label, value string) (string, string, error) {
+func (fakeConvertor) ConvertFieldLabel(group, version, kind, label, value string) (string, string, error) {
 	return label, value, nil
 }
 

--- a/pkg/api/ref.go
+++ b/pkg/api/ref.go
@@ -57,7 +57,8 @@ func GetReference(obj runtime.Object) (*ObjectReference, error) {
 	// if we are building an object reference to something not yet persisted, we should fallback to scheme
 	kind := meta.Kind()
 	if kind == "" {
-		_, kind, err = Scheme.ObjectVersionAndKind(obj)
+		tm, err := Scheme.ObjectTypeMeta(obj)
+		kind = tm.Kind
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -20,11 +20,13 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
+const Group string = "api"
+
 // Scheme is the default instance of runtime.Scheme to which types in the Kubernetes API are already registered.
-var Scheme = runtime.NewScheme()
+var Scheme = runtime.NewScheme(Group)
 
 func init() {
-	Scheme.AddKnownTypes("",
+	Scheme.AddKnownTypes(Group, "",
 		&Pod{},
 		&PodList{},
 		&PodStatusResult{},
@@ -68,8 +70,8 @@ func init() {
 		&RangeAllocation{},
 	)
 	// Legacy names are supported
-	Scheme.AddKnownTypeWithName("", "Minion", &Node{})
-	Scheme.AddKnownTypeWithName("", "MinionList", &NodeList{})
+	Scheme.AddKnownTypeWithName(Group, "", "Minion", &Node{})
+	Scheme.AddKnownTypeWithName(Group, "", "MinionList", &NodeList{})
 }
 
 func (*Pod) IsAnAPIObject()                       {}

--- a/pkg/api/rest/create.go
+++ b/pkg/api/rest/create.go
@@ -94,9 +94,9 @@ func objectMetaAndKind(typer runtime.ObjectTyper, obj runtime.Object) (*api.Obje
 	if err != nil {
 		return nil, "", errors.NewInternalError(err)
 	}
-	_, kind, err := typer.ObjectVersionAndKind(obj)
+	tm, err := typer.ObjectTypeMeta(obj)
 	if err != nil {
 		return nil, "", errors.NewInternalError(err)
 	}
-	return objectMeta, kind, nil
+	return objectMeta, tm.Kind, nil
 }

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -100,7 +100,7 @@ func TestSpecificKind(t *testing.T) {
 	defer api.Scheme.Log(nil)
 
 	kind := "PodList"
-	item, err := api.Scheme.New("", kind)
+	item, err := api.Scheme.New(api.Group, "", kind)
 	if err != nil {
 		t.Errorf("Couldn't make a %v? %v", kind, err)
 		return
@@ -113,7 +113,7 @@ func TestList(t *testing.T) {
 	defer api.Scheme.Log(nil)
 
 	kind := "List"
-	item, err := api.Scheme.New("", kind)
+	item, err := api.Scheme.New(api.Group, "", kind)
 	if err != nil {
 		t.Errorf("Couldn't make a %v? %v", kind, err)
 		return
@@ -129,13 +129,13 @@ func TestRoundTripTypes(t *testing.T) {
 	// api.Scheme.Log(t)
 	// defer api.Scheme.Log(nil)
 
-	for kind := range api.Scheme.KnownTypes("") {
+	for kind := range api.Scheme.KnownTypes(api.Group, "") {
 		if nonRoundTrippableTypes.Has(kind) {
 			continue
 		}
 		// Try a few times, since runTest uses random values.
 		for i := 0; i < *fuzzIters; i++ {
-			item, err := api.Scheme.New("", kind)
+			item, err := api.Scheme.New(api.Group, "", kind)
 			if err != nil {
 				t.Fatalf("Couldn't make a %v? %v", kind, err)
 			}

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -51,12 +51,6 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			j.APIVersion = ""
 			j.Kind = ""
 		},
-		func(j *api.TypeMeta, c fuzz.Continue) {
-			// We have to customize the randomization of TypeMetas because their
-			// APIVersion and Kind must remain blank in memory.
-			j.APIVersion = ""
-			j.Kind = ""
-		},
 		func(j *api.ObjectMeta, c fuzz.Continue) {
 			j.Name = c.RandString()
 			j.ResourceVersion = strconv.FormatUint(c.RandUint64(), 10)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -254,8 +254,8 @@ type PersistentVolumeClaimVolumeSource struct {
 }
 
 type PersistentVolume struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 
 	//Spec defines a persistent volume owned by the cluster
 	Spec PersistentVolumeSpec `json:"spec,omitempty"`
@@ -305,15 +305,15 @@ type PersistentVolumeStatus struct {
 }
 
 type PersistentVolumeList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
-	Items    []PersistentVolume `json:"items,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
+	Items            []PersistentVolume `json:"items,omitempty"`
 }
 
 // PersistentVolumeClaim is a user's request for and claim to a persistent volume
 type PersistentVolumeClaim struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 
 	// Spec defines the volume requested by a pod author
 	Spec PersistentVolumeClaimSpec `json:"spec,omitempty"`
@@ -323,9 +323,9 @@ type PersistentVolumeClaim struct {
 }
 
 type PersistentVolumeClaimList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
-	Items    []PersistentVolumeClaim `json:"items,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
+	Items            []PersistentVolumeClaim `json:"items,omitempty"`
 }
 
 // PersistentVolumeClaimSpec describes the common attributes of storage devices
@@ -865,8 +865,8 @@ const (
 
 // PodList is a list of Pods.
 type PodList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
 
 	Items []Pod `json:"items"`
 }
@@ -951,8 +951,8 @@ type PodStatus struct {
 
 // PodStatusResult is a wrapper for PodStatus returned by kubelet that can be encode/decoded
 type PodStatusResult struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 	// Status represents the current information about a pod. This data may not be up
 	// to date.
 	Status PodStatus `json:"status,omitempty"`
@@ -960,8 +960,8 @@ type PodStatusResult struct {
 
 // Pod is a collection of containers, used as either input (create, update) or as output (list, get).
 type Pod struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 
 	// Spec defines the behavior of a pod.
 	Spec PodSpec `json:"spec,omitempty"`
@@ -982,8 +982,8 @@ type PodTemplateSpec struct {
 
 // PodTemplate describes a template for creating copies of a predefined pod.
 type PodTemplate struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 
 	// Template defines the pods that will be created from this pod template
 	Template PodTemplateSpec `json:"template,omitempty"`
@@ -991,8 +991,8 @@ type PodTemplate struct {
 
 // PodTemplateList is a list of PodTemplates.
 type PodTemplateList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
 
 	Items []PodTemplate `json:"items"`
 }
@@ -1031,8 +1031,8 @@ type ReplicationControllerStatus struct {
 
 // ReplicationController represents the configuration of a replication controller.
 type ReplicationController struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 
 	// Spec defines the desired behavior of this replication controller.
 	Spec ReplicationControllerSpec `json:"spec,omitempty"`
@@ -1044,8 +1044,8 @@ type ReplicationController struct {
 
 // ReplicationControllerList is a collection of replication controllers.
 type ReplicationControllerList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
 
 	Items []ReplicationController `json:"items"`
 }
@@ -1058,8 +1058,8 @@ const (
 
 // ServiceList holds a list of services.
 type ServiceList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
 
 	Items []Service `json:"items"`
 }
@@ -1178,8 +1178,8 @@ type ServicePort struct {
 // (for example 3306) that the proxy listens on, and the selector that determines which pods
 // will answer requests sent through the proxy.
 type Service struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 
 	// Spec defines the behavior of a service.
 	Spec ServiceSpec `json:"spec,omitempty"`
@@ -1193,8 +1193,8 @@ type Service struct {
 // * a principal that can be authenticated and authorized
 // * a set of secrets
 type ServiceAccount struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 
 	// Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount
 	Secrets []ObjectReference `json:"secrets"`
@@ -1207,8 +1207,8 @@ type ServiceAccount struct {
 
 // ServiceAccountList is a list of ServiceAccount objects
 type ServiceAccountList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
 
 	Items []ServiceAccount `json:"items"`
 }
@@ -1226,8 +1226,8 @@ type ServiceAccountList struct {
 //     },
 //  ]
 type Endpoints struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 
 	// The set of all endpoints is the union of all subsets.
 	Subsets []EndpointSubset
@@ -1273,8 +1273,8 @@ type EndpointPort struct {
 
 // EndpointsList is a list of endpoints.
 type EndpointsList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
 
 	Items []Endpoints `json:"items"`
 }
@@ -1403,8 +1403,8 @@ type ResourceList map[ResourceName]resource.Quantity
 // Node is a worker node in Kubernetes
 // The name of the node according to etcd is in ObjectMeta.Name.
 type Node struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 
 	// Spec defines the behavior of a node.
 	Spec NodeSpec `json:"spec,omitempty"`
@@ -1415,8 +1415,8 @@ type Node struct {
 
 // NodeList is a list of nodes.
 type NodeList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
 
 	Items []Node `json:"items"`
 }
@@ -1453,8 +1453,8 @@ const (
 // A namespace provides a scope for Names.
 // Use of multiple namespaces is optional
 type Namespace struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 
 	// Spec defines the behavior of the Namespace.
 	Spec NamespaceSpec `json:"spec,omitempty"`
@@ -1465,15 +1465,15 @@ type Namespace struct {
 
 // NamespaceList is a list of Namespaces.
 type NamespaceList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
 
 	Items []Namespace `json:"items"`
 }
 
 // Binding ties one object to another - for example, a pod is bound to a node by a scheduler.
 type Binding struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 	// ObjectMeta describes the object that is being bound.
 	ObjectMeta `json:"metadata,omitempty"`
 
@@ -1483,7 +1483,7 @@ type Binding struct {
 
 // DeleteOptions may be provided when deleting an API object
 type DeleteOptions struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 
 	// Optional duration in seconds before the object should be deleted. Value must be non-negative integer.
 	// The value zero indicates delete immediately. If this value is nil, the default grace period for the
@@ -1494,7 +1494,7 @@ type DeleteOptions struct {
 // ListOptions is the query options to a standard REST list call, and has future support for
 // watch calls.
 type ListOptions struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 
 	// A selector based on labels
 	LabelSelector labels.Selector
@@ -1508,7 +1508,7 @@ type ListOptions struct {
 
 // PodLogOptions is the query options for a Pod's logs REST call
 type PodLogOptions struct {
-	TypeMeta
+	runtime.TypeMeta
 
 	// Container for which to return logs
 	Container string
@@ -1522,7 +1522,7 @@ type PodLogOptions struct {
 
 // PodExecOptions is the query options to a Pod's remote exec call
 type PodExecOptions struct {
-	TypeMeta
+	runtime.TypeMeta
 
 	// Stdin if true indicates that stdin is to be redirected for the exec call
 	Stdin bool
@@ -1545,7 +1545,7 @@ type PodExecOptions struct {
 
 // PodProxyOptions is the query options to a Pod's proxy call
 type PodProxyOptions struct {
-	TypeMeta
+	runtime.TypeMeta
 
 	// Path is the URL path to use for the current proxy request
 	Path string
@@ -1555,8 +1555,8 @@ type PodProxyOptions struct {
 // TODO: this could go in apiserver, but I'm including it here so clients needn't
 // import both.
 type Status struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
 
 	// One of: "Success" or "Failure"
 	Status string `json:"status,omitempty"`
@@ -1785,8 +1785,8 @@ type LocalObjectReference struct {
 }
 
 type SerializedReference struct {
-	TypeMeta  `json:",inline"`
-	Reference ObjectReference `json:"reference,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	Reference        ObjectReference `json:"reference,omitempty"`
 }
 
 type EventSource struct {
@@ -1799,8 +1799,8 @@ type EventSource struct {
 // Event is a report of an event somewhere in the cluster.
 // TODO: Decide whether to store these separately or with the object they apply to.
 type Event struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 
 	// Required. The object that this event is about.
 	InvolvedObject ObjectReference `json:"involvedObject,omitempty"`
@@ -1818,7 +1818,7 @@ type Event struct {
 	// Optional. The component reporting this event. Should be a short machine understandable string.
 	Source EventSource `json:"source,omitempty"`
 
-	// The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)
+	// The time at which the event was first recorded. (Time of server receipt is in runtime.TypeMeta.)
 	FirstTimestamp util.Time `json:"firstTimestamp,omitempty"`
 
 	// The time at which the most recent occurance of this event was recorded.
@@ -1830,16 +1830,16 @@ type Event struct {
 
 // EventList is a list of events.
 type EventList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
 
 	Items []Event `json:"items"`
 }
 
 // List holds a list of objects, which may not be known by the server.
 type List struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
 
 	Items []runtime.Object `json:"items"`
 }
@@ -1874,8 +1874,8 @@ type LimitRangeSpec struct {
 
 // LimitRange sets resource usage limits for each kind of resource in a Namespace
 type LimitRange struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 
 	// Spec defines the limits enforced
 	Spec LimitRangeSpec `json:"spec,omitempty"`
@@ -1883,8 +1883,8 @@ type LimitRange struct {
 
 // LimitRangeList is a list of LimitRange items.
 type LimitRangeList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
 
 	// Items is a list of LimitRange objects
 	Items []LimitRange `json:"items"`
@@ -1922,8 +1922,8 @@ type ResourceQuotaStatus struct {
 
 // ResourceQuota sets aggregate quota restrictions enforced per namespace
 type ResourceQuota struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 
 	// Spec defines the desired quota
 	Spec ResourceQuotaSpec `json:"spec,omitempty"`
@@ -1934,8 +1934,8 @@ type ResourceQuota struct {
 
 // ResourceQuotaList is a list of ResourceQuota items
 type ResourceQuotaList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
 
 	// Items is a list of ResourceQuota objects
 	Items []ResourceQuota `json:"items"`
@@ -1944,8 +1944,8 @@ type ResourceQuotaList struct {
 // Secret holds secret data of a certain type.  The total bytes of the values in
 // the Data field must be less than MaxSecretSize bytes.
 type Secret struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 
 	// Data contains the secret data.  Each key must be a valid DNS_SUBDOMAIN
 	// or leading dot followed by valid DNS_SUBDOMAIN.
@@ -1995,8 +1995,8 @@ const (
 )
 
 type SecretList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
 
 	Items []Secret `json:"items"`
 }
@@ -2058,15 +2058,15 @@ type ComponentCondition struct {
 
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.
 type ComponentStatus struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 
 	Conditions []ComponentCondition `json:"conditions,omitempty"`
 }
 
 type ComponentStatusList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty"`
 
 	Items []ComponentStatus `json:"items"`
 }
@@ -2113,8 +2113,8 @@ type SELinuxOptions struct {
 // data encoding hints). A range allocation should *ALWAYS* be recreatable at any time by observation
 // of the cluster, thus the object is less strongly typed than most.
 type RangeAllocation struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty"`
 	// A string representing a unique label for a range of resources, such as a CIDR "10.0.0.0/8" or
 	// port range "10000-30000". Range is not strongly schema'd here. The Range is expected to define
 	// a start and end unless there is an implicit end.

--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -36,7 +36,7 @@ func addConversionFuncs() {
 	}
 
 	// Add field conversion funcs.
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Pod",
+	err = api.Scheme.AddFieldLabelConversionFunc(api.Group, "v1", "Pod",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name",
@@ -52,7 +52,7 @@ func addConversionFuncs() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Node",
+	err = api.Scheme.AddFieldLabelConversionFunc(api.Group, "v1", "Node",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name":
@@ -67,7 +67,7 @@ func addConversionFuncs() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "ReplicationController",
+	err = api.Scheme.AddFieldLabelConversionFunc(api.Group, "v1", "ReplicationController",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name",
@@ -81,7 +81,7 @@ func addConversionFuncs() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Event",
+	err = api.Scheme.AddFieldLabelConversionFunc(api.Group, "v1", "Event",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "involvedObject.kind",
@@ -102,7 +102,7 @@ func addConversionFuncs() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Namespace",
+	err = api.Scheme.AddFieldLabelConversionFunc(api.Group, "v1", "Namespace",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "status.phase":
@@ -115,7 +115,7 @@ func addConversionFuncs() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Secret",
+	err = api.Scheme.AddFieldLabelConversionFunc(api.Group, "v1", "Secret",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "type":
@@ -128,7 +128,7 @@ func addConversionFuncs() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "ServiceAccount",
+	err = api.Scheme.AddFieldLabelConversionFunc(api.Group, "v1", "ServiceAccount",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name":
@@ -141,7 +141,7 @@ func addConversionFuncs() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Endpoints",
+	err = api.Scheme.AddFieldLabelConversionFunc(api.Group, "v1", "Endpoints",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name":

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -40,7 +40,7 @@ func convert_api_Binding_To_v1_Binding(in *api.Binding, out *Binding, s conversi
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Binding))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -90,7 +90,7 @@ func convert_api_ComponentStatus_To_v1_ComponentStatus(in *api.ComponentStatus, 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ComponentStatus))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -113,7 +113,7 @@ func convert_api_ComponentStatusList_To_v1_ComponentStatusList(in *api.Component
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ComponentStatusList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -327,7 +327,7 @@ func convert_api_DeleteOptions_To_v1_DeleteOptions(in *api.DeleteOptions, out *D
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.DeleteOptions))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if in.GracePeriodSeconds != nil {
@@ -404,7 +404,7 @@ func convert_api_Endpoints_To_v1_Endpoints(in *api.Endpoints, out *Endpoints, s 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Endpoints))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -427,7 +427,7 @@ func convert_api_EndpointsList_To_v1_EndpointsList(in *api.EndpointsList, out *E
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.EndpointsList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -482,7 +482,7 @@ func convert_api_Event_To_v1_Event(in *api.Event, out *Event, s conversion.Scope
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Event))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -510,7 +510,7 @@ func convert_api_EventList_To_v1_EventList(in *api.EventList, out *EventList, s 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.EventList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -674,7 +674,7 @@ func convert_api_LimitRange_To_v1_LimitRange(in *api.LimitRange, out *LimitRange
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.LimitRange))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -734,7 +734,7 @@ func convert_api_LimitRangeList_To_v1_LimitRangeList(in *api.LimitRangeList, out
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.LimitRangeList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -774,7 +774,7 @@ func convert_api_List_To_v1_List(in *api.List, out *List, s conversion.Scope) er
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.List))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -799,7 +799,7 @@ func convert_api_ListOptions_To_v1_ListOptions(in *api.ListOptions, out *ListOpt
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ListOptions))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := s.Convert(&in.LabelSelector, &out.LabelSelector, 0); err != nil {
@@ -861,7 +861,7 @@ func convert_api_Namespace_To_v1_Namespace(in *api.Namespace, out *Namespace, s 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Namespace))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -880,7 +880,7 @@ func convert_api_NamespaceList_To_v1_NamespaceList(in *api.NamespaceList, out *N
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NamespaceList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -926,7 +926,7 @@ func convert_api_Node_To_v1_Node(in *api.Node, out *Node, s conversion.Scope) er
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Node))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -971,7 +971,7 @@ func convert_api_NodeList_To_v1_NodeList(in *api.NodeList, out *NodeList, s conv
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NodeList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1126,7 +1126,7 @@ func convert_api_PersistentVolume_To_v1_PersistentVolume(in *api.PersistentVolum
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolume))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1145,7 +1145,7 @@ func convert_api_PersistentVolumeClaim_To_v1_PersistentVolumeClaim(in *api.Persi
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolumeClaim))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1164,7 +1164,7 @@ func convert_api_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList(in *a
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolumeClaimList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1243,7 +1243,7 @@ func convert_api_PersistentVolumeList_To_v1_PersistentVolumeList(in *api.Persist
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolumeList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1378,7 +1378,7 @@ func convert_api_Pod_To_v1_Pod(in *api.Pod, out *Pod, s conversion.Scope) error 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Pod))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1406,7 +1406,7 @@ func convert_api_PodExecOptions_To_v1_PodExecOptions(in *api.PodExecOptions, out
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodExecOptions))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	out.Stdin = in.Stdin
@@ -1429,7 +1429,7 @@ func convert_api_PodList_To_v1_PodList(in *api.PodList, out *PodList, s conversi
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1452,7 +1452,7 @@ func convert_api_PodLogOptions_To_v1_PodLogOptions(in *api.PodLogOptions, out *P
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodLogOptions))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	out.Container = in.Container
@@ -1465,7 +1465,7 @@ func convert_api_PodProxyOptions_To_v1_PodProxyOptions(in *api.PodProxyOptions, 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodProxyOptions))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	out.Path = in.Path
@@ -1577,7 +1577,7 @@ func convert_api_PodStatusResult_To_v1_PodStatusResult(in *api.PodStatusResult, 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodStatusResult))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1593,7 +1593,7 @@ func convert_api_PodTemplate_To_v1_PodTemplate(in *api.PodTemplate, out *PodTemp
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodTemplate))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1609,7 +1609,7 @@ func convert_api_PodTemplateList_To_v1_PodTemplateList(in *api.PodTemplateList, 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodTemplateList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1686,7 +1686,7 @@ func convert_api_RangeAllocation_To_v1_RangeAllocation(in *api.RangeAllocation, 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.RangeAllocation))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1703,7 +1703,7 @@ func convert_api_ReplicationController_To_v1_ReplicationController(in *api.Repli
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ReplicationController))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1722,7 +1722,7 @@ func convert_api_ReplicationControllerList_To_v1_ReplicationControllerList(in *a
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ReplicationControllerList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1754,7 +1754,7 @@ func convert_api_ResourceQuota_To_v1_ResourceQuota(in *api.ResourceQuota, out *R
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ResourceQuota))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1773,7 +1773,7 @@ func convert_api_ResourceQuotaList_To_v1_ResourceQuotaList(in *api.ResourceQuota
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ResourceQuotaList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1888,7 +1888,7 @@ func convert_api_Secret_To_v1_Secret(in *api.Secret, out *Secret, s conversion.S
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Secret))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1914,7 +1914,7 @@ func convert_api_SecretList_To_v1_SecretList(in *api.SecretList, out *SecretList
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.SecretList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1980,7 +1980,7 @@ func convert_api_SerializedReference_To_v1_SerializedReference(in *api.Serialize
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.SerializedReference))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectReference_To_v1_ObjectReference(&in.Reference, &out.Reference, s); err != nil {
@@ -1993,7 +1993,7 @@ func convert_api_Service_To_v1_Service(in *api.Service, out *Service, s conversi
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Service))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -2012,7 +2012,7 @@ func convert_api_ServiceAccount_To_v1_ServiceAccount(in *api.ServiceAccount, out
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ServiceAccount))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -2045,7 +2045,7 @@ func convert_api_ServiceAccountList_To_v1_ServiceAccountList(in *api.ServiceAcco
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ServiceAccountList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -2068,7 +2068,7 @@ func convert_api_ServiceList_To_v1_ServiceList(in *api.ServiceList, out *Service
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ServiceList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -2151,7 +2151,7 @@ func convert_api_Status_To_v1_Status(in *api.Status, out *Status, s conversion.S
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Status))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -2209,15 +2209,6 @@ func convert_api_TCPSocketAction_To_v1_TCPSocketAction(in *api.TCPSocketAction, 
 	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
 		return err
 	}
-	return nil
-}
-
-func convert_api_TypeMeta_To_v1_TypeMeta(in *api.TypeMeta, out *TypeMeta, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*api.TypeMeta))(in)
-	}
-	out.Kind = in.Kind
-	out.APIVersion = in.APIVersion
 	return nil
 }
 
@@ -2352,7 +2343,7 @@ func convert_v1_Binding_To_api_Binding(in *Binding, out *api.Binding, s conversi
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Binding))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -2402,7 +2393,7 @@ func convert_v1_ComponentStatus_To_api_ComponentStatus(in *ComponentStatus, out 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ComponentStatus))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -2425,7 +2416,7 @@ func convert_v1_ComponentStatusList_To_api_ComponentStatusList(in *ComponentStat
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ComponentStatusList))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -2639,7 +2630,7 @@ func convert_v1_DeleteOptions_To_api_DeleteOptions(in *DeleteOptions, out *api.D
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DeleteOptions))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if in.GracePeriodSeconds != nil {
@@ -2716,7 +2707,7 @@ func convert_v1_Endpoints_To_api_Endpoints(in *Endpoints, out *api.Endpoints, s 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Endpoints))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -2739,7 +2730,7 @@ func convert_v1_EndpointsList_To_api_EndpointsList(in *EndpointsList, out *api.E
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*EndpointsList))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -2794,7 +2785,7 @@ func convert_v1_Event_To_api_Event(in *Event, out *api.Event, s conversion.Scope
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Event))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -2822,7 +2813,7 @@ func convert_v1_EventList_To_api_EventList(in *EventList, out *api.EventList, s 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*EventList))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -2986,7 +2977,7 @@ func convert_v1_LimitRange_To_api_LimitRange(in *LimitRange, out *api.LimitRange
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*LimitRange))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3046,7 +3037,7 @@ func convert_v1_LimitRangeList_To_api_LimitRangeList(in *LimitRangeList, out *ap
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*LimitRangeList))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3086,7 +3077,7 @@ func convert_v1_List_To_api_List(in *List, out *api.List, s conversion.Scope) er
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*List))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3111,7 +3102,7 @@ func convert_v1_ListOptions_To_api_ListOptions(in *ListOptions, out *api.ListOpt
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ListOptions))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := s.Convert(&in.LabelSelector, &out.LabelSelector, 0); err != nil {
@@ -3173,7 +3164,7 @@ func convert_v1_Namespace_To_api_Namespace(in *Namespace, out *api.Namespace, s 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Namespace))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3192,7 +3183,7 @@ func convert_v1_NamespaceList_To_api_NamespaceList(in *NamespaceList, out *api.N
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NamespaceList))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3238,7 +3229,7 @@ func convert_v1_Node_To_api_Node(in *Node, out *api.Node, s conversion.Scope) er
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Node))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3283,7 +3274,7 @@ func convert_v1_NodeList_To_api_NodeList(in *NodeList, out *api.NodeList, s conv
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NodeList))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3438,7 +3429,7 @@ func convert_v1_PersistentVolume_To_api_PersistentVolume(in *PersistentVolume, o
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolume))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3457,7 +3448,7 @@ func convert_v1_PersistentVolumeClaim_To_api_PersistentVolumeClaim(in *Persisten
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolumeClaim))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3476,7 +3467,7 @@ func convert_v1_PersistentVolumeClaimList_To_api_PersistentVolumeClaimList(in *P
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolumeClaimList))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3555,7 +3546,7 @@ func convert_v1_PersistentVolumeList_To_api_PersistentVolumeList(in *PersistentV
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolumeList))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3690,7 +3681,7 @@ func convert_v1_Pod_To_api_Pod(in *Pod, out *api.Pod, s conversion.Scope) error 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Pod))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3718,7 +3709,7 @@ func convert_v1_PodExecOptions_To_api_PodExecOptions(in *PodExecOptions, out *ap
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodExecOptions))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	out.Stdin = in.Stdin
@@ -3741,7 +3732,7 @@ func convert_v1_PodList_To_api_PodList(in *PodList, out *api.PodList, s conversi
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodList))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3764,7 +3755,7 @@ func convert_v1_PodLogOptions_To_api_PodLogOptions(in *PodLogOptions, out *api.P
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodLogOptions))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	out.Container = in.Container
@@ -3777,7 +3768,7 @@ func convert_v1_PodProxyOptions_To_api_PodProxyOptions(in *PodProxyOptions, out 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodProxyOptions))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	out.Path = in.Path
@@ -3889,7 +3880,7 @@ func convert_v1_PodStatusResult_To_api_PodStatusResult(in *PodStatusResult, out 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodStatusResult))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3905,7 +3896,7 @@ func convert_v1_PodTemplate_To_api_PodTemplate(in *PodTemplate, out *api.PodTemp
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodTemplate))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3921,7 +3912,7 @@ func convert_v1_PodTemplateList_To_api_PodTemplateList(in *PodTemplateList, out 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodTemplateList))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3998,7 +3989,7 @@ func convert_v1_RangeAllocation_To_api_RangeAllocation(in *RangeAllocation, out 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*RangeAllocation))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -4015,7 +4006,7 @@ func convert_v1_ReplicationController_To_api_ReplicationController(in *Replicati
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ReplicationController))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -4034,7 +4025,7 @@ func convert_v1_ReplicationControllerList_To_api_ReplicationControllerList(in *R
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ReplicationControllerList))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -4066,7 +4057,7 @@ func convert_v1_ResourceQuota_To_api_ResourceQuota(in *ResourceQuota, out *api.R
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ResourceQuota))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -4085,7 +4076,7 @@ func convert_v1_ResourceQuotaList_To_api_ResourceQuotaList(in *ResourceQuotaList
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ResourceQuotaList))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -4200,7 +4191,7 @@ func convert_v1_Secret_To_api_Secret(in *Secret, out *api.Secret, s conversion.S
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Secret))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -4226,7 +4217,7 @@ func convert_v1_SecretList_To_api_SecretList(in *SecretList, out *api.SecretList
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*SecretList))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -4292,7 +4283,7 @@ func convert_v1_SerializedReference_To_api_SerializedReference(in *SerializedRef
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*SerializedReference))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectReference_To_api_ObjectReference(&in.Reference, &out.Reference, s); err != nil {
@@ -4305,7 +4296,7 @@ func convert_v1_Service_To_api_Service(in *Service, out *api.Service, s conversi
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Service))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -4324,7 +4315,7 @@ func convert_v1_ServiceAccount_To_api_ServiceAccount(in *ServiceAccount, out *ap
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ServiceAccount))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -4357,7 +4348,7 @@ func convert_v1_ServiceAccountList_To_api_ServiceAccountList(in *ServiceAccountL
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ServiceAccountList))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -4380,7 +4371,7 @@ func convert_v1_ServiceList_To_api_ServiceList(in *ServiceList, out *api.Service
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ServiceList))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -4463,7 +4454,7 @@ func convert_v1_Status_To_api_Status(in *Status, out *api.Status, s conversion.S
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Status))(in)
 	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -4521,15 +4512,6 @@ func convert_v1_TCPSocketAction_To_api_TCPSocketAction(in *TCPSocketAction, out 
 	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
 		return err
 	}
-	return nil
-}
-
-func convert_v1_TypeMeta_To_api_TypeMeta(in *TypeMeta, out *api.TypeMeta, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*TypeMeta))(in)
-	}
-	out.Kind = in.Kind
-	out.APIVersion = in.APIVersion
 	return nil
 }
 
@@ -4760,7 +4742,6 @@ func init() {
 		convert_api_StatusDetails_To_v1_StatusDetails,
 		convert_api_Status_To_v1_Status,
 		convert_api_TCPSocketAction_To_v1_TCPSocketAction,
-		convert_api_TypeMeta_To_v1_TypeMeta,
 		convert_api_VolumeMount_To_v1_VolumeMount,
 		convert_api_VolumeSource_To_v1_VolumeSource,
 		convert_api_Volume_To_v1_Volume,
@@ -4873,7 +4854,6 @@ func init() {
 		convert_v1_StatusDetails_To_api_StatusDetails,
 		convert_v1_Status_To_api_Status,
 		convert_v1_TCPSocketAction_To_api_TCPSocketAction,
-		convert_v1_TypeMeta_To_api_TypeMeta,
 		convert_v1_VolumeMount_To_api_VolumeMount,
 		convert_v1_VolumeSource_To_api_VolumeSource,
 		convert_v1_Volume_To_api_Volume,

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -50,7 +50,7 @@ func deepCopy_v1_AWSElasticBlockStoreVolumeSource(in AWSElasticBlockStoreVolumeS
 }
 
 func deepCopy_v1_Binding(in Binding, out *Binding, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -91,7 +91,7 @@ func deepCopy_v1_ComponentCondition(in ComponentCondition, out *ComponentConditi
 }
 
 func deepCopy_v1_ComponentStatus(in ComponentStatus, out *ComponentStatus, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -111,7 +111,7 @@ func deepCopy_v1_ComponentStatus(in ComponentStatus, out *ComponentStatus, c *co
 }
 
 func deepCopy_v1_ComponentStatusList(in ComponentStatusList, out *ComponentStatusList, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -301,7 +301,7 @@ func deepCopy_v1_ContainerStatus(in ContainerStatus, out *ContainerStatus, c *co
 }
 
 func deepCopy_v1_DeleteOptions(in DeleteOptions, out *DeleteOptions, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if in.GracePeriodSeconds != nil {
@@ -363,7 +363,7 @@ func deepCopy_v1_EndpointSubset(in EndpointSubset, out *EndpointSubset, c *conve
 }
 
 func deepCopy_v1_Endpoints(in Endpoints, out *Endpoints, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -383,7 +383,7 @@ func deepCopy_v1_Endpoints(in Endpoints, out *Endpoints, c *conversion.Cloner) e
 }
 
 func deepCopy_v1_EndpointsList(in EndpointsList, out *EndpointsList, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -429,7 +429,7 @@ func deepCopy_v1_EnvVarSource(in EnvVarSource, out *EnvVarSource, c *conversion.
 }
 
 func deepCopy_v1_Event(in Event, out *Event, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -454,7 +454,7 @@ func deepCopy_v1_Event(in Event, out *Event, c *conversion.Cloner) error {
 }
 
 func deepCopy_v1_EventList(in EventList, out *EventList, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -585,7 +585,7 @@ func deepCopy_v1_Lifecycle(in Lifecycle, out *Lifecycle, c *conversion.Cloner) e
 }
 
 func deepCopy_v1_LimitRange(in LimitRange, out *LimitRange, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -639,7 +639,7 @@ func deepCopy_v1_LimitRangeItem(in LimitRangeItem, out *LimitRangeItem, c *conve
 }
 
 func deepCopy_v1_LimitRangeList(in LimitRangeList, out *LimitRangeList, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -673,7 +673,7 @@ func deepCopy_v1_LimitRangeSpec(in LimitRangeSpec, out *LimitRangeSpec, c *conve
 }
 
 func deepCopy_v1_List(in List, out *List, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -699,7 +699,7 @@ func deepCopy_v1_ListMeta(in ListMeta, out *ListMeta, c *conversion.Cloner) erro
 }
 
 func deepCopy_v1_ListOptions(in ListOptions, out *ListOptions, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	out.LabelSelector = in.LabelSelector
@@ -742,7 +742,7 @@ func deepCopy_v1_NFSVolumeSource(in NFSVolumeSource, out *NFSVolumeSource, c *co
 }
 
 func deepCopy_v1_Namespace(in Namespace, out *Namespace, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -758,7 +758,7 @@ func deepCopy_v1_Namespace(in Namespace, out *Namespace, c *conversion.Cloner) e
 }
 
 func deepCopy_v1_NamespaceList(in NamespaceList, out *NamespaceList, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -795,7 +795,7 @@ func deepCopy_v1_NamespaceStatus(in NamespaceStatus, out *NamespaceStatus, c *co
 }
 
 func deepCopy_v1_Node(in Node, out *Node, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -831,7 +831,7 @@ func deepCopy_v1_NodeCondition(in NodeCondition, out *NodeCondition, c *conversi
 }
 
 func deepCopy_v1_NodeList(in NodeList, out *NodeList, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -966,7 +966,7 @@ func deepCopy_v1_ObjectReference(in ObjectReference, out *ObjectReference, c *co
 }
 
 func deepCopy_v1_PersistentVolume(in PersistentVolume, out *PersistentVolume, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -982,7 +982,7 @@ func deepCopy_v1_PersistentVolume(in PersistentVolume, out *PersistentVolume, c 
 }
 
 func deepCopy_v1_PersistentVolumeClaim(in PersistentVolumeClaim, out *PersistentVolumeClaim, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -998,7 +998,7 @@ func deepCopy_v1_PersistentVolumeClaim(in PersistentVolumeClaim, out *Persistent
 }
 
 func deepCopy_v1_PersistentVolumeClaimList(in PersistentVolumeClaimList, out *PersistentVolumeClaimList, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1065,7 +1065,7 @@ func deepCopy_v1_PersistentVolumeClaimVolumeSource(in PersistentVolumeClaimVolum
 }
 
 func deepCopy_v1_PersistentVolumeList(in PersistentVolumeList, out *PersistentVolumeList, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1188,7 +1188,7 @@ func deepCopy_v1_PersistentVolumeStatus(in PersistentVolumeStatus, out *Persiste
 }
 
 func deepCopy_v1_Pod(in Pod, out *Pod, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1210,7 +1210,7 @@ func deepCopy_v1_PodCondition(in PodCondition, out *PodCondition, c *conversion.
 }
 
 func deepCopy_v1_PodExecOptions(in PodExecOptions, out *PodExecOptions, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	out.Stdin = in.Stdin
@@ -1230,7 +1230,7 @@ func deepCopy_v1_PodExecOptions(in PodExecOptions, out *PodExecOptions, c *conve
 }
 
 func deepCopy_v1_PodList(in PodList, out *PodList, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1250,7 +1250,7 @@ func deepCopy_v1_PodList(in PodList, out *PodList, c *conversion.Cloner) error {
 }
 
 func deepCopy_v1_PodLogOptions(in PodLogOptions, out *PodLogOptions, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	out.Container = in.Container
@@ -1260,7 +1260,7 @@ func deepCopy_v1_PodLogOptions(in PodLogOptions, out *PodLogOptions, c *conversi
 }
 
 func deepCopy_v1_PodProxyOptions(in PodProxyOptions, out *PodProxyOptions, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	out.Path = in.Path
@@ -1364,7 +1364,7 @@ func deepCopy_v1_PodStatus(in PodStatus, out *PodStatus, c *conversion.Cloner) e
 }
 
 func deepCopy_v1_PodStatusResult(in PodStatusResult, out *PodStatusResult, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1377,7 +1377,7 @@ func deepCopy_v1_PodStatusResult(in PodStatusResult, out *PodStatusResult, c *co
 }
 
 func deepCopy_v1_PodTemplate(in PodTemplate, out *PodTemplate, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1390,7 +1390,7 @@ func deepCopy_v1_PodTemplate(in PodTemplate, out *PodTemplate, c *conversion.Clo
 }
 
 func deepCopy_v1_PodTemplateList(in PodTemplateList, out *PodTemplateList, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1455,7 +1455,7 @@ func deepCopy_v1_RBDVolumeSource(in RBDVolumeSource, out *RBDVolumeSource, c *co
 }
 
 func deepCopy_v1_RangeAllocation(in RangeAllocation, out *RangeAllocation, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1474,7 +1474,7 @@ func deepCopy_v1_RangeAllocation(in RangeAllocation, out *RangeAllocation, c *co
 }
 
 func deepCopy_v1_ReplicationController(in ReplicationController, out *ReplicationController, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1490,7 +1490,7 @@ func deepCopy_v1_ReplicationController(in ReplicationController, out *Replicatio
 }
 
 func deepCopy_v1_ReplicationControllerList(in ReplicationControllerList, out *ReplicationControllerList, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1542,7 +1542,7 @@ func deepCopy_v1_ReplicationControllerStatus(in ReplicationControllerStatus, out
 }
 
 func deepCopy_v1_ResourceQuota(in ResourceQuota, out *ResourceQuota, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1558,7 +1558,7 @@ func deepCopy_v1_ResourceQuota(in ResourceQuota, out *ResourceQuota, c *conversi
 }
 
 func deepCopy_v1_ResourceQuotaList(in ResourceQuotaList, out *ResourceQuotaList, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1658,7 +1658,7 @@ func deepCopy_v1_SELinuxOptions(in SELinuxOptions, out *SELinuxOptions, c *conve
 }
 
 func deepCopy_v1_Secret(in Secret, out *Secret, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1681,7 +1681,7 @@ func deepCopy_v1_Secret(in Secret, out *Secret, c *conversion.Cloner) error {
 }
 
 func deepCopy_v1_SecretList(in SecretList, out *SecretList, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1738,7 +1738,7 @@ func deepCopy_v1_SecurityContext(in SecurityContext, out *SecurityContext, c *co
 }
 
 func deepCopy_v1_SerializedReference(in SerializedReference, out *SerializedReference, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectReference(in.Reference, &out.Reference, c); err != nil {
@@ -1748,7 +1748,7 @@ func deepCopy_v1_SerializedReference(in SerializedReference, out *SerializedRefe
 }
 
 func deepCopy_v1_Service(in Service, out *Service, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1764,7 +1764,7 @@ func deepCopy_v1_Service(in Service, out *Service, c *conversion.Cloner) error {
 }
 
 func deepCopy_v1_ServiceAccount(in ServiceAccount, out *ServiceAccount, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1794,7 +1794,7 @@ func deepCopy_v1_ServiceAccount(in ServiceAccount, out *ServiceAccount, c *conve
 }
 
 func deepCopy_v1_ServiceAccountList(in ServiceAccountList, out *ServiceAccountList, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1814,7 +1814,7 @@ func deepCopy_v1_ServiceAccountList(in ServiceAccountList, out *ServiceAccountLi
 }
 
 func deepCopy_v1_ServiceList(in ServiceList, out *ServiceList, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1885,7 +1885,7 @@ func deepCopy_v1_ServiceStatus(in ServiceStatus, out *ServiceStatus, c *conversi
 }
 
 func deepCopy_v1_Status(in Status, out *Status, c *conversion.Cloner) error {
-	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1934,12 +1934,6 @@ func deepCopy_v1_TCPSocketAction(in TCPSocketAction, out *TCPSocketAction, c *co
 	if err := deepCopy_util_IntOrString(in.Port, &out.Port, c); err != nil {
 		return err
 	}
-	return nil
-}
-
-func deepCopy_v1_TypeMeta(in TypeMeta, out *TypeMeta, c *conversion.Cloner) error {
-	out.Kind = in.Kind
-	out.APIVersion = in.APIVersion
 	return nil
 }
 
@@ -2059,6 +2053,13 @@ func deepCopy_runtime_RawExtension(in runtime.RawExtension, out *runtime.RawExte
 	} else {
 		out.RawJSON = nil
 	}
+	return nil
+}
+
+func deepCopy_runtime_TypeMeta(in runtime.TypeMeta, out *runtime.TypeMeta, c *conversion.Cloner) error {
+	out.APIGroup = in.APIGroup
+	out.APIVersion = in.APIVersion
+	out.Kind = in.Kind
 	return nil
 }
 
@@ -2191,11 +2192,11 @@ func init() {
 		deepCopy_v1_StatusCause,
 		deepCopy_v1_StatusDetails,
 		deepCopy_v1_TCPSocketAction,
-		deepCopy_v1_TypeMeta,
 		deepCopy_v1_Volume,
 		deepCopy_v1_VolumeMount,
 		deepCopy_v1_VolumeSource,
 		deepCopy_runtime_RawExtension,
+		deepCopy_runtime_TypeMeta,
 		deepCopy_util_IntOrString,
 		deepCopy_util_Time,
 	)

--- a/pkg/api/v1/register.go
+++ b/pkg/api/v1/register.go
@@ -39,7 +39,7 @@ func init() {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes() {
-	api.Scheme.AddKnownTypes("v1",
+	api.Scheme.AddKnownTypes(api.Group, "v1",
 		&Pod{},
 		&PodList{},
 		&PodStatusResult{},
@@ -83,8 +83,8 @@ func addKnownTypes() {
 		&RangeAllocation{},
 	)
 	// Legacy names are supported
-	api.Scheme.AddKnownTypeWithName("v1", "Minion", &Node{})
-	api.Scheme.AddKnownTypeWithName("v1", "MinionList", &NodeList{})
+	api.Scheme.AddKnownTypeWithName(api.Group, "v1", "Minion", &Node{})
+	api.Scheme.AddKnownTypeWithName(api.Group, "v1", "MinionList", &NodeList{})
 }
 
 func (*Pod) IsAnAPIObject()                       {}

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -237,8 +237,8 @@ type PersistentVolumeSource struct {
 }
 
 type PersistentVolume struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Spec defines a persistent volume owned by the cluster
 	Spec PersistentVolumeSpec `json:"spec,omitempty" description:"specification of a persistent volume as provisioned by an administrator"`
@@ -288,15 +288,15 @@ type PersistentVolumeStatus struct {
 }
 
 type PersistentVolumeList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
-	Items    []PersistentVolume `json:"items,omitempty" description:"list of persistent volumes"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
+	Items            []PersistentVolume `json:"items,omitempty" description:"list of persistent volumes"`
 }
 
 // PersistentVolumeClaim is a user's request for and claim to a persistent volume
 type PersistentVolumeClaim struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Spec defines the volume requested by a pod author
 	Spec PersistentVolumeClaimSpec `json:"spec,omitempty" description:"the desired characteristics of a volume"`
@@ -306,9 +306,9 @@ type PersistentVolumeClaim struct {
 }
 
 type PersistentVolumeClaimList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
-	Items    []PersistentVolumeClaim `json:"items,omitempty" description:"a list of persistent volume claims"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
+	Items            []PersistentVolumeClaim `json:"items,omitempty" description:"a list of persistent volume claims"`
 }
 
 // PersistentVolumeClaimSpec describes the common attributes of storage devices
@@ -914,8 +914,8 @@ type PodStatus struct {
 
 // PodStatusResult is a wrapper for PodStatus returned by kubelet that can be encode/decoded
 type PodStatusResult struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 	// Status represents the current information about a pod. This data may not be up
 	// to date.
 	Status PodStatus `json:"status,omitempty" description:"most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
@@ -924,8 +924,8 @@ type PodStatusResult struct {
 // Pod is a collection of containers that can run on a host. This resource is created
 // by clients and scheduled onto hosts.
 type Pod struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a pod.
 	Spec PodSpec `json:"spec,omitempty" description:"specification of the desired behavior of the pod; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
@@ -937,8 +937,8 @@ type Pod struct {
 
 // PodList is a list of Pods.
 type PodList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
 
 	Items []Pod `json:"items" description:"list of pods"`
 }
@@ -954,8 +954,8 @@ type PodTemplateSpec struct {
 
 // PodTemplate describes a template for creating copies of a predefined pod.
 type PodTemplate struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Template defines the pods that will be created from this pod template
 	Template PodTemplateSpec `json:"template,omitempty" description:"the template of the desired behavior of the pod; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
@@ -963,8 +963,8 @@ type PodTemplate struct {
 
 // PodTemplateList is a list of PodTemplates.
 type PodTemplateList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []PodTemplate `json:"items" description:"list of pod templates"`
 }
@@ -1000,7 +1000,7 @@ type ReplicationControllerStatus struct {
 
 // ReplicationController represents the configuration of a replication controller.
 type ReplicationController struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 
 	// If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages.
 	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
@@ -1015,8 +1015,8 @@ type ReplicationController struct {
 
 // ReplicationControllerList is a collection of replication controllers.
 type ReplicationControllerList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []ReplicationController `json:"items" description:"list of replication controllers"`
 }
@@ -1131,8 +1131,8 @@ type ServicePort struct {
 // (for example 3306) that the proxy listens on, and the selector that determines which pods
 // will answer requests sent through the proxy.
 type Service struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a service.
 	Spec ServiceSpec `json:"spec,omitempty" description:"specification of the desired behavior of the service; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
@@ -1149,8 +1149,8 @@ const (
 
 // ServiceList holds a list of services.
 type ServiceList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []Service `json:"items" description:"list of services"`
 }
@@ -1160,8 +1160,8 @@ type ServiceList struct {
 // * a principal that can be authenticated and authorized
 // * a set of secrets
 type ServiceAccount struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount
 	Secrets []ObjectReference `json:"secrets,omitempty" description:"list of secrets that can be used by pods running as this service account" patchStrategy:"merge" patchMergeKey:"name"`
@@ -1174,8 +1174,8 @@ type ServiceAccount struct {
 
 // ServiceAccountList is a list of ServiceAccount objects
 type ServiceAccountList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []ServiceAccount `json:"items" description:"list of ServiceAccounts"`
 }
@@ -1193,8 +1193,8 @@ type ServiceAccountList struct {
 //     },
 //  ]
 type Endpoints struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// The set of all endpoints is the union of all subsets.
 	Subsets []EndpointSubset `json:"subsets" description:"sets of addresses and ports that comprise a service"`
@@ -1240,8 +1240,8 @@ type EndpointPort struct {
 
 // EndpointsList is a list of endpoints.
 type EndpointsList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []Endpoints `json:"items" description:"list of endpoints"`
 }
@@ -1356,8 +1356,8 @@ type ResourceList map[ResourceName]resource.Quantity
 // Node is a worker node in Kubernetes.
 // The name of the node according to etcd is in ID.
 type Node struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a node.
 	Spec NodeSpec `json:"spec,omitempty" description:"specification of a node; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
@@ -1368,8 +1368,8 @@ type Node struct {
 
 // NodeList is a list of minions.
 type NodeList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []Node `json:"items" description:"list of nodes"`
 }
@@ -1406,8 +1406,8 @@ const (
 // A namespace provides a scope for Names.
 // Use of multiple namespaces is optional
 type Namespace struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of the Namespace.
 	Spec NamespaceSpec `json:"spec,omitempty" description:"spec defines the behavior of the Namespace; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
@@ -1418,8 +1418,8 @@ type Namespace struct {
 
 // NamespaceList is a list of Namespaces.
 type NamespaceList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Items is the list of Namespace objects in the list
 	Items []Namespace `json:"items"  description:"items is the list of Namespace objects in the list"`
@@ -1427,7 +1427,7 @@ type NamespaceList struct {
 
 // Binding ties one object to another - for example, a pod is bound to a node by a scheduler.
 type Binding struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 	// ObjectMeta describes the object that is being bound.
 	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
@@ -1437,7 +1437,7 @@ type Binding struct {
 
 // DeleteOptions may be provided when deleting an API object
 type DeleteOptions struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 
 	// Optional duration in seconds before the object should be deleted. Value must be non-negative integer.
 	// The value zero indicates delete immediately. If this value is nil, the default grace period for the
@@ -1447,7 +1447,7 @@ type DeleteOptions struct {
 
 // ListOptions is the query options to a standard REST list call
 type ListOptions struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 
 	// A selector based on labels
 	LabelSelector string `json:"labelSelector,omitempty" description:"a selector to restrict the list of returned objects by their labels; defaults to everything"`
@@ -1461,7 +1461,7 @@ type ListOptions struct {
 
 // PodLogOptions is the query options for a Pod's logs REST call
 type PodLogOptions struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 
 	// Container for which to return logs
 	Container string `json:"container,omitempty" description:"the container for which to stream logs; defaults to only container if there is one container in the pod"`
@@ -1475,7 +1475,7 @@ type PodLogOptions struct {
 
 // PodExecOptions is the query options to a Pod's remote exec call
 type PodExecOptions struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 
 	// Stdin if true indicates that stdin is to be redirected for the exec call
 	Stdin bool `json:"stdin,omitempty" description:"redirect the standard input stream of the pod for this call; defaults to false"`
@@ -1498,7 +1498,7 @@ type PodExecOptions struct {
 
 // PodProxyOptions is the query options to a Pod's proxy call
 type PodProxyOptions struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 
 	// Path is the URL path to use for the current proxy request
 	Path string `json:"path,omitempty" description:"URL path to use in proxy request to pod"`
@@ -1506,8 +1506,8 @@ type PodProxyOptions struct {
 
 // Status is a return value for calls that don't return other objects.
 type Status struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// One of: "Success" or "Failure"
 	Status string `json:"status,omitempty" description:"status of the operation; either Success, or Failure"`
@@ -1685,8 +1685,8 @@ type LocalObjectReference struct {
 }
 
 type SerializedReference struct {
-	TypeMeta  `json:",inline"`
-	Reference ObjectReference `json:"reference,omitempty" description:"the reference to an object in the system"`
+	runtime.TypeMeta `json:",inline"`
+	Reference        ObjectReference `json:"reference,omitempty" description:"the reference to an object in the system"`
 }
 
 type EventSource struct {
@@ -1699,8 +1699,8 @@ type EventSource struct {
 // Event is a report of an event somewhere in the cluster.
 // TODO: Decide whether to store these separately or with the object they apply to.
 type Event struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Required. The object that this event is about.
 	InvolvedObject ObjectReference `json:"involvedObject" description:"object this event is about"`
@@ -1717,7 +1717,7 @@ type Event struct {
 	// Optional. The component reporting this event. Should be a short machine understandable string.
 	Source EventSource `json:"source,omitempty" description:"component reporting this event"`
 
-	// The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)
+	// The time at which the event was first recorded. (Time of server receipt is in runtime.TypeMeta.)
 	FirstTimestamp util.Time `json:"firstTimestamp,omitempty" description:"the time at which the event was first recorded"`
 
 	// The time at which the most recent occurance of this event was recorded.
@@ -1729,16 +1729,16 @@ type Event struct {
 
 // EventList is a list of events.
 type EventList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []Event `json:"items" description:"list of events"`
 }
 
 // List holds a list of objects, which may not be known by the server.
 type List struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []runtime.RawExtension `json:"items" description:"list of objects"`
 }
@@ -1773,8 +1773,8 @@ type LimitRangeSpec struct {
 
 // LimitRange sets resource usage limits for each kind of resource in a Namespace
 type LimitRange struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Spec defines the limits enforced
 	Spec LimitRangeSpec `json:"spec,omitempty" description:"spec defines the limits enforced; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
@@ -1782,8 +1782,8 @@ type LimitRange struct {
 
 // LimitRangeList is a list of LimitRange items.
 type LimitRangeList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Items is a list of LimitRange objects
 	Items []LimitRange `json:"items" description:"items is a list of LimitRange objects"`
@@ -1821,8 +1821,8 @@ type ResourceQuotaStatus struct {
 
 // ResourceQuota sets aggregate quota restrictions enforced per namespace
 type ResourceQuota struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Spec defines the desired quota
 	Spec ResourceQuotaSpec `json:"spec,omitempty" description:"spec defines the desired quota; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
@@ -1833,8 +1833,8 @@ type ResourceQuota struct {
 
 // ResourceQuotaList is a list of ResourceQuota items
 type ResourceQuotaList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Items is a list of ResourceQuota objects
 	Items []ResourceQuota `json:"items" description:"items is a list of ResourceQuota objects"`
@@ -1843,8 +1843,8 @@ type ResourceQuotaList struct {
 // Secret holds secret data of a certain type.  The total bytes of the values in
 // the Data field must be less than MaxSecretSize bytes.
 type Secret struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Data contains the secret data.  Each key must be a valid DNS_SUBDOMAIN
 	// or leading dot followed by valid DNS_SUBDOMAIN.
@@ -1894,8 +1894,8 @@ const (
 )
 
 type SecretList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []Secret `json:"items" description:"items is a list of secret objects"`
 }
@@ -1917,15 +1917,15 @@ type ComponentCondition struct {
 
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.
 type ComponentStatus struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Conditions []ComponentCondition `json:"conditions,omitempty" description:"list of component conditions observed" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 type ComponentStatusList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []ComponentStatus `json:"items" description:"list of component status objects"`
 }
@@ -1968,8 +1968,8 @@ type SELinuxOptions struct {
 
 // RangeAllocation is not a public type
 type RangeAllocation struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Range string `json:"range" description:"a range string that identifies the range represented by 'data'; required"`
 	Data  []byte `json:"data" description:"a bit array containing all allocated addresses in the previous segment"`

--- a/pkg/api/v1beta3/conversion.go
+++ b/pkg/api/v1beta3/conversion.go
@@ -50,7 +50,7 @@ func addConversionFuncs() {
 	}
 
 	// Add field conversion funcs.
-	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "Pod",
+	err = api.Scheme.AddFieldLabelConversionFunc(api.Group, "v1beta3", "Pod",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name",
@@ -67,7 +67,7 @@ func addConversionFuncs() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "Node",
+	err = api.Scheme.AddFieldLabelConversionFunc(api.Group, "v1beta3", "Node",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name":
@@ -82,7 +82,7 @@ func addConversionFuncs() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "ReplicationController",
+	err = api.Scheme.AddFieldLabelConversionFunc(api.Group, "v1beta3", "ReplicationController",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name",
@@ -96,7 +96,7 @@ func addConversionFuncs() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "Event",
+	err = api.Scheme.AddFieldLabelConversionFunc(api.Group, "v1beta3", "Event",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "involvedObject.kind",
@@ -117,7 +117,7 @@ func addConversionFuncs() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "Namespace",
+	err = api.Scheme.AddFieldLabelConversionFunc(api.Group, "v1beta3", "Namespace",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "status.phase":
@@ -130,7 +130,7 @@ func addConversionFuncs() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "Secret",
+	err = api.Scheme.AddFieldLabelConversionFunc(api.Group, "v1beta3", "Secret",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "type":
@@ -143,7 +143,7 @@ func addConversionFuncs() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "ServiceAccount",
+	err = api.Scheme.AddFieldLabelConversionFunc(api.Group, "v1beta3", "ServiceAccount",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name":
@@ -156,7 +156,7 @@ func addConversionFuncs() {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "Endpoints",
+	err = api.Scheme.AddFieldLabelConversionFunc(api.Group, "v1beta3", "Endpoints",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name":

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -40,7 +40,7 @@ func convert_api_Binding_To_v1beta3_Binding(in *api.Binding, out *Binding, s con
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Binding))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -90,7 +90,7 @@ func convert_api_ComponentStatus_To_v1beta3_ComponentStatus(in *api.ComponentSta
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ComponentStatus))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -113,7 +113,7 @@ func convert_api_ComponentStatusList_To_v1beta3_ComponentStatusList(in *api.Comp
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ComponentStatusList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -185,7 +185,7 @@ func convert_api_DeleteOptions_To_v1beta3_DeleteOptions(in *api.DeleteOptions, o
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.DeleteOptions))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if in.GracePeriodSeconds != nil {
@@ -262,7 +262,7 @@ func convert_api_Endpoints_To_v1beta3_Endpoints(in *api.Endpoints, out *Endpoint
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Endpoints))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -285,7 +285,7 @@ func convert_api_EndpointsList_To_v1beta3_EndpointsList(in *api.EndpointsList, o
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.EndpointsList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -340,7 +340,7 @@ func convert_api_Event_To_v1beta3_Event(in *api.Event, out *Event, s conversion.
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Event))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -368,7 +368,7 @@ func convert_api_EventList_To_v1beta3_EventList(in *api.EventList, out *EventLis
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.EventList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -532,7 +532,7 @@ func convert_api_LimitRange_To_v1beta3_LimitRange(in *api.LimitRange, out *Limit
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.LimitRange))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -592,7 +592,7 @@ func convert_api_LimitRangeList_To_v1beta3_LimitRangeList(in *api.LimitRangeList
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.LimitRangeList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -632,7 +632,7 @@ func convert_api_List_To_v1beta3_List(in *api.List, out *List, s conversion.Scop
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.List))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -657,7 +657,7 @@ func convert_api_ListOptions_To_v1beta3_ListOptions(in *api.ListOptions, out *Li
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ListOptions))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := s.Convert(&in.LabelSelector, &out.LabelSelector, 0); err != nil {
@@ -719,7 +719,7 @@ func convert_api_Namespace_To_v1beta3_Namespace(in *api.Namespace, out *Namespac
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Namespace))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -738,7 +738,7 @@ func convert_api_NamespaceList_To_v1beta3_NamespaceList(in *api.NamespaceList, o
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NamespaceList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -784,7 +784,7 @@ func convert_api_Node_To_v1beta3_Node(in *api.Node, out *Node, s conversion.Scop
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Node))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -829,7 +829,7 @@ func convert_api_NodeList_To_v1beta3_NodeList(in *api.NodeList, out *NodeList, s
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NodeList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -984,7 +984,7 @@ func convert_api_PersistentVolume_To_v1beta3_PersistentVolume(in *api.Persistent
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolume))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1003,7 +1003,7 @@ func convert_api_PersistentVolumeClaim_To_v1beta3_PersistentVolumeClaim(in *api.
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolumeClaim))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1022,7 +1022,7 @@ func convert_api_PersistentVolumeClaimList_To_v1beta3_PersistentVolumeClaimList(
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolumeClaimList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1101,7 +1101,7 @@ func convert_api_PersistentVolumeList_To_v1beta3_PersistentVolumeList(in *api.Pe
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolumeList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1236,7 +1236,7 @@ func convert_api_Pod_To_v1beta3_Pod(in *api.Pod, out *Pod, s conversion.Scope) e
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Pod))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1264,7 +1264,7 @@ func convert_api_PodExecOptions_To_v1beta3_PodExecOptions(in *api.PodExecOptions
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodExecOptions))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	out.Stdin = in.Stdin
@@ -1287,7 +1287,7 @@ func convert_api_PodList_To_v1beta3_PodList(in *api.PodList, out *PodList, s con
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1310,7 +1310,7 @@ func convert_api_PodLogOptions_To_v1beta3_PodLogOptions(in *api.PodLogOptions, o
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodLogOptions))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	out.Container = in.Container
@@ -1323,7 +1323,7 @@ func convert_api_PodProxyOptions_To_v1beta3_PodProxyOptions(in *api.PodProxyOpti
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodProxyOptions))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	out.Path = in.Path
@@ -1373,7 +1373,7 @@ func convert_api_PodStatusResult_To_v1beta3_PodStatusResult(in *api.PodStatusRes
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodStatusResult))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1389,7 +1389,7 @@ func convert_api_PodTemplate_To_v1beta3_PodTemplate(in *api.PodTemplate, out *Po
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodTemplate))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1405,7 +1405,7 @@ func convert_api_PodTemplateList_To_v1beta3_PodTemplateList(in *api.PodTemplateL
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodTemplateList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1482,7 +1482,7 @@ func convert_api_RangeAllocation_To_v1beta3_RangeAllocation(in *api.RangeAllocat
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.RangeAllocation))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1499,7 +1499,7 @@ func convert_api_ReplicationController_To_v1beta3_ReplicationController(in *api.
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ReplicationController))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1518,7 +1518,7 @@ func convert_api_ReplicationControllerList_To_v1beta3_ReplicationControllerList(
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ReplicationControllerList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1550,7 +1550,7 @@ func convert_api_ResourceQuota_To_v1beta3_ResourceQuota(in *api.ResourceQuota, o
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ResourceQuota))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1569,7 +1569,7 @@ func convert_api_ResourceQuotaList_To_v1beta3_ResourceQuotaList(in *api.Resource
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ResourceQuotaList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1684,7 +1684,7 @@ func convert_api_Secret_To_v1beta3_Secret(in *api.Secret, out *Secret, s convers
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Secret))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1710,7 +1710,7 @@ func convert_api_SecretList_To_v1beta3_SecretList(in *api.SecretList, out *Secre
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.SecretList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1776,7 +1776,7 @@ func convert_api_SerializedReference_To_v1beta3_SerializedReference(in *api.Seri
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.SerializedReference))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectReference_To_v1beta3_ObjectReference(&in.Reference, &out.Reference, s); err != nil {
@@ -1789,7 +1789,7 @@ func convert_api_Service_To_v1beta3_Service(in *api.Service, out *Service, s con
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Service))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1808,7 +1808,7 @@ func convert_api_ServiceAccount_To_v1beta3_ServiceAccount(in *api.ServiceAccount
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ServiceAccount))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -1841,7 +1841,7 @@ func convert_api_ServiceAccountList_To_v1beta3_ServiceAccountList(in *api.Servic
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ServiceAccountList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1864,7 +1864,7 @@ func convert_api_ServiceList_To_v1beta3_ServiceList(in *api.ServiceList, out *Se
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ServiceList))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1911,7 +1911,7 @@ func convert_api_Status_To_v1beta3_Status(in *api.Status, out *Status, s convers
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Status))(in)
 	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -1939,15 +1939,6 @@ func convert_api_TCPSocketAction_To_v1beta3_TCPSocketAction(in *api.TCPSocketAct
 	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
 		return err
 	}
-	return nil
-}
-
-func convert_api_TypeMeta_To_v1beta3_TypeMeta(in *api.TypeMeta, out *TypeMeta, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*api.TypeMeta))(in)
-	}
-	out.Kind = in.Kind
-	out.APIVersion = in.APIVersion
 	return nil
 }
 
@@ -2082,7 +2073,7 @@ func convert_v1beta3_Binding_To_api_Binding(in *Binding, out *api.Binding, s con
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Binding))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -2132,7 +2123,7 @@ func convert_v1beta3_ComponentStatus_To_api_ComponentStatus(in *ComponentStatus,
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ComponentStatus))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -2155,7 +2146,7 @@ func convert_v1beta3_ComponentStatusList_To_api_ComponentStatusList(in *Componen
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ComponentStatusList))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -2227,7 +2218,7 @@ func convert_v1beta3_DeleteOptions_To_api_DeleteOptions(in *DeleteOptions, out *
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DeleteOptions))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if in.GracePeriodSeconds != nil {
@@ -2304,7 +2295,7 @@ func convert_v1beta3_Endpoints_To_api_Endpoints(in *Endpoints, out *api.Endpoint
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Endpoints))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -2327,7 +2318,7 @@ func convert_v1beta3_EndpointsList_To_api_EndpointsList(in *EndpointsList, out *
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*EndpointsList))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -2382,7 +2373,7 @@ func convert_v1beta3_Event_To_api_Event(in *Event, out *api.Event, s conversion.
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Event))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -2410,7 +2401,7 @@ func convert_v1beta3_EventList_To_api_EventList(in *EventList, out *api.EventLis
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*EventList))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -2574,7 +2565,7 @@ func convert_v1beta3_LimitRange_To_api_LimitRange(in *LimitRange, out *api.Limit
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*LimitRange))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -2634,7 +2625,7 @@ func convert_v1beta3_LimitRangeList_To_api_LimitRangeList(in *LimitRangeList, ou
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*LimitRangeList))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -2674,7 +2665,7 @@ func convert_v1beta3_List_To_api_List(in *List, out *api.List, s conversion.Scop
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*List))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -2699,7 +2690,7 @@ func convert_v1beta3_ListOptions_To_api_ListOptions(in *ListOptions, out *api.Li
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ListOptions))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := s.Convert(&in.LabelSelector, &out.LabelSelector, 0); err != nil {
@@ -2761,7 +2752,7 @@ func convert_v1beta3_Namespace_To_api_Namespace(in *Namespace, out *api.Namespac
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Namespace))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -2780,7 +2771,7 @@ func convert_v1beta3_NamespaceList_To_api_NamespaceList(in *NamespaceList, out *
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NamespaceList))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -2826,7 +2817,7 @@ func convert_v1beta3_Node_To_api_Node(in *Node, out *api.Node, s conversion.Scop
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Node))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -2871,7 +2862,7 @@ func convert_v1beta3_NodeList_To_api_NodeList(in *NodeList, out *api.NodeList, s
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NodeList))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3026,7 +3017,7 @@ func convert_v1beta3_PersistentVolume_To_api_PersistentVolume(in *PersistentVolu
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolume))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3045,7 +3036,7 @@ func convert_v1beta3_PersistentVolumeClaim_To_api_PersistentVolumeClaim(in *Pers
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolumeClaim))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3064,7 +3055,7 @@ func convert_v1beta3_PersistentVolumeClaimList_To_api_PersistentVolumeClaimList(
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolumeClaimList))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3143,7 +3134,7 @@ func convert_v1beta3_PersistentVolumeList_To_api_PersistentVolumeList(in *Persis
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolumeList))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3278,7 +3269,7 @@ func convert_v1beta3_Pod_To_api_Pod(in *Pod, out *api.Pod, s conversion.Scope) e
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Pod))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3306,7 +3297,7 @@ func convert_v1beta3_PodExecOptions_To_api_PodExecOptions(in *PodExecOptions, ou
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodExecOptions))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	out.Stdin = in.Stdin
@@ -3329,7 +3320,7 @@ func convert_v1beta3_PodList_To_api_PodList(in *PodList, out *api.PodList, s con
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodList))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3352,7 +3343,7 @@ func convert_v1beta3_PodLogOptions_To_api_PodLogOptions(in *PodLogOptions, out *
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodLogOptions))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	out.Container = in.Container
@@ -3365,7 +3356,7 @@ func convert_v1beta3_PodProxyOptions_To_api_PodProxyOptions(in *PodProxyOptions,
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodProxyOptions))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	out.Path = in.Path
@@ -3415,7 +3406,7 @@ func convert_v1beta3_PodStatusResult_To_api_PodStatusResult(in *PodStatusResult,
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodStatusResult))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3431,7 +3422,7 @@ func convert_v1beta3_PodTemplate_To_api_PodTemplate(in *PodTemplate, out *api.Po
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodTemplate))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3447,7 +3438,7 @@ func convert_v1beta3_PodTemplateList_To_api_PodTemplateList(in *PodTemplateList,
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodTemplateList))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3524,7 +3515,7 @@ func convert_v1beta3_RangeAllocation_To_api_RangeAllocation(in *RangeAllocation,
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*RangeAllocation))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3541,7 +3532,7 @@ func convert_v1beta3_ReplicationController_To_api_ReplicationController(in *Repl
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ReplicationController))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3560,7 +3551,7 @@ func convert_v1beta3_ReplicationControllerList_To_api_ReplicationControllerList(
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ReplicationControllerList))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3592,7 +3583,7 @@ func convert_v1beta3_ResourceQuota_To_api_ResourceQuota(in *ResourceQuota, out *
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ResourceQuota))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3611,7 +3602,7 @@ func convert_v1beta3_ResourceQuotaList_To_api_ResourceQuotaList(in *ResourceQuot
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ResourceQuotaList))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3726,7 +3717,7 @@ func convert_v1beta3_Secret_To_api_Secret(in *Secret, out *api.Secret, s convers
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Secret))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3752,7 +3743,7 @@ func convert_v1beta3_SecretList_To_api_SecretList(in *SecretList, out *api.Secre
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*SecretList))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3818,7 +3809,7 @@ func convert_v1beta3_SerializedReference_To_api_SerializedReference(in *Serializ
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*SerializedReference))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectReference_To_api_ObjectReference(&in.Reference, &out.Reference, s); err != nil {
@@ -3831,7 +3822,7 @@ func convert_v1beta3_Service_To_api_Service(in *Service, out *api.Service, s con
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Service))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3850,7 +3841,7 @@ func convert_v1beta3_ServiceAccount_To_api_ServiceAccount(in *ServiceAccount, ou
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ServiceAccount))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
@@ -3883,7 +3874,7 @@ func convert_v1beta3_ServiceAccountList_To_api_ServiceAccountList(in *ServiceAcc
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ServiceAccountList))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3906,7 +3897,7 @@ func convert_v1beta3_ServiceList_To_api_ServiceList(in *ServiceList, out *api.Se
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ServiceList))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3953,7 +3944,7 @@ func convert_v1beta3_Status_To_api_Status(in *Status, out *api.Status, s convers
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Status))(in)
 	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
 	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
@@ -3981,15 +3972,6 @@ func convert_v1beta3_TCPSocketAction_To_api_TCPSocketAction(in *TCPSocketAction,
 	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
 		return err
 	}
-	return nil
-}
-
-func convert_v1beta3_TypeMeta_To_api_TypeMeta(in *TypeMeta, out *api.TypeMeta, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*TypeMeta))(in)
-	}
-	out.Kind = in.Kind
-	out.APIVersion = in.APIVersion
 	return nil
 }
 
@@ -4213,7 +4195,6 @@ func init() {
 		convert_api_Service_To_v1beta3_Service,
 		convert_api_Status_To_v1beta3_Status,
 		convert_api_TCPSocketAction_To_v1beta3_TCPSocketAction,
-		convert_api_TypeMeta_To_v1beta3_TypeMeta,
 		convert_api_VolumeMount_To_v1beta3_VolumeMount,
 		convert_api_VolumeSource_To_v1beta3_VolumeSource,
 		convert_api_Volume_To_v1beta3_Volume,
@@ -4319,7 +4300,6 @@ func init() {
 		convert_v1beta3_Service_To_api_Service,
 		convert_v1beta3_Status_To_api_Status,
 		convert_v1beta3_TCPSocketAction_To_api_TCPSocketAction,
-		convert_v1beta3_TypeMeta_To_api_TypeMeta,
 		convert_v1beta3_VolumeMount_To_api_VolumeMount,
 		convert_v1beta3_VolumeSource_To_api_VolumeSource,
 		convert_v1beta3_Volume_To_api_Volume,

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -50,7 +50,7 @@ func deepCopy_v1beta3_AWSElasticBlockStoreVolumeSource(in AWSElasticBlockStoreVo
 }
 
 func deepCopy_v1beta3_Binding(in Binding, out *Binding, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -91,7 +91,7 @@ func deepCopy_v1beta3_ComponentCondition(in ComponentCondition, out *ComponentCo
 }
 
 func deepCopy_v1beta3_ComponentStatus(in ComponentStatus, out *ComponentStatus, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -111,7 +111,7 @@ func deepCopy_v1beta3_ComponentStatus(in ComponentStatus, out *ComponentStatus, 
 }
 
 func deepCopy_v1beta3_ComponentStatusList(in ComponentStatusList, out *ComponentStatusList, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -305,7 +305,7 @@ func deepCopy_v1beta3_ContainerStatus(in ContainerStatus, out *ContainerStatus, 
 }
 
 func deepCopy_v1beta3_DeleteOptions(in DeleteOptions, out *DeleteOptions, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if in.GracePeriodSeconds != nil {
@@ -367,7 +367,7 @@ func deepCopy_v1beta3_EndpointSubset(in EndpointSubset, out *EndpointSubset, c *
 }
 
 func deepCopy_v1beta3_Endpoints(in Endpoints, out *Endpoints, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -387,7 +387,7 @@ func deepCopy_v1beta3_Endpoints(in Endpoints, out *Endpoints, c *conversion.Clon
 }
 
 func deepCopy_v1beta3_EndpointsList(in EndpointsList, out *EndpointsList, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -433,7 +433,7 @@ func deepCopy_v1beta3_EnvVarSource(in EnvVarSource, out *EnvVarSource, c *conver
 }
 
 func deepCopy_v1beta3_Event(in Event, out *Event, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -458,7 +458,7 @@ func deepCopy_v1beta3_Event(in Event, out *Event, c *conversion.Cloner) error {
 }
 
 func deepCopy_v1beta3_EventList(in EventList, out *EventList, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -589,7 +589,7 @@ func deepCopy_v1beta3_Lifecycle(in Lifecycle, out *Lifecycle, c *conversion.Clon
 }
 
 func deepCopy_v1beta3_LimitRange(in LimitRange, out *LimitRange, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -643,7 +643,7 @@ func deepCopy_v1beta3_LimitRangeItem(in LimitRangeItem, out *LimitRangeItem, c *
 }
 
 func deepCopy_v1beta3_LimitRangeList(in LimitRangeList, out *LimitRangeList, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -677,7 +677,7 @@ func deepCopy_v1beta3_LimitRangeSpec(in LimitRangeSpec, out *LimitRangeSpec, c *
 }
 
 func deepCopy_v1beta3_List(in List, out *List, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -703,7 +703,7 @@ func deepCopy_v1beta3_ListMeta(in ListMeta, out *ListMeta, c *conversion.Cloner)
 }
 
 func deepCopy_v1beta3_ListOptions(in ListOptions, out *ListOptions, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	out.LabelSelector = in.LabelSelector
@@ -746,7 +746,7 @@ func deepCopy_v1beta3_NFSVolumeSource(in NFSVolumeSource, out *NFSVolumeSource, 
 }
 
 func deepCopy_v1beta3_Namespace(in Namespace, out *Namespace, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -762,7 +762,7 @@ func deepCopy_v1beta3_Namespace(in Namespace, out *Namespace, c *conversion.Clon
 }
 
 func deepCopy_v1beta3_NamespaceList(in NamespaceList, out *NamespaceList, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -799,7 +799,7 @@ func deepCopy_v1beta3_NamespaceStatus(in NamespaceStatus, out *NamespaceStatus, 
 }
 
 func deepCopy_v1beta3_Node(in Node, out *Node, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -835,7 +835,7 @@ func deepCopy_v1beta3_NodeCondition(in NodeCondition, out *NodeCondition, c *con
 }
 
 func deepCopy_v1beta3_NodeList(in NodeList, out *NodeList, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -970,7 +970,7 @@ func deepCopy_v1beta3_ObjectReference(in ObjectReference, out *ObjectReference, 
 }
 
 func deepCopy_v1beta3_PersistentVolume(in PersistentVolume, out *PersistentVolume, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -986,7 +986,7 @@ func deepCopy_v1beta3_PersistentVolume(in PersistentVolume, out *PersistentVolum
 }
 
 func deepCopy_v1beta3_PersistentVolumeClaim(in PersistentVolumeClaim, out *PersistentVolumeClaim, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1002,7 +1002,7 @@ func deepCopy_v1beta3_PersistentVolumeClaim(in PersistentVolumeClaim, out *Persi
 }
 
 func deepCopy_v1beta3_PersistentVolumeClaimList(in PersistentVolumeClaimList, out *PersistentVolumeClaimList, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1069,7 +1069,7 @@ func deepCopy_v1beta3_PersistentVolumeClaimVolumeSource(in PersistentVolumeClaim
 }
 
 func deepCopy_v1beta3_PersistentVolumeList(in PersistentVolumeList, out *PersistentVolumeList, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1192,7 +1192,7 @@ func deepCopy_v1beta3_PersistentVolumeStatus(in PersistentVolumeStatus, out *Per
 }
 
 func deepCopy_v1beta3_Pod(in Pod, out *Pod, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1214,7 +1214,7 @@ func deepCopy_v1beta3_PodCondition(in PodCondition, out *PodCondition, c *conver
 }
 
 func deepCopy_v1beta3_PodExecOptions(in PodExecOptions, out *PodExecOptions, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	out.Stdin = in.Stdin
@@ -1234,7 +1234,7 @@ func deepCopy_v1beta3_PodExecOptions(in PodExecOptions, out *PodExecOptions, c *
 }
 
 func deepCopy_v1beta3_PodList(in PodList, out *PodList, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1254,7 +1254,7 @@ func deepCopy_v1beta3_PodList(in PodList, out *PodList, c *conversion.Cloner) er
 }
 
 func deepCopy_v1beta3_PodLogOptions(in PodLogOptions, out *PodLogOptions, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	out.Container = in.Container
@@ -1264,7 +1264,7 @@ func deepCopy_v1beta3_PodLogOptions(in PodLogOptions, out *PodLogOptions, c *con
 }
 
 func deepCopy_v1beta3_PodProxyOptions(in PodProxyOptions, out *PodProxyOptions, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	out.Path = in.Path
@@ -1368,7 +1368,7 @@ func deepCopy_v1beta3_PodStatus(in PodStatus, out *PodStatus, c *conversion.Clon
 }
 
 func deepCopy_v1beta3_PodStatusResult(in PodStatusResult, out *PodStatusResult, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1381,7 +1381,7 @@ func deepCopy_v1beta3_PodStatusResult(in PodStatusResult, out *PodStatusResult, 
 }
 
 func deepCopy_v1beta3_PodTemplate(in PodTemplate, out *PodTemplate, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1394,7 +1394,7 @@ func deepCopy_v1beta3_PodTemplate(in PodTemplate, out *PodTemplate, c *conversio
 }
 
 func deepCopy_v1beta3_PodTemplateList(in PodTemplateList, out *PodTemplateList, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1459,7 +1459,7 @@ func deepCopy_v1beta3_RBDVolumeSource(in RBDVolumeSource, out *RBDVolumeSource, 
 }
 
 func deepCopy_v1beta3_RangeAllocation(in RangeAllocation, out *RangeAllocation, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1478,7 +1478,7 @@ func deepCopy_v1beta3_RangeAllocation(in RangeAllocation, out *RangeAllocation, 
 }
 
 func deepCopy_v1beta3_ReplicationController(in ReplicationController, out *ReplicationController, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1494,7 +1494,7 @@ func deepCopy_v1beta3_ReplicationController(in ReplicationController, out *Repli
 }
 
 func deepCopy_v1beta3_ReplicationControllerList(in ReplicationControllerList, out *ReplicationControllerList, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1546,7 +1546,7 @@ func deepCopy_v1beta3_ReplicationControllerStatus(in ReplicationControllerStatus
 }
 
 func deepCopy_v1beta3_ResourceQuota(in ResourceQuota, out *ResourceQuota, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1562,7 +1562,7 @@ func deepCopy_v1beta3_ResourceQuota(in ResourceQuota, out *ResourceQuota, c *con
 }
 
 func deepCopy_v1beta3_ResourceQuotaList(in ResourceQuotaList, out *ResourceQuotaList, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1662,7 +1662,7 @@ func deepCopy_v1beta3_SELinuxOptions(in SELinuxOptions, out *SELinuxOptions, c *
 }
 
 func deepCopy_v1beta3_Secret(in Secret, out *Secret, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1685,7 +1685,7 @@ func deepCopy_v1beta3_Secret(in Secret, out *Secret, c *conversion.Cloner) error
 }
 
 func deepCopy_v1beta3_SecretList(in SecretList, out *SecretList, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1742,7 +1742,7 @@ func deepCopy_v1beta3_SecurityContext(in SecurityContext, out *SecurityContext, 
 }
 
 func deepCopy_v1beta3_SerializedReference(in SerializedReference, out *SerializedReference, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectReference(in.Reference, &out.Reference, c); err != nil {
@@ -1752,7 +1752,7 @@ func deepCopy_v1beta3_SerializedReference(in SerializedReference, out *Serialize
 }
 
 func deepCopy_v1beta3_Service(in Service, out *Service, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1768,7 +1768,7 @@ func deepCopy_v1beta3_Service(in Service, out *Service, c *conversion.Cloner) er
 }
 
 func deepCopy_v1beta3_ServiceAccount(in ServiceAccount, out *ServiceAccount, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
@@ -1798,7 +1798,7 @@ func deepCopy_v1beta3_ServiceAccount(in ServiceAccount, out *ServiceAccount, c *
 }
 
 func deepCopy_v1beta3_ServiceAccountList(in ServiceAccountList, out *ServiceAccountList, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1818,7 +1818,7 @@ func deepCopy_v1beta3_ServiceAccountList(in ServiceAccountList, out *ServiceAcco
 }
 
 func deepCopy_v1beta3_ServiceList(in ServiceList, out *ServiceList, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1890,7 +1890,7 @@ func deepCopy_v1beta3_ServiceStatus(in ServiceStatus, out *ServiceStatus, c *con
 }
 
 func deepCopy_v1beta3_Status(in Status, out *Status, c *conversion.Cloner) error {
-	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+	if err := deepCopy_runtime_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
 	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
@@ -1939,12 +1939,6 @@ func deepCopy_v1beta3_TCPSocketAction(in TCPSocketAction, out *TCPSocketAction, 
 	if err := deepCopy_util_IntOrString(in.Port, &out.Port, c); err != nil {
 		return err
 	}
-	return nil
-}
-
-func deepCopy_v1beta3_TypeMeta(in TypeMeta, out *TypeMeta, c *conversion.Cloner) error {
-	out.Kind = in.Kind
-	out.APIVersion = in.APIVersion
 	return nil
 }
 
@@ -2064,6 +2058,13 @@ func deepCopy_runtime_RawExtension(in runtime.RawExtension, out *runtime.RawExte
 	} else {
 		out.RawJSON = nil
 	}
+	return nil
+}
+
+func deepCopy_runtime_TypeMeta(in runtime.TypeMeta, out *runtime.TypeMeta, c *conversion.Cloner) error {
+	out.APIGroup = in.APIGroup
+	out.APIVersion = in.APIVersion
+	out.Kind = in.Kind
 	return nil
 }
 
@@ -2196,11 +2197,11 @@ func init() {
 		deepCopy_v1beta3_StatusCause,
 		deepCopy_v1beta3_StatusDetails,
 		deepCopy_v1beta3_TCPSocketAction,
-		deepCopy_v1beta3_TypeMeta,
 		deepCopy_v1beta3_Volume,
 		deepCopy_v1beta3_VolumeMount,
 		deepCopy_v1beta3_VolumeSource,
 		deepCopy_runtime_RawExtension,
+		deepCopy_runtime_TypeMeta,
 		deepCopy_util_IntOrString,
 		deepCopy_util_Time,
 	)

--- a/pkg/api/v1beta3/register.go
+++ b/pkg/api/v1beta3/register.go
@@ -39,7 +39,7 @@ func init() {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes() {
-	api.Scheme.AddKnownTypes("v1beta3",
+	api.Scheme.AddKnownTypes(api.Group, "v1beta3",
 		&Pod{},
 		&PodList{},
 		&PodStatusResult{},
@@ -83,8 +83,8 @@ func addKnownTypes() {
 		&RangeAllocation{},
 	)
 	// Legacy names are supported
-	api.Scheme.AddKnownTypeWithName("v1beta3", "Minion", &Node{})
-	api.Scheme.AddKnownTypeWithName("v1beta3", "MinionList", &NodeList{})
+	api.Scheme.AddKnownTypeWithName(api.Group, "v1beta3", "Minion", &Node{})
+	api.Scheme.AddKnownTypeWithName(api.Group, "v1beta3", "MinionList", &NodeList{})
 }
 
 func (*Pod) IsAnAPIObject()                       {}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -237,8 +237,8 @@ type PersistentVolumeSource struct {
 }
 
 type PersistentVolume struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	//Spec defines a persistent volume owned by the cluster
 	Spec PersistentVolumeSpec `json:"spec,omitempty" description:"specification of a persistent volume as provisioned by an administrator"`
@@ -288,15 +288,15 @@ type PersistentVolumeStatus struct {
 }
 
 type PersistentVolumeList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
-	Items    []PersistentVolume `json:"items,omitempty" description:"list of persistent volumes"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
+	Items            []PersistentVolume `json:"items,omitempty" description:"list of persistent volumes"`
 }
 
 // PersistentVolumeClaim is a user's request for and claim to a persistent volume
 type PersistentVolumeClaim struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Spec defines the volume requested by a pod author
 	Spec PersistentVolumeClaimSpec `json:"spec,omitempty" description:"the desired characteristics of a volume"`
@@ -306,9 +306,9 @@ type PersistentVolumeClaim struct {
 }
 
 type PersistentVolumeClaimList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
-	Items    []PersistentVolumeClaim `json:"items,omitempty" description:"a list of persistent volume claims"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
+	Items            []PersistentVolumeClaim `json:"items,omitempty" description:"a list of persistent volume claims"`
 }
 
 // PersistentVolumeClaimSpec describes the common attributes of storage devices
@@ -918,8 +918,8 @@ type PodStatus struct {
 
 // PodStatusResult is a wrapper for PodStatus returned by kubelet that can be encode/decoded
 type PodStatusResult struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 	// Status represents the current information about a pod. This data may not be up
 	// to date.
 	Status PodStatus `json:"status,omitempty" description:"most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
@@ -928,8 +928,8 @@ type PodStatusResult struct {
 // Pod is a collection of containers that can run on a host. This resource is created
 // by clients and scheduled onto hosts.
 type Pod struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a pod.
 	Spec PodSpec `json:"spec,omitempty" description:"specification of the desired behavior of the pod; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
@@ -941,8 +941,8 @@ type Pod struct {
 
 // PodList is a list of Pods.
 type PodList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
 
 	Items []Pod `json:"items" description:"list of pods"`
 }
@@ -958,8 +958,8 @@ type PodTemplateSpec struct {
 
 // PodTemplate describes a template for creating copies of a predefined pod.
 type PodTemplate struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Template defines the pods that will be created from this pod template
 	Template PodTemplateSpec `json:"template,omitempty" description:"the template of the desired behavior of the pod; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
@@ -967,8 +967,8 @@ type PodTemplate struct {
 
 // PodTemplateList is a list of PodTemplates.
 type PodTemplateList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []PodTemplate `json:"items" description:"list of pod templates"`
 }
@@ -1004,7 +1004,7 @@ type ReplicationControllerStatus struct {
 
 // ReplicationController represents the configuration of a replication controller.
 type ReplicationController struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 	// If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages.
 	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
@@ -1018,8 +1018,8 @@ type ReplicationController struct {
 
 // ReplicationControllerList is a collection of replication controllers.
 type ReplicationControllerList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []ReplicationController `json:"items" description:"list of replication controllers"`
 }
@@ -1137,8 +1137,8 @@ type ServicePort struct {
 // (for example 3306) that the proxy listens on, and the selector that determines which pods
 // will answer requests sent through the proxy.
 type Service struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a service.
 	Spec ServiceSpec `json:"spec,omitempty" description:"specification of the desired behavior of the service; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
@@ -1155,8 +1155,8 @@ const (
 
 // ServiceList holds a list of services.
 type ServiceList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []Service `json:"items" description:"list of services"`
 }
@@ -1166,8 +1166,8 @@ type ServiceList struct {
 // * a principal that can be authenticated and authorized
 // * a set of secrets
 type ServiceAccount struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount
 	Secrets []ObjectReference `json:"secrets,omitempty" description:"list of secrets that can be used by pods running as this service account" patchStrategy:"merge" patchMergeKey:"name"`
@@ -1180,8 +1180,8 @@ type ServiceAccount struct {
 
 // ServiceAccountList is a list of ServiceAccount objects
 type ServiceAccountList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []ServiceAccount `json:"items" description:"list of ServiceAccounts"`
 }
@@ -1199,8 +1199,8 @@ type ServiceAccountList struct {
 //     },
 //  ]
 type Endpoints struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// The set of all endpoints is the union of all subsets.
 	Subsets []EndpointSubset `json:"subsets" description:"sets of addresses and ports that comprise a service"`
@@ -1246,8 +1246,8 @@ type EndpointPort struct {
 
 // EndpointsList is a list of endpoints.
 type EndpointsList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []Endpoints `json:"items" description:"list of endpoints"`
 }
@@ -1362,8 +1362,8 @@ type ResourceList map[ResourceName]resource.Quantity
 // Node is a worker node in Kubernetes.
 // The name of the node according to etcd is in ID.
 type Node struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a node.
 	Spec NodeSpec `json:"spec,omitempty" description:"specification of a node; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
@@ -1374,8 +1374,8 @@ type Node struct {
 
 // NodeList is a list of minions.
 type NodeList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []Node `json:"items" description:"list of nodes"`
 }
@@ -1412,8 +1412,8 @@ const (
 // A namespace provides a scope for Names.
 // Use of multiple namespaces is optional
 type Namespace struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of the Namespace.
 	Spec NamespaceSpec `json:"spec,omitempty" description:"spec defines the behavior of the Namespace; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
@@ -1424,8 +1424,8 @@ type Namespace struct {
 
 // NamespaceList is a list of Namespaces.
 type NamespaceList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Items is the list of Namespace objects in the list
 	Items []Namespace `json:"items"  description:"items is the list of Namespace objects in the list"`
@@ -1433,7 +1433,7 @@ type NamespaceList struct {
 
 // Binding ties one object to another - for example, a pod is bound to a node by a scheduler.
 type Binding struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 	// ObjectMeta describes the object that is being bound.
 	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
@@ -1443,7 +1443,7 @@ type Binding struct {
 
 // DeleteOptions may be provided when deleting an API object
 type DeleteOptions struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 
 	// Optional duration in seconds before the object should be deleted. Value must be non-negative integer.
 	// The value zero indicates delete immediately. If this value is nil, the default grace period for the
@@ -1453,7 +1453,7 @@ type DeleteOptions struct {
 
 // ListOptions is the query options to a standard REST list call
 type ListOptions struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 
 	// A selector based on labels
 	LabelSelector string `json:"labelSelector,omitempty" description:"a selector to restrict the list of returned objects by their labels; defaults to everything"`
@@ -1467,7 +1467,7 @@ type ListOptions struct {
 
 // PodLogOptions is the query options for a Pod's logs REST call
 type PodLogOptions struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 
 	// Container for which to return logs
 	Container string `json:"container,omitempty" description:"the container for which to stream logs; defaults to only container if there is one container in the pod"`
@@ -1481,7 +1481,7 @@ type PodLogOptions struct {
 
 // PodExecOptions is the query options to a Pod's remote exec call
 type PodExecOptions struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 
 	// Stdin if true indicates that stdin is to be redirected for the exec call
 	Stdin bool `json:"stdin,omitempty" description:"redirect the standard input stream of the pod for this call; defaults to false"`
@@ -1504,7 +1504,7 @@ type PodExecOptions struct {
 
 // PodProxyOptions is the query options to a Pod's proxy call
 type PodProxyOptions struct {
-	TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 
 	// Path is the URL path to use for the current proxy request
 	Path string `json:"path,omitempty" description:"URL path to use in proxy request to pod"`
@@ -1512,8 +1512,8 @@ type PodProxyOptions struct {
 
 // Status is a return value for calls that don't return other objects.
 type Status struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// One of: "Success" or "Failure"
 	Status string `json:"status,omitempty" description:"status of the operation; either Success, or Failure"`
@@ -1691,8 +1691,8 @@ type LocalObjectReference struct {
 }
 
 type SerializedReference struct {
-	TypeMeta  `json:",inline"`
-	Reference ObjectReference `json:"reference,omitempty" description:"the reference to an object in the system"`
+	runtime.TypeMeta `json:",inline"`
+	Reference        ObjectReference `json:"reference,omitempty" description:"the reference to an object in the system"`
 }
 
 type EventSource struct {
@@ -1705,8 +1705,8 @@ type EventSource struct {
 // Event is a report of an event somewhere in the cluster.
 // TODO: Decide whether to store these separately or with the object they apply to.
 type Event struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Required. The object that this event is about.
 	InvolvedObject ObjectReference `json:"involvedObject" description:"object this event is about"`
@@ -1723,7 +1723,7 @@ type Event struct {
 	// Optional. The component reporting this event. Should be a short machine understandable string.
 	Source EventSource `json:"source,omitempty" description:"component reporting this event"`
 
-	// The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)
+	// The time at which the event was first recorded. (Time of server receipt is in runtime.TypeMeta.)
 	FirstTimestamp util.Time `json:"firstTimestamp,omitempty" description:"the time at which the event was first recorded"`
 
 	// The time at which the most recent occurance of this event was recorded.
@@ -1735,16 +1735,16 @@ type Event struct {
 
 // EventList is a list of events.
 type EventList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []Event `json:"items" description:"list of events"`
 }
 
 // List holds a list of objects, which may not be known by the server.
 type List struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []runtime.RawExtension `json:"items" description:"list of objects"`
 }
@@ -1779,8 +1779,8 @@ type LimitRangeSpec struct {
 
 // LimitRange sets resource usage limits for each kind of resource in a Namespace
 type LimitRange struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Spec defines the limits enforced
 	Spec LimitRangeSpec `json:"spec,omitempty" description:"spec defines the limits enforced; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
@@ -1788,8 +1788,8 @@ type LimitRange struct {
 
 // LimitRangeList is a list of LimitRange items.
 type LimitRangeList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Items is a list of LimitRange objects
 	Items []LimitRange `json:"items" description:"items is a list of LimitRange objects"`
@@ -1827,8 +1827,8 @@ type ResourceQuotaStatus struct {
 
 // ResourceQuota sets aggregate quota restrictions enforced per namespace
 type ResourceQuota struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Spec defines the desired quota
 	Spec ResourceQuotaSpec `json:"spec,omitempty" description:"spec defines the desired quota; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
@@ -1839,8 +1839,8 @@ type ResourceQuota struct {
 
 // ResourceQuotaList is a list of ResourceQuota items
 type ResourceQuotaList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Items is a list of ResourceQuota objects
 	Items []ResourceQuota `json:"items" description:"items is a list of ResourceQuota objects"`
@@ -1849,8 +1849,8 @@ type ResourceQuotaList struct {
 // Secret holds secret data of a certain type.  The total bytes of the values in
 // the Data field must be less than MaxSecretSize bytes.
 type Secret struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	// Data contains the secret data.  Each key must be a valid DNS_SUBDOMAIN
 	// or leading dot followed by valid DNS_SUBDOMAIN.
@@ -1900,8 +1900,8 @@ const (
 )
 
 type SecretList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []Secret `json:"items" description:"items is a list of secret objects"`
 }
@@ -1923,15 +1923,15 @@ type ComponentCondition struct {
 
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.
 type ComponentStatus struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Conditions []ComponentCondition `json:"conditions,omitempty" description:"list of component conditions observed" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 type ComponentStatusList struct {
-	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ListMeta         `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Items []ComponentStatus `json:"items" description:"list of component status objects"`
 }
@@ -1974,8 +1974,8 @@ type SELinuxOptions struct {
 
 // RangeAllocation is not a public type
 type RangeAllocation struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	runtime.TypeMeta `json:",inline"`
+	ObjectMeta       `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
 
 	Range string `json:"range" description:"a range string that identifies the range represented by 'data'; required"`
 	Data  []byte `json:"data" description:"a bit array containing all allocated addresses in the previous segment"`

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -669,7 +669,7 @@ func validateObjectFieldSelector(fs *api.ObjectFieldSelector) errs.ValidationErr
 	} else if fs.FieldPath == "" {
 		allErrs = append(allErrs, errs.NewFieldRequired("fieldPath"))
 	} else {
-		internalFieldPath, _, err := api.Scheme.ConvertFieldLabel(fs.APIVersion, "Pod", fs.FieldPath, "")
+		internalFieldPath, _, err := api.Scheme.ConvertFieldLabel(api.Group, fs.APIVersion, "Pod", fs.FieldPath, "")
 		if err != nil {
 			allErrs = append(allErrs, errs.NewFieldInvalid("fieldPath", fs.FieldPath, "error converting fieldPath"))
 		} else if !validFieldPathExpressions.Has(internalFieldPath) {

--- a/pkg/apiserver/api_installer_test.go
+++ b/pkg/apiserver/api_installer_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
 	"github.com/emicklei/go-restful"
 )
@@ -43,7 +44,7 @@ func TestScopeNamingGenerateLink(t *testing.T) {
 			Name:      "foo",
 			Namespace: "other",
 		},
-		TypeMeta: api.TypeMeta{
+		TypeMeta: runtime.TypeMeta{
 			Kind: "Service",
 		},
 	}

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -103,25 +103,25 @@ func newMapper() *meta.DefaultRESTMapper {
 func addTestTypes() {
 	type ListOptions struct {
 		runtime.Object
-		api.TypeMeta    `json:",inline"`
-		LabelSelector   string `json:"labels,omitempty"`
-		FieldSelector   string `json:"fields,omitempty"`
-		Watch           bool   `json:"watch,omitempty"`
-		ResourceVersion string `json:"resourceVersion,omitempty"`
+		runtime.TypeMeta `json:",inline"`
+		LabelSelector    string `json:"labels,omitempty"`
+		FieldSelector    string `json:"fields,omitempty"`
+		Watch            bool   `json:"watch,omitempty"`
+		ResourceVersion  string `json:"resourceVersion,omitempty"`
 	}
-	api.Scheme.AddKnownTypes(testVersion, &Simple{}, &SimpleList{}, &api.Status{}, &ListOptions{}, &api.DeleteOptions{}, &SimpleGetOptions{}, &SimpleRoot{})
+	api.Scheme.AddKnownTypes(api.Group, testVersion, &Simple{}, &SimpleList{}, &api.Status{}, &ListOptions{}, &api.DeleteOptions{}, &SimpleGetOptions{}, &SimpleRoot{})
 }
 
 func addNewTestTypes() {
 	type ListOptions struct {
 		runtime.Object
-		api.TypeMeta    `json:",inline"`
-		LabelSelector   string `json:"labelSelector,omitempty"`
-		FieldSelector   string `json:"fieldSelector,omitempty"`
-		Watch           bool   `json:"watch,omitempty"`
-		ResourceVersion string `json:"resourceVersion,omitempty"`
+		runtime.TypeMeta `json:",inline"`
+		LabelSelector    string `json:"labelSelector,omitempty"`
+		FieldSelector    string `json:"fieldSelector,omitempty"`
+		Watch            bool   `json:"watch,omitempty"`
+		ResourceVersion  string `json:"resourceVersion,omitempty"`
 	}
-	api.Scheme.AddKnownTypes(newVersion, &Simple{}, &SimpleList{}, &api.Status{}, &ListOptions{}, &api.DeleteOptions{}, &SimpleGetOptions{}, &SimpleRoot{})
+	api.Scheme.AddKnownTypes(api.Group, newVersion, &Simple{}, &SimpleList{}, &api.Status{}, &ListOptions{}, &api.DeleteOptions{}, &SimpleGetOptions{}, &SimpleRoot{})
 }
 
 func init() {
@@ -129,7 +129,7 @@ func init() {
 	// api.Status is returned in errors
 
 	// "internal" version
-	api.Scheme.AddKnownTypes("", &Simple{}, &SimpleList{}, &api.Status{}, &api.ListOptions{}, &SimpleGetOptions{}, &SimpleRoot{})
+	api.Scheme.AddKnownTypes(api.Group, "", &Simple{}, &SimpleList{}, &api.Status{}, &api.ListOptions{}, &SimpleGetOptions{}, &SimpleRoot{})
 	addTestTypes()
 	addNewTestTypes()
 
@@ -138,7 +138,7 @@ func init() {
 	// enumerate all supported versions, get the kinds, and register with
 	// the mapper how to address our resources
 	for _, version := range versions {
-		for kind := range api.Scheme.KnownTypes(version) {
+		for kind := range api.Scheme.KnownTypes(api.Group, version) {
 			root := kind == "SimpleRoot"
 			if root {
 				nsMapper.Add(meta.RESTScopeRoot, kind, version, false)
@@ -153,12 +153,12 @@ func init() {
 	admissionControl = admit.NewAlwaysAdmit()
 	requestContextMapper = api.NewRequestContextMapper()
 
-	api.Scheme.AddFieldLabelConversionFunc(testVersion, "Simple",
+	api.Scheme.AddFieldLabelConversionFunc(api.Group, testVersion, "Simple",
 		func(label, value string) (string, string, error) {
 			return label, value, nil
 		},
 	)
-	api.Scheme.AddFieldLabelConversionFunc(newVersion, "Simple",
+	api.Scheme.AddFieldLabelConversionFunc(api.Group, newVersion, "Simple",
 		func(label, value string) (string, string, error) {
 			return label, value, nil
 		},
@@ -236,36 +236,36 @@ func handleInternal(legacy bool, storage map[string]rest.Storage, admissionContr
 }
 
 type Simple struct {
-	api.TypeMeta   `json:",inline"`
-	api.ObjectMeta `json:"metadata"`
-	Other          string            `json:"other,omitempty"`
-	Labels         map[string]string `json:"labels,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	api.ObjectMeta   `json:"metadata"`
+	Other            string            `json:"other,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
 }
 
 func (*Simple) IsAnAPIObject() {}
 
 type SimpleRoot struct {
-	api.TypeMeta   `json:",inline"`
-	api.ObjectMeta `json:"metadata"`
-	Other          string            `json:"other,omitempty"`
-	Labels         map[string]string `json:"labels,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	api.ObjectMeta   `json:"metadata"`
+	Other            string            `json:"other,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
 }
 
 func (*SimpleRoot) IsAnAPIObject() {}
 
 type SimpleGetOptions struct {
-	api.TypeMeta `json:",inline"`
-	Param1       string `json:"param1"`
-	Param2       string `json:"param2"`
-	Path         string `json:"atAPath"`
+	runtime.TypeMeta `json:",inline"`
+	Param1           string `json:"param1"`
+	Param2           string `json:"param2"`
+	Path             string `json:"atAPath"`
 }
 
 func (*SimpleGetOptions) IsAnAPIObject() {}
 
 type SimpleList struct {
-	api.TypeMeta `json:",inline"`
-	api.ListMeta `json:"metadata,inline"`
-	Items        []Simple `json:"items,omitempty"`
+	runtime.TypeMeta `json:",inline"`
+	api.ListMeta     `json:"metadata,inline"`
+	Items            []Simple `json:"items,omitempty"`
 }
 
 func (*SimpleList) IsAnAPIObject() {}

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -361,7 +361,7 @@ func TestWatchHTTPTimeout(t *testing.T) {
 	req, _ := http.NewRequest("GET", dest.String(), nil)
 	client := http.Client{}
 	resp, err := client.Do(req)
-	watcher.Add(&Simple{TypeMeta: api.TypeMeta{APIVersion: newVersion}})
+	watcher.Add(&Simple{TypeMeta: runtime.TypeMeta{APIVersion: newVersion}})
 
 	// Make sure we can actually watch an endpoint
 	decoder := json.NewDecoder(resp.Body)

--- a/pkg/client/clientcmd/api/register.go
+++ b/pkg/client/clientcmd/api/register.go
@@ -17,14 +17,15 @@ limitations under the License.
 package api
 
 import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
 // Scheme is the default instance of runtime.Scheme to which types in the Kubernetes API are already registered.
-var Scheme = runtime.NewScheme()
+var Scheme = runtime.NewScheme(api.Group)
 
 func init() {
-	Scheme.AddKnownTypes("",
+	Scheme.AddKnownTypes(api.Group, "",
 		&Config{},
 	)
 }

--- a/pkg/client/clientcmd/api/v1/register.go
+++ b/pkg/client/clientcmd/api/v1/register.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
@@ -25,7 +26,7 @@ import (
 var Codec = runtime.CodecFor(api.Scheme, "v1")
 
 func init() {
-	api.Scheme.AddKnownTypes("v1",
+	api.Scheme.AddKnownTypes(kapi.Group, "v1",
 		&Config{},
 	)
 }

--- a/pkg/client/testclient/fixture.go
+++ b/pkg/client/testclient/fixture.go
@@ -129,7 +129,7 @@ func NewObjects(scheme runtime.ObjectScheme, decoder runtime.ObjectDecoder) Obje
 }
 
 func (o objects) Kind(kind, name string) (runtime.Object, error) {
-	empty, _ := o.scheme.New("", kind)
+	empty, _ := o.scheme.New(api.Group, "", kind)
 	nilValue := reflect.Zero(reflect.TypeOf(empty)).Interface().(runtime.Object)
 
 	arr, ok := o.types[kind]
@@ -140,7 +140,7 @@ func (o objects) Kind(kind, name string) (runtime.Object, error) {
 			if !ok {
 				return empty, nil
 			}
-			out, err := o.scheme.New("", kind)
+			out, err := o.scheme.New(api.Group, "", kind)
 			if err != nil {
 				return nilValue, err
 			}
@@ -181,10 +181,11 @@ func (o objects) Kind(kind, name string) (runtime.Object, error) {
 }
 
 func (o objects) Add(obj runtime.Object) error {
-	_, kind, err := o.scheme.ObjectVersionAndKind(obj)
+	tm, err := o.scheme.ObjectTypeMeta(obj)
 	if err != nil {
 		return err
 	}
+	kind := tm.Kind
 
 	switch {
 	case runtime.IsListType(obj):

--- a/pkg/controller/replication_controller_test.go
+++ b/pkg/controller/replication_controller_test.go
@@ -98,7 +98,7 @@ func getKey(rc *api.ReplicationController, t *testing.T) string {
 
 func newReplicationController(replicas int) *api.ReplicationController {
 	rc := &api.ReplicationController{
-		TypeMeta: api.TypeMeta{APIVersion: testapi.Version()},
+		TypeMeta: runtime.TypeMeta{APIVersion: testapi.Version()},
 		ObjectMeta: api.ObjectMeta{
 			UID:             util.NewUUID(),
 			Name:            "foobar",

--- a/pkg/conversion/encode.go
+++ b/pkg/conversion/encode.go
@@ -56,18 +56,18 @@ func (s *Scheme) EncodeToVersion(obj interface{}, destVersion string) (data []by
 		return nil, fmt.Errorf("type %v is not registered for %q and it will be impossible to Decode it, therefore Encode will refuse to encode it.", v.Type(), destVersion)
 	}
 
-	objVersion, objKind, err := s.ObjectVersionAndKind(obj)
+	group, version, kind, err := s.ObjectTypeMeta(obj)
 	if err != nil {
 		return nil, err
 	}
 
 	// Perform a conversion if necessary.
-	if objVersion != destVersion {
-		objOut, err := s.NewObject(destVersion, objKind)
+	if version != destVersion {
+		objOut, err := s.NewObject(group, destVersion, kind)
 		if err != nil {
 			return nil, err
 		}
-		flags, meta := s.generateConvertMeta(objVersion, destVersion, obj)
+		flags, meta := s.generateConvertMeta(version, destVersion, obj)
 		err = s.converter.Convert(obj, objOut, flags, meta)
 		if err != nil {
 			return nil, err
@@ -76,13 +76,13 @@ func (s *Scheme) EncodeToVersion(obj interface{}, destVersion string) (data []by
 	}
 
 	// ensure the output object name comes from the destination type
-	_, objKind, err = s.ObjectVersionAndKind(obj)
+	group, version, kind, err = s.ObjectTypeMeta(obj)
 	if err != nil {
 		return nil, err
 	}
 
 	// Version and Kind should be set on the wire.
-	err = s.SetVersionAndKind(destVersion, objKind, obj)
+	err = s.SetTypeMeta(group, destVersion, kind, obj)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (s *Scheme) EncodeToVersion(obj interface{}, destVersion string) (data []by
 
 	// Version and Kind should be blank in memory. Reset them, since it's
 	// possible that we modified a user object and not a copy above.
-	err = s.SetVersionAndKind("", "", obj)
+	err = s.SetTypeMeta("", "", "", obj)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/conversion/error.go
+++ b/pkg/conversion/error.go
@@ -22,8 +22,9 @@ import (
 )
 
 type notRegisteredErr struct {
-	kind    string
+	group   string
 	version string
+	kind    string
 	t       reflect.Type
 }
 
@@ -31,13 +32,13 @@ func (k *notRegisteredErr) Error() string {
 	if k.t != nil {
 		return fmt.Sprintf("no kind is registered for the type %v", k.t)
 	}
-	if len(k.kind) == 0 {
-		return fmt.Sprintf("no version %q has been registered", k.version)
+	if k.kind == "" {
+		return fmt.Sprintf("no group %q and version %q have been registered", k.group, k.version)
 	}
-	if len(k.version) == 0 {
+	if k.version == "" {
 		return fmt.Sprintf("no kind %q is registered for the default version", k.kind)
 	}
-	return fmt.Sprintf("no kind %q is registered for version %q", k.kind, k.version)
+	return fmt.Sprintf("no kind %q is registered for version %q and group %q", k.kind, k.version, k.group)
 }
 
 // IsNotRegisteredError returns true if the error indicates the provided

--- a/pkg/conversion/scheme.go
+++ b/pkg/conversion/scheme.go
@@ -21,19 +21,28 @@ import (
 	"reflect"
 )
 
+type groupVersion struct {
+	Group   string
+	Version string
+}
+
 // Scheme defines an entire encoding and decoding scheme.
 type Scheme struct {
 	// versionMap allows one to figure out the go type of an object with
-	// the given version and name.
-	versionMap map[string]map[string]reflect.Type
+	// the given groupVersion and name.
+	groupVersionMap map[groupVersion]map[string]reflect.Type
 
-	// typeToVersion allows one to figure out the version for a given go object.
+	// typeToGroup allows one to figure out the group for a given go object.
 	// The reflect.Type we index by should *not* be a pointer. If the same type
-	// is registered for multiple versions, the last one wins.
+	// is registered for multiple groups, the last one wins.
+	typeToGroup map[reflect.Type]string
+
+	// typeToVersion allows one to figure out the desired "apiVersion" field for a given
+	// go object. Requirements and caveats are the same as typeToGroup.
 	typeToVersion map[reflect.Type]string
 
 	// typeToKind allows one to figure out the desired "kind" field for a given
-	// go object. Requirements and caveats are the same as typeToVersion.
+	// go object. Requirements and caveats are the same as typeToGroup.
 	typeToKind map[reflect.Type][]string
 
 	// converter stores all registered conversion functions. It also has
@@ -43,6 +52,9 @@ type Scheme struct {
 	// cloner stores all registered copy functions. It also has default
 	// deep copy behavior.
 	cloner *Cloner
+
+	// defaulGroup is the assumed api group when no such field is present.
+	defaultGroup string
 
 	// Indent will cause the JSON output from Encode to be indented, iff it is true.
 	Indent bool
@@ -58,13 +70,15 @@ type Scheme struct {
 }
 
 // NewScheme manufactures a new scheme.
-func NewScheme() *Scheme {
+func NewScheme(defaultGroup string) *Scheme {
 	s := &Scheme{
-		versionMap:      map[string]map[string]reflect.Type{},
+		groupVersionMap: map[groupVersion]map[string]reflect.Type{},
+		typeToGroup:     map[reflect.Type]string{},
 		typeToVersion:   map[reflect.Type]string{},
 		typeToKind:      map[reflect.Type][]string{},
 		converter:       NewConverter(),
 		cloner:          NewCloner(),
+		defaultGroup:    defaultGroup,
 		InternalVersion: "",
 		MetaFactory:     DefaultMetaFactory,
 	}
@@ -85,7 +99,8 @@ func (s *Scheme) nameFunc(t reflect.Type) string {
 	if !ok {
 		return t.Name()
 	}
-	if internal, ok := s.versionMap[""]; ok {
+	group := s.typeToGroup[t] // must be in a group since we know a kind for t
+	if internal, ok := s.groupVersionMap[groupVersion{group, ""}]; ok {
 		for _, name := range names {
 			if t, ok := internal[name]; ok {
 				return s.typeToKind[t][0]
@@ -99,11 +114,12 @@ func (s *Scheme) nameFunc(t reflect.Type) string {
 // Encode() will refuse objects unless their type has been registered with AddKnownTypes.
 // All objects passed to types should be pointers to structs. The name that go reports for
 // the struct becomes the "kind" field when encoding.
-func (s *Scheme) AddKnownTypes(version string, types ...interface{}) {
-	knownTypes, found := s.versionMap[version]
+func (s *Scheme) AddKnownTypes(group string, version string, types ...interface{}) {
+	gv := groupVersion{group, version}
+	knownTypes, found := s.groupVersionMap[gv]
 	if !found {
 		knownTypes = map[string]reflect.Type{}
-		s.versionMap[version] = knownTypes
+		s.groupVersionMap[gv] = knownTypes
 	}
 	for _, obj := range types {
 		t := reflect.TypeOf(obj)
@@ -115,6 +131,7 @@ func (s *Scheme) AddKnownTypes(version string, types ...interface{}) {
 			panic("All types must be pointers to structs.")
 		}
 		knownTypes[t.Name()] = t
+		s.typeToGroup[t] = group
 		s.typeToVersion[t] = version
 		s.typeToKind[t] = append(s.typeToKind[t], t.Name())
 	}
@@ -123,11 +140,12 @@ func (s *Scheme) AddKnownTypes(version string, types ...interface{}) {
 // AddKnownTypeWithName is like AddKnownTypes, but it lets you specify what this type should
 // be encoded as. Useful for testing when you don't want to make multiple packages to define
 // your structs.
-func (s *Scheme) AddKnownTypeWithName(version, kind string, obj interface{}) {
-	knownTypes, found := s.versionMap[version]
+func (s *Scheme) AddKnownTypeWithName(group, version, kind string, obj interface{}) {
+	gv := groupVersion{group, version}
+	knownTypes, found := s.groupVersionMap[gv]
 	if !found {
 		knownTypes = map[string]reflect.Type{}
-		s.versionMap[version] = knownTypes
+		s.groupVersionMap[gv] = knownTypes
 	}
 	t := reflect.TypeOf(obj)
 	if t.Kind() != reflect.Ptr {
@@ -138,13 +156,14 @@ func (s *Scheme) AddKnownTypeWithName(version, kind string, obj interface{}) {
 		panic("All types must be pointers to structs.")
 	}
 	knownTypes[kind] = t
+	s.typeToGroup[t] = group
 	s.typeToVersion[t] = version
 	s.typeToKind[t] = append(s.typeToKind[t], kind)
 }
 
 // KnownTypes returns an array of the types that are known for a particular version.
-func (s *Scheme) KnownTypes(version string) map[string]reflect.Type {
-	all, ok := s.versionMap[version]
+func (s *Scheme) KnownTypes(group, version string) map[string]reflect.Type {
+	all, ok := s.groupVersionMap[groupVersion{group, version}]
 	if !ok {
 		return map[string]reflect.Type{}
 	}
@@ -157,14 +176,14 @@ func (s *Scheme) KnownTypes(version string) map[string]reflect.Type {
 
 // NewObject returns a new object of the given version and name,
 // or an error if it hasn't been registered.
-func (s *Scheme) NewObject(versionName, kind string) (interface{}, error) {
-	if types, ok := s.versionMap[versionName]; ok {
+func (s *Scheme) NewObject(group, version, kind string) (interface{}, error) {
+	if types, ok := s.groupVersionMap[groupVersion{group, version}]; ok {
 		if t, ok := types[kind]; ok {
 			return reflect.New(t).Interface(), nil
 		}
-		return nil, &notRegisteredErr{kind: kind, version: versionName}
+		return nil, &notRegisteredErr{group: group, version: version, kind: kind}
 	}
-	return nil, &notRegisteredErr{kind: kind, version: versionName}
+	return nil, &notRegisteredErr{group: group, version: version, kind: kind}
 }
 
 // AddConversionFuncs adds functions to the list of conversion functions. The given
@@ -273,8 +292,11 @@ func (s *Scheme) AddDefaultingFuncs(defaultingFuncs ...interface{}) error {
 
 // Recognizes returns true if the scheme is able to handle the provided version and kind
 // of an object.
-func (s *Scheme) Recognizes(version, kind string) bool {
-	m, ok := s.versionMap[version]
+func (s *Scheme) Recognizes(group, version, kind string) bool {
+	if group == "" {
+		group = s.defaultGroup
+	}
+	m, ok := s.groupVersionMap[groupVersion{group, version}]
 	if !ok {
 		return false
 	}
@@ -304,11 +326,11 @@ func (s *Scheme) DeepCopy(in interface{}) (interface{}, error) {
 func (s *Scheme) Convert(in, out interface{}) error {
 	inVersion := "unknown"
 	outVersion := "unknown"
-	if v, _, err := s.ObjectVersionAndKind(in); err == nil {
-		inVersion = v
+	if _, version, _, err := s.ObjectTypeMeta(in); err == nil {
+		inVersion = version
 	}
-	if v, _, err := s.ObjectVersionAndKind(out); err == nil {
-		outVersion = v
+	if _, version, _, err := s.ObjectTypeMeta(out); err == nil {
+		outVersion = version
 	}
 	flags, meta := s.generateConvertMeta(inVersion, outVersion, in)
 	if flags == 0 {
@@ -336,12 +358,12 @@ func (s *Scheme) ConvertToVersion(in interface{}, outVersion string) (interface{
 	}
 	outKind := kinds[0]
 
-	inVersion, _, err := s.ObjectVersionAndKind(in)
+	inGroup, inVersion, _, err := s.ObjectTypeMeta(in)
 	if err != nil {
 		return nil, err
 	}
 
-	out, err := s.NewObject(outVersion, outKind)
+	out, err := s.NewObject(inGroup, outVersion, outKind)
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +373,7 @@ func (s *Scheme) ConvertToVersion(in interface{}, outVersion string) (interface{
 		return nil, err
 	}
 
-	if err := s.SetVersionAndKind(outVersion, outKind, out); err != nil {
+	if err := s.SetTypeMeta(inGroup, outVersion, outKind, out); err != nil {
 		return nil, err
 	}
 
@@ -373,35 +395,41 @@ func (s *Scheme) generateConvertMeta(srcVersion, destVersion string, in interfac
 	}
 }
 
-// DataVersionAndKind will return the APIVersion and Kind of the given wire-format
+// DataTypeMeta will return the APIVersion and Kind of the given wire-format
 // encoding of an API Object, or an error.
-func (s *Scheme) DataVersionAndKind(data []byte) (version, kind string, err error) {
-	return s.MetaFactory.Interpret(data)
+func (s *Scheme) DataTypeMeta(data []byte) (group, version, kind string, err error) {
+	group, version, kind, err = s.MetaFactory.Interpret(data)
+	if err != nil {
+		return
+	}
+	if group == "" {
+		group = s.defaultGroup
+	}
+	return
 }
 
-// ObjectVersionAndKind returns the API version and kind of the go object,
+// ObjectTypeMeta returns the API version and kind of the go object,
 // or an error if it's not a pointer or is unregistered.
-func (s *Scheme) ObjectVersionAndKind(obj interface{}) (apiVersion, kind string, err error) {
+func (s *Scheme) ObjectTypeMeta(obj interface{}) (group, version, kind string, err error) {
 	v, err := EnforcePtr(obj)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	t := v.Type()
+	group, gOK := s.typeToGroup[t]
 	version, vOK := s.typeToVersion[t]
 	kinds, kOK := s.typeToKind[t]
-	if !vOK || !kOK {
-		return "", "", &notRegisteredErr{t: t}
+	if !gOK || !vOK || !kOK {
+		return "", "", "", &notRegisteredErr{t: t}
 	}
-	apiVersion = version
-	kind = kinds[0]
-	return
+	return group, version, kinds[0], nil
 }
 
 // SetVersionAndKind sets the version and kind fields (with help from
 // MetaInsertionFactory). Returns an error if this isn't possible. obj
 // must be a pointer.
-func (s *Scheme) SetVersionAndKind(version, kind string, obj interface{}) error {
-	return s.MetaFactory.Update(version, kind, obj)
+func (s *Scheme) SetTypeMeta(group, version, kind string, obj interface{}) error {
+	return s.MetaFactory.Update(group, version, kind, obj)
 }
 
 // maybeCopy copies obj if it is not a pointer, to get a settable/addressable

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -63,11 +63,11 @@ func (*externalType) IsAnAPIObject()  {}
 func (*ExternalType2) IsAnAPIObject() {}
 
 func newExternalScheme() (*runtime.Scheme, meta.RESTMapper, runtime.Codec) {
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypeWithName("", "Type", &internalType{})
-	scheme.AddKnownTypeWithName("unlikelyversion", "Type", &externalType{})
+	scheme := runtime.NewScheme(api.Group)
+	scheme.AddKnownTypeWithName(api.Group, "", "Type", &internalType{})
+	scheme.AddKnownTypeWithName(api.Group, "unlikelyversion", "Type", &externalType{})
 	//This tests that kubectl will not confuse the external scheme with the internal scheme, even when they accidentally have versions of the same name.
-	scheme.AddKnownTypeWithName(testapi.Version(), "Type", &ExternalType2{})
+	scheme.AddKnownTypeWithName(api.Group, testapi.Version(), "Type", &ExternalType2{})
 
 	codec := runtime.CodecFor(scheme, "unlikelyversion")
 	validVersion := testapi.Version()
@@ -79,7 +79,7 @@ func newExternalScheme() (*runtime.Scheme, meta.RESTMapper, runtime.Codec) {
 		}, (version == validVersion || version == "unlikelyversion")
 	})
 	for _, version := range []string{"unlikelyversion", validVersion} {
-		for kind := range scheme.KnownTypes(version) {
+		for kind := range scheme.KnownTypes(api.Group, version) {
 			mixedCase := false
 			scope := meta.RESTScopeNamespace
 			mapper.Add(scope, kind, version, mixedCase)

--- a/pkg/kubectl/cmd/expose_test.go
+++ b/pkg/kubectl/cmd/expose_test.go
@@ -49,7 +49,7 @@ func TestRunExposeService(t *testing.T) {
 			},
 			input: &api.Service{
 				ObjectMeta: api.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
-				TypeMeta:   api.TypeMeta{Kind: "Service", APIVersion: "v1"},
+				TypeMeta:   runtime.TypeMeta{Kind: "Service", APIVersion: "v1"},
 				Spec: api.ServiceSpec{
 					Selector: map[string]string{"app": "go"},
 				},
@@ -57,7 +57,7 @@ func TestRunExposeService(t *testing.T) {
 			flags: map[string]string{"selector": "func=stream", "protocol": "UDP", "port": "14", "name": "foo", "labels": "svc=test"},
 			output: &api.Service{
 				ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "test", ResourceVersion: "12", Labels: map[string]string{"svc": "test"}},
-				TypeMeta:   api.TypeMeta{Kind: "Service", APIVersion: "v1"},
+				TypeMeta:   runtime.TypeMeta{Kind: "Service", APIVersion: "v1"},
 				Spec: api.ServiceSpec{
 					Ports: []api.ServicePort{
 						{
@@ -81,7 +81,7 @@ func TestRunExposeService(t *testing.T) {
 			},
 			input: &api.Service{
 				ObjectMeta: api.ObjectMeta{Name: "mayor", Namespace: "default", ResourceVersion: "12"},
-				TypeMeta:   api.TypeMeta{Kind: "Service", APIVersion: "v1"},
+				TypeMeta:   runtime.TypeMeta{Kind: "Service", APIVersion: "v1"},
 				Spec: api.ServiceSpec{
 					Selector: map[string]string{"run": "this"},
 				},
@@ -90,7 +90,7 @@ func TestRunExposeService(t *testing.T) {
 			flags: map[string]string{"selector": "run=this", "port": "80", "labels": "runas=amayor"},
 			output: &api.Service{
 				ObjectMeta: api.ObjectMeta{Name: "mayor", Namespace: "default", ResourceVersion: "12", Labels: map[string]string{"runas": "amayor"}},
-				TypeMeta:   api.TypeMeta{Kind: "Service", APIVersion: "v1"},
+				TypeMeta:   runtime.TypeMeta{Kind: "Service", APIVersion: "v1"},
 				Spec: api.ServiceSpec{
 					Ports: []api.ServicePort{
 						{
@@ -114,7 +114,7 @@ func TestRunExposeService(t *testing.T) {
 			},
 			input: &api.Service{
 				ObjectMeta: api.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
-				TypeMeta:   api.TypeMeta{Kind: "Service", APIVersion: "v1"},
+				TypeMeta:   runtime.TypeMeta{Kind: "Service", APIVersion: "v1"},
 				Spec: api.ServiceSpec{
 					Selector: map[string]string{"app": "go"},
 				},
@@ -122,7 +122,7 @@ func TestRunExposeService(t *testing.T) {
 			flags: map[string]string{"selector": "func=stream", "protocol": "UDP", "port": "14", "name": "foo", "labels": "svc=test", "create-external-load-balancer": "true"},
 			output: &api.Service{
 				ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "test", ResourceVersion: "12", Labels: map[string]string{"svc": "test"}},
-				TypeMeta:   api.TypeMeta{Kind: "Service", APIVersion: "v1"},
+				TypeMeta:   runtime.TypeMeta{Kind: "Service", APIVersion: "v1"},
 				Spec: api.ServiceSpec{
 					Ports: []api.ServicePort{
 						{

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -419,7 +419,7 @@ func TestGetMultipleTypeObjectsAsList(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(expected, out) {
-		t.Errorf("unexpected output: %#v", out)
+		t.Errorf("unexpected output: \n%#v\n%#v", expected, out)
 	}
 }
 

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -175,8 +175,8 @@ func RunRollingUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, arg
 		}
 		newRc, ok = obj.(*api.ReplicationController)
 		if !ok {
-			if _, kind, err := typer.ObjectVersionAndKind(obj); err == nil {
-				return cmdutil.UsageError(cmd, "%s contains a %s not a ReplicationController", filename, kind)
+			if tm, err := typer.ObjectTypeMeta(obj); err == nil {
+				return cmdutil.UsageError(cmd, "%s contains a %s not a ReplicationController", filename, tm.Kind)
 			}
 			glog.V(4).Infof("Object %#v is not a ReplicationController", obj)
 			return cmdutil.UsageError(cmd, "%s does not specify a valid ReplicationController", filename)

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -266,15 +266,15 @@ type clientSwaggerSchema struct {
 }
 
 func (c *clientSwaggerSchema) ValidateBytes(data []byte) error {
-	version, _, err := runtime.UnstructuredJSONScheme.DataVersionAndKind(data)
+	tm, err := runtime.UnstructuredJSONScheme.DataTypeMeta(data)
 	if err != nil {
 		return err
 	}
-	if ok := registered.IsRegisteredAPIVersion(version); !ok {
-		return fmt.Errorf("API version %q isn't supported, only supports API versions %q", version, registered.RegisteredVersions)
+	if ok := registered.IsRegisteredAPIVersion(tm.APIVersion); !ok {
+		return fmt.Errorf("API version %q isn't supported, only supports API versions %q", tm.APIVersion, registered.RegisteredVersions)
 	}
 	schemaData, err := c.c.RESTClient.Get().
-		AbsPath("/swaggerapi/api", version).
+		AbsPath("/swaggerapi/api", tm.APIVersion).
 		Do().
 		Raw()
 	if err != nil {
@@ -344,12 +344,12 @@ func DefaultClientConfig(flags *pflag.FlagSet) clientcmd.ClientConfig {
 // PrintObject prints an api object given command line flags to modify the output format
 func (f *Factory) PrintObject(cmd *cobra.Command, obj runtime.Object, out io.Writer) error {
 	mapper, _ := f.Object()
-	_, kind, err := api.Scheme.ObjectVersionAndKind(obj)
+	tm, err := api.Scheme.ObjectTypeMeta(obj)
 	if err != nil {
 		return err
 	}
 
-	mapping, err := mapper.RESTMapping(kind)
+	mapping, err := mapper.RESTMapping(tm.Kind)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/util/factory_test.go
+++ b/pkg/kubectl/cmd/util/factory_test.go
@@ -117,7 +117,7 @@ func TestLabelsForObject(t *testing.T) {
 			name: "successful re-use of labels",
 			object: &api.Service{
 				ObjectMeta: api.ObjectMeta{Name: "baz", Namespace: "test", Labels: map[string]string{"svc": "test"}},
-				TypeMeta:   api.TypeMeta{Kind: "Service", APIVersion: "v1"},
+				TypeMeta:   runtime.TypeMeta{Kind: "Service", APIVersion: "v1"},
 			},
 			expected: "svc=test",
 			err:      nil,
@@ -126,7 +126,7 @@ func TestLabelsForObject(t *testing.T) {
 			name: "empty labels",
 			object: &api.Service{
 				ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "test", Labels: map[string]string{}},
-				TypeMeta:   api.TypeMeta{Kind: "Service", APIVersion: "v1"},
+				TypeMeta:   runtime.TypeMeta{Kind: "Service", APIVersion: "v1"},
 			},
 			expected: "",
 			err:      nil,
@@ -135,7 +135,7 @@ func TestLabelsForObject(t *testing.T) {
 			name: "nil labels",
 			object: &api.Service{
 				ObjectMeta: api.ObjectMeta{Name: "zen", Namespace: "test", Labels: nil},
-				TypeMeta:   api.TypeMeta{Kind: "Service", APIVersion: "v1"},
+				TypeMeta:   runtime.TypeMeta{Kind: "Service", APIVersion: "v1"},
 			},
 			expected: "",
 			err:      nil,

--- a/pkg/kubectl/resource/result.go
+++ b/pkg/kubectl/resource/result.go
@@ -239,7 +239,7 @@ func AsVersionedObjects(infos []*Info, version string) ([]runtime.Object, error)
 		// objects that are not part of api.Scheme must be converted to JSON
 		// TODO: convert to map[string]interface{}, attach to runtime.Unknown?
 		if len(version) > 0 {
-			if _, _, err := api.Scheme.ObjectVersionAndKind(info.Object); runtime.IsNotRegisteredError(err) {
+			if _, err := api.Scheme.ObjectTypeMeta(info.Object); runtime.IsNotRegisteredError(err) {
 				// TODO: ideally this would encode to version, but we don't expose multiple codecs here.
 				data, err := info.Mapping.Codec.Encode(info.Object)
 				if err != nil {

--- a/pkg/kubectl/resource_printer_test.go
+++ b/pkg/kubectl/resource_printer_test.go
@@ -35,19 +35,19 @@ import (
 )
 
 type testStruct struct {
-	api.TypeMeta   `json:",inline"`
-	api.ObjectMeta `json:"metadata,omitempty"`
-	Key            string         `json:"Key"`
-	Map            map[string]int `json:"Map"`
-	StringList     []string       `json:"StringList"`
-	IntList        []int          `json:"IntList"`
+	runtime.TypeMeta `json:",inline"`
+	api.ObjectMeta   `json:"metadata,omitempty"`
+	Key              string         `json:"Key"`
+	Map              map[string]int `json:"Map"`
+	StringList       []string       `json:"StringList"`
+	IntList          []int          `json:"IntList"`
 }
 
 func (ts *testStruct) IsAnAPIObject() {}
 
 func init() {
-	api.Scheme.AddKnownTypes("", &testStruct{})
-	api.Scheme.AddKnownTypes(testapi.Version(), &testStruct{})
+	api.Scheme.AddKnownTypes(api.Group, "", &testStruct{})
+	api.Scheme.AddKnownTypes(api.Group, testapi.Version(), &testStruct{})
 }
 
 var testData = testStruct{

--- a/pkg/kubelet/config/common_test.go
+++ b/pkg/kubelet/config/common_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/registered"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/securitycontext"
 
 	"github.com/ghodss/yaml"
@@ -32,7 +33,7 @@ func noDefault(*api.Pod) error { return nil }
 
 func TestDecodeSinglePod(t *testing.T) {
 	pod := &api.Pod{
-		TypeMeta: api.TypeMeta{
+		TypeMeta: runtime.TypeMeta{
 			APIVersion: "",
 		},
 		ObjectMeta: api.ObjectMeta{
@@ -92,7 +93,7 @@ func TestDecodeSinglePod(t *testing.T) {
 
 func TestDecodePodList(t *testing.T) {
 	pod := &api.Pod{
-		TypeMeta: api.TypeMeta{
+		TypeMeta: runtime.TypeMeta{
 			APIVersion: "",
 		},
 		ObjectMeta: api.ObjectMeta{

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -77,7 +77,7 @@ func TestReadPodsFromFile(t *testing.T) {
 		{
 			desc: "Simple pod",
 			pod: &api.Pod{
-				TypeMeta: api.TypeMeta{
+				TypeMeta: runtime.TypeMeta{
 					Kind:       "Pod",
 					APIVersion: "",
 				},

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -57,16 +57,16 @@ func TestExtractInvalidPods(t *testing.T) {
 	}{
 		{
 			desc: "No version",
-			pod:  &api.Pod{TypeMeta: api.TypeMeta{APIVersion: ""}},
+			pod:  &api.Pod{TypeMeta: runtime.TypeMeta{APIVersion: ""}},
 		},
 		{
 			desc: "Invalid version",
-			pod:  &api.Pod{TypeMeta: api.TypeMeta{APIVersion: "v1betta2"}},
+			pod:  &api.Pod{TypeMeta: runtime.TypeMeta{APIVersion: "v1betta2"}},
 		},
 		{
 			desc: "Invalid volume name",
 			pod: &api.Pod{
-				TypeMeta: api.TypeMeta{APIVersion: testapi.Version()},
+				TypeMeta: runtime.TypeMeta{APIVersion: testapi.Version()},
 				Spec: api.PodSpec{
 					Volumes: []api.Volume{{Name: "_INVALID_"}},
 				},
@@ -75,7 +75,7 @@ func TestExtractInvalidPods(t *testing.T) {
 		{
 			desc: "Duplicate volume names",
 			pod: &api.Pod{
-				TypeMeta: api.TypeMeta{APIVersion: testapi.Version()},
+				TypeMeta: runtime.TypeMeta{APIVersion: testapi.Version()},
 				Spec: api.PodSpec{
 					Volumes: []api.Volume{{Name: "repeated"}, {Name: "repeated"}},
 				},
@@ -84,7 +84,7 @@ func TestExtractInvalidPods(t *testing.T) {
 		{
 			desc: "Unspecified container name",
 			pod: &api.Pod{
-				TypeMeta: api.TypeMeta{APIVersion: testapi.Version()},
+				TypeMeta: runtime.TypeMeta{APIVersion: testapi.Version()},
 				Spec: api.PodSpec{
 					Containers: []api.Container{{Name: ""}},
 				},
@@ -93,7 +93,7 @@ func TestExtractInvalidPods(t *testing.T) {
 		{
 			desc: "Invalid container name",
 			pod: &api.Pod{
-				TypeMeta: api.TypeMeta{APIVersion: testapi.Version()},
+				TypeMeta: runtime.TypeMeta{APIVersion: testapi.Version()},
 				Spec: api.PodSpec{
 					Containers: []api.Container{{Name: "_INVALID_"}},
 				},
@@ -130,7 +130,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 		{
 			desc: "Single pod",
 			pods: &api.Pod{
-				TypeMeta: api.TypeMeta{
+				TypeMeta: runtime.TypeMeta{
 					Kind:       "Pod",
 					APIVersion: "",
 				},
@@ -170,7 +170,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 		{
 			desc: "Multiple pods",
 			pods: &api.PodList{
-				TypeMeta: api.TypeMeta{
+				TypeMeta: runtime.TypeMeta{
 					Kind:       "PodList",
 					APIVersion: "",
 				},

--- a/pkg/kubelet/container/ref_test.go
+++ b/pkg/kubelet/container/ref_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
 func TestFieldPath(t *testing.T) {
@@ -64,7 +65,7 @@ func TestFieldPath(t *testing.T) {
 func TestGenerateContainerRef(t *testing.T) {
 	var (
 		okPod = api.Pod{
-			TypeMeta: api.TypeMeta{
+			TypeMeta: runtime.TypeMeta{
 				Kind:       "Pod",
 				APIVersion: testapi.Version(),
 			},

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1037,7 +1037,11 @@ func (kl *Kubelet) makeEnvironmentVariables(pod *api.Pod, container *api.Contain
 }
 
 func (kl *Kubelet) podFieldSelectorRuntimeValue(fs *api.ObjectFieldSelector, pod *api.Pod) (string, error) {
-	internalFieldPath, _, err := api.Scheme.ConvertFieldLabel(fs.APIVersion, "Pod", fs.FieldPath, "")
+	tm, err := api.Scheme.ObjectTypeMeta(pod)
+	if err != nil {
+		return "", err
+	}
+	internalFieldPath, _, err := api.Scheme.ConvertFieldLabel(tm.APIGroup, fs.APIVersion, tm.Kind, fs.FieldPath, "")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/runtime/conversion_generation_test.go
+++ b/pkg/runtime/conversion_generation_test.go
@@ -37,7 +37,7 @@ import (
 func generateConversions(t *testing.T, version string) bytes.Buffer {
 	g := runtime.NewConversionGenerator(api.Scheme.Raw())
 	g.OverwritePackage(version, "")
-	for _, knownType := range api.Scheme.KnownTypes(version) {
+	for _, knownType := range api.Scheme.KnownTypes(api.Group, version) {
 		if err := g.GenerateConversionsForType(version, knownType); err != nil {
 			glog.Errorf("error while generating conversion functions for %v: %v", knownType, err)
 		}

--- a/pkg/runtime/conversion_generator.go
+++ b/pkg/runtime/conversion_generator.go
@@ -57,7 +57,7 @@ type conversionGenerator struct {
 
 func (g *conversionGenerator) GenerateConversionsForType(version string, reflection reflect.Type) error {
 	kind := reflection.Name()
-	internalObj, err := g.scheme.NewObject(g.scheme.InternalVersion, kind)
+	internalObj, err := g.scheme.NewObject("api", g.scheme.InternalVersion, kind)
 	if err != nil {
 		return fmt.Errorf("cannot create an object of type %v in internal version", kind)
 	}

--- a/pkg/runtime/conversion_test.go
+++ b/pkg/runtime/conversion_test.go
@@ -45,10 +45,10 @@ func (*InternalComplex) IsAnAPIObject() {}
 func (*ExternalComplex) IsAnAPIObject() {}
 
 func TestStringMapConversion(t *testing.T) {
-	scheme := runtime.NewScheme()
+	scheme := runtime.NewScheme("api")
 	scheme.Log(t)
-	scheme.AddKnownTypeWithName("", "Complex", &InternalComplex{})
-	scheme.AddKnownTypeWithName("external", "Complex", &ExternalComplex{})
+	scheme.AddKnownTypeWithName("api", "", "Complex", &InternalComplex{})
+	scheme.AddKnownTypeWithName("api", "external", "Complex", &ExternalComplex{})
 
 	testCases := map[string]struct {
 		input    map[string][]string

--- a/pkg/runtime/deep_copy_generation_test.go
+++ b/pkg/runtime/deep_copy_generation_test.go
@@ -40,7 +40,7 @@ func generateDeepCopies(t *testing.T, version string) bytes.Buffer {
 	if version == "api" {
 		testedVersion = api.Scheme.Raw().InternalVersion
 	}
-	for _, knownType := range api.Scheme.KnownTypes(testedVersion) {
+	for _, knownType := range api.Scheme.KnownTypes(api.Group, testedVersion) {
 		if err := g.AddType(knownType); err != nil {
 			glog.Errorf("error while generating deep-copy functions for %v: %v", knownType, err)
 		}

--- a/pkg/runtime/embedded_test.go
+++ b/pkg/runtime/embedded_test.go
@@ -60,11 +60,11 @@ func (*EmbeddedTest) IsAnAPIObject()         {}
 func (*EmbeddedTestExternal) IsAnAPIObject() {}
 
 func TestDecodeEmptyRawExtensionAsObject(t *testing.T) {
-	s := runtime.NewScheme()
-	s.AddKnownTypes("", &ObjectTest{})
-	s.AddKnownTypeWithName("v1test", "ObjectTest", &ObjectTestExternal{})
+	s := runtime.NewScheme("api")
+	s.AddKnownTypes("api", "", &ObjectTest{})
+	s.AddKnownTypeWithName("api", "v1test", "ObjectTest", &ObjectTestExternal{})
 
-	obj, err := s.Decode([]byte(`{"kind":"ObjectTest","apiVersion":"v1test","items":[{}]}`))
+	obj, err := s.Decode([]byte(`{"kind":"ObjectTest","apiVersion":"v1test","apiGroup":"api","items":[{}]}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestDecodeEmptyRawExtensionAsObject(t *testing.T) {
 		t.Fatalf("unexpected object: %#v", test.Items[0])
 	}
 
-	obj, err = s.Decode([]byte(`{"kind":"ObjectTest","apiVersion":"v1test","items":[{"kind":"Other","apiVersion":"v1"}]}`))
+	obj, err = s.Decode([]byte(`{"kind":"ObjectTest","apiVersion":"v1test","apiGroup":"api","items":[{"kind":"Other","apiVersion":"v1"}]}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -84,11 +84,11 @@ func TestDecodeEmptyRawExtensionAsObject(t *testing.T) {
 }
 
 func TestArrayOfRuntimeObject(t *testing.T) {
-	s := runtime.NewScheme()
-	s.AddKnownTypes("", &EmbeddedTest{})
-	s.AddKnownTypeWithName("v1test", "EmbeddedTest", &EmbeddedTestExternal{})
-	s.AddKnownTypes("", &ObjectTest{})
-	s.AddKnownTypeWithName("v1test", "ObjectTest", &ObjectTestExternal{})
+	s := runtime.NewScheme("api")
+	s.AddKnownTypes("api", "", &EmbeddedTest{})
+	s.AddKnownTypeWithName("api", "v1test", "EmbeddedTest", &EmbeddedTestExternal{})
+	s.AddKnownTypes("api", "", &ObjectTest{})
+	s.AddKnownTypeWithName("api", "v1test", "ObjectTest", &ObjectTestExternal{})
 
 	internal := &ObjectTest{
 		Items: []runtime.Object{
@@ -146,9 +146,9 @@ func TestArrayOfRuntimeObject(t *testing.T) {
 }
 
 func TestEmbeddedObject(t *testing.T) {
-	s := runtime.NewScheme()
-	s.AddKnownTypes("", &EmbeddedTest{})
-	s.AddKnownTypeWithName("v1test", "EmbeddedTest", &EmbeddedTestExternal{})
+	s := runtime.NewScheme("api")
+	s.AddKnownTypes("api", "", &EmbeddedTest{})
+	s.AddKnownTypeWithName("api", "v1test", "EmbeddedTest", &EmbeddedTestExternal{})
 
 	outer := &EmbeddedTest{
 		ID: "outer",
@@ -205,9 +205,9 @@ func TestEmbeddedObject(t *testing.T) {
 
 // TestDeepCopyOfEmbeddedObject checks to make sure that EmbeddedObject's can be passed through DeepCopy with fidelity
 func TestDeepCopyOfEmbeddedObject(t *testing.T) {
-	s := runtime.NewScheme()
-	s.AddKnownTypes("", &EmbeddedTest{})
-	s.AddKnownTypeWithName("v1test", "EmbeddedTest", &EmbeddedTestExternal{})
+	s := runtime.NewScheme("api")
+	s.AddKnownTypes("api", "", &EmbeddedTest{})
+	s.AddKnownTypeWithName("api", "v1test", "EmbeddedTest", &EmbeddedTestExternal{})
 
 	original := &EmbeddedTest{
 		ID: "outer",

--- a/pkg/runtime/helper.go
+++ b/pkg/runtime/helper.go
@@ -158,7 +158,7 @@ func DecodeList(objects []Object, decoders ...ObjectDecoder) []error {
 		switch t := obj.(type) {
 		case *Unknown:
 			for _, decoder := range decoders {
-				if !decoder.Recognizes(t.APIVersion, t.Kind) {
+				if !decoder.Recognizes(t.TypeMeta) {
 					continue
 				}
 				obj, err := decoder.Decode(t.RawJSON)
@@ -179,9 +179,9 @@ type MultiObjectTyper []ObjectTyper
 
 var _ ObjectTyper = MultiObjectTyper{}
 
-func (m MultiObjectTyper) DataVersionAndKind(data []byte) (version, kind string, err error) {
+func (m MultiObjectTyper) DataTypeMeta(data []byte) (tm TypeMeta, err error) {
 	for _, t := range m {
-		version, kind, err = t.DataVersionAndKind(data)
+		tm, err = t.DataTypeMeta(data)
 		if err == nil {
 			return
 		}
@@ -189,9 +189,9 @@ func (m MultiObjectTyper) DataVersionAndKind(data []byte) (version, kind string,
 	return
 }
 
-func (m MultiObjectTyper) ObjectVersionAndKind(obj Object) (version, kind string, err error) {
+func (m MultiObjectTyper) ObjectTypeMeta(obj Object) (tm TypeMeta, err error) {
 	for _, t := range m {
-		version, kind, err = t.ObjectVersionAndKind(obj)
+		tm, err = t.ObjectTypeMeta(obj)
 		if err == nil {
 			return
 		}
@@ -199,9 +199,9 @@ func (m MultiObjectTyper) ObjectVersionAndKind(obj Object) (version, kind string
 	return
 }
 
-func (m MultiObjectTyper) Recognizes(version, kind string) bool {
+func (m MultiObjectTyper) Recognizes(tm TypeMeta) bool {
 	for _, t := range m {
-		if t.Recognizes(version, kind) {
+		if t.Recognizes(tm) {
 			return true
 		}
 	}

--- a/pkg/runtime/helper_test.go
+++ b/pkg/runtime/helper_test.go
@@ -137,7 +137,7 @@ func TestDecodeList(t *testing.T) {
 	pl := &api.List{
 		Items: []runtime.Object{
 			&api.Pod{ObjectMeta: api.ObjectMeta{Name: "1"}},
-			&runtime.Unknown{TypeMeta: runtime.TypeMeta{Kind: "Pod", APIVersion: testapi.Version()}, RawJSON: []byte(`{"kind":"Pod","apiVersion":"` + testapi.Version() + `","metadata":{"name":"test"}}`)},
+			&runtime.Unknown{TypeMeta: runtime.TypeMeta{Kind: "Pod", APIVersion: testapi.Version(), APIGroup: "api"}, RawJSON: []byte(`{"kind":"Pod","apiVersion":"` + testapi.Version() + `","apiGroup":"api","metadata":{"name":"test"}}`)},
 			&runtime.Unstructured{TypeMeta: runtime.TypeMeta{Kind: "Foo", APIVersion: "Bar"}, Object: map[string]interface{}{"test": "value"}},
 		},
 	}

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -71,28 +71,28 @@ type ObjectEncoder interface {
 type ObjectConvertor interface {
 	Convert(in, out interface{}) error
 	ConvertToVersion(in Object, outVersion string) (out Object, err error)
-	ConvertFieldLabel(version, kind, label, value string) (string, string, error)
+	ConvertFieldLabel(group, version, kind, label, value string) (string, string, error)
 }
 
 // ObjectTyper contains methods for extracting the APIVersion and Kind
 // of objects.
 type ObjectTyper interface {
-	// DataVersionAndKind returns the version and kind of the provided data, or an error
+	// DataTypeMeta returns the version and kind of the provided data, or an error
 	// if another problem is detected. In many cases this method can be as expensive to
 	// invoke as the Decode method.
-	DataVersionAndKind([]byte) (version, kind string, err error)
-	// ObjectVersionAndKind returns the version and kind of the provided object, or an
+	DataTypeMeta([]byte) (TypeMeta, error)
+	// ObjectTypeMeta returns the version and kind of the provided object, or an
 	// error if the object is not recognized (IsNotRegisteredError will return true).
-	ObjectVersionAndKind(Object) (version, kind string, err error)
-	// Recognizes returns true if the scheme is able to handle the provided version and kind,
+	ObjectTypeMeta(Object) (TypeMeta, error)
+	// Recognizes returns true if the scheme is able to handle the provided TypeMeta,
 	// or more precisely that the provided version is a possible conversion or decoding
 	// target.
-	Recognizes(version, kind string) bool
+	Recognizes(tm TypeMeta) bool
 }
 
 // ObjectCreater contains methods for instantiating an object by kind and version.
 type ObjectCreater interface {
-	New(version, kind string) (out Object, err error)
+	New(group, version, kind string) (Object, error)
 }
 
 // ObjectDecoder is a convenience interface for identifying serialized versions of objects
@@ -100,13 +100,13 @@ type ObjectCreater interface {
 // Decoder for use in decode only paths.
 type ObjectDecoder interface {
 	Decoder
-	// DataVersionAndKind returns the version and kind of the provided data, or an error
+	// DataTypeMeta returns the version and kind of the provided data, or an error
 	// if another problem is detected. In many cases this method can be as expensive to
 	// invoke as the Decode method.
-	DataVersionAndKind([]byte) (version, kind string, err error)
-	// Recognizes returns true if the scheme is able to handle the provided version and kind
-	// of an object.
-	Recognizes(version, kind string) bool
+	DataTypeMeta([]byte) (TypeMeta, error)
+	// Recognizes returns true if the scheme is able to handle the provided TypeMeta of an
+	// object.
+	Recognizes(tm TypeMeta) bool
 }
 
 // ResourceVersioner provides methods for setting and retrieving

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -31,6 +31,7 @@ package runtime
 // your own with the same fields.
 //
 type TypeMeta struct {
+	APIGroup   string `json:"apiGroup,omitempty" yaml:"apiVersion,omitempty"`
 	APIVersion string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
 	Kind       string `json:"kind,omitempty" yaml:"kind,omitempty"`
 }

--- a/pkg/service/endpoints_controller_test.go
+++ b/pkg/service/endpoints_controller_test.go
@@ -35,7 +35,7 @@ import (
 func addPods(store cache.Store, namespace string, nPods int, nPorts int) {
 	for i := 0; i < nPods; i++ {
 		p := &api.Pod{
-			TypeMeta: api.TypeMeta{APIVersion: testapi.Version()},
+			TypeMeta: runtime.TypeMeta{APIVersion: testapi.Version()},
 			ObjectMeta: api.ObjectMeta{
 				Namespace: namespace,
 				Name:      fmt.Sprintf("pod%d", i),

--- a/pkg/tools/etcd_helper_test.go
+++ b/pkg/tools/etcd_helper_test.go
@@ -42,9 +42,9 @@ import (
 const validEtcdVersion = "etcd 2.0.9"
 
 type TestResource struct {
-	api.TypeMeta   `json:",inline"`
-	api.ObjectMeta `json:"metadata"`
-	Value          int `json:"value"`
+	runtime.TypeMeta `json:",inline"`
+	api.ObjectMeta   `json:"metadata"`
+	Value            int `json:"value"`
 }
 
 func (*TestResource) IsAnAPIObject() {}
@@ -53,9 +53,9 @@ var scheme *runtime.Scheme
 var codec runtime.Codec
 
 func init() {
-	scheme = runtime.NewScheme()
-	scheme.AddKnownTypes("", &TestResource{})
-	scheme.AddKnownTypes(testapi.Version(), &TestResource{})
+	scheme = runtime.NewScheme(api.Group)
+	scheme.AddKnownTypes(api.Group, "", &TestResource{})
+	scheme.AddKnownTypes(api.Group, testapi.Version(), &TestResource{})
 	codec = runtime.CodecFor(scheme, testapi.Version())
 	scheme.AddConversionFuncs(
 		func(in *TestResource, out *TestResource, s conversion.Scope) error {

--- a/plugin/pkg/scheduler/api/register.go
+++ b/plugin/pkg/scheduler/api/register.go
@@ -17,14 +17,15 @@ limitations under the License.
 package api
 
 import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
 // Scheme is the default instance of runtime.Scheme to which types in the Kubernetes API are already registered.
-var Scheme = runtime.NewScheme()
+var Scheme = runtime.NewScheme(api.Group)
 
 func init() {
-	Scheme.AddKnownTypes("",
+	Scheme.AddKnownTypes(api.Group, "",
 		&Policy{},
 	)
 }

--- a/plugin/pkg/scheduler/api/types.go
+++ b/plugin/pkg/scheduler/api/types.go
@@ -17,11 +17,11 @@ limitations under the License.
 package api
 
 import (
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
 type Policy struct {
-	api.TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 	// Holds the information to configure the fit predicate functions
 	Predicates []PredicatePolicy `json:"predicates"`
 	// Holds the information to configure the priority functions

--- a/plugin/pkg/scheduler/api/v1/register.go
+++ b/plugin/pkg/scheduler/api/v1/register.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/api"
 )
@@ -25,7 +26,7 @@ import (
 var Codec = runtime.CodecFor(api.Scheme, "v1")
 
 func init() {
-	api.Scheme.AddKnownTypes("v1",
+	api.Scheme.AddKnownTypes(kapi.Group, "v1",
 		&Policy{},
 	)
 }

--- a/plugin/pkg/scheduler/api/v1/types.go
+++ b/plugin/pkg/scheduler/api/v1/types.go
@@ -17,11 +17,11 @@ limitations under the License.
 package v1
 
 import (
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 )
 
 type Policy struct {
-	v1beta3.TypeMeta `json:",inline"`
+	runtime.TypeMeta `json:",inline"`
 	// Holds the information to configure the fit predicate functions
 	Predicates []PredicatePolicy `json:"predicates"`
 	// Holds the information to configure the priority functions

--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -404,7 +404,7 @@ func createRunningPod(wg *sync.WaitGroup, c *client.Client, name, ns, image stri
 	defer GinkgoRecover()
 	defer wg.Done()
 	pod := &api.Pod{
-		TypeMeta: api.TypeMeta{
+		TypeMeta: runtime.TypeMeta{
 			Kind: "Pod",
 		},
 		ObjectMeta: api.ObjectMeta{

--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/wait"
 
@@ -40,7 +41,7 @@ var dnsServiceLableSelector = labels.Set{
 
 func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd string) *api.Pod {
 	pod := &api.Pod{
-		TypeMeta: api.TypeMeta{
+		TypeMeta: runtime.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: latest.Version,
 		},

--- a/test/e2e/empty_dir.go
+++ b/test/e2e/empty_dir.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	. "github.com/onsi/ginkgo"
@@ -75,7 +76,7 @@ func testPodWithVolume(path string, source *api.EmptyDirVolumeSource) *api.Pod {
 	podName := "pod-" + string(util.NewUUID())
 
 	return &api.Pod{
-		TypeMeta: api.TypeMeta{
+		TypeMeta: runtime.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: latest.Version,
 		},

--- a/test/e2e/host_path.go
+++ b/test/e2e/host_path.go
@@ -21,6 +21,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"os"
 	"path"
@@ -115,7 +116,7 @@ func testPodWithHostVol(path string, source *api.HostPathVolumeSource) *api.Pod 
 	podName := "pod-" + string(util.NewUUID())
 
 	return &api.Pod{
-		TypeMeta: api.TypeMeta{
+		TypeMeta: runtime.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: latest.Version,
 		},

--- a/test/e2e/max_pods.go
+++ b/test/e2e/max_pods.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	. "github.com/onsi/ginkgo"
@@ -108,7 +109,7 @@ var _ = Describe("MaxPods", func() {
 		Logf("Observed %v running Pods. Need %v to fully saturate the cluster.", len(pods.Items), totalPodCapacity)
 
 		_, err = c.Pods(ns).Create(&api.Pod{
-			TypeMeta: api.TypeMeta{
+			TypeMeta: runtime.TypeMeta{
 				Kind: "Pod",
 			},
 			ObjectMeta: api.ObjectMeta{

--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	. "github.com/onsi/ginkgo"
@@ -55,7 +56,7 @@ var _ = Describe("Networking", func() {
 		podName := "wget-test"
 		contName := "wget-test-container"
 		pod := &api.Pod{
-			TypeMeta: api.TypeMeta{
+			TypeMeta: runtime.TypeMeta{
 				Kind: "Pod",
 			},
 			ObjectMeta: api.ObjectMeta{

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/aws"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -233,7 +234,7 @@ func detachPD(hostName, pdName string) error {
 
 func testPDPod(diskName, targetHost string, readOnly bool) *api.Pod {
 	pod := &api.Pod{
-		TypeMeta: api.TypeMeta{
+		TypeMeta: runtime.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: latest.Version,
 		},

--- a/test/e2e/persistent_volumes.go
+++ b/test/e2e/persistent_volumes.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"time"
@@ -161,7 +162,7 @@ func makeCheckPod(ns string, nfsserver string) *api.Pod {
 	// Prepare pod that mounts the NFS volume again and
 	// checks that /mnt/index.html was scrubbed there
 	return &api.Pod{
-		TypeMeta: api.TypeMeta{
+		TypeMeta: runtime.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: testapi.Version(),
 		},

--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/wait"
 
@@ -211,7 +212,7 @@ func rcByNameContainer(name string, replicas int, image string, labels map[strin
 	// Add "name": name to the labels, overwriting if it exists.
 	labels["name"] = name
 	return &api.ReplicationController{
-		TypeMeta: api.TypeMeta{
+		TypeMeta: runtime.TypeMeta{
 			Kind:       "ReplicationController",
 			APIVersion: latest.Version,
 		},

--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -35,6 +35,7 @@ import (
 	"fmt"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -77,7 +78,7 @@ func startVolumeServer(client *client.Client, config VolumeTestConfig) *api.Pod 
 	privileged := new(bool)
 	*privileged = true
 	serverPod := &api.Pod{
-		TypeMeta: api.TypeMeta{
+		TypeMeta: runtime.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: "v1",
 		},
@@ -135,7 +136,7 @@ func testVolumeClient(client *client.Client, config VolumeTestConfig, volume api
 	podClient := client.Pods(config.namespace)
 
 	clientPod := &api.Pod{
-		TypeMeta: api.TypeMeta{
+		TypeMeta: runtime.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: "v1",
 		},
@@ -280,7 +281,7 @@ var _ = Describe("Volumes", func() {
 
 			// create Endpoints for the server
 			endpoints := api.Endpoints{
-				TypeMeta: api.TypeMeta{
+				TypeMeta: runtime.TypeMeta{
 					Kind:       "Endpoints",
 					APIVersion: "v1",
 				},


### PR DESCRIPTION
[Apologies for the large diff, the majority of these are trivial renames, additional arguments/returns, or autogenerated code]

This is initial work towards supporting multiple API groups in kubernetes. pkg/conversion and pkg/runtime now identify kinds as belonging to a (group, version) pair rather than just a version. Additionally,  api(/v1*).TypeMeta are now obsolete and have been fully replaced by runtime.TypeMeta. Finally, a few methods have been renamed in conversion.Scheme and runtime.Scheme.

@lavalamp @smarterclayton 
