### PR TITLE
contrib/ansible: save iptables rules after docker restart

### DIFF
--- a/contrib/ansible/roles/docker/handlers/main.yml
+++ b/contrib/ansible/roles/docker/handlers/main.yml
@@ -1,3 +1,10 @@
 ---
 - name: restart docker
   service: name=docker state=restarted
+  notify:
+    - Save iptables rules
+
+# We need to make sure iptables will remember the DOCKER
+# chain if/when it gets restarted.
+- name: Save iptables rules
+  command: service iptables save


### PR DESCRIPTION
When docker is restarted, we need to save the iptables rules so that any subsequent iptables service restart doesn't wipe out the DOCKER chain.

Without this patch, the current playbook causes issues because the Docker service gets restarted prior to the iptables service.

I'm still getting familiar with these scripts (and Ansible in general) so there might be a more appropriate way to solve this.
