### PR TITLE
Fix hack/cherry_pick_pull.sh on OS X (sigh):

### DIFF
--- a/hack/cherry_pick_pull.sh
+++ b/hack/cherry_pick_pull.sh
@@ -53,8 +53,8 @@ shift 1
 declare -r PULLS=( "$@" )
 
 function join { local IFS="$1"; shift; echo "$*"; }
-declare -r PULLDASH=$(join - "${PULLS[@]/#/\#}") # Generates something like "#12345-#56789"
-declare -r PULLSUBJ=$(join " " "${PULLS[@]/#/\#}") # Generates something like "#12345 #56789"
+declare -r PULLDASH=$(join - "${PULLS[@]/#/#}") # Generates something like "#12345-#56789"
+declare -r PULLSUBJ=$(join " " "${PULLS[@]/#/#}") # Generates something like "#12345 #56789"
 
 echo "+++ Updating remotes..."
 git remote update


### PR DESCRIPTION
On OS X bash, for whatever reason, the ancient, forsaken bash version
(3.2!?) that will never be updated because it might insult the memory
of Steve Jobs doesn't allow me to accidentally escape the hash
character. Fix the unnecessary escaping.

For reviewers out there wondering about this syntax, it's documented
here: http://www.tldp.org/LDP/abs/html/parameter-substitution.html
under:

```
${var/#Pattern/Replacement}

  If prefix of var matches Pattern, then substitute Replacement for Pattern.
```

It just looks odd here because I'm adding the hash character to the
start of each array element.
