### PR TITLE
`kubectl proxy` supports picking random unused port, add e2e test

### DIFF
--- a/docs/man/man1/kubectl-proxy.1
+++ b/docs/man/man1/kubectl-proxy.1
@@ -60,7 +60,7 @@ The above lets you 'curl localhost:8001/custom/api/v1/pods'
 
 .PP
 \fB\-p\fP, \fB\-\-port\fP=8001
-    The port on which to run the proxy.
+    The port on which to run the proxy. Set to 0 to pick a random port.
 
 .PP
 \fB\-\-reject\-methods\fP="POST,PUT,PATCH"
@@ -184,6 +184,10 @@ The above lets you 'curl localhost:8001/custom/api/v1/pods'
 .nf
 // Run a proxy to kubernetes apiserver on port 8011, serving static content from ./local/www/
 $ kubectl proxy \-\-port=8011 \-\-www=./local/www/
+
+// Run a proxy to kubernetes apiserver on an arbitrary local port.
+// The chosen port for the server will be output to stdout.
+$ kubectl proxy \-\-port=0
 
 // Run a proxy to kubernetes apiserver, changing the api prefix to k8s\-api
 // This makes e.g. the pods api available at localhost:8011/k8s\-api/v1/pods/

--- a/docs/user-guide/kubectl/kubectl_proxy.md
+++ b/docs/user-guide/kubectl/kubectl_proxy.md
@@ -65,6 +65,10 @@ kubectl proxy [--port=PORT] [--www=static-dir] [--www-prefix=prefix] [--api-pref
 // Run a proxy to kubernetes apiserver on port 8011, serving static content from ./local/www/
 $ kubectl proxy --port=8011 --www=./local/www/
 
+// Run a proxy to kubernetes apiserver on an arbitrary local port.
+// The chosen port for the server will be output to stdout.
+$ kubectl proxy --port=0
+
 // Run a proxy to kubernetes apiserver, changing the api prefix to k8s-api
 // This makes e.g. the pods api available at localhost:8011/k8s-api/v1/pods/
 $ kubectl proxy --api-prefix=/k8s-api
@@ -78,7 +82,7 @@ $ kubectl proxy --api-prefix=/k8s-api
       --api-prefix="/api/": Prefix to serve the proxied API under.
       --disable-filter=false: If true, disable request filtering in the proxy. This is dangerous, and can leave you vulnerable to XSRF attacks.  Use with caution.
   -h, --help=false: help for proxy
-  -p, --port=8001: The port on which to run the proxy.
+  -p, --port=8001: The port on which to run the proxy. Set to 0 to pick a random port.
       --reject-methods="POST,PUT,PATCH": Regular expression for HTTP methods that the proxy should reject.
       --reject-paths="^/api/.*/exec,^/api/.*/run": Regular expression for paths that the proxy should reject.
   -w, --www="": Also serve static files from the given directory under the specified prefix.

--- a/pkg/kubectl/proxy_server_test.go
+++ b/pkg/kubectl/proxy_server_test.go
@@ -287,7 +287,7 @@ func TestPathHandling(t *testing.T) {
 
 	for _, item := range table {
 		func() {
-			p, err := NewProxyServer("", item.prefix, "/not/used/for/this/test", nil, cc)
+			p, err := NewProxyServer(0, "", item.prefix, "/not/used/for/this/test", nil, cc)
 			if err != nil {
 				t.Fatalf("%#v: %v", item, err)
 			}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -887,6 +887,13 @@ func startCmdAndStreamOutput(cmd *exec.Cmd) (stdout, stderr io.ReadCloser, err e
 	return
 }
 
+// Rough equivalent of ctrl+c for cleaning up processes. Intended to be run in defer.
+func tryKill(cmd *exec.Cmd) {
+	if err := cmd.Process.Kill(); err != nil {
+		Logf("ERROR failed to kill command %v! The process may leak", cmd)
+	}
+}
+
 // testContainerOutputInNamespace runs the given pod in the given namespace and waits
 // for all of the containers in the podSpec to move into the 'Success' status.  It retrieves
 // the exact container log and searches for lines of expected output.


### PR DESCRIPTION
Explicitly support`--port 0` to pick a random unused port. This functionality existed previously but was undocumented. Changed command to output the port after Listener is created so users can tell what port proxy is running on, and updated help text. 
Default command behavior unchanged, but we could make picking random unused port the default (`-p` default to 0) to be consistent with `kubectl port-forward`.
Note that the primary motivation for the code change is to make `kubectl proxy` testable by the included e2e test (specifying explicit port would be unlikely to work, especially when test is run in parallel on jenkins).
#10764

cc @bgrant0607, @nikhiljindal  
