### PR TITLE
populate the instructions on installing kubectl in getting-started-guides

### DIFF
--- a/docs/getting-started-guides/aws-coreos.md
+++ b/docs/getting-started-guides/aws-coreos.md
@@ -38,7 +38,7 @@ no security tokens, no basic auth). For demonstration purposes only.
 
 * [aws CLI](http://aws.amazon.com/cli)
 * [CoreOS image for AWS](https://coreos.com/docs/running-coreos/cloud-providers/ec2/)
-* [kubectl CLI](aws/kubectl.md)
+* [kubectl CLI](aws/kubectl.md) ([installation](aws.md#command-line-administration-tool-kubectl))
 
 ## Starting a Cluster
 

--- a/docs/getting-started-guides/aws.md
+++ b/docs/getting-started-guides/aws.md
@@ -42,7 +42,6 @@ Getting started on AWS EC2
 3. You need an AWS [instance profile and role](http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html) with EC2 full access.
 
 ## Cluster turnup
-### Supported procedure: `get-kube`
 ```bash
 #Using wget
 export KUBERNETES_PROVIDER=aws; wget -q -O - https://get.k8s.io | bash
@@ -83,14 +82,17 @@ AWS CloudFormation or EC2 with user data (cloud-config).
 
 ## Getting started with your cluster
 ### Command line administration tool: `kubectl`
-Copy the appropriate `kubectl` binary to any location defined in your `PATH` environment variable, for example:
+The cluster startup script will leave you with a ```kubernetes``` directory on your workstation.
+Alternately, you can download the latest Kubernetes release from [this page](https://github.com/GoogleCloudPlatform/kubernetes/releases).
+
+Next, add the appropriate binary folder to your ```PATH``` to access kubectl:
 
 ```bash
 # OS X
-sudo cp kubernetes/platforms/darwin/amd64/kubectl /usr/local/bin/kubectl
+export PATH=<path/to/kubernetes-directory>/platforms/darwin/amd64:$PATH
 
 # Linux
-sudo cp kubernetes/platforms/linux/amd64/kubectl /usr/local/bin/kubectl
+export PATH=<path/to/kubernetes-directory>/platforms/linux/amd64:$PATH
 ```
 
 An up-to-date documentation page for this tool is available here: [kubectl manual](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/kubectl.md)

--- a/docs/getting-started-guides/azure.md
+++ b/docs/getting-started-guides/azure.md
@@ -48,6 +48,7 @@ installed](https://docs.docker.com/installation/).  On Mac OS X you can use
 [boot2docker](http://boot2docker.io/).
 
 ## Setup
+###Starting a cluster
 The cluster setup scripts can setup Kubernetes for multiple targets. First modify `cluster/kube-env.sh` to specify azure:
 
     KUBERNETES_PROVIDER="azure"
@@ -63,12 +64,25 @@ You can create a virtual network:
 
 Now you're ready.
 
-You can then use the `cluster/kube-*.sh` scripts to manage your azure cluster, start with:
+You can download and install the latest Kubernetes release from [this page](https://github.com/GoogleCloudPlatform/kubernetes/releases), then run the `<kubernetes>/cluster/kube-up.sh` script to start the cluster:
 
+    cd kubernetes
     cluster/kube-up.sh
 
 The script above will start (by default) a single master VM along with 4 worker VMs.  You
 can tweak some of these parameters by editing `cluster/azure/config-default.sh`.
+
+### Adding the kubernetes command line tools to PATH
+The [kubectl](../../docs/user-guide/kubectl/kubectl.md) tool controls the Kubernetes cluster manager.  It lets you inspect your cluster resources, create, delete, and update components, and much more.
+You will use it to look at your new cluster and bring up example apps.
+
+Add the appropriate binary folder to your ```PATH``` to access kubectl:
+
+    # OS X
+    export PATH=<path/to/kubernetes-directory>/platforms/darwin/amd64:$PATH
+
+    # Linux
+    export PATH=<path/to/kubernetes-directory>/platforms/linux/amd64:$PATH
 
 ## Getting started with your cluster
 See [a simple nginx example](../user-guide/simple-nginx.md) to try out your new cluster.

--- a/docs/getting-started-guides/juju.md
+++ b/docs/getting-started-guides/juju.md
@@ -80,6 +80,8 @@ interface.
 
 ## Launch Kubernetes cluster
 
+Kubernetes releases can be downloaded from [this page](https://github.com/GoogleCloudPlatform/kubernetes/releases).
+
 You will need to have the Kubernetes tools compiled before launching the cluster
 
     make all WHAT=cmd/kubectl

--- a/docs/getting-started-guides/mesos.md
+++ b/docs/getting-started-guides/mesos.md
@@ -155,6 +155,12 @@ Disown your background jobs so that they'll stay running if you log out.
 $ disown -a
 ```
 #### Validate KM Services
+Add the appropriate binary folder to your ```PATH``` to access kubectl:
+
+```bash
+export PATH=<path/to/kubernetes-directory>/platforms/linux/amd64:$PATH
+```
+
 Interact with the kubernetes-mesos framework via `kubectl`:
 
 ```bash

--- a/docs/user-guide/prereqs.md
+++ b/docs/user-guide/prereqs.md
@@ -21,11 +21,28 @@ certainly want the docs that go with that version.</h1>
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 # Kubernetes User Guide: Managing Applications: Prerequisites
+To deploy and manage applications on Kubernetes, you’ll use the Kubernetes command-line tool, [kubectl](kubectl/kubectl.md). It lets you inspect your cluster resources, create, delete, and update components, and much more. You will use it to look at your new cluster and bring up example apps. 
 
-To deploy and manage applications on Kubernetes, you’ll use the Kubernetes command-line tool, [kubectl](kubectl/kubectl.md). It can be found in the release tar bundle, or can be built from source from github. Ensure that it is executable and in your path.
+##Install kubectl
+You can find it in the [release](https://github.com/GoogleCloudPlatform/kubernetes/releases) tar bundle, under platforms/<os>/<arch>;
+or if you build from source, kubectl should be either under _output/local/bin/<os>/<arch> or _output/dockerized/bin/<os>/<arch>.
 
+Next, make sure the kubectl tool is in your path, assuming you download a release:
+```
+# OS X
+export PATH=<path/to/kubernetes-directory>/platforms/darwin/amd64:$PATH
+
+# Linux
+export PATH=<path/to/kubernetes-directory>/platforms/linux/amd64:$PATH
+```
+
+##Configure kubectl
 In order for kubectl to find and access the Kubernetes cluster, it needs a [kubeconfig file](kubeconfig-file.md), which is created automatically when creating a cluster using kube-up.sh (see the [getting started guides](../../docs/getting-started-guides/) for more about creating clusters). If you need access to a cluster you didn’t create, see the [Sharing Cluster Access document](sharing-clusters.md).
 
+Check that kubectl is properly configured by getting the cluster state:
+```
+$ kubectl cluster-info
+```
 ## What's next?
 
 [Learn how to launch and expose your application.](quick-start.md)


### PR DESCRIPTION
Fixes #9632 and some nits in getting-started-guides

Regarding this [comment](https://github.com/GoogleCloudPlatform/kubernetes/issues/9632#issuecomment-120567421), because there is no TOC page for docs/user-guide, so I followed the previous [comment](https://github.com/GoogleCloudPlatform/kubernetes/issues/9632#issuecomment-119004568)

@nikhiljindal @JanetKuo 
