### PR TITLE
Don't hold lock while opening new sshTunnels.

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -802,6 +802,8 @@ func (m *Master) Dial(net, addr string) (net.Conn, error) {
 }
 
 func (m *Master) needToReplaceTunnels(addrs []string) bool {
+	m.tunnelsLock.Lock()
+	defer m.tunnelsLock.Unlock()
 	if m.tunnels == nil || m.tunnels.Len() != len(addrs) {
 		return true
 	}
@@ -837,6 +839,8 @@ func (m *Master) replaceTunnels(user, keyfile string, newAddrs []string) error {
 	if err := tunnels.Open(); err != nil {
 		return err
 	}
+	m.tunnelsLock.Lock()
+	defer m.tunnelsLock.Unlock()
 	if m.tunnels != nil {
 		m.tunnels.Close()
 	}
@@ -845,8 +849,6 @@ func (m *Master) replaceTunnels(user, keyfile string, newAddrs []string) error {
 }
 
 func (m *Master) loadTunnels(user, keyfile string) error {
-	m.tunnelsLock.Lock()
-	defer m.tunnelsLock.Unlock()
 	addrs, err := m.getNodeAddresses()
 	if err != nil {
 		return err
@@ -861,8 +863,6 @@ func (m *Master) loadTunnels(user, keyfile string) error {
 }
 
 func (m *Master) refreshTunnels(user, keyfile string) error {
-	m.tunnelsLock.Lock()
-	defer m.tunnelsLock.Unlock()
 	addrs, err := m.getNodeAddresses()
 	if err != nil {
 		return err


### PR DESCRIPTION
This fixes the timeouts that we see from time to time in the GKE proxy tests.

This does cause the master to drop the lock between checking if new tunnels are needed and actually creating the new tunnels. Net result, if a node drops out and comes right back at exactly the wrong time, we may end up updating the tunnels unnecessarily. That is fine.

@dbsmith @roberthbailey 
