### PR TITLE
vxlan as bankend of flannel & auto restart k8s with daemon

### DIFF
--- a/docs/getting-started-guides/docker-multinode/master.sh
+++ b/docs/getting-started-guides/docker-multinode/master.sh
@@ -94,7 +94,7 @@ start_k8s(){
 
     sleep 5
     # Set flannel net config
-    docker -H unix:///var/run/docker-bootstrap.sock run --net=host gcr.io/google_containers/etcd:2.0.12 etcdctl set /coreos.com/network/config '{ "Network": "10.1.0.0/16" }'
+    docker -H unix:///var/run/docker-bootstrap.sock run --net=host gcr.io/google_containers/etcd:2.0.12 etcdctl set /coreos.com/network/config '{ "Network": "10.1.0.0/16", "Backend": {"Type": "vxlan"}}'
 
     # iface may change to a private network interface, eth0 is for default
     flannelCID=$(docker -H unix:///var/run/docker-bootstrap.sock run --restart=always -d --net=host --privileged -v /dev/net:/dev/net quay.io/coreos/flannel:0.5.0 /opt/bin/flanneld -iface="eth0")
@@ -135,7 +135,7 @@ start_k8s(){
     sleep 5
 
     # Start kubelet & proxy, then start master components as pods
-    docker run --net=host --privileged -d -v /sys:/sys:ro -v /var/run/docker.sock:/var/run/docker.sock  gcr.io/google_containers/hyperkube:v${K8S_VERSION} /hyperkube kubelet --api-servers=http://localhost:8080 --v=2 --address=0.0.0.0 --enable-server --hostname-override=127.0.0.1 --config=/etc/kubernetes/manifests-multi
+    docker run --net=host --privileged --restart=always -d -v /sys:/sys:ro -v /var/run/docker.sock:/var/run/docker.sock  gcr.io/google_containers/hyperkube:v${K8S_VERSION} /hyperkube kubelet --api-servers=http://localhost:8080 --v=2 --address=0.0.0.0 --enable-server --hostname-override=127.0.0.1 --config=/etc/kubernetes/manifests-multi
     docker run -d --net=host --privileged gcr.io/google_containers/hyperkube:v${K8S_VERSION} /hyperkube proxy --master=http://127.0.0.1:8080 --v=2   
 }
 

--- a/docs/getting-started-guides/docker-multinode/worker.sh
+++ b/docs/getting-started-guides/docker-multinode/worker.sh
@@ -133,8 +133,8 @@ start_k8s() {
     sleep 5
     
     # Start kubelet & proxy in container
-    sudo docker run --net=host --privileged -d -v /sys:/sys:ro -v /var/run/docker.sock:/var/run/docker.sock  gcr.io/google_containers/hyperkube:v${K8S_VERSION} /hyperkube kubelet --api-servers=http://${MASTER_IP}:8080 --v=2 --address=0.0.0.0 --enable-server --hostname-override=$(hostname -i)
-    sudo docker run -d --net=host --privileged gcr.io/google_containers/hyperkube:v${K8S_VERSION} /hyperkube proxy --master=http://${MASTER_IP}:8080 --v=2
+    sudo docker run --net=host --privileged --restart=always -d -v /sys:/sys:ro -v /var/run/docker.sock:/var/run/docker.sock  gcr.io/google_containers/hyperkube:v${K8S_VERSION} /hyperkube kubelet --api-servers=http://${MASTER_IP}:8080 --v=2 --address=0.0.0.0 --enable-server --hostname-override=$(hostname -i)
+    sudo docker run -d --net=host --privileged --restart=always gcr.io/google_containers/hyperkube:v${K8S_VERSION} /hyperkube proxy --master=http://${MASTER_IP}:8080 --v=2
 
 }
 


### PR DESCRIPTION
According to my test, vxlan backend can improve network performance remarkably. Mainly because it's kernel routing rather than userspace routing by default flannel (correct me if I'm wrong).

Here's a simple test by `qperf`:

```
#flannel UDP
tcp_bw:
    bw  =  28.7 MB/sec
tcp_lat:
    latency  =  200 us

#flannel vxlan
tcp_bw:
    bw  =  47.8 MB/sec
tcp_lat:
    latency  =  127 us


#Host to host
tcp_bw:
    bw  =  62.5 MB/sec
tcp_lat:
    latency  =  96.1 us
```

So I'd like to propose it here. btw, make kube containers restart automatically with dockerd.
