### PR TITLE
Vagrant: virtualbox host-only network (eth1) not working after network restart

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -27,10 +27,8 @@ rm -f /etc/sysconfig/network-scripts/ifcfg-enp0s3
 
 # Disable network interface being managed by Network Manager (needed for Fedora 21+)
 NETWORK_CONF_PATH=/etc/sysconfig/network-scripts/
-sed -i 's/^NM_CONTROLLED=no/#NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
-
-systemctl restart network
-sleep 5
+grep -q ^NM_CONTROLLED= ${NETWORK_CONF_PATH}ifcfg-eth1 || echo 'NM_CONTROLLED=no' >> ${NETWORK_CONF_PATH}ifcfg-eth1
+sed -i 's/^#NM_CONTROLLED=.*/NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
 systemctl restart network
 
 function release_not_found() {

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -28,6 +28,9 @@ rm -f /etc/sysconfig/network-scripts/ifcfg-enp0s3
 # Disable network interface being managed by Network Manager (needed for Fedora 21+)
 NETWORK_CONF_PATH=/etc/sysconfig/network-scripts/
 sed -i 's/^NM_CONTROLLED=no/#NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
+
+systemctl restart network
+sleep 5
 systemctl restart network
 
 function release_not_found() {

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -79,6 +79,9 @@ rm -f /etc/sysconfig/network-scripts/ifcfg-enp0s3
 # Disable network interface being managed by Network Manager (needed for Fedora 21+)
 NETWORK_CONF_PATH=/etc/sysconfig/network-scripts/
 sed -i 's/^NM_CONTROLLED=no/#NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
+
+systemctl restart network
+sleep 5
 systemctl restart network
 
 # Setup hosts file to support ping by hostname to master

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -78,10 +78,8 @@ rm -f /etc/sysconfig/network-scripts/ifcfg-enp0s3
 
 # Disable network interface being managed by Network Manager (needed for Fedora 21+)
 NETWORK_CONF_PATH=/etc/sysconfig/network-scripts/
-sed -i 's/^NM_CONTROLLED=no/#NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
-
-systemctl restart network
-sleep 5
+grep -q ^NM_CONTROLLED= ${NETWORK_CONF_PATH}ifcfg-eth1 || echo 'NM_CONTROLLED=no' >> ${NETWORK_CONF_PATH}ifcfg-eth1
+sed -i 's/^#NM_CONTROLLED=.*/NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
 systemctl restart network
 
 # Setup hosts file to support ping by hostname to master


### PR DESCRIPTION
PR #9093 upgraded to Fedora 21 and changed scripts to disable NetworkManager and restart network.

For some reason (fedora/NetworkManager bug?) eth1 will not be restarted properly and because of this host-only networking will cease to function, resulting in the inability for VMs to talk to each other and so salt provisioning doesn't work.

Restarting the network a second time will allow eth1 to start just fine. This PR does exactly this.

@derekwaynecarr any idea what might cause this?
