### PR TITLE
exclude imports from repack

### DIFF
--- a/cmd/gendeepcopy/deep_copy.go
+++ b/cmd/gendeepcopy/deep_copy.go
@@ -85,7 +85,7 @@ func main() {
 			glog.Errorf("error while generating deep copy functions for %v: %v", knownType, err)
 		}
 	}
-	generator.RepackImports()
+	generator.RepackImports(util.StringSet{})
 	if err := generator.WriteImports(funcOut); err != nil {
 		glog.Fatalf("error while writing imports: %v", err)
 	}

--- a/pkg/runtime/deep_copy_generator.go
+++ b/pkg/runtime/deep_copy_generator.go
@@ -48,7 +48,7 @@ type DeepCopyGenerator interface {
 	AddImport(pkgPath string) string
 
 	// RepackImports creates a stable ordering of import short names
-	RepackImports()
+	RepackImports(exclude util.StringSet)
 
 	// Writes all imports that are necessary for deep-copy function and
 	// their registration.
@@ -205,7 +205,7 @@ func (g *deepCopyGenerator) AddType(inType reflect.Type) error {
 	return g.addAllRecursiveTypes(inType)
 }
 
-func (g *deepCopyGenerator) RepackImports() {
+func (g *deepCopyGenerator) RepackImports(exclude util.StringSet) {
 	var packages []string
 	for key := range g.imports {
 		packages = append(packages, key)
@@ -213,10 +213,11 @@ func (g *deepCopyGenerator) RepackImports() {
 	sort.Strings(packages)
 	g.imports = make(map[string]string)
 	g.shortImports = make(map[string]string)
-
 	g.targetPackage(g.targetPkg)
 	for _, pkg := range packages {
-		g.addImportByPath(pkg)
+		if !exclude.Has(pkg) {
+			g.addImportByPath(pkg)
+		}
 	}
 }
 


### PR DESCRIPTION
Allows some packages to avoid repacking and keep their existing names.

@smarterclayton Needed for rebase.
