### PR TITLE
Fix links in types.go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
   - PATH=$GOPATH/bin:$PATH ./hack/verify-generated-deep-copies.sh
   - PATH=$GOPATH/bin:./third_party/etcd:$PATH ./hack/verify-gendocs.sh
   - PATH=$GOPATH/bin:./third_party/etcd:$PATH ./hack/verify-swagger-spec.sh
+  - PATH=$GOPATH/bin:./third_party/etcd:$PATH ./hack/verify-linkcheck.sh
   - godep go test ./cmd/mungedocs
 
 notifications:

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -10583,15 +10583,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "target": {
       "$ref": "v1.ObjectReference",
@@ -10604,15 +10604,15 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated; see http://releases.k8s.io/HEAD/docs/identifiers.md#names"
+      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated; see http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names"
      },
      "generateName": {
       "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified; see http://releases.k8s.io/HEAD/docs/api-conventions.md#idempotency"
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#idempotency"
      },
      "namespace": {
       "type": "string",
-      "description": "namespace of the object; must be a DNS_LABEL; cannot be updated; see http://releases.k8s.io/HEAD/docs/namespaces.md"
+      "description": "namespace of the object; must be a DNS_LABEL; cannot be updated; see http://releases.k8s.io/HEAD/docs/user-guide/namespaces.md"
      },
      "selfLink": {
       "type": "string",
@@ -10620,11 +10620,11 @@
      },
      "uid": {
       "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only; see http://releases.k8s.io/HEAD/docs/identifiers.md#uids"
+      "description": "unique UUID across space and time; populated by the system; read-only; see http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#uids"
      },
      "resourceVersion": {
       "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/HEAD/docs/api-conventions.md#concurrency-control-and-consistency"
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
      },
      "generation": {
       "type": "integer",
@@ -10633,19 +10633,19 @@
      },
      "creationTimestamp": {
       "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionTimestamp": {
       "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "labels": {
       "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services; see http://releases.k8s.io/HEAD/docs/labels.md"
+      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services; see http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
      },
      "annotations": {
       "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects; see http://releases.k8s.io/HEAD/docs/annotations.md"
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects; see http://releases.k8s.io/HEAD/docs/user-guide/annotations.md"
      }
     }
    },
@@ -10654,19 +10654,19 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of the referent; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of the referent; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "namespace": {
       "type": "string",
-      "description": "namespace of the referent; see http://releases.k8s.io/HEAD/docs/namespaces.md"
+      "description": "namespace of the referent; see http://releases.k8s.io/HEAD/docs/user-guide/namespaces.md"
      },
      "name": {
       "type": "string",
-      "description": "name of the referent; see http://releases.k8s.io/HEAD/docs/identifiers.md#names"
+      "description": "name of the referent; see http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names"
      },
      "uid": {
       "type": "string",
-      "description": "uid of the referent; see http://releases.k8s.io/HEAD/docs/identifiers.md#uids"
+      "description": "uid of the referent; see http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#uids"
      },
      "apiVersion": {
       "type": "string",
@@ -10674,7 +10674,7 @@
      },
      "resourceVersion": {
       "type": "string",
-      "description": "specific resourceVersion to which this reference is made, if any: http://releases.k8s.io/HEAD/docs/api-conventions.md#concurrency-control-and-consistency"
+      "description": "specific resourceVersion to which this reference is made, if any: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
      },
      "fieldPath": {
       "type": "string",
@@ -10690,15 +10690,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -10718,7 +10718,7 @@
      },
      "resourceVersion": {
       "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/HEAD/docs/api-conventions.md#concurrency-control-and-consistency"
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
      }
     }
    },
@@ -10727,15 +10727,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "conditions": {
       "type": "array",
@@ -10779,15 +10779,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -10806,15 +10806,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "subsets": {
       "type": "array",
@@ -10903,19 +10903,19 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "status": {
       "type": "string",
-      "description": "status of the operation; either Success, or Failure; see http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"
+      "description": "status of the operation; either Success, or Failure; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
      },
      "message": {
       "type": "string",
@@ -10945,7 +10945,7 @@
      },
      "kind": {
       "type": "string",
-      "description": "the kind attribute of the resource associated with the status StatusReason; on some operations may differ from the requested resource Kind; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "the kind attribute of the resource associated with the status StatusReason; on some operations may differ from the requested resource Kind; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "causes": {
       "type": "array",
@@ -10986,11 +10986,11 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "gracePeriodSeconds": {
       "type": "integer",
@@ -11007,15 +11007,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -11035,15 +11035,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "involvedObject": {
       "$ref": "v1.ObjectReference",
@@ -11097,15 +11097,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -11121,19 +11121,19 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.LimitRangeSpec",
-      "description": "spec defines the limits enforced; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"
+      "description": "spec defines the limits enforced; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -11181,22 +11181,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.Namespace"
       },
-      "description": "items is the list of Namespace objects in the list; see http://releases.k8s.io/HEAD/docs/namespaces.md"
+      "description": "items is the list of Namespace objects in the list; see http://releases.k8s.io/HEAD/docs/user-guide/namespaces.md"
      }
     }
    },
@@ -11205,23 +11205,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.NamespaceSpec",
-      "description": "spec defines the behavior of the Namespace; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"
+      "description": "spec defines the behavior of the Namespace; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.NamespaceStatus",
-      "description": "status describes the current status of a Namespace; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"
+      "description": "status describes the current status of a Namespace; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -11258,15 +11258,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -11282,23 +11282,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.NodeSpec",
-      "description": "specification of a node; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"
+      "description": "specification of a node; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.NodeStatus",
-      "description": "most recently observed status of the node; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"
+      "description": "most recently observed status of the node; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -11319,7 +11319,7 @@
      },
      "unschedulable": {
       "type": "boolean",
-      "description": "disable pod scheduling on the node; see http://releases.k8s.io/HEAD/docs/node.md#manual-node-administration"
+      "description": "disable pod scheduling on the node; see http://releases.k8s.io/HEAD/docs/admin/node.md#manual-node-administration"
      }
     }
    },
@@ -11328,29 +11328,29 @@
     "properties": {
      "capacity": {
       "type": "any",
-      "description": "compute resource capacity of the node; see http://releases.k8s.io/HEAD/docs/compute_resources.md"
+      "description": "compute resource capacity of the node; see http://releases.k8s.io/HEAD/docs/user-guide/compute-resources.md"
      },
      "phase": {
       "type": "string",
-      "description": "most recently observed lifecycle phase of the node; see http://releases.k8s.io/HEAD/docs/node.md#node-phase"
+      "description": "most recently observed lifecycle phase of the node; see http://releases.k8s.io/HEAD/docs/admin/node.md#node-phase"
      },
      "conditions": {
       "type": "array",
       "items": {
        "$ref": "v1.NodeCondition"
       },
-      "description": "list of node conditions observed; see http://releases.k8s.io/HEAD/docs/node.md#node-condition"
+      "description": "list of node conditions observed; see http://releases.k8s.io/HEAD/docs/admin/node.md#node-condition"
      },
      "addresses": {
       "type": "array",
       "items": {
        "$ref": "v1.NodeAddress"
       },
-      "description": "list of addresses reachable to the node; see http://releases.k8s.io/HEAD/docs/node.md#node-addresses"
+      "description": "list of addresses reachable to the node; see http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses"
      },
      "nodeInfo": {
       "$ref": "v1.NodeSystemInfo",
-      "description": "set of ids/uuids to uniquely identify the node; see http://releases.k8s.io/HEAD/docs/node.md#node-info"
+      "description": "set of ids/uuids to uniquely identify the node; see http://releases.k8s.io/HEAD/docs/admin/node.md#node-info"
      }
     }
    },
@@ -11456,22 +11456,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.PersistentVolumeClaim"
       },
-      "description": "a list of persistent volume claims; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims"
+      "description": "a list of persistent volume claims; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      }
     }
    },
@@ -11480,23 +11480,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.PersistentVolumeClaimSpec",
-      "description": "the desired characteristics of a volume; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims"
+      "description": "the desired characteristics of a volume; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      },
      "status": {
       "$ref": "v1.PersistentVolumeClaimStatus",
-      "description": "the current status of a persistent volume claim; read-only; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims"
+      "description": "the current status of a persistent volume claim; read-only; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      }
     }
    },
@@ -11508,11 +11508,11 @@
       "items": {
        "$ref": "v1.PersistentVolumeAccessMode"
       },
-      "description": "the desired access modes the volume should have; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#access-modes-1"
+      "description": "the desired access modes the volume should have; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#access-modes-1"
      },
      "resources": {
       "$ref": "v1.ResourceRequirements",
-      "description": "the desired resources the volume should have; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#resources"
+      "description": "the desired resources the volume should have; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#resources"
      },
      "volumeName": {
       "type": "string",
@@ -11549,7 +11549,7 @@
       "items": {
        "$ref": "v1.PersistentVolumeAccessMode"
       },
-      "description": "the actual access modes the volume has; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#access-modes-1"
+      "description": "the actual access modes the volume has; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#access-modes-1"
      },
      "capacity": {
       "type": "any",
@@ -11562,22 +11562,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.PersistentVolume"
       },
-      "description": "list of persistent volumes; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md"
+      "description": "list of persistent volumes; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md"
      }
     }
    },
@@ -11586,23 +11586,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.PersistentVolumeSpec",
-      "description": "specification of a persistent volume as provisioned by an administrator; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistent-volumes"
+      "description": "specification of a persistent volume as provisioned by an administrator; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistent-volumes"
      },
      "status": {
       "$ref": "v1.PersistentVolumeStatus",
-      "description": "current status of a persistent volume; populated by the system, read-only; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistent-volumes"
+      "description": "current status of a persistent volume; populated by the system, read-only; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistent-volumes"
      }
     }
    },
@@ -11611,19 +11611,19 @@
     "properties": {
      "capacity": {
       "type": "any",
-      "description": "a description of the persistent volume's resources and capacityr; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#capacity"
+      "description": "a description of the persistent volume's resources and capacityr; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#capacity"
      },
      "gcePersistentDisk": {
       "$ref": "v1.GCEPersistentDiskVolumeSource",
-      "description": "GCE disk resource provisioned by an admin; see http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk"
+      "description": "GCE disk resource provisioned by an admin; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "awsElasticBlockStore": {
       "$ref": "v1.AWSElasticBlockStoreVolumeSource",
-      "description": "AWS disk resource provisioned by an admin; see http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore"
+      "description": "AWS disk resource provisioned by an admin; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "hostPath": {
       "$ref": "v1.HostPathVolumeSource",
-      "description": "a HostPath provisioned by a developer or tester; for develment use only; see http://releases.k8s.io/HEAD/docs/volumes.md#hostpath"
+      "description": "a HostPath provisioned by a developer or tester; for develment use only; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#hostpath"
      },
      "glusterfs": {
       "$ref": "v1.GlusterfsVolumeSource",
@@ -11631,7 +11631,7 @@
      },
      "nfs": {
       "$ref": "v1.NFSVolumeSource",
-      "description": "NFS volume resource provisioned by an admin; see http://releases.k8s.io/HEAD/docs/volumes.md#nfs"
+      "description": "NFS volume resource provisioned by an admin; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#nfs"
      },
      "rbd": {
       "$ref": "v1.RBDVolumeSource",
@@ -11646,15 +11646,15 @@
       "items": {
        "$ref": "v1.PersistentVolumeAccessMode"
       },
-      "description": "all ways the volume can be mounted; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#access-modes"
+      "description": "all ways the volume can be mounted; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#access-modes"
      },
      "claimRef": {
       "$ref": "v1.ObjectReference",
-      "description": "when bound, a reference to the bound claim; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#binding"
+      "description": "when bound, a reference to the bound claim; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#binding"
      },
      "persistentVolumeReclaimPolicy": {
       "type": "string",
-      "description": "what happens to a volume when released from its claim; Valid options are Retain (default) and Recycle.  Recyling must be supported by the volume plugin underlying this persistent volume. See http://releases.k8s.io/HEAD/docs/persistent-volumes.md#recycling-policy"
+      "description": "what happens to a volume when released from its claim; Valid options are Retain (default) and Recycle.  Recyling must be supported by the volume plugin underlying this persistent volume. See http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#recycling-policy"
      }
     }
    },
@@ -11667,20 +11667,20 @@
     "properties": {
      "pdName": {
       "type": "string",
-      "description": "unique name of the PD resource in GCE; see http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk"
+      "description": "unique name of the PD resource in GCE; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "fsType": {
       "type": "string",
-      "description": "file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk"
+      "description": "file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "partition": {
       "type": "integer",
       "format": "int32",
-      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk"
+      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "read-only if true, read-write otherwise (false or unspecified); see http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk"
+      "description": "read-only if true, read-write otherwise (false or unspecified); see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"
      }
     }
    },
@@ -11693,20 +11693,20 @@
     "properties": {
      "volumeID": {
       "type": "string",
-      "description": "unique id of the PD resource in AWS; see http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore"
+      "description": "unique id of the PD resource in AWS; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "fsType": {
       "type": "string",
-      "description": "file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore"
+      "description": "file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "partition": {
       "type": "integer",
       "format": "int32",
-      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore"
+      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "read-only if true, read-write otherwise (false or unspecified); see http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore"
+      "description": "read-only if true, read-write otherwise (false or unspecified); see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"
      }
     }
    },
@@ -11718,7 +11718,7 @@
     "properties": {
      "path": {
       "type": "string",
-      "description": "path of the directory on the host; see http://releases.k8s.io/HEAD/docs/volumes.md#hostpath"
+      "description": "path of the directory on the host; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#hostpath"
      }
     }
    },
@@ -11752,15 +11752,15 @@
     "properties": {
      "server": {
       "type": "string",
-      "description": "the hostname or IP address of the NFS server; see http://releases.k8s.io/HEAD/docs/volumes.md#nfs"
+      "description": "the hostname or IP address of the NFS server; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#nfs"
      },
      "path": {
       "type": "string",
-      "description": "the path that is exported by the NFS server; see http://releases.k8s.io/HEAD/docs/volumes.md#nfs"
+      "description": "the path that is exported by the NFS server; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#nfs"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "forces the NFS export to be mounted with read-only permissions; see http://releases.k8s.io/HEAD/docs/volumes.md#nfs"
+      "description": "forces the NFS export to be mounted with read-only permissions; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#nfs"
      }
     }
    },
@@ -11817,7 +11817,7 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "name of the referent; see http://releases.k8s.io/HEAD/docs/identifiers.md#names"
+      "description": "name of the referent; see http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names"
      }
     }
    },
@@ -11858,7 +11858,7 @@
     "properties": {
      "phase": {
       "type": "string",
-      "description": "the current phase of a persistent volume; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#phase"
+      "description": "the current phase of a persistent volume; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#phase"
      },
      "message": {
       "type": "string",
@@ -11878,22 +11878,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.Pod"
       },
-      "description": "list of pods; see http://releases.k8s.io/HEAD/docs/pods.md"
+      "description": "list of pods; see http://releases.k8s.io/HEAD/docs/user-guide/pods.md"
      }
     }
    },
@@ -11902,23 +11902,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.PodSpec",
-      "description": "specification of the desired behavior of the pod; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"
+      "description": "specification of the desired behavior of the pod; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.PodStatus",
-      "description": "most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"
+      "description": "most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -11933,18 +11933,18 @@
       "items": {
        "$ref": "v1.Volume"
       },
-      "description": "list of volumes that can be mounted by containers belonging to the pod; see http://releases.k8s.io/HEAD/docs/volumes.md"
+      "description": "list of volumes that can be mounted by containers belonging to the pod; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md"
      },
      "containers": {
       "type": "array",
       "items": {
        "$ref": "v1.Container"
       },
-      "description": "list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod; see http://releases.k8s.io/HEAD/docs/containers.md"
+      "description": "list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod; see http://releases.k8s.io/HEAD/docs/user-guide/containers.md"
      },
      "restartPolicy": {
       "type": "string",
-      "description": "restart policy for all containers within the pod; one of Always, OnFailure, Never; defaults to Always; see http://releases.k8s.io/HEAD/docs/pod-states.md#restartpolicy"
+      "description": "restart policy for all containers within the pod; one of Always, OnFailure, Never; defaults to Always; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#restartpolicy"
      },
      "terminationGracePeriodSeconds": {
       "type": "integer",
@@ -11961,11 +11961,11 @@
      },
      "nodeSelector": {
       "type": "any",
-      "description": "selector which must match a node's labels for the pod to be scheduled on that node; see http://releases.k8s.io/HEAD/examples/node-selection/README.md"
+      "description": "selector which must match a node's labels for the pod to be scheduled on that node; see http://releases.k8s.io/HEAD/docs/user-guide/node-selection/README.md"
      },
      "serviceAccountName": {
       "type": "string",
-      "description": "name of the ServiceAccount to use to run this pod; see http://releases.k8s.io/HEAD/docs/service_accounts.md"
+      "description": "name of the ServiceAccount to use to run this pod; see http://releases.k8s.io/HEAD/docs/design/service_accounts.md"
      },
      "serviceAccount": {
       "type": "string",
@@ -11984,7 +11984,7 @@
       "items": {
        "$ref": "v1.LocalObjectReference"
       },
-      "description": "list of references to secrets in the same namespace available for pulling the container images; see http://releases.k8s.io/HEAD/docs/images.md#specifying-imagepullsecrets-on-a-pod"
+      "description": "list of references to secrets in the same namespace available for pulling the container images; see http://releases.k8s.io/HEAD/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod"
      }
     }
    },
@@ -11996,23 +11996,23 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "volume name; must be a DNS_LABEL and unique within the pod; see http://releases.k8s.io/HEAD/docs/identifiers.md#names"
+      "description": "volume name; must be a DNS_LABEL and unique within the pod; see http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names"
      },
      "hostPath": {
       "$ref": "v1.HostPathVolumeSource",
-      "description": "pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host; see http://releases.k8s.io/HEAD/docs/volumes.md#hostpath"
+      "description": "pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#hostpath"
      },
      "emptyDir": {
       "$ref": "v1.EmptyDirVolumeSource",
-      "description": "temporary directory that shares a pod's lifetime; see http://releases.k8s.io/HEAD/docs/volumes.md#emptydir"
+      "description": "temporary directory that shares a pod's lifetime; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#emptydir"
      },
      "gcePersistentDisk": {
       "$ref": "v1.GCEPersistentDiskVolumeSource",
-      "description": "GCE disk resource attached to the host machine on demand; see http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk"
+      "description": "GCE disk resource attached to the host machine on demand; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "awsElasticBlockStore": {
       "$ref": "v1.AWSElasticBlockStoreVolumeSource",
-      "description": "AWS disk resource attached to the host machine on demand; see http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore"
+      "description": "AWS disk resource attached to the host machine on demand; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "gitRepo": {
       "$ref": "v1.GitRepoVolumeSource",
@@ -12020,11 +12020,11 @@
      },
      "secret": {
       "$ref": "v1.SecretVolumeSource",
-      "description": "secret to populate volume; see http://releases.k8s.io/HEAD/docs/volumes.md#secrets"
+      "description": "secret to populate volume; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#secrets"
      },
      "nfs": {
       "$ref": "v1.NFSVolumeSource",
-      "description": "NFS volume that will be mounted in the host machine; see http://releases.k8s.io/HEAD/docs/volumes.md#nfs"
+      "description": "NFS volume that will be mounted in the host machine; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#nfs"
      },
      "iscsi": {
       "$ref": "v1.ISCSIVolumeSource",
@@ -12036,7 +12036,7 @@
      },
      "persistentVolumeClaim": {
       "$ref": "v1.PersistentVolumeClaimVolumeSource",
-      "description": "a reference to a PersistentVolumeClaim in the same namespace; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims"
+      "description": "a reference to a PersistentVolumeClaim in the same namespace; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      },
      "rbd": {
       "$ref": "v1.RBDVolumeSource",
@@ -12049,7 +12049,7 @@
     "properties": {
      "medium": {
       "type": "string",
-      "description": "type of storage used to back the volume; must be an empty string (default) or Memory; see http://releases.k8s.io/HEAD/docs/volumes.md#emptydir"
+      "description": "type of storage used to back the volume; must be an empty string (default) or Memory; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#emptydir"
      }
     }
    },
@@ -12078,7 +12078,7 @@
     "properties": {
      "secretName": {
       "type": "string",
-      "description": "secretName is the name of a secret in the pod's namespace; see http://releases.k8s.io/HEAD/docs/volumes.md#secrets"
+      "description": "secretName is the name of a secret in the pod's namespace; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#secrets"
      }
     }
    },
