### PR TITLE
Add status.podIP as a valid downward API target

### DIFF
--- a/docs/user-guide/downward-api.md
+++ b/docs/user-guide/downward-api.md
@@ -51,6 +51,7 @@ The following information is available to a `Pod` through the downward API:
 
 *   The pod's name
 *   The pod's namespace
+*   The pod's IP
 
 More information will be exposed through this same API over time.
 
@@ -101,6 +102,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
   restartPolicy: Never
 ```
 

--- a/docs/user-guide/downward-api/README.md
+++ b/docs/user-guide/downward-api/README.md
@@ -61,8 +61,9 @@ through the pod logs to see that the pod was injected with the correct values:
 
 ```console
 $ kubectl logs dapi-test-pod | grep POD_
-2015-04-30T20:22:18.568024817Z POD_NAME=dapi-test-pod
-2015-04-30T20:22:18.568087688Z POD_NAMESPACE=default
+2015-04-30T20:22:18.568024817Z MY_POD_NAME=dapi-test-pod
+2015-04-30T20:22:18.568087688Z MY_POD_NAMESPACE=default
+2015-04-30T20:22:18.568092435Z MY_POD_IP=10.0.1.6
 ```
 
 

--- a/docs/user-guide/downward-api/dapi-pod.yaml
+++ b/docs/user-guide/downward-api/dapi-pod.yaml
@@ -16,4 +16,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
   restartPolicy: Never

--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -44,6 +44,7 @@ func addConversionFuncs() {
 			case "metadata.name",
 				"metadata.namespace",
 				"status.phase",
+				"status.podIP",
 				"spec.nodeName":
 				return label, value, nil
 				// This is for backwards compatibility with old v1 clients which send spec.host

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -680,7 +680,7 @@ func validateEnvVarValueFrom(ev api.EnvVar) errs.ValidationErrorList {
 	return allErrs
 }
 
-var validFieldPathExpressions = util.NewStringSet("metadata.name", "metadata.namespace")
+var validFieldPathExpressions = util.NewStringSet("metadata.name", "metadata.namespace", "status.podIP")
 
 func validateObjectFieldSelector(fs *api.ObjectFieldSelector) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -667,7 +667,7 @@ func TestValidateEnv(t *testing.T) {
 					},
 				},
 			}},
-			expectedError: "[0].valueFrom.fieldRef.fieldPath: unsupported value 'status.phase', Details: supported values: metadata.name, metadata.namespace",
+			expectedError: "[0].valueFrom.fieldRef.fieldPath: unsupported value 'status.phase', Details: supported values: metadata.name, metadata.namespace, status.podIP",
 		},
 	}
 	for _, tc := range errorCases {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1051,7 +1051,10 @@ func (kl *Kubelet) podFieldSelectorRuntimeValue(fs *api.ObjectFieldSelector, pod
 	if err != nil {
 		return "", err
 	}
-
+	switch internalFieldPath {
+	case "status.podIP":
+		return pod.Status.PodIP, nil
+	}
 	return fieldpath.ExtractFieldPathAsString(pod, internalFieldPath)
 }
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1187,6 +1187,15 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 							},
 						},
 					},
+					{
+						Name: "POD_IP",
+						ValueFrom: &api.EnvVarSource{
+							FieldRef: &api.ObjectFieldSelector{
+								APIVersion: testapi.Version(),
+								FieldPath:  "status.podIP",
+							},
+						},
+					},
 				},
 			},
 			masterServiceNs: "nothing",
@@ -1194,6 +1203,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			expectedEnvs: []kubecontainer.EnvVar{
 				{Name: "POD_NAME", Value: "dapi-test-pod-name"},
 				{Name: "POD_NAMESPACE", Value: "downward-api"},
+				{Name: "POD_IP", Value: "1.2.3.4"},
 			},
 		},
 		{
@@ -1345,6 +1355,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 				Name:      "dapi-test-pod-name",
 			},
 		}
+		testPod.Status.PodIP = "1.2.3.4"
 
 		result, err := kl.makeEnvironmentVariables(testPod, tc.container)
 		if err != nil {


### PR DESCRIPTION
Getting the public IP a container is supposed to use is O(hard),
and usually involves ugly gyrations in python or with interfaces.
Using the downward API means that the IP Kube is announcing to
other endpoints is also visible inside the container for pods to
identify themselves.

Fixes #11288

@bgrant0607 for addition to downward API
