### PR TITLE
Extracting out the code to versionize docs from mark-new-version and fixing a bunch of issues

### DIFF
--- a/build/mark-new-version.sh
+++ b/build/mark-new-version.sh
@@ -89,35 +89,8 @@ if ! ($SED --version 2>&1 | grep -q GNU); then
   echo "!!! GNU sed is required.  If on OS X, use 'brew install gnu-sed'."
 fi
 
-echo "+++ Versioning documentation and examples"
-
-# Update the docs to match this version.
-HTML_PREVIEW_PREFIX="https://htmlpreview.github.io/?https://github.com/GoogleCloudPlatform/kubernetes"
-md_dirs=(docs examples)
-md_files=()
-for dir in "${md_dirs[@]}"; do
-  mdfiles+=($( find "${dir}" -name "*.md" -type f ))
-done
-for doc in "${mdfiles[@]}"; do
-  $SED -ri \
-      -e '/<!-- BEGIN STRIP_FOR_RELEASE -->/,/<!-- END STRIP_FOR_RELEASE -->/d' \
-      -e "s|(releases.k8s.io)/[^/]+|\1/${NEW_VERSION}|" \
-      "${doc}"
-
-  # Replace /HEAD in html preview links with /NEW_VERSION.
-  $SED -ri -e "s|(${HTML_PREVIEW_PREFIX}/HEAD)|${HTML_PREVIEW_PREFIX}/${NEW_VERSION}|" "${doc}"
-
-  is_versioned_tag='<!-- TAG IS_VERSIONED -->'
-  if ! grep -q "${is_versioned_tag}" "${doc}"; then
-    echo "${is_versioned_tag}" >> "${doc}"
-  fi
-done
-
-# Update API descriptions to match this version.
-$SED -ri -e "s|(releases.k8s.io)/[^/]+|\1/${NEW_VERSION}|" pkg/api/v[0-9]*/types.go
-
-${KUBE_ROOT}/hack/run-gendocs.sh
-${KUBE_ROOT}/hack/update-swagger-spec.sh
+echo "+++ Running ./versionize-docs"
+${KUBE_ROOT}/build/versionize-docs.sh ${NEW_VERSION}
 git commit -am "Versioning docs and examples for ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
 
 dochash=$(git log -n1 --format=%H)

--- a/build/versionize-docs.sh
+++ b/build/versionize-docs.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Updates the docs to be ready to be used as release docs for a particular
+# version.
+# Example usage:
+# ./versionize-docs.sh v1.0.1
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+NEW_VERSION=${1-}
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: versionize-docs <release-version>"
+    exit 1
+fi
+
+SED=sed
+if which gsed &>/dev/null; then
+  SED=gsed
+fi
+if ! ($SED --version 2>&1 | grep -q GNU); then
+  echo "!!! GNU sed is required.  If on OS X, use 'brew install gnu-sed'."
+  exit 1
+fi
+
+echo "+++ Versioning documentation and examples"
+
+# Update the docs to match this version.
+HTML_PREVIEW_PREFIX="https://htmlpreview.github.io/\?https://github.com/GoogleCloudPlatform/kubernetes"
+
+md_dirs=(docs examples)
+md_files=()
+for dir in "${md_dirs[@]}"; do
+  mdfiles+=($( find "${dir}" -name "*.md" -type f ))
+done
+for doc in "${mdfiles[@]}"; do
+  $SED -ri \
+      -e '/<!-- BEGIN STRIP_FOR_RELEASE -->/,/<!-- END STRIP_FOR_RELEASE -->/d' \
+      -e "s|(releases.k8s.io)/[^/]+|\1/${NEW_VERSION}|" \
+      "${doc}"
+
+  # Replace /HEAD in html preview links with /NEW_VERSION.
+  $SED -ri -e "s|(${HTML_PREVIEW_PREFIX}/HEAD)|${HTML_PREVIEW_PREFIX}/${NEW_VERSION}|" "${doc}"
+
+  is_versioned_tag="<!-- BEGIN MUNGE: IS_VERSIONED -->
+  <!-- TAG IS_VERSIONED -->
+  <!-- END MUNGE: IS_VERSIONED -->"
+  if ! grep -q "${is_versioned_tag}" "${doc}"; then
+    echo -e "\n\n${is_versioned_tag}\n\n" >> "${doc}"
+  fi
+done
+
+# Update API descriptions to match this version.
+$SED -ri -e "s|(releases.k8s.io)/[^/]+|\1/${NEW_VERSION}|" pkg/api/v[0-9]*/types.go
+
+${KUBE_ROOT}/hack/run-gendocs.sh
+${KUBE_ROOT}/hack/update-swagger-spec.sh

--- a/cmd/mungedocs/analytics.go
+++ b/cmd/mungedocs/analytics.go
@@ -32,7 +32,7 @@ var (
 
 	// Matches the analytics blurb, with or without the munge headers.
 	analyticsRE = regexp.MustCompile(`[\n]*` + analyticsExp + `[\n]?` +
-		`|` + `[\n]*` + beginMungeExp + `[^<]*` + endMungeExp + `[\n]*`)
+		`|` + `[\n]*` + beginMungeExp + `[^<]*` + endMungeExp)
 )
 
 // This adds the analytics link to every .md file.

