### PR TITLE
Fix creating external load balancer in OpenStack - IP Assignment (#12287)

### DIFF
--- a/pkg/cloudprovider/openstack/openstack.go
+++ b/pkg/cloudprovider/openstack/openstack.go
@@ -624,7 +624,7 @@ func (lb *LoadBalancer) CreateTCPLoadBalancer(name, region string, externalIP ne
 		PoolID:       pool.ID,
 		Persistence:  persistence,
 	}
-	if !externalIP.IsUnspecified() {
+	if externalIP != nil {
 		createOpts.Address = externalIP.String()
 	}
 


### PR DESCRIPTION
Fixes #12287 

If not specified on the CLI/Service definition, OpenStack should automatically assign an IP address for the VirtualIP when creating a new load balancer.

Currently, this checks with `.IsUnspecified()` which is also `false` for `nil`.

This will always be either `nil` or specified.

Tested on private implementation of OpenStack Kilo
