### PR TITLE
Don't ignore containers restarting during tests

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -43,6 +43,9 @@ import (
 // NodeStartupThreshold is a rough estimate of the time allocated for a pod to start on a node.
 const NodeStartupThreshold = 4 * time.Second
 
+// Maximum container failures this test tolerates before failing.
+var MaxContainerFailures = 0
+
 // podLatencyData encapsulates pod startup latency information.
 type podLatencyData struct {
 	// Name of the pod
@@ -190,14 +193,14 @@ var _ = Describe("Density", func() {
 			fileHndl, err := os.Create(fmt.Sprintf(testContext.OutputDir+"/%s/pod_states.csv", uuid))
 			expectNoError(err)
 			defer fileHndl.Close()
-
 			config := RCConfig{Client: c,
-				Image:         "gcr.io/google_containers/pause:go",
-				Name:          RCName,
-				Namespace:     ns,
-				PollInterval:  itArg.interval,
-				PodStatusFile: fileHndl,
-				Replicas:      totalPods,
+				Image:                "gcr.io/google_containers/pause:go",
+				Name:                 RCName,
+				Namespace:            ns,
+				PollInterval:         itArg.interval,
+				PodStatusFile:        fileHndl,
+				Replicas:             totalPods,
+				MaxContainerFailures: &MaxContainerFailures,
 			}
 
 			// Create a listener for events.

--- a/test/e2e/kubelet_stats.go
+++ b/test/e2e/kubelet_stats.go
@@ -162,7 +162,7 @@ func HighLatencyKubeletOperations(c *client.Client, threshold time.Duration, nod
 	}
 	sort.Sort(KubeletMetricByLatency(metric))
 	var badMetrics []KubeletMetric
-	Logf("Latency metrics for node %v", nodeName)
+	Logf("\nLatency metrics for node %v", nodeName)
 	for _, m := range metric {
 		if m.Latency > threshold {
 			badMetrics = append(badMetrics, m)


### PR DESCRIPTION
Containers restarting is a serious issue, no one like their database whacked without reason. Instead of ignoring them I'd rather work toward adding the clarity we need to debug it, when it happens. 
/ref https://github.com/GoogleCloudPlatform/kubernetes/issues/10720

@gmarek @davidopp  

I ran density a few times on a small cluster, nothing restarted. Plan to try the same on a larger cluster tomorrow. 
