### PR TITLE
Refactor probe.Result enumeration

### DIFF
--- a/pkg/apiserver/validator_test.go
+++ b/pkg/apiserver/validator_test.go
@@ -89,7 +89,7 @@ func TestValidate(t *testing.T) {
 			t.Errorf("expected empty string, got %s", status)
 		}
 		if status != test.expectedStatus {
-			t.Errorf("expected %s, got %s", test.expectedStatus.String(), status.String())
+			t.Errorf("expected %s, got %s", test.expectedStatus, status)
 		}
 	}
 }

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -16,22 +16,10 @@ limitations under the License.
 
 package probe
 
-type Result int
+type Result string
 
-// Status values must be one of these constants.
 const (
-	Success Result = iota
-	Failure
-	Unknown
+	Success Result = "success"
+	Failure Result = "failure"
+	Unknown Result = "unknown"
 )
-
-func (s Result) String() string {
-	switch s {
-	case Success:
-		return "success"
-	case Failure:
-		return "failure"
-	default:
-		return "unknown"
-	}
-}


### PR DESCRIPTION
Refactors the usage of `iota` in `probe` package.