--- a/cmd/mungedocs/analytics_test.go
+++ b/cmd/mungedocs/analytics_test.go
@@ -27,53 +27,57 @@ func TestAnalytics(t *testing.T) {
 		in  string
 		out string
 	}{
-		{`aoeu`, `aoeu
-
-
-` + beginMungeTag("GENERATED_ANALYTICS") + `
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()
-` + endMungeTag("GENERATED_ANALYTICS") + `
-`},
-		{`aoeu
-
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()
-`, `aoeu
-
-
-` + beginMungeTag("GENERATED_ANALYTICS") + `
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()
-` + endMungeTag("GENERATED_ANALYTICS") + `
-`},
-		{`aoeu
-
-` + beginMungeTag("GENERATED_ANALYTICS") + `
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()
-` + endMungeTag("GENERATED_ANALYTICS") + `
-`, `aoeu
-
-
-` + beginMungeTag("GENERATED_ANALYTICS") + `
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()
-` + endMungeTag("GENERATED_ANALYTICS") + `
-`},
-		{`aoeu
-
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()
-
-
-
-` + beginMungeTag("GENERATED_ANALYTICS") + `
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()
-` + endMungeTag("GENERATED_ANALYTICS") + `
-`, `aoeu
-
-
-` + beginMungeTag("GENERATED_ANALYTICS") + `
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()
-` + endMungeTag("GENERATED_ANALYTICS") + `
-`},
+		{
+			"aoeu",
+			"aoeu" + "\n" + "\n" + "\n" +
+				beginMungeTag("GENERATED_ANALYTICS") + "\n" +
+				"[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()" + "\n" +
+				endMungeTag("GENERATED_ANALYTICS") + "\n"},
+		{
+			"aoeu" + "\n" + "\n" + "\n" +
+				"[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()",
+			"aoeu" + "\n" + "\n" + "\n" +
+				beginMungeTag("GENERATED_ANALYTICS") + "\n" +
+				"[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()" + "\n" +
+				endMungeTag("GENERATED_ANALYTICS") + "\n"},
+		{
+			"aoeu" + "\n" +
+				beginMungeTag("GENERATED_ANALYTICS") + "\n" +
+				"[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()" + "\n" +
+				endMungeTag("GENERATED_ANALYTICS") + "\n",
+			"aoeu" + "\n" + "\n" + "\n" +
+				beginMungeTag("GENERATED_ANALYTICS") + "\n" +
+				"[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()" + "\n" +
+				endMungeTag("GENERATED_ANALYTICS") + "\n"},
+		{
+			"aoeu" + "\n" + "\n" +
+				"[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()" + "\n" + "\n" + "\n" +
+				beginMungeTag("GENERATED_ANALYTICS") + "\n" +
+				"[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()" + "\n" +
+				endMungeTag("GENERATED_ANALYTICS") + "\n",
+			"aoeu" + "\n" + "\n" + "\n" +
+				beginMungeTag("GENERATED_ANALYTICS") + "\n" +
+				"[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()" + "\n" +
+				endMungeTag("GENERATED_ANALYTICS") + "\n"},
+		{
+			"prefix" + "\n" +
+				beginMungeTag("GENERATED_ANALYTICS") + "\n" +
+				"[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()" + "\n" +
+				endMungeTag("GENERATED_ANALYTICS") +
+				"\n" + "suffix",
+			"prefix" + "\n" + "suffix" + "\n" + "\n" + "\n" +
+				beginMungeTag("GENERATED_ANALYTICS") + "\n" +
+				"[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()" + "\n" +
+				endMungeTag("GENERATED_ANALYTICS") + "\n"},
+		{
+			"aoeu" + "\n" + "\n" + "\n" +
+				beginMungeTag("GENERATED_ANALYTICS") + "\n" +
+				"[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()" + "\n" +
+				endMungeTag("GENERATED_ANALYTICS") + "\n",
+			"aoeu" + "\n" + "\n" + "\n" +
+				beginMungeTag("GENERATED_ANALYTICS") + "\n" +
+				"[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/path/to/file-name.md?pixel)]()" + "\n" +
+				endMungeTag("GENERATED_ANALYTICS") + "\n"},
 	}
 	for _, c := range cases {
 		out, err := checkAnalytics("path/to/file-name.md", []byte(c.in))

--- a/cmd/mungedocs/mungedocs.go
+++ b/cmd/mungedocs/mungedocs.go
@@ -46,10 +46,10 @@ Examples:
 	// TODO: allow selection from command line. (e.g., just check links in the examples directory.)
 	allMunges = []munge{
 		{"table-of-contents", updateTOC},
+		{"unversioned-warning", updateUnversionedWarning},
 		{"check-links", checkLinks},
 		{"blank-lines-surround-preformatted", checkPreformatted},
 		{"header-lines", checkHeaderLines},
-		{"unversioned-warning", updateUnversionedWarning},
 		{"analytics", checkAnalytics},
 		{"kubectl-dash-f", checkKubectlFileTargets},
 	}


### PR DESCRIPTION
Extracting out the relevant code to versionize our docs into a separate script.
Have also added a script to verify that running versionize-docs multiple times does not produce any diffs.
Apart from the refactoring, this PR fixes the following issues as well:
- Fixed HTML_PREVIEW_PREFIX regex, so that HEAD in htmlpreview links is now replaced appropriately.
- Updated the IS_VERSIONED tag to be enclosed in "BEGIN MUNGE" and "END MUNGE" tags, so that it is not stripped off by gendocs (Right now, gendocs strips off IS_VERSIONED and hence all our versioned kubectl docs contain the unversioned warnings)
- Fixed analytics munger to not delete line breaks which it should not. Also, added a relevant test case. (Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/11676)
- Changed the ordering of mungedocs, so that checkHeaderLines mungedoc is run after unversioned warning is added, so that it can add line breaks after unversioned warnings.

Original description:
Extracted the relevant code to a separate script.
This PR also includes a temporary commit produced by running versionize-docs.
