### PR TITLE
Clarify disk formatting for Meteor example.

### DIFF
--- a/examples/meteor/README.md
+++ b/examples/meteor/README.md
@@ -112,6 +112,8 @@ gcloud compute disks create --size=200GB mongo-disk
 ```
 
 You also need to format the disk before you can use it:
+> Note: This uses the `kubernetes-master` machine. Any node in the cluster could be used instead.
+
 ```
 gcloud compute instances attach-disk --disk=mongo-disk --device-name temp-data kubernetes-master
 gcloud compute ssh kubernetes-master --command "sudo mkdir /mnt/tmp && sudo /usr/share/google/safe_format_and_mount /dev/disk/by-id/google-temp-data /mnt/tmp"


### PR DESCRIPTION
GKE has a hosted master now. We can leave this as `kubernetes-master` as this is written for kubernetes and not GKE. Added note to clarify.
