### PR TITLE
Install the kubectl binary on nodes in addition to the master.

### DIFF
--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -11,6 +11,7 @@ base:
 {% endif %}
     - helpers
     - cadvisor
+    - kube-client-tools
     - kubelet
     - kube-proxy
 {% if pillar.get('enable_node_logging', '').lower() == 'true' and pillar['logging_destination'] is defined %}


### PR DESCRIPTION
We need to decide if we want to drop the kubectl binary that exactly matches the release version running on the cluster or bake the binary into the container vm. 

Fixes #10337.
