### PR TITLE
Merge NamespaceExists into NamespaceLifecycle

### DIFF
--- a/docs/admin/admission-controllers.md
+++ b/docs/admin/admission-controllers.md
@@ -48,7 +48,7 @@ Documentation for other releases can be found at
     - [SecurityContextDeny](#securitycontextdeny)
     - [ResourceQuota](#resourcequota)
     - [LimitRanger](#limitranger)
-    - [NamespaceExists](#namespaceexists)
+    - [NamespaceExists (deprecated)](#namespaceexists-deprecated)
     - [NamespaceAutoProvision (deprecated)](#namespaceautoprovision-deprecated)
     - [NamespaceLifecycle](#namespacelifecycle)
   - [Is there a recommended set of plug-ins to use?](#is-there-a-recommended-set-of-plug-ins-to-use)
@@ -129,28 +129,28 @@ applies a 0.1 CPU requirement to all Pods in the `default` namespace.
 
 See the [limitRange design doc](../design/admission_control_limit_range.md) and the [example of Limit Range](limitrange/) for more details.
 
-### NamespaceExists
+### NamespaceExists (deprecated)
 
 This plug-in will observe all incoming requests that attempt to create a resource in a Kubernetes `Namespace`
 and reject the request if the `Namespace` was not previously created.  We strongly recommend running
 this plug-in to ensure integrity of your data.
+
+The functionality of this admission controller has been merged into `NamespaceLifecycle`
 
 ### NamespaceAutoProvision (deprecated)
 
 This plug-in will observe all incoming requests that attempt to create a resource in a Kubernetes `Namespace`
 and create a new `Namespace` if one did not already exist previously.
 
-We strongly recommend `NamespaceExists` over `NamespaceAutoProvision`.
+We strongly recommend `NamespaceLifecycle` over `NamespaceAutoProvision`.
 
 ### NamespaceLifecycle
 
-This plug-in enforces that a `Namespace` that is undergoing termination cannot have new objects created in it.
+This plug-in enforces that a `Namespace` that is undergoing termination cannot have new objects created in it,
+and ensures that requests in a non-existant `Namespace` are rejected.
 
 A `Namespace` deletion kicks off a sequence of operations that remove all objects (pods, services, etc.) in that
 namespace.  In order to enforce integrity of that process, we strongly recommend running this plug-in.
-
-Once `NamespaceAutoProvision` is deprecated, we anticipate `NamespaceLifecycle` and `NamespaceExists` will
-be merged into a single plug-in that enforces the life-cycle of a `Namespace` in Kubernetes.
 
 ## Is there a recommended set of plug-ins to use?
 
@@ -159,7 +159,7 @@ Yes.
 For Kubernetes 1.0, we strongly recommend running the following set of admission control plug-ins (order matters):
 
 ```
---admission-control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
+--admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
 ```
 
 


### PR DESCRIPTION
This commit merges the NamespaceExists admission controller
into the NamespaceLifecycle admission controller.

New tests were added to the NamespaceLifecycle addmission controller
tests, and the test case was fixed so that it runs without panicing.

Closes #12053
