### PR TITLE
disable irc notifications for shippable and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ script:
   - godep go test ./cmd/mungedocs
 
 notifications:
-  irc: "chat.freenode.net#google-containers"
+  irc: "chat.freenode.net#kubernetes-dev"

--- a/shippable.yml
+++ b/shippable.yml
@@ -43,4 +43,4 @@ script:
   - PATH=$HOME/gopath/bin:./third_party/etcd:$PATH ./hack/test-update-storage-objects.sh
 
 notifications:
-  irc: "chat.freenode.net#google-containers"
+  irc: "chat.freenode.net#kubernetes-dev"


### PR DESCRIPTION
They are pretty spammy. If no objections, I'd like to get rid of them. We would still have kubot notifications.
