### PR TITLE
Add ability to specify machine type for GKE

### DIFF
--- a/cluster/gke/config-common.sh
+++ b/cluster/gke/config-common.sh
@@ -28,6 +28,7 @@ GCLOUD="${GCLOUD:-gcloud}"
 CMD_GROUP="${CMD_GROUP:-beta}"
 GCLOUD_CONFIG_DIR="${GCLOUD_CONFIG_DIR:-${HOME}/.config/gcloud/kubernetes}"
 MINION_SCOPES="${MINION_SCOPES:-"compute-rw,storage-ro"}"
+MACHINE_TYPE="${MACHINE_TYPE:-n1-standard-1}"
 
 # WARNING: any new vars added here must correspond to options that can be
 # passed to `gcloud {CMD_GROUP} container clusters create`, or they will

--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -113,6 +113,7 @@ function verify-prereqs() {
 #   CLUSTER_API_VERSION (optional)
 #   NUM_MINIONS
 #   MINION_SCOPES
+#   MACHINE_TYPE
 function kube-up() {
   echo "... in gke:kube-up()" >&2
   detect-project >&2
@@ -145,6 +146,7 @@ function kube-up() {
     "--network=${NETWORK}"
     "--scopes=${MINION_SCOPES}"
     "--cluster-version=${CLUSTER_API_VERSION}"
+    "--machine-type=${MACHINE_TYPE}"
   )
 
   # Bring up the cluster.


### PR DESCRIPTION
This PR adds the ability to specify the `--machine-type` option when deploying a cluster with the GKE provider.
