### PR TITLE
Fix libvirt-coreos cluster

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -80,7 +80,9 @@ function create-kubeconfig() {
   fi
 
   "${kubectl}" config set-cluster "${CONTEXT}" "${cluster_args[@]}"
-  "${kubectl}" config set-credentials "${CONTEXT}" "${user_args[@]}"
+  if [ -n "${user_args[@]:-}" ]; then
+      "${kubectl}" config set-credentials "${CONTEXT}" "${user_args[@]}"
+  fi
   "${kubectl}" config set-context "${CONTEXT}" --cluster="${CONTEXT}" --user="${CONTEXT}"
   "${kubectl}" config use-context "${CONTEXT}"  --cluster="${CONTEXT}"
 

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -200,7 +200,6 @@ function wait-cluster-readiness {
 function kube-up {
   detect-master
   detect-minions
-  get-password
   initialize-pool keep_base_image
   initialize-network
 
@@ -326,12 +325,6 @@ function test-setup {
 # Execute after running tests to perform any required clean-up
 function test-teardown {
   kube-down
-}
-
-# Set the {KUBE_USER} and {KUBE_PASSWORD} environment values required to interact with provider
-function get-password {
-  export KUBE_USER=''
-  export KUBE_PASSWORD=''
 }
 
 # SSH to a node by name or IP ($1) and run a command ($2).


### PR DESCRIPTION
`KUBERNETES=libvirt-coreos cluster/kube-up.sh` produced the following error:

```
cluster/../cluster/libvirt-coreos/../../cluster/common.sh: line 83: user_args[@]: unbound variable
```

This was coming from the fact that, as a `libvirt-coreos` cluster runs locally on local VMs,
there is no authentication mechanism. This led to have `user_args` of `common.sh` unset.

In the case of libvirt-coreos, it is in fact expected to have no authentication token.
