### PR TITLE
Redundant groupadd

### DIFF
--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -368,7 +368,6 @@ function provision-master() {
 
   # remote login to MASTER and use sudo to configue k8s master
   ssh $SSH_OPTS -t $MASTER "source ~/kube/util.sh; \
-                            groupadd -f -r kube-cert; \
                             setClusterInfo; \
                             create-etcd-opts "${mm[${MASTER_IP}]}" "${MASTER_IP}" "${CLUSTER}"; \
                             create-kube-apiserver-opts "${SERVICE_CLUSTER_IP_RANGE}" "${ADMISSION_CONTROL}" "${SERVICE_NODE_PORT_RANGE}"; \


### PR DESCRIPTION
util.sh had redundant groupadd, which cause the following error:

groupadd: Permission denied.
groupadd: cannot lock /etc/group; try again later.
