### PR TITLE
Modify the TestCase TestServiceRegistryIPUpdate

### DIFF
--- a/pkg/registry/service/rest_test.go
+++ b/pkg/registry/service/rest_test.go
@@ -569,6 +569,7 @@ func TestServiceRegistryIPAllocation(t *testing.T) {
 	for _, ip := range testIPs {
 		if !rest.serviceIPs.(*ipallocator.Range).Has(net.ParseIP(ip)) {
 			testIP = ip
+			break
 		}
 	}
 
@@ -687,9 +688,18 @@ func TestServiceRegistryIPUpdate(t *testing.T) {
 		t.Errorf("Expected port 6503, but got %v", updated_service.Spec.Ports[0].Port)
 	}
 
+	testIPs := []string{"1.2.3.93", "1.2.3.94", "1.2.3.95", "1.2.3.96"}
+	testIP := ""
+	for _, ip := range testIPs {
+		if !rest.serviceIPs.(*ipallocator.Range).Has(net.ParseIP(ip)) {
+			testIP = ip
+			break
+		}
+	}
+
 	update = deepCloneService(created_service)
 	update.Spec.Ports[0].Port = 6503
-	update.Spec.ClusterIP = "1.2.3.76" // error
+	update.Spec.ClusterIP = testIP // Error: Cluster IP is immutable
 
 	_, _, err := rest.Update(ctx, update)
 	if err == nil || !errors.IsInvalid(err) {


### PR DESCRIPTION
I have meet a problem on the latest code at master branch while doing **make release**

<pre><code>!!! Error in hack/test-go.sh:159
  'go test "${goflags[@]:+${goflags[@]}}" ${KUBE_RACE} ${KUBE_TIMEOUT} "${@+${@/#/${KUBE_GO_PACKAGE}/}}" "${testargs[@]:+${testargs[@]}}"' exited with status 1
Call stack:
  1: hack/test-go.sh:159 runTests(...)
  2: hack/test-go.sh:221 main(...)
Exiting with status 1
!!! Error in build/../build/common.sh:472
  '"${docker_cmd[@]}" "$@"' exited with status 1</code></pre>
  

I notice a test case failed which cause the build error.

<pre><code>--- FAIL: TestServiceRegistryIPUpdate (0.00s)
    rest_test.go:696: Unexpected error type: <nil>
FAIL
FAIL    k8s.io/kubernetes/pkg/registry/service  0.013s
</code></pre>


The slice of code is:

<pre><code>update = deepCloneService(created_service)
    update.Spec.Ports[0].Port = 6503
    update.Spec.ClusterIP = "1.2.3.76" // error

    _, _, err := rest.Update(ctx, update)
    if err == nil || !errors.IsInvalid(err) {
        t.Errorf("Unexpected error type: %v", err)
    }</code></pre>


It seems the cluster IP is in the range of 1.2.3.0/24 as defined before. So it doesn't generate the error as expected. Then I change the cluster from 1.2.3.76 to 1.2.4.76. The test case run successfully and generate the release finally. 

Please help to make sure whether this modification is suitable or not? Thanks.
