### PR TITLE
Add generic master detector; simplify conformance.

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -171,6 +171,32 @@ function get-kubeconfig-bearertoken() {
   fi
 }
 
+# Get the master IP for the current-context in kubeconfig if one exists.
+#
+# Assumed vars:
+#   KUBECONFIG  # if unset, defaults to global
+#
+# Vars set:
+#   KUBE_MASTER_URL
+#
+# KUBE_MASTER_URL will be empty if no current-context is set, or the
+# current-context user does not exist or contain a server entry.
+function detect-master-from-kubeconfig() {
+  export KUBECONFIG=${KUBECONFIG:-$DEFAULT_KUBECONFIG}
+  # Template to safely extract the server for the current-context cluster.
+  # The long chain of 'with' commands avoids indexing nil if any of the
+  # entries ("current-context", "contexts"."current-context", "users", etc)
+  # is missing.
+  # Note: we save dot ('.') to $root because the 'with' action overrides it.
+  # See http://golang.org/pkg/text/template/.
+  local server_tpl='{{$dot := .}}{{with $ctx := index $dot "current-context"}}{{range $element := (index $dot "contexts")}}{{ if eq .name $ctx }}{{ with $cluster := .context.cluster }}{{range $element := (index $dot "clusters")}}{{ if eq .name $cluster }}{{ index . "cluster" "server" }}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}'
+  KUBE_MASTER_URL=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o template --template="${server_tpl}")
+  # Handle empty/missing server
+  if [[ "${KUBE_MASTER_URL}" == '<no value>' ]]; then
+    KUBE_MASTER_URL=''
+  fi
+}
+
 # Sets KUBE_VERSION variable to the version passed in as an argument, or if argument is
 # latest_stable, latest_release, or latest_ci fetches and sets the corresponding version number
 #

--- a/hack/conformance-test.sh
+++ b/hack/conformance-test.sh
@@ -23,8 +23,6 @@
 #    cluster to be tested, and with suitable auth setting.
 #  - Specify the location of that kubeconfig with, e.g.:
 #    declare -x KUBECONFIG="$HOME/.kube/config"
-#  - Specify the location of the master with, e.g.:
-#    declare -x KUBE_MASTER_IP="1.2.3.4"
 #  - Make sure only essential pods are running and there are no failed/pending pods.
 #  - Go to a git tree that contains the kubernetes source.
 #    - git clone git://github.com/kubernetes/kubernetes.git
@@ -65,8 +63,7 @@
 
 
 : ${KUBECONFIG:?"Must set KUBECONFIG before running conformance test."}
-: ${KUBE_MASTER_IP:?"Must set KUBE_MASTER_IP before running conformance test."}
-echo "Conformance test using ${KUBECONFIG} against master at ${KUBE_MASTER_IP}"
+echo "Conformance test using current-context of ${KUBECONFIG}"
 echo -n "Conformance test run date:"
 date
 echo -n "Conformance test SHA:"

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -45,6 +45,9 @@ source "${KUBE_ROOT}/cluster/kube-env.sh"
 if [[ -n "${KUBERNETES_CONFORMANCE_TEST:-}" ]]; then
     echo "Conformance test: not doing test setup."
     KUBERNETES_PROVIDER=""
+
+    detect-master-from-kubeconfig
+
     auth_config=(
       "--kubeconfig=${KUBECONFIG}"
     )
@@ -56,6 +59,7 @@ else
     prepare-e2e
 
     detect-master >/dev/null
+    KUBE_MASTER_URL="${KUBE_MASTER_URL:-https://${KUBE_MASTER_IP:-}}"
 
     auth_config=(
       "--kubeconfig=${KUBECONFIG:-$DEFAULT_KUBECONFIG}"
@@ -89,7 +93,7 @@ fi
 export PATH=$(dirname "${e2e_test}"):"${PATH}"
 "${ginkgo}" "${ginkgo_args[@]:+${ginkgo_args[@]}}" "${e2e_test}" -- \
   "${auth_config[@]:+${auth_config[@]}}" \
-  --host="https://${KUBE_MASTER_IP:-}" \
+  --host="${KUBE_MASTER_URL}" \
   --provider="${KUBERNETES_PROVIDER}" \
   --gce-project="${PROJECT:-}" \
   --gce-zone="${ZONE:-}" \


### PR DESCRIPTION
Add detect-master-from-kubeconfig bash function.
Use it to no longer require conformance test user
to specify KUBE_MASTER_IP.
