### PR TITLE
a mungedoc tool that splits long commands to multiple lines

### DIFF
--- a/docs/admin/cluster-management.md
+++ b/docs/admin/cluster-management.md
@@ -180,8 +180,8 @@ You can use the `kube-version-change` utility to convert config files between di
 
 ```console
 $ hack/build-go.sh cmd/kube-version-change
-$ _output/local/go/bin/kube-version-change -i myPod.v1beta3.yaml -o \
-    myPod.v1.yaml
+$ _output/local/go/bin/kube-version-change -i myPod.v1beta3.yaml \
+    -o myPod.v1.yaml
 ```
 
 

--- a/docs/admin/cluster-management.md
+++ b/docs/admin/cluster-management.md
@@ -180,7 +180,8 @@ You can use the `kube-version-change` utility to convert config files between di
 
 ```console
 $ hack/build-go.sh cmd/kube-version-change
-$ _output/local/go/bin/kube-version-change -i myPod.v1beta3.yaml -o myPod.v1.yaml
+$ _output/local/go/bin/kube-version-change -i myPod.v1beta3.yaml -o \
+    myPod.v1.yaml
 ```
 
 

--- a/docs/admin/namespaces/README.md
+++ b/docs/admin/namespaces/README.md
@@ -164,8 +164,10 @@ users:
 The next step is to define a context for the kubectl client to work in each namespace. The value of "cluster" and "user" fields are copied from the current context.
 
 ```console
-$ kubectl config set-context dev --namespace=development --cluster=lithe-cocoa-92103_kubernetes --user=lithe-cocoa-92103_kubernetes
-$ kubectl config set-context prod --namespace=production --cluster=lithe-cocoa-92103_kubernetes --user=lithe-cocoa-92103_kubernetes
+$ kubectl config set-context dev --namespace=development \
+    --cluster=lithe-cocoa-92103_kubernetes --user=lithe-cocoa-92103_kubernetes
+$ kubectl config set-context prod --namespace=production \
+    --cluster=lithe-cocoa-92103_kubernetes --user=lithe-cocoa-92103_kubernetes
 ```
 
 The above commands provided two request contexts you can alternate against depending on what namespace you

--- a/docs/devel/api-conventions.md
+++ b/docs/devel/api-conventions.md
@@ -526,7 +526,8 @@ The status object is encoded as JSON and provided as the body of the response.  
 **Example:**
 
 ```console
-$ curl -v -k -H "Authorization: Bearer WhCDvq4VPpYhrcfmF6ei7V9qlbqTubUc" https://10.240.122.184:443/api/v1/namespaces/default/pods/grafana
+$ curl -v -k -H "Authorization: Bearer WhCDvq4VPpYhrcfmF6ei7V9qlbqTubUc" \
+    https://10.240.122.184:443/api/v1/namespaces/default/pods/grafana
 
 > GET /api/v1/namespaces/default/pods/grafana HTTP/1.1
 > User-Agent: curl/7.26.0

--- a/docs/user-guide/application-troubleshooting.md
+++ b/docs/user-guide/application-troubleshooting.md
@@ -120,8 +120,8 @@ $ kubectl logs --previous ${POD_NAME} ${CONTAINER_NAME}
 Alternately, you can run commands inside that container with `exec`:
 
 ```console
-$ kubectl exec ${POD_NAME} -c ${CONTAINER_NAME} -- ${CMD} ${ARG1} ${ARG2} ... \
-    ${ARGN}
+$ kubectl exec ${POD_NAME} -c ${CONTAINER_NAME} -- \
+    ${CMD} ${ARG1} ${ARG2} ... ${ARGN}
 ```
 
 Note that `-c ${CONTAINER_NAME}` is optional and can be omitted for Pods that only contain a single container.

--- a/docs/user-guide/application-troubleshooting.md
+++ b/docs/user-guide/application-troubleshooting.md
@@ -120,7 +120,8 @@ $ kubectl logs --previous ${POD_NAME} ${CONTAINER_NAME}
 Alternately, you can run commands inside that container with `exec`:
 
 ```console
-$ kubectl exec ${POD_NAME} -c ${CONTAINER_NAME} -- ${CMD} ${ARG1} ${ARG2} ... ${ARGN}
+$ kubectl exec ${POD_NAME} -c ${CONTAINER_NAME} -- ${CMD} ${ARG1} ${ARG2} ... \
+    ${ARGN}
 ```
 
 Note that `-c ${CONTAINER_NAME}` is optional and can be omitted for Pods that only contain a single container.

--- a/docs/user-guide/connecting-applications.md
+++ b/docs/user-guide/connecting-applications.md
@@ -176,7 +176,8 @@ KUBERNETES_SERVICE_PORT=443
 Note there’s no mention of your Service. This is because you created the replicas before the Service. Another disadvantage of doing this is that the scheduler might put both pods on the same machine, which will take your entire Service down if it dies. We can do this the right way by killing the 2 pods and waiting for the replication controller to recreate them. This time around the Service exists *before* the replicas. This will given you scheduler level Service spreading of your pods (provided all your nodes have equal capacity), as well as the right environment variables:
 
 ```console
-$ kubectl scale rc my-nginx --replicas=0; kubectl scale rc my-nginx --replicas=2;
+$ kubectl scale rc my-nginx --replicas=0; kubectl scale rc my-nginx \
+    --replicas=2;
 $ kubectl get pods -l app=nginx -o wide
 NAME             READY   STATUS     RESTARTS   AGE   NODE
 my-nginx-5j8ok   1/1     Running   	0         2m    node1
