### PR TITLE
Implement resource accounting for pods with the Mesos scheduler

### DIFF
--- a/contrib/mesos/docs/issues.md
+++ b/contrib/mesos/docs/issues.md
@@ -7,15 +7,6 @@ Upon further consideration it has been decided that a greater alignment between 
 Currently it is not possible to specify pod placement constraints for the kubernetes-mesos scheduler.
 This issue is being tracked here: https://github.com/mesosphere/kubernetes-mesos/issues/338
 
-### Resource Allocation
-
-Resource requirements (limits) specified on Kubernetes pods are currently ignored, both in the scheduler and on the node. Instead hardcoded values are used for the time being. This issue is being tracked here: https://github.com/mesosphere/kubernetes-mesos/issues/68.
-
-In general Mesos is designed to handle resource accounting and enforcement across the cluster. Part of that enforcement involves "growing" and "shrinking" the pool of resources allocated for executor containers.
-The current implementation of the kubelet-executor launches pods as Docker containers (just like the upstream kubelet) and makes no attempt to actually "contain" the pods that are launched.  Because the kubernetes-mesos scheduler cannot depend on the kubelet-executor to properly contain resources, it foregoes implementing accurate resource accounting.
-
-Recent changes to both the Docker and Kubernetes codebase have made it possible to implement the necessary changes in the kubelet-executor for proper pod containment. This is in the works and will be merged into a later version when ready.
-
 ### Ports
 
 Mesos typically defines `ports` resources for each slave and these ports are consumed by tasks, as they are launched, that require one or more host ports.
