### PR TITLE
watch: Check for stopped channel in fake watcher before sending

### DIFF
--- a/pkg/watch/watch_test.go
+++ b/pkg/watch/watch_test.go
@@ -52,7 +52,7 @@ func TestFake(t *testing.T) {
 				t.Fatalf("Expected %v, got %v", expect.s, a)
 			}
 		}
-		_, stillOpen := <-w.ResultChan()
+		stillOpen := w.ResultChan() != nil
 		if stillOpen {
 			t.Fatal("Never stopped")
 		}


### PR DESCRIPTION
I am using the fake watcher for some tests where I send multiple objects down f.result. While there is probably some misconfiguration and my fake client doesn't properly pick up the field selector, I hit a _send on closed chan_ panic. This PR fixes that panic so I can move on with testing/debugging.

@smarterclayton PTAL
