### PR TITLE
Set resource limit for addon containers

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -22,6 +22,10 @@ spec:
       containers:
         - image: gcr.io/google_containers/heapster:v0.15.0
           name: heapster
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
           command:
             - /heapster
             - --source=kubernetes:''

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -22,6 +22,10 @@ spec:
       containers:
         - image: gcr.io/google_containers/heapster:v0.15.0
           name: heapster
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
           command:
             - /heapster
             - --source=kubernetes:''

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -22,6 +22,10 @@ spec:
       containers:
         - image: gcr.io/google_containers/heapster:v0.15.0
           name: heapster
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
           command:
             - /heapster
             - --source=kubernetes:''

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -22,6 +22,10 @@ spec:
       containers: 
         - image: gcr.io/google_containers/heapster_influxdb:v0.3
           name: influxdb
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
           ports: 
             - containerPort: 8083
               hostPort: 8083
@@ -29,6 +33,10 @@ spec:
               hostPort: 8086
         - image: gcr.io/google_containers/heapster_grafana:v0.7
           name: grafana
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
           env: 
             - name: INFLUXDB_EXTERNAL_URL
               value: /api/v1beta3/proxy/namespaces/default/services/monitoring-influxdb:api/db/

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -22,6 +22,10 @@ spec:
       containers:
         - image: gcr.io/google_containers/heapster:v0.15.0
           name: heapster
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
           command:
             - /heapster
             - --source=kubernetes:''

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -22,6 +22,10 @@ spec:
       containers:
       - name: etcd
         image: gcr.io/google_containers/etcd:2.0.9
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
         command:
         - /usr/local/bin/etcd
         - -listen-client-urls
@@ -32,11 +36,19 @@ spec:
         - skydns-etcd
       - name: kube2sky
         image: gcr.io/google_containers/kube2sky:1.10
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
         args:
         # command = "/kube2sky"
         - -domain={{ pillar['dns_domain'] }}
       - name: skydns
         image: gcr.io/google_containers/skydns:2015-03-11-001
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
         args:
         # command = "/skydns"
         - -machines=http://localhost:4001

--- a/cluster/addons/fluentd-elasticsearch/es-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-controller.yaml
@@ -22,6 +22,9 @@ spec:
       containers:
       - image: gcr.io/google_containers/elasticsearch:1.4
         name: elasticsearch-logging         
+        resources:
+          limits:
+            cpu: 100m
         ports:
         - containerPort: 9200
           name: es-port

--- a/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
@@ -22,6 +22,9 @@ spec:
       containers:
       - name: kibana-logging
         image: gcr.io/google_containers/kibana:1.3
+        resources:
+          limits:
+            cpu: 100m
         env:
           - name: "ELASTICSEARCH_URL"
             value: "http://elasticsearch-logging:9200"

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -9,6 +9,7 @@ spec:
     resources:
       limits:
         cpu: 100m
+        memory: 200Mi
     env:
     - name: "FLUENTD_ARGS"
       value: "-qq"


### PR DESCRIPTION
Measurement is based on current default configuration for GCE / GKE (?) and AWS: 4 nodes, 30~50 pods per node. 

For all containers, I allocate 100m for cpu even they all use less than that since it matches today's default setting from LimitRange of default namespace. Memory is very complicated here:

1) all containers in dns service is very stable, and use tiny bit of memory (< 5Mi), but I rounded them up to 50Mi anyway.
2) Looks like fluentd have memory leakage issue over time, but since it is stateless, it is safe to be oom-killed for now. But it is static pod for now, I decided to do nothing on it since it is too hard to change static pods' configuration today.
3) We observed both influxdb and heapster memory leakage issues. Witthout any new pods scheduled to cluster, over one night, the memory usage of influxdb is shooting to 2.5Gi from 150Mi, and one of heapster to 2Gi from 150Mi. I chose 200Mi now for both. Influxdb now has an emtpy dir volume attached to pod, and could be recovered. 
4) We observed elasticsearch and kibana have memory leakage issue. Since elasticsearch and kibana are not started by default for GCE and GKE, I decided to not give memory limit for now. 

cc/ @bgrant0607 @thockin @saad-ali @a-robinson 

@eparis and @justinsb  too on valgrant case. 
