### PR TITLE
Changed JobSucceded to JobComplete

### DIFF
--- a/docs/proposals/job.md
+++ b/docs/proposals/job.md
@@ -154,8 +154,8 @@ type JobConditionType string
 
 // These are valid conditions of a job.
 const (
-    // JobSucceeded means the job has successfully completed its execution.
-    JobSucceeded JobConditionType = "Complete"
+    // JobComplete means the job has completed its execution.
+    JobComplete JobConditionType = "Complete"
 )
 
 // JobCondition describes current state of a job.


### PR DESCRIPTION
While working on implementation and reviewing all the comments on the original PR I've decided to change the JobSucceded Condition on Job to JobComplete. The idea behind is to show when a Job has actually completed its execution. The actual status of a job (success/failure) relies heavily on the user requirements and can be interpreted differently. This is especially important for RestartPolicyNever when running multipod task, eg. 10, a couple of them will fail, eg. 2. Job controller does not have any information about how to tell if a Job was successful or not, but the user can interpret those values from a JobStatus (JobStatus.Successful and JobStatus.Unsuccessful).
@smarterclayton @erictune @bgrant0607 ptal
@sdminonne @akram fyi
