### PR TITLE
fix the overlapped leftside nav entries

### DIFF
--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -19,12 +19,13 @@ ul, ul ul {
 }
 .menu > li > a {
 	width: 100%;
-	height: 2em;
+	height: auto;
 	color:#505050;
-	line-height: 2em;
 	display: block;
 	position: center;
 	padding-right: .25em;
+	margin-top: 1em;
+	margin-bottom: 1em;
 }
 .menu ul li a {
 	width: 100%;


### PR DESCRIPTION
see the wrapped lines in the red rectangular for example
![screenshot from 2015-07-19 14 30 34](https://cloud.githubusercontent.com/assets/2823529/8767988/ae9bb512-2e24-11e5-9d32-6b51623230e5.png)

@thockin @RichieEscarez @bgrant0607 
