### PR TITLE
Fix typo in service account documentation

### DIFF
--- a/docs/user-guide/service-accounts.md
+++ b/docs/user-guide/service-accounts.md
@@ -82,13 +82,13 @@ metadata:
   name: build-robot
 EOF
 $ kubectl create -f /tmp/serviceaccount.json
-serviceacccounts/build-robot
+serviceaccounts/build-robot
 ```
 
 If you get a complete dump of the service account object, like this:
 
 ```console
-$ kubectl get serviceacccounts/build-robot -o yaml
+$ kubectl get serviceaccounts/build-robot -o yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
Extra "c" in "serviceaccounts" made example not work when copy-pasting.
