### PR TITLE
Don't leak tickers during an exec probe

### DIFF
--- a/pkg/kubelet/dockertools/exec.go
+++ b/pkg/kubelet/dockertools/exec.go
@@ -123,7 +123,8 @@ func (*NativeExecHandler) ExecInContainer(client DockerInterface, container *doc
 	if err != nil {
 		return err
 	}
-	tick := time.Tick(2 * time.Second)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
 	count := 0
 	for {
 		inspect, err2 := client.InspectExec(execObj.ID)
@@ -143,7 +144,7 @@ func (*NativeExecHandler) ExecInContainer(client DockerInterface, container *doc
 			break
 		}
 
-		<-tick
+		<-ticker.C
 	}
 
 	return err

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -945,7 +945,8 @@ func (dm *DockerManager) RunInContainer(containerID string, cmd []string) ([]byt
 		glog.V(2).Infof("StartExec With error: %v", err)
 		return nil, err
 	}
-	tick := time.Tick(2 * time.Second)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
 	for {
 		inspect, err2 := dm.client.InspectExec(execObj.ID)
 		if err2 != nil {
@@ -959,7 +960,7 @@ func (dm *DockerManager) RunInContainer(containerID string, cmd []string) ([]byt
 			}
 			break
 		}
-		<-tick
+		<-ticker.C
 	}
 
 	return buf.Bytes(), err


### PR DESCRIPTION
Every call to tick adds a new ticker to the heap, which leads to unbounded cpu and heap usage if done periodically (tickers can't be automatically gc'd because they're in the timers list https://golang.org/src/runtime/time.go). This happens form the exec handler used to perform probes for kube-dns, so it happens periodically.

Eg: https://gist.github.com/bprashanth/503eb6f6dcbceb413aa5
@lavalamp and @dchen1107 are probably the best leads to review this.
