### PR TITLE
bug fix: DOCKER_OPTS not works when deploying using Ubuntu scripts

### DIFF
--- a/cluster/ubuntu/reconfDocker.sh
+++ b/cluster/ubuntu/reconfDocker.sh
@@ -48,6 +48,6 @@ sudo brctl delbr docker0
 
 source /run/flannel/subnet.env
 
-echo DOCKER_OPTS=\"-H tcp://127.0.0.1:4243 -H unix:///var/run/docker.sock \
+echo DOCKER_OPTS=\"${DOCKER_OPTS} -H tcp://127.0.0.1:4243 -H unix:///var/run/docker.sock \
      --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU}\" > /etc/default/docker
 sudo service docker restart


### PR DESCRIPTION
When deploying the kubernetes using Ubuntu scripts, the value of configuration item `DOCKER_OPTS` is not set to `/etc/default/docker`.
This commit is to fix this bug.
