### PR TITLE
AWS: Add disk size/type defaults to config-test

### DIFF
--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -42,7 +42,7 @@ MASTER_DISK_SIZE=${MASTER_DISK_SIZE:-20}
 # The master root EBS volume size (typically does not need to be very large)
 MASTER_ROOT_DISK_TYPE="${MASTER_ROOT_DISK_TYPE:-gp2}"
 MASTER_ROOT_DISK_SIZE=${MASTER_ROOT_DISK_SIZE:-8}
-# The minions root EBS volume size (used to house Docker images
+# The minions root EBS volume size (used to house Docker images)
 MINION_ROOT_DISK_TYPE="${MINION_ROOT_DISK_TYPE:-gp2}"
 MINION_ROOT_DISK_SIZE=${MINION_ROOT_DISK_SIZE:-32}
 

--- a/cluster/aws/config-test.sh
+++ b/cluster/aws/config-test.sh
@@ -35,6 +35,12 @@ LOG="/dev/null"
 
 MASTER_DISK_TYPE="${MASTER_DISK_TYPE:-gp2}"
 MASTER_DISK_SIZE=${MASTER_DISK_SIZE:-20}
+# The master root EBS volume size (typically does not need to be very large)
+MASTER_ROOT_DISK_TYPE="${MASTER_ROOT_DISK_TYPE:-gp2}"
+MASTER_ROOT_DISK_SIZE=${MASTER_ROOT_DISK_SIZE:-8}
+# The minions root EBS volume size (used to house Docker images)
+MINION_ROOT_DISK_TYPE="${MINION_ROOT_DISK_TYPE:-gp2}"
+MINION_ROOT_DISK_SIZE=${MINION_ROOT_DISK_SIZE:-32}
 
 MASTER_NAME="${INSTANCE_PREFIX}-master"
 MASTER_TAG="${INSTANCE_PREFIX}-master"


### PR DESCRIPTION
Otherwise they needed to be manually specified (for example in the
Jenkins jobs)
