### PR TITLE
build: Fix docker image lookup for docker 1.6+

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -272,7 +272,7 @@ function kube::build::docker_image_exists() {
 
   # We cannot just specify the IMAGE here as `docker images` doesn't behave as
   # expected.  See: https://github.com/docker/docker/issues/8048
-  "${DOCKER[@]}" images | grep -Eq "^${1}\s+${2}\s+"
+  "${DOCKER[@]}" images | grep -Eq "^(\S+/)?${1}\s+${2}\s+"
 }
 
 # Takes $1 and computes a short has for it. Useful for unique tag generation


### PR DESCRIPTION
Some versions of docker display image listings like this:

```
docker.io/golang    1.4                 ebd45caf377c        2 weeks ago
```

The regular expression used to detect presence of images
needs to be updated. It's unfortunate that we're still
screen-scaping here, due to:

https://github.com/docker/docker/issues/8048
