### PR TITLE
Revert "Implement 'Nodes Network' test for GKE"

### DIFF
--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -210,17 +210,18 @@ function get-password() {
     | grep password | cut -f 4 -d ' ')
 }
 
-# Detect the IP for the master. Note that on GKE, we don't know the name of the
-# master, so KUBE_MASTER is not set.
+# Detect the instance name and IP for the master
 #
 # Assumed vars:
 #   ZONE
 #   CLUSTER_NAME
 # Vars set:
+#   KUBE_MASTER
 #   KUBE_MASTER_IP
 function detect-master() {
   echo "... in gke:detect-master()" >&2
   detect-project >&2
+  KUBE_MASTER="k8s-${CLUSTER_NAME}-master"
   KUBE_MASTER_IP=$("${GCLOUD}" "${CMD_GROUP}" container clusters describe \
     --project="${PROJECT}" --zone="${ZONE}" "${CLUSTER_NAME}" \
     | grep endpoint | cut -f 2 -d ' ')

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -89,7 +89,7 @@ fi
 export PATH=$(dirname "${e2e_test}"):"${PATH}"
 "${ginkgo}" "${ginkgo_args[@]:+${ginkgo_args[@]}}" "${e2e_test}" -- \
   "${auth_config[@]:+${auth_config[@]}}" \
-  --host="https://${KUBE_MASTER_IP:-}" \
+  --host="https://${KUBE_MASTER_IP-}" \
   --provider="${KUBERNETES_PROVIDER}" \
   --gce-project="${PROJECT:-}" \
   --gce-zone="${ZONE:-}" \

--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -326,8 +326,22 @@ func performTemporaryNetworkFailure(c *client.Client, ns, rcName string, replica
 		Failf("Couldn't get the external IP of host %s with addresses %v", node.Name, node.Status.Addresses)
 	}
 	By(fmt.Sprintf("block network traffic from node %s to the master", node.Name))
-	iptablesRule := fmt.Sprintf("OUTPUT --destination %s --jump DROP",
-		strings.TrimPrefix(testContext.Host, "https://"))
+
+	// TODO marekbiskup 2015-06-19 #10085
+	// The use of MasterName will cause iptables to do a DNS lookup to
+	// resolve the name to an IP address, which will slow down the test
+	// and cause it to fail if DNS is absent or broken.
+	// Use the IP address instead.
+
+	destination := testContext.CloudConfig.MasterName
+	if providerIs("aws") {
+		// This is the (internal) IP address used on AWS for the master
+		// TODO: Use IP address for all clouds?
+		// TODO: Avoid hard-coding this
+		destination = "172.20.0.9"
+	}
+
+	iptablesRule := fmt.Sprintf("OUTPUT --destination %s --jump DROP", destination)
 	defer func() {
 		// This code will execute even if setting the iptables rule failed.
 		// It is on purpose because we may have an error even if the new rule


### PR DESCRIPTION
Reverts GoogleCloudPlatform/kubernetes#11789

Reason: constantly failing Jenkins - test:
"recreates pods scheduled on the unreachable minion node AND allows scheduling of pods on a minion after it rejoins the cluster"

@mbforbes @ixdy @mikedanese 
