### PR TITLE
Update advice for getting support and filing issues.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,12 @@
-# How to become a contributor and submit your own code
+# Contributing guidelines
 
-## Contributor License Agreements
+## Filing issues
+
+If you have a question about Kubernetes or have a problem using Kubernetes, before filing an issue, please read the [troubleshooting guide](docs/troubleshooting.md).
+
+## How to become a contributor and submit your own code
+
+### Contributor License Agreements
 
 We'd love to accept your patches! Before we can take them, we have to jump a couple of legal hurdles.
 
@@ -11,9 +17,9 @@ Please fill out either the individual or corporate Contributor License Agreement
 
 Follow either of the two links above to access the appropriate CLA and instructions for how to sign and return it. Once we receive it, we'll be able to accept your pull requests.
 
-***NOTE***: Only original source code from you and other people that have signed the CLA can be accepted into the main repository. This policy does not apply to [third_party](https://github.com/GoogleCloudPlatform/kubernetes/tree/master/third_party).
+***NOTE***: Only original source code from you and other people that have signed the CLA can be accepted into the main repository. This policy does not apply to [third_party](https://github.com/kubernetes/kubernetes/tree/master/third_party).
 
-## Contributing A Patch
+### Contributing A Patch
 
 1. Submit an issue describing your proposed change to the repo in question.
 1. The repo owner will respond to your issue promptly.
@@ -21,12 +27,12 @@ Follow either of the two links above to access the appropriate CLA and instructi
 1. Fork the desired repo, develop and test your code changes.
 1. Submit a pull request.
 
-## Protocols for Collaborative Development
+### Protocols for Collaborative Development
 
 Please read [this doc](docs/devel/collab.md) for information on how we're running development for the project.
 Also take a look at the [development guide](docs/devel/development.md) for information on how to set up your environment, run tests, manage dependencies, etc.
 
-## Adding dependencies
+### Adding dependencies
 
 If your patch depends on new packages, add that package with [`godep`](https://github.com/tools/godep).  Follow the [instructions to add a dependency](docs/devel/development.md#godep-and-dependency-management).
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -45,22 +45,22 @@ If your problem isn't answered by any of the guides above, there are variety of 
 
 ## Questions
 
-We have a number of FAQ pages
-   * [User FAQ](https://github.com/GoogleCloudPlatform/kubernetes/wiki/User-FAQ)
-   * [Debugging FAQ](https://github.com/GoogleCloudPlatform/kubernetes/wiki/Debugging-FAQ)
-   * [Services FAQ](https://github.com/GoogleCloudPlatform/kubernetes/wiki/Services-FAQ)
+If you aren't familiar with it, many of your questions may be answered by the [user guide](user-guide/README.md).
 
-You may also find the StackOverflow topics relevant
+We also have a number of FAQ pages:
+   * [User FAQ](https://github.com/kubernetes/kubernetes/wiki/User-FAQ)
+   * [Debugging FAQ](https://github.com/kubernetes/kubernetes/wiki/Debugging-FAQ)
+   * [Services FAQ](https://github.com/kubernetes/kubernetes/wiki/Services-FAQ)
+
+You may also find the StackOverflow topics relevant:
    * [Kubernetes](http://stackoverflow.com/questions/tagged/kubernetes)
    * [Google Container Engine - GKE](http://stackoverflow.com/questions/tagged/google-container-engine)
 
-## Bugs and Feature requests
-
-If you have what looks like a bug, or you would like to make a feature request, please use the [Github issue tracking system](https://github.com/GoogleCloudPlatform/kubernetes/issues).
-
-Before you file an issue, please search existing issues to see if your issue is already covered.
-
 # Help! My question isn't covered!  I need help now!
+
+## Stackoverflow
+
+Someone else from the community may have already asked a similar question or may be able to help with your problem. The Kubernetes team will also monitor posts tagged kubernetes.
 
 ## IRC
 
@@ -68,8 +68,15 @@ The Kubernetes team hangs out on IRC at [`#google-containers`](https://botbot.me
 
 ## Mailing List
 
-The Kubernetes mailing list is [google-containers@googlegroups.com](https://groups.google.com/forum/#!forum/google-containers)
+The Google Container Engine mailing list is [google-containers@googlegroups.com](https://groups.google.com/forum/#!forum/google-containers)
 
+## Bugs and Feature requests
+
+If you have what looks like a bug, or you would like to make a feature request, please use the [Github issue tracking system](https://github.com/kubernetes/kubernetes/issues).
+
+Before you file an issue, please search existing issues to see if your issue is already covered.
+
+If filing a bug, please include detailed information about how to reproduce the problem.
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/troubleshooting.md?pixel)]()


### PR DESCRIPTION
Re. discussion about directing people to stackoverflow for support.

CONTRIBUTING.md is what users are directed to from the new issue page. Happy to add more details, since we don't have an issue template yet.

cc @quinton-hoole @brendandburns @dchen1107 