@@ -12090,7 +12090,7 @@
     "properties": {
      "claimName": {
       "type": "string",
-      "description": "the name of the claim in the same namespace to be mounted as a volume; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims"
+      "description": "the name of the claim in the same namespace to be mounted as a volume; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      },
      "readOnly": {
       "type": "boolean",
@@ -12110,21 +12110,21 @@
      },
      "image": {
       "type": "string",
-      "description": "Docker image name; see http://releases.k8s.io/HEAD/docs/images.md"
+      "description": "Docker image name; see http://releases.k8s.io/HEAD/docs/user-guide/images.md"
      },
      "command": {
       "type": "array",
       "items": {
        "type": "string"
       },
-      "description": "entrypoint array; not executed within a shell; the docker image's entrypoint is used if this is not provided; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see http://releases.k8s.io/HEAD/docs/containers.md#containers-and-commands"
+      "description": "entrypoint array; not executed within a shell; the docker image's entrypoint is used if this is not provided; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see http://releases.k8s.io/HEAD/docs/user-guide/containers.md#containers-and-commands"
      },
      "args": {
       "type": "array",
       "items": {
        "type": "string"
       },
-      "description": "command array; the docker image's cmd is used if this is not provided; arguments to the entrypoint; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see http://releases.k8s.io/HEAD/docs/containers.md#containers-and-commands"
+      "description": "command array; the docker image's cmd is used if this is not provided; arguments to the entrypoint; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see http://releases.k8s.io/HEAD/docs/user-guide/containers.md#containers-and-commands"
      },
      "workingDir": {
       "type": "string",
@@ -12146,7 +12146,7 @@
      },
      "resources": {
       "$ref": "v1.ResourceRequirements",
-      "description": "Compute Resources required by this container; cannot be updated; see http://releases.k8s.io/HEAD/docs/compute_resources.md"
+      "description": "Compute Resources required by this container; cannot be updated; see http://releases.k8s.io/HEAD/docs/user-guide/compute-resources.md"
      },
      "volumeMounts": {
       "type": "array",
@@ -12157,11 +12157,11 @@
      },
      "livenessProbe": {
       "$ref": "v1.Probe",
-      "description": "periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated; see http://releases.k8s.io/HEAD/docs/pod-states.md#container-probes"
+      "description": "periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes"
      },
      "readinessProbe": {
       "$ref": "v1.Probe",
-      "description": "periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated; see http://releases.k8s.io/HEAD/docs/pod-states.md#container-probes"
+      "description": "periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes"
      },
      "lifecycle": {
       "$ref": "v1.Lifecycle",
@@ -12173,11 +12173,11 @@
      },
      "imagePullPolicy": {
       "type": "string",
-      "description": "image pull policy; one of Always, Never, IfNotPresent; defaults to Always if :latest tag is specified, or IfNotPresent otherwise; cannot be updated; see http://releases.k8s.io/HEAD/docs/images.md#updating-images"
+      "description": "image pull policy; one of Always, Never, IfNotPresent; defaults to Always if :latest tag is specified, or IfNotPresent otherwise; cannot be updated; see http://releases.k8s.io/HEAD/docs/user-guide/images.md#updating-images"
      },
      "securityContext": {
       "$ref": "v1.SecurityContext",
-      "description": "security options the pod should run with; see http://releases.k8s.io/HEAD/docs/security_context.md"
+      "description": "security options the pod should run with; see http://releases.k8s.io/HEAD/docs/design/security_context.md"
      }
     }
    },
@@ -12298,12 +12298,12 @@
      "initialDelaySeconds": {
       "type": "integer",
       "format": "int64",
-      "description": "number of seconds after the container has started before liveness probes are initiated; see http://releases.k8s.io/HEAD/docs/pod-states.md#container-probes"
+      "description": "number of seconds after the container has started before liveness probes are initiated; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes"
      },
      "timeoutSeconds": {
       "type": "integer",
       "format": "int64",
-      "description": "number of seconds after which liveness probes timeout; defaults to 1 second; see http://releases.k8s.io/HEAD/docs/pod-states.md#container-probes"
+      "description": "number of seconds after which liveness probes timeout; defaults to 1 second; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes"
      }
     }
    },
@@ -12360,11 +12360,11 @@
     "properties": {
      "postStart": {
       "$ref": "v1.Handler",
-      "description": "called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes; see http://releases.k8s.io/HEAD/docs/container-environment.md#hook-details"
+      "description": "called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes; see http://releases.k8s.io/HEAD/docs/user-guide/container-environment.md#hook-details"
      },
      "preStop": {
       "$ref": "v1.Handler",
-      "description": "called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes; see http://releases.k8s.io/HEAD/docs/container-environment.md#hook-details"
+      "description": "called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes; see http://releases.k8s.io/HEAD/docs/user-guide/container-environment.md#hook-details"
      }
     }
    },
@@ -12435,19 +12435,19 @@
     "properties": {
      "user": {
       "type": "string",
-      "description": "the user label to apply to the container; see http://releases.k8s.io/HEAD/docs/labels.md"
+      "description": "the user label to apply to the container; see http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
      },
      "role": {
       "type": "string",
-      "description": "the role label to apply to the container; see http://releases.k8s.io/HEAD/docs/labels.md"
+      "description": "the role label to apply to the container; see http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
      },
      "type": {
       "type": "string",
-      "description": "the type label to apply to the container; see http://releases.k8s.io/HEAD/docs/labels.md"
+      "description": "the type label to apply to the container; see http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
      },
      "level": {
       "type": "string",
-      "description": "the level label to apply to the container; see http://releases.k8s.io/HEAD/docs/labels.md"
+      "description": "the level label to apply to the container; see http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
      }
     }
    },
@@ -12456,14 +12456,14 @@
     "properties": {
      "phase": {
       "type": "string",
-      "description": "current condition of the pod; see http://releases.k8s.io/HEAD/docs/pod-states.md#pod-phase"
+      "description": "current condition of the pod; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#pod-phase"
      },
      "conditions": {
       "type": "array",
       "items": {
        "$ref": "v1.PodCondition"
       },
-      "description": "current service state of pod; see http://releases.k8s.io/HEAD/docs/pod-states.md#pod-conditions"
+      "description": "current service state of pod; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#pod-conditions"
      },
      "message": {
       "type": "string",
@@ -12490,7 +12490,7 @@
       "items": {
        "$ref": "v1.ContainerStatus"
       },
-      "description": "list of container statuses; see http://releases.k8s.io/HEAD/docs/pod-states.md#container-statuses"
+      "description": "list of container statuses; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-statuses"
      }
     }
    },
@@ -12503,11 +12503,11 @@
     "properties": {
      "type": {
       "type": "string",
-      "description": "kind of the condition, currently only Ready; see http://releases.k8s.io/HEAD/docs/pod-states.md#pod-conditions"
+      "description": "kind of the condition, currently only Ready; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#pod-conditions"
      },
      "status": {
       "type": "string",
-      "description": "status of the condition, one of True, False, Unknown; see http://releases.k8s.io/HEAD/docs/pod-states.md#pod-conditions"
+      "description": "status of the condition, one of True, False, Unknown; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#pod-conditions"
      }
     }
    },
@@ -12544,7 +12544,7 @@
      },
      "image": {
       "type": "string",
-      "description": "image of the container; see http://releases.k8s.io/HEAD/docs/images.md"
+      "description": "image of the container; see http://releases.k8s.io/HEAD/docs/user-guide/images.md"
      },
      "imageID": {
       "type": "string",
@@ -12552,7 +12552,7 @@
      },
      "containerID": {
       "type": "string",
-      "description": "container's ID in the format 'docker://\u003ccontainer_id\u003e'; see http://releases.k8s.io/HEAD/docs/container-environment.md#container-information"
+      "description": "container's ID in the format 'docker://\u003ccontainer_id\u003e'; see http://releases.k8s.io/HEAD/docs/user-guide/container-environment.md#container-information"
      }
     }
    },
@@ -12637,15 +12637,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -12661,19 +12661,19 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "template": {
       "$ref": "v1.PodTemplateSpec",
-      "description": "the template of the desired behavior of the pod; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"
+      "description": "the template of the desired behavior of the pod; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -12682,11 +12682,11 @@
     "properties": {
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.PodSpec",
-      "description": "specification of the desired behavior of the pod; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"
+      "description": "specification of the desired behavior of the pod; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -12698,22 +12698,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.ReplicationController"
       },
-      "description": "list of replication controllers; see http://releases.k8s.io/HEAD/docs/replication-controller.md"
+      "description": "list of replication controllers; see http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md"
      }
     }
    },
@@ -12722,23 +12722,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.ReplicationControllerSpec",
-      "description": "specification of the desired behavior of the replication controller; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"
+      "description": "specification of the desired behavior of the replication controller; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.ReplicationControllerStatus",
-      "description": "most recently observed status of the replication controller; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"
+      "description": "most recently observed status of the replication controller; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -12748,15 +12748,15 @@
      "replicas": {
       "type": "integer",
       "format": "int32",
-      "description": "number of replicas desired; defaults to 1; see http://releases.k8s.io/HEAD/docs/replication-controller.md#what-is-a-replication-controller"
+      "description": "number of replicas desired; defaults to 1; see http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#what-is-a-replication-controller"
      },
      "selector": {
       "type": "any",
-      "description": "label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template; see http://releases.k8s.io/HEAD/docs/labels.md#label-selectors"
+      "description": "label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template; see http://releases.k8s.io/HEAD/docs/user-guide/labels.md#label-selectors"
      },
      "template": {
       "$ref": "v1.PodTemplateSpec",
-      "description": "object that describes the pod that will be created if insufficient replicas are detected; takes precendence over templateRef; see http://releases.k8s.io/HEAD/docs/replication-controller.md#pod-template"
+      "description": "object that describes the pod that will be created if insufficient replicas are detected; takes precendence over templateRef; see http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#pod-template"
      }
     }
    },
@@ -12769,7 +12769,7 @@
      "replicas": {
       "type": "integer",
       "format": "int32",
-      "description": "most recently oberved number of replicas; see http://releases.k8s.io/HEAD/docs/replication-controller.md#what-is-a-replication-controller"
+      "description": "most recently oberved number of replicas; see http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#what-is-a-replication-controller"
      },
      "observedGeneration": {
       "type": "integer",
@@ -12786,15 +12786,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -12810,23 +12810,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.ResourceQuotaSpec",
-      "description": "spec defines the desired quota; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"
+      "description": "spec defines the desired quota; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.ResourceQuotaStatus",
-      "description": "status defines the actual enforced quota and current usage; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"
+      "description": "status defines the actual enforced quota and current usage; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -12860,22 +12860,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.Secret"
       },
-      "description": "items is a list of secret objects; see http://releases.k8s.io/HEAD/docs/secrets.md"
+      "description": "items is a list of secret objects; see http://releases.k8s.io/HEAD/docs/user-guide/secrets.md"
      }
     }
    },
@@ -12884,15 +12884,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "data": {
       "type": "any",
@@ -12912,22 +12912,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.ServiceAccount"
       },
-      "description": "list of ServiceAccounts; see http://releases.k8s.io/HEAD/docs/service_accounts.md#service-accounts"
+      "description": "list of ServiceAccounts; see http://releases.k8s.io/HEAD/docs/design/service_accounts.md#service-accounts"
      }
     }
    },
@@ -12936,29 +12936,29 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "secrets": {
       "type": "array",
       "items": {
        "$ref": "v1.ObjectReference"
       },
-      "description": "list of secrets that can be used by pods running as this service account; see http://releases.k8s.io/HEAD/docs/secrets.md"
+      "description": "list of secrets that can be used by pods running as this service account; see http://releases.k8s.io/HEAD/docs/user-guide/secrets.md"
      },
      "imagePullSecrets": {
       "type": "array",
       "items": {
        "$ref": "v1.LocalObjectReference"
       },
-      "description": "list of references to secrets in the same namespace available for pulling container images; see http://releases.k8s.io/HEAD/docs/secrets.md#manually-specifying-an-imagepullsecret"
+      "description": "list of references to secrets in the same namespace available for pulling container images; see http://releases.k8s.io/HEAD/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret"
      }
     }
    },
@@ -12970,15 +12970,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -12994,23 +12994,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.ServiceSpec",
-      "description": "specification of the desired behavior of the service; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"
+      "description": "specification of the desired behavior of the service; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.ServiceStatus",
-      "description": "most recently observed status of the service; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"
+      "description": "most recently observed status of the service; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -13025,19 +13025,19 @@
       "items": {
        "$ref": "v1.ServicePort"
       },
-      "description": "ports exposed by the service; see http://releases.k8s.io/HEAD/docs/services.md#virtual-ips-and-service-proxies"
+      "description": "ports exposed by the service; see http://releases.k8s.io/HEAD/docs/user-guide/services.md#virtual-ips-and-service-proxies"
      },
      "selector": {
       "type": "any",
-      "description": "label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified; see http://releases.k8s.io/HEAD/docs/services.md#overview"
+      "description": "label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified; see http://releases.k8s.io/HEAD/docs/user-guide/services.md#overview"
      },
      "clusterIP": {
       "type": "string",
-      "description": "IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; cannot be updated; 'None' can be specified for a headless service when proxying is not required; see http://releases.k8s.io/HEAD/docs/services.md#virtual-ips-and-service-proxies"
+      "description": "IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; cannot be updated; 'None' can be specified for a headless service when proxying is not required; see http://releases.k8s.io/HEAD/docs/user-guide/services.md#virtual-ips-and-service-proxies"
      },
      "type": {
       "type": "string",
-      "description": "type of this service; must be ClusterIP, NodePort, or LoadBalancer; defaults to ClusterIP; see http://releases.k8s.io/HEAD/docs/services.md#external-services"
+      "description": "type of this service; must be ClusterIP, NodePort, or LoadBalancer; defaults to ClusterIP; see http://releases.k8s.io/HEAD/docs/user-guide/services.md#external-services"
      },
      "deprecatedPublicIPs": {
       "type": "array",
@@ -13048,7 +13048,7 @@
      },
      "sessionAffinity": {
       "type": "string",
-      "description": "enable client IP based session affinity; must be ClientIP or None; defaults to None; see http://releases.k8s.io/HEAD/docs/services.md#virtual-ips-and-service-proxies"
+      "description": "enable client IP based session affinity; must be ClientIP or None; defaults to None; see http://releases.k8s.io/HEAD/docs/user-guide/services.md#virtual-ips-and-service-proxies"
      }
     }
    },
@@ -13074,12 +13074,12 @@
      },
      "targetPort": {
       "type": "string",
-      "description": "number or name of the port to access on the pods targeted by the service; defaults to the service port; number must be in the range 1 to 65535; name must be an IANA_SVC_NAME; see http://releases.k8s.io/HEAD/docs/services.md#defining-a-service"
+      "description": "number or name of the port to access on the pods targeted by the service; defaults to the service port; number must be in the range 1 to 65535; name must be an IANA_SVC_NAME; see http://releases.k8s.io/HEAD/docs/user-guide/services.md#defining-a-service"
      },
      "nodePort": {
       "type": "integer",
       "format": "int32",
-      "description": "the port on each node on which this service is exposed when type=NodePort or LoadBalancer; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; see http://releases.k8s.io/HEAD/docs/services.md#type--nodeport"
+      "description": "the port on each node on which this service is exposed when type=NodePort or LoadBalancer; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; see http://releases.k8s.io/HEAD/docs/user-guide/services.md#type--nodeport"
      }
     }
    },

--- a/cmd/linkcheck/links.go
+++ b/cmd/linkcheck/links.go
@@ -14,6 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//This command checks if the hyperlinks in files are valid. It checks the files
+//with 'fileSuffix' in 'rootDir' for URLs that match 'prefix'. It trims the
+//'prefix' from the URL, uses what's left as the relative path to repoRoot to
+//verify if the link is valid. For example:
+//$ linkcheck --root-dir=${TYPEROOT} --repo-root=${KUBE_ROOT} \
+//  --file-suffix=types.go --prefix=http://releases.k8s.io/HEAD
+
 package main
 
 import (

--- a/cmd/linkcheck/links.go
+++ b/cmd/linkcheck/links.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	flag "github.com/spf13/pflag"
+)
+
+var (
+	httpRE *regexp.Regexp
+
+	rootDir    = flag.String("root-dir", "", "Root directory containing documents to be processed.")
+	repoRoot   = flag.String("repo-root", "", `Root directory of k8s repository.`)
+	fileSuffix = flag.String("file-suffix", "", "suffix of files to be checked")
+	prefix     = flag.String("prefix", "", "Longest common prefix of the link URL, e.g., http://release.k8s.io/HEAD/ for links in pkg/api/types.go")
+)
+
+func newWalkFunc(invalidLink *bool) filepath.WalkFunc {
+	return func(filePath string, info os.FileInfo, err error) error {
+		if !strings.HasSuffix(info.Name(), *fileSuffix) {
+			return nil
+		}
+		fileBytes, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			return err
+		}
+		foundInvalid := false
+		matches := httpRE.FindAllSubmatch(fileBytes, -1)
+		for _, match := range matches {
+			//match[1] should look like docs/devel/api-conventions.md
+			if _, err := os.Stat(path.Join(*repoRoot, string(match[1]))); err != nil {
+				fmt.Fprintf(os.Stderr, "Link is not valid: %s\n", string(match[0]))
+				foundInvalid = true
+			}
+		}
+		if foundInvalid {
+			fmt.Fprintf(os.Stderr, "Found invalid links in %s\n", filePath)
+			*invalidLink = true
+		}
+		return nil
+	}
+}
+
+func main() {
+	flag.Parse()
+	httpRE = regexp.MustCompile(*prefix + `(.*\.md)`)
+
+	if *rootDir == "" || *repoRoot == "" || *prefix == "" {
+		flag.Usage()
+		os.Exit(2)
+	}
+	invalidLink := false
+	if err := filepath.Walk(*rootDir, newWalkFunc(&invalidLink)); err != nil {
+		fmt.Fprintf(os.Stderr, "Fail: %v.\n", err)
+		os.Exit(2)
+	}
+	if invalidLink {
+		os.Exit(1)
+	}
+}

