### PR TITLE
Add information about ports opened by Kubelet to API

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -11770,9 +11770,13 @@
       },
       "description": "List of addresses reachable to the node. Queried from cloud provider, if available. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses"
      },
+     "daemonEndpoints": {
+      "$ref": "v1.NodeDaemonEndpoints",
+      "description": "Endpoints of daemons running on the Node."
+     },
      "nodeInfo": {
       "$ref": "v1.NodeSystemInfo",
-      "description": "NodeSystemInfo is a set of ids/uuids to uniquely identify the node. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-info"
+      "description": "Set of ids/uuids to uniquely identify the node. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-info"
      }
     }
    },
@@ -11828,6 +11832,30 @@
      }
     }
    },
+   "v1.NodeDaemonEndpoints": {
+    "id": "v1.NodeDaemonEndpoints",
+    "description": "NodeDaemonEndpoints lists ports opened by daemons running on the Node.",
+    "properties": {
+     "kubeletEndpoint": {
+      "$ref": "v1.DaemonEndpoint",
+      "description": "Endpoint on which Kubelet is listening."
+     }
+    }
+   },
+   "v1.DaemonEndpoint": {
+    "id": "v1.DaemonEndpoint",
+    "description": "DaemonEndpoint contains information about a single Daemon endpoint.",
+    "required": [
+     "Port"
+    ],
+    "properties": {
+     "Port": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Port number of the given endpoint."
+     }
+    }
+   },
    "v1.NodeSystemInfo": {
     "id": "v1.NodeSystemInfo",
     "description": "NodeSystemInfo is a set of ids/uuids to uniquely identify the node.",
@@ -11844,35 +11872,35 @@
     "properties": {
      "machineID": {
       "type": "string",
-      "description": "MachineID is the machine-id reported by the node."
+      "description": "Machine ID reported by the node."
      },
      "systemUUID": {
       "type": "string",
-      "description": "SystemUUID is the system-uuid reported by the node."
+      "description": "System UUID reported by the node."
      },
      "bootID": {
       "type": "string",
-      "description": "BootID is the boot-id reported by the node."
+      "description": "Boot ID reported by the node."
      },
      "kernelVersion": {
       "type": "string",
-      "description": "Kernel version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64)"
+      "description": "Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64)."
      },
      "osImage": {
       "type": "string",
-      "description": "OS image used reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy))"
+      "description": "OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy))."
      },
      "containerRuntimeVersion": {
       "type": "string",
-      "description": "Container runtime version reported by the node through runtime remote API (e.g. docker://1.5.0)"
+      "description": "ContainerRuntime Version reported by the node through runtime remote API (e.g. docker://1.5.0)."
      },
      "kubeletVersion": {
       "type": "string",
-      "description": "Kubelet version reported by the node."
+      "description": "Kubelet Version reported by the node."
      },
      "kubeProxyVersion": {
       "type": "string",
-      "description": "Kube-proxy version reported by the node."
+      "description": "KubeProxy Version reported by the node."
      }
     }
    },

--- a/contrib/mesos/pkg/executor/service/service.go
+++ b/contrib/mesos/pkg/executor/service/service.go
@@ -132,7 +132,7 @@ func (s *KubeletExecutorServer) Run(hks hyperkube.Interface, _ []string) error {
 		return err
 	}
 
