### PR TITLE
add non-root directive to SC and kubelet checking

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -12774,6 +12774,10 @@
       "type": "integer",
       "format": "int64",
       "description": "the user id that runs the first process in the container; see http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+     },
+     "runAsNonRoot": {
+      "type": "boolean",
+      "description": "indicates the container must be run as a non-root user either by specifying the runAsUser or in the image specification"
      }
     }
    },

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1803,6 +1803,7 @@ func deepCopy_api_SecurityContext(in SecurityContext, out *SecurityContext, c *c
 	} else {
 		out.RunAsUser = nil
 	}
+	out.RunAsNonRoot = in.RunAsNonRoot
 	return nil
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2166,6 +2166,11 @@ type SecurityContext struct {
 
 	// RunAsUser is the UID to run the entrypoint of the container process.
 	RunAsUser *int64 `json:"runAsUser,omitempty"`
+
+	// RunAsNonRoot indicates that the container should be run as a non-root user.  If the RunAsUser
+	// field is not explicitly set then the kubelet may check the image for a specified user or
+	// perform defaulting to specify a user.
+	RunAsNonRoot bool
 }
 
 // SELinuxOptions are the labels to be applied to the container.

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -2002,6 +2002,7 @@ func convert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityContext, 
 	} else {
 		out.RunAsUser = nil
 	}
+	out.RunAsNonRoot = in.RunAsNonRoot
 	return nil
 }
 
@@ -4344,6 +4345,7 @@ func convert_v1_SecurityContext_To_api_SecurityContext(in *SecurityContext, out 
 	} else {
 		out.RunAsUser = nil
 	}
+	out.RunAsNonRoot = in.RunAsNonRoot
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1812,6 +1812,7 @@ func deepCopy_v1_SecurityContext(in SecurityContext, out *SecurityContext, c *co
 	} else {
 		out.RunAsUser = nil
 	}
+	out.RunAsNonRoot = in.RunAsNonRoot
 	return nil
 }
 

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2030,6 +2030,11 @@ type SecurityContext struct {
 
 	// RunAsUser is the UID to run the entrypoint of the container process.
 	RunAsUser *int64 `json:"runAsUser,omitempty" description:"the user id that runs the first process in the container; see http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"`
+
+	// RunAsNonRoot indicates that the container should be run as a non-root user.  If the RunAsUser
+	// field is not explicitly set then the kubelet may check the image for a specified user or
+	// perform defaulting to specify a user.
+	RunAsNonRoot bool `json:"runAsNonRoot,omitempty" description:"indicates the container must be run as a non-root user either by specifying the runAsUser or in the image specification"`
 }
 
 // SELinuxOptions are the labels to be applied to the container

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -852,6 +852,8 @@ func (r *runtime) SyncPod(pod *api.Pod, runningPod kubecontainer.Pod, podStatus 
 			continue
 		}
 
+		// TODO: check for non-root image directives.  See ../docker/manager.go#SyncPod
+
 		// TODO(yifan): Take care of host network change.
 		containerChanged := c.Hash != 0 && c.Hash != expectedHash
 		if containerChanged {

--- a/pkg/securitycontext/util.go
+++ b/pkg/securitycontext/util.go
@@ -66,3 +66,24 @@ func ParseSELinuxOptions(context string) (*api.SELinuxOptions, error) {
 		Level: fields[3],
 	}, nil
 }
+
+// HasNonRootUID returns true if the runAsUser is set and is greater than 0.
+func HasRootUID(container *api.Container) bool {
+	if container.SecurityContext == nil {
+		return false
+	}
+	if container.SecurityContext.RunAsUser == nil {
+		return false
+	}
+	return *container.SecurityContext.RunAsUser == 0
+}
+
+// HasRunAsUser determines if the sc's runAsUser field is set.
+func HasRunAsUser(container *api.Container) bool {
+	return container.SecurityContext != nil && container.SecurityContext.RunAsUser != nil
+}
+
+// HasRootRunAsUser returns true if the run as user is set and it is set to 0.
+func HasRootRunAsUser(container *api.Container) bool {
+	return HasRunAsUser(container) && HasRootUID(container)
+}

