### PR TITLE
Fixed some kubelet related flag default value for v1.0

### DIFF
--- a/cluster/aws/coreos/node.yaml
+++ b/cluster/aws/coreos/node.yaml
@@ -67,7 +67,6 @@ coreos:
         ExecStart=/opt/kubernetes/server/bin/kubelet \
         --api_servers=https://${MASTER_IP} \
         --config=/etc/kubernetes/manifests \
-        --allow_privileged=False \
         --v=2 \
         --cluster_dns=10.0.0.10 \
         --cluster_domain=${DNS_DOMAIN} \

--- a/cluster/gce/coreos/node.yaml
+++ b/cluster/gce/coreos/node.yaml
@@ -144,7 +144,6 @@ coreos:
         ExecStart=/opt/kubernetes/server/bin/kubelet \
         --api_servers=https://${KUBERNETES_MASTER_NAME}.c.${PROJECT_ID}.internal \
         --config=/etc/kubernetes/manifests \
-        --allow_privileged=False \
         --v=2 \
         --cluster_dns=10.0.0.10 \
         --cluster_domain=cluster.local \

--- a/cluster/saltbase/pillar/privilege.sls
+++ b/cluster/saltbase/pillar/privilege.sls
@@ -1,2 +1,2 @@
 # If true, allow privileged containers to be created by API
-allow_privileged: false
+allow_privileged: true

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -84,4 +84,4 @@
   {% set pod_cidr = "--pod-cidr=" + grains['cbr-cidr'] %}
 {% endif %} 
 
-DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}} {{pod_cidr}}"
+DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{config}} --allow-privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}} {{pod_cidr}}"

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -206,7 +206,7 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.PodInfraContainerImage, "pod-infra-container-image", s.PodInfraContainerImage, "The image whose network/ipc namespaces containers in each pod will use.")
 	fs.StringVar(&s.DockerEndpoint, "docker-endpoint", s.DockerEndpoint, "If non-empty, use this for the docker endpoint to communicate with")
 	fs.StringVar(&s.RootDirectory, "root-dir", s.RootDirectory, "Directory path for managing kubelet files (volume mounts,etc).")
-	fs.BoolVar(&s.AllowPrivileged, "allow-privileged", s.AllowPrivileged, "If true, allow containers to request privileged mode. [default=false]")
+	fs.BoolVar(&s.AllowPrivileged, "allow-privileged", s.AllowPrivileged, "If true, allow containers to request privileged mode. [default=true]")
 	fs.StringVar(&s.HostNetworkSources, "host-network-sources", s.HostNetworkSources, "Comma-separated list of sources from which the Kubelet allows pods to use of host network. For all sources use \"*\" [default=\"file\"]")
 	fs.Float64Var(&s.RegistryPullQPS, "registry-qps", s.RegistryPullQPS, "If > 0, limit registry pull QPS to this value.  If 0, unlimited. [default=0.0]")
 	fs.IntVar(&s.RegistryBurst, "registry-burst", s.RegistryBurst, "Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry_qps.  Only used if --registry_qps > 0")

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -240,7 +240,7 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ContainerRuntime, "container_runtime", s.ContainerRuntime, "The container runtime to use. Possible values: 'docker', 'rkt'. Default: 'docker'.")
 	fs.StringVar(&s.SystemContainer, "system-container", s.SystemContainer, "Optional resource-only container in which to place all non-kernel processes that are not already in a container. Empty for no container. Rolling back the flag requires a reboot. (Default: \"\").")
 	fs.BoolVar(&s.ConfigureCBR0, "configure-cbr0", s.ConfigureCBR0, "If true, kubelet will configure cbr0 based on Node.Spec.PodCIDR.")
-	fs.IntVar(&s.MaxPods, "max-pods", 100, "Number of Pods that can run on this Kubelet.")
+	fs.IntVar(&s.MaxPods, "max-pods", 40, "Number of Pods that can run on this Kubelet.")
 	fs.StringVar(&s.DockerExecHandlerName, "docker-exec-handler", s.DockerExecHandlerName, "Handler to use when executing a command in a container. Valid values are 'native' and 'nsenter'. Defaults to 'native'.")
 	fs.StringVar(&s.PodCIDR, "pod-cidr", "", "The CIDR to use for pod IP addresses, only used in standalone mode.  In cluster mode, this is obtained from the master.")
 	// Flags intended for testing, not recommended used in production environments.

