### PR TITLE
Remove delete action of "/var/lib/kubelet"

### DIFF
--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -442,7 +442,7 @@ function kube-down {
       echo "Cleaning on node ${i#*@}"
       ssh -t $i 'pgrep etcd && sudo -p "[sudo] password for cleaning etcd data: " service etcd stop && sudo rm -rf /infra*'
       # Delete the files in order to generate a clean environment, so you can change each node's role at next deployment.
-      ssh -t $i 'rm -f /opt/bin/kube* /etc/init/kube* /etc/init.d/kube* /etc/default/kube*; rm -rf ~/kube /var/lib/kubelet'
+      ssh -t $i 'rm -f /opt/bin/kube* /etc/init/kube* /etc/init.d/kube* /etc/default/kube*; rm -rf ~/kube'
     }
   done
   wait


### PR DESCRIPTION
The function kube-down of shell script "ubuntu/util.sh" can not run normally, when the k8s cluster has some pods. Because the path "/var/lib/kubelet" contains some pods' information, and it can not be deleted. If you run "rm -rf /var/lib/kubelet", the error "rm: cannot remove ... Device or resource busy" will return.
Moreover, the existence of  the path "/var/lib/kubelet" will not affect a new deployment. So the delete action can remove.
