### PR TITLE
Clarify and make less verbose event message for infeasible pods.

### DIFF
--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -125,7 +125,7 @@ func (s *Scheduler) scheduleOne() {
 	metrics.SchedulingAlgorithmLatency.Observe(metrics.SinceInMicroseconds(start))
 	if err != nil {
 		glog.V(1).Infof("Failed to schedule: %v", pod)
-		s.config.Recorder.Eventf(pod, "failedScheduling", "Error scheduling: %v", err)
+		s.config.Recorder.Eventf(pod, "failedScheduling", "%v", err)
 		s.config.Error(pod, err)
 		return
 	}


### PR DESCRIPTION
Partially addresses #9207 

@lavalamp @bprashanth This PR has interesting behavior. I created a pod that requests too much resources as well as having an infeasible node selector. Here are the events I get:

```
$ kubectl get events | grep testpod4
Wed, 01 Jul 2015 13:23:54 -0700   Wed, 01 Jul 2015 13:23:54 -0700   1         testpod4                                       Pod                                                              failedScheduling   {scheduler }                       Of 4 nodes, pod failed predicate for each of these reasons on the indicated number of nodes: MatchNodeSelector/3,PodFitsResources/1
Wed, 01 Jul 2015 13:24:24 -0700   Wed, 01 Jul 2015 13:26:03 -0700   3         testpod4                                       Pod                                                              failedScheduling   {scheduler }                       4/4 nodes failed to satisfy predicate MatchNodeSelector
Wed, 01 Jul 2015 13:23:53 -0700   Wed, 01 Jul 2015 13:26:11 -0700   6         testpod4                                       Pod                                                              failedScheduling   {scheduler }                       Of 4 nodes, pod failed predicate for each of these reasons on the indicated number of nodes: MatchNodeSelector/2,PodFitsResources/2
Wed, 01 Jul 2015 13:23:56 -0700   Wed, 01 Jul 2015 13:26:27 -0700   3         testpod4                                       Pod                                                              failedScheduling   {scheduler }                       Of 4 nodes, pod failed predicate for each of these reasons on the indicated number of nodes: MatchNodeSelector/1,PodFitsResources/3
```

There are two things going on:
1) findNodesThatFit() exits after it finds the first infeasible reason for a node, so you're not guaranteed to get all the infeasible reasons, either for a node (obviously) or even across all nodes (see for example the event above where it never got a PodsFitsResources failure)
2) for some reason iteration through predicateFuncs in that function is not deterministic, so the first predicate that fails for each node can be different each time you call findNodesThatFit()

We could test every predicate for every node, even once we know the node is infeasible, but that will cause a performance problem. So maybe the best we can do is really just to say "here is a possibly incomplete list of predicates that failed on at least one node."
