### PR TITLE
Added create folder command to avoid situation when apiserver doesn't…

### DIFF
--- a/cluster/rackspace/util.sh
+++ b/cluster/rackspace/util.sh
@@ -322,6 +322,7 @@ kube-up() {
   # TODO look for a better way to get the known_tokens to the master. This is needed over file injection since the files were too large on a 4 node cluster.
   $(scp -o StrictHostKeyChecking=no -i ~/.ssh/${SSH_KEY_NAME} ${KUBE_TEMP}/known_tokens.csv core@${KUBE_MASTER_IP}:/home/core/known_tokens.csv)
   $(sleep 2)
+  $(ssh -o StrictHostKeyChecking=no -i ~/.ssh/${SSH_KEY_NAME} core@${KUBE_MASTER_IP} sudo /usr/bin/mkdir -p /var/lib/kube-apiserver)
   $(ssh -o StrictHostKeyChecking=no -i ~/.ssh/${SSH_KEY_NAME} core@${KUBE_MASTER_IP} sudo mv /home/core/known_tokens.csv /var/lib/kube-apiserver/known_tokens.csv)
   $(ssh -o StrictHostKeyChecking=no -i ~/.ssh/${SSH_KEY_NAME} core@${KUBE_MASTER_IP} sudo chown root.root /var/lib/kube-apiserver/known_tokens.csv)
   $(ssh -o StrictHostKeyChecking=no -i ~/.ssh/${SSH_KEY_NAME} core@${KUBE_MASTER_IP} sudo systemctl restart kube-apiserver)


### PR DESCRIPTION
… start fast enough.

kube-apiserver.service has 'ExecStartPre=/usr/bin/mkdir -p /var/lib/kube-apiserver', but if server is not fast enough 'mv /home/core/known_tokens.csv /var/lib/kube-apiserver/known_tokens.csv' will fail.
