### PR TITLE
make testclient threadsafe by guarding internal state with accessors

### DIFF
--- a/pkg/client/testclient/fake_endpoints.go
+++ b/pkg/client/testclient/fake_endpoints.go
@@ -51,8 +51,8 @@ func (c *FakeEndpoints) Delete(name string) error {
 }
 
 func (c *FakeEndpoints) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-endpoints", Value: resourceVersion})
-	return c.Fake.Watch, c.Fake.Err
+	c.Fake.Invokes(FakeAction{Action: "watch-endpoints", Value: resourceVersion}, nil)
+	return c.Fake.Watch, c.Fake.Err()
 }
 
 func (c *FakeEndpoints) Update(endpoints *api.Endpoints) (*api.Endpoints, error) {

--- a/pkg/client/testclient/fake_events.go
+++ b/pkg/client/testclient/fake_events.go
@@ -56,8 +56,8 @@ func (c *FakeEvents) Get(id string) (*api.Event, error) {
 
 // Watch starts watching for events matching the given selectors.
 func (c *FakeEvents) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-events", Value: resourceVersion})
-	return c.Fake.Watch, c.Fake.Err
+	c.Fake.Invokes(FakeAction{Action: "watch-events", Value: resourceVersion}, nil)
+	return c.Fake.Watch, c.Fake.Err()
 }
 
 // Search returns a list of events matching the specified object.
@@ -72,6 +72,6 @@ func (c *FakeEvents) Delete(name string) error {
 }
 
 func (c *FakeEvents) GetFieldSelector(involvedObjectName, involvedObjectNamespace, involvedObjectKind, involvedObjectUID *string) fields.Selector {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-field-selector"})
+	c.Fake.Invokes(FakeAction{Action: "get-field-selector"}, nil)
 	return fields.Everything()
 }

--- a/pkg/client/testclient/fake_limit_ranges.go
+++ b/pkg/client/testclient/fake_limit_ranges.go
@@ -56,6 +56,6 @@ func (c *FakeLimitRanges) Update(limitRange *api.LimitRange) (*api.LimitRange, e
 }
 
 func (c *FakeLimitRanges) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-limitRange", Value: resourceVersion})
+	c.Fake.Invokes(FakeAction{Action: "watch-limitRange", Value: resourceVersion}, nil)
 	return c.Fake.Watch, nil
 }

--- a/pkg/client/testclient/fake_namespaces.go
+++ b/pkg/client/testclient/fake_namespaces.go
@@ -45,8 +45,8 @@ func (c *FakeNamespaces) Delete(name string) error {
 }
 
 func (c *FakeNamespaces) Create(namespace *api.Namespace) (*api.Namespace, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "create-namespace"})
-	return &api.Namespace{}, c.Fake.Err
+	c.Fake.Invokes(FakeAction{Action: "create-namespace"}, nil)
+	return &api.Namespace{}, c.Fake.Err()
 }
 
 func (c *FakeNamespaces) Update(namespace *api.Namespace) (*api.Namespace, error) {
@@ -55,7 +55,7 @@ func (c *FakeNamespaces) Update(namespace *api.Namespace) (*api.Namespace, error
 }
 
 func (c *FakeNamespaces) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-namespaces", Value: resourceVersion})
+	c.Fake.Invokes(FakeAction{Action: "watch-namespaces", Value: resourceVersion}, nil)
 	return c.Fake.Watch, nil
 }
 

--- a/pkg/client/testclient/fake_nodes.go
+++ b/pkg/client/testclient/fake_nodes.go
@@ -60,6 +60,6 @@ func (c *FakeNodes) UpdateStatus(minion *api.Node) (*api.Node, error) {
 }
 
 func (c *FakeNodes) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-nodes", Value: resourceVersion})
-	return c.Fake.Watch, c.Fake.Err
+	c.Fake.Invokes(FakeAction{Action: "watch-nodes", Value: resourceVersion}, nil)
+	return c.Fake.Watch, c.Fake.Err()
 }

