### PR TITLE
downgrade errors returned by watchHandler in reflector.go to warnnings

### DIFF
--- a/pkg/client/cache/reflector.go
+++ b/pkg/client/cache/reflector.go
@@ -224,7 +224,7 @@ func (r *Reflector) listAndWatch(stopCh <-chan struct{}) {
 		}
 		if err := r.watchHandler(w, &resourceVersion, resyncCh, stopCh); err != nil {
 			if err != errorResyncRequested && err != errorStopRequested {
-				util.HandleError(fmt.Errorf("%s: watch of %v ended with: %v", r.name, r.expectedType, err))
+				glog.Warningf("%s: watch of %v ended with: %v", r.name, r.expectedType, err)
 			}
 			return
 		}


### PR DESCRIPTION
Because the Reflector will try to reconnect, so downgrading errors returned by watchHandler in reflector.go to warnnings

fix #11854

@dalanlan @lavalamp 
