### PR TITLE
Add namespace to kubectl create command

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -6,8 +6,8 @@ By default, the Kubernetes UI is deployed as a cluster addon. To access it, visi
 
 If you find that you're not able to access the UI, it may be because the kube-ui service has not been started on your cluster. In that case, you can start it manually with:
 ```sh
-kubectl create -f cluster/addons/kube-ui/kube-ui-rc.yaml
-kubectl create -f cluster/addons/kube-ui/kube-ui-svc.yaml
+kubectl create -f cluster/addons/kube-ui/kube-ui-rc.yaml --namespace=kube-system
+kubectl create -f cluster/addons/kube-ui/kube-ui-svc.yaml --namespace=kube-system
 ```
 Normally, this should be taken care of automatically by the [`kube-addons.sh`](../cluster/saltbase/salt/kube-addons/kube-addons.sh) script that runs on the master.
 


### PR DESCRIPTION
Running the `kubectl create` command, as prior, gives the following error.

```
the namespace from the provided object "kube-system" does not match the namespace 
"default". You must pass '--namespace=kube-system' to perform this operation.
```
