### PR TITLE
Node controller did not handle an error

### DIFF
--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -211,6 +211,9 @@ func (nc *NodeController) getCondition(status *api.NodeStatus, conditionType api
 // not reachable for a long period of time.
 func (nc *NodeController) monitorNodeStatus() error {
 	nodes, err := nc.kubeClient.Nodes().List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return err
+	}
 	for _, node := range nodes.Items {
 		if !nc.knownNodeSet.Has(node.Name) {
 			glog.V(1).Infof("NodeController observed a new Node: %#v", node)


### PR DESCRIPTION
This means if List() fails because the API server is not up, nodes are considered deleted (which is bad), which means the entire cluster can get evicted when the api server comes back.

@gmarek
