### PR TITLE
Changed monitoring level to googleinfluxdb in kubernetes-e2e-gce Jenk…

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -151,6 +151,8 @@ case ${JOB_NAME} in
           )"}
     : ${KUBE_GCE_INSTANCE_PREFIX="e2e-gce"}
     : ${PROJECT:="k8s-jkns-e2e-gce"}
+    # Override GCE default for cluster size autoscaling purposes.
+    ENABLE_CLUSTER_MONITORING="googleinfluxdb"
     ;;
 
   # Runs only the examples tests on GCE.


### PR DESCRIPTION
…ins job.

This is for cluster size autoscaling tests purposes. I've already enabled Google Cloud Monitoring API for this project on GCE.

cc @ixdy @zmerlynn @vishh 
