### PR TITLE
Remove legacy files when stop the cluster

### DIFF
--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -438,7 +438,7 @@ function kube-down {
       echo "Cleaning on node ${i#*@}"
       ssh -t $i 'pgrep etcd && sudo -p "[sudo] password for cleaning etcd data: " service etcd stop && sudo rm -rf /infra*'
       # Delete the files in order to generate a clean environment, so you can change each node's role at next deployment.
-      ssh -t $i 'rm -f /opt/bin/kube* /etc/init/kube* /etc/init.d/kube* /etc/default/kube*; rm -rf ~/kube'
+      ssh -t $i 'rm -f /opt/bin/kube* /etc/init/kube* /etc/init.d/kube* /etc/default/kube*; rm -rf ~/kube /var/lib/kubelet'
     }
   done
   wait

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -437,6 +437,8 @@ function kube-down {
     {
       echo "Cleaning on node ${i#*@}"
       ssh -t $i 'pgrep etcd && sudo -p "[sudo] password for cleaning etcd data: " service etcd stop && sudo rm -rf /infra*'
+      # Delete the files in order to generate a clean environment, so you can change each node's role at next deployment.
+      ssh -t $i 'rm -f /opt/bin/kube* /etc/init/kube* /etc/init.d/kube* /etc/default/kube*; rm -rf ~/kube'
     }
   done
   wait


### PR DESCRIPTION
When we deploy the kubernetes using Ubuntu's script. 
1. First we set the roles "ai i i" and NUM_MINIONS=3, it runs as expected.
2. Then we stop the cluster and change the roles to "a i i" and NUM_MINIONS=2, it will run with errors:
Waiting for 2 ready nodes. 3 ready nodes, 3 registered. Retrying.

It's because there are history files left on the previous deployment. 
This commit will delete the files when stop the cluster.
