### PR TITLE
expose e2e methods for downstream use

### DIFF
--- a/test/e2e/core.go
+++ b/test/e2e/core.go
@@ -29,7 +29,7 @@ type command struct {
 	component string
 }
 
-func coreDump(dir string) {
+func CoreDump(dir string) {
 	c, err := loadClient()
 	if err != nil {
 		fmt.Printf("Error creating client: %v", err)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -91,7 +91,7 @@ func TestE2E(t *testing.T) {
 		if err := os.MkdirAll(*reportDir, 0755); err != nil {
 			glog.Errorf("Failed creating report directory: %v", err)
 		}
-		defer coreDump(*reportDir)
+		defer CoreDump(*reportDir)
 	}
 
 	if testContext.Provider == "" {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -125,6 +125,10 @@ type TestContextType struct {
 
 var testContext TestContextType
 
+func SetTestContext(t TestContextType) {
+	testContext = t
+}
+
 type ContainerFailures struct {
 	status   *api.ContainerStateTerminated
 	restarts int


### PR DESCRIPTION
We're using a couple methods from e2e in our extended tests downstream.  These used to be exposed.  I'm open to alternatives if you prefer like exposing `testContext` as `TestContext`.

@smarterclayton part of the rebase.