--- a/contrib/ansible/roles/kubernetes/templates/config.j2
+++ b/contrib/ansible/roles/kubernetes/templates/config.j2
@@ -16,8 +16,5 @@ KUBE_LOGTOSTDERR="--logtostderr=true"
 # journal message level, 0 is debug
 KUBE_LOG_LEVEL="--v=0"
 
-# Should this cluster be allowed to run privileged docker containers
-KUBE_ALLOW_PRIV="--allow_privileged=true"
-
 # How the replication controller, scheduler, and proxy
 KUBE_MASTER="--master=https://{{ groups['masters'][0] }}:443"

--- a/contrib/init/systemd/environ/config
+++ b/contrib/init/systemd/environ/config
@@ -15,8 +15,5 @@ KUBE_LOGTOSTDERR="--logtostderr=true"
 # journal message level, 0 is debug
 KUBE_LOG_LEVEL="--v=0"
 
-# Should this cluster be allowed to run privileged docker containers
-KUBE_ALLOW_PRIV="--allow_privileged=false"
-
 # How the controller-manager, scheduler, and proxy find the apiserver
 KUBE_MASTER="--master=http://127.0.0.1:8080"

--- a/docs/getting-started-guides/coreos/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/master.yaml
@@ -91,7 +91,6 @@ coreos:
         --service_account_lookup=false \
         --admission_control=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \
         --runtime_config=api/v1 \
-        --allow_privileged=true \
         --insecure_bind_address=0.0.0.0 \
         --insecure_port=8080 \
         --kubelet_https=true \

--- a/docs/getting-started-guides/coreos/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/node.yaml
@@ -86,7 +86,6 @@ coreos:
         --port=10250 \
         --hostname_override=${DEFAULT_IPV4} \
         --api_servers=<master-private-ip>:8080 \
-        --allow_privileged=true \
         --logtostderr=true \
         --cadvisor_port=4194 \
         --healthz_bind_address=0.0.0.0 \

--- a/docs/high-availability/kube-apiserver.manifest
+++ b/docs/high-availability/kube-apiserver.manifest
@@ -11,7 +11,7 @@
     "command": [
                  "/bin/sh",
                  "-c",
-                 "/usr/local/bin/kube-apiserver --address=127.0.0.1 --etcd_servers=http://127.0.0.1:4001 --cloud_provider=gce   --admission_control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota --service-cluster-ip-range=10.0.0.0/16 --client_ca_file=/srv/kubernetes/ca.crt --basic_auth_file=/srv/kubernetes/basic_auth.csv --cluster_name=e2e-test-bburns --tls_cert_file=/srv/kubernetes/server.cert --tls_private_key_file=/srv/kubernetes/server.key --secure_port=443 --token_auth_file=/srv/kubernetes/known_tokens.csv  --v=2 --allow_privileged=False 1>>/var/log/kube-apiserver.log 2>&1"
+                 "/usr/local/bin/kube-apiserver --address=127.0.0.1 --etcd_servers=http://127.0.0.1:4001 --cloud_provider=gce   --admission_control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota --service-cluster-ip-range=10.0.0.0/16 --client_ca_file=/srv/kubernetes/ca.crt --basic_auth_file=/srv/kubernetes/basic_auth.csv --cluster_name=e2e-test-bburns --tls_cert_file=/srv/kubernetes/server.cert --tls_private_key_file=/srv/kubernetes/server.key --secure_port=443 --token_auth_file=/srv/kubernetes/known_tokens.csv  --v=2 1>>/var/log/kube-apiserver.log 2>&1"
                ],
     "ports":[
       { "name": "https",

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -64,7 +64,7 @@ func Get() Capabilities {
 	// This check prevents clobbering of capabilities that might've been set via SetForTests
 	if capabilities == nil {
 		Initialize(Capabilities{
-			AllowPrivileged:    false,
+			AllowPrivileged:    true,
 			HostNetworkSources: []string{},
 		})
 	}


### PR DESCRIPTION
- changed --allow_privileged to --allow-privileged, which is defined: 
  https://github.com/GoogleCloudPlatform/kubernetes/blob/master/cmd/kubelet/app/server.go#L209
- Turn on allow_privileged by default for kubernetes. The user can disable it through salt's privilege.sls
- changed the default value of --max-pods to 40 from 100 based on v1.0 roadmap: 30 pods per node. Adding 10 more for kube-system pods. 

cc/ @bgrant0607 @thockin @davidopp @lavalamp 

cc/ @eparis  and @justinsb  for aws @bakins  for coreos
#10760 for document on how to disable this through salt configure.
