### PR TITLE
Allow testing graceful shutdown via network-tester (2/7)

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -51,6 +51,7 @@ current-release-pr
 current-replicas
 default-container-cpu-limit
 default-container-mem-limit
+delay-shutdown
 deleting-pods-burst
 deleting-pods-qps
 deployment-label-key

--- a/test/images/network-tester/slow-pod.json
+++ b/test/images/network-tester/slow-pod.json
@@ -1,0 +1,28 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "slow-pod",
+    "labels": {
+      "name": "nettest"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "webserver",
+        "image": "gcr.io/google_containers/nettest:1.5",
+        "args": [
+          "-service=nettest",
+          "-delay-shutdown=10"
+        ],
+        "ports": [
+          {
+            "containerPort": 8080,
+            "protocol": "TCP"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/images/network-tester/slow-rc.json
+++ b/test/images/network-tester/slow-rc.json
@@ -1,0 +1,42 @@
+{
+  "kind": "ReplicationController",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "slow-rc",
+    "labels": {
+      "name": "nettest"
+    }
+  },
+  "spec": {
+    "replicas": 8,
+    "selector": {
+      "name": "nettest"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "name": "nettest"
+        }
+      },
+      "spec": {
+        "terminationGracePeriodSeconds": 5,
+        "containers": [
+          {
+            "name": "webserver",
+            "image": "gcr.io/google_containers/nettest:1.5",
+            "args": [
+              "-service=nettest",
+              "-delay-shutdown=10"
+            ],
+            "ports": [
+              {
+                "containerPort": 8080,
+                "protocol": "TCP"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/images/network-tester/webserver.go
+++ b/test/images/network-tester/webserver.go
@@ -39,7 +39,9 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 	"time"
 
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -47,10 +49,11 @@ import (
 )
 
 var (
-	port      = flag.Int("port", 8080, "Port number to serve at.")
-	peerCount = flag.Int("peers", 8, "Must find at least this many peers for the test to pass.")
-	service   = flag.String("service", "nettest", "Service to find other network test pods in.")
-	namespace = flag.String("namespace", "default", "Namespace of this pod. TODO: kubernetes should make this discoverable.")
+	port          = flag.Int("port", 8080, "Port number to serve at.")
+	peerCount     = flag.Int("peers", 8, "Must find at least this many peers for the test to pass.")
+	service       = flag.String("service", "nettest", "Service to find other network test pods in.")
+	namespace     = flag.String("namespace", "default", "Namespace of this pod. TODO: kubernetes should make this discoverable.")
+	delayShutdown = flag.Int("delay-shutdown", 0, "Number of seconds to delay shutdown when receiving SIGTERM.")
 )
 
 // State tracks the internal state of our little http server.
@@ -176,6 +179,17 @@ func main() {
 	hostname, err := os.Hostname()
 	if err != nil {
 		log.Fatalf("Error getting hostname: %v", err)
+	}
+
+	if *delayShutdown > 0 {
+		termCh := make(chan os.Signal)
+		signal.Notify(termCh, syscall.SIGTERM)
+		go func() {
+			<-termCh
+			log.Printf("Sleeping %d seconds before exit ...", *delayShutdown)
+			time.Sleep(time.Duration(*delayShutdown) * time.Second)
+			os.Exit(0)
+		}()
 	}
 
 	state := State{


### PR DESCRIPTION
Extracted from #9165

Not used yet, will need to be rebuilt for future e2e tests based on this
