### PR TITLE
Add LogDir

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -12852,6 +12852,32 @@
      "mountPath": {
       "type": "string",
       "description": "Path within the container at which the volume should be mounted."
+     },
+     "policy": {
+      "$ref": "v1.VolumeMountPolicy"
+     }
+    }
+   },
+   "v1.VolumeMountPolicy": {
+    "id": "v1.VolumeMountPolicy",
+    "properties": {
+     "logDir": {
+      "$ref": "v1.LogDirPolicy"
+     }
+    }
+   },
+   "v1.LogDirPolicy": {
+    "id": "v1.LogDirPolicy",
+    "properties": {
+     "glob": {
+      "type": "string"
+     },
+     "rotate": {
+      "type": "string"
+     },
+     "maxFileSize": {
+      "type": "integer",
+      "format": "int32"
      }
     }
    },

--- a/docs/proposals/logdir.md
+++ b/docs/proposals/logdir.md
@@ -1,0 +1,163 @@
+<!-- BEGIN MUNGE: UNVERSIONED_WARNING -->
+
+<!-- BEGIN STRIP_FOR_RELEASE -->
+
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+
+<h2>PLEASE NOTE: This document applies to the HEAD of the source tree</h2>
+
+If you are using a released version of Kubernetes, you should
+refer to the docs that go with that version.
+
+<strong>
+The latest 1.0.x release of this document can be found
+[here](http://releases.k8s.io/release-1.0/docs/proposals/logdir.md).
+
+Documentation for other releases can be found at
+[releases.k8s.io](http://releases.k8s.io).
+</strong>
+--
+
+<!-- END STRIP_FOR_RELEASE -->
+
+<!-- END MUNGE: UNVERSIONED_WARNING -->
+
+# LogDir
+
+## Abstract
+
+A proposal for implementing `LogDir`. A `LogDir` can preserve and manage a pod's log files.
+
+Several existing issues and PRs were already created regarding that particular subject:
+* Collect logfiles inside the container [#12567](https://github.com/kubernetes/kubernetes/issues/12567)
+* Add LogDir [#13010](https://github.com/kubernetes/kubernetes/pull/13010#issuecomment-133997188)
+
+Author: WuLonghui (@wulonghui)
+
+## Motivation
+
+Some applications will write log to files, so need to add  `LogDir`. It can add some useful infomation to make logging agent easy to collect the logs, also we can manage the log files(like log rotation and maximum log file sizes).
+
+## Implementation
+
+Create `LogDir` as a policy  to `api.VolumeMount` struct :
+
+```
+// VolumeMount describes a mounting of a Volume within a container.
+type VolumeMount struct {
+  // Required: This must match the Name of a Volume [above].
+  Name string `json:"name"`
+  // Optional: Defaults to false (read-write).
+  ReadOnly bool `json:"readOnly,omitempty"`
+  // Required.
+  MountPath string `json:"mountPath"`
+  // Optional: Policies of VolumeMount.
+  Policy *VolumeMountPolicy `json:"policy,omitempty"`
+}
+
+// VolumeMountPolicy describes policies of a VolumeMount.
+type VolumeMountPolicy struct {
+  // Optional: LogDir policy.
+  LogDir *LogDirPolicy `json:"logDir,omitempty"`
+}
+
+// LogDirPolicy describes a policy of logDir, include log rotation and maximum log file size.
+type LogDirPolicy struct {
+  // Optional: Glob pattern of log files.
+  Glob string `json:"glob,omitempty"`
+  // Optional: Log rotation.
+  Rotate string `json:"rotate,omitempty"`
+  // Optional: Maximum log file size.
+  MaxFileSize int `json:"maxFileSize,omitempty"`
+}
+
+```
+
+If users set the LogDir policy of the VolumeMount in a container:
+
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-app
+spec:
+  containers:
+  - name: container1
+    image: ubuntu:14.04
+    command: ["bash", "-c", "i=\"0\"; while true; do echo \"`hostname`_container1: $i \"; date --rfc-3339 ns >> /varlog/container1.log; sleep 4; i=$[$i+1]; done"]
+    volumeMounts:
+    - name: log-storage
+      mountPath: /varlog
+      policy:
+        logDir: {}
+    securityContext:
+        privileged: true
+  volumes:
+  - name: log-storage
+    emptyDir: {}
+```
+
+Kubelet will create a symbolic link to the volume path in `/var/log/containers`.
+
+```
+/var/log/containers/<pod_full_name>_<contianer_name> => <volume_path>
+```
+
+Then the logging agent(e.g.Fluentd) can watch `/var/log/containers` on host to collect log files, add tag by `<pod_full_name>_<contianer_name>`, which can be used for search terms in Elasticsearch or for
+labels for Cloud Logging.
+
+
+## Integrated with Fluentd
+
+We can use Fluentd to collect log files in `LogDir`. Fluentd should be installed on each Kubernetes node, and it will watch LogDir `/var/log/containers`, the Fluentd's configuration as follows:
+
+```
+<source>
+  type tail
+  format none
+  time_key time
+  path /var/log/containers/*/**/*.log
+  pos_file /lib/pods.log.pos
+  time_format %Y-%m-%dT%H:%M:%S
+  tag reform.*
+  read_from_head true
+</source>
+
+<match reform.**>
+  type record_reformer
+  enable_ruby true
+  tag kubernetes.${hostname}.${tag_suffix[4]}
+</match>
+
+<match **>
+  type stdout
+</match>
+```
+
+The Fluentd will tail any files in the LogDir `/var/log/containers`, and add tag `kubernetes.<node_host_name>.<pod_full_name>_<container_name>.<file_name>`. We only print the logs to stdout,  also can forward to logging storage endpoint(e.g Elasticsearch).
+
+Then the Fluentd prints the logs to stdout:
+
+```
+2015-09-11 11:00:10 +0000 kubernetes.8f5cd4af528a.my-app_default_container1.container1.log: {"message":"2015-09-11 10:59:53.331748730+00:00"}
+2015-09-11 11:00:10 +0000 kubernetes.8f5cd4af528a.my-app_default_container1.container1.log: {"message":"2015-09-11 10:59:57.335719322+00:00"}
+2015-09-11 11:00:10 +0000 kubernetes.8f5cd4af528a.my-app_default_container1.container1.log: {"message":"2015-09-11 11:00:01.339536181+00:00"}
+```
+
+## Future work
+
+*  Be able to limit maximum log file sizes
+*  Be able to support log rotation
+
+<!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/proposals/logdir.md?pixel)]()
+<!-- END MUNGE: GENERATED_ANALYTICS -->

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -817,6 +817,13 @@ func deepCopy_api_LocalObjectReference(in LocalObjectReference, out *LocalObject
 	return nil
 }
 
+func deepCopy_api_LogDirPolicy(in LogDirPolicy, out *LogDirPolicy, c *conversion.Cloner) error {
+	out.Glob = in.Glob
+	out.Rotate = in.Rotate
+	out.MaxFileSize = in.MaxFileSize
+	return nil
+}
+
 func deepCopy_api_NFSVolumeSource(in NFSVolumeSource, out *NFSVolumeSource, c *conversion.Cloner) error {
 	out.Server = in.Server
 	out.Path = in.Path
@@ -2069,6 +2076,26 @@ func deepCopy_api_VolumeMount(in VolumeMount, out *VolumeMount, c *conversion.Cl
 	out.Name = in.Name
 	out.ReadOnly = in.ReadOnly
 	out.MountPath = in.MountPath
+	if in.Policy != nil {
+		out.Policy = new(VolumeMountPolicy)
+		if err := deepCopy_api_VolumeMountPolicy(*in.Policy, out.Policy, c); err != nil {
+			return err
+		}
+	} else {
+		out.Policy = nil
+	}
+	return nil
+}
+
+func deepCopy_api_VolumeMountPolicy(in VolumeMountPolicy, out *VolumeMountPolicy, c *conversion.Cloner) error {
+	if in.LogDir != nil {
+		out.LogDir = new(LogDirPolicy)
+		if err := deepCopy_api_LogDirPolicy(*in.LogDir, out.LogDir, c); err != nil {
+			return err
+		}
+	} else {
+		out.LogDir = nil
+	}
 	return nil
 }
 
@@ -2270,6 +2297,7 @@ func init() {
 		deepCopy_api_LoadBalancerIngress,
 		deepCopy_api_LoadBalancerStatus,
 		deepCopy_api_LocalObjectReference,
+		deepCopy_api_LogDirPolicy,
 		deepCopy_api_NFSVolumeSource,
 		deepCopy_api_Namespace,
 		deepCopy_api_NamespaceList,
@@ -2340,6 +2368,7 @@ func init() {
 		deepCopy_api_TypeMeta,
 		deepCopy_api_Volume,
 		deepCopy_api_VolumeMount,
+		deepCopy_api_VolumeMountPolicy,
 		deepCopy_api_VolumeSource,
 		deepCopy_resource_Quantity,
 		deepCopy_util_IntOrString,

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -638,6 +638,24 @@ type VolumeMount struct {
 	ReadOnly bool `json:"readOnly,omitempty"`
 	// Required.
 	MountPath string `json:"mountPath"`
+	// Optional: Policies of VolumeMount.
+	Policy *VolumeMountPolicy `json:"policy,omitempty"`
+}
+
+// VolumeMountPolicy describes policies of a VolumeMount.
+type VolumeMountPolicy struct {
+	// Optional: LogDir policy.
+	LogDir *LogDirPolicy `json:"logDir,omitempty"`
+}
+
+// LogDirPolicy describes a policy of logDir, include log rotation and maximum log file size.
+type LogDirPolicy struct {
+	// Optional: Glob pattern of log files.
+	Glob string `json:"glob,omitempty"`
+	// Optional: Log rotation.
+	Rotate string `json:"rotate,omitempty"`
+	// Optional: Maximum log file size.
+	MaxFileSize int `json:"maxFileSize,omitempty"`
 }
 
 // EnvVar represents an environment variable present in a Container.

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -938,6 +938,16 @@ func convert_api_LocalObjectReference_To_v1_LocalObjectReference(in *api.LocalOb
 	return nil
 }
 
+func convert_api_LogDirPolicy_To_v1_LogDirPolicy(in *api.LogDirPolicy, out *LogDirPolicy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.LogDirPolicy))(in)
+	}
+	out.Glob = in.Glob
+	out.Rotate = in.Rotate
+	out.MaxFileSize = in.MaxFileSize
+	return nil
+}
+
 func convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in *api.NFSVolumeSource, out *NFSVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NFSVolumeSource))(in)
@@ -2307,6 +2317,29 @@ func convert_api_VolumeMount_To_v1_VolumeMount(in *api.VolumeMount, out *VolumeM
 	out.Name = in.Name
 	out.ReadOnly = in.ReadOnly
 	out.MountPath = in.MountPath
+	if in.Policy != nil {
+		out.Policy = new(VolumeMountPolicy)
+		if err := convert_api_VolumeMountPolicy_To_v1_VolumeMountPolicy(in.Policy, out.Policy, s); err != nil {
+			return err
+		}
+	} else {
+		out.Policy = nil
+	}
+	return nil
+}
+
+func convert_api_VolumeMountPolicy_To_v1_VolumeMountPolicy(in *api.VolumeMountPolicy, out *VolumeMountPolicy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.VolumeMountPolicy))(in)
+	}
+	if in.LogDir != nil {
+		out.LogDir = new(LogDirPolicy)
+		if err := convert_api_LogDirPolicy_To_v1_LogDirPolicy(in.LogDir, out.LogDir, s); err != nil {
+			return err
+		}
+	} else {
+		out.LogDir = nil
+	}
 	return nil
 }
 
@@ -3338,6 +3371,16 @@ func convert_v1_LocalObjectReference_To_api_LocalObjectReference(in *LocalObject
 		defaulting.(func(*LocalObjectReference))(in)
 	}
 	out.Name = in.Name
+	return nil
+}
+
+func convert_v1_LogDirPolicy_To_api_LogDirPolicy(in *LogDirPolicy, out *api.LogDirPolicy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*LogDirPolicy))(in)
+	}
+	out.Glob = in.Glob
+	out.Rotate = in.Rotate
+	out.MaxFileSize = in.MaxFileSize
 	return nil
 }
 
@@ -4710,6 +4753,29 @@ func convert_v1_VolumeMount_To_api_VolumeMount(in *VolumeMount, out *api.VolumeM
 	out.Name = in.Name
 	out.ReadOnly = in.ReadOnly
 	out.MountPath = in.MountPath
+	if in.Policy != nil {
+		out.Policy = new(api.VolumeMountPolicy)
+		if err := convert_v1_VolumeMountPolicy_To_api_VolumeMountPolicy(in.Policy, out.Policy, s); err != nil {
+			return err
+		}
+	} else {
+		out.Policy = nil
+	}
+	return nil
+}
+
+func convert_v1_VolumeMountPolicy_To_api_VolumeMountPolicy(in *VolumeMountPolicy, out *api.VolumeMountPolicy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*VolumeMountPolicy))(in)
+	}
+	if in.LogDir != nil {
+		out.LogDir = new(api.LogDirPolicy)
+		if err := convert_v1_LogDirPolicy_To_api_LogDirPolicy(in.LogDir, out.LogDir, s); err != nil {
+			return err
+		}
+	} else {
+		out.LogDir = nil
+	}
 	return nil
 }
 
@@ -4882,6 +4948,7 @@ func init() {
 		convert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress,
 		convert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus,
 		convert_api_LocalObjectReference_To_v1_LocalObjectReference,
+		convert_api_LogDirPolicy_To_v1_LogDirPolicy,
 		convert_api_NFSVolumeSource_To_v1_NFSVolumeSource,
 		convert_api_NamespaceList_To_v1_NamespaceList,
 		convert_api_NamespaceSpec_To_v1_NamespaceSpec,
@@ -4948,6 +5015,7 @@ func init() {
 		convert_api_Status_To_v1_Status,
 		convert_api_TCPSocketAction_To_v1_TCPSocketAction,
 		convert_api_TypeMeta_To_v1_TypeMeta,
+		convert_api_VolumeMountPolicy_To_v1_VolumeMountPolicy,
 		convert_api_VolumeMount_To_v1_VolumeMount,
 		convert_api_VolumeSource_To_v1_VolumeSource,
 		convert_api_Volume_To_v1_Volume,
@@ -4999,6 +5067,7 @@ func init() {
 		convert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress,
 		convert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus,
 		convert_v1_LocalObjectReference_To_api_LocalObjectReference,
+		convert_v1_LogDirPolicy_To_api_LogDirPolicy,
 		convert_v1_NFSVolumeSource_To_api_NFSVolumeSource,
 		convert_v1_NamespaceList_To_api_NamespaceList,
 		convert_v1_NamespaceSpec_To_api_NamespaceSpec,
@@ -5065,6 +5134,7 @@ func init() {
 		convert_v1_Status_To_api_Status,
 		convert_v1_TCPSocketAction_To_api_TCPSocketAction,
 		convert_v1_TypeMeta_To_api_TypeMeta,
+		convert_v1_VolumeMountPolicy_To_api_VolumeMountPolicy,
 		convert_v1_VolumeMount_To_api_VolumeMount,
 		convert_v1_VolumeSource_To_api_VolumeSource,
 		convert_v1_Volume_To_api_Volume,

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -816,6 +816,13 @@ func deepCopy_v1_LocalObjectReference(in LocalObjectReference, out *LocalObjectR
 	return nil
 }
 
+func deepCopy_v1_LogDirPolicy(in LogDirPolicy, out *LogDirPolicy, c *conversion.Cloner) error {
+	out.Glob = in.Glob
+	out.Rotate = in.Rotate
+	out.MaxFileSize = in.MaxFileSize
+	return nil
+}
+
 func deepCopy_v1_NFSVolumeSource(in NFSVolumeSource, out *NFSVolumeSource, c *conversion.Cloner) error {
 	out.Server = in.Server
 	out.Path = in.Path
@@ -2074,6 +2081,26 @@ func deepCopy_v1_VolumeMount(in VolumeMount, out *VolumeMount, c *conversion.Clo
 	out.Name = in.Name
 	out.ReadOnly = in.ReadOnly
 	out.MountPath = in.MountPath
+	if in.Policy != nil {
+		out.Policy = new(VolumeMountPolicy)
+		if err := deepCopy_v1_VolumeMountPolicy(*in.Policy, out.Policy, c); err != nil {
+			return err
+		}
+	} else {
+		out.Policy = nil
+	}
+	return nil
+}
+
+func deepCopy_v1_VolumeMountPolicy(in VolumeMountPolicy, out *VolumeMountPolicy, c *conversion.Cloner) error {
+	if in.LogDir != nil {
+		out.LogDir = new(LogDirPolicy)
+		if err := deepCopy_v1_LogDirPolicy(*in.LogDir, out.LogDir, c); err != nil {
+			return err
+		}
+	} else {
+		out.LogDir = nil
+	}
 	return nil
 }
 
@@ -2272,6 +2299,7 @@ func init() {
 		deepCopy_v1_LoadBalancerIngress,
 		deepCopy_v1_LoadBalancerStatus,
 		deepCopy_v1_LocalObjectReference,
+		deepCopy_v1_LogDirPolicy,
 		deepCopy_v1_NFSVolumeSource,
 		deepCopy_v1_Namespace,
 		deepCopy_v1_NamespaceList,
@@ -2342,6 +2370,7 @@ func init() {
 		deepCopy_v1_TypeMeta,
 		deepCopy_v1_Volume,
 		deepCopy_v1_VolumeMount,
+		deepCopy_v1_VolumeMountPolicy,
 		deepCopy_v1_VolumeSource,
 		deepCopy_runtime_RawExtension,
 		deepCopy_util_IntOrString,

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -773,6 +773,24 @@ type VolumeMount struct {
 	ReadOnly bool `json:"readOnly,omitempty"`
 	// Path within the container at which the volume should be mounted.
 	MountPath string `json:"mountPath"`
+	// Optional: Policies of VolumeMount.
+	Policy *VolumeMountPolicy `json:"policy,omitempty"`
+}
+
+// VolumeMountPolicy describes policies of a VolumeMount.
+type VolumeMountPolicy struct {
+	// Optional: LogDir policy.
+	LogDir *LogDirPolicy `json:"logDir,omitempty"`
+}
+
+// LogDirPolicy describes a policy of logDir, include log rotation and maximum log file size.
+type LogDirPolicy struct {
+	// Optional: Glob pattern of log files.
+	Glob string `json:"glob,omitempty"`
+	// Optional: Log rotation.
+	Rotate string `json:"rotate,omitempty"`
+	// Optional: Maximum log file size.
+	MaxFileSize int `json:"maxFileSize,omitempty"`
 }
 
 // EnvVar represents an environment variable present in a Container.

--- a/pkg/expapi/deep_copy_generated.go
+++ b/pkg/expapi/deep_copy_generated.go
@@ -356,6 +356,13 @@ func deepCopy_api_LocalObjectReference(in api.LocalObjectReference, out *api.Loc
 	return nil
 }
 
+func deepCopy_api_LogDirPolicy(in api.LogDirPolicy, out *api.LogDirPolicy, c *conversion.Cloner) error {
+	out.Glob = in.Glob
+	out.Rotate = in.Rotate
+	out.MaxFileSize = in.MaxFileSize
+	return nil
+}
+
 func deepCopy_api_NFSVolumeSource(in api.NFSVolumeSource, out *api.NFSVolumeSource, c *conversion.Cloner) error {
 	out.Server = in.Server
 	out.Path = in.Path
@@ -622,6 +629,26 @@ func deepCopy_api_VolumeMount(in api.VolumeMount, out *api.VolumeMount, c *conve
 	out.Name = in.Name
 	out.ReadOnly = in.ReadOnly
 	out.MountPath = in.MountPath
+	if in.Policy != nil {
+		out.Policy = new(api.VolumeMountPolicy)
+		if err := deepCopy_api_VolumeMountPolicy(*in.Policy, out.Policy, c); err != nil {
+			return err
+		}
+	} else {
+		out.Policy = nil
+	}
+	return nil
+}
+
+func deepCopy_api_VolumeMountPolicy(in api.VolumeMountPolicy, out *api.VolumeMountPolicy, c *conversion.Cloner) error {
+	if in.LogDir != nil {
+		out.LogDir = new(api.LogDirPolicy)
+		if err := deepCopy_api_LogDirPolicy(*in.LogDir, out.LogDir, c); err != nil {
+			return err
+		}
+	} else {
+		out.LogDir = nil
+	}
 	return nil
 }
 
@@ -1174,6 +1201,7 @@ func init() {
 		deepCopy_api_Lifecycle,
 		deepCopy_api_ListMeta,
 		deepCopy_api_LocalObjectReference,
+		deepCopy_api_LogDirPolicy,
 		deepCopy_api_NFSVolumeSource,
 		deepCopy_api_ObjectFieldSelector,
 		deepCopy_api_ObjectMeta,
@@ -1190,6 +1218,7 @@ func init() {
 		deepCopy_api_TypeMeta,
 		deepCopy_api_Volume,
 		deepCopy_api_VolumeMount,
+		deepCopy_api_VolumeMountPolicy,
 		deepCopy_api_VolumeSource,
 		deepCopy_resource_Quantity,
 		deepCopy_expapi_APIVersion,

--- a/pkg/expapi/v1/conversion_generated.go
+++ b/pkg/expapi/v1/conversion_generated.go
@@ -422,6 +422,16 @@ func convert_api_LocalObjectReference_To_v1_LocalObjectReference(in *api.LocalOb
 	return nil
 }
 
+func convert_api_LogDirPolicy_To_v1_LogDirPolicy(in *api.LogDirPolicy, out *v1.LogDirPolicy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.LogDirPolicy))(in)
+	}
+	out.Glob = in.Glob
+	out.Rotate = in.Rotate
+	out.MaxFileSize = in.MaxFileSize
+	return nil
+}
+
 func convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in *api.NFSVolumeSource, out *v1.NFSVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NFSVolumeSource))(in)
@@ -673,6 +683,29 @@ func convert_api_VolumeMount_To_v1_VolumeMount(in *api.VolumeMount, out *v1.Volu
 	out.Name = in.Name
 	out.ReadOnly = in.ReadOnly
 	out.MountPath = in.MountPath
+	if in.Policy != nil {
+		out.Policy = new(v1.VolumeMountPolicy)
+		if err := convert_api_VolumeMountPolicy_To_v1_VolumeMountPolicy(in.Policy, out.Policy, s); err != nil {
+			return err
+		}
+	} else {
+		out.Policy = nil
+	}
+	return nil
+}
+
+func convert_api_VolumeMountPolicy_To_v1_VolumeMountPolicy(in *api.VolumeMountPolicy, out *v1.VolumeMountPolicy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.VolumeMountPolicy))(in)
+	}
+	if in.LogDir != nil {
+		out.LogDir = new(v1.LogDirPolicy)
+		if err := convert_api_LogDirPolicy_To_v1_LogDirPolicy(in.LogDir, out.LogDir, s); err != nil {
+			return err
+		}
+	} else {
+		out.LogDir = nil
+	}
 	return nil
 }
 
@@ -1189,6 +1222,16 @@ func convert_v1_LocalObjectReference_To_api_LocalObjectReference(in *v1.LocalObj
 	return nil
 }
 
+func convert_v1_LogDirPolicy_To_api_LogDirPolicy(in *v1.LogDirPolicy, out *api.LogDirPolicy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*v1.LogDirPolicy))(in)
+	}
+	out.Glob = in.Glob
+	out.Rotate = in.Rotate
+	out.MaxFileSize = in.MaxFileSize
+	return nil
+}
+
 func convert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in *v1.NFSVolumeSource, out *api.NFSVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.NFSVolumeSource))(in)
@@ -1440,6 +1483,29 @@ func convert_v1_VolumeMount_To_api_VolumeMount(in *v1.VolumeMount, out *api.Volu
 	out.Name = in.Name
 	out.ReadOnly = in.ReadOnly
 	out.MountPath = in.MountPath
+	if in.Policy != nil {
+		out.Policy = new(api.VolumeMountPolicy)
+		if err := convert_v1_VolumeMountPolicy_To_api_VolumeMountPolicy(in.Policy, out.Policy, s); err != nil {
+			return err
+		}
+	} else {
+		out.Policy = nil
+	}
+	return nil
+}
+
+func convert_v1_VolumeMountPolicy_To_api_VolumeMountPolicy(in *v1.VolumeMountPolicy, out *api.VolumeMountPolicy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*v1.VolumeMountPolicy))(in)
+	}
+	if in.LogDir != nil {
+		out.LogDir = new(api.LogDirPolicy)
+		if err := convert_v1_LogDirPolicy_To_api_LogDirPolicy(in.LogDir, out.LogDir, s); err != nil {
+			return err
+		}
+	} else {
+		out.LogDir = nil
+	}
 	return nil
 }
 
@@ -2362,6 +2428,7 @@ func init() {
 		convert_api_Lifecycle_To_v1_Lifecycle,
 		convert_api_ListMeta_To_v1_ListMeta,
 		convert_api_LocalObjectReference_To_v1_LocalObjectReference,
+		convert_api_LogDirPolicy_To_v1_LogDirPolicy,
 		convert_api_NFSVolumeSource_To_v1_NFSVolumeSource,
 		convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector,
 		convert_api_ObjectMeta_To_v1_ObjectMeta,
@@ -2375,6 +2442,7 @@ func init() {
 		convert_api_SecurityContext_To_v1_SecurityContext,
 		convert_api_TCPSocketAction_To_v1_TCPSocketAction,
 		convert_api_TypeMeta_To_v1_TypeMeta,
+		convert_api_VolumeMountPolicy_To_v1_VolumeMountPolicy,
 		convert_api_VolumeMount_To_v1_VolumeMount,
 		convert_api_VolumeSource_To_v1_VolumeSource,
 		convert_api_Volume_To_v1_Volume,
@@ -2434,6 +2502,7 @@ func init() {
 		convert_v1_Lifecycle_To_api_Lifecycle,
 		convert_v1_ListMeta_To_api_ListMeta,
 		convert_v1_LocalObjectReference_To_api_LocalObjectReference,
+		convert_v1_LogDirPolicy_To_api_LogDirPolicy,
 		convert_v1_NFSVolumeSource_To_api_NFSVolumeSource,
 		convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector,
 		convert_v1_ObjectMeta_To_api_ObjectMeta,
@@ -2457,6 +2526,7 @@ func init() {
 		convert_v1_ThirdPartyResourceList_To_expapi_ThirdPartyResourceList,
 		convert_v1_ThirdPartyResource_To_expapi_ThirdPartyResource,
 		convert_v1_TypeMeta_To_api_TypeMeta,
+		convert_v1_VolumeMountPolicy_To_api_VolumeMountPolicy,
 		convert_v1_VolumeMount_To_api_VolumeMount,
 		convert_v1_VolumeSource_To_api_VolumeSource,
 		convert_v1_Volume_To_api_Volume,

--- a/pkg/expapi/v1/deep_copy_generated.go
+++ b/pkg/expapi/v1/deep_copy_generated.go
@@ -373,6 +373,13 @@ func deepCopy_v1_LocalObjectReference(in v1.LocalObjectReference, out *v1.LocalO
 	return nil
 }
 
+func deepCopy_v1_LogDirPolicy(in v1.LogDirPolicy, out *v1.LogDirPolicy, c *conversion.Cloner) error {
+	out.Glob = in.Glob
+	out.Rotate = in.Rotate
+	out.MaxFileSize = in.MaxFileSize
+	return nil
+}
+
 func deepCopy_v1_NFSVolumeSource(in v1.NFSVolumeSource, out *v1.NFSVolumeSource, c *conversion.Cloner) error {
 	out.Server = in.Server
 	out.Path = in.Path
@@ -640,6 +647,26 @@ func deepCopy_v1_VolumeMount(in v1.VolumeMount, out *v1.VolumeMount, c *conversi
 	out.Name = in.Name
 	out.ReadOnly = in.ReadOnly
 	out.MountPath = in.MountPath
+	if in.Policy != nil {
+		out.Policy = new(v1.VolumeMountPolicy)
+		if err := deepCopy_v1_VolumeMountPolicy(*in.Policy, out.Policy, c); err != nil {
+			return err
+		}
+	} else {
+		out.Policy = nil
+	}
+	return nil
+}
+
+func deepCopy_v1_VolumeMountPolicy(in v1.VolumeMountPolicy, out *v1.VolumeMountPolicy, c *conversion.Cloner) error {
+	if in.LogDir != nil {
+		out.LogDir = new(v1.LogDirPolicy)
+		if err := deepCopy_v1_LogDirPolicy(*in.LogDir, out.LogDir, c); err != nil {
+			return err
+		}
+	} else {
+		out.LogDir = nil
+	}
 	return nil
 }
 
@@ -1197,6 +1224,7 @@ func init() {
 		deepCopy_v1_Lifecycle,
 		deepCopy_v1_ListMeta,
 		deepCopy_v1_LocalObjectReference,
+		deepCopy_v1_LogDirPolicy,
 		deepCopy_v1_NFSVolumeSource,
 		deepCopy_v1_ObjectFieldSelector,
 		deepCopy_v1_ObjectMeta,
@@ -1213,6 +1241,7 @@ func init() {
 		deepCopy_v1_TypeMeta,
 		deepCopy_v1_Volume,
 		deepCopy_v1_VolumeMount,
+		deepCopy_v1_VolumeMountPolicy,
 		deepCopy_v1_VolumeSource,
 		deepCopy_v1_APIVersion,
 		deepCopy_v1_DaemonSet,

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -520,7 +520,7 @@ func TestMakeVolumeMounts(t *testing.T) {
 		"disk5": &stubVolume{"/var/lib/kubelet/podID/volumes/empty/disk5"},
 	}
 
-	mounts := makeMounts(&container, podVolumes)
+	mounts := makeMounts(nil, &container, podVolumes)
 
 	expectedMounts := []kubecontainer.Mount{
 		{


### PR DESCRIPTION
# LogDir
## Abstract

A proposal for implementing `LogDir`. A `LogDir` can preserve and manage a pod's log files.

Several existing issues and PRs were already created regarding that particular subject:
- Collect logfiles inside the container [#12567](https://github.com/kubernetes/kubernetes/issues/12567)
- Add LogDir [#13010](https://github.com/kubernetes/kubernetes/pull/13010#issuecomment-133997188)

Author: WuLonghui (@wulonghui)
## Motivation

Some applications will write log to files, so need to add  `LogDir`. It can add some useful infomation to make logging agent easy to collect the logs, also we can manage the log files(like log rotation and maximum log file sizes).
## Implementation

Create `LogDir` as a policy  to `api.VolumeMount` struct :

```
// VolumeMount describes a mounting of a Volume within a container.
type VolumeMount struct {
    // Required: This must match the Name of a Volume [above].
    Name string `json:"name"`
    // Optional: Defaults to false (read-write).
    ReadOnly bool `json:"readOnly,omitempty"`
    // Required.
    MountPath string `json:"mountPath"`
    // Optional: Policies of VolumeMount.
    Policy *VolumeMountPolicy `json:"policy,omitempty"`
}

// VolumeMountPolicy describes policies of a VolumeMount.
type VolumeMountPolicy struct {
    // Optional: LogDir policy.
    LogDir *LogDirPolicy `json:"logDir,omitempty"`
}

// LogDirPolicy describes a policy of logDir, include log rotation and maximum log file size.
type LogDirPolicy struct {
    // Optional: Glob pattern of log files.
    Glob string `json:"glob,omitempty"`
    // Optional: Log rotation.
    Rotate string `json:"rotate,omitempty"`
    // Optional: Maximum log file size.
    MaxFileSize int `json:"maxFileSize,omitempty"`
}

```

If users set the LogDir policy of the VolumeMount in a container:

```
apiVersion: v1
kind: Pod
metadata:
  name: my-app
spec:
  containers:
  - name: container1
    image: ubuntu:14.04
    command: ["bash", "-c", "i=\"0\"; while true; do echo \"`hostname`_container1: $i \"; date --rfc-3339 ns >> /varlog/container1.log; sleep 4; i=$[$i+1]; done"]
    volumeMounts:
    - name: log-storage
      mountPath: /varlog
      policy:
        logDir: {}
    securityContext:
        privileged: true
  volumes:
  - name: log-storage
    emptyDir: {}
```

Kubelet will create a symbolic link to the volume path in `/var/log/containers`.

```
/var/log/containers/<pod_full_name>_<contianer_name> => <volume_path>
```

Then the logging agent(e.g.Fluentd) can watch `/var/log/containers` on host to collect log files, add tag by `<pod_full_name>_<contianer_name>`, which can be used for search terms in Elasticsearch or for
labels for Cloud Logging.
## Integrated with Fluentd

We can use Fluentd to collect log files in `LogDir`. Fluentd should be installed on each Kubernetes node, and it will watch LogDir `/var/log/containers`, the Fluentd's configuration as follows:

```
<source>
  type tail
  format none
  time_key time
  path /var/log/containers/*/**/*.log
  pos_file /lib/pods.log.pos
  time_format %Y-%m-%dT%H:%M:%S
  tag reform.*
  read_from_head true
</source>

<match reform.**>
  type record_reformer
  enable_ruby true
  tag kubernetes.${hostname}.${tag_suffix[4]}
</match>

<match **>
  type stdout
</match>
```

The Fluentd will tail any files in the LogDir `/var/log/containers`, and add tag `kubernetes.<node_host_name>.<pod_full_name>_<container_name>.<file_name>`. We only print the logs to stdout,  also can forward to logging storage endpoint(e.g Elasticsearch).

Then the Fluentd prints the logs to stdout:

```
2015-09-11 11:00:10 +0000 kubernetes.8f5cd4af528a.my-app_default_container1.container1.log: {"message":"2015-09-11 10:59:53.331748730+00:00"}
2015-09-11 11:00:10 +0000 kubernetes.8f5cd4af528a.my-app_default_container1.container1.log: {"message":"2015-09-11 10:59:57.335719322+00:00"}
2015-09-11 11:00:10 +0000 kubernetes.8f5cd4af528a.my-app_default_container1.container1.log: {"message":"2015-09-11 11:00:01.339536181+00:00"}
```
## Future work
-  Be able to limit maximum log file sizes
-  Be able to support log rotation
