### PR TITLE
(GKE) Stop 'gcloud preview' call from failing Jenkins jobs

### DIFF
--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -244,7 +244,7 @@ function detect-minion-names {
   detect-project
   detect-node-instance-group
   MINION_NAMES=($(gcloud preview --project "${PROJECT}" instance-groups \
-    --zone "${ZONE}" instances --group "${NODE_INSTANCE_GROUP}" list \
+    --zone "${ZONE}" instances --group "${NODE_INSTANCE_GROUP}" list --quiet \
     | cut -d'/' -f11))
   echo "MINION_NAMES=${MINION_NAMES[*]}"
 }


### PR DESCRIPTION
No mater how much we do `gcloud components update`, we end up hitting a time where gcloud needs to update right as a command is first called, and Jenkins crashes ([example from today](http://kubekins.dls.corp.google.com/view/Upgrade%20Test%20-%20GKE/job/kubernetes-upgrade-0.19.3-0.21.2-gke-step1-deploy/83/console)).

This makes the `gcloud preview` call itself just give default answers to these prompts rather than hard failing an entire pipeline because the shell isn't interactive.
