### PR TITLE
add command for workaround for issue 10836

### DIFF
--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -129,6 +129,7 @@ nginx     <none>    run=nginx             <ip-addr>   80/TCP
 ```
 
 If ip-addr is blank run the following command to obtain it. Know issue #10836
+
 ```sh
 kubectl get svc nginx
 ```

--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -128,6 +128,11 @@ NAME      LABELS    SELECTOR              IP          PORT(S)
 nginx     <none>    run=nginx             <ip-addr>   80/TCP
 ```
 
+If ip-addr is blank run the following command to obtain it. Know issue #10836
+```sh
+kubectl get svc nginx
+```
+
 Hit the webserver:
 
 ```sh


### PR DESCRIPTION
I needed to use the the following command "kubectl get svc nginx" to obtain the cluster ip for the service.
Could be useful for others also as the default command didn't display an IP. #10836 
