### PR TITLE
kubelet: switch to using pod UID as the key in status manager

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1167,7 +1167,7 @@ func (kl *Kubelet) syncPod(pod *api.Pod, mirrorPod *api.Pod, runningPod kubecont
 			if mirrorPod != nil {
 				podToUpdate = mirrorPod
 			}
-			existingStatus, ok := kl.statusManager.GetPodStatus(podFullName)
+			existingStatus, ok := kl.statusManager.GetPodStatus(podToUpdate.UID)
 			if !ok || existingStatus.Phase == api.PodPending && status.Phase == api.PodRunning &&
 				!firstSeenTime.IsZero() {
 				metrics.PodStartLatency.Observe(metrics.SinceInMicroseconds(firstSeenTime))
@@ -1273,10 +1273,6 @@ func (kl *Kubelet) syncPod(pod *api.Pod, mirrorPod *api.Pod, runningPod kubecont
 			if err := kl.podManager.CreateMirrorPod(pod); err != nil {
 				glog.Errorf("Failed creating a mirror pod %q: %v", podFullName, err)
 			}
-			// Pod status update is edge-triggered. If there is any update of the
-			// mirror pod, we need to delete the existing status associated with
-			// the static pod to trigger an update.
-			kl.statusManager.DeletePodStatus(podFullName)
 		}
 	}
 	return nil
@@ -1398,7 +1394,7 @@ func (kl *Kubelet) cleanupTerminatedPods(pods []*api.Pod, runningPods []*kubecon
 func (kl *Kubelet) pastActiveDeadline(pod *api.Pod) bool {
 	now := util.Now()
 	if pod.Spec.ActiveDeadlineSeconds != nil {
-		podStatus, ok := kl.statusManager.GetPodStatus(kubecontainer.GetPodFullName(pod))
+		podStatus, ok := kl.statusManager.GetPodStatus(pod.UID)
 		if !ok {
 			podStatus = pod.Status
 		}
@@ -1428,7 +1424,7 @@ func (kl *Kubelet) filterOutTerminatedPods(allPods []*api.Pod) []*api.Pod {
 	for _, pod := range allPods {
 		var status api.PodStatus
 		// Check the cached pod status which was set after the last sync.
-		status, ok := kl.statusManager.GetPodStatus(kubecontainer.GetPodFullName(pod))
+		status, ok := kl.statusManager.GetPodStatus(pod.UID)
 		if !ok {
 			// If there is no cached status, use the status from the
 			// apiserver. This is useful if kubelet has recently been
@@ -1450,7 +1446,7 @@ func (kl *Kubelet) SyncPods(allPods []*api.Pod, podSyncTypes map[types.UID]SyncP
 		metrics.SyncPodsLatency.Observe(metrics.SinceInMicroseconds(start))
 	}()
 
-	kl.removeOrphanedPodStatuses(allPods)
+	kl.removeOrphanedPodStatuses(allPods, mirrorPods)
 	// Handles pod admission.
 	pods := kl.admitPods(allPods, podSyncTypes)
 	glog.V(4).Infof("Desired pods: %s", kubeletUtil.FormatPodNames(pods))
@@ -1465,14 +1461,15 @@ func (kl *Kubelet) SyncPods(allPods []*api.Pod, podSyncTypes map[types.UID]SyncP
 
 // removeOrphanedPodStatuses removes obsolete entries in podStatus where
 // the pod is no longer considered bound to this node.
-// TODO(yujuhong): consider using pod UID as they key in the status manager
-// to avoid returning the wrong status.
-func (kl *Kubelet) removeOrphanedPodStatuses(pods []*api.Pod) {
-	podFullNames := make(map[string]bool)
+func (kl *Kubelet) removeOrphanedPodStatuses(pods []*api.Pod, mirrorPods map[string]*api.Pod) {
+	podUIDs := make(map[types.UID]bool)
 	for _, pod := range pods {
-		podFullNames[kubecontainer.GetPodFullName(pod)] = true
+		podUIDs[pod.UID] = true
 	}
-	kl.statusManager.RemoveOrphanedStatuses(podFullNames)
+	for _, pod := range mirrorPods {
+		podUIDs[pod.UID] = true
+	}
+	kl.statusManager.RemoveOrphanedStatuses(podUIDs)
 }
 
 // dispatchWork dispatches pod updates to workers.
@@ -1900,10 +1897,21 @@ func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName, tail stri
 	// Pod workers periodically write status to statusManager. If status is not
 	// cached there, something is wrong (or kubelet just restarted and hasn't
 	// caught up yet). Just assume the pod is not ready yet.
-	podStatus, found := kl.statusManager.GetPodStatus(podFullName)
+	name, namespace, err := kubecontainer.ParsePodFullName(podFullName)
+	if err != nil {
+		return fmt.Errorf("unable to parse pod full name %q: %v", podFullName, err)
+	}
+
+	pod, ok := kl.GetPodByName(namespace, name)
+	if !ok {
+		return fmt.Errorf("unable to get logs for container %q in pod %q: unable to find pod", containerName, podFullName)
+	}
+
+	podStatus, found := kl.statusManager.GetPodStatus(pod.UID)
 	if !found {
 		return fmt.Errorf("failed to get status for pod %q", podFullName)
 	}
+
 	if err := kl.validatePodPhase(&podStatus); err != nil {
 		// No log is available if pod is not in a "known" phase (e.g. Unknown).
 		return err
@@ -1913,10 +1921,6 @@ func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName, tail stri
 		// No log is available if the container status is missing or is in the
 		// waiting state.
 		return err
-	}
-	pod, ok := kl.GetPodByFullName(podFullName)
-	if !ok {
-		return fmt.Errorf("unable to get logs for container %q in pod %q: unable to find pod", containerName, podFullName)
 	}
 	return kl.containerRuntime.GetContainerLogs(pod, containerID, tail, follow, stdout, stderr)
 }

--- a/pkg/kubelet/status_manager_test.go
+++ b/pkg/kubelet/status_manager_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
-	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/util"
 )
 
@@ -94,7 +93,7 @@ func TestNewStatus(t *testing.T) {
 	syncer.SetPodStatus(testPod, getRandomPodStatus())
 	verifyUpdates(t, syncer, 1)
 
-	status, _ := syncer.GetPodStatus(kubecontainer.GetPodFullName(testPod))
+	status, _ := syncer.GetPodStatus(testPod.UID)
 	if status.StartTime.IsZero() {
 		t.Errorf("SetPodStatus did not set a proper start time value")
 	}
@@ -115,7 +114,7 @@ func TestNewStatusPreservesPodStartTime(t *testing.T) {
 	pod.Status.StartTime = &startTime
 	syncer.SetPodStatus(pod, getRandomPodStatus())
 
-	status, _ := syncer.GetPodStatus(kubecontainer.GetPodFullName(pod))
+	status, _ := syncer.GetPodStatus(pod.UID)
 	if !status.StartTime.Time.Equal(startTime.Time) {
 		t.Errorf("Unexpected start time, expected %v, actual %v", startTime, status.StartTime)
 	}
@@ -136,7 +135,7 @@ func TestChangedStatusKeepsStartTime(t *testing.T) {
 	syncer.SetPodStatus(testPod, firstStatus)
 	syncer.SetPodStatus(testPod, getRandomPodStatus())
 	verifyUpdates(t, syncer, 2)
-	finalStatus, _ := syncer.GetPodStatus(kubecontainer.GetPodFullName(testPod))
+	finalStatus, _ := syncer.GetPodStatus(testPod.UID)
 	if finalStatus.StartTime.IsZero() {
 		t.Errorf("StartTime should not be zero")
 	}


### PR DESCRIPTION
We chose to use podFullName (name_namespace) as key in the status manager
because mirror pod and static pod share the same status. This is no longer
needed because we do not store statuses for static pods anymore (we only
store statuses for their mirror pods). Also, previously, a few fixes were
merged to ensure statuses are cleaned up so that a new pod with the same
name would not resuse an old status.

This change cleans up the code by using UID as key so that the code would
become less brittle.
