### PR TITLE
Keep event reason consistent in scheduler and controller

### DIFF
--- a/contrib/mesos/pkg/scheduler/plugin.go
+++ b/contrib/mesos/pkg/scheduler/plugin.go
@@ -758,7 +758,7 @@ func (s *schedulingPlugin) scheduleOne() {
 	dest, err := s.config.Algorithm.Schedule(pod, s.config.MinionLister) // call kubeScheduler.Schedule
 	if err != nil {
 		log.V(1).Infof("Failed to schedule: %v", pod)
-		s.config.Recorder.Eventf(pod, "failedScheduling", "Error scheduling: %v", err)
+		s.config.Recorder.Eventf(pod, "FailedScheduling", "Error scheduling: %v", err)
 		s.config.Error(pod, err)
 		return
 	}
@@ -771,11 +771,11 @@ func (s *schedulingPlugin) scheduleOne() {
 	}
 	if err := s.config.Binder.Bind(b); err != nil {
 		log.V(1).Infof("Failed to bind pod: %v", err)
-		s.config.Recorder.Eventf(pod, "failedScheduling", "Binding rejected: %v", err)
+		s.config.Recorder.Eventf(pod, "FailedScheduling", "Binding rejected: %v", err)
 		s.config.Error(pod, err)
 		return
 	}
-	s.config.Recorder.Eventf(pod, "scheduled", "Successfully assigned %v to %v", pod.Name, dest)
+	s.config.Recorder.Eventf(pod, "Scheduled", "Successfully assigned %v to %v", pod.Name, dest)
 }
 
 // this pod may be out of sync with respect to the API server registry:

--- a/pkg/client/record/event.go
+++ b/pkg/client/record/event.go
@@ -51,9 +51,10 @@ type EventRecorder interface {
 	// Event constructs an event from the given information and puts it in the queue for sending.
 	// 'object' is the object this event is about. Event will make a reference-- or you may also
 	// pass a reference to the object directly.
-	// 'reason' is the reason this event is generated. 'reason' should be short and unique; it will
-	// be used to automate handling of events, so imagine people writing switch statements to
-	// handle them. You want to make that easy.
+	// 'reason' is the reason this event is generated. 'reason' should be short and unique; it
+	// should be in UpperCamelCase format (starting with a capital letter). "reason" will be used
+	// to automate handling of events, so imagine people writing switch statements to handle them.
+	// You want to make that easy.
 	// 'message' is intended to be human readable.
 	//
 	// The resulting event will be created in the same namespace as the reference object.

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -281,11 +281,11 @@ func (r RealPodControl) CreateReplica(namespace string, controller *api.Replicat
 		return fmt.Errorf("unable to create pod replica, no labels")
 	}
 	if newPod, err := r.KubeClient.Pods(namespace).Create(pod); err != nil {
-		r.Recorder.Eventf(controller, "failedCreate", "Error creating: %v", err)
+		r.Recorder.Eventf(controller, "FailedCreate", "Error creating: %v", err)
 		return fmt.Errorf("unable to create pod replica: %v", err)
 	} else {
 		glog.V(4).Infof("Controller %v created pod %v", controller.Name, newPod.Name)
-		r.Recorder.Eventf(controller, "successfulCreate", "Created pod: %v", newPod.Name)
+		r.Recorder.Eventf(controller, "SuccessfulCreate", "Created pod: %v", newPod.Name)
 	}
 	return nil
 }

--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -125,7 +125,7 @@ func (s *Scheduler) scheduleOne() {
 	metrics.SchedulingAlgorithmLatency.Observe(metrics.SinceInMicroseconds(start))
 	if err != nil {
 		glog.V(1).Infof("Failed to schedule: %v", pod)
-		s.config.Recorder.Eventf(pod, "failedScheduling", "%v", err)
+		s.config.Recorder.Eventf(pod, "FailedScheduling", "%v", err)
 		s.config.Error(pod, err)
 		return
 	}
@@ -145,11 +145,11 @@ func (s *Scheduler) scheduleOne() {
 		metrics.BindingLatency.Observe(metrics.SinceInMicroseconds(bindingStart))
 		if err != nil {
 			glog.V(1).Infof("Failed to bind pod: %v", err)
-			s.config.Recorder.Eventf(pod, "failedScheduling", "Binding rejected: %v", err)
+			s.config.Recorder.Eventf(pod, "FailedScheduling", "Binding rejected: %v", err)
 			s.config.Error(pod, err)
 			return
 		}
-		s.config.Recorder.Eventf(pod, "scheduled", "Successfully assigned %v to %v", pod.Name, dest)
+		s.config.Recorder.Eventf(pod, "Scheduled", "Successfully assigned %v to %v", pod.Name, dest)
 		// tell the model to assume that this binding took effect.
 		assumed := *pod
 		assumed.Spec.NodeName = dest

--- a/plugin/pkg/scheduler/scheduler_test.go
+++ b/plugin/pkg/scheduler/scheduler_test.go
@@ -85,13 +85,13 @@ func TestScheduler(t *testing.T) {
 			algo:             mockScheduler{"machine1", nil},
 			expectBind:       &api.Binding{ObjectMeta: api.ObjectMeta{Name: "foo"}, Target: api.ObjectReference{Kind: "Node", Name: "machine1"}},
 			expectAssumedPod: podWithID("foo", "machine1"),
-			eventReason:      "scheduled",
+			eventReason:      "Scheduled",
 		}, {
 			sendPod:        podWithID("foo", ""),
 			algo:           mockScheduler{"machine1", errS},
 			expectError:    errS,
 			expectErrorPod: podWithID("foo", ""),
-			eventReason:    "failedScheduling",
+			eventReason:    "FailedScheduling",
 		}, {
 			sendPod:         podWithID("foo", ""),
 			algo:            mockScheduler{"machine1", nil},
@@ -99,7 +99,7 @@ func TestScheduler(t *testing.T) {
 			injectBindError: errB,
 			expectError:     errB,
 			expectErrorPod:  podWithID("foo", ""),
-			eventReason:     "failedScheduling",
+			eventReason:     "FailedScheduling",
 		},
 	}
 
@@ -218,7 +218,7 @@ func TestSchedulerForgetAssumedPodAfterDelete(t *testing.T) {
 	s := New(c)
 	called := make(chan struct{})
 	events := eventBroadcaster.StartEventWatcher(func(e *api.Event) {
-		if e, a := "scheduled", e.Reason; e != a {
+		if e, a := "Scheduled", e.Reason; e != a {
 			t.Errorf("expected %v, got %v", e, a)
 		}
 		close(called)
@@ -277,7 +277,7 @@ func TestSchedulerForgetAssumedPodAfterDelete(t *testing.T) {
 
 	called = make(chan struct{})
 	events = eventBroadcaster.StartEventWatcher(func(e *api.Event) {
-		if e, a := "scheduled", e.Reason; e != a {
+		if e, a := "Scheduled", e.Reason; e != a {
 			t.Errorf("expected %v, got %v", e, a)
 		}
 		close(called)


### PR DESCRIPTION
As talking in #12464, Event.Reason should be CamelCase (starting with a capital letter), as with Reason everywhere in the API.
