### PR TITLE
Handle full hostname when computing host tag on GCE

### DIFF
--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -451,6 +451,7 @@ func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.I
 // This is kind of hacky, but the managed instance group adds 4 random chars and a hyphen
 // to the base name.
 func (gce *GCECloud) computeHostTag(host string) string {
+	host = strings.SplitN(host, ".", 2)[0]
 	return host[:len(host)-5]
 }
 

--- a/pkg/cloudprovider/gce/gce_test.go
+++ b/pkg/cloudprovider/gce/gce_test.go
@@ -50,6 +50,10 @@ func TestGetHostTag(t *testing.T) {
 			host:     "gke-test-ea6e8c80-node-8ytk",
 			expected: "gke-test-ea6e8c80-node",
 		},
+		{
+			host:     "kubernetes-minion-559o.c.PROJECT_NAME.internal",
+			expected: "kubernetes-minion",
+		},
 	}
 
 	gce := &GCECloud{}


### PR DESCRIPTION
The current code assumes the full domain name will not be included,
which is not always the case. This patch adds support for computing the
host tag from a fully qualified domain name.
