### PR TITLE
Print update/event type in kubectl get -w

### DIFF
--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
 type internalType struct {
@@ -96,7 +97,7 @@ type testPrinter struct {
 	Err     error
 }
 
-func (t *testPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
+func (t *testPrinter) PrintObj(obj runtime.Object, eventType *watch.EventType, out io.Writer) error {
 	t.Objects = append(t.Objects, obj)
 	fmt.Fprintf(out, "%#v", obj)
 	return t.Err
@@ -142,7 +143,7 @@ func NewTestFactory() (*cmdutil.Factory, *testFactory, runtime.Codec) {
 		Describer: func(*meta.RESTMapping) (kubectl.Describer, error) {
 			return t.Describer, t.Err
 		},
-		Printer: func(mapping *meta.RESTMapping, noHeaders, withNamespace bool, wide bool, columnLabels []string) (kubectl.ResourcePrinter, error) {
+		Printer: func(mapping *meta.RESTMapping, noHeaders, withNamespace bool, withEvent bool, wide bool, columnLabels []string) (kubectl.ResourcePrinter, error) {
 			return t.Printer, t.Err
 		},
 		Validator: func() (validation.Schema, error) {
@@ -196,7 +197,7 @@ func NewAPIFactory() (*cmdutil.Factory, *testFactory, runtime.Codec) {
 		Describer: func(*meta.RESTMapping) (kubectl.Describer, error) {
 			return t.Describer, t.Err
 		},
-		Printer: func(mapping *meta.RESTMapping, noHeaders, withNamespace bool, wide bool, columnLabels []string) (kubectl.ResourcePrinter, error) {
+		Printer: func(mapping *meta.RESTMapping, noHeaders, withNamespace bool, withEvent bool, wide bool, columnLabels []string) (kubectl.ResourcePrinter, error) {
 			return t.Printer, t.Err
 		},
 		Validator: func() (validation.Schema, error) {
@@ -245,7 +246,7 @@ func stringBody(body string) io.ReadCloser {
 
 func ExamplePrintReplicationControllerWithNamespace() {
 	f, tf, codec := NewAPIFactory()
-	tf.Printer = kubectl.NewHumanReadablePrinter(false, true, false, []string{})
+	tf.Printer = kubectl.NewHumanReadablePrinter(false, true, false, false, []string{})
 	tf.Client = &client.FakeRESTClient{
 		Codec:  codec,
 		Client: nil,
@@ -286,7 +287,7 @@ func ExamplePrintReplicationControllerWithNamespace() {
 
 func ExamplePrintPodWithWideFormat() {
 	f, tf, codec := NewAPIFactory()
-	tf.Printer = kubectl.NewHumanReadablePrinter(false, false, true, []string{})
+	tf.Printer = kubectl.NewHumanReadablePrinter(false, false, false, true, []string{})
 	tf.Client = &client.FakeRESTClient{
 		Codec:  codec,
 		Client: nil,
@@ -321,7 +322,7 @@ func ExamplePrintPodWithWideFormat() {
 
 func ExamplePrintServiceWithNamespacesAndLabels() {
 	f, tf, codec := NewAPIFactory()
-	tf.Printer = kubectl.NewHumanReadablePrinter(false, true, false, []string{"l1"})
+	tf.Printer = kubectl.NewHumanReadablePrinter(false, true, false, false, []string{"l1"})
 	tf.Client = &client.FakeRESTClient{
 		Codec:  codec,
 		Client: nil,

--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -107,7 +107,7 @@ func (o ViewOptions) Run(out io.Writer, printer kubectl.ResourcePrinter) error {
 		clientcmdapi.ShortenConfig(config)
 	}
 
-	err = printer.PrintObj(config, out)
+	err = printer.PrintObj(config, nil, out)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -25,7 +25,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
-
 	"github.com/spf13/cobra"
 )
 
@@ -64,7 +63,7 @@ $ kubectl get rc/web service/frontend pods/web-pod-13je7`
 // NewCmdGet creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
 func NewCmdGet(f *cmdutil.Factory, out io.Writer) *cobra.Command {
-	p := kubectl.NewHumanReadablePrinter(false, false, false, []string{})
+	p := kubectl.NewHumanReadablePrinter(false, false, false, false, []string{})
 	validArgs := p.HandledResources()
 
 	cmd := &cobra.Command{
@@ -122,7 +121,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 			return err
 		}
 
-		printer, err := f.PrinterForMapping(cmd, mapping, allNamespaces)
+		printer, err := f.PrinterForMapping(cmd, mapping, allNamespaces, true)
 		if err != nil {
 			return err
 		}
@@ -139,7 +138,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 
 		// print the current object
 		if !isWatchOnly {
-			if err := printer.PrintObj(obj, out); err != nil {
+			if err := printer.PrintObj(obj, nil, out); err != nil {
 				return fmt.Errorf("unable to output the provided object: %v", err)
 			}
 		}
@@ -151,7 +150,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 		}
 
 		kubectl.WatchLoop(w, func(e watch.Event) error {
-			return printer.PrintObj(e.Object, out)
+			return printer.PrintObj(e.Object, &e.Type, out)
 		})
 		return nil
 	}
@@ -189,15 +188,15 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 			return err
 		}
 
-		return printer.PrintObj(obj, out)
+		return printer.PrintObj(obj, nil, out)
 	}
 
 	// use the default printer for each object
 	return b.Do().Visit(func(r *resource.Info) error {
-		printer, err := f.PrinterForMapping(cmd, r.Mapping, allNamespaces)
+		printer, err := f.PrinterForMapping(cmd, r.Mapping, allNamespaces, false)
 		if err != nil {
 			return err
 		}
-		return printer.PrintObj(r.Object, out)
+		return printer.PrintObj(r.Object, nil, out)
 	})
 }

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -222,10 +222,10 @@ func RunLabel(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 			return err
 		}
 
-		printer, err := f.PrinterForMapping(cmd, info.Mapping, false)
+		printer, err := f.PrinterForMapping(cmd, info.Mapping, false, false)
 		if err != nil {
 			return err
 		}
-		return printer.PrintObj(obj, out)
+		return printer.PrintObj(obj, nil, out)
 	})
 }

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -65,7 +65,7 @@ type Factory struct {
 	// Returns a Describer for displaying the specified RESTMapping type or an error.
 	Describer func(mapping *meta.RESTMapping) (kubectl.Describer, error)
 	// Returns a Printer for formatting objects of the given type or an error.
-	Printer func(mapping *meta.RESTMapping, noHeaders, withNamespace bool, wide bool, columnLabels []string) (kubectl.ResourcePrinter, error)
+	Printer func(mapping *meta.RESTMapping, noHeaders, withNamespace bool, withEvent bool, wide bool, columnLabels []string) (kubectl.ResourcePrinter, error)
 	// Returns a Scaler for changing the size of the specified RESTMapping type or an error
 	Scaler func(mapping *meta.RESTMapping) (kubectl.Scaler, error)
 	// Returns a Reaper for gracefully shutting down resources.
@@ -143,8 +143,8 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 			}
 			return describer, nil
 		},
-		Printer: func(mapping *meta.RESTMapping, noHeaders, withNamespace bool, wide bool, columnLabels []string) (kubectl.ResourcePrinter, error) {
-			return kubectl.NewHumanReadablePrinter(noHeaders, withNamespace, wide, columnLabels), nil
+		Printer: func(mapping *meta.RESTMapping, noHeaders, withNamespace bool, withEvent bool, wide bool, columnLabels []string) (kubectl.ResourcePrinter, error) {
+			return kubectl.NewHumanReadablePrinter(noHeaders, withNamespace, withEvent, wide, columnLabels), nil
 		},
 		PodSelectorForObject: func(object runtime.Object) (string, error) {
 			// TODO: replace with a swagger schema based approach (identify pod selector via schema introspection)
@@ -354,16 +354,16 @@ func (f *Factory) PrintObject(cmd *cobra.Command, obj runtime.Object, out io.Wri
 		return err
 	}
 
-	printer, err := f.PrinterForMapping(cmd, mapping, false)
+	printer, err := f.PrinterForMapping(cmd, mapping, false, false)
 	if err != nil {
 		return err
 	}
-	return printer.PrintObj(obj, out)
+	return printer.PrintObj(obj, nil, out)
 }
 
 // PrinterForMapping returns a printer suitable for displaying the provided resource type.
 // Requires that printer flags have been added to cmd (see AddPrinterFlags).
-func (f *Factory) PrinterForMapping(cmd *cobra.Command, mapping *meta.RESTMapping, withNamespace bool) (kubectl.ResourcePrinter, error) {
+func (f *Factory) PrinterForMapping(cmd *cobra.Command, mapping *meta.RESTMapping, withNamespace bool, withHeader bool) (kubectl.ResourcePrinter, error) {
 	printer, ok, err := PrinterForCommand(cmd)
 	if err != nil {
 		return nil, err
@@ -384,7 +384,7 @@ func (f *Factory) PrinterForMapping(cmd *cobra.Command, mapping *meta.RESTMappin
 		}
 		printer = kubectl.NewVersionedPrinter(printer, mapping.ObjectConvertor, version, mapping.APIVersion)
 	} else {
-		printer, err = f.Printer(mapping, GetFlagBool(cmd, "no-headers"), withNamespace, GetWideFlag(cmd), GetFlagStringList(cmd, "label-columns"))
+		printer, err = f.Printer(mapping, GetFlagBool(cmd, "no-headers"), withNamespace, withHeader, GetWideFlag(cmd), GetFlagStringList(cmd, "label-columns"))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes #11370 and #11338. 
What happens inside the PR:
-  Possibly nil pointer to watch.EventType is passed to PrintObj.
-  If kubectl get -w is used then the output has 1 extra column UPDATE
-  Because of large number, arguments (io.Writer, withNamespace, columns, etc) to functions like printPod are put to  private `PrintContext` struct.

Sample output:

```
$ kubectl get se -w 
UPDATE    NAME               LABELS                                    SELECTOR                IP(S)          PORT(S)
-         hazelcast          name=hazelcast                            name=hazelcast          10.0.251.80    5701/TCP
-         kubernetes         component=apiserver,provider=kubernetes   <none>                  10.0.0.1       443/TCP
-         redis-master-2     app=redis,role=master                     app=redis,role=master   10.0.220.190   1234/TCP
-         rethinkdb-driver   db=influxdb                               db=rethinkdb            10.0.235.59    28015/TCP
UPDATE    NAME        LABELS           SELECTOR         IP(S)         PORT(S)
ADDED     cassandra   name=cassandra   name=cassandra   10.0.27.165   9042/TCP
DELETED   cassandra   name=cassandra   name=cassandra   10.0.27.165   9042/TCP
DELETED   redis-master-2   app=redis,role=master   app=redis,role=master   10.0.220.190   1234/TCP
```