@@ -245,7 +246,8 @@ Till now we have only accessed the nginx server from within the cluster. Before 
 You can acquire all these from the [nginx https example](../../examples/https-nginx/README.md), in short:
 
 ```console
-$ make keys secret KEY=/tmp/nginx.key CERT=/tmp/nginx.crt SECRET=/tmp/secret.json
+$ make keys secret KEY=/tmp/nginx.key CERT=/tmp/nginx.crt \
+    SECRET=/tmp/secret.json
 $ kubectl create -f /tmp/secret.json
 secrets/nginxsecret
 $ kubectl get secrets
@@ -364,7 +366,8 @@ NAME             READY     STATUS    RESTARTS   AGE
 curlpod          1/1       Running   0          2m
 my-nginx-7006w   1/1       Running   0          24m
 
-$ kubectl exec curlpod -- curl https://nginxsvc --cacert /etc/nginx/ssl/nginx.crt
+$ kubectl exec curlpod -- curl https://nginxsvc --cacert \
+    /etc/nginx/ssl/nginx.crt
 ...
 <title>Welcome to nginx!</title>
 ...

--- a/docs/user-guide/connecting-applications.md
+++ b/docs/user-guide/connecting-applications.md
@@ -176,8 +176,8 @@ KUBERNETES_SERVICE_PORT=443
 Note there’s no mention of your Service. This is because you created the replicas before the Service. Another disadvantage of doing this is that the scheduler might put both pods on the same machine, which will take your entire Service down if it dies. We can do this the right way by killing the 2 pods and waiting for the replication controller to recreate them. This time around the Service exists *before* the replicas. This will given you scheduler level Service spreading of your pods (provided all your nodes have equal capacity), as well as the right environment variables:
 
 ```console
-$ kubectl scale rc my-nginx --replicas=0; kubectl scale rc my-nginx \
-    --replicas=2;
+$ kubectl scale rc my-nginx --replicas=0; \
+    kubectl scale rc my-nginx --replicas=2;
 $ kubectl get pods -l app=nginx -o wide
 NAME             READY   STATUS     RESTARTS   AGE   NODE
 my-nginx-5j8ok   1/1     Running   	0         2m    node1
@@ -366,8 +366,8 @@ NAME             READY     STATUS    RESTARTS   AGE
 curlpod          1/1       Running   0          2m
 my-nginx-7006w   1/1       Running   0          24m
 
-$ kubectl exec curlpod -- curl https://nginxsvc --cacert \
-    /etc/nginx/ssl/nginx.crt
+$ kubectl exec curlpod -- curl https://nginxsvc \
+    --cacert /etc/nginx/ssl/nginx.crt
 ...
 <title>Welcome to nginx!</title>
 ...

--- a/docs/user-guide/connecting-to-applications-port-forward.md
+++ b/docs/user-guide/connecting-to-applications-port-forward.md
@@ -56,7 +56,8 @@ redis-master   2/2       Running   0          41s
 The Redis master is listening on port 6397, to verify this,
 
 ```console
-$ kubectl get pods redis-master -t='{{(index (index .spec.containers 0).ports 0).containerPort}}{{"\n"}}'
+$ kubectl get pods redis-master \
+    -t='{{(index (index .spec.containers 0).ports 0).containerPort}}{{"\n"}}'
 6379
 ```
 

--- a/docs/user-guide/kubeconfig-file.md
+++ b/docs/user-guide/kubeconfig-file.md
@@ -128,7 +128,8 @@ See [kubectl/kubectl_config.md](kubectl/kubectl_config.md) for help.
 ```console
 $ kubectl config set-credentials myself --username=admin --password=secret
 $ kubectl config set-cluster local-server --server=http://localhost:8080
-$ kubectl config set-context default-context --cluster=local-server --user=myself
+$ kubectl config set-context default-context --cluster=local-server \
+    --user=myself
 $ kubectl config use-context default-context
 $ kubectl config set contexts.default-context.namespace the-right-prefix
 $ kubectl config view
@@ -181,13 +182,19 @@ users:
 
 ```console
 $ kubectl config set preferences.colors true
-$ kubectl config set-cluster cow-cluster --server=http://cow.org:8080 --api-version=v1
-$ kubectl config set-cluster horse-cluster --server=https://horse.org:4443 --certificate-authority=path/to/my/cafile
-$ kubectl config set-cluster pig-cluster --server=https://pig.org:443 --insecure-skip-tls-verify=true
+$ kubectl config set-cluster cow-cluster --server=http://cow.org:8080 \
+    --api-version=v1
+$ kubectl config set-cluster horse-cluster --server=https://horse.org:4443 \
+    --certificate-authority=path/to/my/cafile
+$ kubectl config set-cluster pig-cluster --server=https://pig.org:443 \
+    --insecure-skip-tls-verify=true
 $ kubectl config set-credentials blue-user --token=blue-token
