### PR TITLE
Allow using NewListWatchFromClient from other client implementation

### DIFF
--- a/pkg/client/cache/listwatch.go
+++ b/pkg/client/cache/listwatch.go
@@ -37,8 +37,13 @@ type ListWatch struct {
 	WatchFunc WatchFunc
 }
 
+// Getter interface knows how to access Get method from RESTClient.
+type Getter interface {
+	Get() *client.Request
+}
+
 // NewListWatchFromClient creates a new ListWatch from the specified client, resource, namespace and field selector.
-func NewListWatchFromClient(c *client.Client, resource string, namespace string, fieldSelector fields.Selector) *ListWatch {
+func NewListWatchFromClient(c Getter, resource string, namespace string, fieldSelector fields.Selector) *ListWatch {
 	listFunc := func() (runtime.Object, error) {
 		return c.Get().
 			Namespace(namespace).


### PR DESCRIPTION
This came up during discussion in https://github.com/openshift/origin/issues/4140. We'd love to limit the amount of code duplication by reusing `NewListWatchFromClient` method for getting `ListerWatcher` complain objects. All credits go to @ncdc for his idea.
@smarterclayton ptal
