### PR TITLE
Do not create subject alt dns names for kubelet self signed certs

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -449,7 +449,11 @@ func (s *APIServer) Run(_ []string) error {
 					s.TLSCertFile = path.Join(s.CertDirectory, "apiserver.crt")
 					s.TLSPrivateKeyFile = path.Join(s.CertDirectory, "apiserver.key")
 					// TODO (cjcullen): Is PublicAddress the right address to sign a cert with?
-					if err := util.GenerateSelfSignedCert(config.PublicAddress.String(), s.TLSCertFile, s.TLSPrivateKeyFile, config.ServiceReadWriteIP); err != nil {
+					alternateIPs := []net.IP{config.ServiceReadWriteIP}
+					alternateDNS := []string{"kubernetes.default.svc", "kubernetes.default", "kubernetes"}
+					// It would be nice to set a fqdn subject alt name, but only the kubelets know, the apiserver is clueless
+					// alternateDNS = append(alternateDNS, "kubernetes.default.svc.CLUSTER.DNS.NAME")
+					if err := util.GenerateSelfSignedCert(config.PublicAddress.String(), s.TLSCertFile, s.TLSPrivateKeyFile, alternateIPs, alternateDNS); err != nil {
 						glog.Errorf("Unable to generate self signed cert: %v", err)
 					} else {
 						glog.Infof("Using self-signed cert (%s, %s)", s.TLSCertFile, s.TLSPrivateKeyFile)

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -395,7 +395,7 @@ func (s *KubeletServer) InitializeTLS() (*kubelet.TLSOptions, error) {
 	if s.TLSCertFile == "" && s.TLSPrivateKeyFile == "" {
 		s.TLSCertFile = path.Join(s.CertDirectory, "kubelet.crt")
 		s.TLSPrivateKeyFile = path.Join(s.CertDirectory, "kubelet.key")
-		if err := util.GenerateSelfSignedCert(nodeutil.GetHostname(s.HostnameOverride), s.TLSCertFile, s.TLSPrivateKeyFile, nil); err != nil {
+		if err := util.GenerateSelfSignedCert(nodeutil.GetHostname(s.HostnameOverride), s.TLSCertFile, s.TLSPrivateKeyFile, nil, nil); err != nil {
 			return nil, fmt.Errorf("unable to generate self signed cert: %v", err)
 		}
 		glog.V(4).Infof("Using self-signed cert (%s, %s)", s.TLSCertFile, s.TLSPrivateKeyFile)

--- a/pkg/util/crypto.go
+++ b/pkg/util/crypto.go
@@ -35,10 +35,11 @@ import (
 
 // GenerateSelfSignedCert creates a self-signed certificate and key for the given host.
 // Host may be an IP or a DNS name
+// You may also specify additional subject alt names (either ip or dns names) for the certificate
 // The certificate will be created with file mode 0644. The key will be created with file mode 0600.
 // If the certificate or key files already exist, they will be overwritten.
 // Any parent directories of the certPath or keyPath will be created as needed with file mode 0755.
-func GenerateSelfSignedCert(host, certPath, keyPath string, ServiceReadWriteIP net.IP) error {
+func GenerateSelfSignedCert(host, certPath, keyPath string, alternateIPs []net.IP, alternateDNS []string) error {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return err
@@ -63,14 +64,8 @@ func GenerateSelfSignedCert(host, certPath, keyPath string, ServiceReadWriteIP n
 		template.DNSNames = append(template.DNSNames, host)
 	}
 
-	if ServiceReadWriteIP != nil {
-		template.IPAddresses = append(template.IPAddresses, ServiceReadWriteIP)
-	}
-	// It would be nice to have the next line, but only the kubelets know the fqdn, the apiserver is clueless
-	// template.DNSNames = append(template.DNSNames, "kubernetes.default.svc.CLUSTER.DNS.NAME")
-	template.DNSNames = append(template.DNSNames, "kubernetes.default.svc")
-	template.DNSNames = append(template.DNSNames, "kubernetes.default")
-	template.DNSNames = append(template.DNSNames, "kubernetes")
+	template.IPAddresses = append(template.IPAddresses, alternateIPs...)
+	template.DNSNames = append(template.DNSNames, alternateDNS...)
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
 	if err != nil {


### PR DESCRIPTION
PR #10643 Started adding the dns names for the kubernetes master to self
sign certs which were created. The kubelet uses this same code, and thus
the kubelet cert started saying it was valid for these name as well.
While hardless, the kubelet cert shouldn't claim to be these things. So
make the caller explicitly list both their ip and dns subject alt names.