--- a/pkg/securitycontext/util_test.go
+++ b/pkg/securitycontext/util_test.go
@@ -83,3 +83,124 @@ func compareContexts(name string, ex, ac *api.SELinuxOptions, t *testing.T) {
 		t.Errorf("%v: expected level: %v, got: %v", name, e, a)
 	}
 }
+
+func TestHaRootUID(t *testing.T) {
+	var nonRoot int64 = 1
+	var root int64 = 0
+
+	tests := map[string]struct {
+		container *api.Container
+		expect    bool
+	}{
+		"nil sc": {
+			container: &api.Container{SecurityContext: nil},
+		},
+		"nil runAsuser": {
+			container: &api.Container{
+				SecurityContext: &api.SecurityContext{
+					RunAsUser: nil,
+				},
+			},
+		},
+		"runAsUser non-root": {
+			container: &api.Container{
+				SecurityContext: &api.SecurityContext{
+					RunAsUser: &nonRoot,
+				},
+			},
+		},
+		"runAsUser root": {
+			container: &api.Container{
+				SecurityContext: &api.SecurityContext{
+					RunAsUser: &root,
+				},
+			},
+			expect: true,
+		},
+	}
+
+	for k, v := range tests {
+		actual := HasRootUID(v.container)
+		if actual != v.expect {
+			t.Errorf("%s failed, expected %t but received %t", k, v.expect, actual)
+		}
+	}
+}
+
+func TestHasRunAsUser(t *testing.T) {
+	var runAsUser int64 = 0
+
+	tests := map[string]struct {
+		container *api.Container
+		expect    bool
+	}{
+		"nil sc": {
+			container: &api.Container{SecurityContext: nil},
+		},
+		"nil runAsUser": {
+			container: &api.Container{
+				SecurityContext: &api.SecurityContext{
+					RunAsUser: nil,
+				},
+			},
+		},
+		"valid runAsUser": {
+			container: &api.Container{
+				SecurityContext: &api.SecurityContext{
+					RunAsUser: &runAsUser,
+				},
+			},
+			expect: true,
+		},
+	}
+
+	for k, v := range tests {
+		actual := HasRunAsUser(v.container)
+		if actual != v.expect {
+			t.Errorf("%s failed, expected %t but received %t", k, v.expect, actual)
+		}
+	}
+}
+
+func TestHasRootRunAsUser(t *testing.T) {
+	var nonRoot int64 = 1
+	var root int64 = 0
+
+	tests := map[string]struct {
+		container *api.Container
+		expect    bool
+	}{
+		"nil sc": {
+			container: &api.Container{SecurityContext: nil},
+		},
+		"nil runAsuser": {
+			container: &api.Container{
+				SecurityContext: &api.SecurityContext{
+					RunAsUser: nil,
+				},
+			},
+		},
+		"runAsUser non-root": {
+			container: &api.Container{
+				SecurityContext: &api.SecurityContext{
+					RunAsUser: &nonRoot,
+				},
+			},
+		},
+		"runAsUser root": {
+			container: &api.Container{
+				SecurityContext: &api.SecurityContext{
+					RunAsUser: &root,
+				},
+			},
+			expect: true,
+		},
+	}
+
+	for k, v := range tests {
+		actual := HasRootRunAsUser(v.container)
+		if actual != v.expect {
+			t.Errorf("%s failed, expected %t but received %t", k, v.expect, actual)
+		}
+	}
+}


### PR DESCRIPTION
Currently a SecurityContext allows you to set the preferred user to run an image.  In some cases it is preferable to not specify the user and allow the system or image to provide the user.  Based on work in https://github.com/GoogleCloudPlatform/kubernetes/pull/7893 it was found that, when dealing with non-root security policies, there must be a way to account for when an image specifies a user but the container's `runAsUser` is not set.

The easiest way to deal with this seems to be allowing the pod to be submitted but having a final check in the kubelet (docker manager).  In order to accomplish this there should be a marker to say that the effective context is expecting to run as non-root.  This allows the kubelet's image implementations to know that in the absence of a `runAsUser` they must ensure that the image being run has a non-root user directive.

Note: currently there is an admission controller that prevents the use of `runAsUser` in Kubernetes so this should not change the current system behavior.

@erictune @pmorie @smarterclayton 
