### PR TITLE
Fix console output formatting for images doc

### DIFF
--- a/docs/user-guide/images.md
+++ b/docs/user-guide/images.md
@@ -116,7 +116,7 @@ example, run these on your desktop/laptop:
 
 Verify by creating a pod that uses a private image, e.g.:
 
-```
+```yaml
 $ cat <<EOF > /tmp/private-image-test-1.yaml
 apiVersion: v1
 kind: Pod
@@ -136,14 +136,14 @@ $
 
 If everything is working, then, after a few moments, you should see:
 
-```
+```console
 $ kubectl logs private-image-test-1
 SUCCESS
 ```
 
 If it failed, then you will see:
 
-```
+```console
 $ kubectl describe pods/private-image-test-1 | grep "Failed"
   Fri, 26 Jun 2015 15:36:13 -0700	Fri, 26 Jun 2015 15:39:13 -0700	19	{kubelet node-i2hq}	spec.containers{uses-private-image}	failed		Failed to pull image "user/privaterepo:v1": Error: image user/privaterepo:v1 not found
 ```
@@ -189,7 +189,7 @@ Kubernetes supports specifying registry keys on a pod.
 First, create a `.dockercfg`, such as running `docker login <registry.domain>`.
 Then put the resulting `.dockercfg` file into a [secret resource](secrets.md).  For example:
 
-```
+```console
 $ docker login
 Username: janedoe
 Password: ●●●●●●●●●●●
@@ -227,7 +227,7 @@ This process only needs to be done one time (per namespace).
 Now, you can create pods which reference that secret by adding an `imagePullSecrets`
 section to a pod definition.
 
-```
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
Not sure wherher to use yaml for console output that has a lot of YAML in it.
In one case here I do, in another case I don't.
Perhaps it is better to be consistent.
