### PR TITLE
Add missing argument to function call and don't set GOPATH directly

### DIFF
--- a/hack/after-build/update-generated-conversions.sh
+++ b/hack/after-build/update-generated-conversions.sh
@@ -44,7 +44,7 @@ EOF
 // AUTO-GENERATED FUNCTIONS END HERE
 EOF
 
-	env GOPATH=$(godep path):$GOPATH goimports -w "$TMPFILE"
+	goimports -w "$TMPFILE"
 	mv "$TMPFILE" "pkg/${version}/conversion_generated.go"
 }
 

--- a/hack/after-build/update-generated-deep-copies.sh
+++ b/hack/after-build/update-generated-deep-copies.sh
@@ -56,7 +56,7 @@ EOF
 // AUTO-GENERATED FUNCTIONS END HERE
 EOF
 
-	env GOPATH=$(godep path):$GOPATH goimports -w "$TMPFILE"
+	goimports -w "$TMPFILE"
 	mv "$TMPFILE" `result_file_name ${version}`
 }
 
@@ -76,4 +76,4 @@ function generate_deep_copies() {
 
 DEFAULT_VERSIONS="api/ api/v1 expapi/ expapi/v1"
 VERSIONS=${VERSIONS:-$DEFAULT_VERSIONS}
-generate_deep_copies
+generate_deep_copies "$VERSIONS"


### PR DESCRIPTION
Followup to some concerns raised in #12411:
- GOPATH is already set.
- We need to pass VERSIONS to generate_deep_copies
