### PR TITLE
Modify the salt master's log config file name

### DIFF
--- a/cluster/azure/templates/salt-master.sh
+++ b/cluster/azure/templates/salt-master.sh
@@ -54,7 +54,7 @@ log_level: debug
 log_level_logfile: debug
 EOF
 
-cat <<EOF >/etc/salt/master.d/log-level-debug.d
+cat <<EOF >/etc/salt/master.d/log-level-debug.conf
 log_level: debug
 log_level_logfile: debug
 EOF


### PR DESCRIPTION
In the salt master's config folder, the file name "log-level-debug.d" change to "log-level-debug.conf" as it's a configure file.
