### PR TITLE
AWS: Always install aufs module & tools

### DIFF
--- a/cluster/aws/templates/format-disks.sh
+++ b/cluster/aws/templates/format-disks.sh
@@ -55,12 +55,6 @@ docker_storage=${DOCKER_STORAGE:-aufs}
 if [[ ${#block_devices[@]} == 0 ]]; then
   echo "No ephemeral block devices found; will use aufs on root"
   docker_storage="aufs"
-
-  # Install aufs kernel module (for ubuntu)
-  apt-get install --yes linux-image-extra-$(uname -r)
-
-  # Install aufs tools (for debian)
-  apt-get install --yes aufs-tools
 else
   echo "Block devices: ${block_devices[@]}"
 
@@ -173,6 +167,9 @@ if [[ ${docker_storage} == "btrfs" ]]; then
 elif [[ ${docker_storage} == "aufs-nolvm" || ${docker_storage} == "aufs" ]]; then
   # Install aufs kernel module
   apt-get install --yes linux-image-extra-$(uname -r)
+
+  # Install aufs tools
+  apt-get install --yes aufs-tools
 
   DOCKER_OPTS="${DOCKER_OPTS} -s aufs"
 elif [[ ${docker_storage} == "devicemapper" ]]; then


### PR DESCRIPTION
Clean up the installation of aufs supporting modules & tools, so we
always install both and only install in one place.

Fixes #12855
