### PR TITLE
glog.Warning -> glog.Warningf

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1797,7 +1797,7 @@ func findSecurityGroupForInstance(instance *ec2.Instance) *string {
 
 		if securityGroupId != nil {
 			// We create instances with one SG
-			glog.Warning("Multiple security groups found for instance (%s); will use first group (%s)", orEmpty(instance.InstanceID), *securityGroupId)
+			glog.Warningf("Multiple security groups found for instance (%s); will use first group (%s)", orEmpty(instance.InstanceID), *securityGroupId)
 			continue
 		} else {
 			securityGroupId = securityGroup.GroupID

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -163,7 +163,7 @@ func (pc *podAndContainerCollector) Describe(ch chan<- *prometheus.Desc) {
 func (pc *podAndContainerCollector) Collect(ch chan<- prometheus.Metric) {
 	runningPods, err := pc.containerCache.GetPods()
 	if err != nil {
-		glog.Warning("Failed to get running container information while collecting metrics: %v", err)
+		glog.Warningf("Failed to get running container information while collecting metrics: %v", err)
 		return
 	}
 

--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -310,7 +310,7 @@ func (runner *runner) run(op operation, args []string) ([]byte, error) {
 func (runner *runner) checkRule(table Table, chain Chain, args ...string) (bool, error) {
 	checkPresent, err := getIptablesHasCheckCommand(runner.exec)
 	if err != nil {
-		glog.Warning("Error checking iptables version, assuming version at least 1.4.11: %v", err)
+		glog.Warningf("Error checking iptables version, assuming version at least 1.4.11: %v", err)
 		checkPresent = true
 	}
 	if checkPresent {


### PR DESCRIPTION
Fix three places where `glog.Warning` is used with a formatted string.
