### PR TITLE
Much smaller hyperkube image creation

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -1,7 +1,14 @@
 FROM debian:jessie
 
-RUN apt-get update
-RUN apt-get -yy -q install iptables ca-certificates file util-linux
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get -yy -q \
+    install \
+    iptables \
+    ca-certificates \
+    file \
+    util-linux \
+    && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN cp /usr/bin/nsenter /nsenter
 


### PR DESCRIPTION
Improve the Dockerfile that creates the Hyperkube image. 
This will drop the image size from ~200+MB    to ~59MB