@@ -29,6 +20,13 @@ If slaves are configured to offer a `ports` resource range, for example [31000-3
 Ports declared outside that range (other than zero) will never match resource offers received by the k8sm scheduler, and so pod specifications that declare such ports will never be executed as tasks on the cluster.
 
 As opposed to Kubernetes proper, a missing pod container host port specification or a host port set to zero will allocate a host port from a resource offer.
+
+### Static Pods
+
+Static pods in general are supported by the k8sm-scheduler. The path of the pod definitions can be set via the `--static-pods-config` flag. There are two restrictions currently in that implementation:
+
+- static pods *must have resource limits* on cpu and memory in their container specs (compare the [k8sm architecture](architecture.md))
+- static pods *are read only once* by the k8sm-scheduler on startup. Only newly started executor will get the latest static pod specs from the defined static pod directory.
 
 ### Service Endpoints
 

--- a/contrib/mesos/pkg/archive/zip.go
+++ b/contrib/mesos/pkg/archive/zip.go
@@ -70,24 +70,24 @@ func ZipWalker(zw *zip.Writer) filepath.WalkFunc {
 
 // Create a zip of all files in a directory recursively, return a byte array and
 // the number of files archived.
-func ZipDir(path string) ([]byte, int, error) {
+func ZipDir(path string) ([]byte, []string, error) {
 	var buf bytes.Buffer
 	zw := zip.NewWriter(&buf)
 	zipWalker := ZipWalker(zw)
-	numberManifests := 0
+	paths := []string{}
 	err := filepath.Walk(path, filepath.WalkFunc(func(path string, info os.FileInfo, err error) error {
 		if !info.IsDir() {
-			numberManifests++
+			paths = append(paths, path)
 		}
 		return zipWalker(path, info, err)
 	}))
 
 	if err != nil {
-		return nil, 0, err
+		return nil, nil, err
 	} else if err = zw.Close(); err != nil {
-		return nil, 0, err
+		return nil, nil, err
 	}
-	return buf.Bytes(), numberManifests, nil
+	return buf.Bytes(), paths, nil
 }
 
 // UnzipDir unzips all files from a given zip byte array into a given directory.

--- a/contrib/mesos/pkg/scheduler/plugin_test.go
+++ b/contrib/mesos/pkg/scheduler/plugin_test.go
@@ -38,6 +38,7 @@ import (
 	schedcfg "github.com/GoogleCloudPlatform/kubernetes/contrib/mesos/pkg/scheduler/config"
 	"github.com/GoogleCloudPlatform/kubernetes/contrib/mesos/pkg/scheduler/ha"
 	"github.com/GoogleCloudPlatform/kubernetes/contrib/mesos/pkg/scheduler/podtask"
+	mresource "github.com/GoogleCloudPlatform/kubernetes/contrib/mesos/pkg/scheduler/resource"
 	log "github.com/golang/glog"
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	util "github.com/mesos/mesos-go/mesosutil"
@@ -388,10 +389,12 @@ func TestPlugin_LifeCycle(t *testing.T) {
 
 	// create scheduler
 	testScheduler := New(Config{
-		Executor:     executor,
-		Client:       client.NewOrDie(&client.Config{Host: testApiServer.server.URL, Version: testapi.Version()}),
-		ScheduleFunc: FCFSScheduleFunc,
-		Schedcfg:     *schedcfg.CreateDefaultConfig(),
+		Executor:                 executor,
+		Client:                   client.NewOrDie(&client.Config{Host: testApiServer.server.URL, Version: testapi.Version()}),
+		ScheduleFunc:             FCFSScheduleFunc,
+		Schedcfg:                 *schedcfg.CreateDefaultConfig(),
+		DefaultContainerCPULimit: mresource.DefaultDefaultContainerCPULimit,
+		DefaultContainerMemLimit: mresource.DefaultDefaultContainerMemLimit,
 	})
 
 	assert.NotNil(testScheduler.client, "client is nil")

--- a/contrib/mesos/pkg/scheduler/podtask/pod_task.go
+++ b/contrib/mesos/pkg/scheduler/podtask/pod_task.go
@@ -25,16 +25,13 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/contrib/mesos/pkg/offers"
 	annotation "github.com/GoogleCloudPlatform/kubernetes/contrib/mesos/pkg/scheduler/meta"
 	"github.com/GoogleCloudPlatform/kubernetes/contrib/mesos/pkg/scheduler/metrics"
+	mresource "github.com/GoogleCloudPlatform/kubernetes/contrib/mesos/pkg/scheduler/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/gogo/protobuf/proto"
+
 	log "github.com/golang/glog"
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	mutil "github.com/mesos/mesos-go/mesosutil"
-)
-
-const (
-	DefaultContainerCpus = 0.25 // initial CPU allocated for executor
-	DefaultContainerMem  = 64   // initial MB of memory allocated for executor
 )
 
 type StateType int
@@ -75,8 +72,8 @@ type T struct {
 
 type Spec struct {
 	SlaveID string
-	CPU     float64
-	Memory  float64
+	CPU     mresource.CPUShares
+	Memory  mresource.MegaBytes
 	PortMap []HostPortMapping
 	Ports   []uint64
 	Data    []byte
@@ -141,8 +138,8 @@ func (t *T) BuildTaskInfo() *mesos.TaskInfo {
 		Executor: t.executor,
 		Data:     t.Spec.Data,
 		Resources: []*mesos.Resource{
-			mutil.NewScalarResource("cpus", t.Spec.CPU),
-			mutil.NewScalarResource("mem", t.Spec.Memory),
+			mutil.NewScalarResource("cpus", float64(t.Spec.CPU)),
+			mutil.NewScalarResource("mem", float64(t.Spec.Memory)),
 		},
 	}
 	if portsResource := rangeResource("ports", t.Spec.Ports); portsResource != nil {
@@ -151,23 +148,25 @@ func (t *T) BuildTaskInfo() *mesos.TaskInfo {
 	return info
 }
 
-// Fill the Spec in the T, should be called during k8s scheduling,
-// before binding.
-// TODO(jdef): remove hardcoded values and make use of actual pod resource settings
+// Fill the Spec in the T, should be called during k8s scheduling, before binding.
 func (t *T) FillFromDetails(details *mesos.Offer) error {
 	if details == nil {
 		//programming error
 		panic("offer details are nil")
 	}
 
-	log.V(3).Infof("Recording offer(s) %v against pod %v", details.Id, t.Pod.Name)
+	// compute used resources
+	cpu := mresource.PodCPULimit(&t.Pod)
+	mem := mresource.PodMemLimit(&t.Pod)
+	log.V(3).Infof("Recording offer(s) %s/%s against pod %v: cpu: %.2f, mem: %.2f MB", details.Id, t.Pod.Namespace, t.Pod.Name, cpu, mem)
 
 	t.Spec = Spec{
 		SlaveID: details.GetSlaveId().GetValue(),
-		CPU:     DefaultContainerCpus,
-		Memory:  DefaultContainerMem,
+		CPU:     cpu,
+		Memory:  mem,
 	}
 
+	// fill in port mapping
 	if mapping, err := t.mapper.Generate(t, details); err != nil {
 		t.Reset()
 		return err
@@ -213,35 +212,39 @@ func (t *T) AcceptOffer(offer *mesos.Offer) bool {
 	if offer == nil {
 		return false
 	}
-	var (
-		cpus float64 = 0
-		mem  float64 = 0
-	)
-	for _, resource := range offer.Resources {
-		if resource.GetName() == "cpus" {
-			cpus = *resource.GetScalar().Value
-		}
 
-		if resource.GetName() == "mem" {
-			mem = *resource.GetScalar().Value
-		}
-	}
+	// check ports
 	if _, err := t.mapper.Generate(t, offer); err != nil {
 		log.V(3).Info(err)
 		return false
 	}
 
-	// for now hard-coded, constant values are used for cpus and mem. This is necessary
-	// until parent-cgroup integration is finished for mesos and k8sm. Then the k8sm
-	// executor can become the parent of pods and subsume their resource usage and
-	// therefore be compliant with expectations of mesos executors w/ respect to
-	// resource allocation and management.
-	//
-	// TODO(jdef): remove hardcoded values and make use of actual pod resource settings
-	if (cpus < DefaultContainerCpus) || (mem < DefaultContainerMem) {
-		log.V(3).Infof("not enough resources: cpus: %f mem: %f", cpus, mem)
+	// find offered cpu and mem
+	var (
+		offeredCpus mresource.CPUShares
+		offeredMem  mresource.MegaBytes
+	)
+	for _, resource := range offer.Resources {
+		if resource.GetName() == "cpus" {
+			offeredCpus = mresource.CPUShares(*resource.GetScalar().Value)
+		}
+
+		if resource.GetName() == "mem" {
+			offeredMem = mresource.MegaBytes(*resource.GetScalar().Value)
+		}
+	}
+
+	// calculate cpu and mem sum over all containers of the pod
+	// TODO (@sttts): also support pod.spec.resources.limit.request
+	// TODO (@sttts): take into account the executor resources
+	cpu := mresource.PodCPULimit(&t.Pod)
+	mem := mresource.PodMemLimit(&t.Pod)
+	log.V(4).Infof("trying to match offer with pod %v/%v: cpus: %.2f mem: %.2f MB", t.Pod.Namespace, t.Pod.Name, cpu, mem)
+	if (cpu > offeredCpus) || (mem > offeredMem) {
+		log.V(3).Infof("not enough resources for pod %v/%v: cpus: %.2f mem: %.2f MB", t.Pod.Namespace, t.Pod.Name, cpu, mem)
 		return false
 	}
+
 	return true
 }
 

--- a/contrib/mesos/pkg/scheduler/resource/doc.go
+++ b/contrib/mesos/pkg/scheduler/resource/doc.go
@@ -14,17 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package config
-
-import (
-	"time"
-)
-
-// default values to use when constructing mesos ExecutorInfo messages
-const (
-	DefaultInfoID         = "k8sm-executor"
-	DefaultInfoSource     = "kubernetes"
-	DefaultInfoName       = "Kubelet-Executor"
-	DefaultSuicideTimeout = 20 * time.Minute
-	DefaultCgroupPrefix   = "mesos"
-)
+// Package resource contains the Mesos scheduler specific resource functions
+package resource

--- a/contrib/mesos/pkg/scheduler/resource/resource.go
+++ b/contrib/mesos/pkg/scheduler/resource/resource.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/resourcequota"
+)
+
+const (
+	DefaultDefaultContainerCPULimit = CPUShares(0.25) // CPUs allocated for pods without CPU limit
+	DefaultDefaultContainerMemLimit = MegaBytes(64.0) // memory allocated for pods without memory limit
+)
+
+// CPUFromPodSpec computes the cpu shares that the pod is admitted to use. Containers
+// without CPU limit are NOT taken into account.
+func PodCPULimit(pod *api.Pod) CPUShares {
+	cpuQuantity := resourcequota.PodCPU(pod)
+	return CPUShares(float64(cpuQuantity.MilliValue()) / 1000.0)
+}
+
+// MemFromPodSpec computes the amount of memory that the pod is admitted to use. Containers
+// without memory limit are NOT taken into account.
+func PodMemLimit(pod *api.Pod) MegaBytes {
+	memQuantity := resourcequota.PodMemory(pod)
+	return MegaBytes(float64(memQuantity.Value()) / 1024.0 / 1024.0)
+}
+
+// limitPodResource sets the given default resource limit for each container that
+// does not limit the given resource yet. limitPodResource returns true iff at least one
+// container had no limit for that resource.
+func limitPodResource(pod *api.Pod, resourceName api.ResourceName, defaultLimit resource.Quantity) bool {
+	unlimited := false
+	for j := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[j]
+		if container.Resources.Limits == nil {
+			container.Resources.Limits = api.ResourceList{}
+		}
+		_, ok := container.Resources.Limits[resourceName]
+		if !ok {
+			container.Resources.Limits[resourceName] = defaultLimit
+			unlimited = true
+		}
+	}
+	return unlimited
+}
+
+// unlimitedPodResources counts how many containers in the pod have no limit for the given resource
+func unlimitedCountainerNum(pod *api.Pod, resourceName api.ResourceName) int {
+	unlimited := 0
+	for j := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[j]
+
+		if container.Resources.Limits == nil {
+			unlimited += 1
+			continue
+		}
+
+		if _, ok := container.Resources.Limits[resourceName]; !ok {
+			unlimited += 1
+		}
+	}
+	return unlimited
+}
+
+// limitPodCPU sets DefaultContainerCPUs for the CPU limit of each container that
+// does not limit its CPU resource yet. limitPodCPU returns true iff at least one
+// container had no CPU limit set.
+func LimitPodCPU(pod *api.Pod, defaultLimit CPUShares) bool {
+	defaultCPUQuantity := resource.NewMilliQuantity(int64(float64(defaultLimit)*1000.0), resource.DecimalSI)
+	return limitPodResource(pod, api.ResourceCPU, *defaultCPUQuantity)
+}
+
+// limitPodMem sets DefaultContainerMem for the memory limit of each container that
+// does not limit its memory resource yet. limitPodMem returns true iff at least one
+// container had no memory limit set.
+func LimitPodMem(pod *api.Pod, defaultLimit MegaBytes) bool {
+	defaultMemQuantity := resource.NewQuantity(int64(float64(defaultLimit)*1024.0*1024.0), resource.BinarySI)
+	return limitPodResource(pod, api.ResourceMemory, *defaultMemQuantity)
+}
+
+// CPUForPod computes the limits from the spec plus the default CPU limit for unlimited containers
+func CPUForPod(pod *api.Pod, defaultLimit CPUShares) CPUShares {
+	return PodCPULimit(pod) + CPUShares(unlimitedCountainerNum(pod, api.ResourceCPU))*defaultLimit
+}
+
+// MemForPod computes the limits from the spec plus the default memory limit for unlimited containers
+func MemForPod(pod *api.Pod, defaultLimit MegaBytes) MegaBytes {
+	return PodMemLimit(pod) + MegaBytes(unlimitedCountainerNum(pod, api.ResourceMemory))*defaultLimit
+}

--- a/contrib/mesos/pkg/scheduler/resource/types.go
+++ b/contrib/mesos/pkg/scheduler/resource/types.go
@@ -14,17 +14,36 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package config
+package resource
 
 import (
-	"time"
+	"fmt"
+	"strconv"
 )
 
-// default values to use when constructing mesos ExecutorInfo messages
-const (
-	DefaultInfoID         = "k8sm-executor"
-	DefaultInfoSource     = "kubernetes"
-	DefaultInfoName       = "Kubelet-Executor"
-	DefaultSuicideTimeout = 20 * time.Minute
-	DefaultCgroupPrefix   = "mesos"
-)
+type MegaBytes float64
+type CPUShares float64
+
+func (f *CPUShares) Set(s string) error {
+	v, err := strconv.ParseFloat(s, 64)
+	*f = CPUShares(v)
+	return err
+}
+
+func (f *CPUShares) Type() string {
+	return "float64"
+}
+
+func (f *CPUShares) String() string { return fmt.Sprintf("%v", *f) }
+
+func (f *MegaBytes) Set(s string) error {
+	v, err := strconv.ParseFloat(s, 64)
+	*f = MegaBytes(v)
+	return err
+}
+
+func (f *MegaBytes) Type() string {
+	return "float64"
+}
+
+func (f *MegaBytes) String() string { return fmt.Sprintf("%v", *f) }

--- a/contrib/mesos/pkg/scheduler/service/service_test.go
+++ b/contrib/mesos/pkg/scheduler/service/service_test.go
@@ -137,9 +137,9 @@ func Test_StaticPods(t *testing.T) {
 	assert.NoError(err)
 
 	// archive config files
-	data, fileNum, err := archive.ZipDir(staticPodsConfigPath)
+	data, paths, err := archive.ZipDir(staticPodsConfigPath)
 	assert.NoError(err)
-	assert.Equal(2, fileNum)
+	assert.Equal(2, len(paths))
 
 	// unarchive config files
 	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))


### PR DESCRIPTION
This patch
- set limits (0.25 cpu, 64 MB) on containers which are not limited in pod spec (these are also passed to the kubelet such that it uses them for the docker run limits)
- sums up the container resource limits for cpu and memory inside a pod,
- compares the sums to the offered resources
- puts the sums into the Mesos TaskInfo such that Mesos does the accounting
  for the pod.
- parses the static pod spec and adds up the resources
- sets the executor resources to 0.25 cpu, 64 MB plus the static pod resources
- sets the cgroups in the kubelet for system containers, resource containers and docker to the one
  of the executor that Mesos assigned
- adds scheduler parameters `--default-container-cpu-limit` and `--default-container-mem-limit`.

The containers themselves are resource limited by the Docker resource limits which
the kubelet applies when launching them.

Fixes mesosphere/kubernetes-mesos#68 and mesosphere/kubernetes-mesos#304
