### PR TITLE
Fix for preventing the nav menu from closing when not a container

### DIFF
--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -47,8 +47,10 @@
 	            $('.menu a').removeClass('active');
 	            $(this).addClass('active').next().stop(true,true).slideDown('normal');
 	        } else {
-	            $(this).removeClass('active');
-	            $(this).next().stop(true,true).slideUp('normal');
+				if($(this).hasClass('active') && $(this).parent().hasClass('haschild')){
+	            	$(this).removeClass('active');
+					$(this).next().stop(true,true).slideUp('normal');
+				}
 	        }
 	    });
 	});


### PR DESCRIPTION
Clicking on a selected child menu item three times causes the nav menu to misbehave and close the submenu. This fix prevents that and will now only close submenus when the container topic is clicked.
