### PR TITLE
Remove duplicated warning of docker version

### DIFF
--- a/docs/getting-started-guides/docker-multinode.md
+++ b/docs/getting-started-guides/docker-multinode.md
@@ -52,10 +52,7 @@ Please install Docker 1.6.2 or wait for Docker 1.7.1.
 
 ## Prerequisites
 
-1. You need a machine with docker installed.
-
-There is a [bug](https://github.com/docker/docker/issues/14106) in Docker 1.7.0 that prevents this guide from working correctly.
-Please install Docker 1.6.2 or wait for Docker 1.7.1.
+1. You need a machine with docker of right version installed.
 
 ## Overview
 


### PR DESCRIPTION
Sorry, but we need to remove duplicated docker version warning. That's verbose.
