### PR TITLE
Use a service between e2e volume tests clients and servers.

### DIFF
--- a/contrib/for-tests/volumes-tester/nfs/run_nfs.sh
+++ b/contrib/for-tests/volumes-tester/nfs/run_nfs.sh
@@ -20,7 +20,9 @@ function start()
     # prepare /etc/exports
     for i in "$@"; do
         # fsid=0: needed for NFSv4
-        echo "$i *(rw,fsid=0,no_root_squash)" >> /etc/exports
+        # no_root_squash: root can read/write
+        # insecure: allow access from ports > 1024
+        echo "$i *(rw,fsid=0,no_root_squash,insecure)" >> /etc/exports
         echo "Serving $i"
     done
 

--- a/test/e2e/persistent_volumes.go
+++ b/test/e2e/persistent_volumes.go
@@ -63,8 +63,7 @@ var _ = Describe("[Skipped] persistentVolumes", func() {
 			volumeTestCleanup(c, config)
 		}()
 
-		pod := startVolumeServer(c, config)
-		serverIP := pod.Status.PodIP
+		serverIP := startVolumeServer(c, config)
 		Logf("NFS server IP address: %v", serverIP)
 
 		pv := makePersistentVolume(serverIP)


### PR DESCRIPTION
This helps with routing of TCP traffic between clients and servers in case
flannel or similar service is not installed and pods don't see each other.
- It needs 'insecure' in /etc/exports to allow NFS clients on ports > 1024,
  Kubernetes service will change client port to a random number.
- glusterfs no longer needs explicit endpoint definition, it uses the service
  instead.
