### PR TITLE
Adding a way to decode to a specified version.

### DIFF
--- a/pkg/api/meta/restmapper_test.go
+++ b/pkg/api/meta/restmapper_test.go
@@ -33,6 +33,10 @@ func (fakeCodec) Decode([]byte) (runtime.Object, error) {
 	return nil, nil
 }
 
+func (fakeCodec) DecodeToVersion([]byte, string) (runtime.Object, error) {
+	return nil, nil
+}
+
 func (fakeCodec) DecodeInto([]byte, runtime.Object) error {
 	return nil
 }

--- a/pkg/runtime/codec.go
+++ b/pkg/runtime/codec.go
@@ -77,3 +77,10 @@ type codecWrapper struct {
 func (c *codecWrapper) Encode(obj Object) ([]byte, error) {
 	return c.EncodeToVersion(obj, c.version)
 }
+
+// TODO: Make this behaviour default when we move everyone away from
+// the unversioned types.
+//
+// func (c *codecWrapper) Decode(data []byte) (Object, error) {
+// 	return c.DecodeToVersion(data, c.version)
+// }

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -37,6 +37,7 @@ type ObjectCodec interface {
 // Decoder defines methods for deserializing API objects into a given type
 type Decoder interface {
 	Decode(data []byte) (Object, error)
+	DecodeToVersion(data []byte, version string) (Object, error)
 	DecodeInto(data []byte, obj Object) error
 	DecodeIntoWithSpecifiedVersionKind(data []byte, obj Object, kind, version string) error
 }

--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -446,6 +446,19 @@ func (s *Scheme) Decode(data []byte) (Object, error) {
 	return obj.(Object), nil
 }
 
+// DecodeToVersion converts a YAML or JSON string back into a pointer to an api
+// object.  Deduces the type based upon the APIVersion and Kind fields, which
+// are set by Encode. Only versioned objects (APIVersion != "") are
+// accepted. The object will be converted into the in-memory versioned type
+// requested before being returned.
+func (s *Scheme) DecodeToVersion(data []byte, version string) (Object, error) {
+	obj, err := s.raw.DecodeToVersion(data, version)
+	if err != nil {
+		return nil, err
+	}
+	return obj.(Object), nil
+}
+
 // DecodeInto parses a YAML or JSON string and stores it in obj. Returns an error
 // if data.Kind is set and doesn't match the type of obj. Obj should be a
 // pointer to an api type.

--- a/pkg/runtime/scheme_test.go
+++ b/pkg/runtime/scheme_test.go
@@ -87,14 +87,15 @@ func TestScheme(t *testing.T) {
 		TestString: "foo",
 	}
 
-	// Test Encode, Decode, and DecodeInto
+	// Test Encode, Decode, DecodeInto, and DecodeToVersion
 	obj := runtime.Object(simple)
 	data, err := scheme.EncodeToVersion(obj, "externalVersion")
 	obj2, err2 := scheme.Decode(data)
 	obj3 := &InternalSimple{}
 	err3 := scheme.DecodeInto(data, obj3)
-	if err != nil || err2 != nil {
-		t.Fatalf("Failure: '%v' '%v' '%v'", err, err2, err3)
+	obj4, err4 := scheme.DecodeToVersion(data, "externalVersion")
+	if err != nil || err2 != nil || err3 != nil || err4 != nil {
+		t.Fatalf("Failure: '%v' '%v' '%v' '%v'", err, err2, err3, err4)
 	}
 	if _, ok := obj2.(*InternalSimple); !ok {
 		t.Fatalf("Got wrong type")
@@ -104,6 +105,9 @@ func TestScheme(t *testing.T) {
 	}
 	if e, a := simple, obj3; !reflect.DeepEqual(e, a) {
 		t.Errorf("Expected:\n %#v,\n Got:\n %#v", e, a)
+	}
+	if _, ok := obj4.(*ExternalSimple); !ok {
+		t.Fatalf("Got wrong type")
 	}
 
 	// Test Convert

--- a/pkg/runtime/unstructured.go
+++ b/pkg/runtime/unstructured.go
@@ -78,6 +78,10 @@ func (unstructuredJSONScheme) DecodeIntoWithSpecifiedVersionKind(data []byte, ob
 	return nil
 }
 
+func (unstructuredJSONScheme) DecodeToVersion(data []byte, version string) (Object, error) {
+	return nil, nil
+}
+
 func (unstructuredJSONScheme) DataVersionAndKind(data []byte) (version, kind string, err error) {
 	obj := TypeMeta{}
 	if err := json.Unmarshal(data, &obj); err != nil {


### PR DESCRIPTION
This is largely needed as a way to get a versioned client without
requiring everyone to switch to versioned types at once.
