### PR TITLE
AWS: Return InstanceNotFound from ExternalID when not found

### DIFF
--- a/pkg/cloudprovider/nodecontroller/nodecontroller.go
+++ b/pkg/cloudprovider/nodecontroller/nodecontroller.go
@@ -408,6 +408,7 @@ func (nc *NodeController) monitorNodeStatus() error {
 					continue
 				}
 				if _, err := instances.ExternalID(node.Name); err != nil && err == cloudprovider.InstanceNotFound {
+					glog.Infof("Deleting node (no longer present in cloud provider): %s", node.Name)
 					if err := nc.kubeClient.Nodes().Delete(node.Name); err != nil {
 						glog.Errorf("Unable to delete node %s: %v", node.Name, err)
 						continue


### PR DESCRIPTION
Despite finding and documenting the importance of this, I was still doing it wrong!

This change affects AWS only, and fixes the reboot tests (mostly, though there are still flakes).