--- a/docs/api-reference/definitions.html
+++ b/docs/api-reference/definitions.html
@@ -497,35 +497,35 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">specification of a node; <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status">http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">specification of a node; <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_nodespec">v1.NodeSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">most recently observed status of the node; populated by the system, read-only; <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status">http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">most recently observed status of the node; populated by the system, read-only; <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_nodestatus">v1.NodeStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -556,28 +556,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_listmeta">v1.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">a list of persistent volume claims; see <a href="http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">a list of persistent volume claims; see <a href="http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#persistentvolumeclaims">http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#persistentvolumeclaims</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumeclaim">v1.PersistentVolumeClaim</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -646,28 +646,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">user</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the user label to apply to the container; see <a href="http://releases.k8s.io/HEAD/docs/labels.md">http://releases.k8s.io/HEAD/docs/labels.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the user label to apply to the container; see <a href="http://kubernetes.io/v1.0/docs/user-guide/labels.html">http://kubernetes.io/v1.0/docs/user-guide/labels.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">role</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the role label to apply to the container; see <a href="http://releases.k8s.io/HEAD/docs/labels.md">http://releases.k8s.io/HEAD/docs/labels.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the role label to apply to the container; see <a href="http://kubernetes.io/v1.0/docs/user-guide/labels.html">http://kubernetes.io/v1.0/docs/user-guide/labels.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the type label to apply to the container; see <a href="http://releases.k8s.io/HEAD/docs/labels.md">http://releases.k8s.io/HEAD/docs/labels.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the type label to apply to the container; see <a href="http://kubernetes.io/v1.0/docs/user-guide/labels.html">http://kubernetes.io/v1.0/docs/user-guide/labels.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">level</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the level label to apply to the container; see <a href="http://releases.k8s.io/HEAD/docs/labels.md">http://releases.k8s.io/HEAD/docs/labels.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the level label to apply to the container; see <a href="http://kubernetes.io/v1.0/docs/user-guide/labels.html">http://kubernetes.io/v1.0/docs/user-guide/labels.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -774,14 +774,14 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">accessModes</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the desired access modes the volume should have; see <a href="http://releases.k8s.io/HEAD/docs/persistent-volumes.md#access-modes-1">http://releases.k8s.io/HEAD/docs/persistent-volumes.md#access-modes-1</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the desired access modes the volume should have; see <a href="http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#access-modes-1">http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#access-modes-1</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumeaccessmode">v1.PersistentVolumeAccessMode</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resources</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the desired resources the volume should have; see <a href="http://releases.k8s.io/HEAD/docs/persistent-volumes.md#resources">http://releases.k8s.io/HEAD/docs/persistent-volumes.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the desired resources the volume should have; see <a href="http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#resources">http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcerequirements">v1.ResourceRequirements</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -819,28 +819,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">pdName</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">unique name of the PD resource in GCE; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk">http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">unique name of the PD resource in GCE; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#gcepersistentdisk">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fsType</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">file system type to mount, such as ext4, xfs, ntfs; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk">http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">file system type to mount, such as ext4, xfs, ntfs; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#gcepersistentdisk">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">partition</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">partition on the disk to mount (e.g., <em>1</em> for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk">http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">partition on the disk to mount (e.g., <em>1</em> for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#gcepersistentdisk">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">read-only if true, read-write otherwise (false or unspecified); see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk">http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">read-only if true, read-write otherwise (false or unspecified); see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#gcepersistentdisk">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -871,7 +871,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">phase</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">phase is the current lifecycle phase of the namespace; see <a href="http://releases.k8s.io/HEAD/docs/design/namespaces.md#phases">http://releases.k8s.io/HEAD/docs/design/namespaces.md#phases</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">phase is the current lifecycle phase of the namespace; see <a href="http://kubernetes.io/v1.0/docs/design/namespaces.html#phases">http://kubernetes.io/v1.0/docs/design/namespaces.html#phases</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -902,7 +902,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hard</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">hard is the set of desired hard limits for each named resource; see <a href="http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota">http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">hard is the set of desired hard limits for each named resource; see <a href="http://kubernetes.io/v1.0/docs/design/admission_control_resource_quota.html#admissioncontrol-plugin-resourcequota">http://kubernetes.io/v1.0/docs/design/admission_control_resource_quota.html#admissioncontrol-plugin-resourcequota</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -933,7 +933,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">finalizers</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">an opaque list of values that must be empty to permanently remove object from storage; see <a href="http://releases.k8s.io/HEAD/docs/design/namespaces.md#finalizers">http://releases.k8s.io/HEAD/docs/design/namespaces.md#finalizers</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">an opaque list of values that must be empty to permanently remove object from storage; see <a href="http://kubernetes.io/v1.0/docs/design/namespaces.html#finalizers">http://kubernetes.io/v1.0/docs/design/namespaces.html#finalizers</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_finalizername">v1.FinalizerName</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -964,35 +964,35 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">specification of a persistent volume as provisioned by an administrator; see <a href="http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistent-volumes">http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistent-volumes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">specification of a persistent volume as provisioned by an administrator; see <a href="http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#persistent-volumes">http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#persistent-volumes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumespec">v1.PersistentVolumeSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">current status of a persistent volume; populated by the system, read-only; see <a href="http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistent-volumes">http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistent-volumes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">current status of a persistent volume; populated by the system, read-only; see <a href="http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#persistent-volumes">http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#persistent-volumes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumestatus">v1.PersistentVolumeStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1023,7 +1023,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">phase</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the current phase of a persistent volume; see <a href="http://releases.k8s.io/HEAD/docs/persistent-volumes.md#phase">http://releases.k8s.io/HEAD/docs/persistent-volumes.md#phase</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the current phase of a persistent volume; see <a href="http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#phase">http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#phase</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1068,21 +1068,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_listmeta">v1.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1262,21 +1262,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_listmeta">v1.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1314,7 +1314,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">name of the referent; see <a href="http://releases.k8s.io/HEAD/docs/identifiers.md#names">http://releases.k8s.io/HEAD/docs/identifiers.md#names</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">name of the referent; see <a href="http://kubernetes.io/v1.0/docs/user-guide/identifiers.html#names">http://kubernetes.io/v1.0/docs/user-guide/identifiers.html#names</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1345,7 +1345,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hard</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">hard is the set of enforced hard limits for each named resource; see <a href="http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota">http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">hard is the set of enforced hard limits for each named resource; see <a href="http://kubernetes.io/v1.0/docs/design/admission_control_resource_quota.html#admissioncontrol-plugin-resourcequota">http://kubernetes.io/v1.0/docs/design/admission_control_resource_quota.html#admissioncontrol-plugin-resourcequota</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1414,21 +1414,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string that identifies an object. Must be unique within a namespace; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/identifiers.md#names">http://releases.k8s.io/HEAD/docs/identifiers.md#names</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string that identifies an object. Must be unique within a namespace; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/user-guide/identifiers.html#names">http://kubernetes.io/v1.0/docs/user-guide/identifiers.html#names</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">generateName</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#idempotency">http://releases.k8s.io/HEAD/docs/api-conventions.md#idempotency</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#idempotency">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#idempotency</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">namespace</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">namespace of the object; must be a DNS_LABEL; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/namespaces.md">http://releases.k8s.io/HEAD/docs/namespaces.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">namespace of the object; must be a DNS_LABEL; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/user-guide/namespaces.html">http://kubernetes.io/v1.0/docs/user-guide/namespaces.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1442,14 +1442,14 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">uid</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">unique UUID across space and time; populated by the system; read-only; see <a href="http://releases.k8s.io/HEAD/docs/identifiers.md#uids">http://releases.k8s.io/HEAD/docs/identifiers.md#uids</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">unique UUID across space and time; populated by the system; read-only; see <a href="http://kubernetes.io/v1.0/docs/user-guide/identifiers.html#uids">http://kubernetes.io/v1.0/docs/user-guide/identifiers.html#uids</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#concurrency-control-and-consistency">http://releases.k8s.io/HEAD/docs/api-conventions.md#concurrency-control-and-consistency</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#concurrency-control-and-consistency">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#concurrency-control-and-consistency</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1463,28 +1463,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">creationTimestamp</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">deletionTimestamp</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">labels</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services; see <a href="http://releases.k8s.io/HEAD/docs/labels.md">http://releases.k8s.io/HEAD/docs/labels.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services; see <a href="http://kubernetes.io/v1.0/docs/user-guide/labels.html">http://kubernetes.io/v1.0/docs/user-guide/labels.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">annotations</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects; see <a href="http://releases.k8s.io/HEAD/docs/annotations.md">http://releases.k8s.io/HEAD/docs/annotations.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects; see <a href="http://kubernetes.io/v1.0/docs/user-guide/annotations.html">http://kubernetes.io/v1.0/docs/user-guide/annotations.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1609,7 +1609,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">medium</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">type of storage used to back the volume; must be an empty string (default) or Memory; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#emptydir">http://releases.k8s.io/HEAD/docs/volumes.md#emptydir</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">type of storage used to back the volume; must be an empty string (default) or Memory; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#emptydir">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#emptydir</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1640,21 +1640,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_listmeta">v1.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1692,35 +1692,35 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the desired characteristics of a volume; see <a href="http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the desired characteristics of a volume; see <a href="http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#persistentvolumeclaims">http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#persistentvolumeclaims</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumeclaimspec">v1.PersistentVolumeClaimSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the current status of a persistent volume claim; read-only; see <a href="http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the current status of a persistent volume claim; read-only; see <a href="http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#persistentvolumeclaims">http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#persistentvolumeclaims</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumeclaimstatus">v1.PersistentVolumeClaimStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1751,28 +1751,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_listmeta">v1.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">items is the list of Namespace objects in the list; see <a href="http://releases.k8s.io/HEAD/docs/namespaces.md">http://releases.k8s.io/HEAD/docs/namespaces.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">items is the list of Namespace objects in the list; see <a href="http://kubernetes.io/v1.0/docs/user-guide/namespaces.html">http://kubernetes.io/v1.0/docs/user-guide/namespaces.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_namespace">v1.Namespace</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1803,35 +1803,35 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secrets</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">list of secrets that can be used by pods running as this service account; see <a href="http://releases.k8s.io/HEAD/docs/secrets.md">http://releases.k8s.io/HEAD/docs/secrets.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">list of secrets that can be used by pods running as this service account; see <a href="http://kubernetes.io/v1.0/docs/user-guide/secrets.html">http://kubernetes.io/v1.0/docs/user-guide/secrets.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectreference">v1.ObjectReference</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">imagePullSecrets</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">list of references to secrets in the same namespace available for pulling container images; see <a href="http://releases.k8s.io/HEAD/docs/secrets.md#manually-specifying-an-imagepullsecret">http://releases.k8s.io/HEAD/docs/secrets.md#manually-specifying-an-imagepullsecret</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">list of references to secrets in the same namespace available for pulling container images; see <a href="http://kubernetes.io/v1.0/docs/user-guide/secrets.html#manually-specifying-an-imagepullsecret">http://kubernetes.io/v1.0/docs/user-guide/secrets.html#manually-specifying-an-imagepullsecret</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_localobjectreference">v1.LocalObjectReference</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1900,35 +1900,35 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">spec defines the behavior of the Namespace; <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status">http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">spec defines the behavior of the Namespace; <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_namespacespec">v1.NamespaceSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">status describes the current status of a Namespace; <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status">http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">status describes the current status of a Namespace; <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_namespacestatus">v1.NamespaceStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1966,7 +1966,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#concurrency-control-and-consistency">http://releases.k8s.io/HEAD/docs/api-conventions.md#concurrency-control-and-consistency</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#concurrency-control-and-consistency">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#concurrency-control-and-consistency</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1997,7 +1997,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">claimName</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the name of the claim in the same namespace to be mounted as a volume; see <a href="http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the name of the claim in the same namespace to be mounted as a volume; see <a href="http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#persistentvolumeclaims">http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#persistentvolumeclaims</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2042,7 +2042,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">accessModes</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the actual access modes the volume has; see <a href="http://releases.k8s.io/HEAD/docs/persistent-volumes.md#access-modes-1">http://releases.k8s.io/HEAD/docs/persistent-volumes.md#access-modes-1</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the actual access modes the volume has; see <a href="http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#access-modes-1">http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#access-modes-1</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumeaccessmode">v1.PersistentVolumeAccessMode</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2080,28 +2080,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_listmeta">v1.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">items is a list of ResourceQuota objects; see <a href="http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota">http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">items is a list of ResourceQuota objects; see <a href="http://kubernetes.io/v1.0/docs/design/admission_control_resource_quota.html#admissioncontrol-plugin-resourcequota">http://kubernetes.io/v1.0/docs/design/admission_control_resource_quota.html#admissioncontrol-plugin-resourcequota</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcequota">v1.ResourceQuota</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2170,7 +2170,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secretName</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">secretName is the name of a secret in the pod&#8217;s namespace; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#secrets">http://releases.k8s.io/HEAD/docs/volumes.md#secrets</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">secretName is the name of a secret in the pod&#8217;s namespace; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#secrets">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#secrets</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2270,35 +2270,35 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">specification of the desired behavior of the service; <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status">http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">specification of the desired behavior of the service; <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_servicespec">v1.ServiceSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">most recently observed status of the service; populated by the system, read-only; <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status">http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">most recently observed status of the service; populated by the system, read-only; <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_servicestatus">v1.ServiceStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2329,28 +2329,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_listmeta">v1.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">list of ServiceAccounts; see <a href="http://releases.k8s.io/HEAD/docs/service_accounts.md#service-accounts">http://releases.k8s.io/HEAD/docs/service_accounts.md#service-accounts</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">list of ServiceAccounts; see <a href="http://kubernetes.io/v1.0/docs/design/service_accounts.html#service-accounts">http://kubernetes.io/v1.0/docs/design/service_accounts.html#service-accounts</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_serviceaccount">v1.ServiceAccount</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2381,28 +2381,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_listmeta">v1.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">items is a list of LimitRange objects; see <a href="http://releases.k8s.io/HEAD/docs/design/admission_control_limit_range.md">http://releases.k8s.io/HEAD/docs/design/admission_control_limit_range.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">items is a list of LimitRange objects; see <a href="http://kubernetes.io/v1.0/docs/design/admission_control_limit_range.html">http://kubernetes.io/v1.0/docs/design/admission_control_limit_range.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_limitrange">v1.LimitRange</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2433,21 +2433,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2485,14 +2485,14 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2530,35 +2530,35 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">volume name; must be a DNS_LABEL and unique within the pod; see <a href="http://releases.k8s.io/HEAD/docs/identifiers.md#names">http://releases.k8s.io/HEAD/docs/identifiers.md#names</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">volume name; must be a DNS_LABEL and unique within the pod; see <a href="http://kubernetes.io/v1.0/docs/user-guide/identifiers.html#names">http://kubernetes.io/v1.0/docs/user-guide/identifiers.html#names</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hostPath</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#hostpath">http://releases.k8s.io/HEAD/docs/volumes.md#hostpath</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#hostpath">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#hostpath</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_hostpathvolumesource">v1.HostPathVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">emptyDir</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">temporary directory that shares a pod&#8217;s lifetime; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#emptydir">http://releases.k8s.io/HEAD/docs/volumes.md#emptydir</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">temporary directory that shares a pod&#8217;s lifetime; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#emptydir">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#emptydir</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_emptydirvolumesource">v1.EmptyDirVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">gcePersistentDisk</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">GCE disk resource attached to the host machine on demand; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk">http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">GCE disk resource attached to the host machine on demand; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#gcepersistentdisk">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_gcepersistentdiskvolumesource">v1.GCEPersistentDiskVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">awsElasticBlockStore</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">AWS disk resource attached to the host machine on demand; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore">http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AWS disk resource attached to the host machine on demand; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#awselasticblockstore">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#awselasticblockstore</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_awselasticblockstorevolumesource">v1.AWSElasticBlockStoreVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2572,42 +2572,42 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secret</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">secret to populate volume; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#secrets">http://releases.k8s.io/HEAD/docs/volumes.md#secrets</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">secret to populate volume; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#secrets">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#secrets</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_secretvolumesource">v1.SecretVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nfs</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">NFS volume that will be mounted in the host machine; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#nfs">http://releases.k8s.io/HEAD/docs/volumes.md#nfs</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">NFS volume that will be mounted in the host machine; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#nfs">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#nfs</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_nfsvolumesource">v1.NFSVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">iscsi</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">iSCSI disk attached to host machine on demand; see <a href="http://releases.k8s.io/HEAD/examples/iscsi/README.md">http://releases.k8s.io/HEAD/examples/iscsi/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">iSCSI disk attached to host machine on demand; see <a href="http://kubernetes.io/v1.0/examples/iscsi/README.html">http://kubernetes.io/v1.0/examples/iscsi/README.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_iscsivolumesource">v1.ISCSIVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">glusterfs</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Glusterfs volume that will be mounted on the host machine; see <a href="http://releases.k8s.io/HEAD/examples/glusterfs/README.md">http://releases.k8s.io/HEAD/examples/glusterfs/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Glusterfs volume that will be mounted on the host machine; see <a href="http://kubernetes.io/v1.0/examples/glusterfs/README.html">http://kubernetes.io/v1.0/examples/glusterfs/README.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_glusterfsvolumesource">v1.GlusterfsVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">persistentVolumeClaim</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">a reference to a PersistentVolumeClaim in the same namespace; see <a href="http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">a reference to a PersistentVolumeClaim in the same namespace; see <a href="http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#persistentvolumeclaims">http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#persistentvolumeclaims</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumeclaimvolumesource">v1.PersistentVolumeClaimVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">rbd</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">rados block volume that will be mounted on the host machine; see <a href="http://releases.k8s.io/HEAD/examples/rbd/README.md">http://releases.k8s.io/HEAD/examples/rbd/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">rados block volume that will be mounted on the host machine; see <a href="http://kubernetes.io/v1.0/examples/rbd/README.html">http://kubernetes.io/v1.0/examples/rbd/README.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_rbdvolumesource">v1.RBDVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2659,14 +2659,14 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">initialDelaySeconds</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">number of seconds after the container has started before liveness probes are initiated; see <a href="http://releases.k8s.io/HEAD/docs/pod-states.md#container-probes">http://releases.k8s.io/HEAD/docs/pod-states.md#container-probes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">number of seconds after the container has started before liveness probes are initiated; see <a href="http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#container-probes">http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#container-probes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">timeoutSeconds</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">number of seconds after which liveness probes timeout; defaults to 1 second; see <a href="http://releases.k8s.io/HEAD/docs/pod-states.md#container-probes">http://releases.k8s.io/HEAD/docs/pod-states.md#container-probes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">number of seconds after which liveness probes timeout; defaults to 1 second; see <a href="http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#container-probes">http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#container-probes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2701,35 +2701,35 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">specification of the desired behavior of the replication controller; <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status">http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">specification of the desired behavior of the replication controller; <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_replicationcontrollerspec">v1.ReplicationControllerSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">most recently observed status of the replication controller; populated by the system, read-only; <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status">http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">most recently observed status of the replication controller; populated by the system, read-only; <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_replicationcontrollerstatus">v1.ReplicationControllerStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2760,28 +2760,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">spec defines the limits enforced; <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status">http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">spec defines the limits enforced; <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_limitrangespec">v1.LimitRangeSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2812,14 +2812,14 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">phase</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">current condition of the pod; see <a href="http://releases.k8s.io/HEAD/docs/pod-states.md#pod-phase">http://releases.k8s.io/HEAD/docs/pod-states.md#pod-phase</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">current condition of the pod; see <a href="http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#pod-phase">http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#pod-phase</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">conditions</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">current service state of pod; see <a href="http://releases.k8s.io/HEAD/docs/pod-states.md#pod-conditions">http://releases.k8s.io/HEAD/docs/pod-states.md#pod-conditions</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">current service state of pod; see <a href="http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#pod-conditions">http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#pod-conditions</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podcondition">v1.PodCondition</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2861,7 +2861,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">containerStatuses</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">list of container statuses; see <a href="http://releases.k8s.io/HEAD/docs/pod-states.md#container-statuses">http://releases.k8s.io/HEAD/docs/pod-states.md#container-statuses</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">list of container statuses; see <a href="http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#container-statuses">http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#container-statuses</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_containerstatus">v1.ContainerStatus</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2892,21 +2892,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">volumes</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">list of volumes that can be mounted by containers belonging to the pod; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md">http://releases.k8s.io/HEAD/docs/volumes.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">list of volumes that can be mounted by containers belonging to the pod; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html">http://kubernetes.io/v1.0/docs/user-guide/volumes.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_volume">v1.Volume</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">containers</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod; see <a href="http://releases.k8s.io/HEAD/docs/containers.md">http://releases.k8s.io/HEAD/docs/containers.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod; see <a href="http://kubernetes.io/v1.0/docs/user-guide/containers.html">http://kubernetes.io/v1.0/docs/user-guide/containers.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_container">v1.Container</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">restartPolicy</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">restart policy for all containers within the pod; one of Always, OnFailure, Never; defaults to Always; see <a href="http://releases.k8s.io/HEAD/docs/pod-states.md#restartpolicy">http://releases.k8s.io/HEAD/docs/pod-states.md#restartpolicy</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">restart policy for all containers within the pod; one of Always, OnFailure, Never; defaults to Always; see <a href="http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#restartpolicy">http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#restartpolicy</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2934,14 +2934,14 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nodeSelector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">selector which must match a node&#8217;s labels for the pod to be scheduled on that node; see <a href="http://releases.k8s.io/HEAD/examples/node-selection/README.md">http://releases.k8s.io/HEAD/examples/node-selection/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">selector which must match a node&#8217;s labels for the pod to be scheduled on that node; see <a href="http://kubernetes.io/v1.0/docs/user-guide/node-selection/README.html">http://kubernetes.io/v1.0/docs/user-guide/node-selection/README.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">serviceAccountName</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">name of the ServiceAccount to use to run this pod; see <a href="http://releases.k8s.io/HEAD/docs/service_accounts.md">http://releases.k8s.io/HEAD/docs/service_accounts.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">name of the ServiceAccount to use to run this pod; see <a href="http://kubernetes.io/v1.0/docs/design/service_accounts.html">http://kubernetes.io/v1.0/docs/design/service_accounts.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2962,7 +2962,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">imagePullSecrets</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">list of references to secrets in the same namespace available for pulling the container images; see <a href="http://releases.k8s.io/HEAD/docs/images.md#specifying-imagepullsecrets-on-a-pod">http://releases.k8s.io/HEAD/docs/images.md#specifying-imagepullsecrets-on-a-pod</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">list of references to secrets in the same namespace available for pulling the container images; see <a href="http://kubernetes.io/v1.0/docs/user-guide/images.html#specifying-imagepullsecrets-on-a-pod">http://kubernetes.io/v1.0/docs/user-guide/images.html#specifying-imagepullsecrets-on-a-pod</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_localobjectreference">v1.LocalObjectReference</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3052,21 +3052,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_listmeta">v1.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3104,35 +3104,35 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">spec defines the desired quota; <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status">http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">spec defines the desired quota; <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcequotaspec">v1.ResourceQuotaSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">status defines the actual enforced quota and current usage; <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status">http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">status defines the actual enforced quota and current usage; <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcequotastatus">v1.ResourceQuotaStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3163,14 +3163,14 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">postStart</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes; see <a href="http://releases.k8s.io/HEAD/docs/container-environment.md#hook-details">http://releases.k8s.io/HEAD/docs/container-environment.md#hook-details</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes; see <a href="http://kubernetes.io/v1.0/docs/user-guide/container-environment.html#hook-details">http://kubernetes.io/v1.0/docs/user-guide/container-environment.html#hook-details</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_handler">v1.Handler</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">preStop</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes; see <a href="http://releases.k8s.io/HEAD/docs/container-environment.md#hook-details">http://releases.k8s.io/HEAD/docs/container-environment.md#hook-details</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes; see <a href="http://kubernetes.io/v1.0/docs/user-guide/container-environment.html#hook-details">http://kubernetes.io/v1.0/docs/user-guide/container-environment.html#hook-details</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_handler">v1.Handler</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3201,35 +3201,35 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">capacity</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">compute resource capacity of the node; see <a href="http://releases.k8s.io/HEAD/docs/compute_resources.md">http://releases.k8s.io/HEAD/docs/compute_resources.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">compute resource capacity of the node; see <a href="http://kubernetes.io/v1.0/docs/user-guide/compute-resources.html">http://kubernetes.io/v1.0/docs/user-guide/compute-resources.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">phase</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">most recently observed lifecycle phase of the node; see <a href="http://releases.k8s.io/HEAD/docs/node.md#node-phase">http://releases.k8s.io/HEAD/docs/node.md#node-phase</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">most recently observed lifecycle phase of the node; see <a href="http://kubernetes.io/v1.0/docs/admin/node.html#node-phase">http://kubernetes.io/v1.0/docs/admin/node.html#node-phase</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">conditions</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">list of node conditions observed; see <a href="http://releases.k8s.io/HEAD/docs/node.md#node-condition">http://releases.k8s.io/HEAD/docs/node.md#node-condition</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">list of node conditions observed; see <a href="http://kubernetes.io/v1.0/docs/admin/node.html#node-condition">http://kubernetes.io/v1.0/docs/admin/node.html#node-condition</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_nodecondition">v1.NodeCondition</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">addresses</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">list of addresses reachable to the node; see <a href="http://releases.k8s.io/HEAD/docs/node.md#node-addresses">http://releases.k8s.io/HEAD/docs/node.md#node-addresses</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">list of addresses reachable to the node; see <a href="http://kubernetes.io/v1.0/docs/admin/node.html#node-addresses">http://kubernetes.io/v1.0/docs/admin/node.html#node-addresses</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_nodeaddress">v1.NodeAddress</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nodeInfo</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">set of ids/uuids to uniquely identify the node; see <a href="http://releases.k8s.io/HEAD/docs/node.md#node-info">http://releases.k8s.io/HEAD/docs/node.md#node-info</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">set of ids/uuids to uniquely identify the node; see <a href="http://kubernetes.io/v1.0/docs/admin/node.html#node-info">http://kubernetes.io/v1.0/docs/admin/node.html#node-info</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_nodesysteminfo">v1.NodeSystemInfo</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3260,21 +3260,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">endpoints</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">gluster hosts endpoints name; see <a href="http://releases.k8s.io/HEAD/examples/glusterfs/README.md#create-a-pod">http://releases.k8s.io/HEAD/examples/glusterfs/README.md#create-a-pod</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">gluster hosts endpoints name; see <a href="http://kubernetes.io/v1.0/examples/glusterfs/README.html#create-a-pod">http://kubernetes.io/v1.0/examples/glusterfs/README.html#create-a-pod</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">path to gluster volume; see <a href="http://releases.k8s.io/HEAD/examples/glusterfs/README.md#create-a-pod">http://releases.k8s.io/HEAD/examples/glusterfs/README.md#create-a-pod</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">path to gluster volume; see <a href="http://kubernetes.io/v1.0/examples/glusterfs/README.html#create-a-pod">http://kubernetes.io/v1.0/examples/glusterfs/README.html#create-a-pod</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">glusterfs volume to be mounted with read-only permissions; see <a href="http://releases.k8s.io/HEAD/examples/glusterfs/README.md#create-a-pod">http://releases.k8s.io/HEAD/examples/glusterfs/README.md#create-a-pod</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">glusterfs volume to be mounted with read-only permissions; see <a href="http://kubernetes.io/v1.0/examples/glusterfs/README.html#create-a-pod">http://kubernetes.io/v1.0/examples/glusterfs/README.html#create-a-pod</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -3350,21 +3350,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">replicas</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">number of replicas desired; defaults to 1; see <a href="http://releases.k8s.io/HEAD/docs/replication-controller.md#what-is-a-replication-controller">http://releases.k8s.io/HEAD/docs/replication-controller.md#what-is-a-replication-controller</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">number of replicas desired; defaults to 1; see <a href="http://kubernetes.io/v1.0/docs/user-guide/replication-controller.html#what-is-a-replication-controller">http://kubernetes.io/v1.0/docs/user-guide/replication-controller.html#what-is-a-replication-controller</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">selector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template; see <a href="http://releases.k8s.io/HEAD/docs/labels.md#label-selectors">http://releases.k8s.io/HEAD/docs/labels.md#label-selectors</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template; see <a href="http://kubernetes.io/v1.0/docs/user-guide/labels.html#label-selectors">http://kubernetes.io/v1.0/docs/user-guide/labels.html#label-selectors</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">template</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">object that describes the pod that will be created if insufficient replicas are detected; takes precendence over templateRef; see <a href="http://releases.k8s.io/HEAD/docs/replication-controller.md#pod-template">http://releases.k8s.io/HEAD/docs/replication-controller.md#pod-template</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">object that describes the pod that will be created if insufficient replicas are detected; takes precendence over templateRef; see <a href="http://kubernetes.io/v1.0/docs/user-guide/replication-controller.html#pod-template">http://kubernetes.io/v1.0/docs/user-guide/replication-controller.html#pod-template</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podtemplatespec">v1.PodTemplateSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3478,14 +3478,14 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of the condition, currently only Ready; see <a href="http://releases.k8s.io/HEAD/docs/pod-states.md#pod-conditions">http://releases.k8s.io/HEAD/docs/pod-states.md#pod-conditions</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of the condition, currently only Ready; see <a href="http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#pod-conditions">http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#pod-conditions</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">status of the condition, one of True, False, Unknown; see <a href="http://releases.k8s.io/HEAD/docs/pod-states.md#pod-conditions">http://releases.k8s.io/HEAD/docs/pod-states.md#pod-conditions</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">status of the condition, one of True, False, Unknown; see <a href="http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#pod-conditions">http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#pod-conditions</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3516,56 +3516,56 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">monitors</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">a collection of Ceph monitors; see <a href="http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">a collection of Ceph monitors; see <a href="http://kubernetes.io/v1.0/examples/rbd/README.html#how-to-use-it">http://kubernetes.io/v1.0/examples/rbd/README.html#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">image</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">rados image name; see <a href="http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">rados image name; see <a href="http://kubernetes.io/v1.0/examples/rbd/README.html#how-to-use-it">http://kubernetes.io/v1.0/examples/rbd/README.html#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fsType</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">file system type to mount, such as ext4, xfs, ntfs; see <a href="http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">file system type to mount, such as ext4, xfs, ntfs; see <a href="http://kubernetes.io/v1.0/examples/rbd/README.html#how-to-use-it">http://kubernetes.io/v1.0/examples/rbd/README.html#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">pool</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">rados pool name; default is rbd; optional; see <a href="http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">rados pool name; default is rbd; optional; see <a href="http://kubernetes.io/v1.0/examples/rbd/README.html#how-to-use-it">http://kubernetes.io/v1.0/examples/rbd/README.html#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">user</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">rados user name; default is admin; optional; see <a href="http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">rados user name; default is admin; optional; see <a href="http://kubernetes.io/v1.0/examples/rbd/README.html#how-to-use-it">http://kubernetes.io/v1.0/examples/rbd/README.html#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">keyring</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">keyring is the path to key ring for rados user; default is /etc/ceph/keyring; optional; see <a href="http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">keyring is the path to key ring for rados user; default is /etc/ceph/keyring; optional; see <a href="http://kubernetes.io/v1.0/examples/rbd/README.html#how-to-use-it">http://kubernetes.io/v1.0/examples/rbd/README.html#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secretRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">name of a secret to authenticate the RBD user; if provided overrides keyring; optional; see <a href="http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">name of a secret to authenticate the RBD user; if provided overrides keyring; optional; see <a href="http://kubernetes.io/v1.0/examples/rbd/README.html#how-to-use-it">http://kubernetes.io/v1.0/examples/rbd/README.html#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_localobjectreference">v1.LocalObjectReference</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">rbd volume to be mounted with read-only permissions; see <a href="http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">rbd volume to be mounted with read-only permissions; see <a href="http://kubernetes.io/v1.0/examples/rbd/README.html#how-to-use-it">http://kubernetes.io/v1.0/examples/rbd/README.html#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -3596,28 +3596,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_listmeta">v1.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">status of the operation; either Success, or Failure; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status">http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">status of the operation; either Success, or Failure; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3676,28 +3676,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">template</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the template of the desired behavior of the pod; <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status">http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the template of the desired behavior of the pod; <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podtemplatespec">v1.PodTemplateSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3759,21 +3759,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">server</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the hostname or IP address of the NFS server; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#nfs">http://releases.k8s.io/HEAD/docs/volumes.md#nfs</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the hostname or IP address of the NFS server; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#nfs">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#nfs</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the path that is exported by the NFS server; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#nfs">http://releases.k8s.io/HEAD/docs/volumes.md#nfs</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the path that is exported by the NFS server; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#nfs">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#nfs</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">forces the NFS export to be mounted with read-only permissions; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#nfs">http://releases.k8s.io/HEAD/docs/volumes.md#nfs</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">forces the NFS export to be mounted with read-only permissions; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#nfs">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#nfs</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -3939,7 +3939,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the kind attribute of the resource associated with the status StatusReason; on some operations may differ from the requested resource Kind; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the kind attribute of the resource associated with the status StatusReason; on some operations may differ from the requested resource Kind; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4015,28 +4015,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_listmeta">v1.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">items is a list of secret objects; see <a href="http://releases.k8s.io/HEAD/docs/secrets.md">http://releases.k8s.io/HEAD/docs/secrets.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">items is a list of secret objects; see <a href="http://kubernetes.io/v1.0/docs/user-guide/secrets.html">http://kubernetes.io/v1.0/docs/user-guide/secrets.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_secret">v1.Secret</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4074,21 +4074,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">image</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Docker image name; see <a href="http://releases.k8s.io/HEAD/docs/images.md">http://releases.k8s.io/HEAD/docs/images.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Docker image name; see <a href="http://kubernetes.io/v1.0/docs/user-guide/images.html">http://kubernetes.io/v1.0/docs/user-guide/images.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">command</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">entrypoint array; not executed within a shell; the docker image&#8217;s entrypoint is used if this is not provided; cannot be updated; variable references $(VAR_NAME) are expanded using the container&#8217;s environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double , ie: (VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see <a href="http://releases.k8s.io/HEAD/docs/containers.md#containers-and-commands">http://releases.k8s.io/HEAD/docs/containers.md#containers-and-commands</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">entrypoint array; not executed within a shell; the docker image&#8217;s entrypoint is used if this is not provided; cannot be updated; variable references $(VAR_NAME) are expanded using the container&#8217;s environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double , ie: (VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see <a href="http://kubernetes.io/v1.0/docs/user-guide/containers.html#containers-and-commands">http://kubernetes.io/v1.0/docs/user-guide/containers.html#containers-and-commands</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">args</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">command array; the docker image&#8217;s cmd is used if this is not provided; arguments to the entrypoint; cannot be updated; variable references $(VAR_NAME) are expanded using the container&#8217;s environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double , ie: (VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see <a href="http://releases.k8s.io/HEAD/docs/containers.md#containers-and-commands">http://releases.k8s.io/HEAD/docs/containers.md#containers-and-commands</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">command array; the docker image&#8217;s .html is used if this is not provided; arguments to the entrypoint; cannot be updated; variable references $(VAR_NAME) are expanded using the container&#8217;s environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double , ie: (VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see <a href="http://kubernetes.io/v1.0/docs/user-guide/containers.html#containers-and-commands">http://kubernetes.io/v1.0/docs/user-guide/containers.html#containers-and-commands</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4116,7 +4116,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resources</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Compute Resources required by this container; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/compute_resources.md">http://releases.k8s.io/HEAD/docs/compute_resources.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Compute Resources required by this container; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/user-guide/compute-resources.html">http://kubernetes.io/v1.0/docs/user-guide/compute-resources.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcerequirements">v1.ResourceRequirements</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4130,14 +4130,14 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">livenessProbe</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/pod-states.md#container-probes">http://releases.k8s.io/HEAD/docs/pod-states.md#container-probes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#container-probes">http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#container-probes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_probe">v1.Probe</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readinessProbe</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/pod-states.md#container-probes">http://releases.k8s.io/HEAD/docs/pod-states.md#container-probes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#container-probes">http://kubernetes.io/v1.0/docs/user-guide/pod-states.html#container-probes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_probe">v1.Probe</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4158,14 +4158,14 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">imagePullPolicy</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">image pull policy; one of Always, Never, IfNotPresent; defaults to Always if :latest tag is specified, or IfNotPresent otherwise; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/images.md#updating-images">http://releases.k8s.io/HEAD/docs/images.md#updating-images</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">image pull policy; one of Always, Never, IfNotPresent; defaults to Always if :latest tag is specified, or IfNotPresent otherwise; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/user-guide/images.html#updating-images">http://kubernetes.io/v1.0/docs/user-guide/images.html#updating-images</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">securityContext</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">security options the pod should run with; see <a href="http://releases.k8s.io/HEAD/docs/security_context.md">http://releases.k8s.io/HEAD/docs/security_context.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">security options the pod should run with; see <a href="http://kubernetes.io/v1.0/docs/design/security_context.html">http://kubernetes.io/v1.0/docs/design/security_context.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_securitycontext">v1.SecurityContext</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4196,49 +4196,49 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">capacity</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">a description of the persistent volume&#8217;s resources and capacityr; see <a href="http://releases.k8s.io/HEAD/docs/persistent-volumes.md#capacity">http://releases.k8s.io/HEAD/docs/persistent-volumes.md#capacity</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">a description of the persistent volume&#8217;s resources and capacityr; see <a href="http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#capacity">http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#capacity</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">gcePersistentDisk</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">GCE disk resource provisioned by an admin; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk">http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">GCE disk resource provisioned by an admin; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#gcepersistentdisk">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_gcepersistentdiskvolumesource">v1.GCEPersistentDiskVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">awsElasticBlockStore</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">AWS disk resource provisioned by an admin; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore">http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AWS disk resource provisioned by an admin; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#awselasticblockstore">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#awselasticblockstore</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_awselasticblockstorevolumesource">v1.AWSElasticBlockStoreVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hostPath</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">a HostPath provisioned by a developer or tester; for develment use only; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#hostpath">http://releases.k8s.io/HEAD/docs/volumes.md#hostpath</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">a HostPath provisioned by a developer or tester; for develment use only; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#hostpath">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#hostpath</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_hostpathvolumesource">v1.HostPathVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">glusterfs</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Glusterfs volume resource provisioned by an admin; see <a href="http://releases.k8s.io/HEAD/examples/glusterfs/README.md">http://releases.k8s.io/HEAD/examples/glusterfs/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Glusterfs volume resource provisioned by an admin; see <a href="http://kubernetes.io/v1.0/examples/glusterfs/README.html">http://kubernetes.io/v1.0/examples/glusterfs/README.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_glusterfsvolumesource">v1.GlusterfsVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nfs</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">NFS volume resource provisioned by an admin; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#nfs">http://releases.k8s.io/HEAD/docs/volumes.md#nfs</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">NFS volume resource provisioned by an admin; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#nfs">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#nfs</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_nfsvolumesource">v1.NFSVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">rbd</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">rados block volume that will be mounted on the host machine; see <a href="http://releases.k8s.io/HEAD/examples/rbd/README.md">http://releases.k8s.io/HEAD/examples/rbd/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">rados block volume that will be mounted on the host machine; see <a href="http://kubernetes.io/v1.0/examples/rbd/README.html">http://kubernetes.io/v1.0/examples/rbd/README.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_rbdvolumesource">v1.RBDVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4252,21 +4252,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">accessModes</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">all ways the volume can be mounted; see <a href="http://releases.k8s.io/HEAD/docs/persistent-volumes.md#access-modes">http://releases.k8s.io/HEAD/docs/persistent-volumes.md#access-modes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">all ways the volume can be mounted; see <a href="http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#access-modes">http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#access-modes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumeaccessmode">v1.PersistentVolumeAccessMode</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">claimRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">when bound, a reference to the bound claim; see <a href="http://releases.k8s.io/HEAD/docs/persistent-volumes.md#binding">http://releases.k8s.io/HEAD/docs/persistent-volumes.md#binding</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">when bound, a reference to the bound claim; see <a href="http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#binding">http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#binding</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectreference">v1.ObjectReference</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">persistentVolumeReclaimPolicy</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">what happens to a volume when released from its claim; Valid options are Retain (default) and Recycle.  Recyling must be supported by the volume plugin underlying this persistent volume. See <a href="http://releases.k8s.io/HEAD/docs/persistent-volumes.md#recycling-policy">http://releases.k8s.io/HEAD/docs/persistent-volumes.md#recycling-policy</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">what happens to a volume when released from its claim; Valid options are Retain (default) and Recycle.  Recyling must be supported by the volume plugin underlying this persistent volume. See <a href="http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#recycling-policy">http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html#recycling-policy</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4297,7 +4297,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">replicas</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">most recently oberved number of replicas; see <a href="http://releases.k8s.io/HEAD/docs/replication-controller.md#what-is-a-replication-controller">http://releases.k8s.io/HEAD/docs/replication-controller.md#what-is-a-replication-controller</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">most recently oberved number of replicas; see <a href="http://kubernetes.io/v1.0/docs/user-guide/replication-controller.html#what-is-a-replication-controller">http://kubernetes.io/v1.0/docs/user-guide/replication-controller.html#what-is-a-replication-controller</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4360,14 +4360,14 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">targetPort</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">number or name of the port to access on the pods targeted by the service; defaults to the service port; number must be in the range 1 to 65535; name must be an IANA_SVC_NAME; see <a href="http://releases.k8s.io/HEAD/docs/services.md#defining-a-service">http://releases.k8s.io/HEAD/docs/services.md#defining-a-service</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">number or name of the port to access on the pods targeted by the service; defaults to the service port; number must be in the range 1 to 65535; name must be an IANA_SVC_NAME; see <a href="http://kubernetes.io/v1.0/docs/user-guide/services.html#defining-a-service">http://kubernetes.io/v1.0/docs/user-guide/services.html#defining-a-service</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nodePort</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the port on each node on which this service is exposed when type=NodePort or LoadBalancer; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; see <a href="http://releases.k8s.io/HEAD/docs/services.md#type&#8212;nodeport">http://releases.k8s.io/HEAD/docs/services.md#type&#8212;nodeport</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the port on each node on which this service is exposed when type=NodePort or LoadBalancer; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; see <a href="http://kubernetes.io/v1.0/docs/user-guide/services.html#type&#8212;nodeport">http://kubernetes.io/v1.0/docs/user-guide/services.html#type&#8212;nodeport</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4450,21 +4450,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_listmeta">v1.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4502,7 +4502,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">path of the directory on the host; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#hostpath">http://releases.k8s.io/HEAD/docs/volumes.md#hostpath</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">path of the directory on the host; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#hostpath">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#hostpath</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4571,21 +4571,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4696,28 +4696,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">capabilities</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the linux capabilites that should be added or removed; see <a href="http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context">http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the linux capabilites that should be added or removed; see <a href="http://kubernetes.io/v1.0/docs/design/security_context.html#security-context">http://kubernetes.io/v1.0/docs/design/security_context.html#security-context</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_capabilities">v1.Capabilities</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">privileged</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">run the container in privileged mode; see <a href="http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context">http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">run the container in privileged mode; see <a href="http://kubernetes.io/v1.0/docs/design/security_context.html#security-context">http://kubernetes.io/v1.0/docs/design/security_context.html#security-context</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">seLinuxOptions</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">options that control the SELinux labels applied; see <a href="http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context">http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">options that control the SELinux labels applied; see <a href="http://kubernetes.io/v1.0/docs/design/security_context.html#security-context">http://kubernetes.io/v1.0/docs/design/security_context.html#security-context</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_selinuxoptions">v1.SELinuxOptions</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">runAsUser</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">the user id that runs the first process in the container; see <a href="http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context">http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">the user id that runs the first process in the container; see <a href="http://kubernetes.io/v1.0/docs/design/security_context.html#security-context">http://kubernetes.io/v1.0/docs/design/security_context.html#security-context</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4793,28 +4793,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">volumeID</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">unique id of the PD resource in AWS; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore">http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">unique id of the PD resource in AWS; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#awselasticblockstore">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#awselasticblockstore</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fsType</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">file system type to mount, such as ext4, xfs, ntfs; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore">http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">file system type to mount, such as ext4, xfs, ntfs; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#awselasticblockstore">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#awselasticblockstore</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">partition</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">partition on the disk to mount (e.g., <em>1</em> for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore">http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">partition on the disk to mount (e.g., <em>1</em> for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#awselasticblockstore">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#awselasticblockstore</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">read-only if true, read-write otherwise (false or unspecified); see <a href="http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore">http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">read-only if true, read-write otherwise (false or unspecified); see <a href="http://kubernetes.io/v1.0/docs/user-guide/volumes.html#awselasticblockstore">http://kubernetes.io/v1.0/docs/user-guide/volumes.html#awselasticblockstore</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -4880,7 +4880,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">image</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">image of the container; see <a href="http://releases.k8s.io/HEAD/docs/images.md">http://releases.k8s.io/HEAD/docs/images.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">image of the container; see <a href="http://kubernetes.io/v1.0/docs/user-guide/images.html">http://kubernetes.io/v1.0/docs/user-guide/images.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4894,7 +4894,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">containerID</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">container&#8217;s ID in the format <em>docker://&lt;container_id&gt;</em>; see <a href="http://releases.k8s.io/HEAD/docs/container-environment.md#container-information">http://releases.k8s.io/HEAD/docs/container-environment.md#container-information</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">container&#8217;s ID in the format <em>docker://&lt;container_id&gt;</em>; see <a href="http://kubernetes.io/v1.0/docs/user-guide/container-environment.html#container-information">http://kubernetes.io/v1.0/docs/user-guide/container-environment.html#container-information</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4925,28 +4925,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_listmeta">v1.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">list of replication controllers; see <a href="http://releases.k8s.io/HEAD/docs/replication-controller.md">http://releases.k8s.io/HEAD/docs/replication-controller.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">list of replication controllers; see <a href="http://kubernetes.io/v1.0/docs/user-guide/replication-controller.html">http://kubernetes.io/v1.0/docs/user-guide/replication-controller.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_replicationcontroller">v1.ReplicationController</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4977,21 +4977,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5036,21 +5036,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5175,14 +5175,14 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">limits</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Maximum amount of compute resources allowed; see <a href="http://releases.k8s.io/HEAD/docs/design/resources.md#resource-specifications">http://releases.k8s.io/HEAD/docs/design/resources.md#resource-specifications</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Maximum amount of compute resources allowed; see <a href="http://kubernetes.io/v1.0/docs/design/resources.html#resource-specifications">http://kubernetes.io/v1.0/docs/design/resources.html#resource-specifications</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">requests</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Minimum amount of resources requested; requests are honored only for persistent volumes as of now; see <a href="http://releases.k8s.io/HEAD/docs/design/resources.md#resource-specifications">http://releases.k8s.io/HEAD/docs/design/resources.md#resource-specifications</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Minimum amount of resources requested; requests are honored only for persistent volumes as of now; see <a href="http://kubernetes.io/v1.0/docs/design/resources.html#resource-specifications">http://kubernetes.io/v1.0/docs/design/resources.html#resource-specifications</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5217,21 +5217,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5321,14 +5321,14 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">specification of the desired behavior of the pod; <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status">http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">specification of the desired behavior of the pod; <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podspec">v1.PodSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5359,28 +5359,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_listmeta">v1.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">list of pods; see <a href="http://releases.k8s.io/HEAD/docs/pods.md">http://releases.k8s.io/HEAD/docs/pods.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">list of pods; see <a href="http://kubernetes.io/v1.0/docs/user-guide/pods.html">http://kubernetes.io/v1.0/docs/user-guide/pods.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_pod">v1.Pod</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5411,21 +5411,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_listmeta">v1.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5463,28 +5463,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard list metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_listmeta">v1.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">list of persistent volumes; see <a href="http://releases.k8s.io/HEAD/docs/persistent-volumes.md">http://releases.k8s.io/HEAD/docs/persistent-volumes.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">list of persistent volumes; see <a href="http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html">http://kubernetes.io/v1.0/docs/user-guide/persistent-volumes.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolume">v1.PersistentVolume</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5515,28 +5515,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of the referent; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of the referent; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">namespace</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">namespace of the referent; see <a href="http://releases.k8s.io/HEAD/docs/namespaces.md">http://releases.k8s.io/HEAD/docs/namespaces.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">namespace of the referent; see <a href="http://kubernetes.io/v1.0/docs/user-guide/namespaces.html">http://kubernetes.io/v1.0/docs/user-guide/namespaces.html</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">name of the referent; see <a href="http://releases.k8s.io/HEAD/docs/identifiers.md#names">http://releases.k8s.io/HEAD/docs/identifiers.md#names</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">name of the referent; see <a href="http://kubernetes.io/v1.0/docs/user-guide/identifiers.html#names">http://kubernetes.io/v1.0/docs/user-guide/identifiers.html#names</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">uid</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">uid of the referent; see <a href="http://releases.k8s.io/HEAD/docs/identifiers.md#uids">http://releases.k8s.io/HEAD/docs/identifiers.md#uids</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">uid of the referent; see <a href="http://kubernetes.io/v1.0/docs/user-guide/identifiers.html#uids">http://kubernetes.io/v1.0/docs/user-guide/identifiers.html#uids</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5550,7 +5550,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">specific resourceVersion to which this reference is made, if any: <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#concurrency-control-and-consistency">http://releases.k8s.io/HEAD/docs/api-conventions.md#concurrency-control-and-consistency</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">specific resourceVersion to which this reference is made, if any: <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#concurrency-control-and-consistency">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#concurrency-control-and-consistency</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5640,7 +5640,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kernelVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kernel version reported by the node from <em>uname -r</em> (e.g. 3.16.0-0.bpo.4-amd64)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kernel version reported by the node from <em>uname -r</em> (e.g. 3.16.0-0.bpo.4-.html64)</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5699,28 +5699,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ports</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ports exposed by the service; see <a href="http://releases.k8s.io/HEAD/docs/services.md#virtual-ips-and-service-proxies">http://releases.k8s.io/HEAD/docs/services.md#virtual-ips-and-service-proxies</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ports exposed by the service; see <a href="http://kubernetes.io/v1.0/docs/user-guide/services.html#virtual-ips-and-service-proxies">http://kubernetes.io/v1.0/docs/user-guide/services.html#virtual-ips-and-service-proxies</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_serviceport">v1.ServicePort</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">selector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified; see <a href="http://releases.k8s.io/HEAD/docs/services.md#overview">http://releases.k8s.io/HEAD/docs/services.md#overview</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified; see <a href="http://kubernetes.io/v1.0/docs/user-guide/services.html#overview">http://kubernetes.io/v1.0/docs/user-guide/services.html#overview</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">clusterIP</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; cannot be updated; <em>None</em> can be specified for a headless service when proxying is not required; see <a href="http://releases.k8s.io/HEAD/docs/services.md#virtual-ips-and-service-proxies">http://releases.k8s.io/HEAD/docs/services.md#virtual-ips-and-service-proxies</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; cannot be updated; <em>None</em> can be specified for a headless service when proxying is not required; see <a href="http://kubernetes.io/v1.0/docs/user-guide/services.html#virtual-ips-and-service-proxies">http://kubernetes.io/v1.0/docs/user-guide/services.html#virtual-ips-and-service-proxies</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">type of this service; must be ClusterIP, NodePort, or LoadBalancer; defaults to ClusterIP; see <a href="http://releases.k8s.io/HEAD/docs/services.md#external-services">http://releases.k8s.io/HEAD/docs/services.md#external-services</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">type of this service; must be ClusterIP, NodePort, or LoadBalancer; defaults to ClusterIP; see <a href="http://kubernetes.io/v1.0/docs/user-guide/services.html#external-services">http://kubernetes.io/v1.0/docs/user-guide/services.html#external-services</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5734,7 +5734,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">sessionAffinity</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">enable client IP based session affinity; must be ClientIP or None; defaults to None; see <a href="http://releases.k8s.io/HEAD/docs/services.md#virtual-ips-and-service-proxies">http://releases.k8s.io/HEAD/docs/services.md#virtual-ips-and-service-proxies</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">enable client IP based session affinity; must be ClientIP or None; defaults to None; see <a href="http://kubernetes.io/v1.0/docs/user-guide/services.html#virtual-ips-and-service-proxies">http://kubernetes.io/v1.0/docs/user-guide/services.html#virtual-ips-and-service-proxies</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5765,35 +5765,35 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds">http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">kind of object, in CamelCase; cannot be updated; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#resources">http://releases.k8s.io/HEAD/docs/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">version of the schema the object should have; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">standard object metadata; see <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">specification of the desired behavior of the pod; <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status">http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">specification of the desired behavior of the pod; <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podspec">v1.PodSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">most recently observed status of the pod; populated by the system, read-only; <a href="http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status">http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">most recently observed status of the pod; populated by the system, read-only; <a href="http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status">http://kubernetes.io/v1.0/docs/devel/api-conventions.html#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podstatus">v1.PodStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5845,7 +5845,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">unschedulable</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">disable pod scheduling on the node; see <a href="http://releases.k8s.io/HEAD/docs/node.md#manual-node-administration">http://releases.k8s.io/HEAD/docs/node.md#manual-node-administration</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">disable pod scheduling on the node; see <a href="http://kubernetes.io/v1.0/docs/admin/node.html#manual-node-administration">http://kubernetes.io/v1.0/docs/admin/node.html#manual-node-administration</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -34,6 +34,7 @@ kube::golang::server_targets() {
     cmd/kubelet
     cmd/hyperkube
     cmd/kubernetes
