### PR TITLE
Declare e2e NodePort test container port

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1467,7 +1467,7 @@ func (t *WebserverTest) BuildServiceSpec() *api.Service {
 // CreateWebserverRC creates rc-backed pods with the well-known webserver
 // configuration and records it for cleanup.
 func (t *WebserverTest) CreateWebserverRC(replicas int) *api.ReplicationController {
-	rcSpec := rcByName(t.name, replicas, t.image, t.Labels)
+	rcSpec := rcByNamePort(t.name, replicas, t.image, 80, t.Labels)
 	rcAct, err := t.createRC(rcSpec)
 	if err != nil {
 		Failf("Failed to create rc %s: %v", rcSpec.Name, err)


### PR DESCRIPTION
The port 80 of the test webserver was not specified in the container spec. This
patch adds the declaration.

Fixes https://github.com/mesosphere/kubernetes-mesos/issues/365
