### PR TITLE
Add floatingIP allocation for LB creation on openstack

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -776,9 +776,11 @@ func (lb *LoadBalancer) EnsureTCPLoadBalancerDeleted(name, region string) error 
 		if err != nil && !isNotFound(err) {
 			return err
 		}
-		error := floatingips.Delete(lb.network, floatingIP.ID).ExtractErr()
-		if error != nil && !isNotFound(error) {
-			return error
+		if floatingIP != nil {
+			error := floatingips.Delete(lb.network, floatingIP.ID).ExtractErr()
+			if error != nil && !isNotFound(error) {
+				return error
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR may relate to issue #12284 .
If a `floating-network-id` is added to the `[LoadBalancer]` section of openstack's cloud provider config, it will associate a new floatingIP to the VIP created.

Without a `floating-network-id` behaviour should remain the same.
