### PR TITLE
update testclient for delegating reaction chain

### DIFF
--- a/pkg/client/unversioned/testclient/fake_daemons.go
+++ b/pkg/client/unversioned/testclient/fake_daemons.go
@@ -72,6 +72,5 @@ func (c *FakeDaemons) Delete(name string) error {
 }
 
 func (c *FakeDaemons) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Invokes(NewWatchAction("daemons", c.Namespace, label, field, resourceVersion), nil)
-	return c.Fake.Watch, nil
+	return c.Fake.InvokesWatch(NewWatchAction("daemons", c.Namespace, label, field, resourceVersion))
 }

--- a/pkg/client/unversioned/testclient/fake_endpoints.go
+++ b/pkg/client/unversioned/testclient/fake_endpoints.go
@@ -72,6 +72,5 @@ func (c *FakeEndpoints) Delete(name string) error {
 }
 
 func (c *FakeEndpoints) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Invokes(NewWatchAction("endpoints", c.Namespace, label, field, resourceVersion), nil)
-	return c.Fake.Watch, c.Fake.Err()
+	return c.Fake.InvokesWatch(NewWatchAction("endpoints", c.Namespace, label, field, resourceVersion))
 }

--- a/pkg/client/unversioned/testclient/fake_events.go
+++ b/pkg/client/unversioned/testclient/fake_events.go
@@ -102,8 +102,7 @@ func (c *FakeEvents) Watch(label labels.Selector, field fields.Selector, resourc
 	if c.Namespace != "" {
 		action = NewWatchAction("events", c.Namespace, label, field, resourceVersion)
 	}
-	c.Fake.Invokes(action, nil)
-	return c.Fake.Watch, c.Fake.Err()
+	return c.Fake.InvokesWatch(action)
 }
 
 // Search returns a list of events matching the specified object.

--- a/pkg/client/unversioned/testclient/fake_limit_ranges.go
+++ b/pkg/client/unversioned/testclient/fake_limit_ranges.go
@@ -72,6 +72,5 @@ func (c *FakeLimitRanges) Delete(name string) error {
 }
 
 func (c *FakeLimitRanges) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Invokes(NewWatchAction("limitranges", c.Namespace, label, field, resourceVersion), nil)
-	return c.Fake.Watch, nil
+	return c.Fake.InvokesWatch(NewWatchAction("limitranges", c.Namespace, label, field, resourceVersion))
 }

--- a/pkg/client/unversioned/testclient/fake_namespaces.go
+++ b/pkg/client/unversioned/testclient/fake_namespaces.go
@@ -53,7 +53,7 @@ func (c *FakeNamespaces) Create(namespace *api.Namespace) (*api.Namespace, error
 		return nil, err
 	}
 
