### PR TITLE
Guestbook updates: GCR images, support both dns service and env vars

### DIFF
--- a/examples/guestbook/frontend-controller.yaml
+++ b/examples/guestbook/frontend-controller.yaml
@@ -15,6 +15,14 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google_containers/example-guestbook-php-redis:v3
+        image: gcr.io/google_samples/gb-frontend:v2
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # If your cluster config does not include a dns service, then to
+          # instead access environment variables to find service host
+          # info, comment out the 'value: dns' line above, and uncomment the
+          # line below.
+          # value: env
         ports:
         - containerPort: 80

--- a/examples/guestbook/php-redis/Dockerfile
+++ b/examples/guestbook/php-redis/Dockerfile
@@ -1,7 +1,10 @@
-FROM brendanburns/php
+FROM php:5-apache
 
-ADD index.php /var/www/index.php
-ADD controllers.js /var/www/controllers.js
-ADD index.html /var/www/index.html
+RUN apt-get update
+RUN apt-get install -y php-pear
+RUN pear channel-discover pear.nrk.io
+RUN pear install nrk/Predis
 
-CMD /run.sh
+ADD guestbook.php /var/www/html/guestbook.php
+ADD controllers.js /var/www/html/controllers.js
+ADD index.html /var/www/html/index.html

--- a/examples/guestbook/php-redis/controllers.js
+++ b/examples/guestbook/php-redis/controllers.js
@@ -9,7 +9,7 @@ RedisController.prototype.onRedis = function() {
     this.scope_.messages.push(this.scope_.msg);
     this.scope_.msg = "";
     var value = this.scope_.messages.join();
-    this.http_.get("index.php?cmd=set&key=messages&value=" + value)
+    this.http_.get("guestbook.php?cmd=set&key=messages&value=" + value)
             .success(angular.bind(this, function(data) {
                 this.scope_.redisResponse = "Updated.";
             }));
@@ -21,7 +21,7 @@ redisApp.controller('RedisCtrl', function ($scope, $http, $location) {
         $scope.controller.location_ = $location;
         $scope.controller.http_ = $http;
 
-        $scope.controller.http_.get("index.php?cmd=get&key=messages")
+        $scope.controller.http_.get("guestbook.php?cmd=get&key=messages")
             .success(function(data) {
                 console.log(data);
                 $scope.messages = data.data.split(",");

--- a/examples/guestbook/php-redis/guestbook.php
+++ b/examples/guestbook/php-redis/guestbook.php
@@ -1,27 +1,37 @@
 <?
 
-set_include_path('.:/usr/share/php:/usr/share/pear:/vendor/predis');
+set_include_path('.:/usr/local/lib/php');
 
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
-require 'predis/autoload.php';
+require 'Predis/Autoloader.php';
+
+Predis\Autoloader::register();
 
 if (isset($_GET['cmd']) === true) {
+  $host = 'redis-master';
+  if (getenv('GET_HOSTS_FROM') == 'env') {
+    $host = getenv('REDIS_MASTER_SERVICE_HOST');
+  }
   header('Content-Type: application/json');
   if ($_GET['cmd'] == 'set') {
     $client = new Predis\Client([
       'scheme' => 'tcp',
-      'host'   => 'redis-master',
+      'host'   => $host,
       'port'   => 6379,
     ]);
-    
+
     $client->set($_GET['key'], $_GET['value']);
     print('{"message": "Updated"}');
   } else {
+    $host = 'redis-slave';
+    if (getenv('GET_HOSTS_FROM') == 'env') {
+      $host = getenv('REDIS_SLAVE_SERVICE_HOST');
+    }
     $client = new Predis\Client([
       'scheme' => 'tcp',
-      'host'   => 'redis-slave',
+      'host'   => $host,
       'port'   => 6379,
     ]);
 

--- a/examples/guestbook/php-redis/index.html
+++ b/examples/guestbook/php-redis/index.html
@@ -4,7 +4,7 @@
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.12/angular.min.js"></script>
     <script src="controllers.js"></script>
-    <script src="ui-bootstrap-tpls-0.10.0.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.13.0/ui-bootstrap-tpls.js"></script>
   </head>
   <body ng-controller="RedisCtrl">
     <div style="width: 50%; margin-left: 20px">

--- a/examples/guestbook/redis-slave-controller.yaml
+++ b/examples/guestbook/redis-slave-controller.yaml
@@ -15,6 +15,14 @@ spec:
     spec:
       containers:
       - name: worker
-        image: kubernetes/redis-slave:v2
+        image: gcr.io/google_samples/gb-redisslave:v1
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # If your cluster config does not include a dns service, then to
+          # instead access an environment variable to find the master
+          # service's host, comment out the 'value: dns' line above, and
+          # uncomment the line below.
+          # value: env
         ports:
         - containerPort: 6379

--- a/examples/guestbook/redis-slave/run.sh
+++ b/examples/guestbook/redis-slave/run.sh
@@ -14,4 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-redis-server --slaveof redis-master 6379
+if [[ ${GET_HOSTS_FROM:-dns} == "env" ]]; then
+  redis-server --slaveof ${REDIS_MASTER_SERVICE_HOST} 6379
+else
+  redis-server --slaveof redis-master 6379
+fi

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -746,7 +746,7 @@ func makeRequestToGuestbook(c *client.Client, cmd, value string, ns string) (str
 		Namespace(ns).
 		Resource("services").
 		Name("frontend").
-		Suffix("/index.php").
+		Suffix("/guestbook.php").
 		Param("cmd", cmd).
 		Param("key", "messages").
 		Param("value", value).


### PR DESCRIPTION
Use GCR images from 'google-samples' project; allow switch on whether dns service is
supported, or to use env vars to get service host info.
Replaces https://github.com/GoogleCloudPlatform/kubernetes/pull/11787 .
