### PR TITLE
Replace "~/.kubernetes_auth" with "${KUBECONFIG:-$DEFAULT_KUBECONFIG}" in util.sh

### DIFF
--- a/cluster/azure/util.sh
+++ b/cluster/azure/util.sh
@@ -493,7 +493,7 @@ function kube-down {
 #  echo
 #  echo "  https://${KUBE_MASTER_IP}"
 # echo
-#  echo "The user name and password to use is located in ~/.kubernetes_auth."
+#  echo "The user name and password to use is located in ${KUBECONFIG:-$DEFAULT_KUBECONFIG}."
 #  echo
 
 #}

--- a/cluster/rackspace/util.sh
+++ b/cluster/rackspace/util.sh
@@ -371,7 +371,7 @@ kube-up() {
   echo
   echo "  https://${KUBE_MASTER_IP}"
   echo
-  echo "The user name and password to use is located in ~/.kubernetes_auth."
+  echo "The user name and password to use is located in ${KUBECONFIG:-$DEFAULT_KUBECONFIG}."
   echo
   echo "Security note: The server above uses a self signed certificate.  This is"
   echo "    subject to \"Man in the middle\" type attacks."

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -261,7 +261,7 @@ EOF
 }
 
 # Ensure that we have a password created for validating to the master. Will
-# read from $HOME/.kubernetes_auth if available.
+# read from ${KUBECONFIG:-$DEFAULT_KUBECONFIG} if available.
 #
 # Vars set:
 #   KUBE_USER

--- a/cluster/vsphere/util.sh
+++ b/cluster/vsphere/util.sh
@@ -441,7 +441,7 @@ function kube-push {
   echo
   echo "  https://${KUBE_MASTER_IP}"
   echo
-  echo "The user name and password to use is located in ~/.kubernetes_auth."
+  echo "The user name and password to use is located in ${KUBECONFIG:-$DEFAULT_KUBECONFIG}."
   echo
 }
 


### PR DESCRIPTION
The script cluster/common.sh is a common util that generates kubeconfig data for the created cluster and stores the info to a file defined by a global variable `$DEFAULT_KUBECONFIG` (if it is not overrided by a local variable such as `KUBECONFIG`), and the defination of  `DEFAULT_KUBECONFIG` is:
`DEFAULT_KUBECONFIG="${HOME}/.kube/config"`
In cluster/{vsphere,rackspace,azure,ubuntu}/util.sh, they wrongly prompt "The user name and password to use is located in `~/.kubernetes_auth`.", which actually should be `~/.kube/config` (the value of `DEFAULT_KUBECONFIG`).
The modification is as following:
`~/.kubernetes_auth -> ${KUBECONFIG:-$DEFAULT_KUBECONFIG}`
Please be noted that if you override this global variable `DEFAULT_KUBECONFIG` with another variable other than `KUBECONFIG`, you should change `$KUBECONFIG` to the value of the variable you defined.
I have validated this on ubuntu 14.04, but not on vsphere, rackspace, azure because of lacking of resources.
