### PR TITLE
Some users of vagrant were getting different ip addresses in cert

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -105,6 +105,7 @@ EOF
 mkdir -p /srv/salt-overlay/pillar
 cat <<EOF >/srv/salt-overlay/pillar/cluster-params.sls
   service_cluster_ip_range: '$(echo "$SERVICE_CLUSTER_IP_RANGE" | sed -e "s/'/''/g")'
+  cert_ip: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
   enable_cluster_monitoring: '$(echo "$ENABLE_CLUSTER_MONITORING" | sed -e "s/'/''/g")'
   enable_cluster_logging: '$(echo "$ENABLE_CLUSTER_LOGGING" | sed -e "s/'/''/g")'
   enable_node_logging: '$(echo "$ENABLE_NODE_LOGGING" | sed -e "s/'/''/g")'


### PR DESCRIPTION
Fixes #10972 

Cert should show following for all users (in case eth1 reports a value different than 10.245.1.2):

```
IP Address: 10.245.1.2
IP Address: 10.247.0.1
DNS Name: kubernetes
DNS Name: kubernetes.default
DNS Name: kubernetes.default.svc
DNS Name: kubernetes.default.svc.cluster.local
DNS Name: kubernetes-master
```
