### PR TITLE
Add a resync period for services in the service controller

### DIFF
--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -119,6 +119,7 @@ func runScheduler(cl *client.Client) {
 
 // RunControllerManager starts a controller
 func runControllerManager(cl *client.Client) {
+	const serviceSyncPeriod = 5 * time.Minute
 	const nodeSyncPeriod = 10 * time.Second
 	nodeController := nodecontroller.NewNodeController(
 		nil, cl, 10, 5*time.Minute, nodecontroller.NewPodEvictor(util.NewTokenBucketRateLimiter(*deletingPodsQps, *deletingPodsBurst)),
@@ -126,7 +127,7 @@ func runControllerManager(cl *client.Client) {
 	nodeController.Run(nodeSyncPeriod)
 
 	serviceController := servicecontroller.New(nil, cl, "kubernetes")
-	if err := serviceController.Run(nodeSyncPeriod); err != nil {
+	if err := serviceController.Run(serviceSyncPeriod, nodeSyncPeriod); err != nil {
 		glog.Warningf("Running without a service controller: %v", err)
 	}
 

--- a/contrib/mesos/pkg/controllermanager/controllermanager.go
+++ b/contrib/mesos/pkg/controllermanager/controllermanager.go
@@ -128,7 +128,7 @@ func (s *CMServer) Run(_ []string) error {
 	nodeController.Run(s.NodeSyncPeriod)
 
 	serviceController := servicecontroller.New(cloud, kubeClient, s.ClusterName)
-	if err := serviceController.Run(s.NodeSyncPeriod); err != nil {
+	if err := serviceController.Run(s.ServiceSyncPeriod, s.NodeSyncPeriod); err != nil {
 		glog.Errorf("Failed to start service controller: %v", err)
 	}
 


### PR DESCRIPTION
This should ensure all load balancers get deleted even if a reordering of
watch events causes us to strand one after its service has been deleted,
because the sync will notice that the service controller's cache has a
service in it that no longer exists in the apiserver.

It could still leak in the case that the controller manager is killed
between when it leaks something and the sync runs, but this should
improve things.

Improves the situation on #9382, but doesn't truly fix it.
