### PR TITLE
Update Elasticsearch example to remove use of secrets

### DIFF
--- a/examples/elasticsearch/Makefile
+++ b/examples/elasticsearch/Makefile
@@ -1,8 +1,8 @@
 .PHONY: elasticsearch_discovery build push all
 
-TAG = 1.0
+TAG = 1.1
 
-build:
+build:	elasticsearch_discovery
 	docker build -t kubernetes/elasticsearch:$(TAG) .
 
 push:

--- a/examples/elasticsearch/apiserver-secret.yaml
+++ b/examples/elasticsearch/apiserver-secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: apiserver-secret
-  namespace: NAMESPACE
-data:
-  token: "TOKEN"
-

--- a/examples/elasticsearch/elasticsearch_discovery.go
+++ b/examples/elasticsearch/elasticsearch_discovery.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -31,8 +30,6 @@ import (
 )
 
 var (
-	token     = flag.String("token", "", "Bearer token for authentication to the API server.")
-	server    = flag.String("server", "", "The address and port of the Kubernetes API server")
 	namespace = flag.String("namespace", api.NamespaceDefault, "The namespace containing Elasticsearch pods")
 	selector  = flag.String("selector", "", "Selector (label query) for selecting Elasticsearch pods")
 )
@@ -40,26 +37,11 @@ var (
 func main() {
 	flag.Parse()
 	glog.Info("Elasticsearch discovery")
-	apiServer := *server
-	if apiServer == "" {
-		kubernetesService := os.Getenv("KUBERNETES_SERVICE_HOST")
-		if kubernetesService == "" {
-			glog.Fatalf("Please specify the Kubernetes server with --server")
-		}
-		apiServer = fmt.Sprintf("https://%s:%s", kubernetesService, os.Getenv("KUBERNETES_SERVICE_PORT"))
-	}
 
-	glog.Infof("Server: %s", apiServer)
 	glog.Infof("Namespace: %q", *namespace)
 	glog.Infof("selector: %q", *selector)
 
-	config := client.Config{
-		Host:        apiServer,
-		BearerToken: *token,
-		Insecure:    true,
-	}
-
-	c, err := client.New(&config)
+	c, err := client.NewInCluster()
 	if err != nil {
 		glog.Fatalf("Failed to make client: %v", err)
 	}

--- a/examples/elasticsearch/music-rc.yaml
+++ b/examples/elasticsearch/music-rc.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: es
-        image: kubernetes/elasticsearch:1.0
+        image: kubernetes/elasticsearch:1.1
         env:
           - name: "CLUSTER_NAME"
             value: "mytunes-db"
@@ -29,11 +29,4 @@ spec:
           containerPort: 9200
         - name: es-transport
           containerPort: 9300
-        volumeMounts:
-        - name: apiserver-secret
-          mountPath: /etc/apiserver-secret
-          readOnly: true
-      volumes:
-      - name: apiserver-secret
-        secret:
-          secretName: apiserver-secret
+

--- a/examples/elasticsearch/mytunes-namespace.yaml
+++ b/examples/elasticsearch/mytunes-namespace.yaml
@@ -1,0 +1,6 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: mytunes
+  labels:
+    name: mytunes

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -237,9 +237,9 @@ func TestExampleObjectSchemas(t *testing.T) {
 			"dapi-pod": &api.Pod{},
 		},
 		"../examples/elasticsearch": {
-			"apiserver-secret": nil,
-			"music-rc":         &api.ReplicationController{},
-			"music-service":    &api.Service{},
+			"mytunes-namespace": &api.Namespace{},
+			"music-rc":          &api.ReplicationController{},
+			"music-service":     &api.Service{},
 		},
 		"../examples/explorer": {
 			"pod": &api.Pod{},


### PR DESCRIPTION
The Elasticsearch example was broken because it no longer needed to use secrets. Fixed, and also updated the example.
