### PR TITLE
Un-skip guestbook application e2e test

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -129,9 +129,6 @@ var _ = Describe("Kubectl client", func() {
 
 		BeforeEach(func() {
 			guestbookPath = filepath.Join(testContext.RepoRoot, "examples/guestbook")
-
-			// requires ExternalLoadBalancer support
-			SkipUnlessProviderIs("gce", "gke", "aws")
 		})
 
 		It("should create and stop a working application", func() {


### PR DESCRIPTION
The comment before this patch said that the guestbook needs LoadBalancer support, which is not
true. The test had been skipped for everything but aws, gke and gce for that
reason.

The guestbook test should be used as smoke test for Mesos because it covers a lot of concepts like pods, services, endpoints and replication controllers. Moreover, it tests kube-dns.

Compare https://github.com/mesosphere/kubernetes-mesos/issues/317
