### PR TITLE
e2e: AWS: Increase timeout on the node resize tests

### DIFF
--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -118,7 +118,13 @@ func waitForGroupSize(size int) error {
 }
 
 func waitForClusterSize(c *client.Client, size int) error {
-	for start := time.Now(); time.Since(start) < 4*time.Minute; time.Sleep(20 * time.Second) {
+	timeout := 4 * time.Minute
+	if providerIs("aws") {
+		// AWS is not as fast as gce/gke at having nodes come online
+		timeout = 10 * time.Minute
+	}
+
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(20 * time.Second) {
 		nodes, err := c.Nodes().List(labels.Everything(), fields.Everything())
 		if err != nil {
 			Logf("Failed to list nodes: %v", err)


### PR DESCRIPTION
Regularly hitting these timeouts, it seems that AWS is just slower to boot;
this makes sense - AWS uses a standard image for example, so has more software
to install (never mind any arguments about the clouds themselves!)
