### PR TITLE
Fix reference to kube-ui proxy path

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -88,7 +88,7 @@ https://<kubernetes-master>/ui/
 which redirects to:
 
 ```
-https://<kubernetes-master>/api/v1/proxy/namespaces/default/services/kube-ui/
+https://<kubernetes-master>/api/v1/proxy/namespaces/kube-system/services/kube-ui/
 ```
 
 ## Configuration


### PR DESCRIPTION
Update docs to reflect move of kube-ui to kube-system namespace.

This is the un-merged portion of #10784 
