### PR TITLE
[mesos/docker] Cleanup cluster scripts

### DIFF
--- a/cluster/mesos/docker/config-default.sh
+++ b/cluster/mesos/docker/config-default.sh
@@ -60,10 +60,5 @@ MESOS_DOCKER_ADDON_TIMEOUT="${MESOS_DOCKER_ADDON_TIMEOUT:-180}"
 # If running in a container, $HOME should be resolved outside of the container.
 MESOS_DOCKER_WORK_DIR="${MESOS_DOCKER_WORK_DIR:-${HOME}/tmp/kubernetes}"
 
-# Path to directory to store mesos slave docker-in-docker images & volumes.
-# Usage: ${MESOS_DOCKER_IMAGE_DIR}/<component>/docker
-# Must not be either an AUFS mount or an SMB/CIFS mount.
-# If using docker-machine or boot2docker, should NOT be under /Users (which is mounted from the host into the docker vm).
-MESOS_DOCKER_IMAGE_DIR="${MESOS_DOCKER_IMAGE_DIR:-/var/tmp/kubernetes}"
-
+# Arguments to pass to docker-engine running on the mesos-slave-dind containers.
 DOCKER_DAEMON_ARGS="${DOCKER_DAEMON_ARGS:---log-level=error}"


### PR DESCRIPTION
Followup to #12503 (which enabled e2e on Mesosphere's CI)
- Remove unused MESOS_DOCKER_IMAGE_DIR
  mesos-slave-dind handles recursive mounting internally now
- Extract docker-compose exec to a function.
  Avoids export pollution.
  Avoids compose file path as a global var.
- Localize some function variables.
- Validate existence of docker & docker-compose
- Improve user account creation output
