### PR TITLE
Close resp.Body before returning error

### DIFF
--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -614,6 +614,9 @@ func (r *Request) Stream() (io.ReadCloser, error) {
 		return resp.Body, nil
 
 	default:
+		// ensure we close the body before returning the error
+		defer resp.Body.Close()
+
 		// we have a decent shot at taking the object returned, parsing it as a status object and returning a more normal error
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		if err != nil {

--- a/pkg/util/httpstream/spdy/roundtripper.go
+++ b/pkg/util/httpstream/spdy/roundtripper.go
@@ -132,6 +132,7 @@ func (s *SpdyRoundTripper) NewConnection(resp *http.Response) (httpstream.Connec
 	connectionHeader := strings.ToLower(resp.Header.Get(httpstream.HeaderConnection))
 	upgradeHeader := strings.ToLower(resp.Header.Get(httpstream.HeaderUpgrade))
 	if !strings.Contains(connectionHeader, strings.ToLower(httpstream.HeaderUpgrade)) || !strings.Contains(upgradeHeader, strings.ToLower(HeaderSpdy31)) {
+		defer resp.Body.Close()
 		responseError := ""
 		responseErrorBytes, err := ioutil.ReadAll(resp.Body)
 		if err != nil {


### PR DESCRIPTION
Fixes a leaked response body when an error is encountered initializing a Stream() operation or during a failed upgrade
