### PR TITLE
Removed obsolete argument 'cloud_provider'. Otherwise service failed …

### DIFF
--- a/cluster/rackspace/cloud-config/master-cloud-config.yaml
+++ b/cluster/rackspace/cloud-config/master-cloud-config.yaml
@@ -87,7 +87,6 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /var/lib/kube-apiserver
         ExecStart=/opt/bin/kube-apiserver \
         --address=127.0.0.1 \
-        --cloud_provider=rackspace \
         --cloud_config=/etc/cloud.conf \
         --etcd_servers=http://127.0.0.1:4001 \
         --logtostderr=true \


### PR DESCRIPTION
…with 'kube-apiserver.service: Main process exited, code=exited, status=2/INVALIDARGUMENT'
