### PR TITLE
Elastic IP need to be assigned after the instance is in running state

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -869,12 +869,12 @@ function kube-up {
         exit 1
       fi
     else
+      # We are not able to add an elastic ip, a route or volume to the instance until that instance is in "running" state.
+      wait-for-instance-running $master_id
+
       KUBE_MASTER=${MASTER_NAME}
       KUBE_MASTER_IP=$(assign-elastic-ip $ip $master_id)
       echo -e " ${color_green}[master running @${KUBE_MASTER_IP}]${color_norm}"
-
-      # We are not able to add a route or volume to the instance until that instance is in "running" state.
-      wait-for-instance-running $master_id
 
       # This is a race between instance start and volume attachment.  There appears to be no way to start an AWS instance with a volume attached.
       # To work around this, we wait for volume to be ready in setup-master-pd.sh


### PR DESCRIPTION
…. Currently always fails with "The pending instance x is not in a valid state for this operation" and defaults to public ip.

Fix: Moved assign-elastic-ip to run after wait-for-instance-running.
