### PR TITLE
When releasing, update versions in title

### DIFF
--- a/build/mark-new-version.sh
+++ b/build/mark-new-version.sh
@@ -96,7 +96,7 @@ DOCS_TO_EDIT=(docs/README.md examples/README.md)
 for DOC in "${DOCS_TO_EDIT[@]}"; do
   $SED -ri \
       -e '/<!-- BEGIN STRIP_FOR_RELEASE -->/,/<!-- END STRIP_FOR_RELEASE -->/d' \
-      -e "s/HEAD/${NEW_VERSION}/" \
+      -e "s|(releases.k8s.io)/[^/]+|\1/${NEW_VERSION}|" \
       "${DOC}"
 done
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Kubernetes Documentation: HEAD
+# Kubernetes Documentation: releases.k8s.io/HEAD
 
 <!-- BEGIN STRIP_FOR_RELEASE -->
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,4 @@
-# Kubernetes Examples: HEAD
+# Kubernetes Examples: releases.k8s.io/HEAD
 
 <!-- BEGIN STRIP_FOR_RELEASE -->
 


### PR DESCRIPTION
When doing an x.y.(z>0) release, the title line was not updated.  This is a little less pretty, but less likely for the regex to screw up.
