### PR TITLE
Fix TestRunExposeService

### DIFF
--- a/pkg/kubectl/cmd/expose_test.go
+++ b/pkg/kubectl/cmd/expose_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 func TestRunExposeService(t *testing.T) {
@@ -126,17 +127,17 @@ func TestRunExposeService(t *testing.T) {
 				Spec: api.ServiceSpec{
 					Ports: []api.ServicePort{
 						{
-							Name:     "default",
-							Protocol: api.Protocol("UDP"),
-							Port:     14,
+							Name:       "default",
+							Protocol:   api.Protocol("UDP"),
+							Port:       14,
+							TargetPort: util.NewIntOrStringFromInt(14),
 						},
 					},
 					Selector: map[string]string{"func": "stream"},
 					Type:     api.ServiceTypeLoadBalancer,
 				},
 			},
-			expected: "you will also need to explicitly open a firewall",
-			status:   200,
+			status: 200,
 		},
 	}
 


### PR DESCRIPTION
No longer emits "you will also need to explicitly open a firewall"
after #10974.

Fixes #11105
