### PR TITLE
Add boundary check before accessing os.Args[1]

### DIFF
--- a/pkg/kubectl/cmd/apiversions.go
+++ b/pkg/kubectl/cmd/apiversions.go
@@ -41,7 +41,7 @@ func NewCmdApiVersions(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunApiVersions(f *cmdutil.Factory, out io.Writer) error {
-	if os.Args[1] == "apiversions" {
+	if len(os.Args) > 1 && os.Args[1] == "apiversions" {
 		printDeprecationWarning("api-versions", "apiversions")
 	}
 

--- a/pkg/kubectl/cmd/clusterinfo.go
+++ b/pkg/kubectl/cmd/clusterinfo.go
@@ -46,7 +46,7 @@ func NewCmdClusterInfo(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunClusterInfo(factory *cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
-	if os.Args[1] == "clusterinfo" {
+	if len(os.Args) > 1 && os.Args[1] == "clusterinfo" {
 		printDeprecationWarning("cluster-info", "clusterinfo")
 	}
 

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -69,7 +69,7 @@ func NewCmdReplace(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunReplace(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string, filenames util.StringList) error {
-	if os.Args[1] == "update" {
+	if len(os.Args) > 1 && os.Args[1] == "update" {
 		printDeprecationWarning("replace", "update")
 	}
 	schema, err := f.Validator()

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -105,7 +105,7 @@ func validateArguments(cmd *cobra.Command, args []string) (deploymentKey, filena
 }
 
 func RunRollingUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) error {
-	if os.Args[1] == "rollingupdate" {
+	if len(os.Args) > 1 && os.Args[1] == "rollingupdate" {
 		printDeprecationWarning("rolling-update", "rollingupdate")
 	}
 	deploymentKey, filename, image, oldName, err := validateArguments(cmd, args)

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -70,7 +70,7 @@ func NewCmdRun(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 }
 
 func Run(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) error {
-	if os.Args[1] == "run-container" {
+	if len(os.Args) > 1 && os.Args[1] == "run-container" {
 		printDeprecationWarning("run", "run-container")
 	}
 

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -65,7 +65,7 @@ func NewCmdScale(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 
 // RunScale executes the scaling
 func RunScale(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) error {
-	if os.Args[1] == "resize" {
+	if len(os.Args) > 1 && os.Args[1] == "resize" {
 		printDeprecationWarning("scale", "resize")
 	}
 


### PR DESCRIPTION
`!!!Outdated!!!`
`calledByAlias(cmd *cobra.Command)` compares `os.Args` with `cmd.Aliases` to check if the command is called by its alias. Note that commands like `kubectl -f replace update` or `kubectl -f update replace` can fool `calledByAlias()`. Because this function will be removed when deprecated aliases are removed, I think it's good enough for now.

Fixes #10572.

@krousey @bgrant0607 
