### PR TITLE
Automated cherry pick of #11084

### DIFF
--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -44,6 +44,9 @@ func addConversionFuncs() {
 				"status.phase",
 				"spec.nodeName":
 				return label, value, nil
+		    // This is for backwards compatability with old v1 clients which send spec.host
+			case "spec.host":
+				return "spec.nodeName", value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)
 			}


### PR DESCRIPTION
#11084 fixes a breaking v1 API change which prevents v0.19.x -> v0.21.x upgrades of master components. cc @brendandburns
