### PR TITLE
Fix build breakage due to ubuntu invalid flag usage

### DIFF
--- a/cluster/gce/trusty/node.yaml
+++ b/cluster/gce/trusty/node.yaml
@@ -190,16 +190,16 @@ script
 	# TODO(andyzheng0831): Add health check functionality.
 	. /etc/kube-env
 	/usr/bin/kubelet \
-  	--api_servers=https://${KUBERNETES_MASTER_NAME} \
+  	--api-servers=https://${KUBERNETES_MASTER_NAME} \
 		--enable-debugging-handlers=true \
-		--cloud_provider=gce \
+		--cloud-provider=gce \
 		--config=/etc/kubernetes/manifests \
-		--allow_privileged=false \
+		--allow-privileged=false \
 		--v=2 \
-		--cluster_dns=10.0.0.10 \
-		--cluster_domain=cluster.local \
+		--cluster-dns=10.0.0.10 \
+		--cluster-domain=cluster.local \
 		--configure-cbr0=true \
-		--cgroup_root=/ \
+		--cgroup-root=/ \
 		--system-container=/system
 end script
 


### PR DESCRIPTION
In PR #12543 / commit fef1ede240a77656a7116a7cd8ad4c1221a255c8
Flags were used with `_` instead of `-`. This broke the build.