--- a/pkg/client/testclient/fake_persistent_volume_claims.go
+++ b/pkg/client/testclient/fake_persistent_volume_claims.go
@@ -59,6 +59,6 @@ func (c *FakePersistentVolumeClaims) UpdateStatus(claim *api.PersistentVolumeCla
 }
 
 func (c *FakePersistentVolumeClaims) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-persistentVolumeClaims", Value: resourceVersion})
-	return c.Fake.Watch, c.Fake.Err
+	c.Fake.Invokes(FakeAction{Action: "watch-persistentVolumeClaims", Value: resourceVersion}, nil)
+	return c.Fake.Watch, c.Fake.Err()
 }

--- a/pkg/client/testclient/fake_persistent_volumes.go
+++ b/pkg/client/testclient/fake_persistent_volumes.go
@@ -59,6 +59,6 @@ func (c *FakePersistentVolumes) UpdateStatus(pv *api.PersistentVolume) (*api.Per
 }
 
 func (c *FakePersistentVolumes) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-persistentVolumes", Value: resourceVersion})
-	return c.Fake.Watch, c.Fake.Err
+	c.Fake.Invokes(FakeAction{Action: "watch-persistentVolumes", Value: resourceVersion}, nil)
+	return c.Fake.Watch, c.Fake.Err()
 }

--- a/pkg/client/testclient/fake_pod_templates.go
+++ b/pkg/client/testclient/fake_pod_templates.go
@@ -56,6 +56,6 @@ func (c *FakePodTemplates) Update(pod *api.PodTemplate) (*api.PodTemplate, error
 }
 
 func (c *FakePodTemplates) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-podTemplates", Value: resourceVersion})
-	return c.Fake.Watch, c.Fake.Err
+	c.Fake.Invokes(FakeAction{Action: "watch-podTemplates", Value: resourceVersion}, nil)
+	return c.Fake.Watch, c.Fake.Err()
 }

--- a/pkg/client/testclient/fake_pods.go
+++ b/pkg/client/testclient/fake_pods.go
@@ -56,12 +56,12 @@ func (c *FakePods) Update(pod *api.Pod) (*api.Pod, error) {
 }
 
 func (c *FakePods) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-pods", Value: resourceVersion})
-	return c.Fake.Watch, c.Fake.Err
+	c.Fake.Invokes(FakeAction{Action: "watch-pods", Value: resourceVersion}, nil)
+	return c.Fake.Watch, c.Fake.Err()
 }
 
 func (c *FakePods) Bind(bind *api.Binding) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "bind-pod", Value: bind.Name})
+	c.Fake.Invokes(FakeAction{Action: "bind-pod", Value: bind.Name}, nil)
 	return nil
 }
 

--- a/pkg/client/testclient/fake_replication_controllers.go
+++ b/pkg/client/testclient/fake_replication_controllers.go
@@ -65,6 +65,6 @@ func (c *FakeReplicationControllers) Delete(name string) error {
 }
 
 func (c *FakeReplicationControllers) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: WatchControllerAction, Value: resourceVersion})
+	c.Fake.Invokes(FakeAction{Action: WatchControllerAction, Value: resourceVersion}, nil)
 	return c.Fake.Watch, nil
 }

--- a/pkg/client/testclient/fake_resource_quotas.go
+++ b/pkg/client/testclient/fake_resource_quotas.go
@@ -61,6 +61,6 @@ func (c *FakeResourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (*ap
 }
 
 func (c *FakeResourceQuotas) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-resourceQuota", Value: resourceVersion})
+	c.Fake.Invokes(FakeAction{Action: "watch-resourceQuota", Value: resourceVersion}, nil)
 	return c.Fake.Watch, nil
 }

--- a/pkg/client/testclient/fake_secrets.go
+++ b/pkg/client/testclient/fake_secrets.go
@@ -56,6 +56,6 @@ func (c *FakeSecrets) Delete(name string) error {
 }
 
 func (c *FakeSecrets) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-secrets", Value: resourceVersion})
