### PR TITLE
Automated cherry pick of #11941

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -50,12 +50,20 @@ kube::version::get_version_vars() {
 
     # Use git describe to find the version based on annotated tags.
     if [[ -n ${KUBE_GIT_VERSION-} ]] || KUBE_GIT_VERSION=$("${git[@]}" describe --tags --abbrev=14 "${KUBE_GIT_COMMIT}^{commit}" 2>/dev/null); then
+      # This translates the "git describe" to an actual semver.org
+      # compatible semantic version that looks something like this:
+      #   v1.1.0-alpha.0.6+84c76d1142ea4d
+      #
+      # TODO: We continue calling this "git version" because so many
+      # downstream consumers are expecting it there.
+      KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\+\2/")
       if [[ "${KUBE_GIT_TREE_STATE}" == "dirty" ]]; then
         # git describe --dirty only considers changes to existing files, but
         # that is problematic since new untracked .go files affect the build,
         # so use our idea of "dirty" from git status instead.
         KUBE_GIT_VERSION+="-dirty"
       fi
+
 
       # Try to match the "git describe" output to a regex to try to extract
       # the "major" and "minor" versions and whether this is the exact tagged

--- a/pkg/version/.gitattributes
+++ b/pkg/version/.gitattributes
@@ -1,0 +1,1 @@
+base.go export-subst

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -23,21 +23,35 @@ package version
 // version for ad-hoc builds (e.g. `go build`) that cannot get the version
 // information from git.
 //
-// The "-dev" suffix in the version info indicates that fact, and it means the
-// current build is from a version greater that version. For example, v0.7-dev
-// means version > 0.7 and < 0.8. (There's exceptions to this rule, see
-// docs/releasing.md for more details.)
+// If you are looking at these fields in the git tree, they look
+// strange. They are modified on the fly by the build process. The
+// in-tree values are dummy values used for "git archive", which also
+// works for GitHub tar downloads.
 //
-// When releasing a new Kubernetes version, this file should be updated to
-// reflect the new version, and then a git annotated tag (using format vX.Y
-// where X == Major version and Y == Minor version) should be created to point
-// to the commit that updates pkg/version/base.go
-
+// When releasing a new Kubernetes version, this file is updated by
+// build/mark_new_version.sh to reflect the new version, and then a
+// git annotated tag (using format vX.Y where X == Major version and Y
+// == Minor version) is created to point to the commit that updates
+// pkg/version/base.go
 var (
-	// TODO: Deprecate gitMajor and gitMinor, use only gitVersion instead.
-	gitMajor     string = "1"              // major version, always numeric
-	gitMinor     string = "0.1+"           // minor version, numeric possibly followed by "+"
-	gitVersion   string = "v1.0.1-dev"     // version from git, output of $(git describe)
-	gitCommit    string = ""               // sha1 from git, output of $(git rev-parse HEAD)
+	// TODO: Deprecate gitMajor and gitMinor, use only gitVersion
+	// instead. First step in deprecation, keep the fields but make
+	// them irrelevant. (Next we'll take it out, which may muck with
+	// scripts consuming the kubectl version output - but most of
+	// these should be looking at gitVersion already anyways.)
+	gitMajor string = "1"   // major version, always numeric
+	gitMinor string = "0.1" // minor version, numeric possibly followed by "+"
+
+	// semantic version, dervied by build scripts (see
+	// https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/versioning.md
+	// for a detailed discussion of this field)
+	//
+	// TODO: This field is still called "gitVersion" for legacy
+	// reasons. For prerelease versions, the build metadata on the
+	// semantic version is a git hash, but the version itself is no
+	// longer the direct output of "git describe", but a slight
+	// translation to be semver compliant.
+	gitVersion   string = "v1.0.1-release-1.0+$Format:%h$"
+	gitCommit    string = "$Format:%H$"    // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 )


### PR DESCRIPTION
Pulling #11941 into the release branch primarily for `build/` consistency. I also went ahead and made the tarball `base.go` values match the script as it would have run.
