### PR TITLE
Add timestamps to test info logs

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -195,16 +195,20 @@ type RCConfig struct {
 	MaxContainerFailures *int
 }
 
+func nowStamp() string {
+	return time.Now().Format(time.StampMilli)
+}
+
 func Logf(format string, a ...interface{}) {
-	fmt.Fprintf(GinkgoWriter, "INFO: "+format+"\n", a...)
+	fmt.Fprintf(GinkgoWriter, nowStamp()+": INFO: "+format+"\n", a...)
 }
 
 func Failf(format string, a ...interface{}) {
-	Fail(fmt.Sprintf(format, a...), 1)
+	Fail(nowStamp()+": "+fmt.Sprintf(format, a...), 1)
 }
 
 func Skipf(format string, args ...interface{}) {
-	Skip(fmt.Sprintf(format, args...))
+	Skip(nowStamp() + ": " + fmt.Sprintf(format, args...))
 }
 
 func SkipUnlessNodeCountIsAtLeast(minNodeCount int) {


### PR DESCRIPTION
This should improve forensics on failed tests based with only the output to make the timing recoverable, with the hope that flaky tests will be easier to debug as a result.

Before:
INFO: foo

After:
Aug  4 17:42:14.876: INFO: foo
