### PR TITLE
Fix resource aliasing test flake

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -747,10 +747,10 @@ __EOF__
   #####################
 
   kube::log::status "Testing resource aliasing"
-  kubectl create -f examples/cassandra/cassandra.yaml "${kube_flags[@]}"
   kubectl create -f examples/cassandra/cassandra-controller.yaml "${kube_flags[@]}"
+  kubectl scale rc cassandra --replicas=1 "${kube_flags[@]}"
   kubectl create -f examples/cassandra/cassandra-service.yaml "${kube_flags[@]}"
-  kube::test::get_object_assert "all -l'name=cassandra'" "{{range.items}}{{$id_field}}:{{end}}" 'cassandra:cassandra:cassandra:'
+  kube::test::get_object_assert "all -l'name=cassandra'" "{{range.items}}{{range .metadata.labels}}{{.}}:{{end}}{{end}}" 'cassandra:cassandra:cassandra:'
   kubectl delete all -l name=cassandra "${kube_flags[@]}"
 
 


### PR DESCRIPTION
Observed in https://app.shippable.com/builds/55b1f044bf65f60b0014e532

Creating a pod just before an rc and expecting only 1 pod at the end is racy, because the rc manager might see the rc via watch before it sees the pod (in fact it probably will because the apiserver has to filter through N entries before sending it down a watch, and N is much smaller for rcs than pods). To do this safely we should just allow the rc to create the pod, and check resource labels instead of names at the end.
