### PR TITLE
Make copy_test.go failures easier to debug

### DIFF
--- a/pkg/api/copy_test.go
+++ b/pkg/api/copy_test.go
@@ -43,7 +43,7 @@ func TestDeepCopyApiObjects(t *testing.T) {
 				}
 
 				if !reflect.DeepEqual(item, itemCopy) {
-					t.Errorf("expected %#v\ngot %#v", item, itemCopy)
+					t.Errorf("\nexpected %#v\ngot      %#v", item, itemCopy)
 				}
 			}
 		}


### PR DESCRIPTION
@thockin @zmerlynn 

It's a lot easier to debug test failures when the output lines up.
