### PR TITLE
Use the correct delimiter for -X option of --ldflags.

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -108,11 +108,11 @@ kube::version::ldflags::new_pair() {
   local delimiter=${3-}
 
   [[ -n ${key} ]] || {
-    return ""
+    return
   }
 
   [[ -n ${value} ]] || {
-    return ""
+    return
   }
 
   # Set implicit delimiter if not set


### PR DESCRIPTION
go1.5 reports warning about use of -X option and recommends
using -X value=key form instead of -X value key.
go1.4 does not like this new form.

In order to support easy migration from go1.4 to go1.5,
correct delimiter of key value pair is used based on go version.