-$ kubectl config set-credentials green-user --client-certificate=path/to/my/client/cert --client-key=path/to/my/client/key
-$ kubectl config set-context queen-anne-context --cluster=pig-cluster --user=black-user --namespace=saw-ns
-$ kubectl config set-context federal-context --cluster=horse-cluster --user=green-user --namespace=chisel-ns
+$ kubectl config set-credentials green-user \
+    --client-certificate=path/to/my/client/cert --client-key=path/to/my/client/key
+$ kubectl config set-context queen-anne-context --cluster=pig-cluster \
+    --user=black-user --namespace=saw-ns
+$ kubectl config set-context federal-context --cluster=horse-cluster \
+    --user=green-user --namespace=chisel-ns
 $ kubectl config use-context federal-context
 ```
 

--- a/docs/user-guide/kubectl/kubectl_config_set-cluster.md
+++ b/docs/user-guide/kubectl/kubectl_config_set-cluster.md
@@ -52,7 +52,8 @@ kubectl config set-cluster NAME [--server=server] [--certificate-authority=path/
 $ kubectl config set-cluster e2e --server=https://1.2.3.4
 
 // Embed certificate authority data for the e2e cluster entry
-$ kubectl config set-cluster e2e --certificate-authority=~/.kube/e2e/kubernetes.ca.crt
+$ kubectl config set-cluster e2e \
+    --certificate-authority=~/.kube/e2e/kubernetes.ca.crt
 
 // Disable cert checking for the dev cluster entry
 $ kubectl config set-cluster e2e --insecure-skip-tls-verify=true

--- a/docs/user-guide/kubectl/kubectl_config_set-credentials.md
+++ b/docs/user-guide/kubectl/kubectl_config_set-credentials.md
@@ -65,10 +65,12 @@ kubectl config set-credentials NAME [--client-certificate=path/to/certfile] [--c
 $ kubectl config set-credentials cluster-admin --client-key=~/.kube/admin.key
 
 // Set basic auth for the "cluster-admin" entry
-$ kubectl config set-credentials cluster-admin --username=admin --password=uXFGweU9l35qcif
+$ kubectl config set-credentials cluster-admin --username=admin \
+    --password=uXFGweU9l35qcif
 
 // Embed client certificate data in the "cluster-admin" entry
-$ kubectl config set-credentials cluster-admin --client-certificate=~/.kube/admin.crt --embed-certs=true
+$ kubectl config set-credentials cluster-admin \
+    --client-certificate=~/.kube/admin.crt --embed-certs=true
 ```
 
 ### Options

--- a/docs/user-guide/kubectl/kubectl_get.md
+++ b/docs/user-guide/kubectl/kubectl_get.md
@@ -68,7 +68,8 @@ $ kubectl get replicationcontroller web
 $ kubectl get -o json pod web-pod-13je7
 
 // Return only the phase value of the specified pod.
-$ kubectl get -o template web-pod-13je7 --template={{.status.phase}} --api-version=v1
+$ kubectl get -o template web-pod-13je7 --template={{.status.phase}} \
+    --api-version=v1
 
 // List all replication controllers and services together in ps output format.
 $ kubectl get rc,services

--- a/docs/user-guide/kubectl/kubectl_run.md
+++ b/docs/user-guide/kubectl/kubectl_run.md
@@ -58,7 +58,8 @@ $ kubectl run nginx --image=nginx --replicas=5
 $ kubectl run nginx --image=nginx --dry-run
 
 // Start a single instance of nginx, but overload the spec of the replication controller with a partial set of values parsed from JSON.
-$ kubectl run nginx --image=nginx --overrides='{ "apiVersion": "v1", "spec": { ... } }'
+$ kubectl run nginx --image=nginx \
+    --overrides='{ "apiVersion": "v1", "spec": { ... } }'
 ```
 
 ### Options

--- a/docs/user-guide/limitrange/README.md
+++ b/docs/user-guide/limitrange/README.md
@@ -132,8 +132,8 @@ $ kubectl get pods --namespace=limit-example
 POD           IP           CONTAINER(S)   IMAGE(S)   HOST          LABELS      STATUS    CREATED          MESSAGE
 nginx-ykj4j   10.246.1.3                             10.245.1.3/   run=nginx   Running   About a minute
                            nginx          nginx                                Running   54 seconds
-$ kubectl get pods nginx-ykj4j --namespace=limit-example -o yaml | grep \
-    resources -C 5
+$ kubectl get pods nginx-ykj4j --namespace=limit-example -o yaml |\
+    grep resources -C 5
 ```
 
 ```yaml
@@ -166,8 +166,8 @@ Let's create a pod that falls within the allowed limit boundaries.
 $ kubectl create -f docs/user-guide/limitrange/valid-pod.yaml \
     --namespace=limit-example
 pods/valid-pod
-$ kubectl get pods valid-pod --namespace=limit-example -o yaml | grep -C 5 \
-    resources
+$ kubectl get pods valid-pod --namespace=limit-example -o yaml |\
+    grep -C 5 resources
 ```
 
 ```yaml

--- a/docs/user-guide/limitrange/README.md
+++ b/docs/user-guide/limitrange/README.md
@@ -85,7 +85,8 @@ Step 2: Apply a limit to the namespace
 Let's create a simple limit in our namespace.
 
 ```console
