### PR TITLE
Update Elasticsearch cluster logging to use v1.9 image

### DIFF
--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: fluentd-elasticsearch
-    image: gcr.io/google_containers/fluentd-elasticsearch:1.8
+    image: gcr.io/google_containers/fluentd-elasticsearch:1.9
     resources:
       limits:
         cpu: 100m


### PR DESCRIPTION
Following on from PR #12942 to address #7345 I have now pushed the image to gcr.io and we can now update the Elasticsearch controller config.
