### PR TITLE
Automated cherry pick of #12024 #11963

### DIFF
--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -41,6 +41,12 @@
 {% endif -%}
 
 {% set config = "--config=/etc/kubernetes/manifests" -%}
+
+{% set manifest_url = "" -%}
+{% if grains['roles'][0] == 'kubernetes-master' and grains.cloud in ['gce'] -%}
+  {% set manifest_url = "--manifest-url=http://metadata.google.internal/computeMetadata/v1/instance/attributes/google-container-manifest --manifest-url-header=Metadata-Flavor:Google" -%}
+{% endif -%}
+
 {% set hostname_override = "" -%}
 {% if grains.hostname_override is defined -%}
   {% set hostname_override = " --hostname_override=" + grains.hostname_override -%}
@@ -84,4 +90,4 @@
   {% set pod_cidr = "--pod-cidr=" + grains['cbr-cidr'] %}
 {% endif %} 
 
-DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{config}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}} {{pod_cidr}}"
+DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{config}} {{manifest_url}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}} {{pod_cidr}}"

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -33,14 +33,16 @@ import (
 
 type sourceURL struct {
 	url      string
+	header   http.Header
 	nodeName string
 	updates  chan<- interface{}
 	data     []byte
 }
 
-func NewSourceURL(url, nodeName string, period time.Duration, updates chan<- interface{}) {
+func NewSourceURL(url string, header http.Header, nodeName string, period time.Duration, updates chan<- interface{}) {
 	config := &sourceURL{
 		url:      url,
+		header:   header,
 		nodeName: nodeName,
 		updates:  updates,
 		data:     nil,
@@ -60,7 +62,13 @@ func (s *sourceURL) applyDefaults(pod *api.Pod) error {
 }
 
 func (s *sourceURL) extractFromURL() error {
-	resp, err := http.Get(s.url)
+	req, err := http.NewRequest("GET", s.url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header = s.header
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -32,11 +32,12 @@ import (
 )
 
 type sourceURL struct {
-	url      string
-	header   http.Header
-	nodeName string
-	updates  chan<- interface{}
-	data     []byte
+	url         string
+	header      http.Header
+	nodeName    string
+	updates     chan<- interface{}
+	data        []byte
+	failureLogs int
 }
 
 func NewSourceURL(url string, header http.Header, nodeName string, period time.Duration, updates chan<- interface{}) {
@@ -53,7 +54,19 @@ func NewSourceURL(url string, header http.Header, nodeName string, period time.D
 
 func (s *sourceURL) run() {
 	if err := s.extractFromURL(); err != nil {
-		glog.Errorf("Failed to read URL: %v", err)
+		// Don't log this multiple times per minute. The first few entries should be
+		// enough to get the point across.
+		if s.failureLogs < 3 {
+			glog.Warningf("Failed to read pods from URL: %v", err)
+		} else if s.failureLogs == 3 {
+			glog.Warningf("Failed to read pods from URL. Won't log this message anymore: %v", err)
+		}
+		s.failureLogs++
+	} else {
+		if s.failureLogs > 0 {
+			glog.Info("Successfully read pods from URL.")
+			s.failureLogs = 0
+		}
 	}
 }
 

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -33,7 +34,7 @@ import (
 
 func TestURLErrorNotExistNoUpdate(t *testing.T) {
 	ch := make(chan interface{})
-	NewSourceURL("http://localhost:49575/_not_found_", "localhost", time.Millisecond, ch)
+	NewSourceURL("http://localhost:49575/_not_found_", http.Header{}, "localhost", time.Millisecond, ch)
 	select {
 	case got := <-ch:
 		t.Errorf("Expected no update, Got %#v", got)
@@ -43,7 +44,7 @@ func TestURLErrorNotExistNoUpdate(t *testing.T) {
 
 func TestExtractFromHttpBadness(t *testing.T) {
 	ch := make(chan interface{}, 1)
-	c := sourceURL{"http://localhost:49575/_not_found_", "other", ch, nil}
+	c := sourceURL{"http://localhost:49575/_not_found_", http.Header{}, "other", ch, nil}
 	if err := c.extractFromURL(); err == nil {
 		t.Errorf("Expected error")
 	}
@@ -112,7 +113,7 @@ func TestExtractInvalidPods(t *testing.T) {
 		testServer := httptest.NewServer(&fakeHandler)
 		defer testServer.Close()
 		ch := make(chan interface{}, 1)
-		c := sourceURL{testServer.URL, "localhost", ch, nil}
+		c := sourceURL{testServer.URL, http.Header{}, "localhost", ch, nil}
 		if err := c.extractFromURL(); err == nil {
 			t.Errorf("%s: Expected error", testCase.desc)
 		}
@@ -259,7 +260,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 		testServer := httptest.NewServer(&fakeHandler)
 		defer testServer.Close()
 		ch := make(chan interface{}, 1)
-		c := sourceURL{testServer.URL, hostname, ch, nil}
+		c := sourceURL{testServer.URL, http.Header{}, hostname, ch, nil}
 		if err := c.extractFromURL(); err != nil {
 			t.Errorf("%s: Unexpected error: %v", testCase.desc, err)
 			continue
@@ -274,5 +275,49 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 				t.Errorf("%s: Expected no validation errors on %#v, Got %v", testCase.desc, pod, errors.NewAggregate(errs))
 			}
 		}
+	}
+}
+
+func TestURLWithHeader(t *testing.T) {
+	pod := &api.Pod{
+		TypeMeta: api.TypeMeta{
+			APIVersion: testapi.Version(),
+			Kind:       "Pod",
+		},
+		ObjectMeta: api.ObjectMeta{
+			Name:      "foo",
+			UID:       "111",
+			Namespace: "mynamespace",
+		},
+		Spec: api.PodSpec{
+			NodeName:   "localhost",
+			Containers: []api.Container{{Name: "1", Image: "foo", ImagePullPolicy: api.PullAlways}},
+		},
+	}
+	data, err := json.Marshal(pod)
+	if err != nil {
+		t.Fatalf("Unexpected json marshalling error: %v", err)
+	}
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(data),
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	ch := make(chan interface{}, 1)
+	header := make(http.Header)
+	header.Set("Metadata-Flavor", "Google")
+	c := sourceURL{testServer.URL, header, "localhost", ch, nil}
+	if err := c.extractFromURL(); err != nil {
+		t.Fatalf("Unexpected error extracting from URL: %v", err)
+	}
+	update := (<-ch).(kubelet.PodUpdate)
+
+	headerVal := fakeHandler.RequestReceived.Header["Metadata-Flavor"]
+	if len(headerVal) != 1 || headerVal[0] != "Google" {
+		t.Errorf("Header missing expected entry %v. Got %v", header, fakeHandler.RequestReceived.Header)
+	}
+	if len(update.Pods) != 1 {
+		t.Errorf("Received wrong number of pods, expected one: %v", update.Pods)
 	}
 }

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -44,7 +44,7 @@ func TestURLErrorNotExistNoUpdate(t *testing.T) {
 
 func TestExtractFromHttpBadness(t *testing.T) {
 	ch := make(chan interface{}, 1)
-	c := sourceURL{"http://localhost:49575/_not_found_", http.Header{}, "other", ch, nil}
+	c := sourceURL{"http://localhost:49575/_not_found_", http.Header{}, "other", ch, nil, 0}
 	if err := c.extractFromURL(); err == nil {
 		t.Errorf("Expected error")
 	}
@@ -113,7 +113,7 @@ func TestExtractInvalidPods(t *testing.T) {
 		testServer := httptest.NewServer(&fakeHandler)
 		defer testServer.Close()
 		ch := make(chan interface{}, 1)
-		c := sourceURL{testServer.URL, http.Header{}, "localhost", ch, nil}
+		c := sourceURL{testServer.URL, http.Header{}, "localhost", ch, nil, 0}
 		if err := c.extractFromURL(); err == nil {
 			t.Errorf("%s: Expected error", testCase.desc)
 		}
@@ -260,7 +260,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 		testServer := httptest.NewServer(&fakeHandler)
 		defer testServer.Close()
 		ch := make(chan interface{}, 1)
-		c := sourceURL{testServer.URL, http.Header{}, hostname, ch, nil}
+		c := sourceURL{testServer.URL, http.Header{}, hostname, ch, nil, 0}
 		if err := c.extractFromURL(); err != nil {
 			t.Errorf("%s: Unexpected error: %v", testCase.desc, err)
 			continue
@@ -307,7 +307,7 @@ func TestURLWithHeader(t *testing.T) {
 	ch := make(chan interface{}, 1)
 	header := make(http.Header)
 	header.Set("Metadata-Flavor", "Google")
-	c := sourceURL{testServer.URL, header, "localhost", ch, nil}
+	c := sourceURL{testServer.URL, header, "localhost", ch, nil, 0}
 	if err := c.extractFromURL(); err != nil {
 		t.Fatalf("Unexpected error extracting from URL: %v", err)
 	}


### PR DESCRIPTION
Two things here:
-Make the Kubelet capable of pulling container manifests from GCE's v1 metadata API, which requires an additional header be specified.
-Have the Kubelet on the master check for pod manifests in the instance metadata (along with limiting the logging that this causes)

@brendandburns @roberthbailey @zmerlynn
