### PR TITLE
Skip GKE for shell services test and make clear why

### DIFF
--- a/test/e2e/shell.go
+++ b/test/e2e/shell.go
@@ -27,8 +27,12 @@ import (
 
 var _ = Describe("Shell", func() {
 	It("should pass tests for services.sh", func() {
-		SkipUnlessProviderIs("gce", "gke")
-
+		// This test requires:
+		// - SSH
+		// - master access
+		// ... so the provider check should be identical to the intersection of
+		// providers that provide those capabilities.
+		SkipUnlessProviderIs("gce")
 		runCmdTest(filepath.Join(testContext.RepoRoot, "hack/e2e-suite/services.sh"))
 	})
 })


### PR DESCRIPTION
Currently, all GKE Jenkins configs must specify skipping this test on their own. However, GKE won't ever be able to run this test because it requires master access.
