### PR TITLE
re-add kubelet server timeouts

### DIFF
--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -65,6 +65,8 @@ func ListenAndServeKubeletServer(host HostInterface, address net.IP, port uint, 
 	s := &http.Server{
 		Addr:           net.JoinHostPort(address.String(), strconv.FormatUint(uint64(port), 10)),
 		Handler:        &handler,
+		ReadTimeout:    60 * time.Minute,
+		WriteTimeout:   60 * time.Minute,
 		MaxHeaderBytes: 1 << 20,
 	}
 	if tlsOptions != nil {
@@ -84,6 +86,8 @@ func ListenAndServeKubeletReadOnlyServer(host HostInterface, address net.IP, por
 	server := &http.Server{
 		Addr:           net.JoinHostPort(address.String(), strconv.FormatUint(uint64(port), 10)),
 		Handler:        &s,
+		ReadTimeout:    60 * time.Minute,
+		WriteTimeout:   60 * time.Minute,
 		MaxHeaderBytes: 1 << 20,
 	}
 	glog.Fatal(server.ListenAndServe())


### PR DESCRIPTION
It looks like https://github.com/GoogleCloudPlatform/kubernetes/pull/10656 removed the kubelet side timeout settings and is only enabled for the API server.  Open question on this issue: https://github.com/GoogleCloudPlatform/kubernetes/pull/10656/files#r36634728

/cc @liggitt 
