### PR TITLE
Deleting a namespace is insufficient to cleanup in e2e

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -141,7 +141,7 @@ var _ = Describe("Density", func() {
 		}
 
 		By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
-		if err := c.Namespaces().Delete(ns); err != nil {
+		if err := deleteNS(c, ns); err != nil {
 			Failf("Couldn't delete ns %s", err)
 		}
 

--- a/test/e2e/docker_containers.go
+++ b/test/e2e/docker_containers.go
@@ -39,7 +39,7 @@ var _ = Describe("Docker Containers", func() {
 	})
 
 	AfterEach(func() {
-		if err := c.Namespaces().Delete(ns); err != nil {
+		if err := deleteNS(c, ns); err != nil {
 			Failf("Couldn't delete ns %s", err)
 		}
 	})

--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -63,7 +63,7 @@ var _ = Describe("Examples e2e", func() {
 
 	AfterEach(func() {
 		By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
-		if err := c.Namespaces().Delete(ns); err != nil {
+		if err := deleteNS(c, ns); err != nil {
 			Failf("Couldn't delete ns %s", err)
 		}
 	})
@@ -458,7 +458,7 @@ var _ = Describe("Examples e2e", func() {
 				var err error
 				namespaces[i], err = createTestingNS(fmt.Sprintf("dnsexample%d", i), c)
 				if namespaces[i] != nil {
-					defer c.Namespaces().Delete(namespaces[i].Name)
+					defer deleteNS(c, namespaces[i].Name)
 				}
 				Expect(err).NotTo(HaveOccurred())
 			}

--- a/test/e2e/host_path.go
+++ b/test/e2e/host_path.go
@@ -52,7 +52,7 @@ var _ = Describe("hostPath", func() {
 
 	AfterEach(func() {
 		By(fmt.Sprintf("Destroying namespace for this suite %v", namespace.Name))
-		if err := c.Namespaces().Delete(namespace.Name); err != nil {
+		if err := deleteNS(c, namespace.Name); err != nil {
 			Failf("Couldn't delete ns %s", err)
 		}
 	})

--- a/test/e2e/load.go
+++ b/test/e2e/load.go
@@ -81,7 +81,7 @@ var _ = Describe("Load capacity", func() {
 		deleteAllRC(configs)
 
 		By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
-		if err := c.Namespaces().Delete(ns); err != nil {
+		if err := deleteNS(c, ns); err != nil {
 			Failf("Couldn't delete ns %s", err)
 		}
 

--- a/test/e2e/persistent_volumes.go
+++ b/test/e2e/persistent_volumes.go
@@ -46,7 +46,7 @@ var _ = Describe("[Skipped] persistentVolumes", func() {
 
 	AfterEach(func() {
 		By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
-		if err := c.Namespaces().Delete(ns); err != nil {
+		if err := deleteNS(c, ns); err != nil {
 			Failf("Couldn't delete ns %s", err)
 		}
 	})

--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -413,7 +413,7 @@ var _ = Describe("Nodes", func() {
 			Failf("Not all nodes are ready: %v", err)
 		}
 		By(fmt.Sprintf("destroying namespace for this suite %s", ns))
-		if err := c.Namespaces().Delete(ns); err != nil {
+		if err := deleteNS(c, ns); err != nil {
 			Failf("Couldn't delete namespace '%s', %v", ns, err)
 		}
 	})

--- a/test/e2e/scheduler_predicates.go
+++ b/test/e2e/scheduler_predicates.go
@@ -160,7 +160,7 @@ var _ = Describe("SchedulerPredicates", func() {
 		}
 
 		By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
-		if err := c.Namespaces().Delete(ns); err != nil {
+		if err := deleteNS(c, ns); err != nil {
 			Failf("Couldn't delete ns %s", err)
 		}
 	})

--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -234,7 +234,7 @@ var _ = Describe("Volumes", func() {
 
 	AfterEach(func() {
 		if clean {
-			if err := c.Namespaces().Delete(namespace.Name); err != nil {
+			if err := deleteNS(c, namespace.Name); err != nil {
 				Failf("Couldn't delete ns %s", err)
 			}
 		}


### PR DESCRIPTION
Graceful deletion requires more time to terminate namespaces, and not
waiting for namespaces to delete causes scheduling errors

@roberthbailey from #9165
