### PR TITLE
Fix for Google Analytics and Adblocker extenstion conflict

### DIFF
--- a/_includes/dochead.html
+++ b/_includes/dochead.html
@@ -31,7 +31,9 @@
   </script>
   <script type="text/javascript" src="{{site.url}}/js/script.js"></script>
   <script>
-    var trackOutboundLink=function(n){ga("send","event","outbound","click",n,{hitCallback:function(){document.location=n}})};
+	var trackOutboundLink=function(n){var f = function(){document.location=n};
+	setTimeout(f, 1000);
+	ga("send","event","outbound","click",n,{hitCallback:f})};
   </script>
  </head>
  <body>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -31,7 +31,9 @@
   </script>
   <script type="text/javascript" src="{{site.url}}/js/script.js"></script>
   <script>
-    var trackOutboundLink=function(n){ga("send","event","outbound","click",n,{hitCallback:function(){document.location=n}})};
+	var trackOutboundLink=function(n){var f = function(){document.location=n};
+	setTimeout(f, 1000);
+	ga("send","event","outbound","click",n,{hitCallback:f})};
   </script>
  </head>
  <body>


### PR DESCRIPTION
Im unable to replicate the issue but several online sources specify that this resolves the issue people are faced when they hit this page and have the chrome extension "adblocker" running (javascript on pages enters endless loop due to adblocker and all buttons/clicks are disabled/frozen).

Ive tested locally and in my fork, finding no negative results (nothing in console either).
