### PR TITLE
Vagrant: Add support for nfs synced folders

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,6 +28,9 @@ $minion_ips = $num_minion.times.collect { |n| $minion_ip_base + "#{n+3}" }
 # Determine the OS platform to use
 $kube_os = ENV['KUBERNETES_OS'] || "fedora"
 
+# Determine whether vagrant should use nfs to sync folders
+$use_nfs = ENV['KUBERNETES_VAGRANT_USE_NFS'] == 'true'
+
 # To override the vagrant provider, use (e.g.):
 #   KUBERNETES_PROVIDER=vagrant VAGRANT_DEFAULT_PROVIDER=... .../cluster/kube-up.sh
 # To override the box, use (e.g.):
@@ -130,6 +133,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   def customize_vm(config, vm_mem)
+
+    if $use_nfs then
+      config.vm.synced_folder ".", "/vagrant", nfs: true
+    end
+
     # Try VMWare Fusion first (see
     # https://docs.vagrantup.com/v2/providers/basic_usage.html)
     config.vm.provider :vmware_fusion do |v, override|

--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -18,7 +18,7 @@ Running kubernetes with Vagrant (and VirtualBox) is an easy way to run/test/deve
     - [I want to change the number of nodes!](#i-want-to-change-the-number-of-nodes)
     - [I want my VMs to have more memory!](#i-want-my-vms-to-have-more-memory)
     - [I ran vagrant suspend and nothing works!](#i-ran-vagrant-suspend-and-nothing-works)
-
+    - [I want vagrant to sync folders via nfs!](#i-want-vagrant-to-sync-folders-via-nfs)
 
 ### Prerequisites
 1. Install latest version >= 1.6.2 of vagrant from http://www.vagrantup.com/downloads.html
@@ -329,6 +329,14 @@ export KUBERNETES_MINION_MEMORY=2048
 
 #### I ran vagrant suspend and nothing works!
 ```vagrant suspend``` seems to mess up the network.  This is not supported at this time.
+
+#### I want vagrant to sync folders via nfs!
+
+You can ensure that vagrant uses nfs to sync folders with virtual machines by setting the KUBERNETES_VAGRANT_USE_NFS environment variable to 'true'. nfs is faster than virtualbox or vmware's 'shared folders' and does not require guest additions. See the [vagrant docs](http://docs.vagrantup.com/v2/synced-folders/nfs.html) for details on configuring nfs on the host. This setting will have no effect on the libvirt provider, which uses nfs by default. For example:
+
+```sh
+export KUBERNETES_VAGRANT_USE_NFS=true
+```
 
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/getting-started-guides/vagrant.md?pixel)]()


### PR DESCRIPTION
nfs synced folders do not require guest additions and are faster than
vmware and virtualbox's shared folders.  This change configures the
default /vagrant synced folder to use nfs if the
KUBERNETES_VAGRANT_USE_NFS environment variable is set to 'true'.
