### PR TITLE
Split kubelet server initialization for easier reuse

### DIFF
--- a/cmd/hyperkube/kubelet.go
+++ b/cmd/hyperkube/kubelet.go
@@ -32,8 +32,8 @@ func NewKubelet() *Server {
 		queries Docker to see what is currently running.  It synchronizes the
 		configuration data, with the running set of containers by starting or stopping
 		Docker containers.`,
-		Run: func(_ *Server, args []string) error {
-			return s.Run(args)
+		Run: func(_ *Server, _ []string) error {
+			return s.Run(nil)
 		},
 	}
 	s.AddFlags(hks.Flags())

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -43,7 +43,7 @@ func main() {
 
 	verflag.PrintAndExitIfRequested()
 
-	if err := s.Run(pflag.CommandLine.Args()); err != nil {
+	if err := s.Run(nil); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
We want to be able to start the Kubelet directly and provide specific
interfaces, but the current structure is difficult to intercept (and we
end up duplicating lots of code).  This splits the server init code up
into two smaller chunks - those that can error but don't start background
processes, and those that do.
