### PR TITLE
make fake client thread-safe

### DIFF
--- a/pkg/client/testclient/fake_endpoints.go
+++ b/pkg/client/testclient/fake_endpoints.go
@@ -51,6 +51,9 @@ func (c *FakeEndpoints) Delete(name string) error {
 }
 
 func (c *FakeEndpoints) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Lock.Lock()
+	defer c.Fake.Lock.Unlock()
+
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-endpoints", Value: resourceVersion})
 	return c.Fake.Watch, c.Fake.Err
 }

--- a/pkg/client/testclient/fake_events.go
+++ b/pkg/client/testclient/fake_events.go
@@ -56,6 +56,9 @@ func (c *FakeEvents) Get(id string) (*api.Event, error) {
 
 // Watch starts watching for events matching the given selectors.
 func (c *FakeEvents) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Lock.Lock()
+	defer c.Fake.Lock.Unlock()
+
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-events", Value: resourceVersion})
 	return c.Fake.Watch, c.Fake.Err
 }
@@ -72,6 +75,9 @@ func (c *FakeEvents) Delete(name string) error {
 }
 
 func (c *FakeEvents) GetFieldSelector(involvedObjectName, involvedObjectNamespace, involvedObjectKind, involvedObjectUID *string) fields.Selector {
+	c.Fake.Lock.Lock()
+	defer c.Fake.Lock.Unlock()
+
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-field-selector"})
 	return fields.Everything()
 }

--- a/pkg/client/testclient/fake_limit_ranges.go
+++ b/pkg/client/testclient/fake_limit_ranges.go
@@ -56,6 +56,9 @@ func (c *FakeLimitRanges) Update(limitRange *api.LimitRange) (*api.LimitRange, e
 }
 
 func (c *FakeLimitRanges) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Lock.Lock()
+	defer c.Fake.Lock.Unlock()
+
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-limitRange", Value: resourceVersion})
 	return c.Fake.Watch, nil
 }

--- a/pkg/client/testclient/fake_namespaces.go
+++ b/pkg/client/testclient/fake_namespaces.go
@@ -55,6 +55,9 @@ func (c *FakeNamespaces) Update(namespace *api.Namespace) (*api.Namespace, error
 }
 
 func (c *FakeNamespaces) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Lock.Lock()
+	defer c.Fake.Lock.Unlock()
+
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-namespaces", Value: resourceVersion})
 	return c.Fake.Watch, nil
 }

--- a/pkg/client/testclient/fake_nodes.go
+++ b/pkg/client/testclient/fake_nodes.go
@@ -60,6 +60,9 @@ func (c *FakeNodes) UpdateStatus(minion *api.Node) (*api.Node, error) {
 }
 
 func (c *FakeNodes) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Lock.Lock()
+	defer c.Fake.Lock.Unlock()
+
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-nodes", Value: resourceVersion})
 	return c.Fake.Watch, c.Fake.Err
 }

--- a/pkg/client/testclient/fake_persistent_volume_claims.go
+++ b/pkg/client/testclient/fake_persistent_volume_claims.go
@@ -59,6 +59,9 @@ func (c *FakePersistentVolumeClaims) UpdateStatus(claim *api.PersistentVolumeCla
 }
 
 func (c *FakePersistentVolumeClaims) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Lock.Lock()
+	defer c.Fake.Lock.Unlock()
+
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-persistentVolumeClaims", Value: resourceVersion})
 	return c.Fake.Watch, c.Fake.Err
 }

--- a/pkg/client/testclient/fake_persistent_volumes.go
+++ b/pkg/client/testclient/fake_persistent_volumes.go
@@ -59,6 +59,9 @@ func (c *FakePersistentVolumes) UpdateStatus(pv *api.PersistentVolume) (*api.Per
 }
 
 func (c *FakePersistentVolumes) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Lock.Lock()
+	defer c.Fake.Lock.Unlock()
+
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-persistentVolumes", Value: resourceVersion})
 	return c.Fake.Watch, c.Fake.Err
 }

--- a/pkg/client/testclient/fake_pod_templates.go
+++ b/pkg/client/testclient/fake_pod_templates.go
@@ -56,6 +56,9 @@ func (c *FakePodTemplates) Update(pod *api.PodTemplate) (*api.PodTemplate, error
 }
 
 func (c *FakePodTemplates) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Lock.Lock()
+	defer c.Fake.Lock.Unlock()
+
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-podTemplates", Value: resourceVersion})
 	return c.Fake.Watch, c.Fake.Err
 }

--- a/pkg/client/testclient/fake_pods.go
+++ b/pkg/client/testclient/fake_pods.go
@@ -56,11 +56,17 @@ func (c *FakePods) Update(pod *api.Pod) (*api.Pod, error) {
 }
 
 func (c *FakePods) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Lock.Lock()
+	defer c.Fake.Lock.Unlock()
+
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-pods", Value: resourceVersion})
 	return c.Fake.Watch, c.Fake.Err
 }
 
 func (c *FakePods) Bind(bind *api.Binding) error {
+	c.Fake.Lock.Lock()
+	defer c.Fake.Lock.Unlock()
+
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "bind-pod", Value: bind.Name})
 	return nil
 }

--- a/pkg/client/testclient/fake_replication_controllers.go
+++ b/pkg/client/testclient/fake_replication_controllers.go
@@ -65,6 +65,9 @@ func (c *FakeReplicationControllers) Delete(name string) error {
 }
 
 func (c *FakeReplicationControllers) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Lock.Lock()
+	defer c.Fake.Lock.Unlock()
+
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: WatchControllerAction, Value: resourceVersion})
 	return c.Fake.Watch, nil
 }

--- a/pkg/client/testclient/fake_resource_quotas.go
+++ b/pkg/client/testclient/fake_resource_quotas.go
@@ -61,6 +61,9 @@ func (c *FakeResourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (*ap
 }
 
 func (c *FakeResourceQuotas) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Lock.Lock()
+	defer c.Fake.Lock.Unlock()
+
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-resourceQuota", Value: resourceVersion})
 	return c.Fake.Watch, nil
 }

--- a/pkg/client/testclient/fake_secrets.go
+++ b/pkg/client/testclient/fake_secrets.go
@@ -56,6 +56,9 @@ func (c *FakeSecrets) Delete(name string) error {
 }
 
 func (c *FakeSecrets) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Lock.Lock()
+	defer c.Fake.Lock.Unlock()
+
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-secrets", Value: resourceVersion})
 	return c.Fake.Watch, c.Fake.Err
 }

--- a/pkg/client/testclient/fake_service_accounts.go
+++ b/pkg/client/testclient/fake_service_accounts.go
@@ -56,6 +56,9 @@ func (c *FakeServiceAccounts) Delete(name string) error {
 }
 
 func (c *FakeServiceAccounts) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Lock.Lock()
+	defer c.Fake.Lock.Unlock()
+
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-serviceAccounts", Value: resourceVersion})
 	return c.Fake.Watch, c.Fake.Err
 }

--- a/pkg/client/testclient/fake_services.go
+++ b/pkg/client/testclient/fake_services.go
@@ -56,6 +56,9 @@ func (c *FakeServices) Delete(name string) error {
 }
 
 func (c *FakeServices) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Lock.Lock()
+	defer c.Fake.Lock.Unlock()
+
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-services", Value: resourceVersion})
 	return c.Fake.Watch, c.Fake.Err
 }


### PR DESCRIPTION
Access to the fake test client isn't synchronized, so it ends up with data races.  This adds a coarse grained lock on accesses to prevent data races when unit testing multi-threaded code.
