### PR TITLE
Update the web ui (kube-ui) pod to v1.1

### DIFF
--- a/cluster/addons/kube-ui/kube-ui-rc.yaml
+++ b/cluster/addons/kube-ui/kube-ui-rc.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: kube-ui
-        image: gcr.io/google_containers/kube-ui:v1
+        image: gcr.io/google_containers/kube-ui:v1.1
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
Updates the default kube-ui container version to 1.1 as discussed in #10645.

ref: #10625

cc/ @lavalamp 
