### PR TITLE
Set default URL in local build config file

### DIFF
--- a/_local_config.yml
+++ b/_local_config.yml
@@ -1,4 +1,4 @@
-url: "" # run from whatever URL they are accessing, good for testing in office
+url: "http://localhost:4000" # run from whatever URL they are accessing, good for testing in office
 google_analytics: ""
 
 sass:


### PR DESCRIPTION
The default URL for local builds is http://localhost:4000 so configuring the local build config file to that so that this is always set (no longer a manual step). By having this file set, local builds behave more like the fork and public builds and URLs within documents are generated as absolute (vs. relative). This also ensures the behavior of javascript matches (since it looks for absolute URLs).

Local build setup info:
https://help.github.com/articles/using-jekyll-with-pages/

Note: to use the local build config file, run jekyll with the --config attribute:
jekyll serve --config=_config.yml,_local_config.yml
