### PR TITLE
Print human readable time for event

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -898,8 +898,8 @@ func DescribeEvents(el *api.EventList, w io.Writer) {
 	fmt.Fprint(w, "Events:\n  FirstSeen\tLastSeen\tCount\tFrom\tSubobjectPath\tReason\tMessage\n")
 	for _, e := range el.Items {
 		fmt.Fprintf(w, "  %s\t%s\t%d\t%v\t%v\t%v\t%v\n",
-			e.FirstTimestamp.Time.Format(time.RFC1123Z),
-			e.LastTimestamp.Time.Format(time.RFC1123Z),
+			translateTimestamp(e.FirstTimestamp),
+			translateTimestamp(e.LastTimestamp),
 			e.Count,
 			e.Source,
 			e.InvolvedObject.FieldPath,

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -850,8 +850,8 @@ func printEvent(event *api.Event, w io.Writer, withNamespace bool, wide bool, co
 	}
 	if _, err := fmt.Fprintf(
 		w, "%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s",
-		event.FirstTimestamp.Time.Format(time.RFC1123Z),
-		event.LastTimestamp.Time.Format(time.RFC1123Z),
+		translateTimestamp(event.FirstTimestamp),
+		translateTimestamp(event.LastTimestamp),
 		event.Count,
 		event.InvolvedObject.Name,
 		event.InvolvedObject.Kind,


### PR DESCRIPTION
Closes #12280
Reduce the length of event time as AGE column does.

Simplified implementation of #12331
This PR uses existing function to reduce the length, no dependency is required.
Doesn't add any new flags, users should use `-o template` to view the precise event time.
