### PR TITLE
Add support for a domain label

### DIFF
--- a/cluster/addons/dns/kube2sky/README.md
+++ b/cluster/addons/dns/kube2sky/README.md
@@ -30,4 +30,39 @@ mutation (insertion or removal of a dns entry) before giving up and crashing.
 
 `--kubecfg_file`: Path to kubecfg file that contains the master URL and tokens to authenticate with the master.
 
+## Domain Label
+
+It is possible to specify a label in the metadata of a Service definition with
+the name "domain" to control the name of the A record created by kube2dns. Consider
+the following Service definition:
+
+```yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-service
+  namespace: web
+  labels:
+    domain: example.com
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+  selector:
+    name: example-web-server
+```
+
+Normally, kube2dns would create an A record with the following name:
+
+```
+example-service.web.svc.skydns.local.
+```
+
+Because the "domain" label has been specified, the following name is used instead:
+
+```
+example.com.web.svc.skydns.local.
+```
+
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/dns/kube2sky/README.md?pixel)]()


### PR DESCRIPTION
This adds support for kube2sky to recognize and use `Service.ObjectMeta.Labels["domain"]` to set the name of the A record that it creates. My use case for this is dynamically routing HTTP requests upstream based on the `Host` header without performing any mutations on this header. Because Kubernetes expects valid RFC1034 DNS names for the names of resources, this is normally not possible.

Here is an example of how you might use Nginx with the sample service included in the readme update:

```
server {
  listen 80;
  server_name ~^(www\.)?(?<domain>.+)$;

  location / {
    proxy_pass http://$domain.default.svc.skydns.local/;
  }
}
```
