### PR TITLE
Add a note of api endpoint in Kubernetes on Mesos getting started guide

### DIFF
--- a/docs/getting-started-guides/mesos.md
+++ b/docs/getting-started-guides/mesos.md
@@ -64,6 +64,8 @@ $ export KUBERNETES_MASTER_IP=$(hostname -i)
 $ export KUBERNETES_MASTER=http://${KUBERNETES_MASTER_IP}:8888
 ```
 
+Note that KUBERNETES_MASTER is used as the api endpoint. If you have existing `~/.kube/config` and point to another endpoint, you need to add option `--server=${KUBERNETES_MASTER}` to kubectl in later steps.
+
 ### Deploy etcd
 Start etcd and verify that it is running:
 


### PR DESCRIPTION
Since master starts with `$(hostname -i):8888`, it is better to specify master IP and port explicitly.
