### PR TITLE
Kubernetes on AWS mutli-AZ by default

### DIFF
--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -14,17 +14,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ZONE=${KUBE_AWS_ZONE:-us-west-2a}
+# AWS Instance sizes
 MASTER_SIZE=${MASTER_SIZE:-t2.micro}
 MINION_SIZE=${MINION_SIZE:-t2.micro}
-NUM_MINIONS=${NUM_MINIONS:-4}
+
+# Number of minions to run in each AZ
+NUM_MINIONS_PRIMARY_ZONE=${NUM_MINIONS_PRIMARY_ZONE:-2}
+NUM_MINIONS_SECONDARY_ZONE=${NUM_MINIONS_SECONDARY_ZONE:-2}
+NUM_MINIONS=$[$NUM_MINIONS_PRIMARY_ZONE+$NUM_MINIONS_SECONDARY_ZONE]
+
+# Which AWS Region to use (for hosts and S3 Bucket)
+AWS_REGION=${AWS_REGION:-us-west-1}
+AWS_S3_REGION=${AWS_S3_REGION:-us-west-1}
+
+# We'll launch minions across two AWS Availability zones
+# Note that 'us-east-1' does not have a region 'b'. Use 'a' and 'c' instead.
+AWS_ZONE_PRIMARY=${AWS_ZONE_PRIMARY:-a}
+AWS_ZONE_SECONDARY=${AWS_ZONE_SECONDARY:-b}
 
 # Optional: Set AWS_S3_BUCKET to the name of an S3 bucket to use for uploading binaries
 # (otherwise a unique bucket name will be generated for you)
 #  AWS_S3_BUCKET=kubernetes-artifacts
 
-# Because regions are globally named, we want to create in a single region; default to us-east-1
-AWS_S3_REGION=${AWS_S3_REGION:-us-east-1}
+# Which CIDR networks ought to be allowed via security groups
+KUBE_AWS_CIDR_WHITELIST="0.0.0.0/0"
 
 # Which docker storage mechanism to use.
 DOCKER_STORAGE=${DOCKER_STORAGE:-aufs}


### PR DESCRIPTION
Hello!

References issue #13056 - Kubernetes on AWS via "kube-up" should be more highly available.

  Part one: Minions should scale across two Amazon Availability zones
  Part two: Kube-master should be highly available with one instance per AZ

This is part one of two.

This has a fairly high potential to break things - but I've done quite a bit of testing and it seems to behave just fine. Since the two AZs exist in one VPC and networking is flat between them, I don't expect any issues.

Additionally, this replaces the subnet which was a single 0/24 with two /24s in the larger /16 of the VPC. Therefore the total number of minions on AWS without any modification is upped from 254 to 508 (two /24s).

@justinsb should probably take a peek at this one :)

Thanks everyone! We're absolutely _loving_ Kubernetes on my team - Keep up the great work!!
