### PR TITLE
MESOS: Stop the kubelet from taking control over cgroups and other processes

### DIFF
--- a/contrib/mesos/pkg/executor/service/service.go
+++ b/contrib/mesos/pkg/executor/service/service.go
@@ -99,6 +99,12 @@ func NewKubeletExecutorServer() *KubeletExecutorServer {
 	k.Address = net.ParseIP(defaultBindingAddress())
 	k.ShutdownFD = -1 // indicates unspecified FD
 
+	// empty string for all containers (= cgroup paths) which stop the kubelet
+	// from taking any control over the cgroups of itself and other system processes.
+	k.SystemContainer = ""
+	k.ResourceContainer = ""
+	k.DockerDaemonContainer = ""
+
 	return k
 }
 
@@ -134,8 +140,6 @@ func (s *KubeletExecutorServer) Run(hks hyperkube.Interface, _ []string) error {
 	// derive the executor cgroup and use it as docker cgroup root
 	mesosCgroup := findMesosCgroup(s.cgroupPrefix)
 	s.cgroupRoot = mesosCgroup
-	s.SystemContainer = mesosCgroup
-	s.ResourceContainer = mesosCgroup
 	log.V(2).Infof("passing cgroup %q to the kubelet as cgroup root", s.CgroupRoot)
 
 	// create apiserver client


### PR DESCRIPTION
The kubelet tries to move different system processes into its own cgroup hierarchy for resource accounting and measurement. This patch sets all those container name to `""` which stops this behaviour.

In the Mesos world the cgroup of the executor is set by the slave and should be inherited (possibly as a sub-cgroup) by the kubelet. But in any case the kubelet _must not do cgroup management for system processes_ like the docker daemon.