+    cmd/linkcheck
     plugin/cmd/kube-scheduler
   )
   if [ -n "${KUBERNETES_CONTRIB:-}" ]; then

--- a/hack/verify-linkcheck.sh
+++ b/hack/verify-linkcheck.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+kube::golang::setup_env
+linkcheck=$(kube::util::find-binary "linkcheck")
+
+if [[ ! -x "$linkcheck" ]]; then
+  {
+    echo "It looks as if you don't have a compiled linkcheck binary"
+    echo
+    echo "If you are running from a clone of the git repo, please run"
+    echo "'./hack/build-go.sh cmd/linkcheck'."
+  } >&2
+  exit 1
+fi
+
+TYPEROOT="${KUBE_ROOT}/pkg/api/"
+"${linkcheck}" "--root-dir=${TYPEROOT}" "--repo-root=${KUBE_ROOT}" "--file-suffix=types.go" "--prefix=http://releases.k8s.io/HEAD" && ret=0 || ret=$?
+if [[ $ret -eq 1 ]]; then
+  echo "links in ${TYPEROOT} is out of date."
+  exit 1
+fi
+if [[ $ret -gt 1 ]]; then
+  echo "Error running linkcheck"
+  exit 1
+fi

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -97,6 +97,16 @@ else
 fi
 echo "${reset}"
 
