### PR TITLE
Improve clarity around PodFitsResource(issue#11453)

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1568,19 +1568,19 @@ func checkHostPortConflicts(pods []*api.Pod) (fitting []*api.Pod, notFitting []*
 	return
 }
 
-// checkCapacityExceeded detects pods that exceeds node's resources.
-func (kl *Kubelet) checkCapacityExceeded(pods []*api.Pod) (fitting []*api.Pod, notFitting []*api.Pod) {
+// checkSufficientfFreeResources detects pods that exceeds node's resources.
+func (kl *Kubelet) checkSufficientfFreeResources(pods []*api.Pod) (fitting []*api.Pod, notFittingCPU, notFittingMemory []*api.Pod) {
 	info, err := kl.GetCachedMachineInfo()
 	if err != nil {
 		glog.Errorf("error getting machine info: %v", err)
-		return pods, nil
+		return pods, nil, nil
 	}
 
 	// Respect the pod creation order when resolving conflicts.
 	sort.Sort(podsByCreationTime(pods))
 
 	capacity := CapacityFromMachineInfo(info)
-	return predicates.CheckPodsExceedingCapacity(pods, capacity)
+	return predicates.CheckPodsExceedingFreeResources(pods, capacity)
 }
 
 // handleOutOfDisk detects if pods can't fit due to lack of disk space.
@@ -1673,14 +1673,22 @@ func (kl *Kubelet) handleNotFittingPods(pods []*api.Pod) []*api.Pod {
 			Reason:  reason,
 			Message: "Pod cannot be started due to node selector mismatch"})
 	}
-	fitting, notFitting = kl.checkCapacityExceeded(fitting)
-	for _, pod := range notFitting {
-		reason := "CapacityExceeded"
-		kl.recorder.Eventf(pod, reason, "Cannot start the pod due to exceeded capacity.")
+	fitting, notFittingCPU, notFittingMemory := kl.checkSufficientfFreeResources(fitting)
+	for _, pod := range notFittingCPU {
+		reason := "InsufficientFreeCPU"
+		kl.recorder.Eventf(pod, reason, "Cannot start the pod due to insufficient free CPU.")
 		kl.statusManager.SetPodStatus(pod, api.PodStatus{
 			Phase:   api.PodFailed,
 			Reason:  reason,
-			Message: "Pod cannot be started due to exceeded capacity"})
+			Message: "Pod cannot be started due to insufficient free CPU"})
+	}
+	for _, pod := range notFittingMemory {
+		reason := "InsufficientFreeMemory"
+		kl.recorder.Eventf(pod, reason, "Cannot start the pod due to insufficient free memory.")
+		kl.statusManager.SetPodStatus(pod, api.PodStatus{
+			Phase:   api.PodFailed,
+			Reason:  reason,
+			Message: "Pod cannot be started due to insufficient free memory"})
 	}
 	return fitting
 }

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -105,6 +105,8 @@ type resourceRequest struct {
 	memory   int64
 }
 