-	return obj.(*api.Namespace), c.Fake.Err()
+	return obj.(*api.Namespace), err
 }
 
 func (c *FakeNamespaces) Update(namespace *api.Namespace) (*api.Namespace, error) {
@@ -71,8 +71,7 @@ func (c *FakeNamespaces) Delete(name string) error {
 }
 
 func (c *FakeNamespaces) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Invokes(NewRootWatchAction("namespaces", label, field, resourceVersion), nil)
-	return c.Fake.Watch, nil
+	return c.Fake.InvokesWatch(NewRootWatchAction("namespaces", label, field, resourceVersion))
 }
 
 func (c *FakeNamespaces) Finalize(namespace *api.Namespace) (*api.Namespace, error) {

--- a/pkg/client/unversioned/testclient/fake_nodes.go
+++ b/pkg/client/unversioned/testclient/fake_nodes.go
@@ -71,8 +71,7 @@ func (c *FakeNodes) Delete(name string) error {
 }
 
 func (c *FakeNodes) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Invokes(NewRootWatchAction("nodes", label, field, resourceVersion), nil)
-	return c.Fake.Watch, c.Fake.Err()
+	return c.Fake.InvokesWatch(NewRootWatchAction("nodes", label, field, resourceVersion))
 }
 
 func (c *FakeNodes) UpdateStatus(minion *api.Node) (*api.Node, error) {

--- a/pkg/client/unversioned/testclient/fake_persistent_volume_claims.go
+++ b/pkg/client/unversioned/testclient/fake_persistent_volume_claims.go
@@ -70,8 +70,7 @@ func (c *FakePersistentVolumeClaims) Delete(name string) error {
 }
 
 func (c *FakePersistentVolumeClaims) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Invokes(NewWatchAction("persistentvolumeclaims", c.Namespace, label, field, resourceVersion), nil)
-	return c.Fake.Watch, c.Fake.Err()
+	return c.Fake.InvokesWatch(NewWatchAction("persistentvolumeclaims", c.Namespace, label, field, resourceVersion))
 }
 
 func (c *FakePersistentVolumeClaims) UpdateStatus(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error) {

--- a/pkg/client/unversioned/testclient/fake_persistent_volumes.go
+++ b/pkg/client/unversioned/testclient/fake_persistent_volumes.go
@@ -69,8 +69,7 @@ func (c *FakePersistentVolumes) Delete(name string) error {
 }
 
 func (c *FakePersistentVolumes) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Invokes(NewRootWatchAction("persistentvolumes", label, field, resourceVersion), nil)
-	return c.Fake.Watch, c.Fake.Err()
+	return c.Fake.InvokesWatch(NewRootWatchAction("persistentvolumes", label, field, resourceVersion))
 }
 
 func (c *FakePersistentVolumes) UpdateStatus(pv *api.PersistentVolume) (*api.PersistentVolume, error) {

--- a/pkg/client/unversioned/testclient/fake_pod_templates.go
+++ b/pkg/client/unversioned/testclient/fake_pod_templates.go
@@ -72,6 +72,5 @@ func (c *FakePodTemplates) Delete(name string, options *api.DeleteOptions) error
 }
 
 func (c *FakePodTemplates) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Invokes(NewWatchAction("podtemplates", c.Namespace, label, field, resourceVersion), nil)
-	return c.Fake.Watch, c.Fake.Err()
+	return c.Fake.InvokesWatch(NewWatchAction("podtemplates", c.Namespace, label, field, resourceVersion))
 }

--- a/pkg/client/unversioned/testclient/fake_pods.go
+++ b/pkg/client/unversioned/testclient/fake_pods.go
@@ -72,8 +72,7 @@ func (c *FakePods) Delete(name string, options *api.DeleteOptions) error {
 }
 
 func (c *FakePods) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Invokes(NewWatchAction("pods", c.Namespace, label, field, resourceVersion), nil)
-	return c.Fake.Watch, c.Fake.Err()
+	return c.Fake.InvokesWatch(NewWatchAction("pods", c.Namespace, label, field, resourceVersion))
 }
 
 func (c *FakePods) Bind(binding *api.Binding) error {

--- a/pkg/client/unversioned/testclient/fake_replication_controllers.go
+++ b/pkg/client/unversioned/testclient/fake_replication_controllers.go
@@ -72,6 +72,5 @@ func (c *FakeReplicationControllers) Delete(name string) error {
 }
 
 func (c *FakeReplicationControllers) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Invokes(NewWatchAction("replicationcontrollers", c.Namespace, label, field, resourceVersion), nil)
-	return c.Fake.Watch, nil
+	return c.Fake.InvokesWatch(NewWatchAction("replicationcontrollers", c.Namespace, label, field, resourceVersion))
 }

--- a/pkg/client/unversioned/testclient/fake_resource_quotas.go
+++ b/pkg/client/unversioned/testclient/fake_resource_quotas.go
@@ -72,8 +72,7 @@ func (c *FakeResourceQuotas) Delete(name string) error {
 }
 
 func (c *FakeResourceQuotas) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Invokes(NewWatchAction("resourcequotas", c.Namespace, label, field, resourceVersion), nil)
