### PR TITLE
WIP/MESOS/EXPERIMENTAL: Fix endpoint subset error for service ports without names

### DIFF
--- a/contrib/mesos/pkg/service/endpoints_controller.go
+++ b/contrib/mesos/pkg/service/endpoints_controller.go
@@ -243,7 +243,6 @@ func (e *endpointController) worker() {
 	}
 }
 
-// HACK(sttts): add annotations to the endpoint about the respective container ports
 func (e *endpointController) syncService(key string) {
 	startTime := time.Now()
 	defer func() {

--- a/contrib/mesos/pkg/service/endpoints_controller.go
+++ b/contrib/mesos/pkg/service/endpoints_controller.go
@@ -324,7 +324,6 @@ func (e *endpointController) syncService(key string) {
 			containerPortAnnotations[fmt.Sprintf(meta.ContainerPortKeyFormat, portProto, pod.Status.HostIP, portNum)] = strconv.Itoa(containerPort)
 		}
 	}
-	subsets = endpoints.RepackSubsets(subsets)
 
 	// See if there's actually an update here.
 	currentEndpoints, err := e.client.Endpoints(service.Namespace).Get(service.Name)


### PR DESCRIPTION
Endpoints have different host ports on Mesos in general. Hence, subset repacking
for addresses with the same ports usually has no effect (with the exception
of the few cases of the same port on different hosts).

Resolves: https://github.com/mesosphere/kubernetes-mesos/issues/322
