### PR TITLE
Kubelet: stop logging "Error on reading termination-log..." messages

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -313,7 +313,7 @@ func (dm *DockerManager) inspectContainer(dockerID, containerName, tPath string)
 			if found {
 				data, err := ioutil.ReadFile(path)
 				if err != nil {
-					glog.Errorf("Error on reading termination-log %s: %v", path, err)
+					result.status.State.Terminated.Message = fmt.Sprintf("Error on reading termination-log %s: %v", path, err)
 				} else {
 					result.status.State.Terminated.Message = string(data)
 				}


### PR DESCRIPTION
If a pod was deleted and the associated volumes/directory were removed, there
could be a window where the pod worker is still active. If the pod worker tries
to inspect the logs, such an error would be logged. Since the pod has been
deleted, such error messages are meaningless.

This change stops logging this error, but stores the error string in the pod
status. The pod status will be updated for pods that are still alive, and will
be discarded eventually for deleted pods.

This fixes #8223
