### PR TITLE
Update ResourceQuota for resource requirements requests

### DIFF
--- a/pkg/api/resource/quantity.go
+++ b/pkg/api/resource/quantity.go
@@ -309,6 +309,14 @@ func (q *Quantity) Add(y Quantity) error {
 	return nil
 }
 
+func (q *Quantity) Sub(y Quantity) error {
+	if q.Format != y.Format {
+		return fmt.Errorf("format mismatch: %v vs. %v", q.Format, y.Format)
+	}
+	q.Amount.Sub(q.Amount, y.Amount)
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface.
 func (q Quantity) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + q.String() + `"`), nil


### PR DESCRIPTION
Implements the changes for ResourceQuota to now track requests instead of limits.

Generalized a lot of the code so it will be easier to support other pod resources (bandwidth, etc.).
