### PR TITLE
Allocating CIDRs for Pods works without a cloud provider.

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -202,12 +202,14 @@ func (s *CMServer) Run(_ []string) error {
 	}
 
 	if s.AllocateNodeCIDRs {
-		routes, ok := cloud.Routes()
-		if !ok {
-			glog.Fatal("Cloud provider must support routes if allocate-node-cidrs is set")
+		if cloud == nil {
+			glog.Warning("allocate-node-cidrs is set, but no cloud provider specified. Will not manage routes.")
+		} else if routes, ok := cloud.Routes(); !ok {
+			glog.Warning("allocate-node-cidrs is set, but cloud provider does not support routes. Will not manage routes.")
+		} else {
+			routeController := routecontroller.New(routes, kubeClient, s.ClusterName, (*net.IPNet)(&s.ClusterCIDR))
+			routeController.Run(s.NodeSyncPeriod)
 		}
-		routeController := routecontroller.New(routes, kubeClient, s.ClusterName, (*net.IPNet)(&s.ClusterCIDR))
-		routeController.Run(s.NodeSyncPeriod)
 	}
 
 	resourceQuotaManager := resourcequota.NewResourceQuotaManager(kubeClient)


### PR DESCRIPTION
Currently setting the `--allocate-node-cidrs` flag to true with an
empty cloud provider causes the kube-controller-manager to crash during
startup.

Fix the issue by checking for an empty cloud provider before setting
up route management on the cloud provider. This change introduces a
change in behavior. The kube-controller-manager now supports allocating
pod CIDRs without a cloud provider. This means users must manage routes
through some other mechanism.

The controller manager logs a warning if `--allocate-node-cidrs` is set,
but not a cloud provider:

```
I0725 17:10:41.587888   43185 plugins.go:70] No cloud provider specified.
I0725 17:10:41.588036   43185 nodecontroller.go:114] Sending events to api server.
E0725 17:10:41.588122   43185 controllermanager.go:201] Failed to start service controller: ServiceController should not be run without a cloudprovider.
W0725 17:10:41.588136   43185 controllermanager.go:213] allocate-node-cidrs is set, but no cloud provider specified. Will not manage routes.
E0725 17:10:41.589703   43185 nodecontroller.go:187] Error monitoring node status: Get http://127.0.0.1:8080/api/v1/nodes: dial tcp 127.0.0.1
```

Fixes #11866
