### PR TITLE
Tolerate overshooting during density tests

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -186,12 +186,9 @@ type RCConfig struct {
 	MaxContainerFailures *int
 }
 
-func LogfPrefix(prefixx string, format string, a ...interface{}) {
-	fmt.Fprintf(GinkgoWriter, prefixx+": "+format+"\n", a...)
-}
-
 func Logf(format string, a ...interface{}) {
-	fmt.Fprintf(GinkgoWriter, "INFO: "+format+"\n", a...)
+	fmt.Fprintf(GinkgoWriter, "[ E2E LOG "+time.Now().Format("2006-01-02-150405")+" ] "+format+"\n", a...)
+
 }
 
 func Failf(format string, a ...interface{}) {
@@ -1162,7 +1159,7 @@ func RunRC(config RCConfig) error {
 		}
 		//TODO: Convert this warning to failure after #10030 is fixed.
 		if len(pods) > config.Replicas {
-			LogfPrefix("WARN", "POD overshoot occured %d (actual pods) > %d (replicas) !!! See https://github.com/GoogleCloudPlatform/kubernetes/issues/10030. This is not necessarily a failure, but hopefully it will be repaired soon.", len(pods), config.Replicas)
+			Logf("WARNING: POD overshoot occured %d (actual pods) > %d (replicas) !!! See https://github.com/GoogleCloudPlatform/kubernetes/issues/10030. This is not necessarily a failure, but hopefully it will be repaired soon.", len(pods), config.Replicas)
 		}
 
 		if len(pods) > len(oldPods) || running > oldRunning {


### PR DESCRIPTION
This will allow us to proceed w/ testing catastrophic HA recovery scenarios (i.e. controller manager dies) without failing.   Otherwise, density can fail pretty easily in a large cluster where there might be pods transitioning to running, because it will overschedule (temporarily).
