### PR TITLE
Adjust permissions so that Cassandra can run without root access

### DIFF
--- a/examples/cassandra/image/Dockerfile
+++ b/examples/cassandra/image/Dockerfile
@@ -15,8 +15,17 @@ RUN apt-get update
 RUN apt-get -qq -y install procps cassandra
 
 COPY cassandra.yaml /etc/cassandra/cassandra.yaml
+COPY logback.xml /etc/cassandra/logback.xml
 COPY run.sh /run.sh
 COPY kubernetes-cassandra.jar /kubernetes-cassandra.jar
-RUN chmod a+x /run.sh
+
+RUN chmod a+x /run.sh && \
+    mkdir -p /cassandra_data/data && \
+    chown -R cassandra.cassandra /etc/cassandra /cassandra_data && \
+    chmod o+w -R /etc/cassandra /cassandra_data
+
+VOLUME ["/cassandra_data/data"]    
+
+USER cassandra
 
 CMD /run.sh

--- a/examples/cassandra/image/cassandra.yaml
+++ b/examples/cassandra/image/cassandra.yaml
@@ -215,7 +215,7 @@ counter_cache_save_period: 7200
 
 # saved caches
 # If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
-saved_caches_directory: /var/lib/cassandra/saved_caches
+saved_caches_directory: /cassandra_data/saved_caches
 
 # commitlog_sync may be either "periodic" or "batch." 
 # When in batch mode, Cassandra won't ack writes until the commit log

--- a/examples/cassandra/image/logback.xml
+++ b/examples/cassandra/image/logback.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<configuration scan="true">
+  <jmxConfigurator/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%-5level %date{HH:mm:ss,SSS} %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
+  <logger name="com.thinkaurelius.thrift" level="ERROR"/>
+</configuration>


### PR DESCRIPTION
Allows both non root access as well as running with `--user=<random id>`

This makes the Cassandra example run on OpenShift.
