### PR TITLE
pass along status errors for upgrades

### DIFF
--- a/pkg/util/httpstream/spdy/roundtripper.go
+++ b/pkg/util/httpstream/spdy/roundtripper.go
@@ -25,6 +25,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	apierrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream"
 	"github.com/GoogleCloudPlatform/kubernetes/third_party/golang/netutil"
 )
@@ -137,6 +139,11 @@ func (s *SpdyRoundTripper) NewConnection(resp *http.Response) (httpstream.Connec
 		if err != nil {
 			responseError = "Unable to read error from server response"
 		} else {
+			if obj, err := api.Scheme.Decode(responseErrorBytes); err == nil {
+				if status, ok := obj.(*api.Status); ok {
+					return nil, &apierrors.StatusError{*status}
+				}
+			}
 			responseError = string(responseErrorBytes)
 		}
 


### PR DESCRIPTION
When doing an upgrade, structured errors end up obfuscated to callers because the error is reduced to a string and chained.  This attempts to decode the value into a status.  If it is possible, it returns back the structured StatusError.  If not, the old behavior is preserved.
