### PR TITLE
Add liveness probe to kube-ui

### DIFF
--- a/cluster/addons/kube-ui/kube-ui-rc.yaml
+++ b/cluster/addons/kube-ui/kube-ui-rc.yaml
@@ -24,3 +24,9 @@ spec:
         image: gcr.io/google_containers/kube-ui:v1
         ports:
         - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 30
+          timeoutSeconds: 5


### PR DESCRIPTION
This would be better if kube-ui had a /healthz endpoint, but it should at least keep it up now.
