### PR TITLE
Make possible to reuse the e2e framework client and namespace

### DIFF
--- a/test/e2e/autoscaling.go
+++ b/test/e2e/autoscaling.go
@@ -25,7 +25,7 @@ import (
 )
 
 var _ = Describe("Autoscaling", func() {
-	f := NewFramework("autoscaling")
+	f := NewFramework("autoscaling", false)
 
 	BeforeEach(func() {
 		// Ensure cluster size is equal to 1.

--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -196,7 +196,9 @@ var _ = Describe("Skipped", func() {
 		svcName, replicas := "baz", 2
 		var rcName, ip, v string
 		var ingress api.LoadBalancerIngress
-		f := Framework{BaseName: "cluster-upgrade"}
+		f := Framework{BaseName: "cluster-upgrade",
+			Reuse: false,
+		}
 		var w *WebserverTest
 
 		BeforeEach(func() {

--- a/test/e2e/container_probe.go
+++ b/test/e2e/container_probe.go
@@ -29,7 +29,9 @@ import (
 )
 
 var _ = Describe("Probing container", func() {
-	framework := Framework{BaseName: "container-probe"}
+	framework := Framework{BaseName: "container-probe",
+		Reuse: false,
+	}
 	var podClient client.PodInterface
 	probe := webserverProbeBuilder{}
 

--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -182,7 +182,7 @@ func validateDNSResults(f *Framework, pod *api.Pod, fileNames []string) {
 }
 
 var _ = Describe("DNS", func() {
-	f := NewFramework("dns")
+	f := NewFramework("dns", false)
 
 	It("should provide DNS for the cluster", func() {
 		// TODO: support DNS on vagrant #3580

--- a/test/e2e/downward_api.go
+++ b/test/e2e/downward_api.go
@@ -26,7 +26,7 @@ import (
 )
 
 var _ = Describe("Downward API", func() {
-	framework := NewFramework("downward-api")
+	framework := NewFramework("downward-api", false)
 
 	It("should provide pod name and namespace as env vars", func() {
 		podName := "downward-api-" + string(util.NewUUID())

--- a/test/e2e/empty_dir.go
+++ b/test/e2e/empty_dir.go
@@ -28,7 +28,7 @@ import (
 )
 
 var _ = Describe("EmptyDir volumes", func() {
-	f := NewFramework("emptydir")
+	f := NewFramework("emptydir", false)
 
 	It("should have the correct mode", func() {
 		volumePath := "/test-volume"

--- a/test/e2e/es_cluster_logging.go
+++ b/test/e2e/es_cluster_logging.go
@@ -32,7 +32,7 @@ import (
 )
 
 var _ = Describe("Cluster level logging using Elasticsearch", func() {
-	f := NewFramework("es-logging")
+	f := NewFramework("es-logging", false)
 
 	BeforeEach(func() {
 		// TODO: For now assume we are only testing cluster logging with Elasticsearch

--- a/test/e2e/etcd_failure.go
+++ b/test/e2e/etcd_failure.go
@@ -31,7 +31,9 @@ import (
 var _ = Describe("Etcd failure", func() {
 
 	var skipped bool
-	framework := Framework{BaseName: "etcd-failure"}
+	framework := Framework{BaseName: "etcd-failure",
+		Reuse: false,
+	}
 
 	BeforeEach(func() {
 		// This test requires:

--- a/test/e2e/events.go
+++ b/test/e2e/events.go
@@ -32,7 +32,7 @@ import (
 )
 
 var _ = Describe("Events", func() {
-	framework := NewFramework("events")
+	framework := NewFramework("events", false)
 
 	It("should be sent by kubelets and the scheduler about pods scheduling and running", func() {
 

--- a/test/e2e/expansion.go
+++ b/test/e2e/expansion.go
@@ -24,7 +24,7 @@ import (
 )
 
 var _ = Describe("Variable Expansion", func() {
-	framework := NewFramework("var-expansion")
+	framework := NewFramework("var-expansion", false)
 
 	It("should allow composing env vars into new env vars", func() {
 		podName := "var-expansion-" + string(util.NewUUID())

--- a/test/e2e/kibana_logging.go
+++ b/test/e2e/kibana_logging.go
@@ -28,7 +28,7 @@ import (
 )
 
 var _ = Describe("Kibana Logging Instances Is Alive", func() {
-	f := NewFramework("kibana-logging")
+	f := NewFramework("kibana-logging", false)
 
 	BeforeEach(func() {
 		// TODO: For now assume we are only testing cluster logging with Elasticsearch

--- a/test/e2e/kube-ui.go
+++ b/test/e2e/kube-ui.go
@@ -36,7 +36,7 @@ var _ = Describe("kube-ui", func() {
 		serverStartTimeout = 1 * time.Minute
 	)
 
-	f := NewFramework("kube-ui")
+	f := NewFramework("kube-ui", false)
 
 	It("should check that the kube-ui instance is alive", func() {
 		By("Checking the kube-ui service exists.")

--- a/test/e2e/kubelet.go
+++ b/test/e2e/kubelet.go
@@ -90,7 +90,7 @@ func waitTillNPodsRunningOnNodes(c *client.Client, nodeNames util.StringSet, pod
 var _ = Describe("Clean up pods on node", func() {
 	var numNodes int
 	var nodeNames util.StringSet
-	framework := NewFramework("kubelet-delete")
+	framework := NewFramework("kubelet-delete", false)
 
 	BeforeEach(func() {
 		nodes, err := framework.Client.Nodes().List(labels.Everything(), fields.Everything())

--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -32,7 +32,7 @@ import (
 )
 
 var _ = Describe("Networking", func() {
-	f := NewFramework("nettest")
+	f := NewFramework("nettest", false)
 
 	var svcname = "nettest"
 

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -41,7 +41,7 @@ var _ = Describe("Pod Disks", func() {
 		host0Name string
 		host1Name string
 	)
-	framework := NewFramework("pod-disks")
+	framework := NewFramework("pod-disks", false)
 
 	BeforeEach(func() {
 		SkipUnlessNodeCountIsAtLeast(2)

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -116,7 +116,7 @@ func testHostIP(c *client.Client, ns string, pod *api.Pod) {
 }
 
 var _ = Describe("Pods", func() {
-	framework := NewFramework("pods")
+	framework := NewFramework("pods", false)
 
 	PIt("should get a host IP", func() {
 		name := "pod-hostip-" + string(util.NewUUID())

--- a/test/e2e/pre_stop.go
+++ b/test/e2e/pre_stop.go
@@ -142,7 +142,7 @@ func testPreStop(c *client.Client, ns string) {
 }
 
 var _ = Describe("PreStop", func() {
-	f := NewFramework("prestop")
+	f := NewFramework("prestop", false)
 
 	It("should call prestop when killing a pod", func() {
 		testPreStop(f.Client, f.Namespace.Name)

--- a/test/e2e/proxy.go
+++ b/test/e2e/proxy.go
@@ -49,7 +49,7 @@ const (
 )
 
 func proxyContext(version string) {
-	f := NewFramework("proxy")
+	f := NewFramework("proxy", false)
 	prefix := "/api/" + version
 
 	It("should proxy logs on node with explicit kubelet port", func() { nodeProxyTest(f, version, ":10250/logs/") })

--- a/test/e2e/rc.go
+++ b/test/e2e/rc.go
@@ -33,7 +33,7 @@ import (
 )
 
 var _ = Describe("ReplicationController", func() {
-	framework := NewFramework("replication-controller")
+	framework := NewFramework("replication-controller", false)
 
 	It("should serve a basic image on each replica with a public image", func() {
 		ServeImageOrFail(framework, "basic", "gcr.io/google_containers/serve_hostname:1.1")

--- a/test/e2e/secrets.go
+++ b/test/e2e/secrets.go
@@ -26,7 +26,7 @@ import (
 )
 
 var _ = Describe("Secrets", func() {
-	f := NewFramework("secrets")
+	f := NewFramework("secrets", false)
 
 	It("should be consumable from pods", func() {
 		name := "secret-test-" + string(util.NewUUID())

--- a/test/e2e/service_accounts.go
+++ b/test/e2e/service_accounts.go
@@ -32,7 +32,7 @@ import (
 )
 
 var _ = Describe("ServiceAccounts", func() {
-	f := NewFramework("svcaccounts")
+	f := NewFramework("svcaccounts", false)
 
 	It("should mount an API token into pods", func() {
 		var tokenName string

--- a/test/e2e/service_latency.go
+++ b/test/e2e/service_latency.go
@@ -41,7 +41,7 @@ func (d durations) Less(i, j int) bool { return d[i] < d[j] }
 func (d durations) Swap(i, j int)      { d[i], d[j] = d[j], d[i] }
 
 var _ = Describe("Service endpoints latency", func() {
-	f := NewFramework("svc-latency")
+	f := NewFramework("svc-latency", false)
 
 	It("should not be very high", func() {
 		const (


### PR DESCRIPTION
Currently there is no clean possibility to share the framework Client and Namespace between specs that share the same Namespace.
Adding `Reuse` field to the `Framework` structure, which will indicate whether the client and Namespace shall be reused in following specs.
Also adding `ToggleReuse` method for negating the `Reuse` value, when following don't want to reuse the Client and Namespace and vice versa.
