### PR TITLE
Added PersistentVolumeSource to describer output

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -595,6 +595,25 @@ func (d *PersistentVolumeDescriber) Describe(namespace, name string) (string, er
 		fmt.Fprintf(out, "Access Modes:\t%s\n", volume.GetAccessModesAsString(pv.Spec.AccessModes))
 		fmt.Fprintf(out, "Capacity:\t%s\n", storage.String())
 		fmt.Fprintf(out, "Message:\t%s\n", pv.Status.Message)
+		fmt.Fprintf(out, "Source:\n")
+
+		switch {
+		case pv.Spec.HostPath != nil:
+			printHostPathVolumeSource(pv.Spec.HostPath, out)
+		case pv.Spec.GCEPersistentDisk != nil:
+			printGCEPersistentDiskVolumeSource(pv.Spec.GCEPersistentDisk, out)
+		case pv.Spec.AWSElasticBlockStore != nil:
+			printAWSElasticBlockStoreVolumeSource(pv.Spec.AWSElasticBlockStore, out)
+		case pv.Spec.NFS != nil:
+			printNFSVolumeSource(pv.Spec.NFS, out)
+		case pv.Spec.ISCSI != nil:
+			printISCSIVolumeSource(pv.Spec.ISCSI, out)
+		case pv.Spec.Glusterfs != nil:
+			printGlusterfsVolumeSource(pv.Spec.Glusterfs, out)
+		case pv.Spec.RBD != nil:
+			printRBDVolumeSource(pv.Spec.RBD, out)
+		}
+
 		return nil
 	})
 }

--- a/pkg/kubectl/describe_test.go
+++ b/pkg/kubectl/describe_test.go
@@ -411,3 +411,71 @@ func TestGetPodsTotalRequests(t *testing.T) {
 		}
 	}
 }
+
+func TestPersistentVolumeDescriber(t *testing.T) {
+	tests := map[string]*api.PersistentVolume{
+
+		"hostpath": {
+			Spec: api.PersistentVolumeSpec{
+				PersistentVolumeSource: api.PersistentVolumeSource{
+					HostPath: &api.HostPathVolumeSource{},
+				},
+			},
+		},
+		"gce": {
+			Spec: api.PersistentVolumeSpec{
+				PersistentVolumeSource: api.PersistentVolumeSource{
+					GCEPersistentDisk: &api.GCEPersistentDiskVolumeSource{},
+				},
+			},
+		},
+		"ebs": {
+			Spec: api.PersistentVolumeSpec{
+				PersistentVolumeSource: api.PersistentVolumeSource{
+					AWSElasticBlockStore: &api.AWSElasticBlockStoreVolumeSource{},
+				},
+			},
+		},
+		"nfs": {
+			Spec: api.PersistentVolumeSpec{
+				PersistentVolumeSource: api.PersistentVolumeSource{
+					NFS: &api.NFSVolumeSource{},
+				},
+			},
+		},
+		"iscsi": {
+			Spec: api.PersistentVolumeSpec{
+				PersistentVolumeSource: api.PersistentVolumeSource{
+					ISCSI: &api.ISCSIVolumeSource{},
+				},
+			},
+		},
+		"gluster": {
+			Spec: api.PersistentVolumeSpec{
+				PersistentVolumeSource: api.PersistentVolumeSource{
+					Glusterfs: &api.GlusterfsVolumeSource{},
+				},
+			},
+		},
+		"rbd": {
+			Spec: api.PersistentVolumeSpec{
+				PersistentVolumeSource: api.PersistentVolumeSource{
+					RBD: &api.RBDVolumeSource{},
+				},
+			},
+		},
+	}
+
+	for name, pv := range tests {
+		fake := testclient.NewSimpleFake(pv)
+		c := PersistentVolumeDescriber{fake}
+		str, err := c.Describe("foo", "bar")
+		if err != nil {
+			t.Errorf("Unexpected error for test %s: %v", name, err)
+		}
+		if str == "" {
+			t.Errorf("Unexpected empty string for test %s.  Expected PV Describer output", name)
+		}
+
+	}
+}


### PR DESCRIPTION
Addition to https://github.com/kubernetes/kubernetes/issues/12424

@smarterclayton 

output is:

```
$ k describe pv pv0003                                                                                                                                                                                                                                            
Name:           pv0003
Labels:         <none>
Status:         Available
Claim:
Reclaim Policy: Retain
Access Modes:   RWO
Capacity:       5Gi
Message:
PersistentVolumeSource:
    Type:       NFS (an NFS mount that lasts the lifetime of a pod)
    Server:     172.17.0.2
    Path:       /tmp
    ReadOnly:   false
```
