### PR TITLE
Fix vagrant kube-up

### DIFF
--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -27,6 +27,9 @@ export KUBE_MASTER_IP=${MASTER_IP}
 export INSTANCE_PREFIX="kubernetes"
 export MASTER_NAME="${INSTANCE_PREFIX}-master"
 
+# Should the master serve as a node
+REGISTER_MASTER_KUBELET=${REGISTER_MASTER:-false}
+
 # Map out the IPs, names and container subnets of each minion
 export MINION_IP_BASE=${MINION_IP_BASE-"10.245.1."}
 MINION_CONTAINER_SUBNET_BASE="10.246"

--- a/cluster/vagrant/config-test.sh
+++ b/cluster/vagrant/config-test.sh
@@ -20,3 +20,6 @@ NUM_MINIONS=2
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${KUBE_ROOT}/cluster/vagrant/config-default.sh"
+
+# Do not register the master kubelet during testing
+REGISTER_MASTER_KUBELET=${REGISTER_MASTER:-false}

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -172,20 +172,20 @@ if [[ ! -f "${known_tokens_file}" ]]; then
   cat > "${kubelet_kubeconfig_file}" << EOF
 apiVersion: v1
 kind: Config
-users:
-- name: kubelet
-  user:
-    token: ${KUBELET_TOKEN}
 clusters:
-- name: local
-  cluster:
+- cluster:
     insecure-skip-tls-verify: true
+  name: local
 contexts:
-  - context:
+- context:
     cluster: local
     user: kubelet
   name: service-account-context
 current-context: service-account-context
+users:
+- name: kubelet
+  user:
+    token: ${KUBELET_TOKEN}
 EOF
 )
 
@@ -199,20 +199,20 @@ EOF
   cat > "${kube_proxy_kubeconfig_file}" << EOF
 apiVersion: v1
 kind: Config
-users:
-- name: kube-proxy
-  user:
-    token: ${KUBE_PROXY_TOKEN}
 clusters:
-- name: local
-  cluster:
-     insecure-skip-tls-verify: true
+- cluster:
+    insecure-skip-tls-verify: true
+  name: local
 contexts:
 - context:
     cluster: local
     user: kube-proxy
   name: service-account-context
 current-context: service-account-context
+users:
+- name: kube-proxy
+  user:
+    token: ${KUBE_PROXY_TOKEN}
 EOF
 )
 


### PR DESCRIPTION
Kubelet was unable to register with master api server because it was attempting to validate certs.
#12349 exposed an error in the kubeconfig file that is generated for the kubelet once we stopped using kubernetes_auth file.  There was a leading space in the YAML definition in contexts/context section that made the kubelet not know to use insecure-skip-tls-verify because it could not actually find the referenced context.

Talk about a pain to debug a leading space char messing up YAML!
