### PR TITLE
Allow a local /cluster/env.sh to be sourced if present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ Session.vim
 .vagrant
 network_closure.sh
 
+# Local cluster env variables
+/cluster/env.sh
+
 # Compiled binaries in third_party
 /third_party/pkg
 

--- a/cluster/kube-down.sh
+++ b/cluster/kube-down.sh
@@ -21,6 +21,11 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+if [ -f "${KUBE_ROOT}/cluster/env.sh" ]; then
+    source "${KUBE_ROOT}/cluster/env.sh"
+fi
+
 source "${KUBE_ROOT}/cluster/kube-env.sh"
 source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
 

--- a/cluster/kube-push.sh
+++ b/cluster/kube-push.sh
@@ -24,6 +24,11 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+if [ -f "${KUBE_ROOT}/cluster/env.sh" ]; then
+    source "${KUBE_ROOT}/cluster/env.sh"
+fi
+
 source "${KUBE_ROOT}/cluster/kube-env.sh"
 source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
 

--- a/cluster/kube-up.sh
+++ b/cluster/kube-up.sh
@@ -25,6 +25,11 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+if [ -f "${KUBE_ROOT}/cluster/env.sh" ]; then
+    source "${KUBE_ROOT}/cluster/env.sh"
+fi
+
 source "${KUBE_ROOT}/cluster/kube-env.sh"
 source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
 


### PR DESCRIPTION
This PR allows for a /cluster/env.sh file to exist which will be sourced at the top of /cluster/kube-up/down/push scripts.

This avoid the need to manually export provider variables before running the scripts. This is useful when iterating rapidly on test clusters because you don't have to remember to export the environment variables every time in every shells/terminals.

This does not change the current behaviour because the /cluster/env.sh file does not exist by default. It is also added to .gitignore for obvious reasons.

Docs changes might be useful to explain that this can be done. However I'm unsure how to go about this because each provider has it's own set of variables and everything is split out under each of the providers guides. Would it be alright to merge this without adding it to the docs since it doesn't change the current/default behaviour?
