### PR TITLE
Change factory name to client.NewInCluster

### DIFF
--- a/docs/accessing-the-cluster.md
+++ b/docs/accessing-the-cluster.md
@@ -113,7 +113,7 @@ From within a pod the recommended ways to connect to API are:
     kubernetes API to the localhost interface of the pod, so that other processes
     in any container of the pod can access it.  See this [example of using kubectl proxy
     in a pod](../examples/kubectl-container/).
-  - use the Go client library, and create a client using the `client.NewInContainer()` factory.
+  - use the Go client library, and create a client using the `client.NewInCluster()` factory.
     This handles locating and authenticating to the apiserver.
 In each case, the credentials of the pod are used to communicate securely with the apiserver.
 


### PR DESCRIPTION
The factory that generates a client for use within the cluster is NewInCluster, rather than NewInContainer.

Definition: 
https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/client/helper.go#L266
