### PR TITLE
Tuned the kube-proxy upstart script

### DIFF
--- a/cluster/ubuntu/minion/init_conf/kube-proxy.conf
+++ b/cluster/ubuntu/minion/init_conf/kube-proxy.conf
@@ -7,6 +7,8 @@ respawn
 start on started etcd
 stop on stopping etcd
 
+limit nofile 65536 65536
+
 pre-start script
 	# see also https://github.com/jainvipin/kubernetes-start
 	KUBE_PROXY=/opt/bin/$UPSTART_JOB


### PR DESCRIPTION
I had this issue on Ubuntu:
https://github.com/GoogleCloudPlatform/kubernetes/issues/5461

Figured out upstart scripts need to specify the nofile limit