-$ kubectl create -f docs/user-guide/limitrange/limits.yaml --namespace=limit-example
+$ kubectl create -f docs/user-guide/limitrange/limits.yaml \
+    --namespace=limit-example
 limitranges/mylimits
 ```
 
@@ -131,7 +132,8 @@ $ kubectl get pods --namespace=limit-example
 POD           IP           CONTAINER(S)   IMAGE(S)   HOST          LABELS      STATUS    CREATED          MESSAGE
 nginx-ykj4j   10.246.1.3                             10.245.1.3/   run=nginx   Running   About a minute
                            nginx          nginx                                Running   54 seconds
-$ kubectl get pods nginx-ykj4j --namespace=limit-example -o yaml | grep resources -C 5
+$ kubectl get pods nginx-ykj4j --namespace=limit-example -o yaml | grep \
+    resources -C 5
 ```
 
 ```yaml
@@ -153,16 +155,19 @@ Note that our nginx container has picked up the namespace default cpu and memory
 Let's create a pod that exceeds our allowed limits by having it have a container that requests 3 cpu cores.
 
 ```console
-$ kubectl create -f docs/user-guide/limitrange/invalid-pod.yaml --namespace=limit-example
+$ kubectl create -f docs/user-guide/limitrange/invalid-pod.yaml \
+    --namespace=limit-example
 Error from server: Pod "invalid-pod" is forbidden: Maximum CPU usage per pod is 2, but requested 3
 ```
 
 Let's create a pod that falls within the allowed limit boundaries.
 
 ```console
-$ kubectl create -f docs/user-guide/limitrange/valid-pod.yaml --namespace=limit-example
+$ kubectl create -f docs/user-guide/limitrange/valid-pod.yaml \
+    --namespace=limit-example
 pods/valid-pod
-$ kubectl get pods valid-pod --namespace=limit-example -o yaml | grep -C 5 resources
+$ kubectl get pods valid-pod --namespace=limit-example -o yaml | grep -C 5 \
+    resources
 ```
 
 ```yaml

--- a/docs/user-guide/managing-deployments.md
+++ b/docs/user-guide/managing-deployments.md
@@ -188,7 +188,8 @@ and
 The labels allow us to slice and dice our resources along any dimension specified by a label:
 
 ```console
-$ kubectl create -f ./guestbook-fe.yaml -f ./redis-master.yaml -f ./redis-slave.yaml
+$ kubectl create -f ./guestbook-fe.yaml -f ./redis-master.yaml -f \
+    ./redis-slave.yaml
 replicationcontrollers/guestbook-fe
 replicationcontrollers/guestbook-redis-master
 replicationcontrollers/guestbook-redis-slave
@@ -414,7 +415,8 @@ You can also run the [update demo](update-demo/) to see a visual representation 
 Sometimes it’s necessary to make narrow, non-disruptive updates to resources you’ve created. For instance, you might want to add an [annotation](annotations.md) with a description of your object. That’s easiest to do with `kubectl patch`:
 
 ```console
-$ kubectl patch rc my-nginx-v4 -p '{"metadata": {"annotations": {"description": "my frontend running nginx"}}}' 
+$ kubectl patch rc my-nginx-v4 -p \
+    '{"metadata": {"annotations": {"description": "my frontend running nginx"}}}' 
 my-nginx-v4
 $ kubectl get rc my-nginx-v4 -o yaml
 apiVersion: v1

--- a/docs/user-guide/managing-deployments.md
+++ b/docs/user-guide/managing-deployments.md
@@ -188,8 +188,8 @@ and
 The labels allow us to slice and dice our resources along any dimension specified by a label:
 
 ```console
-$ kubectl create -f ./guestbook-fe.yaml -f ./redis-master.yaml -f \
-    ./redis-slave.yaml
+$ kubectl create -f ./guestbook-fe.yaml -f ./redis-master.yaml \
+    -f ./redis-slave.yaml
 replicationcontrollers/guestbook-fe
 replicationcontrollers/guestbook-redis-master
 replicationcontrollers/guestbook-redis-slave
@@ -415,8 +415,8 @@ You can also run the [update demo](update-demo/) to see a visual representation 
 Sometimes it’s necessary to make narrow, non-disruptive updates to resources you’ve created. For instance, you might want to add an [annotation](annotations.md) with a description of your object. That’s easiest to do with `kubectl patch`:
 
 ```console
-$ kubectl patch rc my-nginx-v4 -p \
-    '{"metadata": {"annotations": {"description": "my frontend running nginx"}}}' 
+$ kubectl patch rc my-nginx-v4 \
+    -p '{"metadata": {"annotations": {"description": "my frontend running nginx"}}}' 
 my-nginx-v4
 $ kubectl get rc my-nginx-v4 -o yaml
 apiVersion: v1

--- a/docs/user-guide/namespaces.md
+++ b/docs/user-guide/namespaces.md
@@ -93,7 +93,8 @@ context.
 First get your current context:
 
 ```console
-$ export CONTEXT=$(kubectl config view | grep current-context | awk '{print $2}')
+$ export CONTEXT=$(kubectl config view | grep current-context | awk \
+    '{print $2}')
 ```
 
 Then update the default namespace:

--- a/docs/user-guide/namespaces.md
+++ b/docs/user-guide/namespaces.md
@@ -93,8 +93,8 @@ context.
 First get your current context:
 
 ```console
-$ export CONTEXT=$(kubectl config view | grep current-context | awk \
-    '{print $2}')
+$ export CONTEXT=$(kubectl config view | grep current-context |\
+    awk '{print $2}')
 ```
 
 Then update the default namespace:

