### PR TITLE
Remove gem update for fluent-plugin-google-cloud

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
@@ -17,9 +17,6 @@ RUN apt-get -q update && \
     apt-get clean && \
     curl -s https://storage.googleapis.com/signals-agents/logging/google-fluentd-install.sh | sudo bash
 
-# Update gem for fluent-plugin-google-cloud
-RUN /usr/sbin/google-fluentd-gem update fluent-plugin-google-cloud
-
 # Copy the Fluentd configuration file for logging Docker container logs.
 COPY google-fluentd.conf /etc/google-fluentd/google-fluentd.conf
 

--- a/contrib/logging/fluentd-sidecar-gcp/Dockerfile
+++ b/contrib/logging/fluentd-sidecar-gcp/Dockerfile
@@ -20,9 +20,6 @@ RUN apt-get -q update && \
     apt-get clean && \
     curl -s https://storage.googleapis.com/signals-agents/logging/google-fluentd-install.sh | sudo bash
 
-# Update gem for fluent-plugin-google-cloud
-RUN /usr/sbin/google-fluentd-gem update fluent-plugin-google-cloud
-
 # Copy the configuration file generator for creating input configurations for
 # each file specified in the FILES_TO_COLLECT environment variable.
 COPY config_generator.sh /usr/local/sbin/config_generator.sh


### PR DESCRIPTION
This was originally submitted to pick up v0.3.1 of the cloud logging
plugin which had a fix for the name 'metadata' failing to resolve.
Since new releases of google-fluentd have this fix, it is no longer
required.

I've done some additional testing of 'gem update' behavior in the interim
and I think it is ok to use in targeted situations, but we should not be
doing an unconstrained update in general. The issue is that updating a
gem may bring new dependencies, some of those dependencies may include
native code, so it may try to launch a compiler, which isn't desirable
and prone to failure.

If we do need to grab an updated gem in the future we should specify an
explicit version and the --minimal-deps flag.
