### PR TITLE
Move sourcing of provider-specific util.sh into kube-util.sh

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -29,7 +29,7 @@ fi
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${KUBE_ROOT}/cluster/kube-env.sh"
-source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+source "${KUBE_ROOT}/cluster/kube-util.sh"
 
 function usage() {
   echo "!!! EXPERIMENTAL !!!"

--- a/cluster/kube-down.sh
+++ b/cluster/kube-down.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/cluster/kube-env.sh"
-source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+source "${KUBE_ROOT}/cluster/kube-util.sh"
 
 echo "Bringing down cluster using provider: $KUBERNETES_PROVIDER"
 

--- a/cluster/kube-push.sh
+++ b/cluster/kube-push.sh
@@ -25,7 +25,7 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/cluster/kube-env.sh"
-source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+source "${KUBE_ROOT}/cluster/kube-util.sh"
 
 function usage() {
   echo "${0} [-m|-n <node id>] <version>"

--- a/cluster/kube-up.sh
+++ b/cluster/kube-up.sh
@@ -26,7 +26,7 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/cluster/kube-env.sh"
-source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+source "${KUBE_ROOT}/cluster/kube-util.sh"
 
 echo "Starting cluster using provider: $KUBERNETES_PROVIDER" >&2
 

--- a/cluster/kube-util.sh
+++ b/cluster/kube-util.sh
@@ -16,73 +16,83 @@
 
 # A library of helper functions that each provider hosting Kubernetes must implement to use cluster/kube-*.sh scripts.
 
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
 # Must ensure that the following ENV vars are set
 function detect-master {
-	echo "KUBE_MASTER_IP: $KUBE_MASTER_IP"
-	echo "KUBE_MASTER: $KUBE_MASTER"
+	echo "KUBE_MASTER_IP: $KUBE_MASTER_IP" 1>&2
+	echo "KUBE_MASTER: $KUBE_MASTER" 1>&2
 }
 
 # Get minion names if they are not static.
 function detect-minion-names {
-        echo "MINION_NAMES: ${MINION_NAMES[*]}"
+	echo "MINION_NAMES: [${MINION_NAMES[*]}]" 1>&2
 }
 
 # Get minion IP addresses and store in KUBE_MINION_IP_ADDRESSES[]
 function detect-minions {
-	echo "KUBE_MINION_IP_ADDRESSES=[]"
+	echo "KUBE_MINION_IP_ADDRESSES: [${KUBE_MINION_IP_ADDRESSES[*]}]" 1>&2
 }
 
 # Verify prereqs on host machine
 function verify-prereqs {
-	echo "TODO"
+	echo "TODO: verify-prereqs" 1>&2
 }
 
 # Instantiate a kubernetes cluster
 function kube-up {
-	echo "TODO"
+	echo "TODO: kube-up" 1>&2
 }
 
 # Delete a kubernetes cluster
 function kube-down {
-	echo "TODO"
+	echo "TODO: kube-down" 1>&2
 }
 
 # Update a kubernetes cluster
 function kube-push {
-	echo "TODO"
+	echo "TODO: kube-push" 1>&2
 }
 
 # Prepare update a kubernetes component
 function prepare-push {
-	echo "TODO"
+	echo "TODO: prepare-push" 1>&2
 }
 
 # Update a kubernetes master
 function push-master {
-	echo "TODO"
+	echo "TODO: push-master" 1>&2
 }
 
 # Update a kubernetes node
 function push-node {
-	echo "TODO"
+	echo "TODO: push-node" 1>&2
 }
 
 # Execute prior to running tests to build a release if required for env
 function test-build-release {
-	echo "TODO"
+	echo "TODO: test-build-release" 1>&2
 }
 
 # Execute prior to running tests to initialize required structure
 function test-setup {
-	echo "TODO"
+	echo "TODO: test-setup" 1>&2
 }
 
 # Execute after running tests to perform any required clean-up
 function test-teardown {
-	echo "TODO"
+	echo "TODO: test-teardown" 1>&2
 }
 
 # Set the {KUBE_USER} and {KUBE_PASSWORD} environment values required to interact with provider
 function get-password {
-	echo "TODO"
+	echo "TODO: get-password" 1>&2
 }
+
+# Providers util.sh scripts should define functions that override the above default functions impls
+if [ -n "${KUBERNETES_PROVIDER}" ]; then
+	PROVIDER_UTILS="${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+	if [ -f ${PROVIDER_UTILS} ]; then
+		source "${PROVIDER_UTILS}"
+	fi
+fi

--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -32,10 +32,7 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/cluster/kube-env.sh"
-UTILS=${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh
-if [ -f ${UTILS} ]; then
-    source "${UTILS}"
-fi
+source "${KUBE_ROOT}/cluster/kube-util.sh"
 
 # Get the absolute path of the directory component of a file, i.e. the
 # absolute path of the dirname of $1.

--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/cluster/kube-env.sh"
-source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+source "${KUBE_ROOT}/cluster/kube-util.sh"
 
 MINIONS_FILE=/tmp/minions-$$
 trap 'rm -rf "${MINIONS_FILE}"' EXIT


### PR DESCRIPTION
- kube-util.sh defines default implementations
- provider util.sh overrides the default implementations as desired
- default kube-util functions now print to stderr to avoid affecting captured output
