### PR TITLE
Ansible: Fix for master ip variable in make_ca_cert.sh

### DIFF
--- a/contrib/ansible/roles/kubernetes/files/make-ca-cert.sh
+++ b/contrib/ansible/roles/kubernetes/files/make-ca-cert.sh
@@ -28,7 +28,7 @@ set -o pipefail
 # CERT_DIR - where to place the finished certs
 # CERT_GROUP - who the group owner of the cert files should be
 
-cert_ip="${MASTER_IP:="${1}"}"
+cert_ip="${1:-$MASTER_IP}"
 master_name="${MASTER_NAME:="kubernetes"}"
 service_range="${SERVICE_CLUSTER_IP_RANGE:="10.0.0.0/16"}"
 dns_domain="${DNS_DOMAIN:="cluster.local"}"


### PR DESCRIPTION
Default arg is not escaped properly. This change also changes the fact that now the first argument takes president over the ENV var.
