### PR TITLE
Fixed flakiness of resize nodes test.

### DIFF
--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -104,7 +104,7 @@ func groupSize() (int, error) {
 }
 
 func waitForGroupSize(size int) error {
-	timeout := 4 * time.Minute
+	timeout := 10 * time.Minute
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(5 * time.Second) {
 		currentSize, err := groupSize()
 		if err != nil {


### PR DESCRIPTION
Fixed flakiness of resize nodes test by increasing timeout for waiting for change of size of managed instance group with nodes. Fixes #11442.
