### PR TITLE
DescribeNodes should use fieldSelector, handle caller not authorized to view pods

### DIFF
--- a/pkg/kubectl/describe_test.go
+++ b/pkg/kubectl/describe_test.go
@@ -359,53 +359,55 @@ func TestDefaultDescribers(t *testing.T) {
 
 func TestGetPodsTotalRequests(t *testing.T) {
 	testCases := []struct {
-		pods                         []*api.Pod
+		pods                         *api.PodList
 		expectedReqs, expectedLimits map[api.ResourceName]resource.Quantity
 	}{
 		{
-			pods: []*api.Pod{
-				{
-					Spec: api.PodSpec{
-						Containers: []api.Container{
-							{
-								Resources: api.ResourceRequirements{
-									Requests: api.ResourceList{
-										api.ResourceName(api.ResourceCPU):     resource.MustParse("1"),
-										api.ResourceName(api.ResourceMemory):  resource.MustParse("300Mi"),
-										api.ResourceName(api.ResourceStorage): resource.MustParse("1G"),
+			pods: &api.PodList{
+				Items: []api.Pod{
+					{
+						Spec: api.PodSpec{
+							Containers: []api.Container{
+								{
+									Resources: api.ResourceRequirements{
+										Requests: api.ResourceList{
+											api.ResourceName(api.ResourceCPU):     resource.MustParse("1"),
+											api.ResourceName(api.ResourceMemory):  resource.MustParse("300Mi"),
+											api.ResourceName(api.ResourceStorage): resource.MustParse("1G"),
+										},
 									},
 								},
-							},
-							{
-								Resources: api.ResourceRequirements{
-									Requests: api.ResourceList{
-										api.ResourceName(api.ResourceCPU):     resource.MustParse("90m"),
-										api.ResourceName(api.ResourceMemory):  resource.MustParse("120Mi"),
-										api.ResourceName(api.ResourceStorage): resource.MustParse("200M"),
+								{
+									Resources: api.ResourceRequirements{
+										Requests: api.ResourceList{
+											api.ResourceName(api.ResourceCPU):     resource.MustParse("90m"),
+											api.ResourceName(api.ResourceMemory):  resource.MustParse("120Mi"),
+											api.ResourceName(api.ResourceStorage): resource.MustParse("200M"),
+										},
 									},
 								},
 							},
 						},
 					},
-				},
-				{
-					Spec: api.PodSpec{
-						Containers: []api.Container{
-							{
-								Resources: api.ResourceRequirements{
-									Requests: api.ResourceList{
-										api.ResourceName(api.ResourceCPU):     resource.MustParse("60m"),
-										api.ResourceName(api.ResourceMemory):  resource.MustParse("43Mi"),
-										api.ResourceName(api.ResourceStorage): resource.MustParse("500M"),
+					{
+						Spec: api.PodSpec{
+							Containers: []api.Container{
+								{
+									Resources: api.ResourceRequirements{
+										Requests: api.ResourceList{
+											api.ResourceName(api.ResourceCPU):     resource.MustParse("60m"),
+											api.ResourceName(api.ResourceMemory):  resource.MustParse("43Mi"),
+											api.ResourceName(api.ResourceStorage): resource.MustParse("500M"),
+										},
 									},
 								},
-							},
-							{
-								Resources: api.ResourceRequirements{
-									Requests: api.ResourceList{
-										api.ResourceName(api.ResourceCPU):     resource.MustParse("34m"),
-										api.ResourceName(api.ResourceMemory):  resource.MustParse("83Mi"),
-										api.ResourceName(api.ResourceStorage): resource.MustParse("700M"),
+								{
+									Resources: api.ResourceRequirements{
+										Requests: api.ResourceList{
+											api.ResourceName(api.ResourceCPU):     resource.MustParse("34m"),
+											api.ResourceName(api.ResourceMemory):  resource.MustParse("83Mi"),
+											api.ResourceName(api.ResourceStorage): resource.MustParse("700M"),
+										},
 									},
 								},
 							},


### PR DESCRIPTION
This PR makes a couple changes:
1. When describing a node, we no longer fetch all pods in the system.  Instead we use a fieldSelector to only fetch pods on my node by name.  Helps traffic on the wire.
2. Update the code to gracefully handle policy aware environments where a user may be able to view a node, but not view all pods.  In that case, we just state that the user is not authorized.

@bgrant0607 @erictune - this is a follow-up to a comment on https://github.com/GoogleCloudPlatform/kubernetes/pull/11788, wanted to make the update before I forget.  I don't care which goes first.
