### PR TITLE
Fix invocation of quay.io etcd in mesos getting started guide

### DIFF
--- a/docs/getting-started-guides/mesos.md
+++ b/docs/getting-started-guides/mesos.md
@@ -102,7 +102,10 @@ export KUBERNETES_MASTER=http://${KUBERNETES_MASTER_IP}:8888
 Start etcd and verify that it is running:
 
 ```bash
-sudo docker run -d --hostname $(uname -n) --name etcd -p 4001:4001 -p 7001:7001 quay.io/coreos/etcd:v2.0.12
+sudo docker run -d --hostname $(uname -n) --name etcd \
+  -p 4001:4001 -p 7001:7001 quay.io/coreos/etcd:v2.0.12 \
+  --listen-client-urls http://0.0.0.0:4001 \
+  --advertise-client-urls http://${KUBERNETES_MASTER_IP}:4001
 ```
 
 ```console


### PR DESCRIPTION
The quay.io version of etcd listens on 127.0.0.1 by default, not on the docker veth interface.
