### PR TITLE
Replace usage of ifup and ifdown in the reboot test with ifconfig

### DIFF
--- a/test/e2e/reboot.go
+++ b/test/e2e/reboot.go
@@ -79,7 +79,7 @@ var _ = Describe("Reboot", func() {
 	It("each node by switching off the network interface and ensure they function upon switch on", func() {
 		// switch the network interface off for a while to simulate a network outage
 		// We sleep 10 seconds to give some time for ssh command to cleanly finish before network is down.
-		testReboot(c, "nohup sh -c 'sleep 10 && sudo ifdown eth0 && sleep 120 && sudo ifup eth0' >/dev/null 2>&1 &")
+		testReboot(c, "nohup sh -c 'sleep 10 && sudo ifconfig eth0 down && sleep 120 && sudo ifconfig eth0 up' >/dev/null 2>&1 &")
 	})
 
 	It("each node by dropping all inbound packets for a while and ensure they function afterwards", func() {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1581,7 +1581,7 @@ func waitForNodeToBeNotReady(c *client.Client, name string, timeout time.Duratio
 func isNodeReadySetAsExpected(node *api.Node, wantReady bool) bool {
 	// Check the node readiness condition (logging all).
 	for i, cond := range node.Status.Conditions {
-		Logf("Node %s condition %d/%d: type: %v, status: %v, reason: %q, message: %q, last transistion time: %v",
+		Logf("Node %s condition %d/%d: type: %v, status: %v, reason: %q, message: %q, last transition time: %v",
 			node.Name, i+1, len(node.Status.Conditions), cond.Type, cond.Status,
 			cond.Reason, cond.Message, cond.LastTransitionTime)
 		// Ensure that the condition type is readiness and the status


### PR DESCRIPTION
...to make it work across more different OS images. Also fix typo in a log message. I'm still running the e2e locally after a failure the first time I tried, but sending out to let k8s-bot test as well.

@andyzheng0831 @jszczepkowski 
