### PR TITLE
Remove empty passphrase from private key

### DIFF
--- a/docs/getting-started-guides/coreos/azure/lib/azure_wrapper.js
+++ b/docs/getting-started-guides/coreos/azure/lib/azure_wrapper.js
@@ -109,6 +109,9 @@ var create_ssh_key = function (prefix) {
     if (err) console.log(clr.red(err));
     fs.chmod(opts.keyout, '0600', function (err) {
       if (err) console.log(clr.red(err));
+      openssl.exec('rsa', { in: opts.keyout, out: opts.keyout }, function (err, buffer) {
+        if (err) console.log(clr.red(err));
+      });
     });
   });
   return {


### PR DESCRIPTION
On OSX 10.10.4 I am unable to ssh into the VMs created.  The ssh command in the example causes a prompt for the passphrase of the private key, and there doesn't seem to be any way to get past the passphrase prompt successfully.

The command I am running to attempt to ssh in is (from the README.md):
`ssh -F ./output/kube_1c1496016083b4_ssh_conf kube-00`

The openssl command that generated the key specifies the `-nodes` option, which seems like it should output the private key without passphrase protection.

I noticed that if I run the private key back through openssl, I do not get prompted for a password, and I get a different key:

```
openssl rsa -in ssh.key -out ssh.key.new
diff ssh.key ssh.key.new
```

If I then replace the original private key with the new private key, I am able to ssh into the VMs in Azure successfully.

Adding the command that runs the key back through openssl feels dirty, but I was unable to figure out a way to generate the private key correctly with the first command.  Perhaps someone else with a better understanding of how openssl works can come up with a better solution.
