### PR TITLE
Fully update gcloud before Jenkins runs

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -217,6 +217,9 @@ if [[ "${E2E_UP,,}" == "true" ]]; then
         # other.
         export KUBE_SKIP_UPDATE=y
         sudo flock -x -n /var/run/lock/gcloud-components.lock -c "gcloud components update -q" || true
+        sudo flock -x -n /var/run/lock/gcloud-components.lock -c "gcloud components update preview -q" || true
+        sudo flock -x -n /var/run/lock/gcloud-components.lock -c "gcloud components update alpha -q" || true
+        sudo flock -x -n /var/run/lock/gcloud-components.lock -c "gcloud components update beta -q" || true
 
         if [[ ! -z ${JENKINS_EXPLICIT_VERSION:-} ]]; then
             # Use an explicit pinned version like "ci/v0.10.0-101-g6c814c4" or


### PR DESCRIPTION
Is there a reason we don't do this already?

Here is all of the verify-prereqs code, which installs the necessary gcloud components:
https://github.com/GoogleCloudPlatform/kubernetes/blob/master/cluster/gke/util.sh#L101

However, we prevent that code from running here:
https://github.com/GoogleCloudPlatform/kubernetes/blob/master/hack/jenkins/e2e.sh#L218

Then, this command will fail if preview isn't installed:
https://github.com/GoogleCloudPlatform/kubernetes/blob/master/cluster/gke/util.sh#L246

As can be seen in this Jenkins run:
[http://goto.google.com/k8s-test/view/Upgrade%20Test%20-%20GKE/job/kubernetes-upgrade-gke-step1-deploy/687/console](http://goto.google.com/k8s-test/view/Upgrade%20Test%20-%20GKE/job/kubernetes-upgrade-gke-step1-deploy/687/console)
