### PR TITLE
Use external id when reconciling routes

### DIFF
--- a/pkg/cloudprovider/aws/aws_routes.go
+++ b/pkg/cloudprovider/aws/aws_routes.go
@@ -62,8 +62,13 @@ func (s *AWSCloud) ListRoutes(clusterName string) ([]*cloudprovider.Route, error
 			continue
 		}
 
+		instance, err := s.getInstanceById(instanceID)
+		if err != nil {
+			return nil, err
+		}
+		instanceName := orEmpty(instance.PrivateDNSName)
 		routeName := clusterName + "-" + destinationCIDR
-		routes = append(routes, &cloudprovider.Route{routeName, instanceID, destinationCIDR})
+		routes = append(routes, &cloudprovider.Route{routeName, instanceName, destinationCIDR})
 	}
 
 	return routes, nil


### PR DESCRIPTION
The node name used by Kubernetes internally doesn't match what is returned from AWS when querying route tables. This changes the reconciliation step to match against the node's external id as returned by AWS.

I know we're trying to make the Kubernetes node name match what is used internally by AWS, but that seems to be blocked on some other issues where the node name is expected to be resolvable. As such, this code will probably need to be revised again when those changes land.

@justinsb PTAL

This is an attempt to resolve #11979 which was experienced by myself and another user. 
