### PR TITLE
Implement 'Nodes Network' test for GKE; add optional verbose SSH.

### DIFF
--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -210,18 +210,17 @@ function get-password() {
     | grep password | cut -f 4 -d ' ')
 }
 
-# Detect the instance name and IP for the master
+# Detect the IP for the master. Note that on GKE, we don't know the name of the
+# master, so KUBE_MASTER is not set.
 #
 # Assumed vars:
 #   ZONE
 #   CLUSTER_NAME
 # Vars set:
-#   KUBE_MASTER
 #   KUBE_MASTER_IP
 function detect-master() {
   echo "... in gke:detect-master()" >&2
   detect-project >&2
-  KUBE_MASTER="k8s-${CLUSTER_NAME}-master"
   KUBE_MASTER_IP=$("${GCLOUD}" "${CMD_GROUP}" container clusters describe \
     --project="${PROJECT}" --zone="${ZONE}" "${CLUSTER_NAME}" \
     | grep endpoint | cut -f 2 -d ' ')

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -89,7 +89,7 @@ fi
 export PATH=$(dirname "${e2e_test}"):"${PATH}"
 "${ginkgo}" "${ginkgo_args[@]:+${ginkgo_args[@]}}" "${e2e_test}" -- \
   "${auth_config[@]:+${auth_config[@]}}" \
-  --host="https://${KUBE_MASTER_IP-}" \
+  --host="https://${KUBE_MASTER_IP:-}" \
   --provider="${KUBERNETES_PROVIDER}" \
   --gce-project="${PROJECT:-}" \
   --gce-zone="${ZONE:-}" \


### PR DESCRIPTION
This is a redemption PR, redoing the work of both #11789 ("Nodes Network" test) and #11805 (verbose SSH logging), both of which broke the build when they went in.

Here's what broke last time and why this is better:

**"Nodes Network" test**
- Why it broke: The reason why #11789 broke GCE was that it used the external IP address of the master. The external IP works for GKE because the master is in a separate project from the nodes and must be addressed externally. However, for GCE, the nodes address the master with the internal IP address. 
- Why this is better: This keeps the DNS name for GCE (as well as the fixed IP for AWS) and just adds the internal address for GKE. I was going to make them all use the internal IP address from `testContext.CloudConfig.Provider.Clusters().Master()`, but it looks like the `Provider` is only init'd with AWS. I've tested this manually with GCE and GKE and it works.

**Verbose SSH logging**
- Why it broke: #11805 broke the scalability tests because it always logged all SSH output for e2e tests, which turned out to be way too much for tests with large clusters (I believe it broke in the cleanup post-test step, but the logs are no longer available on Jenkins).
- Why this is better: This makes SSH verbose logging an explicit call, which I only turned on for the "Nodes Network" test for better debugging. We can turn this on more places as it's deemed safe.
