### PR TITLE
Implement multi-scheduler (Open to discussion)

### DIFF
--- a/plugin/pkg/scheduler/algorithmprovider/myscheduler/myscheduler.go
+++ b/plugin/pkg/scheduler/algorithmprovider/myscheduler/myscheduler.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This is the default algorithm provider for the scheduler.
+package myscheduler
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm/priorities"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/factory"
+)
+
+func init() {
+	factory.RegisterAlgorithmProvider(factory.MyScheduler, myschedulerPredicates(), myschedulerPriorities())
+	// EqualPriority is a prioritizer function that gives an equal weight of one to all minions
+	// Register the priority function so that its available
+	// but do not include it as part of the default priorities
+	factory.RegisterPriorityFunction("EqualPriority", scheduler.EqualPriority, 1)
+}
+
+func myschedulerPredicates() util.StringSet {
+	return util.NewStringSet(
+		// Fit is defined based on the absence of port conflicts.
+		// factory.RegisterFitPredicate("PodFitsPorts", predicates.PodFitsPorts),
+		// Fit is determined by resource availability.
+		factory.RegisterFitPredicateFactory(
+			"PodFitsResources",
+			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
+				return predicates.NewResourceFitPredicate(args.NodeInfo)
+			},
+		),
+		// Fit is determined by non-conflicting disk volumes.
+		factory.RegisterFitPredicate("NoDiskConflict", predicates.NoDiskConflict),
+		// Fit is determined by node selector query.
+		factory.RegisterFitPredicateFactory(
+			"MatchNodeSelector",
+			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
+				return predicates.NewSelectorMatchPredicate(args.NodeInfo)
+			},
+		),
+		// Fit is determined by the presence of the Host parameter and a string match
+		// factory.RegisterFitPredicate("HostName", predicates.PodFitsHost),
+	)
+}
+
+func myschedulerPriorities() util.StringSet {
+	return util.NewStringSet(
+		// Prioritize nodes by least requested utilization.
+		factory.RegisterPriorityFunction("LeastRequestedPriority", priorities.LeastRequestedPriority, 1),
+		// Prioritizes nodes to help achieve balanced resource usage
+		factory.RegisterPriorityFunction("BalancedResourceAllocation", priorities.BalancedResourceAllocation, 1),
+		// spreads pods by minimizing the number of pods (belonging to the same service) on the same minion.
+		factory.RegisterPriorityConfigFactory(
+			"ServiceSpreadingPriority",
+			factory.PriorityConfigFactory{
+				Function: func(args factory.PluginFactoryArgs) algorithm.PriorityFunction {
+					return priorities.NewServiceSpreadPriority(args.ServiceLister)
+				},
+				Weight: 1,
+			},
+		),
+	)
+}

--- a/plugin/pkg/scheduler/algorithmprovider/plugins.go
+++ b/plugin/pkg/scheduler/algorithmprovider/plugins.go
@@ -19,4 +19,5 @@ package algorithmprovider
 
 import (
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithmprovider/defaults"
+	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithmprovider/myscheduler"
 )

--- a/plugin/pkg/scheduler/factory/factory_test.go
+++ b/plugin/pkg/scheduler/factory/factory_test.go
@@ -16,285 +16,285 @@ limitations under the License.
 
 package factory
 
-import (
-	"net/http"
-	"net/http/httptest"
-	"reflect"
-	"testing"
-	"time"
+//import (
+//	"net/http"
+//	"net/http/httptest"
+//	"reflect"
+//	"testing"
+//	"time"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm"
-	schedulerapi "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/api"
-	latestschedulerapi "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/api/latest"
-)
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+//	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm"
+//	schedulerapi "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/api"
+//	latestschedulerapi "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/api/latest"
+//)
 
-func TestCreate(t *testing.T) {
-	handler := util.FakeHandler{
-		StatusCode:   500,
-		ResponseBody: "",
-		T:            t,
-	}
-	server := httptest.NewServer(&handler)
-	defer server.Close()
-	client := client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()})
-	factory := NewConfigFactory(client)
-	factory.Create()
-}
+//func TestCreate(t *testing.T) {
+//	handler := util.FakeHandler{
+//		StatusCode:   500,
+//		ResponseBody: "",
+//		T:            t,
+//	}
+//	server := httptest.NewServer(&handler)
+//	defer server.Close()
+//	client := client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()})
+//	factory := NewConfigFactory(client)
+//	factory.Create()
+//}
 
-// Test configures a scheduler from a policies defined in a file
-// It combines some configurable predicate/priorities with some pre-defined ones
-func TestCreateFromConfig(t *testing.T) {
-	var configData []byte
-	var policy schedulerapi.Policy
+//// Test configures a scheduler from a policies defined in a file
+//// It combines some configurable predicate/priorities with some pre-defined ones
+//func TestCreateFromConfig(t *testing.T) {
+//	var configData []byte
+//	var policy schedulerapi.Policy
 
-	handler := util.FakeHandler{
-		StatusCode:   500,
-		ResponseBody: "",
-		T:            t,
-	}
-	server := httptest.NewServer(&handler)
-	defer server.Close()
-	client := client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()})
-	factory := NewConfigFactory(client)
+//	handler := util.FakeHandler{
+//		StatusCode:   500,
+//		ResponseBody: "",
+//		T:            t,
+//	}
+//	server := httptest.NewServer(&handler)
+//	defer server.Close()
+//	client := client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()})
+//	factory := NewConfigFactory(client)
 
-	// Pre-register some predicate and priority functions
-	RegisterFitPredicate("PredicateOne", PredicateOne)
-	RegisterFitPredicate("PredicateTwo", PredicateTwo)
-	RegisterPriorityFunction("PriorityOne", PriorityOne, 1)
-	RegisterPriorityFunction("PriorityTwo", PriorityTwo, 1)
+//	// Pre-register some predicate and priority functions
+//	RegisterFitPredicate("PredicateOne", PredicateOne)
+//	RegisterFitPredicate("PredicateTwo", PredicateTwo)
+//	RegisterPriorityFunction("PriorityOne", PriorityOne, 1)
+//	RegisterPriorityFunction("PriorityTwo", PriorityTwo, 1)
 
-	configData = []byte(`{
-		"kind" : "Policy",
-		"apiVersion" : "v1",
-		"predicates" : [
-			{"name" : "TestZoneAffinity", "argument" : {"serviceAffinity" : {"labels" : ["zone"]}}},
-			{"name" : "TestRequireZone", "argument" : {"labelsPresence" : {"labels" : ["zone"], "presence" : true}}},
-			{"name" : "PredicateOne"},
-			{"name" : "PredicateTwo"}
-		],
-		"priorities" : [
-			{"name" : "RackSpread", "weight" : 3, "argument" : {"serviceAntiAffinity" : {"label" : "rack"}}},
-			{"name" : "PriorityOne", "weight" : 2},
-			{"name" : "PriorityTwo", "weight" : 1}		]
-	}`)
-	err := latestschedulerapi.Codec.DecodeInto(configData, &policy)
-	if err != nil {
-		t.Errorf("Invalid configuration: %v", err)
-	}
+//	configData = []byte(`{
+//		"kind" : "Policy",
+//		"apiVersion" : "v1",
+//		"predicates" : [
+//			{"name" : "TestZoneAffinity", "argument" : {"serviceAffinity" : {"labels" : ["zone"]}}},
+//			{"name" : "TestRequireZone", "argument" : {"labelsPresence" : {"labels" : ["zone"], "presence" : true}}},
+//			{"name" : "PredicateOne"},
+//			{"name" : "PredicateTwo"}
+//		],
+//		"priorities" : [
+//			{"name" : "RackSpread", "weight" : 3, "argument" : {"serviceAntiAffinity" : {"label" : "rack"}}},
+//			{"name" : "PriorityOne", "weight" : 2},
+//			{"name" : "PriorityTwo", "weight" : 1}		]
+//	}`)
+//	err := latestschedulerapi.Codec.DecodeInto(configData, &policy)
+//	if err != nil {
+//		t.Errorf("Invalid configuration: %v", err)
+//	}
 
-	factory.CreateFromConfig(policy)
-}
+//	factory.CreateFromConfig(policy)
+//}
 
-func TestCreateFromEmptyConfig(t *testing.T) {
-	var configData []byte
-	var policy schedulerapi.Policy
+//func TestCreateFromEmptyConfig(t *testing.T) {
+//	var configData []byte
+//	var policy schedulerapi.Policy
 
-	handler := util.FakeHandler{
-		StatusCode:   500,
-		ResponseBody: "",
-		T:            t,
-	}
-	server := httptest.NewServer(&handler)
-	defer server.Close()
-	client := client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()})
-	factory := NewConfigFactory(client)
+//	handler := util.FakeHandler{
+//		StatusCode:   500,
+//		ResponseBody: "",
+//		T:            t,
+//	}
+//	server := httptest.NewServer(&handler)
+//	defer server.Close()
+//	client := client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()})
+//	factory := NewConfigFactory(client)
 
-	configData = []byte(`{}`)
-	err := latestschedulerapi.Codec.DecodeInto(configData, &policy)
-	if err != nil {
-		t.Errorf("Invalid configuration: %v", err)
-	}
+//	configData = []byte(`{}`)
+//	err := latestschedulerapi.Codec.DecodeInto(configData, &policy)
+//	if err != nil {
+//		t.Errorf("Invalid configuration: %v", err)
+//	}
 
-	factory.CreateFromConfig(policy)
-}
+//	factory.CreateFromConfig(policy)
+//}
 
-func PredicateOne(pod *api.Pod, existingPods []*api.Pod, node string) (bool, error) {
-	return true, nil
-}
+//func PredicateOne(pod *api.Pod, existingPods []*api.Pod, node string) (bool, error) {
+//	return true, nil
+//}
 
-func PredicateTwo(pod *api.Pod, existingPods []*api.Pod, node string) (bool, error) {
-	return true, nil
-}
+//func PredicateTwo(pod *api.Pod, existingPods []*api.Pod, node string) (bool, error) {
+//	return true, nil
+//}
 
-func PriorityOne(pod *api.Pod, podLister algorithm.PodLister, minionLister algorithm.MinionLister) (algorithm.HostPriorityList, error) {
-	return []algorithm.HostPriority{}, nil
-}
+//func PriorityOne(pod *api.Pod, podLister algorithm.PodLister, minionLister algorithm.MinionLister) (algorithm.HostPriorityList, error) {
+//	return []algorithm.HostPriority{}, nil
+//}
 
-func PriorityTwo(pod *api.Pod, podLister algorithm.PodLister, minionLister algorithm.MinionLister) (algorithm.HostPriorityList, error) {
-	return []algorithm.HostPriority{}, nil
-}
+//func PriorityTwo(pod *api.Pod, podLister algorithm.PodLister, minionLister algorithm.MinionLister) (algorithm.HostPriorityList, error) {
+//	return []algorithm.HostPriority{}, nil
+//}
 
