### PR TITLE
Resolves #9773, vmware_fusion can't find component

### DIFF
--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -83,7 +83,12 @@ function verify-prereqs {
 
   if [ -z "${provider_found}" ]; then
     if [ -n "${VAGRANT_DEFAULT_PROVIDER}" ]; then
-      echo "Can't find the necessary components for the ${VAGRANT_DEFAULT_PROVIDER} vagrant provider, please fix and retry."
+      echo "Can't find the necessary components for the ${VAGRANT_DEFAULT_PROVIDER} vagrant provider."
+      echo "Possible reasons could be: "
+      echo -e "\t- vmrun utility is not in your path"
+      echo -e "\t- Vagrant plugin was not found."
+      echo -e "\t- VAGRANT_DEFAULT_PROVIDER is set, but not found."
+      echo "Please fix and retry."
     else
       echo "Can't find the necessary components for any viable vagrant providers (e.g., virtualbox), please fix and retry."
     fi


### PR DESCRIPTION
The error message thrown when the KUBERNETES_PROVIDER is vagrant and the
vagrant plugin cannot be found is ambiguous. This does not change
functionality, just provides more feedback as to the source of the
error.
