### PR TITLE
Add proxy support in deployment script

### DIFF
--- a/cluster/ubuntu/config-default.sh
+++ b/cluster/ubuntu/config-default.sh
@@ -66,3 +66,7 @@ ENABLE_CLUSTER_UI="${KUBE_ENABLE_CLUSTER_UI:-true}"
 
 # Optional: Enable setting flags for kube-apiserver to turn on behavior in active-dev
 #RUNTIME_CONFIG=""
+
+# Optional: Enable proxy in kube-up. If you neet set proxy when download easy-rsa in kube-up.
+HTTP_PROXY=${HTTP_PROXY:-""}
+HTTPS_PROXY=${HTTPS_PROXY:-""}

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -464,7 +464,6 @@ function prepare-e2e() {
 
 # Set proxy environment variables
 function setProxy() {
-  source "kube/${KUBE_CONFIG_FILE-"config-default.sh"}"
   if grep -xn 'Defaults env_keep += "http_proxy https_proxy"' /etc/sudoers;then
     echo "proxy env is kept"
     set_env=false


### PR DESCRIPTION
1. Some users need to set the proxy to download file.
2. When deploying,  we need download easy-rsa. Otherwise, we can't make a CA to authenticate users. 
3. The sudo command can't transfer the environment variables.
4.  We provide some parameters in config-default.sh to solve this problem. Across these parameters, we can set proxy before the download, and unset proxy after download. Fix this problem.
