### PR TITLE
Fix error with variable re-declaration in ES logging test

### DIFF
--- a/test/e2e/es_cluster_logging.go
+++ b/test/e2e/es_cluster_logging.go
@@ -97,9 +97,10 @@ func ClusterLevelLoggingWithElasticsearch(f *Framework) {
 	var statusCode float64
 	var esResponse map[string]interface{}
 	err = nil
+	var body []byte
 	for start := time.Now(); time.Since(start) < graceTime; time.Sleep(5 * time.Second) {
 		// Query against the root URL for Elasticsearch.
-		body, err := f.Client.Get().
+		body, err = f.Client.Get().
 			Namespace(api.NamespaceSystem).
 			Prefix("proxy").
 			Resource("services").
@@ -143,7 +144,6 @@ func ClusterLevelLoggingWithElasticsearch(f *Framework) {
 	// Now assume we really are talking to an Elasticsearch instance.
 	// Check the cluster health.
 	By("Checking health of Elasticsearch service.")
-	var body []byte
 	for start := time.Now(); time.Since(start) < graceTime; time.Sleep(5 * time.Second) {
 		body, err = f.Client.Get().
 			Namespace(api.NamespaceSystem).


### PR DESCRIPTION
There is a bad redefinition of `err` which causes a failure to be masked.
@quinton-hoole 
