### PR TITLE
Cleanup: "scaler" -> "scale".

### DIFF
--- a/pkg/expapi/types.go
+++ b/pkg/expapi/types.go
@@ -50,10 +50,10 @@ type Scale struct {
 	api.TypeMeta   `json:",inline"`
 	api.ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
-	// Spec defines the behavior of the scaler.
-	Spec ScaleSpec `json:"spec,omitempty" description:"specification of the desired behavior of the scaler; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
+	// Spec defines the behavior of the scale.
+	Spec ScaleSpec `json:"spec,omitempty" description:"specification of the desired behavior of the scale; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 
-	// Status represents the current status of the scaler.
+	// Status represents the current status of the scale.
 	Status ScaleStatus `json:"status,omitempty" description:"most recently observed status of the service; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 }
 

--- a/pkg/expapi/v1/types.go
+++ b/pkg/expapi/v1/types.go
@@ -38,10 +38,10 @@ type Scale struct {
 	v1.TypeMeta   `json:",inline"`
 	v1.ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
-	// Spec defines the behavior of the scaler.
-	Spec ScaleSpec `json:"spec,omitempty" description:"specification of the desired behavior of the scaler; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
+	// Spec defines the behavior of the scale.
+	Spec ScaleSpec `json:"spec,omitempty" description:"specification of the desired behavior of the scale; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 
-	// Status represents the current status of the scaler.
+	// Status represents the current status of the scale.
 	Status ScaleStatus `json:"status,omitempty" description:"most recently observed status of the service; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 }
 

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -780,8 +780,8 @@ func (m *Master) expapi(c *Config) *apiserver.APIGroupVersion {
 
 	controllerStorage := expcontrolleretcd.NewStorage(c.DatabaseStorage)
 	storage := map[string]rest.Storage{
-		strings.ToLower("replicationControllers"):        controllerStorage.ReplicationController,
-		strings.ToLower("replicationControllers/scaler"): controllerStorage.Scale,
+		strings.ToLower("replicationControllers"):       controllerStorage.ReplicationController,
+		strings.ToLower("replicationControllers/scale"): controllerStorage.Scale,
 	}
 
 	return &apiserver.APIGroupVersion{

--- a/pkg/registry/experimental/controller/etcd/etcd.go
+++ b/pkg/registry/experimental/controller/etcd/etcd.go
@@ -61,7 +61,7 @@ func (r *ScaleREST) New() runtime.Object {
 func (r *ScaleREST) Get(ctx api.Context, name string) (runtime.Object, error) {
 	rc, err := (*r.registry).GetController(ctx, name)
 	if err != nil {
-		return nil, errors.NewNotFound("scaler", name)
+		return nil, errors.NewNotFound("scale", name)
 	}
 	return &expapi.Scale{
 		ObjectMeta: api.ObjectMeta{
@@ -83,18 +83,18 @@ func (r *ScaleREST) Update(ctx api.Context, obj runtime.Object) (runtime.Object,
 	if obj == nil {
 		return nil, false, errors.NewBadRequest(fmt.Sprintf("nil update passed to Scale"))
 	}
-	scaler, ok := obj.(*expapi.Scale)
+	scale, ok := obj.(*expapi.Scale)
 	if !ok {
 		return nil, false, errors.NewBadRequest(fmt.Sprintf("wrong object passed to Scale update: %v", obj))
 	}
-	rc, err := (*r.registry).GetController(ctx, scaler.Name)
+	rc, err := (*r.registry).GetController(ctx, scale.Name)
 	if err != nil {
-		return nil, false, errors.NewNotFound("scaler", scaler.Name)
+		return nil, false, errors.NewNotFound("scale", scale.Name)
 	}
-	rc.Spec.Replicas = scaler.Spec.Replicas
+	rc.Spec.Replicas = scale.Spec.Replicas
 	rc, err = (*r.registry).UpdateController(ctx, rc)
 	if err != nil {
-		return nil, false, errors.NewConflict("scaler", scaler.Name, err)
+		return nil, false, errors.NewConflict("scale", scale.Name, err)
 	}
 	return &expapi.Scale{
 		ObjectMeta: api.ObjectMeta{

--- a/pkg/registry/experimental/controller/etcd/etcd_test.go
+++ b/pkg/registry/experimental/controller/etcd/etcd_test.go
@@ -106,12 +106,12 @@ func TestGet(t *testing.T) {
 	storage := NewStorage(etcdStorage).Scale
 
 	obj, err := storage.Get(api.WithNamespace(api.NewContext(), "test"), "foo")
-	scaler := obj.(*expapi.Scale)
+	scale := obj.(*expapi.Scale)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if e, a := expect, scaler; !api.Semantic.DeepEqual(e, a) {
-		t.Errorf("Unexpected scaler: %s", util.ObjectDiff(e, a))
+	if e, a := expect, scale; !api.Semantic.DeepEqual(e, a) {
+		t.Errorf("Unexpected scale: %s", util.ObjectDiff(e, a))
 	}
 }
 


### PR DESCRIPTION
Cosmetic cleanup: "scaler" replaced with "scale" (the proper name for sub-resource).
