### PR TITLE
don't swallow bad request errors

### DIFF
--- a/pkg/kubectl/resource/selector.go
+++ b/pkg/kubectl/resource/selector.go
@@ -17,7 +17,7 @@ limitations under the License.
 package resource
 
 import (
-	"github.com/golang/glog"
+	"fmt"
 
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/meta"
@@ -50,11 +50,10 @@ func (r *Selector) Visit(fn VisitorFunc) error {
 	if err != nil {
 		if errors.IsBadRequest(err) || errors.IsNotFound(err) {
 			if r.Selector.Empty() {
-				glog.V(2).Infof("Unable to list %q: %v", r.Mapping.Resource, err)
+				return fmt.Errorf("Unable to list %q: %v", r.Mapping.Resource, err)
 			} else {
-				glog.V(2).Infof("Unable to find %q that match the selector %q: %v", r.Mapping.Resource, r.Selector, err)
+				return fmt.Errorf("Unable to find %q that match the selector %q: %v", r.Mapping.Resource, r.Selector, err)
 			}
-			return nil
 		}
 		return err
 	}


### PR DESCRIPTION
@sdminonne - I ran into this while testing disabling some features.  The effect was that  `get <some disabled feature>` gave empty output unless the log level was bumped.  Was there a reason that they were not returned like other errors that are encountered?

/cc @liggitt @smarterclayton 
