### PR TITLE
Avoid error 4, wait while iptables xtables is busy

### DIFF
--- a/pkg/kubelet/container_bridge.go
+++ b/pkg/kubelet/container_bridge.go
@@ -121,13 +121,13 @@ func cbr0CidrCorrect(wantCIDR *net.IPNet) bool {
 // TODO(dawnchen): Using pkg/util/iptables
 func ensureIPTablesMasqRule() error {
 	// Check if the MASQUERADE rule exist or not
-	if err := exec.Command("iptables", "-t", "nat", "-C", "POSTROUTING", "-o", "eth0", "-j", "MASQUERADE", "!", "-d", "10.0.0.0/8").Run(); err == nil {
+	if err := exec.Command("iptables", "-t", "nat", "-C", "POSTROUTING", "-o", "eth0", "-j", "MASQUERADE", "!", "-d", "10.0.0.0/8", "-w").Run(); err == nil {
 		// The MASQUERADE rule exists
 		return nil
 	}
 
 	glog.Infof("MASQUERADE rule doesn't exist, recreate it")
-	if err := exec.Command("iptables", "-t", "nat", "-A", "POSTROUTING", "-o", "eth0", "-j", "MASQUERADE", "!", "-d", "10.0.0.0/8").Run(); err != nil {
+	if err := exec.Command("iptables", "-t", "nat", "-A", "POSTROUTING", "-o", "eth0", "-j", "MASQUERADE", "!", "-d", "10.0.0.0/8", "-w").Run(); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Without waiting for iptable xtables lock release a race could begin between kube-proxy & kubelet on access to this file.
Without this parameter, it lead to a new postrouting rule creation. I suspect that all duplicated rules massively slow down the kube-proxy daemon.

Checked on > 150 svc - 11 nodes.