--- a/docs/user-guide/production-pods.md
+++ b/docs/user-guide/production-pods.md
@@ -371,11 +371,11 @@ The message is recorded along with the other state of the last (i.e., most recen
 $ kubectl create -f ./pod.yaml
 pods/pod-w-message
 $ sleep 70
-$ kubectl get pods/pod-w-message -o template -t \
-    "{{range .status.containerStatuses}}{{.lastState.terminated.message}}{{end}}"
+$ kubectl get pods/pod-w-message -o template \
+    -t "{{range .status.containerStatuses}}{{.lastState.terminated.message}}{{end}}"
 Sleep expired
-$ kubectl get pods/pod-w-message -o template -t \
-    "{{range .status.containerStatuses}}{{.lastState.terminated.exitCode}}{{end}}"
+$ kubectl get pods/pod-w-message -o template \
+    -t "{{range .status.containerStatuses}}{{.lastState.terminated.exitCode}}{{end}}"
 0
 ```
 

--- a/docs/user-guide/production-pods.md
+++ b/docs/user-guide/production-pods.md
@@ -371,9 +371,11 @@ The message is recorded along with the other state of the last (i.e., most recen
 $ kubectl create -f ./pod.yaml
 pods/pod-w-message
 $ sleep 70
-$ kubectl get pods/pod-w-message -o template -t "{{range .status.containerStatuses}}{{.lastState.terminated.message}}{{end}}"
+$ kubectl get pods/pod-w-message -o template -t \
+    "{{range .status.containerStatuses}}{{.lastState.terminated.message}}{{end}}"
 Sleep expired
-$ kubectl get pods/pod-w-message -o template -t "{{range .status.containerStatuses}}{{.lastState.terminated.exitCode}}{{end}}"
+$ kubectl get pods/pod-w-message -o template -t \
+    "{{range .status.containerStatuses}}{{.lastState.terminated.exitCode}}{{end}}"
 0
 ```
 

--- a/docs/user-guide/resourcequota/README.md
+++ b/docs/user-guide/resourcequota/README.md
@@ -63,7 +63,8 @@ and API resources (pods, services, etc.) that a namespace may consume.
 Let's create a simple quota in our namespace:
 
 ```console
-$ kubectl create -f docs/user-guide/resourcequota/quota.yaml --namespace=quota-example
+$ kubectl create -f docs/user-guide/resourcequota/quota.yaml \
+    --namespace=quota-example
 ```
 
 Once your quota is applied to a namespace, the system will restrict any creation of content
@@ -131,7 +132,8 @@ do not specify any memory usage.
 So let's set some default limits for the amount of cpu and memory a pod can consume:
 
 ```console
-$ kubectl create -f docs/user-guide/resourcequota/limits.yaml --namespace=quota-example
+$ kubectl create -f docs/user-guide/resourcequota/limits.yaml \
+    --namespace=quota-example
 limitranges/limits
 $ kubectl describe limits limits --namespace=quota-example
 Name:           limits

--- a/docs/user-guide/sharing-clusters.md
+++ b/docs/user-guide/sharing-clusters.md
@@ -102,7 +102,8 @@ $ kubectl config set-credentials $USER_NICK \
     --kubeconfig=/path/to/standalone/.kubeconfig
 
 # create context entry
-$ kubectl config set-context $CONTEXT_NAME --cluster=$CLUSTER_NICKNAME --user=$USER_NICK
+$ kubectl config set-context $CONTEXT_NAME --cluster=$CLUSTER_NICKNAME \
+    --user=$USER_NICK
 ```
 
 Notes:

--- a/docs/user-guide/update-demo/README.md
+++ b/docs/user-guide/update-demo/README.md
@@ -99,8 +99,8 @@ If you go back to the [demo website](http://localhost:8001/static/index.html) yo
 We will now update the docker image to serve a different image by doing a rolling update to a new Docker image.
 
 ```console
-$ kubectl rolling-update update-demo-nautilus --update-period=10s -f \
-    docs/user-guide/update-demo/kitten-rc.yaml
+$ kubectl rolling-update update-demo-nautilus --update-period=10s \
+    -f docs/user-guide/update-demo/kitten-rc.yaml
 ```
 
 The rolling-update command in kubectl will do 2 things:

--- a/docs/user-guide/update-demo/README.md
+++ b/docs/user-guide/update-demo/README.md
@@ -99,7 +99,8 @@ If you go back to the [demo website](http://localhost:8001/static/index.html) yo
 We will now update the docker image to serve a different image by doing a rolling update to a new Docker image.
 
 ```console
-$ kubectl rolling-update update-demo-nautilus --update-period=10s -f docs/user-guide/update-demo/kitten-rc.yaml
+$ kubectl rolling-update update-demo-nautilus --update-period=10s -f \
+    docs/user-guide/update-demo/kitten-rc.yaml
 ```
 
 The rolling-update command in kubectl will do 2 things:

--- a/docs/user-guide/walkthrough/k8s201.md
+++ b/docs/user-guide/walkthrough/k8s201.md
@@ -217,8 +217,10 @@ On most providers, the service IPs are not externally accessible. The easiest wa
 Provided the service IP is accessible, you should be able to access its http endpoint with curl on port 80:
 
 ```console
-$ export SERVICE_IP=$(kubectl get service nginx-service -o=template -t={{.spec.clusterIP}})
-$ export SERVICE_PORT=$(kubectl get service nginx-service -o=template '-t={{(index .spec.ports 0).port}}')
+$ export SERVICE_IP=$(kubectl get service nginx-service -o=template \
+    -t={{.spec.clusterIP}})
+$ export SERVICE_PORT=$(kubectl get service nginx-service -o=template \
+    '-t={{(index .spec.ports 0).port}}')
 $ curl http://${SERVICE_IP}:${SERVICE_PORT}
 ```
 

--- a/examples/aws_ebs/README.md
+++ b/examples/aws_ebs/README.md
@@ -44,9 +44,7 @@ the pod:
 Add some data to the volume if is empty:
 
 ```sh
-  $ echo  "Hello World" >& \
-    /var/lib/kubelet/plugins/kubernetes.io/aws-ebs/mounts/aws/{Region}/{Volume \
-    ID}/index.html
+  $ echo  "Hello World" >& /var/lib/kubelet/plugins/kubernetes.io/aws-ebs/mounts/aws/{Region}/{Volume ID}/index.html
 ```
 
 You should now be able to query your web server:

--- a/examples/aws_ebs/README.md
+++ b/examples/aws_ebs/README.md
@@ -44,7 +44,9 @@ the pod:
 Add some data to the volume if is empty:
 
 ```sh
-  $ echo  "Hello World" >& /var/lib/kubelet/plugins/kubernetes.io/aws-ebs/mounts/aws/{Region}/{Volume ID}/index.html
+  $ echo  "Hello World" >& \
+    /var/lib/kubelet/plugins/kubernetes.io/aws-ebs/mounts/aws/{Region}/{Volume \
+    ID}/index.html
 ```
 
 You should now be able to query your web server:

--- a/examples/celery-rabbitmq/README.md
+++ b/examples/celery-rabbitmq/README.md
@@ -245,7 +245,8 @@ It is marked as external (LoadBalanced). However on many platforms you will have
 On GCE this can be done with:
 
 ```
- $ gcloud compute firewall-rules create --allow=tcp:5555 --target-tags=kubernetes-minion kubernetes-minion-5555
+ $ gcloud compute firewall-rules create --allow=tcp:5555 \
+    --target-tags=kubernetes-minion kubernetes-minion-5555
 ```
 
 Please remember to delete the rule after you are done with the example (on GCE: `$ gcloud compute firewall-rules delete kubernetes-minion-5555`)

--- a/examples/cluster-dns/README.md
+++ b/examples/cluster-dns/README.md
@@ -66,8 +66,10 @@ production    name=production    Active
 For kubectl client to work with each namespace, we define two contexts:
 
 ```sh
-$ kubectl config set-context dev --namespace=development --cluster=${CLUSTER_NAME} --user=${USER_NAME}
-$ kubectl config set-context prod --namespace=production --cluster=${CLUSTER_NAME} --user=${USER_NAME}
+$ kubectl config set-context dev --namespace=development \
+    --cluster=${CLUSTER_NAME} --user=${USER_NAME}
+$ kubectl config set-context prod --namespace=production \
+    --cluster=${CLUSTER_NAME} --user=${USER_NAME}
 ```
 
 You can view your cluster name and user name in kubernetes config at ~/.kube/config.

--- a/examples/elasticsearch/README.md
+++ b/examples/elasticsearch/README.md
@@ -191,7 +191,8 @@ spec:
 Let's create the service with an external load balancer:
 
 ```console
-$ kubectl create -f examples/elasticsearch/music-service.yaml --namespace=mytunes
+$ kubectl create -f examples/elasticsearch/music-service.yaml \
+    --namespace=mytunes
 services/music-server
 ```
 
@@ -295,7 +296,8 @@ $ curl 104.197.12.157:9200/_nodes?pretty=true
 Let's ramp up the number of Elasticsearch nodes from 4 to 10:
 
 ```console
-$ kubectl scale --replicas=10 replicationcontrollers music-db --namespace=mytunes
+$ kubectl scale --replicas=10 replicationcontrollers music-db \
+    --namespace=mytunes
 scaled
 $ kubectl get pods --namespace=mytunes
 NAME             READY     STATUS    RESTARTS   AGE

--- a/examples/guestbook/README.md
+++ b/examples/guestbook/README.md
@@ -574,7 +574,8 @@ frontend              us-central1 130.211.188.51 TCP         us-central1/targetP
 In Google Compute Engine, you also may need to open the firewall for port 80 using the [console][cloud-console] or the `gcloud` tool. The following command will allow traffic from any source to instances tagged `kubernetes-minion` (replace with your tags as appropriate):
 
 ```console
-$ gcloud compute firewall-rules create --allow=tcp:80 --target-tags=kubernetes-minion kubernetes-minion-80
+$ gcloud compute firewall-rules create --allow=tcp:80 \
+    --target-tags=kubernetes-minion kubernetes-minion-80
 ```
 
 For Google Compute Engine details about limiting traffic to specific sources, see the [Google Compute Engine firewall documentation][gce-firewall-docs].

--- a/examples/https-nginx/README.md
+++ b/examples/https-nginx/README.md
@@ -41,7 +41,8 @@ It uses an [nginx server block](http://wiki.nginx.org/ServerBlockExample) to ser
 First generate a self signed rsa key and certificate that the server can use for TLS.
 
 ```sh
-$ make keys secret KEY=/tmp/nginx.key CERT=/tmp/nginx.crt SECRET=/tmp/secret.json
+$ make keys secret KEY=/tmp/nginx.key CERT=/tmp/nginx.crt \
+    SECRET=/tmp/secret.json
 ```
 
 ### Create a https nginx application running in a kubernetes cluster

--- a/examples/mysql-wordpress-pd/README.md
+++ b/examples/mysql-wordpress-pd/README.md
@@ -303,7 +303,8 @@ $ kubectl get services
 Then, find the external IP for your WordPress service by running:
 
 ```
-$ kubectl get services/wpfrontend --template="{{range .status.loadBalancer.ingress}} {{.ip}} {{end}}"
+$ kubectl get services/wpfrontend \
+    --template="{{range .status.loadBalancer.ingress}} {{.ip}} {{end}}"
 ```
 
 or by listing the forwarding rules for your project:

--- a/examples/openshift-origin/README.md
+++ b/examples/openshift-origin/README.md
@@ -79,7 +79,8 @@ $ mkdir ${OPENSHIFT_CONFIG}
 OpenShift Origin uses a configuration file to know how to access your Kubernetes cluster with administrative authority.
 
 ```
-$ cluster/kubectl.sh config view --output=yaml --flatten=true --minify=true > ${OPENSHIFT_CONFIG}/kubeconfig
+$ cluster/kubectl.sh config view --output=yaml --flatten=true --minify=true > \
+    ${OPENSHIFT_CONFIG}/kubeconfig
 ```
 
 The output from this command will contain a single file that has all the required information needed to connect to your
@@ -108,7 +109,8 @@ build default certificates.
 Grab the public IP address of the service we previously created.
 
 ```sh
-$ export PUBLIC_IP=$(cluster/kubectl.sh get services openshift --template="{{ index .status.loadBalancer.ingress 0 \"ip\" }}")
+$ export PUBLIC_IP=$(cluster/kubectl.sh get services openshift \
+    --template="{{ index .status.loadBalancer.ingress 0 \"ip\" }}")
 $ echo $PUBLIC_IP
 ```
 
@@ -182,7 +184,9 @@ Open a browser and visit the OpenShift master public address reported in your lo
 You can use the CLI commands by running the following:
 
 ```sh
-$ docker run --privileged --entrypoint="/usr/bin/bash" -it -e="OPENSHIFTCONFIG=/config/admin.kubeconfig" -v ${OPENSHIFT_CONFIG}:/config openshift/origin
+$ docker run --privileged --entrypoint="/usr/bin/bash" -it \
+    -e="OPENSHIFTCONFIG=/config/admin.kubeconfig" -v ${OPENSHIFT_CONFIG}:/config \
+    openshift/origin
 $ osc config use-context public-default
 $ osc --help
 ```

--- a/examples/phabricator/README.md
+++ b/examples/phabricator/README.md
@@ -250,7 +250,8 @@ phabricator
 To play with the service itself, find the external IP of the load balancer:
 
 ```sh
-$ kubectl get services phabricator -o template --template='{{(index .status.loadBalancer.ingress 0).ip}}{{"\n"}}'
+$ kubectl get services phabricator -o template \
+    --template='{{(index .status.loadBalancer.ingress 0).ip}}{{"\n"}}'
 ```
 
 and then visit port 80 of that IP address.
@@ -258,7 +259,8 @@ and then visit port 80 of that IP address.
 **Note**: You may need to open the firewall for port 80 using the [console][cloud-console] or the `gcloud` tool. The following command will allow traffic from any source to instances tagged `kubernetes-minion`:
 
 ```sh
-$ gcloud compute firewall-rules create phabricator-node-80 --allow=tcp:80 --target-tags kubernetes-minion
+$ gcloud compute firewall-rules create phabricator-node-80 --allow=tcp:80 \
+    --target-tags kubernetes-minion
 ```
 
 ### Step Six: Cleanup

--- a/examples/storm/README.md
+++ b/examples/storm/README.md
@@ -132,8 +132,8 @@ kubernetes          component=apiserver,provider=kubernetes   <none>            
 zookeeper           name=zookeeper                            name=zookeeper      10.254.139.141      2181
 nimbus              name=nimbus                               name=nimbus         10.254.115.208      6627
 
-$ sudo docker run -it -w /opt/apache-storm mattf/storm-base sh -c \
-    '/configure.sh 10.254.139.141 10.254.115.208; ./bin/storm list'
+$ sudo docker run -it -w /opt/apache-storm mattf/storm-base sh \
+    -c '/configure.sh 10.254.139.141 10.254.115.208; ./bin/storm list'
 ...
 No topologies running.
 ```

--- a/examples/storm/README.md
+++ b/examples/storm/README.md
@@ -132,7 +132,8 @@ kubernetes          component=apiserver,provider=kubernetes   <none>            
 zookeeper           name=zookeeper                            name=zookeeper      10.254.139.141      2181
 nimbus              name=nimbus                               name=nimbus         10.254.115.208      6627
 
-$ sudo docker run -it -w /opt/apache-storm mattf/storm-base sh -c '/configure.sh 10.254.139.141 10.254.115.208; ./bin/storm list'
+$ sudo docker run -it -w /opt/apache-storm mattf/storm-base sh -c \
+    '/configure.sh 10.254.139.141 10.254.115.208; ./bin/storm list'
 ...
 No topologies running.
 ```

--- a/pkg/kubectl/cmd/config/create_authinfo.go
+++ b/pkg/kubectl/cmd/config/create_authinfo.go
@@ -63,10 +63,12 @@ const create_authinfo_example = `// Set only the "client-key" field on the "clus
 $ kubectl config set-credentials cluster-admin --client-key=~/.kube/admin.key
 
 // Set basic auth for the "cluster-admin" entry
-$ kubectl config set-credentials cluster-admin --username=admin --password=uXFGweU9l35qcif
+$ kubectl config set-credentials cluster-admin --username=admin \
+    --password=uXFGweU9l35qcif
 
 // Embed client certificate data in the "cluster-admin" entry
-$ kubectl config set-credentials cluster-admin --client-certificate=~/.kube/admin.crt --embed-certs=true`
+$ kubectl config set-credentials cluster-admin \
+    --client-certificate=~/.kube/admin.crt --embed-certs=true`
 
 func NewCmdConfigSetAuthInfo(out io.Writer, configAccess ConfigAccess) *cobra.Command {
 	options := &createAuthInfoOptions{configAccess: configAccess}

--- a/pkg/kubectl/cmd/config/create_cluster.go
+++ b/pkg/kubectl/cmd/config/create_cluster.go
@@ -47,7 +47,8 @@ Specifying a name that already exists will merge new fields on top of existing v
 $ kubectl config set-cluster e2e --server=https://1.2.3.4
 
 // Embed certificate authority data for the e2e cluster entry
-$ kubectl config set-cluster e2e --certificate-authority=~/.kube/e2e/kubernetes.ca.crt
+$ kubectl config set-cluster e2e \
+    --certificate-authority=~/.kube/e2e/kubernetes.ca.crt
 
 // Disable cert checking for the dev cluster entry
 $ kubectl config set-cluster e2e --insecure-skip-tls-verify=true`

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -52,7 +52,8 @@ $ kubectl get replicationcontroller web
 $ kubectl get -o json pod web-pod-13je7
 
 // Return only the phase value of the specified pod.
-$ kubectl get -o template web-pod-13je7 --template={{.status.phase}} --api-version=v1
+$ kubectl get -o template web-pod-13je7 --template={{.status.phase}} \
+    --api-version=v1
 
 // List all replication controllers and services together in ps output format.
 $ kubectl get rc,services

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -40,7 +40,8 @@ $ kubectl run nginx --image=nginx --replicas=5
 $ kubectl run nginx --image=nginx --dry-run
 
 // Start a single instance of nginx, but overload the spec of the replication controller with a partial set of values parsed from JSON.
-$ kubectl run nginx --image=nginx --overrides='{ "apiVersion": "v1", "spec": { ... } }'`
+$ kubectl run nginx --image=nginx \
+    --overrides='{ "apiVersion": "v1", "spec": { ... } }'`
 )
 
 func NewCmdRun(f *cmdutil.Factory, out io.Writer) *cobra.Command {


### PR DESCRIPTION
Replace #11635.

This is a mungedoc tool that splits long commands to multiple lines. 

One thing worths mentioning is how it handles the docs for kubectl command (docs/user-guide/kubectl/). This tool will fix the md files in docs/user-guide/kubectl/, but it  **_won't**_ touch the go files nor the man files, because I think let a tool modifying go files directly is too risky. In turn, verify-gendoc.sh will report error and ask user to manually break long commands in the corresponding go files. Here is an example output in such cases:

```
$ hack/verify-gendocs.sh
diffing /usr/local/google/home/xuchao/go-workspace/src/github.com/GoogleCloudPlatform/kubernetes/docs/ against freshly generated docs
diff -NauprBw /usr/local/google/home/xuchao/go-workspace/src/github.com/GoogleCloudPlatform/kubernetes/docs/user-guide/kubectl/kubectl_run.md /usr/local/google/home/xuchao/go-workspace/src/github.com/GoogleCloudPlatform/kubernetes/_tmp/docs/user-guide/kubectl/kubectl_run.md
--- /usr/local/google/home/xuchao/go-workspace/src/github.com/GoogleCloudPlatform/kubernetes/docs/user-guide/kubectl/kubectl_run.md 2015-07-23 17:09:52.035130755 -0700
+++ /usr/local/google/home/xuchao/go-workspace/src/github.com/GoogleCloudPlatform/kubernetes/_tmp/docs/user-guide/kubectl/kubectl_run.md    2015-07-23 17:11:51.872489439 -0700
@@ -1,36 +1,3 @@
 ## kubectl run

 Run a particular image on the cluster.
@@ -58,8 +25,7 @@ $ kubectl run nginx --image=nginx --repl
 $ kubectl run nginx --image=nginx --dry-run

 // Start a single instance of nginx, but overload the spec of the replication controller with a partial set of values parsed from JSON.
-$ kubectl run nginx --image=nginx \
-  --overrides='{ "apiVersion": "v1", "spec": { ... } }'
+$ kubectl run nginx --image=nginx --overrides='{ "apiVersion": "v1", "spec": { ... } }'

 ### Options
@@ -110,12 +76,6 @@ $ kubectl run nginx --image=nginx \

 ### SEE ALSO
 * [kubectl](kubectl.md)     - kubectl controls the Kubernetes cluster manager

/usr/local/google/home/xuchao/go-workspace/src/github.com/GoogleCloudPlatform/kubernetes/docs/ is out of date. Please run hack/run-gendocs.sh.
If the diff shows kubectl commands split to multiple lines in kubectl's documentation, you need to manually split those commands in corresponding go files.
```

@thockin @lavalamp @nikhiljindal @bgrant0607 @mikedanese 
