### PR TITLE
Extra newlines in error output

### DIFF
--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -188,7 +188,7 @@ func NegotiateVersion(client *Client, c *Config, version string, clientRegistere
 	}
 	apiVersions, err := client.ServerAPIVersions()
 	if err != nil {
-		return "", fmt.Errorf("couldn't read version from server: %v\n", err)
+		return "", fmt.Errorf("couldn't read version from server: %v", err)
 	}
 	serverVersions := util.StringSet{}
 	for _, v := range apiVersions.Versions {

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -93,7 +93,7 @@ func checkErr(err error, handleErr func(string)) {
 
 	msg, ok := StandardErrorMessage(err)
 	if !ok {
-		msg = fmt.Sprintf("error: %s\n", err.Error())
+		msg = fmt.Sprintf("error: %s", err.Error())
 	}
 	handleErr(msg)
 }


### PR DESCRIPTION
StandardErrorMessage does not have a newline by default, other
error messages should not end with a newline.
