### PR TITLE
Improve pod update error message

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -984,7 +984,8 @@ func ValidatePodUpdate(newPod, oldPod *api.Pod) errs.ValidationErrorList {
 	}
 	pod.Spec.Containers = newContainers
 	if !api.Semantic.DeepEqual(pod.Spec, oldPod.Spec) {
-		allErrs = append(allErrs, errs.NewFieldInvalid("spec", newPod.Spec, "may not update fields other than container.image"))
+		allErrs = append(allErrs, errs.NewFieldInvalid("spec", newPod.Spec, fmt.Sprintf(
+			"may not update fields other than 'container.image'; old spec: %+v", pod.Spec)))
 	}
 
 	newPod.Status = oldPod.Status


### PR DESCRIPTION
I'm debugging an e2e failure, and am looking at the following error message:

>   "failed to update pod: Pod "pod-update-4005f1c5-2b3d-11e5-8ace-42010af01555" is invalid: spec: invalid value '{Volumes:[{Name:default-token-w5pkz VolumeSource:{HostPath:<nil> EmptyDir:<nil> GCEPersistentDisk:<nil> AWSElasticBlockStore:<nil> GitRepo:<nil> Secret:<_>(0xc209e6b020){SecretName:default-token-w5pkz} NFS:<nil> ISCSI:<nil> Glusterfs:<nil> PersistentVolumeClaim:<nil> RBD:<nil>}}] Containers:[{Name:nginx Image:gcr.io/google_containers/nginx:1.7.9 Command:<nil> Args:<nil> WorkingDir: Ports:[{Name: HostPort:0 ContainerPort:80 Protocol:TCP HostIP:}] Env:<nil> Resources:{Limits:map[cpu:100m] Requests:map[]} VolumeMounts:[{Name:default-token-w5pkz ReadOnly:true MountPath:/var/run/secrets/kubernetes.io/serviceaccount}] LivenessProbe:<_>(0xc209ec4780){Handler:{Exec:<nil> HTTPGet:<*>(0xc20a6e2730){Path:/index.html Port:8080 Host: Scheme:HTTP} TCPSocket:<nil>} InitialDelaySeconds:30 TimeoutSeconds:1} ReadinessProbe:<nil> Lifecycle:<nil> TerminationMessagePath:/dev/termination-log ImagePullPolicy:IfNotPresent SecurityContext:<nil>}] RestartPolicy:Always TerminationGracePeriodSeconds:<nil> ActiveDeadlineSeconds:<nil> DNSPolicy:ClusterFirst NodeSelector:<nil> ServiceAccountName: NodeName:gke-gke-upgrade-fc15646e-node-6l7c HostNetwork:false ImagePullSecrets:<nil>}': may not update fields other than container.image"

That's terrible. So I did a little hand expansion of the error object:

``` go
failed to update pod: Pod "pod-update-4005f1c5-2b3d-11e5-8ace-42010af01555" is invalid:
spec: invalid value
{
    Volumes: [{
        Name:default-token-7sezo
        VolumeSource: {
            HostPath:<nil>
            EmptyDir:<nil>
            GCEPersistentDisk:<nil>
            AWSElasticBlockStore:<nil>
            GitRepo:<nil>
            Secret:<*>(0xc209b18b30){SecretName:default-token-7sezo}
            NFS:<nil>
            ISCSI:<nil>
            Glusterfs:<nil>
            PersistentVolumeClaim:<nil>
            RBD:<nil>
        }
    }]
    Containers: [{
        Name:nginx
        Image:gcr.io/google_containers/nginx:1.7.9
        Command:<nil>
        Args:<nil>
        WorkingDir:
        Ports: [{
            Name:
            HostPort:0
            ContainerPort:80
            Protocol:TCP
            HostIP:
        }]
        Env:<nil>
        Resources: {Limits:map[cpu:100m] Requests:map[]}
        VolumeMounts: [{
            Name:default-token-7sezo
            ReadOnly:true
            MountPath:/var/run/secrets/kubernetes.io/serviceaccount
        }]
        LivenessProbe:<*>(0xc209d2da70){
            Handler:{
                Exec:<nil>
                HTTPGet:<*>(0xc20898c190){
                    Path:/index.html
                    Port:8080
                    Host:
                    Scheme:HTTP
                }
                TCPSocket:<nil>
            }
            InitialDelaySeconds:30
            TimeoutSeconds:1
        }
        ReadinessProbe:<nil>
        Lifecycle:<nil>
        TerminationMessagePath:/dev/termination-log
        ImagePullPolicy:IfNotPresent
        SecurityContext:<nil>
    }]
    RestartPolicy:Always
    TerminationGracePeriodSeconds:<nil>
    ActiveDeadlineSeconds:<nil>
    DNSPolicy:ClusterFirst
    NodeSelector:<nil>
    ServiceAccountName:
    NodeName:gke-gke-upgrade-13e30713-node-xg2o
    HostNetwork:false
    ImagePullSecrets:<nil>
}
may not update fields other than container.image
```

Which is still terrible. There are a lot of fields. What am I trying to update?

The best thing to do here would probably be to return the field that is different. However, I looked at the `api.Semantic.DeepEqual` code, and changing all of that, and the code it calls, to return values instead of bools seemed like a huge amount of work I'd probably screw up.

So, a hacky but functional fix is to just return the object that is being diff'd, and force callers to visually diff. Again, this isn't great, but it would at least let me debug further.
