### PR TITLE
pkg/kubectl/resource_printer.go refactoring

### DIFF
--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -112,6 +112,10 @@ func (t *testPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 	return t.Err
 }
 
+func (t *testPrinter) AddObjectPreprocessor(preprocessor kubectl.ObjectPreprocessor) {
+	// do nothing
+}
+
 type testDescriber struct {
 	Name, Namespace string
 	Output          string

--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -66,7 +66,8 @@ func NewCmdConfigView(out io.Writer, ConfigAccess ConfigAccess) *cobra.Command {
 				glog.FatalDepth(1, err)
 			}
 			version := cmdutil.OutputVersion(cmd, latest.Version)
-			printer = kubectl.NewVersionedPrinter(printer, clientcmdapi.Scheme, version)
+			preprocessor := kubectl.NewVersionConverter(clientcmdapi.Scheme, version)
+			printer.AddObjectPreprocessor(preprocessor)
 
 			if err := options.Run(out, printer); err != nil {
 				glog.FatalDepth(1, err)

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -211,7 +211,7 @@ func RunLabel(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 			return err
 		}
 
-		printer, err := f.PrinterForMapping(cmd, info.Mapping, false)
+		printer, err := f.PrinterForMapping(cmd, info.Mapping, false, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-
 	"github.com/spf13/cobra"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"

--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -92,16 +92,16 @@ func PrinterForCommand(cmd *cobra.Command) (kubectl.ResourcePrinter, bool, error
 		return nil, generic, err
 	}
 
-	return maybeWrapSortingPrinter(cmd, printer), generic, nil
+	return maybeAddSortingPreprocessor(cmd, printer), generic, nil
 }
 
-func maybeWrapSortingPrinter(cmd *cobra.Command, printer kubectl.ResourcePrinter) kubectl.ResourcePrinter {
+func maybeAddSortingPreprocessor(cmd *cobra.Command, printer kubectl.ResourcePrinter) kubectl.ResourcePrinter {
 	sorting := GetFlagString(cmd, "sort-by")
 	if len(sorting) != 0 {
-		return &kubectl.SortingPrinter{
+		printer.AddObjectPreprocessor(kubectl.SortingPreprocessor{
 			Delegate:  printer,
 			SortField: fmt.Sprintf("{%s}", sorting),
-		}
+		})
 	}
 	return printer
 }

--- a/pkg/kubectl/resource_columns.go
+++ b/pkg/kubectl/resource_columns.go
@@ -1,0 +1,593 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+type ColumnPrinter interface {
+	Title() string
+	Content(runtime.Object) ([]string, error)
+}
+
+// Contains information about what columns should be included.
+type printContext struct {
+	withNamespace bool
+	withEvent     bool
+	wide          bool
+	columnLabels  []string
+}
+
+// Simple implementation of ColumnPrinter that has also an indicator whether
+// the printer should be included based on the given configuration (printContext)
+type funcColumnPrinter struct {
+	title     string
+	content   interface{}
+	condition func(printContext) bool
+}
+
+func (f funcColumnPrinter) Title() string {
+	return f.title
+}
+
+func (f funcColumnPrinter) shouldInclude(c printContext) bool {
+	return f.condition == nil || f.condition(c)
+}
+
+func (f funcColumnPrinter) Content(obj runtime.Object) ([]string, error) {
+	objType := reflect.TypeOf(obj)
+	contentValue := reflect.ValueOf(f.content)
+
+	if contentValue.Kind() != reflect.Func {
+		return nil, fmt.Errorf("invalid print handler. %#v is not a function", f.content)
+	}
+	funcType := contentValue.Type()
+
+	args := []reflect.Value{}
+	if funcType.NumIn() > 1 {
+		return nil, fmt.Errorf("invalid print handler. %#v takes too many args", f.content)
+	}
+	// Zero or 1 arg
+	if funcType.NumIn() == 1 {
+		if funcType.In(0) == objType {
+			args = append(args, reflect.ValueOf(obj))
+		} else if funcType.In(0) == reflect.TypeOf((*runtime.Object)(nil)).Elem() {
+			args = append(args, reflect.ValueOf(obj))
+		} else {
+			return nil, fmt.Errorf("Cannot populate type %v for %s", funcType.In(0), f.title)
+		}
+	}
+
+	resultValue := contentValue.Call(args)
+	var result []string
+
+	if funcType.Out(0) == reflect.TypeOf((*string)(nil)).Elem() {
+		result = []string{resultValue[0].String()}
+	} else if funcType.Out(0) == reflect.TypeOf((*[]string)(nil)).Elem() {
+		result = []string{}
+		for i := 0; i < resultValue[0].Len(); i++ {
+			result = append(result, resultValue[0].Index(i).String())
+		}
+	} else if funcType.Out(0) == reflect.TypeOf((*error)(nil)).Elem() {
+		if !resultValue[0].IsNil() {
+			return nil, resultValue[0].Interface().(error)
+		}
+	} else {
+		return nil, fmt.Errorf("Wrong return type %v for %s", funcType.In(0), f.title)
+	}
+
+	if funcType.NumOut() == 2 {
+		if funcType.Out(1) == reflect.TypeOf((*error)(nil)).Elem() {
+			if !resultValue[1].IsNil() {
+				return nil, resultValue[1].Interface().(error)
+			}
+		} else {
+			return nil, fmt.Errorf("Wrong return type %v for %s", funcType.In(1), f.title)
+		}
+	}
+	return result, nil
+}
+
+// Helper functions for getting fields viar reflection
+func getStringField(obj runtime.Object, name string) string {
+	return reflect.ValueOf(obj).Elem().FieldByName(name).String()
+}
+
+func getInterfaceField(obj runtime.Object, name string) interface{} {
+	return reflect.ValueOf(obj).Elem().FieldByName(name).Interface()
+}
+
+func makeUpdateColumn(event *watch.EventType) funcColumnPrinter {
+	return funcColumnPrinter{
+		title: "UPDATE",
+		content: func(c printContext) string {
+			if event == nil {
+				return "-"
+			}
+			return fmt.Sprintf("%s", *event)
+		}}
+}
+
+func makeNameColumn(name string) funcColumnPrinter {
+	return funcColumnPrinter{
+		title:   name,
+		content: func(obj runtime.Object) string { return getStringField(obj, "Name") }}
+}
+
+var namespaceColumn = funcColumnPrinter{
+	title:     "NAMESPACE",
+	content:   func(obj runtime.Object) string { return getStringField(obj, "Namespace") },
+	condition: func(c printContext) bool { return c.withNamespace }}
+
+var noNamespaceColumn = funcColumnPrinter{
+	title:     "NAMESPACE",
+	content:   func(obj runtime.Object) error { return fmt.Errorf("Namespace not supported") },
+	condition: func(c printContext) bool { return c.withNamespace }}
+
+var ageColumn = funcColumnPrinter{
+	title: "AGE",
+	content: func(obj runtime.Object) string {
+		return translateTimestamp(getInterfaceField(obj, "CreationTimestamp").(util.Time))
+	}}
+
+func makeLabelColumn(labelName string) funcColumnPrinter {
+	splitLabelName := strings.Split(labelName, "/")
+	columnLabel := strings.ToUpper(splitLabelName[len(splitLabelName)-1])
+	return funcColumnPrinter{
+		title: columnLabel,
+		content: func(obj runtime.Object) string {
+			labelsMap := reflect.ValueOf(obj).Elem().FieldByName("Labels")
+			val := labelsMap.MapIndex(reflect.ValueOf(labelName))
+			if val.IsValid() {
+				return val.String()
+			} else {
+				return "<n/a>"
+			}
+		}}
+}
+
+var podColumns = []funcColumnPrinter{
+	namespaceColumn,
+	makeNameColumn("NAME"),
+	{title: "READY", content: func(pod *api.Pod) string {
+		readyContainers := 0
+		for i := 0; i < len(pod.Status.ContainerStatuses); i++ {
+			container := pod.Status.ContainerStatuses[i]
+			if container.Ready && container.State.Running != nil {
+				readyContainers++
+			}
+		}
+		totalContainers := len(pod.Spec.Containers)
+		return fmt.Sprintf("%d/%d", readyContainers, totalContainers)
+	}},
+	{title: "STATUS", content: func(pod *api.Pod) string {
+		reason := string(pod.Status.Phase)
+		if pod.Status.Reason != "" {
+			reason = pod.Status.Reason
+		}
+		for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
+			container := pod.Status.ContainerStatuses[i]
+
+			if container.State.Waiting != nil && container.State.Waiting.Reason != "" {
+				reason = container.State.Waiting.Reason
+			} else if container.State.Terminated != nil && container.State.Terminated.Reason != "" {
+				reason = container.State.Terminated.Reason
+			} else if container.State.Terminated != nil && container.State.Terminated.Reason == "" {
+				if container.State.Terminated.Signal != 0 {
+					reason = fmt.Sprintf("Signal:%d", container.State.Terminated.Signal)
+				} else {
+					reason = fmt.Sprintf("ExitCode:%d", container.State.Terminated.ExitCode)
+				}
+			}
+		}
+		return reason
+	}},
+	{title: "RESTARTS", content: func(pod *api.Pod) string {
+		restarts := 0
+		for i := 0; i < len(pod.Status.ContainerStatuses); i++ {
+			restarts += pod.Status.ContainerStatuses[i].RestartCount
+		}
+		return fmt.Sprintf("%d", restarts)
+	}},
+	ageColumn,
+	{title: "NODE", content: func(pod *api.Pod) string { return pod.Spec.NodeName },
+		condition: func(c printContext) bool { return c.wide }},
+}
+
+var podTemplateColumns = []funcColumnPrinter{
+	namespaceColumn,
+	makeNameColumn("TEMPLATE"),
+	{title: "CONTAINER(S)", content: func(pod *api.PodTemplate) []string {
+		result := []string{}
+		for _, container := range pod.Template.Spec.Containers {
+			result = append(result, container.Name)
+		}
+		return result
+	}},
+	{title: "IMAGE(S)", content: func(pod *api.PodTemplate) []string {
+		result := []string{}
+		for _, container := range pod.Template.Spec.Containers {
+			result = append(result, container.Image)
+		}
+		return result
+	}},
+	{title: "PODLABELS", content: func(pod *api.PodTemplate) string { return formatLabels(pod.Template.Labels) }},
+}
+
+var replicationControllerColumns = []funcColumnPrinter{
+	namespaceColumn,
+	makeNameColumn("CONTROLLER"),
+	{title: "CONTAINER(S)", content: func(rc *api.ReplicationController) []string {
+		result := []string{}
+		for _, container := range rc.Spec.Template.Spec.Containers {
+			result = append(result, container.Name)
+		}
+		return result
+	}},
+	{title: "IMAGE(S)", content: func(rc *api.ReplicationController) []string {
+		result := []string{}
+		for _, container := range rc.Spec.Template.Spec.Containers {
+			result = append(result, container.Image)
+		}
+		return result
+	}},
+	{title: "SELECTOR", content: func(rc *api.ReplicationController) string { return formatLabels(rc.Spec.Selector) }},
+	{title: "REPLICAS", content: func(rc *api.ReplicationController) string { return fmt.Sprintf("%d", rc.Spec.Replicas) }},
+	ageColumn,
+}
+
+var serviceColumns = []funcColumnPrinter{
+	namespaceColumn,
+	makeNameColumn("NAME"),
+	{title: "CLUSTER_IP", content: func(s *api.Service) string {
+		return s.Spec.ClusterIP
+	}},
+	{title: "EXTERNAL_IP", content: func(s *api.Service) string {
+		switch s.Spec.Type {
+		case api.ServiceTypeClusterIP:
+			return "<none>"
+		case api.ServiceTypeNodePort:
+			return "nodes"
+		case api.ServiceTypeLoadBalancer:
+			ingress := s.Status.LoadBalancer.Ingress
+			result := []string{}
+			for i := range ingress {
+				if ingress[i].IP != "" {
+					result = append(result, ingress[i].IP)
+				}
+			}
+			return strings.Join(result, ",")
+		}
+		return "unknown"
+	}},
+	{title: "PORT(S)", content: func(s *api.Service) string {
+		ports := []string{}
+		for _, port := range s.Spec.Ports {
+			ports = append(ports, fmt.Sprintf("%d/%s", port.Port, port.Protocol))
+		}
+		return strings.Join(ports, ",")
+	}},
+	{title: "SELECTOR", content: func(s *api.Service) string { return formatLabels(s.Spec.Selector) }},
+	ageColumn,
+}
+
+var endpointsColumns = []funcColumnPrinter{
+	namespaceColumn,
+	makeNameColumn("NAME"),
+	{title: "ENDPOINTS", content: func(e *api.Endpoints) string { return formatEndpoints(e, nil) }},
+	ageColumn,
+}
+
+var nodeColumns = []funcColumnPrinter{
+	noNamespaceColumn,
+	makeNameColumn("NAME"),
+	{title: "LABELS", content: func(node *api.Node) string { return formatLabels(node.Labels) }},
+	{title: "STATUS", content: func(node *api.Node) string {
+		conditionMap := make(map[api.NodeConditionType]*api.NodeCondition)
+		NodeAllConditions := []api.NodeConditionType{api.NodeReady}
+		for i := range node.Status.Conditions {
+			cond := node.Status.Conditions[i]
+			conditionMap[cond.Type] = &cond
+		}
+		var status []string
+		for _, validCondition := range NodeAllConditions {
+			if condition, ok := conditionMap[validCondition]; ok {
+				if condition.Status == api.ConditionTrue {
+					status = append(status, string(condition.Type))
+				} else {
+					status = append(status, "Not"+string(condition.Type))
+				}
+			}
+		}
+		if len(status) == 0 {
+			status = append(status, "Unknown")
+		}
+		if node.Spec.Unschedulable {
+			status = append(status, "SchedulingDisabled")
+		}
+		return strings.Join(status, ",")
+	}},
+	ageColumn,
+}
+
+var eventColumns = []funcColumnPrinter{
+	namespaceColumn,
+	{title: "FIRSTSEEN", content: func(event *api.Event) string { return translateTimestamp(event.FirstTimestamp) }},
+	{title: "LASTSEEN", content: func(event *api.Event) string { return translateTimestamp(event.LastTimestamp) }},
+	{title: "COUNT", content: func(event *api.Event) string { return fmt.Sprintf("%d", event.Count) }},
+	{title: "NAME", content: func(event *api.Event) string { return event.InvolvedObject.Name }},
+	{title: "KIND", content: func(event *api.Event) string { return event.InvolvedObject.Kind }},
+	{title: "SUBOBJECT", content: func(event *api.Event) string { return event.InvolvedObject.FieldPath }},
+	{title: "REASON", content: func(event *api.Event) string { return event.Reason }},
+	{title: "SOURCE", content: func(event *api.Event) string { return fmt.Sprintf("%s", event.Source) }},
+	{title: "MESSAGE", content: func(event *api.Event) string { return event.Message }},
+}
+
+var limitRangeColumns = []funcColumnPrinter{
+	namespaceColumn,
+	makeNameColumn("NAME"),
+	ageColumn,
+}
+
+var resourceQuotaColumns = []funcColumnPrinter{
+	namespaceColumn,
+	makeNameColumn("NAME"),
+	ageColumn,
+}
+
+var namespaceColumns = []funcColumnPrinter{
+	noNamespaceColumn,
+	makeNameColumn("NAME"),
+	{title: "LABELS", content: func(n *api.Namespace) string { return formatLabels(n.Labels) }},
+	{title: "STATUS", content: func(n *api.Namespace) string { return fmt.Sprintf("%s", n.Status.Phase) }},
+	ageColumn,
+}
+
+var secretColumns = []funcColumnPrinter{
+	namespaceColumn,
+	makeNameColumn("NAME"),
+	{title: "TYPE", content: func(s *api.Secret) string { return fmt.Sprintf("%s", s.Type) }},
+	{title: "DATA", content: func(s *api.Secret) string { return fmt.Sprintf("%d", len(s.Data)) }},
+	ageColumn,
+}
+
+var serviceAccountColumns = []funcColumnPrinter{
+	namespaceColumn,
+	makeNameColumn("NAME"),
+	{title: "SECRETS", content: func(s *api.ServiceAccount) string { return fmt.Sprintf("%d", len(s.Secrets)) }},
+	ageColumn,
+}
+
+var persistentVolumeColumns = []funcColumnPrinter{
+	noNamespaceColumn,
+	makeNameColumn("NAME"),
+	{title: "LABELS", content: func(p *api.PersistentVolume) string { return formatLabels(p.Labels) }},
+	{title: "CAPACITY", content: func(p *api.PersistentVolume) string {
+		aQty := p.Spec.Capacity[api.ResourceStorage]
+		aSize := aQty.String()
+		return aSize
+	}},
+	{title: "ACCESSMODES", content: func(p *api.PersistentVolume) string { return volume.GetAccessModesAsString(p.Spec.AccessModes) }},
+	{title: "STATUS", content: func(p *api.PersistentVolume) string { return fmt.Sprintf("%s", p.Status.Phase) }},
+	{title: "CLAIM", content: func(p *api.PersistentVolume) string {
+		claimRefUID := ""
+		if p.Spec.ClaimRef != nil {
+			claimRefUID += p.Spec.ClaimRef.Namespace
+			claimRefUID += "/"
+			claimRefUID += p.Spec.ClaimRef.Name
+		}
+		return claimRefUID
+	}},
+	{title: "REASON", content: func(p *api.PersistentVolume) string { return p.Status.Reason }},
+	ageColumn,
+}
+
+var persistentVolumeClaimColumns = []funcColumnPrinter{
+	namespaceColumn,
+	makeNameColumn("NAME"),
+	{title: "STATUS", content: func(p *api.PersistentVolumeClaim) string { return fmt.Sprintf("%s", p.Status.Phase) }},
+	{title: "LABELS", content: func(p *api.PersistentVolumeClaim) string { return formatLabels(p.Labels) }},
+	{title: "VOLUME", content: func(p *api.PersistentVolumeClaim) string { return p.Spec.VolumeName }},
+	{title: "CAPACITY", content: func(p *api.PersistentVolumeClaim) string {
+		if p.Spec.VolumeName != "" {
+			storage := p.Status.Capacity[api.ResourceStorage]
+			return storage.String()
+		}
+		return ""
+	}},
+	{title: "ACCESSMODES", content: func(p *api.PersistentVolumeClaim) string {
+		if p.Spec.VolumeName != "" {
+			return volume.GetAccessModesAsString(p.Status.AccessModes)
+		}
+		return ""
+	}},
+	ageColumn,
+}
+
+var componentStatus = []funcColumnPrinter{
+	noNamespaceColumn,
+	makeNameColumn("NAME"),
+	{title: "STATUS", content: func(cs *api.ComponentStatus) string {
+		status := "Unknown"
+		for _, condition := range cs.Conditions {
+			if condition.Type == api.ComponentHealthy {
+				if condition.Status == api.ConditionTrue {
+					status = "Healthy"
+				} else {
+					status = "Unhealthy"
+				}
+				break
+			}
+		}
+		return status
+	}},
+	{title: "MESSAGE", content: func(cs *api.ComponentStatus) string {
+		message := ""
+		for _, condition := range cs.Conditions {
+			if condition.Type == api.ComponentHealthy {
+				message = condition.Message
+				break
+			}
+		}
+		return message
+	}},
+	{title: "ERROR", content: func(cs *api.ComponentStatus) string {
+		error := ""
+		for _, condition := range cs.Conditions {
+			if condition.Type == api.ComponentHealthy {
+				error = condition.Error
+				break
+			}
+		}
+		return error
+	}},
+}
+
+var columnMap = map[reflect.Type][]funcColumnPrinter{
+	reflect.TypeOf((*api.Pod)(nil)):                   podColumns,
+	reflect.TypeOf((*api.PodTemplate)(nil)):           podTemplateColumns,
+	reflect.TypeOf((*api.ReplicationController)(nil)): replicationControllerColumns,
+	reflect.TypeOf((*api.Service)(nil)):               serviceColumns,
+	reflect.TypeOf((*api.Endpoints)(nil)):             endpointsColumns,
+	reflect.TypeOf((*api.Node)(nil)):                  nodeColumns,
+	reflect.TypeOf((*api.Event)(nil)):                 eventColumns,
+	reflect.TypeOf((*api.LimitRange)(nil)):            limitRangeColumns,
+	reflect.TypeOf((*api.ResourceQuota)(nil)):         resourceQuotaColumns,
+	reflect.TypeOf((*api.Namespace)(nil)):             namespaceColumns,
+	reflect.TypeOf((*api.Secret)(nil)):                secretColumns,
+	reflect.TypeOf((*api.ServiceAccount)(nil)):        serviceAccountColumns,
+	reflect.TypeOf((*api.PersistentVolume)(nil)):      persistentVolumeColumns,
+	reflect.TypeOf((*api.PersistentVolumeClaim)(nil)): persistentVolumeClaimColumns,
+	reflect.TypeOf((*api.ComponentStatus)(nil)):       componentStatus,
+}
+
+func getSupportedTypeNames() []string {
+	keys := make([]string, 0)
+
+	for k := range columnMap {
+		// k.String looks like "*api.PodList" and we want just "pod"
+		api := strings.Split(k.String(), ".")
+		resource := api[len(api)-1]
+		if strings.HasSuffix(resource, "List") {
+			continue
+		}
+		resource = strings.ToLower(resource)
+		keys = append(keys, resource)
+	}
+	return keys
+}
+
+func getColumnPrintersFor(t reflect.Type, c printContext) ([]ColumnPrinter, error) {
+	columns, ok := columnMap[t]
+	if !ok {
+		return nil, fmt.Errorf("Type not supported")
+	}
+	result := []ColumnPrinter{}
+	for _, column := range columns {
+		if column.shouldInclude(c) {
+			result = append(result, column)
+		}
+	}
+
+	for _, label := range c.columnLabels {
+		result = append(result, makeLabelColumn(label))
+	}
+	return result, nil
+}
+
+func buildHeaders(columns []ColumnPrinter) []string {
+	headers := []string{}
+	for _, entry := range columns {
+		headers = append(headers, entry.Title())
+	}
+	return headers
+}
+
+func populateColumns(obj runtime.Object, columns []ColumnPrinter) ([][]string, error) {
+	var result [][]string
+	for _, column := range columns {
+		columnContent, err := column.Content(obj)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, columnContent)
+	}
+	return result, nil
+}
+
+// Pass ports=nil for all ports.
+func formatEndpoints(endpoints *api.Endpoints, ports util.StringSet) string {
+	if len(endpoints.Subsets) == 0 {
+		return "<none>"
+	}
+	list := []string{}
+	max := 3
+	more := false
+	count := 0
+	for i := range endpoints.Subsets {
+		ss := &endpoints.Subsets[i]
+		for i := range ss.Ports {
+			port := &ss.Ports[i]
+			if ports == nil || ports.Has(port.Name) {
+				for i := range ss.Addresses {
+					if len(list) == max {
+						more = true
+					}
+					addr := &ss.Addresses[i]
+					if !more {
+						list = append(list, fmt.Sprintf("%s:%d", addr.IP, port.Port))
+					}
+					count++
+				}
+			}
+		}
+	}
+	ret := strings.Join(list, ",")
+	if more {
+		return fmt.Sprintf("%s + %d more...", ret, count-max)
+	}
+	return ret
+}
+
+func shortHumanDuration(d time.Duration) string {
+	if seconds := int(d.Seconds()); seconds < 60 {
+		return fmt.Sprintf("%ds", seconds)
+	} else if minutes := int(d.Minutes()); minutes < 60 {
+		return fmt.Sprintf("%dm", minutes)
+	} else if hours := int(d.Hours()); hours < 24 {
+		return fmt.Sprintf("%dh", hours)
+	} else if hours < 24*364 {
+		return fmt.Sprintf("%dd", hours/24)
+	}
+	return fmt.Sprintf("%dy", int(d.Hours()/24/365))
+}
+
+// translateTimestamp returns the elapsed time since timestamp in
+// human-readable approximation.
+func translateTimestamp(timestamp util.Time) string {
+	return shortHumanDuration(time.Now().Sub(timestamp.Time))
+}

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -27,15 +27,12 @@ import (
 	"strings"
 	"text/tabwriter"
 	"text/template"
-	"time"
 
 	"github.com/ghodss/yaml"
-	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
-	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/watch"
 )
 
 // GetPrinter takes a format type, an optional format argument. It will return true
@@ -85,6 +82,10 @@ func GetPrinter(format, formatArgument string) (ResourcePrinter, bool, error) {
 type ResourcePrinter interface {
 	// Print receives a runtime object, formats it and prints it to a writer.
 	PrintObj(runtime.Object, io.Writer) error
+
+	// Adds an ObjectProcessor. All object processors will be executed
+	// in the order they were added to the ResourcePrinter.
+	AddObjectPreprocessor(ObjectPreprocessor)
 }
 
 // ResourcePrinterFunc is a function that can print objects
@@ -95,27 +96,55 @@ func (fn ResourcePrinterFunc) PrintObj(obj runtime.Object, w io.Writer) error {
 	return fn(obj, w)
 }
 
-// VersionedPrinter takes runtime objects and ensures they are converted to a given API version
-// prior to being passed to a nested printer.
-type VersionedPrinter struct {
-	printer   ResourcePrinter
+type ObjectPreprocessor interface {
+	Process(runtime.Object) (runtime.Object, error)
+}
+
+type chainObjectPreprocessor struct {
+	first ObjectPreprocessor
+	next  ObjectPreprocessor
+}
+
+func (c chainObjectPreprocessor) Process(obj runtime.Object) (runtime.Object, error) {
+	if c.first != nil {
+		var err error
+		obj, err = c.first.Process(obj)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if c.next != nil {
+		return c.next.Process(obj)
+	}
+	return obj, nil
+}
+
+func addObjectPreprocessor(oldPreprocessor ObjectPreprocessor, newPreprocessor ObjectPreprocessor) ObjectPreprocessor {
+	if oldPreprocessor == nil {
+		return newPreprocessor
+	}
+	return chainObjectPreprocessor{
+		first: oldPreprocessor,
+		next:  newPreprocessor,
+	}
+}
+
+// VersionConverter takes runtime objects and ensures they are converted to a given API version
+type VersionConverter struct {
 	convertor runtime.ObjectConvertor
 	version   []string
 }
 
-// NewVersionedPrinter wraps a printer to convert objects to a known API version prior to printing.
-func NewVersionedPrinter(printer ResourcePrinter, convertor runtime.ObjectConvertor, version ...string) ResourcePrinter {
-	return &VersionedPrinter{
-		printer:   printer,
+func NewVersionConverter(convertor runtime.ObjectConvertor, version ...string) ObjectPreprocessor {
+	return &VersionConverter{
 		convertor: convertor,
 		version:   version,
 	}
 }
 
-// PrintObj implements ResourcePrinter
-func (p *VersionedPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+func (p *VersionConverter) Process(obj runtime.Object) (runtime.Object, error) {
 	if len(p.version) == 0 {
-		return fmt.Errorf("no version specified, object cannot be converted")
+		return nil, fmt.Errorf("no version specified, object cannot be converted")
 	}
 	for _, version := range p.version {
 		if len(version) == 0 {
@@ -126,19 +155,31 @@ func (p *VersionedPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 			continue
 		}
 		if err != nil {
-			return err
+			return nil, err
 		}
-		return p.printer.PrintObj(converted, w)
+		return converted, nil
 	}
-	return fmt.Errorf("the object cannot be converted to any of the versions: %v", p.version)
+	return nil, fmt.Errorf("the object cannot be converted to any of the versions: %v", p.version)
 }
 
 // JSONPrinter is an implementation of ResourcePrinter which outputs an object as JSON.
 type JSONPrinter struct {
+	preprocessor ObjectPreprocessor
+}
+
+func (p *JSONPrinter) AddObjectPreprocessor(newPreprocessor ObjectPreprocessor) {
+	p.preprocessor = addObjectPreprocessor(p.preprocessor, newPreprocessor)
 }
 
 // PrintObj is an implementation of ResourcePrinter.PrintObj which simply writes the object to the Writer.
 func (p *JSONPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	if p.preprocessor != nil {
+		var err error
+		obj, err = p.preprocessor.Process(obj)
+		if err != nil {
+			return err
+		}
+	}
 	data, err := json.Marshal(obj)
 	if err != nil {
 		return err
@@ -154,12 +195,23 @@ func (p *JSONPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 // The input object is assumed to be in the internal version of an API and is converted
 // to the given version first.
 type YAMLPrinter struct {
-	version   string
-	convertor runtime.ObjectConvertor
+	preprocessor ObjectPreprocessor
+}
+
+func (p *YAMLPrinter) AddObjectPreprocessor(newPreprocessor ObjectPreprocessor) {
+	p.preprocessor = addObjectPreprocessor(p.preprocessor, newPreprocessor)
 }
 
 // PrintObj prints the data as YAML.
 func (p *YAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	if p.preprocessor != nil {
+		var err error
+		obj, err = p.preprocessor.Process(obj)
+		if err != nil {
+			return err
+		}
+	}
+
 	output, err := yaml.Marshal(obj)
 	if err != nil {
 		return err
@@ -178,885 +230,172 @@ type handlerEntry struct {
 // will only be printed if the object type changes. This makes it useful for printing items
 // received from watches.
 type HumanReadablePrinter struct {
-	handlerMap    map[reflect.Type]*handlerEntry
+	preprocessor  ObjectPreprocessor
 	noHeaders     bool
 	withNamespace bool
 	wide          bool
 	columnLabels  []string
+	extraColumns  []ColumnPrinter
 	lastType      reflect.Type
+}
+
+func (h *HumanReadablePrinter) AddObjectPreprocessor(newPreprocessor ObjectPreprocessor) {
+	h.preprocessor = addObjectPreprocessor(h.preprocessor, newPreprocessor)
 }
 
 // NewHumanReadablePrinter creates a HumanReadablePrinter.
 func NewHumanReadablePrinter(noHeaders, withNamespace bool, wide bool, columnLabels []string) *HumanReadablePrinter {
 	printer := &HumanReadablePrinter{
-		handlerMap:    make(map[reflect.Type]*handlerEntry),
 		noHeaders:     noHeaders,
 		withNamespace: withNamespace,
 		wide:          wide,
 		columnLabels:  columnLabels,
 	}
-	printer.addDefaultHandlers()
 	return printer
 }
 
-// Handler adds a print handler with a given set of columns to HumanReadablePrinter instance.
-// See validatePrintHandlerFunc for required method signature.
-func (h *HumanReadablePrinter) Handler(columns []string, printFunc interface{}) error {
-	printFuncValue := reflect.ValueOf(printFunc)
-	if err := h.validatePrintHandlerFunc(printFuncValue); err != nil {
-		glog.Errorf("Unable to add print handler: %v", err)
-		return err
-	}
-	objType := printFuncValue.Type().In(0)
-	h.handlerMap[objType] = &handlerEntry{
-		columns:   columns,
-		printFunc: printFuncValue,
-	}
-	return nil
-}
-
-// validatePrintHandlerFunc validates print handler signature.
-// printFunc is the function that will be called to print an object.
-// It must be of the following type:
-//  func printFunc(object ObjectType, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error
-// where ObjectType is the type of the object that will be printed.
-func (h *HumanReadablePrinter) validatePrintHandlerFunc(printFunc reflect.Value) error {
-	if printFunc.Kind() != reflect.Func {
-		return fmt.Errorf("invalid print handler. %#v is not a function", printFunc)
-	}
-	funcType := printFunc.Type()
-	if funcType.NumIn() != 5 || funcType.NumOut() != 1 {
-		return fmt.Errorf("invalid print handler." +
-			"Must accept 5 parameters and return 1 value.")
-	}
-	if funcType.In(1) != reflect.TypeOf((*io.Writer)(nil)).Elem() ||
-		funcType.In(4) != reflect.TypeOf((*[]string)(nil)).Elem() ||
-		funcType.Out(0) != reflect.TypeOf((*error)(nil)).Elem() {
-		return fmt.Errorf("invalid print handler. The expected signature is: "+
-			"func handler(obj %v, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error", funcType.In(0))
-	}
-	return nil
-}
-
 func (h *HumanReadablePrinter) HandledResources() []string {
-	keys := make([]string, 0)
+	return getSupportedTypeNames()
+}
 
-	for k := range h.handlerMap {
-		// k.String looks like "*api.PodList" and we want just "pod"
-		api := strings.Split(k.String(), ".")
-		resource := api[len(api)-1]
-		if strings.HasSuffix(resource, "List") {
-			continue
+func printColumns(data [][]string, writer io.Writer) error {
+	maxRows := 0
+	for _, column := range data {
+		if maxRows < len(column) {
+			maxRows = len(column)
 		}
-		resource = strings.ToLower(resource)
-		keys = append(keys, resource)
 	}
-	return keys
-}
 
-// NOTE: When adding a new resource type here, please update the list
-// pkg/kubectl/cmd/get.go to reflect the new resource type.
-var podColumns = []string{"NAME", "READY", "STATUS", "RESTARTS", "AGE"}
-var podTemplateColumns = []string{"TEMPLATE", "CONTAINER(S)", "IMAGE(S)", "PODLABELS"}
-var replicationControllerColumns = []string{"CONTROLLER", "CONTAINER(S)", "IMAGE(S)", "SELECTOR", "REPLICAS", "AGE"}
-var serviceColumns = []string{"NAME", "CLUSTER_IP", "EXTERNAL_IP", "PORT(S)", "SELECTOR", "AGE"}
-var endpointColumns = []string{"NAME", "ENDPOINTS", "AGE"}
-var nodeColumns = []string{"NAME", "LABELS", "STATUS", "AGE"}
-var eventColumns = []string{"FIRSTSEEN", "LASTSEEN", "COUNT", "NAME", "KIND", "SUBOBJECT", "REASON", "SOURCE", "MESSAGE"}
-var limitRangeColumns = []string{"NAME", "AGE"}
-var resourceQuotaColumns = []string{"NAME", "AGE"}
-var namespaceColumns = []string{"NAME", "LABELS", "STATUS", "AGE"}
-var secretColumns = []string{"NAME", "TYPE", "DATA", "AGE"}
-var serviceAccountColumns = []string{"NAME", "SECRETS", "AGE"}
-var persistentVolumeColumns = []string{"NAME", "LABELS", "CAPACITY", "ACCESSMODES", "STATUS", "CLAIM", "REASON", "AGE"}
-var persistentVolumeClaimColumns = []string{"NAME", "LABELS", "STATUS", "VOLUME", "CAPACITY", "ACCESSMODES", "AGE"}
-var componentStatusColumns = []string{"NAME", "STATUS", "MESSAGE", "ERROR"}
-var withNamespacePrefixColumns = []string{"NAMESPACE"} // TODO(erictune): print cluster name too.
-
-// addDefaultHandlers adds print handlers for default Kubernetes types.
-func (h *HumanReadablePrinter) addDefaultHandlers() {
-	h.Handler(podColumns, printPod)
-	h.Handler(podColumns, printPodList)
-	h.Handler(podTemplateColumns, printPodTemplate)
-	h.Handler(podTemplateColumns, printPodTemplateList)
-	h.Handler(replicationControllerColumns, printReplicationController)
-	h.Handler(replicationControllerColumns, printReplicationControllerList)
-	h.Handler(serviceColumns, printService)
-	h.Handler(serviceColumns, printServiceList)
-	h.Handler(endpointColumns, printEndpoints)
-	h.Handler(endpointColumns, printEndpointsList)
-	h.Handler(nodeColumns, printNode)
-	h.Handler(nodeColumns, printNodeList)
-	h.Handler(eventColumns, printEvent)
-	h.Handler(eventColumns, printEventList)
-	h.Handler(limitRangeColumns, printLimitRange)
-	h.Handler(limitRangeColumns, printLimitRangeList)
-	h.Handler(resourceQuotaColumns, printResourceQuota)
-	h.Handler(resourceQuotaColumns, printResourceQuotaList)
-	h.Handler(namespaceColumns, printNamespace)
-	h.Handler(namespaceColumns, printNamespaceList)
-	h.Handler(secretColumns, printSecret)
-	h.Handler(secretColumns, printSecretList)
-	h.Handler(serviceAccountColumns, printServiceAccount)
-	h.Handler(serviceAccountColumns, printServiceAccountList)
-	h.Handler(persistentVolumeClaimColumns, printPersistentVolumeClaim)
-	h.Handler(persistentVolumeClaimColumns, printPersistentVolumeClaimList)
-	h.Handler(persistentVolumeColumns, printPersistentVolume)
-	h.Handler(persistentVolumeColumns, printPersistentVolumeList)
-	h.Handler(componentStatusColumns, printComponentStatus)
-	h.Handler(componentStatusColumns, printComponentStatusList)
-}
-
-func (h *HumanReadablePrinter) unknown(data []byte, w io.Writer) error {
-	_, err := fmt.Fprintf(w, "Unknown object: %s", string(data))
-	return err
-}
-
-func (h *HumanReadablePrinter) printHeader(columnNames []string, w io.Writer) error {
-	if _, err := fmt.Fprintf(w, "%s\n", strings.Join(columnNames, "\t")); err != nil {
-		return err
-	}
-	return nil
-}
-
-// Pass ports=nil for all ports.
-func formatEndpoints(endpoints *api.Endpoints, ports util.StringSet) string {
-	if len(endpoints.Subsets) == 0 {
-		return "<none>"
-	}
-	list := []string{}
-	max := 3
-	more := false
-	count := 0
-	for i := range endpoints.Subsets {
-		ss := &endpoints.Subsets[i]
-		for i := range ss.Ports {
-			port := &ss.Ports[i]
-			if ports == nil || ports.Has(port.Name) {
-				for i := range ss.Addresses {
-					if len(list) == max {
-						more = true
-					}
-					addr := &ss.Addresses[i]
-					if !more {
-						list = append(list, fmt.Sprintf("%s:%d", addr.IP, port.Port))
-					}
-					count++
+	for row := 0; row < maxRows; row++ {
+		for i, column := range data {
+			if i > 0 {
+				_, err := fmt.Fprintf(writer, "\t")
+				if err != nil {
+					return err
+				}
+			}
+			if row < len(column) {
+				_, err := fmt.Fprintf(writer, "%s", column[row])
+				if err != nil {
+					return err
 				}
 			}
 		}
-	}
-	ret := strings.Join(list, ",")
-	if more {
-		return fmt.Sprintf("%s + %d more...", ret, count-max)
-	}
-	return ret
-}
-
-func podHostString(host, ip string) string {
-	if host == "" && ip == "" {
-		return "<unassigned>"
-	}
-	return host + "/" + ip
-}
-
-func shortHumanDuration(d time.Duration) string {
-	if seconds := int(d.Seconds()); seconds < 60 {
-		return fmt.Sprintf("%ds", seconds)
-	} else if minutes := int(d.Minutes()); minutes < 60 {
-		return fmt.Sprintf("%dm", minutes)
-	} else if hours := int(d.Hours()); hours < 24 {
-		return fmt.Sprintf("%dh", hours)
-	} else if hours < 24*364 {
-		return fmt.Sprintf("%dd", hours/24)
-	}
-	return fmt.Sprintf("%dy", int(d.Hours()/24/365))
-}
-
-// translateTimestamp returns the elapsed time since timestamp in
-// human-readable approximation.
-func translateTimestamp(timestamp util.Time) string {
-	return shortHumanDuration(time.Now().Sub(timestamp.Time))
-}
-
-func printPod(pod *api.Pod, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	name := pod.Name
-	namespace := pod.Namespace
-
-	restarts := 0
-	totalContainers := len(pod.Spec.Containers)
-	readyContainers := 0
-
-	reason := string(pod.Status.Phase)
-	if pod.Status.Reason != "" {
-		reason = pod.Status.Reason
-	}
-
-	for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
-		container := pod.Status.ContainerStatuses[i]
-
-		restarts += container.RestartCount
-		if container.State.Waiting != nil && container.State.Waiting.Reason != "" {
-			reason = container.State.Waiting.Reason
-		} else if container.State.Terminated != nil && container.State.Terminated.Reason != "" {
-			reason = container.State.Terminated.Reason
-		} else if container.State.Terminated != nil && container.State.Terminated.Reason == "" {
-			if container.State.Terminated.Signal != 0 {
-				reason = fmt.Sprintf("Signal:%d", container.State.Terminated.Signal)
-			} else {
-				reason = fmt.Sprintf("ExitCode:%d", container.State.Terminated.ExitCode)
-			}
-		} else if container.Ready && container.State.Running != nil {
-			readyContainers++
-		}
-	}
-
-	if withNamespace {
-		if _, err := fmt.Fprintf(w, "%s\t", namespace); err != nil {
-			return err
-		}
-	}
-	if _, err := fmt.Fprintf(w, "%s\t%d/%d\t%s\t%d\t%s",
-		name,
-		readyContainers,
-		totalContainers,
-		reason,
-		restarts,
-		translateTimestamp(pod.CreationTimestamp),
-	); err != nil {
-		return err
-	}
-
-	if wide {
-		nodeName := pod.Spec.NodeName
-		if _, err := fmt.Fprintf(w, "\t%s",
-			nodeName,
-		); err != nil {
-			return err
-		}
-	}
-
-	_, err := fmt.Fprint(w, appendLabels(pod.Labels, columnLabels))
-	return err
-}
-
-func printPodList(podList *api.PodList, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	for _, pod := range podList.Items {
-		if err := printPod(&pod, w, withNamespace, wide, columnLabels); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func printPodTemplate(pod *api.PodTemplate, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	name := pod.Name
-	namespace := pod.Namespace
-
-	containers := pod.Template.Spec.Containers
-	var firstContainer api.Container
-	if len(containers) > 0 {
-		firstContainer, containers = containers[0], containers[1:]
-	}
-
-	if withNamespace {
-		if _, err := fmt.Fprintf(w, "%s\t", namespace); err != nil {
-			return err
-		}
-	}
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s",
-		name,
-		firstContainer.Name,
-		firstContainer.Image,
-		formatLabels(pod.Template.Labels),
-	); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprint(w, appendLabels(pod.Labels, columnLabels)); err != nil {
-		return err
-	}
-
-	// Lay out all the other containers on separate lines.
-	extraLinePrefix := "\t"
-	if withNamespace {
-		extraLinePrefix = "\t\t"
-	}
-	for _, container := range containers {
-		_, err := fmt.Fprintf(w, "%s%s\t%s\t%s", extraLinePrefix, container.Name, container.Image, "")
+		_, err := fmt.Fprintf(writer, "\n")
 		if err != nil {
 			return err
 		}
-		if _, err := fmt.Fprint(w, appendLabelTabs(columnLabels)); err != nil {
-			return err
-		}
 	}
 	return nil
 }
 
-func printPodTemplateList(podList *api.PodTemplateList, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	for _, pod := range podList.Items {
-		if err := printPodTemplate(&pod, w, withNamespace, wide, columnLabels); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func printReplicationController(controller *api.ReplicationController, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	name := controller.Name
-	namespace := controller.Namespace
-
-	containers := controller.Spec.Template.Spec.Containers
-	var firstContainer api.Container
-	if len(containers) > 0 {
-		firstContainer, containers = containers[0], containers[1:]
-	}
-
-	if withNamespace {
-		if _, err := fmt.Fprintf(w, "%s\t", namespace); err != nil {
-			return err
-		}
-	}
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s",
-		name,
-		firstContainer.Name,
-		firstContainer.Image,
-		formatLabels(controller.Spec.Selector),
-		controller.Spec.Replicas,
-		translateTimestamp(controller.CreationTimestamp),
-	); err != nil {
+func printHeaders(headers []string, writer io.Writer) error {
+	_, err := fmt.Fprintln(writer, strings.Join(headers, "\t"))
+	if err != nil {
 		return err
-	}
-	if _, err := fmt.Fprint(w, appendLabels(controller.Labels, columnLabels)); err != nil {
-		return err
-	}
-
-	// Lay out all the other containers on separate lines.
-	extraLinePrefix := "\t"
-	if withNamespace {
-		extraLinePrefix = "\t\t"
-	}
-	for _, container := range containers {
-		_, err := fmt.Fprintf(w, "%s%s\t%s\t%s\t%s", extraLinePrefix, container.Name, container.Image, "", "")
-		if err != nil {
-			return err
-		}
-		if _, err := fmt.Fprint(w, appendLabelTabs(columnLabels)); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func printReplicationControllerList(list *api.ReplicationControllerList, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	for _, controller := range list.Items {
-		if err := printReplicationController(&controller, w, withNamespace, wide, columnLabels); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func getServiceExternalIP(svc *api.Service) string {
-	switch svc.Spec.Type {
-	case api.ServiceTypeClusterIP:
-		return "<none>"
-	case api.ServiceTypeNodePort:
-		return "nodes"
-	case api.ServiceTypeLoadBalancer:
-		ingress := svc.Status.LoadBalancer.Ingress
-		result := []string{}
-		for i := range ingress {
-			if ingress[i].IP != "" {
-				result = append(result, ingress[i].IP)
-			}
-		}
-		return strings.Join(result, ",")
-	}
-	return "unknown"
-}
-
-func makePortString(ports []api.ServicePort) string {
-	pieces := make([]string, len(ports))
-	for ix := range ports {
-		port := &ports[ix]
-		pieces[ix] = fmt.Sprintf("%d/%s", port.Port, port.Protocol)
-	}
-	return strings.Join(pieces, ",")
-}
-
-func printService(svc *api.Service, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	name := svc.Name
-	namespace := svc.Namespace
-
-	internalIP := svc.Spec.ClusterIP
-	externalIP := getServiceExternalIP(svc)
-
-	if withNamespace {
-		if _, err := fmt.Fprintf(w, "%s\t", namespace); err != nil {
-			return err
-		}
-	}
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s",
-		name,
-		internalIP,
-		externalIP,
-		makePortString(svc.Spec.Ports),
-		formatLabels(svc.Spec.Selector),
-		translateTimestamp(svc.CreationTimestamp),
-	); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprint(w, appendLabels(svc.Labels, columnLabels)); err != nil {
-		return err
-	}
-	return nil
-}
-
-func printServiceList(list *api.ServiceList, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	for _, svc := range list.Items {
-		if err := printService(&svc, w, withNamespace, wide, columnLabels); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func printEndpoints(endpoints *api.Endpoints, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	name := endpoints.Name
-	namespace := endpoints.Namespace
-
-	if withNamespace {
-		if _, err := fmt.Fprintf(w, "%s\t", namespace); err != nil {
-			return err
-		}
-	}
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s", name, formatEndpoints(endpoints, nil), translateTimestamp(endpoints.CreationTimestamp)); err != nil {
-		return err
-	}
-	_, err := fmt.Fprint(w, appendLabels(endpoints.Labels, columnLabels))
-	return err
-}
-
-func printEndpointsList(list *api.EndpointsList, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	for _, item := range list.Items {
-		if err := printEndpoints(&item, w, withNamespace, wide, columnLabels); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func printNamespace(item *api.Namespace, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	if withNamespace {
-		return fmt.Errorf("namespace is not namespaced")
-	}
-
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s", item.Name, formatLabels(item.Labels), item.Status.Phase, translateTimestamp(item.CreationTimestamp)); err != nil {
-		return err
-	}
-	_, err := fmt.Fprint(w, appendLabels(item.Labels, columnLabels))
-	return err
-}
-
-func printNamespaceList(list *api.NamespaceList, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	for _, item := range list.Items {
-		if err := printNamespace(&item, w, withNamespace, wide, columnLabels); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func printSecret(item *api.Secret, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	name := item.Name
-	namespace := item.Namespace
-
-	if withNamespace {
-		if _, err := fmt.Fprintf(w, "%s\t", namespace); err != nil {
-			return err
-		}
-	}
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%v\t%s", name, item.Type, len(item.Data), translateTimestamp(item.CreationTimestamp)); err != nil {
-		return err
-	}
-	_, err := fmt.Fprint(w, appendLabels(item.Labels, columnLabels))
-	return err
-}
-
-func printSecretList(list *api.SecretList, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	for _, item := range list.Items {
-		if err := printSecret(&item, w, withNamespace, wide, columnLabels); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func printServiceAccount(item *api.ServiceAccount, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	name := item.Name
-	namespace := item.Namespace
-
-	if withNamespace {
-		if _, err := fmt.Fprintf(w, "%s\t", namespace); err != nil {
-			return err
-		}
-	}
-	if _, err := fmt.Fprintf(w, "%s\t%d\t%s", name, len(item.Secrets), translateTimestamp(item.CreationTimestamp)); err != nil {
-		return err
-	}
-	_, err := fmt.Fprint(w, appendLabels(item.Labels, columnLabels))
-	return err
-}
-
-func printServiceAccountList(list *api.ServiceAccountList, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	for _, item := range list.Items {
-		if err := printServiceAccount(&item, w, withNamespace, wide, columnLabels); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func printNode(node *api.Node, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	if withNamespace {
-		return fmt.Errorf("node is not namespaced")
-	}
-	conditionMap := make(map[api.NodeConditionType]*api.NodeCondition)
-	NodeAllConditions := []api.NodeConditionType{api.NodeReady}
-	for i := range node.Status.Conditions {
-		cond := node.Status.Conditions[i]
-		conditionMap[cond.Type] = &cond
-	}
-	var status []string
-	for _, validCondition := range NodeAllConditions {
-		if condition, ok := conditionMap[validCondition]; ok {
-			if condition.Status == api.ConditionTrue {
-				status = append(status, string(condition.Type))
-			} else {
-				status = append(status, "Not"+string(condition.Type))
-			}
-		}
-	}
-	if len(status) == 0 {
-		status = append(status, "Unknown")
-	}
-	if node.Spec.Unschedulable {
-		status = append(status, "SchedulingDisabled")
-	}
-
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s", node.Name, formatLabels(node.Labels), strings.Join(status, ","), translateTimestamp(node.CreationTimestamp)); err != nil {
-		return err
-	}
-	_, err := fmt.Fprint(w, appendLabels(node.Labels, columnLabels))
-	return err
-}
-
-func printNodeList(list *api.NodeList, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	for _, node := range list.Items {
-		if err := printNode(&node, w, withNamespace, wide, columnLabels); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func printPersistentVolume(pv *api.PersistentVolume, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	if withNamespace {
-		return fmt.Errorf("persistentVolume is not namespaced")
-	}
-	name := pv.Name
-
-	claimRefUID := ""
-	if pv.Spec.ClaimRef != nil {
-		claimRefUID += pv.Spec.ClaimRef.Namespace
-		claimRefUID += "/"
-		claimRefUID += pv.Spec.ClaimRef.Name
-	}
-
-	modesStr := volume.GetAccessModesAsString(pv.Spec.AccessModes)
-
-	aQty := pv.Spec.Capacity[api.ResourceStorage]
-	aSize := aQty.String()
-
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s",
-		name,
-		formatLabels(pv.Labels),
-		aSize, modesStr,
-		pv.Status.Phase,
-		claimRefUID,
-		pv.Status.Reason,
-		translateTimestamp(pv.CreationTimestamp),
-	); err != nil {
-		return err
-	}
-	_, err := fmt.Fprint(w, appendLabels(pv.Labels, columnLabels))
-	return err
-}
-
-func printPersistentVolumeList(list *api.PersistentVolumeList, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	for _, pv := range list.Items {
-		if err := printPersistentVolume(&pv, w, withNamespace, wide, columnLabels); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func printPersistentVolumeClaim(pvc *api.PersistentVolumeClaim, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	name := pvc.Name
-	namespace := pvc.Namespace
-
-	if withNamespace {
-		if _, err := fmt.Fprintf(w, "%s\t", namespace); err != nil {
-			return err
-		}
-	}
-
-	labels := formatLabels(pvc.Labels)
-	phase := pvc.Status.Phase
-	storage := pvc.Spec.Resources.Requests[api.ResourceStorage]
-	capacity := ""
-	accessModes := ""
-	if pvc.Spec.VolumeName != "" {
-		accessModes = volume.GetAccessModesAsString(pvc.Status.AccessModes)
-		storage = pvc.Status.Capacity[api.ResourceStorage]
-		capacity = storage.String()
-	}
-
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s", name, labels, phase, pvc.Spec.VolumeName, capacity, accessModes, translateTimestamp(pvc.CreationTimestamp)); err != nil {
-		return err
-	}
-	_, err := fmt.Fprint(w, appendLabels(pvc.Labels, columnLabels))
-	return err
-}
-
-func printPersistentVolumeClaimList(list *api.PersistentVolumeClaimList, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	for _, psd := range list.Items {
-		if err := printPersistentVolumeClaim(&psd, w, withNamespace, wide, columnLabels); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func printEvent(event *api.Event, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	namespace := event.Namespace
-	if withNamespace {
-		if _, err := fmt.Fprintf(w, "%s\t", namespace); err != nil {
-			return err
-		}
-	}
-	if _, err := fmt.Fprintf(
-		w, "%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s",
-		translateTimestamp(event.FirstTimestamp),
-		translateTimestamp(event.LastTimestamp),
-		event.Count,
-		event.InvolvedObject.Name,
-		event.InvolvedObject.Kind,
-		event.InvolvedObject.FieldPath,
-		event.Reason,
-		event.Source,
-		event.Message,
-	); err != nil {
-		return err
-	}
-	_, err := fmt.Fprint(w, appendLabels(event.Labels, columnLabels))
-	return err
-}
-
-// Sorts and prints the EventList in a human-friendly format.
-func printEventList(list *api.EventList, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	sort.Sort(SortableEvents(list.Items))
-	for i := range list.Items {
-		if err := printEvent(&list.Items[i], w, withNamespace, wide, columnLabels); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func printLimitRange(limitRange *api.LimitRange, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	name := limitRange.Name
-	namespace := limitRange.Namespace
-
-	if withNamespace {
-		if _, err := fmt.Fprintf(w, "%s\t", namespace); err != nil {
-			return err
-		}
-	}
-
-	if _, err := fmt.Fprintf(
-		w, "%s\t%s",
-		name,
-		translateTimestamp(limitRange.CreationTimestamp),
-	); err != nil {
-		return err
-	}
-	_, err := fmt.Fprint(w, appendLabels(limitRange.Labels, columnLabels))
-	return err
-}
-
-// Prints the LimitRangeList in a human-friendly format.
-func printLimitRangeList(list *api.LimitRangeList, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	for i := range list.Items {
-		if err := printLimitRange(&list.Items[i], w, withNamespace, wide, columnLabels); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func printResourceQuota(resourceQuota *api.ResourceQuota, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	name := resourceQuota.Name
-	namespace := resourceQuota.Namespace
-
-	if withNamespace {
-		if _, err := fmt.Fprintf(w, "%s\t", namespace); err != nil {
-			return err
-		}
-	}
-
-	if _, err := fmt.Fprintf(
-		w, "%s\t%s",
-		name,
-		translateTimestamp(resourceQuota.CreationTimestamp),
-	); err != nil {
-		return err
-	}
-	_, err := fmt.Fprint(w, appendLabels(resourceQuota.Labels, columnLabels))
-	return err
-}
-
-// Prints the ResourceQuotaList in a human-friendly format.
-func printResourceQuotaList(list *api.ResourceQuotaList, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	for i := range list.Items {
-		if err := printResourceQuota(&list.Items[i], w, withNamespace, wide, columnLabels); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func printComponentStatus(item *api.ComponentStatus, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	if withNamespace {
-		return fmt.Errorf("componentStatus is not namespaced")
-	}
-	status := "Unknown"
-	message := ""
-	error := ""
-	for _, condition := range item.Conditions {
-		if condition.Type == api.ComponentHealthy {
-			if condition.Status == api.ConditionTrue {
-				status = "Healthy"
-			} else {
-				status = "Unhealthy"
-			}
-			message = condition.Message
-			error = condition.Error
-			break
-		}
-	}
-
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s", item.Name, status, message, error); err != nil {
-		return err
-	}
-	_, err := fmt.Fprint(w, appendLabels(item.Labels, columnLabels))
-	return err
-}
-
-func printComponentStatusList(list *api.ComponentStatusList, w io.Writer, withNamespace bool, wide bool, columnLabels []string) error {
-	for _, item := range list.Items {
-		if err := printComponentStatus(&item, w, withNamespace, wide, columnLabels); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func appendLabels(itemLabels map[string]string, columnLabels []string) string {
-	var buffer bytes.Buffer
-
-	for _, cl := range columnLabels {
-		buffer.WriteString(fmt.Sprint("\t"))
-		if il, ok := itemLabels[cl]; ok {
-			buffer.WriteString(fmt.Sprint(il))
-		} else {
-			buffer.WriteString("<none>")
-		}
-	}
-	buffer.WriteString("\n")
-
-	return buffer.String()
-}
-
-// Append a set of tabs for each label column.  We need this in the case where
-// we have extra lines so that the tabwriter will still line things up.
-func appendLabelTabs(columnLabels []string) string {
-	var buffer bytes.Buffer
-
-	for i := range columnLabels {
-		// NB: This odd dance is to make the loop both compatible with go 1.3 and
-		// pass `gofmt -s`
-		_ = i
-		buffer.WriteString("\t")
-	}
-	buffer.WriteString("\n")
-
-	return buffer.String()
-}
-
-func formatLabelHeaders(columnLabels []string) []string {
-	formHead := make([]string, len(columnLabels))
-	for i, l := range columnLabels {
-		p := strings.Split(l, "/")
-		formHead[i] = strings.ToUpper((p[len(p)-1]))
-	}
-	return formHead
-}
-
-// headers for -o wide
-func formatWideHeaders(wide bool, t reflect.Type) []string {
-	if wide {
-		if t.String() == "*api.Pod" || t.String() == "*api.PodList" {
-			return []string{"NODE"}
-		}
 	}
 	return nil
 }
 
 // PrintObj prints the obj in a human-friendly format according to the type of the obj.
 func (h *HumanReadablePrinter) PrintObj(obj runtime.Object, output io.Writer) error {
-	w := tabwriter.NewWriter(output, 10, 4, 3, ' ', 0)
-	defer w.Flush()
-	t := reflect.TypeOf(obj)
-	if handler := h.handlerMap[t]; handler != nil {
+	return h.printObjWithExtraColumns(obj, output)
+}
+
+func (h *HumanReadablePrinter) printObjWithExtraColumns(obj runtime.Object, output io.Writer, extraColumns ...ColumnPrinter) error {
+	if h.preprocessor != nil {
+		var err error
+		obj, err = h.preprocessor.Process(obj)
+		if err != nil {
+			return err
+		}
+	}
+	writer := tabwriter.NewWriter(output, 10, 4, 3, ' ', 0)
+	defer writer.Flush()
+
+	toBePrinted := []runtime.Object{}
+
+	// Sort events
+	eventList, isEventList := obj.(*api.EventList)
+	if isEventList {
+		sort.Sort(SortableEvents(eventList.Items))
+	}
+
+	// Multiple items to be printed.
+	if strings.HasSuffix(reflect.TypeOf(obj).String(), "List") {
+		items := reflect.ValueOf(obj).Elem().FieldByName("Items")
+		for i := 0; i < items.Len(); i++ {
+			item := items.Index(i).Addr().Interface().(runtime.Object)
+			toBePrinted = append(toBePrinted, item)
+		}
+	} else {
+		toBePrinted = append(toBePrinted, obj)
+	}
+
+	c := printContext{
+		withNamespace: h.withNamespace,
+		wide:          h.wide,
+		columnLabels:  h.columnLabels,
+	}
+
+	// Print all.
+	for _, item := range toBePrinted {
+		t := reflect.TypeOf(item)
+		columns, err := getColumnPrintersFor(t, c)
+		columns = append(extraColumns, columns...)
+
+		if err != nil {
+			return err
+		}
 		if !h.noHeaders && t != h.lastType {
-			headers := append(handler.columns, formatWideHeaders(h.wide, t)...)
-			headers = append(headers, formatLabelHeaders(h.columnLabels)...)
-			if h.withNamespace {
-				headers = append(withNamespacePrefixColumns, headers...)
+			err := printHeaders(buildHeaders(columns), writer)
+			if err != nil {
+				return err
 			}
-			h.printHeader(headers, w)
 			h.lastType = t
 		}
-		args := []reflect.Value{reflect.ValueOf(obj), reflect.ValueOf(w), reflect.ValueOf(h.withNamespace), reflect.ValueOf(h.wide), reflect.ValueOf(h.columnLabels)}
-		resultValue := handler.printFunc.Call(args)[0]
-		if resultValue.IsNil() {
-			return nil
+
+		columnsData, err := populateColumns(item, columns)
+		if err != nil {
+			return err
 		}
-		return resultValue.Interface().(error)
+		printColumns(columnsData, writer)
 	}
-	return fmt.Errorf("error: unknown type %#v", obj)
+	return nil
+}
+
+// PrinterWithEvent is a wrapper around HumanReadablePrinter that prints
+// the type of update that happened to the runtime.Object along with the object
+// itself.
+type printerWithEvent struct {
+	printer   *HumanReadablePrinter
+	eventType *watch.EventType
+}
+
+func NewPrinterWithEvent(h *HumanReadablePrinter, event *watch.EventType) *printerWithEvent {
+	return &printerWithEvent{
+		printer:   h,
+		eventType: event,
+	}
+}
+
+func (h *printerWithEvent) AddObjectPreprocessor(preprocessor ObjectPreprocessor) {
+	h.printer.AddObjectPreprocessor(preprocessor)
+}
+
+func (h *printerWithEvent) PrintObj(obj runtime.Object, output io.Writer) error {
+	return h.printer.printObjWithExtraColumns(obj, output, makeUpdateColumn(h.eventType))
 }
 
 // TemplatePrinter is an implementation of ResourcePrinter which formats data with a Go Template.
 type TemplatePrinter struct {
-	rawTemplate string
-	template    *template.Template
+	rawTemplate  string
+	template     *template.Template
+	preprocessor ObjectPreprocessor
+}
+
+func (p *TemplatePrinter) AddObjectPreprocessor(newPreprocessor ObjectPreprocessor) {
+	p.preprocessor = addObjectPreprocessor(p.preprocessor, newPreprocessor)
 }
 
 func NewTemplatePrinter(tmpl []byte) (*TemplatePrinter, error) {
@@ -1074,6 +413,13 @@ func NewTemplatePrinter(tmpl []byte) (*TemplatePrinter, error) {
 
 // PrintObj formats the obj with the Go Template.
 func (p *TemplatePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	if p.preprocessor != nil {
+		var err error
+		obj, err = p.preprocessor.Process(obj)
+		if err != nil {
+			return err
+		}
+	}
 	data, err := json.Marshal(obj)
 	if err != nil {
 		return err

--- a/pkg/kubectl/sorting_preprocessor_test.go
+++ b/pkg/kubectl/sorting_preprocessor_test.go
@@ -159,8 +159,10 @@ func TestSortingPrinter(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		sort := &SortingPrinter{SortField: test.field}
-		if err := sort.sortObj(test.obj); err != nil {
+		sort := &SortingPreprocessor{SortField: test.field}
+		// TODO: preprocessor has side effects.
+		_, err := sort.Process(test.obj)
+		if err != nil {
 			t.Errorf("unexpected error: %v (%s)", err, test.name)
 			continue
 		}


### PR DESCRIPTION
Do not merge (yet)
ref: #11617, #11440

Changes:
- column labels and content defined in one place `resource_columns.go`
- clear view when which column is populated
- less boilerplate code (automatically print Items from api.*List)
- build [][]string for each object instead of writing directly to io.Writer
- pass context-like struct with all "global" parameters instead of 5-6 separate params
- pass `*EventType` (possibly nil) to the printer so `kubectl get * -w output` is understandable 
