### PR TITLE
Fixed newRecycler func for HostPath & NFS

### DIFF
--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -86,11 +86,10 @@ func (plugin *hostPathPlugin) NewRecycler(spec *volume.Spec) (volume.Recycler, e
 }
 
 func newRecycler(spec *volume.Spec, host volume.VolumeHost) (volume.Recycler, error) {
-	if spec.VolumeSource.HostPath != nil {
-		return &hostPathRecycler{spec.Name, spec.VolumeSource.HostPath.Path, host}, nil
-	} else {
-		return &hostPathRecycler{spec.Name, spec.PersistentVolumeSource.HostPath.Path, host}, nil
+	if spec.PersistentVolumeSource.HostPath == nil {
+		return nil, fmt.Errorf("spec.PersistentVolumeSource.HostPath is nil")
 	}
+	return &hostPathRecycler{spec.Name, spec.PersistentVolumeSource.HostPath.Path, host}, nil
 }
 
 // HostPath volumes represent a bare host file or directory mount.

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -223,21 +223,15 @@ func (c *nfsCleaner) TearDownAt(dir string) error {
 }
 
 func newRecycler(spec *volume.Spec, host volume.VolumeHost) (volume.Recycler, error) {
-	if spec.VolumeSource.HostPath != nil {
-		return &nfsRecycler{
-			name:   spec.Name,
-			server: spec.VolumeSource.NFS.Server,
-			path:   spec.VolumeSource.NFS.Path,
-			host:   host,
-		}, nil
-	} else {
-		return &nfsRecycler{
-			name:   spec.Name,
-			server: spec.PersistentVolumeSource.NFS.Server,
-			path:   spec.PersistentVolumeSource.NFS.Path,
-			host:   host,
-		}, nil
+	if spec.PersistentVolumeSource.NFS == nil {
+		return nil, fmt.Errorf("spec.PersistentVolumeSource.NFS is nil")
 	}
+	return &nfsRecycler{
+		name:   spec.Name,
+		server: spec.PersistentVolumeSource.NFS.Server,
+		path:   spec.PersistentVolumeSource.NFS.Path,
+		host:   host,
+	}, nil
 }
 
 // nfsRecycler scrubs an NFS volume by running "rm -rf" on the volume in a pod.


### PR DESCRIPTION
@thockin only PV can do recycling, not regular volumes.  Both conditional statements will never be true for VolumeSource.   The NFS one, in particular, was a poor cut/paste oversight.
