### PR TITLE
remove duplicated cluster verify logic in ubuntu deployments scripts.

### DIFF
--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -155,6 +155,8 @@ function verify-master(){
   printf "Validating master"
   local -a required_daemon=("kube-apiserver" "kube-controller-manager" "kube-scheduler")
   local validated="1"
+  local try_count=1
+  local max_try_count=30
   until [[ "$validated" == "0" ]]; do
     validated="0"
     local daemon
@@ -162,6 +164,11 @@ function verify-master(){
       ssh $SSH_OPTS "$MASTER" "pgrep -f ${daemon}" >/dev/null 2>&1 || {
         printf "."
         validated="1"
+        ((try_count=try_count+1))
+        if [[ ${try_count} -gt ${max_try_count} ]]; then
+          printf "\nWarning: Process \"${daemon}\" status check timeout, please check manually.\n"
+          exit 1
+        fi
         sleep 2
       }
     done
@@ -175,6 +182,8 @@ function verify-minion(){
   printf "Validating ${1}"
   local -a required_daemon=("kube-proxy" "kubelet" "docker")
   local validated="1"
+  local try_count=1
+  local max_try_count=30
   until [[ "$validated" == "0" ]]; do
     validated="0"
     local daemon
@@ -182,6 +191,11 @@ function verify-minion(){
       ssh $SSH_OPTS "$1" "pgrep -f $daemon" >/dev/null 2>&1 || {
         printf "."
         validated="1"
+        ((try_count=try_count+1))
+        if [[ ${try_count} -gt ${max_try_count} ]]; then
+          printf "\nWarning: Process \"${daemon}\" status check timeout, please check manually.\n"
+          exit 1
+        fi
         sleep 2
       }
     done

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -166,7 +166,7 @@ function verify-master(){
         validated="1"
         ((try_count=try_count+1))
         if [[ ${try_count} -gt ${max_try_count} ]]; then
-          printf "\nWarning: Process \"${daemon}\" status check timeout, please check manually.\n"
+          printf "\nWarning: Process \"${daemon}\" failed to run on ${MASTER}, please check.\n"
           exit 1
         fi
         sleep 2
@@ -193,7 +193,7 @@ function verify-minion(){
         validated="1"
         ((try_count=try_count+1))
         if [[ ${try_count} -gt ${max_try_count} ]]; then
-          printf "\nWarning: Process \"${daemon}\" status check timeout, please check manually.\n"
+          printf "\nWarning: Process \"${daemon}\" failed to run on ${1}, please check.\n"
           exit 1
         fi
         sleep 2


### PR DESCRIPTION
When deploying with Ubuntu scripts, if processes not started correctly on master or minion, the scripts will keep waiting and checking, instead of exit with any error message. With this commit, the scripts will exit with a message like `Warning: Process "docker" status check timeout, please check manually` after 60s waiting and checking.  

---

Update in 2015-9-7
In ubuntu deployment scripts, there are two ways to verfiy the cluster:
    1. `cluster/validate-cluster.sh` called after `kube-up()` in `cluster/kube-up.sh`, is the standard way.
    2. `verify_master()` and `verify_minion()` in `ubuntu/util.sh` which are ssh into node and check if processes are running, are not accurate.

As a result of discussion, this PR is to remove the duplicated cluster verify logic(in `ubuntu/util.sh`) and keep the standard way(calling `cluster/validate-cluster.sh`).
