### PR TITLE
Convert guestbook example to relative urls

### DIFF
--- a/examples/guestbook/README.md
+++ b/examples/guestbook/README.md
@@ -393,7 +393,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: kubernetes/example-guestbook-php-redis:v2
+        image: kubernetes/example-guestbook-php-redis:v3
         ports:
         - containerPort: 80
 ```

--- a/examples/guestbook/README.md
+++ b/examples/guestbook/README.md
@@ -393,7 +393,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: kubernetes/example-guestbook-php-redis:v3
+        image: gcr.io/google_containers/example-guestbook-php-redis:v3
         ports:
         - containerPort: 80
 ```

--- a/examples/guestbook/frontend-controller.yaml
+++ b/examples/guestbook/frontend-controller.yaml
@@ -15,6 +15,6 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: kubernetes/example-guestbook-php-redis:v3
+        image: gcr.io/google_containers/example-guestbook-php-redis:v3
         ports:
         - containerPort: 80

--- a/examples/guestbook/frontend-controller.yaml
+++ b/examples/guestbook/frontend-controller.yaml
@@ -15,6 +15,6 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: kubernetes/example-guestbook-php-redis:v2
+        image: kubernetes/example-guestbook-php-redis:v3
         ports:
         - containerPort: 80

--- a/examples/guestbook/php-redis/controllers.js
+++ b/examples/guestbook/php-redis/controllers.js
@@ -9,7 +9,7 @@ RedisController.prototype.onRedis = function() {
     this.scope_.messages.push(this.scope_.msg);
     this.scope_.msg = "";
     var value = this.scope_.messages.join();
-    this.http_.get("/index.php?cmd=set&key=messages&value=" + value) 
+    this.http_.get("index.php?cmd=set&key=messages&value=" + value)
             .success(angular.bind(this, function(data) {
                 this.scope_.redisResponse = "Updated.";
             }));
@@ -21,7 +21,7 @@ redisApp.controller('RedisCtrl', function ($scope, $http, $location) {
         $scope.controller.location_ = $location;
         $scope.controller.http_ = $http;
 
-        $scope.controller.http_.get("/index.php?cmd=get&key=messages")
+        $scope.controller.http_.get("index.php?cmd=get&key=messages")
             .success(function(data) {
                 console.log(data);
                 $scope.messages = data.data.split(",");

--- a/examples/guestbook/php-redis/index.html
+++ b/examples/guestbook/php-redis/index.html
@@ -3,7 +3,7 @@
     <title>Guestbook</title>
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.12/angular.min.js"></script>
-    <script src="/controllers.js"></script>
+    <script src="controllers.js"></script>
     <script src="ui-bootstrap-tpls-0.10.0.min.js"></script>
   </head>
   <body ng-controller="RedisCtrl">


### PR DESCRIPTION
Without this change the guestbook example will not work behind non-href-rewriting proxies.

The same use-cases apply as for the guestbook-go example in #11716

**Note**: The container must be rebuilt and pushed as version v3.
