### PR TITLE
MESOS: Set the cpu+mem default limit in the SchedulerServer

### DIFF
--- a/contrib/mesos/pkg/scheduler/service/service.go
+++ b/contrib/mesos/pkg/scheduler/service/service.go
@@ -160,9 +160,11 @@ func NewSchedulerServer() *SchedulerServer {
 		Address:         util.IP(net.ParseIP("127.0.0.1")),
 		FailoverTimeout: time.Duration((1 << 62) - 1).Seconds(),
 
-		RunProxy:               true,
-		ExecutorSuicideTimeout: execcfg.DefaultSuicideTimeout,
-		ExecutorCgroupPrefix:   execcfg.DefaultCgroupPrefix,
+		RunProxy:                 true,
+		ExecutorSuicideTimeout:   execcfg.DefaultSuicideTimeout,
+		ExecutorCgroupPrefix:     execcfg.DefaultCgroupPrefix,
+		DefaultContainerCPULimit: mresource.DefaultDefaultContainerCPULimit,
+		DefaultContainerMemLimit: mresource.DefaultDefaultContainerMemLimit,
 
 		MinionLogMaxSize:      minioncfg.DefaultLogMaxSize(),
 		MinionLogMaxBackups:   minioncfg.DefaultLogMaxBackups,

--- a/contrib/mesos/pkg/scheduler/service/service_test.go
+++ b/contrib/mesos/pkg/scheduler/service/service_test.go
@@ -28,6 +28,8 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/contrib/mesos/pkg/archive"
+	mresource "github.com/GoogleCloudPlatform/kubernetes/contrib/mesos/pkg/scheduler/resource"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -113,6 +115,14 @@ func Test_awaitFailoverDoneFailover(t *testing.T) {
 	if !failoverHandlerCalled {
 		t.Fatalf("expected call to failover handler")
 	}
+}
+
+func Test_DefaultResourceLimits(t *testing.T) {
+	assert := assert.New(t)
+
+	s := NewSchedulerServer()
+	assert.Equal(s.DefaultContainerCPULimit, mresource.DefaultDefaultContainerCPULimit)
+	assert.Equal(s.DefaultContainerMemLimit, mresource.DefaultDefaultContainerMemLimit)
 }
 
 func Test_StaticPods(t *testing.T) {


### PR DESCRIPTION
The default was 0 for both limits such that no container without defined limits came up. Probably these two lines were lost during a rebase.
