### PR TITLE
Add a Hostname field to the EndpointAddress object.

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -10847,12 +10847,17 @@
    "v1.EndpointAddress": {
     "id": "v1.EndpointAddress",
     "required": [
-     "ip"
+     "ip",
+     "hostname"
     ],
     "properties": {
      "ip": {
       "type": "string",
       "description": "IP address of the endpoint"
+     },
+     "hostname": {
+      "type": "string",
+      "description": "Hostname for this endpoint"
      },
      "targetRef": {
       "$ref": "v1.ObjectReference",

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -307,6 +307,7 @@ func deepCopy_api_EmptyDirVolumeSource(in EmptyDirVolumeSource, out *EmptyDirVol
 
 func deepCopy_api_EndpointAddress(in EndpointAddress, out *EndpointAddress, c *conversion.Cloner) error {
 	out.IP = in.IP
+	out.Hostname = in.Hostname
 	if in.TargetRef != nil {
 		out.TargetRef = new(ObjectReference)
 		if err := deepCopy_api_ObjectReference(*in.TargetRef, out.TargetRef, c); err != nil {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1245,14 +1245,16 @@ type EndpointSubset struct {
 	Ports     []EndpointPort
 }
 
-// EndpointAddress is a tuple that describes single IP address.
+// EndpointAddress is a tuple that describes single endpoint address.
 type EndpointAddress struct {
-	// The IP of this endpoint.
-	// TODO: This should allow hostname or IP, see #4447.
-	IP string
+	// The IP of this endpoint, mutually exclusive with Hostname
+	IP string `json:"ip" description:"IP address of the endpoint"`
+
+	// Hostname for this endpoint, you can specify IP or Hostname, but not both.
+	Hostname string `json:"hostname" description:"Hostname for this endpoint"`
 
 	// Optional: The kubernetes object related to the entry point.
-	TargetRef *ObjectReference
+	TargetRef *ObjectReference `json:"targetRef,omitempty" description:"reference to object providing the endpoint"`
 }
 
 // EndpointPort is a tuple that describes a single port.

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -352,6 +352,7 @@ func convert_api_EndpointAddress_To_v1_EndpointAddress(in *api.EndpointAddress, 
 		defaulting.(func(*api.EndpointAddress))(in)
 	}
 	out.IP = in.IP
+	out.Hostname = in.Hostname
 	if in.TargetRef != nil {
 		out.TargetRef = new(ObjectReference)
 		if err := convert_api_ObjectReference_To_v1_ObjectReference(in.TargetRef, out.TargetRef, s); err != nil {
@@ -2602,6 +2603,7 @@ func convert_v1_EndpointAddress_To_api_EndpointAddress(in *EndpointAddress, out 
 		defaulting.(func(*EndpointAddress))(in)
 	}
 	out.IP = in.IP
+	out.Hostname = in.Hostname
 	if in.TargetRef != nil {
 		out.TargetRef = new(api.ObjectReference)
 		if err := convert_v1_ObjectReference_To_api_ObjectReference(in.TargetRef, out.TargetRef, s); err != nil {

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -320,6 +320,7 @@ func deepCopy_v1_EmptyDirVolumeSource(in EmptyDirVolumeSource, out *EmptyDirVolu
 
 func deepCopy_v1_EndpointAddress(in EndpointAddress, out *EndpointAddress, c *conversion.Cloner) error {
 	out.IP = in.IP
+	out.Hostname = in.Hostname
 	if in.TargetRef != nil {
 		out.TargetRef = new(ObjectReference)
 		if err := deepCopy_v1_ObjectReference(*in.TargetRef, out.TargetRef, c); err != nil {

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1217,11 +1217,13 @@ type EndpointSubset struct {
 	Ports     []EndpointPort    `json:"ports,omitempty" description:"port numbers available on the related IP addresses"`
 }
 
-// EndpointAddress is a tuple that describes single IP address.
+// EndpointAddress is a tuple that describes single endpoint address.
 type EndpointAddress struct {
-	// The IP of this endpoint.
-	// TODO: This should allow hostname or IP, see #4447.
+	// The IP of this endpoint, mutually exclusive with Hostname
 	IP string `json:"ip" description:"IP address of the endpoint"`
+
+	// Hostname for this endpoint, you can specify IP or Hostname, but not both.
+	Hostname string `json:"hostname" description:"Hostname for this endpoint"`
 
 	// Optional: The kubernetes object related to the entry point.
 	TargetRef *ObjectReference `json:"targetRef,omitempty" description:"reference to object providing the endpoint"`


### PR DESCRIPTION
This will be used for DNS CName services, and also using DNS to lookup addresses for Headless services.

Related to #4447

@thockin @bgrant0607 @lavalamp 
