### PR TITLE
Create a Jenkins project to run only the examples e2e tests on GCE

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -124,6 +124,16 @@ case ${JOB_NAME} in
     : ${PROJECT:="k8s-jkns-e2e-gce"}
     ;;
 
+  # Runs only the examples tests on GCE.
+  kubernetes-e2e-gce-examples)
+    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-examples"}
+    : ${E2E_DOWN:="false"}
+    : ${E2E_NETWORK:="e2e-examples"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=Example"}
+    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-examples"}
+    : ${PROJECT:="kubernetes-jenkins"}
+    ;;
+
   # Runs the flaky tests on GCE, sequentially.
   kubernetes-e2e-gce-flaky)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-flaky"}


### PR DESCRIPTION
Ref #10548 and #10013.

This should have no effect on the other Jenkins projects, but it'll allow us to start getting coverage of the examples e2e tests (of which only 2 are currently merged).

cc @mwielgus @mbforbes @zmerlynn @davidopp @quinton-hoole @jayunit100
