### PR TITLE
Check error before accessing returned value in e2e/kubectl.go

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -72,8 +72,8 @@ var _ = Describe("Kubectl client", func() {
 		c, err = loadClient()
 		expectNoError(err)
 		testingNs, err = createTestingNS("kubectl", c)
-		ns = testingNs.Name
 		Expect(err).NotTo(HaveOccurred())
+		ns = testingNs.Name
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
This avoids test panics.
