### PR TITLE
When calling kubectl.sh, allow error due to API server bouncing

### DIFF
--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -40,7 +40,7 @@ while true; do
   # Suppress errors from kubectl output because during cluster bootstrapping
   # for clusters where the master node is registered, the apiserver will become
   # available and then get restarted as the kubelet configures the docker bridge.
-  nodes_status=$("${KUBE_ROOT}/cluster/kubectl.sh" get nodes -o template --template='{{range .items}}{{with index .status.conditions 0}}{{.type}}:{{.status}},{{end}}{{end}}' --api-version=v1)
+  nodes_status=$("${KUBE_ROOT}/cluster/kubectl.sh" get nodes -o template --template='{{range .items}}{{with index .status.conditions 0}}{{.type}}:{{.status}},{{end}}{{end}}' --api-version=v1) || true
   found=$(echo "${nodes_status}" | tr "," "\n" | grep -c 'Ready:') || true
   ready=$(echo "${nodes_status}" | tr "," "\n" | grep -c 'Ready:True') || true
 


### PR DESCRIPTION
This seems to be the simple fix for #12617.
