### PR TITLE
Fix salt configuration on systemd setups

### DIFF
--- a/cluster/saltbase/salt/kube-proxy/default
+++ b/cluster/saltbase/salt/kube-proxy/default
@@ -31,7 +31,5 @@
   {% set test_args=pillar['kubeproxy_test_args'] %}
 {% endif -%}
 
-DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{kubeconfig}} {{pillar['log_level']}}"
-
 # test_args has to be kept at the end, so they'll overwrite any prior configuration
-DAEMON_ARGS="$DAEMON_ARGS + {{test_args}}"
+DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{kubeconfig}} {{pillar['log_level']}} {{test_args}}"

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -95,7 +95,5 @@
   {% set test_args=pillar['kubelet_test_args'] %}
 {% endif -%}
 
-DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{config}} {{manifest_url}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}} {{pod_cidr}}"
-
 # test_args has to be kept at the end, so they'll overwrite any prior configuration
-DAEMON_ARGS="$DAEMON_ARGS + {{test_args}}"
+DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{config}} {{manifest_url}} --allow_privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}} {{pod_cidr}} {{test_args}}"


### PR DESCRIPTION
The following PR caused a regression in systemd environments:
https://github.com/GoogleCloudPlatform/kubernetes/pull/11308

The issue is that EnvironmentFiles are not truly bash scripts so we need to append {{test_args}} on the existing line and not treat it like a program.  Moved the line change and added the comment to note that test_args must always be last.

This fixes deploying the kubelet on systemd environments.

@BenTheElder @justinsb @gmarek @alex-mohr 

Fixes: https://github.com/GoogleCloudPlatform/kubernetes/issues/12285
