### PR TITLE
Do not build genconversion and gendeepcopy twice

### DIFF
--- a/hack/after-build/verify-generated-conversions.sh
+++ b/hack/after-build/verify-generated-conversions.sh
@@ -37,7 +37,7 @@ for APIROOT in ${APIROOTS}; do
 	cp -a "${KUBE_ROOT}/${APIROOT}" "${_tmp}/${APIROOT}"
 done
 
-"${KUBE_ROOT}/hack/update-generated-conversions.sh"
+"${KUBE_ROOT}/hack/after-build/update-generated-conversions.sh"
 for APIROOT in ${APIROOTS}; do
 	TMP_APIROOT="${_tmp}/${APIROOT}"
 	echo "diffing ${APIROOT} against freshly generated conversions"

--- a/hack/after-build/verify-generated-deep-copies.sh
+++ b/hack/after-build/verify-generated-deep-copies.sh
@@ -39,7 +39,7 @@ for APIROOT in ${APIROOTS}; do
 	cp -a "${KUBE_ROOT}/${APIROOT}" "${_tmp}/${APIROOT}"
 done
 
-"${KUBE_ROOT}/hack/update-generated-deep-copies.sh"
+"${KUBE_ROOT}/hack/after-build/update-generated-deep-copies.sh"
 
 for APIROOT in ${APIROOTS}; do
 	TMP_APIROOT="${_tmp}/${APIROOT}"


### PR DESCRIPTION
The hack/after-build/verify-\* functions were using the hack/update-*
functions.  Which means that if you call hack/verify-\* you will do the
build twice. Stop it.
