### PR TITLE
Fix verifying prerequisites for local golang docker image

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -272,7 +272,7 @@ function kube::build::docker_image_exists() {
 
   # We cannot just specify the IMAGE here as `docker images` doesn't behave as
   # expected.  See: https://github.com/docker/docker/issues/8048
-  "${DOCKER[@]}" images | grep -Eq "^${1}\s+${2}\s+"
+  "${DOCKER[@]}" images | grep -Eq "${1}\s+${2}\s+"
 }
 
 # Takes $1 and computes a short has for it. Useful for unique tag generation


### PR DESCRIPTION
The image is prefixing with "docker.io", fix the regex.

Signed-off-by: Guohua Ouyang gouyang@redhat.com