-	return c.Fake.Watch, nil
+	return c.Fake.InvokesWatch(NewWatchAction("resourcequotas", c.Namespace, label, field, resourceVersion))
 }
 
 func (c *FakeResourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error) {

--- a/pkg/client/unversioned/testclient/fake_secrets.go
+++ b/pkg/client/unversioned/testclient/fake_secrets.go
@@ -72,6 +72,5 @@ func (c *FakeSecrets) Delete(name string) error {
 }
 
 func (c *FakeSecrets) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Invokes(NewWatchAction("secrets", c.Namespace, label, field, resourceVersion), nil)
-	return c.Fake.Watch, c.Fake.Err()
+	return c.Fake.InvokesWatch(NewWatchAction("secrets", c.Namespace, label, field, resourceVersion))
 }

--- a/pkg/client/unversioned/testclient/fake_service_accounts.go
+++ b/pkg/client/unversioned/testclient/fake_service_accounts.go
@@ -72,6 +72,5 @@ func (c *FakeServiceAccounts) Delete(name string) error {
 }
 
 func (c *FakeServiceAccounts) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Invokes(NewWatchAction("serviceaccounts", c.Namespace, label, field, resourceVersion), nil)
-	return c.Fake.Watch, c.Fake.Err()
+	return c.Fake.InvokesWatch(NewWatchAction("serviceaccounts", c.Namespace, label, field, resourceVersion))
 }

--- a/pkg/client/unversioned/testclient/fake_services.go
+++ b/pkg/client/unversioned/testclient/fake_services.go
@@ -73,8 +73,7 @@ func (c *FakeServices) Delete(name string) error {
 }
 
 func (c *FakeServices) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Invokes(NewWatchAction("services", c.Namespace, label, field, resourceVersion), nil)
-	return c.Fake.Watch, nil
+	return c.Fake.InvokesWatch(NewWatchAction("services", c.Namespace, label, field, resourceVersion))
 }
 
 func (c *FakeServices) ProxyGet(name, path string, params map[string]string) unversioned.ResponseWrapper {

--- a/pkg/client/unversioned/testclient/testclient_test.go
+++ b/pkg/client/unversioned/testclient/testclient_test.go
@@ -31,7 +31,8 @@ func TestNewClient(t *testing.T) {
 	if err := AddObjectsFromPath("../../../../examples/guestbook/frontend-service.yaml", o, api.Scheme); err != nil {
 		t.Fatal(err)
 	}
-	client := &Fake{ReactFn: ObjectReaction(o, latest.RESTMapper)}
+	client := &Fake{}
+	client.AddReactor("*", "*", ObjectReaction(o, latest.RESTMapper))
 	list, err := client.Services("test").List(labels.Everything())
 	if err != nil {
 		t.Fatal(err)
@@ -61,7 +62,8 @@ func TestErrors(t *testing.T) {
 			&(errors.NewForbidden("ServiceList", "", nil).(*errors.StatusError).ErrStatus),
 		},
 	})
-	client := &Fake{ReactFn: ObjectReaction(o, latest.RESTMapper)}
+	client := &Fake{}
+	client.AddReactor("*", "*", ObjectReaction(o, latest.RESTMapper))
 	_, err := client.Services("test").List(labels.Everything())
 	if !errors.IsNotFound(err) {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -134,9 +134,8 @@ func TestSyncNamespaceThatIsActive(t *testing.T) {
 }
 
 func TestRunStop(t *testing.T) {
-	o := testclient.NewObjects(api.Scheme, api.Scheme)
-	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, api.RESTMapper)}
-	nsController := NewNamespaceController(client, 1*time.Second)
+	mockClient := &testclient.Fake{}
+	nsController := NewNamespaceController(mockClient, 1*time.Second)
 
 	if nsController.StopEverything != nil {
 		t.Errorf("Non-running manager should not have a stop channel.  Got %v", nsController.StopEverything)

--- a/pkg/controller/persistentvolume/persistentvolume_claim_binder_controller_test.go
+++ b/pkg/controller/persistentvolume/persistentvolume_claim_binder_controller_test.go
@@ -30,8 +30,7 @@ import (
 )
 
 func TestRunStop(t *testing.T) {
-	o := testclient.NewObjects(api.Scheme, api.Scheme)
-	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, api.RESTMapper)}
+	client := &testclient.Fake{}
 	binder := NewPersistentVolumeClaimBinder(client, 1*time.Second)
 
 	if len(binder.stopChannels) != 0 {
@@ -118,7 +117,8 @@ func TestExampleObjects(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, api.RESTMapper)}
+		client := &testclient.Fake{}
+		client.AddReactor("*", "*", testclient.ObjectReaction(o, api.RESTMapper))
 
 		if reflect.TypeOf(scenario.expected) == reflect.TypeOf(&api.PersistentVolumeClaim{}) {
 			pvc, err := client.PersistentVolumeClaims("ns").Get("doesntmatter")
@@ -178,7 +178,8 @@ func TestBindingWithExamples(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, api.RESTMapper)}
+	client := &testclient.Fake{}
+	client.AddReactor("*", "*", testclient.ObjectReaction(o, api.RESTMapper))
 
 	pv, err := client.PersistentVolumes().Get("any")
 	pv.Spec.PersistentVolumeReclaimPolicy = api.PersistentVolumeReclaimRecycle
@@ -281,7 +282,8 @@ func TestMissingFromIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, api.RESTMapper)}
+	client := &testclient.Fake{}
+	client.AddReactor("*", "*", testclient.ObjectReaction(o, api.RESTMapper))
 
 	pv, err := client.PersistentVolumes().Get("any")
 	if err != nil {

--- a/pkg/volume/aws_ebs/aws_ebs_test.go
+++ b/pkg/volume/aws_ebs/aws_ebs_test.go
@@ -191,7 +191,8 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	o := testclient.NewObjects(api.Scheme, api.Scheme)
 	o.Add(pv)
 	o.Add(claim)
-	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}
+	client := &testclient.Fake{}
+	client.AddReactor("*", "*", testclient.ObjectReaction(o, latest.RESTMapper))
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))

