### PR TITLE
For the ubuntu cluster, master and minion services should respawn.

### DIFF
--- a/cluster/ubuntu/master/init_conf/flanneld.conf
+++ b/cluster/ubuntu/master/init_conf/flanneld.conf
@@ -1,7 +1,7 @@
 description "Flannel service"
 author "@chenxingyu"
 
-# respawn
+respawn
 
 # start in conjunction with etcd
 start on started etcd

--- a/cluster/ubuntu/master/init_conf/kube-apiserver.conf
+++ b/cluster/ubuntu/master/init_conf/kube-apiserver.conf
@@ -1,7 +1,7 @@
 description "Kube-Apiserver service"
 author "@jainvipin"
 
-# respawn
+respawn
 
 # start in conjunction with etcd
 start on started etcd

--- a/cluster/ubuntu/master/init_conf/kube-controller-manager.conf
+++ b/cluster/ubuntu/master/init_conf/kube-controller-manager.conf
@@ -1,7 +1,7 @@
 description "Kube-Controller-Manager service"
 author "@jainvipin"
 
-# respawn
+respawn
 
 # start in conjunction with etcd
 start on started etcd

--- a/cluster/ubuntu/master/init_conf/kube-scheduler.conf
+++ b/cluster/ubuntu/master/init_conf/kube-scheduler.conf
@@ -1,7 +1,7 @@
 description "Kube-Scheduler service"
 author "@jainvipin"
 
-# respawn
+respawn
 
 # start in conjunction with etcd
 start on started etcd

--- a/cluster/ubuntu/minion/init_conf/flanneld.conf
+++ b/cluster/ubuntu/minion/init_conf/flanneld.conf
@@ -1,7 +1,7 @@
 description "Flannel service"
 author "@chenxingyu"
 
-# respawn
+respawn
 
 # start in conjunction with etcd
 start on started etcd

--- a/cluster/ubuntu/minion/init_conf/kube-proxy.conf
+++ b/cluster/ubuntu/minion/init_conf/kube-proxy.conf
@@ -1,7 +1,7 @@
 description "Kube-Proxy service"
 author "@jainvipin"
 
-# respawn
+respawn
 
 # start in conjunction with etcd
 start on started etcd

--- a/cluster/ubuntu/minion/init_conf/kubelet.conf
+++ b/cluster/ubuntu/minion/init_conf/kubelet.conf
@@ -1,7 +1,7 @@
 description "Kubelet service"
 author "@jainvipin"
 
-# respawn
+respawn
 
 # start in conjunction with etcd
 start on started etcd


### PR DESCRIPTION
Updated master and minion upstart confs to include respawn.

This will allow more frequent successful kube-up.sh executions. Since kube-apiserver doesn't start on the first try after etcd first starts up possibly due to the lack of resources on my server.
