### PR TITLE
Update travis and shippable to have less needless cruft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,11 @@ script:
   - ./hack/verify-gofmt.sh
   - ./hack/verify-boilerplate.sh
   - ./hack/verify-description.sh
-  - PATH=$GOPATH/bin:$PATH ./hack/verify-generated-conversions.sh
-  - PATH=$GOPATH/bin:$PATH ./hack/verify-generated-deep-copies.sh
-  - PATH=$GOPATH/bin:./third_party/etcd:$PATH ./hack/verify-generated-docs.sh
-  - PATH=$GOPATH/bin:./third_party/etcd:$PATH ./hack/verify-swagger-spec.sh
-  - PATH=$GOPATH/bin:./third_party/etcd:$PATH ./hack/verify-linkcheck.sh
-  - godep go test ./cmd/mungedocs
+  - ./hack/verify-generated-conversions.sh
+  - ./hack/verify-generated-deep-copies.sh
+  - ./hack/verify-generated-docs.sh
+  - PATH=./third_party/etcd:$PATH ./hack/verify-swagger-spec.sh
+  - ./hack/verify-linkcheck.sh
 
 notifications:
   irc: "chat.freenode.net#kubernetes-dev"

--- a/shippable.yml
+++ b/shippable.yml
@@ -23,18 +23,18 @@ install:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
   - go get github.com/tools/godep
+  - ./hack/build-go.sh
+  - PATH=$GOPATH/bin:$PATH godep go install ./...
   - ./hack/travis/install-etcd.sh
   - ./hack/verify-gofmt.sh
   - ./hack/verify-boilerplate.sh
   - ./hack/verify-description.sh
   - ./hack/travis/install-std-race.sh
-  - ./hack/build-go.sh
-  - PATH=$GOPATH/bin:$PATH godep go install ./...
-  - PATH=$GOPATH/bin:$PATH ./hack/verify-generated-conversions.sh
-  - PATH=$GOPATH/bin:$PATH ./hack/verify-generated-deep-copies.sh
-  - PATH=$GOPATH/bin:./third_party/etcd:$PATH ./hack/verify-generated-docs.sh
-  - PATH=$GOPATH/bin:./third_party/etcd:$PATH ./hack/verify-swagger-spec.sh
-  - PATH=$GOPATH/bin:./third_party/etcd:$PATH ./hack/verify-linkcheck.sh
+  - ./hack/verify-generated-conversions.sh
+  - ./hack/verify-generated-deep-copies.sh
+  - ./hack/verify-generated-docs.sh
+  - PATH=./third_party/etcd:$PATH ./hack/verify-swagger-spec.sh
+  - ./hack/verify-linkcheck.sh
 
 script:
   - KUBE_RACE="-race" KUBE_COVER="y" KUBE_GOVERALLS_BIN="$HOME/gopath/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES}" KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" ./hack/test-go.sh -- -p=2


### PR DESCRIPTION
It looks like there are places where things needed for one command
were being just needlessly copied. Which made the files harder to
recognize what mattered and what didn't...
