### PR TITLE
fix mungedocs that is break verify on master

### DIFF
--- a/docs/getting-started-guides/README.md
+++ b/docs/getting-started-guides/README.md
@@ -22,7 +22,7 @@ If you are considering contributing a new guide, please read the
 
 IaaS Provider        | Config. Mgmt | OS     | Networking  | Docs                                                                           | Conforms    | Support Level                | Notes
 -------------------- | ------------ | ------ | ----------  | ------------------------------------------------------------------------------ | ----------- | ---------------------------- | -----
-GKE                  |              |        | GCE         | [docs](https://cloud.google.com/container-engine)                              | [✓](1)      | Commercial                   | Uses K8s version 0.15.0
+GKE                  |              |        | GCE         | [docs](https://cloud.google.com/container-engine)                              | ✓           | Commercial                   | Uses K8s version 0.15.0
 Vagrant              | Saltstack    | Fedora | OVS         | [docs](../../docs/getting-started-guides/vagrant.md)                           |             | Project                      | Uses latest via https://get.k8s.io/
 GCE                  | Saltstack    | Debian | GCE         | [docs](../../docs/getting-started-guides/gce.md)                               |             | Project                      | Tested with 0.15.0 by @robertbailey
 Azure                | CoreOS       | CoreOS | Weave       | [docs](../../docs/getting-started-guides/coreos/azure/README.md)               |             | Community ([@errordeveloper](https://github.com/errordeveloper), [@squillace](https://github.com/squillace), [@chanezon](https://github.com/chanezon), [@crossorigin](https://github.com/crossorigin)) | Uses K8s version 0.17.0

--- a/docs/getting-started-guides/README.md
+++ b/docs/getting-started-guides/README.md
@@ -22,7 +22,7 @@ If you are considering contributing a new guide, please read the
 
 IaaS Provider        | Config. Mgmt | OS     | Networking  | Docs                                                                           | Conforms    | Support Level                | Notes
 -------------------- | ------------ | ------ | ----------  | ------------------------------------------------------------------------------ | ----------- | ---------------------------- | -----
-GKE                  |              |        | GCE         | [docs](https://cloud.google.com/container-engine)                              | ✓           | Commercial                   | Uses K8s version 0.15.0
+GKE                  |              |        | GCE         | [docs](https://cloud.google.com/container-engine)                              | [✓] [1]     | Commercial                   | Uses K8s version 0.15.0
 Vagrant              | Saltstack    | Fedora | OVS         | [docs](../../docs/getting-started-guides/vagrant.md)                           |             | Project                      | Uses latest via https://get.k8s.io/
 GCE                  | Saltstack    | Debian | GCE         | [docs](../../docs/getting-started-guides/gce.md)                               |             | Project                      | Tested with 0.15.0 by @robertbailey
 Azure                | CoreOS       | CoreOS | Weave       | [docs](../../docs/getting-started-guides/coreos/azure/README.md)               |             | Community ([@errordeveloper](https://github.com/errordeveloper), [@squillace](https://github.com/squillace), [@chanezon](https://github.com/chanezon), [@crossorigin](https://github.com/crossorigin)) | Uses K8s version 0.17.0


### PR DESCRIPTION
@erictune was this intentional? It is being interpretted by github markdown and mungedocs as a link (and is broken). @thockin 