-	cadvisorInterface, err := cadvisor.New(s.CadvisorPort)
+	cAdvisorInterface, err := cadvisor.New(s.CAdvisorPort)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func (s *KubeletExecutorServer) Run(hks hyperkube.Interface, _ []string) error {
 		Runonce:                        s.RunOnce,
 		Port:                           s.Port,
 		ReadOnlyPort:                   s.ReadOnlyPort,
-		CadvisorInterface:              cadvisorInterface,
+		CAdvisorInterface:              cAdvisorInterface,
 		EnableServer:                   s.EnableServer,
 		EnableDebuggingHandlers:        s.EnableDebuggingHandlers,
 		DockerClient:                   dockertools.ConnectToDockerOrDie(s.DockerEndpoint),
@@ -315,7 +315,7 @@ func (ks *KubeletExecutorServer) createAndInitKubelet(
 		kc.NetworkPluginName,
 		kc.StreamingConnectionIdleTimeout,
 		kc.Recorder,
-		kc.CadvisorInterface,
+		kc.CAdvisorInterface,
 		kc.ImageGCPolicy,
 		kc.DiskSpacePolicy,
 		kc.Cloud,
@@ -335,6 +335,9 @@ func (ks *KubeletExecutorServer) createAndInitKubelet(
 		kc.DockerExecHandler,
 		kc.ResolverConfig,
 		kc.CPUCFSQuota,
+		&api.NodeDaemonEndpoints{
+			KubeletEndpoint: api.DaemonEndpoint{Port: int(kc.Port)},
+		},
 	)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -322,6 +322,11 @@ func deepCopy_api_ContainerStatus(in ContainerStatus, out *ContainerStatus, c *c
 	return nil
 }
 
+func deepCopy_api_DaemonEndpoint(in DaemonEndpoint, out *DaemonEndpoint, c *conversion.Cloner) error {
+	out.Port = in.Port
+	return nil
+}
+
 func deepCopy_api_DeleteOptions(in DeleteOptions, out *DeleteOptions, c *conversion.Cloner) error {
 	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -914,6 +919,13 @@ func deepCopy_api_NodeCondition(in NodeCondition, out *NodeCondition, c *convers
 	return nil
 }
 
+func deepCopy_api_NodeDaemonEndpoints(in NodeDaemonEndpoints, out *NodeDaemonEndpoints, c *conversion.Cloner) error {
+	if err := deepCopy_api_DaemonEndpoint(in.KubeletEndpoint, &out.KubeletEndpoint, c); err != nil {
+		return err
+	}
+	return nil
+}
+
 func deepCopy_api_NodeList(in NodeList, out *NodeList, c *conversion.Cloner) error {
 	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -975,6 +987,9 @@ func deepCopy_api_NodeStatus(in NodeStatus, out *NodeStatus, c *conversion.Clone
 		}
 	} else {
 		out.Addresses = nil
+	}
+	if err := deepCopy_api_NodeDaemonEndpoints(in.DaemonEndpoints, &out.DaemonEndpoints, c); err != nil {
+		return err
 	}
 	if err := deepCopy_api_NodeSystemInfo(in.NodeInfo, &out.NodeInfo, c); err != nil {
 		return err
@@ -2238,6 +2253,7 @@ func init() {
 		deepCopy_api_ContainerStateTerminated,
 		deepCopy_api_ContainerStateWaiting,
 		deepCopy_api_ContainerStatus,
+		deepCopy_api_DaemonEndpoint,
 		deepCopy_api_DeleteOptions,
 		deepCopy_api_DownwardAPIVolumeFile,
 		deepCopy_api_DownwardAPIVolumeSource,
@@ -2279,6 +2295,7 @@ func init() {
 		deepCopy_api_Node,
 		deepCopy_api_NodeAddress,
 		deepCopy_api_NodeCondition,
+		deepCopy_api_NodeDaemonEndpoints,
 		deepCopy_api_NodeList,
 		deepCopy_api_NodeSpec,
 		deepCopy_api_NodeStatus,

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1366,23 +1366,35 @@ type NodeSpec struct {
 	Unschedulable bool `json:"unschedulable,omitempty"`
 }
 
+// DaemonEndpoint contains information about a single Daemon endpoint.
+type DaemonEndpoint struct {
+	// Port number of the given endpoint.
+	Port int `json:port`
+}
+
+// NodeDaemonEndpoints lists ports opened by daemons running on the Node.
+type NodeDaemonEndpoints struct {
+	// Endpoint on which Kubelet is listening.
+	KubeletEndpoint DaemonEndpoint `json:"kubeletEndpoint,omitempty"`
+}
+
 // NodeSystemInfo is a set of ids/uuids to uniquely identify the node.
 type NodeSystemInfo struct {
-	// MachineID is the machine-id reported by the node
+	// Machine ID reported by the node.
 	MachineID string `json:"machineID"`
-	// SystemUUID is the system-uuid reported by the node
+	// System UUID reported by the node.
 	SystemUUID string `json:"systemUUID"`
-	// BootID is the boot-id reported by the node
+	// Boot ID reported by the node.
 	BootID string `json:"bootID"`
-	// Kernel version reported by the node
+	// Kernel Version reported by the node.
 	KernelVersion string `json:"kernelVersion"`
-	// OS image used reported by the node
+	// OS Image reported by the node.
 	OsImage string `json:"osImage"`
-	// Container runtime version reported by the node
+	// ContainerRuntime Version reported by the node.
 	ContainerRuntimeVersion string `json:"containerRuntimeVersion"`
-	// Kubelet version reported by the node
+	// Kubelet Version reported by the node.
 	KubeletVersion string `json:"kubeletVersion"`
-	// Kube-proxy version reported by the node
+	// KubeProxy Version reported by the node.
 	KubeProxyVersion string `json:"kubeProxyVersion"`
 }
 
@@ -1396,7 +1408,9 @@ type NodeStatus struct {
 	Conditions []NodeCondition `json:"conditions,omitempty"`
 	// Queried from cloud provider, if available.
 	Addresses []NodeAddress `json:"addresses,omitempty"`
-	// NodeSystemInfo is a set of ids/uuids to uniquely identify the node
+	// Endpoints of daemons running on the Node.
+	DaemonEndpoints NodeDaemonEndpoints `json:"daemonEndpoints,omitempty"`
+	// Set of ids/uuids to uniquely identify the node.
 	NodeInfo NodeSystemInfo `json:"nodeInfo,omitempty"`
 }
 

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -363,6 +363,14 @@ func convert_api_ContainerStatus_To_v1_ContainerStatus(in *api.ContainerStatus, 
 	return nil
 }
 
+func convert_api_DaemonEndpoint_To_v1_DaemonEndpoint(in *api.DaemonEndpoint, out *DaemonEndpoint, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.DaemonEndpoint))(in)
+	}
+	out.Port = in.Port
+	return nil
+}
+
 func convert_api_DeleteOptions_To_v1_DeleteOptions(in *api.DeleteOptions, out *DeleteOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.DeleteOptions))(in)
@@ -1059,6 +1067,16 @@ func convert_api_NodeCondition_To_v1_NodeCondition(in *api.NodeCondition, out *N
 	return nil
 }
 
+func convert_api_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints(in *api.NodeDaemonEndpoints, out *NodeDaemonEndpoints, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.NodeDaemonEndpoints))(in)
+	}
+	if err := convert_api_DaemonEndpoint_To_v1_DaemonEndpoint(&in.KubeletEndpoint, &out.KubeletEndpoint, s); err != nil {
+		return err
+	}
+	return nil
+}
+
 func convert_api_NodeList_To_v1_NodeList(in *api.NodeList, out *NodeList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NodeList))(in)
