### PR TITLE
Add --cleanup-iptables flag to kube-proxy

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -31,6 +31,7 @@ certificate-authority
 cgroup-prefix
 cgroup-root
 chaos-chance
+cleanup-iptables
 client-ca-file
 client-certificate
 client-key

--- a/pkg/proxy/userspace/proxier.go
+++ b/pkg/proxy/userspace/proxier.go
@@ -134,8 +134,6 @@ func createProxier(loadBalancer LoadBalancer, listenIP net.IP, iptables iptables
 	if proxyPorts == nil {
 		proxyPorts = newPortAllocator(util.PortRange{})
 	}
-	glog.V(2).Info("Tearing down pure-iptables proxy rules. Errors here are acceptable.")
-	tearDownIptablesProxierRules(iptables)
 	// Set up the iptables foundations we need.
 	if err := iptablesInit(iptables); err != nil {
 		return nil, fmt.Errorf("failed to initialize iptables: %v", err)
@@ -157,17 +155,48 @@ func createProxier(loadBalancer LoadBalancer, listenIP net.IP, iptables iptables
 	}, nil
 }
 
-// remove the iptables rules from the pure iptables Proxier
-func tearDownIptablesProxierRules(ipt iptables.Interface) {
-	//TODO: actually tear down all rules and chains.
-	//NOTE: this needs to be kept in sync with the proxy/iptables Proxier's rules.
-	args := []string{"-j", "KUBE-SERVICES"}
-	if err := ipt.DeleteRule(iptables.TableNAT, iptables.ChainOutput, args...); err != nil {
-		glog.Errorf("Error removing pure-iptables proxy rule: %v", err)
+// CleanupLeftovers removes all iptables rules and chains created by the Proxier
+// It returns true if an error was encountered. Errors are logged.
+func CleanupLeftovers(ipt iptables.Interface) (encounteredError bool) {
+	// NOTE: Warning, this needs to be kept in sync with the userspace Proxier,
+	// we want to ensure we remove all of the iptables rules it creates.
+	// Currently they are all in iptablesInit()
+	// Delete Rules first, then Flush and Delete Chains
+	args := []string{"-m", "comment", "--comment", "handle ClusterIPs; NOTE: this must be before the NodePort rules"}
+	if err := ipt.DeleteRule(iptables.TableNAT, iptables.ChainOutput, append(args, "-j", string(iptablesHostPortalChain))...); err != nil {
+		glog.Errorf("Error removing userspace rule: %v", err)
+		encounteredError = true
 	}
-	if err := ipt.DeleteRule(iptables.TableNAT, iptables.ChainPrerouting, args...); err != nil {
-		glog.Errorf("Error removing pure-iptables proxy rule: %v", err)
+	if err := ipt.DeleteRule(iptables.TableNAT, iptables.ChainPrerouting, append(args, "-j", string(iptablesContainerPortalChain))...); err != nil {
+		glog.Errorf("Error removing userspace rule: %v", err)
+		encounteredError = true
 	}
+	args = []string{"-m", "addrtype", "--dst-type", "LOCAL"}
+	args = append(args, "-m", "comment", "--comment", "handle service NodePorts; NOTE: this must be the last rule in the chain")
+	if err := ipt.DeleteRule(iptables.TableNAT, iptables.ChainOutput, append(args, "-j", string(iptablesHostNodePortChain))...); err != nil {
+		glog.Errorf("Error removing userspace rule: %v", err)
+		encounteredError = true
+	}
+	if err := ipt.DeleteRule(iptables.TableNAT, iptables.ChainPrerouting, append(args, "-j", string(iptablesContainerNodePortChain))...); err != nil {
+		glog.Errorf("Error removing userspace rule: %v", err)
+		encounteredError = true
+	}
+
+	// flush and delete chains.
+	chains := []iptables.Chain{iptablesContainerPortalChain, iptablesHostPortalChain, iptablesHostNodePortChain, iptablesContainerNodePortChain}
+	for _, c := range chains {
+		// flush chain, then if sucessful delete, delete will fail if flush fails.
+		if err := ipt.FlushChain(iptables.TableNAT, c); err != nil {
+			glog.Errorf("Error flushing userspace chain: %v", err)
+			encounteredError = true
+		} else {
+			if err = ipt.DeleteChain(iptables.TableNAT, c); err != nil {
+				glog.Errorf("Error flushing userspace chain: %v", err)
+				encounteredError = true
+			}
+		}
+	}
+	return encounteredError
 }
 
 // SyncLoop runs periodic work.  This is expected to run as a goroutine or as the main loop of the app.  It does not return.


### PR DESCRIPTION
Adds a flag to cleanup iptables rules created by kube-proxy per
https://github.com/mesosphere/kubernetes-mesos/issues/353#issuecomment-1
27382832
