### PR TITLE
Speed up pre-commit boilerplate by only checking changed files

### DIFF
--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -21,33 +21,7 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 boiler="${KUBE_ROOT}/hack/boilerplate/boilerplate.py"
 
-cd ${KUBE_ROOT}
-
-find_files() {
-  local ext=$1
-  find . -not \( \
-      \( \
-        -wholename './output' \
-        -o -wholename './_output' \
-        -o -wholename './release' \
-        -o -wholename './target' \
-        -o -wholename './.git' \
-        -o -wholename '*/third_party/*' \
-        -o -wholename '*/Godeps/*' \
-      \) -prune \
-    \) -name "*.${ext}"
-}
-
-files_need_boilerplate=()
-
-files=($(find_files "go"))
-files_need_boilerplate+=($(${boiler} "go" "${files[@]}"))
-
-files=($(find_files "sh"))
-files_need_boilerplate+=($(${boiler} "sh" "${files[@]}"))
-
-files=($(find_files "py"))
-files_need_boilerplate+=($(${boiler} "py" "${files[@]}"))
+files_need_boilerplate=($(${boiler} "$@"))
 
 if [[ ${#files_need_boilerplate[@]} -gt 0 ]]; then
   for file in "${files_need_boilerplate[@]}"; do

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -39,11 +39,12 @@ fi
 echo "${reset}"
 
 echo -ne "Checking for files that need boilerplate... "
-out=($(hack/verify-boilerplate.sh))
-if [[ $? -ne 0 ]]; then
+files=($(git diff --cached --name-only --diff-filter ACM))
+out=($(hack/boilerplate/boilerplate.py "${files[@]}"))
+if [[ "${#out}" -ne 0 ]]; then
   echo "${red}ERROR!"
   echo "Some files are missing the required boilerplate header"
-  echo "from hooks/boilerplate.txt:"
+  echo "from hack/boilerplate/boilerplate.*.txt:"
   for f in "${out[@]}"; do
     echo "  ${f}"
   done


### PR DESCRIPTION
Although the boilerplate checker was very fast it can be faster. With
this change we can hand the boilerplate a list of files which need to be
checked or give it no files. If given no files it will run all files in
the repo. Before you had to explicitly tell the boiler checker the
'extention' of the the files.  In this case we let the checker figure it
out and load the headers as needed.

Doing the whole repo takes about 0.4 seconds. Doing a single go file
takes < .04 seconds.