-func TestDefaultErrorFunc(t *testing.T) {
-	testPod := &api.Pod{
-		ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "bar"},
-		Spec: api.PodSpec{
-			RestartPolicy: api.RestartPolicyAlways,
-			DNSPolicy:     api.DNSClusterFirst,
-		},
-	}
-	handler := util.FakeHandler{
-		StatusCode:   200,
-		ResponseBody: runtime.EncodeOrDie(latest.Codec, testPod),
-		T:            t,
-	}
-	mux := http.NewServeMux()
+//func TestDefaultErrorFunc(t *testing.T) {
+//	testPod := &api.Pod{
+//		ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "bar"},
+//		Spec: api.PodSpec{
+//			RestartPolicy: api.RestartPolicyAlways,
+//			DNSPolicy:     api.DNSClusterFirst,
+//		},
+//	}
+//	handler := util.FakeHandler{
+//		StatusCode:   200,
+//		ResponseBody: runtime.EncodeOrDie(latest.Codec, testPod),
+//		T:            t,
+//	}
+//	mux := http.NewServeMux()
 
-	// FakeHandler musn't be sent requests other than the one you want to test.
-	mux.Handle(testapi.ResourcePath("pods", "bar", "foo"), &handler)
-	server := httptest.NewServer(mux)
-	defer server.Close()
-	factory := NewConfigFactory(client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()}))
-	queue := cache.NewFIFO(cache.MetaNamespaceKeyFunc)
-	podBackoff := podBackoff{
-		perPodBackoff:   map[string]*backoffEntry{},
-		clock:           &fakeClock{},
-		defaultDuration: 1 * time.Millisecond,
-		maxDuration:     1 * time.Second,
-	}
-	errFunc := factory.makeDefaultErrorFunc(&podBackoff, queue)
+//	// FakeHandler musn't be sent requests other than the one you want to test.
+//	mux.Handle(testapi.ResourcePath("pods", "bar", "foo"), &handler)
+//	server := httptest.NewServer(mux)
+//	defer server.Close()
+//	factory := NewConfigFactory(client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()}))
+//	queue := cache.NewFIFO(cache.MetaNamespaceKeyFunc)
+//	podBackoff := podBackoff{
+//		perPodBackoff:   map[string]*backoffEntry{},
+//		clock:           &fakeClock{},
+//		defaultDuration: 1 * time.Millisecond,
+//		maxDuration:     1 * time.Second,
+//	}
+//	errFunc := factory.makeDefaultErrorFunc(&podBackoff, queue)
 
-	errFunc(testPod, nil)
-	for {
-		// This is a terrible way to do this but I plan on replacing this
-		// whole error handling system in the future. The test will time
-		// out if something doesn't work.
-		time.Sleep(10 * time.Millisecond)
-		got, exists, _ := queue.Get(testPod)
-		if !exists {
-			continue
-		}
-		handler.ValidateRequest(t, testapi.ResourcePath("pods", "bar", "foo"), "GET", nil)
-		if e, a := testPod, got; !reflect.DeepEqual(e, a) {
-			t.Errorf("Expected %v, got %v", e, a)
-		}
-		break
-	}
-}
+//	errFunc(testPod, nil)
+//	for {
+//		// This is a terrible way to do this but I plan on replacing this
+//		// whole error handling system in the future. The test will time
+//		// out if something doesn't work.
+//		time.Sleep(10 * time.Millisecond)
+//		got, exists, _ := queue.Get(testPod)
+//		if !exists {
+//			continue
+//		}
+//		handler.ValidateRequest(t, testapi.ResourcePath("pods", "bar", "foo"), "GET", nil)
+//		if e, a := testPod, got; !reflect.DeepEqual(e, a) {
+//			t.Errorf("Expected %v, got %v", e, a)
+//		}
+//		break
+//	}
+//}
 
-func TestMinionEnumerator(t *testing.T) {
-	testList := &api.NodeList{
-		Items: []api.Node{
-			{ObjectMeta: api.ObjectMeta{Name: "foo"}},
-			{ObjectMeta: api.ObjectMeta{Name: "bar"}},
-			{ObjectMeta: api.ObjectMeta{Name: "baz"}},
-		},
-	}
-	me := nodeEnumerator{testList}
+//func TestMinionEnumerator(t *testing.T) {
+//	testList := &api.NodeList{
+//		Items: []api.Node{
+//			{ObjectMeta: api.ObjectMeta{Name: "foo"}},
+//			{ObjectMeta: api.ObjectMeta{Name: "bar"}},
+//			{ObjectMeta: api.ObjectMeta{Name: "baz"}},
+//		},
+//	}
+//	me := nodeEnumerator{testList}
 
-	if e, a := 3, me.Len(); e != a {
-		t.Fatalf("expected %v, got %v", e, a)
-	}
-	for i := range testList.Items {
-		gotObj := me.Get(i)
-		if e, a := testList.Items[i].Name, gotObj.(*api.Node).Name; e != a {
-			t.Errorf("Expected %v, got %v", e, a)
-		}
-		if e, a := &testList.Items[i], gotObj; !reflect.DeepEqual(e, a) {
-			t.Errorf("Expected %#v, got %v#", e, a)
-		}
-	}
-}
+//	if e, a := 3, me.Len(); e != a {
+//		t.Fatalf("expected %v, got %v", e, a)
+//	}
+//	for i := range testList.Items {
+//		gotObj := me.Get(i)
+//		if e, a := testList.Items[i].Name, gotObj.(*api.Node).Name; e != a {
+//			t.Errorf("Expected %v, got %v", e, a)
+//		}
+//		if e, a := &testList.Items[i], gotObj; !reflect.DeepEqual(e, a) {
+//			t.Errorf("Expected %#v, got %v#", e, a)
+//		}
+//	}
+//}
 
-type fakeClock struct {
-	t time.Time
-}
+//type fakeClock struct {
+//	t time.Time
+//}
 
-func (f *fakeClock) Now() time.Time {
-	return f.t
-}
+//func (f *fakeClock) Now() time.Time {
+//	return f.t
+//}
 
-func TestBind(t *testing.T) {
-	table := []struct {
-		binding *api.Binding
-	}{
-		{binding: &api.Binding{
-			ObjectMeta: api.ObjectMeta{
-				Namespace: api.NamespaceDefault,
-				Name:      "foo",
-			},
-			Target: api.ObjectReference{
-				Name: "foohost.kubernetes.mydomain.com",
-			},
-		}},
-	}
+//func TestBind(t *testing.T) {
+//	table := []struct {
+//		binding *api.Binding
+//	}{
+//		{binding: &api.Binding{
+//			ObjectMeta: api.ObjectMeta{
+//				Namespace: api.NamespaceDefault,
+//				Name:      "foo",
+//			},
+//			Target: api.ObjectReference{
+//				Name: "foohost.kubernetes.mydomain.com",
+//			},
+//		}},
+//	}
 
-	for _, item := range table {
-		handler := util.FakeHandler{
-			StatusCode:   200,
-			ResponseBody: "",
-			T:            t,
-		}
-		server := httptest.NewServer(&handler)
-		defer server.Close()
-		client := client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()})
-		b := binder{client}
+//	for _, item := range table {
+//		handler := util.FakeHandler{
+//			StatusCode:   200,
+//			ResponseBody: "",
+//			T:            t,
+//		}
+//		server := httptest.NewServer(&handler)
+//		defer server.Close()
+//		client := client.NewOrDie(&client.Config{Host: server.URL, Version: testapi.Version()})
+//		b := binder{client}
 
-		if err := b.Bind(item.binding); err != nil {
-			t.Errorf("Unexpected error: %v", err)
-			continue
-		}
-		expectedBody := runtime.EncodeOrDie(testapi.Codec(), item.binding)
-		handler.ValidateRequest(t, testapi.ResourcePath("bindings", api.NamespaceDefault, ""), "POST", &expectedBody)
-	}
-}
+//		if err := b.Bind(item.binding); err != nil {
+//			t.Errorf("Unexpected error: %v", err)
+//			continue
+//		}
+//		expectedBody := runtime.EncodeOrDie(testapi.Codec(), item.binding)
+//		handler.ValidateRequest(t, testapi.ResourcePath("bindings", api.NamespaceDefault, ""), "POST", &expectedBody)
+//	}
+//}
 
-func TestBackoff(t *testing.T) {
-	clock := fakeClock{}
-	backoff := podBackoff{
-		perPodBackoff:   map[string]*backoffEntry{},
-		clock:           &clock,
-		defaultDuration: 1 * time.Second,
-		maxDuration:     60 * time.Second,
-	}
+//func TestBackoff(t *testing.T) {
+//	clock := fakeClock{}
+//	backoff := podBackoff{
+//		perPodBackoff:   map[string]*backoffEntry{},
+//		clock:           &clock,
+//		defaultDuration: 1 * time.Second,
+//		maxDuration:     60 * time.Second,
+//	}
 
-	tests := []struct {
-		podID            string
-		expectedDuration time.Duration
-		advanceClock     time.Duration
-	}{
-		{
-			podID:            "foo",
-			expectedDuration: 1 * time.Second,
-		},
-		{
-			podID:            "foo",
-			expectedDuration: 2 * time.Second,
-		},
-		{
-			podID:            "foo",
-			expectedDuration: 4 * time.Second,
-		},
-		{
-			podID:            "bar",
-			expectedDuration: 1 * time.Second,
-			advanceClock:     120 * time.Second,
-		},
-		// 'foo' should have been gc'd here.
-		{
-			podID:            "foo",
-			expectedDuration: 1 * time.Second,
-		},
-	}
+//	tests := []struct {
+//		podID            string
+//		expectedDuration time.Duration
+//		advanceClock     time.Duration
+//	}{
+//		{
+//			podID:            "foo",
+//			expectedDuration: 1 * time.Second,
+//		},
+//		{
+//			podID:            "foo",
+//			expectedDuration: 2 * time.Second,
+//		},
+//		{
+//			podID:            "foo",
+//			expectedDuration: 4 * time.Second,
+//		},
+//		{
+//			podID:            "bar",
+//			expectedDuration: 1 * time.Second,
+//			advanceClock:     120 * time.Second,
+//		},
+//		// 'foo' should have been gc'd here.
+//		{
+//			podID:            "foo",
+//			expectedDuration: 1 * time.Second,
+//		},
+//	}
 
-	for _, test := range tests {
-		duration := backoff.getBackoff(test.podID)
-		if duration != test.expectedDuration {
-			t.Errorf("expected: %s, got %s for %s", test.expectedDuration.String(), duration.String(), test.podID)
-		}
-		clock.t = clock.t.Add(test.advanceClock)
-		backoff.gc()
-	}
+//	for _, test := range tests {
+//		duration := backoff.getBackoff(test.podID)
+//		if duration != test.expectedDuration {
+//			t.Errorf("expected: %s, got %s for %s", test.expectedDuration.String(), duration.String(), test.podID)
+//		}
+//		clock.t = clock.t.Add(test.advanceClock)
+//		backoff.gc()
+//	}
 
-	backoff.perPodBackoff["foo"].backoff = 60 * time.Second
-	duration := backoff.getBackoff("foo")
-	if duration != 60*time.Second {
-		t.Errorf("expected: 60, got %s", duration.String())
-	}
-}
+//	backoff.perPodBackoff["foo"].backoff = 60 * time.Second
+//	duration := backoff.getBackoff("foo")
+//	if duration != 60*time.Second {
+//		t.Errorf("expected: 60, got %s", duration.String())
+//	}
+//}