-	return c.Fake.Watch, c.Fake.Err
+	c.Fake.Invokes(FakeAction{Action: "watch-secrets", Value: resourceVersion}, nil)
+	return c.Fake.Watch, c.Fake.Err()
 }

--- a/pkg/client/testclient/fake_service_accounts.go
+++ b/pkg/client/testclient/fake_service_accounts.go
@@ -56,6 +56,6 @@ func (c *FakeServiceAccounts) Delete(name string) error {
 }
 
 func (c *FakeServiceAccounts) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-serviceAccounts", Value: resourceVersion})
-	return c.Fake.Watch, c.Fake.Err
+	c.Fake.Invokes(FakeAction{Action: "watch-serviceAccounts", Value: resourceVersion}, nil)
+	return c.Fake.Watch, c.Fake.Err()
 }

--- a/pkg/client/testclient/fake_services.go
+++ b/pkg/client/testclient/fake_services.go
@@ -56,6 +56,6 @@ func (c *FakeServices) Delete(name string) error {
 }
 
 func (c *FakeServices) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-services", Value: resourceVersion})
-	return c.Fake.Watch, c.Fake.Err
+	c.Fake.Invokes(FakeAction{Action: "watch-services", Value: resourceVersion}, nil)
+	return c.Fake.Watch, c.Fake.Err()
 }

