### PR TITLE
Make guestbook-go url paths relative to survive multiple proxies

### DIFF
--- a/examples/guestbook-go/_src/public/index.html
+++ b/examples/guestbook-go/_src/public/index.html
@@ -4,7 +4,7 @@
     <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
     <meta charset="utf-8">
     <meta content="width=device-width" name="viewport">
-    <link href="/style.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
     <title>Guestbook</title>
   </head>
   <body>
@@ -25,10 +25,10 @@
 
     <div>
       <p><h2 id="guestbook-host-address"></h2></p>
-      <p><a href="/env">/env</a>
-      <a href="/info">/info</a></p>
+      <p><a href="env">/env</a>
+      <a href="info">/info</a></p>
     </div>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-    <script src="/script.js"></script>
+    <script src="script.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Use Case: 
When using the apiserver service proxy to access the guestbook, absolute urls are rewritten and relative urls are not. When using an external proxy to access the apiserver, sometimes absolute urls are not rewritten (depending on the external proxy implementation).

Options:
A. Use relative links
B. Use an external proxy that does absolute url rewriting

In this case, I opted for option A, because it's easier to change without side effects, tho option B is a more robust solution and is also being looked into.
