### PR TITLE
Remove external function setting Kubelet flags

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -210,7 +210,6 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.MarkDeprecated("service-node-ports", "see --service-node-port-range instead.")
 	fs.StringVar(&s.MasterServiceNamespace, "master-service-namespace", s.MasterServiceNamespace, "The namespace from which the kubernetes master services should be injected into pods")
 	fs.Var(&s.RuntimeConfig, "runtime-config", "A set of key=value pairs that describe runtime configuration that may be passed to the apiserver. api/<version> key can be used to turn on/off specific api versions. api/all and api/legacy are special keys to control all and legacy api versions respectively.")
-	client.BindKubeletClientConfigFlags(fs, &s.KubeletConfig)
 	fs.StringVar(&s.ClusterName, "cluster-name", s.ClusterName, "The instance prefix for the cluster")
 	fs.BoolVar(&s.EnableProfiling, "profiling", true, "Enable profiling via web interface host:port/debug/pprof/")
 	fs.StringVar(&s.ExternalHost, "external-hostname", "", "The hostname to use when generating externalized URLs for this master (e.g. Swagger API Docs.)")
@@ -220,6 +219,13 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.SSHUser, "ssh-user", "", "If non-empty, use secure SSH proxy to the nodes, using this user name")
 	fs.StringVar(&s.SSHKeyfile, "ssh-keyfile", "", "If non-empty, use secure SSH proxy to the nodes, using this user keyfile")
 	fs.Int64Var(&s.MaxConnectionBytesPerSec, "max-connection-bytes-per-sec", 0, "If non-zero, throttle each user connection to this number of bytes/sec.  Currently only applies to long-running requests")
+	// Kubelet related flags:
+	fs.BoolVar(&s.KubeletConfig.EnableHttps, "kubelet-https", s.KubeletConfig.EnableHttps, "Use https for kubelet connections")
+	fs.UintVar(&s.KubeletConfig.Port, "kubelet-port", s.KubeletConfig.Port, "Kubelet port")
+	fs.DurationVar(&s.KubeletConfig.HTTPTimeout, "kubelet-timeout", s.KubeletConfig.HTTPTimeout, "Timeout for kubelet operations")
+	fs.StringVar(&s.KubeletConfig.CertFile, "kubelet-client-certificate", s.KubeletConfig.CertFile, "Path to a client key file for TLS.")
+	fs.StringVar(&s.KubeletConfig.KeyFile, "kubelet-client-key", s.KubeletConfig.KeyFile, "Path to a client key file for TLS.")
+	fs.StringVar(&s.KubeletConfig.CAFile, "kubelet-certificate-authority", s.KubeletConfig.CAFile, "Path to a cert. file for the certificate authority.")
 }
 
 // TODO: Longer term we should read this from some config store, rather than a flag.

--- a/pkg/client/unversioned/flags.go
+++ b/pkg/client/unversioned/flags.go
@@ -29,12 +29,3 @@ type FlagSet interface {
 	DurationVar(p *time.Duration, name string, value time.Duration, usage string)
 	IntVar(p *int, name string, value int, usage string)
 }
-
-func BindKubeletClientConfigFlags(flags FlagSet, config *KubeletConfig) {
-	flags.BoolVar(&config.EnableHttps, "kubelet-https", config.EnableHttps, "Use https for kubelet connections")
-	flags.UintVar(&config.Port, "kubelet-port", config.Port, "Kubelet port")
-	flags.DurationVar(&config.HTTPTimeout, "kubelet-timeout", config.HTTPTimeout, "Timeout for kubelet operations")
-	flags.StringVar(&config.CertFile, "kubelet-client-certificate", config.CertFile, "Path to a client key file for TLS.")
-	flags.StringVar(&config.KeyFile, "kubelet-client-key", config.KeyFile, "Path to a client key file for TLS.")
-	flags.StringVar(&config.CAFile, "kubelet-certificate-authority", config.CAFile, "Path to a cert. file for the certificate authority.")
-}

--- a/pkg/client/unversioned/flags_test.go
+++ b/pkg/client/unversioned/flags_test.go
@@ -77,12 +77,3 @@ func (f *fakeFlagSet) IntVar(p *int, name string, value int, usage string) {
 	}
 	f.set.Insert(name)
 }
-
-func TestBindKubeletClientConfigFlags(t *testing.T) {
-	flags := &fakeFlagSet{t, util.StringSet{}}
-	config := &KubeletConfig{}
-	BindKubeletClientConfigFlags(flags, config)
-	if len(flags.set) != 6 {
-		t.Errorf("unexpected flag set: %#v", flags)
-	}
-}


### PR DESCRIPTION
I find this function unnecessary. It made me look into different file to see how flags are named, plus it's used only in this one place.

@davidopp 
