### PR TITLE
Clean the static check errors (Go vet)

### DIFF
--- a/pkg/api/resource/quantity_test.go
+++ b/pkg/api/resource/quantity_test.go
@@ -488,7 +488,7 @@ func TestUninitializedNoCrash(t *testing.T) {
 	q.Value()
 	q.MilliValue()
 	q.Copy()
-	q.String()
+	_ = q.String()
 	q.MarshalJSON()
 }
 

--- a/pkg/storage/cacher.go
+++ b/pkg/storage/cacher.go
@@ -322,11 +322,11 @@ func (c *cacheWatcher) sendWatchCacheEvent(event cache.WatchCacheEvent) {
 	}
 	switch {
 	case curObjPasses && !oldObjPasses:
-		c.result <- watch.Event{watch.Added, event.Object}
+		c.result <- watch.Event{Type: watch.Added, Object: event.Object}
 	case curObjPasses && oldObjPasses:
-		c.result <- watch.Event{watch.Modified, event.Object}
+		c.result <- watch.Event{Type: watch.Modified, Object: event.Object}
 	case !curObjPasses && oldObjPasses:
-		c.result <- watch.Event{watch.Deleted, event.Object}
+		c.result <- watch.Event{Type: watch.Deleted, Object: event.Object}
 	}
 }
 


### PR DESCRIPTION
Fix the go vet errors while using "make vet" command.

<pre><code>[root@hj-k8s-1 kubernetes]# make vet
hack/vet-go.sh  
pkg/api/resource/quantity_test.go:491: result of (resource.Quantity).String call not used
pkg/expapi/v1/types.go:82: struct field tag `json:"target"  description:"target average consumption of resource that the autoscaler will try to maintain by adjusting the desired number of pods"` not compatible with reflect.StructTag.Get: bad syntax for struct tag key
pkg/expapi/validation/validation_test.go:41: k8s.io/kubernetes/pkg/expapi.TargetConsumption composite literal uses unkeyed fields
pkg/expapi/validation/validation_test.go:63: k8s.io/kubernetes/pkg/expapi.TargetConsumption composite literal uses unkeyed fields
pkg/expapi/validation/validation_test.go:77: k8s.io/kubernetes/pkg/expapi.TargetConsumption composite literal uses unkeyed fields
pkg/expapi/validation/validation_test.go:91: k8s.io/kubernetes/pkg/expapi.TargetConsumption composite literal uses unkeyed fields
pkg/expapi/validation/validation_test.go:105: k8s.io/kubernetes/pkg/expapi.TargetConsumption composite literal uses unkeyed fields
pkg/expapi/validation/validation_test.go:116: k8s.io/kubernetes/pkg/expapi.TargetConsumption composite literal uses unkeyed fields
pkg/proxy/iptables/proxier.go:242: k8s.io/kubernetes/pkg/types.NamespacedName composite literal uses unkeyed fields
pkg/proxy/iptables/proxier.go:249: k8s.io/kubernetes/pkg/proxy.ServicePortName composite literal uses unkeyed fields
pkg/proxy/iptables/proxier.go:249: k8s.io/kubernetes/pkg/types.NamespacedName composite literal uses unkeyed fields
pkg/proxy/iptables/proxier.go:320: k8s.io/kubernetes/pkg/proxy.ServicePortName composite literal uses unkeyed fields
pkg/proxy/iptables/proxier.go:320: k8s.io/kubernetes/pkg/types.NamespacedName composite literal uses unkeyed fields
pkg/registry/event/rest.go:70: k8s.io/kubernetes/pkg/registry/generic.SelectionPredicate composite literal uses unkeyed fields
pkg/registry/horizontalpodautoscaler/etcd/etcd_test.go:68: k8s.io/kubernetes/pkg/expapi.TargetConsumption composite literal uses unkeyed fields
make: *** [vet] Error 1
</code></pre>
