### PR TITLE
Replace Port with NodePort for creating LB members

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -586,7 +586,7 @@ func (lb *LoadBalancer) CreateTCPLoadBalancer(name, region string, externalIP ne
 
 		_, err = members.Create(lb.network, members.CreateOpts{
 			PoolID:       pool.ID,
-			ProtocolPort: ports[0].Port, //TODO: need to handle multi-port
+			ProtocolPort: ports[0].NodePort, //TODO: need to handle multi-port
 			Address:      addr,
 		}).Extract()
 		if err != nil {


### PR DESCRIPTION
Fixes issue #12261 

Each member should be created using the NodePort value or the load balancer will map to the wrong port on the nodes.
