### PR TITLE
point kubectl -f examples to correct paths

### DIFF
--- a/docs/design/admission_control_limit_range.md
+++ b/docs/design/admission_control_limit_range.md
@@ -131,7 +131,7 @@ For example,
 
 ```shell
 $ kubectl namespace myspace
-$ kubectl create -f examples/limitrange/limit-range.json
+$ kubectl create -f docs/user-guide/limitrange/limits.yaml
 $ kubectl get limits
 NAME
 limits

--- a/docs/design/admission_control_resource_quota.md
+++ b/docs/design/admission_control_resource_quota.md
@@ -158,7 +158,7 @@ For example,
 
 ```
 $ kubectl namespace myspace
-$ kubectl create -f examples/resourcequota/resource-quota.json
+$ kubectl create -f docs/user-guide/resourcequota/quota.yaml
 $ kubectl get quota
 NAME
 quota

--- a/docs/getting-started-guides/locally.md
+++ b/docs/getting-started-guides/locally.md
@@ -114,7 +114,7 @@ However you cannot view the nginx start page on localhost. To verify that nginx 
 You can control the specifications of a pod via a user defined manifest, and reach nginx through your browser on the port specified therein:
 
 ```
-cluster/kubectl.sh create -f examples/pod.yaml
+cluster/kubectl.sh create -f docs/user-guide/pod.yaml
 ```
 
 Congratulations!

--- a/docs/user-guide/downward-api/README.md
+++ b/docs/user-guide/downward-api/README.md
@@ -40,7 +40,7 @@ Use the [`examples/downward-api/dapi-pod.yaml`](dapi-pod.yaml) file to create a 
 downward API.
 
 ```shell
-$ kubectl create -f examples/downward-api/dapi-pod.yaml
+$ kubectl create -f docs/user-guide/downward-api/dapi-pod.yaml
 ```
 
 ### Examine the logs

--- a/docs/user-guide/getting-into-containers.md
+++ b/docs/user-guide/getting-into-containers.md
@@ -53,7 +53,7 @@ We can use these environment variables in applications to find the service.
 It is convenient to use `kubectl exec` to check if the volumes are mounted as expected.
 We first create a Pod with a volume mounted at /data/redis,
 ```
-kubectl create -f examples/walkthrough/pod2.yaml
+kubectl create -f docs/user-guide/walkthrough/pod2.yaml
 ```
 wait until the pod is Running and Ready,
 ```

--- a/docs/user-guide/managing-deployments.md
+++ b/docs/user-guide/managing-deployments.md
@@ -100,7 +100,7 @@ It is a recommended practice to put resources related to the same microservice o
 
 A URL can also be specified as a configuration source, which is handy for deploying directly from configuration files checked into github:
 ```bash
-$ kubectl create -f https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/examples/replication.yaml
+$ kubectl create -f https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/docs/user-guide/replication.yaml
 replicationcontrollers/nginx
 ```
 ## Bulk operations in kubectl

--- a/docs/user-guide/persistent-volumes/README.md
+++ b/docs/user-guide/persistent-volumes/README.md
@@ -50,7 +50,7 @@ $ echo 'I love Kubernetes storage!' > /tmp/data01/index.html
 PVs are created by posting them to the API server.
 
 ```
-$ kubectl create -f examples/persistent-volumes/volumes/local-01.yaml
+$ kubectl create -f docs/user-guide/persistent-volumes/volumes/local-01.yaml
 NAME      LABELS       CAPACITY      ACCESSMODES   STATUS      CLAIM     REASON
 pv0001    type=local   10737418240   RWO           Available 
 ```
@@ -64,7 +64,7 @@ Claims must be created in the same namespace as the pods that use them.
 
 ```
 
-$ kubectl create -f examples/persistent-volumes/claims/claim-01.yaml
+$ kubectl create -f docs/user-guide/persistent-volumes/claims/claim-01.yaml
 
 $ kubectl get pvc
 NAME                LABELS              STATUS              VOLUME
@@ -88,19 +88,17 @@ pv0001    type=local   10737418240   RWO           Bound     default/myclaim-1
 Claims are used as volumes in pods.  Kubernetes uses the claim to look up its bound PV.  The PV is then exposed to the pod.
 
 ```
-$ kubectl create -f examples/persistent-volumes/simpletest/pod.yaml
+$ kubectl create -f docs/user-guide/persistent-volumes/simpletest/pod.yaml
 
 $ kubectl get pods
 NAME      READY     STATUS    RESTARTS   AGE
 mypod     1/1       Running   0          1h
 
-$ kubectl create -f examples/persistent-volumes/simpletest/service.json
+$ kubectl create -f docs/user-guide/persistent-volumes/simpletest/service.json
 $ kubectl get services
 NAME              LABELS                                    SELECTOR            IP(S)        PORT(S)
 frontendservice   <none>                                    name=frontendhttp   10.0.0.241   3000/TCP
 kubernetes        component=apiserver,provider=kubernetes   <none>              10.0.0.2     443/TCP
-
-
 ```
 
 ## Next steps

