### PR TITLE
Clean up UI docs

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,7 +1,14 @@
-# Kubernetes UI Instructions
+# Kubernetes User Interface
+Kubernetes has an extensible user interface with default functionality that describes the current cluster. It is accessible via `https://<kubernetes-master>/ui`, which redirects to `https://<kubernetes-master>/api/v1/proxy/namespaces/kube-system/services/kube-ui/#/dashboard/`.
 
-## Kubernetes User Interface
-Kubernetes has an extensible user interface with default functionality that describes the current cluster. See the [README](../www/README.md) in the www directory for more information.
+## Running the UI
+The UI is run by default as a [cluster addon](../cluster/addons/README.md) through the [kube-ui](../cluster/addons/kube-ui) service. It is accessible via `https://<kubernetes-master>/ui`, which redirects to `https://<kubernetes-master>/api/v1/proxy/namespaces/kube-system/services/kube-ui/#/dashboard/`.
+
+If the [`kube-addons.sh`](../cluster/saltbase/salt/kube-addons/kube-addons.sh) script is not running, the kube-ui service will not be started. In this case, it can be started manually with:
+```sh
+kubectl create -f cluster/addons/kube-ui/kube-ui-rc.yaml
+kubectl create -f cluster/addons/kube-ui/kube-ui-svc.yaml
+```
 
 ### Running locally
 Assuming that you have a cluster running locally at `localhost:8080`, as described [here](getting-started-guides/locally.md), you can run the UI against it with kubectl:
@@ -14,7 +21,7 @@ You should now be able to access it by visiting [localhost:8001](http://localhos
 
 You can also use other web servers to serve the contents of the www/app directory, as described [here](../www/README.md#serving-the-app-during-development).
 
-### Running remotely
-When Kubernetes is deployed remotely, the UI is deployed as a cluster addon. To access it, visit `/ui`, which redirects to `/api/v1/proxy/namespaces/default/services/kube-ui/#/dashboard/`, on your master server.
+## Development
+Kubernetes UI development is described [here](../www/README.md).
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/ui.md?pixel)]()

--- a/www/README.md
+++ b/www/README.md
@@ -88,7 +88,7 @@ https://<kubernetes-master>/ui/
 which redirects to:
 
 ```
-https://<kubernetes-master>/api/v1/proxy/namespaces/default/services/kube-ui/
+https://<kubernetes-master>/api/v1/proxy/namespaces/kube-system/services/kube-ui/
 ```
 
 ## Configuration


### PR DESCRIPTION
Updated ui.md to include details about how the UI is run as a cluster addon, and where to find it. Also, make it more clear that www/README.md is for development, and not general dashboard UI information.

Changes motived by #10697
Partially addresses #10097
