### PR TITLE
golang 1.5 issues

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -195,7 +195,7 @@
 		},
 		{
 			"ImportPath": "github.com/elazarl/go-bindata-assetfs",
-			"Rev": "ae4665cf2d188c65764c73fe4af5378acc549510"
+			"Rev": "c57a80f1ab2ad67bafa83f5fd0b4c2ecbd253dd5"
 		},
 		{
 			"ImportPath": "github.com/emicklei/go-restful",

--- a/Godeps/_workspace/src/github.com/elazarl/go-bindata-assetfs/README.md
+++ b/Godeps/_workspace/src/github.com/elazarl/go-bindata-assetfs/README.md
@@ -1,16 +1,44 @@
-go-bindata-http
-===============
+# go-bindata-assetfs
 
 Serve embedded files from [jteeuwen/go-bindata](https://github.com/jteeuwen/go-bindata) with `net/http`.
 
 [GoDoc](http://godoc.org/github.com/elazarl/go-bindata-assetfs)
 
-After running
+### Installation
 
-    $ go-bindata data/...
+Install with
 
-Use
+    $ go get github.com/jteeuwen/go-bindata/...
+    $ go get github.com/elazarl/go-bindata-assetfs/...
 
+### Creating embedded data
+
+Usage is identical to [jteeuwen/go-bindata](https://github.com/jteeuwen/go-bindata) usage,
+instead of running `go-bindata` run `go-bindata-assetfs`.
+
+The tool will create a `bindata_assetfs.go` file, which contains the embedded data.
+
+A typical use case is
+
+    $ go-bindata-assetfs data/...
+
+### Using assetFS in your code
+
+The generated file provides an `assetFS()` function that returns a `http.Filesystem`
+wrapping the embedded files. What you usually want to do is:
+
+    http.Handle("/", http.FileServer(assetFS()))
+
+This would run an HTTP server serving the embedded files.
+
+## Without running binary tool
+
+You can always just run the `go-bindata` tool, and then
+
+use
+
+     import "github.com/elazarl/go-bindata-assetfs"
+     ...
      http.Handle("/",
         http.FileServer(
         &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, Prefix: "data"}))

--- a/Godeps/_workspace/src/github.com/elazarl/go-bindata-assetfs/assetfs.go
+++ b/Godeps/_workspace/src/github.com/elazarl/go-bindata-assetfs/assetfs.go
@@ -3,7 +3,6 @@ package assetfs
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -11,6 +10,10 @@ import (
 	"path"
 	"path/filepath"
 	"time"
+)
+
+var (
+	fileTimestamp = time.Now()
 )
 
 // FakeFile implements os.FileInfo interface for a given path and size
@@ -37,7 +40,7 @@ func (f *FakeFile) Mode() os.FileMode {
 }
 
 func (f *FakeFile) ModTime() time.Time {
-	return time.Unix(0, 0)
+	return fileTimestamp
 }
 
 func (f *FakeFile) Size() int64 {
@@ -70,6 +73,10 @@ func (f *AssetFile) Readdir(count int) ([]os.FileInfo, error) {
 	return nil, errors.New("not a directory")
 }
 
+func (f *AssetFile) Size() int64 {
+	return f.FakeFile.Size()
+}
+
 func (f *AssetFile) Stat() (os.FileInfo, error) {
 	return f, nil
 }
@@ -98,7 +105,6 @@ func NewAssetDirectory(name string, children []string, fs *AssetFS) *AssetDirect
 }
 
 func (f *AssetDirectory) Readdir(count int) ([]os.FileInfo, error) {
-	fmt.Println(f, count)
 	if count <= 0 {
 		return f.Children, nil
 	}

--- a/Godeps/_workspace/src/github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs/main.go
+++ b/Godeps/_workspace/src/github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+const bindatafile = "bindata.go"
+
+func main() {
+	if _, err := exec.LookPath("go-bindata"); err != nil {
+		fmt.Println("Cannot find go-bindata executable in path")
+		fmt.Println("Maybe you need: go get github.com/elazarl/go-bindata-assetfs/...")
+		os.Exit(1)
+	}
+	cmd := exec.Command("go-bindata", os.Args[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		os.Exit(1)
+	}
+	in, err := os.Open(bindatafile)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Cannot read", bindatafile, err)
+		return
+	}
+	out, err := os.Create("bindata_assetfs.go")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Cannot write 'bindata_assetfs.go'", err)
+		return
+	}
+	r := bufio.NewReader(in)
+	done := false
+	for line, isPrefix, err := r.ReadLine(); err == nil; line, isPrefix, err = r.ReadLine() {
+		line = append(line, '\n')
+		if _, err := out.Write(line); err != nil {
+			fmt.Fprintln(os.Stderr, "Cannot write to 'bindata_assetfs.go'", err)
+			return
+		}
+		if !done && !isPrefix && bytes.HasPrefix(line, []byte("import (")) {
+			fmt.Fprintln(out, "\t\"github.com/elazarl/go-bindata-assetfs\"")
+			done = true
+		}
+	}
+	fmt.Fprintln(out, `
+func assetFS() *assetfs.AssetFS {
+	for k := range _bintree.Children {
+		return &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, Prefix: k}
+	}
+	panic("unreachable")
+}`)
+	// Close files BEFORE remove calls (don't use defer).
+	in.Close()
+	out.Close()
+	if err := os.Remove(bindatafile); err != nil {
+		fmt.Fprintln(os.Stderr, "Cannot remove", bindatafile, err)
+	}
+}


### PR DESCRIPTION
If kubernetes is built with golang 1.5, it fails due to extending bytes.Reader for Size method [1]. To fix this github.com/elazarl/go-bindata-assetfs needs to be updated to at least  c57a80f1ab2ad67bafa83f5fd0b4c2ecbd253dd5 commit

Building kubernetes with this patch with golang-1.4 is successful, all tests run via hack/test-cmd.sh passes. Building kubernetes with the patch with golang-1.5 is successful. However, hack/test-cmd.sh fails with:

Successful get rc {{range.items}}{{.metadata.name}}:{{end}}: frontend:redis-slave:
Successful get rc {{range.items}}{{.metadata.name}}:{{end}}: frontend:redis-slave:
replicationcontrollers/frontend
I0720 17:44:59.481729    9070 replication_controller.go:370] Replication Controller has been deleted default/frontend
replicationcontrollers/redis-slave
I0720 17:45:01.498616    9070 replication_controller.go:370] Replication Controller has been deleted default/redis-slave
Successful get rc {{range.items}}{{.metadata.name}}:{{end}}: 
error: error parsing template {{range.items}}{{..metadata.name}}:{{end}}, template: output:1: unexpected . after term "."

[1] https://github.com/elazarl/go-bindata-assetfs/pull/13.
