### PR TITLE
MESOS: Add path-override for minion controller so that kube-proxy can find iptables

### DIFF
--- a/contrib/mesos/pkg/scheduler/service/service.go
+++ b/contrib/mesos/pkg/scheduler/service/service.go
@@ -107,6 +107,7 @@ type SchedulerServer struct {
 	ProxyBindall bool
 	ProxyLogV    int
 
+	MinionPathOverride    string
 	MinionLogMaxSize      resource.Quantity
 	MinionLogMaxBackups   int
 	MinionLogMaxAgeInDays int
@@ -237,6 +238,7 @@ func (s *SchedulerServer) addCoreFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.RunProxy, "run-proxy", s.RunProxy, "Run the kube-proxy as a side process of the executor.")
 	fs.IntVar(&s.ProxyLogV, "proxy-logv", s.ProxyLogV, "Logging verbosity of spawned minion proxy processes.")
 
+	fs.StringVar(&s.MinionPathOverride, "minion-path-override", s.MinionPathOverride, "Override the PATH in the environment of the minion sub-processes.")
 	fs.Var(resource.NewQuantityFlagValue(&s.MinionLogMaxSize), "minion-max-log-size", "Maximum log file size for the executor and proxy before rotation")
 	fs.IntVar(&s.MinionLogMaxAgeInDays, "minion-max-log-age", s.MinionLogMaxAgeInDays, "Maximum log file age of the executor and proxy in days")
 	fs.IntVar(&s.MinionLogMaxBackups, "minion-max-log-backups", s.MinionLogMaxBackups, "Maximum log file backups of the executor and proxy to keep after rotation")
@@ -327,6 +329,7 @@ func (s *SchedulerServer) prepareExecutorInfo(hks hyperkube.Interface) (*mesos.E
 		ci.Arguments = append(ci.Arguments, fmt.Sprintf("--proxy-bindall=%v", s.ProxyBindall))
 		ci.Arguments = append(ci.Arguments, fmt.Sprintf("--proxy-logv=%d", s.ProxyLogV))
 
+		ci.Arguments = append(ci.Arguments, fmt.Sprintf("--path-override=%s", s.MinionPathOverride))
 		ci.Arguments = append(ci.Arguments, fmt.Sprintf("--max-log-size=%v", s.MinionLogMaxSize.String()))
 		ci.Arguments = append(ci.Arguments, fmt.Sprintf("--max-log-backups=%d", s.MinionLogMaxBackups))
 		ci.Arguments = append(ci.Arguments, fmt.Sprintf("--max-log-age=%d", s.MinionLogMaxAgeInDays))

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -156,6 +156,7 @@ minimum-container-ttl-duration
 minion-max-log-age
 minion-max-log-backups
 minion-max-log-size
+minion-path-override
 min-pr-number
 min-request-timeout
 namespace-sync-period
@@ -176,6 +177,7 @@ oidc-username-claim
 oom-score-adj
 output-version
 out-version
+path-override
 pod-cidr
 pod-eviction-timeout
 pod-infra-container-image


### PR DESCRIPTION
iptables on DCOS is in /usr/sbin. The minion though does not have /usr/sbin in its path. Hence, we have to modify it for kyperkube commands.

Fixes https://github.com/mesosphere/kubernetes-mesos/issues/454

~~test that forwarding `hostname-override` flag from minion controller to kube-proxy works in dcos (had added this in response to "missing uname" binary with PATH isn't set properly)~~
