### PR TITLE
Enable reporting test coverage to Coveralls from Shippable and disable per-PR coverage

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -204,8 +204,12 @@ runTests() {
 }
 
 reportCoverageToCoveralls() {
-  if [[ -x "${KUBE_GOVERALLS_BIN}" ]]; then
-    ${KUBE_GOVERALLS_BIN} -coverprofile="${COMBINED_COVER_PROFILE}" || true
+  if [[ ${KUBE_COVER} =~ ^[yY]$ ]] && [[ -x "${KUBE_GOVERALLS_BIN}" ]]; then
+    kube::log::status "Reporting coverage results to Coveralls for service ${CI_NAME:-}"
+    ${KUBE_GOVERALLS_BIN} -coverprofile="${COMBINED_COVER_PROFILE}" \
+    ${CI_NAME:+"-service=${CI_NAME}"} \
+    ${COVERALLS_REPO_TOKEN:+"-repotoken=${COVERALLS_REPO_TOKEN}"} \
+      || true
   fi
 }
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -7,16 +7,30 @@ matrix:
     - go: 1.4
       env:
         - KUBE_TEST_API_VERSIONS=v1 KUBE_TEST_ETCD_PREFIXES=registry
+        - CI_NAME="shippable"
+        - CI_BUILD_NUMBER="$BUILD_NUMBER"
+        - CI_BUILD_URL="$BUILD_URL"
+        - CI_BRANCH="$BRANCH"
+        - CI_PULL_REQUEST="$PULL_REQUEST"
+        # Set COVERALLS_REPO_TOKEN
+        - secure: hfh1Kwl2XYUlJCn4dtKSG0C9yXl5TtksVOY74OeqolvDAdVj4sc+GJD3Bywsp91CJe8YMEnkt9rN0WGI+gPVMcjTmZ9tMUxKiNNBP8m5oLRFbdgKOkNuXjpjpFHHWGAnNhMmh9vjI+ehADo+QIpU1fGxd3yO4tmIJ1qoK3QqvUrOZ1RwUubRXoeVn3xy3LK5yg4vP5ruitbNeWMw/RZZ7D6czvqvEfCgV6b4mdNDRMiqlUJNkaTRc3em1APXr30yagDV3a7hXLq3HdlyFwvF+9pmB4AKhQctyjPN4zvvPd0/gJXq3ZHXSlZXOZBMPXHlSS5pizfSInNszyZyrP3+/w==
     - go: 1.3
       env:
         - KUBE_TEST_API_VERSIONS=v1 KUBE_TEST_ETCD_PREFIXES=kubernetes.io/registry
+        - CI_NAME="shippable"
+        - CI_BUILD_NUMBER="$BUILD_NUMBER"
+        - CI_BUILD_URL="$BUILD_URL"
+        - CI_BRANCH="$BRANCH"
+        - CI_PULL_REQUEST="$PULL_REQUEST"
+        # Set COVERALLS_REPO_TOKEN
+        - secure: hfh1Kwl2XYUlJCn4dtKSG0C9yXl5TtksVOY74OeqolvDAdVj4sc+GJD3Bywsp91CJe8YMEnkt9rN0WGI+gPVMcjTmZ9tMUxKiNNBP8m5oLRFbdgKOkNuXjpjpFHHWGAnNhMmh9vjI+ehADo+QIpU1fGxd3yO4tmIJ1qoK3QqvUrOZ1RwUubRXoeVn3xy3LK5yg4vP5ruitbNeWMw/RZZ7D6czvqvEfCgV6b4mdNDRMiqlUJNkaTRc3em1APXr30yagDV3a7hXLq3HdlyFwvF+9pmB4AKhQctyjPN4zvvPd0/gJXq3ZHXSlZXOZBMPXHlSS5pizfSInNszyZyrP3+/w==
 
 before_install:
   - source $HOME/.gvm/scripts/gvm;
   - if [[ $SHIPPABLE_GO_VERSION == "tip" ]]; then gvm install tip; gvm use tip; fi
   - if [[ $SHIPPABLE_GO_VERSION == *release* ]]; then gvm install release; gvm use release; fi
   - if [[ $SHIPPABLE_GO_VERSION =~ [0-9].[0-9] ]]; then gvm install go$SHIPPABLE_GO_VERSION; gvm use go$SHIPPABLE_GO_VERSION; fi
-  - ./hack/travis/install-etcd.sh 
+  - ./hack/travis/install-etcd.sh
   - export GOPATH=$SHIPPABLE_GOPATH
   - mkdir -p /root/workspace/src/k8s.io; mv /root/workspace/src/github.com/kubernetes/kubernetes /root/workspace/src/k8s.io/kubernetes
   - export PATH=$GOPATH/bin:./third_party/etcd:$PATH
@@ -40,7 +54,8 @@ install:
   - ./hack/verify-linkcheck.sh
 
 script:
-  - KUBE_RACE="-race" KUBE_COVER="y" KUBE_GOVERALLS_BIN="$HOME/gopath/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES}" KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" ./hack/test-go.sh -- -p=2
+  # Disable coverage collection on pull requests
+  - KUBE_RACE="-race" KUBE_COVER=$([[ "$PULL_REQUEST" =~ ^[0-9]+$ ]] && echo "n" || echo "y") KUBE_GOVERALLS_BIN="$GOPATH/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES}" KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" ./hack/test-go.sh -- -p=2
   - ./hack/test-cmd.sh
   - KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4 LOG_LEVEL=4 ./hack/test-integration.sh
   - ./hack/test-update-storage-objects.sh


### PR DESCRIPTION
Fix Coveralls coverage reporting from Shippable by fixing path to `goveralls` and adding necessary environment variables (I think).

Also disable unit test coverage collection on PRs to speed up the build.
