### PR TITLE
Disable indented code blocks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ markdown: kramdown
 #highlighter: pygments
 markdown: redcarpet
 redcarpet:
-    extensions: ["no_intra_emphasis", "tables", "autolink", "strikethrough", "with_toc_data", "lax_spacing", "space_after_headers" ]
+    extensions: ["no_intra_emphasis", "tables", "autolink", "strikethrough", "with_toc_data", "lax_spacing", "space_after_headers", "disable_indented_code_blocks" ]
 
 sass:
     style: :compressed


### PR DESCRIPTION
We use ``` everywhere
