### PR TITLE
Update twitter and g+ links to point to Kubernetes specific accounts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -67,9 +67,9 @@ footer:
       - label: stackoverflow
         url: http://stackoverflow.com/questions/tagged/kubernetes
       - label: twitter
-        url: https://twitter.com/googlecloud
+        url: https://twitter.com/kubernetesio
       - label: googleplus
-        url: https://plus.google.com/+googlecloudplatform
+        url: https://plus.google.com/u/0/b/116512812300813784482/116512812300813784482
             
     links:
       - label: Freenode


### PR DESCRIPTION
Current links are outdated and point to googlecloud, this updates them to the K8s twitter and g+ accounts
