### PR TITLE
Move prioritizer function EqualPriority to package priorities

### DIFF
--- a/plugin/pkg/scheduler/algorithm/priorities/priorities.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/priorities.go
@@ -245,3 +245,21 @@ func fractionOfCapacity(requested, capacity int64) float64 {
 	}
 	return float64(requested) / float64(capacity)
 }
+
+// EqualPriority is a prioritizer function that gives an equal score of one to all nodes
+func EqualPriority(_ *api.Pod, podLister algorithm.PodLister, minionLister algorithm.MinionLister) (algorithm.HostPriorityList, error) {
+	nodes, err := minionLister.List()
+	if err != nil {
+		glog.Errorf("failed to list nodes: %v", err)
+		return []algorithm.HostPriority{}, err
+	}
+
+	result := []algorithm.HostPriority{}
+	for _, minion := range nodes.Items {
+		result = append(result, algorithm.HostPriority{
+			Host:  minion.Name,
+			Score: 1,
+		})
+	}
+	return result, nil
+}

--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -19,7 +19,6 @@ package defaults
 
 import (
 	"k8s.io/kubernetes/pkg/util"
-	"k8s.io/kubernetes/plugin/pkg/scheduler"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/priorities"
@@ -31,7 +30,7 @@ func init() {
 	// EqualPriority is a prioritizer function that gives an equal weight of one to all minions
 	// Register the priority function so that its available
 	// but do not include it as part of the default priorities
-	factory.RegisterPriorityFunction("EqualPriority", scheduler.EqualPriority, 1)
+	factory.RegisterPriorityFunction("EqualPriority", priorities.EqualPriority, 1)
 }
 
 func defaultPredicates() util.StringSet {

--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/priorities"
 )
 
 type FailedPredicateMap map[string]util.StringSet
@@ -148,7 +149,7 @@ func PrioritizeNodes(pod *api.Pod, podLister algorithm.PodLister, priorityConfig
 	// If no priority configs are provided, then the EqualPriority function is applied
 	// This is required to generate the priority list in the required format
 	if len(priorityConfigs) == 0 {
-		return EqualPriority(pod, podLister, minionLister)
+		return priorities.EqualPriority(pod, podLister, minionLister)
 	}
 
 	combinedScores := map[string]int{}
@@ -184,24 +185,6 @@ func getBestHosts(list algorithm.HostPriorityList) []string {
 		}
 	}
 	return result
-}
-
-// EqualPriority is a prioritizer function that gives an equal weight of one to all nodes
-func EqualPriority(_ *api.Pod, podLister algorithm.PodLister, minionLister algorithm.MinionLister) (algorithm.HostPriorityList, error) {
-	nodes, err := minionLister.List()
-	if err != nil {
-		glog.Errorf("failed to list nodes: %v", err)
-		return []algorithm.HostPriority{}, err
-	}
-
-	result := []algorithm.HostPriority{}
-	for _, minion := range nodes.Items {
-		result = append(result, algorithm.HostPriority{
-			Host:  minion.Name,
-			Score: 1,
-		})
-	}
-	return result, nil
 }
 
 func NewGenericScheduler(predicates map[string]algorithm.FitPredicate, prioritizers []algorithm.PriorityConfig, pods algorithm.PodLister, random *rand.Rand) algorithm.ScheduleAlgorithm {

--- a/plugin/pkg/scheduler/generic_scheduler_test.go
+++ b/plugin/pkg/scheduler/generic_scheduler_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/priorities"
 )
 
 func falsePredicate(pod *api.Pod, existingPods []*api.Pod, node string) (bool, error) {
@@ -176,14 +177,14 @@ func TestGenericScheduler(t *testing.T) {
 	}{
 		{
 			predicates:   map[string]algorithm.FitPredicate{"false": falsePredicate},
-			prioritizers: []algorithm.PriorityConfig{{Function: EqualPriority, Weight: 1}},
+			prioritizers: []algorithm.PriorityConfig{{Function: priorities.EqualPriority, Weight: 1}},
 			nodes:        []string{"machine1", "machine2"},
 			expectsErr:   true,
 			name:         "test 1",
 		},
 		{
 			predicates:   map[string]algorithm.FitPredicate{"true": truePredicate},
-			prioritizers: []algorithm.PriorityConfig{{Function: EqualPriority, Weight: 1}},
+			prioritizers: []algorithm.PriorityConfig{{Function: priorities.EqualPriority, Weight: 1}},
 			nodes:        []string{"machine1", "machine2"},
 			// Random choice between both, the rand seeded above with zero, chooses "machine1"
 			expectedHost: "machine1",
@@ -192,7 +193,7 @@ func TestGenericScheduler(t *testing.T) {
 		{
 			// Fits on a machine where the pod ID matches the machine name
 			predicates:   map[string]algorithm.FitPredicate{"matches": matchesPredicate},
-			prioritizers: []algorithm.PriorityConfig{{Function: EqualPriority, Weight: 1}},
+			prioritizers: []algorithm.PriorityConfig{{Function: priorities.EqualPriority, Weight: 1}},
 			nodes:        []string{"machine1", "machine2"},
 			pod:          &api.Pod{ObjectMeta: api.ObjectMeta{Name: "machine2"}},
 			expectedHost: "machine2",


### PR DESCRIPTION
This PR moves prioritizer function EqualPriority() to package ./plugin/pkg/scheduler/algorithm/priorities

EqualPriority() is one of the many prioritizer functions in Kubernetes scheduler algorithm. It is now located at package ./plugin/pkg/scheduler while all the other priority functions are in package ./plugin/pkg/scheduler/algorithm/priorities.