@@ -1129,6 +1147,9 @@ func convert_api_NodeStatus_To_v1_NodeStatus(in *api.NodeStatus, out *NodeStatus
 		}
 	} else {
 		out.Addresses = nil
+	}
+	if err := convert_api_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints(&in.DaemonEndpoints, &out.DaemonEndpoints, s); err != nil {
+		return err
 	}
 	if err := convert_api_NodeSystemInfo_To_v1_NodeSystemInfo(&in.NodeInfo, &out.NodeInfo, s); err != nil {
 		return err
@@ -2767,6 +2788,14 @@ func convert_v1_ContainerStatus_To_api_ContainerStatus(in *ContainerStatus, out 
 	return nil
 }
 
+func convert_v1_DaemonEndpoint_To_api_DaemonEndpoint(in *DaemonEndpoint, out *api.DaemonEndpoint, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*DaemonEndpoint))(in)
+	}
+	out.Port = in.Port
+	return nil
+}
+
 func convert_v1_DeleteOptions_To_api_DeleteOptions(in *DeleteOptions, out *api.DeleteOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DeleteOptions))(in)
@@ -3463,6 +3492,16 @@ func convert_v1_NodeCondition_To_api_NodeCondition(in *NodeCondition, out *api.N
 	return nil
 }
 
+func convert_v1_NodeDaemonEndpoints_To_api_NodeDaemonEndpoints(in *NodeDaemonEndpoints, out *api.NodeDaemonEndpoints, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*NodeDaemonEndpoints))(in)
+	}
+	if err := convert_v1_DaemonEndpoint_To_api_DaemonEndpoint(&in.KubeletEndpoint, &out.KubeletEndpoint, s); err != nil {
+		return err
+	}
+	return nil
+}
+
 func convert_v1_NodeList_To_api_NodeList(in *NodeList, out *api.NodeList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NodeList))(in)
