### PR TITLE
Add hack/cherry_pick_list.sh to list all automated cherry picks

### DIFF
--- a/docs/devel/releasing.md
+++ b/docs/devel/releasing.md
@@ -137,7 +137,9 @@ manage cherry picks prior to cutting the release.
    version commit.
 1. Follow the instructions given to you by that script. They are canon for the
    remainder of the Git process. If you don't understand something in that
-   process, please ask!
+   process, please ask! When proposing PRs, you can pre-fill the body with
+   `hack/cherry_pick_list.sh upstream/release-${VER}` to inform people of what
+   is already on the branch.
 
 **TODO**: how to fix tags, etc., if the release is changed.
 
@@ -154,10 +156,10 @@ In your git repo (you still have `${VER}` and `${PATCH}` set from above right?):
 
 #### Writing Release Notes
 
-Release notes for a patch release are relatives fast: `git log release-${VER}`
-(If you followed the procedure in the first section, all the cherry-picks will
-have the pull request number in the commit log). Unless there's some reason not
-to, just include all the PRs back to the last release.
+Run `hack/cherry_pick_list.sh ${VER}.${PATCH}~1` to get the release notes for
+the patch release you just created. Feel free to prune anything internal, like
+you would for a major release, but typically for patch releases we tend to
+include everything in the release notes.
 
 ## Origin of the Sources
 

--- a/hack/cherry_pick_list.sh
+++ b/hack/cherry_pick_list.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# List cherry picks sitting on a release branch that AREN'T YET part
+# of a release. Used when constructing a release.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+declare -r KUBE_ROOT="$(dirname "${BASH_SOURCE}")/.."
+
+if [[ "$#" -ne 1 ]]; then
+  echo "${0} <remote branch>: list all automated cherry picks on <remote release branch> since last release."
+  echo "  (assumes branch format of cherry_pick_pull.sh)"
+  echo ""
+  echo "Example:"
+  echo "  $0 upstream/release-1.0  # Lists all PRs on release-1.0 since list patch release."
+  exit 2
+fi
+
+declare -r BRANCH="$1"
+
+git remote update >/dev/null
+
+# First, the range specification: --abbrev=0 is saying to find the tag
+# relevant for the branch, so this essentially the git log all the way
+# back to the most recent tag on the release branch.
+#
+# The git log outputs something like:
+#  0f3cdb7234e2239707e4c3fc58f5f89552f41c65 Merge pull request #98765 from zaphod/automated-cherry-pick-of-#12345-#56789-#13579-upstream-release-1.0
+PULLS=( $(git log $(git describe --abbrev=0 "${BRANCH}").."${BRANCH}" -E --grep="Merge pull request \#[0-9]+ from .+/automated-cherry-pick-of-" --pretty=oneline |
+  awk '{ print $7 }' | sed -e 's/.*automated-cherry-pick-of-\(#[0-9]\{1,\}\)/\1/' -e 's/\(#[0-9]\{1,\}\)-[^#].*/\1/' -e 's/-/\
+/g' | sed 's/^#//g') )
+
+${KUBE_ROOT}/hack/lookup_pull.py "${PULLS[@]}"

--- a/hack/lookup_pull.py
+++ b/hack/lookup_pull.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script to print out PR info in release note format.
+
+import json
+import sys
+import urllib2
+
+PULLQUERY=("https://api.github.com/repos/"
+           "GoogleCloudPlatform/kubernetes/pulls/{pull}")
+LOGIN="login"
+TITLE="title"
+USER="user"
+
+def print_pulls(pulls):
+  for pull in pulls:
+    d = json.loads(urllib2.urlopen(PULLQUERY.format(pull=pull)).read())
+    print "* {title} #{pull} ({author})".format(
+        title=d[TITLE], pull=pull, author=d[USER][LOGIN])
+
+if __name__ == "__main__":
+  if len(sys.argv) < 2:
+    print ("Usage: {cmd} <pulls>...: Prints out short " +
+           "markdown description for PRs appropriate for release notes.")
+    sys.exit(1)
+  print_pulls(sys.argv[1:])


### PR DESCRIPTION
- Adds hack/cherry_pick_list.sh to list all automated cherry picks
  since the last tag.
- Adds a short python script to extract title/author and print it in
  markdown style like our current release notes.
- Revises patch release instructions to use said script.
