### PR TITLE
Lengthen e2e kubectl timeout

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -332,7 +332,7 @@ var _ = Describe("Kubectl client", func() {
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 
 			redisPort := 6379
-			serviceTimeout := 30 * time.Second
+			serviceTimeout := 60 * time.Second
 
 			By("creating Redis RC")
 			runKubectl("create", "-f", controllerJson, nsFlag)


### PR DESCRIPTION
30s on guestbook-go being pulled from the docker hub is tight - occasionally lag in scheduling can cause "kubectl expose it should create services for rc" to flake.

Extracted from #12959
