### PR TITLE
Fix "Proxy version v1 should proxy logs on node *" test failures

### DIFF
--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -124,6 +124,11 @@ func waitForClusterSize(c *client.Client, size int) error {
 			Logf("Failed to list nodes: %v", err)
 			continue
 		}
+		// Filter out not-ready nodes.
+		filterNodes(nodes, func(node api.Node) bool {
+			return isNodeReadySetAsExpected(&node, true)
+		})
+
 		if len(nodes.Items) == size {
 			Logf("Cluster has reached the desired size %d", size)
 			return nil


### PR DESCRIPTION
All the failures of that test were cause by running this test right after test resizing the cluster ("should be able to delete nodes") which didn't wait for the newly added node to become ready at the end. Since the node didn't have the network configured properly yet (indicated by being not-ready), the proxying requests to it were causing failures.

Ref #9312 

cc @jszczepkowski @quinton-hoole @davidopp 
