### PR TITLE
Use the exec-sidecar as a healthz probe for the syndns container

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -1,22 +1,22 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kube-dns-v6
+  name: kube-dns-v7
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v6
+    version: v7
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: {{ pillar['dns_replicas'] }}
   selector:
     k8s-app: kube-dns
-    version: v6
+    version: v7
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v6
+        version: v7
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
@@ -60,5 +60,24 @@ spec:
           protocol: UDP
         - containerPort: 53
           name: dns-tcp
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+      - name: healthz
+        image: gcr.io/google_containers/exechealthz:1.0
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+        args:
+        - -cmd=nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} localhost >/dev/null
+        - -port=8080
+        ports:
+        - containerPort: 8080
           protocol: TCP
       dnsPolicy: Default  # Don't use cluster DNS.


### PR DESCRIPTION
Gives kube-dns a liveness probe that uses the healthz-sidecar container. Also given etcd a emptyDir volume so cluster dns survives across etcd restarts.

Related: #10659, #10926, #10925
@dchen1107 @thockin
