### PR TITLE
Reuse round tripper for identical TLS configurations

### DIFF
--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -117,6 +117,16 @@ func TLSConfigFor(config *Config) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
+// tlsConfigKey returns a unique key for tls.Config objects returned from TLSConfigFor
+func tlsConfigKey(config *Config) (string, error) {
+	// Make sure ca/key/cert content is loaded
+	if err := LoadTLSFiles(config); err != nil {
+		return "", err
+	}
+	// Only include the things that actually affect the tls.Config
+	return fmt.Sprintf("%v/%x/%x/%x", config.Insecure, config.CAData, config.CertData, config.KeyData), nil
+}
+
 // LoadTLSFiles copies the data from the CertFile, KeyFile, and CAFile fields into the CertData,
 // KeyData, and CAFile fields, or returns an error. If no error is returned, all three fields are
 // either populated or were empty to start.

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -20,6 +20,8 @@ import (
 	"encoding/base64"
 	"net/http"
 	"testing"
+
+	"k8s.io/kubernetes/pkg/api/latest"
 )
 
 func TestUnsecuredTLSTransport(t *testing.T) {
@@ -97,5 +99,76 @@ func TestUserAgentRoundTripper(t *testing.T) {
 	}
 	if rt.Request.Header.Get("User-Agent") != "test" {
 		t.Errorf("unexpected user agent header: %#v", rt.Request)
+	}
+}
+
+func TestTLSConfigKey(t *testing.T) {
+	// Make sure config fields that don't affect the tls config don't affect the cache key
+	identicalConfigurations := map[string]*Config{
+		"empty":          {},
+		"host":           {Host: "foo"},
+		"prefix":         {Prefix: "foo"},
+		"version":        {Version: "foo"},
+		"codec":          {Codec: latest.Codec},
+		"basic":          {Username: "bob", Password: "password"},
+		"bearer":         {BearerToken: "token"},
+		"user agent":     {UserAgent: "useragent"},
+		"transport":      {Transport: http.DefaultTransport},
+		"wrap transport": {WrapTransport: func(http.RoundTripper) http.RoundTripper { return nil }},
+		"qps/burst":      {QPS: 1.0, Burst: 10},
+	}
+	for nameA, valueA := range identicalConfigurations {
+		for nameB, valueB := range identicalConfigurations {
+			keyA, err := tlsConfigKey(valueA)
+			if err != nil {
+				t.Errorf("Unexpected error for %q: %v", nameA, err)
+				continue
+			}
+			keyB, err := tlsConfigKey(valueB)
+			if err != nil {
+				t.Errorf("Unexpected error for %q: %v", nameB, err)
+				continue
+			}
+			if keyA != keyB {
+				t.Errorf("Expected identical cache keys for %q and %q, got:\n\t%s\n\t%s", nameA, nameB, keyA, keyB)
+				continue
+			}
+		}
+	}
+
+	// Make sure config fields that affect the tls config affect the cache key
+	uniqueConfigurations := map[string]*Config{
+		"no tls":                  {},
+		"insecure":                {Insecure: true},
+		"cadata 1":                {TLSClientConfig: TLSClientConfig{CAData: []byte{1}}},
+		"cadata 2":                {TLSClientConfig: TLSClientConfig{CAData: []byte{2}}},
+		"cert 1, key 1":           {TLSClientConfig: TLSClientConfig{CertData: []byte{1}, KeyData: []byte{1}}},
+		"cert 1, key 2":           {TLSClientConfig: TLSClientConfig{CertData: []byte{1}, KeyData: []byte{2}}},
+		"cert 2, key 1":           {TLSClientConfig: TLSClientConfig{CertData: []byte{2}, KeyData: []byte{1}}},
+		"cert 2, key 2":           {TLSClientConfig: TLSClientConfig{CertData: []byte{2}, KeyData: []byte{2}}},
+		"cadata 1, cert 1, key 1": {TLSClientConfig: TLSClientConfig{CAData: []byte{1}, CertData: []byte{1}, KeyData: []byte{1}}},
+	}
+	for nameA, valueA := range uniqueConfigurations {
+		for nameB, valueB := range uniqueConfigurations {
+			// Don't compare to ourselves
+			if nameA == nameB {
+				continue
+			}
+
+			keyA, err := tlsConfigKey(valueA)
+			if err != nil {
+				t.Errorf("Unexpected error for %q: %v", nameA, err)
+				continue
+			}
+			keyB, err := tlsConfigKey(valueB)
+			if err != nil {
+				t.Errorf("Unexpected error for %q: %v", nameB, err)
+				continue
+			}
+			if keyA == keyB {
+				t.Errorf("Expected unique cache keys for %q and %q, got:\n\t%s\n\t%s", nameA, nameB, keyA, keyB)
+				continue
+			}
+		}
 	}
 }


### PR DESCRIPTION
It is possible to "leak" idle connections when part of the system repeatedly constructs clients for short-term use (we do this in OpenShift to make API calls on behalf of a user by building a new client using their provided authorization token). The connections are in the `http.Transport` idle pool, which holds connections open until the server times out. The options I see to improve this are:
1. Set `Transport.DisableKeepAlives=true` when setting up the transport (bad for places where we want to make several requests before discarding the client, which is pretty much everywhere)
2. Call `Transport.CloseIdleConnections` after we're done with a client (hard to plumb through access after the transport has been wrapped 4-5 times (for debugging, custom wrapping, bearer/basic auth, and user agent header-setting), sometimes hard to know when we're done with a client
3. Avoid constructing lots of identical `http.Transport` objects. If lots of clients are built with different TLS options, we can still see growth, but this will drastically help the "client per use" case

This PR implements option 3 by building a key around all the unique inputs to the constructed transport. Ideally, a combination of 2 and 3 would be possible, but if we start collecting the constructed `http.Transport` objects in one place, that gives us a potential way to sweep them and call `CloseIdleConnections` occasionally.
