### PR TITLE
Rename getPodControllers to getPodController .

### DIFF
--- a/pkg/controller/replication/replication_controller_test.go
+++ b/pkg/controller/replication/replication_controller_test.go
@@ -484,7 +484,7 @@ func TestPodControllerLookup(t *testing.T) {
 		for _, r := range c.inRCs {
 			manager.rcStore.Add(r)
 		}
-		if rc := manager.getPodControllers(c.pod); rc != nil {
+		if rc := manager.getPodController(c.pod); rc != nil {
 			if c.outRCName != rc.Name {
 				t.Errorf("Got controller %+v expected %+v", rc.Name, c.outRCName)
 			}


### PR DESCRIPTION
This clarifies the issue around ReplicationController <-> Pod cardinality (a little bit), since we only pick one controller in case of dupes. cc @ixdy @bprashanth 
