### PR TITLE
AWS: Configure SSL certificate alternate-names

### DIFF
--- a/cluster/aws/templates/salt-master.sh
+++ b/cluster/aws/templates/salt-master.sh
@@ -44,6 +44,12 @@ if [[ -n "${KUBELET_ROOT}" ]]; then
 EOF
 fi
 
+if [[ -n "${MASTER_EXTRA_SANS}" ]]; then
+  cat <<EOF >>/etc/salt/minion.d/grains.conf
+  master_extra_sans: '$(echo "$MASTER_EXTRA_SANS" | sed -e "s/'/''/g")'
+EOF
+fi
+
 # Auto accept all keys from minions that try to join
 mkdir -p /etc/salt/master.d
 cat <<EOF >/etc/salt/master.d/auto-accept.conf

--- a/cluster/saltbase/salt/generate-cert/init.sls
+++ b/cluster/saltbase/salt/generate-cert/init.sls
@@ -1,3 +1,4 @@
+{% set master_extra_sans=grains.get('master_extra_sans', '') %}
 {% if grains.cloud is defined %}
   {% if grains.cloud == 'gce' %}
     {% set cert_ip='_use_gce_external_ip_' %}
@@ -35,7 +36,7 @@ kubernetes-cert:
     - unless: test -f /srv/kubernetes/server.cert
     - source: salt://generate-cert/{{certgen}}
 {% if cert_ip is defined %}
-    - args: {{cert_ip}}
+    - args: {{cert_ip}} {{master_extra_sans}}
     - require:
       - pkg: curl
 {% endif %}


### PR DESCRIPTION
GCE does this in its per-provider scripts; this does the same for AWS and lets
other providers do the same; I believe kube2sky requires 10.0.0.1 as a SAN.
