### PR TITLE
Allow csv query param

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -5909,7 +5909,7 @@
         "allowMultiple": false
        },
        {
-        "type": "",
+        "type": "string",
         "paramType": "query",
         "name": "command",
         "description": "the command to execute; argv array; not executed within a shell",
@@ -5987,7 +5987,7 @@
         "allowMultiple": false
        },
        {
-        "type": "",
+        "type": "string",
         "paramType": "query",
         "name": "command",
         "description": "the command to execute; argv array; not executed within a shell",

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1572,7 +1572,7 @@ type PodExecOptions struct {
 	Container string `json:"container,omitempty" description:"the container in which to execute the command. Defaults to only container if there is only one container in the pod."`
 
 	// Command is the remote command to execute; argv array; not executed within a shell.
-	Command []string `json:"command" description:"the command to execute; argv array; not executed within a shell"`
+	Command []string `json:"command,csv" description:"the command to execute; argv array; not executed within a shell"`
 }
 
 // PodProxyOptions is the query options to a Pod's proxy call

--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -797,7 +797,7 @@ func addObjectParams(ws *restful.WebService, route *restful.RouteBuilder, obj in
 					continue
 				}
 				desc := sf.Tag.Get("description")
-				route.Param(ws.QueryParameter(jsonName, desc).DataType(typeToJSON(sf.Type.Name())))
+				route.Param(ws.QueryParameter(jsonName, desc).DataType(typeToJSON(sf.Type.String())))
 			}
 		}
 	}
@@ -812,11 +812,13 @@ func typeToJSON(typeName string) string {
 		return "boolean"
 	case "uint8", "int", "int32", "int64", "uint32", "uint64":
 		return "integer"
-	case "byte":
-		return "string"
 	case "float64", "float32":
 		return "number"
+	case "byte":
+		return "string"
 	case "util.Time":
+		return "string"
+	case "[]string":
 		return "string"
 	default:
 		return typeName

--- a/pkg/conversion/scheme.go
+++ b/pkg/conversion/scheme.go
@@ -282,12 +282,12 @@ func (s *Scheme) Recognizes(version, kind string) bool {
 	return ok
 }
 
-// RegisterInputDefaults sets the provided field mapping function and field matching
-// as the defaults for the provided input type.  The fn may be nil, in which case no
+// RegisterInputDefaults sets the provided field key and value mapping functions
+// as the defaults for the provided input type.  The functions may be nil, in which case no
 // mapping will happen by default. Use this method to register a mechanism for handling
 // a specific input type in conversion, such as a map[string]string to structs.
-func (s *Scheme) RegisterInputDefaults(in interface{}, fn FieldMappingFunc, defaultFlags FieldMatchingFlags) error {
-	return s.converter.RegisterInputDefaults(in, fn, defaultFlags)
+func (s *Scheme) RegisterInputDefaults(in interface{}, keyMapper FieldKeyMappingFunc, valueMapper FieldValueMappingFunc, defaultFlags FieldMatchingFlags) error {
+	return s.converter.RegisterInputDefaults(in, keyMapper, valueMapper, defaultFlags)
 }
 
 // Performs a deep copy of the given object.
@@ -369,7 +369,8 @@ func (s *Scheme) generateConvertMeta(srcVersion, destVersion string, in interfac
 	return s.converter.inputDefaultFlags[t], &Meta{
 		SrcVersion:     srcVersion,
 		DestVersion:    destVersion,
-		KeyNameMapping: s.converter.inputFieldMappingFuncs[t],
+		KeyNameMapping: s.converter.inputFieldKeyMappingFuncs[t],
+		ValueMapping:   s.converter.inputFieldValueMappingFuncs[t],
 	}
 }
 

--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -234,10 +234,10 @@ func NewScheme() *Scheme {
 	if err := s.raw.AddConversionFuncs(DefaultStringConversions...); err != nil {
 		panic(err)
 	}
-	if err := s.raw.RegisterInputDefaults(&map[string][]string{}, JSONKeyMapper, conversion.AllowDifferentFieldTypeNames|conversion.IgnoreMissingFields); err != nil {
+	if err := s.raw.RegisterInputDefaults(&map[string][]string{}, JSONKeyMapper, nil, conversion.AllowDifferentFieldTypeNames|conversion.IgnoreMissingFields); err != nil {
 		panic(err)
 	}
-	if err := s.raw.RegisterInputDefaults(&url.Values{}, JSONKeyMapper, conversion.AllowDifferentFieldTypeNames|conversion.IgnoreMissingFields); err != nil {
+	if err := s.raw.RegisterInputDefaults(&url.Values{}, JSONKeyMapper, CSVFieldValueMapper, conversion.AllowDifferentFieldTypeNames|conversion.IgnoreMissingFields); err != nil {
 		panic(err)
 	}
 	return s


### PR DESCRIPTION
Forked from https://github.com/kubernetes/kubernetes/pull/12507

Updates the server to accept multiple values of a query param in csv form (exec?command=echo,Hi) in addition to the current way of requiring multiple instances of the param (exec?command=echo&command=Hi)
This is because swagger 1.0 has no way of defining a query param that accepts multiple instances. It only supports multiple values in the form of csv using the allowMultiple property(https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#524-parameter-object)
Swagger 2.0, however, supports that with collectionFormat using multi:

```
multi - corresponds to multiple parameter instances instead of multiple values 
for a single instance foo=bar&foo=baz. This is valid only for parameters in 
"query" or "formData"
```

So we can just wait for go-restful to support 2.0 or accept this PR.

Without a fix, clients generated using swagger spec will not be able to pass multiple command arguments.

cc @bgrant0607 @lavalamp @smarterclayton 