--- a/pkg/cloudprovider/nodecontroller/nodecontroller_test.go
+++ b/pkg/cloudprovider/nodecontroller/nodecontroller_test.go
@@ -342,7 +342,7 @@ func TestMonitorNodeStatusEvictPods(t *testing.T) {
 
 		podEvictor.TryEvict(func(nodeName string) { nodeController.deletePods(nodeName) })
 		podEvicted := false
-		for _, action := range item.fakeNodeHandler.Actions {
+		for _, action := range item.fakeNodeHandler.Actions() {
 			if action.Action == "delete-pod" {
 				podEvicted = true
 			}

--- a/pkg/controller/replication/replication_controller_test.go
+++ b/pkg/controller/replication/replication_controller_test.go
@@ -693,7 +693,7 @@ func TestControllerUpdateStatusWithFailure(t *testing.T) {
 	numReplicas := 10
 	updateReplicaCount(fakeRCClient, *rc, numReplicas)
 	updates, gets := 0, 0
-	for _, a := range fakeClient.Actions {
+	for _, a := range fakeClient.Actions() {
 		switch a.Action {
 		case testclient.GetControllerAction:
 			gets++

--- a/pkg/kubectl/rolling_updater_test.go
+++ b/pkg/kubectl/rolling_updater_test.go
@@ -74,19 +74,19 @@ func (c *fakeRc) Get(name string) (*api.ReplicationController, error) {
 	if len(c.responses) == 0 {
 		return nil, fmt.Errorf("Unexpected Action: %s", action)
 	}
-	c.Fake.Actions = append(c.Fake.Actions, action)
+	c.Fake.Invokes(action, nil)
 	result := c.responses[0]
 	c.responses = c.responses[1:]
 	return result.controller, result.err
 }
 
 func (c *fakeRc) Create(controller *api.ReplicationController) (*api.ReplicationController, error) {
-	c.Fake.Actions = append(c.Fake.Actions, testclient.FakeAction{Action: "create-controller", Value: controller.ObjectMeta.Name})
+	c.Fake.Invokes(testclient.FakeAction{Action: "create-controller", Value: controller.ObjectMeta.Name}, nil)
 	return controller, nil
 }
 
 func (c *fakeRc) Update(controller *api.ReplicationController) (*api.ReplicationController, error) {
-	c.Fake.Actions = append(c.Fake.Actions, testclient.FakeAction{Action: "update-controller", Value: controller.ObjectMeta.Name})
+	c.Fake.Invokes(testclient.FakeAction{Action: "update-controller", Value: controller.ObjectMeta.Name}, nil)
 	return controller, nil
 }
 

--- a/pkg/kubectl/scale_test.go
+++ b/pkg/kubectl/scale_test.go
@@ -73,14 +73,15 @@ func TestReplicationControllerScale(t *testing.T) {
 	name := "foo"
 	scaler.Scale("default", name, count, &preconditions, nil, nil)
 
-	if len(fake.Actions) != 2 {
-		t.Errorf("unexpected actions: %v, expected 2 actions (get, update)", fake.Actions)
+	actions := fake.Actions()
+	if len(actions) != 2 {
+		t.Errorf("unexpected actions: %v, expected 2 actions (get, update)", actions)
 	}
-	if fake.Actions[0].Action != "get-replicationController" || fake.Actions[0].Value != name {
-		t.Errorf("unexpected action: %v, expected get-replicationController %s", fake.Actions[0], name)
+	if actions[0].Action != "get-replicationController" || actions[0].Value != name {
+		t.Errorf("unexpected action: %v, expected get-replicationController %s", actions[0], name)
 	}
-	if fake.Actions[1].Action != "update-replicationController" || fake.Actions[1].Value.(*api.ReplicationController).Spec.Replicas != int(count) {
-		t.Errorf("unexpected action %v, expected update-replicationController with replicas = %d", fake.Actions[1], count)
+	if actions[1].Action != "update-replicationController" || actions[1].Value.(*api.ReplicationController).Spec.Replicas != int(count) {
+		t.Errorf("unexpected action %v, expected update-replicationController with replicas = %d", actions[1], count)
 	}
 }
 
@@ -96,11 +97,12 @@ func TestReplicationControllerScaleFailsPreconditions(t *testing.T) {
 	name := "foo"
 	scaler.Scale("default", name, count, &preconditions, nil, nil)
 
-	if len(fake.Actions) != 1 {
-		t.Errorf("unexpected actions: %v, expected 2 actions (get, update)", fake.Actions)
+	actions := fake.Actions()
+	if len(actions) != 1 {
+		t.Errorf("unexpected actions: %v, expected 2 actions (get, update)", actions)
 	}
-	if fake.Actions[0].Action != "get-replicationController" || fake.Actions[0].Value != name {
-		t.Errorf("unexpected action: %v, expected get-replicationController %s", fake.Actions[0], name)
+	if actions[0].Action != "get-replicationController" || actions[0].Value != name {
+		t.Errorf("unexpected action: %v, expected get-replicationController %s", actions[0], name)
 	}
 }
 

--- a/pkg/kubectl/stop_test.go
+++ b/pkg/kubectl/stop_test.go
@@ -47,12 +47,13 @@ func TestReplicationControllerStop(t *testing.T) {
 	if s != expected {
 		t.Errorf("expected %s, got %s", expected, s)
 	}
-	if len(fake.Actions) != 7 {
+	actions := fake.Actions()
+	if len(actions) != 7 {
 		t.Errorf("unexpected actions: %v, expected 6 actions (get, list, get, update, get, get, delete)", fake.Actions)
 	}
 	for i, action := range []string{"get", "list", "get", "update", "get", "get", "delete"} {
-		if fake.Actions[i].Action != action+"-replicationController" {
-			t.Errorf("unexpected action: %+v, expected %s-replicationController", fake.Actions[i], action)
+		if actions[i].Action != action+"-replicationController" {
+			t.Errorf("unexpected action: %+v, expected %s-replicationController", actions[i], action)
 		}
 	}
 }
@@ -159,10 +160,11 @@ func TestSimpleStop(t *testing.T) {
 				t.Errorf("unexpected return: %s (%s)", s, test.test)
 			}
 		}
-		if len(test.actions) != len(fake.Actions) {
+		actions := fake.Actions()
+		if len(test.actions) != len(actions) {
 			t.Errorf("unexpected actions: %v; expected %v (%s)", fake.Actions, test.actions, test.test)
 		}
-		for i, action := range fake.Actions {
+		for i, action := range actions {
 			testAction := test.actions[i]
 			if action.Action != testAction {
 				t.Errorf("unexpected action: %v; expected %v (%s)", action, testAction, test.test)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2322,10 +2322,11 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 	if err := kubelet.updateNodeStatus(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if len(kubeClient.Actions) != 2 || kubeClient.Actions[1].Action != "update-status-node" {
-		t.Fatalf("unexpected actions: %v", kubeClient.Actions)
+	actions := kubeClient.Actions()
+	if len(actions) != 2 || actions[1].Action != "update-status-node" {
+		t.Fatalf("unexpected actions: %v", actions)
 	}
-	updatedNode, ok := kubeClient.Actions[1].Value.(*api.Node)
+	updatedNode, ok := actions[1].Value.(*api.Node)
 	if !ok {
 		t.Errorf("unexpected object type")
 	}
@@ -2419,10 +2420,11 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 	if err := kubelet.updateNodeStatus(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if len(kubeClient.Actions) != 2 {
-		t.Errorf("unexpected actions: %v", kubeClient.Actions)
+	actions := kubeClient.Actions()
+	if len(actions) != 2 {
+		t.Errorf("unexpected actions: %v", actions)
 	}
-	updatedNode, ok := kubeClient.Actions[1].Value.(*api.Node)
+	updatedNode, ok := actions[1].Value.(*api.Node)
 	if !ok {
 		t.Errorf("unexpected object type")
 	}
@@ -2506,10 +2508,11 @@ func TestUpdateNodeStatusWithoutContainerRuntime(t *testing.T) {
 	if err := kubelet.updateNodeStatus(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if len(kubeClient.Actions) != 2 || kubeClient.Actions[1].Action != "update-status-node" {
-		t.Fatalf("unexpected actions: %v", kubeClient.Actions)
+	actions := kubeClient.Actions()
+	if len(actions) != 2 || actions[1].Action != "update-status-node" {
+		t.Fatalf("unexpected actions: %v", actions)
 	}
-	updatedNode, ok := kubeClient.Actions[1].Value.(*api.Node)
+	updatedNode, ok := actions[1].Value.(*api.Node)
 	if !ok {
 		t.Errorf("unexpected object type")
 	}
@@ -2536,8 +2539,8 @@ func TestUpdateNodeStatusError(t *testing.T) {
 	if err := kubelet.updateNodeStatus(); err == nil {
 		t.Errorf("unexpected non error: %v", err)
 	}
-	if len(testKubelet.fakeKubeClient.Actions) != nodeStatusUpdateRetry {
-		t.Errorf("unexpected actions: %v", testKubelet.fakeKubeClient.Actions)
+	if len(testKubelet.fakeKubeClient.Actions()) != nodeStatusUpdateRetry {
+		t.Errorf("unexpected actions: %v", testKubelet.fakeKubeClient.Actions())
 	}
 }
 

--- a/pkg/kubelet/status_manager_test.go
+++ b/pkg/kubelet/status_manager_test.go
@@ -53,7 +53,7 @@ func getRandomPodStatus() api.PodStatus {
 }
 
 func verifyActions(t *testing.T, kubeClient client.Interface, expectedActions []string) {
-	actions := kubeClient.(*testclient.Fake).Actions
+	actions := kubeClient.(*testclient.Fake).Actions()
 	if len(actions) != len(expectedActions) {
 		t.Errorf("unexpected actions, got: %s expected: %s", actions, expectedActions)
 		return

--- a/pkg/namespace/namespace_controller_test.go
+++ b/pkg/namespace/namespace_controller_test.go
@@ -53,13 +53,14 @@ func TestFinalize(t *testing.T) {
 		},
 	}
 	finalize(mockClient, testNamespace)
-	if len(mockClient.Actions) != 1 {
-		t.Errorf("Expected 1 mock client action, but got %v", len(mockClient.Actions))
+	actions := mockClient.Actions()
+	if len(actions) != 1 {
+		t.Errorf("Expected 1 mock client action, but got %v", len(actions))
 	}
-	if mockClient.Actions[0].Action != "finalize-namespace" {
-		t.Errorf("Expected finalize-namespace action %v", mockClient.Actions[0].Action)
+	if actions[0].Action != "finalize-namespace" {
+		t.Errorf("Expected finalize-namespace action %v", actions[0].Action)
 	}
-	finalizers := mockClient.Actions[0].Value.(*api.Namespace).Spec.Finalizers
+	finalizers := actions[0].Value.(*api.Namespace).Spec.Finalizers
 	if len(finalizers) != 1 {
 		t.Errorf("There should be a single finalizer remaining")
 	}
@@ -100,8 +101,8 @@ func TestSyncNamespaceThatIsTerminating(t *testing.T) {
 		"finalize-namespace",
 		"delete-namespace")
 	actionSet := util.NewStringSet()
-	for i := range mockClient.Actions {
-		actionSet.Insert(mockClient.Actions[i].Action)
+	for _, action := range mockClient.Actions() {
+		actionSet.Insert(action.Action)
 	}
 	if !actionSet.HasAll(expectedActionSet.List()...) {
 		t.Errorf("Expected actions: %v, but got: %v", expectedActionSet, actionSet)
@@ -127,8 +128,8 @@ func TestSyncNamespaceThatIsActive(t *testing.T) {
 		t.Errorf("Unexpected error when synching namespace %v", err)
 	}
 	actionSet := util.NewStringSet()
-	for i := range mockClient.Actions {
-		actionSet.Insert(mockClient.Actions[i].Action)
+	for _, action := range mockClient.Actions() {
+		actionSet.Insert(action.Action)
 	}
 	if len(actionSet) != 0 {
 		t.Errorf("Expected no action from controller, but got: %v", actionSet)

--- a/pkg/resourcequota/resource_quota_controller_test.go
+++ b/pkg/resourcequota/resource_quota_controller_test.go
@@ -158,7 +158,7 @@ func TestSyncResourceQuota(t *testing.T) {
 		t.Fatalf("Unexpected error %v", err)
 	}
 
-	usage := kubeClient.Actions[1].Value.(*api.ResourceQuota)
+	usage := kubeClient.Actions()[1].Value.(*api.ResourceQuota)
 
 	// ensure hard and used limits are what we expected
 	for k, v := range expectedUsage.Status.Hard {
@@ -216,7 +216,7 @@ func TestSyncResourceQuotaSpecChange(t *testing.T) {
 		t.Fatalf("Unexpected error %v", err)
 	}
 
-	usage := kubeClient.Actions[1].Value.(*api.ResourceQuota)
+	usage := kubeClient.Actions()[1].Value.(*api.ResourceQuota)
 
 	// ensure hard and used limits are what we expected
 	for k, v := range expectedUsage.Status.Hard {
@@ -263,7 +263,8 @@ func TestSyncResourceQuotaNoChange(t *testing.T) {
 		t.Fatalf("Unexpected error %v", err)
 	}
 
-	if len(kubeClient.Actions) != 1 && kubeClient.Actions[0].Action != "list-pods" {
+	actions := kubeClient.Actions()
+	if len(actions) != 1 && actions[0].Action != "list-pods" {
 		t.Errorf("SyncResourceQuota made an unexpected client action when state was not dirty: %v", kubeClient.Actions)
 	}
 }

--- a/pkg/serviceaccount/serviceaccounts_controller_test.go
+++ b/pkg/serviceaccount/serviceaccounts_controller_test.go
@@ -192,12 +192,13 @@ func TestServiceAccountCreation(t *testing.T) {
 			controller.serviceAccountDeleted(tc.DeletedServiceAccount)
 		}
 
-		if len(tc.ExpectCreatedServiceAccounts) != len(client.Actions) {
-			t.Errorf("%s: Expected to create accounts %#v. Actual actions were: %#v", k, tc.ExpectCreatedServiceAccounts, client.Actions)
+		actions := client.Actions()
+		if len(tc.ExpectCreatedServiceAccounts) != len(actions) {
+			t.Errorf("%s: Expected to create accounts %#v. Actual actions were: %#v", k, tc.ExpectCreatedServiceAccounts, actions)
 			continue
 		}
 		for i, expectedName := range tc.ExpectCreatedServiceAccounts {
-			action := client.Actions[i]
+			action := actions[i]
 			if action.Action != "create-serviceaccount" {
 				t.Errorf("%s: Unexpected action %s", k, action.Action)
 				break

--- a/pkg/serviceaccount/tokens_controller_test.go
+++ b/pkg/serviceaccount/tokens_controller_test.go
@@ -462,9 +462,10 @@ func TestTokenCreation(t *testing.T) {
 			controller.secretDeleted(tc.DeletedSecret)
 		}
 
-		for i, action := range client.Actions {
+		actions := client.Actions()
+		for i, action := range actions {
 			if len(tc.ExpectedActions) < i+1 {
-				t.Errorf("%s: %d unexpected actions: %+v", k, len(client.Actions)-len(tc.ExpectedActions), client.Actions[i:])
+				t.Errorf("%s: %d unexpected actions: %+v", k, len(actions)-len(tc.ExpectedActions), actions[i:])
 				break
 			}
 
@@ -479,8 +480,8 @@ func TestTokenCreation(t *testing.T) {
 			}
 		}
 
-		if len(tc.ExpectedActions) > len(client.Actions) {
-			t.Errorf("%s: %d additional expected actions:%+v", k, len(tc.ExpectedActions)-len(client.Actions), tc.ExpectedActions[len(client.Actions):])
+		if len(tc.ExpectedActions) > len(actions) {
+			t.Errorf("%s: %d additional expected actions:%+v", k, len(tc.ExpectedActions)-len(actions), tc.ExpectedActions[len(actions):])
 		}
 	}
 }

--- a/plugin/pkg/admission/namespace/autoprovision/admission_test.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission_test.go
@@ -45,10 +45,11 @@ func TestAdmission(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler")
 	}
-	if len(mockClient.Actions) != 1 {
+	actions := mockClient.Actions()
+	if len(actions) != 1 {
 		t.Errorf("Expected a create-namespace request")
 	}
-	if mockClient.Actions[0].Action != "create-namespace" {
+	if actions[0].Action != "create-namespace" {
 		t.Errorf("Expected a create-namespace request to be made via the client")
 	}
 }
@@ -76,7 +77,7 @@ func TestAdmissionNamespaceExists(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler")
 	}
-	if len(mockClient.Actions) != 0 {
+	if len(mockClient.Actions()) != 0 {
 		t.Errorf("No client request should have been made")
 	}
 }
@@ -97,7 +98,7 @@ func TestIgnoreAdmission(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler")
 	}
-	if len(mockClient.Actions) != 0 {
+	if len(mockClient.Actions()) != 0 {
 		t.Errorf("No client request should have been made")
 	}
 }
@@ -105,9 +106,9 @@ func TestIgnoreAdmission(t *testing.T) {
 // TestAdmissionNamespaceExistsUnknownToHandler
 func TestAdmissionNamespaceExistsUnknownToHandler(t *testing.T) {
 	namespace := "test"
-	mockClient := &testclient.Fake{
-		Err: errors.NewAlreadyExists("namespaces", namespace),
-	}
+	mockClient := &testclient.Fake{}
+	mockClient.SetErr(errors.NewAlreadyExists("namespaces", namespace))
+
 	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
 	handler := &provision{
 		client: mockClient,


### PR DESCRIPTION
Often this client is used async with a controller. Calls to Get, Watch will cause data races and lead to flaky tests. This PR locks mutable internal state in the testclient

Fixes  #10768 #9843

@smarterclayton as this will affect downstream tests.
