### PR TITLE
Fix spark-driver in examples/spark

### DIFF
--- a/examples/spark/images/driver/Dockerfile
+++ b/examples/spark/images/driver/Dockerfile
@@ -1,4 +1,3 @@
 FROM gcr.io/google_containers/spark-base
 ADD start.sh /start.sh
-ADD log4j.properties /opt/spark/conf/log4j.properties
 CMD ["/start.sh"]

--- a/examples/spark/images/driver/start.sh
+++ b/examples/spark/images/driver/start.sh
@@ -17,7 +17,7 @@
 echo "$SPARK_MASTER_SERVICE_HOST spark-master" >> /etc/hosts
 echo "SPARK_LOCAL_HOSTNAME=$(hostname -i)" >> /opt/spark/conf/spark-env.sh
 echo "MASTER=spark://spark-master:$SPARK_MASTER_SERVICE_PORT" >> /opt/spark/conf/spark-env.sh
-
+echo "Use kubectl exec spark-driver -it bash to invoke commands"
 while true; do
   sleep 100
 done

--- a/examples/spark/spark-driver.json
+++ b/examples/spark/spark-driver.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "spark-driver",
-        "image": "gurvin/spark-driver",
+        "image": "gcr.io/google_containers/spark-driver:1.4.0_v1",
         "resources": {
           "limits": {
             "cpu": "100m"

--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -189,7 +189,7 @@ var _ = Describe("Examples e2e", func() {
 			Expect(err).NotTo(HaveOccurred())
 			_, err = lookForStringInLog(ns, "spark-master", "spark-master", "Starting Spark master at", serverStartTimeout)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = lookForStringInLog(ns, "spark-driver", "spark-driver", "Starting Spark driver at", serverStartTimeout)
+			_, err = lookForStringInLog(ns, "spark-driver", "spark-driver", "Use kubectl exec", serverStartTimeout)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("starting workers")


### PR DESCRIPTION
Fixed Issues:
- dockerfile refers a non-existing file
- e2e test timeouts waiting for a wrong string in logs
- start script should print something so that we know that the pod is really up (and check it in E2E tests)
