### PR TITLE
Increase latency metrics limit in capacity load

### DIFF
--- a/test/e2e/load.go
+++ b/test/e2e/load.go
@@ -87,7 +87,7 @@ var _ = Describe("Load capacity", func() {
 		}
 
 		// Verify latency metrics
-		highLatencyRequests, err := HighLatencyRequests(c, 1*time.Second, util.NewStringSet("events"))
+		highLatencyRequests, err := HighLatencyRequests(c, 3*time.Second, util.NewStringSet("events"))
 		expectNoError(err, "Too many instances metrics above the threshold")
 		Expect(highLatencyRequests).NotTo(BeNumerically(">", 0))
 	})


### PR DESCRIPTION
After merging #10391 - we are finally measuring all the requests from the whole test.
Unfortunately, this increase the latency of listing pods - it now exceeds 1s (similarly to what we observe in Density tests). I observed 1.68s and 1.84s latencies.
Thus I'm increasing the limit to avoid test failures on Jenkins.

cc @piosz @davidopp 
