### PR TITLE
Stop prompting for storage account type

### DIFF
--- a/cluster/azure/util.sh
+++ b/cluster/azure/util.sh
@@ -150,7 +150,7 @@ function upload-server-tars() {
     if [[ -z "$(azure_call storage account show $AZ_STG 2>/dev/null | \
     grep data)" ]]; then
         echo "--> Creating storage..."
-        azure_call storage account create -l "$AZ_LOCATION" $AZ_STG
+        azure_call storage account create -l "$AZ_LOCATION" $AZ_STG --type LRS
     fi
 
     echo "--> Getting storage key..."


### PR DESCRIPTION
`--type` is a mandatory parameter when creating a storage account, I used the cheapest one (Locally Redundant Storage). More details about the different types of storage can be found here: https://azure.microsoft.com/en-us/documentation/articles/storage-introduction/#replication-for-durability-and-high-availability