+echo -ne "Checking for links in API descriptions... "
+if ! hack/verify-linkcheck.sh > /dev/null; then
+  echo "${red}ERROR!"
+  echo "Some links in pkg/api/.*types.go is outdated. They require manual fix."
+  exit_code=1
+else
+  echo "${green}OK"
+fi
+echo "${reset}"
+
 echo -ne "Checking for docs that need updating... "
 if ! hack/verify-gendocs.sh > /dev/null; then
   echo "${red}ERROR!"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -100,7 +100,7 @@ echo "${reset}"
 echo -ne "Checking for links in API descriptions... "
 if ! hack/verify-linkcheck.sh > /dev/null; then
   echo "${red}ERROR!"
-  echo "Some links in pkg/api/.*types.go is outdated. They require manual fix."
+  echo "Some links in pkg/api/.*types.go are outdated. They require a manual fix."
   exit_code=1
 else
   echo "${green}OK"

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1375,7 +1375,7 @@ type NodeAddress struct {
 }
 
 // NodeResources is an object for conveying resource information about a node.
-// see http://docs.k8s.io/resources.md for more details.
+// see http://docs.k8s.io/design/resources.md for more details.
 type NodeResources struct {
 	// Capacity represents the available resources of a node
 	Capacity ResourceList `json:"capacity,omitempty"`

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -58,12 +58,12 @@ import (
 type TypeMeta struct {
 	// Kind is a string value representing the REST resource this object represents.
 	// Servers may infer this from the endpoint the client submits requests to.
-	Kind string `json:"kind,omitempty" description:"kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
+	Kind string `json:"kind,omitempty" description:"kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"`
 
 	// APIVersion defines the versioned schema of this representation of an object.
 	// Servers should convert recognized schemas to the latest internal value, and
 	// may reject unrecognized values.
-	APIVersion string `json:"apiVersion,omitempty" description:"version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/api-conventions.md#resources"`
+	APIVersion string `json:"apiVersion,omitempty" description:"version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"`
 }
 
 // ListMeta describes metadata that synthetic resources must have, including lists and
@@ -76,7 +76,7 @@ type ListMeta struct {
 	// concurrency and change monitoring endpoints.  Clients must treat these values as opaque
 	// and values may only be valid for a particular resource or set of resources. Only servers
 	// will generate resource versions.
-	ResourceVersion string `json:"resourceVersion,omitempty" description:"string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/HEAD/docs/api-conventions.md#concurrency-control-and-consistency"`
+	ResourceVersion string `json:"resourceVersion,omitempty" description:"string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"`
 }
 
 // ObjectMeta is metadata that all persisted resources must have, which includes all objects
@@ -86,7 +86,7 @@ type ObjectMeta struct {
 	// some resources may allow a client to request the generation of an appropriate name
 	// automatically. Name is primarily intended for creation idempotence and configuration
 	// definition.
-	Name string `json:"name,omitempty" description:"string that identifies an object. Must be unique within a namespace; cannot be updated; see http://releases.k8s.io/HEAD/docs/identifiers.md#names"`
+	Name string `json:"name,omitempty" description:"string that identifies an object. Must be unique within a namespace; cannot be updated; see http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names"`
 
 	// GenerateName indicates that the name should be made unique by the server prior to persisting
 	// it. A non-empty value for the field indicates the name will be made unique (and the name
@@ -99,13 +99,13 @@ type ObjectMeta struct {
 	// generated name exists - instead, it will either return 201 Created or 500 with Reason
 	// ServerTimeout indicating a unique name could not be found in the time allotted, and the client
 	// should retry (optionally after the time indicated in the Retry-After header).
-	GenerateName string `json:"generateName,omitempty" description:"an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified; see http://releases.k8s.io/HEAD/docs/api-conventions.md#idempotency"`
+	GenerateName string `json:"generateName,omitempty" description:"an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#idempotency"`
 
 	// Namespace defines the space within which name must be unique. An empty namespace is
 	// equivalent to the "default" namespace, but "default" is the canonical representation.
 	// Not all objects are required to be scoped to a namespace - the value of this field for
 	// those objects will be empty.
-	Namespace string `json:"namespace,omitempty" description:"namespace of the object; must be a DNS_LABEL; cannot be updated; see http://releases.k8s.io/HEAD/docs/namespaces.md"`
+	Namespace string `json:"namespace,omitempty" description:"namespace of the object; must be a DNS_LABEL; cannot be updated; see http://releases.k8s.io/HEAD/docs/user-guide/namespaces.md"`
 
 	// SelfLink is a URL representing this object.
 	SelfLink string `json:"selfLink,omitempty" description:"URL for the object; populated by the system, read-only"`
@@ -113,13 +113,13 @@ type ObjectMeta struct {
 	// UID is the unique in time and space value for this object. It is typically generated by
 	// the server on successful creation of a resource and is not allowed to change on PUT
 	// operations.
-	UID types.UID `json:"uid,omitempty" description:"unique UUID across space and time; populated by the system; read-only; see http://releases.k8s.io/HEAD/docs/identifiers.md#uids"`
+	UID types.UID `json:"uid,omitempty" description:"unique UUID across space and time; populated by the system; read-only; see http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#uids"`
 
 	// An opaque value that represents the version of this resource. May be used for optimistic
 	// concurrency, change detection, and the watch operation on a resource or set of resources.
 	// Clients must treat these values as opaque and values may only be valid for a particular
 	// resource or set of resources. Only servers will generate resource versions.
-	ResourceVersion string `json:"resourceVersion,omitempty" description:"string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/HEAD/docs/api-conventions.md#concurrency-control-and-consistency"`
+	ResourceVersion string `json:"resourceVersion,omitempty" description:"string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"`
 
 	// A sequence number representing a specific generation of the desired state.
 	// Currently only implemented by replication controllers.
@@ -128,7 +128,7 @@ type ObjectMeta struct {
 	// CreationTimestamp is a timestamp representing the server time when this object was
 	// created. It is not guaranteed to be set in happens-before order across separate operations.
 	// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-	CreationTimestamp util.Time `json:"creationTimestamp,omitempty" description:"RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	CreationTimestamp util.Time `json:"creationTimestamp,omitempty" description:"RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// DeletionTimestamp is the time after which this resource will be deleted. This
 	// field is set by the server when a graceful deletion is requested by the user, and is not
@@ -139,16 +139,16 @@ type ObjectMeta struct {
 	// a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination
 	// signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet
 	// will send a hard termination signal to the container.
-	DeletionTimestamp *util.Time `json:"deletionTimestamp,omitempty" description:"RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	DeletionTimestamp *util.Time `json:"deletionTimestamp,omitempty" description:"RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Labels are key value pairs that may be used to scope and select individual resources.
 	// TODO: replace map[string]string with labels.LabelSet type
-	Labels map[string]string `json:"labels,omitempty" description:"map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services; see http://releases.k8s.io/HEAD/docs/labels.md"`
+	Labels map[string]string `json:"labels,omitempty" description:"map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services; see http://releases.k8s.io/HEAD/docs/user-guide/labels.md"`
 
 	// Annotations are unstructured key value data stored with a resource that may be set by
 	// external tooling. They are not queryable and should be preserved when modifying
 	// objects.
-	Annotations map[string]string `json:"annotations,omitempty" description:"map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects; see http://releases.k8s.io/HEAD/docs/annotations.md"`
+	Annotations map[string]string `json:"annotations,omitempty" description:"map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects; see http://releases.k8s.io/HEAD/docs/user-guide/annotations.md"`
 }
 
 const (
@@ -162,7 +162,7 @@ const (
 type Volume struct {
 	// Required: This must be a DNS_LABEL.  Each volume in a pod must have
 	// a unique name.
-	Name string `json:"name" description:"volume name; must be a DNS_LABEL and unique within the pod; see http://releases.k8s.io/HEAD/docs/identifiers.md#names"`
+	Name string `json:"name" description:"volume name; must be a DNS_LABEL and unique within the pod; see http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names"`
 	// Source represents the location and type of a volume to mount.
 	// This is optional for now. If not specified, the Volume is implied to be an EmptyDir.
 	// This implied behavior is deprecated and will be removed in a future version.
@@ -178,35 +178,35 @@ type VolumeSource struct {
 	// to see the host machine. Most containers will NOT need this.
 	// TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
 	// mount host directories as read/write.
-	HostPath *HostPathVolumeSource `json:"hostPath,omitempty" description:"pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host; see http://releases.k8s.io/HEAD/docs/volumes.md#hostpath"`
+	HostPath *HostPathVolumeSource `json:"hostPath,omitempty" description:"pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#hostpath"`
 	// EmptyDir represents a temporary directory that shares a pod's lifetime.
-	EmptyDir *EmptyDirVolumeSource `json:"emptyDir,omitempty" description:"temporary directory that shares a pod's lifetime; see http://releases.k8s.io/HEAD/docs/volumes.md#emptydir"`
+	EmptyDir *EmptyDirVolumeSource `json:"emptyDir,omitempty" description:"temporary directory that shares a pod's lifetime; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#emptydir"`
 	// GCEPersistentDisk represents a GCE Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod.
-	GCEPersistentDisk *GCEPersistentDiskVolumeSource `json:"gcePersistentDisk,omitempty" description:"GCE disk resource attached to the host machine on demand; see http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk"`
+	GCEPersistentDisk *GCEPersistentDiskVolumeSource `json:"gcePersistentDisk,omitempty" description:"GCE disk resource attached to the host machine on demand; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"`
 	// AWSElasticBlockStore represents an AWS Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod.
-	AWSElasticBlockStore *AWSElasticBlockStoreVolumeSource `json:"awsElasticBlockStore,omitempty" description:"AWS disk resource attached to the host machine on demand; see http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore"`
+	AWSElasticBlockStore *AWSElasticBlockStoreVolumeSource `json:"awsElasticBlockStore,omitempty" description:"AWS disk resource attached to the host machine on demand; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"`
 	// GitRepo represents a git repository at a particular revision.
 	GitRepo *GitRepoVolumeSource `json:"gitRepo,omitempty" description:"git repository at a particular revision"`
 	// Secret represents a secret that should populate this volume.
-	Secret *SecretVolumeSource `json:"secret,omitempty" description:"secret to populate volume; see http://releases.k8s.io/HEAD/docs/volumes.md#secrets"`
+	Secret *SecretVolumeSource `json:"secret,omitempty" description:"secret to populate volume; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#secrets"`
 	// NFS represents an NFS mount on the host that shares a pod's lifetime
-	NFS *NFSVolumeSource `json:"nfs,omitempty" description:"NFS volume that will be mounted in the host machine; see http://releases.k8s.io/HEAD/docs/volumes.md#nfs"`
+	NFS *NFSVolumeSource `json:"nfs,omitempty" description:"NFS volume that will be mounted in the host machine; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#nfs"`
 	// ISCSI represents an ISCSI Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod.
 	ISCSI *ISCSIVolumeSource `json:"iscsi,omitempty" description:"iSCSI disk attached to host machine on demand; see http://releases.k8s.io/HEAD/examples/iscsi/README.md"`
 	// Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime
 	Glusterfs *GlusterfsVolumeSource `json:"glusterfs,omitempty" description:"Glusterfs volume that will be mounted on the host machine; see http://releases.k8s.io/HEAD/examples/glusterfs/README.md"`
 	// PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace
-	PersistentVolumeClaim *PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty" description:"a reference to a PersistentVolumeClaim in the same namespace; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims"`
+	PersistentVolumeClaim *PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty" description:"a reference to a PersistentVolumeClaim in the same namespace; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"`
 	// RBD represents a Rados Block Device mount on the host that shares a pod's lifetime
 	RBD *RBDVolumeSource `json:"rbd,omitempty" description:"rados block volume that will be mounted on the host machine; see http://releases.k8s.io/HEAD/examples/rbd/README.md"`
 }
 
 type PersistentVolumeClaimVolumeSource struct {
 	// ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume
-	ClaimName string `json:"claimName" description:"the name of the claim in the same namespace to be mounted as a volume; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims"`
+	ClaimName string `json:"claimName" description:"the name of the claim in the same namespace to be mounted as a volume; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"`
 	// Optional: Defaults to false (read/write).  ReadOnly here
 	// will force the ReadOnly setting in VolumeMounts
 	ReadOnly bool `json:"readOnly,omitempty" description:"mount volume as read-only when true; default false"`
@@ -217,18 +217,18 @@ type PersistentVolumeClaimVolumeSource struct {
 type PersistentVolumeSource struct {
 	// GCEPersistentDisk represents a GCE Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod.
-	GCEPersistentDisk *GCEPersistentDiskVolumeSource `json:"gcePersistentDisk,omitempty" description:"GCE disk resource provisioned by an admin; see http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk"`
+	GCEPersistentDisk *GCEPersistentDiskVolumeSource `json:"gcePersistentDisk,omitempty" description:"GCE disk resource provisioned by an admin; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"`
 	// AWSElasticBlockStore represents an AWS Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod.
-	AWSElasticBlockStore *AWSElasticBlockStoreVolumeSource `json:"awsElasticBlockStore,omitempty" description:"AWS disk resource provisioned by an admin; see http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore"`
+	AWSElasticBlockStore *AWSElasticBlockStoreVolumeSource `json:"awsElasticBlockStore,omitempty" description:"AWS disk resource provisioned by an admin; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"`
 	// HostPath represents a directory on the host.
 	// This is useful for development and testing only.
 	// on-host storage is not supported in any way.
-	HostPath *HostPathVolumeSource `json:"hostPath,omitempty" description:"a HostPath provisioned by a developer or tester; for develment use only; see http://releases.k8s.io/HEAD/docs/volumes.md#hostpath"`
+	HostPath *HostPathVolumeSource `json:"hostPath,omitempty" description:"a HostPath provisioned by a developer or tester; for develment use only; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#hostpath"`
 	// Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod
 	Glusterfs *GlusterfsVolumeSource `json:"glusterfs,omitempty" description:"Glusterfs volume resource provisioned by an admin; see http://releases.k8s.io/HEAD/examples/glusterfs/README.md"`
 	// NFS represents an NFS mount on the host
-	NFS *NFSVolumeSource `json:"nfs,omitempty" description:"NFS volume resource provisioned by an admin; see http://releases.k8s.io/HEAD/docs/volumes.md#nfs"`
+	NFS *NFSVolumeSource `json:"nfs,omitempty" description:"NFS volume resource provisioned by an admin; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#nfs"`
 	// RBD represents a Rados Block Device mount on the host that shares a pod's lifetime
 	RBD *RBDVolumeSource `json:"rbd,omitempty" description:"rados block volume that will be mounted on the host machine; see http://releases.k8s.io/HEAD/examples/rbd/README.md"`
 	// ISCSI represents an ISCSI Disk resource that is attached to a
@@ -238,28 +238,28 @@ type PersistentVolumeSource struct {
 
 type PersistentVolume struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines a persistent volume owned by the cluster
-	Spec PersistentVolumeSpec `json:"spec,omitempty" description:"specification of a persistent volume as provisioned by an administrator; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistent-volumes"`
+	Spec PersistentVolumeSpec `json:"spec,omitempty" description:"specification of a persistent volume as provisioned by an administrator; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistent-volumes"`
 
 	// Status represents the current information about persistent volume.
-	Status PersistentVolumeStatus `json:"status,omitempty" description:"current status of a persistent volume; populated by the system, read-only; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistent-volumes"`
+	Status PersistentVolumeStatus `json:"status,omitempty" description:"current status of a persistent volume; populated by the system, read-only; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistent-volumes"`
 }
 
 type PersistentVolumeSpec struct {
 	// Resources represents the actual resources of the volume
-	Capacity ResourceList `json:"capacity,omitempty" description:"a description of the persistent volume's resources and capacityr; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#capacity"`
+	Capacity ResourceList `json:"capacity,omitempty" description:"a description of the persistent volume's resources and capacityr; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#capacity"`
 	// Source represents the location and type of a volume to mount.
 	PersistentVolumeSource `json:",inline" description:"the actual volume backing the persistent volume"`
 	// AccessModes contains all ways the volume can be mounted
-	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"all ways the volume can be mounted; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#access-modes"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"all ways the volume can be mounted; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#access-modes"`
 	// ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim.
 	// ClaimRef is expected to be non-nil when bound.
 	// claim.VolumeName is the authoritative bind between PV and PVC.
-	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#binding"`
+	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#binding"`
 	// Optional: what happens to a persistent volume when released from its claim.
-	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"persistentVolumeReclaimPolicy,omitempty" description:"what happens to a volume when released from its claim; Valid options are Retain (default) and Recycle.  Recyling must be supported by the volume plugin underlying this persistent volume. See http://releases.k8s.io/HEAD/docs/persistent-volumes.md#recycling-policy"`
+	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"persistentVolumeReclaimPolicy,omitempty" description:"what happens to a volume when released from its claim; Valid options are Retain (default) and Recycle.  Recyling must be supported by the volume plugin underlying this persistent volume. See http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#recycling-policy"`
 }
 
 // PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes
@@ -280,7 +280,7 @@ const (
 
 type PersistentVolumeStatus struct {
 	// Phase indicates if a volume is available, bound to a claim, or released by a claim
-	Phase PersistentVolumePhase `json:"phase,omitempty" description:"the current phase of a persistent volume; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#phase"`
+	Phase PersistentVolumePhase `json:"phase,omitempty" description:"the current phase of a persistent volume; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#phase"`
 	// A human-readable message indicating details about why the volume is in this state.
 	Message string `json:"message,omitempty" description:"human-readable message indicating details about why the volume is in this state"`
 	// Reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI
@@ -289,35 +289,35 @@ type PersistentVolumeStatus struct {
 
 type PersistentVolumeList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
-	Items    []PersistentVolume `json:"items,omitempty" description:"list of persistent volumes; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"`
+	Items    []PersistentVolume `json:"items,omitempty" description:"list of persistent volumes; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md"`
 }
 
 // PersistentVolumeClaim is a user's request for and claim to a persistent volume
 type PersistentVolumeClaim struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the volume requested by a pod author
-	Spec PersistentVolumeClaimSpec `json:"spec,omitempty" description:"the desired characteristics of a volume; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims"`
+	Spec PersistentVolumeClaimSpec `json:"spec,omitempty" description:"the desired characteristics of a volume; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"`
 
 	// Status represents the current information about a claim
-	Status PersistentVolumeClaimStatus `json:"status,omitempty" description:"the current status of a persistent volume claim; read-only; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims"`
+	Status PersistentVolumeClaimStatus `json:"status,omitempty" description:"the current status of a persistent volume claim; read-only; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"`
 }
 
 type PersistentVolumeClaimList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
-	Items    []PersistentVolumeClaim `json:"items,omitempty" description:"a list of persistent volume claims; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#persistentvolumeclaims"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"`
+	Items    []PersistentVolumeClaim `json:"items,omitempty" description:"a list of persistent volume claims; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"`
 }
 
 // PersistentVolumeClaimSpec describes the common attributes of storage devices
 // and allows a Source for provider-specific attributes
 type PersistentVolumeClaimSpec struct {
 	// Contains the types of access modes required
-	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"the desired access modes the volume should have; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#access-modes-1"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"the desired access modes the volume should have; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#access-modes-1"`
 	// Resources represents the minimum resources required
-	Resources ResourceRequirements `json:"resources,omitempty" description:"the desired resources the volume should have; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#resources"`
+	Resources ResourceRequirements `json:"resources,omitempty" description:"the desired resources the volume should have; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#resources"`
 	// VolumeName is the binding reference to the PersistentVolume backing this claim
 	VolumeName string `json:"volumeName,omitempty" description:"the binding reference to the persistent volume backing this claim"`
 }
@@ -326,7 +326,7 @@ type PersistentVolumeClaimStatus struct {
 	// Phase represents the current phase of PersistentVolumeClaim
 	Phase PersistentVolumeClaimPhase `json:"phase,omitempty" description:"the current phase of the claim"`
 	// AccessModes contains all ways the volume backing the PVC can be mounted
-	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"the actual access modes the volume has; see http://releases.k8s.io/HEAD/docs/persistent-volumes.md#access-modes-1"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"the actual access modes the volume has; see http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#access-modes-1"`
 	// Represents the actual resources of the underlying volume
 	Capacity ResourceList `json:"capacity,omitempty" description:"the actual resources the volume has"`
 }
@@ -371,13 +371,13 @@ const (
 
 // HostPathVolumeSource represents bare host directory volume.
 type HostPathVolumeSource struct {
-	Path string `json:"path" description:"path of the directory on the host; see http://releases.k8s.io/HEAD/docs/volumes.md#hostpath"`
+	Path string `json:"path" description:"path of the directory on the host; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#hostpath"`
 }
 
 type EmptyDirVolumeSource struct {
 	// Optional: what type of storage medium should back this directory.
 	// The default is "" which means to use the node's default medium.
-	Medium StorageMedium `json:"medium,omitempty" description:"type of storage used to back the volume; must be an empty string (default) or Memory; see http://releases.k8s.io/HEAD/docs/volumes.md#emptydir"`
+	Medium StorageMedium `json:"medium,omitempty" description:"type of storage used to back the volume; must be an empty string (default) or Memory; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#emptydir"`
 }
 
 // GlusterfsVolumeSource represents a Glusterfs Mount that lasts the lifetime of a pod
@@ -442,19 +442,19 @@ const (
 // A GCE PD can only be mounted as read/write once.
 type GCEPersistentDiskVolumeSource struct {
 	// Unique name of the PD resource. Used to identify the disk in GCE
-	PDName string `json:"pdName" description:"unique name of the PD resource in GCE; see http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk"`
+	PDName string `json:"pdName" description:"unique name of the PD resource in GCE; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"`
 	// Required: Filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs"
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
-	FSType string `json:"fsType" description:"file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk"`
+	FSType string `json:"fsType" description:"file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"`
 	// Optional: Partition on the disk to mount.
 	// If omitted, kubelet will attempt to mount the device name.
 	// Ex. For /dev/sda1, this field is "1", for /dev/sda, this field is 0 or empty.
-	Partition int `json:"partition,omitempty" description:"partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk"`
+	Partition int `json:"partition,omitempty" description:"partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"`
 	// Optional: Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
-	ReadOnly bool `json:"readOnly,omitempty" description:"read-only if true, read-write otherwise (false or unspecified); see http://releases.k8s.io/HEAD/docs/volumes.md#gcepersistentdisk"`
+	ReadOnly bool `json:"readOnly,omitempty" description:"read-only if true, read-write otherwise (false or unspecified); see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"`
 }
 
 // AWSElasticBlockStoreVolumeSource represents a Persistent Disk resource in AWS.
@@ -464,19 +464,19 @@ type GCEPersistentDiskVolumeSource struct {
 // A AWS PD can only be mounted on a single machine.
 type AWSElasticBlockStoreVolumeSource struct {
 	// Unique id of the PD resource. Used to identify the disk in AWS
-	VolumeID string `json:"volumeID" description:"unique id of the PD resource in AWS; see http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore"`
+	VolumeID string `json:"volumeID" description:"unique id of the PD resource in AWS; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"`
 	// Required: Filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs"
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
-	FSType string `json:"fsType" description:"file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore"`
+	FSType string `json:"fsType" description:"file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"`
 	// Optional: Partition on the disk to mount.
 	// If omitted, kubelet will attempt to mount the device name.
 	// Ex. For /dev/sda1, this field is "1", for /dev/sda, this field 0 or empty.
-	Partition int `json:"partition,omitempty" description:"partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore"`
+	Partition int `json:"partition,omitempty" description:"partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"`
 	// Optional: Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
-	ReadOnly bool `json:"readOnly,omitempty" description:"read-only if true, read-write otherwise (false or unspecified); see http://releases.k8s.io/HEAD/docs/volumes.md#awselasticblockstore"`
+	ReadOnly bool `json:"readOnly,omitempty" description:"read-only if true, read-write otherwise (false or unspecified); see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"`
 }
 
 // GitRepoVolumeSource represents a volume that is pulled from git when the pod is created.
@@ -489,23 +489,23 @@ type GitRepoVolumeSource struct {
 
 // SecretVolumeSource adapts a Secret into a VolumeSource
 //
-// http://releases.k8s.io/HEAD/docs/design/secrets.md
+// http://releases.k8s.io/HEAD/docs/design//secrets.md
 type SecretVolumeSource struct {
 	// Name of the secret in the pod's namespace to use
-	SecretName string `json:"secretName" description:"secretName is the name of a secret in the pod's namespace; see http://releases.k8s.io/HEAD/docs/volumes.md#secrets"`
+	SecretName string `json:"secretName" description:"secretName is the name of a secret in the pod's namespace; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#secrets"`
 }
 
 // NFSVolumeSource represents an NFS mount that lasts the lifetime of a pod
 type NFSVolumeSource struct {
 	// Server is the hostname or IP address of the NFS server
-	Server string `json:"server" description:"the hostname or IP address of the NFS server; see http://releases.k8s.io/HEAD/docs/volumes.md#nfs"`
+	Server string `json:"server" description:"the hostname or IP address of the NFS server; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#nfs"`
 
 	// Path is the exported NFS share
-	Path string `json:"path" description:"the path that is exported by the NFS server; see http://releases.k8s.io/HEAD/docs/volumes.md#nfs"`
+	Path string `json:"path" description:"the path that is exported by the NFS server; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#nfs"`
 
 	// Optional: Defaults to false (read/write). ReadOnly here will force
 	// the NFS export to be mounted with read-only permissions
-	ReadOnly bool `json:"readOnly,omitempty" description:"forces the NFS export to be mounted with read-only permissions; see http://releases.k8s.io/HEAD/docs/volumes.md#nfs"`
+	ReadOnly bool `json:"readOnly,omitempty" description:"forces the NFS export to be mounted with read-only permissions; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#nfs"`
 }
 
 // A ISCSI Disk can only be mounted as read/write once.
@@ -626,9 +626,9 @@ type Probe struct {
 	// The action taken to determine the health of a container
 	Handler `json:",inline"`
 	// Length of time before health checking is activated.  In seconds.
-	InitialDelaySeconds int64 `json:"initialDelaySeconds,omitempty" description:"number of seconds after the container has started before liveness probes are initiated; see http://releases.k8s.io/HEAD/docs/pod-states.md#container-probes"`
+	InitialDelaySeconds int64 `json:"initialDelaySeconds,omitempty" description:"number of seconds after the container has started before liveness probes are initiated; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes"`
 	// Length of time before health checking times out.  In seconds.
-	TimeoutSeconds int64 `json:"timeoutSeconds,omitempty" description:"number of seconds after which liveness probes timeout; defaults to 1 second; see http://releases.k8s.io/HEAD/docs/pod-states.md#container-probes"`
+	TimeoutSeconds int64 `json:"timeoutSeconds,omitempty" description:"number of seconds after which liveness probes timeout; defaults to 1 second; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes"`
 }
 
 // PullPolicy describes a policy for if/when to pull a container image
@@ -676,34 +676,34 @@ type Container struct {
 	// have a unique name.
 	Name string `json:"name" description:"name of the container; must be a DNS_LABEL and unique within the pod; cannot be updated"`
 	// Optional.
-	Image string `json:"image,omitempty" description:"Docker image name; see http://releases.k8s.io/HEAD/docs/images.md"`
+	Image string `json:"image,omitempty" description:"Docker image name; see http://releases.k8s.io/HEAD/docs/user-guide/images.md"`
 	// Optional: The docker image's entrypoint is used if this is not provided; cannot be updated.
 	// Variable references $(VAR_NAME) are expanded using the container's environment.  If a variable
 	// cannot be resolved, the reference in the input string will be unchanged.  The $(VAR_NAME) syntax
 	// can be escaped with a double $$, ie: $$(VAR_NAME).  Escaped references will never be expanded,
 	// regardless of whether the variable exists or not.
-	Command []string `json:"command,omitempty" description:"entrypoint array; not executed within a shell; the docker image's entrypoint is used if this is not provided; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see http://releases.k8s.io/HEAD/docs/containers.md#containers-and-commands"`
+	Command []string `json:"command,omitempty" description:"entrypoint array; not executed within a shell; the docker image's entrypoint is used if this is not provided; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see http://releases.k8s.io/HEAD/docs/user-guide/containers.md#containers-and-commands"`
 	// Optional: The docker image's cmd is used if this is not provided; cannot be updated.
 	// Variable references $(VAR_NAME) are expanded using the container's environment.  If a variable
 	// cannot be resolved, the reference in the input string will be unchanged.  The $(VAR_NAME) syntax
 	// can be escaped with a double $$, ie: $$(VAR_NAME).  Escaped references will never be expanded,
 	// regardless of whether the variable exists or not.
-	Args []string `json:"args,omitempty" description:"command array; the docker image's cmd is used if this is not provided; arguments to the entrypoint; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see http://releases.k8s.io/HEAD/docs/containers.md#containers-and-commands"`
+	Args []string `json:"args,omitempty" description:"command array; the docker image's cmd is used if this is not provided; arguments to the entrypoint; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see http://releases.k8s.io/HEAD/docs/user-guide/containers.md#containers-and-commands"`
 	// Optional: Defaults to Docker's default.
 	WorkingDir     string               `json:"workingDir,omitempty" description:"container's working directory; defaults to image's default; cannot be updated"`
 	Ports          []ContainerPort      `json:"ports,omitempty" description:"list of ports to expose from the container; cannot be updated" patchStrategy:"merge" patchMergeKey:"containerPort"`
 	Env            []EnvVar             `json:"env,omitempty" description:"list of environment variables to set in the container; cannot be updated" patchStrategy:"merge" patchMergeKey:"name"`
-	Resources      ResourceRequirements `json:"resources,omitempty" description:"Compute Resources required by this container; cannot be updated; see http://releases.k8s.io/HEAD/docs/compute_resources.md"`
+	Resources      ResourceRequirements `json:"resources,omitempty" description:"Compute Resources required by this container; cannot be updated; see http://releases.k8s.io/HEAD/docs/user-guide/compute-resources.md"`
 	VolumeMounts   []VolumeMount        `json:"volumeMounts,omitempty" description:"pod volumes to mount into the container's filesyste; cannot be updated" patchStrategy:"merge" patchMergeKey:"name"`
-	LivenessProbe  *Probe               `json:"livenessProbe,omitempty" description:"periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated; see http://releases.k8s.io/HEAD/docs/pod-states.md#container-probes"`
-	ReadinessProbe *Probe               `json:"readinessProbe,omitempty" description:"periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated; see http://releases.k8s.io/HEAD/docs/pod-states.md#container-probes"`
+	LivenessProbe  *Probe               `json:"livenessProbe,omitempty" description:"periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes"`
+	ReadinessProbe *Probe               `json:"readinessProbe,omitempty" description:"periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes"`
 	Lifecycle      *Lifecycle           `json:"lifecycle,omitempty" description:"actions that the management system should take in response to container lifecycle events; cannot be updated"`
 	// Optional: Defaults to /dev/termination-log
 	TerminationMessagePath string `json:"terminationMessagePath,omitempty" description:"path at which the file to which the container's termination message will be written is mounted into the container's filesystem; message written is intended to be brief final status, such as an assertion failure message; defaults to /dev/termination-log; cannot be updated"`
 	// Optional: Policy for pulling images for this container
-	ImagePullPolicy PullPolicy `json:"imagePullPolicy,omitempty" description:"image pull policy; one of Always, Never, IfNotPresent; defaults to Always if :latest tag is specified, or IfNotPresent otherwise; cannot be updated; see http://releases.k8s.io/HEAD/docs/images.md#updating-images"`
+	ImagePullPolicy PullPolicy `json:"imagePullPolicy,omitempty" description:"image pull policy; one of Always, Never, IfNotPresent; defaults to Always if :latest tag is specified, or IfNotPresent otherwise; cannot be updated; see http://releases.k8s.io/HEAD/docs/user-guide/images.md#updating-images"`
 	// Optional: SecurityContext defines the security options the pod should be run with
-	SecurityContext *SecurityContext `json:"securityContext,omitempty" description:"security options the pod should run with; see http://releases.k8s.io/HEAD/docs/security_context.md"`
+	SecurityContext *SecurityContext `json:"securityContext,omitempty" description:"security options the pod should run with; see http://releases.k8s.io/HEAD/docs/design/security_context.md"`
 }
 
 // Handler defines a specific action that should be taken
@@ -725,10 +725,10 @@ type Handler struct {
 type Lifecycle struct {
 	// PostStart is called immediately after a container is created.  If the handler fails, the container
 	// is terminated and restarted.
-	PostStart *Handler `json:"postStart,omitempty" description:"called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes; see http://releases.k8s.io/HEAD/docs/container-environment.md#hook-details"`
+	PostStart *Handler `json:"postStart,omitempty" description:"called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes; see http://releases.k8s.io/HEAD/docs/user-guide/container-environment.md#hook-details"`
 	// PreStop is called immediately before a container is terminated.  The reason for termination is
 	// passed to the handler.  Regardless of the outcome of the handler, the container is eventually terminated.
-	PreStop *Handler `json:"preStop,omitempty" description:"called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes; see http://releases.k8s.io/HEAD/docs/container-environment.md#hook-details"`
+	PreStop *Handler `json:"preStop,omitempty" description:"called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes; see http://releases.k8s.io/HEAD/docs/user-guide/container-environment.md#hook-details"`
 }
 
 type ConditionStatus string
@@ -784,9 +784,9 @@ type ContainerStatus struct {
 	RestartCount int `json:"restartCount" description:"the number of times the container has been restarted, currently based on the number of dead containers that have not yet been removed"`
 	// TODO(dchen1107): Which image the container is running with?
 	// The image the container is running
-	Image       string `json:"image" description:"image of the container; see http://releases.k8s.io/HEAD/docs/images.md"`
+	Image       string `json:"image" description:"image of the container; see http://releases.k8s.io/HEAD/docs/user-guide/images.md"`
 	ImageID     string `json:"imageID" description:"ID of the container's image"`
-	ContainerID string `json:"containerID,omitempty" description:"container's ID in the format 'docker://<container_id>'; see http://releases.k8s.io/HEAD/docs/container-environment.md#container-information"`
+	ContainerID string `json:"containerID,omitempty" description:"container's ID in the format 'docker://<container_id>'; see http://releases.k8s.io/HEAD/docs/user-guide/container-environment.md#container-information"`
 }
 
 // PodPhase is a label for the condition of a pod at the current time.
@@ -825,9 +825,9 @@ const (
 // TODO: add LastTransitionTime, Reason, Message to match NodeCondition api.
 type PodCondition struct {
 	// Type is the type of the condition
-	Type PodConditionType `json:"type" description:"kind of the condition, currently only Ready; see http://releases.k8s.io/HEAD/docs/pod-states.md#pod-conditions"`
+	Type PodConditionType `json:"type" description:"kind of the condition, currently only Ready; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#pod-conditions"`
 	// Status is the status of the condition
-	Status ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown; see http://releases.k8s.io/HEAD/docs/pod-states.md#pod-conditions"`
+	Status ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#pod-conditions"`
 }
 
 // RestartPolicy describes how the container should be restarted.
@@ -858,10 +858,10 @@ const (
 
 // PodSpec is a description of a pod
 type PodSpec struct {
-	Volumes []Volume `json:"volumes,omitempty" description:"list of volumes that can be mounted by containers belonging to the pod; see http://releases.k8s.io/HEAD/docs/volumes.md" patchStrategy:"merge" patchMergeKey:"name"`
+	Volumes []Volume `json:"volumes,omitempty" description:"list of volumes that can be mounted by containers belonging to the pod; see http://releases.k8s.io/HEAD/docs/user-guide/volumes.md" patchStrategy:"merge" patchMergeKey:"name"`
 	// Required: there must be at least one container in a pod.
-	Containers    []Container   `json:"containers" description:"list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod; see http://releases.k8s.io/HEAD/docs/containers.md" patchStrategy:"merge" patchMergeKey:"name"`
-	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty" description:"restart policy for all containers within the pod; one of Always, OnFailure, Never; defaults to Always; see http://releases.k8s.io/HEAD/docs/pod-states.md#restartpolicy"`
+	Containers    []Container   `json:"containers" description:"list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod; see http://releases.k8s.io/HEAD/docs/user-guide/containers.md" patchStrategy:"merge" patchMergeKey:"name"`
+	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty" description:"restart policy for all containers within the pod; one of Always, OnFailure, Never; defaults to Always; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#restartpolicy"`
 	// Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
 	// Value must be non-negative integer. The value zero indicates delete immediately.
 	// If this value is nil, the default grace period will be used instead.
@@ -873,10 +873,10 @@ type PodSpec struct {
 	// Optional: Set DNS policy.  Defaults to "ClusterFirst"
 	DNSPolicy DNSPolicy `json:"dnsPolicy,omitempty" description:"DNS policy for containers within the pod; one of 'ClusterFirst' or 'Default'"`
 	// NodeSelector is a selector which must be true for the pod to fit on a node
-	NodeSelector map[string]string `json:"nodeSelector,omitempty" description:"selector which must match a node's labels for the pod to be scheduled on that node; see http://releases.k8s.io/HEAD/examples/node-selection/README.md"`
+	NodeSelector map[string]string `json:"nodeSelector,omitempty" description:"selector which must match a node's labels for the pod to be scheduled on that node; see http://releases.k8s.io/HEAD/docs/user-guide/node-selection/README.md"`
 
 	// ServiceAccountName is the name of the ServiceAccount to use to run this pod
-	ServiceAccountName string `json:"serviceAccountName,omitempty" description:"name of the ServiceAccount to use to run this pod; see http://releases.k8s.io/HEAD/docs/service_accounts.md"`
+	ServiceAccountName string `json:"serviceAccountName,omitempty" description:"name of the ServiceAccount to use to run this pod; see http://releases.k8s.io/HEAD/docs/design/service_accounts.md"`
 	// DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
 	DeprecatedServiceAccount string `json:"serviceAccount,omitempty" description:"deprecated; use serviceAccountName instead"`
 
@@ -891,14 +891,14 @@ type PodSpec struct {
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
 	// If specified, these secrets will be passed to individual puller implementations for them to use.  For example,
 	// in the case of docker, only DockerConfig type secrets are honored.
-	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" description:"list of references to secrets in the same namespace available for pulling the container images; see http://releases.k8s.io/HEAD/docs/images.md#specifying-imagepullsecrets-on-a-pod"  patchStrategy:"merge" patchMergeKey:"name"`
+	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" description:"list of references to secrets in the same namespace available for pulling the container images; see http://releases.k8s.io/HEAD/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod"  patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // PodStatus represents information about the status of a pod. Status may trail the actual
 // state of a system.
 type PodStatus struct {
-	Phase      PodPhase       `json:"phase,omitempty" description:"current condition of the pod; see http://releases.k8s.io/HEAD/docs/pod-states.md#pod-phase"`
-	Conditions []PodCondition `json:"conditions,omitempty" description:"current service state of pod; see http://releases.k8s.io/HEAD/docs/pod-states.md#pod-conditions" patchStrategy:"merge" patchMergeKey:"type"`
+	Phase      PodPhase       `json:"phase,omitempty" description:"current condition of the pod; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#pod-phase"`
+	Conditions []PodCondition `json:"conditions,omitempty" description:"current service state of pod; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#pod-conditions" patchStrategy:"merge" patchMergeKey:"type"`
 	// A human readable message indicating details about why the pod is in this state.
 	Message string `json:"message,omitempty" description:"human readable message indicating details about why the pod is in this condition"`
 	// A brief CamelCase message indicating details about why the pod is in this state. e.g. 'OutOfDisk'
@@ -911,62 +911,62 @@ type PodStatus struct {
 
 	// The list has one entry per container in the manifest. Each entry is currently the output
 	// of `docker inspect`.
-	ContainerStatuses []ContainerStatus `json:"containerStatuses,omitempty" description:"list of container statuses; see http://releases.k8s.io/HEAD/docs/pod-states.md#container-statuses"`
+	ContainerStatuses []ContainerStatus `json:"containerStatuses,omitempty" description:"list of container statuses; see http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-statuses"`
 }
 
 // PodStatusResult is a wrapper for PodStatus returned by kubelet that can be encode/decoded
 type PodStatusResult struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 	// Status represents the current information about a pod. This data may not be up
 	// to date.
-	Status PodStatus `json:"status,omitempty" description:"most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Status PodStatus `json:"status,omitempty" description:"most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // Pod is a collection of containers that can run on a host. This resource is created
 // by clients and scheduled onto hosts.
 type Pod struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a pod.
-	Spec PodSpec `json:"spec,omitempty" description:"specification of the desired behavior of the pod; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Spec PodSpec `json:"spec,omitempty" description:"specification of the desired behavior of the pod; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 
 	// Status represents the current information about a pod. This data may not be up
 	// to date.
-	Status PodStatus `json:"status,omitempty" description:"most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Status PodStatus `json:"status,omitempty" description:"most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // PodList is a list of Pods.
 type PodList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"`
 
-	Items []Pod `json:"items" description:"list of pods; see http://releases.k8s.io/HEAD/docs/pods.md"`
+	Items []Pod `json:"items" description:"list of pods; see http://releases.k8s.io/HEAD/docs/user-guide/pods.md"`
 }
 
 // PodTemplateSpec describes the data a pod should have when created from a template
 type PodTemplateSpec struct {
 	// Metadata of the pods created from this template.
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a pod.
-	Spec PodSpec `json:"spec,omitempty" description:"specification of the desired behavior of the pod; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Spec PodSpec `json:"spec,omitempty" description:"specification of the desired behavior of the pod; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // PodTemplate describes a template for creating copies of a predefined pod.
 type PodTemplate struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Template defines the pods that will be created from this pod template
-	Template PodTemplateSpec `json:"template,omitempty" description:"the template of the desired behavior of the pod; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Template PodTemplateSpec `json:"template,omitempty" description:"the template of the desired behavior of the pod; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // PodTemplateList is a list of PodTemplates.
 type PodTemplateList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	Items []PodTemplate `json:"items" description:"list of pod templates"`
 }
@@ -974,11 +974,11 @@ type PodTemplateList struct {
 // ReplicationControllerSpec is the specification of a replication controller.
 type ReplicationControllerSpec struct {
 	// Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified.
-	Replicas *int `json:"replicas,omitempty" description:"number of replicas desired; defaults to 1; see http://releases.k8s.io/HEAD/docs/replication-controller.md#what-is-a-replication-controller"`
+	Replicas *int `json:"replicas,omitempty" description:"number of replicas desired; defaults to 1; see http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#what-is-a-replication-controller"`
 
 	// Selector is a label query over pods that should match the Replicas count.
 	// If Selector is empty, it is defaulted to the labels present on the Pod template.
-	Selector map[string]string `json:"selector,omitempty" description:"label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template; see http://releases.k8s.io/HEAD/docs/labels.md#label-selectors"`
+	Selector map[string]string `json:"selector,omitempty" description:"label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template; see http://releases.k8s.io/HEAD/docs/user-guide/labels.md#label-selectors"`
 
 	// TemplateRef is a reference to an object that describes the pod that will be created if
 	// insufficient replicas are detected.
@@ -987,14 +987,14 @@ type ReplicationControllerSpec struct {
 	// Template is the object that describes the pod that will be created if
 	// insufficient replicas are detected. This takes precedence over a
 	// TemplateRef.
-	Template *PodTemplateSpec `json:"template,omitempty" description:"object that describes the pod that will be created if insufficient replicas are detected; takes precendence over templateRef; see http://releases.k8s.io/HEAD/docs/replication-controller.md#pod-template"`
+	Template *PodTemplateSpec `json:"template,omitempty" description:"object that describes the pod that will be created if insufficient replicas are detected; takes precendence over templateRef; see http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#pod-template"`
 }
 
 // ReplicationControllerStatus represents the current status of a replication
 // controller.
 type ReplicationControllerStatus struct {
 	// Replicas is the number of actual replicas.
-	Replicas int `json:"replicas" description:"most recently oberved number of replicas; see http://releases.k8s.io/HEAD/docs/replication-controller.md#what-is-a-replication-controller"`
+	Replicas int `json:"replicas" description:"most recently oberved number of replicas; see http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#what-is-a-replication-controller"`
 
 	// ObservedGeneration is the most recent generation observed by the controller.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" description:"reflects the generation of the most recently observed replication controller"`
@@ -1005,22 +1005,22 @@ type ReplicationController struct {
 	TypeMeta `json:",inline"`
 
 	// If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages.
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the desired behavior of this replication controller.
-	Spec ReplicationControllerSpec `json:"spec,omitempty" description:"specification of the desired behavior of the replication controller; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Spec ReplicationControllerSpec `json:"spec,omitempty" description:"specification of the desired behavior of the replication controller; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 
 	// Status is the current status of this replication controller. This data may be
 	// out of date by some window of time.
-	Status ReplicationControllerStatus `json:"status,omitempty" description:"most recently observed status of the replication controller; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Status ReplicationControllerStatus `json:"status,omitempty" description:"most recently observed status of the replication controller; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // ReplicationControllerList is a collection of replication controllers.
 type ReplicationControllerList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
-	Items []ReplicationController `json:"items" description:"list of replication controllers; see http://releases.k8s.io/HEAD/docs/replication-controller.md"`
+	Items []ReplicationController `json:"items" description:"list of replication controllers; see http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md"`
 }
 
 // Session Affinity Type string
@@ -1081,27 +1081,27 @@ type LoadBalancerIngress struct {
 // ServiceSpec describes the attributes that a user creates on a service
 type ServiceSpec struct {
 	// Required: The list of ports that are exposed by this service.
-	Ports []ServicePort `json:"ports" description:"ports exposed by the service; see http://releases.k8s.io/HEAD/docs/services.md#virtual-ips-and-service-proxies"`
+	Ports []ServicePort `json:"ports" description:"ports exposed by the service; see http://releases.k8s.io/HEAD/docs/user-guide/services.md#virtual-ips-and-service-proxies"`
 
 	// This service will route traffic to pods having labels matching this selector. If null, no endpoints will be automatically created. If empty, all pods will be selected.
-	Selector map[string]string `json:"selector,omitempty" description:"label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified; see http://releases.k8s.io/HEAD/docs/services.md#overview"`
+	Selector map[string]string `json:"selector,omitempty" description:"label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified; see http://releases.k8s.io/HEAD/docs/user-guide/services.md#overview"`
 
 	// ClusterIP is usually assigned by the master.  If specified by the user
 	// we will try to respect it or else fail the request.  This field can
 	// not be changed by updates.
 	// Valid values are None, empty string (""), or a valid IP address
 	// None can be specified for headless services when proxying is not required
-	ClusterIP string `json:"clusterIP,omitempty" description:"IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; cannot be updated; 'None' can be specified for a headless service when proxying is not required; see http://releases.k8s.io/HEAD/docs/services.md#virtual-ips-and-service-proxies"`
+	ClusterIP string `json:"clusterIP,omitempty" description:"IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; cannot be updated; 'None' can be specified for a headless service when proxying is not required; see http://releases.k8s.io/HEAD/docs/user-guide/services.md#virtual-ips-and-service-proxies"`
 
 	// Type determines how the service will be exposed.  Valid options: ClusterIP, NodePort, LoadBalancer
-	Type ServiceType `json:"type,omitempty" description:"type of this service; must be ClusterIP, NodePort, or LoadBalancer; defaults to ClusterIP; see http://releases.k8s.io/HEAD/docs/services.md#external-services"`
+	Type ServiceType `json:"type,omitempty" description:"type of this service; must be ClusterIP, NodePort, or LoadBalancer; defaults to ClusterIP; see http://releases.k8s.io/HEAD/docs/user-guide/services.md#external-services"`
 
 	// Deprecated. PublicIPs are used by external load balancers, or can be set by
 	// users to handle external traffic that arrives at a node.
 	DeprecatedPublicIPs []string `json:"deprecatedPublicIPs,omitempty" description:"deprecated. externally visible IPs (e.g. load balancers) that should be proxied to this service"`
 
 	// Optional: Supports "ClientIP" and "None".  Used to maintain session affinity.
-	SessionAffinity ServiceAffinity `json:"sessionAffinity,omitempty" description:"enable client IP based session affinity; must be ClientIP or None; defaults to None; see http://releases.k8s.io/HEAD/docs/services.md#virtual-ips-and-service-proxies"`
+	SessionAffinity ServiceAffinity `json:"sessionAffinity,omitempty" description:"enable client IP based session affinity; must be ClientIP or None; defaults to None; see http://releases.k8s.io/HEAD/docs/user-guide/services.md#virtual-ips-and-service-proxies"`
 }
 
 type ServicePort struct {
@@ -1122,11 +1122,11 @@ type ServicePort struct {
 	// If this is a string, it will be looked up as a named port in the
 	// target Pod's container ports.  If this is not specified, the value
 	// of Port is used (an identity map).
-	TargetPort util.IntOrString `json:"targetPort,omitempty" description:"number or name of the port to access on the pods targeted by the service; defaults to the service port; number must be in the range 1 to 65535; name must be an IANA_SVC_NAME; see http://releases.k8s.io/HEAD/docs/services.md#defining-a-service"`
+	TargetPort util.IntOrString `json:"targetPort,omitempty" description:"number or name of the port to access on the pods targeted by the service; defaults to the service port; number must be in the range 1 to 65535; name must be an IANA_SVC_NAME; see http://releases.k8s.io/HEAD/docs/user-guide/services.md#defining-a-service"`
 
 	// The port on each node on which this service is exposed.
 	// Default is to auto-allocate a port if the ServiceType of this Service requires one.
-	NodePort int `json:"nodePort" description:"the port on each node on which this service is exposed when type=NodePort or LoadBalancer; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; see http://releases.k8s.io/HEAD/docs/services.md#type--nodeport"`
+	NodePort int `json:"nodePort" description:"the port on each node on which this service is exposed when type=NodePort or LoadBalancer; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; see http://releases.k8s.io/HEAD/docs/user-guide/services.md#type--nodeport"`
 }
 
 // Service is a named abstraction of software service (for example, mysql) consisting of local port
@@ -1134,13 +1134,13 @@ type ServicePort struct {
 // will answer requests sent through the proxy.
 type Service struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a service.
-	Spec ServiceSpec `json:"spec,omitempty" description:"specification of the desired behavior of the service; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Spec ServiceSpec `json:"spec,omitempty" description:"specification of the desired behavior of the service; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 
 	// Status represents the current status of a service.
-	Status ServiceStatus `json:"status,omitempty" description:"most recently observed status of the service; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Status ServiceStatus `json:"status,omitempty" description:"most recently observed status of the service; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 const (
@@ -1152,7 +1152,7 @@ const (
 // ServiceList holds a list of services.
 type ServiceList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	Items []Service `json:"items" description:"list of services"`
 }
@@ -1163,23 +1163,23 @@ type ServiceList struct {
 // * a set of secrets
 type ServiceAccount struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount
-	Secrets []ObjectReference `json:"secrets,omitempty" description:"list of secrets that can be used by pods running as this service account; see http://releases.k8s.io/HEAD/docs/secrets.md" patchStrategy:"merge" patchMergeKey:"name"`
+	Secrets []ObjectReference `json:"secrets,omitempty" description:"list of secrets that can be used by pods running as this service account; see http://releases.k8s.io/HEAD/docs/user-guide/secrets.md" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images
 	// in pods that reference this ServiceAccount.  ImagePullSecrets are distinct from Secrets because Secrets
 	// can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet.
-	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" description:"list of references to secrets in the same namespace available for pulling container images; see http://releases.k8s.io/HEAD/docs/secrets.md#manually-specifying-an-imagepullsecret"`
+	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" description:"list of references to secrets in the same namespace available for pulling container images; see http://releases.k8s.io/HEAD/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret"`
 }
 
 // ServiceAccountList is a list of ServiceAccount objects
 type ServiceAccountList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
-	Items []ServiceAccount `json:"items" description:"list of ServiceAccounts; see http://releases.k8s.io/HEAD/docs/service_accounts.md#service-accounts"`
+	Items []ServiceAccount `json:"items" description:"list of ServiceAccounts; see http://releases.k8s.io/HEAD/docs/design/service_accounts.md#service-accounts"`
 }
 
 // Endpoints is a collection of endpoints that implement the actual service.  Example:
@@ -1196,7 +1196,7 @@ type ServiceAccountList struct {
 //  ]
 type Endpoints struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// The set of all endpoints is the union of all subsets.
 	Subsets []EndpointSubset `json:"subsets" description:"sets of addresses and ports that comprise a service"`
@@ -1243,7 +1243,7 @@ type EndpointPort struct {
 // EndpointsList is a list of endpoints.
 type EndpointsList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	Items []Endpoints `json:"items" description:"list of endpoints"`
 }
@@ -1257,7 +1257,7 @@ type NodeSpec struct {
 	// ID of the node assigned by the cloud provider
 	ProviderID string `json:"providerID,omitempty" description:"ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>"`
 	// Unschedulable controls node schedulability of new pods. By default node is schedulable.
-	Unschedulable bool `json:"unschedulable,omitempty" description:"disable pod scheduling on the node; see http://releases.k8s.io/HEAD/docs/node.md#manual-node-administration"`
+	Unschedulable bool `json:"unschedulable,omitempty" description:"disable pod scheduling on the node; see http://releases.k8s.io/HEAD/docs/admin/node.md#manual-node-administration"`
 }
 
 // NodeSystemInfo is a set of ids/uuids to uniquely identify the node.
@@ -1283,16 +1283,16 @@ type NodeSystemInfo struct {
 // NodeStatus is information about the current status of a node.
 type NodeStatus struct {
 	// Capacity represents the available resources of a node.
-	// see http://releases.k8s.io/HEAD/docs/compute_resources.md for more details.
-	Capacity ResourceList `json:"capacity,omitempty" description:"compute resource capacity of the node; see http://releases.k8s.io/HEAD/docs/compute_resources.md"`
+	// see http://releases.k8s.io/HEAD/docs/user-guide/compute-resources.md for more details.
+	Capacity ResourceList `json:"capacity,omitempty" description:"compute resource capacity of the node; see http://releases.k8s.io/HEAD/docs/user-guide/compute-resources.md"`
 	// NodePhase is the current lifecycle phase of the node.
-	Phase NodePhase `json:"phase,omitempty" description:"most recently observed lifecycle phase of the node; see http://releases.k8s.io/HEAD/docs/node.md#node-phase"`
+	Phase NodePhase `json:"phase,omitempty" description:"most recently observed lifecycle phase of the node; see http://releases.k8s.io/HEAD/docs/admin/node.md#node-phase"`
 	// Conditions is an array of current node conditions.
-	Conditions []NodeCondition `json:"conditions,omitempty" description:"list of node conditions observed; see http://releases.k8s.io/HEAD/docs/node.md#node-condition" patchStrategy:"merge" patchMergeKey:"type"`
+	Conditions []NodeCondition `json:"conditions,omitempty" description:"list of node conditions observed; see http://releases.k8s.io/HEAD/docs/admin/node.md#node-condition" patchStrategy:"merge" patchMergeKey:"type"`
 	// Queried from cloud provider, if available.
-	Addresses []NodeAddress `json:"addresses,omitempty" description:"list of addresses reachable to the node; see http://releases.k8s.io/HEAD/docs/node.md#node-addresses" patchStrategy:"merge" patchMergeKey:"type"`
+	Addresses []NodeAddress `json:"addresses,omitempty" description:"list of addresses reachable to the node; see http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses" patchStrategy:"merge" patchMergeKey:"type"`
 	// NodeSystemInfo is a set of ids/uuids to uniquely identify the node
-	NodeInfo NodeSystemInfo `json:"nodeInfo,omitempty" description:"set of ids/uuids to uniquely identify the node; see http://releases.k8s.io/HEAD/docs/node.md#node-info"`
+	NodeInfo NodeSystemInfo `json:"nodeInfo,omitempty" description:"set of ids/uuids to uniquely identify the node; see http://releases.k8s.io/HEAD/docs/admin/node.md#node-info"`
 }
 
 type NodePhase string
@@ -1359,19 +1359,19 @@ type ResourceList map[ResourceName]resource.Quantity
 // Each node will have a unique identifier in the cache (i.e. in etcd).
 type Node struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a node.
-	Spec NodeSpec `json:"spec,omitempty" description:"specification of a node; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Spec NodeSpec `json:"spec,omitempty" description:"specification of a node; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 
 	// Status describes the current status of a Node
-	Status NodeStatus `json:"status,omitempty" description:"most recently observed status of the node; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Status NodeStatus `json:"status,omitempty" description:"most recently observed status of the node; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // NodeList is the whole list of all Nodes which have been registered with master.
 type NodeList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	Items []Node `json:"items" description:"list of nodes"`
 }
@@ -1409,29 +1409,29 @@ const (
 // Use of multiple namespaces is optional
 type Namespace struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of the Namespace.
-	Spec NamespaceSpec `json:"spec,omitempty" description:"spec defines the behavior of the Namespace; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Spec NamespaceSpec `json:"spec,omitempty" description:"spec defines the behavior of the Namespace; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 
 	// Status describes the current status of a Namespace
-	Status NamespaceStatus `json:"status,omitempty" description:"status describes the current status of a Namespace; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Status NamespaceStatus `json:"status,omitempty" description:"status describes the current status of a Namespace; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // NamespaceList is a list of Namespaces.
 type NamespaceList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Items is the list of Namespace objects in the list
-	Items []Namespace `json:"items"  description:"items is the list of Namespace objects in the list; see http://releases.k8s.io/HEAD/docs/namespaces.md"`
+	Items []Namespace `json:"items"  description:"items is the list of Namespace objects in the list; see http://releases.k8s.io/HEAD/docs/user-guide/namespaces.md"`
 }
 
 // Binding ties one object to another - for example, a pod is bound to a node by a scheduler.
 type Binding struct {
 	TypeMeta `json:",inline"`
 	// ObjectMeta describes the object that is being bound.
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Target is the object to bind to.
 	Target ObjectReference `json:"target" description:"an object to bind to"`
@@ -1509,10 +1509,10 @@ type PodProxyOptions struct {
 // Status is a return value for calls that don't return other objects.
 type Status struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// One of: "Success" or "Failure"
-	Status string `json:"status,omitempty" description:"status of the operation; either Success, or Failure; see http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Status string `json:"status,omitempty" description:"status of the operation; either Success, or Failure; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 	// A human-readable description of the status of this operation.
 	Message string `json:"message,omitempty" description:"human-readable description of the status of this operation"`
 	// A machine-readable description of why this operation is in the
@@ -1541,7 +1541,7 @@ type StatusDetails struct {
 	Name string `json:"name,omitempty" description:"the name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)"`
 	// The kind attribute of the resource associated with the status StatusReason.
 	// On some operations may differ from the requested resource Kind.
-	Kind string `json:"kind,omitempty" description:"the kind attribute of the resource associated with the status StatusReason; on some operations may differ from the requested resource Kind; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
+	Kind string `json:"kind,omitempty" description:"the kind attribute of the resource associated with the status StatusReason; on some operations may differ from the requested resource Kind; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"`
 	// The Causes array includes more details associated with the StatusReason
 	// failure. Not all StatusReasons may provide detailed causes.
 	Causes []StatusCause `json:"causes,omitempty" description:"the Causes array includes more details associated with the StatusReason failure; not all StatusReasons may provide detailed causes"`
@@ -1662,12 +1662,12 @@ const (
 
 // ObjectReference contains enough information to let you inspect or modify the referred object.
 type ObjectReference struct {
-	Kind            string    `json:"kind,omitempty" description:"kind of the referent; see http://releases.k8s.io/HEAD/docs/api-conventions.md#types-kinds"`
-	Namespace       string    `json:"namespace,omitempty" description:"namespace of the referent; see http://releases.k8s.io/HEAD/docs/namespaces.md"`
-	Name            string    `json:"name,omitempty" description:"name of the referent; see http://releases.k8s.io/HEAD/docs/identifiers.md#names"`
-	UID             types.UID `json:"uid,omitempty" description:"uid of the referent; see http://releases.k8s.io/HEAD/docs/identifiers.md#uids"`
+	Kind            string    `json:"kind,omitempty" description:"kind of the referent; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"`
+	Namespace       string    `json:"namespace,omitempty" description:"namespace of the referent; see http://releases.k8s.io/HEAD/docs/user-guide/namespaces.md"`
+	Name            string    `json:"name,omitempty" description:"name of the referent; see http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names"`
+	UID             types.UID `json:"uid,omitempty" description:"uid of the referent; see http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#uids"`
 	APIVersion      string    `json:"apiVersion,omitempty" description:"API version of the referent"`
-	ResourceVersion string    `json:"resourceVersion,omitempty" description:"specific resourceVersion to which this reference is made, if any: http://releases.k8s.io/HEAD/docs/api-conventions.md#concurrency-control-and-consistency"`
+	ResourceVersion string    `json:"resourceVersion,omitempty" description:"specific resourceVersion to which this reference is made, if any: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"`
 
 	// Optional. If referring to a piece of an object instead of an entire object, this string
 	// should contain information to identify the sub-object. For example, if the object
@@ -1683,7 +1683,7 @@ type ObjectReference struct {
 // LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
 type LocalObjectReference struct {
 	//TODO: Add other useful fields.  apiVersion, kind, uid?
-	Name string `json:"name,omitempty" description:"name of the referent; see http://releases.k8s.io/HEAD/docs/identifiers.md#names"`
+	Name string `json:"name,omitempty" description:"name of the referent; see http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names"`
 }
 
 type SerializedReference struct {
@@ -1702,7 +1702,7 @@ type EventSource struct {
 // TODO: Decide whether to store these separately or with the object they apply to.
 type Event struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Required. The object that this event is about.
 	InvolvedObject ObjectReference `json:"involvedObject" description:"object this event is about"`
@@ -1732,7 +1732,7 @@ type Event struct {
 // EventList is a list of events.
 type EventList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	Items []Event `json:"items" description:"list of events"`
 }
@@ -1740,7 +1740,7 @@ type EventList struct {
 // List holds a list of objects, which may not be known by the server.
 type List struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	Items []runtime.RawExtension `json:"items" description:"list of objects"`
 }
@@ -1776,16 +1776,16 @@ type LimitRangeSpec struct {
 // LimitRange sets resource usage limits for each kind of resource in a Namespace
 type LimitRange struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the limits enforced
-	Spec LimitRangeSpec `json:"spec,omitempty" description:"spec defines the limits enforced; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Spec LimitRangeSpec `json:"spec,omitempty" description:"spec defines the limits enforced; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // LimitRangeList is a list of LimitRange items.
 type LimitRangeList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Items is a list of LimitRange objects
 	Items []LimitRange `json:"items" description:"items is a list of LimitRange objects; see http://releases.k8s.io/HEAD/docs/design/admission_control_limit_range.md"`
@@ -1824,19 +1824,19 @@ type ResourceQuotaStatus struct {
 // ResourceQuota sets aggregate quota restrictions enforced per namespace
 type ResourceQuota struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the desired quota
-	Spec ResourceQuotaSpec `json:"spec,omitempty" description:"spec defines the desired quota; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Spec ResourceQuotaSpec `json:"spec,omitempty" description:"spec defines the desired quota; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 
 	// Status defines the actual enforced quota and its current usage
-	Status ResourceQuotaStatus `json:"status,omitempty" description:"status defines the actual enforced quota and current usage; http://releases.k8s.io/HEAD/docs/api-conventions.md#spec-and-status"`
+	Status ResourceQuotaStatus `json:"status,omitempty" description:"status defines the actual enforced quota and current usage; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // ResourceQuotaList is a list of ResourceQuota items
 type ResourceQuotaList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Items is a list of ResourceQuota objects
 	Items []ResourceQuota `json:"items" description:"items is a list of ResourceQuota objects; see http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"`
@@ -1846,7 +1846,7 @@ type ResourceQuotaList struct {
 // the Data field must be less than MaxSecretSize bytes.
 type Secret struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	// Data contains the secret data.  Each key must be a valid DNS_SUBDOMAIN
 	// or leading dot followed by valid DNS_SUBDOMAIN.
@@ -1897,9 +1897,9 @@ const (
 
 type SecretList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
-	Items []Secret `json:"items" description:"items is a list of secret objects; see http://releases.k8s.io/HEAD/docs/secrets.md"`
+	Items []Secret `json:"items" description:"items is a list of secret objects; see http://releases.k8s.io/HEAD/docs/user-guide/secrets.md"`
 }
 
 // Type and constants for component health validation.
@@ -1920,14 +1920,14 @@ type ComponentCondition struct {
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.
 type ComponentStatus struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	Conditions []ComponentCondition `json:"conditions,omitempty" description:"list of component conditions observed" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 type ComponentStatusList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	Items []ComponentStatus `json:"items" description:"list of component status objects"`
 }
@@ -1956,22 +1956,22 @@ type SecurityContext struct {
 // SELinuxOptions are the labels to be applied to the container
 type SELinuxOptions struct {
 	// SELinux user label
-	User string `json:"user,omitempty" description:"the user label to apply to the container; see http://releases.k8s.io/HEAD/docs/labels.md"`
+	User string `json:"user,omitempty" description:"the user label to apply to the container; see http://releases.k8s.io/HEAD/docs/user-guide/labels.md"`
 
 	// SELinux role label
-	Role string `json:"role,omitempty" description:"the role label to apply to the container; see http://releases.k8s.io/HEAD/docs/labels.md"`
+	Role string `json:"role,omitempty" description:"the role label to apply to the container; see http://releases.k8s.io/HEAD/docs/user-guide/labels.md"`
 
 	// SELinux type label
-	Type string `json:"type,omitempty" description:"the type label to apply to the container; see http://releases.k8s.io/HEAD/docs/labels.md"`
+	Type string `json:"type,omitempty" description:"the type label to apply to the container; see http://releases.k8s.io/HEAD/docs/user-guide/labels.md"`
 
 	// SELinux level label.
-	Level string `json:"level,omitempty" description:"the level label to apply to the container; see http://releases.k8s.io/HEAD/docs/labels.md"`
+	Level string `json:"level,omitempty" description:"the level label to apply to the container; see http://releases.k8s.io/HEAD/docs/user-guide/labels.md"`
 }
 
 // RangeAllocation is not a public type
 type RangeAllocation struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
 	Range string `json:"range" description:"a range string that identifies the range represented by 'data'; required"`
 	Data  []byte `json:"data" description:"a bit array containing all allocated addresses in the previous segment"`

--- a/shippable.yml
+++ b/shippable.yml
@@ -35,6 +35,7 @@ install:
   - PATH=$GOPATH/bin:$PATH ./hack/verify-generated-deep-copies.sh
   - PATH=$GOPATH/bin:./third_party/etcd:$PATH ./hack/verify-gendocs.sh
   - PATH=$GOPATH/bin:./third_party/etcd:$PATH ./hack/verify-swagger-spec.sh
+  - PATH=$GOPATH/bin:./third_party/etcd:$PATH ./hack/verify-linkcheck.sh
 
 script:
   - KUBE_RACE="-race" KUBE_COVER="y" KUBE_GOVERALLS_BIN="$HOME/gopath/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES}" KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" ./hack/test-go.sh -- -p=2


### PR DESCRIPTION
Fix the links in types.go in HEAD;
Fix the links in docs/api-reference/definitions.html;
Check the links in types.go in mungedoc and add path pkg/api/ to verify-gendoc.sh

Partially address #11677.

@nikhiljindal @RichieEscarez @bgrant0607 @JanetKuo 
