### PR TITLE
AWS: Install ntp daemon on all nodes

### DIFF
--- a/cluster/saltbase/salt/ntp/init.sls
+++ b/cluster/saltbase/salt/ntp/init.sls
@@ -1,0 +1,11 @@
+ntp:
+  pkg:
+    - installed
+
+ntp-service:
+  service:
+    - running
+    - name: ntp
+    - watch:
+      - pkg: ntp
+

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -3,6 +3,9 @@ base:
     - base
     - debian-auto-upgrades
     - salt-helpers
+{% if grains.get('cloud') == 'aws' %}
+    - ntp
+{% endif %}
 
   'roles:kubernetes-pool':
     - match: grain


### PR DESCRIPTION
The AWS API requires a signature on method calls, including the
timestamp to prevent replay attacks.  A time drift of up to 5 minutes
between client and server is tolerated.

However, if the client clock drifts by >5 minutes, the server will start
to reject API calls (with the cryptic "AWS was not able to validate the
provided access credentials").

To prevent this happening, we install ntp on all nodes.

Fix #11371
