### PR TITLE
Revert "Fix kube-up for GKE. cluster-version is no more."

### DIFF
--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -110,6 +110,7 @@ function verify-prereqs() {
 #   GCLOUD
 #   CLUSTER_NAME
 #   ZONE
+#   CLUSTER_API_VERSION (optional)
 #   NUM_MINIONS
 #   MINION_SCOPES
 function kube-up() {
@@ -144,6 +145,11 @@ function kube-up() {
     "--network=${NETWORK}"
     "--scopes=${MINION_SCOPES}"
   )
+  if [[ ! -z "${DOGFOOD_GCLOUD:-}" ]]; then
+    create_args+=("--cluster-version=${CLUSTER_API_VERSION:-}")
+  else
+    create_args+=("--cluster-api-version=${CLUSTER_API_VERSION:-}")
+  fi
 
   # Bring up the cluster.
   "${GCLOUD}" "${CMD_GROUP}" container clusters create "${CLUSTER_NAME}" "${create_args[@]}"


### PR DESCRIPTION
Reverts GoogleCloudPlatform/kubernetes#12522

It turns out that the cluster-version in only mostly gone.
