### PR TITLE
Kubelet checks max-pods in addition to cpu and memory

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -240,7 +240,7 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ContainerRuntime, "container_runtime", s.ContainerRuntime, "The container runtime to use. Possible values: 'docker', 'rkt'. Default: 'docker'.")
 	fs.StringVar(&s.SystemContainer, "system-container", s.SystemContainer, "Optional resource-only container in which to place all non-kernel processes that are not already in a container. Empty for no container. Rolling back the flag requires a reboot. (Default: \"\").")
 	fs.BoolVar(&s.ConfigureCBR0, "configure-cbr0", s.ConfigureCBR0, "If true, kubelet will configure cbr0 based on Node.Spec.PodCIDR.")
-	fs.IntVar(&s.MaxPods, "max-pods", 40, "Number of Pods that can run on this Kubelet.")
+	fs.IntVar(&s.MaxPods, "max-pods", kubelet.MaxPods, "Number of Pods that can run on this Kubelet.")
 	fs.StringVar(&s.DockerExecHandlerName, "docker-exec-handler", s.DockerExecHandlerName, "Handler to use when executing a command in a container. Valid values are 'native' and 'nsenter'. Defaults to 'native'.")
 	fs.StringVar(&s.PodCIDR, "pod-cidr", "", "The CIDR to use for pod IP addresses, only used in standalone mode.  In cluster mode, this is obtained from the master.")
 	// Flags intended for testing, not recommended used in production environments.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -78,6 +78,10 @@ const (
 
 	// Location of container logs.
 	containerLogsDir = "/var/log/containers"
+
+	// Default for the maximum number of pods this kubelet can handle.
+	// Configurable via the max-pods command line flag give to the kubelet server.
+	MaxPods = 40
 )
 
 var (
@@ -1580,6 +1584,7 @@ func (kl *Kubelet) checkCapacityExceeded(pods []*api.Pod) (fitting []*api.Pod, n
 	sort.Sort(podsByCreationTime(pods))
 
 	capacity := CapacityFromMachineInfo(info)
+	capacity[api.ResourcePods] = *resource.NewQuantity(int64(kl.pods), resource.DecimalSI)
 	return predicates.CheckPodsExceedingCapacity(pods, capacity)
 }
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -86,6 +86,7 @@ func newTestKubelet(t *testing.T) *TestKubelet {
 	kubelet.kubeClient = fakeKubeClient
 	kubelet.os = kubecontainer.FakeOS{}
 
+	kubelet.pods = MaxPods
 	kubelet.hostname = testKubeletHostname
 	kubelet.nodeName = testKubeletHostname
 	kubelet.runtimeUpThreshold = maxWaitForContainerRuntime
@@ -2139,6 +2140,44 @@ func TestHandleMemExceeded(t *testing.T) {
 	}
 }
 
+// Tests that we reject pods > max-pods.
+func TestMaxPods(t *testing.T) {
+	testKubelet := newTestKubelet(t)
+	kl := testKubelet.kubelet
+	kl.pods = 0
+	kl.nodeLister = testNodeLister{nodes: []api.Node{
+		{ObjectMeta: api.ObjectMeta{Name: testKubeletHostname}},
+	}}
+	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorApi.MachineInfo{}, nil)
+	testKubelet.fakeCadvisor.On("DockerImagesFsInfo").Return(cadvisorApiv2.FsInfo{}, nil)
+	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorApiv2.FsInfo{}, nil)
+	pods := []*api.Pod{
+		{
+			ObjectMeta: api.ObjectMeta{
+				Name:      "podA",
+				Namespace: "foo",
+			},
+		},
+		{
+			ObjectMeta: api.ObjectMeta{
+				Name:      "podB",
+				Namespace: "foo",
+			},
+		},
+	}
+	kl.handleNotFittingPods(pods)
+	for i := range pods {
+		notfittingPodName := kubecontainer.GetPodFullName(pods[i])
+		status, found := kl.statusManager.GetPodStatus(notfittingPodName)
+		if !found {
+			t.Fatalf("status of pod %q is not found in the status map", notfittingPodName)
+		}
+		if status.Phase != api.PodFailed || !strings.Contains(status.Reason, "CapacityExceeded") {
+			t.Fatalf("expected pod status %q. Got %q.", api.PodFailed, status.Phase)
+		}
+	}
+}
+
 // TODO(filipg): This test should be removed once StatusSyncer can do garbage collection without external signal.
 func TestPurgingObsoleteStatusMapEntries(t *testing.T) {
 	testKubelet := newTestKubelet(t)
@@ -2312,7 +2351,7 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 			Capacity: api.ResourceList{
 				api.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
 				api.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-				api.ResourcePods:   *resource.NewQuantity(0, resource.DecimalSI),
+				api.ResourcePods:   *resource.NewQuantity(MaxPods, resource.DecimalSI),
 			},
 			Addresses: []api.NodeAddress{{Type: api.NodeLegacyHostIP, Address: "127.0.0.1"}},
 		},
@@ -2363,7 +2402,7 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 				Capacity: api.ResourceList{
 					api.ResourceCPU:    *resource.NewMilliQuantity(3000, resource.DecimalSI),
 					api.ResourceMemory: *resource.NewQuantity(2048, resource.BinarySI),
-					api.ResourcePods:   *resource.NewQuantity(0, resource.DecimalSI),
+					api.ResourcePods:   *resource.NewQuantity(MaxPods, resource.DecimalSI),
 				},
 			},
 		},
@@ -2409,7 +2448,7 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 			Capacity: api.ResourceList{
 				api.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
 				api.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-				api.ResourcePods:   *resource.NewQuantity(0, resource.DecimalSI),
+				api.ResourcePods:   *resource.NewQuantity(MaxPods, resource.DecimalSI),
 			},
 			Addresses: []api.NodeAddress{{Type: api.NodeLegacyHostIP, Address: "127.0.0.1"}},
 		},
@@ -2495,7 +2534,7 @@ func TestUpdateNodeStatusWithoutContainerRuntime(t *testing.T) {
 			Capacity: api.ResourceList{
 				api.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
 				api.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-				api.ResourcePods:   *resource.NewQuantity(0, resource.DecimalSI),
+				api.ResourcePods:   *resource.NewQuantity(MaxPods, resource.DecimalSI),
 			},
 			Addresses: []api.NodeAddress{{Type: api.NodeLegacyHostIP, Address: "127.0.0.1"}},
 		},


### PR DESCRIPTION
Max-pods should be checked once in the scheduler, and again in the kubelet. We should never overcommit the node.

/ref #10720
@gmarek @davidopp
