### PR TITLE
Print env vars in kubectl describe pod

### DIFF
--- a/pkg/kubectl/describe_test.go
+++ b/pkg/kubectl/describe_test.go
@@ -182,6 +182,16 @@ func TestDescribeContainers(t *testing.T) {
 			},
 			expectedElements: []string{"test", "State", "Waiting", "Ready", "True", "Restart Count", "7", "Image", "image"},
 		},
+		//env
+		{
+			container: api.Container{Name: "test", Image: "image", Env: []api.EnvVar{{Name: "envname", Value: "xyz"}}},
+			status: api.ContainerStatus{
+				Name:         "test",
+				Ready:        true,
+				RestartCount: 7,
+			},
+			expectedElements: []string{"test", "State", "Waiting", "Ready", "True", "Restart Count", "7", "Image", "image", "envname", "xyz"},
+		},
 		// Using limits.
 		{
 			container: api.Container{


### PR DESCRIPTION
print env vars in kubectl describe pod
Signed-off-by: Sam Abed samabed@gmail.com
fixes #5756
