### PR TITLE
realContainerGC reports warning when err is nil

### DIFF
--- a/pkg/kubelet/container_gc.go
+++ b/pkg/kubelet/container_gc.go
@@ -207,7 +207,7 @@ func (cgc *realContainerGC) removeOldestN(containers []containerGCInfo, toRemove
 		}
 		symlinkPath := dockertools.LogSymlink(cgc.containerLogsDir, containers[i].podNameWithNamespace, containers[i].containerName, containers[i].id)
 		err = os.Remove(symlinkPath)
-		if !os.IsNotExist(err) {
+		if err != nil && !os.IsNotExist(err) {
 			glog.Warningf("Failed to remove container %q log symlink %q: %v", containers[i].name, symlinkPath, err)
 		}
 	}


### PR DESCRIPTION
Hi, a small fix avoiding a log when there is no error. The false-positive log was:

```
W0720 11:56:26.539064    1692 container_gc.go:211] Failed to remove container "/k8s_xxx" log symlink "/var/log/containers/yyy.log": <nil>
```
