### PR TITLE
examples/cassandra - image version inc and reduced cpu requirements

### DIFF
--- a/examples/cassandra/README.md
+++ b/examples/cassandra/README.md
@@ -30,7 +30,7 @@ spec:
     resources:
       limits:
         cpu: "0.5"
-    image: gcr.io/google_containers/cassandra:v4
+    image: gcr.io/google_containers/cassandra:v5
     name: cassandra
     ports:
     - name: cql
@@ -166,7 +166,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: gcr.io/google_containers/cassandra:v4
+          image: gcr.io/google_containers/cassandra:v5
           name: cassandra
           ports:
             - containerPort: 9042

--- a/examples/cassandra/cassandra-controller.yaml
+++ b/examples/cassandra/cassandra-controller.yaml
@@ -18,7 +18,7 @@ spec:
             - /run.sh
           resources:
             limits:
-              cpu: 0.5
+              cpu: 0.1
           env:
             - name: MAX_HEAP_SIZE
               value: 512M
@@ -28,7 +28,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: gcr.io/google_containers/cassandra:v4
+          image: gcr.io/google_containers/cassandra:v5
           name: cassandra
           ports:
             - containerPort: 9042

--- a/examples/cassandra/cassandra.yaml
+++ b/examples/cassandra/cassandra.yaml
@@ -10,8 +10,8 @@ spec:
     - /run.sh
     resources:
       limits:
-        cpu: "0.5"
-    image: gcr.io/google_containers/cassandra:v4
+        cpu: "0.1"
+    image: gcr.io/google_containers/cassandra:v5
     name: cassandra
     ports:
     - name: cql


### PR DESCRIPTION
This PR is needed to make #10231 effective and fully fix #10034. Reduced cpu requirement will make scheduling Cassandra possible on a 2 node cluster (full of addons) used in e2e tests.
