### PR TITLE
Salt: install socat; needed for port-forward

### DIFF
--- a/cluster/saltbase/salt/base.sls
+++ b/cluster/saltbase/salt/base.sls
@@ -10,4 +10,5 @@ pkg-core:
       - apt-transport-https
       - python-apt
       - glusterfs-client
+      - socat
 {% endif %}


### PR DESCRIPTION
port-forward needs socat on the node hosts; we technically
don't need it today on the master, but this seems the right
place to put it, and socat is a small dependency.
