### PR TITLE
Move service env e2e out of default ns and remove dead code

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -893,11 +893,6 @@ func startCmdAndStreamOutput(cmd *exec.Cmd) (stdout, stderr io.ReadCloser, err e
 	return
 }
 
-// testContainerOutput runs testContainerOutputInNamespace with the default namespace.
-func testContainerOutput(scenarioName string, c *client.Client, pod *api.Pod, containerIndex int, expectedOutput []string) {
-	testContainerOutputInNamespace(scenarioName, c, pod, containerIndex, expectedOutput, api.NamespaceDefault)
-}
-
 // testContainerOutputInNamespace runs the given pod in the given namespace and waits
 // for all of the containers in the podSpec to move into the 'Success' status.  It retrieves
 // the exact container log and searches for lines of expected output.


### PR DESCRIPTION
I was making an e2e for the downward api example tonight and found that a bunch of the pod e2e tests run in the default namespace.  This fixes that situation and removes the `testContainerOutput` method.

@zmerlynn  
