### PR TITLE
Enable e2e networking test for intra-pod communication for vagrant

### DIFF
--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -103,8 +103,6 @@ var _ = Describe("Networking", func() {
 
 	//Now we can proceed with the test.
 	It("should function for intra-pod communication", func() {
-		// TODO: support DNS on vagrant #3580
-		SkipIfProviderIs("vagrant")
 
 		By(fmt.Sprintf("Creating a service named %q in namespace %q", svcname, f.Namespace.Name))
 		svc, err := f.Client.Services(f.Namespace.Name).Create(&api.Service{


### PR DESCRIPTION
This test passes without issue on the vagrant cluster at HEAD.
