### PR TITLE
Fix scheduler race

### DIFF
--- a/plugin/pkg/scheduler/modeler.go
+++ b/plugin/pkg/scheduler/modeler.go
@@ -191,5 +191,7 @@ type simpleModelerPods struct {
 
 // List returns pods known and assumed to exist.
 func (s simpleModelerPods) List(selector labels.Selector) (pods []*api.Pod, err error) {
-	return s.simpleModeler.listPods(selector)
+	s.simpleModeler.LockedAction(
+		func() { pods, err = s.simpleModeler.listPods(selector) })
+	return
 }


### PR DESCRIPTION
The scheduler counts pods by combining the pods in the scheduled and assumed pod stores. The listing needs a to be synchronized with the informer.

/ref https://github.com/GoogleCloudPlatform/kubernetes/issues/10720
@davidopp @gmarek @lavalamp 
