### PR TITLE
Boot a Vagrant on VMWare Kubernetes Cluster

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,8 +74,8 @@ $kube_provider_boxes = {
   },
   :vmware_desktop => {
     'fedora' => {
-      :box_name => 'kube-fedora20',
-      :box_url => 'http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_fedora-20-i386_chef-provisionerless.box'
+      :box_name => 'kube-fedora21',
+      :box_url => 'http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_fedora-21_chef-provisionerless.box'
     }
   }
 }

--- a/cluster/saltbase/salt/generate-cert/init.sls
+++ b/cluster/saltbase/salt/generate-cert/init.sls
@@ -9,9 +9,6 @@
   {% if grains.cloud == 'azure' %}
     {% set cert_ip='_use_azure_dns_name_' %}
   {% endif %}
-  {% if grains.cloud == 'vagrant' %}
-    {% set cert_ip=grains.ip_interfaces.eth1[0] %}
-  {% endif %}
   {% if grains.cloud == 'vsphere' %}
     {% set cert_ip=grains.ip_interfaces.eth0[0] %}
   {% endif %}

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -79,10 +79,15 @@ if [[ "$(grep 'VERSION_ID' /etc/os-release)" =~ ^VERSION_ID=21 ]]; then
 
   # Disable network interface being managed by Network Manager (needed for Fedora 21+)
   NETWORK_CONF_PATH=/etc/sysconfig/network-scripts/
-  grep -q ^NM_CONTROLLED= ${NETWORK_CONF_PATH}ifcfg-eth1 || echo 'NM_CONTROLLED=no' >> ${NETWORK_CONF_PATH}ifcfg-eth1
-  sed -i 's/^#NM_CONTROLLED=.*/NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
+  if_to_edit=$( find ${NETWORK_CONF_PATH}ifcfg-* | xargs grep -l VAGRANT-BEGIN )
+  for if_conf in ${if_to_edit}; do
+    grep -q ^NM_CONTROLLED= ${if_conf} || echo 'NM_CONTROLLED=no' >> ${if_conf}
+    sed -i 's/#^NM_CONTROLLED=.*/NM_CONTROLLED=no/' ${if_conf}
+  done;
   systemctl restart network
 fi
+
+NETWORK_IF_NAME=`echo ${if_to_edit} | awk -F- '{ print $3 }'`
 
 # Setup hosts file to support ping by hostname to master
 if [ ! "$(cat /etc/hosts | grep $MASTER_NAME)" ]; then
@@ -142,7 +147,7 @@ grains:
   network_mode: openvswitch
   node_ip: '$(echo "$MINION_IP" | sed -e "s/'/''/g")'
   api_servers: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
-  networkInterfaceName: eth1
+  networkInterfaceName: '$(echo "$NETWORK_IF_NAME" | sed -e "s/'/''/g")'
   roles:
     - kubernetes-pool
   cbr-cidr: '$(echo "$CONTAINER_SUBNET" | sed -e "s/'/''/g")'


### PR DESCRIPTION
This addresses #10906 

This PR takes the following steps:
- Upgrade the underlying box to Fedora 21 (64 bit)
- Discover the main network interface instead of relying on the presence of eth1
- Pin the self-signed certificate to the API Server's IP address, which matches the Master server's IP address.

This results in a Kubernetes cluster that boots and responds to the API commands.
