### PR TITLE
bind filenames var instead of looking up

### DIFF
--- a/pkg/kubectl/bash_comp_utils.go
+++ b/pkg/kubectl/bash_comp_utils.go
@@ -22,8 +22,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func AddJsonFilenameFlag(cmd *cobra.Command, usage string) {
-	cmd.Flags().StringSliceP("filename", "f", []string{}, usage)
+func AddJsonFilenameFlag(cmd *cobra.Command, value *[]string, usage string) {
+	cmd.Flags().StringSliceVarP(value, "filename", "f", *value, usage)
 
 	annotations := []string{"json", "yaml", "yml"}
 	cmd.Flags().SetAnnotation("filename", cobra.BashCompFilenameExt, annotations)

--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -85,7 +85,6 @@ func NewCmdAnnotate(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    annotate_long,
 		Example: annotate_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			options.filenames = cmdutil.GetFlagStringSlice(cmd, "filename")
 			if err := options.Complete(f, args); err != nil {
 				cmdutil.CheckErr(err)
 			}
@@ -101,7 +100,7 @@ func NewCmdAnnotate(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVar(&options.all, "all", false, "select all resources in the namespace of the specified resource types")
 	cmd.Flags().StringVar(&options.resourceVersion, "resource-version", "", "If non-empty, the annotation update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource.")
 	usage := "Filename, directory, or URL to a file identifying the resource to update the annotation"
-	kubectl.AddJsonFilenameFlag(cmd, usage)
+	kubectl.AddJsonFilenameFlag(cmd, &options.filenames, usage)
 	return cmd
 }
 

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -30,6 +30,12 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
+// CreateOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
+// referencing the cmd.Flags()
+type CreateOptions struct {
+	Filenames []string
+}
+
 const (
 	create_long = `Create a resource by filename or stdin.
 
@@ -42,6 +48,8 @@ $ cat pod.json | kubectl create -f -`
 )
 
 func NewCmdCreate(f *cmdutil.Factory, out io.Writer) *cobra.Command {
+	options := &CreateOptions{}
+
 	cmd := &cobra.Command{
 		Use:     "create -f FILENAME",
 		Short:   "Create a resource by filename or stdin",
@@ -50,12 +58,12 @@ func NewCmdCreate(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(ValidateArgs(cmd, args))
 			cmdutil.CheckErr(cmdutil.ValidateOutputArgs(cmd))
-			cmdutil.CheckErr(RunCreate(f, cmd, out))
+			cmdutil.CheckErr(RunCreate(f, cmd, out, options))
 		},
 	}
 
 	usage := "Filename, directory, or URL to file to use to create the resource"
-	kubectl.AddJsonFilenameFlag(cmd, usage)
+	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
 	cmd.MarkFlagRequired("filename")
 	cmdutil.AddValidateFlag(cmd)
 	cmdutil.AddOutputFlagsForMutation(cmd)
@@ -69,7 +77,7 @@ func ValidateArgs(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func RunCreate(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer) error {
+func RunCreate(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *CreateOptions) error {
 	schema, err := f.Validator(cmdutil.GetFlagBool(cmd, "validate"))
 	if err != nil {
 		return err
@@ -80,13 +88,12 @@ func RunCreate(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer) error {
 		return err
 	}
 
-	filenames := cmdutil.GetFlagStringSlice(cmd, "filename")
 	mapper, typer := f.Object()
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, filenames...).
+		FilenameParam(enforceNamespace, options.Filenames...).
 		Flatten().
 		Do()
 	err = r.Err()

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -31,6 +31,12 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 )
 
+// DeleteOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
+// referencing the cmd.Flags()
+type DeleteOptions struct {
+	Filenames []string
+}
+
 const (
 	delete_long = `Delete resources by filenames, stdin, resources and names, or by resources and label selector.
 
@@ -64,6 +70,8 @@ func NewCmdDelete(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	p := kubectl.NewHumanReadablePrinter(false, false, false, false, []string{})
 	validArgs := p.HandledResources()
 
+	options := &DeleteOptions{}
+
 	cmd := &cobra.Command{
 		Use:     "delete ([-f FILENAME] | TYPE [(NAME | -l label | --all)])",
 		Short:   "Delete resources by filenames, stdin, resources and names, or by resources and label selector.",
@@ -71,13 +79,13 @@ func NewCmdDelete(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 		Example: delete_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(cmdutil.ValidateOutputArgs(cmd))
-			err := RunDelete(f, out, cmd, args)
+			err := RunDelete(f, out, cmd, args, options)
 			cmdutil.CheckErr(err)
 		},
 		ValidArgs: validArgs,
 	}
 	usage := "Filename, directory, or URL to a file containing the resource to delete."
-	kubectl.AddJsonFilenameFlag(cmd, usage)
+	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
 	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on.")
 	cmd.Flags().Bool("all", false, "[-all] to select all the specified resources.")
 	cmd.Flags().Bool("ignore-not-found", false, "Treat \"resource not found\" as a successful delete. Defaults to \"true\" when --all is specified.")
@@ -88,7 +96,7 @@ func NewCmdDelete(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func RunDelete(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) error {
+func RunDelete(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string, options *DeleteOptions) error {
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
@@ -98,7 +106,7 @@ func RunDelete(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, cmdutil.GetFlagStringSlice(cmd, "filename")...).
+		FilenameParam(enforceNamespace, options.Filenames...).
 		SelectorParam(cmdutil.GetFlagString(cmd, "selector")).
 		SelectAllParam(deleteAll).
 		ResourceTypeOrNameArgs(false, args...).RequireObject(false).

--- a/pkg/kubectl/cmd/delete_test.go
+++ b/pkg/kubectl/cmd/delete_test.go
@@ -143,10 +143,12 @@ func TestDeleteObjectNotFound(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 
 	cmd := NewCmdDelete(f, buf)
-	cmd.Flags().Set("filename", "../../../examples/guestbook/redis-master-controller.yaml")
+	options := &DeleteOptions{
+		Filenames: []string{"../../../examples/guestbook/redis-master-controller.yaml"},
+	}
 	cmd.Flags().Set("cascade", "false")
 	cmd.Flags().Set("output", "name")
-	err := RunDelete(f, buf, cmd, []string{})
+	err := RunDelete(f, buf, cmd, []string{}, options)
 	if err == nil || !errors.IsNotFound(err) {
 		t.Errorf("unexpected error: expected NotFound, got %v", err)
 	}
@@ -218,7 +220,7 @@ func TestDeleteAllNotFound(t *testing.T) {
 	cmd.Flags().Set("ignore-not-found", "false")
 	cmd.Flags().Set("output", "name")
 
-	err := RunDelete(f, buf, cmd, []string{"services"})
+	err := RunDelete(f, buf, cmd, []string{"services"}, &DeleteOptions{})
 	if err == nil || !errors.IsNotFound(err) {
 		t.Errorf("unexpected error: expected NotFound, got %v", err)
 	}
@@ -321,11 +323,12 @@ func TestDeleteMultipleObjectContinueOnMissing(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 
 	cmd := NewCmdDelete(f, buf)
-	cmd.Flags().Set("filename", "../../../examples/guestbook/redis-master-controller.yaml")
-	cmd.Flags().Set("filename", "../../../examples/guestbook/frontend-service.yaml")
+	options := &DeleteOptions{
+		Filenames: []string{"../../../examples/guestbook/redis-master-controller.yaml", "../../../examples/guestbook/frontend-service.yaml"},
+	}
 	cmd.Flags().Set("cascade", "false")
 	cmd.Flags().Set("output", "name")
-	err := RunDelete(f, buf, cmd, []string{})
+	err := RunDelete(f, buf, cmd, []string{}, options)
 	if err == nil || !errors.IsNotFound(err) {
 		t.Errorf("unexpected error: expected NotFound, got %v", err)
 	}

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -27,6 +27,12 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+// GetOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
+// referencing the cmd.Flags()
+type GetOptions struct {
+	Filenames []string
+}
+
 const (
 	get_long = `Display one or many resources.
 
@@ -70,6 +76,7 @@ $ kubectl get rc/web service/frontend pods/web-pod-13je7`
 func NewCmdGet(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	p := kubectl.NewHumanReadablePrinter(false, false, false, false, []string{})
 	validArgs := p.HandledResources()
+	options := &GetOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "get [(-o|--output=)json|yaml|template|templatefile|wide|jsonpath|...] (TYPE [NAME | -l label] | TYPE/NAME ...) [flags]",
@@ -77,7 +84,7 @@ func NewCmdGet(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    get_long,
 		Example: get_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := RunGet(f, out, cmd, args)
+			err := RunGet(f, out, cmd, args, options)
 			cmdutil.CheckErr(err)
 		},
 		ValidArgs: validArgs,
@@ -89,13 +96,13 @@ func NewCmdGet(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().Bool("all-namespaces", false, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 	cmd.Flags().StringSliceP("label-columns", "L", []string{}, "Accepts a comma separated list of labels that are going to be presented as columns. Names are case-sensitive. You can also use multiple flag statements like -L label1 -L label2...")
 	usage := "Filename, directory, or URL to a file identifying the resource to get from a server."
-	kubectl.AddJsonFilenameFlag(cmd, usage)
+	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
 	return cmd
 }
 
 // RunGet implements the generic Get command
 // TODO: convert all direct flag accessors to a struct and pass that instead of cmd
-func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) error {
+func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string, options *GetOptions) error {
 	selector := cmdutil.GetFlagString(cmd, "selector")
 	allNamespaces := cmdutil.GetFlagBool(cmd, "all-namespaces")
 	mapper, typer := f.Object()
@@ -105,9 +112,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 		return err
 	}
 
-	filenames := cmdutil.GetFlagStringSlice(cmd, "filename")
-
-	if len(args) == 0 && len(filenames) == 0 {
+	if len(args) == 0 && len(options.Filenames) == 0 {
 		fmt.Fprint(out, "You must specify the type of resource to get. ", valid_resources, `   * componentstatuses (aka 'cs')
    * endpoints (aka 'ep')
 `)
@@ -119,7 +124,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 	if isWatch || isWatchOnly {
 		r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 			NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).
-			FilenameParam(enforceNamespace, filenames...).
+			FilenameParam(enforceNamespace, options.Filenames...).
 			SelectorParam(selector).
 			ResourceTypeOrNameArgs(true, args...).
 			SingleResourceType().
@@ -172,7 +177,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 
 	b := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).
-		FilenameParam(enforceNamespace, filenames...).
+		FilenameParam(enforceNamespace, options.Filenames...).
 		SelectorParam(selector).
 		ResourceTypeOrNameArgs(true, args...).
 		ContinueOnError().

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -206,7 +206,7 @@ func TestGetUnknownSchemaObjectListGeneric(t *testing.T) {
 		cmd.SetOutput(buf)
 		cmd.Flags().Set("output", "json")
 		cmd.Flags().Set("output-version", test.outputVersion)
-		err := RunGet(f, buf, cmd, []string{"type/foo", "replicationcontrollers/foo"})
+		err := RunGet(f, buf, cmd, []string{"type/foo", "replicationcontrollers/foo"}, &GetOptions{})
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", k, err)
 			continue

--- a/pkg/kubectl/cmd/label_test.go
+++ b/pkg/kubectl/cmd/label_test.go
@@ -309,7 +309,7 @@ func TestLabelErrors(t *testing.T) {
 		for k, v := range testCase.flags {
 			cmd.Flags().Set(k, v)
 		}
-		err := RunLabel(f, buf, cmd, testCase.args)
+		err := RunLabel(f, buf, cmd, testCase.args, &LabelOptions{})
 		if !testCase.errFn(err) {
 			t.Errorf("%s: unexpected error: %v", k, err)
 			continue
@@ -357,9 +357,11 @@ func TestLabelForResourceFromFile(t *testing.T) {
 
 	buf := bytes.NewBuffer([]byte{})
 	cmd := NewCmdLabel(f, buf)
-	cmd.Flags().Set("filename", "../../../examples/cassandra/cassandra.yaml")
+	options := &LabelOptions{
+		Filenames: []string{"../../../examples/cassandra/cassandra.yaml"},
+	}
 
-	err := RunLabel(f, buf, cmd, []string{"a=b"})
+	err := RunLabel(f, buf, cmd, []string{"a=b"}, options)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -406,7 +408,7 @@ func TestLabelMultipleObjects(t *testing.T) {
 	cmd := NewCmdLabel(f, buf)
 	cmd.Flags().Set("all", "true")
 
-	if err := RunLabel(f, buf, cmd, []string{"pods", "a=b"}); err != nil {
+	if err := RunLabel(f, buf, cmd, []string{"pods", "a=b"}, &LabelOptions{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if strings.Count(buf.String(), "labeled") != len(pods.Items) {

--- a/pkg/kubectl/cmd/rollingupdate_test.go
+++ b/pkg/kubectl/cmd/rollingupdate_test.go
@@ -26,6 +26,7 @@ func TestValidateArgs(t *testing.T) {
 
 	tests := []struct {
 		flags     map[string]string
+		filenames []string
 		args      []string
 		expectErr bool
 		testName  string
@@ -41,11 +42,9 @@ func TestValidateArgs(t *testing.T) {
 			testName:  "no file, no image",
 		},
 		{
-			flags: map[string]string{
-				"filename": "bar.yaml",
-			},
-			args:     []string{"foo"},
-			testName: "valid file example",
+			filenames: []string{"bar.yaml"},
+			args:      []string{"foo"},
+			testName:  "valid file example",
 		},
 		{
 			flags: map[string]string{
@@ -63,9 +62,9 @@ func TestValidateArgs(t *testing.T) {
 		},
 		{
 			flags: map[string]string{
-				"image":    "foo:v2",
-				"filename": "bar.yaml",
+				"image": "foo:v2",
 			},
+			filenames: []string{"bar.yaml"},
 			args:      []string{"foo", "foo-v2"},
 			expectErr: true,
 			testName:  "both filename and image example",
@@ -80,7 +79,7 @@ func TestValidateArgs(t *testing.T) {
 				cmd.Flags().Set(key, val)
 			}
 		}
-		_, _, _, _, err := validateArguments(cmd, test.args)
+		_, _, _, _, err := validateArguments(cmd, test.filenames, test.args)
 		if err != nil && !test.expectErr {
 			t.Errorf("unexpected error: %v (%s)", err, test.testName)
 		}

--- a/pkg/kubectl/cmd/stop.go
+++ b/pkg/kubectl/cmd/stop.go
@@ -25,6 +25,12 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 )
 
+// StopOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
+// referencing the cmd.Flags()
+type StopOptions struct {
+	Filenames []string
+}
+
 const (
 	stop_long = `Deprecated: Gracefully shut down a resource by name or filename.
 
@@ -47,6 +53,8 @@ $ kubectl stop -f path/to/resources`
 )
 
 func NewCmdStop(f *cmdutil.Factory, out io.Writer) *cobra.Command {
+	options := &StopOptions{}
+
 	cmd := &cobra.Command{
 		Use:     "stop (-f FILENAME | TYPE (NAME | -l label | --all))",
 		Short:   "Deprecated: Gracefully shut down a resource by name or filename.",
@@ -54,11 +62,11 @@ func NewCmdStop(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 		Example: stop_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(cmdutil.ValidateOutputArgs(cmd))
-			cmdutil.CheckErr(RunStop(f, cmd, args, out))
+			cmdutil.CheckErr(RunStop(f, cmd, args, out, options))
 		},
 	}
 	usage := "Filename, directory, or URL to file of resource(s) to be stopped."
-	kubectl.AddJsonFilenameFlag(cmd, usage)
+	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
 	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on.")
 	cmd.Flags().Bool("all", false, "[-all] to select all the specified resources.")
 	cmd.Flags().Bool("ignore-not-found", false, "Treat \"resource not found\" as a successful stop.")
@@ -68,19 +76,18 @@ func NewCmdStop(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func RunStop(f *cmdutil.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func RunStop(f *cmdutil.Factory, cmd *cobra.Command, args []string, out io.Writer, options *StopOptions) error {
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
 
-	filenames := cmdutil.GetFlagStringSlice(cmd, "filename")
 	mapper, typer := f.Object()
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		ResourceTypeOrNameArgs(false, args...).
-		FilenameParam(enforceNamespace, filenames...).
+		FilenameParam(enforceNamespace, options.Filenames...).
 		SelectorParam(cmdutil.GetFlagString(cmd, "selector")).
 		SelectAllParam(cmdutil.GetFlagBool(cmd, "all")).
 		Flatten().


### PR DESCRIPTION
The elimination of `util.StringList` here https://github.com/kubernetes/kubernetes/commit/7cbb52ce0418994e89e4e8380785fd9edabdc444#diff-4b43cea33f490ce3393439029e5712ee, removed the variable binding as side effect.  This restores that binding.

Binding flags to variables makes it easier for the implementation of commands to avoid coupling to the particular flagsets that originate them.  Decoupling that connection makes composing commands as helpers functions much easier.  
