### PR TITLE
contrib/podex: support for insecure HTTP/self-signed registries

### DIFF
--- a/contrib/podex/README.md
+++ b/contrib/podex/README.md
@@ -8,14 +8,19 @@ Manifests can then be edited by a human to match deployment needs.
 
 ## Usage
 ```
-$ podex [-format json|yaml] [-type=pod|container] [-name PODNAME] IMAGES...
+$ podex [-daemon] [-insecure-registry] [-insecure-skip-verify] [-format yaml|json] [-type=pod|container] [-name PODNAME] IMAGES...
 
 ```
 
 ### Options
 - `format`: manifest format to output, `yaml` (default) or `json`
-- `json`: manifest type to output, `pod` (default) or `container`
+- `type`: manifest type to output, `pod` (default) or `container`
 - `name`: manifest name (required with multiple images, optional with single image: default to image base name)
+
+### Flags
+- `daemon`: run in daemon mode
+- `insecure-registry`: connect to insecure registry using HTTP
+- `insecure-skip-verify`: skip registry certificate verify (registry with self-signed certificate)
 
 ### Examples
 ```

--- a/contrib/podex/podex.go
+++ b/contrib/podex/podex.go
@@ -29,13 +29,13 @@ package main
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
-	"crypto/tls"
 	"os"
 	"strconv"
 	"strings"
@@ -250,9 +250,9 @@ type imageMetadata struct {
 func getImageMetadata(host, namespace, repo, tag string) (*imageMetadata, error) {
 	var scheme string
 	if *flInsecureRegistry {
-    	scheme = "http"
+		scheme = "http"
 	} else {
-    	scheme = "https"
+		scheme = "https"
 	}
 	if *flInsecureSkipVerify {
 
@@ -268,13 +268,13 @@ func getImageMetadata(host, namespace, repo, tag string) (*imageMetadata, error)
 	}
 
 	tr := &http.Transport{
-        TLSClientConfig: &tls.Config{
-        	InsecureSkipVerify: *flInsecureSkipVerify,
-        },
-    }
-    client := &http.Client{
-    	Transport: tr,
-    }
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: *flInsecureSkipVerify,
+		},
+	}
+	client := &http.Client{
+		Transport: tr,
+	}
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s://%s/v1/repositories/%s/%s/images", scheme, host, namespace, repo), nil)
 	if err != nil {

--- a/contrib/podex/podex.go
+++ b/contrib/podex/podex.go
@@ -254,9 +254,6 @@ func getImageMetadata(host, namespace, repo, tag string) (*imageMetadata, error)
 	} else {
 		scheme = "https"
 	}
-	if *flInsecureSkipVerify {
-
-	}
 	if host == "" {
 		host = "index.docker.io"
 	}

--- a/contrib/podex/podex.go
+++ b/contrib/podex/podex.go
@@ -35,6 +35,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"crypto/tls"
 	"os"
 	"strconv"
 	"strings"
@@ -43,12 +44,14 @@ import (
 	goyaml "gopkg.in/yaml.v2"
 )
 
-const usage = "podex [-format=yaml|json] [-type=pod|container] [-id NAME] IMAGES..."
+const usage = "podex [-daemon] [-insecure-registry] [-insecure-skip-verify] [-format=yaml|json] [-type=pod|container] [-name NAME] IMAGES..."
 
 var flManifestFormat = flag.String("format", "yaml", "manifest format to output, `yaml` or `json`")
 var flManifestType = flag.String("type", "pod", "manifest type to output, `pod` or `container`")
 var flManifestName = flag.String("name", "", "manifest name, default to image base name")
 var flDaemon = flag.Bool("daemon", false, "daemon mode")
+var flInsecureRegistry = flag.Bool("insecure-registry", false, "connect to insecure registry")
+var flInsecureSkipVerify = flag.Bool("insecure-skip-verify", false, "skip certificate verify")
 
 func init() {
 	flag.Usage = func() {
@@ -245,6 +248,15 @@ type imageMetadata struct {
 }
 
 func getImageMetadata(host, namespace, repo, tag string) (*imageMetadata, error) {
+	var scheme string
+	if *flInsecureRegistry {
+    	scheme = "http"
+	} else {
+    	scheme = "https"
+	}
+	if *flInsecureSkipVerify {
+
+	}
 	if host == "" {
 		host = "index.docker.io"
 	}
@@ -254,13 +266,22 @@ func getImageMetadata(host, namespace, repo, tag string) (*imageMetadata, error)
 	if tag == "" {
 		tag = "latest"
 	}
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/v1/repositories/%s/%s/images", host, namespace, repo), nil)
 
+	tr := &http.Transport{
+        TLSClientConfig: &tls.Config{
+        	InsecureSkipVerify: *flInsecureSkipVerify,
+        },
+    }
+    client := &http.Client{
+    	Transport: tr,
+    }
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s://%s/v1/repositories/%s/%s/images", scheme, host, namespace, repo), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %v", err)
 	}
 	req.Header.Add("X-Docker-Token", "true")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error making request to %q: %v", host, err)
 	}
@@ -270,12 +291,12 @@ func getImageMetadata(host, namespace, repo, tag string) (*imageMetadata, error)
 
 	endpoints := resp.Header.Get("X-Docker-Endpoints")
 	token := resp.Header.Get("X-Docker-Token")
-	req, err = http.NewRequest("GET", fmt.Sprintf("https://%s/v1/repositories/%s/%s/tags/%s", endpoints, namespace, repo, tag), nil)
+	req, err = http.NewRequest("GET", fmt.Sprintf("%s://%s/v1/repositories/%s/%s/tags/%s", scheme, endpoints, namespace, repo, tag), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %v", err)
 	}
 	req.Header.Add("Authorization", "Token "+token)
-	resp, err = http.DefaultClient.Do(req)
+	resp, err = client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error getting image id for %s/%s:%s %v", namespace, repo, tag, err)
 	}
@@ -283,12 +304,12 @@ func getImageMetadata(host, namespace, repo, tag string) (*imageMetadata, error)
 	if err = json.NewDecoder(resp.Body).Decode(&imageID); err != nil {
 		return nil, fmt.Errorf("error decoding image id: %v", err)
 	}
-	req, err = http.NewRequest("GET", fmt.Sprintf("https://%s/v1/images/%s/json", endpoints, imageID), nil)
+	req, err = http.NewRequest("GET", fmt.Sprintf("%s://%s/v1/images/%s/json", scheme, endpoints, imageID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %v", err)
 	}
 	req.Header.Add("Authorization", "Token "+token)
-	resp, err = http.DefaultClient.Do(req)
+	resp, err = client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error getting json for image %q: %v", imageID, err)
 	}

--- a/contrib/podex/podex.go
+++ b/contrib/podex/podex.go
@@ -248,11 +248,9 @@ type imageMetadata struct {
 }
 
 func getImageMetadata(host, namespace, repo, tag string) (*imageMetadata, error) {
-	var scheme string
+	scheme := "https"
 	if *flInsecureRegistry {
 		scheme = "http"
-	} else {
-		scheme = "https"
 	}
 	if host == "" {
 		host = "index.docker.io"
@@ -264,13 +262,12 @@ func getImageMetadata(host, namespace, repo, tag string) (*imageMetadata, error)
 		tag = "latest"
 	}
 
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: *flInsecureSkipVerify,
-		},
-	}
 	client := &http.Client{
-		Transport: tr,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: *flInsecureSkipVerify,
+			},
+		},
 	}
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s://%s/v1/repositories/%s/%s/images", scheme, host, namespace, repo), nil)


### PR DESCRIPTION
Added two new command-line flags for support insecure (HTTP/self-signed HTTPS) docker registries:
- `insecure-registry`: connect to insecure registry using HTTP
- `insecure-skip-verify`: skip registry certificate verify (useful for HTTPS registries with self-signed certificate)
