### PR TITLE
No such file or directory error: make-ca-cert

### DIFF
--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -369,7 +369,6 @@ function provision-master() {
   # remote login to MASTER and use sudo to configue k8s master
   ssh $SSH_OPTS -t $MASTER "source ~/kube/util.sh; \
                             groupadd -f -r kube-cert; \
-                            ~/kube/make-ca-cert ${MASTER_IP} IP:${MASTER_IP},IP:${SERVICE_CLUSTER_IP_RANGE%.*}.1,DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.cluster.local; \
                             setClusterInfo; \
                             create-etcd-opts "${mm[${MASTER_IP}]}" "${MASTER_IP}" "${CLUSTER}"; \
                             create-kube-apiserver-opts "${SERVICE_CLUSTER_IP_RANGE}" "${ADMISSION_CONTROL}" "${SERVICE_NODE_PORT_RANGE}"; \


### PR DESCRIPTION
When executing kube-up on a ubuntu cluster I'm getting the following error:
bash: /root/kube/make-ca-cert: No such file or directory

The following typo needs to be fixed:
kubernetes/cluster/ubuntu/util.sh

```
function provision-master() {
...
    ~/kube/make-ca-cert ... <<< BROKEN
    ~/kube/make-ca-cert.sh ... <<< FIXED  
...
```
