### PR TITLE
Removed the left over call to popstate 

### DIFF
--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -24,9 +24,6 @@
 	            $(this).next().stop(true,true).slideUp('normal');
 	        }
 	    });
-		window.addEventListener("popstate", function(e) {
-		        window.location.href = location.href
-		});
 	});
 </script>
 {% include docfooter.html %}


### PR DESCRIPTION
Replaced with new logic in _indcludes/documentation.html.

This is the remaining fix for #12030 
