### PR TITLE
- fixed the defencing of the rbd lock

### DIFF
--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -148,13 +148,18 @@ func (plugin *rbdPlugin) NewCleaner(volName string, podUID types.UID, mounter mo
 }
 
 func (plugin *rbdPlugin) newCleanerInternal(volName string, podUID types.UID, manager diskManager, mounter mount.Interface) (volume.Cleaner, error) {
-	return &rbdCleaner{&rbd{
-		podUID:  podUID,
-		volName: volName,
-		manager: manager,
-		mounter: mounter,
-		plugin:  plugin,
-	}}, nil
+	return &rbdCleaner{
+		rbdBuilder: &rbdBuilder{
+			rbd: &rbd{
+				podUID:  podUID,
+				volName: volName,
+				manager: manager,
+				mounter: mounter,
+				plugin:  plugin,
+			},
+			Mon: make([]string, 0),
+		},
+	}, nil
 }
 
 type rbd struct {
@@ -211,7 +216,7 @@ func (b *rbdBuilder) SetUpAt(dir string) error {
 }
 
 type rbdCleaner struct {
-	*rbd
+	*rbdBuilder
 }
 
 var _ volume.Cleaner = &rbdCleaner{}

--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -155,7 +155,7 @@ func (util *RBDUtil) loadRBD(builder *rbdBuilder, mnt string) error {
 	if err = decoder.Decode(builder); err != nil {
 		return fmt.Errorf("rbd: decode err: %v.", err)
 	}
-	
+
 	return nil
 }
 

--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -143,7 +143,7 @@ func (util *RBDUtil) persistRBD(rbd rbdBuilder, mnt string) error {
 	return nil
 }
 
-func (util *RBDUtil) loadRBD(rbd *rbd, mnt string) error {
+func (util *RBDUtil) loadRBD(builder *rbdBuilder, mnt string) error {
 	file := path.Join(mnt, "rbd.json")
 	fp, err := os.Open(file)
 	if err != nil {
@@ -152,10 +152,10 @@ func (util *RBDUtil) loadRBD(rbd *rbd, mnt string) error {
 	defer fp.Close()
 
 	decoder := json.NewDecoder(fp)
-	if err = decoder.Decode(rbd); err != nil {
+	if err = decoder.Decode(builder); err != nil {
 		return fmt.Errorf("rbd: decode err: %v.", err)
 	}
-
+	
 	return nil
 }
 
@@ -173,7 +173,7 @@ func (util *RBDUtil) defencing(c rbdCleaner) error {
 		return nil
 	}
 
-	return util.rbdLock(rbdBuilder{rbd: c.rbd}, false)
+	return util.rbdLock(*c.rbdBuilder, false)
 }
 
 func (util *RBDUtil) AttachDisk(b rbdBuilder) error {
@@ -262,7 +262,7 @@ func (util *RBDUtil) DetachDisk(c rbdCleaner, mntPath string) error {
 		}
 
 		// load ceph and image/pool info to remove fencing
-		if err := util.loadRBD(c.rbd, mntPath); err == nil {
+		if err := util.loadRBD(c.rbdBuilder, mntPath); err == nil {
 			// remove rbd lock
 			util.defencing(c)
 		}


### PR DESCRIPTION
Locking was working fine for me. The cleanup code however was throwing an exception when attempting to remove the lock. The code reads in a json file left in the <plugin>/rbd.json folder and then attempts to decode this into a rbdCleaner{*rbd} which doesn't support the field and later throws a 'divide by zero exception' due to size being zero (i.e. nothing as been reread)  ...a typo perhaps on the struct? ... Either way, changing the rbdCleaner to a rbdBuilder allows use to decode the file and successfully release the lock.  

https://github.com/GoogleCloudPlatform/kubernetes/issues/12481