@@ -3533,6 +3572,9 @@ func convert_v1_NodeStatus_To_api_NodeStatus(in *NodeStatus, out *api.NodeStatus
 		}
 	} else {
 		out.Addresses = nil
+	}
+	if err := convert_v1_NodeDaemonEndpoints_To_api_NodeDaemonEndpoints(&in.DaemonEndpoints, &out.DaemonEndpoints, s); err != nil {
+		return err
 	}
 	if err := convert_v1_NodeSystemInfo_To_api_NodeSystemInfo(&in.NodeInfo, &out.NodeInfo, s); err != nil {
 		return err
@@ -4851,6 +4893,7 @@ func init() {
 		convert_api_ContainerState_To_v1_ContainerState,
 		convert_api_ContainerStatus_To_v1_ContainerStatus,
 		convert_api_Container_To_v1_Container,
+		convert_api_DaemonEndpoint_To_v1_DaemonEndpoint,
 		convert_api_DeleteOptions_To_v1_DeleteOptions,
 		convert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile,
 		convert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource,
@@ -4891,6 +4934,7 @@ func init() {
 		convert_api_Namespace_To_v1_Namespace,
 		convert_api_NodeAddress_To_v1_NodeAddress,
 		convert_api_NodeCondition_To_v1_NodeCondition,
+		convert_api_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints,
 		convert_api_NodeList_To_v1_NodeList,
 		convert_api_NodeSpec_To_v1_NodeSpec,
 		convert_api_NodeStatus_To_v1_NodeStatus,
@@ -4968,6 +5012,7 @@ func init() {
 		convert_v1_ContainerState_To_api_ContainerState,
 		convert_v1_ContainerStatus_To_api_ContainerStatus,
 		convert_v1_Container_To_api_Container,
+		convert_v1_DaemonEndpoint_To_api_DaemonEndpoint,
 		convert_v1_DeleteOptions_To_api_DeleteOptions,
 		convert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile,
 		convert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource,
@@ -5008,6 +5053,7 @@ func init() {
 		convert_v1_Namespace_To_api_Namespace,
 		convert_v1_NodeAddress_To_api_NodeAddress,
 		convert_v1_NodeCondition_To_api_NodeCondition,
+		convert_v1_NodeDaemonEndpoints_To_api_NodeDaemonEndpoints,
 		convert_v1_NodeList_To_api_NodeList,
 		convert_v1_NodeSpec_To_api_NodeSpec,
 		convert_v1_NodeStatus_To_api_NodeStatus,

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -337,6 +337,11 @@ func deepCopy_v1_ContainerStatus(in ContainerStatus, out *ContainerStatus, c *co
 	return nil
 }
 
+func deepCopy_v1_DaemonEndpoint(in DaemonEndpoint, out *DaemonEndpoint, c *conversion.Cloner) error {
+	out.Port = in.Port
+	return nil
+}
+
 func deepCopy_v1_DeleteOptions(in DeleteOptions, out *DeleteOptions, c *conversion.Cloner) error {
 	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -913,6 +918,13 @@ func deepCopy_v1_NodeCondition(in NodeCondition, out *NodeCondition, c *conversi
 	return nil
 }
 
+func deepCopy_v1_NodeDaemonEndpoints(in NodeDaemonEndpoints, out *NodeDaemonEndpoints, c *conversion.Cloner) error {
+	if err := deepCopy_v1_DaemonEndpoint(in.KubeletEndpoint, &out.KubeletEndpoint, c); err != nil {
+		return err
+	}
+	return nil
+}
+
 func deepCopy_v1_NodeList(in NodeList, out *NodeList, c *conversion.Cloner) error {
 	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -974,6 +986,9 @@ func deepCopy_v1_NodeStatus(in NodeStatus, out *NodeStatus, c *conversion.Cloner
 		}
 	} else {
 		out.Addresses = nil
+	}
+	if err := deepCopy_v1_NodeDaemonEndpoints(in.DaemonEndpoints, &out.DaemonEndpoints, c); err != nil {
+		return err
 	}
 	if err := deepCopy_v1_NodeSystemInfo(in.NodeInfo, &out.NodeInfo, c); err != nil {
 		return err
@@ -2240,6 +2255,7 @@ func init() {
 		deepCopy_v1_ContainerStateTerminated,
 		deepCopy_v1_ContainerStateWaiting,
 		deepCopy_v1_ContainerStatus,
+		deepCopy_v1_DaemonEndpoint,
 		deepCopy_v1_DeleteOptions,
 		deepCopy_v1_DownwardAPIVolumeFile,
 		deepCopy_v1_DownwardAPIVolumeSource,
@@ -2281,6 +2297,7 @@ func init() {
 		deepCopy_v1_Node,
 		deepCopy_v1_NodeAddress,
 		deepCopy_v1_NodeCondition,
+		deepCopy_v1_NodeDaemonEndpoints,
 		deepCopy_v1_NodeList,
 		deepCopy_v1_NodeSpec,
 		deepCopy_v1_NodeStatus,

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1715,23 +1715,35 @@ type NodeSpec struct {
 	Unschedulable bool `json:"unschedulable,omitempty"`
 }
 
+// DaemonEndpoint contains information about a single Daemon endpoint.
+type DaemonEndpoint struct {
+	// Port number of the given endpoint.
+	Port int `json:port`
+}
+
+// NodeDaemonEndpoints lists ports opened by daemons running on the Node.
+type NodeDaemonEndpoints struct {
+	// Endpoint on which Kubelet is listening.
+	KubeletEndpoint DaemonEndpoint `json:"kubeletEndpoint,omitempty"`
+}
+
 // NodeSystemInfo is a set of ids/uuids to uniquely identify the node.
 type NodeSystemInfo struct {
-	// MachineID is the machine-id reported by the node.
+	// Machine ID reported by the node.
 	MachineID string `json:"machineID"`
-	// SystemUUID is the system-uuid reported by the node.
+	// System UUID reported by the node.
 	SystemUUID string `json:"systemUUID"`
-	// BootID is the boot-id reported by the node.
+	// Boot ID reported by the node.
 	BootID string `json:"bootID"`
-	// Kernel version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64)
+	// Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).
 	KernelVersion string `json:"kernelVersion"`
-	// OS image used reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy))
+	// OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).
 	OsImage string `json:"osImage"`
-	// Container runtime version reported by the node through runtime remote API (e.g. docker://1.5.0)
+	// ContainerRuntime Version reported by the node through runtime remote API (e.g. docker://1.5.0).
 	ContainerRuntimeVersion string `json:"containerRuntimeVersion"`
-	// Kubelet version reported by the node.
+	// Kubelet Version reported by the node.
 	KubeletVersion string `json:"kubeletVersion"`
-	// Kube-proxy version reported by the node.
+	// KubeProxy Version reported by the node.
 	KubeProxyVersion string `json:"kubeProxyVersion"`
 }
 
@@ -1750,7 +1762,9 @@ type NodeStatus struct {
 	// Queried from cloud provider, if available.
 	// More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses
 	Addresses []NodeAddress `json:"addresses,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
-	// NodeSystemInfo is a set of ids/uuids to uniquely identify the node.
+	// Endpoints of daemons running on the Node.
+	DaemonEndpoints NodeDaemonEndpoints `json:"daemonEndpoints,omitempty"`
+	// Set of ids/uuids to uniquely identify the node.
 	// More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-info
 	NodeInfo NodeSystemInfo `json:"nodeInfo,omitempty"`
 }

--- a/pkg/api/v1/types_swagger_doc_generated.go
+++ b/pkg/api/v1/types_swagger_doc_generated.go
@@ -224,6 +224,15 @@ func (ContainerStatus) SwaggerDoc() map[string]string {
 	return map_ContainerStatus
 }
 
+var map_DaemonEndpoint = map[string]string{
+	"":     "DaemonEndpoint contains information about a single Daemon endpoint.",
+	"Port": "Port number of the given endpoint.",
+}
+
+func (DaemonEndpoint) SwaggerDoc() map[string]string {
+	return map_DaemonEndpoint
+}
+
 var map_DeleteOptions = map[string]string{
 	"":                   "DeleteOptions may be provided when deleting an API object",
 	"gracePeriodSeconds": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
@@ -653,6 +662,15 @@ func (NodeCondition) SwaggerDoc() map[string]string {
 	return map_NodeCondition
 }
 
+var map_NodeDaemonEndpoints = map[string]string{
+	"":                "NodeDaemonEndpoints lists ports opened by daemons running on the Node.",
+	"kubeletEndpoint": "Endpoint on which Kubelet is listening.",
+}
+
+func (NodeDaemonEndpoints) SwaggerDoc() map[string]string {
+	return map_NodeDaemonEndpoints
+}
+
 var map_NodeList = map[string]string{
 	"":         "NodeList is the whole list of all Nodes which have been registered with master.",
 	"metadata": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
@@ -676,12 +694,13 @@ func (NodeSpec) SwaggerDoc() map[string]string {
 }
 
 var map_NodeStatus = map[string]string{
-	"":           "NodeStatus is information about the current status of a node.",
-	"capacity":   "Capacity represents the available resources of a node. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#capacity for more details.",
-	"phase":      "NodePhase is the recently observed lifecycle phase of the node. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-phase",
-	"conditions": "Conditions is an array of current observed node conditions. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-condition",
-	"addresses":  "List of addresses reachable to the node. Queried from cloud provider, if available. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses",
-	"nodeInfo":   "NodeSystemInfo is a set of ids/uuids to uniquely identify the node. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-info",
+	"":                "NodeStatus is information about the current status of a node.",
+	"capacity":        "Capacity represents the available resources of a node. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#capacity for more details.",
+	"phase":           "NodePhase is the recently observed lifecycle phase of the node. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-phase",
+	"conditions":      "Conditions is an array of current observed node conditions. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-condition",
+	"addresses":       "List of addresses reachable to the node. Queried from cloud provider, if available. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses",
+	"daemonEndpoints": "Endpoints of daemons running on the Node.",
+	"nodeInfo":        "Set of ids/uuids to uniquely identify the node. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-info",
 }
 
 func (NodeStatus) SwaggerDoc() map[string]string {
@@ -690,14 +709,14 @@ func (NodeStatus) SwaggerDoc() map[string]string {
 
 var map_NodeSystemInfo = map[string]string{
 	"":                        "NodeSystemInfo is a set of ids/uuids to uniquely identify the node.",
-	"machineID":               "MachineID is the machine-id reported by the node.",
-	"systemUUID":              "SystemUUID is the system-uuid reported by the node.",
-	"bootID":                  "BootID is the boot-id reported by the node.",
-	"kernelVersion":           "Kernel version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64)",
-	"osImage":                 "OS image used reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy))",
-	"containerRuntimeVersion": "Container runtime version reported by the node through runtime remote API (e.g. docker://1.5.0)",
-	"kubeletVersion":          "Kubelet version reported by the node.",
-	"kubeProxyVersion":        "Kube-proxy version reported by the node.",
+	"machineID":               "Machine ID reported by the node.",
+	"systemUUID":              "System UUID reported by the node.",
+	"bootID":                  "Boot ID reported by the node.",
+	"kernelVersion":           "Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).",
+	"osImage":                 "OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).",
+	"containerRuntimeVersion": "ContainerRuntime Version reported by the node through runtime remote API (e.g. docker://1.5.0).",
+	"kubeletVersion":          "Kubelet Version reported by the node.",
+	"kubeProxyVersion":        "KubeProxy Version reported by the node.",
 }
 
 func (NodeSystemInfo) SwaggerDoc() map[string]string {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -109,6 +109,7 @@ func newTestKubelet(t *testing.T) *TestKubelet {
 	if err := kubelet.setupDataDirs(); err != nil {
 		t.Fatalf("can't initialize kubelet data dirs: %v", err)
 	}
+	kubelet.daemonEndpoints = &api.NodeDaemonEndpoints{}
 	mockCadvisor := &cadvisor.Mock{}
 	kubelet.cadvisor = mockCadvisor
 	podManager, fakeMirrorClient := newFakePodManager()


### PR DESCRIPTION
Related to #12634. Currently we require user to pass the same port in multiple configurations, other ports are hardcoded. This makes changing them hard. This PR is the first one in the process of making network configuration more flexible. I stopped on modifying API predicting some discussion about it;)

cc @fgrzadkowski @wojtek-t @bgrant0607 @davidopp @timothysc @smarterclayton 
