### PR TITLE
Make kubectl describe node include allocated resource

### DIFF
--- a/pkg/api/resource/quantity.go
+++ b/pkg/api/resource/quantity.go
@@ -301,6 +301,14 @@ func (q *Quantity) String() string {
 	return number + string(suffix)
 }
 
+func (q *Quantity) Add(y Quantity) error {
+	if q.Format != y.Format {
+		return fmt.Errorf("format mismatch: %v vs. %v", q.Format, y.Format)
+	}
+	q.Amount.Add(q.Amount, y.Amount)
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface.
 func (q Quantity) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + q.String() + `"`), nil


### PR DESCRIPTION
Fixes #11238

After this update, `kubectl describe node` now looks at the pods (only the non-terminated ones) assigned to the node and compute: 

```
Allocated resources (total requests):
 cpu:       400m
 memory:    200Mi
 pods:      4
```
