### PR TITLE
Cleanup GKE bash logging

### DIFF
--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -29,7 +29,7 @@ source "${KUBE_ROOT}/cluster/gke/${KUBE_CONFIG_FILE:-config-default.sh}"
 # Assumed vars:
 #   GCLOUD
 function prepare-e2e() {
-  echo "... in prepare-e2e()" >&2
+  echo "... in gke:prepare-e2e()" >&2
 
   # Ensure GCLOUD is set to some gcloud binary.
   if [[ -z "${GCLOUD:-}" ]]; then
@@ -48,7 +48,7 @@ function prepare-e2e() {
 # Vars set:
 #   PROJECT
 function detect-project() {
-  echo "... in detect-project()" >&2
+  echo "... in gke:detect-project()" >&2
   if [[ -z "${PROJECT:-}" ]]; then
     export PROJECT=$("${GCLOUD}" config list project | tail -n 1 | cut -f 3 -d ' ')
   fi
@@ -63,13 +63,14 @@ function detect-project() {
 
 # Execute prior to running tests to build a release if required for env.
 function test-build-release() {
-  echo "... in test-build-release()" >&2
+  echo "... in gke:test-build-release()" >&2
   # We currently use the Kubernetes version that GKE supports (not testing
   # bleeding-edge builds).
 }
 
 # Verify needed binaries exist.
 function verify-prereqs() {
+  echo "... in gke:verify-prereqs()" >&2
   if ! which gcloud >/dev/null; then
     local resp
     if [[ "${KUBE_PROMPT_FOR_UPDATE}" == "y" ]]; then
@@ -113,7 +114,7 @@ function verify-prereqs() {
 #   CLUSTER_API_VERSION (optional)
 #   NUM_MINIONS
 function kube-up() {
-  echo "... in kube-up()" >&2
+  echo "... in gke:kube-up()" >&2
   detect-project >&2
 
   # Make the specified network if we need to.
@@ -164,7 +165,7 @@ function kube-up() {
 # Vars set:
 #   MINION_TAG
 function test-setup() {
-  echo "... in test-setup()" >&2
+  echo "... in gke:test-setup()" >&2
   # Detect the project into $PROJECT if it isn't set
   detect-project >&2
   detect-minions >&2
@@ -198,7 +199,7 @@ function test-setup() {
 #   KUBE_USER
 #   KUBE_PASSWORD
 function get-password() {
-  echo "... in get-password()" >&2
+  echo "... in gke:get-password()" >&2
   detect-project >&2
   KUBE_USER=$("${GCLOUD}" "${CMD_GROUP}" container clusters describe \
     --project="${PROJECT}" --zone="${ZONE}" "${CLUSTER_NAME}" \
@@ -217,7 +218,7 @@ function get-password() {
 #   KUBE_MASTER
 #   KUBE_MASTER_IP
 function detect-master() {
-  echo "... in detect-master()" >&2
+  echo "... in gke:detect-master()" >&2
   detect-project >&2
   KUBE_MASTER="k8s-${CLUSTER_NAME}-master"
   KUBE_MASTER_IP=$("${GCLOUD}" "${CMD_GROUP}" container clusters describe \
@@ -230,7 +231,7 @@ function detect-master() {
 # Vars set:
 #   MINION_NAMES
 function detect-minions() {
-  echo "... in detect-minions()" >&2
+  echo "... in gke:detect-minions()" >&2
   detect-minion-names
 }
 
@@ -241,6 +242,7 @@ function detect-minions() {
 # Vars set:
 #   MINION_NAMES
 function detect-minion-names {
+  echo "... in gke:detect-minion-names()" >&2
   detect-project
   detect-node-instance-group
   MINION_NAMES=($(gcloud preview --project "${PROJECT}" instance-groups \
@@ -259,6 +261,7 @@ function detect-minion-names {
 # Vars set:
 #   NODE_INSTANCE_GROUP
 function detect-node-instance-group {
+  echo "... in gke:detect-node-instance-group()" >&2
   NODE_INSTANCE_GROUP=$("${GCLOUD}" "${CMD_GROUP}" container clusters describe \
     --project="${PROJECT}" --zone="${ZONE}" "${CLUSTER_NAME}" \
     | grep instanceGroupManagers | cut -d '/' -f 11)
@@ -270,7 +273,7 @@ function detect-node-instance-group {
 #   GCLOUD
 #   ZONE
 function ssh-to-node() {
-  echo "... in ssh-to-node()" >&2
+  echo "... in gke:ssh-to-node()" >&2
   detect-project >&2
 
   local node="$1"
@@ -288,13 +291,13 @@ function ssh-to-node() {
 
 # Restart the kube-proxy on a node ($1)
 function restart-kube-proxy() {
-  echo "... in restart-kube-proxy()"  >&2
+  echo "... in gke:restart-kube-proxy()"  >&2
   ssh-to-node "$1" "sudo /etc/init.d/kube-proxy restart"
 }
 
 # Restart the kube-proxy on master ($1)
 function restart-apiserver() {
-  echo "... in restart-kube-apiserver()"  >&2
+  echo "... in gke:restart-apiserver()"  >&2
   ssh-to-node "$1" "sudo docker ps | grep /kube-apiserver | cut -d ' ' -f 1 | xargs sudo docker kill"
 }
 
@@ -308,7 +311,7 @@ function restart-apiserver() {
 #   KUBE_ROOT
 #   ZONE
 function test-teardown() {
-  echo "... in test-teardown()" >&2
+  echo "... in gke:test-teardown()" >&2
 
   detect-project >&2
   detect-minions >&2
@@ -333,7 +336,7 @@ function test-teardown() {
 #  ZONE
 #  CLUSTER_NAME
 function kube-down() {
-  echo "... in kube-down()" >&2
+  echo "... in gke:kube-down()" >&2
   detect-project >&2
   "${GCLOUD}" "${CMD_GROUP}" container clusters delete --project="${PROJECT}" \
     --zone="${ZONE}" "${CLUSTER_NAME}" --quiet


### PR DESCRIPTION
When the e2e tests are calling bash, failures don't give traces of what function is being called ([example](http://kubekins.dls.corp.google.com/view/Upgrade%20Test%20-%20GKE/job/kubernetes-upgrade-0.19.3-0.21.2-gke-step1-deploy/83/console)). This cleans up the existing logging to make it consistent and adds a little `gke` tag for quick parsing. This should make debugging failures easier.

(I've previously fixed the wrong bash because it wasn't clear exactly what was going wrong.)
