### PR TITLE
add spec.host as a synonym for spec.nodeName in v1

### DIFF
--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -44,7 +44,7 @@ func addConversionFuncs() {
 				"status.phase",
 				"spec.nodeName":
 				return label, value, nil
-		    // This is for backwards compatability with old v1 clients which send spec.host
+				// This is for backwards compatability with old v1 clients which send spec.host
 			case "spec.host":
 				return "spec.nodeName", value, nil
 			default:

--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -44,6 +44,9 @@ func addConversionFuncs() {
 				"status.phase",
 				"spec.nodeName":
 				return label, value, nil
+		    // This is for backwards compatability with old v1 clients which send spec.host
+			case "spec.host":
+				return "spec.nodeName", value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)
 			}


### PR DESCRIPTION
This fixes a breaking change between different v1 api clients (0.19.3 to head)
