### PR TITLE
Update Fedora Getting Started to indicate needs v0.18 or later

### DIFF
--- a/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -27,7 +27,7 @@ fed-node = 192.168.121.65
 
 **Prepare the hosts:**
     
-* Install kubernetes on all hosts - fed-{master,node}.  This will also pull in docker. Also install etcd on fed-master.  This guide has been tested with kubernetes-0.15.0 but should work with other versions too.
+* Install kubernetes on all hosts - fed-{master,node}.  This will also pull in docker. Also install etcd on fed-master.  This guide has been tested with kubernetes-0.18 and beyond.
 * The [--enablerepo=update-testing](https://fedoraproject.org/wiki/QA:Updates_Testing) directive in the yum command below will ensure that the most recent Kubernetes version that is scheduled for pre-release will be installed. This should be a more recent version than the Fedora "stable" release for Kubernetes that you would get without adding the directive. 
 * If you want the very latest Kubernetes release [you can download and yum install the RPM directly from Fedora Koji](http://koji.fedoraproject.org/koji/packageinfo?packageID=19202) instead of using the yum install command below.
 


### PR DESCRIPTION
The option --service-cluster-ip-range was introduced with kubernetes 0.18. So this fix changes tested version for this guide to 0.18 and beyond.

Signed-off-by: Avesh Agarwal avagarwa@redhat.com
