### PR TITLE
Factor out validate-cluster.sh call from kube-up.sh

### DIFF
--- a/cluster/kube-up.sh
+++ b/cluster/kube-up.sh
@@ -36,8 +36,8 @@ verify-prereqs
 echo "... calling kube-up" >&2
 kube-up
 
-echo "... calling validate-cluster.sh" >&2
-"${KUBE_ROOT}/cluster/validate-cluster.sh"
+echo "... calling validate-cluster" >&2
+validate-cluster
 
 echo -e "Done, listing cluster services:\n" >&2
 "${KUBE_ROOT}/cluster/kubectl.sh" cluster-info

--- a/cluster/kube-util.sh
+++ b/cluster/kube-util.sh
@@ -39,6 +39,13 @@ function verify-prereqs {
 	echo "TODO: verify-prereqs" 1>&2
 }
 
+# Validate a kubernetes cluster
+function validate-cluster {
+	# by default call the generic validate-cluster.sh script, customizable by
+	# any cluster provider if this does not fit.
+	"${KUBE_ROOT}/cluster/validate-cluster.sh"
+}
+
 # Instantiate a kubernetes cluster
 function kube-up {
 	echo "TODO: kube-up" 1>&2


### PR DESCRIPTION
Not every cluster can be validated the same way. Factoring out the
validate-cluster call into a kube-util.sh function allows customization.

This allows to proceed with GoogleCloudPlatform/kubernetes#10049 before
the mid/long-term unified cluster validation in GoogleCloudPlatform/kubernetes#11908
is implemented. Otherwise, the later blocks the former.
