### PR TITLE
Revert "Support Stdin and TTY in the kubelet"

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -593,9 +593,6 @@ func (dm *DockerManager) runContainer(
 			CPUShares:  cpuShares,
 			WorkingDir: container.WorkingDir,
 			Labels:     labels,
-			// Interactive containers:
-			OpenStdin: container.Stdin,
-			Tty:       container.TTY,
 		},
 	}
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/kubernetes#12168
