### PR TITLE
Use self-signed cert as CA for local-up-cluster.sh

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -200,6 +200,11 @@ function start_apiserver {
     # Admission Controllers to invoke prior to persisting objects in cluster
     ADMISSION_CONTROL=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
 
+    # This is the default dir and filename where the apiserver will generate a self-signed cert
+    # which should be able to be used as the CA to verify itself
+    CERT_DIR=/var/run/kubernetes
+    ROOT_CA_FILE=$CERT_DIR/apiserver.crt
+
     priv_arg=""
     if [[ -n "${ALLOW_PRIVILEGED}" ]]; then
       priv_arg="--allow-privileged "
@@ -208,6 +213,7 @@ function start_apiserver {
     APISERVER_LOG=/tmp/kube-apiserver.log
     sudo -E "${GO_OUT}/kube-apiserver" ${priv_arg}\
       --v=${LOG_LEVEL} \
+      --cert_dir="${CERT_DIR}" \
       --service_account_key_file="${SERVICE_ACCOUNT_KEY}" \
       --service_account_lookup="${SERVICE_ACCOUNT_LOOKUP}" \
       --admission_control="${ADMISSION_CONTROL}" \
@@ -228,6 +234,7 @@ function start_controller_manager {
     sudo -E "${GO_OUT}/kube-controller-manager" \
       --v=${LOG_LEVEL} \
       --service_account_private_key_file="${SERVICE_ACCOUNT_KEY}" \
+      --root_ca_file="${ROOT_CA_FILE}" \
       --master="${API_HOST}:${API_PORT}" >"${CTLRMGR_LOG}" 2>&1 &
     CTLRMGR_PID=$!
 }

--- a/pkg/util/crypto.go
+++ b/pkg/util/crypto.go
@@ -53,9 +53,10 @@ func GenerateSelfSignedCert(host, certPath, keyPath string, alternateIPs []net.I
 		NotBefore: time.Now(),
 		NotAfter:  time.Now().Add(time.Hour * 24 * 365),
 
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
+		IsCA: true,
 	}
 
 	if ip := net.ParseIP(host); ip != nil {


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/11225
- Makes the generated self-signed cert a valid CA (which it need to be in order to be used to validate itself)
- Adds the generated apiserver.crt in local-up-cluster.sh
