### PR TITLE
Fix up memory requirements for release w/ boot2docker.

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -104,10 +104,16 @@ readonly KUBE_CLIENT_PLATFORMS=(
   windows/amd64
 )
 
-# Gigabytes desired for parallel platform builds. 8 is fairly
+# Gigabytes desired for parallel platform builds. 11 is fairly
 # arbitrary, but is a reasonable splitting point for 2015
 # laptops-versus-not.
-readonly KUBE_PARALLEL_BUILD_MEMORY=8
+#
+# If you are using boot2docker, the following seems to work (note 
+# that 12000 rounds to 11G):
+#   boot2docker down
+#   VBoxManage modifyvm boot2docker-vm --memory 12000
+#   boot2docker up
+readonly KUBE_PARALLEL_BUILD_MEMORY=11
 
 readonly KUBE_ALL_TARGETS=(
   "${KUBE_SERVER_TARGETS[@]}"


### PR DESCRIPTION
Related: #10840
