### PR TITLE
build hyperkube as a nonstatic binary

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -119,7 +119,6 @@ readonly KUBE_STATIC_LIBRARIES=(
   kube-apiserver
   kube-controller-manager
   kube-scheduler
-  hyperkube
 )
 
 kube::golang::is_statically_linked_library() {


### PR DESCRIPTION
hyperkube should not be a static binary, otherwise it would cause problems as #8772.
Confirmed by @vishh 's [comment](https://github.com/GoogleCloudPlatform/kubernetes/issues/8772#issuecomment-123769784) and [this](https://github.com/GoogleCloudPlatform/kubernetes/issues/8772#issuecomment-109202743) also.
