### PR TITLE
integrate bandwidth shaping and the kubelet.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -58,6 +58,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/bandwidth"
 	utilErrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/mount"
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
@@ -552,6 +553,9 @@ type Kubelet struct {
 	// DNS resolver configuration file. This can be used in conjunction with
 	// clusterDomain and clusterDNS.
 	resolverConfig string
+
+	// Optionally shape the bandwidth of a pod
+	shaper bandwidth.BandwidthShaper
 }
 
 // getRootDir returns the full path to the directory under which kubelet can
@@ -1314,6 +1318,31 @@ func (kl *Kubelet) syncPod(pod *api.Pod, mirrorPod *api.Pod, runningPod kubecont
 		return err
 	}
 
+	ingress, egress, err := extractBandwidthResources(pod)
+	if err != nil {
+		return err
+	}
+	if egress != nil || ingress != nil {
+		if pod.Spec.HostNetwork {
+			kl.recorder.Event(pod, "host network not supported", "Bandwidth shaping is not currently supported on the host network")
+		} else if kl.shaper != nil {
+			status, found := kl.statusManager.GetPodStatus(pod.UID)
+			if !found {
+				statusPtr, err := kl.containerRuntime.GetPodStatus(pod)
+				if err != nil {
+					glog.Errorf("Error getting pod for bandwidth shaping")
+					return err
+				}
+				status = *statusPtr
+			}
+			if len(status.PodIP) > 0 {
+				err = kl.shaper.ReconcileCIDR(fmt.Sprintf("%s/32", status.PodIP), egress, ingress)
+			}
+		} else {
+			kl.recorder.Event(pod, "nil shaper", "Pod requests bandwidth shaping, but the shaper is undefined")
+		}
+	}
+
 	if isStaticPod(pod) {
 		if mirrorPod != nil && !kl.podManager.IsMirrorPodOf(mirrorPod, pod) {
 			// The mirror pod is semantically different from the static pod. Remove
@@ -1389,6 +1418,48 @@ func (kl *Kubelet) cleanupOrphanedPodDirs(pods []*api.Pod, runningPods []*kubeco
 		}
 	}
 	return utilErrors.NewAggregate(errlist)
+}
+
+func (kl *Kubelet) cleanupBandwidthLimits(allPods []*api.Pod) error {
+	if kl.shaper == nil {
+		return nil
+	}
+	currentCIDRs, err := kl.shaper.GetCIDRs()
+	if err != nil {
+		return err
+	}
+	possibleCIDRs := util.StringSet{}
+	for ix := range allPods {
+		pod := allPods[ix]
+		ingress, egress, err := extractBandwidthResources(pod)
+		if err != nil {
+			return err
+		}
+		if ingress == nil && egress == nil {
+			glog.V(8).Infof("Not a bandwidth limited container...")
+			continue
+		}
+		status, found := kl.statusManager.GetPodStatus(pod.UID)
+		if !found {
+			statusPtr, err := kl.containerRuntime.GetPodStatus(pod)
+			if err != nil {
+				return err
+			}
+			status = *statusPtr
+		}
+		if status.Phase == api.PodRunning {
+			possibleCIDRs.Insert(fmt.Sprintf("%s/32", status.PodIP))
+		}
+	}
+	for _, cidr := range currentCIDRs {
+		if !possibleCIDRs.Has(cidr) {
+			glog.V(2).Infof("Removing CIDR: %s (%v)", cidr, possibleCIDRs)
+			if err := kl.shaper.Reset(cidr); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // Compares the map of current volumes to the map of desired volumes.
@@ -1621,6 +1692,11 @@ func (kl *Kubelet) HandlePodCleanups() error {
 
 	if err := kl.cleanupTerminatedPods(allPods, runningPods); err != nil {
 		glog.Errorf("Failed to cleanup terminated pods: %v", err)
+	}
+
+	// Clear out any old bandwith rules
+	if err = kl.cleanupBandwidthLimits(allPods); err != nil {
+		return err
 	}
 
 	kl.backOff.GC()
@@ -2071,7 +2147,11 @@ func (kl *Kubelet) reconcileCBR0(podCIDR string) error {
 	if err := ensureCbr0(cidr); err != nil {
 		return err
 	}
-	return nil
+	if kl.shaper == nil {
+		glog.V(5).Info("Shaper is nil, creating")
+		kl.shaper = bandwidth.NewTCShaper("cbr0")
+	}
+	return kl.shaper.ReconcileInterface()
 }
 
 // updateNodeStatus updates node status to master with retries.
@@ -2641,4 +2721,39 @@ func (kl *Kubelet) ListenAndServeReadOnly(address net.IP, port uint) {
 // is exported to simplify integration with third party kubelet extensions (e.g. kubernetes-mesos).
 func (kl *Kubelet) GetRuntime() kubecontainer.Runtime {
 	return kl.containerRuntime
+}
+
+var minRsrc = resource.MustParse("1k")
+var maxRsrc = resource.MustParse("1P")
+
+func validateBandwidthIsReasonable(rsrc *resource.Quantity) error {
+	if rsrc.Value() < minRsrc.Value() {
+		return fmt.Errorf("resource is unreasonably small (< 1kbit)")
+	}
+	if rsrc.Value() > maxRsrc.Value() {
+		return fmt.Errorf("resoruce is unreasonably large (> 1Pbit)")
+	}
+	return nil
+}
+
+func extractBandwidthResources(pod *api.Pod) (ingress, egress *resource.Quantity, err error) {
+	str, found := pod.Annotations["kubernetes.io/ingress-bandwidth"]
+	if found {
+		if ingress, err = resource.ParseQuantity(str); err != nil {
+			return nil, nil, err
+		}
+		if err := validateBandwidthIsReasonable(ingress); err != nil {
+			return nil, nil, err
+		}
+	}
+	str, found = pod.Annotations["kubernetes.io/egress-bandwidth"]
+	if found {
+		if egress, err = resource.ParseQuantity(str); err != nil {
+			return nil, nil, err
+		}
+		if err := validateBandwidthIsReasonable(egress); err != nil {
+			return nil, nil, err
+		}
+	}
+	return ingress, egress, nil
 }

--- a/pkg/util/bandwidth/fake_shaper.go
+++ b/pkg/util/bandwidth/fake_shaper.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bandwidth
+
+import (
+	"errors"
+
+	"k8s.io/kubernetes/pkg/api/resource"
+)
+
+type FakeShaper struct {
+	CIDRs      []string
+	ResetCIDRs []string
+}
+
+func (f *FakeShaper) Limit(cidr string, egress, ingress *resource.Quantity) error {
+	return errors.New("unimplemented")
+}
+
+func (f *FakeShaper) Reset(cidr string) error {
+	f.ResetCIDRs = append(f.ResetCIDRs, cidr)
+	return nil
+}
+
+func (f *FakeShaper) ReconcileInterface() error {
+	return errors.New("unimplemented")
+}
+
+func (f *FakeShaper) ReconcileCIDR(cidr string, egress, ingress *resource.Quantity) error {
+	return errors.New("unimplemented")
+}
+
+func (f *FakeShaper) GetCIDRs() ([]string, error) {
+	return f.CIDRs, nil
+}

--- a/pkg/util/bandwidth/interfaces.go
+++ b/pkg/util/bandwidth/interfaces.go
@@ -26,7 +26,13 @@ type BandwidthShaper interface {
 	// 'ingress' bandwidth limit applies to all packets on the interface whose destination matches 'cidr'
 	// Limits are aggregate limits for the CIDR, not per IP address.  CIDRs must be unique, but can be overlapping, traffic
 	// that matches multiple CIDRs counts against all limits.
-	Limit(cidr string, egress, ingress resource.Quantity) error
+	Limit(cidr string, egress, ingress *resource.Quantity) error
 	// Remove a bandwidth limit for a particular CIDR on a particular network interface
 	Reset(cidr string) error
+	// Reconcile the interface managed by this shaper with the state on the ground.
+	ReconcileInterface() error
+	// Reconcile a CIDR managed by this shaper with the state on the ground
+	ReconcileCIDR(cidr string, egress, ingress *resource.Quantity) error
+	// GetCIDRs returns the set of CIDRs that are being managed by this shaper
+	GetCIDRs() ([]string, error)
 }


### PR DESCRIPTION
Part #2 of adding bandwidth limiting support.
@thockin @dchen1107 @erictune 
## Testing:
### No limit testing

``` yaml
# Copy of pod.yaml without file extension for test
apiVersion: v1
kind: Pod
metadata:
  name: iperf
  labels:
    name: iperf
spec:
  containers:
  - name: iperf
    image: moutten/iperf
```

``` console
kubectl create -f iperf.yml
```

On some other machine, `iperf -c <pod-ip-address>` look at the speed, on most real setups, this is in the GBits
### Limit testing

``` yaml
# Copy of pod.yaml without file extension for test
apiVersion: v1
kind: Pod
metadata:
  name: iperf-slow
  labels:
    name: iperf
  annotations:
    kubernetes.io/ingress-bandwidth: 10M
    kubernetes.io/egress-bandwidth: 10M
spec:
  containers:
  - name: iperf
    image: moutten/iperf 
```

``` console
kubectl create -f pod-slow.yml
```

Repeat the `iperf -c <slow-pod-ip>`, you should see something in the neighborhood of 10Mbits
