### PR TITLE
Fix build/release.sh with enabled unit tests on Mac

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -337,7 +337,9 @@ function kube::build::build_image() {
   kube::build::build_image_cross
 
   mkdir -p "${build_context_dir}"
-  tar czf "${build_context_dir}/kube-source.tar.gz" $(kube::build::source_targets)
+
+  # exclude ._* files with Apple tar by setting COPYFILE_DISABLE=1
+  COPYFILE_DISABLE=1 tar czf "${build_context_dir}/kube-source.tar.gz" $(kube::build::source_targets)
 
   kube::version::get_version_vars
   kube::version::save_version_vars "${build_context_dir}/kube-version-defs"


### PR DESCRIPTION
Apple's tar stores extended file attributes in files prefixed with "._". The tar inside the build container does not know about those and blindly extracts them. The unit tests – especially TestExampleObjectSchemas – complains about invalid files. Setting COPYFILE_DISABLE=1 for the tar process stops this behaviour.
