### PR TITLE
register_minion.sh json incomplete, resulted in unexpected EOF

### DIFF
--- a/docs/getting-started-guides/coreos/azure/cloud_config_templates/kubernetes-cluster-main-nodes-template.yml
+++ b/docs/getting-started-guides/coreos/azure/cloud_config_templates/kubernetes-cluster-main-nodes-template.yml
@@ -31,7 +31,7 @@ write_files:
         "metadata": {
           "name": "%s",
           "labels": { "environment": "%s" }
-        }' "${node_id}" "${env_label}" \
+        }}' "${node_id}" "${env_label}" \
         | /opt/bin/kubectl create -s "${master_url}" -f -
 
   - path: /etc/kubernetes/manifests/fluentd.manifest


### PR DESCRIPTION
The JSON data in the register_minion.sh script was incomplete, resulting in a _unexpected EOF_ when running the azure kubernetes cluster setup scripts
