### PR TITLE
Revert "Require at least one healthy startup pod in GCE Jenkins e2e t…

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -100,6 +100,5 @@ export PATH=$(dirname "${e2e_test}"):"${PATH}"
   --node-instance-group="${NODE_INSTANCE_GROUP:-}" \
   --num-nodes="${NUM_MINIONS:-}" \
   --prefix="${KUBE_GCE_INSTANCE_PREFIX:-e2e}" \
-  ${E2E_MIN_STARTUP_PODS+"--minStartupPods=${E2E_MIN_STARTUP_PODS}"} \
   ${E2E_REPORT_DIR+"--report-dir=${E2E_REPORT_DIR}"} \
   "${@:-}"

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -55,7 +55,6 @@ E2E_OPT=${E2E_OPT:-""}
 # Set environment variables shared for all of the GCE Jenkins projects.
 if [[ ${JOB_NAME} =~ ^kubernetes-.*-gce ]]; then
   KUBERNETES_PROVIDER="gce"
-  : ${E2E_MIN_STARTUP_PODS:="1"}
   : ${E2E_ZONE:="us-central1-f"}
   : ${MASTER_SIZE:="n1-standard-2"}
   : ${MINION_SIZE:="n1-standard-2"}
@@ -261,7 +260,6 @@ export ZONE=${E2E_ZONE}
 export KUBE_GKE_NETWORK=${E2E_NETWORK}
 
 # Shared cluster variables
-export E2E_MIN_STARTUP_PODS=${E2E_MIN_STARTUP_PODS:-}
 export MASTER_SIZE=${MASTER_SIZE:-}
 export MINION_SIZE=${MINION_SIZE:-}
 export NUM_MINIONS=${NUM_MINIONS:-}


### PR DESCRIPTION
Reverts GoogleCloudPlatform/kubernetes#11081

Reason:
- broke kubernetes-e2e-gke-ci Jenkins:
  invalid value "" for flag -minStartupPods: strconv.ParseInt: parsing "": invalid syntax
