### PR TITLE
Update build/README.md to note memory requirements for boot2docker.

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -5,7 +5,8 @@ To build Kubernetes you need to have access to a Docker installation through eit
 ## Requirements
 
 1. Be running Docker.  2 options supported/tested:
-  1. **Mac OS X** The best way to go is to use `boot2docker`.  See instructions [here](https://docs.docker.com/installation/mac/).
+  1. **Mac OS X** The best way to go is to use `boot2docker`.  See instructions [here](https://docs.docker.com/installation/mac/).  
+  **Note**: You will want to set the boot2docker vm to have at least 3GB of initial memory or building will likely fail. (See: [#11852]( https://github.com/GoogleCloudPlatform/kubernetes/issues/11852))
   2. **Linux with local Docker**  Install Docker according to the [instructions](https://docs.docker.com/installation/#installation) for your OS.  The scripts here assume that they are using a local Docker server and that they can "reach around" docker and grab results directly from the file system.
 2. Have python installed.  Pretty much it is installed everywhere at this point so you can probably ignore this.
 3. *Optional* For uploading your release to Google Cloud Storage, have the [Google Cloud SDK](https://developers.google.com/cloud/sdk/) installed and configured.


### PR DESCRIPTION
Updates `build/README.md` to note memory requirements for building with boot2docker. See: https://github.com/GoogleCloudPlatform/kubernetes/issues/11852
