### PR TITLE
Install rkt to a directory that doesn't require environment variables…

### DIFF
--- a/cluster/gce/coreos/node.yaml
+++ b/cluster/gce/coreos/node.yaml
@@ -91,11 +91,13 @@ coreos:
         [Service]
         Type=oneshot
         EnvironmentFile=/etc/kube-env
+        ExecStartPre=/usr/bin/rm -rf /opt/rkt
         ExecStartPre=/usr/bin/mkdir -p /opt/rkt
         ExecStartPre=/usr/bin/wget \
         -O /opt/rkt/rkt-v${RKT_VERSION}.tar.gz \
         https://github.com/coreos/rkt/releases/download/v${RKT_VERSION}/rkt-v${RKT_VERSION}.tar.gz
-        ExecStart=/usr/bin/tar xzvf /opt/rkt/rkt-v${RKT_VERSION}.tar.gz -C /opt --overwrite
+        ExecStartPre=/usr/bin/tar xzvf /opt/rkt/rkt-v${RKT_VERSION}.tar.gz -C /opt --overwrite
+        ExecStart=/usr/bin/mv /opt/rkt-v${RKT_VERSION} /opt/rkt/rkt
 
     - name: kubernetes-install-minion.service
       command: start
@@ -200,4 +202,4 @@ coreos:
         After=kubernetes-install-rkt.service
         [Service]
         EnvironmentFile=/etc/kube-env
-        ExecStart=/opt/rkt-v${RKT_VERSION}/rkt metadata-service
+        ExecStart=/opt/rkt/rkt metadata-service


### PR DESCRIPTION
… to find.

Systemd doesn't do variable substitution on the name of the command to run, so we have to install
rkt to a directory with an absolute literal path that we can reference with environment variables.

This addresses [Issue 12435](https://github.com/GoogleCloudPlatform/kubernetes/issues/12435).
