### PR TITLE
kubectl: Don't hang forever in proxy when watch is quiet

### DIFF
--- a/pkg/kubectl/proxy_server.go
+++ b/pkg/kubectl/proxy_server.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/golang/glog"
@@ -171,7 +172,7 @@ func newProxy(target *url.URL) *httputil.ReverseProxy {
 		req.URL.Host = target.Host
 		req.URL.Path = singleJoiningSlash(target.Path, req.URL.Path)
 	}
-	return &httputil.ReverseProxy{Director: director}
+	return &httputil.ReverseProxy{Director: director, FlushInterval: 50 * time.Millisecond}
 }
 
 func newFileHandler(prefix, base string) http.Handler {


### PR DESCRIPTION
When a `kubectl proxy` is used with a rather quiet watch, the data is not flushed, and HTTP request hangs with buffered data not making it to the client.

This commit fixes this by adding a `FlushInterval` to the `httputil.ReverseProxy`