--- a/pkg/volume/gce_pd/gce_pd_test.go
+++ b/pkg/volume/gce_pd/gce_pd_test.go
@@ -205,7 +205,8 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	o := testclient.NewObjects(api.Scheme, api.Scheme)
 	o.Add(pv)
 	o.Add(claim)
-	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}
+	client := &testclient.Fake{}
+	client.AddReactor("*", "*", testclient.ObjectReaction(o, latest.RESTMapper))
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))

--- a/pkg/volume/glusterfs/glusterfs_test.go
+++ b/pkg/volume/glusterfs/glusterfs_test.go
@@ -200,7 +200,8 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	o.Add(pv)
 	o.Add(claim)
 	o.Add(ep)
-	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}
+	client := &testclient.Fake{}
+	client.AddReactor("*", "*", testclient.ObjectReaction(o, latest.RESTMapper))
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))

--- a/pkg/volume/host_path/host_path_test.go
+++ b/pkg/volume/host_path/host_path_test.go
@@ -176,7 +176,8 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	o := testclient.NewObjects(api.Scheme, api.Scheme)
 	o.Add(pv)
 	o.Add(claim)
-	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}
+	client := &testclient.Fake{}
+	client.AddReactor("*", "*", testclient.ObjectReaction(o, latest.RESTMapper))
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))

--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -234,7 +234,8 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	o := testclient.NewObjects(api.Scheme, api.Scheme)
 	o.Add(pv)
 	o.Add(claim)
-	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}
+	client := &testclient.Fake{}
+	client.AddReactor("*", "*", testclient.ObjectReaction(o, latest.RESTMapper))
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -235,7 +235,8 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	o := testclient.NewObjects(api.Scheme, api.Scheme)
 	o.Add(pv)
 	o.Add(claim)
-	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}
+	client := &testclient.Fake{}
+	client.AddReactor("*", "*", testclient.ObjectReaction(o, latest.RESTMapper))
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))

