### PR TITLE
kubectl: Handle splitting host:port when no port is present

### DIFF
--- a/pkg/kubectl/proxy_server.go
+++ b/pkg/kubectl/proxy_server.go
@@ -106,8 +106,17 @@ func (f *FilterServer) HandlerFor(delegate http.Handler) *FilterServer {
 	return &f2
 }
 
+// Get host from a host header value like "localhost" or "localhost:8080"
+func extractHost(header string) (host string) {
+	host, _, err := net.SplitHostPort(header)
+	if err != nil {
+		host = header
+	}
+	return host
+}
+
 func (f *FilterServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	host, _, _ := net.SplitHostPort(req.Host)
+	host := extractHost(req.Host)
 	if f.accept(req.Method, req.URL.Path, host) {
 		f.delegate.ServeHTTP(rw, req)
 		return

--- a/pkg/kubectl/proxy_server_test.go
+++ b/pkg/kubectl/proxy_server_test.go
@@ -309,3 +309,16 @@ func TestPathHandling(t *testing.T) {
 		}()
 	}
 }
+
+func TestExtractHost(t *testing.T) {
+	fixtures := map[string]string{
+		"localhost:8085": "localhost",
+		"marmalade":      "marmalade",
+	}
+	for header, expected := range fixtures {
+		host := extractHost(header)
+		if host != expected {
+			t.Fatalf("%s != %s", host, expected)
+		}
+	}
+}


### PR DESCRIPTION
In the proxy filter, if listening on port 80 or 443 there will be no port present in the `Host:` HTTP header. Just use the entire thing in these cases, and don't reject requests when no port is present in the `Host:` HTTP header.
