### PR TITLE
Set the right master port to kube-proxy in libvirt-coreos.

### DIFF
--- a/cluster/libvirt-coreos/user_data_minion.yml
+++ b/cluster/libvirt-coreos/user_data_minion.yml
@@ -37,7 +37,7 @@ coreos:
 
         [Service]
         ExecStart=/opt/kubernetes/bin/kube-proxy \
-        --master=http://${MASTER_IP}:7080
+        --master=http://${MASTER_IP}:8080
         Restart=always
         RestartSec=2
 


### PR DESCRIPTION
The currently specified port is the old 7080 read-only-port. As the
libvirt-coreos doesn't configure security, change it to the insecure-port 8080.