--- a/pkg/volume/persistent_claim/persistent_claim_test.go
+++ b/pkg/volume/persistent_claim/persistent_claim_test.go
@@ -237,7 +237,8 @@ func TestNewBuilder(t *testing.T) {
 		o := testclient.NewObjects(api.Scheme, api.Scheme)
 		o.Add(item.pv)
 		o.Add(item.claim)
-		client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, api.RESTMapper)}
+		client := &testclient.Fake{}
+		client.AddReactor("*", "*", testclient.ObjectReaction(o, api.RESTMapper))
 
 		plugMgr := volume.VolumePluginMgr{}
 		plugMgr.InitPlugins(testProbeVolumePlugins(), newTestHost(t, client))
@@ -294,7 +295,8 @@ func TestNewBuilderClaimNotBound(t *testing.T) {
 	o := testclient.NewObjects(api.Scheme, api.Scheme)
 	o.Add(pv)
 	o.Add(claim)
-	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, api.RESTMapper)}
+	client := &testclient.Fake{}
+	client.AddReactor("*", "*", testclient.ObjectReaction(o, api.RESTMapper))
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(testProbeVolumePlugins(), newTestHost(t, client))

--- a/pkg/volume/rbd/rbd_test.go
+++ b/pkg/volume/rbd/rbd_test.go
@@ -191,7 +191,8 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	o := testclient.NewObjects(api.Scheme, api.Scheme)
 	o.Add(pv)
 	o.Add(claim)
-	client := &testclient.Fake{ReactFn: testclient.ObjectReaction(o, latest.RESTMapper)}
+	client := &testclient.Fake{}
+	client.AddReactor("*", "*", testclient.ObjectReaction(o, latest.RESTMapper))
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))

--- a/plugin/pkg/admission/exec/denyprivileged/admission_test.go
+++ b/plugin/pkg/admission/exec/denyprivileged/admission_test.go
@@ -36,15 +36,14 @@ func TestAdmissionDeny(t *testing.T) {
 }
 
 func testAdmission(t *testing.T, pod *api.Pod, shouldAccept bool) {
-	mockClient := &testclient.Fake{
-		ReactFn: func(action testclient.Action) (runtime.Object, error) {
-			if action.Matches("get", "pods") && action.(testclient.GetAction).GetName() == pod.Name {
-				return pod, nil
-			}
-			t.Errorf("Unexpected API call: %#v", action)
-			return nil, nil
-		},
-	}
+	mockClient := &testclient.Fake{}
+	mockClient.AddReactor("get", "pods", func(action testclient.Action) (bool, runtime.Object, error) {
+		if action.(testclient.GetAction).GetName() == pod.Name {
+			return true, pod, nil
+		}
+		t.Errorf("Unexpected API call: %#v", action)
+		return true, nil, nil
+	})
 	handler := &denyExecOnPrivileged{
 		client: mockClient,
 	}

--- a/plugin/pkg/admission/namespace/autoprovision/admission_test.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/client/unversioned/cache"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/runtime"
 )
 
 // TestAdmission verifies a namespace is created on create requests for namespace managed resources
@@ -107,7 +108,9 @@ func TestIgnoreAdmission(t *testing.T) {
 func TestAdmissionNamespaceExistsUnknownToHandler(t *testing.T) {
 	namespace := "test"
 	mockClient := &testclient.Fake{}
-	mockClient.SetErr(errors.NewAlreadyExists("namespaces", namespace))
+	mockClient.AddReactor("create", "namespaces", func(action testclient.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.NewAlreadyExists("namespaces", namespace)
+	})
 
 	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
 	handler := &provision{


### PR DESCRIPTION
This introduces the idea of a reaction chain instead of a reaction function.  This allows people to only override default behavior for specific cases, which is more likely to be what they meant to do instead of overriding behavior for all verb,resource tuples.

I see this as a step on the path to having the testclient able to handle basic "create, get, delete" flows without custom reaction functions.  This structure would allow that behavior for most resource types, while allows a few specific cases to behave differently.
