### PR TITLE
Enable readonly PD tests for Jenkins GCE E2E run

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -69,7 +69,7 @@ fi
 GCE_DEFAULT_SKIP_TEST_REGEX="Skipped|Density|Reboot|Restart"
 # The following tests are known to be flaky, and are thus run only in their own
 # -flaky- build variants.
-GCE_FLAKY_TEST_REGEX="Addon|Elasticsearch|Nodes.*network\spartition|Shell.*services|readonly\sPD"
+GCE_FLAKY_TEST_REGEX="Addon|Elasticsearch|Nodes.*network\spartition|Shell.*services"
 # Tests which are not able to be run in parallel.
 GCE_PARALLEL_SKIP_TEST_REGEX="${GCE_DEFAULT_SKIP_TEST_REGEX}|Etcd|NetworkingNew|Nodes\sNetwork|Nodes\sResize"
 # Tests which are known to be flaky when run in parallel.


### PR DESCRIPTION
With PR #10169, PersistentDisk attachment and detachment should be much more stable.  Therefore, re-enabling `readonly PD` E2E test for Jenkins GCE E2E.

Risk assessment: low. This will only affect Jenkins E2E runs.
