### PR TITLE
fix AGE error when resource has no creationTimeStamp

### DIFF
--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -361,7 +361,13 @@ func podHostString(host, ip string) string {
 }
 
 func shortHumanDuration(d time.Duration) string {
-	if seconds := int(d.Seconds()); seconds < 60 {
+	// Allow deviation no more than 2 seconds(excluded) to tolerate machine time
+	// inconsistence, it can be considered as almost now.
+	if seconds := int(d.Seconds()); seconds < -1 {
+		return fmt.Sprintf("<invalid>")
+	} else if seconds < 0 {
+		return fmt.Sprintf("0s")
+	} else if seconds < 60 {
 		return fmt.Sprintf("%ds", seconds)
 	} else if minutes := int(d.Minutes()); minutes < 60 {
 		return fmt.Sprintf("%dm", minutes)

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -376,6 +376,9 @@ func shortHumanDuration(d time.Duration) string {
 // translateTimestamp returns the elapsed time since timestamp in
 // human-readable approximation.
 func translateTimestamp(timestamp util.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
 	return shortHumanDuration(time.Now().Sub(timestamp.Time))
 }
 

--- a/pkg/kubectl/resource_printer_test.go
+++ b/pkg/kubectl/resource_printer_test.go
@@ -1104,6 +1104,8 @@ type stringTestList []struct {
 
 func TestTranslateTimestamp(t *testing.T) {
 	tl := stringTestList{
+		{"a while from now", translateTimestamp(util.Time{Time: time.Now().Add(2.1e9)}), "<invalid>"},
+		{"almost now", translateTimestamp(util.Time{Time: time.Now().Add(1.9e9)}), "0s"},
 		{"now", translateTimestamp(util.Time{Time: time.Now()}), "0s"},
 		{"unknown", translateTimestamp(util.Time{}), "<unknown>"},
 		{"30 seconds ago", translateTimestamp(util.Time{Time: time.Now().Add(-3e10)}), "30s"},

--- a/pkg/kubectl/resource_printer_test.go
+++ b/pkg/kubectl/resource_printer_test.go
@@ -1097,3 +1097,26 @@ func TestPrintPodWithLabels(t *testing.T) {
 		buf.Reset()
 	}
 }
+
+type stringTestList []struct {
+	name, got, exp string
+}
+
+func TestTranslateTimestamp(t *testing.T) {
+	tl := stringTestList{
+		{"now", translateTimestamp(util.Time{Time: time.Now()}), "0s"},
+		{"unknown", translateTimestamp(util.Time{}), "<unknown>"},
+		{"30 seconds ago", translateTimestamp(util.Time{Time: time.Now().Add(-3e10)}), "30s"},
+		{"5 minutes ago", translateTimestamp(util.Time{Time: time.Now().Add(-3e11)}), "5m"},
+		{"an hour ago", translateTimestamp(util.Time{Time: time.Now().Add(-6e12)}), "1h"},
+		{"2 days ago", translateTimestamp(util.Time{Time: time.Now().AddDate(0, 0, -2)}), "2d"},
+		{"months ago", translateTimestamp(util.Time{Time: time.Now().AddDate(0, -3, 0)}), "92d"},
+		{"10 years ago", translateTimestamp(util.Time{Time: time.Now().AddDate(-10, 0, 0)}), "10y"},
+	}
+	for _, test := range tl {
+		if test.got != test.exp {
+			t.Errorf("On %v, expected '%v', but got '%v'",
+				test.name, test.exp, test.got)
+		}
+	}
+}


### PR DESCRIPTION
Fixes: #12581

If the resource doesn't contain creationTimeStamp, report AGE as
`unknown`. This usually happens when the resouces is created locally
or is not accually created at server side.
