### PR TITLE
to add tests for RC selector overlapping and fix few comments

### DIFF
--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -202,10 +202,10 @@ func (rm *ReplicationManager) getPodController(pod *api.Pod) *api.ReplicationCon
 		return nil
 	}
 	// In theory, overlapping controllers is user error. This sorting will not prevent
-	// osciallation of replicas in all cases, eg:
-	// rc1 (older rc): [(k1:v1)], replicas=1 rc2: [(k2:v2), (k1:v1)], replicas=2
-	// pod: [(k1:v1)] will wake both rc1 and rc2, and we will sync rc1.
-	// pod: [(k2:v2), (k1:v1)] will wake rc2 which creates a new replica.
+	// oscillation of replicas in all cases, eg:
+	// rc1 (older rc): [(k1=v1)], replicas=1 rc2: [(k2=v2)], replicas=2
+	// pod: [(k1:v1), (k2:v2)] will wake both rc1 and rc2, and we will sync rc1.
+	// pod: [(k2:v2)] will wake rc2 which creates a new replica.
 	sort.Sort(overlappingControllers(controllers))
 	return &controllers[0]
 }

--- a/pkg/kubectl/stop.go
+++ b/pkg/kubectl/stop.go
@@ -117,19 +117,20 @@ func (reaper *ReplicationControllerReaper) Stop(namespace, name string, timeout 
 
 	// The rc manager will try and detect all matching rcs for a pod's labels,
 	// and only sync the oldest one. This means if we have a pod with labels
-	// [(k1, v1)] and rcs with selectors [(k1, v2)] and [(k1, v1), (k2, v2)],
+	// [(k1: v1), (k2: v2)] and two rcs: rc1 with selector [(k1=v1)], and rc2 with selector [(k1=v1),(k2=v2)],
 	// the rc manager will sync the older of the two rcs.
 	//
 	// If there are rcs with a superset of labels, eg:
-	// deleting: (k1:v1), superset: (k2:v2, k1:v1)
+	// deleting: (k1=v1), superset: (k2=v2, k1=v1)
 	//	- It isn't safe to delete the rc because there could be a pod with labels
-	//	  (k1:v1) that isn't managed by the superset rc. We can't scale it down
-	//	  either, because there could be a pod (k2:v2, k1:v1) that it deletes
+	//	  (k1=v1) that isn't managed by the superset rc. We can't scale it down
+	//	  either, because there could be a pod (k2=v2, k1=v1) that it deletes
 	//	  causing a fight with the superset rc.
 	// If there are rcs with a subset of labels, eg:
-	// deleting: (k2:v2, k1:v1), subset: (k1: v1), superset: (k2:v2, k1:v1, k3:v3)
-	//  - It's safe to delete this rc without a scale down because all it's pods
-	//	  are being controlled by the subset rc.
+	// deleting: (k2=v2, k1=v1), subset: (k1=v1), superset: (k2=v2, k1=v1, k3=v3)
+	//  - Even if it's safe to delete this rc without a scale down because all it's pods
+	//	  are being controlled by the subset rc the code returns an error.
+
 	// In theory, creating overlapping controllers is user error, so the loop below
 	// tries to account for this logic only in the common case, where we end up
 	// with multiple rcs that have an exact match on selectors.


### PR DESCRIPTION
Goal of this PR is to try to solve some issues in kubectl/stop code

These issues have been spotted during the refresh of https://github.com/kubernetes/kubernetes/pull/7053.

Code comments  [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/stop.go#L118) here [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/stop.go#L131) and [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/replication/replication_controller.go#L207) have been modified since the current ones looks incorrect

The test [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/stop_test.go#L29) is not testing the labels.Selectors (there's no labels.Selector at all in the ReplicationController) and few tests have been added

@smarterclayton @bgrant0607 @lavalamp @pmorie 
Thanks to have a look and let me know

@EricMountain-1A as discussed
