### PR TITLE
e2e: update namespace test to create/delete test namespaces in parallel

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -153,7 +153,7 @@ case ${JOB_NAME} in
     : ${GINKGO_PARALLEL:="y"}
     # This list should match the list in kubernetes-e2e-gce-parallel. It
     # currently also excludes a slow namespace test.
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=${GCE_DEFAULT_SKIP_TEST_REGEX}|${GCE_PARALLEL_SKIP_TEST_REGEX}|${GCE_PARALLEL_FLAKY_TEST_REGEX}|Namespaces\sDelete\s90\spercent\sof\s100\snamespace\sin\s150\sseconds"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=${GCE_DEFAULT_SKIP_TEST_REGEX}|${GCE_PARALLEL_SKIP_TEST_REGEX}|${GCE_PARALLEL_FLAKY_TEST_REGEX}"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="pull-e2e-${EXECUTOR_NUMBER}"}
     : ${KUBE_GCS_STAGING_PATH_SUFFIX:="-${EXECUTOR_NUMBER}"}
     : ${PROJECT:="kubernetes-jenkins-pull"}

--- a/test/e2e/namespace.go
+++ b/test/e2e/namespace.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/wait"
 	"strings"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -42,27 +43,44 @@ func countRemaining(c *client.Client, withName string) (int, error) {
 }
 
 func extinguish(c *client.Client, totalNS int, maxAllowedAfterDel int, maxSeconds int) {
-
 	var err error
 
+	By("Creating testing namespaces")
+	wg := &sync.WaitGroup{}
 	for n := 0; n < totalNS; n += 1 {
-		_, err = createTestingNS(fmt.Sprintf("nslifetest-%v", n), c)
-		Expect(err).NotTo(HaveOccurred())
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			defer GinkgoRecover()
+			_, err = createTestingNS(fmt.Sprintf("nslifetest-%v", n), c)
+			Expect(err).NotTo(HaveOccurred())
+		}(n)
 	}
+	wg.Wait()
 
+	By("Waiting 10 seconds")
 	//Wait 10 seconds, then SEND delete requests for all the namespaces.
 	time.Sleep(time.Duration(10 * time.Second))
+	By("Deleting namespaces")
 	nsList, err := c.Namespaces().List(labels.Everything(), fields.Everything())
 	Expect(err).NotTo(HaveOccurred())
+	var nsCount = 0
 	for _, item := range nsList.Items {
 		if strings.Contains(item.Name, "nslifetest") {
-			if err := c.Namespaces().Delete(item.Name); err != nil {
-				Failf("Failed deleting error ::: --- %v ", err)
-			}
+			wg.Add(1)
+			nsCount++
+			go func(nsName string) {
+				defer wg.Done()
+				defer GinkgoRecover()
+				Expect(c.Namespaces().Delete(nsName)).To(Succeed())
+				Logf("namespace : %v api call to delete is complete ", nsName)
+			}(item.Name)
 		}
-		Logf("namespace : %v api call to delete is complete ", item)
 	}
+	Expect(nsCount).To(Equal(totalNS))
+	wg.Wait()
 
+	By("Waiting for namespaces to vanish")
 	//Now POLL until all namespaces have been eradicated.
 	expectNoError(wait.Poll(2*time.Second, time.Duration(maxSeconds)*time.Second,
 		func() (bool, error) {


### PR DESCRIPTION
The namespace test is currently taking about 18 minutes because it
creates and deletes namespaces sequentially, and for various reasons it
takes at least 10 seconds for each namespace.

By parallelizing the creation and deletion of namespaces, this test now
takes about 2-3 minutes.

Additionally, re-enable this test on the pull request Jenkins.

cc @jayunit100 @derekwaynecarr @quinton-hoole from #8434
