### PR TITLE
tolerate output without template file

### DIFF
--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -82,7 +82,10 @@ func OutputVersion(cmd *cobra.Command, defaultVersion string) string {
 // Requires that printer flags have been added to cmd (see AddPrinterFlags).
 func PrinterForCommand(cmd *cobra.Command) (kubectl.ResourcePrinter, bool, error) {
 	outputFormat := GetFlagString(cmd, "output")
-	templateFile := GetFlagString(cmd, "template")
+
+	// templates are logically optional for specifying a format.
+	// TODO once https://github.com/kubernetes/kubernetes/issues/12668 is fixed, this should fall back to GetFlagString
+	templateFile, _ := cmd.Flags().GetString("template")
 	if len(outputFormat) == 0 && len(templateFile) != 0 {
 		outputFormat = "template"
 	}


### PR DESCRIPTION
It is reasonable (though not recommended) to want support different output types without supporting a template in particular.  For instance, you want to support versioned json and yaml, but not templating.  This allows for such usage.
