### PR TITLE
Shutup presubmit

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -40,13 +40,13 @@ kube::etcd::start() {
 
   # Start etcd
   ETCD_DIR=$(mktemp -d -t test-etcd.XXXXXX)
-  kube::log::usage "etcd -data-dir ${ETCD_DIR} --bind-addr ${host}:${port} >/dev/null 2>/dev/null"
+  kube::log::info "etcd -data-dir ${ETCD_DIR} --bind-addr ${host}:${port} >/dev/null 2>/dev/null"
   etcd -data-dir ${ETCD_DIR} --bind-addr ${host}:${port} >/dev/null 2>/dev/null &
   ETCD_PID=$!
 
   echo "Waiting for etcd to come up."
   kube::util::wait_for_url "http://${host}:${port}/v2/machines" "etcd: " 0.25 80
-  curl -X PUT "http://${host}:${port}/v2/keys/_test"
+  curl -fs -X PUT "http://${host}:${port}/v2/keys/_test"
 }
 
 kube::etcd::stop() {

--- a/hack/update-swagger-spec.sh
+++ b/hack/update-swagger-spec.sh
@@ -54,17 +54,17 @@ KUBE_API_VERSIONS="v1,v1beta3" "${KUBE_OUTPUT_HOSTBIN}/kube-apiserver" \
   --public_address_override="127.0.0.1" \
   --kubelet_port=${KUBELET_PORT} \
   --runtime_config=api/v1beta3 \
-  --service-cluster-ip-range="10.0.0.0/24" 1>&2 &
+  --service-cluster-ip-range="10.0.0.0/24" >/dev/null 2>&1 &
 APISERVER_PID=$!
 
 kube::util::wait_for_url "http://127.0.0.1:${API_PORT}/healthz" "apiserver: "
 
 SWAGGER_API_PATH="http://127.0.0.1:${API_PORT}/swaggerapi/"
 kube::log::status "Updating " ${SWAGGER_ROOT_DIR}
-curl ${SWAGGER_API_PATH} > ${SWAGGER_ROOT_DIR}/resourceListing.json
-curl ${SWAGGER_API_PATH}version > ${SWAGGER_ROOT_DIR}/version.json
-curl ${SWAGGER_API_PATH}api > ${SWAGGER_ROOT_DIR}/api.json
-curl ${SWAGGER_API_PATH}api/v1beta3 > ${SWAGGER_ROOT_DIR}/v1beta3.json
-curl ${SWAGGER_API_PATH}api/v1 > ${SWAGGER_ROOT_DIR}/v1.json
+curl -fs ${SWAGGER_API_PATH} > ${SWAGGER_ROOT_DIR}/resourceListing.json
+curl -fs ${SWAGGER_API_PATH}version > ${SWAGGER_ROOT_DIR}/version.json
+curl -fs ${SWAGGER_API_PATH}api > ${SWAGGER_ROOT_DIR}/api.json
+curl -fs ${SWAGGER_API_PATH}api/v1beta3 > ${SWAGGER_ROOT_DIR}/v1beta3.json
+curl -fs ${SWAGGER_API_PATH}api/v1 > ${SWAGGER_ROOT_DIR}/v1.json
 
 kube::log::status "SUCCESS"

--- a/hack/verify-gendocs.sh
+++ b/hack/verify-gendocs.sh
@@ -22,7 +22,6 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
-"${KUBE_ROOT}/hack/build-go.sh" cmd/gendocs cmd/genman cmd/genbashcomp
 
 gendocs=$(kube::util::find-binary "gendocs")
 genman=$(kube::util::find-binary "genman")

--- a/hack/verify-generated-conversions.sh
+++ b/hack/verify-generated-conversions.sh
@@ -22,7 +22,6 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
-"${KUBE_ROOT}/hack/build-go.sh" cmd/genconversion
 
 genconversion=$(kube::util::find-binary "genconversion")
 

--- a/hack/verify-generated-deep-copies.sh
+++ b/hack/verify-generated-deep-copies.sh
@@ -22,7 +22,6 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
-"${KUBE_ROOT}/hack/build-go.sh" cmd/gendeepcopy
 
 genconversion=$(kube::util::find-binary "gendeepcopy")
 

--- a/hack/verify-swagger-spec.sh
+++ b/hack/verify-swagger-spec.sh
@@ -30,7 +30,6 @@ _tmp="${KUBE_ROOT}/_tmp"
 mkdir -p "${_tmp}"
 cp -a "${SPECROOT}" "${TMP_SPECROOT}"
 
-"${KUBE_ROOT}/hack/build-go.sh"
 "${KUBE_ROOT}/hack/update-swagger-spec.sh"
 echo "diffing ${SPECROOT} against freshly generated swagger spec"
 ret=0

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -8,12 +8,22 @@ KUBE_HOOKS_DIR="$(dirname "$(test -L "$0" && echo "$(dirname $0)/$(readlink "$0"
 
 exit_code=0
 
+echo -ne "Checking that it builds... "
+if ! OUT=$("hack/build-go.sh" 2>&1); then
+  echo
+  echo "${red}${OUT}"
+  exit_code=1
+else
+  echo "${green}OK"
+fi
+echo "${reset}"
+
 echo -ne "Checking for files that need gofmt... "
 files_need_gofmt=()
 files=($(git diff --cached --name-only --diff-filter ACM | grep "\.go" | grep -v -e "third_party" -e "Godeps"))
 for file in "${files[@]}"; do
   # Check for files that fail gofmt.
-  diff="$(git show ":${file}" | gofmt -s -d)"
+  diff="$(git show ":${file}" | gofmt -s -d 2>&1)"
   if [[ -n "$diff" ]]; then
     files_need_gofmt+=("${file}")
   fi
@@ -135,4 +145,7 @@ else
 fi
 echo "${reset}"
 
-exit $exit_code
+if [[ "${exit_code}" != 0 ]]; then
+  echo "${red}Aborting commit${reset}"
+fi
+exit ${exit_code}


### PR DESCRIPTION
Don't dump stuff all over the screen during presubmit checks.

Make build-go an explicit part of the presubmit, rather than being run a little here and a little there.  sadly, it's just not fast enough.
