### PR TITLE
Check loopback and link-local multicast endpoints

### DIFF
--- a/api/swagger-spec/api.json
+++ b/api/swagger-spec/api.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "",
-  "basePath": "https://127.0.0.1:6443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/api",
   "apis": [
    {

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "v1",
-  "basePath": "https://127.0.0.1:6443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/api/v1",
   "apis": [
    {

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -11230,7 +11230,7 @@
     "properties": {
      "ip": {
       "type": "string",
-      "description": "IP address of the endpoint"
+      "description": "IP address of the endpoint; may not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24)"
      },
      "targetRef": {
       "$ref": "v1.ObjectReference",

--- a/api/swagger-spec/version.json
+++ b/api/swagger-spec/version.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "",
-  "basePath": "https://127.0.0.1:6443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/version",
   "apis": [
    {

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -264,8 +264,9 @@ func (s *APIServer) Run(_ []string) error {
 	s.verifyClusterIPFlags()
 
 	// If advertise-address is not specified, use bind-address. If bind-address
-	// is also unset (or 0.0.0.0), setDefaults() in pkg/master/master.go will
-	// do the right thing and use the host's default interface.
+	// is not usable (unset, 0.0.0.0, or loopback), setDefaults() in
+	// pkg/master/master.go will do the right thing and use the host's default
+	// interface.
 	if s.AdvertiseAddress == nil || s.AdvertiseAddress.IsUnspecified() {
 		s.AdvertiseAddress = s.BindAddress
 	}

--- a/docs/user-guide/services.md
+++ b/docs/user-guide/services.md
@@ -195,6 +195,9 @@ created. You can manually map the service to your own specific endpoints:
 }
 ```
 
+NOTE: Endpoint IPs may not be loopback (127.0.0.0/8), link-local
+(169.254.0.0/16), or link-local multicast ((224.0.0.0/24).
+
 Accessing a `Service` without a selector works the same as if it had selector.
 The traffic will be routed to endpoints defined by the user (`1.2.3.4:80` in
 this example).

--- a/hack/after-build/update-swagger-spec.sh
+++ b/hack/after-build/update-swagger-spec.sh
@@ -56,6 +56,7 @@ KUBE_API_VERSIONS="v1" "${KUBE_OUTPUT_HOSTBIN}/kube-apiserver" \
   --port="${API_PORT}" \
   --etcd-servers="http://${ETCD_HOST}:${ETCD_PORT}" \
   --public-address-override="127.0.0.1" \
+  --advertise-address="10.10.10.10" \
   --kubelet-port=${KUBELET_PORT} \
   --runtime-config=api/v1 \
   --service-cluster-ip-range="10.0.0.0/24" >/dev/null 2>&1 &

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1273,7 +1273,7 @@ type EndpointSubset struct {
 type EndpointAddress struct {
 	// The IP of this endpoint.
 	// TODO: This should allow hostname or IP, see #4447.
-	IP string `json:"ip" description:"IP address of the endpoint"`
+	IP string `json:"ip" description:"IP address of the endpoint; may not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24)"`
 
 	// Optional: The kubernetes object related to the entry point.
 	TargetRef *ObjectReference `json:"targetRef,omitempty" description:"reference to object providing the endpoint"`

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -3948,6 +3948,19 @@ func TestValidateEndpoints(t *testing.T) {
 			},
 			errorType: "FieldValueRequired",
 		},
+		"Address is loopback": {
+			endpoints: api.Endpoints{
+				ObjectMeta: api.ObjectMeta{Name: "mysvc", Namespace: "namespace"},
+				Subsets: []api.EndpointSubset{
+					{
+						Addresses: []api.EndpointAddress{{IP: "127.0.0.1"}},
+						Ports:     []api.EndpointPort{{Name: "p", Port: 93, Protocol: "TCP"}},
+					},
+				},
+			},
+			errorType:   "FieldValueInvalid",
+			errorDetail: "loopback",
+		},
 		"Address is link-local": {
 			endpoints: api.Endpoints{
 				ObjectMeta: api.ObjectMeta{Name: "mysvc", Namespace: "namespace"},
@@ -3960,6 +3973,19 @@ func TestValidateEndpoints(t *testing.T) {
 			},
 			errorType:   "FieldValueInvalid",
 			errorDetail: "link-local",
+		},
+		"Address is link-local multicast": {
+			endpoints: api.Endpoints{
+				ObjectMeta: api.ObjectMeta{Name: "mysvc", Namespace: "namespace"},
+				Subsets: []api.EndpointSubset{
+					{
+						Addresses: []api.EndpointAddress{{IP: "224.0.0.1"}},
+						Ports:     []api.EndpointPort{{Name: "p", Port: 93, Protocol: "TCP"}},
+					},
+				},
+			},
+			errorType:   "FieldValueInvalid",
+			errorDetail: "link-local multicast",
 		},
 	}
 

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -286,7 +286,7 @@ func setDefaults(c *Config) {
 	if c.CacheTimeout == 0 {
 		c.CacheTimeout = 5 * time.Second
 	}
-	for c.PublicAddress == nil || c.PublicAddress.IsUnspecified() {
+	for c.PublicAddress == nil || c.PublicAddress.IsUnspecified() || c.PublicAddress.IsLoopback() {
 		// TODO: This should be done in the caller and just require a
 		// valid value to be passed in.
 		hostIP, err := util.ChooseHostInterface()


### PR DESCRIPTION
Previously we just disallowed link-local (unicast).  This disallows loopback
and link-local multicast.

Fixes #10349