+var FailedResourceType string
+
 func getResourceRequest(pod *api.Pod) resourceRequest {
 	result := resourceRequest{}
 	for ix := range pod.Spec.Containers {
@@ -115,7 +117,7 @@ func getResourceRequest(pod *api.Pod) resourceRequest {
 	return result
 }
 
-func CheckPodsExceedingCapacity(pods []*api.Pod, capacity api.ResourceList) (fitting []*api.Pod, notFitting []*api.Pod) {
+func CheckPodsExceedingFreeResources(pods []*api.Pod, capacity api.ResourceList) (fitting []*api.Pod, notFittingCPU, notFittingMemory []*api.Pod) {
 	totalMilliCPU := capacity.Cpu().MilliValue()
 	totalMemory := capacity.Memory().Value()
 	milliCPURequested := int64(0)
@@ -124,9 +126,14 @@ func CheckPodsExceedingCapacity(pods []*api.Pod, capacity api.ResourceList) (fit
 		podRequest := getResourceRequest(pod)
 		fitsCPU := totalMilliCPU == 0 || (totalMilliCPU-milliCPURequested) >= podRequest.milliCPU
 		fitsMemory := totalMemory == 0 || (totalMemory-memoryRequested) >= podRequest.memory
-		if !fitsCPU || !fitsMemory {
-			// the pod doesn't fit
-			notFitting = append(notFitting, pod)
+		if !fitsCPU {
+			// the pod doesn't fit due to CPU limit
+			notFittingCPU = append(notFittingCPU, pod)
+			continue
+		}
+		if !fitsMemory {
+			// the pod doesn't fit due to Memory limit
+			notFittingMemory = append(notFittingMemory, pod)
 			continue
 		}
 		// the pod fits
@@ -150,9 +157,20 @@ func (r *ResourceFit) PodFitsResources(pod *api.Pod, existingPods []*api.Pod, no
 	pods := []*api.Pod{}
 	copy(pods, existingPods)
 	pods = append(existingPods, pod)
-	_, exceeding := CheckPodsExceedingCapacity(pods, info.Status.Capacity)
-	if len(exceeding) > 0 || int64(len(pods)) > info.Status.Capacity.Pods().Value() {
+	_, exceedingCPU, exceedingMemory := CheckPodsExceedingFreeResources(pods, info.Status.Capacity)
+	if int64(len(pods)) > info.Status.Capacity.Pods().Value() {
 		glog.V(4).Infof("Cannot schedule Pod %v, because Node %v is full, running %v out of %v Pods.", pod, node, len(pods)-1, info.Status.Capacity.Pods().Value())
+		FailedResourceType = "PodExceedsMaxPodNumber"
+		return false, nil
+	}
+	if len(exceedingCPU) > 0 {
+		glog.V(4).Infof("Cannot schedule Pod %v, because Node does not have sufficient CPU", pod)
+		FailedResourceType = "PodExceedsFreeCPU"
+		return false, nil
+	}
+	if len(exceedingMemory) > 0 {
+		glog.V(4).Infof("Cannot schedule Pod %v, because Node does not have sufficient Memory", pod)
+		FailedResourceType = "PodExceedsFreeMemory"
 		return false, nil
 	}
 	glog.V(4).Infof("Schedule Pod %v on Node %v is allowed, Node is running only %v out of %v Pods.", pod, node, len(pods)-1, info.Status.Capacity.Pods().Value())

--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -116,6 +116,7 @@ func findNodesThatFit(pod *api.Pod, podLister algorithm.PodLister, predicateFunc
 	for _, node := range nodes.Items {
 		fits := true
 		for name, predicate := range predicateFuncs {
+			predicates.FailedResourceType = ""
 			fit, err := predicate(pod, machineToPods[node.Name], node.Name)
 			if err != nil {
 				return api.NodeList{}, FailedPredicateMap{}, err
@@ -124,6 +125,10 @@ func findNodesThatFit(pod *api.Pod, podLister algorithm.PodLister, predicateFunc
 				fits = false
 				if _, found := failedPredicateMap[node.Name]; !found {
 					failedPredicateMap[node.Name] = util.StringSet{}
+				}
+				if predicates.FailedResourceType != "" {
+					failedPredicateMap[node.Name].Insert(predicates.FailedResourceType)
+					break
 				}
 				failedPredicateMap[node.Name].Insert(name)
 				break


### PR DESCRIPTION
@bprashanth @davidopp 

Related issue: https://github.com/GoogleCloudPlatform/kubernetes/issues/11453

Improve clarity around PodFitsResource by showing pods limits in `kubectl describe node`

There are two suggestions in the original PR:
1. Show what resource failed in the scheduler event
2. Show each pods limits in describe node output

"1. Show what resource failed in the scheduler event" is not implemented in this PR and the reason is given below, any suggestion is welcome:)

This PR implements "2. Show each pods limits in describe node output".  The output, for example, looks like:

```
Name:           127.0.0.1
Labels:         kubernetes.io/hostname=127.0.0.1
CreationTimestamp:  Thu, 23 Jul 2015 10:37:25 +0000
Conditions:
  Type      Status  LastHeartbeatTime           LastTransitionTime          Reason                  Message
  Ready     True    Thu, 23 Jul 2015 10:59:37 +0000     Thu, 23 Jul 2015 10:37:25 +0000     kubelet is posting ready status     
Addresses:  127.0.0.1
Capacity:
 cpu:       4
 memory:    8176512Ki
 pods:      40
Version:
 Kernel Version:        3.13.0-46-generic
 OS Image:          Ubuntu precise (12.04.4 LTS)
 Container Runtime Version: docker://1.6.0
 Kubelet Version:       v1.0.0-557-g5bb5d4ee321aea-dirty
 Kube-Proxy Version:        v1.0.0-557-g5bb5d4ee321aea-dirty
ExternalID:         127.0.0.1
Pods:               (2 in total)
  Namespace         Name    CPU-limit(milliCPU) Memory-limit(bytes)
  default           apache1 1000            8000000
  default           apache2 1000            8000000
TotoalResourceLimits:
  CPU-limit(milliCPU):  2000 (50% of total)
  Memory-limit(bytes):  16000000 (0% of total)
Events:
  FirstSeen             LastSeen            Count   From            SubobjectPath   Reason      Message
  Thu, 23 Jul 2015 10:37:25 +0000   Thu, 23 Jul 2015 10:37:25 +0000 1   {kubelet 127.0.0.1}         starting    Starting kubelet.
  Thu, 23 Jul 2015 10:37:25 +0000   Thu, 23 Jul 2015 10:37:25 +0000 1   {kubelet 127.0.0.1}         NodeReady   Node 127.0.0.1 status is now: NodeReady
```

Please comment if you have any suggestions.

**Why not showing failed resource in this PR**:

I have tried to implement "1. Show what resource failed in the scheduler event", however, it seems to me that showing failed resource would require much modification in the source code. 
- The PodFitsResources verifies both CPU and Memory together in `func CheckPodsExceedingCapacity()`(https://github.com/GoogleCloudPlatform/kubernetes/blob/master/plugin/pkg/scheduler/algorithm/predicates/predicates.go#L118).
- The return value of `PodFitsResources` is either (`true`, nil) or (`false`, nil) after calling `func CheckPodsExceedingCapacity()`, so it is quite difficult to pass any specific resource type.
- Based on the facts above, I think specifying failed resource would result in many modifications (for instance, [1]add one more output for `PodFitsResources` and handles it OR, [2]verify CPU and Memory separately in two functions) which is a huge cost. Maybe just showing enough details in `kubectl describe node` is enough for a user to find out which resource failed for the Pod.

These are just my personal opinions, and it is quite possible that there is a good solution which I failed to find. So please feel free to share you ideas in the comments.

Regards,

Haiyang DING
