### PR TITLE
Fix nav menu close behavior (so sub menus with unselected items are closed)

### DIFF
--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -57,15 +57,8 @@
 				$('html, body').animate({scrollTop: 0}, 500);
 			} 
 			if(!$(clickedon).hasClass('active')) {//Animate navigation menu to open/close and highlight item
-				if(!$(clickedon).parent().hasClass('haschild')){
-					if(!$(clickedon).parent().parent().parent().find('a').hasClass('active')){
-						menu_ul.filter(':visible').slideUp('normal');
-					}
-				}
-				else{
-					if(!$(clickedon).parent().find('a').hasClass('active')){
-						menu_ul.filter(':visible').slideUp('normal');
-					}
+				if($(clickedon).parents('li.haschild').length === 0 || $(clickedon).parents('li').find('a.active').length === 0){
+					menu_ul.filter(':visible').slideUp('normal');
 				}
 	            $('.menu a').removeClass('active');
 	            $(clickedon).addClass('active').next().stop(true,true).slideDown('normal');


### PR DESCRIPTION
Noticed that the sub menu does not close when navigating from a topic in a sub menu to a top level topic that is not a container (one that doesn't enclose a sub menu). Any of these menus that are left open misbehave and close when items are clicked on.

Example: 
Start from this topic:
http://kubernetes.io/v1.0/docs/user-guide/quick-start.html

Then click "Application Admin Guide" in the nav menu:
http://kubernetes.io/v1.0/docs/user-guide/README.html
