### PR TITLE
Fix up alignment of columns w/ namespaces.

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -103,16 +103,21 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 	if len(args) == 0 {
 		fmt.Fprint(out, `
 You must specify the type of resource to get. Valid resource types include:
-   * pods (aka 'po')
-   * replicationcontrollers (aka 'rc')
-   * services
-   * nodes (aka 'no')
+   * componentStatuses (aka 'cs')
+   * endpoints (aka 'ep')
    * events (aka 'ev')
-   * secrets
    * limits
-   * persistentVolumes (aka 'pv')
+   * namespaces
+   * nodes (aka 'no')
    * persistentVolumeClaims (aka 'pvc')
+   * persistentVolumes (aka 'pv')
+   * pods (aka 'po')
+   * podTemplates
    * quota
+   * replicationcontrollers (aka 'rc')
+   * secrets
+   * serviceAccounts
+   * services
 `)
 		return errors.New("Required resource not specified.")
 	}

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -254,6 +254,8 @@ func (h *HumanReadablePrinter) HandledResources() []string {
 	return keys
 }
 
+// NOTE: When adding a new resource type here, please update the list
+// pkg/kubectl/cmd/get.go to reflect the new resource type.
 var podColumns = []string{"NAME", "READY", "STATUS", "RESTARTS", "AGE"}
 var podTemplateColumns = []string{"TEMPLATE", "CONTAINER(S)", "IMAGE(S)", "PODLABELS"}
 var replicationControllerColumns = []string{"CONTROLLER", "CONTAINER(S)", "IMAGE(S)", "SELECTOR", "REPLICAS"}

--- a/pkg/util/line_delimiter.go
+++ b/pkg/util/line_delimiter.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	"io"
+	"strings"
+)
+
+// A Line Delimiter is a filter that will
+type LineDelimiter struct {
+	output    io.Writer
+	delimiter []byte
+	buf       bytes.Buffer
+}
+
+// NewLineDelimiter allocates a new io.Writer that will split input on lines
+// and bracket each line with the delimiter string.  This can be useful in
+// output tests where it is difficult to see and test trailing whitespace.
+func NewLineDelimiter(output io.Writer, delimiter string) *LineDelimiter {
+	return &LineDelimiter{output: output, delimiter: []byte(delimiter)}
+}
+
+// Write writes buf to the LineDelimiter ld. The only errors returned are ones
+// encountered while writing to the underlying output stream.
+func (ld *LineDelimiter) Write(buf []byte) (n int, err error) {
+	return ld.buf.Write(buf)
+}
+
+// Flush all lines up until now.  This will assume insert a linebreak at the current point of the stream.
+func (ld *LineDelimiter) Flush() (err error) {
+	lines := strings.Split(ld.buf.String(), "\n")
+	for _, line := range lines {
+		if _, err = ld.output.Write(ld.delimiter); err != nil {
+			return
+		}
+		if _, err = ld.output.Write([]byte(line)); err != nil {
+			return
+		}
+		if _, err = ld.output.Write(ld.delimiter); err != nil {
+			return
+		}
+		if _, err = ld.output.Write([]byte("\n")); err != nil {
+			return
+		}
+	}
+	return
+}

--- a/pkg/util/line_delimiter_test.go
+++ b/pkg/util/line_delimiter_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"os"
+)
+
+func ExampleTrailingNewline() {
+	ld := NewLineDelimiter(os.Stdout, "|")
+	defer ld.Flush()
+	fmt.Fprint(ld, "  Hello  \n  World  \n")
+	// Output:
+	// |  Hello  |
+	// |  World  |
+	// ||
+}
+func ExampleNoTrailingNewline() {
+	ld := NewLineDelimiter(os.Stdout, "|")
+	defer ld.Flush()
+	fmt.Fprint(ld, "  Hello  \n  World  ")
+	// Output:
+	// |  Hello  |
+	// |  World  |
+}


### PR DESCRIPTION
Fixes #10842

All issues for types that use "extra lines" for extended information.  Two issues fixed: (1) When namespaces are listed an extra column isn't inserted for extra lines and (2) trailing tabs aren't inserted when label columns are specified.

This code should probably move to a more explicit model of putting data into "cells".

Also updated list of resources for help output for `kubectl get`.