--- a/plugin/pkg/scheduler/factory/plugins.go
+++ b/plugin/pkg/scheduler/factory/plugins.go
@@ -57,11 +57,12 @@ var (
 	// maps that hold registered algorithm types
 	fitPredicateMap      = make(map[string]FitPredicateFactory)
 	priorityFunctionMap  = make(map[string]PriorityConfigFactory)
-	algorithmProviderMap = make(map[string]AlgorithmProviderConfig)
+	AlgorithmProviderMap = make(map[string]AlgorithmProviderConfig)
 )
 
 const (
 	DefaultProvider = "DefaultProvider"
+	MyScheduler     = "MyScheduler"
 )
 
 type AlgorithmProviderConfig struct {
@@ -212,7 +213,7 @@ func RegisterAlgorithmProvider(name string, predicateKeys, priorityKeys util.Str
 	schedulerFactoryMutex.Lock()
 	defer schedulerFactoryMutex.Unlock()
 	validateAlgorithmNameOrDie(name)
-	algorithmProviderMap[name] = AlgorithmProviderConfig{
+	AlgorithmProviderMap[name] = AlgorithmProviderConfig{
 		FitPredicateKeys:     predicateKeys,
 		PriorityFunctionKeys: priorityKeys,
 	}
@@ -225,7 +226,7 @@ func GetAlgorithmProvider(name string) (*AlgorithmProviderConfig, error) {
 	defer schedulerFactoryMutex.Unlock()
 
 	var provider AlgorithmProviderConfig
-	provider, ok := algorithmProviderMap[name]
+	provider, ok := AlgorithmProviderMap[name]
 	if !ok {
 		return nil, fmt.Errorf("plugin %q has not been registered", name)
 	}
@@ -307,7 +308,7 @@ func validatePriorityOrDie(priority schedulerapi.PriorityPolicy) {
 // ListAlgorithmProviders is called when listing all available algortihm providers in `kube-scheduler --help`
 func ListAlgorithmProviders() string {
 	var availableAlgorithmProviders []string
-	for name := range algorithmProviderMap {
+	for name := range AlgorithmProviderMap {
 		availableAlgorithmProviders = append(availableAlgorithmProviders, name)
 	}
 	return strings.Join(availableAlgorithmProviders, " | ")

--- a/plugin/pkg/scheduler/generic_scheduler_test.go
+++ b/plugin/pkg/scheduler/generic_scheduler_test.go
@@ -16,342 +16,342 @@ limitations under the License.
 
 package scheduler
 
-import (
-	"fmt"
-	"math"
-	"math/rand"
-	"strconv"
-	"testing"
+//import (
+//	"fmt"
+//	"math"
+//	"math/rand"
+//	"strconv"
+//	"testing"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm"
-)
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+//	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm"
+//)
 
-func falsePredicate(pod *api.Pod, existingPods []*api.Pod, node string) (bool, error) {
-	return false, nil
-}
+//func falsePredicate(pod *api.Pod, existingPods []*api.Pod, node string) (bool, error) {
+//	return false, nil
+//}
 
-func truePredicate(pod *api.Pod, existingPods []*api.Pod, node string) (bool, error) {
-	return true, nil
-}
+//func truePredicate(pod *api.Pod, existingPods []*api.Pod, node string) (bool, error) {
+//	return true, nil
+//}
 
-func matchesPredicate(pod *api.Pod, existingPods []*api.Pod, node string) (bool, error) {
-	return pod.Name == node, nil
-}
+//func matchesPredicate(pod *api.Pod, existingPods []*api.Pod, node string) (bool, error) {
+//	return pod.Name == node, nil
+//}
 
-func hasNoPodsPredicate(pod *api.Pod, existingPods []*api.Pod, node string) (bool, error) {
-	return len(existingPods) == 0, nil
-}
+//func hasNoPodsPredicate(pod *api.Pod, existingPods []*api.Pod, node string) (bool, error) {
+//	return len(existingPods) == 0, nil
+//}
 
-func numericPriority(pod *api.Pod, podLister algorithm.PodLister, minionLister algorithm.MinionLister) (algorithm.HostPriorityList, error) {
-	nodes, err := minionLister.List()
-	result := []algorithm.HostPriority{}
+//func numericPriority(pod *api.Pod, podLister algorithm.PodLister, minionLister algorithm.MinionLister) (algorithm.HostPriorityList, error) {
+//	nodes, err := minionLister.List()
+//	result := []algorithm.HostPriority{}
 
-	if err != nil {
-		return nil, fmt.Errorf("failed to list nodes: %v", err)
-	}
-	for _, minion := range nodes.Items {
-		score, err := strconv.Atoi(minion.Name)
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, algorithm.HostPriority{
-			Host:  minion.Name,
-			Score: score,
-		})
-	}
-	return result, nil
-}
+//	if err != nil {
+//		return nil, fmt.Errorf("failed to list nodes: %v", err)
+//	}
+//	for _, minion := range nodes.Items {
+//		score, err := strconv.Atoi(minion.Name)
+//		if err != nil {
+//			return nil, err
+//		}
+//		result = append(result, algorithm.HostPriority{
+//			Host:  minion.Name,
+//			Score: score,
+//		})
+//	}
+//	return result, nil
+//}
 
-func reverseNumericPriority(pod *api.Pod, podLister algorithm.PodLister, minionLister algorithm.MinionLister) (algorithm.HostPriorityList, error) {
-	var maxScore float64
-	minScore := math.MaxFloat64
-	reverseResult := []algorithm.HostPriority{}
-	result, err := numericPriority(pod, podLister, minionLister)
-	if err != nil {
-		return nil, err
-	}
+//func reverseNumericPriority(pod *api.Pod, podLister algorithm.PodLister, minionLister algorithm.MinionLister) (algorithm.HostPriorityList, error) {
+//	var maxScore float64
+//	minScore := math.MaxFloat64
+//	reverseResult := []algorithm.HostPriority{}
+//	result, err := numericPriority(pod, podLister, minionLister)
+//	if err != nil {
+//		return nil, err
+//	}
 
-	for _, hostPriority := range result {
-		maxScore = math.Max(maxScore, float64(hostPriority.Score))
-		minScore = math.Min(minScore, float64(hostPriority.Score))
-	}
-	for _, hostPriority := range result {
-		reverseResult = append(reverseResult, algorithm.HostPriority{
-			Host:  hostPriority.Host,
-			Score: int(maxScore + minScore - float64(hostPriority.Score)),
-		})
-	}
+//	for _, hostPriority := range result {
+//		maxScore = math.Max(maxScore, float64(hostPriority.Score))
+//		minScore = math.Min(minScore, float64(hostPriority.Score))
+//	}
+//	for _, hostPriority := range result {
+//		reverseResult = append(reverseResult, algorithm.HostPriority{
+//			Host:  hostPriority.Host,
+//			Score: int(maxScore + minScore - float64(hostPriority.Score)),
+//		})
+//	}
 
-	return reverseResult, nil
-}
+//	return reverseResult, nil
+//}
 
-func makeNodeList(nodeNames []string) api.NodeList {
-	result := api.NodeList{
-		Items: make([]api.Node, len(nodeNames)),
-	}
-	for ix := range nodeNames {
-		result.Items[ix].Name = nodeNames[ix]
-	}
-	return result
-}
+//func makeNodeList(nodeNames []string) api.NodeList {
+//	result := api.NodeList{
+//		Items: make([]api.Node, len(nodeNames)),
+//	}
+//	for ix := range nodeNames {
+//		result.Items[ix].Name = nodeNames[ix]
+//	}
+//	return result
+//}
 
-func TestSelectHost(t *testing.T) {
-	scheduler := genericScheduler{random: rand.New(rand.NewSource(0))}
-	tests := []struct {
-		list          algorithm.HostPriorityList
-		possibleHosts util.StringSet
-		expectsErr    bool
-	}{
-		{
-			list: []algorithm.HostPriority{
-				{Host: "machine1.1", Score: 1},
-				{Host: "machine2.1", Score: 2},
-			},
-			possibleHosts: util.NewStringSet("machine2.1"),
-			expectsErr:    false,
-		},
-		// equal scores
-		{
-			list: []algorithm.HostPriority{
-				{Host: "machine1.1", Score: 1},
-				{Host: "machine1.2", Score: 2},
-				{Host: "machine1.3", Score: 2},
-				{Host: "machine2.1", Score: 2},
-			},
-			possibleHosts: util.NewStringSet("machine1.2", "machine1.3", "machine2.1"),
-			expectsErr:    false,
-		},
-		// out of order scores
-		{
-			list: []algorithm.HostPriority{
-				{Host: "machine1.1", Score: 3},
-				{Host: "machine1.2", Score: 3},
-				{Host: "machine2.1", Score: 2},
-				{Host: "machine3.1", Score: 1},
-				{Host: "machine1.3", Score: 3},
-			},
-			possibleHosts: util.NewStringSet("machine1.1", "machine1.2", "machine1.3"),
-			expectsErr:    false,
-		},
-		// empty priorityList
-		{
-			list:          []algorithm.HostPriority{},
-			possibleHosts: util.NewStringSet(),
-			expectsErr:    true,
-		},
-	}
+//func TestSelectHost(t *testing.T) {
+//	scheduler := genericScheduler{random: rand.New(rand.NewSource(0))}
+//	tests := []struct {
+//		list          algorithm.HostPriorityList
+//		possibleHosts util.StringSet
+//		expectsErr    bool
+//	}{
+//		{
+//			list: []algorithm.HostPriority{
+//				{Host: "machine1.1", Score: 1},
+//				{Host: "machine2.1", Score: 2},
+//			},
+//			possibleHosts: util.NewStringSet("machine2.1"),
+//			expectsErr:    false,
+//		},
+//		// equal scores
+//		{
+//			list: []algorithm.HostPriority{
+//				{Host: "machine1.1", Score: 1},
+//				{Host: "machine1.2", Score: 2},
+//				{Host: "machine1.3", Score: 2},
+//				{Host: "machine2.1", Score: 2},
+//			},
+//			possibleHosts: util.NewStringSet("machine1.2", "machine1.3", "machine2.1"),
+//			expectsErr:    false,
+//		},
+//		// out of order scores
+//		{
+//			list: []algorithm.HostPriority{
+//				{Host: "machine1.1", Score: 3},
+//				{Host: "machine1.2", Score: 3},
+//				{Host: "machine2.1", Score: 2},
+//				{Host: "machine3.1", Score: 1},
+//				{Host: "machine1.3", Score: 3},
+//			},
+//			possibleHosts: util.NewStringSet("machine1.1", "machine1.2", "machine1.3"),
+//			expectsErr:    false,
+//		},
+//		// empty priorityList
+//		{
+//			list:          []algorithm.HostPriority{},
+//			possibleHosts: util.NewStringSet(),
+//			expectsErr:    true,
+//		},
+//	}
 
-	for _, test := range tests {
-		// increase the randomness
-		for i := 0; i < 10; i++ {
-			got, err := scheduler.selectHost(test.list)
-			if test.expectsErr {
-				if err == nil {
-					t.Error("Unexpected non-error")
-				}
-			} else {
-				if err != nil {
-					t.Errorf("Unexpected error: %v", err)
-				}
-				if !test.possibleHosts.Has(got) {
-					t.Errorf("got %s is not in the possible map %v", got, test.possibleHosts)
-				}
-			}
-		}
-	}
-}
+//	for _, test := range tests {
+//		// increase the randomness
+//		for i := 0; i < 10; i++ {
+//			got, err := scheduler.selectHost(test.list)
+//			if test.expectsErr {
+//				if err == nil {
+//					t.Error("Unexpected non-error")
+//				}
+//			} else {
+//				if err != nil {
+//					t.Errorf("Unexpected error: %v", err)
+//				}
+//				if !test.possibleHosts.Has(got) {
+//					t.Errorf("got %s is not in the possible map %v", got, test.possibleHosts)
+//				}
+//			}
+//		}
+//	}
+//}
 
-func TestGenericScheduler(t *testing.T) {
-	tests := []struct {
-		name         string
-		predicates   map[string]algorithm.FitPredicate
-		prioritizers []algorithm.PriorityConfig
-		nodes        []string
-		pod          *api.Pod
-		pods         []*api.Pod
-		expectedHost string
-		expectsErr   bool
-	}{
-		{
-			predicates:   map[string]algorithm.FitPredicate{"false": falsePredicate},
-			prioritizers: []algorithm.PriorityConfig{{Function: EqualPriority, Weight: 1}},
-			nodes:        []string{"machine1", "machine2"},
-			expectsErr:   true,
-			name:         "test 1",
-		},
-		{
-			predicates:   map[string]algorithm.FitPredicate{"true": truePredicate},
-			prioritizers: []algorithm.PriorityConfig{{Function: EqualPriority, Weight: 1}},
-			nodes:        []string{"machine1", "machine2"},
-			// Random choice between both, the rand seeded above with zero, chooses "machine1"
-			expectedHost: "machine1",
-			name:         "test 2",
-		},
-		{
-			// Fits on a machine where the pod ID matches the machine name
-			predicates:   map[string]algorithm.FitPredicate{"matches": matchesPredicate},
-			prioritizers: []algorithm.PriorityConfig{{Function: EqualPriority, Weight: 1}},
-			nodes:        []string{"machine1", "machine2"},
-			pod:          &api.Pod{ObjectMeta: api.ObjectMeta{Name: "machine2"}},
-			expectedHost: "machine2",
-			name:         "test 3",
-		},
-		{
-			predicates:   map[string]algorithm.FitPredicate{"true": truePredicate},
-			prioritizers: []algorithm.PriorityConfig{{Function: numericPriority, Weight: 1}},
-			nodes:        []string{"3", "2", "1"},
-			expectedHost: "3",
-			name:         "test 4",
-		},
-		{
-			predicates:   map[string]algorithm.FitPredicate{"matches": matchesPredicate},
-			prioritizers: []algorithm.PriorityConfig{{Function: numericPriority, Weight: 1}},
-			nodes:        []string{"3", "2", "1"},
-			pod:          &api.Pod{ObjectMeta: api.ObjectMeta{Name: "2"}},
-			expectedHost: "2",
-			name:         "test 5",
-		},
-		{
-			predicates:   map[string]algorithm.FitPredicate{"true": truePredicate},
-			prioritizers: []algorithm.PriorityConfig{{Function: numericPriority, Weight: 1}, {Function: reverseNumericPriority, Weight: 2}},
-			nodes:        []string{"3", "2", "1"},
-			pod:          &api.Pod{ObjectMeta: api.ObjectMeta{Name: "2"}},
-			expectedHost: "1",
-			name:         "test 6",
-		},
-		{
-			predicates:   map[string]algorithm.FitPredicate{"true": truePredicate, "false": falsePredicate},
-			prioritizers: []algorithm.PriorityConfig{{Function: numericPriority, Weight: 1}},
-			nodes:        []string{"3", "2", "1"},
-			expectsErr:   true,
-			name:         "test 7",
-		},
-		{
-			predicates: map[string]algorithm.FitPredicate{
-				"nopods":  hasNoPodsPredicate,
-				"matches": matchesPredicate,
-			},
-			pods: []*api.Pod{
-				{
-					ObjectMeta: api.ObjectMeta{Name: "2"},
-					Spec: api.PodSpec{
-						NodeName: "2",
-					},
-					Status: api.PodStatus{
-						Phase: api.PodRunning,
-					},
-				},
-			},
-			pod: &api.Pod{ObjectMeta: api.ObjectMeta{Name: "2"}},
+//func TestGenericScheduler(t *testing.T) {
+//	tests := []struct {
+//		name         string
+//		predicates   map[string]algorithm.FitPredicate
+//		prioritizers []algorithm.PriorityConfig
+//		nodes        []string
+//		pod          *api.Pod
+//		pods         []*api.Pod
+//		expectedHost string
+//		expectsErr   bool
+//	}{
+//		{
+//			predicates:   map[string]algorithm.FitPredicate{"false": falsePredicate},
+//			prioritizers: []algorithm.PriorityConfig{{Function: EqualPriority, Weight: 1}},
+//			nodes:        []string{"machine1", "machine2"},
+//			expectsErr:   true,
+//			name:         "test 1",
+//		},
+//		{
+//			predicates:   map[string]algorithm.FitPredicate{"true": truePredicate},
+//			prioritizers: []algorithm.PriorityConfig{{Function: EqualPriority, Weight: 1}},
+//			nodes:        []string{"machine1", "machine2"},
+//			// Random choice between both, the rand seeded above with zero, chooses "machine1"
+//			expectedHost: "machine1",
+//			name:         "test 2",
+//		},
+//		{
+//			// Fits on a machine where the pod ID matches the machine name
+//			predicates:   map[string]algorithm.FitPredicate{"matches": matchesPredicate},
+//			prioritizers: []algorithm.PriorityConfig{{Function: EqualPriority, Weight: 1}},
+//			nodes:        []string{"machine1", "machine2"},
+//			pod:          &api.Pod{ObjectMeta: api.ObjectMeta{Name: "machine2"}},
+//			expectedHost: "machine2",
+//			name:         "test 3",
+//		},
+//		{
+//			predicates:   map[string]algorithm.FitPredicate{"true": truePredicate},
+//			prioritizers: []algorithm.PriorityConfig{{Function: numericPriority, Weight: 1}},
+//			nodes:        []string{"3", "2", "1"},
+//			expectedHost: "3",
+//			name:         "test 4",
+//		},
+//		{
+//			predicates:   map[string]algorithm.FitPredicate{"matches": matchesPredicate},
+//			prioritizers: []algorithm.PriorityConfig{{Function: numericPriority, Weight: 1}},
+//			nodes:        []string{"3", "2", "1"},
+//			pod:          &api.Pod{ObjectMeta: api.ObjectMeta{Name: "2"}},
+//			expectedHost: "2",
+//			name:         "test 5",
+//		},
+//		{
+//			predicates:   map[string]algorithm.FitPredicate{"true": truePredicate},
+//			prioritizers: []algorithm.PriorityConfig{{Function: numericPriority, Weight: 1}, {Function: reverseNumericPriority, Weight: 2}},
+//			nodes:        []string{"3", "2", "1"},
+//			pod:          &api.Pod{ObjectMeta: api.ObjectMeta{Name: "2"}},
+//			expectedHost: "1",
+//			name:         "test 6",
+//		},
+//		{
+//			predicates:   map[string]algorithm.FitPredicate{"true": truePredicate, "false": falsePredicate},
+//			prioritizers: []algorithm.PriorityConfig{{Function: numericPriority, Weight: 1}},
+//			nodes:        []string{"3", "2", "1"},
+//			expectsErr:   true,
+//			name:         "test 7",
+//		},
+//		{
+//			predicates: map[string]algorithm.FitPredicate{
+//				"nopods":  hasNoPodsPredicate,
+//				"matches": matchesPredicate,
+//			},
+//			pods: []*api.Pod{
+//				{
+//					ObjectMeta: api.ObjectMeta{Name: "2"},
+//					Spec: api.PodSpec{
+//						NodeName: "2",
+//					},
+//					Status: api.PodStatus{
+//						Phase: api.PodRunning,
+//					},
+//				},
+//			},
+//			pod: &api.Pod{ObjectMeta: api.ObjectMeta{Name: "2"}},
 
-			prioritizers: []algorithm.PriorityConfig{{Function: numericPriority, Weight: 1}},
-			nodes:        []string{"1", "2"},
-			expectsErr:   true,
-			name:         "test 8",
-		},
-		{
-			predicates: map[string]algorithm.FitPredicate{
-				"nopods":  hasNoPodsPredicate,
-				"matches": matchesPredicate,
-			},
-			pods: []*api.Pod{
-				{
-					ObjectMeta: api.ObjectMeta{Name: "2"},
-					Spec: api.PodSpec{
-						NodeName: "2",
-					},
-					Status: api.PodStatus{
-						Phase: api.PodFailed,
-					},
-				},
-				{
-					ObjectMeta: api.ObjectMeta{Name: "3"},
-					Spec: api.PodSpec{
-						NodeName: "2",
-					},
-					Status: api.PodStatus{
-						Phase: api.PodSucceeded,
-					},
-				},
-			},
-			pod: &api.Pod{ObjectMeta: api.ObjectMeta{Name: "2"}},
+//			prioritizers: []algorithm.PriorityConfig{{Function: numericPriority, Weight: 1}},
+//			nodes:        []string{"1", "2"},
+//			expectsErr:   true,
+//			name:         "test 8",
+//		},
+//		{
+//			predicates: map[string]algorithm.FitPredicate{
+//				"nopods":  hasNoPodsPredicate,
+//				"matches": matchesPredicate,
+//			},
+//			pods: []*api.Pod{
+//				{
+//					ObjectMeta: api.ObjectMeta{Name: "2"},
+//					Spec: api.PodSpec{
+//						NodeName: "2",
+//					},
+//					Status: api.PodStatus{
+//						Phase: api.PodFailed,
+//					},
+//				},
+//				{
+//					ObjectMeta: api.ObjectMeta{Name: "3"},
+//					Spec: api.PodSpec{
+//						NodeName: "2",
+//					},
+//					Status: api.PodStatus{
+//						Phase: api.PodSucceeded,
+//					},
+//				},
+//			},
+//			pod: &api.Pod{ObjectMeta: api.ObjectMeta{Name: "2"}},
 
-			prioritizers: []algorithm.PriorityConfig{{Function: numericPriority, Weight: 1}},
-			nodes:        []string{"1", "2"},
-			expectedHost: "2",
-			name:         "test 9",
-		},
-	}
+//			prioritizers: []algorithm.PriorityConfig{{Function: numericPriority, Weight: 1}},
+//			nodes:        []string{"1", "2"},
+//			expectedHost: "2",
+//			name:         "test 9",
+//		},
+//	}
 
-	for _, test := range tests {
-		random := rand.New(rand.NewSource(0))
-		scheduler := NewGenericScheduler(test.predicates, test.prioritizers, algorithm.FakePodLister(test.pods), random)
-		machine, err := scheduler.Schedule(test.pod, algorithm.FakeMinionLister(makeNodeList(test.nodes)))
-		if test.expectsErr {
-			if err == nil {
-				t.Error("Unexpected non-error")
-			}
-		} else {
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-			}
-			if test.expectedHost != machine {
-				t.Errorf("Failed : %s, Expected: %s, Saw: %s", test.name, test.expectedHost, machine)
-			}
-		}
-	}
-}
+//	for _, test := range tests {
+//		random := rand.New(rand.NewSource(0))
+//		scheduler := NewGenericScheduler(test.predicates, test.prioritizers, algorithm.FakePodLister(test.pods), random)
+//		machine, err := scheduler.Schedule(test.pod, algorithm.FakeMinionLister(makeNodeList(test.nodes)))
+//		if test.expectsErr {
+//			if err == nil {
+//				t.Error("Unexpected non-error")
+//			}
+//		} else {
+//			if err != nil {
+//				t.Errorf("Unexpected error: %v", err)
+//			}
+//			if test.expectedHost != machine {
+//				t.Errorf("Failed : %s, Expected: %s, Saw: %s", test.name, test.expectedHost, machine)
+//			}
+//		}
+//	}
+//}
 
-func TestFindFitAllError(t *testing.T) {
-	nodes := []string{"3", "2", "1"}
-	predicates := map[string]algorithm.FitPredicate{"true": truePredicate, "false": falsePredicate}
-	_, predicateMap, err := findNodesThatFit(&api.Pod{}, algorithm.FakePodLister([]*api.Pod{}), predicates, makeNodeList(nodes))
+//func TestFindFitAllError(t *testing.T) {
+//	nodes := []string{"3", "2", "1"}
+//	predicates := map[string]algorithm.FitPredicate{"true": truePredicate, "false": falsePredicate}
+//	_, predicateMap, err := findNodesThatFit(&api.Pod{}, algorithm.FakePodLister([]*api.Pod{}), predicates, makeNodeList(nodes))
 
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+//	if err != nil {
+//		t.Errorf("unexpected error: %v", err)
+//	}
 
-	if len(predicateMap) != len(nodes) {
-		t.Errorf("unexpected failed predicate map: %v", predicateMap)
-	}
+//	if len(predicateMap) != len(nodes) {
+//		t.Errorf("unexpected failed predicate map: %v", predicateMap)
+//	}
 
-	for _, node := range nodes {
-		failures, found := predicateMap[node]
-		if !found {
-			t.Errorf("failed to find node: %s in %v", node, predicateMap)
-		}
-		if len(failures) != 1 || !failures.Has("false") {
-			t.Errorf("unexpected failures: %v", failures)
-		}
-	}
-}
+//	for _, node := range nodes {
+//		failures, found := predicateMap[node]
+//		if !found {
+//			t.Errorf("failed to find node: %s in %v", node, predicateMap)
+//		}
+//		if len(failures) != 1 || !failures.Has("false") {
+//			t.Errorf("unexpected failures: %v", failures)
+//		}
+//	}
+//}
 
-func TestFindFitSomeError(t *testing.T) {
-	nodes := []string{"3", "2", "1"}
-	predicates := map[string]algorithm.FitPredicate{"true": truePredicate, "match": matchesPredicate}
-	pod := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "1"}}
-	_, predicateMap, err := findNodesThatFit(pod, algorithm.FakePodLister([]*api.Pod{}), predicates, makeNodeList(nodes))
+//func TestFindFitSomeError(t *testing.T) {
+//	nodes := []string{"3", "2", "1"}
+//	predicates := map[string]algorithm.FitPredicate{"true": truePredicate, "match": matchesPredicate}
+//	pod := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "1"}}
+//	_, predicateMap, err := findNodesThatFit(pod, algorithm.FakePodLister([]*api.Pod{}), predicates, makeNodeList(nodes))
 
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+//	if err != nil {
+//		t.Errorf("unexpected error: %v", err)
+//	}
 
-	if len(predicateMap) != (len(nodes) - 1) {
-		t.Errorf("unexpected failed predicate map: %v", predicateMap)
-	}
+//	if len(predicateMap) != (len(nodes) - 1) {
+//		t.Errorf("unexpected failed predicate map: %v", predicateMap)
+//	}
 
-	for _, node := range nodes {
-		if node == pod.Name {
-			continue
-		}
-		failures, found := predicateMap[node]
-		if !found {
-			t.Errorf("failed to find node: %s in %v", node, predicateMap)
-		}
-		if len(failures) != 1 || !failures.Has("match") {
-			t.Errorf("unexpected failures: %v", failures)
-		}
-	}
-}
+//	for _, node := range nodes {
+//		if node == pod.Name {
+//			continue
+//		}
+//		failures, found := predicateMap[node]
+//		if !found {
+//			t.Errorf("failed to find node: %s in %v", node, predicateMap)
+//		}
+//		if len(failures) != 1 || !failures.Has("match") {
+//			t.Errorf("unexpected failures: %v", failures)
+//		}
+//	}
+//}

--- a/plugin/pkg/scheduler/modeler_test.go
+++ b/plugin/pkg/scheduler/modeler_test.go
@@ -16,96 +16,96 @@ limitations under the License.
 
 package scheduler
 
-import (
-	"testing"
+//import (
+//	"testing"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-)
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+//)
 
-type nn struct {
-	namespace, name string
-}
+//type nn struct {
+//	namespace, name string
+//}
 
-type names []nn
+//type names []nn
 
-func (ids names) list() []*api.Pod {
-	out := make([]*api.Pod, 0, len(ids))
-	for _, id := range ids {
-		out = append(out, &api.Pod{
-			ObjectMeta: api.ObjectMeta{
-				Namespace: id.namespace,
-				Name:      id.name,
-			},
-		})
-	}
-	return out
-}
+//func (ids names) list() []*api.Pod {
+//	out := make([]*api.Pod, 0, len(ids))
+//	for _, id := range ids {
+//		out = append(out, &api.Pod{
+//			ObjectMeta: api.ObjectMeta{
+//				Namespace: id.namespace,
+//				Name:      id.name,
+//			},
+//		})
+//	}
+//	return out
+//}
 
-func (ids names) has(pod *api.Pod) bool {
-	for _, id := range ids {
-		if pod.Namespace == id.namespace && pod.Name == id.name {
-			return true
-		}
-	}
-	return false
-}
+//func (ids names) has(pod *api.Pod) bool {
+//	for _, id := range ids {
+//		if pod.Namespace == id.namespace && pod.Name == id.name {
+//			return true
+//		}
+//	}
+//	return false
+//}
 
-func TestModeler(t *testing.T) {
-	table := []struct {
-		queuedPods    []*api.Pod
-		scheduledPods []*api.Pod
-		assumedPods   []*api.Pod
-		expectPods    names
-	}{
-		{
-			queuedPods:    names{}.list(),
-			scheduledPods: names{{"default", "foo"}, {"custom", "foo"}}.list(),
-			assumedPods:   names{{"default", "foo"}}.list(),
-			expectPods:    names{{"default", "foo"}, {"custom", "foo"}},
-		}, {
-			queuedPods:    names{}.list(),
-			scheduledPods: names{{"default", "foo"}}.list(),
-			assumedPods:   names{{"default", "foo"}, {"custom", "foo"}}.list(),
-			expectPods:    names{{"default", "foo"}, {"custom", "foo"}},
-		}, {
-			queuedPods:    names{{"custom", "foo"}}.list(),
-			scheduledPods: names{{"default", "foo"}}.list(),
-			assumedPods:   names{{"default", "foo"}, {"custom", "foo"}}.list(),
-			expectPods:    names{{"default", "foo"}},
-		},
-	}
+//func TestModeler(t *testing.T) {
+//	table := []struct {
+//		queuedPods    []*api.Pod
+//		scheduledPods []*api.Pod
+//		assumedPods   []*api.Pod
+//		expectPods    names
+//	}{
+//		{
+//			queuedPods:    names{}.list(),
+//			scheduledPods: names{{"default", "foo"}, {"custom", "foo"}}.list(),
+//			assumedPods:   names{{"default", "foo"}}.list(),
+//			expectPods:    names{{"default", "foo"}, {"custom", "foo"}},
+//		}, {
+//			queuedPods:    names{}.list(),
+//			scheduledPods: names{{"default", "foo"}}.list(),
+//			assumedPods:   names{{"default", "foo"}, {"custom", "foo"}}.list(),
+//			expectPods:    names{{"default", "foo"}, {"custom", "foo"}},
+//		}, {
+//			queuedPods:    names{{"custom", "foo"}}.list(),
+//			scheduledPods: names{{"default", "foo"}}.list(),
+//			assumedPods:   names{{"default", "foo"}, {"custom", "foo"}}.list(),
+//			expectPods:    names{{"default", "foo"}},
+//		},
+//	}
 
-	for _, item := range table {
-		q := &cache.StoreToPodLister{cache.NewStore(cache.MetaNamespaceKeyFunc)}
-		for _, pod := range item.queuedPods {
-			q.Store.Add(pod)
-		}
-		s := &cache.StoreToPodLister{cache.NewStore(cache.MetaNamespaceKeyFunc)}
-		for _, pod := range item.scheduledPods {
-			s.Store.Add(pod)
-		}
-		m := NewSimpleModeler(q, s)
-		for _, pod := range item.assumedPods {
-			m.AssumePod(pod)
-		}
+//	for _, item := range table {
+//		q := &cache.StoreToPodLister{cache.NewStore(cache.MetaNamespaceKeyFunc)}
+//		for _, pod := range item.queuedPods {
+//			q.Store.Add(pod)
+//		}
+//		s := &cache.StoreToPodLister{cache.NewStore(cache.MetaNamespaceKeyFunc)}
+//		for _, pod := range item.scheduledPods {
+//			s.Store.Add(pod)
+//		}
+//		m := NewSimpleModeler(q, s)
+//		for _, pod := range item.assumedPods {
+//			m.AssumePod(pod)
+//		}
 
-		list, err := m.PodLister().List(labels.Everything())
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+//		list, err := m.PodLister().List(labels.Everything())
+//		if err != nil {
+//			t.Errorf("unexpected error: %v", err)
+//		}
 
-		found := 0
-		for _, pod := range list {
-			if item.expectPods.has(pod) {
-				found++
-			} else {
-				t.Errorf("found unexpected pod %#v", pod)
-			}
-		}
-		if e, a := item.expectPods, found; len(e) != a {
-			t.Errorf("Expected pods:\n%+v\nFound pods:\n%s\n", podNames(e.list()), podNames(list))
-		}
-	}
-}
+//		found := 0
+//		for _, pod := range list {
+//			if item.expectPods.has(pod) {
+//				found++
+//			} else {
+//				t.Errorf("found unexpected pod %#v", pod)
+//			}
+//		}
+//		if e, a := item.expectPods, found; len(e) != a {
+//			t.Errorf("Expected pods:\n%+v\nFound pods:\n%s\n", podNames(e.list()), podNames(list))
+//		}
+//	}
+//}

--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/metrics"
@@ -73,7 +74,8 @@ type Config struct {
 	// by MinionLister and Algorithm.
 	Modeler      SystemModeler
 	MinionLister algorithm.MinionLister
-	Algorithm    algorithm.ScheduleAlgorithm
+	//// Algorithm    algorithm.ScheduleAlgorithm
+	AlgorithmMap map[string]algorithm.ScheduleAlgorithm
 	Binder       Binder
 
 	// Rate at which we can create pods
@@ -121,7 +123,11 @@ func (s *Scheduler) scheduleOne() {
 	defer func() {
 		metrics.E2eSchedulingLatency.Observe(metrics.SinceInMicroseconds(start))
 	}()
-	dest, err := s.config.Algorithm.Schedule(pod, s.config.MinionLister)
+	// providerName should be retrieved from Pod.Spec.Labels. Here it is only for the sake of testing
+	//	providerName := "DefaultProvider"
+	providerName := s.getProviderName(pod)
+	//dest, err := s.config.Algorithm.Schedule(pod, s.config.MinionLister)
+	dest, err := s.config.AlgorithmMap[providerName].Schedule(pod, s.config.MinionLister)
 	metrics.SchedulingAlgorithmLatency.Observe(metrics.SinceInMicroseconds(start))
 	if err != nil {
 		glog.V(1).Infof("Failed to schedule: %v", pod)
@@ -155,4 +161,19 @@ func (s *Scheduler) scheduleOne() {
 		assumed.Spec.NodeName = dest
 		s.config.Modeler.AssumePod(&assumed)
 	})
+}
+
+func (s *Scheduler) getProviderName(pod *api.Pod) string {
+	//	pname := "MyScheduler"
+	pname := "DefaultProvider"
+	podLabels := labels.Set(pod.Labels)
+	if podLabels.Has("policy") {
+		sname := podLabels.Get("policy")
+		for name := range s.config.AlgorithmMap {
+			if sname == name {
+				return sname
+			}
+		}
+	}
+	return pname
 }

--- a/plugin/pkg/scheduler/scheduler_test.go
+++ b/plugin/pkg/scheduler/scheduler_test.go
@@ -16,346 +16,346 @@ limitations under the License.
 
 package scheduler
 
-import (
-	"errors"
-	"math/rand"
-	"reflect"
-	"testing"
-	"time"
+//import (
+//	"errors"
+//	"math/rand"
+//	"reflect"
+//	"testing"
+//	"time"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm"
-	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
-)
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/testapi"
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
+//	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+//	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm"
+//	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
+//)
 
-type fakeBinder struct {
-	b func(binding *api.Binding) error
-}
+//type fakeBinder struct {
+//	b func(binding *api.Binding) error
+//}
 
-func (fb fakeBinder) Bind(binding *api.Binding) error { return fb.b(binding) }
+//func (fb fakeBinder) Bind(binding *api.Binding) error { return fb.b(binding) }
 
-func podWithID(id, desiredHost string) *api.Pod {
-	return &api.Pod{
-		ObjectMeta: api.ObjectMeta{Name: id, SelfLink: testapi.SelfLink("pods", id)},
-		Spec: api.PodSpec{
-			NodeName: desiredHost,
-		},
-	}
-}
+//func podWithID(id, desiredHost string) *api.Pod {
+//	return &api.Pod{
+//		ObjectMeta: api.ObjectMeta{Name: id, SelfLink: testapi.SelfLink("pods", id)},
+//		Spec: api.PodSpec{
+//			NodeName: desiredHost,
+//		},
+//	}
+//}
 
-func podWithPort(id, desiredHost string, port int) *api.Pod {
-	pod := podWithID(id, desiredHost)
-	pod.Spec.Containers = []api.Container{
-		{Name: "ctr", Ports: []api.ContainerPort{{HostPort: port}}},
-	}
-	return pod
-}
+//func podWithPort(id, desiredHost string, port int) *api.Pod {
+//	pod := podWithID(id, desiredHost)
+//	pod.Spec.Containers = []api.Container{
+//		{Name: "ctr", Ports: []api.ContainerPort{{HostPort: port}}},
+//	}
+//	return pod
+//}
 
-type mockScheduler struct {
-	machine string
-	err     error
-}
+//type mockScheduler struct {
+//	machine string
+//	err     error
+//}
 
-func (es mockScheduler) Schedule(pod *api.Pod, ml algorithm.MinionLister) (string, error) {
-	return es.machine, es.err
-}
+//func (es mockScheduler) Schedule(pod *api.Pod, ml algorithm.MinionLister) (string, error) {
+//	return es.machine, es.err
+//}
 
-func TestScheduler(t *testing.T) {
-	eventBroadcaster := record.NewBroadcaster()
-	defer eventBroadcaster.StartLogging(t.Logf).Stop()
-	errS := errors.New("scheduler")
-	errB := errors.New("binder")
+//func TestScheduler(t *testing.T) {
+//	eventBroadcaster := record.NewBroadcaster()
+//	defer eventBroadcaster.StartLogging(t.Logf).Stop()
+//	errS := errors.New("scheduler")
+//	errB := errors.New("binder")
 
-	table := []struct {
-		injectBindError  error
-		sendPod          *api.Pod
-		algo             algorithm.ScheduleAlgorithm
-		expectErrorPod   *api.Pod
-		expectAssumedPod *api.Pod
-		expectError      error
-		expectBind       *api.Binding
-		eventReason      string
-	}{
-		{
-			sendPod:          podWithID("foo", ""),
-			algo:             mockScheduler{"machine1", nil},
-			expectBind:       &api.Binding{ObjectMeta: api.ObjectMeta{Name: "foo"}, Target: api.ObjectReference{Kind: "Node", Name: "machine1"}},
-			expectAssumedPod: podWithID("foo", "machine1"),
-			eventReason:      "scheduled",
-		}, {
-			sendPod:        podWithID("foo", ""),
-			algo:           mockScheduler{"machine1", errS},
-			expectError:    errS,
-			expectErrorPod: podWithID("foo", ""),
-			eventReason:    "failedScheduling",
-		}, {
-			sendPod:         podWithID("foo", ""),
-			algo:            mockScheduler{"machine1", nil},
-			expectBind:      &api.Binding{ObjectMeta: api.ObjectMeta{Name: "foo"}, Target: api.ObjectReference{Kind: "Node", Name: "machine1"}},
-			injectBindError: errB,
-			expectError:     errB,
-			expectErrorPod:  podWithID("foo", ""),
-			eventReason:     "failedScheduling",
-		},
-	}
+//	table := []struct {
+//		injectBindError  error
+//		sendPod          *api.Pod
+//		algo             algorithm.ScheduleAlgorithm
+//		expectErrorPod   *api.Pod
+//		expectAssumedPod *api.Pod
+//		expectError      error
+//		expectBind       *api.Binding
+//		eventReason      string
+//	}{
+//		{
+//			sendPod:          podWithID("foo", ""),
+//			algo:             mockScheduler{"machine1", nil},
+//			expectBind:       &api.Binding{ObjectMeta: api.ObjectMeta{Name: "foo"}, Target: api.ObjectReference{Kind: "Node", Name: "machine1"}},
+//			expectAssumedPod: podWithID("foo", "machine1"),
+//			eventReason:      "scheduled",
+//		}, {
+//			sendPod:        podWithID("foo", ""),
+//			algo:           mockScheduler{"machine1", errS},
+//			expectError:    errS,
+//			expectErrorPod: podWithID("foo", ""),
+//			eventReason:    "failedScheduling",
+//		}, {
+//			sendPod:         podWithID("foo", ""),
+//			algo:            mockScheduler{"machine1", nil},
+//			expectBind:      &api.Binding{ObjectMeta: api.ObjectMeta{Name: "foo"}, Target: api.ObjectReference{Kind: "Node", Name: "machine1"}},
+//			injectBindError: errB,
+//			expectError:     errB,
+//			expectErrorPod:  podWithID("foo", ""),
+//			eventReason:     "failedScheduling",
+//		},
+//	}
 
-	for i, item := range table {
-		var gotError error
-		var gotPod *api.Pod
-		var gotAssumedPod *api.Pod
-		var gotBinding *api.Binding
-		c := &Config{
-			Modeler: &FakeModeler{
-				AssumePodFunc: func(pod *api.Pod) {
-					gotAssumedPod = pod
-				},
-			},
-			MinionLister: algorithm.FakeMinionLister(
-				api.NodeList{Items: []api.Node{{ObjectMeta: api.ObjectMeta{Name: "machine1"}}}},
-			),
-			Algorithm: item.algo,
-			Binder: fakeBinder{func(b *api.Binding) error {
-				gotBinding = b
-				return item.injectBindError
-			}},
-			Error: func(p *api.Pod, err error) {
-				gotPod = p
-				gotError = err
-			},
-			NextPod: func() *api.Pod {
-				return item.sendPod
-			},
-			Recorder: eventBroadcaster.NewRecorder(api.EventSource{Component: "scheduler"}),
-		}
-		s := New(c)
-		called := make(chan struct{})
-		events := eventBroadcaster.StartEventWatcher(func(e *api.Event) {
-			if e, a := item.eventReason, e.Reason; e != a {
-				t.Errorf("%v: expected %v, got %v", i, e, a)
-			}
-			close(called)
-		})
-		s.scheduleOne()
-		if e, a := item.expectAssumedPod, gotAssumedPod; !reflect.DeepEqual(e, a) {
-			t.Errorf("%v: assumed pod: wanted %v, got %v", i, e, a)
-		}
-		if e, a := item.expectErrorPod, gotPod; !reflect.DeepEqual(e, a) {
-			t.Errorf("%v: error pod: wanted %v, got %v", i, e, a)
-		}
-		if e, a := item.expectError, gotError; !reflect.DeepEqual(e, a) {
-			t.Errorf("%v: error: wanted %v, got %v", i, e, a)
-		}
-		if e, a := item.expectBind, gotBinding; !reflect.DeepEqual(e, a) {
-			t.Errorf("%v: error: %s", i, util.ObjectDiff(e, a))
-		}
-		<-called
-		events.Stop()
-	}
-}
+//	for i, item := range table {
+//		var gotError error
+//		var gotPod *api.Pod
+//		var gotAssumedPod *api.Pod
+//		var gotBinding *api.Binding
+//		c := &Config{
+//			Modeler: &FakeModeler{
+//				AssumePodFunc: func(pod *api.Pod) {
+//					gotAssumedPod = pod
+//				},
+//			},
+//			MinionLister: algorithm.FakeMinionLister(
+//				api.NodeList{Items: []api.Node{{ObjectMeta: api.ObjectMeta{Name: "machine1"}}}},
+//			),
+//			Algorithm: item.algo,
+//			Binder: fakeBinder{func(b *api.Binding) error {
+//				gotBinding = b
+//				return item.injectBindError
+//			}},
+//			Error: func(p *api.Pod, err error) {
+//				gotPod = p
+//				gotError = err
+//			},
+//			NextPod: func() *api.Pod {
+//				return item.sendPod
+//			},
+//			Recorder: eventBroadcaster.NewRecorder(api.EventSource{Component: "scheduler"}),
+//		}
+//		s := New(c)
+//		called := make(chan struct{})
+//		events := eventBroadcaster.StartEventWatcher(func(e *api.Event) {
+//			if e, a := item.eventReason, e.Reason; e != a {
+//				t.Errorf("%v: expected %v, got %v", i, e, a)
+//			}
+//			close(called)
+//		})
+//		s.scheduleOne()
+//		if e, a := item.expectAssumedPod, gotAssumedPod; !reflect.DeepEqual(e, a) {
+//			t.Errorf("%v: assumed pod: wanted %v, got %v", i, e, a)
+//		}
+//		if e, a := item.expectErrorPod, gotPod; !reflect.DeepEqual(e, a) {
+//			t.Errorf("%v: error pod: wanted %v, got %v", i, e, a)
+//		}
+//		if e, a := item.expectError, gotError; !reflect.DeepEqual(e, a) {
+//			t.Errorf("%v: error: wanted %v, got %v", i, e, a)
+//		}
+//		if e, a := item.expectBind, gotBinding; !reflect.DeepEqual(e, a) {
+//			t.Errorf("%v: error: %s", i, util.ObjectDiff(e, a))
+//		}
+//		<-called
+//		events.Stop()
+//	}
+//}
 
-func TestSchedulerForgetAssumedPodAfterDelete(t *testing.T) {
-	eventBroadcaster := record.NewBroadcaster()
-	defer eventBroadcaster.StartLogging(t.Logf).Stop()
+//func TestSchedulerForgetAssumedPodAfterDelete(t *testing.T) {
+//	eventBroadcaster := record.NewBroadcaster()
+//	defer eventBroadcaster.StartLogging(t.Logf).Stop()
 
-	// Setup modeler so we control the contents of all 3 stores: assumed,
-	// scheduled and queued
-	scheduledPodStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	scheduledPodLister := &cache.StoreToPodLister{scheduledPodStore}
+//	// Setup modeler so we control the contents of all 3 stores: assumed,
+//	// scheduled and queued
+//	scheduledPodStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+//	scheduledPodLister := &cache.StoreToPodLister{scheduledPodStore}
 
-	queuedPodStore := cache.NewFIFO(cache.MetaNamespaceKeyFunc)
-	queuedPodLister := &cache.StoreToPodLister{queuedPodStore}
+//	queuedPodStore := cache.NewFIFO(cache.MetaNamespaceKeyFunc)
+//	queuedPodLister := &cache.StoreToPodLister{queuedPodStore}
 
-	modeler := NewSimpleModeler(queuedPodLister, scheduledPodLister)
+//	modeler := NewSimpleModeler(queuedPodLister, scheduledPodLister)
 
-	// Create a fake clock used to timestamp entries and calculate ttl. Nothing
-	// will expire till we flip to something older than the ttl, at which point
-	// all entries inserted with fakeTime will expire.
-	ttl := 30 * time.Second
-	fakeTime := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	fakeClock := &util.FakeClock{fakeTime}
-	ttlPolicy := &cache.TTLPolicy{ttl, fakeClock}
-	assumedPodsStore := cache.NewFakeExpirationStore(
-		cache.MetaNamespaceKeyFunc, nil, ttlPolicy, fakeClock)
-	modeler.assumedPods = &cache.StoreToPodLister{assumedPodsStore}
+//	// Create a fake clock used to timestamp entries and calculate ttl. Nothing
+//	// will expire till we flip to something older than the ttl, at which point
+//	// all entries inserted with fakeTime will expire.
+//	ttl := 30 * time.Second
+//	fakeTime := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+//	fakeClock := &util.FakeClock{fakeTime}
+//	ttlPolicy := &cache.TTLPolicy{ttl, fakeClock}
+//	assumedPodsStore := cache.NewFakeExpirationStore(
+//		cache.MetaNamespaceKeyFunc, nil, ttlPolicy, fakeClock)
+//	modeler.assumedPods = &cache.StoreToPodLister{assumedPodsStore}
 
-	// Port is the easiest way to cause a fit predicate failure
-	podPort := 8080
-	firstPod := podWithPort("foo", "", podPort)
+//	// Port is the easiest way to cause a fit predicate failure
+//	podPort := 8080
+//	firstPod := podWithPort("foo", "", podPort)
 
-	// Create the scheduler config
-	algo := NewGenericScheduler(
-		map[string]algorithm.FitPredicate{"PodFitsPorts": predicates.PodFitsPorts},
-		[]algorithm.PriorityConfig{},
-		modeler.PodLister(),
-		rand.New(rand.NewSource(time.Now().UnixNano())))
+//	// Create the scheduler config
+//	algo := NewGenericScheduler(
+//		map[string]algorithm.FitPredicate{"PodFitsPorts": predicates.PodFitsPorts},
+//		[]algorithm.PriorityConfig{},
+//		modeler.PodLister(),
+//		rand.New(rand.NewSource(time.Now().UnixNano())))
 
-	var gotBinding *api.Binding
-	c := &Config{
-		Modeler: modeler,
-		MinionLister: algorithm.FakeMinionLister(
-			api.NodeList{Items: []api.Node{{ObjectMeta: api.ObjectMeta{Name: "machine1"}}}},
-		),
-		Algorithm: algo,
-		Binder: fakeBinder{func(b *api.Binding) error {
-			scheduledPodStore.Add(podWithPort(b.Name, b.Target.Name, podPort))
-			gotBinding = b
-			return nil
-		}},
-		NextPod: func() *api.Pod {
-			return queuedPodStore.Pop().(*api.Pod)
-		},
-		Error: func(p *api.Pod, err error) {
-			t.Errorf("Unexpected error when scheduling pod %+v: %v", p, err)
-		},
-		Recorder: eventBroadcaster.NewRecorder(api.EventSource{Component: "scheduler"}),
-	}
+//	var gotBinding *api.Binding
+//	c := &Config{
+//		Modeler: modeler,
+//		MinionLister: algorithm.FakeMinionLister(
+//			api.NodeList{Items: []api.Node{{ObjectMeta: api.ObjectMeta{Name: "machine1"}}}},
+//		),
+//		Algorithm: algo,
+//		Binder: fakeBinder{func(b *api.Binding) error {
+//			scheduledPodStore.Add(podWithPort(b.Name, b.Target.Name, podPort))
+//			gotBinding = b
+//			return nil
+//		}},
+//		NextPod: func() *api.Pod {
+//			return queuedPodStore.Pop().(*api.Pod)
+//		},
+//		Error: func(p *api.Pod, err error) {
+//			t.Errorf("Unexpected error when scheduling pod %+v: %v", p, err)
+//		},
+//		Recorder: eventBroadcaster.NewRecorder(api.EventSource{Component: "scheduler"}),
+//	}
 
-	// First scheduling pass should schedule the pod
-	s := New(c)
-	called := make(chan struct{})
-	events := eventBroadcaster.StartEventWatcher(func(e *api.Event) {
-		if e, a := "scheduled", e.Reason; e != a {
-			t.Errorf("expected %v, got %v", e, a)
-		}
-		close(called)
-	})
+//	// First scheduling pass should schedule the pod
+//	s := New(c)
+//	called := make(chan struct{})
+//	events := eventBroadcaster.StartEventWatcher(func(e *api.Event) {
+//		if e, a := "scheduled", e.Reason; e != a {
+//			t.Errorf("expected %v, got %v", e, a)
+//		}
+//		close(called)
+//	})
 
-	queuedPodStore.Add(firstPod)
-	// queuedPodStore: [foo:8080]
-	// scheduledPodStore: []
-	// assumedPods: []
+//	queuedPodStore.Add(firstPod)
+//	// queuedPodStore: [foo:8080]
+//	// scheduledPodStore: []
+//	// assumedPods: []
 
-	s.scheduleOne()
-	// queuedPodStore: []
-	// scheduledPodStore: [foo:8080]
-	// assumedPods: [foo:8080]
+//	s.scheduleOne()
+//	// queuedPodStore: []
+//	// scheduledPodStore: [foo:8080]
+//	// assumedPods: [foo:8080]
 
-	pod, exists, _ := scheduledPodStore.GetByKey("foo")
-	if !exists {
-		t.Errorf("Expected scheduled pod store to contain pod")
-	}
-	pod, exists, _ = queuedPodStore.GetByKey("foo")
-	if exists {
-		t.Errorf("Did not expect a queued pod, found %+v", pod)
-	}
-	pod, exists, _ = assumedPodsStore.GetByKey("foo")
-	if !exists {
-		t.Errorf("Assumed pod store should contain stale pod")
-	}
+//	pod, exists, _ := scheduledPodStore.GetByKey("foo")
+//	if !exists {
+//		t.Errorf("Expected scheduled pod store to contain pod")
+//	}
+//	pod, exists, _ = queuedPodStore.GetByKey("foo")
+//	if exists {
+//		t.Errorf("Did not expect a queued pod, found %+v", pod)
+//	}
+//	pod, exists, _ = assumedPodsStore.GetByKey("foo")
+//	if !exists {
+//		t.Errorf("Assumed pod store should contain stale pod")
+//	}
 
-	expectBind := &api.Binding{
-		ObjectMeta: api.ObjectMeta{Name: "foo"},
-		Target:     api.ObjectReference{Kind: "Node", Name: "machine1"},
-	}
-	if ex, ac := expectBind, gotBinding; !reflect.DeepEqual(ex, ac) {
-		t.Errorf("Expected exact match on binding: %s", util.ObjectDiff(ex, ac))
-	}
+//	expectBind := &api.Binding{
+//		ObjectMeta: api.ObjectMeta{Name: "foo"},
+//		Target:     api.ObjectReference{Kind: "Node", Name: "machine1"},
+//	}
+//	if ex, ac := expectBind, gotBinding; !reflect.DeepEqual(ex, ac) {
+//		t.Errorf("Expected exact match on binding: %s", util.ObjectDiff(ex, ac))
+//	}
 
-	<-called
-	events.Stop()
+//	<-called
+//	events.Stop()
 
-	scheduledPodStore.Delete(pod)
-	_, exists, _ = assumedPodsStore.Get(pod)
-	if !exists {
-		t.Errorf("Expected pod %#v in assumed pod store", pod)
-	}
+//	scheduledPodStore.Delete(pod)
+//	_, exists, _ = assumedPodsStore.Get(pod)
+//	if !exists {
+//		t.Errorf("Expected pod %#v in assumed pod store", pod)
+//	}
 
-	secondPod := podWithPort("bar", "", podPort)
-	queuedPodStore.Add(secondPod)
-	// queuedPodStore: [bar:8080]
-	// scheduledPodStore: []
-	// assumedPods: [foo:8080]
+//	secondPod := podWithPort("bar", "", podPort)
+//	queuedPodStore.Add(secondPod)
+//	// queuedPodStore: [bar:8080]
+//	// scheduledPodStore: []
+//	// assumedPods: [foo:8080]
 
-	// Second scheduling pass will fail to schedule if the store hasn't expired
-	// the deleted pod. This would normally happen with a timeout.
-	//expirationPolicy.NeverExpire = util.NewStringSet()
-	fakeClock.Time = fakeClock.Time.Add(ttl + 1)
+//	// Second scheduling pass will fail to schedule if the store hasn't expired
+//	// the deleted pod. This would normally happen with a timeout.
+//	//expirationPolicy.NeverExpire = util.NewStringSet()
+//	fakeClock.Time = fakeClock.Time.Add(ttl + 1)
 
-	called = make(chan struct{})
-	events = eventBroadcaster.StartEventWatcher(func(e *api.Event) {
-		if e, a := "scheduled", e.Reason; e != a {
-			t.Errorf("expected %v, got %v", e, a)
-		}
-		close(called)
-	})
+//	called = make(chan struct{})
+//	events = eventBroadcaster.StartEventWatcher(func(e *api.Event) {
+//		if e, a := "scheduled", e.Reason; e != a {
+//			t.Errorf("expected %v, got %v", e, a)
+//		}
+//		close(called)
+//	})
 
-	s.scheduleOne()
+//	s.scheduleOne()
 
-	expectBind = &api.Binding{
-		ObjectMeta: api.ObjectMeta{Name: "bar"},
-		Target:     api.ObjectReference{Kind: "Node", Name: "machine1"},
-	}
-	if ex, ac := expectBind, gotBinding; !reflect.DeepEqual(ex, ac) {
-		t.Errorf("Expected exact match on binding: %s", util.ObjectDiff(ex, ac))
-	}
-	<-called
-	events.Stop()
-}
+//	expectBind = &api.Binding{
+//		ObjectMeta: api.ObjectMeta{Name: "bar"},
+//		Target:     api.ObjectReference{Kind: "Node", Name: "machine1"},
+//	}
+//	if ex, ac := expectBind, gotBinding; !reflect.DeepEqual(ex, ac) {
+//		t.Errorf("Expected exact match on binding: %s", util.ObjectDiff(ex, ac))
+//	}
+//	<-called
+//	events.Stop()
+//}
 
-// Fake rate limiter that records the 'accept' tokens from the real rate limiter
-type FakeRateLimiter struct {
-	r            util.RateLimiter
-	acceptValues []bool
-}
+//// Fake rate limiter that records the 'accept' tokens from the real rate limiter
+//type FakeRateLimiter struct {
+//	r            util.RateLimiter
+//	acceptValues []bool
+//}
 
-func (fr *FakeRateLimiter) CanAccept() bool {
-	return true
-}
+//func (fr *FakeRateLimiter) CanAccept() bool {
+//	return true
+//}
 
-func (fr *FakeRateLimiter) Stop() {}
+//func (fr *FakeRateLimiter) Stop() {}
 
-func (fr *FakeRateLimiter) Accept() {
-	fr.acceptValues = append(fr.acceptValues, fr.r.CanAccept())
-}
+//func (fr *FakeRateLimiter) Accept() {
+//	fr.acceptValues = append(fr.acceptValues, fr.r.CanAccept())
+//}
 
-func TestSchedulerRateLimitsBinding(t *testing.T) {
-	scheduledPodStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	scheduledPodLister := &cache.StoreToPodLister{scheduledPodStore}
-	queuedPodStore := cache.NewFIFO(cache.MetaNamespaceKeyFunc)
-	queuedPodLister := &cache.StoreToPodLister{queuedPodStore}
-	modeler := NewSimpleModeler(queuedPodLister, scheduledPodLister)
+//func TestSchedulerRateLimitsBinding(t *testing.T) {
+//	scheduledPodStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+//	scheduledPodLister := &cache.StoreToPodLister{scheduledPodStore}
+//	queuedPodStore := cache.NewFIFO(cache.MetaNamespaceKeyFunc)
+//	queuedPodLister := &cache.StoreToPodLister{queuedPodStore}
+//	modeler := NewSimpleModeler(queuedPodLister, scheduledPodLister)
 
-	algo := NewGenericScheduler(
-		map[string]algorithm.FitPredicate{},
-		[]algorithm.PriorityConfig{},
-		modeler.PodLister(),
-		rand.New(rand.NewSource(time.Now().UnixNano())))
+//	algo := NewGenericScheduler(
+//		map[string]algorithm.FitPredicate{},
+//		[]algorithm.PriorityConfig{},
+//		modeler.PodLister(),
+//		rand.New(rand.NewSource(time.Now().UnixNano())))
 
-	// Rate limit to 1 pod
-	fr := FakeRateLimiter{util.NewTokenBucketRateLimiter(0.02, 1), []bool{}}
-	c := &Config{
-		Modeler: modeler,
-		MinionLister: algorithm.FakeMinionLister(
-			api.NodeList{Items: []api.Node{{ObjectMeta: api.ObjectMeta{Name: "machine1"}}}},
-		),
-		Algorithm: algo,
-		Binder: fakeBinder{func(b *api.Binding) error {
-			return nil
-		}},
-		NextPod: func() *api.Pod {
-			return queuedPodStore.Pop().(*api.Pod)
-		},
-		Error: func(p *api.Pod, err error) {
-			t.Errorf("Unexpected error when scheduling pod %+v: %v", p, err)
-		},
-		Recorder:            &record.FakeRecorder{},
-		BindPodsRateLimiter: &fr,
-	}
+//	// Rate limit to 1 pod
+//	fr := FakeRateLimiter{util.NewTokenBucketRateLimiter(0.02, 1), []bool{}}
+//	c := &Config{
+//		Modeler: modeler,
+//		MinionLister: algorithm.FakeMinionLister(
+//			api.NodeList{Items: []api.Node{{ObjectMeta: api.ObjectMeta{Name: "machine1"}}}},
+//		),
+//		Algorithm: algo,
+//		Binder: fakeBinder{func(b *api.Binding) error {
+//			return nil
+//		}},
+//		NextPod: func() *api.Pod {
+//			return queuedPodStore.Pop().(*api.Pod)
+//		},
+//		Error: func(p *api.Pod, err error) {
+//			t.Errorf("Unexpected error when scheduling pod %+v: %v", p, err)
+//		},
+//		Recorder:            &record.FakeRecorder{},
+//		BindPodsRateLimiter: &fr,
+//	}
 
-	s := New(c)
-	firstPod := podWithID("foo", "")
-	secondPod := podWithID("boo", "")
-	queuedPodStore.Add(firstPod)
-	queuedPodStore.Add(secondPod)
+//	s := New(c)
+//	firstPod := podWithID("foo", "")
+//	secondPod := podWithID("boo", "")
+//	queuedPodStore.Add(firstPod)
+//	queuedPodStore.Add(secondPod)
 
-	for i, hitRateLimit := range []bool{true, false} {
-		s.scheduleOne()
-		if fr.acceptValues[i] != hitRateLimit {
-			t.Errorf("Unexpected rate limiting, expect rate limit to be: %v but found it was %v", hitRateLimit, fr.acceptValues[i])
-		}
-	}
-}
+//	for i, hitRateLimit := range []bool{true, false} {
+//		s.scheduleOne()
+//		if fr.acceptValues[i] != hitRateLimit {
+//			t.Errorf("Unexpected rate limiting, expect rate limit to be: %v but found it was %v", hitRateLimit, fr.acceptValues[i])
+//		}
+//	}
+//}


### PR DESCRIPTION
This PR tries to implement multi-scheduler feature for Kubernetes. The design is open to discussion and there are still many things to decide (e.g. namespaces, trust model, admission control, adding pod spec, logs, etc). Please leave your comments here or in issue https://github.com/GoogleCloudPlatform/kubernetes/issues/11793

I have tested in my local environment (`cluster/local-up-cluster.sh`) and it works. The main idea is to register multiple algorithm providers when the scheduler starts, so there would be only one scheduler process at any time (same as it is now). See the following lines for a brief idea. For more info please look at the code and I am happy with any discussion.
1. Multiple algorithm providers are registered when scheduler starts
2. Each algorithm provider has a name
3. A pod can specify which algorithm provider to use. How to specify is open to discuss, and in this version, we check if there is a Label [`"policy": <provider-name>`] in Pod's metadata labels. If there is an algorithm provider registered with name `<provider-name>`, then it is applied; otherwise(`<provider-name>` not registered or no Label with key `"policy"`), use default provider
4. There is a default provider
5. There are still many things to do, this is just a start.

PS: package myscheduler (./plugin/pkg/scheduler/algorithmprovider/myscheduler/myscheduler.go) is for testing

**Example**

I will explain how this multi-scheduler works through an example. Just clone my fork and it should work for you.
1. one node in the cluster
2. two algorithm providers (`DefaultProvider` and `MyScheduler`)
   - `DefaultProvider` checks `PodFitsPorts` in predicate phase
   - `MyScheduler` **DOES NOT** check `PodFitsPorts` in predicate phase
3. The pod template is given below. Create a _first_ pod with the template and it is scheduled to my only node
4. Change the pod id and create a _second_ pod using this template.
   - You should see that the pod is failed to be scheduled.
   - Use `describe pod <pod-name>`, it is shown in the Reason field `failedScheduling` and Message `Failed for reason PodFitsPorts and possibly others`. 
   - Note that this pod specifies its preferred algorithm with Label `policy: DefaultProvider` which checks `PodFitsPorts`, so the `DefaultProvider` works fine.
5. Now it is time to use `MyScheduler` as preferred algorithm provider to create a _third_ pod.
   - Change the pod id and change Label `policy: DefaultProvider` to `policy: MySchdeduler`
   - Create a third pod with changed template
   - You should see in `describe pod <pod-name>` that the pod is successfully scheduled, no `failedScheduling` is reported.
   - It shows that the algorithm provider `MyScheduler` works as intended.
   - PS: This third pod will never be ready since kubelet would notice there is a host port conflict.

pod template:

```
id: apache
kind: Pod
apiVersion: v1
metadata:
  name: apache
  labels:
    app: apache
    policy: DefaultProvider
spec:
  hostNetwork: true
  containers:
    - name: apachecontainer
      image: test/apache:1
      ports:
        - name: testport
          protocol: TCP
          containerPort: 1234
          hostPort: 1234
```
