### PR TITLE
Fixed vnet create command

### DIFF
--- a/docs/getting-started-guides/azure.md
+++ b/docs/getting-started-guides/azure.md
@@ -37,7 +37,7 @@ Next, specify an existing virtual network and subnet in `cluster/azure/config-de
 
 You can create a virtual network:
 
-    azure network vnet create <vnet name> --subnet=<subnet name> --location "West US" -v
+    azure network vnet create <vnet name> --subnet-name=<subnet name> --location "West US" -v
 
 Now you're ready.
 


### PR DESCRIPTION
The parameter name should be `--subnet-name` instead of `--subnet` with the latest version of the CLI (0.9.5).
