### PR TITLE
Increase kubelet start timeout in Monit config

### DIFF
--- a/cluster/saltbase/salt/monit/kubelet
+++ b/cluster/saltbase/salt/monit/kubelet
@@ -1,6 +1,6 @@
 check process kubelet with pidfile /var/run/kubelet.pid
 group kubelet
-start program = "/etc/init.d/kubelet start"
+start program = "/etc/init.d/kubelet start" with timeout 60 seconds
 stop program = "/etc/init.d/kubelet stop"
 if does not exist then restart
 if failed


### PR DESCRIPTION
Ref #11215 

For more detailed explanation of this change see:
https://github.com/GoogleCloudPlatform/kubernetes/issues/11215#issuecomment-121585851

I was able to replicate the problem locally and this change really helped.

cc @dchen1107 @davidopp @thockin @gmarek @saad-ali 
