### PR TITLE
Use gb (getgb.io) in the precommit hook if it is available

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -433,6 +433,44 @@ kube::golang::get_physmem() {
   echo 1
 }
 
+
+kube::golang::verify_code_builds() {
+  if ! OUT=$(which gb 2>&1); then
+    hack/build-go.sh
+    return
+  fi
+  # Check for `go` binary and set ${GOPATH}.
+  kube::golang::setup_env
+
+  local alltargets
+  alltargets=("${KUBE_ALL_TARGETS[@]}")
+
+  local targets=()
+  for target in "${alltargets[@]}"; do
+    # KUBE_ALL_TARGETS will call things pkg.test when it wants to use go test to build pkg.
+    # since there is no pkg.test and we don't want to build these with gb, just ignore them.
+    # This basically is only getting rid of test/e2e/e2e.test on 16 Aug 2015.
+    if [[ "${target}" == *".test" ]]; then
+      continue
+    fi
+    targets+=("${target}")
+  done
+  local binaries
+  binaries=($(kube::golang::binaries_from_targets "${targets[@]}"))
+
+  kube::log::status "Fast building the whole tree"
+  kube::log::status "  DO NOT USE THESE BUILDS FOR ANYTHING OTHER THAN A COMPILE CHECK"
+
+  # We need to make the godeps available where gb wants them.
+  if [[ ! -d "${KUBE_ROOT}/_output/local/go/vendor" ]]; then
+    ln -s "${KUBE_ROOT}/Godeps/_workspace" -T "${KUBE_ROOT}/_output/local/go/vendor"
+  fi
+
+  pushd "${KUBE_ROOT}/_output/local/go" > /dev/null
+  gb build "${binaries[@]}"
+  kube::golang::place_bins
+}
+
 # Build binaries targets specified
 #
 # Input:
@@ -524,3 +562,5 @@ kube::golang::build_binaries() {
     fi
   )
 }
+
+# ex: ts=2 sw=2 et filetype=sh

--- a/hack/verify-code-builds.sh
+++ b/hack/verify-code-builds.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script sets up a go workspace locally and builds all go components.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+kube::golang::verify_code_builds

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -6,8 +6,10 @@ readonly green=$(tput bold; tput setaf 2)
 
 exit_code=0
 
+echo "If this takes a long time you can try installing gb (getgb.io) in your path. It should HUGELY speed this up after the first build."
+echo "BUT BUT BUT having gb in your \$PATH will cause everything to fail if you have symlinks in your cwd due to a bug in gb"
 echo -ne "Checking that it builds... "
-if ! OUT=$("hack/build-go.sh" 2>&1); then
+if ! OUT=$("hack/verify-code-builds.sh" 2>&1); then
   echo
   echo "${red}${OUT}"
   exit_code=1


### PR DESCRIPTION
gb can rebuild a clean tree in < .4 seconds.  hack/build-go.sh test over
10 seconds.
