### PR TITLE
Automated cherry pick of #11147

### DIFF
--- a/pkg/kubectl/cmd/expose_test.go
+++ b/pkg/kubectl/cmd/expose_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 func TestRunExposeService(t *testing.T) {
@@ -126,17 +127,17 @@ func TestRunExposeService(t *testing.T) {
 				Spec: api.ServiceSpec{
 					Ports: []api.ServicePort{
 						{
-							Name:     "default",
-							Protocol: api.Protocol("UDP"),
-							Port:     14,
+							Name:       "default",
+							Protocol:   api.Protocol("UDP"),
+							Port:       14,
+							TargetPort: util.NewIntOrStringFromInt(14),
 						},
 					},
 					Selector: map[string]string{"func": "stream"},
 					Type:     api.ServiceTypeLoadBalancer,
 				},
 			},
-			expected: "you will also need to explicitly open a firewall",
-			status:   200,
+			status: 200,
 		},
 	}
 


### PR DESCRIPTION
#11147 fixes #11105 on `release-1.0`, so Shippable / unit tests will pass on the release branch.
