### PR TITLE
Updating kubectl expose to extract ports from the service being cloned

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -634,9 +634,13 @@ __EOF__
   kubectl expose rc frontend --port=80 --name=frontend-4 --generator=service/v1 "${kube_flags[@]}"
   # Post-condition: service exists and the port is named default.
   kube::test::get_object_assert 'service frontend-4' "{{$port_name}} {{$port_field}}" 'default 80'
+  # Verify that expose service works without specifying a port.
+  kubectl expose service frontend --name=frontend-5 "${kube_flags[@]}"
+  # Post-condition: service exists with the same port as the original service.
+  kube::test::get_object_assert 'service frontend-5' "{{$port_field}}" '80'
   # Cleanup services
   kubectl delete pod valid-pod "${kube_flags[@]}"
-  kubectl delete service frontend{,-2,-3,-4} "${kube_flags[@]}"
+  kubectl delete service frontend{,-2,-3,-4,-5} "${kube_flags[@]}"
 
   ### Perform a rolling update with --image
   # Command

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -177,9 +177,9 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 				return getPorts(t.Spec.Template.Spec), nil
 			case *api.Pod:
 				return getPorts(t.Spec), nil
+			case *api.Service:
+				return getServicePorts(t.Spec), nil
 			default:
-				// TODO: support extracting ports from service:
-				// https://github.com/GoogleCloudPlatform/kubernetes/issues/11392
 				_, kind, err := api.Scheme.ObjectVersionAndKind(object)
 				if err != nil {
 					return nil, err
@@ -259,6 +259,15 @@ func getPorts(spec api.PodSpec) []string {
 		for _, port := range container.Ports {
 			result = append(result, strconv.Itoa(port.ContainerPort))
 		}
+	}
+	return result
+}
+
+// Extracts the ports exposed by a service from the given service spec.
+func getServicePorts(spec api.ServiceSpec) []string {
+	result := []string{}
+	for _, servicePort := range spec.Ports {
+		result = append(result, strconv.Itoa(servicePort.Port))
 	}
 	return result
 }


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/11392

Running:

```
$ kubectl.sh expose service frontend --name=frontend2
```

Before:

```
error: couldn't find port via --port flag or introspection: cannot extract ports from Service
see 'kubectl expose -h' for help.
```

Now creates the service.
