### PR TITLE
Increase DNS test's timeout to 5 minutes to reduce flakiness

### DIFF
--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -128,7 +128,7 @@ func createProbeCommand(namesToResolve []string, fileNamePrefix string) (string,
 func assertFilesExist(fileNames []string, fileDir string, pod *api.Pod, client *client.Client) {
 	var failed []string
 
-	expectNoError(wait.Poll(time.Second*2, time.Second*60, func() (bool, error) {
+	expectNoError(wait.Poll(time.Second*2, time.Minute*5, func() (bool, error) {
 		failed = []string{}
 		for _, fileName := range fileNames {
 			if _, err := client.Get().

--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -128,6 +128,7 @@ func createProbeCommand(namesToResolve []string, fileNamePrefix string) (string,
 func assertFilesExist(fileNames []string, fileDir string, pod *api.Pod, client *client.Client) {
 	var failed []string
 
+	start := time.Now()
 	expectNoError(wait.Poll(time.Second*2, time.Minute*5, func() (bool, error) {
 		failed = []string{}
 		for _, fileName := range fileNames {
@@ -148,6 +149,7 @@ func assertFilesExist(fileNames []string, fileDir string, pod *api.Pod, client *
 		Logf("Lookups using %s failed for: %v\n", pod.Name, failed)
 		return false, nil
 	}))
+	Logf("Reading files from pods took %v\n", time.Since(start))
 	Expect(len(failed)).To(Equal(0))
 }
 


### PR DESCRIPTION
Increase DNS test's timeout from 60 seconds to 5 minutes to reduce flakiness.  At least 2 successful runs took > 40 seconds, so 60 seconds seems short.
