### PR TITLE
Handle errors properly in kube::gcs::release functions

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -119,7 +119,7 @@ readonly KUBE_DOCKER_WRAPPED_BINARIES=(
 #   DOCKER_MOUNT_ARGS
 function kube::build::verify_prereqs() {
   kube::log::status "Verifying Prerequisites...."
-  kube::build::ensure_tar
+  kube::build::ensure_tar || return 1
 
   if [[ "${1-}" != "clean" ]]; then
     if [[ -z "$(which docker)" ]]; then
@@ -800,9 +800,9 @@ function kube::release::create_tarball() {
 function kube::release::gcs::release() {
   [[ ${KUBE_GCS_UPLOAD_RELEASE} =~ ^[yY]$ ]] || return 0
 
-  kube::release::gcs::verify_prereqs
-  kube::release::gcs::ensure_release_bucket
-  kube::release::gcs::copy_release_artifacts
+  kube::release::gcs::verify_prereqs || return 1
+  kube::release::gcs::ensure_release_bucket || return 1
+  kube::release::gcs::copy_release_artifacts || return 1
 }
 
 # Verify things are set up for uploading to GCS
@@ -844,12 +844,12 @@ function kube::release::gcs::ensure_release_bucket() {
 
   if ! gsutil ls "gs://${KUBE_GCS_RELEASE_BUCKET}" >/dev/null 2>&1 ; then
     echo "Creating Google Cloud Storage bucket: $KUBE_GCS_RELEASE_BUCKET"
-    gsutil mb -p "${GCLOUD_PROJECT}" "gs://${KUBE_GCS_RELEASE_BUCKET}"
+    gsutil mb -p "${GCLOUD_PROJECT}" "gs://${KUBE_GCS_RELEASE_BUCKET}" || return 1
   fi
 }
 
 function kube::release::gcs::stage_and_hash() {
-  kube::build::ensure_tar
+  kube::build::ensure_tar || return 1
 
   # Split the args into srcs... and dst
   local -r args=( "$@" )
@@ -860,8 +860,8 @@ function kube::release::gcs::stage_and_hash() {
   for src in ${srcs[@]}; do
     srcdir=$(dirname ${src})
     srcthing=$(basename ${src})
-    mkdir -p ${GCS_STAGE}/${dst}
-    "${TAR}" c -C ${srcdir} ${srcthing} | "${TAR}" x -C ${GCS_STAGE}/${dst}
+    mkdir -p ${GCS_STAGE}/${dst} || return 1
+    "${TAR}" c -C ${srcdir} ${srcthing} | "${TAR}" x -C ${GCS_STAGE}/${dst} || return 1
   done
 }
 
@@ -874,15 +874,15 @@ function kube::release::gcs::copy_release_artifacts() {
 
   kube::log::status "Staging release artifacts to ${GCS_STAGE}"
 
-  rm -rf ${GCS_STAGE}
-  mkdir -p ${GCS_STAGE}
+  rm -rf ${GCS_STAGE} || return 1
+  mkdir -p ${GCS_STAGE} || return 1
 
   # Stage everything in release directory
-  kube::release::gcs::stage_and_hash "${RELEASE_DIR}"/* .
+  kube::release::gcs::stage_and_hash "${RELEASE_DIR}"/* . || return 1
 
   # Having the configure-vm.sh script from the GCE cluster deploy hosted with the
   # release is useful for GKE.
-  kube::release::gcs::stage_and_hash "${RELEASE_STAGE}/full/kubernetes/cluster/gce/configure-vm.sh" extra/gce
+  kube::release::gcs::stage_and_hash "${RELEASE_STAGE}/full/kubernetes/cluster/gce/configure-vm.sh" extra/gce || return 1
 
   # Upload the "naked" binaries to GCS.  This is useful for install scripts that
   # download the binaries directly and don't need tars.
@@ -895,13 +895,13 @@ function kube::release::gcs::copy_release_artifacts() {
     if [[ -d "${RELEASE_STAGE}/server/${platform}" ]]; then
       src="${RELEASE_STAGE}/server/${platform}/kubernetes/server/bin/*"
     fi
-    kube::release::gcs::stage_and_hash "$src" "$dst"
+    kube::release::gcs::stage_and_hash "$src" "$dst" || return 1
   done
 
   kube::log::status "Hashing files in ${GCS_STAGE}"
   find ${GCS_STAGE} -type f | while read path; do
-    kube::release::md5 ${path} > "${path}.md5"
-    kube::release::sha1 ${path} > "${path}.sha1"
+    kube::release::md5 ${path} > "${path}.md5" || return 1
+    kube::release::sha1 ${path} > "${path}.sha1" || return 1
   done
 
   kube::log::status "Copying release artifacts to ${gcs_destination}"
@@ -919,7 +919,7 @@ function kube::release::gcs::copy_release_artifacts() {
         return
       }
     }
-    gsutil -q -m rm -f -R "${gcs_destination}"
+    gsutil -q -m rm -f -R "${gcs_destination}" || return 1
   fi
 
   local gcs_options=()
@@ -927,7 +927,7 @@ function kube::release::gcs::copy_release_artifacts() {
     gcs_options=("-h" "Cache-Control:private, max-age=0")
   fi
 
-  gsutil -q -m "${gcs_options[@]+${gcs_options[@]}}" cp -r "${GCS_STAGE}"/* ${gcs_destination}
+  gsutil -q -m "${gcs_options[@]+${gcs_options[@]}}" cp -r "${GCS_STAGE}"/* ${gcs_destination} || return 1
 
   # TODO(jbeda): Generate an HTML page with links for this release so it is easy
   # to see it.  For extra credit, generate a dynamic page that builds up the
@@ -936,26 +936,26 @@ function kube::release::gcs::copy_release_artifacts() {
 
   if [[ ${KUBE_GCS_MAKE_PUBLIC} =~ ^[yY]$ ]]; then
     kube::log::status "Marking all uploaded objects public"
-    gsutil -q -m acl ch -R -g all:R "${gcs_destination}" >/dev/null 2>&1
+    gsutil -q -m acl ch -R -g all:R "${gcs_destination}" >/dev/null 2>&1 || return 1
   fi
 
-  gsutil ls -lhr "${gcs_destination}"
+  gsutil ls -lhr "${gcs_destination}" || return 1
 }
 
 function kube::release::gcs::publish_latest() {
   local latest_file_dst="gs://${KUBE_GCS_RELEASE_BUCKET}/${KUBE_GCS_LATEST_FILE}"
 
-  mkdir -p "${RELEASE_STAGE}/upload"
-  echo ${KUBE_GCS_LATEST_CONTENTS} > "${RELEASE_STAGE}/upload/latest"
+  mkdir -p "${RELEASE_STAGE}/upload" || return 1
+  echo ${KUBE_GCS_LATEST_CONTENTS} > "${RELEASE_STAGE}/upload/latest" || return 1
 
-  gsutil -m cp "${RELEASE_STAGE}/upload/latest" "${latest_file_dst}"
+  gsutil -m cp "${RELEASE_STAGE}/upload/latest" "${latest_file_dst}" || return 1
 
   if [[ ${KUBE_GCS_MAKE_PUBLIC} =~ ^[yY]$ ]]; then
-    gsutil acl ch -R -g all:R "${latest_file_dst}" >/dev/null 2>&1
+    gsutil acl ch -R -g all:R "${latest_file_dst}" >/dev/null 2>&1 || return 1
   fi
 
   kube::log::status "gsutil cat ${latest_file_dst}:"
-  gsutil cat ${latest_file_dst}
+  gsutil cat ${latest_file_dst} || return 1
 }
 
 # Publish a new latest.txt, but only if the release we're dealing with
@@ -1005,5 +1005,5 @@ function kube::release::gcs::publish_latest_official() {
   fi
 
   kube::log::status "${new_version} (just uploaded) > ${gcs_version} (latest on GCS), updating ${latest_file_dst}"
-  kube::release::gcs::publish_latest
+  kube::release::gcs::publish_latest || return 1
 }


### PR DESCRIPTION
errexit doesn't actually do anything when commands are run inside a function on the left-hand side of a &&. Thus after #12177, all errors were being swallowed, rather than being handled correctly.

The only way to fix this is to stop relying on errexit's functionality entirely.

I've only updated the kube::release::gcs functions for now, though we probably need a full audit of everything.
