### PR TITLE
Update release notes tool and documentation

### DIFF
--- a/build/make-release-notes.sh
+++ b/build/make-release-notes.sh
@@ -27,7 +27,8 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 if [[ -z "${1:-}" ]]; then
-  echo "Usage: ${0} <pr-number> [opts]"
+  echo "Usage: ${0} <last-release-pr-number> <current-release-pr-number> --api-token=$TOKEN [opts]"
+  echo "To create a GitHub API token, see https://github.com/settings/tokens"
   exit 1
 fi
 
@@ -36,6 +37,7 @@ trap 'pop_dir' INT TERM EXIT
 
 kube::golang::build_binaries contrib/release-notes
 kube::golang::place_bins
+echo "Fetching release notes"
 releasenotes=$(kube::util::find-binary "release-notes")
-"${releasenotes}" --last-release-pr=${1} ${@}
+"${releasenotes}" --last-release-pr=${1} --current-release-pr=${2} ${@}
 

--- a/contrib/release-notes/README.md
+++ b/contrib/release-notes/README.md
@@ -1,8 +1,23 @@
 ## A simple tool that scrapes the github API to build a starting point for release notes.
 
 ### Usage
+Find the rollup PR number that was most-recently merged into the previous .0 release.
+ * Note: The most-recent PR included in the release, but not the PR that cuts the release.
+ * Something like: LAST_RELEASE_PR=$(git log v0.19.0 | grep "Merge pull request" | head -1)
+ * ... but check the log manually to confirm.
+
+Find the rollup PR number that was most-recently merged into the current .0 release.
+ * Something like: CURRENT_RELEASE_PR=$(git log v0.20.0 | grep "Merge pull request" | head -1)
+ * ... but check the log manually to confirm.
+
+You'll need to manually remove any PRs there were cherrypicked into the previous release's patch versions.
+
+There are too many PRs for the tool to work without an api-token.  See https://github.com/settings/tokens to generate one."
+
+
 ```bash
-${KUBERNETES_ROOT}/build/make-release-notes.sh <pr-number>
+${KUBERNETES_ROOT}/build/make-release-notes.sh --last-release-pr=<pr-number> --current-release-pr=<pr-number> --api-token=<github-api-token>
+
 ```
 
 

--- a/contrib/release-notes/release-notes.go
+++ b/contrib/release-notes/release-notes.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	target  int
+	last    int
 	current int
 	token   string
 )
@@ -42,20 +42,20 @@ func (a ByMerged) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a ByMerged) Less(i, j int) bool { return a[i].MergedAt.Before(*a[j].MergedAt) }
 
 func init() {
-	flag.IntVar(&target, "last-release-pr", 0, "The PR number of the last versioned release.")
+	flag.IntVar(&last, "last-release-pr", 0, "The PR number of the last versioned release.")
 	flag.IntVar(&current, "current-release-pr", 0, "The PR number of the current versioned release.")
-	flag.StringVar(&token, "api-token", "", "Github api token for rate limiting. See https://developer.github.com/v3/#rate-limiting.")
+	flag.StringVar(&token, "api-token", "", "Github api token for rate limiting. Background: https://developer.github.com/v3/#rate-limiting and create a token: https://github.com/settings/tokens")
 }
 
 func main() {
 	flag.Parse()
 	// Automatically determine this from github.
-	if target == 0 {
+	if last == 0 {
 		fmt.Printf("--last-release-pr is required.\n")
 		os.Exit(1)
 	}
 	if current == 0 {
-		fmt.Printf("--curent-release-pr is required.\n")
+		fmt.Printf("--current-release-pr is required.\n")
 		os.Exit(1)
 	}
 	var tc *http.Client
@@ -85,34 +85,43 @@ func main() {
 	buffer := &bytes.Buffer{}
 	prs := []*github.PullRequest{}
 	var lastVersionMerged *time.Time
-	var currentVersionCreated *time.Time
+	var currentVersionMerged *time.Time
 	for !done {
 		opts.Page++
+		fmt.Printf("Fetching PR list page %2d\n", opts.Page)
 		results, _, err := client.PullRequests.List("GoogleCloudPlatform", "kubernetes", &opts)
 		if err != nil {
 			fmt.Printf("Error contacting github: %v", err)
 			os.Exit(1)
 		}
+		unmerged := 0
+		merged := 0
 		for ix := range results {
 			result := &results[ix]
 			// Skip Closed but not Merged PRs
 			if result.MergedAt == nil {
+				unmerged++
 				continue
 			}
-			if *result.Number == target {
+			if *result.Number == last {
 				done = true
 				lastVersionMerged = result.MergedAt
+				fmt.Printf(" ... found last PR %d.\n", last)
 				break
 			}
 			if *result.Number == current {
-				currentVersionCreated = result.CreatedAt
+				currentVersionMerged = result.MergedAt
+				fmt.Printf(" ... found current PR %d.\n", current)
 			}
 			prs = append(prs, result)
+			merged++
 		}
+		fmt.Printf(" ... %d merged PRs, %d unmerged PRs.\n", merged, unmerged)
 	}
+	fmt.Printf("Compiling pretty-printed list of PRs...\n")
 	sort.Sort(ByMerged(prs))
 	for _, pr := range prs {
-		if lastVersionMerged.Before(*pr.MergedAt) && pr.MergedAt.Before(*currentVersionCreated) {
+		if lastVersionMerged.Before(*pr.MergedAt) && (pr.MergedAt.Before(*currentVersionMerged) || (*pr.Number == current)) {
 			fmt.Fprintf(buffer, "   * %s #%d (%s)\n", *pr.Title, *pr.Number, *pr.User.Login)
 		}
 	}

--- a/docs/devel/making-release-notes.md
+++ b/docs/devel/making-release-notes.md
@@ -2,17 +2,21 @@
 This documents the process for making release notes for a release.
 
 ### 1) Note the PR number of the previous release
-Find the PR that was merged with the previous release.  Remember this number
+Find the most-recent PR that was merged with the previous .0 release.  Remember this as $LASTPR.
 _TODO_: Figure out a way to record this somewhere to save the next release engineer time.
 
-### 2) Build the release-notes tool
+Find the most-recent PR that was merged with the current .0 release.  Remeber this as $CURRENTPR.
+
+### 2) Run the release-notes tool
 ```bash
-${KUBERNETES_ROOT}/build/make-release-notes.sh <pr-number-from-1>
+${KUBERNETES_ROOT}/build/make-release-notes.sh $LASTPR $CURRENTPR
 ```
 
 ### 3) Trim the release notes
-This generates a list of the entire set of PRs merged since the last release.  It is likely long
-and many PRs aren't worth mentioning.
+This generates a list of the entire set of PRs merged since the last minor
+release.  It is likely long and many PRs aren't worth mentioning.  If any of the
+PRs were cherrypicked into patches on the last minor release, you should exclude
+them from the current release's notes.
 
 Open up ```candidate-notes.md``` in your favorite editor.
 


### PR DESCRIPTION
- Document how to fetch github api tokens
- Make it easier to find the 2 PR commits for last and current release.
- Have the tool actually require the two PRs explicitly.
- Fix the tool to print PRs between the rollup PR and the cut-branch PR.
