### PR TITLE
Fix typo in image directory (graphic missing from Media page)

### DIFF
--- a/_data/videos.yml
+++ b/_data/videos.yml
@@ -51,4 +51,4 @@
     description: "Find all the latest videos on"
     location: "YouTube"
     url: "https://www.youtube.com/channel/UCZ2bu0qutTOM0tHYa_jkIwg"
-    img: "/img/desktop/Media/KubernetesYouTube.png"
+    img: "/img/desktop/media/KubernetesYouTube.png"


### PR DESCRIPTION
Fix for missing graphic out on k8s.io - for some reason in the local build, this does not cause issues but out on the site, the graphic is not found.
