### PR TITLE
Skip service tests that require external load balancer when using vagrant provider

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -327,6 +327,9 @@ var _ = Describe("Services", func() {
 	})
 
 	It("should be able to change the type and nodeport settings of a service", func() {
+		// requires ExternalLoadBalancer
+		SkipUnlessProviderIs("gce", "gke", "aws")
+
 		serviceName := "mutability-service-test"
 		ns := namespaces[0]
 
@@ -490,6 +493,9 @@ var _ = Describe("Services", func() {
 	})
 
 	It("should release the load balancer when Type goes from LoadBalancer -> NodePort", func() {
+		// requires ExternalLoadBalancer
+		SkipUnlessProviderIs("gce", "gke", "aws")
+
 		serviceName := "service-release-lb"
 		ns := namespaces[0]
 


### PR DESCRIPTION
I am working on getting the Vagrant cluster to pass @erictune conformance test suite (ideally all of e2e), and in the process found a couple tests that fail because they require an external load balancer and they were not being properly skipped.
