### PR TITLE
Fix maxTimes comment to clarify infinit waits

### DIFF
--- a/pkg/util/wait/wait.go
+++ b/pkg/util/wait/wait.go
@@ -43,12 +43,16 @@ type ConditionFunc func() (done bool, err error)
 // Poll tries a condition func until it returns true, an error, or the timeout
 // is reached. condition will always be invoked at least once but some intervals
 // may be missed if the condition takes too long or the time window is too short.
-// If you pass maxTimes = 0, Poll will loop until condition returns true or an
-// error.
+// If you want to Poll something forever, see PollInfinite.
 // Poll always waits the interval before the first check of the condition.
 // TODO: create a separate PollImmediate function that does not wait.
 func Poll(interval, timeout time.Duration, condition ConditionFunc) error {
 	return WaitFor(poller(interval, timeout), condition)
+}
+
+// PollInfinite polls forever.
+func PollInfinite(interval time.Duration, condition ConditionFunc) error {
+	return WaitFor(poller(interval, 0), condition)
 }
 
 // WaitFunc creates a channel that receives an item every time a test
@@ -81,7 +85,7 @@ func WaitFor(wait WaitFunc, c ConditionFunc) error {
 // poller returns a WaitFunc that will send to the channel every
 // interval until timeout has elapsed and then close the channel.
 // Over very short intervals you may receive no ticks before
-// the channel is closed closed.  If maxTimes is 0, the channel
+// the channel is closed.  If timeout is 0, the channel
 // will never be closed.
 func poller(interval, timeout time.Duration) WaitFunc {
 	return WaitFunc(func() <-chan struct{} {

--- a/pkg/util/wait/wait_test.go
+++ b/pkg/util/wait/wait_test.go
@@ -91,9 +91,10 @@ func TestPollForever(t *testing.T) {
 			}
 			return false, nil
 		})
-		if err := Poll(time.Microsecond, 0, f); err != nil {
+		if err := PollInfinite(time.Microsecond, f); err != nil {
 			t.Fatalf("unexpected error %v", err)
 		}
+
 		close(ch)
 		complete <- struct{}{}
 	}()


### PR DESCRIPTION
make infinite polling explicit and fix comments.
- maxTimes seems to refer to **timeout** so the comment needs fixing... but
- I dont think anyone is using Poll(,0,) anywhere in the codebase right now, so this is a good time to prevent folks from needing to rely on that somewhat counterintuitive **impl detail**.
- for infinite polling i think **PollInfinite** will make things much more clear in the code.
- (trivial) in my mind, in the future, maybe poll(,0,) should literally poll for **0 seconds**, rather than polling infinitely..

this seems to be clearer and more transparent way to do the infinite waiting , which won't rely on comments to understand how it works... 

@smarterclayton @ixdy 
