### PR TITLE
Allow network plugin to expose information about configured network(s) to target container(s)

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -1585,7 +1585,9 @@ func (dm *DockerManager) SyncPod(pod *api.Pod, runningPod kubecontainer.Pod, pod
 	// Start everything
 	for idx := range containerChanges.ContainersToStart {
 		container := &pod.Spec.Containers[idx]
-		container.Env = append(container.Env, api.EnvVar{Name: containerNetworkEnvKey, Value: containerNetworkEnvVal})
+		if len(containerNetworkEnvVal) > 0 {
+			container.Env = append(container.Env, api.EnvVar{Name: containerNetworkEnvKey, Value: containerNetworkEnvVal})
+		}
 		glog.V(4).Infof("Creating container %+v in pod %v", container, podFullName)
 		err := dm.pullImage(pod, container, pullSecrets)
 		dm.updateReasonCache(pod, container, err)

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -64,6 +64,8 @@ const (
 	// we want to able to consider SRV lookup names like _dns._udp.kube-dns.default.svc to be considered relative.
 	// hence, setting ndots to be 5.
 	ndotsDNSOption = "options ndots:5\n"
+
+	containerNetworkEnvKey = "NETWORK"
 )
 
 // DockerManager implements the Runtime interface.
@@ -1561,23 +1563,29 @@ func (dm *DockerManager) SyncPod(pod *api.Pod, runningPod kubecontainer.Pod, pod
 
 	// If we should create infra container then we do it first.
 	podInfraContainerID := containerChanges.InfraContainerId
+	var containerNetworkEnvVal string
 	if containerChanges.StartInfraContainer && (len(containerChanges.ContainersToStart) > 0) {
 		glog.V(4).Infof("Creating pod infra container for %q", podFullName)
 		podInfraContainerID, err = dm.createPodInfraContainer(pod)
 
-		// Call the networking plugin
-		if err == nil {
-			err = dm.networkPlugin.SetUpPod(pod.Namespace, pod.Name, podInfraContainerID)
-		}
 		if err != nil {
 			glog.Errorf("Failed to create pod infra container: %v; Skipping pod %q", err, podFullName)
 			return err
 		}
+
+		// Call the networking plugin
+		result, err := dm.networkPlugin.SetUpPod(pod.Namespace, pod.Name, podInfraContainerID)
+		if err != nil {
+			glog.Errorf("Network plugin failed for pod infra container: %v; Skipping pod %q", err, podFullName)
+			return err
+		}
+		containerNetworkEnvVal = result.Output
 	}
 
 	// Start everything
 	for idx := range containerChanges.ContainersToStart {
 		container := &pod.Spec.Containers[idx]
+		container.Env = append(container.Env, api.EnvVar{Name: containerNetworkEnvKey, Value: containerNetworkEnvVal})
 		glog.V(4).Infof("Creating container %+v in pod %v", container, podFullName)
 		err := dm.pullImage(pod, container, pullSecrets)
 		dm.updateReasonCache(pod, container, err)

--- a/pkg/kubelet/network/exec/exec.go
+++ b/pkg/kubelet/network/exec/exec.go
@@ -120,10 +120,15 @@ func (plugin *execNetworkPlugin) validate() error {
 	return nil
 }
 
-func (plugin *execNetworkPlugin) SetUpPod(namespace string, name string, id kubeletTypes.DockerID) error {
+func (plugin *execNetworkPlugin) SetUpPod(namespace string, name string, id kubeletTypes.DockerID) (*network.SetUpPodResult, error) {
 	out, err := utilexec.New().Command(plugin.getExecutable(), setUpCmd, namespace, name, string(id)).CombinedOutput()
 	glog.V(5).Infof("SetUpPod 'exec' network plugin output: %s, %v", string(out), err)
-	return err
+	lines := strings.Split(string(out), "\n")
+	result := &network.SetUpPodResult{}
+	if len(lines) > 0 {
+		result.Output = lines[len(lines)-1]
+	}
+	return result, err
 }
 
 func (plugin *execNetworkPlugin) TearDownPod(namespace string, name string, id kubeletTypes.DockerID) error {

--- a/pkg/kubelet/network/plugins.go
+++ b/pkg/kubelet/network/plugins.go
@@ -30,7 +30,7 @@ import (
 
 const DefaultPluginName = "kubernetes.io/no-op"
 
-// Plugin is an interface to network plugins for the kubelet
+// NetworkPlugin is an interface to network plugins for the kubelet
 type NetworkPlugin interface {
 	// Init initializes the plugin.  This will be called exactly once
 	// before any other methods are called.
@@ -43,10 +43,16 @@ type NetworkPlugin interface {
 	// SetUpPod is the method called after the infra container of
 	// the pod has been created but before the other containers of the
 	// pod are launched.
-	SetUpPod(namespace string, name string, podInfraContainerID kubeletTypes.DockerID) error
+	SetUpPod(namespace string, name string, podInfraContainerID kubeletTypes.DockerID) (*SetUpPodResult, error)
 
 	// TearDownPod is the method called before a pod's infra container will be deleted
 	TearDownPod(namespace string, name string, podInfraContainerID kubeletTypes.DockerID) error
+}
+
+// SetUpPodResult is returned when calling NetworkPlugin.SetUpPod. It contains the output
+// of running the plugin.
+type SetUpPodResult struct {
+	Output string
 }
 
 // Host is an interface that plugins can use to access the kubelet.
@@ -113,8 +119,8 @@ func (plugin *noopNetworkPlugin) Name() string {
 	return DefaultPluginName
 }
 
-func (plugin *noopNetworkPlugin) SetUpPod(namespace string, name string, id kubeletTypes.DockerID) error {
-	return nil
+func (plugin *noopNetworkPlugin) SetUpPod(namespace string, name string, id kubeletTypes.DockerID) (*SetUpPodResult, error) {
+	return &SetUpPodResult{}, nil
 }
 
 func (plugin *noopNetworkPlugin) TearDownPod(namespace string, name string, id kubeletTypes.DockerID) error {


### PR DESCRIPTION
Its desirable to provide containers with metadata about the networks they are configured for without depending on the kuberenetes-ro api., especially when the network configuration doesn't allow connectivity to the kube apiserver. With this pull the docker manager will set the `NETWORK` environment variable to the last line of the output from the network plugin. 
