### PR TITLE
Added div id to override the overflow of the 'hero include' to stop auto scroll bar

### DIFF
--- a/_sass/_documents.scss
+++ b/_sass/_documents.scss
@@ -120,3 +120,7 @@ div #doccontent {
         max-width: 100%;
     }
 }
+
+div #docbanner{
+	overflow: hidden;
+}

--- a/v1.0/index.md
+++ b/v1.0/index.md
@@ -10,5 +10,6 @@ hero:
     img: /img/desktop/logo.png
 ---
 
-&nbsp;
+<div id="docbanner">
 {% include hero.html %}
+</div>


### PR DESCRIPTION
Fix for the scroll bar that displays under the banner in the k8s.io Documentation page 
