### PR TITLE
Speed up pre-commit by always passing at least one file to programs

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -40,6 +40,12 @@ echo "${reset}"
 
 echo -ne "Checking for files that need boilerplate... "
 files=($(git diff --cached --name-only --diff-filter ACM))
+# We always make sure there is one file in the files list. Some tools check
+# the whole repo if they get no files, so in fact, this is much faster on
+# git commit --amend
+if [[ ${#files[@]} -eq 0 ]]; then
+  files+=("README.md")
+fi
 out=($(hack/boilerplate/boilerplate.py "${files[@]}"))
 if [[ "${#out}" -ne 0 ]]; then
   echo "${red}ERROR!"
@@ -54,10 +60,8 @@ else
 fi
 echo "${reset}"
 
-allfiles=($(git diff --cached --name-only --diff-filter ACM | grep -v -e "third_party" -e "Godeps"))
-
 echo -ne "Checking for problems with flag names... "
-invalid_flag_lines=$(hack/verify-flags-underscore.py "${allfiles[@]}")
+invalid_flag_lines=$(hack/verify-flags-underscore.py "${files[@]}")
 if [[ "${invalid_flag_lines:-}" != "" ]]; then
   echo "${red}ERROR!"
   echo "There appear to be problems with the following"


### PR DESCRIPTION
Some programs like the boilerplate or the flag checker will check the
whole repo if they aren't given a specific set of files to test. If you
use `git commit --amend` to change commit messages you will be calling
these functions with no args, and thus it take a lot longer to commit no
changes than it does to actually commit changes!
