### PR TITLE
Automated cherry pick of #11028 and #11033 on upstream release 0.21

### DIFF
--- a/build/mark-new-version.sh
+++ b/build/mark-new-version.sh
@@ -101,7 +101,7 @@ for DOC in "${DOCS_TO_EDIT[@]}"; do
 done
 
 # Update API descriptions to match this version.
-$SED -ri -e "s|(releases.k8s.io)/HEAD|\1/${NEW_VERSION}|" pkg/api/v[0-9]*/types.go
+$SED -ri -e "s|(releases.k8s.io)/[^/]*|\1/${NEW_VERSION}|" pkg/api/v[0-9]*/types.go
 
 ${KUBE_ROOT}/hack/run-gendocs.sh
 ${KUBE_ROOT}/hack/update-swagger-spec.sh

--- a/build/mark-new-version.sh
+++ b/build/mark-new-version.sh
@@ -101,7 +101,7 @@ for DOC in "${DOCS_TO_EDIT[@]}"; do
 done
 
 # Update API descriptions to match this version.
-$SED -ri -e "s|(releases.k8s.io)/[^/]*|\1/${NEW_VERSION}|" pkg/api/v[0-9]*/types.go
+$SED -ri -e "s|(releases.k8s.io)/[^/]+|\1/${NEW_VERSION}|" pkg/api/v[0-9]*/types.go
 
 ${KUBE_ROOT}/hack/run-gendocs.sh
 ${KUBE_ROOT}/hack/update-swagger-spec.sh


### PR DESCRIPTION
#11033 is not in yet, but I am being presumptuous.

I verified this by running mark-new-release which does update release numbers in API docs.