--- a/docs/user-guide/secrets/README.md
+++ b/docs/user-guide/secrets/README.md
@@ -38,7 +38,7 @@ A secret contains a set of named byte arrays.
 Use the [`examples/secrets/secret.yaml`](secret.yaml) file to create a secret:
 
 ```shell
-$ kubectl create -f examples/secrets/secret.yaml
+$ kubectl create -f docs/user-guide/secrets/secret.yaml
 ```
 
 You can use `kubectl` to see information about the secret:
@@ -69,7 +69,7 @@ consumes it.
 Use the [`examples/secrets/secret-pod.yaml`](secret-pod.yaml) file to create a Pod that consumes the secret.
 
 ```shell
-$ kubectl create -f examples/secrets/secret-pod.yaml
+$ kubectl create -f docs/user-guide/secrets/secret-pod.yaml
 ```
 
 This pod runs a binary that displays the content of one of the pieces of secret data in the secret

--- a/docs/user-guide/update-demo/README.md
+++ b/docs/user-guide/update-demo/README.md
@@ -67,7 +67,7 @@ Now visit the the [demo website](http://localhost:8001/static).  You won't see a
 Now we will turn up two replicas of an image.  They all serve on internal port 80.
 
 ```bash
-$ kubectl create -f examples/update-demo/nautilus-rc.yaml
+$ kubectl create -f docs/user-guide/update-demo/nautilus-rc.yaml
 ```
 
 After pulling the image from the Docker Hub to your worker nodes (which may take a minute or so) you'll see a couple of squares in the UI detailing the pods that are running along with the image that they are serving up.  A cute little nautilus.
@@ -86,7 +86,7 @@ If you go back to the [demo website](http://localhost:8001/static/index.html) yo
 We will now update the docker image to serve a different image by doing a rolling update to a new Docker image.
 
 ```bash
-$ kubectl rolling-update update-demo-nautilus --update-period=10s -f examples/update-demo/kitten-rc.yaml
+$ kubectl rolling-update update-demo-nautilus --update-period=10s -f docs/user-guide/update-demo/kitten-rc.yaml
 ```
 The rolling-update command in kubectl will do 2 things:
 


### PR DESCRIPTION
I think this is all of them. I checked for broken kubectl -f commands in examples as well and couldn't find any.

```
➜  kubernetes git:(kubectl-example-fix) ✗ git grep -- "-f " docs | sed -n -e 's/^.*-f //p' | cut -d ' ' -f 1 | grep ^docs/ | sort | uniq | xargs ls -l
-rw-r----- 1 mikedanese eng 450 Jul 14 14:33 docs/user-guide/downward-api/dapi-pod.yaml
-rw-r----- 1 mikedanese eng 328 Jul 14 14:33 docs/user-guide/limitrange/limits.yaml
-rw-r----- 1 mikedanese eng 158 Jul 14 14:33 docs/user-guide/persistent-volumes/claims/claim-01.yaml
-rw-r----- 1 mikedanese eng 374 Jul 14 14:33 docs/user-guide/persistent-volumes/simpletest/pod.yaml
-rw-r----- 1 mikedanese eng 290 Jul 14 14:33 docs/user-guide/persistent-volumes/simpletest/service.json
-rw-r----- 1 mikedanese eng 196 Jul 14 14:33 docs/user-guide/persistent-volumes/volumes/local-01.yaml
-rw-r----- 1 mikedanese eng 163 Jul 14 14:33 docs/user-guide/pod.yaml
-rw-r----- 1 mikedanese eng 244 Jul 14 14:33 docs/user-guide/resourcequota/quota.yaml
-rw-r----- 1 mikedanese eng 463 Jul 14 14:33 docs/user-guide/secrets/secret-pod.yaml
-rw-r----- 1 mikedanese eng 114 Jul 14 14:33 docs/user-guide/secrets/secret.yaml
-rw-r----- 1 mikedanese eng 410 Jul 14 14:33 docs/user-guide/update-demo/kitten-rc.yaml
-rw-r----- 1 mikedanese eng 432 Jul 14 14:33 docs/user-guide/update-demo/nautilus-rc.yaml
-rw-r----- 1 mikedanese eng 363 Jul 14 14:33 docs/user-guide/walkthrough/pod2.yaml
➜  kubernetes git:(kubectl-example-fix) ✗ git grep -- "-f " docs | sed -n -e 's/^.*-f //p' | cut -d ' ' -f 1 | grep ^examples/ | sort | uniq | xargs ls -l
-rw-r----- 1 mikedanese eng 344 Jul 14 11:23 examples/guestbook/redis-master-controller.yaml
-rw-r----- 1 mikedanese eng 228 Jul 14 11:23 examples/guestbook/redis-master-service.yaml
```

Related to #11305

@bgrant0607 @marekbiskup 
