### PR TITLE
Updating the scripts to not delete v1beta3 conversions and copies

### DIFF
--- a/hack/update-generated-conversions.sh
+++ b/hack/update-generated-conversions.sh
@@ -49,6 +49,8 @@ EOF
 }
 
 VERSIONS="v1beta3 v1"
-for ver in $VERSIONS; do 
-	generate_version "${ver}"
+for ver in $VERSIONS; do
+  # Ensure that the version being processed is registered by setting
+  # KUBE_API_VERSIONS.
+  KUBE_API_VERSIONS="${ver}" generate_version "${ver}"
 done

--- a/hack/update-generated-deep-copies.sh
+++ b/hack/update-generated-deep-copies.sh
@@ -50,11 +50,21 @@ EOF
 	mv $TMPFILE `result_file_name ${version}`
 }
 
-VERSIONS="api v1beta3 v1"
-# To avoid compile errors, remove the currently existing files.
-for ver in $VERSIONS; do
-	rm -f `result_file_name ${ver}`
-done
-for ver in $VERSIONS; do 
-	generate_version "${ver}"
-done
+function generate_deep_copies() {
+  local versions="api v1beta3 v1"
+  # To avoid compile errors, remove the currently existing files.
+  for ver in ${versions}; do
+    rm -f `result_file_name ${ver}`
+  done
+  apiVersions=""
+  for ver in ${versions}; do
+    # Ensure that the version being processed is registered by setting
+    # KUBE_API_VERSIONS.
+    if [ "${ver}" != "api" ]; then
+      apiVersions="${ver}"
+    fi
+    KUBE_API_VERSIONS="${apiVersions}" generate_version "${ver}"
+  done
+}
+
+generate_deep_copies


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/11031

Running update-generated-conversions and update-generated-deep-copies deletes v1beta3 objects since that apiVersion is not registered by default anymore.
Users can change that by including v1beta3 in KUBE_API_VERSIONS, so we still need to generate the conversion and copy functions.

Updating our scripts to set KUBE_API_VERSIONS appropriately, so that we still keep generating the desired code for them.
