### PR TITLE
to fix go vet: composite literal uses unkeyed fields

### DIFF
--- a/pkg/registry/service/etcd/etcd.go
+++ b/pkg/registry/service/etcd/etcd.go
@@ -61,7 +61,7 @@ func NewStorage(s storage.Interface) *REST {
 }
 
 func MatchServices(label labels.Selector, field fields.Selector) generic.Matcher {
-	return &generic.SelectionPredicate{label, field, ServiceAttributes}
+	return &generic.SelectionPredicate{Label: label, Field: field, GetAttrs: ServiceAttributes}
 }
 
 func ServiceAttributes(obj runtime.Object) (objLabels labels.Set, objFields fields.Set, err error) {


### PR DESCRIPTION
got this error
`pkg/registry/service/etcd/etcd.go:64: k8s.io/kubernetes/pkg/registry/generic.SelectionPredicate composite literal uses unkeyed fields`
running `./hack/vet-go.sh` 
this PR should fix it
