### PR TITLE
Install 'docker' package for Fedora 22

### DIFF
--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -9,10 +9,6 @@ bridge-utils:
 
 {% if grains.os_family == 'RedHat' %}
 
-docker-io:
-  pkg:
-    - installed
-
 {{ environment_file }}:
   file.managed:
     - source: salt://docker/default
@@ -22,6 +18,25 @@ docker-io:
     - mode: 644
     - makedirs: true
 
+{% if grains.os == 'Fedora' and grains.osrelease_info[0] >= 22 %}
+
+docker:
+  pkg:
+    - installed
+  service.running:
+    - enable: True
+    - require:
+      - pkg: docker
+    - watch:
+      - file: {{ environment_file }}
+      - pkg: docker
+
+{% else %}
+
+docker-io:
+  pkg:
+    - installed
+
 docker:
   service.running:
     - enable: True
@@ -30,6 +45,8 @@ docker:
     - watch:
       - file: {{ environment_file }}
       - pkg: docker-io
+
+{% endif %}
 
 {% else %}
 


### PR DESCRIPTION
Fedora < 22 provides docker via the 'docker-io' package, but this
package was renamed to 'docker' as of Fedora 22.  Though the docker
package can be installed manually with 'dnf install docker-io' on F22,
Salt requires the explicit package name or deployment will fail.
