### PR TITLE
Vagrant passes conformance tests at HEAD

### DIFF
--- a/docs/getting-started-guides/README.md
+++ b/docs/getting-started-guides/README.md
@@ -134,7 +134,7 @@ Here are all the solutions mentioned above in table form.
 IaaS Provider        | Config. Mgmt | OS     | Networking  | Docs                                              | Conforms | Support Level
 -------------------- | ------------ | ------ | ----------  | ---------------------------------------------     | ---------| ----------------------------
 GKE                  |              |        | GCE         | [docs](https://cloud.google.com/container-engine) |          | Commercial
-Vagrant              | Saltstack    | Fedora | OVS         | [docs](vagrant.md)                                |          | Project
+Vagrant              | Saltstack    | Fedora | OVS         | [docs](vagrant.md)                                | [✓][2]   | Project
 GCE                  | Saltstack    | Debian | GCE         | [docs](gce.md)                                    | [✓][1]   | Project
 Azure                | CoreOS       | CoreOS | Weave       | [docs](coreos/azure/README.md)                    |          | Community ([@errordeveloper](https://github.com/errordeveloper), [@squillace](https://github.com/squillace), [@chanezon](https://github.com/chanezon), [@crossorigin](https://github.com/crossorigin))
 Docker Single Node   | custom       | N/A    | local       | [docs](docker.md)                                 |          | Project (@brendandburns)
@@ -189,6 +189,8 @@ Definition of columns:
 <!-- reference style links below here -->
 <!-- GCE conformance test result -->
 [1]: https://gist.github.com/erictune/4cabc010906afbcc5061
+<!-- Vagrant conformance test result -->
+[2]: https://gist.github.com/derekwaynecarr/505e56036cdf010bf6b6
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -231,6 +231,8 @@ var _ = Describe("Services", func() {
 	})
 
 	It("should be able to up and down services", func() {
+		// this test uses NodeSSHHosts that does not work if a Node only reports LegacyHostIP
+		SkipUnlessProviderIs("gce", "gke", "aws")
 		ns := namespaces[0]
 		numPods, servicePort := 3, 80
 


### PR DESCRIPTION
@erictune - ran conformance tests at HEAD and updated the tick mark which passes after the update to the one test in service.go which requires `Node.ExternalIP` to function.

Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/9681
