### PR TITLE
Fix godeps restore by responding to structural changes in go-md2man

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -141,9 +141,9 @@
 			"Rev": "97e243d21a8e232e9d8af38ba2366dfcfceebeba"
 		},
 		{
-			"ImportPath": "github.com/cpuguy83/go-md2man/mangen",
-			"Comment": "v1.0.2-5-g2831f11",
-			"Rev": "2831f11f66ff4008f10e2cd7ed9a85e3d3fc2bed"
+			"ImportPath": "github.com/cpuguy83/go-md2man",
+			"Comment": "v1.0.3",
+			"Rev": "e69ac41993d9dad8006559d4e28763d241ab53a6"
 		},
 		{
 			"ImportPath": "github.com/davecgh/go-spew/spew",

--- a/Godeps/_workspace/src/github.com/cpuguy83/go-md2man/LICENSE.md
+++ b/Godeps/_workspace/src/github.com/cpuguy83/go-md2man/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Brian Goff
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Godeps/_workspace/src/github.com/cpuguy83/go-md2man/README.md
+++ b/Godeps/_workspace/src/github.com/cpuguy83/go-md2man/README.md
@@ -1,0 +1,11 @@
+go-md2man
+=========
+
+** Work in Progress **
+This still needs a lot of help to be complete, or even usable!
+
+Uses blackfriday to process markdown into man pages.
+
+### Usage
+
+./md2man -in /path/to/markdownfile.md -out /manfile/output/path

--- a/Godeps/_workspace/src/github.com/cpuguy83/go-md2man/go-md2man.1.md
+++ b/Godeps/_workspace/src/github.com/cpuguy83/go-md2man/go-md2man.1.md
@@ -1,0 +1,21 @@
+go-md2man 1 "January 2015" go-md2man "User Manual"
+==================================================
+
+# NAME
+  go-md2man - Convert mardown files into manpages
+
+# SYNOPSIS
+  go-md2man -in=[/path/to/md/file] -out=[/path/to/output]
+
+# Description
+  go-md2man converts standard markdown formatted documents into manpages. It is
+  written purely in Go so as to reduce dependencies on 3rd party libs.
+
+# Example
+  Convert the markdown file "go-md2man.1.md" into a manpage.
+
+    go-md2man -in=README.md -out=go-md2man.1.out
+
+# HISTORY
+  January 2015, Originally compiled by Brian Goff( cpuguy83@gmail.com )
+

--- a/Godeps/_workspace/src/github.com/cpuguy83/go-md2man/md2man.go
+++ b/Godeps/_workspace/src/github.com/cpuguy83/go-md2man/md2man.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/russross/blackfriday"
+)
+
+var inFilePath = flag.String("in", "", "Path to file to be processed")
+var outFilePath = flag.String("out", "", "Path to output processed file")
+
+func main() {
+	flag.Parse()
+
+	inFile, err := os.Open(*inFilePath)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer inFile.Close()
+
+	doc, err := ioutil.ReadAll(inFile)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	renderer := RoffRenderer(0)
+	extensions := 0
+	extensions |= blackfriday.EXTENSION_NO_INTRA_EMPHASIS
+	extensions |= blackfriday.EXTENSION_TABLES
+	extensions |= blackfriday.EXTENSION_FENCED_CODE
+	extensions |= blackfriday.EXTENSION_AUTOLINK
+	extensions |= blackfriday.EXTENSION_SPACE_HEADERS
+	extensions |= blackfriday.EXTENSION_FOOTNOTES
+	extensions |= blackfriday.EXTENSION_TITLEBLOCK
+
+	out := blackfriday.Markdown(doc, renderer, extensions)
+
+	outFile, err := os.Create(*outFilePath)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer outFile.Close()
+	_, err = outFile.Write(out)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/Godeps/_workspace/src/github.com/cpuguy83/go-md2man/roff.go
+++ b/Godeps/_workspace/src/github.com/cpuguy83/go-md2man/roff.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"html"
+	"strings"
+
+	"github.com/russross/blackfriday"
+)
+
+type roffRenderer struct{}
+
+func RoffRenderer(flags int) blackfriday.Renderer {
+	return &roffRenderer{}
+}
+
+func (r *roffRenderer) GetFlags() int {
+	return 0
+}
+
+func (r *roffRenderer) TitleBlock(out *bytes.Buffer, text []byte) {
+	out.WriteString(".TH ")
+
+	splitText := bytes.Split(text, []byte("\n"))
+	for i, line := range splitText {
+		line = bytes.TrimPrefix(line, []byte("% "))
+		if i == 0 {
+			line = bytes.Replace(line, []byte("("), []byte("\" \""), 1)
+			line = bytes.Replace(line, []byte(")"), []byte("\" \""), 1)
+		}
+		line = append([]byte("\""), line...)
+		line = append(line, []byte("\" ")...)
+		out.Write(line)
+	}
+
+	out.WriteString(" \"\"\n")
+}
+
+func (r *roffRenderer) BlockCode(out *bytes.Buffer, text []byte, lang string) {
+	out.WriteString("\n.PP\n.RS\n\n.nf\n")
+	escapeSpecialChars(out, text)
+	out.WriteString("\n.fi\n.RE\n")
+}
+
+func (r *roffRenderer) BlockQuote(out *bytes.Buffer, text []byte) {
+	out.WriteString("\n.PP\n.RS\n")
+	out.Write(text)
+	out.WriteString("\n.RE\n")
+}
+
+func (r *roffRenderer) BlockHtml(out *bytes.Buffer, text []byte) {
+	out.Write(text)
+}
+
+func (r *roffRenderer) Header(out *bytes.Buffer, text func() bool, level int, id string) {
+	marker := out.Len()
+
+	switch {
+	case marker == 0:
+		// This is the doc header
+		out.WriteString(".TH ")
+	case level == 1:
+		out.WriteString("\n\n.SH ")
+	case level == 2:
+		out.WriteString("\n.SH ")
+	default:
+		out.WriteString("\n.SS ")
+	}
+
+	if !text() {
+		out.Truncate(marker)
+		return
+	}
+}
+
+func (r *roffRenderer) HRule(out *bytes.Buffer) {
+	out.WriteString("\n.ti 0\n\\l'\\n(.lu'\n")
+}
+
+func (r *roffRenderer) List(out *bytes.Buffer, text func() bool, flags int) {
+	marker := out.Len()
+	out.WriteString(".IP ")
+	if flags&blackfriday.LIST_TYPE_ORDERED != 0 {
+		out.WriteString("\\(bu 2")
+	} else {
+		out.WriteString("\\n+[step" + string(flags) + "]")
+	}
+	out.WriteString("\n")
+	if !text() {
+		out.Truncate(marker)
+		return
+	}
+
+}
+
+func (r *roffRenderer) ListItem(out *bytes.Buffer, text []byte, flags int) {
+	out.WriteString("\n\\item ")
+	out.Write(text)
+}
+
+func (r *roffRenderer) Paragraph(out *bytes.Buffer, text func() bool) {
+	marker := out.Len()
+	out.WriteString("\n.PP\n")
+	if !text() {
+		out.Truncate(marker)
+		return
+	}
+	if marker != 0 {
+		out.WriteString("\n")
+	}
+}
+
+// TODO: This might now work
+func (r *roffRenderer) Table(out *bytes.Buffer, header []byte, body []byte, columnData []int) {
+	out.WriteString(".TS\nallbox;\n")
+
+	out.Write(header)
+	out.Write(body)
+	out.WriteString("\n.TE\n")
+}
+
+func (r *roffRenderer) TableRow(out *bytes.Buffer, text []byte) {
+	if out.Len() > 0 {
+		out.WriteString("\n")
+	}
+	out.Write(text)
+	out.WriteString("\n")
+}
+
+func (r *roffRenderer) TableHeaderCell(out *bytes.Buffer, text []byte, align int) {
+	if out.Len() > 0 {
+		out.WriteString(" ")
+	}
+	out.Write(text)
+	out.WriteString(" ")
+}
+
+// TODO: This is probably broken
+func (r *roffRenderer) TableCell(out *bytes.Buffer, text []byte, align int) {
+	if out.Len() > 0 {
+		out.WriteString("\t")
+	}
+	out.Write(text)
+	out.WriteString("\t")
+}
+
+func (r *roffRenderer) Footnotes(out *bytes.Buffer, text func() bool) {
+
+}
+
+func (r *roffRenderer) FootnoteItem(out *bytes.Buffer, name, text []byte, flags int) {
+
+}
+
+func (r *roffRenderer) AutoLink(out *bytes.Buffer, link []byte, kind int) {
+	out.WriteString("\n\\[la]")
+	out.Write(link)
+	out.WriteString("\\[ra]")
+}
+
+func (r *roffRenderer) CodeSpan(out *bytes.Buffer, text []byte) {
+	out.WriteString("\\fB\\fC")
+	escapeSpecialChars(out, text)
+	out.WriteString("\\fR")
+}
+
+func (r *roffRenderer) DoubleEmphasis(out *bytes.Buffer, text []byte) {
+	out.WriteString("\\fB")
+	out.Write(text)
+	out.WriteString("\\fP")
+}
+
+func (r *roffRenderer) Emphasis(out *bytes.Buffer, text []byte) {
+	out.WriteString("\\fI")
+	out.Write(text)
+	out.WriteString("\\fP")
+}
+
+func (r *roffRenderer) Image(out *bytes.Buffer, link []byte, title []byte, alt []byte) {
+}
+
+func (r *roffRenderer) LineBreak(out *bytes.Buffer) {
+	out.WriteString("\n.br\n")
+}
+
+func (r *roffRenderer) Link(out *bytes.Buffer, link []byte, title []byte, content []byte) {
+	r.AutoLink(out, link, 0)
+}
+
+func (r *roffRenderer) RawHtmlTag(out *bytes.Buffer, tag []byte) {
+	out.Write(tag)
+}
+
+func (r *roffRenderer) TripleEmphasis(out *bytes.Buffer, text []byte) {
+	out.WriteString("\\s+2")
+	out.Write(text)
+	out.WriteString("\\s-2")
+}
+
+func (r *roffRenderer) StrikeThrough(out *bytes.Buffer, text []byte) {
+}
+
+func (r *roffRenderer) FootnoteRef(out *bytes.Buffer, ref []byte, id int) {
+
+}
+
+func (r *roffRenderer) Entity(out *bytes.Buffer, entity []byte) {
+	out.WriteString(html.UnescapeString(string(entity)))
+}
+
+func processFooterText(text []byte) []byte {
+	text = bytes.TrimPrefix(text, []byte("% "))
+	newText := []byte{}
+	textArr := strings.Split(string(text), ") ")
+
+	for i, w := range textArr {
+		if i == 0 {
+			w = strings.Replace(w, "(", "\" \"", 1)
+			w = fmt.Sprintf("\"%s\"", w)
+		} else {
+			w = fmt.Sprintf(" \"%s\"", w)
+		}
+		newText = append(newText, []byte(w)...)
+	}
+	newText = append(newText, []byte(" \"\"")...)
+
+	return newText
+}
+
+func (r *roffRenderer) NormalText(out *bytes.Buffer, text []byte) {
+	escapeSpecialChars(out, text)
+}
+
+func (r *roffRenderer) DocumentHeader(out *bytes.Buffer) {
+}
+
+func (r *roffRenderer) DocumentFooter(out *bytes.Buffer) {
+}
+
+func needsBackslash(c byte) bool {
+	for _, r := range []byte("-_&\\~") {
+		if c == r {
+			return true
+		}
+	}
+	return false
+}
+
+func escapeSpecialChars(out *bytes.Buffer, text []byte) {
+	for i := 0; i < len(text); i++ {
+		// directly copy normal characters
+		org := i
+
+		for i < len(text) && !needsBackslash(text[i]) {
+			i++
+		}
+		if i > org {
+			out.Write(text[org:i])
+		}
+
+		// escape a character
+		if i >= len(text) {
+			break
+		}
+		out.WriteByte('\\')
+		out.WriteByte(text[i])
+	}
+}

