### PR TITLE
Limit field errors to a single field name

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -223,7 +223,9 @@ func ValidateObjectMeta(meta *api.ObjectMeta, requiresNamespace bool, nameFn Val
 	// report it here. This may confuse users, but indicates a programming bug and still must be validated.
 	// If there are multiple fields out of which one is required then add a or as a separator
 	if len(meta.Name) == 0 {
-		allErrs = append(allErrs, errs.NewFieldRequired("name or generateName"))
+		requiredErr := errs.NewFieldRequired("name")
+		requiredErr.Detail = "name or generateName is required"
+		allErrs = append(allErrs, requiredErr)
 	} else {
 		if ok, qualifier := nameFn(meta.Name, false); !ok {
 			allErrs = append(allErrs, errs.NewFieldInvalid("name", meta.Name, qualifier))

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -2323,7 +2323,7 @@ func TestValidateReplicationController(t *testing.T) {
 		for i := range errs {
 			field := errs[i].(*errors.ValidationError).Field
 			if !strings.HasPrefix(field, "spec.template.") &&
-				field != "metadata.name or metadata.generateName" &&
+				field != "metadata.name" &&
 				field != "metadata.namespace" &&
 				field != "spec.selector" &&
 				field != "spec.template" &&
@@ -2736,7 +2736,7 @@ func TestValidateDaemon(t *testing.T) {
 		for i := range errs {
 			field := errs[i].(*errors.ValidationError).Field
 			if !strings.HasPrefix(field, "spec.template.") &&
-				field != "metadata.name or metadata.generateName" &&
+				field != "metadata.name" &&
 				field != "metadata.namespace" &&
 				field != "spec.selector" &&
 				field != "spec.template" &&
@@ -2850,11 +2850,11 @@ func TestValidateNode(t *testing.T) {
 		for i := range errs {
 			field := errs[i].(*errors.ValidationError).Field
 			expectedFields := map[string]bool{
-				"metadata.name or metadata.generateName": true,
-				"metadata.labels":                        true,
-				"metadata.annotations":                   true,
-				"metadata.namespace":                     true,
-				"spec.ExternalID":                        true,
+				"metadata.name":        true,
+				"metadata.labels":      true,
+				"metadata.annotations": true,
+				"metadata.namespace":   true,
+				"spec.ExternalID":      true,
 			}
 			if expectedFields[field] == false {
 				t.Errorf("%s: missing prefix for: %v", k, errs[i])
@@ -3286,7 +3286,7 @@ func TestValidateLimitRange(t *testing.T) {
 	}{
 		"zero-length Name": {
 			api.LimitRange{ObjectMeta: api.ObjectMeta{Name: "", Namespace: "foo"}, Spec: spec},
-			"",
+			"name or generateName is required",
 		},
 		"zero-length-namespace": {
 			api.LimitRange{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: ""}, Spec: spec},
@@ -3361,7 +3361,7 @@ func TestValidateResourceQuota(t *testing.T) {
 	}{
 		"zero-length Name": {
 			api.ResourceQuota{ObjectMeta: api.ObjectMeta{Name: "", Namespace: "foo"}, Spec: spec},
-			"",
+			"name or generateName is required",
 		},
 		"zero-length Namespace": {
 			api.ResourceQuota{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: ""}, Spec: spec},
@@ -3384,7 +3384,7 @@ func TestValidateResourceQuota(t *testing.T) {
 		for i := range errs {
 			field := errs[i].(*errors.ValidationError).Field
 			detail := errs[i].(*errors.ValidationError).Detail
-			if field != "metadata.name" && field != "metadata.name or metadata.generateName" && field != "metadata.namespace" {
+			if field != "metadata.name" && field != "metadata.namespace" {
 				t.Errorf("%s: missing prefix for: %v", k, field)
 			}
 			if detail != v.D {

--- a/pkg/util/fielderrors/fielderrors.go
+++ b/pkg/util/fielderrors/fielderrors.go
@@ -148,7 +148,6 @@ func NewFieldTooLong(field string, value interface{}, maxLength int) *Validation
 type ValidationErrorList []error
 
 // Prefix adds a prefix to the Field of every ValidationError in the list.
-// Also adds prefixes to multiple fields if you send an or separator.
 // Returns the list for convenience.
 func (list ValidationErrorList) Prefix(prefix string) ValidationErrorList {
 	for i := range list {
@@ -156,11 +155,7 @@ func (list ValidationErrorList) Prefix(prefix string) ValidationErrorList {
 			if strings.HasPrefix(err.Field, "[") {
 				err.Field = prefix + err.Field
 			} else if len(err.Field) != 0 {
-				fields := strings.SplitAfter(err.Field, " or ")
-				err.Field = ""
-				for j := range fields {
-					err.Field += prefix + "." + fields[j]
-				}
+				err.Field = prefix + "." + err.Field
 			} else {
 				err.Field = prefix
 			}


### PR DESCRIPTION
Fixes #12552

Example API response:

```
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "Secret \"\" is invalid: metadata.name: required value, Details: name or generateName is required",
  "reason": "Invalid",
  "details": {
    "kind": "Secret",
    "causes": [
      {
        "reason": "FieldValueRequired",
        "message": "required value, Details: name or generateName is required",
        "field": "metadata.name"
      }
    ]
  },
  "code": 422
}
```

Example output for client:

```
$ echo '{"apiVersion":"v1","kind":"Secret"}' | kubectl create -f -
The Secret "" is invalid.
metadata.name: required value, Details: name or generateName is required
```
