### PR TITLE
Add more logging to scheduler predicates to help debugging max_pods e2e test flakyness

### DIFF
--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -23,6 +23,8 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm"
+
+	"github.com/golang/glog"
 )
 
 type NodeInfo interface {
@@ -150,8 +152,10 @@ func (r *ResourceFit) PodFitsResources(pod *api.Pod, existingPods []*api.Pod, no
 	pods = append(existingPods, pod)
 	_, exceeding := CheckPodsExceedingCapacity(pods, info.Status.Capacity)
 	if len(exceeding) > 0 || int64(len(pods)) > info.Status.Capacity.Pods().Value() {
+		glog.V(4).Infof("Cannot schedule Pod %v, because Node %v is full, running %v out of %v Pods.", pod, node, len(pods)-1, info.Status.Capacity.Pods().Value())
 		return false, nil
 	}
+	glog.V(4).Infof("Schedule Pod %v on Node %v is allowed, Node is running only %v out of %v Pods.", pod, node, len(pods)-1, info.Status.Capacity.Pods().Value())
 	return true, nil
 }
 


### PR DESCRIPTION
I'd also need to increase verbosity for Jenkins flaky test suite #10915. 