--- a/cmd/genman/gen_kubectl_man.go
+++ b/cmd/genman/gen_kubectl_man.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/cmd/genutils"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
 	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
-	"github.com/cpuguy83/go-md2man/mangen"
+	mangen "github.com/cpuguy83/go-md2man"
 	"github.com/russross/blackfriday"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -144,7 +144,7 @@ func genMarkdown(command *cobra.Command, parent, docsDir string) {
 January 2015, Originally compiled by Eric Paris (eparis at redhat dot com) based on the kubernetes source material, but hopefully they have been automatically generated since!
 `)
 
-	renderer := mangen.ManRenderer(0)
+	renderer := mangen.RoffRenderer(0)
 	extensions := 0
 	extensions |= blackfriday.EXTENSION_NO_INTRA_EMPHASIS
 	extensions |= blackfriday.EXTENSION_TABLES

--- a/docs/man/man1/kubectl-api-versions.1
+++ b/docs/man/man1/kubectl-api-versions.1
@@ -52,6 +52,10 @@ Print available API versions.
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -82,6 +86,10 @@ Print available API versions.
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-cluster-info.1
+++ b/docs/man/man1/kubectl-cluster-info.1
@@ -52,6 +52,10 @@ Display addresses of the master and services with label kubernetes.io/cluster\-s
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -82,6 +86,10 @@ Display addresses of the master and services with label kubernetes.io/cluster\-s
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-config-set-cluster.1
+++ b/docs/man/man1/kubectl-config-set-cluster.1
@@ -65,6 +65,10 @@ Specifying a name that already exists will merge new fields on top of existing v
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-kubeconfig\fP=""
     use a particular kubeconfig file
 
@@ -91,6 +95,10 @@ Specifying a name that already exists will merge new fields on top of existing v
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-config-set-context.1
+++ b/docs/man/man1/kubectl-config-set-context.1
@@ -61,6 +61,10 @@ Specifying a name that already exists will merge new fields on top of existing v
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -87,6 +91,10 @@ Specifying a name that already exists will merge new fields on top of existing v
 .PP
 \fB\-\-match\-server\-version\fP=false
     Require server version to match client version
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-config-set-credentials.1
+++ b/docs/man/man1/kubectl-config-set-credentials.1
@@ -84,6 +84,10 @@ Bearer token and basic auth are mutually exclusive.
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -114,6 +118,10 @@ Bearer token and basic auth are mutually exclusive.
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-s\fP, \fB\-\-server\fP=""

--- a/docs/man/man1/kubectl-config-set.1
+++ b/docs/man/man1/kubectl-config-set.1
@@ -54,6 +54,10 @@ PROPERTY\_VALUE is the new value you wish to set.
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -84,6 +88,10 @@ PROPERTY\_VALUE is the new value you wish to set.
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-config-unset.1
+++ b/docs/man/man1/kubectl-config-unset.1
@@ -53,6 +53,10 @@ PROPERTY\_NAME is a dot delimited name where each token represents either a attr
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -83,6 +87,10 @@ PROPERTY\_NAME is a dot delimited name where each token represents either a attr
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-config-use-context.1
+++ b/docs/man/man1/kubectl-config-use-context.1
@@ -52,6 +52,10 @@ Sets the current\-context in a kubeconfig file
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -82,6 +86,10 @@ Sets the current\-context in a kubeconfig file
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-config-view.1
+++ b/docs/man/man1/kubectl-config-view.1
@@ -88,6 +88,10 @@ You can use \-\-output=template \-\-template=TEMPLATE to extract specific values
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -118,6 +122,10 @@ You can use \-\-output=template \-\-template=TEMPLATE to extract specific values
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""
@@ -165,7 +173,7 @@ You can use \-\-output=template \-\-template=TEMPLATE to extract specific values
 $ kubectl config view
 
 // Get the password for the e2e user
-$ kubectl config view \-o template \-\-template='\{\{range .users\}\}\{\{ if eq .name "e2e" \}\}\{\{ index .user.password \}\}\{\{end\}\}\{\{end\}\}'
+$ kubectl config view \-o template \-\-template='{{range .users}}{{ if eq .name "e2e" }}{{ index .user.password }}{{end}}{{end}}'
 
 .fi
 .RE

--- a/docs/man/man1/kubectl-config.1
+++ b/docs/man/man1/kubectl-config.1
@@ -19,7 +19,7 @@ config modifies kubeconfig files using subcommands like "kubectl config set curr
 The loading order follows these rules:
     1. If the \-\-kubeconfig flag is set, then only that file is loaded.  The flag may only be set once and no merging takes place.
     2. If $KUBECONFIG environment variable is set, then it is used a list of paths (normal path delimitting rules for your system).  These paths are merged together.  When a value is modified, it is modified in the file that defines the stanza.  When a value is created, it is created in the first file that exists.  If no files in the chain exist, then it creates the last file in the list.
-    3. Otherwise, $\{HOME\}/.kube/config is used and no merging takes place.
+    3. Otherwise, ${HOME}/.kube/config is used and no merging takes place.
 
 
 .SH OPTIONS
@@ -62,6 +62,10 @@ The loading order follows these rules:
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -88,6 +92,10 @@ The loading order follows these rules:
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-create.1
+++ b/docs/man/man1/kubectl-create.1
@@ -63,6 +63,10 @@ JSON and YAML formats are accepted.
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -93,6 +97,10 @@ JSON and YAML formats are accepted.
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-delete.1
+++ b/docs/man/man1/kubectl-delete.1
@@ -96,6 +96,10 @@ will be lost along with the rest of the resource.
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -126,6 +130,10 @@ will be lost along with the rest of the resource.
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-describe.1
+++ b/docs/man/man1/kubectl-describe.1
@@ -73,6 +73,10 @@ resourcequotas (quota) or secrets.
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -103,6 +107,10 @@ resourcequotas (quota) or secrets.
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-exec.1
+++ b/docs/man/man1/kubectl-exec.1
@@ -68,6 +68,10 @@ Execute a command in a container.
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -98,6 +102,10 @@ Execute a command in a container.
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-expose.1
+++ b/docs/man/man1/kubectl-expose.1
@@ -126,6 +126,10 @@ re\-use the labels from the resource it exposes.
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -156,6 +160,10 @@ re\-use the labels from the resource it exposes.
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-get.1
+++ b/docs/man/man1/kubectl-get.1
@@ -99,6 +99,10 @@ of the \-\-template flag, you can filter the attributes of the fetched resource(
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -129,6 +133,10 @@ of the \-\-template flag, you can filter the attributes of the fetched resource(
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""
@@ -185,7 +193,7 @@ $ kubectl get replicationcontroller web
 $ kubectl get \-o json pod web\-pod\-13je7
 
 // Return only the phase value of the specified pod.
-$ kubectl get \-o template web\-pod\-13je7 \-\-template=\{\{.status.phase\}\} \-\-api\-version=v1
+$ kubectl get \-o template web\-pod\-13je7 \-\-template={{.status.phase}} \-\-api\-version=v1
 
 // List all replication controllers and services together in ps output format.
 $ kubectl get rc,services

--- a/docs/man/man1/kubectl-label.1
+++ b/docs/man/man1/kubectl-label.1
@@ -90,6 +90,10 @@ If \-\-resource\-version is specified, then updates will use this resource versi
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -120,6 +124,10 @@ If \-\-resource\-version is specified, then updates will use this resource versi
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-logs.1
+++ b/docs/man/man1/kubectl-logs.1
@@ -68,6 +68,10 @@ Print the logs for a container in a pod. If the pod has only one container, the 
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -98,6 +102,10 @@ Print the logs for a container in a pod. If the pod has only one container, the 
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-namespace.1
+++ b/docs/man/man1/kubectl-namespace.1
@@ -55,6 +55,10 @@ namespace has been superceded by the context.namespace field of .kubeconfig file
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -85,6 +89,10 @@ namespace has been superceded by the context.namespace field of .kubeconfig file
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-patch.1
+++ b/docs/man/man1/kubectl-patch.1
@@ -63,6 +63,10 @@ JSON and YAML formats are accepted.
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -93,6 +97,10 @@ JSON and YAML formats are accepted.
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""
@@ -138,7 +146,7 @@ JSON and YAML formats are accepted.
 .nf
 
 // Partially update a node using strategic merge patch
-kubectl patch node k8s\-node\-1 \-p '\{"spec":\{"unschedulable":true\}\}'
+kubectl patch node k8s\-node\-1 \-p '{"spec":{"unschedulable":true}}'
 
 .fi
 .RE

--- a/docs/man/man1/kubectl-port-forward.1
+++ b/docs/man/man1/kubectl-port-forward.1
@@ -56,6 +56,10 @@ Forward one or more local ports to a pod.
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -86,6 +90,10 @@ Forward one or more local ports to a pod.
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-proxy.1
+++ b/docs/man/man1/kubectl-proxy.1
@@ -109,6 +109,10 @@ The above lets you 'curl localhost:8001/custom/api/v1/pods'
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -139,6 +143,10 @@ The above lets you 'curl localhost:8001/custom/api/v1/pods'
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-replace.1
+++ b/docs/man/man1/kubectl-replace.1
@@ -79,6 +79,10 @@ JSON and YAML formats are accepted.
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -109,6 +113,10 @@ JSON and YAML formats are accepted.
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-rolling-update.1
+++ b/docs/man/man1/kubectl-rolling-update.1
@@ -106,6 +106,10 @@ existing replication controller and overwrite at least one (common) label in its
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -136,6 +140,10 @@ existing replication controller and overwrite at least one (common) label in its
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-run.1
+++ b/docs/man/man1/kubectl-run.1
@@ -102,6 +102,10 @@ Creates a replication controller to manage the created container(s).
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -132,6 +136,10 @@ Creates a replication controller to manage the created container(s).
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""
@@ -185,7 +193,7 @@ $ kubectl run nginx \-\-image=nginx \-\-replicas=5
 $ kubectl run nginx \-\-image=nginx \-\-dry\-run
 
 // Start a single instance of nginx, but overload the spec of the replication controller with a partial set of values parsed from JSON.
-$ kubectl run nginx \-\-image=nginx \-\-overrides='\{ "apiVersion": "v1", "spec": \{ ... \} \}'
+$ kubectl run nginx \-\-image=nginx \-\-overrides='{ "apiVersion": "v1", "spec": { ... } }'
 
 .fi
 .RE

--- a/docs/man/man1/kubectl-scale.1
+++ b/docs/man/man1/kubectl-scale.1
@@ -74,6 +74,10 @@ scale is sent to the server.
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -104,6 +108,10 @@ scale is sent to the server.
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-stop.1
+++ b/docs/man/man1/kubectl-stop.1
@@ -88,6 +88,10 @@ If the resource is scalable it will be scaled to 0 before deletion.
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -118,6 +122,10 @@ If the resource is scalable it will be scaled to 0 before deletion.
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl-version.1
+++ b/docs/man/man1/kubectl-version.1
@@ -56,6 +56,10 @@ Print the client and server version information.
     The name of the kubeconfig context to use
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -86,6 +90,10 @@ Print the client and server version information.
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""

--- a/docs/man/man1/kubectl.1
+++ b/docs/man/man1/kubectl.1
@@ -54,6 +54,10 @@ Find more information at
     help for kubectl
 
 .PP
+\fB\-\-in\fP=""
+    Path to file to be processed
+
+.PP
 \fB\-\-insecure\-skip\-tls\-verify\fP=false
     If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
 
@@ -84,6 +88,10 @@ Find more information at
 .PP
 \fB\-\-namespace\fP=""
     If present, the namespace scope for this CLI request.
+
+.PP
+\fB\-\-out\fP=""
+    Path to output processed file
 
 .PP
 \fB\-\-password\fP=""


### PR DESCRIPTION
In an effort to try to bump up a dependency in go-dockerclient I discovered that we are no longer able to do a godep restore or save at head because of changes to go-md2man.

I updated the go-md2man dependency and changed the code in gen_kubectl_man to match.

cc @eparis since you were in this area.

Fixes https://github.com/GoogleCloudPlatform/kubernetes/issues/10195
