### PR TITLE
Set resource limit for kube-ui addon container.

### DIFF
--- a/cluster/addons/kube-ui/kube-ui-rc.yaml
+++ b/cluster/addons/kube-ui/kube-ui-rc.yaml
@@ -22,5 +22,9 @@ spec:
       containers:
       - name: kube-ui
         image: gcr.io/google_containers/kube-ui:v1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
         ports:
         - containerPort: 8080


### PR DESCRIPTION
This is what I left from #10653 for newly introduced addon container: kube-ui. Measurement is based on current default configuration for GCE / GKE (?) and AWS: 4 nodes, 30~50 pods per node.

Based on measurement, kube-ui uses tiny bit of resources on both cpu and memory. I decided to allocate 100m for cpu even they all use less than that since it matches today's default setting from LimitRange of default namespace anyway. For memory it uses ~10M after many poke and explore on ui. I allocated 50M to it. 

cc/ @zmerlynn @lavalamp @bgrant0607 
