### PR TITLE
Kubectl describe for experimental HorizontalPodAutoscaler

### DIFF
--- a/pkg/controller/autoscaler/horizontalpodautoscaler_controller.go
+++ b/pkg/controller/autoscaler/horizontalpodautoscaler_controller.go
@@ -171,13 +171,13 @@ func (a *HorizontalPodAutoscalerController) reconcileAutoscalers() error {
 
 		if desiredReplicas != count {
 			// Going down
-			if desiredReplicas < count && (hpa.Status.LastScaleTimestamp == nil ||
+			if desiredReplicas < count && (hpa.Status == nil || hpa.Status.LastScaleTimestamp == nil ||
 				hpa.Status.LastScaleTimestamp.Add(downscaleForbiddenWindow).Before(now)) {
 				rescale = true
 			}
 
 			// Going up
-			if desiredReplicas > count && (hpa.Status.LastScaleTimestamp == nil ||
+			if desiredReplicas > count && (hpa.Status == nil || hpa.Status.LastScaleTimestamp == nil ||
 				hpa.Status.LastScaleTimestamp.Add(upscaleForbiddenWindow).Before(now)) {
 				rescale = true
 			}
@@ -192,11 +192,12 @@ func (a *HorizontalPodAutoscalerController) reconcileAutoscalers() error {
 			}
 		}
 
-		hpa.Status = expapi.HorizontalPodAutoscalerStatus{
+		status := expapi.HorizontalPodAutoscalerStatus{
 			CurrentReplicas:    count,
 			DesiredReplicas:    desiredReplicas,
-			CurrentConsumption: currentConsumption,
+			CurrentConsumption: &currentConsumption,
 		}
+		hpa.Status = &status
 		if rescale {
 			now := util.NewTime(now)
 			hpa.Status.LastScaleTimestamp = &now

--- a/pkg/controller/autoscaler/horizontalpodautoscaler_controller_test.go
+++ b/pkg/controller/autoscaler/horizontalpodautoscaler_controller_test.go
@@ -165,6 +165,10 @@ func TestSyncEndpointsItemsPreserveNoSelector(t *testing.T) {
 			LatestTimestamp: timestamp,
 		}}}
 
+	status := expapi.HorizontalPodAutoscalerStatus{
+		CurrentReplicas: 1,
+		DesiredReplicas: 3,
+	}
 	updateHpaResponse := serverResponse{http.StatusOK, &expapi.HorizontalPodAutoscaler{
 
 		ObjectMeta: api.ObjectMeta{
@@ -182,10 +186,7 @@ func TestSyncEndpointsItemsPreserveNoSelector(t *testing.T) {
 			MaxCount: 5,
 			Target:   expapi.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("0.3")},
 		},
-		Status: expapi.HorizontalPodAutoscalerStatus{
-			CurrentReplicas: 1,
-			DesiredReplicas: 3,
-		},
+		Status: &status,
 	}}
 
 	heapsterRawResponse, _ := json.Marshal(&metrics)

--- a/pkg/expapi/deep_copy_generated.go
+++ b/pkg/expapi/deep_copy_generated.go
@@ -787,8 +787,13 @@ func deepCopy_expapi_HorizontalPodAutoscaler(in HorizontalPodAutoscaler, out *Ho
 	if err := deepCopy_expapi_HorizontalPodAutoscalerSpec(in.Spec, &out.Spec, c); err != nil {
 		return err
 	}
-	if err := deepCopy_expapi_HorizontalPodAutoscalerStatus(in.Status, &out.Status, c); err != nil {
-		return err
+	if in.Status != nil {
+		out.Status = new(HorizontalPodAutoscalerStatus)
+		if err := deepCopy_expapi_HorizontalPodAutoscalerStatus(*in.Status, out.Status, c); err != nil {
+			return err
+		}
+	} else {
+		out.Status = nil
 	}
 	return nil
 }
@@ -833,8 +838,13 @@ func deepCopy_expapi_HorizontalPodAutoscalerSpec(in HorizontalPodAutoscalerSpec,
 func deepCopy_expapi_HorizontalPodAutoscalerStatus(in HorizontalPodAutoscalerStatus, out *HorizontalPodAutoscalerStatus, c *conversion.Cloner) error {
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	if err := deepCopy_expapi_ResourceConsumption(in.CurrentConsumption, &out.CurrentConsumption, c); err != nil {
-		return err
+	if in.CurrentConsumption != nil {
+		out.CurrentConsumption = new(ResourceConsumption)
+		if err := deepCopy_expapi_ResourceConsumption(*in.CurrentConsumption, out.CurrentConsumption, c); err != nil {
+			return err
+		}
+	} else {
+		out.CurrentConsumption = nil
 	}
 	if in.LastScaleTimestamp != nil {
 		out.LastScaleTimestamp = new(util.Time)

--- a/pkg/expapi/types.go
+++ b/pkg/expapi/types.go
@@ -108,7 +108,7 @@ type HorizontalPodAutoscalerStatus struct {
 	// CurrentConsumption is the current average consumption of the given resource that the autoscaler will
 	// try to maintain by adjusting the desired number of pods.
 	// Two types of resources are supported: "cpu" and "memory".
-	CurrentConsumption ResourceConsumption `json:"currentConsumption"`
+	CurrentConsumption *ResourceConsumption `json:"currentConsumption"`
 
 	// LastScaleTimestamp is the last time the HorizontalPodAutoscaler scaled the number of pods.
 	// This is used by the autoscaler to controll how often the number of pods is changed.
@@ -124,7 +124,7 @@ type HorizontalPodAutoscaler struct {
 	Spec HorizontalPodAutoscalerSpec `json:"spec,omitempty"`
 
 	// Status represents the current information about the autoscaler.
-	Status HorizontalPodAutoscalerStatus `json:"status,omitempty"`
+	Status *HorizontalPodAutoscalerStatus `json:"status,omitempty"`
 }
 
 // HorizontalPodAutoscaler is a collection of pod autoscalers.

--- a/pkg/expapi/v1/conversion_generated.go
+++ b/pkg/expapi/v1/conversion_generated.go
@@ -1513,8 +1513,13 @@ func convert_expapi_HorizontalPodAutoscaler_To_v1_HorizontalPodAutoscaler(in *ex
 	if err := convert_expapi_HorizontalPodAutoscalerSpec_To_v1_HorizontalPodAutoscalerSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_expapi_HorizontalPodAutoscalerStatus_To_v1_HorizontalPodAutoscalerStatus(&in.Status, &out.Status, s); err != nil {
-		return err
+	if in.Status != nil {
+		out.Status = new(HorizontalPodAutoscalerStatus)
+		if err := convert_expapi_HorizontalPodAutoscalerStatus_To_v1_HorizontalPodAutoscalerStatus(in.Status, out.Status, s); err != nil {
+			return err
+		}
+	} else {
+		out.Status = nil
 	}
 	return nil
 }
@@ -1568,8 +1573,13 @@ func convert_expapi_HorizontalPodAutoscalerStatus_To_v1_HorizontalPodAutoscalerS
 	}
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	if err := convert_expapi_ResourceConsumption_To_v1_ResourceConsumption(&in.CurrentConsumption, &out.CurrentConsumption, s); err != nil {
-		return err
+	if in.CurrentConsumption != nil {
+		out.CurrentConsumption = new(ResourceConsumption)
+		if err := convert_expapi_ResourceConsumption_To_v1_ResourceConsumption(in.CurrentConsumption, out.CurrentConsumption, s); err != nil {
+			return err
+		}
+	} else {
+		out.CurrentConsumption = nil
 	}
 	if in.LastScaleTimestamp != nil {
 		if err := s.Convert(&in.LastScaleTimestamp, &out.LastScaleTimestamp, 0); err != nil {
@@ -1845,8 +1855,13 @@ func convert_v1_HorizontalPodAutoscaler_To_expapi_HorizontalPodAutoscaler(in *Ho
 	if err := convert_v1_HorizontalPodAutoscalerSpec_To_expapi_HorizontalPodAutoscalerSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_v1_HorizontalPodAutoscalerStatus_To_expapi_HorizontalPodAutoscalerStatus(&in.Status, &out.Status, s); err != nil {
-		return err
+	if in.Status != nil {
+		out.Status = new(expapi.HorizontalPodAutoscalerStatus)
+		if err := convert_v1_HorizontalPodAutoscalerStatus_To_expapi_HorizontalPodAutoscalerStatus(in.Status, out.Status, s); err != nil {
+			return err
+		}
+	} else {
+		out.Status = nil
 	}
 	return nil
 }
@@ -1900,8 +1915,13 @@ func convert_v1_HorizontalPodAutoscalerStatus_To_expapi_HorizontalPodAutoscalerS
 	}
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	if err := convert_v1_ResourceConsumption_To_expapi_ResourceConsumption(&in.CurrentConsumption, &out.CurrentConsumption, s); err != nil {
-		return err
+	if in.CurrentConsumption != nil {
+		out.CurrentConsumption = new(expapi.ResourceConsumption)
+		if err := convert_v1_ResourceConsumption_To_expapi_ResourceConsumption(in.CurrentConsumption, out.CurrentConsumption, s); err != nil {
+			return err
+		}
+	} else {
+		out.CurrentConsumption = nil
 	}
 	if in.LastScaleTimestamp != nil {
 		if err := s.Convert(&in.LastScaleTimestamp, &out.LastScaleTimestamp, 0); err != nil {

--- a/pkg/expapi/v1/deep_copy_generated.go
+++ b/pkg/expapi/v1/deep_copy_generated.go
@@ -789,8 +789,13 @@ func deepCopy_v1_HorizontalPodAutoscaler(in HorizontalPodAutoscaler, out *Horizo
 	if err := deepCopy_v1_HorizontalPodAutoscalerSpec(in.Spec, &out.Spec, c); err != nil {
 		return err
 	}
-	if err := deepCopy_v1_HorizontalPodAutoscalerStatus(in.Status, &out.Status, c); err != nil {
-		return err
+	if in.Status != nil {
+		out.Status = new(HorizontalPodAutoscalerStatus)
+		if err := deepCopy_v1_HorizontalPodAutoscalerStatus(*in.Status, out.Status, c); err != nil {
+			return err
+		}
+	} else {
+		out.Status = nil
 	}
 	return nil
 }
@@ -835,8 +840,13 @@ func deepCopy_v1_HorizontalPodAutoscalerSpec(in HorizontalPodAutoscalerSpec, out
 func deepCopy_v1_HorizontalPodAutoscalerStatus(in HorizontalPodAutoscalerStatus, out *HorizontalPodAutoscalerStatus, c *conversion.Cloner) error {
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	if err := deepCopy_v1_ResourceConsumption(in.CurrentConsumption, &out.CurrentConsumption, c); err != nil {
-		return err
+	if in.CurrentConsumption != nil {
+		out.CurrentConsumption = new(ResourceConsumption)
+		if err := deepCopy_v1_ResourceConsumption(*in.CurrentConsumption, out.CurrentConsumption, c); err != nil {
+			return err
+		}
+	} else {
+		out.CurrentConsumption = nil
 	}
 	if in.LastScaleTimestamp != nil {
 		out.LastScaleTimestamp = new(util.Time)

--- a/pkg/expapi/v1/types.go
+++ b/pkg/expapi/v1/types.go
@@ -94,7 +94,7 @@ type HorizontalPodAutoscalerStatus struct {
 	// CurrentConsumption is the current average consumption of the given resource that the autoscaler will
 	// try to maintain by adjusting the desired number of pods.
 	// Two types of resources are supported: "cpu" and "memory".
-	CurrentConsumption ResourceConsumption `json:"currentConsumption" description:"current resource consumption"`
+	CurrentConsumption *ResourceConsumption `json:"currentConsumption" description:"current resource consumption"`
 
 	// LastScaleTimestamp is the last time the HorizontalPodAutoscaler scaled the number of pods.
 	// This is used by the autoscaler to controll how often the number of pods is changed.
@@ -110,7 +110,7 @@ type HorizontalPodAutoscaler struct {
 	Spec HorizontalPodAutoscalerSpec `json:"spec,omitempty" description:"specification of the desired behavior of the autoscaler; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
 
 	// Status represents the current information about the autoscaler.
-	Status HorizontalPodAutoscalerStatus `json:"status,omitempty"`
+	Status *HorizontalPodAutoscalerStatus `json:"status,omitempty"`
 }
 
 // HorizontalPodAutoscaler is a collection of pod autoscalers.


### PR DESCRIPTION
Sample output:

```
$ kubectl --server=127.0.0.1:8080 describe horizontalpodautoscaler cassandra-hpa
Name:               cassandra-hpa
Namespace:          default
Labels:             <none>
CreationTimestamp:      Thu, 20 Aug 2015 10:54:07 +0200
Reference:          ReplicationController\default\cassandra\scale
Target resource consumption:    500m cpu
Current resource consumption:   <not available>
Min pods:           1
Max pods:           5
ReplicationController pods: 1 current / 1 desired
```
