### PR TITLE
Promote ElasticSearch test to non-flaky suite

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -68,7 +68,6 @@ fi
 # Specialized tests which should be skipped by default for projects.
 GCE_DEFAULT_SKIP_TEST_REGEX="\
 Skipped|\
-Density|\
 Reboot|\
 Restart|\
 Example\
@@ -76,8 +75,7 @@ Example\
 # The following tests are known to be flaky, and are thus run only in their own
 # -flaky- build variants.
 GCE_FLAKY_TEST_REGEX="\
-Elasticsearch\
-|Shell.*services\
+Shell.*services\
 |MaxPods.*\
 "
 # Tests which are not able to be run in parallel.
@@ -92,10 +90,10 @@ ${GCE_DEFAULT_SKIP_TEST_REGEX}\
 # Tests which are known to be flaky when run in parallel.
 # TODO: figure out why GCE_FLAKY_TEST_REGEX is not a perfect subset of this list.
 GCE_PARALLEL_FLAKY_TEST_REGEX="\
-Addon\
-|Elasticsearch\
+Elasticsearch\
 |Hostdir.*MOD\
-|Networking.*intra|PD\
+|Networking.*intra\
+|PD\
 |ServiceAccounts\
 |Service\sendpoints\slatency\
 |Services.*change\sthe\stype\


### PR DESCRIPTION
This test didn't fail during last 70 runs.

Also small cleanup:
- all Density tests have "Skipped" in their name, so there is no need to explicitly mentioning them
- "Addon" test were promoted to non-flaky suite yesterday but I forgot to remove it from parallel-flaky

cc @quinton-hoole @davidopp @satnam6502 
